### PR TITLE
chore(ui): README brand logo parity + pre-fill scan preset from URL + light-theme token verify (#3966)

### DIFF
--- a/docs/images/brand/logo-dark.svg
+++ b/docs/images/brand/logo-dark.svg
@@ -1,44 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" fill="none" role="img" aria-label="agent-bom — agent in the BOM">
-  <g transform="translate(8, 6) scale(0.84)">
-
   <defs>
     <linearGradient id="abg" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#34d399"/>
       <stop offset="100%" stop-color="#06b6d4"/>
     </linearGradient>
   </defs>
-  <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abg)" stroke-width="2"/>
-  <!-- B -->
-  <path fill="url(#abg)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- Detailed agent as the O: helmet + visor + side sensors + jaw + antenna -->
-  <circle cx="32" cy="30.2" r="12.2" fill="none" stroke="url(#abg)" stroke-width="2.2"/>
-  <!-- helmet fill -->
-  <path fill="#111a17" stroke="url(#abg)" stroke-width="1.15"
-        d="M22.8 30.2c0-5.1 4.1-9.2 9.2-9.2s9.2 4.1 9.2 9.2c0 2.55-1.05 4.85-2.7 6.5l-1.4 1.35c-.7.65-1.7 1.05-2.75 1.05h-4.7c-1.05 0-2.05-.4-2.75-1.05l-1.4-1.35a9.15 9.15 0 0 1-2.7-6.5z"/>
-  <!-- visor band -->
-  <rect x="24.2" y="26.2" width="15.6" height="5.2" rx="2.2" fill="#0c1210" stroke="url(#abg)" stroke-width="1"/>
-  <!-- eyes -->
-  <rect x="25.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#34d399"/>
-  <rect x="33.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#06b6d4"/>
-  <!-- eye glow dots -->
-  <circle cx="27.2" cy="28.8" r="0.7" fill="#ecfdf5"/>
-  <circle cx="35.2" cy="28.8" r="0.7" fill="#ecfeff"/>
-  <!-- jaw / status bar -->
-  <path d="M26.2 35.4h11.6" fill="none" stroke="url(#abg)" stroke-width="1.8" stroke-linecap="round"/>
-  <path d="M28.2 37.6h7.6" fill="none" stroke="#06b6d4" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/>
-  <!-- side sensors -->
-  <path d="M21.4 29.2h1.8M40.8 29.2h1.8" stroke="url(#abg)" stroke-width="1.5" stroke-linecap="round"/>
-  <!-- antenna -->
-  <path d="M32 18.8V13.8" stroke="url(#abg)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.2" r="2.1" fill="url(#abg)"/>
-  <circle cx="32" cy="12.2" r="0.85" fill="#0c1210"/>
-  <!-- M -->
-  <path fill="url(#abg)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
-  <!-- materials ticks -->
-  <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#34d399" fill-opacity="0.45"/>
-  <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abg)"/>
-  <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#06b6d4" fill-opacity="0.45"/>
-
+  <g transform="translate(8, 6) scale(0.84)">
+    <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abg)" stroke-width="2"/>
+    <!-- B -->
+    <path fill="url(#abg)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
+    <!-- O as the agent HUD: ring-as-head + antenna + two eyes + mouth (matches platform mark) -->
+    <circle cx="32" cy="30.2" r="12" fill="#0f1a17" stroke="url(#abg)" stroke-width="2.4"/>
+    <path d="M32 18.4V13.5" stroke="url(#abg)" stroke-width="2.2" stroke-linecap="round"/>
+    <circle cx="32" cy="11.9" r="2.1" fill="url(#abg)"/>
+    <circle cx="28" cy="28.9" r="2.7" fill="#34d399"/>
+    <circle cx="36" cy="28.9" r="2.7" fill="#22d3ee"/>
+    <path d="M28.3 35.4h7.4" stroke="url(#abg)" stroke-width="1.9" stroke-linecap="round"/>
+    <!-- M -->
+    <path fill="url(#abg)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
+    <!-- materials ticks -->
+    <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#34d399" fill-opacity="0.45"/>
+    <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abg)"/>
+    <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#06b6d4" fill-opacity="0.45"/>
   </g>
   <text x="88" y="46" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#e6edf3">agent<tspan fill="url(#abg)">·bom</tspan></text>
 </svg>

