### PR TITLE
feat(observability): security-eval scorecard + observe→enforce block-rule proposals

### DIFF
--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -18,6 +18,9 @@ This page is the canonical runtime surface map. The detail docs:
 - [`RUNTIME_PROXY_AUDIT_JSONL.md`](RUNTIME_PROXY_AUDIT_JSONL.md) — the proxy
   audit JSONL record format for SIEM forwarding and release evidence
 - `docs/POLICY_PRECEDENCE.md` — policy-layer ordering inside a single tool-call
+- [`design/OBSERVE_ENFORCE.md`](design/OBSERVE_ENFORCE.md) — security-eval
+  scorecard + the observe→enforce bridge that turns runtime↔scan correlation
+  into audit-mode gateway block-rule proposals (enforce only on explicit opt-in)
 
 ## Which surface owns which decision
 

--- a/docs/accuracy-baseline.json
+++ b/docs/accuracy-baseline.json
@@ -98,5 +98,86 @@
       "graph reachability precision for every framework and dynamic import path"
     ],
     "release_gate": true
+  },
+  "security_eval_scorecard": {
+    "attack_cases": 23,
+    "attacks_run": 25,
+    "benign_cases": 2,
+    "catalog_size": 25,
+    "coverage_pct": 100.0,
+    "detected": 23,
+    "detection_rate": 100.0,
+    "eval_name": "red-team-adversarial-coverage",
+    "eval_type": "security",
+    "false_positive_rate": 0.0,
+    "false_positives": 0,
+    "missed": 0,
+    "passed": true,
+    "per_category": {
+      "benign": {
+        "detected": 0,
+        "failed": 0,
+        "pass": true,
+        "passed": 2,
+        "total": 2
+      },
+      "bias": {
+        "detected": 2,
+        "failed": 0,
+        "pass": true,
+        "passed": 2,
+        "total": 2
+      },
+      "credential_leak": {
+        "detected": 3,
+        "failed": 0,
+        "pass": true,
+        "passed": 3,
+        "total": 3
+      },
+      "data_exfiltration": {
+        "detected": 1,
+        "failed": 0,
+        "pass": true,
+        "passed": 1,
+        "total": 1
+      },
+      "hallucination": {
+        "detected": 2,
+        "failed": 0,
+        "pass": true,
+        "passed": 2,
+        "total": 2
+      },
+      "prompt_injection": {
+        "detected": 5,
+        "failed": 0,
+        "pass": true,
+        "passed": 5,
+        "total": 5
+      },
+      "response_manipulation": {
+        "detected": 3,
+        "failed": 0,
+        "pass": true,
+        "passed": 3,
+        "total": 3
+      },
+      "tool_abuse": {
+        "detected": 5,
+        "failed": 0,
+        "pass": true,
+        "passed": 5,
+        "total": 5
+      },
+      "toxicity": {
+        "detected": 2,
+        "failed": 0,
+        "pass": true,
+        "passed": 2,
+        "total": 2
+      }
+    },
+    "schema_version": "security-eval-scorecard/v1"
   }
 }

