### PR TITLE
ASPM/coverage lanes as overlapping posture lenses

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -148,12 +148,43 @@ in `src/agent_bom/finding_scope.py`:
 | `SAST`, secret/credential exposure | `aspm` |
 | MCP / proxy / skill / prompt / graph + AI-native types | `aispm` |
 
+### Coverage lanes are overlapping posture lenses
+
+`security_domain` above is the single **primary** lane a finding is stored and
+displayed under. The five coverage lanes on the overview, however, are
+**overlapping posture disciplines** applied to the one unified finding model —
+not a strict one-lane-per-finding partition. A finding can count under more than
+one lane. `security_lenses_for()` (in `finding_scope.py`) returns the full lens
+set, derived from the same `(source, finding_type, evidence)` inputs — no schema
+migration:
+
+| Lens | A finding is counted here when… |
+|---|---|
+| `vuln` | it is a CVE / carries a CVE id / is a dependency or package vulnerability (container, SBOM, external, or filesystem dependency) — the vulnerability-management discipline |
+| `aspm` | it originates from the application / code / repo layer — SAST, secret or credential scanning, a repo/project-checkout dependency graph (SBOM or filesystem), or IaC-template misconfiguration |
+| `cspm` | cloud configuration / CIS benchmark |
+| `dspm` | data-access governance |
+| `aispm` | AI / agent / MCP / prompt / proxy / skill signals |
+
+So a **repo dependency CVE is in both `vuln` and `aspm`**, while a
+container-image CVE is `vuln` only and a SAST weakness is `aspm` only.
+
+Consequences:
+
+* The **sum of lane counts is NOT the total finding count** — lanes overlap.
+* Each **lane's own count still equals the sum of its severity strip**
+  (including the `unrated` bucket for unknown-severity findings), so a lane's
+  metric never contradicts its own strip.
+* The exec **headline / grade histogram is computed independently, once per
+  finding**, over the unified findings spine — never by summing the lanes.
+
 A **finding** is raw scanner output; an **issue** is a correlated/deduped
 grouping of findings for display. `GET /v1/findings` accepts optional
 `provider`, `account`, `environment`, and `domain` filters (canonicalized
-server-side, never rejected), and `GET /v1/overview` returns a `coverage` array
-of the five domain lanes whose per-lane severity histogram — including an
-`unrated` bucket for unknown-severity findings — sums to the lane count.
+server-side, never rejected); the `domain` facet matches a finding's **lens
+set**, so `domain=aspm` returns SAST + secrets + repo dependencies + IaC and
+`domain=vuln` returns every CVE. `GET /v1/overview` returns a `coverage` array
+of the five overlapping lanes.
 
 ---
 

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -244,12 +244,15 @@ def _fold_findings(
 ) -> tuple[int, int, int]:
     """Fold unified findings-spine rows into the shared estate accumulators.
 
-    Every row is counted into exactly one severity bucket AND its security
-    domain's coverage lane from the same pass, so the headline can never
-    disagree with the lanes. Returns ``(added, kev, credential_exposed)`` for
-    this batch. A finding whose severity is critical/high marks each of its
-    ``applicable_frameworks`` as failing (feeds the exec grade's compliance
-    driver, #3962).
+    Every row is counted once into exactly one bucket of the all-domain severity
+    histogram (the headline/grade basis) AND into EVERY coverage lens it belongs
+    to (the coverage lanes are overlapping posture disciplines, not a partition —
+    a repo dependency CVE counts under both ``vuln`` and ``aspm``). Because lanes
+    overlap, the sum of lane counts is not the total; the histogram is the
+    single source of truth for the headline. Returns
+    ``(added, kev, credential_exposed)`` for this batch. A finding whose severity
+    is critical/high marks each of its ``applicable_frameworks`` as failing
+    (feeds the exec grade's compliance driver, #3962).
     """
     from agent_bom.compliance_coverage import normalize_framework_slug
 