--- a/docs/images/brand/logo-light.svg
+++ b/docs/images/brand/logo-light.svg
@@ -1,36 +1,27 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" fill="none" role="img" aria-label="agent-bom — agent in the BOM">
-  <g transform="translate(8, 6) scale(0.84)">
-
   <defs>
     <linearGradient id="abg" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#059669"/>
       <stop offset="100%" stop-color="#0891b2"/>
     </linearGradient>
   </defs>
-  <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abg)" stroke-width="2"/>
-  <!-- B -->
-  <path fill="url(#abg)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- Detailed agent as the O -->
-  <circle cx="32" cy="30.2" r="12.2" fill="none" stroke="url(#abg)" stroke-width="2.2"/>
-  <path fill="#ecfdf5" stroke="url(#abg)" stroke-width="1.15"
-        d="M22.8 30.2c0-5.1 4.1-9.2 9.2-9.2s9.2 4.1 9.2 9.2c0 2.55-1.05 4.85-2.7 6.5l-1.4 1.35c-.7.65-1.7 1.05-2.75 1.05h-4.7c-1.05 0-2.05-.4-2.75-1.05l-1.4-1.35a9.15 9.15 0 0 1-2.7-6.5z"/>
-  <rect x="24.2" y="26.2" width="15.6" height="5.2" rx="2.2" fill="#f8fafc" stroke="url(#abg)" stroke-width="1"/>
-  <rect x="25.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#059669"/>
-  <rect x="33.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#0891b2"/>
-  <circle cx="27.2" cy="28.8" r="0.7" fill="#ffffff"/>
-  <circle cx="35.2" cy="28.8" r="0.7" fill="#ffffff"/>
-  <path d="M26.2 35.4h11.6" fill="none" stroke="url(#abg)" stroke-width="1.8" stroke-linecap="round"/>
-  <path d="M28.2 37.6h7.6" fill="none" stroke="#0891b2" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/>
-  <path d="M21.4 29.2h1.8M40.8 29.2h1.8" stroke="url(#abg)" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M32 18.8V13.8" stroke="url(#abg)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.2" r="2.1" fill="url(#abg)"/>
-  <circle cx="32" cy="12.2" r="0.85" fill="#f8fafc"/>
-  <!-- M -->
-  <path fill="url(#abg)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
-  <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#059669" fill-opacity="0.4"/>
-  <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abg)"/>
-  <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#0891b2" fill-opacity="0.4"/>
-
+  <g transform="translate(8, 6) scale(0.84)">
+    <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abg)" stroke-width="2"/>
+    <!-- B -->
+    <path fill="url(#abg)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
+    <!-- O as the agent HUD: ring-as-head + antenna + two eyes + mouth (matches platform mark) -->
+    <circle cx="32" cy="30.2" r="12" fill="#ecfdf5" stroke="url(#abg)" stroke-width="2.4"/>
+    <path d="M32 18.4V13.5" stroke="url(#abg)" stroke-width="2.2" stroke-linecap="round"/>
+    <circle cx="32" cy="11.9" r="2.1" fill="url(#abg)"/>
+    <circle cx="28" cy="28.9" r="2.7" fill="#059669"/>
+    <circle cx="36" cy="28.9" r="2.7" fill="#0891b2"/>
+    <path d="M28.3 35.4h7.4" stroke="url(#abg)" stroke-width="1.9" stroke-linecap="round"/>
+    <!-- M -->
+    <path fill="url(#abg)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
+    <!-- materials ticks -->
+    <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#059669" fill-opacity="0.4"/>
+    <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abg)"/>
+    <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#0891b2" fill-opacity="0.4"/>
   </g>
   <text x="88" y="46" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#1f2937">agent<tspan fill="url(#abg)">·bom</tspan></text>
 </svg>

