### PR TITLE
Overview & Findings declutter + ASPM coverage lane

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -132,7 +132,7 @@ domain** so they roll up into exactly one posture lane:
 | `account_ref` | One normalized string: `aws:123456789012`, `azure:<sub-id>`, `gcp:<project-id>`, `snowflake:<account>` |
 | `region` | Cloud region (parsed from the ARN where available) |
 | `environment` | `prod` \| `staging` \| `dev` \| … when known |
-| `security_domain` (derived) | Exactly one of `cspm`, `vuln`, `appsec_sca`, `dspm`, `aispm` |
+| `security_domain` (derived) | Exactly one of `cspm`, `vuln`, `aspm`, `dspm`, `aispm` |
 
 Scope is populated at ingest by the cloud converters
 (`cloud_cis_check_to_finding`, `snowflake_governance_finding_to_finding`) and
@@ -145,7 +145,7 @@ in `src/agent_bom/finding_scope.py`:
 | `CLOUD_CIS` (CIS benchmark) | `cspm` |
 | `CLOUD_CIS` Snowflake governance (data access) | `dspm` |
 | CVE / malicious package / license (any source) | `vuln` |
-| `SAST`, secret/credential exposure | `appsec_sca` |
+| `SAST`, secret/credential exposure | `aspm` |
 | MCP / proxy / skill / prompt / graph + AI-native types | `aispm` |
 
 A **finding** is raw scanner output; an **issue** is a correlated/deduped

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -61,11 +61,13 @@ _ALL_SEVERITY_KEYS = (*_SEVERITY_KEYS, _UNRATED_KEY)
 _HUB_SEVERITY_KEYS = ("critical", "high", "medium", "low", "info", "unknown")
 
 # Coverage lanes — the five security domains, in display order (issue #3946).
