### PR TITLE
fix(cloud): serve Snowflake estate inventory over REST

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -7287,7 +7287,7 @@
     },
     "/v1/cloud/{provider}/inventory": {
       "get": {
-        "description": "Estate-wide cloud asset inventory summary for a provider (or ``all``).\n\nCalls the same ``discover_inventory`` functions the CLI and MCP ``cloud_inventory``\ntool use and reduces each provider payload to the identical non-secret count\nshape (``_summarize_inventory_payload``). Each provider self-gates on its own\n``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider returns a\nclear ``status`` and contributes zero nodes.",
+        "description": "Estate-wide cloud asset inventory summary for a provider (or ``all``).\n\nCalls the same ``discover_inventory`` / ``discover`` functions the CLI and MCP\n``cloud_inventory`` tool use and reduces each provider payload to the identical\nnon-secret count shape. ``aws`` | ``azure`` | ``gcp`` | ``snowflake`` (and\n``all``) are supported; Snowflake's AI-resource discovery is projected onto the\nsame summary fields (see ``_snowflake_inventory``). Each provider self-gates on\nits own ``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider\nreturns a clear ``status`` and contributes zero nodes.",
         "operationId": "cloud_inventory_v1_cloud__provider__inventory_get",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -4804,17 +4804,22 @@ paths:
       description: 'Estate-wide cloud asset inventory summary for a provider (or ``all``).
 
 
-        Calls the same ``discover_inventory`` functions the CLI and MCP ``cloud_inventory``
+        Calls the same ``discover_inventory`` / ``discover`` functions the CLI and
+        MCP
 
-        tool use and reduces each provider payload to the identical non-secret count
+        ``cloud_inventory`` tool use and reduces each provider payload to the identical
 
-        shape (``_summarize_inventory_payload``). Each provider self-gates on its
-        own
+        non-secret count shape. ``aws`` | ``azure`` | ``gcp`` | ``snowflake`` (and
 
-        ``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider returns
-        a
+        ``all``) are supported; Snowflake''s AI-resource discovery is projected onto
+        the
 
-        clear ``status`` and contributes zero nodes.'
+        same summary fields (see ``_snowflake_inventory``). Each provider self-gates
+        on
+
+        its own ``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider
+
+        returns a clear ``status`` and contributes zero nodes.'
       operationId: cloud_inventory_v1_cloud__provider__inventory_get
       parameters:
       - in: path

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -11,8 +11,8 @@ Endpoints:
     GET /v1/cloud/{provider}/inventory       estate asset inventory summary
     GET /v1/cloud/{provider}/cis-benchmark   CIS Foundations benchmark report
 
-``provider`` is one of ``aws`` | ``azure`` | ``gcp``; ``all`` is also accepted for
-inventory (estate-wide fan-out). Every endpoint enforces the same tenant + role
+For inventory, ``provider`` is one of ``aws`` | ``azure`` | ``gcp`` | ``snowflake``;
+``all`` is also accepted (estate-wide fan-out). Every endpoint enforces the same tenant + role
 gate the sibling routes use: ``require_request_tenant_id`` plus the ``scan``
 permission ({admin, analyst}) via the shared RBAC dependency, so there is no
 unauthenticated cloud scan and an under-privileged role is rejected with 403.
@@ -25,6 +25,7 @@ envelope (``permissions_used`` / discovery scope), it is surfaced under
 from __future__ import annotations
 
 import logging
+import os
 import re
 from typing import Any, cast
 from urllib.parse import urlencode
@@ -70,7 +71,7 @@ _CIS_SECTIONS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("databricks", ("databricks_cis_benchmark", "databricks_cis_benchmark_data")),
 )
 
-_INVENTORY_PROVIDERS = ("aws", "azure", "gcp")
+_INVENTORY_PROVIDERS = ("aws", "azure", "gcp", "snowflake")
 _CIS_PROVIDERS = ("aws", "azure", "gcp", "snowflake")
 _REGION_RE = re.compile(r"[a-z]{2}(-gov)?-[a-z]+-\d{1,2}")
 _PROFILE_RE = re.compile(r"[a-zA-Z0-9._-]{1,100}")
@@ -157,6 +158,84 @@ def _audit_metadata(payloads: list[dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def _snowflake_inventory() -> tuple[dict[str, Any], dict[str, Any]]:
+    """Project Snowflake estate discovery into the canonical inventory summary.
+
+    Snowflake discovery returns a list of AI resources (Cortex agents / search
+    services, native MCP servers, notebooks, Streamlit apps, Snowpark package
+    environments) rather than the infra buckets/instances/roles/users the other
+    providers enumerate. To keep one consistent schema across providers, the
+    discovered resources are projected onto the identical summary fields the
+    aws/azure/gcp path emits (``_summarize_inventory_payload``): their count is
+    surfaced as ``resource_count`` while the infra ``node_summary`` keys stay
+    zero (Snowflake exposes none of those node types) and ``identity_count`` is
+    zero (IAM/role enumeration is a separate governance discovery, not part of
+    the inventory sweep).
+
+    Graceful degradation mirrors the CIS branch: a disabled inventory gate, an
+    absent ``snowflake-connector-python``, or missing account credentials yields
+    a clear non-``ok`` status with zero resources — never a raise, never a 500.
+
+    Returns ``(summary, raw_payload)`` where ``raw_payload`` carries the
+    ``discovery_envelope`` the shared ``_audit_metadata`` roll-up consumes.
+    """
+    from agent_bom.cloud import CloudDiscoveryError, snowflake
+
+    node_summary = {"buckets": 0, "instances": 0, "security_groups": 0, "roles": 0, "users": 0}
+
+    def _summary(status: str, account: str | None, resource_count: int, warning_count: int) -> dict[str, Any]:
+        return {
+            "provider": "snowflake",
+            "status": status,
+            "account": account,
+            "region": "",
+            "resource_count": resource_count,
+            "identity_count": 0,
+            "node_summary": dict(node_summary),
+            "warnings": (
+                [f"{warning_count} provider discovery warning(s) — run via CLI/MCP or see server logs for detail."]
+                if warning_count
+                else []
+            ),
+        }
+
+    if not snowflake.inventory_enabled():
+        # Opt-in per provider; symmetric with the aws/azure/gcp disabled path.
+        return _summary("disabled", None, 0, 0), {"status": "disabled", "discovery_envelope": None}
+
+    try:
+        agents, sf_warnings = snowflake.discover()
+    except CloudDiscoveryError:
+        # Connector absent — degrade to a clear "not configured" summary (HTTP
+        # 200), never a 500. Log a canonical literal only (no user string / no
+        # exception text) to avoid log injection + detail exposure.
+        _logger.warning("Snowflake inventory unavailable for %s", "snowflake")
+        return _summary("no_credentials", None, 0, 0), {"status": "no_credentials", "discovery_envelope": None}
+
+    account = os.environ.get("SNOWFLAKE_ACCOUNT", "").strip() or None
+    if agents:
+        status = "ok"
+    elif not account:
+        status = "no_credentials"  # enabled but not configured (no account/creds)
+    elif sf_warnings:
+        status = "partial"  # configured, but discovery could not complete cleanly
+    else:
+        status = "ok"
+
+    # Every agent carries the same run-level discovery envelope; surface the
+    # first for the read-only audit roll-up (permissions_used / scope).
+    envelope = None
+    for agent in agents:
+        candidate = getattr(agent, "discovery_envelope", None)
+        if isinstance(candidate, dict):
+            envelope = candidate
+            break
+
+    summary = _summary(status, account, len(agents), len(sf_warnings))
+    raw_payload = {"status": status, "account_id": account, "discovery_envelope": envelope, "warnings": sf_warnings}
+    return summary, raw_payload
+
+
 @router.get("/cloud/{provider}/inventory")
 async def cloud_inventory(
     request: Request,
@@ -166,11 +245,13 @@ async def cloud_inventory(
 ) -> dict[str, Any]:
     """Estate-wide cloud asset inventory summary for a provider (or ``all``).
 
-    Calls the same ``discover_inventory`` functions the CLI and MCP ``cloud_inventory``
-    tool use and reduces each provider payload to the identical non-secret count
-    shape (``_summarize_inventory_payload``). Each provider self-gates on its own
-    ``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider returns a
-    clear ``status`` and contributes zero nodes.
+    Calls the same ``discover_inventory`` / ``discover`` functions the CLI and MCP
+    ``cloud_inventory`` tool use and reduces each provider payload to the identical
+    non-secret count shape. ``aws`` | ``azure`` | ``gcp`` | ``snowflake`` (and
+    ``all``) are supported; Snowflake's AI-resource discovery is projected onto the
+    same summary fields (see ``_snowflake_inventory``). Each provider self-gates on
+    its own ``AGENT_BOM_*_INVENTORY`` env flag + credentials; a disabled provider
+    returns a clear ``status`` and contributes zero nodes.
     """
     tenant_id = _tenant(request)
     requested = provider.strip().lower()
@@ -206,6 +287,14 @@ async def cloud_inventory(
             payload = gcp_inventory.discover_inventory()
             raw_payloads.append(payload)
             summaries.append(_summarize_inventory_payload("gcp", payload))
+        if "snowflake" in selected:
+            # Snowflake discovery returns AI resources (Agents), not the infra
+            # payload the other providers emit, so it is projected onto the same
+            # canonical summary fields here rather than through
+            # _summarize_inventory_payload. Graceful when the gate/creds are absent.
+            sf_summary, sf_payload = _snowflake_inventory()
+            raw_payloads.append(sf_payload)
+            summaries.append(sf_summary)
 
         any_enabled = any(s["status"] != "disabled" for s in summaries)
         return {
@@ -218,8 +307,10 @@ async def cloud_inventory(
             "audit_metadata": _audit_metadata(raw_payloads),
             "note": (
                 "Estate-wide inventory is opt-in per provider via AGENT_BOM_CLOUD_INVENTORY / "
-                "AGENT_BOM_AZURE_INVENTORY / AGENT_BOM_GCP_INVENTORY. Reference-only counts; "
-                "no resource secrets are returned."
+                "AGENT_BOM_AZURE_INVENTORY / AGENT_BOM_GCP_INVENTORY / AGENT_BOM_SNOWFLAKE_INVENTORY. "
+                "Reference-only counts; no resource secrets are returned. For Snowflake, resource_count "
+                "reflects discovered AI resources (Cortex agents, MCP servers, notebooks); the infra "
+                "node_summary keys stay zero."
             ),
         }
     except HTTPException:

--- a/tests/api/test_api_cloud_surface_parity.py
+++ b/tests/api/test_api_cloud_surface_parity.py
@@ -101,13 +101,121 @@ def test_cloud_inventory_all_providers() -> None:
     resp = client.get("/v1/cloud/all/inventory", headers=_proxy_headers())
     assert resp.status_code == 200
     providers = [p["provider"] for p in resp.json()["providers"]]
-    assert providers == ["aws", "azure", "gcp"]
+    assert providers == ["aws", "azure", "gcp", "snowflake"]
 
 
-def test_cloud_inventory_unknown_provider_404() -> None:
+def test_cloud_inventory_unknown_provider_404_lists_snowflake() -> None:
     client = TestClient(app)
     resp = client.get("/v1/cloud/bogus/inventory", headers=_proxy_headers())
     assert resp.status_code == 404
+    # The 404 detail enumerates every supported provider, including snowflake.
+    assert "snowflake" in resp.json()["detail"]
+
+
+# --------------------------------------------------------------------------- #
+# Snowflake inventory over REST (closes #3967) — was a 404 before it was wired.
+# --------------------------------------------------------------------------- #
+
+
+def _canonical_summary_keys() -> set[str]:
+    return {"provider", "status", "account", "region", "resource_count", "identity_count", "node_summary", "warnings"}
+
+
+def test_cloud_inventory_snowflake_not_404() -> None:
+    # The route exists now; it must not 404 the way it did before #3967.
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/snowflake/inventory", headers=_proxy_headers())
+    assert resp.status_code == 200
+
+
+def test_cloud_inventory_snowflake_disabled_by_default(monkeypatch) -> None:
+    # Gate off (default): a clean "disabled" summary, zero resources, never a 500.
+    monkeypatch.delenv("AGENT_BOM_SNOWFLAKE_INVENTORY", raising=False)
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/snowflake/inventory", headers=_proxy_headers())
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schema_version"] == "cloud.inventory.summary.v1"
+    sf = body["providers"][0]
+    assert sf["provider"] == "snowflake"
+    assert sf["status"] == "disabled"
+    assert sf["resource_count"] == 0
+    assert set(sf) == _canonical_summary_keys()
+
+
+def test_cloud_inventory_snowflake_not_configured_when_enabled_without_creds(monkeypatch) -> None:
+    # Gate on but no account/creds and no connector -> "not configured" 200, not 500.
+    from agent_bom.cloud import CloudDiscoveryError, snowflake
+
+    monkeypatch.setenv("AGENT_BOM_SNOWFLAKE_INVENTORY", "1")
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+
+    def _no_connector(*_a, **_k):
+        raise CloudDiscoveryError("snowflake-connector-python is required")
+
+    monkeypatch.setattr(snowflake, "discover", _no_connector)
+
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/snowflake/inventory", headers=_proxy_headers())
+    assert resp.status_code == 200
+    sf = resp.json()["providers"][0]
+    assert sf["status"] == "no_credentials"
+    assert sf["resource_count"] == 0
+
+
+def test_cloud_inventory_snowflake_returns_canonical_shape_with_data(monkeypatch) -> None:
+    # Gate on + discovery yields resources -> "ok" with the canonical summary.
+    from agent_bom.cloud import snowflake
+    from agent_bom.discovery_envelope import RedactionStatus, ScanMode, attach_envelope_to_agents
+    from agent_bom.models import Agent, AgentType
+
+    monkeypatch.setenv("AGENT_BOM_SNOWFLAKE_INVENTORY", "1")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "myorg-acct")
+
+    def _fake_discover(*_a, **_k):
+        agents = [
+            Agent(name="cortex:analyst", agent_type=AgentType.CUSTOM, config_path="snowflake://myorg-acct/a", source="snowflake-cortex"),
+            Agent(name="mcp-server:data", agent_type=AgentType.CUSTOM, config_path="snowflake://myorg-acct/m", source="snowflake-mcp"),
+        ]
+        attach_envelope_to_agents(
+            agents,
+            scan_mode=ScanMode.SAAS_READ_ONLY,
+            discovery_scope=("snowflake:account/myorg-acct",),
+            permissions_used=("INFORMATION_SCHEMA.AGENTS:SELECT",),
+            redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
+        )
+        return agents, []
+
+    monkeypatch.setattr(snowflake, "discover", _fake_discover)
+
+    client = TestClient(app)
+    resp = client.get("/v1/cloud/snowflake/inventory", headers=_proxy_headers())
+    assert resp.status_code == 200
+    body = resp.json()
+    sf = body["providers"][0]
+    assert set(sf) == _canonical_summary_keys()
+    assert sf["provider"] == "snowflake"
+    assert sf["status"] == "ok"
+    assert sf["resource_count"] == 2
+    assert sf["identity_count"] == 0
+    assert sf["node_summary"] == {"buckets": 0, "instances": 0, "security_groups": 0, "roles": 0, "users": 0}
+    assert body["total_resources"] == 2
+    # The discovery envelope is rolled into the read-only audit block.
+    assert "INFORMATION_SCHEMA.AGENTS:SELECT" in body["audit_metadata"]["permissions_used"]
+    assert "snowflake:account/myorg-acct" in body["audit_metadata"]["discovery_scope"]
+
+
+def test_cloud_inventory_snowflake_shape_matches_other_providers(monkeypatch) -> None:
+    # Snowflake's per-provider summary must carry the exact same field set as aws.
+    from agent_bom.cloud import snowflake
+
+    monkeypatch.setenv("AGENT_BOM_SNOWFLAKE_INVENTORY", "1")
+    monkeypatch.setattr(snowflake, "discover", lambda *a, **k: ([], []))
+
+    client = TestClient(app)
+    body = client.get("/v1/cloud/all/inventory", headers=_proxy_headers()).json()
+    by_provider = {p["provider"]: p for p in body["providers"]}
+    assert set(by_provider["snowflake"]) == set(by_provider["aws"])
 
 
 def test_cloud_inventory_bad_region_400() -> None:


### PR DESCRIPTION
Closes #3967.

## What

`GET /v1/cloud/snowflake/inventory` (and `/v1/cloud/all/inventory`) returned **404** because `snowflake` was missing from `_INVENTORY_PROVIDERS` in `api/routes/cloud.py`, even though Snowflake estate discovery already exists (`cloud/snowflake.py::discover` / `inventory_enabled`) and the CIS REST branch already supported it. This wires Snowflake into the inventory endpoint so REST reaches parity with the CLI/MCP surfaces.

## How

- Add `"snowflake"` to `_INVENTORY_PROVIDERS` — the route now resolves and the unsupported-provider `404` detail enumerates snowflake.
- **Payload-shape mapping:** the aws/azure/gcp providers return an infra payload (`buckets`/`instances`/`security_groups`/`roles`/`users`) reduced by `_summarize_inventory_payload`. `snowflake.discover()` instead returns AI-resource `Agent` objects (Cortex agents/search, native MCP servers, notebooks, Streamlit apps, Snowpark package environments). `_snowflake_inventory()` projects those onto the **identical** canonical summary field set: the discovered resource count becomes `resource_count`, the infra `node_summary` keys stay zero (Snowflake exposes none of those node types), and `identity_count` is `0` (IAM/role enumeration is a separate governance discovery). One consistent schema across all four providers — no snowflake-specific fields leak.
- **Graceful degradation** mirrors the CIS branch — always HTTP 200, never a 500/crash:
  - gate off (default) -> `status: disabled`, zero resources, no discovery call
  - `snowflake-connector-python` absent (`CloudDiscoveryError`) -> `status: no_credentials`
  - enabled but no account/creds -> `status: no_credentials`
  - configured but discovery incomplete -> `status: partial`
- Surface the run-level discovery envelope (`permissions_used` / `discovery_scope`) into the shared read-only `audit_metadata` roll-up.
- Same tenant + `scan`-role gate as the other inventory providers (no auth bypass).
- Regenerated `docs/openapi/{v1.yaml,v1.json}` and updated the endpoint note/docstring.

## Scope / issue closure

The other two items of #3967 (exec score-saturation and SPDX-3.0.1 validity) were already fixed on `main`; this REST wiring was the last open piece, so it closes the issue.

## Tests

Added to `tests/api/test_api_cloud_surface_parity.py`: snowflake inventory returns **200** (not 404); canonical shape with data (mocked `discover`); clean `no_credentials` when creds/connector absent; envelope rolled into `audit_metadata`; `all` includes snowflake; per-provider field set matches aws; 404 detail lists snowflake.

- `pytest tests/api/test_api_cloud_surface_parity.py -q` -> 32 passed
- `pytest tests/ -k "cloud and (inventory or snowflake)" -q` -> 166 passed, 2 skipped
- `pytest tests/ -k "snowflake" -q` -> 403 passed, 2 skipped (no CIS/discovery regression)
- `scripts/check-counts.py` -> consistent; `make preflight` -> passed
- `ruff` + `mypy` on `api/routes/cloud.py` -> clean