--- a/docs/images/logo-dark.svg
+++ b/docs/images/logo-dark.svg
@@ -1,44 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="3 1 267 64" fill="none" role="img" aria-label="agent-bom — agent in the BOM">
-  <g transform="translate(8, 6) scale(0.84)">
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" fill="none" role="img" aria-label="agent-bom — agent in the BOM">
   <defs>
     <linearGradient id="abg" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#34d399"/>
       <stop offset="100%" stop-color="#06b6d4"/>
     </linearGradient>
   </defs>
-  <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abg)" stroke-width="2"/>
-  <!-- B -->
-  <path fill="url(#abg)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- Detailed agent as the O: helmet + visor + side sensors + jaw + antenna -->
-  <circle cx="32" cy="30.2" r="12.2" fill="none" stroke="url(#abg)" stroke-width="2.2"/>
-  <!-- helmet fill -->
-  <path fill="#111a17" stroke="url(#abg)" stroke-width="1.15"
-        d="M22.8 30.2c0-5.1 4.1-9.2 9.2-9.2s9.2 4.1 9.2 9.2c0 2.55-1.05 4.85-2.7 6.5l-1.4 1.35c-.7.65-1.7 1.05-2.75 1.05h-4.7c-1.05 0-2.05-.4-2.75-1.05l-1.4-1.35a9.15 9.15 0 0 1-2.7-6.5z"/>
-  <!-- visor band -->
-  <rect x="24.2" y="26.2" width="15.6" height="5.2" rx="2.2" fill="#0c1210" stroke="url(#abg)" stroke-width="1"/>
-  <!-- eyes -->
-  <rect x="25.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#34d399"/>
-  <rect x="33.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#06b6d4"/>
-  <!-- eye glow dots -->
-  <circle cx="27.2" cy="28.8" r="0.7" fill="#ecfdf5"/>
-  <circle cx="35.2" cy="28.8" r="0.7" fill="#ecfeff"/>
-  <!-- jaw / status bar -->
-  <path d="M26.2 35.4h11.6" fill="none" stroke="url(#abg)" stroke-width="1.8" stroke-linecap="round"/>
-  <path d="M28.2 37.6h7.6" fill="none" stroke="#06b6d4" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/>
-  <!-- side sensors -->
-  <path d="M21.4 29.2h1.8M40.8 29.2h1.8" stroke="url(#abg)" stroke-width="1.5" stroke-linecap="round"/>
-  <!-- antenna -->
-  <path d="M32 18.8V13.8" stroke="url(#abg)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.2" r="2.1" fill="url(#abg)"/>
-  <circle cx="32" cy="12.2" r="0.85" fill="#0c1210"/>
-  <!-- M -->
-  <path fill="url(#abg)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
-  <!-- materials ticks -->
-  <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#34d399" fill-opacity="0.45"/>
-  <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abg)"/>
-  <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#06b6d4" fill-opacity="0.45"/>
-
+  <g transform="translate(8, 6) scale(0.84)">
+    <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abg)" stroke-width="2"/>
+    <!-- B -->
+    <path fill="url(#abg)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
+    <!-- O as the agent HUD: ring-as-head + antenna + two eyes + mouth (matches platform mark) -->
+    <circle cx="32" cy="30.2" r="12" fill="#0f1a17" stroke="url(#abg)" stroke-width="2.4"/>
+    <path d="M32 18.4V13.5" stroke="url(#abg)" stroke-width="2.2" stroke-linecap="round"/>
+    <circle cx="32" cy="11.9" r="2.1" fill="url(#abg)"/>
+    <circle cx="28" cy="28.9" r="2.7" fill="#34d399"/>
+    <circle cx="36" cy="28.9" r="2.7" fill="#22d3ee"/>
+    <path d="M28.3 35.4h7.4" stroke="url(#abg)" stroke-width="1.9" stroke-linecap="round"/>
+    <!-- M -->
+    <path fill="url(#abg)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
+    <!-- materials ticks -->
+    <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#34d399" fill-opacity="0.45"/>
+    <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abg)"/>
+    <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#06b6d4" fill-opacity="0.45"/>
   </g>