-_COVERAGE_DOMAINS = ("cspm", "vuln", "appsec_sca", "dspm", "aispm")
+# Symmetric posture-management family: CSPM · ASPM · DSPM · AISPM, plus Vuln
+# mgmt as the cross-surface CVE lane.
+_COVERAGE_DOMAINS = ("cspm", "vuln", "aspm", "dspm", "aispm")
 _COVERAGE_LABELS = {
     "cspm": "CSPM",
     "vuln": "Vuln mgmt",
-    "appsec_sca": "AppSec / SCA",
+    "aspm": "ASPM",
     "dspm": "DSPM",
     "aispm": "AISPM",
 }

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1491,7 +1491,12 @@ def _canonical_scope_filters(
     if environment and environment.strip():
         filters["environment"] = environment.strip().lower()
     if domain and domain.strip():
-        filters["domain"] = domain.strip().lower()
+        # Map the pre-rename ``appsec_sca`` alias to ``aspm`` so historical
+        # deep-links keep resolving; unknown values pass through untouched.
+        from agent_bom.finding_scope import _LEGACY_DOMAIN_ALIASES
+
+        key = domain.strip().lower()
+        filters["domain"] = _LEGACY_DOMAIN_ALIASES.get(key, key)
     return filters
 
 

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -430,7 +430,7 @@ class Finding:
 
     @property
     def security_domain(self) -> str:
-        """Derived posture lane: one of cspm/vuln/appsec_sca/dspm/aispm.
+        """Derived posture lane: one of cspm/vuln/aspm/dspm/aispm.
 
         A pure function of source + finding type (+ evidence for the cloud
         data-vs-config split), so the overview and findings surfaces route each

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -24,17 +24,35 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from agent_bom.finding import FindingSource, FindingType
 
 # The five posture lanes. Kept as plain strings (not an enum) so the value can
-# flow through JSON, the API, and the UI without a serialization shim.
-SECURITY_DOMAINS: tuple[str, ...] = ("cspm", "vuln", "appsec_sca", "dspm", "aispm")
+# flow through JSON, the API, and the UI without a serialization shim. The
+# posture-management family is symmetric: CSPM (cloud) · ASPM (application) ·
+# DSPM (data) · AISPM (AI), with Vuln mgmt as the cross-surface CVE lane.
+SECURITY_DOMAINS: tuple[str, ...] = ("cspm", "vuln", "aspm", "dspm", "aispm")
 
 # Human labels for the UI coverage lanes (one per domain, 1:1).
 SECURITY_DOMAIN_LABELS: dict[str, str] = {
     "cspm": "CSPM",
     "vuln": "Vuln mgmt",
-    "appsec_sca": "AppSec / SCA",
+    "aspm": "ASPM",
     "dspm": "DSPM",
     "aispm": "AISPM",
 }
+
+# Back-compat: rows persisted under the pre-rename ``appsec_sca`` key still
+# resolve to the ``aspm`` lane so historical findings are never dropped.
+_LEGACY_DOMAIN_ALIASES: dict[str, str] = {"appsec_sca": "aspm"}
+
+
+def canonical_domain(value: str | None) -> Optional[str]:
+    """Return a recognized posture-lane key for ``value``, applying legacy aliases.
+
+    Accepts a stored/queried domain string, maps the pre-rename ``appsec_sca``
+    alias to ``aspm``, and returns the canonical key only when it is one of the
+    five posture lanes (else None so callers decide the default).
+    """
+    key = (value or "").strip().lower()
+    key = _LEGACY_DOMAIN_ALIASES.get(key, key)
+    return key if key in SECURITY_DOMAINS else None
 
 
 # ---------------------------------------------------------------------------
@@ -104,7 +122,7 @@ def security_domain_for(
          other cloud CIS finding is CSPM.
       2. ``FindingType`` is decisive for the portable signals — a dependency CVE
          or malicious package is vuln-management wherever it was discovered; SAST
-         and secret findings are AppSec/SCA.
+         and secret-in-code findings are application-security posture (ASPM).
       3. Otherwise route by source (container/SBOM/external/filesystem → vuln;
          everything MCP/agent/runtime/prompt/skill/graph → AISPM).
     """
@@ -128,7 +146,7 @@ def security_domain_for(
         return "vuln"
 
     if finding_type in (FindingType.SAST, FindingType.CREDENTIAL_EXPOSURE):
-        return "appsec_sca"
+        return "aspm"
 
     if source in (
         FindingSource.CONTAINER,
@@ -139,7 +157,7 @@ def security_domain_for(
         return "vuln"
 
     if source in (FindingSource.SAST, FindingSource.SECRET_SCAN):
-        return "appsec_sca"
+        return "aspm"
 
     # MCP scan, proxy, skill, browser-ext, prompt scan, graph correlation, and
     # any AI-native finding type (tool drift, injection, cloaking, blocklist,
@@ -154,8 +172,8 @@ def domain_for_row(row: dict) -> Optional[str]:
     source/type mapping for legacy rows. Returns None when neither the field nor
     a recognizable source/type is present, so callers decide the default.
     """
-    dom = str(row.get("security_domain") or "").strip().lower()
-    if dom in SECURITY_DOMAINS:
+    dom = canonical_domain(row.get("security_domain"))
+    if dom is not None:
         return dom
     from agent_bom.finding import FindingSource, FindingType
 

--- a/tests/test_cloud_account_summary.py
+++ b/tests/test_cloud_account_summary.py
@@ -126,7 +126,7 @@ def test_summary_domains_are_five_lanes_each_reconciled() -> None:
     body = client.get("/v1/cloud/accounts/aws:111111111111/summary", headers=_AUTH).json()
 
     lanes = {lane["domain"]: lane for lane in body["domains"]}
-    assert set(lanes) == {"cspm", "vuln", "appsec_sca", "dspm", "aispm"}
+    assert set(lanes) == {"cspm", "vuln", "aspm", "dspm", "aispm"}
     assert lanes["cspm"]["count"] == 1
     assert lanes["vuln"]["count"] == 1
     assert lanes["aispm"]["count"] == 1

--- a/tests/test_finding_scope.py
+++ b/tests/test_finding_scope.py
@@ -65,9 +65,9 @@ def test_domain_dependency_cve_is_vuln() -> None:
     assert security_domain_for(FindingSource.MCP_SCAN, FindingType.MALICIOUS_PACKAGE) == "vuln"
 
 
-def test_domain_sast_and_secret_is_appsec_sca() -> None:
-    assert security_domain_for(FindingSource.SAST, FindingType.SAST) == "appsec_sca"
-    assert security_domain_for(FindingSource.SECRET_SCAN, FindingType.CREDENTIAL_EXPOSURE) == "appsec_sca"
+def test_domain_sast_and_secret_is_aspm() -> None:
+    assert security_domain_for(FindingSource.SAST, FindingType.SAST) == "aspm"
+    assert security_domain_for(FindingSource.SECRET_SCAN, FindingType.CREDENTIAL_EXPOSURE) == "aspm"
 
 
 def test_domain_mcp_agent_signals_are_aispm() -> None:
@@ -83,10 +83,20 @@ def test_domain_snowflake_governance_is_dspm() -> None:
 
 
 def test_domain_is_one_of_the_five() -> None:
-    valid = {"cspm", "vuln", "appsec_sca", "dspm", "aispm"}
+    valid = {"cspm", "vuln", "aspm", "dspm", "aispm"}
     for source in FindingSource:
         for ftype in FindingType:
             assert security_domain_for(source, ftype) in valid
+
+
+def test_legacy_appsec_sca_domain_resolves_to_aspm() -> None:
+    """Rows persisted under the pre-rename key still land in the ASPM lane."""
+    from agent_bom.finding_scope import canonical_domain, domain_for_row
+
+    assert canonical_domain("appsec_sca") == "aspm"
+    assert canonical_domain("aspm") == "aspm"
+    assert canonical_domain("bogus") is None
+    assert domain_for_row({"security_domain": "appsec_sca"}) == "aspm"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -308,7 +308,7 @@ def test_overview_coverage_lanes_map_to_five_domains() -> None:
 
     data = client_get_overview()
     coverage = {lane["domain"]: lane for lane in data["coverage"]}
-    assert set(coverage) == {"cspm", "vuln", "appsec_sca", "dspm", "aispm"}
+    assert set(coverage) == {"cspm", "vuln", "aspm", "dspm", "aispm"}
 
     cspm = coverage["cspm"]
     assert cspm["count"] == 2
@@ -319,7 +319,7 @@ def test_overview_coverage_lanes_map_to_five_domains() -> None:
     assert coverage["vuln"]["count"] == 1
     assert coverage["aispm"]["count"] == 1
     assert coverage["dspm"]["count"] == 0
-    assert coverage["appsec_sca"]["count"] == 0
+    assert coverage["aspm"]["count"] == 0
     # CIS misconfig went to CSPM, not the vuln lane.
     assert coverage["vuln"]["severity"]["critical"] == 1
 
@@ -359,7 +359,7 @@ def test_overview_headline_reflects_noncve_spine_critical() -> None:
             {"id": "vuln-cve", "security_domain": "vuln", "severity": "medium", "cve_id": "CVE-2025-1000"},
             {
                 "id": "mal-1",
-                "security_domain": "appsec_sca",
+                "security_domain": "aspm",
                 "severity": "critical",
                 "is_malicious": True,
                 "title": "malicious package foo",
@@ -373,7 +373,7 @@ def test_overview_headline_reflects_noncve_spine_critical() -> None:
     assert data["headline"]["critical"] == 1
     # Coverage (which always read the spine) and the headline now agree.
     coverage = {lane["domain"]: lane for lane in data["coverage"]}
-    assert coverage["appsec_sca"]["severity"]["critical"] == 1
+    assert coverage["aspm"]["severity"]["critical"] == 1
     # The grade moves off a clean posture — a critical carries penalty.
     assert data["posture"]["grade"] not in {"N/A", "A"}
     crit_row = next(r for r in data["posture"]["breakdown"] if r["driver"] == "critical")

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState, useMemo, type ElementType } from "react";
+import { Suspense, useCallback, useEffect, useState, useMemo, useRef, type ElementType } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import {
   api,
@@ -49,7 +49,7 @@ import {
 } from "@/lib/findings-lens";
 import { useFindingsLens } from "@/hooks/use-findings-lens";
 import { severityRank } from "@/lib/severity";
-import { Bug, ChevronDown, ChevronRight, Download, Layers, Loader2, Package, Server, ClipboardCheck } from "lucide-react";
+import { Bug, ChevronDown, ChevronRight, Download, Layers, Loader2, Package, Server, ClipboardCheck, SlidersHorizontal, X } from "lucide-react";
 import { PageLaneHeader } from "@/components/page-lane";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
@@ -257,7 +257,7 @@ const DOMAIN_FILTERS: { key: string; label: string }[] = [
   { key: "all", label: "All domains" },
   { key: "cspm", label: "CSPM" },
   { key: "vuln", label: "Vuln mgmt" },
-  { key: "appsec_sca", label: "AppSec / SCA" },
+  { key: "aspm", label: "ASPM" },
   { key: "dspm", label: "DSPM" },
   { key: "aispm", label: "AISPM" },
 ];
@@ -345,6 +345,27 @@ function FindingsPage() {
   const PAGE_SIZE = 25;
   const useServerPaging = groupBy === "none" && !search.trim();
   const showLifecycleColumns = useMemo(() => hasLifecycleMetadata(vulns), [vulns]);
+  // Advanced-filter popover (scope / domain / cloud scope) — kept behind a
+  // single "Filters (n)" control so the primary toolbar stays compact.
+  const [filtersOpen, setFiltersOpen] = useState(false);
+  const filtersRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => {
+    if (!filtersOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFiltersOpen(false);
+    };
+    const onPointer = (e: MouseEvent) => {
+      if (filtersRef.current && !filtersRef.current.contains(e.target as Node)) {
+        setFiltersOpen(false);
+      }
+    };
+    document.addEventListener("keydown", onKey);
+    document.addEventListener("mousedown", onPointer);
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.removeEventListener("mousedown", onPointer);
+    };
+  }, [filtersOpen]);
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set());
   const toggleGroup = useCallback((groupLabel: string) => {
     setCollapsedGroups((prev) => {
@@ -878,7 +899,36 @@ function FindingsPage() {
     useServerPaging && findingsTotalApproximate,
   );
 
-  const cloudScopeActive = Boolean(providerFilter.trim() || accountFilter.trim() || environmentFilter.trim());
+  // Advanced filters live behind the "Filters (n)" popover. ``n`` counts the
+  // non-default ones; each active filter is also surfaced as a removable chip so
+  // state stays visible without opening the panel. Clearing a chip resets the
+  // filter to its default, which the URL-sync effect drops from the query string.
+  const domainFilterLabel = DOMAIN_FILTERS.find((d) => d.key === domainFilter)?.label ?? domainFilter;
+  const activeFilterChips: { key: string; label: string; onClear: () => void }[] = [
+    scope !== "latest"
+      ? { key: "scope", label: "Scope: All scans", onClear: () => setScope("latest") }
+      : null,
+    domainFilter !== "all"
+      ? { key: "domain", label: `Domain: ${domainFilterLabel}`, onClear: () => setDomainFilter("all") }
+      : null,
+    providerFilter.trim()
+      ? { key: "provider", label: `Cloud: ${providerFilter.trim().toUpperCase()}`, onClear: () => setProviderFilter("") }
+      : null,
+    accountFilter.trim()
+      ? { key: "account", label: `Account: ${accountFilter.trim()}`, onClear: () => setAccountFilter("") }
+      : null,
+    environmentFilter.trim()
+      ? { key: "environment", label: `Env: ${environmentFilter.trim()}`, onClear: () => setEnvironmentFilter("") }
+      : null,
+  ].filter((chip): chip is { key: string; label: string; onClear: () => void } => chip !== null);
+  const activeFilterCount = activeFilterChips.length;
+  const clearAdvancedFilters = () => {
+    setScope("latest");
+    setDomainFilter("all");
+    setProviderFilter("");
+    setAccountFilter("");
+    setEnvironmentFilter("");
+  };
 
   const FILTERS: { key: SeverityFilter; label: string; color: string }[] = [
     {
@@ -1015,20 +1065,22 @@ function FindingsPage() {
 
       {!error && vulns.length > 0 && (
         <>
-          {/* Controls */}
+          {/* Controls — compact toolbar; advanced facets live behind a single
+              "Filters (n)" popover with removable active-filter chips. */}
           <div className="flex flex-col gap-3">
-            <div className="flex flex-col gap-2 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-              <div>
-                <h2 className="text-sm font-semibold text-[var(--foreground)]">{findingsQueueTitle(lens)}</h2>
-                <p className="mt-1 text-xs text-[var(--text-tertiary)]">{findingsQueueDetail(lens)}</p>
-              </div>
-              <div className="flex flex-wrap gap-2 text-xs text-[var(--text-tertiary)]">
-                <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1">{PAGE_SIZE} per page</span>
-                <span className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1">{displayed.length} filtered</span>
-                <span
-                  className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1"
-                  title="OpenVEX export is available after a finding is triaged as not_affected with justification"
-                >
+            {/* One-line queue caption (verbose explainer moved to the title tooltip). */}
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="flex flex-wrap items-center gap-x-1.5 text-xs text-[var(--text-tertiary)]">
+                <span className="font-semibold text-[var(--text-secondary)]" title={findingsQueueDetail(lens)}>
+                  {findingsQueueTitle(lens)}
+                </span>
+                <span aria-hidden="true">·</span>
+                <span>{displayed.length} filtered</span>
+                <span aria-hidden="true">·</span>
+                <span>{PAGE_SIZE} per page</span>
+              </p>
+              <div className="flex flex-wrap items-center gap-2 text-xs text-[var(--text-tertiary)]">
+                <span title="OpenVEX export is available after a finding is triaged as not_affected with justification">
                   {vexEligibleCount} OpenVEX-ready
                 </span>
                 {lens === "trust" ? (
@@ -1041,7 +1093,7 @@ function FindingsPage() {
                 ) : (
                   <a
                     href="/remediation"
-                    className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1 hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
+                    className="rounded-full border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1 hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]"
                   >
                     Remediation
                   </a>
@@ -1049,27 +1101,147 @@ function FindingsPage() {
               </div>
             </div>
 
-            {/* Issue type + severity filters */}
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-              <div className="flex flex-col gap-2">
-                <div className="flex flex-wrap items-center gap-1">
-                  <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">Issue type</span>
-                  {ISSUE_TYPE_FILTERS.map(({ key, label, hint }) => (
-                    <button
-                      key={key}
-                      type="button"
-                      onClick={() => setIssueTypeFilter(key)}
-                      title={hint}
-                      className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
-                        issueTypeFilter === key
-                          ? "border-cyan-700 bg-cyan-950/40 text-cyan-200"
-                          : "border-[var(--border-subtle)] text-[var(--text-tertiary)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
-                      }`}
+            {/* Primary toolbar: search + issue type + severity + group by, with
+                advanced filters tucked into the "Filters (n)" popover. */}
+            <div className="flex flex-col gap-2.5 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 px-3 py-2.5">
+              <div className="flex flex-wrap items-center gap-2">
+                <input
+                  type="text"
+                  placeholder={findingsSearchPlaceholder(lens)}
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  className="min-w-[12rem] flex-1 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-1.5 text-sm text-[var(--foreground)] placeholder-[var(--text-tertiary)] focus:border-[var(--border-strong)] focus:outline-none"
+                />
+                <div className="relative" ref={filtersRef}>
+                  <button
+                    type="button"
+                    onClick={() => setFiltersOpen((o) => !o)}
+                    aria-expanded={filtersOpen}
+                    aria-haspopup="dialog"
+                    data-testid="findings-filters-toggle"
+                    className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                      activeFilterCount > 0
+                        ? "border-[color:var(--border-strong)] bg-[var(--surface-elevated)] text-[var(--foreground)]"
+                        : "border-[var(--border-subtle)] text-[var(--text-secondary)] hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+                    }`}
+                  >
+                    <SlidersHorizontal className="h-3.5 w-3.5" />
+                    Filters{activeFilterCount > 0 ? ` (${activeFilterCount})` : ""}
+                  </button>
+                  {filtersOpen && (
+                    <div
+                      role="dialog"
+                      aria-label="Advanced filters"
+                      data-testid="findings-filters-popover"
+                      className="absolute right-0 z-40 mt-2 flex w-[min(22rem,90vw)] flex-col gap-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3 shadow-xl"
                     >
-                      {label}
-                    </button>
-                  ))}
+                      <div className="flex flex-col gap-1">
+                        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Scope</span>
+                        <select
+                          value={scope}
+                          onChange={(e) => setScope(e.target.value as ScanScope)}
+                          className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-3 py-1.5 text-sm text-[var(--foreground)] focus:border-[var(--border-strong)] focus:outline-none"
+                        >
+                          <option value="latest">Latest completed scan</option>
+                          <option value="all">All completed scans</option>
+                        </select>
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Domain</span>
+                        <div className="flex flex-wrap items-center gap-1">
+                          {DOMAIN_FILTERS.map(({ key, label }) => (
+                            <button
+                              key={key}
+                              type="button"
+                              onClick={() => setDomainFilter(key)}
+                              className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
+                                domainFilter === key
+                                  ? "border-[color:var(--accent-mint)] bg-[color:var(--surface-muted)] text-[color:var(--foreground)]"
+                                  : "border-[color:var(--border-subtle)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+                              }`}
+                            >
+                              {label}
+                            </button>
+                          ))}
+                        </div>
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Cloud</span>
+                        <select
+                          value={providerFilter}
+                          onChange={(e) => setProviderFilter(e.target.value)}
+                          className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                        >
+                          <option value="">Any provider</option>
+                          {PROVIDER_OPTIONS.map((p) => (
+                            <option key={p} value={p}>
+                              {p.toUpperCase()}
+                            </option>
+                          ))}
+                        </select>
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Account</span>
+                        <input
+                          type="text"
+                          placeholder="e.g. aws:123456789012"
+                          value={accountFilter}
+                          onChange={(e) => setAccountFilter(e.target.value)}
+                          className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                        />
+                      </div>
+                      <div className="flex flex-col gap-1">
+                        <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Environment</span>
+                        <input
+                          type="text"
+                          placeholder="e.g. prod"
+                          value={environmentFilter}
+                          onChange={(e) => setEnvironmentFilter(e.target.value)}
+                          className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
+                        />
+                      </div>
+                      <div className="flex items-center justify-between gap-2 border-t border-[color:var(--border-subtle)] pt-2">
+                        <button
+                          type="button"
+                          onClick={clearAdvancedFilters}
+                          disabled={activeFilterCount === 0}
+                          className="rounded-lg px-2.5 py-1.5 text-xs font-medium text-[color:var(--text-secondary)] transition-colors hover:text-[color:var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+                        >
+                          Clear all
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setFiltersOpen(false)}
+                          className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs font-medium text-[color:var(--foreground)] transition-colors hover:border-[color:var(--border-strong)]"
+                        >
+                          Done
+                        </button>
+                      </div>
+                    </div>
+                  )}
                 </div>
+              </div>
+
+              <div className="flex flex-wrap items-center gap-1">
+                <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">Issue type</span>
+                {ISSUE_TYPE_FILTERS.map(({ key, label, hint }) => (
+                  <button
+                    key={key}
+                    type="button"
+                    onClick={() => setIssueTypeFilter(key)}
+                    title={hint}
+                    className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
+                      issueTypeFilter === key
+                        ? "border-cyan-700 bg-cyan-950/40 text-cyan-200"
+                        : "border-[var(--border-subtle)] text-[var(--text-tertiary)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]"
+                    }`}
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+
+              <div className="flex flex-wrap items-center justify-between gap-2">
                 <div className="flex flex-wrap items-center gap-1">
                   <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">Severity</span>
                   {FILTERS?.map(({ key, label, color }) => (
@@ -1079,114 +1251,60 @@ function FindingsPage() {
                       className={`rounded-md border px-3 py-1 text-xs font-medium transition-colors ${
                         filter === key
                           ? `${color} border-[var(--border-strong)] bg-[var(--surface-elevated)]`
-                          : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
+                          : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]"
                       }`}
                     >
                       {label}
                     </button>
                   ))}
                 </div>
+                <div className="flex items-center gap-1">
+                  <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">Group by</span>
+                  {GROUP_OPTIONS?.map(({ key, label, icon: Icon }) => (
+                    <button
+                      key={key}
+                      onClick={() => setGroupBy(key)}
+                      className={`flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
+                        groupBy === key
+                          ? "text-[var(--foreground)] border-[var(--border-strong)] bg-[var(--surface-elevated)]"
+                          : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]"
+                      }`}
+                    >
+                      <Icon className="h-3 w-3" />
+                      {label}
+                    </button>
+                  ))}
+                </div>
               </div>
-              <input
-                type="text"
-                placeholder={findingsSearchPlaceholder(lens)}
-                value={search}
-                onChange={(e) => setSearch(e.target.value)}
-                className="w-full sm:w-64 bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg px-3 py-1.5 text-sm text-[var(--foreground)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-[var(--border-strong)]"
-              />
             </div>
 
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-[var(--text-tertiary)] uppercase tracking-wide font-medium">Scope</span>
-                <select
-                  value={scope}
-                  onChange={(e) => setScope(e.target.value as ScanScope)}
-                  className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-lg px-3 py-1.5 text-sm text-[var(--foreground)] focus:outline-none focus:border-[var(--border-strong)]"
-                >
-                  <option value="latest">Latest completed scan</option>
-                  <option value="all">All completed scans</option>
-                </select>
-              </div>
-              <p className="text-xs text-[var(--text-tertiary)]">
-                Default stays scoped for speed. Expand to all scans only when you need history-wide findings aggregation.
-              </p>
-            </div>
-
-            {/* Security domain + cloud scope facets (issue #3946). Design-token
-                styled so both themes read correctly; URL-synced via state. */}
-            <div className="flex flex-col gap-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3">
-              <div className="flex flex-wrap items-center gap-1">
-                <span className="mr-1 text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
-                  Domain
-                </span>
-                {DOMAIN_FILTERS.map(({ key, label }) => (
+            {/* Active advanced-filter chips — removable, keep state visible
+                without opening the panel. Clearing resets to default, which the
+                URL-sync effect drops from the query string. */}
+            {activeFilterChips.length > 0 && (
+              <div className="flex flex-wrap items-center gap-1.5" data-testid="findings-active-filters">
+                {activeFilterChips.map((chip) => (
                   <button
-                    key={key}
+                    key={chip.key}
                     type="button"
-                    onClick={() => setDomainFilter(key)}
-                    className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
-                      domainFilter === key
-                        ? "border-[color:var(--accent-mint)] bg-[color:var(--surface-muted)] text-[color:var(--foreground)]"
-                        : "border-[color:var(--border-subtle)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                    }`}
+                    onClick={chip.onClear}
+                    data-testid={`findings-chip-${chip.key}`}
+                    aria-label={`Remove filter ${chip.label}`}
+                    className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1 text-xs font-medium text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                   >
-                    {label}
+                    {chip.label}
+                    <X className="h-3 w-3" aria-hidden="true" />
                   </button>
                 ))}
+                <button
+                  type="button"
+                  onClick={clearAdvancedFilters}
+                  className="rounded-full px-2 py-1 text-xs font-medium text-[color:var(--text-tertiary)] transition hover:text-[color:var(--foreground)]"
+                >
+                  Clear all
+                </button>
               </div>
-              <div className="flex flex-wrap items-end gap-3">
-                <label className="flex flex-col gap-1">
-                  <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Cloud</span>
-                  <select
-                    value={providerFilter}
-                    onChange={(e) => setProviderFilter(e.target.value)}
-                    className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] focus:border-[color:var(--border-strong)] focus:outline-none"
-                  >
-                    <option value="">Any provider</option>
-                    {PROVIDER_OPTIONS.map((p) => (
-                      <option key={p} value={p}>
-                        {p.toUpperCase()}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <label className="flex flex-col gap-1">
-                  <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Account</span>
-                  <input
-                    type="text"
-                    placeholder="e.g. aws:123456789012"
-                    value={accountFilter}
-                    onChange={(e) => setAccountFilter(e.target.value)}
-                    className="w-52 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
-                  />
-                </label>
-                <label className="flex flex-col gap-1">
-                  <span className="text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Environment</span>
-                  <input
-                    type="text"
-                    placeholder="e.g. prod"
-                    value={environmentFilter}
-                    onChange={(e) => setEnvironmentFilter(e.target.value)}
-                    className="w-40 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-1.5 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
-                  />
-                </label>
-                {(cloudScopeActive || domainFilter !== "all") && (
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setDomainFilter("all");
-                      setProviderFilter("");
-                      setAccountFilter("");
-                      setEnvironmentFilter("");
-                    }}
-                    className="rounded-lg border border-[color:var(--border-subtle)] px-3 py-1.5 text-xs font-medium text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                  >
-                    Clear scope
-                  </button>
-                )}
-              </div>
-            </div>
+            )}
 
             {detailLoading && vulns.length > 0 && (
               <div className="flex items-center gap-2 text-xs text-[var(--text-tertiary)]">
@@ -1194,25 +1312,6 @@ function FindingsPage() {
                 {scope === "latest" ? "Refreshing latest scan..." : "Refreshing historical aggregation..."}
               </div>
             )}
-
-            {/* Group by */}
-            <div className="flex items-center gap-2">
-              <span className="text-xs text-[var(--text-tertiary)] uppercase tracking-wide font-medium">Group by</span>
-              {GROUP_OPTIONS?.map(({ key, label, icon: Icon }) => (
-                <button
-                  key={key}
-                  onClick={() => setGroupBy(key)}
-                  className={`flex items-center gap-1 px-2.5 py-1 text-xs font-medium rounded-md border transition-colors ${
-                    groupBy === key
-                      ? "text-[var(--foreground)] border-[var(--border-strong)] bg-[var(--surface-elevated)]"
-                      : "text-[var(--text-tertiary)] border-[var(--border-subtle)] hover:border-[var(--border-subtle)] hover:text-[var(--text-secondary)]"
-                  }`}
-                >
-                  <Icon className="w-3 h-3" />
-                  {label}
-                </button>
-              ))}
-            </div>
           </div>
 
           {/* Grouped view */}

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -111,17 +111,26 @@ function OverviewTab({ vuln }: { vuln: EnrichedVuln }) {
   const published = vuln.published_at ?? vuln.published ?? vuln.nvd_published;
   const fixCandidates = vuln.remediation_items.filter((item) => item.fixed_version || item.command || item.verify_command);
 
+  // Severity is already the header badge — the stat row leads with exploit
+  // signal (CVSS / EPSS) plus one KEV-or-risk tile, never re-showing severity.
+  const stats: { label: string; value: string }[] = [
+    { label: "CVSS", value: typeof vuln.cvss_score === "number" ? vuln.cvss_score.toFixed(1) : "Not published" },
+    { label: "EPSS", value: typeof vuln.epss_score === "number" ? `${(vuln.epss_score * 100).toFixed(1)}%` : "Not available" },
+  ];
+  if (vuln.is_kev) stats.push({ label: "KEV", value: "Known-exploited" });
+  else if (typeof vuln.risk_score === "number") stats.push({ label: "Risk", value: vuln.risk_score.toFixed(1) });
+
   return (
-    <div className="space-y-4">
-      <div className="grid gap-3 sm:grid-cols-3">
-        <DetailStat label="Severity" value={vuln.severity} accent={severityColor(vuln.severity)} />
-        <DetailStat label="CVSS" value={typeof vuln.cvss_score === "number" ? vuln.cvss_score.toFixed(1) : "Not published"} />
-        <DetailStat label="EPSS" value={typeof vuln.epss_score === "number" ? `${(vuln.epss_score * 100).toFixed(1)}%` : "Not available"} />
+    <div className="space-y-3">
+      <div className={`grid gap-2 ${stats.length >= 3 ? "sm:grid-cols-3" : "sm:grid-cols-2"}`}>
+        {stats.map((stat) => (
+          <DetailStat key={stat.label} label={stat.label} value={stat.value} />
+        ))}
       </div>
 
       <ReachBadges vuln={vuln} />
 
-      <Panel title="Attack summary">
+      <Section title="Attack summary">
         <p className="text-sm leading-6 text-[color:var(--text-secondary)]">{summary}</p>
         {cweMatches.length > 0 ? (
           <div className="mt-2 flex flex-wrap gap-1">
@@ -130,31 +139,50 @@ function OverviewTab({ vuln }: { vuln: EnrichedVuln }) {
             ))}
           </div>
         ) : null}
-      </Panel>
+      </Section>
 
       {whyItMatters ? (
-        <div className="rounded-xl border border-emerald-900/50 bg-emerald-950/20 p-4">
-          <h4 className="text-[11px] font-semibold uppercase tracking-wide text-emerald-400/90">Why it matters</h4>
-          <p className="mt-2 text-sm font-medium text-[color:var(--foreground)]">{whyItMatters.headline}</p>
-          <div className="mt-2 space-y-2 text-sm leading-6 text-[color:var(--text-secondary)]">
-            {whyItMatters.paragraphs.map((paragraph) => (
-              <p key={paragraph}>{paragraph}</p>
-            ))}
-          </div>
+        <Section title="Why it matters" accent>
+          <p className="text-sm font-medium text-[color:var(--foreground)]">{whyItMatters.headline}</p>
+          {whyItMatters.paragraphs.length > 0 ? (
+            <div className="mt-1.5 space-y-1.5 text-sm leading-6 text-[color:var(--text-secondary)]">
+              {whyItMatters.paragraphs.map((paragraph) => (
+                <p key={paragraph}>{paragraph}</p>
+              ))}
+            </div>
+          ) : null}
+          {whyItMatters.complianceTags.length > 0 ? (
+            <div className="mt-2.5 flex flex-wrap items-center gap-1.5">
+              <span className="text-[11px] font-medium text-[color:var(--text-tertiary)]">
+                {whyItMatters.complianceTags.length} compliance control{whyItMatters.complianceTags.length === 1 ? "" : "s"}
+              </span>
+              {whyItMatters.complianceTags.slice(0, 3).map((tag) => (
+                <Chip key={tag} mono>{tag}</Chip>
+              ))}
+              {whyItMatters.complianceTags.length > 3 ? (
+                <span className="text-[11px] text-[color:var(--text-tertiary)]">
+                  +{whyItMatters.complianceTags.length - 3} more
+                </span>
+              ) : null}
+              <Link href="/compliance" className="text-xs text-[color:var(--accent-mint)] hover:underline">
+                View evidence
+              </Link>
+            </div>
+          ) : null}
           {whyItMatters.links.length > 0 ? (
-            <div className="mt-3 flex flex-wrap gap-3">
+            <div className="mt-2.5 flex flex-wrap gap-3">
               {whyItMatters.links.map((link) => (
-                <Link key={link.href} href={link.href} className="text-xs text-emerald-300 hover:underline">
+                <Link key={link.href} href={link.href} className="text-xs text-[color:var(--accent-mint)] hover:underline">
                   {link.label}
                 </Link>
               ))}
             </div>
           ) : null}
-        </div>
+        </Section>
       ) : null}
 
-      <Panel title="Fix context">
-        <div className="grid gap-2 text-sm text-[color:var(--text-secondary)] sm:grid-cols-2">
+      <Section title="Fix context">
+        <div className="grid gap-x-4 gap-y-1.5 text-sm text-[color:var(--text-secondary)] sm:grid-cols-2">
           <KeyVal label="Fix" value={vuln.fixed_version ?? "No published fix"} />
           {published ? <KeyVal label="Published" value={new Date(published).toLocaleDateString()} /> : null}
           {vuln.modified_at ? <KeyVal label="Modified" value={new Date(vuln.modified_at).toLocaleDateString()} /> : null}
@@ -162,16 +190,16 @@ function OverviewTab({ vuln }: { vuln: EnrichedVuln }) {
           {vuln.severity_source ? <KeyVal label="Severity source" value={vuln.severity_source} /> : null}
         </div>
         {fixCandidates.length > 0 ? (
-          <div className="mt-3 space-y-3">
+          <div className="mt-3 divide-y divide-[color:var(--border-subtle)] overflow-hidden rounded-lg border border-[color:var(--border-subtle)]">
             {fixCandidates.slice(0, 2).map((item) => (
-              <div key={`${item.package}:${item.current_version}`} className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
+              <div key={`${item.package}:${item.current_version}`} className="p-2.5">
                 <div className="flex items-center justify-between gap-2">
                   <span className="text-xs font-medium text-[color:var(--foreground)]">{item.package}</span>
-                  <span className="text-[11px] font-mono text-emerald-400">
+                  <span className="font-mono text-[11px] text-[color:var(--accent-mint)]">
                     {item.current_version} → {item.fixed_version ?? "monitor"}
                   </span>
                 </div>
-                {item.action ? <p className="mt-2 text-xs text-[color:var(--text-tertiary)]">{item.action}</p> : null}
+                {item.action ? <p className="mt-1.5 text-xs text-[color:var(--text-tertiary)]">{item.action}</p> : null}
                 {item.command ? <CodeLine label="Apply" value={item.command} /> : null}
                 {item.verify_command ? <CodeLine label="Verify" value={item.verify_command} /> : null}
               </div>
@@ -181,8 +209,32 @@ function OverviewTab({ vuln }: { vuln: EnrichedVuln }) {
         {vuln.remediation_items[0]?.risk_narrative ? (
           <p className="mt-3 text-xs leading-5 text-[color:var(--text-tertiary)]">{vuln.remediation_items[0].risk_narrative}</p>
         ) : null}
-      </Panel>
+      </Section>
     </div>
+  );
+}
+
+// Flat section with a subtle top divider (and an optional left accent) — used
+// in the Overview tab so related content reads as tighter sections instead of
+// chunky cards-within-cards.
+function Section({
+  title,
+  children,
+  accent = false,
+}: {
+  title: string;
+  children: ReactNode;
+  accent?: boolean;
+}) {
+  return (
+    <section
+      className={`border-t border-[color:var(--border-subtle)] pt-3 ${
+        accent ? "border-l-2 border-l-[color:var(--accent-mint)] pl-3" : ""
+      }`}
+    >
+      <h4 className="text-[11px] font-semibold uppercase tracking-wide text-[color:var(--text-tertiary)]">{title}</h4>
+      <div className="mt-2">{children}</div>
+    </section>
   );
 }
 
@@ -534,11 +586,11 @@ function TriageButton({
   );
 }
 
-function DetailStat({ label, value, accent }: { label: string; value: string; accent?: string }) {
+function DetailStat({ label, value }: { label: string; value: string }) {
   return (
-    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
+    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2.5">
       <div className="text-[11px] font-medium uppercase tracking-wide text-[color:var(--text-tertiary)]">{label}</div>
-      <div className={`mt-2 text-sm font-medium text-[color:var(--foreground)] ${accent ?? ""}`}>{value}</div>
+      <div className="mt-1.5 text-sm font-semibold text-[color:var(--foreground)]">{value}</div>
     </div>
   );
 }
@@ -591,7 +643,7 @@ function CodeLine({ label, value }: { label: string; value: string }) {
   return (
     <div className="mt-2">
       <div className="text-[11px] font-medium uppercase tracking-wide text-[color:var(--text-tertiary)]">{label}</div>
-      <code className="mt-1 block overflow-x-auto rounded bg-black/30 px-2 py-1.5 text-[11px] text-emerald-300">{value}</code>
+      <code className="mt-1 block overflow-x-auto rounded bg-[color:var(--surface)] px-2 py-1.5 text-[11px] text-[color:var(--foreground)]">{value}</code>
     </div>
   );
 }

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -23,7 +23,7 @@ import {
   PanelLeftClose,
   PanelLeft,
   Search,
-  LayoutGrid,
+  BrainCircuit,
   LayoutDashboard,
   Wrench,
   RefreshCw,
@@ -129,7 +129,7 @@ const NAV_GROUPS: NavGroup[] = [
   },
   {
     label: "AI inventory",
-    icon: LayoutGrid,
+    icon: BrainCircuit,
     links: [
       { href: "/agents", label: "Agents", icon: Bot },
       { href: "/manifest", label: "AI BOM", icon: ClipboardList },

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowRight, ChevronRight } from "lucide-react";
+import type { ElementType } from "react";
+import {
+  ArrowRight,
+  Bug,
+  ChevronRight,
+  Fingerprint,
+  Flame,
+  KeyRound,
+  ShieldCheck,
+  SlidersHorizontal,
+} from "lucide-react";
 
 import type { OverviewResponse } from "@/lib/api";
 import type {
@@ -158,7 +168,7 @@ export interface OverviewCockpitProps {
   /** Severity × issue-type matrix (CVEs, misconfigs, secrets, identity). */
   issueMatrix?: IssueSeverityMatrix | null | undefined;
   domains: OverviewResponse["domains"] | null;
-  /** Five security-posture coverage lanes (CSPM / Vuln / AppSec-SCA / DSPM /
+  /** Five security-posture coverage lanes (CSPM / Vuln / ASPM / DSPM /
    *  AISPM) with reconciled, non-overlapping counts (issue #3946). */
   coverage?: OverviewCoverageLane[] | null | undefined;
   topPath: ExposurePathView | null;
@@ -253,7 +263,7 @@ export function OverviewCockpit({
 
           {/* 2b — Estate / operations: the genuinely-operational lanes
               (runtime, cost, identity, ops) shown by activation. The security
-              lanes above already cover cloud posture, vuln mgmt, and AppSec. */}
+              lanes above already cover cloud posture, vuln mgmt, and application posture. */}
           <EstateOpsStrip domains={domains} services={services} />
 
           {/* 3 — Compliance: one honest strip, coverage after first scan */}
@@ -289,7 +299,7 @@ const COVERAGE_SEVERITY_BANDS: { key: keyof OverviewCoverageLane["severity"]; la
 
 /**
  * The five security-posture coverage lanes rendered 1:1 (CSPM / Vuln mgmt /
- * AppSec-SCA / DSPM / AISPM). Each lane's count is the sum of its severity
+ * ASPM / DSPM / AISPM). Each lane's count is the sum of its severity
  * strip, so the metric can never contradict the strip. An ``unrated`` chip is
  * surfaced only when unknown-severity findings are present. All colors come from
  * design tokens (no hardcoded palette) so light + dark both read correctly.
@@ -357,7 +367,7 @@ function SecurityCoverageLanes({ coverage }: { coverage?: OverviewCoverageLane[]
 
 // The genuinely-operational estate lanes — cloud / vuln / code are deliberately
 // excluded because the five security-coverage lanes above already own CSPM,
-// Vuln mgmt, and AppSec-SCA. Rendering them here too would double-count.
+// Vuln mgmt, and ASPM. Rendering them here too would double-count.
 const OPERATIONAL_DOMAIN_KEYS = ["runtime", "cost", "identity", "ops"] as const;
 type OperationalDomainKey = (typeof OPERATIONAL_DOMAIN_KEYS)[number];
 
@@ -976,6 +986,54 @@ function PostureHero({
   );
 }
 
+// One distinct glyph per issue type so a category reads by shape, not by a
+// severity hue it doesn't own (KEV/Secrets/Misconfig/Identity all go neutral).
+const ISSUE_TYPE_GLYPH: Record<IssueType, ElementType> = {
+  vulnerability: Bug,
+  misconfiguration: SlidersHorizontal,
+  secret: KeyRound,
+  identity: Fingerprint,
+};
+
+// Neutral grayscale fills for the in-tile issue-type mini bar — segments stay
+// distinguishable by lightness (theme-safe text tokens), never by severity hue.
+const ISSUE_TYPE_BAR: Record<IssueType, string> = {
+  vulnerability: "bg-[color:var(--text-secondary)]",
+  misconfiguration: "bg-[color:var(--text-tertiary)]",
+  secret: "bg-[color:var(--text-secondary)] opacity-60",
+  identity: "bg-[color:var(--text-tertiary)] opacity-50",
+};
+
+/**
+ * A neutral, iconified category chip for the Open-issues header (KEV / Secrets /
+ * Compliance). Uses only surface/border/text tokens so it never mimics a
+ * severity band; the glyph carries the category meaning. Works in both themes.
+ */
+function CategoryChip({
+  href,
+  icon: Icon,
+  label,
+  value,
+  title,
+}: {
+  href: string;
+  icon: ElementType;
+  label: string;
+  value: number | string;
+  title?: string | undefined;
+}) {
+  return (
+    <Link
+      href={href}
+      title={title}
+      className="inline-flex items-center gap-1 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2 py-0.5 text-[10px] font-semibold text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+    >
+      <Icon className="h-3 w-3 text-[color:var(--text-tertiary)]" aria-hidden="true" />
+      {label} {value}
+    </Link>
+  );
+}
+
 function SeverityIssueStrip({
   summaryReady,
   critical,
@@ -1029,12 +1087,6 @@ function SeverityIssueStrip({
   ];
   const stackedTotal = bands.reduce((sum, band) => sum + band.value, 0);
   const issueTypes: IssueType[] = ["vulnerability", "misconfiguration", "secret", "identity"];
-  const issueTone: Record<IssueType, string> = {
-    vulnerability: "bg-[color:var(--severity-critical)]",
-    misconfiguration: "bg-[color:var(--severity-high)]",
-    secret: "bg-[color:var(--status-warn)]",
-    identity: "bg-[color:var(--severity-low)]",
-  };
 
   return (
     <div
@@ -1049,29 +1101,36 @@ function SeverityIssueStrip({
         defaultOpen
         actions={
           <div className="flex flex-wrap items-center gap-1.5">
+            {/* Category chips are neutral + iconified: hue is reserved for
+                severity alone, so a category never mimics a severity band
+                (KEV is not amber, Secrets is not red, Compliance is not a
+                green pass). The glyph carries the distinction. */}
             {summaryReady && kev != null ? (
-              <Link
+              <CategoryChip
                 href={findingsHref({ kev: true })}
-                className="rounded-full border border-amber-500/35 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-200"
-              >
-                KEV {kev}
-              </Link>
+                icon={Flame}
+                label="KEV"
+                value={kev}
+                title="Known-exploited vulnerabilities (CISA KEV)"
+              />
             ) : null}
             {summaryReady && credentials != null ? (
-              <Link
+              <CategoryChip
                 href={findingsHref({ issue: "secret" })}
-                className="rounded-full border border-rose-500/30 bg-rose-500/10 px-2 py-0.5 text-[10px] font-semibold text-rose-200"
-              >
-                Secrets {credentials}
-              </Link>
+                icon={KeyRound}
+                label="Secrets"
+                value={credentials}
+                title="Findings that expose credentials or secrets"
+              />
             ) : null}
             {complianceScore ? (
-              <Link
+              <CategoryChip
                 href="/compliance"
-                className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-semibold text-emerald-200"
-              >
-                Compliance {complianceScore}
-              </Link>
+                icon={ShieldCheck}
+                label="Compliance"
+                value={complianceScore}
+                title="Overall compliance score across evaluated frameworks"
+              />
             ) : null}
           </div>
         }
@@ -1123,7 +1182,7 @@ function SeverityIssueStrip({
                     return (
                       <div
                         key={issue}
-                        className={issueTone[issue]}
+                        className={ISSUE_TYPE_BAR[issue]}
                         style={{ width: `${(count / band.value) * 100}%` }}
                         title={`${ISSUE_TYPE_SHORT[issue]}: ${count}`}
                       />
@@ -1134,8 +1193,10 @@ function SeverityIssueStrip({
                   {issueTypes.map((issue) => {
                     const count = resolved[issue][band.key];
                     if (count <= 0) return null;
+                    const Glyph = ISSUE_TYPE_GLYPH[issue];
                     return (
-                      <span key={issue}>
+                      <span key={issue} className="inline-flex items-center gap-0.5">
+                        <Glyph className="h-2.5 w-2.5" aria-hidden="true" />
                         {ISSUE_TYPE_SHORT[issue]} {count}
                       </span>
                     );
@@ -1154,13 +1215,14 @@ function SeverityIssueStrip({
           {issueTypes.map((issue) => {
             const total = resolved.byType[issue];
             if (total <= 0) return null;
+            const Glyph = ISSUE_TYPE_GLYPH[issue];
             return (
               <Link
                 key={issue}
                 href={findingsHref({ issue })}
-                className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-0.5 text-[10px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)]"
+                className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-0.5 text-[10px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
               >
-                <span className={`h-1.5 w-1.5 rounded-full ${issueTone[issue]}`} aria-hidden="true" />
+                <Glyph className="h-3 w-3 text-[color:var(--text-tertiary)]" aria-hidden="true" />
                 {ISSUE_TYPE_SHORT[issue]} {total}
               </Link>
             );

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2314,9 +2314,9 @@ export interface CoverageSeverity {
   unrated: number;
 }
 
-/** One security-posture coverage lane (CSPM / Vuln mgmt / AppSec-SCA / DSPM / AISPM). */
+/** One security-posture coverage lane (CSPM / Vuln mgmt / ASPM / DSPM / AISPM). */
 export interface OverviewCoverageLane {
-  domain: "cspm" | "vuln" | "appsec_sca" | "dspm" | "aispm";
+  domain: "cspm" | "vuln" | "aspm" | "dspm" | "aispm";
   label: string;
   href: string;
   count: number;
@@ -2426,7 +2426,7 @@ export interface OverviewResponse {
 /** One security-domain lane on the per-account drill summary (#3931). Its
  * severity strip sums to ``count`` (same honest invariant as the overview). */
 export interface AccountSummaryDomain {
-  domain: "cspm" | "vuln" | "appsec_sca" | "dspm" | "aispm";
+  domain: "cspm" | "vuln" | "aspm" | "dspm" | "aispm";
   label: string;
   count: number;
   severity: CoverageSeverity;

--- a/ui/lib/finding-why-matters.ts
+++ b/ui/lib/finding-why-matters.ts
@@ -8,6 +8,9 @@ export interface WhyItMattersLink {
 export interface WhyItMattersNarrative {
   headline: string;
   paragraphs: string[];
+  /** Compliance control tags this finding maps to — rendered as scannable
+   *  chips + a count rather than a run-on sentence. */
+  complianceTags: string[];
   links: WhyItMattersLink[];
 }
 
@@ -62,23 +65,18 @@ function exposureSentence(vuln: EnrichedVuln): string | null {
   return sentence;
 }
 
-function complianceSentence(vuln: EnrichedVuln): string | null {
-  const tags = vuln.framework_tags?.filter(Boolean) ?? [];
-  if (tags.length === 0) return null;
-  const preview = tags.slice(0, 3).join(", ");
-  const suffix = tags.length > 3 ? ` and ${tags.length - 3} more` : "";
-  return `Maps to ${tags.length} compliance control tag${tags.length === 1 ? "" : "s"} (${preview}${suffix}) for exportable evidence packs.`;
-}
-
 export function buildWhyItMatters(vuln: EnrichedVuln): WhyItMattersNarrative | null {
   const paragraphs = [
     reachSentence(vuln),
     runtimeSentence(vuln),
     exposureSentence(vuln),
-    complianceSentence(vuln),
   ].filter((line): line is string => Boolean(line));
 
-  if (paragraphs.length === 0) {
+  // Compliance mapping is surfaced as scannable chips + a count (not a run-on
+  // sentence), so it no longer gates the narrative on its own.
+  const complianceTags = vuln.framework_tags?.filter(Boolean) ?? [];
+
+  if (paragraphs.length === 0 && complianceTags.length === 0) {
     return null;
   }
 
@@ -100,5 +98,5 @@ export function buildWhyItMatters(vuln: EnrichedVuln): WhyItMattersNarrative | n
       ? "Prioritize remediation — reachable exposure with governance impact"
       : "Why this finding is ranked in your queue";
 
-  return { headline, paragraphs, links };
+  return { headline, paragraphs, complianceTags, links };
 }

--- a/ui/tests/account-drill.test.tsx
+++ b/ui/tests/account-drill.test.tsx
@@ -27,7 +27,7 @@ function summary(overrides: Partial<AccountSummaryResponse> = {}): AccountSummar
     domains: [
       { domain: "cspm", label: "CSPM", count: 1, severity: { ...emptySeverity(), high: 1 }, href: "/findings?provider=aws&account=aws%3A111111111111&domain=cspm" },
       { domain: "vuln", label: "Vuln mgmt", count: 1, severity: { ...emptySeverity(), critical: 1 }, href: "/findings?provider=aws&account=aws%3A111111111111&domain=vuln" },
-      { domain: "appsec_sca", label: "AppSec / SCA", count: 0, severity: emptySeverity(), href: "/findings?provider=aws&account=aws%3A111111111111&domain=appsec_sca" },
+      { domain: "aspm", label: "ASPM", count: 0, severity: emptySeverity(), href: "/findings?provider=aws&account=aws%3A111111111111&domain=aspm" },
       { domain: "dspm", label: "DSPM", count: 0, severity: emptySeverity(), href: "/findings?provider=aws&account=aws%3A111111111111&domain=dspm" },
       { domain: "aispm", label: "AISPM", count: 1, severity: { ...emptySeverity(), medium: 1 }, href: "/findings?provider=aws&account=aws%3A111111111111&domain=aispm" },
     ],
@@ -58,7 +58,7 @@ describe("AccountDrillPage", () => {
       expect(screen.getByRole("heading", { name: /AWS · 111111111111/i })).toBeInTheDocument();
     });
     // Five domain lanes, each drill-linked and pre-filtered by account.
-    for (const label of ["CSPM", "Vuln mgmt", "AppSec / SCA", "DSPM", "AISPM"]) {
+    for (const label of ["CSPM", "Vuln mgmt", "ASPM", "DSPM", "AISPM"]) {
       expect(screen.getByText(label)).toBeInTheDocument();
     }
     const cspmLane = screen.getByTestId("account-lane-cspm");

--- a/ui/tests/finding-why-matters.test.ts
+++ b/ui/tests/finding-why-matters.test.ts
@@ -50,7 +50,8 @@ describe("buildWhyItMatters", () => {
     expect(narrative?.paragraphs.join(" ")).toMatch(/Reachability is high/);
     expect(narrative?.paragraphs.join(" ")).toMatch(/Runtime enforcement already blocked/);
     expect(narrative?.paragraphs.join(" ")).toMatch(/Blast radius spans/);
-    expect(narrative?.paragraphs.join(" ")).toMatch(/compliance control tag/);
+    // Compliance mapping is now scannable chip data, not a run-on paragraph.
+    expect(narrative?.complianceTags).toEqual(["owasp_llm:llm06", "mitre_atlas:exfiltration"]);
     expect(narrative?.links.map((link) => link.href)).toEqual(
       expect.arrayContaining(["/security-graph", "/traces", "/compliance"]),
     );

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -174,4 +174,35 @@ describe("FindingsPage", () => {
     expect(duplicateKeyWarning).toBe(false);
     consoleError.mockRestore();
   });
+
+  it("tucks advanced filters into a Filters (n) popover with removable active chips", async () => {
+    render(<FindingsPage />);
+    expect(await screen.findByText("CVE-2026-1234")).toBeInTheDocument();
+
+    // Advanced filters start collapsed: the toggle shows no active count and no
+    // chips are rendered.
+    const toggle = screen.getByTestId("findings-filters-toggle");
+    expect(toggle).toHaveTextContent("Filters");
+    expect(toggle).not.toHaveTextContent("(1)");
+    expect(screen.queryByTestId("findings-active-filters")).not.toBeInTheDocument();
+
+    // Open the popover and pick a domain facet.
+    fireEvent.click(toggle);
+    const popover = screen.getByTestId("findings-filters-popover");
+    fireEvent.click(within(popover).getByRole("button", { name: "ASPM" }));
+
+    // Active count reflects the selection and a removable chip surfaces it.
+    await waitFor(() =>
+      expect(screen.getByTestId("findings-filters-toggle")).toHaveTextContent("Filters (1)"),
+    );
+    const chip = screen.getByTestId("findings-chip-domain");
+    expect(chip).toHaveTextContent("Domain: ASPM");
+
+    // Removing the chip clears the filter (count returns to zero, chip gone).
+    fireEvent.click(chip);
+    await waitFor(() =>
+      expect(screen.queryByTestId("findings-chip-domain")).not.toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("findings-filters-toggle")).not.toHaveTextContent("(1)");
+  });
 });

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -98,7 +98,7 @@ describe("OverviewCockpit", () => {
     const coverage = [
       { domain: "cspm" as const, label: "CSPM", href: "/findings?domain=cspm", count: 3, severity: { critical: 1, high: 1, medium: 0, low: 0, unrated: 1 } },
       { domain: "vuln" as const, label: "Vuln mgmt", href: "/findings?domain=vuln", count: 2, severity: { critical: 2, high: 0, medium: 0, low: 0, unrated: 0 } },
-      { domain: "appsec_sca" as const, label: "AppSec / SCA", href: "/findings?domain=appsec_sca", count: 0, severity: { critical: 0, high: 0, medium: 0, low: 0, unrated: 0 } },
+      { domain: "aspm" as const, label: "ASPM", href: "/findings?domain=aspm", count: 0, severity: { critical: 0, high: 0, medium: 0, low: 0, unrated: 0 } },
       { domain: "dspm" as const, label: "DSPM", href: "/findings?domain=dspm", count: 0, severity: { critical: 0, high: 0, medium: 0, low: 0, unrated: 0 } },
       { domain: "aispm" as const, label: "AISPM", href: "/findings?domain=aispm", count: 1, severity: { critical: 0, high: 0, medium: 1, low: 0, unrated: 0 } },
     ];


### PR DESCRIPTION
Five dogfooding-polish items on the exec Overview and Findings surfaces, bundled because they overlap the same files.

## 1 — ASPM coverage lane (rename `appsec_sca` → `aspm`)
The posture-management family now reads symmetrically: **CSPM** (cloud) · **ASPM** (application) · **DSPM** (data) · **AISPM** (AI), with **Vuln mgmt** as the cross-surface CVE lane. "AppSec / SCA" double-labelled (SCA = dependency-CVEs, which already live in Vuln mgmt).

This is a **pure rename** — counts are identical:
- Dependency CVEs, malicious/blocklisted packages, and licenses already route to `vuln`.
- Only SAST/code weaknesses and secret-in-code findings map to the application-posture lane.
- The sum-of-lanes invariant (`sum(severity) == count`) is preserved; no finding is dropped or re-bucketed.
- A back-compat alias resolves rows and deep-links persisted under the old key to the new lane.

Threaded through model → taxonomy → API (overview + account-summary + findings domain filter) → schema/OpenAPI enum → UI pills/lanes → tests → docs.

## 2 — Open-issues color language: severity owns the heat ramp
Hue now means **severity only**. The four severity tiles keep their critical→low tint ramp. The category chips (KEV / Secrets / Compliance) and the in-tile issue-type sub-labels + dot-chips go **neutral + iconified** (distinct glyph each) so a category never mimics a severity band. Tokens only; both themes.

## 3 — AI-inventory nav icon
Swapped the generic grid glyph for a domain-relevant one; verified no other nav section reuses it.

## 4 — Findings filter stack → compact toolbar
Search + severity + issue-type + group-by stay inline. Scope, domain, and cloud/account/environment move behind a single **"Filters (n)"** popover (Esc-to-close, click-outside, keyboard-focusable). Set filters render as **removable active-filter chips**; clearing one resets to default. Everything stays URL-synced for deep-links and back/forward. The verbose queue explainer collapses to a one-line caption.

## 5 — Finding evidence drawer: denser, no render artifacts
- Fixed the severity render artifact (a full-width tint bar behind the value) by dropping the duplicate Severity stat tile — the header badge is canonical and the stat row now leads with CVSS / EPSS / KEV-or-risk.
- Flattened cards-within-cards into tighter token-styled sections with subtle dividers; trimmed padding.
- Turned the compliance-control run-on sentence into a scannable count + a few chips + a "view evidence" link.

## Verification
- Python: touched-module suites green (`test_finding_scope`, `test_overview`, `test_cloud_account_summary`); broader `-k "overview or coverage or finding or domain or scope"` = 800 passed; scope-filter route tests green.
- `scripts/check-counts.py`: consistent (no count shift).
- UI: `npm run build` clean; touched vitest suites (findings-page, overview-cockpit, account-drill, finding-why-matters, nav) all pass; bundle budget PASS (3266/3300 KiB — no bump needed).