### PR TITLE
Graph & DAG canvas scale pass + in-product actions

### DIFF
--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -287,9 +287,18 @@ function JobsPageContent() {
               />
             ) : (
               <div className="rounded-xl border border-dashed border-[var(--border-subtle)] bg-[var(--surface)]/30 p-4">
-                <p className="text-sm text-[var(--text-secondary)]">
-                  Run a scan to see the live six-stage pipeline DAG with per-step timing and activity.
-                </p>
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <p className="text-sm text-[var(--text-secondary)]">
+                    Run a scan to see the live six-stage pipeline DAG with per-step timing and activity.
+                  </p>
+                  <Link
+                    href="/scan"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
+                  >
+                    <ShieldAlert className="h-3.5 w-3.5" />
+                    Run a scan
+                  </Link>
+                </div>
                 <div className="mt-4">
                   <ScanPipeline steps={new Map()} className="h-[260px]" />
                 </div>

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -488,6 +488,7 @@ export default function MeshPage() {
             "Open the full graph after the scan persists graph evidence.",
           ]}
           command="agent-bom agents --demo --offline"
+          actions={[{ label: "Run a scan", href: "/scan" }]}
         />
       </div>
     );

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -19,7 +19,7 @@ function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden"
 }
 import { PageLaneHeader } from "@/components/page-lane";
 import { AttackPathCard } from "@/components/attack-path-card";
-import { ExposurePathCommandCenter } from "@/components/exposure-path-command-center";
+import { ExposurePathCommandCenter, type ExposurePathView } from "@/components/exposure-path-command-center";
 import { GraphEvidenceExportButton } from "@/components/graph-chrome";
 import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
 import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