@@ -264,10 +267,12 @@ def _fold_findings(
             continue
         seen.add(identity)
         bucket = _bucket(str(row.get("severity") or ""), severity)
+        # All-domain histogram: once per finding (the headline/grade basis).
         severity[bucket] += 1
-        dom = _row_domain(row)
-        lanes[dom][bucket] += 1
-        lane_counts[dom] += 1
+        # Coverage lanes: increment EVERY applicable lens (lanes overlap).
+        for dom in _row_lenses(row):
+            lanes[dom][bucket] += 1
+            lane_counts[dom] += 1
         added += 1
         if bool(row.get("is_kev") or row.get("cisa_kev")):
             kev += 1
@@ -432,6 +437,22 @@ def _row_domain(row: dict[str, Any]) -> str:
     from agent_bom.finding_scope import domain_for_row
 
     return domain_for_row(row) or "vuln"
+
+
+def _row_lenses(row: dict[str, Any]) -> set[str]:
+    """Overlapping coverage lenses for a row, guaranteeing the primary lane.
+
+    The coverage lanes are posture lenses, not a partition — a repo dependency
+    CVE counts under both ``vuln`` and ``aspm``. The primary lane (or the
+    ``vuln`` default for legacy rows) is always included so every finding lands
+    in at least one lane, while the all-domain histogram is still counted once
+    per finding.
+    """
+    from agent_bom.finding_scope import lenses_for_row
+
+    lenses = set(lenses_for_row(row))
+    lenses.add(_row_domain(row))
+    return {dom for dom in lenses if dom in _COVERAGE_DOMAINS}
 
 
 def _posture_snapshot(jobs: list[Any]) -> dict[str, Any]:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1502,16 +1502,24 @@ def _canonical_scope_filters(
 
 
 def _row_matches_scope(row: dict[str, Any], filters: dict[str, str]) -> bool:
-    """Return True when a finding row matches every active scope filter."""
-    from agent_bom.finding_scope import domain_for_row
+    """Return True when a finding row matches every active scope filter.
+
+    The ``domain`` facet matches against the finding's overlapping coverage-lens
+    set, not just its primary domain, so ``domain=aspm`` returns SAST + secrets +
+    repo dependencies + IaC, and ``domain=vuln`` returns every CVE (mirroring the
+    overlapping coverage lanes on the overview).
+    """
+    from agent_bom.finding_scope import domain_for_row, lenses_for_row
 
     for key in ("provider", "account_ref", "environment"):
         wanted = filters.get(key)
         if wanted is not None and str(row.get(key) or "").strip().lower() != wanted:
             return False
     wanted_domain = filters.get("domain")
-    if wanted_domain is not None and (domain_for_row(row) or "") != wanted_domain:
-        return False
+    if wanted_domain is not None:
+        lenses = lenses_for_row(row) or ({domain_for_row(row) or ""} if domain_for_row(row) else set())
+        if wanted_domain not in lenses:
+            return False
     return True
 
 

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -184,3 +184,124 @@ def domain_for_row(row: dict) -> Optional[str]:
         return None
     evidence = row.get("evidence") if isinstance(row.get("evidence"), dict) else None
     return security_domain_for(source, ftype, evidence)
+
+
+# ---------------------------------------------------------------------------
+# Coverage lenses (overlapping posture disciplines)
+# ---------------------------------------------------------------------------
+#
+# ``security_domain_for`` picks the single PRIMARY lane a finding is stored and
+# displayed under. The coverage lanes on the overview, however, are *overlapping
+# posture lenses*, not a strict one-lane-per-finding partition: a single repo
+# dependency CVE is both a vulnerability-management concern (``vuln``) and an
+# application-security-posture concern (``aspm``). ``security_lenses_for``
+# returns the SET of lenses a finding belongs to. It derives entirely from the
+# same ``(source, finding_type, evidence)`` inputs the primary mapping uses — no
+# schema migration. The primary is always a member of the set.
+#
+# Because lanes overlap, the sum of lane counts is NOT the total finding count.
+# The exec headline / grade histogram is computed independently over the unified
+# findings spine (once per finding), never by summing lenses.
+
+
+def _is_iac_misconfig(source: "FindingSource", ftype: "FindingType", ev: dict) -> bool:
+    """True when a misconfiguration finding describes infrastructure-as-code.
+
+    IaC template scanning (Terraform / CloudFormation / K8s manifests in a repo)
+    is an application/code-layer concern, so such misconfigs also belong to the
+    ``aspm`` lens even though their primary cloud-config lane is ``cspm``.
+    Detected from evidence markers only — absent a marker this never fires, so
+    live-cloud CIS findings stay purely ``cspm``.
+    """
+    from agent_bom.finding import FindingType
+
+    if ftype != FindingType.CIS_FAIL:
+        return False
+    if ev.get("iac"):
+        return True
+    marker = " ".join(
+        str(ev.get(key) or "") for key in ("category", "scan_type", "framework", "resource_type", "source_kind")
+    ).lower()
+    return any(token in marker for token in ("iac", "terraform", "cloudformation", "k8s manifest", "kubernetes manifest"))
+
+
+def security_lenses_for(
+    source: "FindingSource",
+    finding_type: "FindingType",
+    evidence: Optional[dict] = None,
+) -> frozenset[str]:
+    """Return the SET of overlapping coverage lenses a finding belongs to.
+
+    Predicates (all derived from the primary mapping's inputs):
+
+      * ``vuln`` — the vulnerability-management discipline: a CVE, malicious
+        package, or license finding, or any dependency/package scanner output
+        (container / SBOM / external / filesystem) that is not itself a
+        code/secret finding.
+      * ``aspm`` — the application/code/repo layer: SAST, secret/credential
+        scanning, a repo/project-checkout dependency graph (SBOM / filesystem),
+        and IaC misconfiguration. So a repo dependency CVE is in {vuln, aspm}.
+      * ``cspm`` / ``dspm`` / ``aispm`` — carried by the primary mapping
+        (cloud config, data governance, and AI/agent signals respectively).
+
+    The primary lane is always included.
+    """
+    from agent_bom.finding import FindingSource, FindingType
+
+    ev = evidence or {}
+    lenses: set[str] = {security_domain_for(source, finding_type, evidence)}
+
+    is_code_or_secret = finding_type in (FindingType.SAST, FindingType.CREDENTIAL_EXPOSURE) or source in (
+        FindingSource.SAST,
+        FindingSource.SECRET_SCAN,
+    )
+
+    # Vulnerability-management lens.
+    if finding_type in (FindingType.CVE, FindingType.MALICIOUS_PACKAGE, FindingType.LICENSE):
+        lenses.add("vuln")
+    if not is_code_or_secret and source in (
+        FindingSource.CONTAINER,
+        FindingSource.SBOM,
+        FindingSource.EXTERNAL,
+        FindingSource.FILESYSTEM,
+    ):
+        lenses.add("vuln")
+
+    # Application-security-posture lens.
+    if is_code_or_secret:
+        lenses.add("aspm")
+    # A repo / project checkout dependency graph is application-layer, so its
+    # dependency findings are ASPM as well as vuln.
+    if source in (FindingSource.SBOM, FindingSource.FILESYSTEM):
+        lenses.add("aspm")
+    if _is_iac_misconfig(source, finding_type, ev):
+        lenses.add("aspm")
+
+    return frozenset(lenses)
+
+
+def lenses_for_row(row: dict) -> frozenset[str]:
+    """Return the overlapping coverage-lens set for a serialized finding row.
+
+    Mirrors :func:`domain_for_row`: the stored ``security_domain`` (canonical,
+    legacy-aliased) is always in the set, and — when the row carries a parseable
+    source/type — the full derived lens set is unioned in. A row bearing a CVE id
+    always counts under ``vuln``. Returns an empty set only when nothing is
+    resolvable, so callers can fall back to a default lane.
+    """
+    lenses: set[str] = set()
+    primary = canonical_domain(row.get("security_domain"))
+    if primary is not None:
+        lenses.add(primary)
+    if str(row.get("cve_id") or "").strip():
+        lenses.add("vuln")
+
+    from agent_bom.finding import FindingSource, FindingType
+
+    try:
+        source = FindingSource(str(row.get("source") or "").upper())
+        ftype = FindingType(str(row.get("finding_type") or "").upper())
+    except ValueError:
+        return frozenset(lenses)
+    evidence = row.get("evidence") if isinstance(row.get("evidence"), dict) else None
+    return frozenset(lenses | security_lenses_for(source, ftype, evidence))

--- a/tests/test_finding_scope.py
+++ b/tests/test_finding_scope.py
@@ -12,9 +12,11 @@ from agent_bom.finding import (
 )
 from agent_bom.finding_scope import (
     account_ref_from_arn,
+    lenses_for_row,
     normalize_account_ref,
     region_from_arn,
     security_domain_for,
+    security_lenses_for,
 )
 
 # ---------------------------------------------------------------------------
@@ -97,6 +99,68 @@ def test_legacy_appsec_sca_domain_resolves_to_aspm() -> None:
     assert canonical_domain("aspm") == "aspm"
     assert canonical_domain("bogus") is None
     assert domain_for_row({"security_domain": "appsec_sca"}) == "aspm"
+
+
+# ---------------------------------------------------------------------------
+# Overlapping coverage lenses (a finding may belong to several)
+# ---------------------------------------------------------------------------
+
+
+def test_repo_dependency_cve_is_both_vuln_and_aspm() -> None:
+    """A repo/project dependency CVE is both a Vuln-mgmt and an ASPM concern."""
+    assert security_lenses_for(FindingSource.SBOM, FindingType.CVE) == {"vuln", "aspm"}
+    assert security_lenses_for(FindingSource.FILESYSTEM, FindingType.CVE) == {"vuln", "aspm"}
+
+
+def test_container_and_external_cve_is_vuln_only() -> None:
+    """Image / external-registry CVEs are vuln-management, not application-layer."""
+    assert security_lenses_for(FindingSource.CONTAINER, FindingType.CVE) == {"vuln"}
+    assert security_lenses_for(FindingSource.EXTERNAL, FindingType.CVE) == {"vuln"}
+
+
+def test_sast_and_secret_lenses_are_aspm_only() -> None:
+    assert security_lenses_for(FindingSource.SAST, FindingType.SAST) == {"aspm"}
+    assert security_lenses_for(FindingSource.SECRET_SCAN, FindingType.CREDENTIAL_EXPOSURE) == {"aspm"}
+
+
+def test_cloud_cis_lens_is_cspm_only() -> None:
+    assert security_lenses_for(FindingSource.CLOUD_CIS, FindingType.CIS_FAIL, {"benchmark": "CIS"}) == {"cspm"}
+
+
+def test_iac_misconfig_lens_adds_aspm() -> None:
+    """An IaC-template misconfig is application-layer as well as cloud config."""
+    ev = {"benchmark": "CIS", "iac": True, "resource_type": "terraform"}
+    assert security_lenses_for(FindingSource.CLOUD_CIS, FindingType.CIS_FAIL, ev) == {"cspm", "aspm"}
+
+
+def test_ai_signal_lens_is_aispm_only() -> None:
+    assert security_lenses_for(FindingSource.MCP_SCAN, FindingType.TOOL_DRIFT) == {"aispm"}
+
+
+def test_snowflake_governance_lens_is_dspm_only() -> None:
+    ev = {"provider": "snowflake", "category": "sensitive-data-access"}
+    assert security_lenses_for(FindingSource.CLOUD_CIS, FindingType.CIS_FAIL, ev) == {"dspm"}
+
+
+def test_every_lens_set_includes_the_primary_domain() -> None:
+    for source in FindingSource:
+        for ftype in FindingType:
+            primary = security_domain_for(source, ftype)
+            lenses = security_lenses_for(source, ftype)
+            assert primary in lenses
+            assert lenses <= {"cspm", "vuln", "aspm", "dspm", "aispm"}
+
+
+def test_lenses_for_row_unions_stored_domain_source_type_and_cve_id() -> None:
+    # A serialized repo dependency CVE row: parseable source/type + a CVE id.
+    row = {"security_domain": "vuln", "source": "SBOM", "finding_type": "CVE", "cve_id": "CVE-2025-1"}
+    assert lenses_for_row(row) == {"vuln", "aspm"}
+    # A row carrying only the stored primary stays single-lane.
+    assert lenses_for_row({"security_domain": "aispm"}) == {"aispm"}
+    # Legacy stored key still resolves into the ASPM lens.
+    assert lenses_for_row({"security_domain": "appsec_sca"}) == {"aspm"}
+    # A bare CVE id with no parseable source/type still counts under vuln.
+    assert lenses_for_row({"cve_id": "CVE-2025-2"}) == {"vuln"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_findings_scope_filter.py
+++ b/tests/test_findings_scope_filter.py
@@ -122,3 +122,79 @@ def test_no_scope_filter_is_backward_compatible() -> None:
     resp = client.get("/v1/findings", headers=_AUTH)
     assert resp.status_code == 200
     assert len(resp.json()["findings"]) == 3
+
+
+def _seed_lens_findings() -> None:
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    job = ScanJob(
+        job_id="lens-job",
+        tenant_id="default",
+        created_at="2026-02-22T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {
+        "agents": [],
+        "scan_sources": ["project"],
+        "findings": [
+            # Repo dependency CVE — lens set {vuln, aspm}.
+            {
+                "id": "repo-cve",
+                "severity": "high",
+                "security_domain": "vuln",
+                "source": "SBOM",
+                "finding_type": "CVE",
+                "cve_id": "CVE-2025-9000",
+                "title": "repo dependency cve",
+            },
+            # A SAST code weakness — lens set {aspm}.
+            {
+                "id": "sast-weak",
+                "severity": "medium",
+                "security_domain": "aspm",
+                "source": "SAST",
+                "finding_type": "SAST",
+                "title": "sql injection sink",
+            },
+            # A container-image CVE — lens set {vuln} only.
+            {
+                "id": "img-cve",
+                "severity": "low",
+                "security_domain": "vuln",
+                "source": "CONTAINER",
+                "finding_type": "CVE",
+                "cve_id": "CVE-2025-9001",
+                "title": "base image cve",
+            },
+        ],
+    }
+    _get_store().put(job)
+
+
+def test_domain_filter_matches_overlapping_lens_set() -> None:
+    """The ``domain`` facet matches a finding's lens set, not just its primary.
+
+    A repo dependency CVE is returned by BOTH ``domain=vuln`` and ``domain=aspm``;
+    a container CVE is vuln-only; a SAST weakness is aspm-only.
+    """
+    _seed_lens_findings()
+    client = TestClient(app)
+
+    aspm = client.get("/v1/findings?domain=aspm", headers=_AUTH)
+    assert aspm.status_code == 200
+    assert _ids(aspm) == {"repo-cve", "sast-weak"}
+
+    vuln = client.get("/v1/findings?domain=vuln", headers=_AUTH)
+    assert vuln.status_code == 200
+    assert _ids(vuln) == {"repo-cve", "img-cve"}
+
+
+def test_legacy_appsec_sca_domain_filter_still_resolves() -> None:
+    """The pre-rename ``appsec_sca`` query alias maps to the ASPM lens."""
+    _seed_lens_findings()
+    client = TestClient(app)
+    resp = client.get("/v1/findings?domain=appsec_sca", headers=_AUTH)
+    assert resp.status_code == 200
+    assert _ids(resp) == {"repo-cve", "sast-weak"}

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -282,7 +282,9 @@ def test_overview_severity_sum_equals_unique_cves_with_unknown_severity() -> Non
 
 
 def test_overview_coverage_lanes_map_to_five_domains() -> None:
-    """Coverage lanes are the five security domains, non-overlapping, invariant-clean."""
+    """Coverage lanes are the five security domains; each lane's per-lane severity
+    strip still sums to its own count (rows with a single stored primary and no
+    parseable source/type map to exactly one lane)."""
     _clear_jobs()
     from agent_bom.api.server import ScanJob, ScanRequest
 
@@ -322,6 +324,78 @@ def test_overview_coverage_lanes_map_to_five_domains() -> None:
     assert coverage["aspm"]["count"] == 0
     # CIS misconfig went to CSPM, not the vuln lane.
     assert coverage["vuln"]["severity"]["critical"] == 1
+
+
+def test_overview_coverage_lanes_overlap_for_repo_dependency_cve() -> None:
+    """Coverage lanes are overlapping posture lenses, not a partition.
+
+    A repo/project dependency CVE counts under BOTH the Vuln-mgmt and the ASPM
+    lane, so the sum of lane counts exceeds the total finding count. The
+    all-domain headline histogram is still computed once per finding and is NOT
+    the sum of the lanes.
+    """
+    _clear_jobs()
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+    from agent_bom.api.server import ScanJob, ScanRequest
+
+    get_compliance_hub_store().clear("default")
+    job = ScanJob(
+        job_id="overlap-job",
+        tenant_id="default",
+        created_at="2026-02-22T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {
+        "agents": [],
+        "scan_sources": ["project"],
+        "findings": [
+            # Repo dependency CVE — lens set {vuln, aspm}.
+            {
+                "id": "dep-1",
+                "security_domain": "vuln",
+                "source": "SBOM",
+                "finding_type": "CVE",
+                "cve_id": "CVE-2025-9000",
+                "severity": "high",
+            },
+            # A SAST code weakness — ASPM only.
+            {
+                "id": "sast-1",
+                "security_domain": "aspm",
+                "source": "SAST",
+                "finding_type": "SAST",
+                "severity": "medium",
+            },
+        ],
+    }
+    _get_store().put(job)
+
+    data = client_get_overview()
+    coverage = {lane["domain"]: lane for lane in data["coverage"]}
+
+    # The dependency CVE appears in vuln AND aspm; the SAST finding in aspm.
+    assert coverage["vuln"]["count"] == 1
+    assert coverage["vuln"]["severity"]["high"] == 1
+    assert coverage["aspm"]["count"] == 2
+    assert coverage["aspm"]["severity"]["high"] == 1
+    assert coverage["aspm"]["severity"]["medium"] == 1
+
+    # Lanes overlap: their counts sum to more than the 2 real findings.
+    lane_total = sum(lane["count"] for lane in data["coverage"])
+    assert lane_total == 3
+    assert lane_total > 2
+
+    # Per-lane invariant still holds: each lane count == sum of its own strip.
+    for lane in data["coverage"]:
+        assert sum(v for v in lane["severity"].values()) == lane["count"]
+
+    # The exec headline histogram is computed once per finding, NOT by summing
+    # lanes: 1 high (the CVE) + 1 medium (the SAST) — not the doubled lane total.
+    assert data["headline"]["high"] == 1
+    assert data["headline"]["critical"] == 0
+    get_compliance_hub_store().clear("default")
 
 
 def test_overview_headline_reflects_noncve_spine_critical() -> None:


### PR DESCRIPTION
Follow-up to the ASPM coverage-lane rename (#3994, already merged). This makes the five coverage lanes **overlapping posture disciplines** over the one unified finding model, the way leading platforms present posture coverage — not a strict one-lane-per-finding partition. Backend + tests + docs only; no UI structural change (the tiles already render per-lane API counts).

## What changed
A finding can now count under **several** lanes. The primary `security_domain` (stored + displayed) is unchanged; a new `security_lenses_for()` returns the full lens set, derived from the same `(source, finding_type, evidence)` inputs — no schema migration.

### Lens predicates
| Lens | Counted when… |
|---|---|
| `vuln` | CVE / carries a CVE id / dependency-or-package scanner output (container, SBOM, external, filesystem) — the vulnerability-management discipline |
| `aspm` | application / code / repo layer: SAST, secret/credential scanning, a repo/project-checkout dependency graph (SBOM or filesystem), or IaC-template misconfiguration |
| `cspm` | cloud configuration / CIS benchmark |
| `dspm` | data-access governance |
| `aispm` | AI / agent / MCP / prompt / proxy / skill signals |

The primary lane is always a member of the set.

### Which findings now appear in multiple lenses
- **Repo/project dependency CVE** (SBOM or filesystem source, CVE type) → `{vuln, aspm}`.
- **IaC-template misconfiguration** (CIS_FAIL with an IaC marker) → `{cspm, aspm}`.
- Container-image / external-registry CVE → `{vuln}` only (not app-layer).
- SAST weakness / secret-in-code → `{aspm}` only. Cloud CIS → `{cspm}`. MCP/agent signals → `{aispm}`.

## Invariants held
- The **exec headline / grade histogram is unchanged** — computed once per finding over the unified spine, never by summing the overlapping lanes.
- **Each lane's own count still equals the sum of its severity strip** (incl. `unrated`).
- The **sum of lane counts is no longer the total** (lanes overlap by design) — the old "sum of lanes == total" assumption was removed from the tests.

## Filter
`GET /v1/findings?domain=<d>` now matches a finding's **lens set**: `domain=aspm` returns SAST + secrets + repo dependencies + IaC; `domain=vuln` returns every CVE. The legacy `appsec_sca` query alias still resolves to `aspm`.

## Verification
- Python: `test_finding_scope` + `test_overview` + `test_findings_scope_filter` = **50 passed**; broad `-k "overview or coverage or finding or domain or scope"` = **815 passed, 2 skipped**; `scripts/check-counts.py` consistent.
- No UI files touched, so UI build/vitest/bundle unaffected.