-  <text x="82" y="46" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#e6edf3">agent<tspan fill="url(#abg)">·bom</tspan></text>
+  <text x="88" y="46" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#e6edf3">agent<tspan fill="url(#abg)">·bom</tspan></text>
 </svg>

--- a/docs/images/logo-light.svg
+++ b/docs/images/logo-light.svg
@@ -1,36 +1,27 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="3 1 267 64" fill="none" role="img" aria-label="agent-bom — agent in the BOM">
-  <g transform="translate(8, 6) scale(0.84)">
-
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 72" fill="none" role="img" aria-label="agent-bom — agent in the BOM">
   <defs>
     <linearGradient id="abg" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
       <stop offset="0%" stop-color="#059669"/>
       <stop offset="100%" stop-color="#0891b2"/>
     </linearGradient>
   </defs>
-  <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abg)" stroke-width="2"/>
-  <!-- B -->
-  <path fill="url(#abg)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
-  <!-- Detailed agent as the O -->
-  <circle cx="32" cy="30.2" r="12.2" fill="none" stroke="url(#abg)" stroke-width="2.2"/>
-  <path fill="#ecfdf5" stroke="url(#abg)" stroke-width="1.15"
-        d="M22.8 30.2c0-5.1 4.1-9.2 9.2-9.2s9.2 4.1 9.2 9.2c0 2.55-1.05 4.85-2.7 6.5l-1.4 1.35c-.7.65-1.7 1.05-2.75 1.05h-4.7c-1.05 0-2.05-.4-2.75-1.05l-1.4-1.35a9.15 9.15 0 0 1-2.7-6.5z"/>
-  <rect x="24.2" y="26.2" width="15.6" height="5.2" rx="2.2" fill="#f8fafc" stroke="url(#abg)" stroke-width="1"/>
-  <rect x="25.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#059669"/>
-  <rect x="33.4" y="27.1" width="5.2" height="3.4" rx="1" fill="#0891b2"/>
-  <circle cx="27.2" cy="28.8" r="0.7" fill="#ffffff"/>
-  <circle cx="35.2" cy="28.8" r="0.7" fill="#ffffff"/>
-  <path d="M26.2 35.4h11.6" fill="none" stroke="url(#abg)" stroke-width="1.8" stroke-linecap="round"/>
-  <path d="M28.2 37.6h7.6" fill="none" stroke="#0891b2" stroke-width="1.2" stroke-linecap="round" opacity="0.7"/>
-  <path d="M21.4 29.2h1.8M40.8 29.2h1.8" stroke="url(#abg)" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M32 18.8V13.8" stroke="url(#abg)" stroke-width="2.2" stroke-linecap="round"/>
-  <circle cx="32" cy="12.2" r="2.1" fill="url(#abg)"/>
-  <circle cx="32" cy="12.2" r="0.85" fill="#f8fafc"/>
-  <!-- M -->
-  <path fill="url(#abg)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
-  <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#059669" fill-opacity="0.4"/>
-  <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abg)"/>
-  <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#0891b2" fill-opacity="0.4"/>
-
+  <g transform="translate(8, 6) scale(0.84)">
+    <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#f8fafc" stroke="url(#abg)" stroke-width="2"/>
+    <!-- B -->
+    <path fill="url(#abg)" d="M7.5 16.5h7.4c3.7 0 5.9 1.9 5.9 4.7 0 1.9-1.05 3.25-2.75 3.95 2 .8 3.3 2.35 3.3 4.7 0 3.05-2.45 4.95-6.45 4.95H7.5V16.5zm3.65 3.1v4.7h2.8c1.7 0 2.7-.85 2.7-2.35s-1.1-2.35-2.95-2.35H11.15zm0 7.55v5h3.15c1.85 0 3-.95 3-2.55s-1.1-2.45-3.05-2.45H11.15z"/>
+    <!-- O as the agent HUD: ring-as-head + antenna + two eyes + mouth (matches platform mark) -->
+    <circle cx="32" cy="30.2" r="12" fill="#ecfdf5" stroke="url(#abg)" stroke-width="2.4"/>
+    <path d="M32 18.4V13.5" stroke="url(#abg)" stroke-width="2.2" stroke-linecap="round"/>
+    <circle cx="32" cy="11.9" r="2.1" fill="url(#abg)"/>
+    <circle cx="28" cy="28.9" r="2.7" fill="#059669"/>
+    <circle cx="36" cy="28.9" r="2.7" fill="#0891b2"/>
+    <path d="M28.3 35.4h7.4" stroke="url(#abg)" stroke-width="1.9" stroke-linecap="round"/>
+    <!-- M -->
+    <path fill="url(#abg)" d="M44.5 16.5h3.7l3.75 11.7 3.75-11.7H59.5v19.6h-3.3V27.8l-3.65 8.5h-2.95l-3.5-8.5v8.5h-3.3V16.5h1.7z"/>
+    <!-- materials ticks -->
+    <rect x="10" y="48.5" width="12" height="2.4" rx="1.2" fill="#059669" fill-opacity="0.4"/>
+    <rect x="26" y="48.5" width="12" height="2.4" rx="1.2" fill="url(#abg)"/>
+    <rect x="42" y="48.5" width="12" height="2.4" rx="1.2" fill="#0891b2" fill-opacity="0.4"/>
   </g>