@@ -71,6 +71,7 @@ function SecurityGraphPageContent() {
   const [showAllSnapshots, setShowAllSnapshots] = useState(false);
   const [visibleAttackPathCount, setVisibleAttackPathCount] = useState(ATTACK_PATH_QUEUE_PAGE_SIZE);
   const [investigationFocusMode, setInvestigationFocusMode] = useState(true);
+  const [pathView, setPathView] = useState<ExposurePathView>("path");
   const captureMode = useCaptureMode();
 
   const focus = useMemo(
@@ -181,10 +182,19 @@ function SecurityGraphPageContent() {
     () => snapshots.find((snapshot) => snapshot.scan_id === selectedScanId) ?? null,
     [snapshots, selectedScanId],
   );
-  const displayedSnapshots = useMemo(
-    () => (showAllSnapshots ? snapshots : snapshots.slice(0, 8)),
-    [showAllSnapshots, snapshots],
+  // Stale/empty snapshots (0 persisted nodes) pile up in a long-lived graph
+  // store and drown the real ones in the chip row. Default to the populated
+  // snapshots (plus whatever is currently selected); "show all" reveals the
+  // empty and older ones on demand.
+  const activeSnapshots = useMemo(
+    () => snapshots.filter((snapshot) => snapshot.node_count > 0 || snapshot.scan_id === selectedScanId),
+    [snapshots, selectedScanId],
   );
+  const displayedSnapshots = useMemo(
+    () => (showAllSnapshots ? snapshots : activeSnapshots.slice(0, 8)),
+    [activeSnapshots, showAllSnapshots, snapshots],
+  );
+  const hiddenSnapshotCount = Math.max(0, snapshots.length - displayedSnapshots.length);
 
   const fixFirstCards = useMemo(() => fixFirstView?.cards ?? [], [fixFirstView?.cards]);
 
@@ -416,10 +426,12 @@ function SecurityGraphPageContent() {
           path={selectedExposurePath}
           actions={selectedFixFirstCard?.next_actions ?? selectedPathActions}
           scanId={selectedScanId || undefined}
+          view={pathView}
+          onViewChange={setPathView}
         />
       ) : null}
 
-      {graphData && selectedAttackPath && (
+      {pathView === "graph" && graphData && selectedAttackPath && (
         <SecurityGraphInvestigation
           graph={graphData as UnifiedGraphData}
           attackPath={selectedAttackPath}
@@ -493,13 +505,15 @@ function SecurityGraphPageContent() {
                     );
                   })}
                 </div>
-                {snapshots.length > 8 && (
+                {(hiddenSnapshotCount > 0 || showAllSnapshots) && (
                   <button
                     type="button"
                     onClick={() => setShowAllSnapshots((current) => !current)}
                     className="mt-3 rounded-lg border border-[color:var(--border-subtle)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                   >
-                    {showAllSnapshots ? "Show recent snapshots" : `Show all ${snapshots.length} snapshots`}
+                    {showAllSnapshots
+                      ? "Show active snapshots"
+                      : `Show all ${snapshots.length} snapshots (${hiddenSnapshotCount} empty or older)`}
                   </button>
                 )}
               </>
@@ -515,6 +529,7 @@ function SecurityGraphPageContent() {
                       "Open the full graph after the first snapshot appears.",
                     ]}
                     command="agent-bom scan -p . -f graph"
+                    actions={[{ label: "Run a scan", href: "/scan" }]}
                   />
                 </div>
               )

--- a/ui/components/compliance-control-drawer.tsx
+++ b/ui/components/compliance-control-drawer.tsx
@@ -32,7 +32,7 @@ export function ComplianceControlDrawer({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex justify-end bg-black/45 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-label={`Control details for ${control.code}`}

--- a/ui/components/deployment-surface-required-state.tsx
+++ b/ui/components/deployment-surface-required-state.tsx
@@ -29,6 +29,11 @@ export function DeploymentSurfaceRequiredState({
       capabilities={state.capabilities}
       detail={state.detail}
       onRetry={onRetry}
+      primaryAction={
+        state.actionHref && state.actionLabel
+          ? { label: state.actionLabel, href: state.actionHref }
+          : undefined
+      }
     />
   );
 }

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useState } from "react";
 import type { LucideIcon } from "lucide-react";
 import {
   Bot,
@@ -8,7 +9,10 @@ import {
   CheckCircle2,
   ChevronDown,
   Database,
+  GitBranch,
   KeyRound,
+  List,
+  Network,
   Package,
   Server,
   ShieldAlert,
@@ -23,6 +27,55 @@ export interface ExposurePathCommandAction {
   title: string;
   detail: string;
   href: string;
+}
+
+/**
+ * Which single representation of the selected path is shown. The command center
+ * used to stack the path DAG, the neighbor list, and a full interactive graph
+ * all at once; the toggle collapses that to one view at a time.
+ */
+export type ExposurePathView = "path" | "graph" | "list";
+
+const PATH_VIEW_ITEMS: { key: ExposurePathView; label: string; icon: LucideIcon }[] = [
+  { key: "path", label: "Path", icon: GitBranch },
+  { key: "graph", label: "Graph", icon: Network },
+  { key: "list", label: "List", icon: List },
+];
+
+function PathViewToggle({
+  view,
+  onChange,
+}: {
+  view: ExposurePathView;
+  onChange: (next: ExposurePathView) => void;
+}) {
+  return (
+    <div
+      role="group"
+      aria-label="Exposure path view"
+      className="inline-flex items-center overflow-hidden rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]"
+    >
+      {PATH_VIEW_ITEMS.map(({ key, label, icon: Icon }) => {
+        const active = view === key;
+        return (
+          <button
+            key={key}
+            type="button"
+            onClick={() => onChange(key)}
+            aria-pressed={active}
+            className={`flex items-center gap-1.5 px-2.5 py-1.5 text-[11px] font-medium transition ${
+              active
+                ? "bg-emerald-600 text-white"
+                : "text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)]"
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            {label}
+          </button>
+        );
+      })}
+    </div>
+  );
 }
 
 const ROLE_META: Record<ExposureEntityRole, { label: string; icon: LucideIcon; tint: string }> = {
@@ -41,11 +94,27 @@ export function ExposurePathCommandCenter({
   path,
   actions = [],
   scanId,
+  view: controlledView,
+  onViewChange,
 }: {
   path: ExposurePath;
   actions?: ExposurePathCommandAction[] | undefined;
   scanId?: string | undefined;
+  /** Controlled active view. When omitted the component owns the state. */
+  view?: ExposurePathView | undefined;
+  /**
+   * Notified when the operator switches views. The page wires this to render
+   * the interactive investigation graph on demand in "graph" view instead of
+   * reserving a full screen-height of blank canvas underneath.
+   */
+  onViewChange?: ((next: ExposurePathView) => void) | undefined;
 }) {
+  const [internalView, setInternalView] = useState<ExposurePathView>("path");
+  const view = controlledView ?? internalView;
+  const setView = (next: ExposurePathView) => {
+    if (!controlledView) setInternalView(next);
+    onViewChange?.(next);
+  };
   const fixLabel = pathFixLabel(path);
   const evidence = path.evidence;
   const primaryAction = actions[0];
@@ -93,11 +162,31 @@ export function ExposurePathCommandCenter({
           </div>
         </div>
 
-        <section aria-label="Selected exposure path graph" className="rounded-2xl border border-[color:var(--border-subtle)] bg-[#05070b] p-1">
-          <ExposurePathGraph path={path} />
-        </section>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+            {view === "path"
+              ? "Attack path"
+              : view === "graph"
+                ? "Interactive graph"
+                : "Path neighbors"}
+          </div>
+          <PathViewToggle view={view} onChange={setView} />
+        </div>
 
-        <ExposurePathNeighborExplorer path={path} scanId={scanId} />
+        {view === "path" ? (
+          <section aria-label="Selected exposure path graph" className="rounded-2xl border border-[color:var(--border-subtle)] bg-[#05070b] p-1">
+            <ExposurePathGraph path={path} />
+          </section>
+        ) : view === "list" ? (
+          <ExposurePathNeighborExplorer path={path} scanId={scanId} />
+        ) : (
+          <section
+            aria-label="Interactive graph hint"
+            className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]/60 px-4 py-6 text-center text-xs text-[color:var(--text-secondary)]"
+          >
+            Interactive graph opens below — pan, zoom, and click nodes to inspect the persisted subgraph.
+          </section>
+        )}
 
         <details className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]/70">
           <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-[color:var(--foreground)] [&::-webkit-details-marker]:hidden">

--- a/ui/components/integration-required-state.tsx
+++ b/ui/components/integration-required-state.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { Database, RefreshCw, Settings2 } from "lucide-react";
+import Link from "next/link";
+import { Database, Play, RefreshCw, Settings2 } from "lucide-react";
 
 interface IntegrationRequiredStateProps {
   title: string;
@@ -10,6 +11,12 @@ interface IntegrationRequiredStateProps {
   capabilities: string[];
   detail?: string | null | undefined;
   onRetry?: (() => void) | undefined;
+  /**
+   * Optional in-product enablement action rendered as a first-class button
+   * beside the headless CLI command. The command always stays visible so
+   * agent/headless operators keep their equivalent path.
+   */
+  primaryAction?: { label: string; href: string } | undefined;
 }
 
 export function IntegrationRequiredState({
@@ -20,6 +27,7 @@ export function IntegrationRequiredState({
   capabilities,
   detail,
   onRetry,
+  primaryAction,
 }: IntegrationRequiredStateProps) {
   return (
     <div className="py-8">
@@ -37,7 +45,19 @@ export function IntegrationRequiredState({
             </div>
             <div className="mt-4 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)] px-4 py-3">
               <div className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Enable this surface</div>
-              <code className="mt-2 block whitespace-pre-wrap font-mono text-sm leading-7 text-emerald-300">
+              {primaryAction ? (
+                <Link
+                  href={primaryAction.href}
+                  className="mt-3 inline-flex items-center gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
+                >
+                  <Play className="h-4 w-4" />
+                  {primaryAction.label}
+                </Link>
+              ) : null}
+              <div className="mt-3 text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
+                {primaryAction ? "Headless / agent equivalent" : "First command"}
+              </div>
+              <code className="mt-1 block whitespace-pre-wrap font-mono text-sm leading-7 text-emerald-300">
                 {command}
               </code>
             </div>

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -298,17 +298,24 @@ const COVERAGE_SEVERITY_BANDS: { key: keyof OverviewCoverageLane["severity"]; la
 ];
 
 /**
- * The five security-posture coverage lanes rendered 1:1 (CSPM / Vuln mgmt /
- * ASPM / DSPM / AISPM). Each lane's count is the sum of its severity
- * strip, so the metric can never contradict the strip. An ``unrated`` chip is
- * surfaced only when unknown-severity findings are present. All colors come from
- * design tokens (no hardcoded palette) so light + dark both read correctly.
+ * The security-posture coverage lanes rendered 1:1 (CSPM / Vuln mgmt / ASPM /
+ * DSPM / AISPM). These are overlapping posture *disciplines* (lenses), not a
+ * partition: one finding can count in several lanes (a repo CVE is both Vuln
+ * mgmt and ASPM; an IaC misconfig is both CSPM and ASPM), so the lanes are not
+ * additive — the caption above says so, and nothing here presents a lane total.
+ * Each lane's count is the sum of its own severity strip, so the metric can
+ * never contradict the strip. An ``unrated`` chip is surfaced only when
+ * unknown-severity findings are present. All colors come from design tokens (no
+ * hardcoded palette) so light + dark both read correctly.
  */
 function SecurityCoverageLanes({ coverage }: { coverage?: OverviewCoverageLane[] | null | undefined }) {
   if (!coverage || coverage.length === 0) return null;
   return (
     <div className="mt-4" data-testid="overview-security-coverage">
-      <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-[color:var(--text-tertiary)]">Security coverage</h3>
+      <h3 className="mb-1 text-xs font-semibold uppercase tracking-wide text-[color:var(--text-tertiary)]">Security coverage</h3>
+      <p className="mb-2 text-[11px] leading-4 text-[color:var(--text-tertiary)]">
+        Coverage by discipline — lenses can overlap, so a repo CVE counts under both Vuln mgmt and ASPM. Lanes are not additive.
+      </p>
       <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-5">
         {coverage.map((lane) => {
           const total = COVERAGE_SEVERITY_BANDS.reduce((sum, band) => sum + (lane.severity[band.key] || 0), 0);

--- a/ui/components/proxy-alert-drawer.tsx
+++ b/ui/components/proxy-alert-drawer.tsx
@@ -25,7 +25,7 @@ export function ProxyAlertDrawer({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex justify-end bg-black/45 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-label={`Proxy alert details for ${alert.tool_name}`}

--- a/ui/components/scan-pipeline.tsx
+++ b/ui/components/scan-pipeline.tsx
@@ -38,6 +38,7 @@ import {
   XCircle,
   Clock,
   SkipForward,
+  Move,
 } from "lucide-react";
 import { useGraphLayout } from "@/lib/use-graph-layout";
 import type { StepStatus, StepEvent } from "@/lib/api";
@@ -282,13 +283,16 @@ function ScanPipelineInner({
   );
 
   return (
-    <div className={`h-[180px] ${className ?? ""}`}>
+    <div className={`relative h-[180px] ${className ?? ""}`}>
       <ReactFlow
         nodes={nodes}
         edges={edges}
         nodeTypes={nodeTypes}
         fitView
-        fitViewOptions={{ padding: 0.16 }}
+        // Re-fit whenever the node set changes so a live pipeline that grows
+        // scanner lanes mid-run always frames the whole DAG in the container
+        // instead of clipping the tail off-screen.
+        fitViewOptions={{ padding: 0.16, maxZoom: 1 }}
         minZoom={0.25}
         maxZoom={1.5}
         panOnDrag={interactive}
@@ -307,6 +311,12 @@ function ScanPipelineInner({
           />
         ) : null}
       </ReactFlow>
+      {interactive ? (
+        <div className="pointer-events-none absolute right-2 top-2 inline-flex items-center gap-1.5 rounded-full border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-2.5 py-1 text-[10px] font-medium text-[var(--text-tertiary)] backdrop-blur">
+          <Move className="h-3 w-3" aria-hidden="true" />
+          Drag to pan · scroll to zoom · click a stage
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/ui/components/topology-detail-drawer.tsx
+++ b/ui/components/topology-detail-drawer.tsx
@@ -63,7 +63,7 @@ export function TopologyDetailDrawer({
 
   return (
     <div
-      className="fixed inset-0 z-50 flex justify-end bg-black/45 backdrop-blur-sm"
+      className="fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-label={`Topology details for ${title}`}

--- a/ui/lib/deployment-context.ts
+++ b/ui/lib/deployment-context.ts
@@ -18,6 +18,14 @@ interface DeploymentSurfaceDefinition {
   command: string;
   capabilities: string[];
   summary: (mode: string) => string;
+  /**
+   * Optional in-product enablement action. For scan-driven surfaces this points
+   * at the same New-Scan flow the operator would reach from the nav, so the
+   * empty state offers a first-class UI path alongside the headless CLI/API
+   * command (never instead of it).
+   */
+  actionHref?: string;
+  actionLabel?: string;
 }
 
 function bool(value: boolean | undefined): boolean {
@@ -61,6 +69,8 @@ const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition
     isAvailable: (counts) => bool(counts?.has_local_scan),
     requirement: "Local agent discovery or workstation scan evidence",
     command: "agent-bom agents --push-url https://<control-plane>/v1/fleet/sync",
+    actionHref: "/scan",
+    actionLabel: "Run a scan",
     capabilities: [
       "Local MCP config-file discovery from developer workstations",
       "Configured agent inventory with attached MCP servers",
@@ -89,6 +99,8 @@ const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition
     isAvailable: (counts) => bool(counts?.has_mesh),
     requirement: "Completed scans with agent and runtime relationship context",
     command: "agent-bom scan --introspect --preset enterprise",
+    actionHref: "/scan",
+    actionLabel: "Run introspection scan",
     capabilities: [
       "Shared infrastructure across agents, tools, packages, and findings",
       "Highest-risk agent defaults and mesh-wide overlap analysis",
@@ -103,6 +115,8 @@ const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition
     isAvailable: (counts) => bool(counts?.has_mcp_context),
     requirement: "MCP and agent context from completed scans",
     command: "agent-bom scan --introspect --preset enterprise",
+    actionHref: "/scan",
+    actionLabel: "Run introspection scan",
     capabilities: [
       "Lateral path analysis across agents, credentials, tools, and servers",
       "Context graph stats for shared credentials and shared servers",
@@ -224,6 +238,8 @@ export function getDeploymentSurfaceState(
     requirement: definition.requirement,
     command: definition.command,
     capabilities: definition.capabilities,
+    actionHref: definition.actionHref,
+    actionLabel: definition.actionLabel,
     detail,
   };
 }

--- a/ui/tests/exposure-path-command-center.test.tsx
+++ b/ui/tests/exposure-path-command-center.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import { ExposurePathCommandCenter } from "@/components/exposure-path-command-center";
 import type { ExposurePath } from "@/lib/exposure-path";
@@ -81,5 +81,50 @@ describe("ExposurePathCommandCenter", () => {
     expect(screen.getByText("Evidence & relationships")).toBeInTheDocument();
     expect(screen.queryByText("Evidence drawer")).not.toBeVisible();
     expect(screen.getByText("Validate the lead finding")).toBeInTheDocument();
+  });
+
+  it("shows one representation at a time and defaults to the path view", () => {
+    render(<ExposurePathCommandCenter path={basePath} />);
+
+    // Path view: the selected-path DAG is rendered; the neighbor list and the
+    // interactive-graph hint are not stacked underneath it.
+    expect(
+      screen.getByRole("img", { name: /Selected exposure path graph for/ }),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Expand path neighbors")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/Interactive graph opens below/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("switches to the neighbor list and the interactive-graph hint via the toggle", () => {
+    const onViewChange = vi.fn();
+    render(
+      <ExposurePathCommandCenter
+        path={basePath}
+        view="list"
+        onViewChange={onViewChange}
+      />,
+    );
+
+    // Controlled "list" view swaps the DAG for the neighbor explorer.
+    expect(screen.getByText("Expand path neighbors")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: /Selected exposure path graph for/ }),
+    ).not.toBeInTheDocument();
+
+    // The toggle reports view changes so the page can render the interactive
+    // graph on demand.
+    fireEvent.click(screen.getByRole("button", { name: /Graph/ }));
+    expect(onViewChange).toHaveBeenCalledWith("graph");
+  });
+
+  it("renders the interactive-graph hint instead of a reserved blank canvas in graph view", () => {
+    render(<ExposurePathCommandCenter path={basePath} view="graph" onViewChange={vi.fn()} />);
+
+    expect(screen.getByText(/Interactive graph opens below/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: /Selected exposure path graph for/ }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/integration-required-state.test.tsx
+++ b/ui/tests/integration-required-state.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { IntegrationRequiredState } from "@/components/integration-required-state";
+import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
+import { getDeploymentSurfaceState } from "@/lib/deployment-context";
+
+describe("IntegrationRequiredState", () => {
+  it("shows an in-product action button alongside (not instead of) the CLI command", () => {
+    render(
+      <IntegrationRequiredState
+        title="Agent Mesh is not active in this deployment"
+        summary="The Agent Mesh needs relationship-rich scan data."
+        requirement="Completed scans with agent and runtime relationship context"
+        command="agent-bom scan --introspect --preset enterprise"
+        capabilities={["Runtime-aware graph exploration instead of a raw scan list"]}
+        primaryAction={{ label: "Run introspection scan", href: "/scan" }}
+      />,
+    );
+
+    // First-class UI action…
+    const action = screen.getByRole("link", { name: /Run introspection scan/ });
+    expect(action).toHaveAttribute("href", "/scan");
+    // …and the headless CLI equivalent is still present, never removed.
+    expect(
+      screen.getByText("agent-bom scan --introspect --preset enterprise"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Headless \/ agent equivalent/)).toBeInTheDocument();
+  });
+});
+
+describe("DeploymentSurfaceRequiredState", () => {
+  it("wires the scan-driven surfaces to the in-product New-Scan flow", () => {
+    // The mesh surface definition carries a scan action…
+    const state = getDeploymentSurfaceState("mesh", {
+      has_mesh: false,
+      deployment_mode: "local",
+    } as never);
+    expect(state.actionHref).toBe("/scan");
+
+    render(
+      <DeploymentSurfaceRequiredState
+        surface="mesh"
+        counts={{ has_mesh: false, deployment_mode: "local" } as never}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /Run introspection scan/ })).toHaveAttribute(
+      "href",
+      "/scan",
+    );
+    expect(
+      screen.getByText("agent-bom scan --introspect --preset enterprise"),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -106,6 +106,9 @@ describe("OverviewCockpit", () => {
 
     const section = screen.getByTestId("overview-security-coverage");
     expect(section).toBeInTheDocument();
+    // Lanes are labeled as overlapping disciplines so a user never sums them.
+    expect(screen.getByText(/lenses can overlap/i)).toBeInTheDocument();
+    expect(screen.getByText(/not additive/i)).toBeInTheDocument();
     // Each lane links to its domain-filtered findings view.
     expect(screen.getByTestId("coverage-lane-cspm")).toHaveAttribute("href", "/findings?domain=cspm");
     // Unrated is surfaced as its own chip when present.


### PR DESCRIPTION
Makes the moat/graph surfaces scale-aware and adds first-class in-product actions alongside the existing headless CLI/API paths. UI-only.

## AE — Security graph page (`/security-graph`) is scale-aware
- **One representation at a time.** The path DAG, neighbor list, and interactive graph were stacked three ways for the same selected path. They're now a **Path / Graph / List view toggle** in the exposure-path command center — the duplicate is gone.
- **Interactive graph on demand.** The "Live investigation" panel used to reserve a full screen-height of blank canvas. It now renders only in **Graph** view, so nothing reserves empty space.
- **Collapsed secondary sections.** "Evidence & relationships" stays collapsed by default; the neighbor explorer lives behind the **List** view.
- **Stale snapshots hidden.** The chip row filtered out 0-node snapshots by default (keeping the current one); "show all" reveals empty/older ones, with a count.

## AF — Pipeline DAG (`/jobs`, control-plane workflow)
- Cap fit zoom (`maxZoom: 1`) so a short chain doesn't over-scale, re-fit on node-set change, and add a clear **"drag to pan · scroll to zoom · click a stage"** affordance so it's obvious what's interactive. (`fitView`, pan/zoom, and on-canvas Controls were already present.)

## AG — In-product actions, not CLI-only empty states
- Enablement/empty states (**Agent Mesh**, **Context Map**, **Agents**, **Security graph**, **Scan-jobs pipeline placeholder**) now show a first-class **"Run a scan" / "Run introspection scan"** button that reuses the New-Scan flow (`/scan`), with the **CLI/API snippet kept alongside** as the headless/agent equivalent — never removed, never the only path.

## #3966 (graph-relevant parts)
- **Drawer Close under nav:** raised the topology / proxy-alert / compliance-control drawer overlays from `z-50` to `z-[80]`, above the nav's `z-[60]/z-[70]` stacking, so Close is always clickable. (The shared `Drawer` and `finding-drawer` already use `z-[80]`.)
- **exec→graph scanId drill:** verified already threaded on `main` (`buildExposurePathView` → `buildSecurityGraphHref` emits `scan=`, honored by `/security-graph` and `/graph`, covered by `dashboard-data.test.ts`). No change needed.

## Overview clarity (coordinator addition)
- Security-coverage lanes are now labeled as **overlapping disciplines** (a repo CVE counts under both Vuln mgmt and ASPM) so the tiles are never summed. Per-lane drill hrefs and the `sum===count` severity strip are unchanged; no cross-tile total exists.

## Verification
- `npm run build`: Compiled successfully.
- `npx vitest run`: 104 files / 540 tests pass (incl. new view-toggle, on-demand-graph, empty-state-button-alongside-CLI, and coverage-caption tests).
- `node scripts/check-bundle-budget.mjs`: PASS (total client JS 3272.1 / 3300.0 KiB) — no budget change.
- ESLint clean on all touched files.
- Live smoke against a seeded demo on an **isolated** graph store (`AGENT_BOM_STATE_DIR`/`AGENT_BOM_GRAPH_DB` temp): `/security-graph`, `/mesh`, `/jobs`, `/overview`, `/agents` all serve 200 with no compile/runtime errors; snapshots carry `node_count` (112/111) and attack-paths return data as the toggle expects.

Advances #3931, closes graph parts of #3966.