### PR TITLE
fix(security): sanitize untrusted VEX log values

### DIFF
--- a/src/agent_bom/vex.py
+++ b/src/agent_bom/vex.py
@@ -14,6 +14,8 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING
 
+from agent_bom.security import sanitize_text
+
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
@@ -111,9 +113,7 @@ _CSAF_FLAG_TO_VEX: dict[str, VexJustification] = {
     "component_not_present": VexJustification.COMPONENT_NOT_PRESENT,
     "vulnerable_code_not_present": VexJustification.VULNERABLE_CODE_NOT_PRESENT,
     "vulnerable_code_not_in_execute_path": VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH,
-    "vulnerable_code_cannot_be_controlled_by_adversary": (
-        VexJustification.VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY
-    ),
+    "vulnerable_code_cannot_be_controlled_by_adversary": (VexJustification.VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY),
     "inline_mitigations_already_exist": VexJustification.INLINE_MITIGATIONS_ALREADY_EXIST,
 }
 
@@ -166,12 +166,10 @@ def _parse_cyclonedx_vex(data: dict) -> VexDocument:
         if just_raw:
             justification = _CDX_JUSTIFICATION_TO_VEX.get(str(just_raw).lower())
             if justification is None:
-                logger.warning("Unknown CycloneDX VEX justification value: %s", just_raw)
+                logger.warning("Unknown CycloneDX VEX justification value: %s", sanitize_text(just_raw, max_len=200))
 
         products = [
-            _extract_cdx_product_ref(aff.get("ref", ""))
-            for aff in entry.get("affects", [])
-            if isinstance(aff, dict) and aff.get("ref")
+            _extract_cdx_product_ref(aff.get("ref", "")) for aff in entry.get("affects", []) if isinstance(aff, dict) and aff.get("ref")
         ]
         detail = analysis.get("detail")
         response = analysis.get("response")
@@ -296,7 +294,7 @@ def _parse_csaf_vex(data: dict) -> VexDocument:
                 continue
             status = _CSAF_STATUS_TO_VEX.get(str(status_key).lower())
             if status is None:
-                logger.warning("Unknown CSAF product_status key: %s", status_key)
+                logger.warning("Unknown CSAF product_status key: %s", sanitize_text(status_key, max_len=200))
                 continue
             justification = _csaf_justification(entry, product_ids)
             if status == VexStatus.NOT_AFFECTED and justification is None:
@@ -345,7 +343,7 @@ def _parse_openvex(data: dict) -> VexDocument:
             try:
                 justification = VexJustification(just_str)
             except ValueError:
-                logger.warning("Unknown VEX justification value: %s", just_str)
+                logger.warning("Unknown VEX justification value: %s", sanitize_text(just_str, max_len=200))
 
         products = stmt_data.get("products", [])
         if isinstance(products, list) and products and isinstance(products[0], dict):

--- a/src/agent_bom/vex.py
+++ b/src/agent_bom/vex.py
@@ -113,7 +113,9 @@ _CSAF_FLAG_TO_VEX: dict[str, VexJustification] = {
     "component_not_present": VexJustification.COMPONENT_NOT_PRESENT,
     "vulnerable_code_not_present": VexJustification.VULNERABLE_CODE_NOT_PRESENT,
     "vulnerable_code_not_in_execute_path": VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH,
-    "vulnerable_code_cannot_be_controlled_by_adversary": (VexJustification.VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY),
+    "vulnerable_code_cannot_be_controlled_by_adversary": (
+        VexJustification.VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY
+    ),
     "inline_mitigations_already_exist": VexJustification.INLINE_MITIGATIONS_ALREADY_EXIST,
 }
 