-  <text x="82" y="46" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#1f2937">agent<tspan fill="url(#abg)">·bom</tspan></text>
+  <text x="88" y="46" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif" font-size="34" font-weight="800" letter-spacing="-0.5" fill="#1f2937">agent<tspan fill="url(#abg)">·bom</tspan></text>
 </svg>

--- a/ui/app/scan/page.tsx
+++ b/ui/app/scan/page.tsx
@@ -21,7 +21,12 @@ function ScanRouter() {
   if (id && view === "attack-flow") return <AttackFlowView id={id} />;
   if (id && view === "mesh") return <ScanMeshView id={id} />;
   if (id) return <ScanResultView id={id} />;
-  return <ScanForm initialConnectionId={searchParams.get("connection") || undefined} />;
+  return (
+    <ScanForm
+      initialConnectionId={searchParams.get("connection") || undefined}
+      initialPreset={searchParams.get("preset") || undefined}
+    />
+  );
 }
 
 export default function ScanPage() {

--- a/ui/components/scan-form.tsx
+++ b/ui/components/scan-form.tsx
@@ -39,7 +39,21 @@ import { REPO_SCAN_SURFACES, repoScanLanguageSummary } from "@/lib/repo-scan-sur
 
 type ScanFormProps = {
   initialConnectionId?: string | undefined;
+  /**
+   * Optional preset carried in the URL (``/scan?preset=enterprise``) by the
+   * in-product "Run introspection scan" actions. It pre-fills the form to the
+   * equivalent of the ``agent-bom scan --introspect --preset enterprise`` CLI:
+   * an ad-hoc workstation introspection scan with enrichment on. Absent or
+   * unknown values leave the normal defaults untouched.
+   */
+  initialPreset?: string | undefined;
 };
+
+/** ``enterprise`` mirrors ``--introspect --preset enterprise``: an ad-hoc
+ * workstation introspection scan with CVSS/EPSS/KEV enrichment enabled. */
+function isEnterprisePreset(preset: string | undefined): boolean {
+  return preset === "enterprise";
+}
 
 /** Client-side guard: accept only well-formed ``http(s)://<host>`` repo URLs
  * before enabling submit. Server-side validation remains authoritative. */
@@ -56,12 +70,19 @@ function isHttpRepoUrl(value: string): boolean {
   return Boolean(parsed.hostname) && parsed.hostname.includes(".");
 }
 
-export function ScanForm({ initialConnectionId }: ScanFormProps) {
+export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) {
   const router = useRouter();
   const { counts } = useDeploymentContext();
   const deploymentMode = counts?.deployment_mode ?? "local";
+  const enterprisePreset = isEnterprisePreset(initialPreset);
   const [scanMode, setScanMode] = useState<ScanMode>(
-    initialConnectionId ? "connected" : deploymentMode === "local" ? "adhoc" : "connected",
+    initialConnectionId
+      ? "connected"
+      : enterprisePreset
+        ? "adhoc"
+        : deploymentMode === "local"
+          ? "adhoc"
+          : "connected",
   );
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
@@ -76,7 +97,7 @@ export function ScanForm({ initialConnectionId }: ScanFormProps) {
     deploymentMode === "local" ? "workstation" : "workstation",
   );
   const [form, setForm] = useState<ScanRequest>({
-    enrich: false,
+    enrich: enterprisePreset,
     k8s: false,
     images: [],
     tf_dirs: [],

--- a/ui/lib/deployment-context.ts
+++ b/ui/lib/deployment-context.ts
@@ -99,7 +99,7 @@ const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition
     isAvailable: (counts) => bool(counts?.has_mesh),
     requirement: "Completed scans with agent and runtime relationship context",
     command: "agent-bom scan --introspect --preset enterprise",
-    actionHref: "/scan",
+    actionHref: "/scan?preset=enterprise",
     actionLabel: "Run introspection scan",
     capabilities: [
       "Shared infrastructure across agents, tools, packages, and findings",
@@ -115,7 +115,7 @@ const SURFACE_DEFINITIONS: Record<DeploymentSurface, DeploymentSurfaceDefinition
     isAvailable: (counts) => bool(counts?.has_mcp_context),
     requirement: "MCP and agent context from completed scans",
     command: "agent-bom scan --introspect --preset enterprise",
-    actionHref: "/scan",
+    actionHref: "/scan?preset=enterprise",
     actionLabel: "Run introspection scan",
     capabilities: [
       "Lateral path analysis across agents, credentials, tools, and servers",

--- a/ui/tests/integration-required-state.test.tsx
+++ b/ui/tests/integration-required-state.test.tsx
@@ -36,7 +36,7 @@ describe("DeploymentSurfaceRequiredState", () => {
       has_mesh: false,
       deployment_mode: "local",
     } as never);
-    expect(state.actionHref).toBe("/scan");
+    expect(state.actionHref).toBe("/scan?preset=enterprise");
 
     render(
       <DeploymentSurfaceRequiredState
@@ -47,7 +47,7 @@ describe("DeploymentSurfaceRequiredState", () => {
 
     expect(screen.getByRole("link", { name: /Run introspection scan/ })).toHaveAttribute(
       "href",
-      "/scan",
+      "/scan?preset=enterprise",
     );
     expect(
       screen.getByText("agent-bom scan --introspect --preset enterprise"),

--- a/ui/tests/scan-form.test.tsx
+++ b/ui/tests/scan-form.test.tsx
@@ -80,6 +80,36 @@ describe("ScanForm", () => {
     expect(screen.getByText("Prod AWS")).toBeInTheDocument();
   });
 
+  it("pre-fills the enterprise introspection preset from the URL", async () => {
+    render(<ScanForm initialPreset="enterprise" />);
+
+    // Enterprise preset lands on the ad-hoc workstation introspection scan…
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: "Ad-hoc" })).toHaveAttribute(
+        "aria-selected",
+        "true",
+      );
+    });
+    expect(screen.getByRole("tab", { name: /Workstation/i })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    // …with enrichment turned on, mirroring `--preset enterprise`.
+    expect(
+      screen.getByRole("checkbox", { name: /Enrich with CVSS/i }),
+    ).toBeChecked();
+  });
+
+  it("leaves enrichment off when no preset is present", async () => {
+    const user = userEvent.setup();
+    render(<ScanForm />);
+
+    await user.click(screen.getByRole("tab", { name: "Ad-hoc" }));
+    expect(
+      screen.getByRole("checkbox", { name: /Enrich with CVSS/i }),
+    ).not.toBeChecked();
+  });
+
   it("shows ad-hoc scope chips and starts a direct scan job", async () => {
     const user = userEvent.setup();
     const startScan = vi.spyOn(api, "startScan").mockResolvedValue({


### PR DESCRIPTION
Three small, related UI-polish changes. No issue is opened by the first two; the third closes the light-theme readability item.

## 1. README hero logo = platform brand mark
The README hero pointed at an older **outline** BOM mark (thin outline O with a helmet/visor/jaw robot face — busy at small sizes). The platform header uses the **clean filled** mark (`ui/public/brand/mark-*.svg`): a ring-as-head O with an antenna, two filled eyes, and a mouth line.

Regenerated the composed logos the README already references (`docs/images/logo-{dark,light}.svg`, plus the `docs/images/brand/logo-{dark,light}.svg` copies) so the O now matches the platform mark exactly — same geometry, same gradient stops (`#34d399 → #06b6d4` dark, `#059669 → #0891b2` light), same eye colors. The `agent·bom` wordmark, the `<picture>` dark/light switch, and the width are unchanged, so the README path is untouched and the `raw.githubusercontent.com/.../docs/images/logo-*.svg` URLs resolve post-merge. Both variants validate as standalone SVGs (`xmllint`, proper `viewBox`, no external refs).

## 2. In-product scan buttons pre-fill the preset
PR #3997 added "Run a scan" / "Run introspection scan" buttons on empty states that open `/scan`, but they landed on a blank form. `ScanForm` now reads a `preset` query param (threaded through the scan page's existing `useSearchParams`, same pattern as `connection`→`initialConnectionId`). `/scan?preset=enterprise` pre-fills the ad-hoc **Workstation** introspection scan with **enrichment on**, mirroring the `agent-bom scan --introspect --preset enterprise` CLI shown alongside. No param → unchanged defaults.

The mesh and context "Run introspection scan" actions now link to `/scan?preset=enterprise`; the headless CLI snippet stays visible beside the button.

## 3. Light-theme readability sweep — Closes #3966
#3966's other parts (exec→graph drill scanId, drawer Close z-index) are already fixed on main. The remaining piece was the hardcoded-neutral → semantic-token sweep for the light theme.

**Verification finding:** that sweep has already landed on main. An exhaustive grep of `ui/` for neutral color utilities (`zinc/slate/gray/neutral/stone` across `bg/text/border/ring/from/to/via/divide/fill/stroke/...`, incl. `dark:` variants, arbitrary `-[#hex]`, and inline `style` hex) returns **0 hardcoded neutral surface / body-text / border classes** (before/after: ~1997 → 0 for surfaces). `globals.css` already carries the `#3966` completion marker.

The only residual neutral literals are in the task's explicit "leave" bucket and were intentionally not touched:
- `nav.tsx` `/audit` → `text-stone-400`: one of 14 decorative per-route icon accents (purple/indigo/orange/pink/…); a category accent, not a surface.
- `exposure-path-command-center.tsx` `unknown` entity tint (`…slate-500/10 text-slate-200`): the neutral member of a 9-entry category-tint map whose siblings are emerald/sky/amber/red/… — the status/category color family.
- `agent-topology.tsx` legend swatch `bg-slate-400/80`: the "inventory" category swatch beside amber (credentials) and red (CVE evidence).
- `sigma-graph-overview.tsx` / `exposure-path` graph canvas `bg-[#050505]` / `bg-[#05070b]` and graph-node/legend hex colors: intentionally dark data-viz viewports; retinting would hurt node contrast.

Forcing any of these to surface tokens would break the consistent per-route accent system / graph legibility and change visual behavior, which the sweep guidance excludes. Net: #3966's readability acceptance bar (no invisible text, no black-on-black / white-on-white chips) is met by already-merged token work; this PR verifies and documents it. No color diffs were introduced, so the token-based light theme is unchanged.

## Verify
- `npm run build`: clean.
- `vitest`: 542 passed (104 files), incl. new `ScanForm` preset tests (`?preset=enterprise` selects ad-hoc + Workstation + enrichment; no param → enrichment off) and the updated mesh-action href assertion (`/scan?preset=enterprise`).
- `node scripts/check-bundle-budget.mjs`: PASS (client JS 3272.6 / 3300 KiB — no meaningful growth).
- ESLint clean on touched files.

Re: epic #3931 — this PR plus already-merged work covers the brand-consistency and in-product-scan follow-ups; leaving the epic open for a maintainer to confirm the remaining criteria rather than auto-closing.