--- a/docs/design/OBSERVE_ENFORCE.md
+++ b/docs/design/OBSERVE_ENFORCE.md
@@ -1,0 +1,119 @@
+# Observability → enforcement: security-eval scorecard + observe→enforce bridge
+
+Two capabilities that turn what agent-bom *observes* about AI-agent runtime
+behaviour into governance evidence and gateway policy, without adding any new
+HTTP surface. Both ride existing outputs.
+
+- **Security-eval scorecard** — packages a red-team run as a structured eval
+  artifact that sits alongside quality/accuracy evals.
+- **Observe→enforce bridge** — turns runtime↔scan correlation (tools that are
+  *both* confirmed-vulnerable *and* actively invoked) into gateway block-rule
+  proposals.
+
+---
+
+## 1. Security-eval scorecard
+
+`agent_bom.security_eval_scorecard.build_security_eval_scorecard()` runs the
+curated red-team attack catalog (`agent_bom.red_team`) through Shield and
+packages the result as a schema-versioned artifact (`security-eval-scorecard/v1`).
+
+It reports the three facets governance reviewers ask for:
+
+| Facet | Field | Meaning |
+|---|---|---|
+| **Coverage %** | `coverage_pct` | `attacks_run / catalog_size` — a partial run scores below 100 %. |
+| **False-positive rate** | `false_positive_rate`, `false_positives` | Benign cases that tripped a detector. |
+| **Per-category pass/fail** | `per_category[cat]` | `{total, detected, passed, failed, pass}` per attack category. |
+
+The artifact is **deterministic** (no clock, no randomness, offline — no LLM),
+so it is safe inside release gates and diff-friendly.
+
+`eval_type: "security"` marks it as a security eval so it can sit alongside
+quality evals in the same eval feed.
+
+### Where it surfaces
+
+It rides the existing **accuracy-baseline eval artifact**
+(`agent_bom.accuracy_baseline.build_accuracy_baseline`), surfaced as
+`docs/accuracy-baseline.json` via `scripts/generate_accuracy_baseline.py`. The
+scorecard is embedded under the `security_eval_scorecard` key, next to the
+runtime red-team and scanner-corpus evidence:
+
+```bash
+python scripts/generate_accuracy_baseline.py          # regenerate
+python scripts/generate_accuracy_baseline.py --check   # release gate
+```
+
+No new CLI subcommand or REST route was added.
+
+---
+
+## 2. Observe→enforce bridge
+
+`agent_bom.observe_enforce.propose_block_rules()` consumes a
+`agent_bom.runtime_correlation.CorrelationReport` and emits gateway block-rule
+**proposals** for every tool that is:
+
+1. **confirmed-vulnerable** — present in a correlated scan finding (a real CVE
+   on a package the tool exposes), *and*
+2. **actively-called** — invoked at least once (`call_count >= 1`) in the proxy
+   audit traces.
+
+A tool that is vulnerable but never called is theoretical risk only and gets no
+proposal. Multiple CVEs on one tool collapse into a single rule (all CVE IDs are
+cited in the rationale).
+
+Each proposal reuses the existing `GatewayRule` model
+(`{action: "block", block_tools: [tool]}`) and the proposals are bundled into a
+single `GatewayPolicy` — the same representation the gateway already evaluates.
+No new rule type, no new route.
+
+### Security model: propose by default, enforce only on opt-in
+
+| Mode | Trigger | Gateway effect |
+|---|---|---|
+| **Audit (default)** | always | Block rules are downgraded to advisory `warn` (see `gateway.gateway_policies_to_proxy_bundle`). Nothing is blocked. |
+| **Enforce** | explicit opt-in | Rules block. Produced only when `enforce=True`. |
+
+Even an enforce-mode result is inert until an operator imports and enables the
+policy through the existing gateway policy layer. There is **no path that
+auto-blocks production traffic without operator intent**.
+
+### Where it surfaces (CLI reference)
+
+The bridge rides the existing `--correlate` flag on the scan command:
+
+```bash
+# Propose only (default): warns which vulnerable+called tools would be blocked.
+agent-bom agents --correlate proxy-audit.jsonl
+
+# Emit an enforce-mode policy for review before import (explicit opt-in).
+AGENT_BOM_ENFORCE_CORRELATED_BLOCKS=1 agent-bom agents --correlate proxy-audit.jsonl
+```
+
+Console output lists each proposed block rule (`block tool:<name> — <CVEs>
+(called Nx)`). The full proposal set — including the generated `GatewayPolicy`
+— is attached to the JSON report under
+`runtime_correlation.observe_enforce` (`gateway.observe_enforce.v1`):
+
+```json
+{
+  "runtime_correlation": {
+    "observe_enforce": {
+      "schema_version": "gateway.observe_enforce.v1",
+      "mode": "audit",
+      "enforced": false,
+      "proposal_count": 1,
+      "proposals": [
+        {"tool_name": "read_file", "vulnerability_ids": ["CVE-2025-1"], "call_count": 3,
+         "rule": {"id": "observe-enforce-read-file", "action": "block", "block_tools": ["read_file"]}}
+      ],
+      "policy": {"policy_id": "agent-bom-observe-enforce", "mode": "audit", "...": "..."}
+    }
+  }
+}
+```
+
+`AGENT_BOM_ENFORCE_CORRELATED_BLOCKS` (`1`/`true`/`yes`/`on`) is the explicit
+operator opt-in that flips the emitted policy from audit to enforce mode.

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -450,3 +450,8 @@ AGENT_BOM_POSTGRES_PASSWORD_FILE
 AGENT_BOM_POSTGRES_AUTH_MODE
 AGENT_BOM_POSTGRES_IAM_PROVIDER
 AGENT_BOM_POSTGRES_IAM_REGION