@@ -169,7 +171,9 @@ def _parse_cyclonedx_vex(data: dict) -> VexDocument:
                 logger.warning("Unknown CycloneDX VEX justification value: %s", sanitize_text(just_raw, max_len=200))
 
         products = [
-            _extract_cdx_product_ref(aff.get("ref", "")) for aff in entry.get("affects", []) if isinstance(aff, dict) and aff.get("ref")
+            _extract_cdx_product_ref(aff.get("ref", ""))
+            for aff in entry.get("affects", [])
+            if isinstance(aff, dict) and aff.get("ref")
         ]
         detail = analysis.get("detail")
         response = analysis.get("response")

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import pytest
 
@@ -145,6 +146,54 @@ class TestVexStatus:
 
 
 class TestVexLoad:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {
+                "bomFormat": "CycloneDX",
+                "vulnerabilities": [
+                    {
+                        "id": "CVE-2024-0001",
+                        "analysis": {
+                            "state": "not_affected",
+                            "justification": "unknown\r\nforged https://user:supersecretvalue123@example.invalid/db",
+                        },
+                    }
+                ],
+            },
+            {
+                "document": {"category": "csaf_vex"},
+                "vulnerabilities": [
+                    {
+                        "cve": "CVE-2024-0001",
+                        "product_status": {"unknown\nforged\tstatus": ["product-1"]},
+                    }
+                ],
+            },
+            {
+                "@context": "https://openvex.dev/ns/v0.2.0",
+                "statements": [
+                    {
+                        "vulnerability": "CVE-2024-0001",
+                        "status": "not_affected",
+                        "justification": "unknown\x1b[31m\nforged",
+                    }
+                ],
+            },
+        ],
+    )
+    def test_unknown_vex_values_are_sanitized_before_logging(self, payload, caplog):
+        with caplog.at_level(logging.WARNING, logger="agent_bom.vex"):
+            parse_vex(payload)
+
+        assert len(caplog.messages) == 1
+        message = caplog.messages[0]
+        assert "\r" not in message
+        assert "\n" not in message
+        assert "\t" not in message
+        assert "\x1b" not in message
+        assert "supersecretvalue123" not in message
+
     def test_load_openvex_format(self, tmp_path):
         data = {
             "@context": "https://openvex.dev/ns/v0.2.0",
@@ -297,11 +346,7 @@ class TestVexLoad:
                         "response": ["will_not_fix", "update"],
                         "detail": "The vulnerable function is not called",
                     },
-                    "affects": [
-                        {
-                            "ref": "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1#pkg:golang/github.com/aws/aws-sdk-go@1.44.234"
-                        }
-                    ],
+                    "affects": [{"ref": "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1#pkg:golang/github.com/aws/aws-sdk-go@1.44.234"}],
                 }
             ],
         }

--- a/tests/test_vex.py
+++ b/tests/test_vex.py
@@ -346,7 +346,11 @@ class TestVexLoad:
                         "response": ["will_not_fix", "update"],
                         "detail": "The vulnerable function is not called",
                     },
-                    "affects": [{"ref": "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1#pkg:golang/github.com/aws/aws-sdk-go@1.44.234"}],
+                    "affects": [
+                        {
+                            "ref": "urn:cdx:3e671687-395b-41f5-a30f-a58921a69b79/1#pkg:golang/github.com/aws/aws-sdk-go@1.44.234"
+                        }
+                    ],
                 }
             ],
         }


### PR DESCRIPTION
## Summary

- sanitize externally supplied CycloneDX VEX justification values before warning logs
- sanitize externally supplied CSAF `product_status` keys before warning logs
- sanitize externally supplied OpenVEX justification values before warning logs
- prevent CR/LF, tab, ANSI, and credential-bearing input from forging or leaking through VEX warning entries

Fixes CodeQL alerts #1794, #1795, and #1796 (`py/log-injection`, CWE-117).

## Verification

- `uv run ruff check src/agent_bom/vex.py tests/test_vex.py`
- `uv run pytest -q tests/test_vex.py` (56 passed)
- `python scripts/check_exception_sanitization.py`
- `git diff --check`

## Notes

The regression exercises all three accepted VEX formats with adversarial control characters. VEX parsing behavior and returned documents are unchanged; only warning-log values are sanitized and capped at 200 characters.