### PR TITLE
chore(ui): resilient control-plane probe, AI nav mark, scale security-graph paths

### DIFF
--- a/ui/app/remediation/page.tsx
+++ b/ui/app/remediation/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { Suspense, useCallback, useEffect, useState, useMemo } from "react";
 import {
   api,
@@ -15,6 +16,7 @@ import {
   ChevronUp,
   Loader2,
   Ticket,
+  ArrowRight,
 } from "lucide-react";
 import { severityRank } from "@/lib/severity";
 
@@ -317,8 +319,15 @@ function NarrativeRow({
   );
 }
 
-// ─── Jira modal ───────────────────────────────────────────────────────────────
+// ─── Ticketing action modal ───────────────────────────────────────────────────
 
+// Pre-freeze hardening: this modal used to collect a Jira URL / email / static
+// API token / project key inline and POST them per action. Pasting a static
+// credential into an action form violates the no-creds-in-forms rule, so the
+// token entry is removed. The scoped ITSM connector — credentials brokered in
+// Connections, never typed into an action modal — is tracked in #4004. The
+// backend endpoint (api.createJiraTicket) is intentionally left in place for
+// that connector rework; only the plaintext-token UI flow is retired here.
 function JiraModal({
   item,
   onClose,
@@ -326,45 +335,6 @@ function JiraModal({
   item: RemediationItem;
   onClose: () => void;
 }) {
-  const [jiraUrl, setJiraUrl] = useState("");
-  const [email, setEmail] = useState("");
-  const [apiToken, setApiToken] = useState("");
-  const [projectKey, setProjectKey] = useState("");
-  const [submitting, setSubmitting] = useState(false);
-  const [result, setResult] = useState<string | null>(null);
-  const [error, setError] = useState("");
-
-  async function handleSubmit(e: React.FormEvent) {
-    e.preventDefault();
-    setSubmitting(true);
-    setError("");
-    try {
-      const res = await api.createJiraTicket({
-        jira_url: jiraUrl,
-        email,
-        api_token: apiToken,
-        project_key: projectKey,
-        finding: {
-          package: item.package,
-          current_version: item.current_version,
-          fixed_version: item.fixed_version,
-          severity: item.severity,
-          impact_score: item.impact_score,
-          affected_agents: item.affected_agents,
-          exposed_credentials: item.exposed_credentials,
-          risk_narrative: item.risk_narrative,
-          owasp_tags: item.owasp_tags,
-          atlas_tags: item.atlas_tags,
-        },
-      });
-      setResult(res.ticket_key);
-    } catch (err: unknown) {
-      setError(err instanceof Error ? err.message : "Failed to create ticket");
-    } finally {
-      setSubmitting(false);
-    }
-  }
-
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center">
       <div
@@ -374,97 +344,38 @@ function JiraModal({
       <div className="relative w-full max-w-md bg-[var(--surface)] border border-[var(--border-subtle)]/60 rounded-xl shadow-2xl overflow-hidden">
         <div className="px-5 py-4 border-b border-[var(--border-subtle)]">
           <h2 className="text-sm font-semibold text-[var(--foreground)]">
-            Create Jira Ticket
+            Create a ticket
           </h2>
           <p className="text-xs text-[var(--text-tertiary)] mt-0.5">
             {item.package} {item.current_version}
           </p>
         </div>
 
-        {result ? (
-          <div className="px-5 py-6 text-center">
-            <p className="text-sm text-emerald-400 font-medium">
-              Ticket created: {result}
-            </p>
+        <div className="px-5 py-5 space-y-4">
+          <p className="text-sm leading-6 text-[var(--text-secondary)]">
+            Ticketing runs through a managed integration configured in{" "}
+            <span className="font-medium text-[var(--foreground)]">Connections</span>{" "}
+            — credentials are brokered there, never entered per action. Direct
+            ticket creation from this row is coming soon.
+          </p>
+
+          <div className="flex items-center justify-end gap-2 pt-1">
             <button
+              type="button"
               onClick={onClose}
-              className="mt-4 px-4 py-2 bg-[var(--surface-elevated)] hover:bg-[var(--surface-muted)] border border-[var(--border-subtle)] text-[var(--text-secondary)] text-sm rounded-lg transition-colors"
+              className="px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
             >
               Close
             </button>
+            <Link
+              href="/connections"
+              className="flex items-center gap-1.5 px-3 py-1.5 bg-emerald-700 hover:bg-emerald-600 text-white text-xs font-medium rounded-lg transition-colors"
+            >
+              Open Connections
+              <ArrowRight className="w-3 h-3" />
+            </Link>
           </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="px-5 py-4 space-y-3">
-            {[
-              {
-                id: "jiraUrl",
-                label: "Jira URL",
-                val: jiraUrl,
-                set: setJiraUrl,
-                type: "url",
-                placeholder: "https://yourorg.atlassian.net",
-              },
-              {
-                id: "email",
-                label: "Email",
-                val: email,
-                set: setEmail,
-                type: "email",
-                placeholder: "you@example.com",
-              },
-              {
-                id: "apiToken",
-                label: "API Token",
-                val: apiToken,
-                set: setApiToken,
-                type: "password",
-                placeholder: "••••••••",
-              },
-              {
-                id: "projectKey",
-                label: "Project Key",
-                val: projectKey,
-                set: setProjectKey,
-                type: "text",
-                placeholder: "SEC",
-              },
-            ].map(({ id, label, val, set, type, placeholder }) => (
-              <div key={id}>
-                <label className="block text-xs text-[var(--text-secondary)] mb-1">
-                  {label}
-                </label>
-                <input
-                  type={type}
-                  value={val}
-                  onChange={(e) => set(e.target.value)}
-                  placeholder={placeholder}
-                  required
-                  className="w-full bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded-lg px-3 py-1.5 text-sm text-[var(--foreground)] placeholder-[var(--text-tertiary)] focus:outline-none focus:border-[var(--border-strong)]"
-                />
-              </div>
-            ))}
-
-            {error && <p className="text-xs text-red-400">{error}</p>}
-
-            <div className="flex items-center justify-end gap-2 pt-1">
-              <button
-                type="button"
-                onClick={onClose}
-                className="px-3 py-1.5 text-xs text-[var(--text-secondary)] hover:text-[var(--foreground)] transition-colors"
-              >
-                Cancel
-              </button>
-              <button
-                type="submit"
-                disabled={submitting}
-                className="flex items-center gap-1.5 px-3 py-1.5 bg-emerald-700 hover:bg-emerald-600 text-white text-xs font-medium rounded-lg transition-colors disabled:opacity-50"
-              >
-                {submitting && <Loader2 className="w-3 h-3 animate-spin" />}
-                Create Ticket
-              </button>
-            </div>
-          </form>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -18,7 +18,7 @@ function _classifyGraphErrorKind(err: unknown): "network" | "auth" | "forbidden"
   return "network";
 }
 import { PageLaneHeader } from "@/components/page-lane";
-import { AttackPathCard } from "@/components/attack-path-card";
+import { RankedPathList, type RankedPathRow } from "@/components/ranked-path-list";
 import { ExposurePathCommandCenter, type ExposurePathView } from "@/components/exposure-path-command-center";
 import { GraphEvidenceExportButton } from "@/components/graph-chrome";
 import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
@@ -39,6 +39,7 @@ import {
   buildSecurityGraphHref,
   descriptiveAttackPathTitle,
   investigationRootForAttackPath,
+  labelsForAttackPathType,
   matchesAttackPathFocus,
   rankedAttackPathRows,
   recommendedAttackPathActions,
@@ -48,11 +49,11 @@ import {
 } from "@/lib/attack-paths";
 import { SecurityGraphInvestigation } from "@/components/security-graph-investigation";
 import type { UnifiedGraphData } from "@/lib/graph-schema";
-import { useCaptureMode } from "@/lib/use-capture-mode";
 
 const ATTACK_PATH_QUEUE_LIMIT = 75;
 const ATTACK_PATH_QUEUE_PAGE_SIZE = 12;
 const FIX_FIRST_CARD_LIMIT = 12;
+const DEFAULT_SNAPSHOT_CHIP_COUNT = 3;
 
 function SecurityGraphPageContent() {
   const searchParams = useSearchParams();
@@ -72,7 +73,6 @@ function SecurityGraphPageContent() {
   const [visibleAttackPathCount, setVisibleAttackPathCount] = useState(ATTACK_PATH_QUEUE_PAGE_SIZE);
   const [investigationFocusMode, setInvestigationFocusMode] = useState(true);
   const [pathView, setPathView] = useState<ExposurePathView>("path");
-  const captureMode = useCaptureMode();
 
   const focus = useMemo(
     () => ({
@@ -182,18 +182,22 @@ function SecurityGraphPageContent() {
     () => snapshots.find((snapshot) => snapshot.scan_id === selectedScanId) ?? null,
     [snapshots, selectedScanId],
   );
-  // Stale/empty snapshots (0 persisted nodes) pile up in a long-lived graph
-  // store and drown the real ones in the chip row. Default to the populated
-  // snapshots (plus whatever is currently selected); "show all" reveals the
-  // empty and older ones on demand.
+  // Stale/empty snapshots (0 persisted nodes) and unrelated older scans pile up
+  // in a long-lived graph store and drown the real ones in the chip row.
+  // Default to the current scan plus at most a couple of recent populated
+  // snapshots; "show all" reveals every empty and older one on demand.
   const activeSnapshots = useMemo(
     () => snapshots.filter((snapshot) => snapshot.node_count > 0 || snapshot.scan_id === selectedScanId),
     [snapshots, selectedScanId],
   );
-  const displayedSnapshots = useMemo(
-    () => (showAllSnapshots ? snapshots : activeSnapshots.slice(0, 8)),
-    [activeSnapshots, showAllSnapshots, snapshots],
-  );
+  const displayedSnapshots = useMemo(() => {
+    if (showAllSnapshots) return snapshots;
+    // Current scan first, then the most recent populated snapshots — never the
+    // empty/unrelated ones up front.
+    const current = activeSnapshots.filter((snapshot) => snapshot.scan_id === selectedScanId);
+    const rest = activeSnapshots.filter((snapshot) => snapshot.scan_id !== selectedScanId);
+    return [...current, ...rest].slice(0, DEFAULT_SNAPSHOT_CHIP_COUNT);
+  }, [activeSnapshots, showAllSnapshots, selectedScanId, snapshots]);
   const hiddenSnapshotCount = Math.max(0, snapshots.length - displayedSnapshots.length);
 
   const fixFirstCards = useMemo(() => fixFirstView?.cards ?? [], [fixFirstView?.cards]);
@@ -230,6 +234,27 @@ function SecurityGraphPageContent() {
     [attackPaths, visibleAttackPathCount],
   );
   const hiddenAttackPathCount = Math.max(0, attackPaths.length - visibleAttackPaths.length);
+
+  const rankedRows = useMemo<RankedPathRow[]>(
+    () =>
+      rankedAttackPathRows(visibleAttackPaths, fixFirstCards)
+        .map(({ path, card, rank, key }) => {
+          const pathNodes = toAttackCardNodes(path, graphNodeById);
+          if (pathNodes.length === 0) return null;
+          return {
+            key,
+            selectionKey: attackPathKey(path),
+            rank,
+            title: descriptiveAttackPathTitle(card?.title, pathNodes),
+            cve: path.vuln_ids[0] ?? null,
+            riskScore: path.composite_risk,
+            hops: Math.max(0, path.hops.length - 1),
+            agents: labelsForAttackPathType(path, graphNodeById, "agent").length,
+          } satisfies RankedPathRow;
+        })
+        .filter((row): row is RankedPathRow => row !== null),
+    [fixFirstCards, graphNodeById, visibleAttackPaths],
+  );
 
   const hasFocusContext = Boolean(focus.cve || focus.packageName || focus.agentName);
   const selectedAttackPath = useMemo(
@@ -428,19 +453,20 @@ function SecurityGraphPageContent() {
           scanId={selectedScanId || undefined}
           view={pathView}
           onViewChange={setPathView}
+          graphSlot={
+            graphData && selectedAttackPath ? (
+              <SecurityGraphInvestigation
+                graph={graphData as UnifiedGraphData}
+                attackPath={selectedAttackPath}
+                focusMode={investigationFocusMode}
+                onFocusModeChange={setInvestigationFocusMode}
+                fullGraphHref={fullGraphHref}
+                loading={loadingGraph}
+              />
+            ) : null
+          }
         />
       ) : null}
-
-      {pathView === "graph" && graphData && selectedAttackPath && (
-        <SecurityGraphInvestigation
-          graph={graphData as UnifiedGraphData}
-          attackPath={selectedAttackPath}
-          focusMode={investigationFocusMode}
-          onFocusModeChange={setInvestigationFocusMode}
-          fullGraphHref={fullGraphHref}
-          loading={loadingGraph}
-        />
-      )}
 
       <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
         <div className="flex flex-wrap items-start justify-between gap-4">
@@ -613,6 +639,9 @@ function SecurityGraphPageContent() {
                 <h2 className="text-base font-semibold text-[color:var(--foreground)]">
                   {attackPaths.length} ranked path{attackPaths.length !== 1 ? "s" : ""}
                 </h2>
+                <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+                  Select a path to open its graph and evidence above.
+                </p>
                 {focusLabel && (
                   <p className="mt-1 text-xs text-emerald-300">Focused: {focusLabel}</p>
                 )}
@@ -620,69 +649,12 @@ function SecurityGraphPageContent() {
               <div className="font-mono text-lg text-red-300">{attackPaths[0]!.composite_risk.toFixed(1)}</div>
             </div>
 
-            <div
-              className="mt-4 grid max-h-[28rem] max-w-full grid-cols-1 gap-2 overflow-y-auto pr-1 outline-none md:grid-cols-2 xl:grid-cols-3"
-              tabIndex={0}
+            <RankedPathList
+              rows={rankedRows}
+              selectedKey={selectedAttackPath ? attackPathKey(selectedAttackPath) : null}
+              onSelect={setSelectedAttackPathKey}
               onKeyDown={handleAttackPathQueueKeyDown}
-              aria-label="Attack path queue"
-            >
-              {rankedAttackPathRows(visibleAttackPaths, fixFirstCards).map(({ path, card, rank, key }) => {
-                const selectionKey = attackPathKey(path);
-                const pathNodes = toAttackCardNodes(path, graphNodeById);
-                if (pathNodes.length === 0) return null;
-                const active = selectedAttackPath ? attackPathKey(selectedAttackPath) === selectionKey : false;
-                const title = descriptiveAttackPathTitle(card?.title, pathNodes);
-                return (
-                  <div
-                    key={key}
-                    className={`min-w-0 rounded-2xl border bg-[color:var(--surface-elevated)] p-3 transition ${
-                      active
-                        ? "border-orange-400/70 ring-2 ring-orange-400/70 ring-offset-2 ring-offset-[color:var(--surface)]"
-                        : "border-[color:var(--border-subtle)]"
-                    }`}
-                  >
-                    <div className="mb-3 flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <div className="text-[11px] uppercase tracking-[0.18em] text-orange-300">#{rank} fix first</div>
-                        <div
-                          title={title}
-                          className="mt-1 text-sm font-semibold leading-5 text-[color:var(--foreground)] [overflow-wrap:anywhere]"
-                        >
-                          {title}
-                        </div>
-                      </div>
-                      <div className="shrink-0 rounded-xl border border-red-900/60 bg-red-950/30 px-2.5 py-1 text-right">
-                        <div className="text-[9px] font-semibold uppercase tracking-[0.14em] text-red-300/80">Path risk</div>
-                        <div className="font-mono text-sm font-semibold leading-4 text-red-200">
-                          {path.composite_risk.toFixed(1)}
-                        </div>
-                      </div>
-                    </div>
-                    <AttackPathCard
-                      nodes={pathNodes}
-                      riskScore={path.composite_risk}
-                      captureMode={captureMode}
-                      compact
-                      showRiskBadge={false}
-                      onClick={() => setSelectedAttackPathKey(selectionKey)}
-                    />
-                    {card && card.risk_reasons.length > 0 && (
-                      <div className="mt-3 flex flex-wrap gap-1.5">
-                        {card.risk_reasons.slice(0, 3).map((reason) => (
-                          <span
-                            key={`${card.id}-${reason.kind}`}
-                            title={reason.detail}
-                            className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-1 text-[11px] text-[color:var(--text-secondary)]"
-                          >
-                            {reason.label}
-                          </span>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
+            />
             {hiddenAttackPathCount > 0 && (
               <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-3">
                 <p className="text-xs text-[color:var(--text-tertiary)]">

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -29,7 +29,7 @@ function isApiReachabilityFailure(message: string): boolean {
 export function AuthGate({ children }: { children: React.ReactNode }) {
   const router = useRouter();
   const pathname = usePathname();
-  const { session, loading, error } = useAuthState();
+  const { session, loading, error, reconnecting } = useAuthState();
 
   const needsAuth =
     !loading &&
@@ -44,8 +44,11 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
   if (loading) {
     return (
-      <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center">
+      <div className="flex min-h-[calc(100vh-5rem)] flex-col items-center justify-center gap-3">
         <Loader2 className="h-6 w-6 animate-spin text-[var(--text-tertiary)]" />
+        {reconnecting ? (
+          <p className="text-xs text-[var(--text-tertiary)]">Reconnecting to the control plane…</p>
+        ) : null}
       </div>
     );
   }

--- a/ui/components/auth-provider.tsx
+++ b/ui/components/auth-provider.tsx
@@ -3,12 +3,24 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useState } from "react";
 
 import { api, type AuthMeResponse } from "@/lib/api";
-import { userFacingApiErrorMessage } from "@/lib/api-errors";
+import {
+  ApiAuthError,
+  ApiForbiddenError,
+  ApiNetworkError,
+  ApiServerError,
+  userFacingApiErrorMessage,
+} from "@/lib/api-errors";
 
 interface AuthContextValue {
   session: AuthMeResponse | null;
   loading: boolean;
   error: string | null;
+  /**
+   * True while the probe is silently retrying a transient/aborted fetch. Lets
+   * the gate show a subtle "reconnecting…" hint instead of the scary fatal
+   * "control plane unreachable" screen on the first aborted request.
+   */
+  reconnecting: boolean;
   refresh: () => Promise<void>;
   hasCapability: (capability: string) => boolean;
 }
@@ -17,28 +29,72 @@ const defaultContext: AuthContextValue = {
   session: null,
   loading: true,
   error: null,
+  reconnecting: false,
   refresh: async () => {},
   hasCapability: () => false,
 };
 
 const AuthContext = createContext<AuthContextValue>(defaultContext);
 
+// Next dev on-demand compilation and route navigation routinely abort the
+// bootstrap auth probe (AbortError / TimeoutError). A single aborted or
+// transient network hiccup should never surface the fatal "control plane
+// unreachable" state — retry a few times with backoff first. A genuine,
+// repeated connection refusal still fails all attempts and shows the fatal UI.
+const MAX_PROBE_ATTEMPTS = 3;
+const PROBE_RETRY_BASE_MS = 150;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRetryableProbeError(err: unknown): boolean {
+  // Auth/authorization outcomes are terminal — the operator must sign in.
+  if (err instanceof ApiAuthError || err instanceof ApiForbiddenError) return false;
+  // Aborted fetches, timeouts, and refused connections all arrive as
+  // ApiNetworkError; transient 5xx as ApiServerError. Retry both.
+  if (err instanceof ApiNetworkError || err instanceof ApiServerError) return true;
+  const message = (err instanceof Error ? err.message : String(err)).toLowerCase();
+  return (
+    message.includes("abort") ||
+    message.includes("timeout") ||
+    message.includes("timed out") ||
+    message.includes("network")
+  );
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [session, setSession] = useState<AuthMeResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [reconnecting, setReconnecting] = useState(false);
 
   const refresh = useCallback(async () => {
     setLoading(true);
     setError(null);
-    try {
-      const next = await api.getAuthMe();
-      setSession(next);
-    } catch (nextError) {
-      setSession(null);
-      setError(userFacingApiErrorMessage(nextError, "Failed to load auth session"));
-    } finally {
-      setLoading(false);
+    setReconnecting(false);
+    for (let attempt = 1; attempt <= MAX_PROBE_ATTEMPTS; attempt += 1) {
+      try {
+        const next = await api.getAuthMe();
+        setSession(next);
+        setError(null);
+        setReconnecting(false);
+        setLoading(false);
+        return;
+      } catch (nextError) {
+        if (isRetryableProbeError(nextError) && attempt < MAX_PROBE_ATTEMPTS) {
+          // Silent recovery: keep the gate in its loading/reconnecting state
+          // rather than flashing the fatal screen for a single aborted fetch.
+          setReconnecting(true);
+          await delay(PROBE_RETRY_BASE_MS * attempt);
+          continue;
+        }
+        setSession(null);
+        setError(userFacingApiErrorMessage(nextError, "Failed to load auth session"));
+        setReconnecting(false);
+        setLoading(false);
+        return;
+      }
     }
   }, []);
 
@@ -51,10 +107,11 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       session,
       loading,
       error,
+      reconnecting,
       refresh,
       hasCapability: (capability: string) => Boolean(session?.role_summary?.capabilities.includes(capability)),
     }),
-    [error, loading, refresh, session]
+    [error, loading, reconnecting, refresh, session]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -96,6 +96,7 @@ export function ExposurePathCommandCenter({
   scanId,
   view: controlledView,
   onViewChange,
+  graphSlot,
 }: {
   path: ExposurePath;
   actions?: ExposurePathCommandAction[] | undefined;
@@ -108,6 +109,13 @@ export function ExposurePathCommandCenter({
    * reserving a full screen-height of blank canvas underneath.
    */
   onViewChange?: ((next: ExposurePathView) => void) | undefined;
+  /**
+   * Interactive graph rendered inline in "graph" view. Consolidating the graph
+   * here means selecting "Graph" shows the live investigation immediately in
+   * one place — no dashed "opens below" placeholder pointing at a separate,
+   * disconnected panel further down the page.
+   */
+  graphSlot?: React.ReactNode | undefined;
 }) {
   const [internalView, setInternalView] = useState<ExposurePathView>("path");
   const view = controlledView ?? internalView;
@@ -117,6 +125,9 @@ export function ExposurePathCommandCenter({
   };
   const fixLabel = pathFixLabel(path);
   const evidence = path.evidence;
+  const pathSummary =
+    path.summary ||
+    "A reachable package or service on this path inherits downstream credential and tool exposure from the agent runtime.";
   const primaryAction = actions[0];
   const hopCount = Math.max(0, path.hops.length - 1);
   const severityTone =
@@ -136,10 +147,6 @@ export function ExposurePathCommandCenter({
               <span className="rounded-full border border-red-500/35 bg-red-500/12 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-red-200">
                 {String(path.severity)} risk
               </span>
-              <span className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-0.5 text-[11px] text-[color:var(--foreground)]">
-                <span className="text-[9px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Path risk</span>
-                <span className="font-mono">{path.riskScore.toFixed(1)}</span>
-              </span>
               {evidence?.isKev ? (
                 <span className="rounded-full border border-amber-500/35 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-200">
                   CISA KEV
@@ -149,9 +156,11 @@ export function ExposurePathCommandCenter({
             <h2 className="text-xl font-semibold leading-8 text-[color:var(--foreground)] [overflow-wrap:anywhere]">
               {pathDisplayTitle(path)}
             </h2>
-            <p className="max-w-3xl text-sm leading-6 text-[color:var(--text-secondary)]">
-              {path.summary ||
-                "A reachable package or service on this path inherits downstream credential and tool exposure from the agent runtime."}
+            <p
+              title={pathSummary}
+              className="max-w-3xl truncate text-sm leading-6 text-[color:var(--text-secondary)]"
+            >
+              {pathSummary}
             </p>
           </div>
           <div className="grid grid-cols-2 gap-2 text-xs sm:grid-cols-4">
@@ -179,12 +188,14 @@ export function ExposurePathCommandCenter({
           </section>
         ) : view === "list" ? (
           <ExposurePathNeighborExplorer path={path} scanId={scanId} />
+        ) : graphSlot ? (
+          <section aria-label="Interactive graph">{graphSlot}</section>
         ) : (
           <section
             aria-label="Interactive graph hint"
             className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)]/60 px-4 py-6 text-center text-xs text-[color:var(--text-secondary)]"
           >
-            Interactive graph opens below — pan, zoom, and click nodes to inspect the persisted subgraph.
+            Interactive graph loads here once graph evidence is available for this snapshot.
           </section>
         )}
 

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -23,7 +23,6 @@ import {
   PanelLeftClose,
   PanelLeft,
   Search,
-  BrainCircuit,
   LayoutDashboard,
   Wrench,
   RefreshCw,
@@ -111,6 +110,23 @@ function activeGroupForPath(path: string | null): string {
   return matched?.label ?? NAV_GROUPS[0]!.label;
 }
 
+/**
+ * Plain "AI" text monogram used as the AI-inventory group glyph. A literal
+ * mark reads unambiguously at rail size where a busy circuit icon did not, and
+ * it satisfies the `icon: React.ElementType` contract by accepting the same
+ * sizing/colour className the Lucide group icons receive.
+ */
+function AiMark({ className = "" }: { className?: string }) {
+  return (
+    <span
+      aria-hidden="true"
+      className={`inline-flex items-center justify-center text-[0.6rem] font-bold leading-none tracking-[-0.02em] ${className}`}
+    >
+      AI
+    </span>
+  );
+}
+
 const NAV_GROUPS: NavGroup[] = [
   {
     label: "Posture",
@@ -129,7 +145,7 @@ const NAV_GROUPS: NavGroup[] = [
   },
   {
     label: "AI inventory",
-    icon: BrainCircuit,
+    icon: AiMark,
     links: [
       { href: "/agents", label: "Agents", icon: Bot },
       { href: "/manifest", label: "AI BOM", icon: ClipboardList },

--- a/ui/components/ranked-path-list.tsx
+++ b/ui/components/ranked-path-list.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { ChevronRight } from "lucide-react";
+
+export interface RankedPathRow {
+  /** Collision-free React key (index-suffixed) for stable list rendering. */
+  key: string;
+  /** Selection key shared with the command-center panel's selected path. */
+  selectionKey: string;
+  rank: number;
+  title: string;
+  cve: string | null;
+  riskScore: number;
+  hops: number;
+  agents: number;
+}
+
+/**
+ * Compact, scannable list of ranked exposure paths. One row per path — the
+ * DAG for the active row renders once in the command-center panel above, not
+ * per-card here, so the surface scales to many paths without a tall stack of
+ * duplicate node diagrams. Selecting a row promotes it into that single panel.
+ */
+export function RankedPathList({
+  rows,
+  selectedKey,
+  onSelect,
+  onKeyDown,
+}: {
+  rows: RankedPathRow[];
+  selectedKey: string | null;
+  onSelect: (key: string) => void;
+  onKeyDown?: ((event: React.KeyboardEvent<HTMLDivElement>) => void) | undefined;
+}) {
+  return (
+    <div
+      className="mt-4 max-h-[28rem] space-y-1.5 overflow-y-auto pr-1 outline-none"
+      tabIndex={0}
+      onKeyDown={onKeyDown}
+      aria-label="Attack path queue"
+    >
+      {rows.map((row) => {
+        const active = row.selectionKey === selectedKey;
+        return (
+          <button
+            key={row.key}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onSelect(row.selectionKey)}
+            className={`flex w-full items-center gap-3 rounded-xl border px-3 py-2.5 text-left transition ${
+              active
+                ? "border-orange-400/70 bg-orange-500/10 ring-1 ring-orange-400/60"
+                : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] hover:border-[color:var(--border-strong)]"
+            }`}
+          >
+            <span
+              className={`shrink-0 rounded-md px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${
+                row.rank === 1
+                  ? "bg-orange-500/15 text-orange-300"
+                  : "bg-[color:var(--surface)] text-[color:var(--text-tertiary)]"
+              }`}
+            >
+              {row.rank === 1 ? "#1 fix first" : `#${row.rank}`}
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-sm font-medium text-[color:var(--foreground)]">
+                {row.cve ? `${row.cve} · ` : ""}
+                {row.title}
+              </span>
+              <span className="mt-0.5 block text-[11px] text-[color:var(--text-tertiary)]">
+                {row.hops} hop{row.hops === 1 ? "" : "s"} · {row.agents} agent{row.agents === 1 ? "" : "s"}
+              </span>
+            </span>
+            <span className="shrink-0 rounded-lg border border-red-900/60 bg-red-950/30 px-2.5 py-1 text-right">
+              <span className="block text-[9px] font-semibold uppercase tracking-[0.14em] text-red-300/80">
+                Path risk
+              </span>
+              <span className="block font-mono text-sm font-semibold leading-4 text-red-200">
+                {row.riskScore.toFixed(1)}
+              </span>
+            </span>
+            <ChevronRight
+              className={`h-4 w-4 shrink-0 transition ${
+                active ? "text-orange-300" : "text-[color:var(--text-tertiary)]"
+              }`}
+              aria-hidden="true"
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ui/components/security-graph-investigation.tsx
+++ b/ui/components/security-graph-investigation.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import {
   Background,
   Controls,
   MiniMap,
   ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
   type Edge,
   type Node,
 } from "@xyflow/react";
@@ -69,6 +71,76 @@ const INVESTIGATION_LAYERS = {
   sourceFile: false,
   configFile: false,
 } as const;
+
+/**
+ * ReactFlow subtree with an imperative re-fit. ReactFlow's `fitView` prop only
+ * runs once, at first mount — but the dagre layout positions nodes on a later
+ * tick, and lens/focus/snapshot switches swap in an entirely new node set. When
+ * the one-shot fit ran against the pre-layout (0,0) positions the canvas ended
+ * up zoomed/panned off its content and rendered blank. Re-fitting whenever the
+ * laid-out node set changes keeps the bounding box in view every time.
+ */
+function InvestigationFlow({
+  nodes,
+  edges,
+  viewportInput,
+  onNodeSelect,
+}: {
+  nodes: Node<LineageNodeData>[];
+  edges: Edge[];
+  viewportInput: {
+    nodeCount: number;
+    edgeCount: number;
+    selectedNode: boolean;
+    mode: "lineage";
+  };
+  onNodeSelect: (id: string) => void;
+}) {
+  const { fitView } = useReactFlow();
+  const fitOptions = useMemo(() => graphFitViewOptions(viewportInput), [viewportInput]);
+  const fitOptionsRef = useRef(fitOptions);
+  fitOptionsRef.current = fitOptions;
+
+  useEffect(() => {
+    if (nodes.length === 0) return;
+    // Fit on the next frame so ReactFlow has measured the freshly laid-out
+    // nodes before we fit to their bounds. Keyed on the node reference, which
+    // changes on mount, layout settle, lens switch, focus toggle, and snapshot
+    // change — every case where the previous viewport can be stale.
+    const raf = requestAnimationFrame(() => {
+      void fitView(fitOptionsRef.current);
+    });
+    return () => cancelAnimationFrame(raf);
+  }, [fitView, nodes]);
+
+  return (
+    <ReactFlow
+      nodes={nodes}
+      edges={edges}
+      nodeTypes={lineageNodeTypes}
+      fitView
+      fitViewOptions={fitOptions}
+      minZoom={0.2}
+      maxZoom={1.8}
+      nodesDraggable={false}
+      nodesConnectable={false}
+      elementsSelectable
+      onNodeClick={(_, node) => onNodeSelect(node.id)}
+      proOptions={{ hideAttribution: true }}
+    >
+      <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
+      <Controls className={CONTROLS_CLASS} showInteractive={false} />
+      {shouldShowGraphMiniMap(viewportInput) && (
+        <MiniMap
+          className={MINIMAP_CLASS}
+          style={{ background: MINIMAP_BG }}
+          maskColor={MINIMAP_MASK}
+          nodeColor={minimapNodeColor}
+        />
+      )}
+    </ReactFlow>
+  );
+}
 
 export function SecurityGraphInvestigation({
   graph,
@@ -190,31 +262,14 @@ export function SecurityGraphInvestigation({
             No graph nodes matched this path. Run a fresh scan or clear focus to inspect the full snapshot.
           </div>
         ) : (
-          <ReactFlow
-            nodes={layout.nodes}
-            edges={displayEdges}
-            nodeTypes={lineageNodeTypes}
-            fitView
-            fitViewOptions={graphFitViewOptions(viewportInput)}
-            minZoom={0.2}
-            maxZoom={1.8}
-            nodesDraggable={false}
-            nodesConnectable={false}
-            elementsSelectable
-            onNodeClick={(_, node) => setSelectedNodeId(node.id)}
-            proOptions={{ hideAttribution: true }}
-          >
-            <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
-            <Controls className={CONTROLS_CLASS} showInteractive={false} />
-            {shouldShowGraphMiniMap(viewportInput) && (
-              <MiniMap
-                className={MINIMAP_CLASS}
-                style={{ background: MINIMAP_BG }}
-                maskColor={MINIMAP_MASK}
-                nodeColor={minimapNodeColor}
-              />
-            )}
-          </ReactFlow>
+          <ReactFlowProvider>
+            <InvestigationFlow
+              nodes={layout.nodes as Node<LineageNodeData>[]}
+              edges={displayEdges}
+              viewportInput={viewportInput}
+              onNodeSelect={setSelectedNodeId}
+            />
+          </ReactFlowProvider>
         )}
 
         <div className="pointer-events-none absolute left-3 top-3 max-w-[min(24rem,calc(100vw-2rem))]">

--- a/ui/tests/auth-gate.test.tsx
+++ b/ui/tests/auth-gate.test.tsx
@@ -79,6 +79,65 @@ describe("AuthGate", () => {
     expect(screen.queryByText("protected surface")).not.toBeInTheDocument();
   });
 
+  it("recovers silently from a single aborted probe without flashing the fatal state", async () => {
+    const abortError = Object.assign(new Error("Fetch is aborted"), { name: "AbortError" });
+    global.fetch = vi
+      .fn()
+      .mockRejectedValueOnce(abortError)
+      .mockResolvedValue({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: () =>
+          Promise.resolve({
+            authenticated: false,
+            auth_required: false,
+            configured_modes: [],
+            recommended_ui_mode: "no_auth",
+            auth_method: null,
+            subject: null,
+            role: null,
+            tenant_id: "default",
+            role_summary: null,
+            memberships: [],
+            request_id: null,
+            trace_id: null,
+            span_id: null,
+          }),
+      }) as typeof fetch;
+
+    render(
+      <AuthProvider>
+        <AuthGate>
+          <div>protected surface</div>
+        </AuthGate>
+      </AuthProvider>,
+    );
+
+    // The retry lands on the second attempt; the fatal screen never renders.
+    await waitFor(() => expect(screen.getByText("protected surface")).toBeInTheDocument());
+    expect(screen.queryByText("Control plane unreachable")).not.toBeInTheDocument();
+  });
+
+  it("shows the fatal control-plane state after the probe keeps aborting", async () => {
+    const abortError = Object.assign(new Error("Fetch is aborted"), { name: "AbortError" });
+    global.fetch = vi.fn().mockRejectedValue(abortError) as typeof fetch;
+
+    render(
+      <AuthProvider>
+        <AuthGate>
+          <div>protected surface</div>
+        </AuthGate>
+      </AuthProvider>,
+    );
+
+    await waitFor(
+      () => expect(screen.getByText("Control plane unreachable")).toBeInTheDocument(),
+      { timeout: 3000 },
+    );
+    expect(screen.queryByText("protected surface")).not.toBeInTheDocument();
+  });
+
   it("blocks protected content when auth discovery gets a server error", async () => {
     global.fetch = vi.fn().mockResolvedValue({
       ok: false,

--- a/ui/tests/exposure-path-command-center.test.tsx
+++ b/ui/tests/exposure-path-command-center.test.tsx
@@ -119,10 +119,31 @@ describe("ExposurePathCommandCenter", () => {
     expect(onViewChange).toHaveBeenCalledWith("graph");
   });
 
-  it("renders the interactive-graph hint instead of a reserved blank canvas in graph view", () => {
+  it("renders a hint instead of a reserved blank canvas when no graph slot is supplied", () => {
     render(<ExposurePathCommandCenter path={basePath} view="graph" onViewChange={vi.fn()} />);
 
-    expect(screen.getByText(/Interactive graph opens below/)).toBeInTheDocument();
+    expect(screen.getByText(/Interactive graph loads here/)).toBeInTheDocument();
+    expect(
+      screen.queryByRole("img", { name: /Selected exposure path graph for/ }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders the interactive graph inline in graph view instead of an 'opens below' placeholder", () => {
+    render(
+      <ExposurePathCommandCenter
+        path={basePath}
+        view="graph"
+        onViewChange={vi.fn()}
+        graphSlot={<div data-testid="inline-investigation-graph">live graph</div>}
+      />,
+    );
+
+    // The graph is shown right here, in the Graph slot — not a placeholder
+    // pointing at a separate panel further down the page.
+    expect(screen.getByTestId("inline-investigation-graph")).toBeInTheDocument();
+    expect(screen.queryByText(/Interactive graph loads here/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/opens below/)).not.toBeInTheDocument();
+    // Only the graph slot renders — the path DAG is not stacked underneath.
     expect(
       screen.queryByRole("img", { name: /Selected exposure path graph for/ }),
     ).not.toBeInTheDocument();

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -113,6 +113,14 @@ describe('Nav', () => {
     expect(screen.getByText('AI inventory')).toBeInTheDocument()
   })
 
+  it('uses a plain "AI" monogram (not a busy circuit icon) for the AI inventory group', () => {
+    renderExpandedNav()
+    const aiGroup = screen.getByRole('button', { name: /ai inventory/i })
+    // The monogram is its own element whose full text is exactly "AI"; the
+    // "AI inventory" label span reads differently and is not matched.
+    expect(within(aiGroup).getByText('AI', { exact: true })).toBeInTheDocument()
+  })
+
   it('renders the Cloud & Data nav group', () => {
     renderExpandedNav()
     expect(screen.getByText('Cloud & Data')).toBeInTheDocument()

--- a/ui/tests/ranked-path-list.test.tsx
+++ b/ui/tests/ranked-path-list.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { RankedPathList, type RankedPathRow } from "@/components/ranked-path-list";
+
+const rows: RankedPathRow[] = [
+  {
+    key: "k1::0",
+    selectionKey: "k1",
+    rank: 1,
+    title: "Agent → Database → werkzeug",
+    cve: "CVE-2026-0002",
+    riskScore: 9.6,
+    hops: 3,
+    agents: 2,
+  },
+  {
+    key: "k2::1",
+    selectionKey: "k2",
+    rank: 2,
+    title: "Agent → API → flask",
+    cve: null,
+    riskScore: 7.1,
+    hops: 2,
+    agents: 1,
+  },
+];
+
+describe("RankedPathList", () => {
+  it("renders one compact row per path and never a per-row DAG", () => {
+    render(<RankedPathList rows={rows} selectedKey="k1" onSelect={vi.fn()} />);
+
+    expect(screen.getByText("#1 fix first")).toBeInTheDocument();
+    expect(screen.getByText("#2")).toBeInTheDocument();
+    expect(screen.getByText(/CVE-2026-0002/)).toBeInTheDocument();
+    expect(screen.getByText(/3 hops · 2 agents/)).toBeInTheDocument();
+    // The single DAG renders in the command-center panel, not per row here.
+    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("selects a path into the shared panel when a collapsed row is clicked", () => {
+    const onSelect = vi.fn();
+    render(<RankedPathList rows={rows} selectedKey="k1" onSelect={onSelect} />);
+
+    fireEvent.click(screen.getByText("#2").closest("button")!);
+    expect(onSelect).toHaveBeenCalledWith("k2");
+  });
+
+  it("marks exactly the selected row active (expanded) and leaves the rest collapsed", () => {
+    render(<RankedPathList rows={rows} selectedKey="k2" onSelect={vi.fn()} />);
+
+    const active = screen
+      .getAllByRole("button")
+      .filter((button) => button.getAttribute("aria-pressed") === "true");
+    expect(active).toHaveLength(1);
+    expect(within(active[0]!).getByText("#2")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Pre-release UI polish from a live dogfooding session. Presentational + one frontend security-hardening change; no backend, no API-type changes.

## AI — control-plane probe resilience
On first load the bootstrap `/v1/auth/me` probe is routinely aborted by Next dev on-demand compilation / navigation (`AbortError`, `TimeoutError`). A single aborted fetch surfaced as `ApiNetworkError("Network request failed: …aborted")`, which the gate treated as fatal — rendering the full-screen **"Control plane unreachable"** even though the API was healthy.

- `auth-provider` now retries the probe with backoff (3 attempts, 150ms·n) for **retryable** errors — `ApiNetworkError`/`ApiServerError` (abort, timeout, refused, transient 5xx). Auth/authorization outcomes (`ApiAuthError`/`ApiForbiddenError`) are terminal and never retried.
- During retries the gate stays in its loading state with a subtle **"Reconnecting to the control plane…"** hint instead of the scary screen.
- A genuine, repeated connection refusal still fails all attempts and shows the fatal state.
- Tests: one aborted-then-success probe recovers silently (no fatal); a probe that keeps aborting shows the fatal state.

## AJ — AI-inventory nav glyph
The AI-inventory group icon (`BrainCircuit`) read as busy/unclear at rail size. Replaced with a plain **"AI" text monogram** that satisfies the `icon: React.ElementType` contract (accepts the same sizing/colour className the Lucide group icons get), renders cleanly at collapsed rail size and in the expanded flyout header, both themes, and duplicates no other glyph. Dropped the now-unused `BrainCircuit` import.

## AK — Security graph: concise / collapsible / scalable
- **Ranked paths are now a compact list** (`ranked-path-list.tsx`): one row per path (#1 FIX FIRST / #N · CVE · title · hops · agents · PATH RISK). Selecting a row promotes it into the single command-center panel — so the DAG renders in **one** place, not a big always-open DAG plus a grid of per-card mini-DAGs. Scales to many paths (capped scroll + "show more").
- **Deduped PATH RISK** in the command center — dropped the badge-row chip; kept the metric pill.
- **Trimmed the verbose per-path description** to a single truncated line with the full text as a tooltip.
- **Snapshot chips** default to the current scan + at most a couple of recent populated snapshots; empty/older/unrelated ones stay behind the existing "Show all N snapshots".

## AL — Interactive graph rendered blank + Graph-view consolidation
Selecting **Graph** showed a dashed *"Interactive graph opens below"* placeholder while the real graph lived in a separate **"Live investigation"** panel further down — which rendered **blank** (viewport zoomed off its content).

- The **Graph view now renders the interactive investigation graph inline** via a new `graphSlot` on the command center; the separate disconnected panel is removed. One interactive graph, shown where the user picks "Graph".
- **Blank-canvas fix:** ReactFlow's `fitView` prop only runs once at mount — before the async dagre layout positions nodes and again after lens/focus/snapshot swaps. Wrapped the flow in `ReactFlowProvider` and re-fit imperatively (via `useReactFlow().fitView`, next-frame) whenever the laid-out node set changes, so the bounding box is always in view. Controls/minimap retained.

## AM — Pre-freeze security hardening (Remediation)
The Remediation row **Jira** action opened a modal collecting a Jira URL / email / **static API token** / project key inline — a static credential typed into an action form. Removed that plaintext-credential flow: the modal is now an informational panel pointing to **Connections** (credentials brokered there), with a code comment referencing the scoped ITSM connector rework (**#4004**). The backend endpoint is left in place for that rework; only the plaintext-token UI is retired.

## #3931 assessment — NOT closing
This PR completes the **Security/Lineage graph IA + interactivity** workstream of #3931 (progressive disclosure, one dominant canvas, collapse groups, dedupe, no default empty state), building on #3994 (declutter), #3997 (graph toggle), #4001 (zinc/logo). But #3931 is an epic with sibling workstreams that this PR and those do not fully cover:
- **Scan-jobs live status + animated pipeline DAG**
- **Findings table density + user-facing column chooser** (findings currently auto-computes columns; no add/remove chooser)

Leaving #3931 open for the maintainer to close once those are verified.

## Verify
- `npm run build` clean; `tsc --noEmit` clean; ESLint clean on touched files (one pre-existing unrelated warning in `nav.tsx`).
- `npx vitest run` → 106 files / 553 tests pass (added AI retry-recovery, AJ monogram, AK ranked-list collapse/single-DAG, graph-slot inline tests).
- `check-bundle-budget.mjs` → PASS (3303.7 / 3304.0 KiB).
- Diff touches no files owned by #4003 (no `api-types.ts`, cost page, or governance/blueprint backend).