+
+# Explicit operator opt-in read at runtime by the CLI observe->enforce bridge
+# (cli/agents). Boolean intent flag that flips auto-proposed gateway block rules
+# from audit (propose only) to enforce mode; not a scalar config knob.
+AGENT_BOM_ENFORCE_CORRELATED_BLOCKS

--- a/src/agent_bom/accuracy_baseline.py
+++ b/src/agent_bom/accuracy_baseline.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from agent_bom.red_team import run_red_team
+from agent_bom.security_eval_scorecard import build_security_eval_scorecard
 
 _SCHEMA_VERSION = "accuracy-baseline/v1"
 
@@ -14,6 +15,9 @@ def build_accuracy_baseline() -> dict[str, Any]:
     red_team = run_red_team()
     return {
         "schema_version": _SCHEMA_VERSION,
+        # Security-eval scorecard sits alongside the accuracy/quality evidence:
+        # catalog coverage %, FP rate, and per-category pass/fail from the same run.
+        "security_eval_scorecard": build_security_eval_scorecard(),
         "scope": {
             "release_gate": True,
             "claims": [

--- a/src/agent_bom/cli/agents/__init__.py
+++ b/src/agent_bom/cli/agents/__init__.py
@@ -2524,8 +2524,42 @@ def scan(
                     f"\n  [green]✓[/green] Runtime correlation: "
                     f"no vulnerable tools were called ({_corr_report.unique_tools_called} tools in audit log)"
                 )
-        except Exception as e:
-            con.print(f"\n  [yellow]⚠[/yellow] Runtime correlation failed: {e}")
+
+            # Observe→enforce: propose gateway block rules for tools that are BOTH
+            # confirmed-vulnerable and actively invoked. Default = propose only
+            # (audit-mode policy = advisory warn); an enforce-mode policy is emitted
+            # only under the explicit AGENT_BOM_ENFORCE_CORRELATED_BLOCKS opt-in.
+            import os as _os
+
+            from agent_bom.observe_enforce import propose_block_rules
+
+            _enforce_optin = _os.environ.get("AGENT_BOM_ENFORCE_CORRELATED_BLOCKS", "").strip().lower() in (
+                "1",
+                "true",
+                "yes",
+                "on",
+            )
+            _oe = propose_block_rules(_corr_report, enforce=_enforce_optin)
+            if isinstance(report.runtime_correlation, dict):
+                report.runtime_correlation["observe_enforce"] = _oe.to_dict()
+            if _oe.proposals:
+                _mode_label = "ENFORCE (opt-in)" if _oe.enforced else "propose-only (audit)"
+                con.print(
+                    f"\n  [yellow]⚑[/yellow] Observe→enforce: {len(_oe.proposals)} gateway block-rule "
+                    f"proposal(s) [{_mode_label}]"
+                )
+                for _p in _oe.proposals[:5]:
+                    con.print(
+                        f"    [yellow]▸[/yellow] block tool:{_p.tool_name} — "
+                        f"{', '.join(_p.vulnerability_ids)} (called {_p.call_count}x)"
+                    )
+                if not _oe.enforced:
+                    con.print(
+                        "    [dim]Advisory only. Set AGENT_BOM_ENFORCE_CORRELATED_BLOCKS=1 to emit an "
+                        "enforce-mode policy for review before import.[/dim]"
+                    )
+        except Exception as exc:  # noqa: BLE001
+            con.print(f"\n  [yellow]⚠[/yellow] Runtime correlation failed: {type(exc).__name__}")
 
     # Apply ignore/allowlist file (.agent-bom-ignore.yaml or --ignore-file)
     from agent_bom.ignores import apply_ignores, load_ignore_file

--- a/src/agent_bom/observe_enforce.py
+++ b/src/agent_bom/observe_enforce.py
@@ -1,0 +1,186 @@
+"""Observe->enforce bridge — confirmed-vulnerable + actively-called tools -> block-rule proposals.
+
+Consumes :class:`~agent_bom.runtime_correlation.CorrelationReport` output (tools
+that are BOTH confirmed-vulnerable in a scan AND actually invoked in proxy audit
+traces) and emits gateway block-rule *proposals*, reusing the existing
+:class:`~agent_bom.api.policy_store.GatewayRule` / ``GatewayPolicy`` model.
+
+Security model (default = propose, never silently enforce):
+
+* Proposals are wrapped in an **audit-mode** ``GatewayPolicy`` by default. The
+  gateway downgrades audit-mode block rules to advisory ``warn`` (see
+  ``gateway.gateway_policies_to_proxy_bundle``), so a proposal never blocks live
+  traffic on its own.
+* An **enforce-mode** policy is produced only under the explicit ``enforce``
+  opt-in. Even then the operator must import/enable the policy through the
+  existing gateway policy layer for it to take effect — there is no path that
+  auto-blocks production traffic without operator intent.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.api.policy_store import GatewayPolicy, GatewayRule, PolicyMode
+from agent_bom.runtime_correlation import CorrelationReport
+
+SCHEMA_VERSION = "gateway.observe_enforce.v1"
+PROPOSAL_POLICY_ID = "agent-bom-observe-enforce"
+PROPOSAL_POLICY_NAME = "agent-bom observe-to-enforce (auto-proposed)"
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(tool_name: str) -> str:
+    slug = _SLUG_RE.sub("-", tool_name.strip().lower()).strip("-")
+    return slug or "tool"
+
+
+@dataclass
+class BlockRuleProposal:
+    """One proposed gateway block rule for a confirmed-vulnerable, called tool."""
+
+    tool_name: str
+    rule: GatewayRule
+    vulnerability_ids: list[str]
+    top_severity: str
+    call_count: int
+    correlated_risk_score: float
+    was_blocked: bool
+    rationale: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "tool_name": self.tool_name,
+            "rule": self.rule.model_dump(mode="json"),
+            "vulnerability_ids": list(self.vulnerability_ids),
+            "top_severity": self.top_severity,
+            "call_count": self.call_count,
+            "correlated_risk_score": round(self.correlated_risk_score, 2),
+            "was_blocked": self.was_blocked,
+            "rationale": self.rationale,
+        }
+
+
+@dataclass
+class ObserveEnforceResult:
+    """Outcome of the observe->enforce bridge."""
+
+    proposals: list[BlockRuleProposal]
+    policy: GatewayPolicy
+    enforced: bool
+    mode: str
+    generated_at: str = field(default_factory=lambda: datetime.now(timezone.utc).isoformat())
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "mode": self.mode,
+            "enforced": self.enforced,
+            "generated_at": self.generated_at,
+            "proposal_count": len(self.proposals),
+            "proposals": [p.to_dict() for p in self.proposals],
+            "policy": self.policy.model_dump(mode="json"),
+        }
+
+
+def propose_block_rules(
+    correlation: CorrelationReport,
+    *,
+    enforce: bool = False,
+    tenant_id: str = "default",
+) -> ObserveEnforceResult:
+    """Turn runtime correlation into gateway block-rule proposals.
+
+    A tool earns a block-rule proposal only when it is BOTH confirmed-vulnerable
+    (present in a correlated scan finding) AND actively-called (``call_count >=
+    1``) in the audit traces. Multiple CVEs on the same tool collapse into one
+    rule; the tool's highest-risk finding drives ordering (the correlation
+    report is already sorted by correlated risk, highest first).
+
+    Args:
+        correlation: The runtime<->scan correlation report.
+        enforce: Explicit opt-in. When ``False`` (default) the returned policy is
+            audit-mode (advisory / warn only). When ``True`` it is enforce-mode.
+        tenant_id: Tenant that owns the generated policy.
+
+    Returns:
+        An :class:`ObserveEnforceResult` carrying the per-tool proposals and a
+        single ``GatewayPolicy`` bundling their rules.
+    """
+    # Group correlated findings by called tool, preserving highest-risk-first order.
+    grouped: dict[str, list] = {}
+    for finding in correlation.correlated_findings:
+        if finding.call_count < 1:
+            continue  # theoretical only — never called
+        grouped.setdefault(finding.tool_name, []).append(finding)
+
+    proposals: list[BlockRuleProposal] = []
+    for tool_name, findings in grouped.items():
+        vuln_ids: list[str] = []
+        for f in findings:
+            if f.vulnerability_id and f.vulnerability_id not in vuln_ids:
+                vuln_ids.append(f.vulnerability_id)
+        top = findings[0]
+        was_blocked = any(f.was_blocked for f in findings)
+        rationale = (
+            f"Tool '{tool_name}' is confirmed-vulnerable ({', '.join(vuln_ids)}) and was "
+            f"actively invoked {top.call_count} time(s) in runtime traces "
+            f"(correlated risk {top.correlated_risk_score:.1f})."
+        )
+        rule = GatewayRule(
+            id=f"observe-enforce-{_slug(tool_name)}",
+            description=rationale,
+            action="block",
+            block_tools=[tool_name],
+        )
+        proposals.append(
+            BlockRuleProposal(
+                tool_name=tool_name,
+                rule=rule,
+                vulnerability_ids=vuln_ids,
+                top_severity=top.severity,
+                call_count=top.call_count,
+                correlated_risk_score=top.correlated_risk_score,
+                was_blocked=was_blocked,
+                rationale=rationale,
+            )
+        )
+
+    mode = PolicyMode.ENFORCE if enforce else PolicyMode.AUDIT
+    now = datetime.now(timezone.utc).isoformat()
+    policy = GatewayPolicy(
+        policy_id=PROPOSAL_POLICY_ID,
+        name=PROPOSAL_POLICY_NAME,
+        description=(
+            "Auto-proposed block rules for tools that are both confirmed-vulnerable and "
+            "actively invoked in runtime traces. Audit mode proposes (advisory warn only); "
+            "enforce mode blocks and is produced only under an explicit operator opt-in."
+        ),
+        mode=mode,
+        rules=[p.rule for p in proposals],
+        created_at=now,
+        updated_at=now,
+        enabled=True,
+        tenant_id=tenant_id,
+    )
+
+    return ObserveEnforceResult(
+        proposals=proposals,
+        policy=policy,
+        enforced=enforce,
+        mode=mode.value,
+    )
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "PROPOSAL_POLICY_ID",
+    "PROPOSAL_POLICY_NAME",
+    "BlockRuleProposal",
+    "ObserveEnforceResult",
+    "propose_block_rules",
+]

--- a/src/agent_bom/security_eval_scorecard.py
+++ b/src/agent_bom/security_eval_scorecard.py
@@ -1,0 +1,75 @@
+"""Security-eval scorecard — package a red-team run as a structured eval artifact.
+
+Turns a ``red_team`` run into a schema-versioned "security-eval scorecard" that
+can sit alongside quality/accuracy evals: catalog coverage %, false-positive
+rate, and per-category pass/fail. Deterministic and offline (no LLM, no clock,
+no randomness) so it is safe to emit inside release gates and to diff.
+
+The three required facets:
+
+* **coverage %** — how much of the curated attack catalog this run exercised
+  (``attacks_run / catalog_size``). A partial run scores below 100 %.
+* **false-positive rate** — benign cases that tripped a detector.
+* **per-category pass/fail** — detection outcome broken out by attack category.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.red_team import _ATTACKS, RedTeamResult, build_report, run_attacks
+
+SCHEMA_VERSION = "security-eval-scorecard/v1"
+
+CATALOG_SIZE = len(_ATTACKS)
+
+
+def build_security_eval_scorecard(results: list[RedTeamResult] | None = None) -> dict[str, Any]:
+    """Build the security-eval scorecard artifact.
+
+    Args:
+        results: Optional pre-computed per-attack results (e.g. from a partial
+            run or the LLM-harnessed variant). When ``None`` the full curated
+            catalog is run through Shield.
+
+    Returns:
+        A deterministic, JSON-serializable scorecard dict.
+    """
+    if results is None:
+        results = run_attacks(_ATTACKS)
+
+    report = build_report(results)
+    attacks_run = report["total"]
+    coverage_pct = round(attacks_run / CATALOG_SIZE * 100, 1) if CATALOG_SIZE else 0.0
+
+    per_category: dict[str, dict[str, Any]] = {}
+    for category, stats in report["by_category"].items():
+        total = int(stats["total"])
+        passed = int(stats["passed"])
+        failed = total - passed
+        per_category[category] = {
+            "total": total,
+            "detected": int(stats["detected"]),
+            "passed": passed,
+            "failed": failed,
+            "pass": failed == 0,
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "eval_type": "security",
+        "eval_name": "red-team-adversarial-coverage",
+        "catalog_size": CATALOG_SIZE,
+        "attacks_run": attacks_run,
+        "coverage_pct": coverage_pct,
+        "attack_cases": report["attacks"],
+        "benign_cases": report["benign"],
+        "detected": report["detected"],
+        "missed": report["missed"],
+        "detection_rate": report["detection_rate"],
+        "false_positives": report["false_positives"],
+        "false_positive_rate": report["false_positive_rate"],
+        "per_category": per_category,
+        # A scorecard passes only with zero missed attacks and zero false positives.
+        "passed": report["missed"] == 0 and report["false_positives"] == 0,
+    }

--- a/tests/test_observe_enforce.py
+++ b/tests/test_observe_enforce.py
@@ -1,0 +1,127 @@
+"""Tests for the observe->enforce block-rule proposal bridge."""
+
+from __future__ import annotations
+
+from agent_bom.api.policy_store import PolicyMode
+from agent_bom.observe_enforce import propose_block_rules
+from agent_bom.runtime_correlation import CorrelatedFinding, CorrelationReport
+
+
+def _finding(tool: str, vuln: str, count: int = 3, risk: float = 8.0) -> CorrelatedFinding:
+    return CorrelatedFinding(
+        vulnerability_id=vuln,
+        severity="high",
+        cvss_score=8.1,
+        epss_score=0.4,
+        is_kev=False,
+        package_name="pkg",
+        package_version="1.0.0",
+        tool_name=tool,
+        server_name="srv",
+        call_count=count,
+        last_called="2026-07-14T00:00:00+00:00",
+        first_called="2026-07-13T00:00:00+00:00",
+        was_blocked=False,
+        risk_amplifier=1.5,
+        original_risk_score=risk,
+        correlated_risk_score=risk,
+    )
+
+
+def _report(findings: list[CorrelatedFinding]) -> CorrelationReport:
+    return CorrelationReport(
+        total_tool_calls=sum(f.call_count for f in findings),
+        unique_tools_called=len(findings),
+        vulnerable_tools_called=len(findings),
+        correlated_findings=findings,
+        uncalled_vulnerable_tools=[],
+    )
+
+
+def test_proposes_block_rule_for_confirmed_vulnerable_and_called_tool() -> None:
+    report = _report([_finding("read_file", "CVE-2025-1")])
+    result = propose_block_rules(report)
+
+    assert len(result.proposals) == 1
+    prop = result.proposals[0]
+    assert prop.tool_name == "read_file"
+    assert prop.rule.action == "block"
+    assert prop.rule.block_tools == ["read_file"]
+    assert "CVE-2025-1" in prop.vulnerability_ids
+
+
+def test_default_is_propose_not_enforce() -> None:
+    report = _report([_finding("read_file", "CVE-2025-1")])
+    result = propose_block_rules(report)
+
+    # Default must NOT enforce: policy is audit-mode (advisory / warn only).
+    assert result.enforced is False
+    assert result.mode == "audit"
+    assert result.policy.mode == PolicyMode.AUDIT
+    assert result.to_dict()["enforced"] is False
+
+
+def test_enforce_requires_explicit_opt_in() -> None:
+    report = _report([_finding("read_file", "CVE-2025-1")])
+    result = propose_block_rules(report, enforce=True)
+
+    assert result.enforced is True
+    assert result.mode == "enforce"
+    assert result.policy.mode == PolicyMode.ENFORCE
+
+
+def test_audit_mode_policy_does_not_block_at_gateway() -> None:
+    # Security invariant: a proposed (audit) policy is downgraded to warn by the
+    # gateway, so nothing is silently blocked without the enforce opt-in.
+    from agent_bom.gateway import evaluate_gateway_policies
+
+    report = _report([_finding("read_file", "CVE-2025-1")])
+    proposed = propose_block_rules(report)  # audit
+    allowed, _reason, _pid = evaluate_gateway_policies([proposed.policy], "read_file", {})
+    assert allowed is True  # audit proposal never blocks
+
+    enforced = propose_block_rules(report, enforce=True)
+    blocked, _r, _p = evaluate_gateway_policies([enforced.policy], "read_file", {})
+    assert blocked is False  # enforce policy actually blocks the call
+
+
+def test_uncalled_vulnerable_tools_get_no_proposal() -> None:
+    # A finding with zero calls is theoretical only — no block proposal.
+    report = _report([_finding("idle_tool", "CVE-2025-9", count=0)])
+    result = propose_block_rules(report)
+    assert result.proposals == []
+    assert result.policy.rules == []
+
+
+def test_duplicate_tool_deduped_into_one_rule() -> None:
+    report = _report(
+        [
+            _finding("read_file", "CVE-2025-1", risk=9.0),
+            _finding("read_file", "CVE-2025-2", risk=5.0),
+        ]
+    )
+    result = propose_block_rules(report)
+    assert len(result.proposals) == 1
+    prop = result.proposals[0]
+    # Both CVEs are cited in the single rule's rationale.
+    assert "CVE-2025-1" in prop.vulnerability_ids
+    assert "CVE-2025-2" in prop.vulnerability_ids
+
+
+def test_empty_correlation_yields_no_proposals() -> None:
+    result = propose_block_rules(_report([]))
+    assert result.proposals == []
+    assert result.to_dict()["proposal_count"] == 0
+
+
+def test_to_dict_is_serializable_and_complete() -> None:
+    report = _report([_finding("read_file", "CVE-2025-1")])
+    payload = propose_block_rules(report).to_dict()
+    assert payload["mode"] == "audit"
+    assert payload["proposal_count"] == 1
+    assert payload["proposals"][0]["tool_name"] == "read_file"
+    assert payload["policy"]["mode"] == "audit"
+    # round-trips through JSON without error
+    import json
+
+    json.loads(json.dumps(payload))

--- a/tests/test_security_eval_scorecard.py
+++ b/tests/test_security_eval_scorecard.py
@@ -1,0 +1,56 @@
+"""Tests for the security-eval scorecard artifact."""
+
+from __future__ import annotations
+
+from agent_bom.red_team import _ATTACKS, run_attacks
+from agent_bom.security_eval_scorecard import (
+    SCHEMA_VERSION,
+    build_security_eval_scorecard,
+)
+
+
+def test_scorecard_full_catalog_shape() -> None:
+    card = build_security_eval_scorecard()
+    assert card["schema_version"] == SCHEMA_VERSION
+    # Sits alongside quality evals: it is explicitly a security eval.
+    assert card["eval_type"] == "security"
+    # Coverage %, FP rate and per-category are the three required facets.
+    assert card["coverage_pct"] == 100.0
+    assert "false_positive_rate" in card
+    assert card["catalog_size"] == len(_ATTACKS)
+    assert card["attacks_run"] == len(_ATTACKS)
+    assert card["per_category"], "per-category pass/fail must be populated"
+    for cat, stats in card["per_category"].items():
+        assert {"total", "detected", "passed", "failed", "pass"} <= set(stats)
+        assert stats["passed"] + stats["failed"] == stats["total"]
+        assert stats["pass"] is (stats["failed"] == 0)
+
+
+def test_scorecard_is_deterministic() -> None:
+    # No timestamps / randomness — the same run yields byte-identical artifacts.
+    assert build_security_eval_scorecard() == build_security_eval_scorecard()
+
+
+def test_coverage_reflects_partial_run() -> None:
+    subset = _ATTACKS[:5]
+    card = build_security_eval_scorecard(run_attacks(subset))
+    assert card["attacks_run"] == 5
+    assert card["catalog_size"] == len(_ATTACKS)
+    assert card["coverage_pct"] < 100.0
+    expected = round(5 / len(_ATTACKS) * 100, 1)
+    assert card["coverage_pct"] == expected
+
+
+def test_false_positive_rate_present_and_numeric() -> None:
+    card = build_security_eval_scorecard()
+    assert isinstance(card["false_positive_rate"], (int, float))
+    assert isinstance(card["false_positives"], int)
+
+
+def test_scorecard_embedded_in_accuracy_baseline() -> None:
+    from agent_bom.accuracy_baseline import build_accuracy_baseline
+
+    baseline = build_accuracy_baseline()
+    card = baseline["security_eval_scorecard"]
+    assert card["schema_version"] == SCHEMA_VERSION
+    assert card["eval_type"] == "security"


### PR DESCRIPTION
Closes #3900 — the last sub-issue of the AI-observability epic #3897 (siblings #3898/#3899 already merged via #4000). Two capabilities that turn what agent-bom *observes* about AI-agent runtime behaviour into governance evidence and gateway policy, with **no new HTTP route**.

## Part 1 — Security-eval scorecard
`agent_bom.security_eval_scorecard.build_security_eval_scorecard()` packages a red-team run (`agent_bom.red_team`) as a schema-versioned artifact (`security-eval-scorecard/v1`) that sits alongside quality/accuracy evals (`eval_type: "security"`):

- **coverage %** — `attacks_run / catalog_size` (a partial run scores < 100%)
- **false-positive rate** + count
- **per-category pass/fail** — `{total, detected, passed, failed, pass}`

Deterministic (no clock/randomness, offline). Rides the **existing** accuracy-baseline eval artifact (`build_accuracy_baseline` → `docs/accuracy-baseline.json`) under a `security_eval_scorecard` key — no new CLI command, no new route.

## Part 2 — Observe→enforce bridge
`agent_bom.observe_enforce.propose_block_rules()` consumes `runtime_correlation.CorrelationReport` and emits gateway block-rule **proposals** for tools that are **both** confirmed-vulnerable (in a correlated scan finding) **and** actively-called (`call_count >= 1`). Vulnerable-but-never-called tools get no proposal; multiple CVEs on one tool collapse into one rule. Proposals reuse the existing `GatewayRule`/`GatewayPolicy` model.

**Security model — propose by default, enforce only on opt-in:**
- Default = **audit-mode** policy → the gateway downgrades block rules to advisory `warn` (verified: an audit proposal does not block at `evaluate_gateway_policies`).
- **Enforce-mode** policy is produced only under the explicit `AGENT_BOM_ENFORCE_CORRELATED_BLOCKS` opt-in, and even then is inert until an operator imports/enables it. No path auto-blocks production traffic without operator intent.

Rides the **existing** `--correlate` scan flag: proposals are printed to the console and attached to the JSON report under `runtime_correlation.observe_enforce` (`gateway.observe_enforce.v1`).

## No new routes
Zero HTTP routes added — `check-counts.py` reports REST operations **310** unchanged, and the diff touches **none** of `docs/openapi/*`, the count-guard docs, `ui/lib/api-types.ts`, the blueprint modules, or `nav.tsx` (so no conflict surface with #3999). No UI changed.

## Verification
- New tests: `tests/test_security_eval_scorecard.py`, `tests/test_observe_enforce.py` (13 pass), asserting the scorecard's coverage%/FP/per-category and that observe→enforce proposes for confirmed-vulnerable+called tools and does NOT enforce without the opt-in.
- Related suite: `pytest -k "red_team or scorecard or correlation or enforce or gateway or policy or observe or accuracy"` → **1194 passed, 2 skipped**.
- `scripts/check_exception_sanitization.py` → clean (also hardened the pre-existing `{e}` in the correlate CLI path to `type(exc).__name__`).
- `scripts/check-counts.py` + `make preflight` → green (registered the new opt-in env var in `scripts/env_var_allowlist.txt`).
- `ruff` + `mypy` on touched modules → clean.

## Docs
- `docs/design/OBSERVE_ENFORCE.md` (governance/observability + CLI reference)
- Linked from `docs/RUNTIME_REFERENCE.md`

Does not touch the count-guard docs or OpenAPI.
