### PR TITLE
feat(governance): ABAC device/group/client attributes + scoped delegation tokens + served MCP-client-config URL

### DIFF
--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 73 tools, 6 resources, 8 workflow prompts |
-| REST API | 321 operations across 37 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 329 operations across 38 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["321 REST operations across 37 route modules\nplus 2 WebSocket routes"]
+        R["329 REST operations across 38 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 273 |
+| `docs/openapi/v1.json` | paths | 280 |
 | `docs/openapi/v1.json` | component schemas | 72 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -340,6 +340,7 @@ Production deployments must keep cryptographic keys separated by purpose:
 - `AGENT_BOM_AUDIT_HMAC_KEY` signs the tamper-evident audit chain and audit exports.
 - `AGENT_BOM_RATE_LIMIT_KEY` fingerprints API keys for rate-limit buckets.
 - `AGENT_BOM_BROWSER_SESSION_SIGNING_KEY` signs httpOnly browser session cookies.
+- `AGENT_BOM_DELEGATION_SIGNING_KEY` signs scoped agent-to-agent delegation tokens; set it (never reuse another key) so delegated handoffs verify consistently across replicas and survive restarts. When unset, a per-process ephemeral key is used and tokens become invalid after restart.
 - `AGENT_BOM_TRUST_PROXY_AUTH_SECRET` attests trusted reverse-proxy identity headers and must contain at least 32 bytes of secret material.
 
 Do not reuse the API key or audit HMAC key as a rate-limit, browser-session, or proxy-attestation secret. Set `AGENT_BOM_TRUST_PROXY_AUTH_ISSUER` when the upstream proxy can inject a stable issuer identifier; the API will then reject trusted-proxy requests from any other issuer.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (273 paths / 321 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (280 paths / 329 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (321 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (329 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -9823,6 +9823,198 @@
         ]
       }
     },
+    "/v1/delegations/propagate": {
+      "post": {
+        "description": "Propagate a delegation token to the next hop, narrowing scope only.\n\nThe child token inherits the parent's expiry (never extended), may only carry\na subset of the parent's scopes, and decrements the delegation-depth budget.",
+        "operationId": "propagate_agent_delegation_v1_delegations_propagate_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Propagate Agent Delegation V1 Delegations Propagate Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Propagate Agent Delegation",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
+    "/v1/delegations/verify": {
+      "post": {
+        "description": "Validate a delegation token for the active tenant (receiver side).\n\nReturns ``{valid: true, delegation: {...}}`` for a well-formed, unexpired,\nin-scope token; ``{valid: false, reason}`` otherwise (fail-closed). When\n``required_scope`` is supplied, an over-scoped call (capability outside the\ntoken's scope) is rejected.",
+        "operationId": "verify_agent_delegation_v1_delegations_verify_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Verify Agent Delegation V1 Delegations Verify Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Verify Agent Delegation",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
     "/v1/discovery/providers": {
       "get": {
         "description": "Return registered discovery provider capability and trust contracts.",
@@ -17512,6 +17704,111 @@
         ]
       }
     },
+    "/v1/identities/{identity_id}/delegations": {
+      "post": {
+        "description": "Issue a scoped, expiring delegation token from this identity to a delegatee.\n\nThe token is signed (HMAC), carries an explicit capability scope, and expires.\nThe delegatee (receiver) validates it via ``POST /v1/delegations/verify``; it\nis propagated across further handoffs via ``POST /v1/delegations/propagate``.",
+        "operationId": "issue_agent_delegation_v1_identities__identity_id__delegations_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "identity_id",
+            "required": true,
+            "schema": {
+              "title": "Identity Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Issue Agent Delegation V1 Identities  Identity Id  Delegations Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Issue Agent Delegation",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
     "/v1/identities/{identity_id}/jit-grants": {
       "get": {
         "description": "List JIT grants attached to one identity.",
@@ -19238,6 +19535,483 @@
         "summary": "Check Malicious",
         "tags": [
           "security"
+        ]
+      }
+    },
+    "/v1/mcp-config/assignments": {
+      "get": {
+        "description": "List MCP-client-config assignments for the active tenant.",
+        "operationId": "list_mcp_config_assignments_v1_mcp_config_assignments_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include_revoked",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Revoked",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "default": 200,
+              "title": "Limit",
+              "type": "integer"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Mcp Config Assignments V1 Mcp Config Assignments Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Mcp Config Assignments",
+        "tags": [
+          "mcp-config"
+        ]
+      },
+      "post": {
+        "description": "Assign a profile + connectors, yielding one distributable read-only config URL.",
+        "operationId": "create_mcp_config_assignment_v1_mcp_config_assignments_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Mcp Config Assignment V1 Mcp Config Assignments Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Mcp Config Assignment",
+        "tags": [
+          "mcp-config"
+        ]
+      }
+    },
+    "/v1/mcp-config/assignments/{config_id}": {
+      "get": {
+        "description": "Return one MCP-client-config assignment (metadata).",
+        "operationId": "get_mcp_config_assignment_v1_mcp_config_assignments__config_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "config_id",
+            "required": true,
+            "schema": {
+              "title": "Config Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Mcp Config Assignment V1 Mcp Config Assignments  Config Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Mcp Config Assignment",
+        "tags": [
+          "mcp-config"
+        ]
+      }
+    },
+    "/v1/mcp-config/assignments/{config_id}/revoke": {
+      "post": {
+        "description": "Revoke an assignment; its served config URL then 404s.",
+        "operationId": "revoke_mcp_config_assignment_v1_mcp_config_assignments__config_id__revoke_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "config_id",
+            "required": true,
+            "schema": {
+              "title": "Config Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Revoke Mcp Config Assignment V1 Mcp Config Assignments  Config Id  Revoke Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Revoke Mcp Config Assignment",
+        "tags": [
+          "mcp-config"
+        ]
+      }
+    },
+    "/v1/mcp-config/{config_id}/mcp.json": {
+      "get": {
+        "description": "Serve the composed, read-only ``.mcp.json`` document for a tenant + config.\n\nReferences connectors/secrets by handle only \u2014 never embeds secret material.\nCross-tenant or revoked assignments 404 (fail-closed).",
+        "operationId": "serve_mcp_client_config_v1_mcp_config__config_id__mcp_json_get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "config_id",
+            "required": true,
+            "schema": {
+              "title": "Config Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Serve Mcp Client Config V1 Mcp Config  Config Id  Mcp Json Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Serve Mcp Client Config",
+        "tags": [
+          "mcp-config"
         ]
       }
     },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6471,6 +6471,132 @@ paths:
       summary: Get Dataset Version
       tags:
       - datasets
+  /v1/delegations/propagate:
+    post:
+      description: 'Propagate a delegation token to the next hop, narrowing scope
+        only.
+
+
+        The child token inherits the parent''s expiry (never extended), may only carry
+
+        a subset of the parent''s scopes, and decrements the delegation-depth budget.'
+      operationId: propagate_agent_delegation_v1_delegations_propagate_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              title: Body
+              type: object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Propagate Agent Delegation V1 Delegations Propagate
+                  Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Propagate Agent Delegation
+      tags:
+      - identity
+  /v1/delegations/verify:
+    post:
+      description: 'Validate a delegation token for the active tenant (receiver side).
+
+
+        Returns ``{valid: true, delegation: {...}}`` for a well-formed, unexpired,
+
+        in-scope token; ``{valid: false, reason}`` otherwise (fail-closed). When
+
+        ``required_scope`` is supplied, an over-scoped call (capability outside the
+
+        token''s scope) is rejected.'
+      operationId: verify_agent_delegation_v1_delegations_verify_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              title: Body
+              type: object
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Verify Agent Delegation V1 Delegations Verify Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Verify Agent Delegation
+      tags:
+      - identity
   /v1/discovery/providers:
     get:
       description: Return registered discovery provider capability and trust contracts.
@@ -11450,6 +11576,77 @@ paths:
       summary: Get Agent Identity
       tags:
       - identity
+  /v1/identities/{identity_id}/delegations:
+    post:
+      description: 'Issue a scoped, expiring delegation token from this identity to
+        a delegatee.
+
+
+        The token is signed (HMAC), carries an explicit capability scope, and expires.
+
+        The delegatee (receiver) validates it via ``POST /v1/delegations/verify``;
+        it
+
+        is propagated across further handoffs via ``POST /v1/delegations/propagate``.'
+      operationId: issue_agent_delegation_v1_identities__identity_id__delegations_post
+      parameters:
+      - in: path
+        name: identity_id
+        required: true
+        schema:
+          title: Identity Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              title: Body
+              type: object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Issue Agent Delegation V1 Identities  Identity Id  Delegations
+                  Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Issue Agent Delegation
+      tags:
+      - identity
   /v1/identities/{identity_id}/jit-grants:
     get:
       description: List JIT grants attached to one identity.
@@ -12521,6 +12718,288 @@ paths:
       summary: Check Malicious
       tags:
       - security
+  /v1/mcp-config/assignments:
+    get:
+      description: List MCP-client-config assignments for the active tenant.
+      operationId: list_mcp_config_assignments_v1_mcp_config_assignments_get
+      parameters:
+      - in: query
+        name: include_revoked
+        required: false
+        schema:
+          default: false
+          title: Include Revoked
+          type: boolean
+      - in: query
+        name: limit
+        required: false
+        schema:
+          default: 200
+          title: Limit
+          type: integer
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Mcp Config Assignments V1 Mcp Config Assignments
+                  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List Mcp Config Assignments
+      tags:
+      - mcp-config
+    post:
+      description: Assign a profile + connectors, yielding one distributable read-only
+        config URL.
+      operationId: create_mcp_config_assignment_v1_mcp_config_assignments_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              title: Body
+              type: object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Create Mcp Config Assignment V1 Mcp Config Assignments
+                  Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Create Mcp Config Assignment
+      tags:
+      - mcp-config
+  /v1/mcp-config/assignments/{config_id}:
+    get:
+      description: Return one MCP-client-config assignment (metadata).
+      operationId: get_mcp_config_assignment_v1_mcp_config_assignments__config_id__get
+      parameters:
+      - in: path
+        name: config_id
+        required: true
+        schema:
+          title: Config Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Mcp Config Assignment V1 Mcp Config Assignments  Config
+                  Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Mcp Config Assignment
+      tags:
+      - mcp-config
+  /v1/mcp-config/assignments/{config_id}/revoke:
+    post:
+      description: Revoke an assignment; its served config URL then 404s.
+      operationId: revoke_mcp_config_assignment_v1_mcp_config_assignments__config_id__revoke_post
+      parameters:
+      - in: path
+        name: config_id
+        required: true
+        schema:
+          title: Config Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Revoke Mcp Config Assignment V1 Mcp Config Assignments  Config
+                  Id  Revoke Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Revoke Mcp Config Assignment
+      tags:
+      - mcp-config
+  /v1/mcp-config/{config_id}/mcp.json:
+    get:
+      description: "Serve the composed, read-only ``.mcp.json`` document for a tenant\
+        \ + config.\n\nReferences connectors/secrets by handle only \u2014 never embeds\
+        \ secret material.\nCross-tenant or revoked assignments 404 (fail-closed)."
+      operationId: serve_mcp_client_config_v1_mcp_config__config_id__mcp_json_get
+      parameters:
+      - in: path
+        name: config_id
+        required: true
+        schema:
+          title: Config Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Serve Mcp Client Config V1 Mcp Config  Config Id  Mcp
+                  Json Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Serve Mcp Client Config
+      tags:
+      - mcp-config
   /v1/mitre/coverage:
     get:
       description: 'Per-framework MITRE technique coverage for the current tenant.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,6 +322,10 @@ show_error_codes = true
 module = [
     "agent_bom.api.access_review",
     "agent_bom.api.agent_identity_store",
+    "agent_bom.api.delegation_token",
+    "agent_bom.api.mcp_config_store",
+    "agent_bom.api.postgres_mcp_config",
+    "agent_bom.api.routes.mcp_config",
     "agent_bom.api.anomaly",
     "agent_bom.api.audit_log",
     "agent_bom.api.auth",

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -147,6 +147,7 @@ AGENT_BOM_DELIVERY_DB  # optional SQLite path for the outbound delivery foundati
 AGENT_BOM_DB_PATH
 AGENT_BOM_DB_SOURCES
 AGENT_BOM_DEFAULT_ROLE
+AGENT_BOM_DELEGATION_SIGNING_KEY  # secret: signs scoped agent-to-agent delegation tokens (HMAC); resolved via secret_source in delegation_token.py
 AGENT_BOM_DISABLE_DOCS
 AGENT_BOM_DISTRIBUTED_SCANS
 AGENT_BOM_ENABLE_LOCAL_PATH_SCANS

--- a/site-docs/reference/configuration.md
+++ b/site-docs/reference/configuration.md
@@ -65,3 +65,49 @@ agent-bom proxy \
   --metrics-port 8422 \
   -- <server-command>
 ```
+
+## Governance: ABAC conditions, delegation tokens, and served MCP-client-config
+
+### Conditional-access (ABAC) attributes
+
+Conditional-access policies (`/v1/conditional-access-policies`) gate a call on
+request-time context. Alongside the existing environment / time-window /
+weekday / source-CIDR conditions, policies also match on **device**, **group**,
+and **client** attributes:
+
+| Condition | Matches against | Request header |
+|-----------|-----------------|----------------|
+| `allowed_devices` | calling workstation / device id (exact) | `x-agent-device-id` |
+| `allowed_groups` | caller's directory groups (membership) | `x-agent-groups` (comma-separated) |
+| `allowed_clients` | MCP client application id (exact) | `x-agent-client-id` |
+
+All conditions are **fail-closed**: a policy that requires a device / group /
+client denies the call when the request cannot prove the attribute. The same
+conditions are enforced at both the gateway and the proxy decision points.
+
+### Scoped delegation tokens
+
+Multi-agent handoffs carry a **scoped, verifiable, expiring** delegation token
+(`POST /v1/identities/{id}/delegations`). The token is HMAC-signed, lists the
+explicit delegated capabilities (`scopes`), and expires. A receiver validates it
+with `POST /v1/delegations/verify` (an over-scoped or expired token is
+rejected); further hops re-issue via `POST /v1/delegations/propagate`, which can
+only **narrow** scope and never extends the expiry or the delegation-depth
+budget.
+
+Set `AGENT_BOM_DELEGATION_SIGNING_KEY` (file via `*_FILE`, or env) so tokens
+survive process restarts and verify consistently across replicas. When unset, a
+per-process ephemeral key is used (tokens become invalid after restart).
+
+### Served MCP-client-config distribution
+
+Assigning a profile composes chosen connectors + a runtime role blueprint into
+ONE distributable, **read-only**, tenant-scoped `.mcp.json` document:
+
+- `POST /v1/mcp-config/assignments` — assign a profile + connectors → returns a
+  `config_url`.
+- `GET /v1/mcp-config/{config_id}/mcp.json` — the served `mcpServers` document.
+
+The served config references each connector's credential env-vars as `${VAR}`
+placeholders and each cloud connection by opaque handle — it **never embeds
+secret material**. Access is RBAC-gated; a cross-tenant fetch is a 404.

--- a/src/agent_bom/api/agent_identity_store.py
+++ b/src/agent_bom/api/agent_identity_store.py
@@ -173,6 +173,14 @@ class AccessContext:
     tool_name: str = ""
     environment: str = ""
     source_ip: str = ""
+    # Device / group / client attributes (ABAC): the calling workstation or
+    # service identity (``device_id``), the caller's directory groups
+    # (``groups``), and the MCP client application making the call
+    # (``client_id``). Empty means "not supplied" — a policy that constrains one
+    # of these fails closed when the request cannot prove it.
+    device_id: str = ""
+    groups: list[str] = field(default_factory=list)
+    client_id: str = ""
     at: datetime | None = None
 
 
@@ -205,6 +213,12 @@ class ConditionalAccessPolicy:
     allowed_hours_utc: list[int] = field(default_factory=list)  # 0..23 UTC
     allowed_weekdays: list[int] = field(default_factory=list)  # 0=Mon .. 6=Sun
     allowed_source_cidrs: list[str] = field(default_factory=list)
+    # Device / group / client conditions (ABAC). Empty list = unconstrained; a
+    # populated list requires the request context to match (membership for
+    # groups, exact for device/client) or the condition fails closed.
+    allowed_devices: list[str] = field(default_factory=list)
+    allowed_groups: list[str] = field(default_factory=list)
+    allowed_clients: list[str] = field(default_factory=list)
     updated_at: str = ""
     description: str = ""
 
@@ -237,6 +251,17 @@ class ConditionalAccessPolicy:
         if self.allowed_weekdays and now.weekday() not in set(self.allowed_weekdays):
             return False
         if self.allowed_source_cidrs and not _ip_in_any_cidr(ctx.source_ip, self.allowed_source_cidrs):
+            return False
+        # Device: exact match against an allow-list. A request that supplies no
+        # device id cannot satisfy a device condition — fail closed.
+        if self.allowed_devices and (not ctx.device_id or ctx.device_id not in set(self.allowed_devices)):
+            return False
+        # Group: membership. The caller must belong to at least one allowed
+        # group; no groups supplied fails closed.
+        if self.allowed_groups and not (set(ctx.groups) & set(self.allowed_groups)):
+            return False
+        # Client: exact match against the allowed MCP client applications.
+        if self.allowed_clients and (not ctx.client_id or ctx.client_id not in set(self.allowed_clients)):
             return False
         return True
 
@@ -1302,6 +1327,9 @@ def create_conditional_policy(
     allowed_hours_utc: list[int] | None = None,
     allowed_weekdays: list[int] | None = None,
     allowed_source_cidrs: list[str] | None = None,
+    allowed_devices: list[str] | None = None,
+    allowed_groups: list[str] | None = None,
+    allowed_clients: list[str] | None = None,
     description: str = "",
 ) -> ConditionalAccessPolicy:
     """Create an active conditional-access policy for ``tenant_id``."""
@@ -1323,6 +1351,9 @@ def create_conditional_policy(
         allowed_hours_utc=sorted({h for h in (allowed_hours_utc or []) if 0 <= int(h) <= 23}),
         allowed_weekdays=sorted({d for d in (allowed_weekdays or []) if 0 <= int(d) <= 6}),
         allowed_source_cidrs=list(allowed_source_cidrs or []),
+        allowed_devices=list(allowed_devices or []),
+        allowed_groups=list(allowed_groups or []),
+        allowed_clients=list(allowed_clients or []),
         updated_at=now,
         description=description[:1000],
     )

--- a/src/agent_bom/api/delegation_token.py
+++ b/src/agent_bom/api/delegation_token.py
@@ -1,0 +1,269 @@
+"""Scoped, verifiable, expiring delegation tokens for multi-agent handoffs.
+
+Today A2A delegation is only *posture-scanned* (``a2a_auth_posture``) and
+mutual-auth enforced. This module issues a first-class **delegation token** that
+a delegating agent hands to a delegatee and that the receiver cryptographically
+verifies before acting on-behalf-of the delegator:
+
+* **Scoped** — the token carries an explicit list of delegated capabilities
+  (tool names / scopes). A receiver validating for a capability outside that
+  list is rejected (over-scoped call), so a token is never bearer-all.
+* **Verifiable** — the token is an HMAC-SHA256 signature over its payload using
+  a control-plane signing key (``AGENT_BOM_DELEGATION_SIGNING_KEY``). The
+  receiver validates the signature with a constant-time compare; a tampered
+  payload or scope fails closed. No shared database lookup is required.
+* **Expiring** — an ``exp`` claim bounds the token's lifetime. An expired token
+  is rejected fail-closed.
+* **Chain-aware** — the token records the ``delegation_chain`` (ordered hops)
+  and a remaining-depth budget. Propagating to the next hop can only *narrow*
+  the scope and *never* extend the expiry or the depth budget, so authority
+  cannot be amplified as it flows down the chain.
+
+The token format mirrors the browser-session token (``payload_b64.sig_b64``)
+and reuses the same file/env secret-source resolution.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import secrets
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+# A delegation chain deeper than this is refused at issue/propagate time so a
+# token cannot fan out authority indefinitely.
+MAX_DELEGATION_DEPTH = 8
+# Hard ceiling on token lifetime so an issuer cannot mint a long-lived bearer.
+MAX_DELEGATION_TTL_SECONDS = 3600
+_EPHEMERAL_SIGNING_KEY = secrets.token_bytes(32)
+
+
+class DelegationTokenError(Exception):
+    """Raised when a delegation token cannot be verified (fails closed)."""
+
+
+def _b64encode(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(value: str) -> bytes:
+    padding = "=" * (-len(value) % 4)
+    return base64.urlsafe_b64decode((value + padding).encode("ascii"))
+
+
+def _signing_key() -> bytes:
+    """Resolve the delegation signing key from the control-plane secret source.
+
+    Derives a 32-byte key from ``AGENT_BOM_DELEGATION_SIGNING_KEY`` (file or env)
+    via PBKDF2. When unset, falls back to a per-process ephemeral key so
+    single-node/dev flows still work; tokens then become invalid after restart
+    (and across replicas), which is the safe default for a signing secret.
+    """
+    from agent_bom.api.secret_source import resolve_secret
+
+    configured = resolve_secret("AGENT_BOM_DELEGATION_SIGNING_KEY")
+    if configured:
+        return hashlib.pbkdf2_hmac(
+            "sha256",
+            configured.encode("utf-8"),
+            b"agent-bom-delegation-signing-key:v1",
+            600_000,
+            dklen=32,
+        )
+    return _EPHEMERAL_SIGNING_KEY
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _normalize_scopes(scopes: list[str] | tuple[str, ...] | None) -> list[str]:
+    out: list[str] = []
+    for scope in scopes or []:
+        value = str(scope).strip()[:200]
+        if value and value not in out:
+            out.append(value)
+        if len(out) >= 100:
+            break
+    return sorted(out)
+
+
+@dataclass(frozen=True)
+class DelegationToken:
+    """The verified claims of a delegation token."""
+
+    jti: str
+    tenant_id: str
+    delegator: str
+    delegatee: str
+    scopes: list[str]
+    chain: list[str]
+    remaining_depth: int
+    iat: int
+    exp: int
+
+    def allows(self, scope: str) -> bool:
+        """True when ``scope`` is within the delegated capability set."""
+        return str(scope).strip() in set(self.scopes)
+
+
+def issue_delegation_token(
+    *,
+    tenant_id: str,
+    delegator: str,
+    delegatee: str,
+    scopes: list[str],
+    ttl_seconds: int,
+    chain: list[str] | None = None,
+    remaining_depth: int = MAX_DELEGATION_DEPTH,
+    at: datetime | None = None,
+) -> tuple[str, DelegationToken]:
+    """Mint a scoped, signed, expiring delegation token.
+
+    ``scopes`` MUST be non-empty — a scopeless token would be bearer-all and is
+    refused. Returns ``(token_string, claims)``.
+    """
+    normalized_scopes = _normalize_scopes(scopes)
+    if not normalized_scopes:
+        raise ValueError("a delegation token must carry at least one scope")
+    if not tenant_id:
+        raise ValueError("tenant_id is required")
+    if not delegator or not delegatee:
+        raise ValueError("delegator and delegatee are required")
+    depth = max(0, min(int(remaining_depth), MAX_DELEGATION_DEPTH))
+    if depth <= 0:
+        raise ValueError("delegation depth budget is exhausted")
+    now = at or _now()
+    ttl = max(1, min(int(ttl_seconds), MAX_DELEGATION_TTL_SECONDS))
+    hops = [str(h).strip()[:200] for h in (chain or []) if str(h).strip()][:MAX_DELEGATION_DEPTH]
+    hops = [*hops, str(delegatee).strip()[:200]]
+    claims = DelegationToken(
+        jti=f"dlg_{secrets.token_hex(8)}",
+        tenant_id=tenant_id,
+        delegator=str(delegator)[:200],
+        delegatee=str(delegatee)[:200],
+        scopes=normalized_scopes,
+        chain=hops,
+        remaining_depth=depth,
+        iat=int(now.timestamp()),
+        exp=int((now + timedelta(seconds=ttl)).timestamp()),
+    )
+    return _encode(claims), claims
+
+
+def _encode(claims: DelegationToken) -> str:
+    payload: dict[str, Any] = {
+        "v": 1,
+        "jti": claims.jti,
+        "tenant_id": claims.tenant_id,
+        "delegator": claims.delegator,
+        "delegatee": claims.delegatee,
+        "scopes": claims.scopes,
+        "chain": claims.chain,
+        "depth": claims.remaining_depth,
+        "iat": claims.iat,
+        "exp": claims.exp,
+    }
+    payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    encoded_payload = _b64encode(payload_bytes)
+    signature = hmac.new(_signing_key(), encoded_payload.encode("ascii"), hashlib.sha256).digest()
+    return f"{encoded_payload}.{_b64encode(signature)}"
+
+
+def verify_delegation_token(
+    token: str,
+    *,
+    tenant_id: str | None = None,
+    required_scope: str | None = None,
+    at: datetime | None = None,
+) -> DelegationToken:
+    """Verify a delegation token and return its claims, or raise fail-closed.
+
+    Checks (in order): structural shape, signature (constant-time), expiry,
+    optional ``tenant_id`` binding, and — when ``required_scope`` is supplied —
+    that the requested capability is within the token's delegated scope. An
+    over-scoped call (capability not delegated) is rejected.
+    """
+    if not token or "." not in token:
+        raise DelegationTokenError("delegation token is missing or malformed")
+    encoded_payload, encoded_signature = token.split(".", 1)
+    expected = hmac.new(_signing_key(), encoded_payload.encode("ascii"), hashlib.sha256).digest()
+    try:
+        supplied = _b64decode(encoded_signature)
+    except Exception as exc:  # noqa: BLE001
+        raise DelegationTokenError("delegation token signature is malformed") from exc
+    if not hmac.compare_digest(supplied, expected):
+        raise DelegationTokenError("delegation token signature is invalid")
+    try:
+        payload = json.loads(_b64decode(encoded_payload).decode("utf-8"))
+    except Exception as exc:  # noqa: BLE001
+        raise DelegationTokenError("delegation token payload is invalid") from exc
+    if not isinstance(payload, dict):
+        raise DelegationTokenError("delegation token payload is invalid")
+    now = int((at or _now()).timestamp())
+    exp = int(payload.get("exp") or 0)
+    if exp <= now:
+        raise DelegationTokenError("delegation token is expired")
+    token_tenant = str(payload.get("tenant_id") or "")
+    if tenant_id is not None and token_tenant != tenant_id:
+        raise DelegationTokenError("delegation token tenant does not match")
+    scopes = [str(s) for s in (payload.get("scopes") or []) if str(s)]
+    claims = DelegationToken(
+        jti=str(payload.get("jti") or ""),
+        tenant_id=token_tenant,
+        delegator=str(payload.get("delegator") or ""),
+        delegatee=str(payload.get("delegatee") or ""),
+        scopes=scopes,
+        chain=[str(h) for h in (payload.get("chain") or []) if str(h)],
+        remaining_depth=int(payload.get("depth") or 0),
+        iat=int(payload.get("iat") or 0),
+        exp=exp,
+    )
+    if required_scope is not None and not claims.allows(required_scope):
+        raise DelegationTokenError(f"delegation token does not grant scope '{required_scope}'")
+    return claims
+
+
+def propagate_delegation_token(
+    token: str,
+    *,
+    next_delegatee: str,
+    scopes: list[str] | None = None,
+    tenant_id: str | None = None,
+    at: datetime | None = None,
+) -> tuple[str, DelegationToken]:
+    """Re-issue a token for the next hop, narrowing scope and decrementing depth.
+
+    The parent token is verified first (fail-closed). The child token:
+
+    * may only carry a **subset** of the parent's scopes (requesting a broader
+      scope raises — authority cannot be amplified down the chain),
+    * inherits the parent's ``exp`` (never extended),
+    * decrements the remaining-depth budget (refused when exhausted),
+    * appends ``next_delegatee`` to the delegation chain.
+    """
+    parent = verify_delegation_token(token, tenant_id=tenant_id, at=at)
+    if parent.remaining_depth <= 1:
+        raise DelegationTokenError("delegation depth budget is exhausted")
+    requested = _normalize_scopes(scopes) if scopes is not None else list(parent.scopes)
+    if not requested:
+        raise DelegationTokenError("a propagated delegation token must retain at least one scope")
+    broadened = set(requested) - set(parent.scopes)
+    if broadened:
+        raise DelegationTokenError("a propagated delegation token cannot broaden scope")
+    child = DelegationToken(
+        jti=f"dlg_{secrets.token_hex(8)}",
+        tenant_id=parent.tenant_id,
+        delegator=parent.delegatee,
+        delegatee=str(next_delegatee)[:200],
+        scopes=requested,
+        chain=[*parent.chain, str(next_delegatee).strip()[:200]],
+        remaining_depth=parent.remaining_depth - 1,
+        iat=parent.iat,
+        exp=parent.exp,
+    )
+    return _encode(child), child

--- a/src/agent_bom/api/mcp_config_store.py
+++ b/src/agent_bom/api/mcp_config_store.py
@@ -1,0 +1,318 @@
+"""Served MCP-client-config distribution store (#3908).
+
+A governed, tenant-scoped way to compose *chosen connectors* + an *assigned
+profile* (runtime role blueprint) into ONE distributable ``.mcp.json`` /
+``mcpServers`` document that an MCP client can consume from a single URL.
+
+Security invariants:
+
+* **Reference-only, never secret-bearing.** The served document lists each
+  connector's credential *env-var names* as ``${VAR}`` reference placeholders
+  (resolved by the consuming client from its own secret manager) and each cloud
+  connection by its opaque handle with ``has_secret`` — it NEVER embeds secret
+  material. This mirrors the existing connection-secret model
+  (:class:`agent_bom.api.connection_store.CloudConnectionRecord`) where
+  ``to_public_dict`` only ever exposes references.
+* **Tenant-scoped.** Assignments are keyed by tenant; a cross-tenant fetch is a
+  miss. Postgres enforces this with FORCE ROW LEVEL SECURITY.
+* **Read-only distribution.** The served document is produced by GET; creating
+  or revoking an assignment is a separate config-gated write.
+
+The store follows the durable-by-default tiering used across the control plane:
+in-memory (explicit ephemeral opt-out), SQLite (single-node durable default),
+and Postgres (multi-replica, tenant RLS).
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import secrets
+import sqlite3
+import threading
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class McpClientConfigAssignment:
+    """One tenant-scoped MCP-client-config assignment.
+
+    ``profile_id`` names a runtime role blueprint; ``connector_ids`` are registry
+    server ids / connector names; ``connection_ids`` are cloud-connection handles.
+    None of these carry secret material — they are references composed into the
+    served document at read time.
+    """
+
+    config_id: str
+    tenant_id: str
+    name: str
+    profile_id: str
+    connector_ids: list[str] = field(default_factory=list)
+    connection_ids: list[str] = field(default_factory=list)
+    created_at: str = ""
+    created_by: str = ""
+    updated_at: str = ""
+    revoked: bool = False
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class McpConfigStore(Protocol):
+    def put(self, assignment: McpClientConfigAssignment) -> None: ...
+
+    def get(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None: ...
+
+    def list_for_tenant(
+        self, tenant_id: str, *, include_revoked: bool = False, limit: int = 200
+    ) -> builtins.list[McpClientConfigAssignment]: ...
+
+
+class InMemoryMcpConfigStore:
+    def __init__(self) -> None:
+        self._rows: dict[str, McpClientConfigAssignment] = {}
+        self._lock = threading.Lock()
+
+    def put(self, assignment: McpClientConfigAssignment) -> None:
+        with self._lock:
+            self._rows[assignment.config_id] = assignment
+
+    def get(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
+        with self._lock:
+            row = self._rows.get(config_id)
+            if row is None or row.tenant_id != tenant_id:
+                return None
+            return row
+
+    def list_for_tenant(
+        self, tenant_id: str, *, include_revoked: bool = False, limit: int = 200
+    ) -> builtins.list[McpClientConfigAssignment]:
+        with self._lock:
+            rows = [r for r in self._rows.values() if r.tenant_id == tenant_id and (include_revoked or not r.revoked)]
+            return sorted(rows, key=lambda r: r.created_at, reverse=True)[:limit]
+
+
+class SQLiteMcpConfigStore:
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "mcp_client_configs")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS mcp_client_configs (
+                config_id  TEXT PRIMARY KEY,
+                tenant_id  TEXT NOT NULL,
+                name       TEXT NOT NULL,
+                profile_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                revoked    INTEGER NOT NULL DEFAULT 0,
+                data       TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_tenant ON mcp_client_configs(tenant_id, created_at)")
+        self._conn.commit()
+
+    def put(self, assignment: McpClientConfigAssignment) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO mcp_client_configs "
+            "(config_id, tenant_id, name, profile_id, created_at, revoked, data) VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                assignment.config_id,
+                assignment.tenant_id,
+                assignment.name,
+                assignment.profile_id,
+                assignment.created_at,
+                1 if assignment.revoked else 0,
+                json.dumps(asdict(assignment), sort_keys=True),
+            ),
+        )
+        self._conn.commit()
+
+    def get(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
+        row = self._conn.execute(
+            "SELECT data FROM mcp_client_configs WHERE config_id = ? AND tenant_id = ?", (config_id, tenant_id)
+        ).fetchone()
+        return McpClientConfigAssignment(**json.loads(row[0])) if row else None
+
+    def list_for_tenant(
+        self, tenant_id: str, *, include_revoked: bool = False, limit: int = 200
+    ) -> builtins.list[McpClientConfigAssignment]:
+        if include_revoked:
+            rows = self._conn.execute(
+                "SELECT data FROM mcp_client_configs WHERE tenant_id = ? ORDER BY created_at DESC LIMIT ?", (tenant_id, limit)
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT data FROM mcp_client_configs WHERE tenant_id = ? AND revoked = 0 ORDER BY created_at DESC LIMIT ?",
+                (tenant_id, limit),
+            ).fetchall()
+        return [McpClientConfigAssignment(**json.loads(r[0])) for r in rows]
+
+
+# ── Composition (reference-only served document) ─────────────────────────────────
+
+
+def _credential_reference(env_var: str, connector_id: str) -> dict[str, str]:
+    """Represent one credential as a reference — never a value.
+
+    ``value`` is the standard ``${VAR}`` env-expansion placeholder the consuming
+    MCP client resolves from its own environment / secret manager. ``handle`` is
+    an opaque control-plane reference to the connector's declared credential.
+    """
+    return {
+        "value": f"${{{env_var}}}",
+        "handle": f"connector:{connector_id}:{env_var}",
+        "source": "reference",
+    }
+
+
+def build_served_mcp_config(
+    assignment: McpClientConfigAssignment,
+    *,
+    registry: list[dict[str, Any]],
+    profile: dict[str, Any] | None,
+    connections: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Compose the served ``.mcp.json`` document for ``assignment``.
+
+    The result carries ``mcpServers`` (one entry per selected connector, with
+    credential *references* only), the assigned ``profile`` blueprint, and any
+    referenced cloud ``connections`` (by handle). It contains NO secret values.
+    """
+    by_id = {str(entry.get("id")): entry for entry in registry}
+    servers: dict[str, Any] = {}
+    unknown: list[str] = []
+    for connector_id in assignment.connector_ids:
+        entry = by_id.get(connector_id)
+        if entry is None:
+            unknown.append(connector_id)
+            continue
+        env_vars = [str(v) for v in (entry.get("credential_env_vars") or []) if str(v)]
+        packages = entry.get("packages") or []
+        server: dict[str, Any] = {
+            "connector_id": connector_id,
+            "name": entry.get("name") or connector_id,
+            "transport": entry.get("transport") or "stdio",
+            "publisher": entry.get("publisher"),
+            "risk_level": entry.get("risk_level"),
+            "packages": packages,
+            # Credentials are references only — never resolved secret values.
+            "env": {env_var: _credential_reference(env_var, connector_id) for env_var in env_vars},
+            "credential_references": [f"connector:{connector_id}:{env_var}" for env_var in env_vars],
+        }
+        servers[str(entry.get("name") or connector_id)] = server
+
+    connection_refs: list[dict[str, Any]] = []
+    for conn in connections or []:
+        connection_refs.append(
+            {
+                "connection_id": conn.get("connection_id") or conn.get("id"),
+                "provider": conn.get("provider"),
+                "display_name": conn.get("display_name"),
+                # Reference the secret by presence flag + handle only.
+                "has_secret": bool(conn.get("has_external_id")),
+                "handle": f"connection:{conn.get('connection_id') or conn.get('id')}",
+            }
+        )
+
+    return {
+        "schema_version": "mcp.client.config.v1",
+        "config_id": assignment.config_id,
+        "tenant_id": assignment.tenant_id,
+        "name": assignment.name,
+        "profile": profile,
+        "profile_id": assignment.profile_id,
+        "mcpServers": servers,
+        "connections": connection_refs,
+        "unknown_connectors": unknown,
+        "generated_at": _now_iso(),
+        "read_only": True,
+    }
+
+
+# ── Lifecycle + selection ────────────────────────────────────────────────────────
+
+
+def create_assignment(
+    store: McpConfigStore,
+    *,
+    tenant_id: str,
+    name: str,
+    profile_id: str,
+    connector_ids: list[str],
+    connection_ids: list[str] | None = None,
+    created_by: str = "",
+) -> McpClientConfigAssignment:
+    """Create and persist a tenant-scoped MCP-client-config assignment."""
+    now = _now_iso()
+    assignment = McpClientConfigAssignment(
+        config_id=f"mcpcfg_{secrets.token_hex(8)}",
+        tenant_id=tenant_id,
+        name=name[:200],
+        profile_id=profile_id,
+        connector_ids=list(connector_ids),
+        connection_ids=list(connection_ids or []),
+        created_at=now,
+        created_by=created_by[:200],
+        updated_at=now,
+        revoked=False,
+    )
+    store.put(assignment)
+    return assignment
+
+
+def revoke_assignment(store: McpConfigStore, *, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
+    assignment = store.get(tenant_id, config_id)
+    if assignment is None:
+        return None
+    assignment.revoked = True
+    assignment.updated_at = _now_iso()
+    store.put(assignment)
+    return assignment
+
+
+_MCP_CONFIG_STORE: McpConfigStore | None = None
+
+
+def get_mcp_config_store() -> McpConfigStore:
+    """Return the process MCP-config store, durable by default (see module docs)."""
+    global _MCP_CONFIG_STORE
+    if _MCP_CONFIG_STORE is not None:
+        return _MCP_CONFIG_STORE
+    from agent_bom.api.durable_store import select_backend, sqlite_path
+
+    backend = select_backend()
+    if backend == "postgres":
+        from agent_bom.api.postgres_mcp_config import PostgresMcpConfigStore
+
+        _MCP_CONFIG_STORE = PostgresMcpConfigStore()
+    elif backend == "memory":
+        _MCP_CONFIG_STORE = InMemoryMcpConfigStore()
+    else:
+        _MCP_CONFIG_STORE = SQLiteMcpConfigStore(sqlite_path())
+    return _MCP_CONFIG_STORE
+
+
+def set_mcp_config_store(store: McpConfigStore | None) -> None:
+    global _MCP_CONFIG_STORE
+    _MCP_CONFIG_STORE = store

--- a/src/agent_bom/api/postgres_mcp_config.py
+++ b/src/agent_bom/api/postgres_mcp_config.py
@@ -1,0 +1,96 @@
+"""Postgres-backed MCP-client-config distribution store (#3908).
+
+Mirrors :class:`agent_bom.api.mcp_config_store.SQLiteMcpConfigStore` but persists
+assignments in shared Postgres with tenant RLS, so a served MCP-client-config
+URL resolves consistently across every control-plane replica. Tenant isolation
+is enforced by Postgres FORCE ROW LEVEL SECURITY, not application filtering
+alone.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+from dataclasses import asdict
+
+from agent_bom.api.mcp_config_store import McpClientConfigAssignment
+from agent_bom.api.postgres_common import (
+    ConnectionPool,
+    _ensure_tenant_rls,
+    _get_pool,
+    _tenant_connection,
+)
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
+
+class PostgresMcpConfigStore:
+    """Shared MCP-client-config assignment store backed by Postgres (tenant RLS)."""
+
+    def __init__(self, pool: ConnectionPool | None = None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "mcp_client_configs")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS mcp_client_configs (
+                    config_id  TEXT PRIMARY KEY,
+                    tenant_id  TEXT NOT NULL,
+                    name       TEXT NOT NULL,
+                    profile_id TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    revoked    BOOLEAN NOT NULL DEFAULT FALSE,
+                    data       TEXT NOT NULL
+                )
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_tenant ON mcp_client_configs(tenant_id, created_at)")
+            _ensure_tenant_rls(conn, "mcp_client_configs", "tenant_id")
+            conn.commit()
+
+    def put(self, assignment: McpClientConfigAssignment) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO mcp_client_configs (config_id, tenant_id, name, profile_id, created_at, revoked, data)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (config_id) DO UPDATE SET
+                    name = EXCLUDED.name,
+                    profile_id = EXCLUDED.profile_id,
+                    revoked = EXCLUDED.revoked,
+                    data = EXCLUDED.data
+                """,
+                (
+                    assignment.config_id,
+                    assignment.tenant_id,
+                    assignment.name,
+                    assignment.profile_id,
+                    assignment.created_at,
+                    bool(assignment.revoked),
+                    json.dumps(asdict(assignment), sort_keys=True),
+                ),
+            )
+            conn.commit()
+
+    def get(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data FROM mcp_client_configs WHERE config_id = %s AND tenant_id = %s", (config_id, tenant_id)
+            ).fetchone()
+        return McpClientConfigAssignment(**json.loads(row[0])) if row else None
+
+    def list_for_tenant(
+        self, tenant_id: str, *, include_revoked: bool = False, limit: int = 200
+    ) -> builtins.list[McpClientConfigAssignment]:
+        with _tenant_connection(self._pool) as conn:
+            if include_revoked:
+                rows = conn.execute(
+                    "SELECT data FROM mcp_client_configs WHERE tenant_id = %s ORDER BY created_at DESC LIMIT %s",
+                    (tenant_id, limit),
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT data FROM mcp_client_configs WHERE tenant_id = %s AND revoked = FALSE ORDER BY created_at DESC LIMIT %s",
+                    (tenant_id, limit),
+                ).fetchall()
+        return [McpClientConfigAssignment(**json.loads(r[0])) for r in rows]

--- a/src/agent_bom/api/routes/identities.py
+++ b/src/agent_bom/api/routes/identities.py
@@ -27,9 +27,16 @@ from agent_bom.api.agent_identity_store import (
     set_conditional_policy_status,
 )
 from agent_bom.api.audit_log import log_action
+from agent_bom.api.delegation_token import (
+    DelegationTokenError,
+    issue_delegation_token,
+    propagate_delegation_token,
+    verify_delegation_token,
+)
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.webhook_store import emit_governance_event
 from agent_bom.rbac import require_authenticated_permission
+from agent_bom.security import sanitize_error
 
 router = APIRouter(tags=["identity"])
 
@@ -465,6 +472,9 @@ async def create_conditional_access_policy(request: Request, body: dict) -> dict
         allowed_hours_utc=_int_list(body, "allowed_hours_utc", lo=0, hi=23),
         allowed_weekdays=_int_list(body, "allowed_weekdays", lo=0, hi=6),
         allowed_source_cidrs=cidrs,
+        allowed_devices=_str_list(body, "allowed_devices", max_len=200),
+        allowed_groups=_str_list(body, "allowed_groups", max_len=120),
+        allowed_clients=_str_list(body, "allowed_clients", max_len=200),
         description=str(body.get("description", "") or ""),
     )
     log_action(
@@ -539,6 +549,159 @@ async def get_conditional_access_policy(request: Request, policy_id: str) -> dic
     """Return one conditional-access policy."""
     policy = _conditional_policy_for_tenant(request, policy_id)
     return {"schema_version": "agent.identity.conditional.v1", "policy": policy.to_public_dict()}
+
+
+# ── Scoped delegation tokens (multi-agent handoff) ──────────────────────────────
+
+
+def _delegation_scopes(body: dict) -> list[str]:
+    raw = body.get("scopes", [])
+    if not isinstance(raw, list) or not raw:
+        raise HTTPException(status_code=400, detail="'scopes' must be a non-empty list of capability strings")
+    scopes = [str(v).strip()[:200] for v in raw if str(v).strip()][:100]
+    if not scopes:
+        raise HTTPException(status_code=400, detail="'scopes' must contain at least one non-empty capability")
+    return scopes
+
+
+@router.post("/identities/{identity_id}/delegations", status_code=201, dependencies=[_dep("config")])
+async def issue_agent_delegation(request: Request, identity_id: str, body: dict) -> dict[str, object]:
+    """Issue a scoped, expiring delegation token from this identity to a delegatee.
+
+    The token is signed (HMAC), carries an explicit capability scope, and expires.
+    The delegatee (receiver) validates it via ``POST /v1/delegations/verify``; it
+    is propagated across further handoffs via ``POST /v1/delegations/propagate``.
+    """
+    identity = _identity_for_tenant(request, identity_id)
+    delegatee = str(body.get("delegatee", "") or "").strip()[:200]
+    if not delegatee:
+        raise HTTPException(status_code=400, detail="'delegatee' is required")
+    scopes = _delegation_scopes(body)
+    ttl_seconds = _ttl_seconds(body, default=900, max_seconds=3600)
+    chain = _str_list(body, "chain", max_len=200)
+    try:
+        token, claims = issue_delegation_token(
+            tenant_id=identity.tenant_id,
+            delegator=identity.agent_id or identity.identity_id,
+            delegatee=delegatee,
+            scopes=scopes,
+            ttl_seconds=ttl_seconds,
+            chain=chain,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="Invalid delegation request") from exc
+    log_action(
+        "agent_identity.delegation_issued",
+        actor=_actor(request),
+        resource=f"delegations/{claims.jti}",
+        tenant_id=identity.tenant_id,
+        delegator=claims.delegator,
+        delegatee=claims.delegatee,
+        scopes=claims.scopes,
+    )
+    _emit(
+        "identity.delegation_issued",
+        tenant_id=identity.tenant_id,
+        subject_id=identity.identity_id,
+        jti=claims.jti,
+        delegatee=claims.delegatee,
+        scopes=claims.scopes,
+        expires_at=claims.exp,
+    )
+    return {
+        "schema_version": "agent.identity.delegation.v1",
+        "token": token,
+        "delegation": {
+            "jti": claims.jti,
+            "tenant_id": claims.tenant_id,
+            "delegator": claims.delegator,
+            "delegatee": claims.delegatee,
+            "scopes": claims.scopes,
+            "chain": claims.chain,
+            "remaining_depth": claims.remaining_depth,
+            "issued_at": claims.iat,
+            "expires_at": claims.exp,
+        },
+    }
+
+
+@router.post("/delegations/verify", dependencies=[_dep("read")])
+async def verify_agent_delegation(request: Request, body: dict) -> dict[str, object]:
+    """Validate a delegation token for the active tenant (receiver side).
+
+    Returns ``{valid: true, delegation: {...}}`` for a well-formed, unexpired,
+    in-scope token; ``{valid: false, reason}`` otherwise (fail-closed). When
+    ``required_scope`` is supplied, an over-scoped call (capability outside the
+    token's scope) is rejected.
+    """
+    token = str(body.get("token", "") or "")
+    required_scope = body.get("required_scope")
+    required_scope = str(required_scope).strip() if required_scope not in (None, "") else None
+    try:
+        claims = verify_delegation_token(token, tenant_id=_tenant(request), required_scope=required_scope)
+    except DelegationTokenError as exc:
+        return {"schema_version": "agent.identity.delegation.v1", "valid": False, "reason": sanitize_error(exc)}
+    return {
+        "schema_version": "agent.identity.delegation.v1",
+        "valid": True,
+        "delegation": {
+            "jti": claims.jti,
+            "tenant_id": claims.tenant_id,
+            "delegator": claims.delegator,
+            "delegatee": claims.delegatee,
+            "scopes": claims.scopes,
+            "chain": claims.chain,
+            "remaining_depth": claims.remaining_depth,
+            "issued_at": claims.iat,
+            "expires_at": claims.exp,
+        },
+    }
+
+
+@router.post("/delegations/propagate", status_code=201, dependencies=[_dep("config")])
+async def propagate_agent_delegation(request: Request, body: dict) -> dict[str, object]:
+    """Propagate a delegation token to the next hop, narrowing scope only.
+
+    The child token inherits the parent's expiry (never extended), may only carry
+    a subset of the parent's scopes, and decrements the delegation-depth budget.
+    """
+    token = str(body.get("token", "") or "")
+    next_delegatee = str(body.get("next_delegatee", "") or "").strip()[:200]
+    if not next_delegatee:
+        raise HTTPException(status_code=400, detail="'next_delegatee' is required")
+    scopes = None
+    if "scopes" in body:
+        scopes = _delegation_scopes(body)
+    try:
+        child_token, claims = propagate_delegation_token(
+            token, next_delegatee=next_delegatee, scopes=scopes, tenant_id=_tenant(request)
+        )
+    except DelegationTokenError as exc:
+        raise HTTPException(status_code=400, detail=f"Delegation cannot be propagated: {sanitize_error(exc)}") from exc
+    log_action(
+        "agent_identity.delegation_propagated",
+        actor=_actor(request),
+        resource=f"delegations/{claims.jti}",
+        tenant_id=claims.tenant_id,
+        delegator=claims.delegator,
+        delegatee=claims.delegatee,
+        scopes=claims.scopes,
+    )
+    return {
+        "schema_version": "agent.identity.delegation.v1",
+        "token": child_token,
+        "delegation": {
+            "jti": claims.jti,
+            "tenant_id": claims.tenant_id,
+            "delegator": claims.delegator,
+            "delegatee": claims.delegatee,
+            "scopes": claims.scopes,
+            "chain": claims.chain,
+            "remaining_depth": claims.remaining_depth,
+            "issued_at": claims.iat,
+            "expires_at": claims.exp,
+        },
+    }
 
 
 @router.post("/identities/discover", dependencies=[_dep("read")])

--- a/src/agent_bom/api/routes/identities.py
+++ b/src/agent_bom/api/routes/identities.py
@@ -639,8 +639,12 @@ async def verify_agent_delegation(request: Request, body: dict) -> dict[str, obj
     required_scope = str(required_scope).strip() if required_scope not in (None, "") else None
     try:
         claims = verify_delegation_token(token, tenant_id=_tenant(request), required_scope=required_scope)
-    except DelegationTokenError as exc:
-        return {"schema_version": "agent.identity.delegation.v1", "valid": False, "reason": sanitize_error(exc)}
+    except DelegationTokenError:
+        return {
+            "schema_version": "agent.identity.delegation.v1",
+            "valid": False,
+            "reason": sanitize_error("delegation token verification failed", generic=True),
+        }
     return {
         "schema_version": "agent.identity.delegation.v1",
         "valid": True,

--- a/src/agent_bom/api/routes/mcp_config.py
+++ b/src/agent_bom/api/routes/mcp_config.py
@@ -1,0 +1,196 @@
+"""Served MCP-client-config distribution API routes (#3908).
+
+Composes chosen connectors + an assigned profile (runtime role blueprint) into
+ONE governed, tenant-scoped, read-only ``.mcp.json`` document a client consumes
+from a single URL.
+
+Endpoints:
+    POST /v1/mcp-config/assignments               assign a profile → yields a config URL (config-gated)
+    GET  /v1/mcp-config/assignments               list assignments for the tenant (read)
+    GET  /v1/mcp-config/assignments/{config_id}   one assignment (read)
+    POST /v1/mcp-config/assignments/{config_id}/revoke   revoke an assignment (config-gated)
+    GET  /v1/mcp-config/{config_id}/mcp.json      serve the composed read-only config (read)
+
+Security: the served document references connectors' credential env-vars and
+cloud connections by *handle* only — it never embeds secret material. Access is
+RBAC-gated and tenant-scoped; a cross-tenant fetch is a 404.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from fastapi import APIRouter, HTTPException, Request
+
+from agent_bom.api.audit_log import log_action
+from agent_bom.api.mcp_config_store import (
+    McpClientConfigAssignment,
+    build_served_mcp_config,
+    create_assignment,
+    get_mcp_config_store,
+    revoke_assignment,
+)
+from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.api.versioning import API_V1_PREFIX
+from agent_bom.rbac import require_authenticated_permission
+from agent_bom.runtime_blueprints import runtime_role_blueprint
+
+router = APIRouter(tags=["mcp-config"])
+
+
+def _dep(permission: str) -> Any:
+    return cast(Any, require_authenticated_permission(permission))
+
+
+def _tenant(request: Request) -> str:
+    return require_request_tenant_id(request)
+
+
+def _actor(request: Request) -> str:
+    return getattr(getattr(request, "state", None), "actor", None) or "api"
+
+
+def _str_list(body: dict, key: str, *, max_items: int = 200, max_len: int = 200) -> list[str]:
+    raw = body.get(key, [])
+    if raw in (None, ""):
+        return []
+    if not isinstance(raw, list):
+        raise HTTPException(status_code=400, detail=f"'{key}' must be a list of strings")
+    return [str(v).strip()[:max_len] for v in raw if str(v).strip()][:max_items]
+
+
+def _registry() -> list[dict[str, Any]]:
+    from agent_bom.api.routes.connectors import _load_registry
+
+    return _load_registry()
+
+
+def _tenant_connections(tenant_id: str) -> list[dict[str, Any]]:
+    """Non-secret public dicts for the tenant's cloud connections (or empty)."""
+    try:
+        from agent_bom.api.connection_store import get_connection_store
+
+        return [r.to_public_dict() for r in get_connection_store().list_for_tenant(tenant_id)]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _config_url(config_id: str) -> str:
+    return f"{API_V1_PREFIX}/mcp-config/{config_id}/mcp.json"
+
+
+@router.post("/mcp-config/assignments", status_code=201, dependencies=[_dep("config")])
+async def create_mcp_config_assignment(request: Request, body: dict) -> dict[str, object]:
+    """Assign a profile + connectors, yielding one distributable read-only config URL."""
+    tenant_id = _tenant(request)
+    name = str(body.get("name", "") or "").strip()
+    if not name:
+        raise HTTPException(status_code=400, detail="'name' is required")
+    profile_id = str(body.get("profile_id", "") or "").strip()
+    if not profile_id:
+        raise HTTPException(status_code=400, detail="'profile_id' is required")
+    if runtime_role_blueprint(profile_id) is None:
+        raise HTTPException(status_code=400, detail="Unknown profile_id")
+
+    connector_ids = _str_list(body, "connector_ids")
+    if not connector_ids:
+        raise HTTPException(status_code=400, detail="'connector_ids' must list at least one connector")
+    known = {str(e.get("id")) for e in _registry()}
+    unknown = [c for c in connector_ids if c not in known]
+    if unknown:
+        raise HTTPException(status_code=400, detail="One or more connector_ids are not in the registry")
+
+    connection_ids = _str_list(body, "connection_ids")
+    if connection_ids:
+        owned = {str(c.get("id")) for c in _tenant_connections(tenant_id)}
+        if any(cid not in owned for cid in connection_ids):
+            raise HTTPException(status_code=404, detail="One or more connection_ids are not available for this tenant")
+
+    assignment = create_assignment(
+        get_mcp_config_store(),
+        tenant_id=tenant_id,
+        name=name,
+        profile_id=profile_id,
+        connector_ids=connector_ids,
+        connection_ids=connection_ids,
+        created_by=_actor(request),
+    )
+    log_action(
+        "mcp_config.assignment_created",
+        actor=_actor(request),
+        resource=f"mcp-config/{assignment.config_id}",
+        tenant_id=tenant_id,
+        profile_id=profile_id,
+        connector_count=len(connector_ids),
+    )
+    return {
+        "schema_version": "mcp.client.config.v1",
+        "assignment": assignment.to_public_dict(),
+        "config_url": _config_url(assignment.config_id),
+    }
+
+
+@router.get("/mcp-config/assignments", dependencies=[_dep("read")])
+async def list_mcp_config_assignments(request: Request, include_revoked: bool = False, limit: int = 200) -> dict[str, object]:
+    """List MCP-client-config assignments for the active tenant."""
+    tenant_id = _tenant(request)
+    bounded = max(1, min(limit, 1000))
+    rows = get_mcp_config_store().list_for_tenant(tenant_id, include_revoked=include_revoked, limit=bounded)
+    return {
+        "schema_version": "mcp.client.config.v1",
+        "tenant_id": tenant_id,
+        "count": len(rows),
+        "assignments": [
+            {**r.to_public_dict(), "config_url": _config_url(r.config_id)} for r in rows
+        ],
+    }
+
+
+def _assignment_for_tenant(request: Request, config_id: str) -> McpClientConfigAssignment:
+    assignment = get_mcp_config_store().get(_tenant(request), config_id)
+    if assignment is None:
+        raise HTTPException(status_code=404, detail="MCP-client-config assignment not found")
+    return assignment
+
+
+@router.get("/mcp-config/assignments/{config_id}", dependencies=[_dep("read")])
+async def get_mcp_config_assignment(request: Request, config_id: str) -> dict[str, object]:
+    """Return one MCP-client-config assignment (metadata)."""
+    assignment = _assignment_for_tenant(request, config_id)
+    return {
+        "schema_version": "mcp.client.config.v1",
+        "assignment": assignment.to_public_dict(),
+        "config_url": _config_url(assignment.config_id),
+    }
+
+
+@router.post("/mcp-config/assignments/{config_id}/revoke", dependencies=[_dep("config")])
+async def revoke_mcp_config_assignment(request: Request, config_id: str) -> dict[str, object]:
+    """Revoke an assignment; its served config URL then 404s."""
+    _assignment_for_tenant(request, config_id)
+    assignment = revoke_assignment(get_mcp_config_store(), tenant_id=_tenant(request), config_id=config_id)
+    if assignment is None:
+        raise HTTPException(status_code=404, detail="MCP-client-config assignment not found")
+    log_action(
+        "mcp_config.assignment_revoked",
+        actor=_actor(request),
+        resource=f"mcp-config/{assignment.config_id}",
+        tenant_id=assignment.tenant_id,
+    )
+    return {"schema_version": "mcp.client.config.v1", "assignment": assignment.to_public_dict()}
+
+
+@router.get("/mcp-config/{config_id}/mcp.json", dependencies=[_dep("read")])
+async def serve_mcp_client_config(request: Request, config_id: str) -> dict[str, object]:
+    """Serve the composed, read-only ``.mcp.json`` document for a tenant + config.
+
+    References connectors/secrets by handle only — never embeds secret material.
+    Cross-tenant or revoked assignments 404 (fail-closed).
+    """
+    tenant_id = _tenant(request)
+    assignment = get_mcp_config_store().get(tenant_id, config_id)
+    if assignment is None or assignment.revoked:
+        raise HTTPException(status_code=404, detail="MCP-client-config not found")
+    profile = runtime_role_blueprint(assignment.profile_id)
+    connections = [c for c in _tenant_connections(tenant_id) if str(c.get("id")) in set(assignment.connection_ids)]
+    return build_served_mcp_config(assignment, registry=_registry(), profile=profile, connections=connections)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -875,6 +875,7 @@ from agent_bom.api.routes.graph import router as _graph_router  # noqa: E402
 from agent_bom.api.routes.identities import router as _identities_router  # noqa: E402
 from agent_bom.api.routes.intel import router as _intel_router  # noqa: E402
 from agent_bom.api.routes.inventory_assets import router as _inventory_assets_router  # noqa: E402
+from agent_bom.api.routes.mcp_config import router as _mcp_config_router  # noqa: E402
 from agent_bom.api.routes.mitre import router as _mitre_router  # noqa: E402
 from agent_bom.api.routes.observability import infra_router as _observability_infra_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
@@ -919,6 +920,7 @@ for _router in (
     _identities_router,
     _intel_router,
     _inventory_assets_router,
+    _mcp_config_router,
     _mitre_router,
     _observability_router,
     _overview_router,

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -496,6 +496,44 @@ def _request_context_attributes(request: Request) -> dict[str, str]:
     return attributes
 
 
+def _request_device_id(request: Request) -> str:
+    """Resolve the caller device/workstation id for device ABAC conditions.
+
+    Read from the ``x-agent-device-id`` header (set by the endpoint agent / MDM
+    posture broker). Empty when unset, in which case a device condition simply
+    fails closed for policies that require one.
+    """
+    return (request.headers.get("x-agent-device-id", "") or "").strip()[:200]
+
+
+def _request_groups(request: Request) -> list[str]:
+    """Resolve the caller's directory groups for group ABAC conditions.
+
+    Groups arrive comma-separated in the ``x-agent-groups`` header (asserted by
+    the IdP / trust proxy after authentication). Bounded and de-duplicated.
+    """
+    raw = (request.headers.get("x-agent-groups", "") or "").strip()
+    if not raw:
+        return []
+    seen: list[str] = []
+    for part in raw.split(","):
+        value = part.strip()[:120]
+        if value and value not in seen:
+            seen.append(value)
+        if len(seen) >= 64:
+            break
+    return seen
+
+
+def _request_client_id(request: Request) -> str:
+    """Resolve the MCP client application id for client ABAC conditions.
+
+    Read from the ``x-agent-client-id`` header (the client app making the call).
+    Empty when unset; a client condition fails closed for policies requiring one.
+    """
+    return (request.headers.get("x-agent-client-id", "") or "").strip()[:200]
+
+
 def _request_cost_center(request: Request, message: dict[str, Any]) -> str:
     """Resolve the chargeback cost-center this call is allocated to.
 
@@ -2103,6 +2141,9 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         tool_name=tool_name,
                         environment=_request_environment(request),
                         source_ip=_request_source_ip(request),
+                        device_id=_request_device_id(request),
+                        groups=_request_groups(request),
+                        client_id=_request_client_id(request),
                     )
                     cond_allowed, cond_reason, cond_policy_id = evaluate_conditional_access_for_request(
                         get_agent_identity_store(),
@@ -2247,6 +2288,9 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     risk_score=_request_risk_score(request),
                     environment=_request_environment(request),
                     source_ip=_request_source_ip(request),
+                    device_id=_request_device_id(request),
+                    groups=_request_groups(request),
+                    client_id=_request_client_id(request),
                     attributes=_request_context_attributes(request),
                 )
                 try:

--- a/src/agent_bom/proxy_policy.py
+++ b/src/agent_bom/proxy_policy.py
@@ -429,6 +429,11 @@ class DecisionContext:
     minute_of_day: int | None = None  # 0..1439 (UTC)
     environment: str = ""
     source_ip: str = ""
+    # Device / group / client ABAC attributes (empty = not supplied → a policy
+    # that constrains one fails closed).
+    device_id: str = ""
+    groups: tuple[str, ...] = ()
+    client_id: str = ""
     attributes: dict[str, str] = field(default_factory=dict)
 
 
@@ -441,6 +446,9 @@ def context_from_now(
     risk_score: float | None = None,
     environment: str = "",
     source_ip: str = "",
+    device_id: str = "",
+    groups: tuple[str, ...] | list[str] | None = None,
+    client_id: str = "",
     attributes: dict[str, str] | None = None,
 ) -> DecisionContext:
     """Build a :class:`DecisionContext`, deriving weekday / minute-of-day from
@@ -458,6 +466,9 @@ def context_from_now(
         minute_of_day=moment.hour * 60 + moment.minute,
         environment=environment,
         source_ip=source_ip,
+        device_id=device_id,
+        groups=tuple(groups or ()),
+        client_id=client_id,
         attributes=dict(attributes or {}),
     )
 
@@ -496,6 +507,12 @@ def evaluate_conditions(conditions: dict[str, Any], ctx: DecisionContext) -> tup
     * ``min_risk_score`` / ``max_risk_score``: numeric bounds on ``risk_score``.
     * ``required_attributes``: ``{key: expected}`` — every key must match
       ``ctx.attributes`` (string-compared).
+    * ``allowed_devices`` / ``allowed_groups`` / ``allowed_clients``: ABAC
+      allow-lists on the calling device, the caller's directory groups
+      (membership), and the MCP client application. A request that does not
+      supply the constrained attribute fails closed (the condition is not met),
+      so a device/group/client guardrail denies rather than waving the call
+      through.
 
     An empty / non-dict block is satisfied (no constraint), preserving the
     behaviour of rules that carry no conditions.
@@ -534,6 +551,21 @@ def evaluate_conditions(conditions: dict[str, Any], ctx: DecisionContext) -> tup
         for key, expected in required.items():
             if str(ctx.attributes.get(str(key), "")) != str(expected):
                 return False, f"required context attribute '{key}' not satisfied"
+
+    allowed_devices = conditions.get("allowed_devices")
+    if isinstance(allowed_devices, list) and allowed_devices:
+        if not ctx.device_id or ctx.device_id not in {str(d) for d in allowed_devices}:
+            return False, "request device is not in the permitted device allow-list"
+
+    allowed_groups = conditions.get("allowed_groups")
+    if isinstance(allowed_groups, list) and allowed_groups:
+        if not (set(ctx.groups) & {str(g) for g in allowed_groups}):
+            return False, "caller is not a member of a permitted group"
+
+    allowed_clients = conditions.get("allowed_clients")
+    if isinstance(allowed_clients, list) and allowed_clients:
+        if not ctx.client_id or ctx.client_id not in {str(c) for c in allowed_clients}:
+            return False, "request client application is not in the permitted client allow-list"
 
     return True, ""
 

--- a/tests/test_governance_abac_delegation.py
+++ b/tests/test_governance_abac_delegation.py
@@ -1,0 +1,241 @@
+"""ABAC device/group/client conditions + scoped delegation tokens (#3906)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom import agent_identity
+from agent_bom.api.agent_identity_store import (
+    AccessContext,
+    InMemoryAgentIdentityStore,
+    create_conditional_policy,
+    evaluate_conditional_access,
+    issue_identity,
+    set_agent_identity_store,
+    verify_token,
+)
+from agent_bom.api.delegation_token import (
+    DelegationTokenError,
+    issue_delegation_token,
+    propagate_delegation_token,
+    verify_delegation_token,
+)
+from agent_bom.proxy_policy import context_from_now, evaluate_conditions
+
+
+@pytest.fixture()
+def store():
+    s = InMemoryAgentIdentityStore()
+    set_agent_identity_store(s)
+    agent_identity.set_local_identity_verifier(lambda tok: verify_token(s, tok))
+    try:
+        yield s
+    finally:
+        set_agent_identity_store(None)
+        agent_identity.set_local_identity_verifier(None)
+
+
+# ── ABAC: ConditionalAccessPolicy device / group / client (gateway path) ─────────
+
+
+def test_require_policy_denies_on_wrong_device_fail_closed():
+    policy = create_conditional_policy(
+        InMemoryAgentIdentityStore(), tenant_id="t1", name="managed-only", effect="require", allowed_devices=["dev-managed-1"]
+    )
+    # No device supplied → cannot prove the condition → deny (fail-closed).
+    allowed, _, pid = evaluate_conditional_access([policy], AccessContext(agent_id="a"))
+    assert not allowed and pid == policy.policy_id
+    # Wrong device → deny.
+    allowed, _, _ = evaluate_conditional_access([policy], AccessContext(agent_id="a", device_id="dev-byod-9"))
+    assert not allowed
+    # Correct device → allow.
+    allowed, _, _ = evaluate_conditional_access([policy], AccessContext(agent_id="a", device_id="dev-managed-1"))
+    assert allowed
+
+
+def test_require_policy_denies_on_missing_group_membership():
+    policy = create_conditional_policy(
+        InMemoryAgentIdentityStore(), tenant_id="t1", name="sec-eng-only", effect="require", allowed_groups=["security-eng"]
+    )
+    allowed, _, _ = evaluate_conditional_access([policy], AccessContext(groups=[]))
+    assert not allowed
+    allowed, _, _ = evaluate_conditional_access([policy], AccessContext(groups=["marketing"]))
+    assert not allowed
+    allowed, _, _ = evaluate_conditional_access([policy], AccessContext(groups=["marketing", "security-eng"]))
+    assert allowed
+
+
+def test_require_policy_denies_on_wrong_client():
+    policy = create_conditional_policy(
+        InMemoryAgentIdentityStore(), tenant_id="t1", name="approved-client", effect="require", allowed_clients=["claude-desktop"]
+    )
+    allowed, _, _ = evaluate_conditional_access([policy], AccessContext(client_id=""))
+    assert not allowed
+    allowed, _, _ = evaluate_conditional_access([policy], AccessContext(client_id="rogue-cli"))
+    assert not allowed
+    allowed, _, _ = evaluate_conditional_access([policy], AccessContext(client_id="claude-desktop"))
+    assert allowed
+
+
+def test_proxy_declarative_conditions_device_group_client_fail_closed():
+    ctx = context_from_now(now=0.0)  # no device/group/client supplied
+    ok, reason = evaluate_conditions({"allowed_devices": ["dev-1"]}, ctx)
+    assert not ok and "device" in reason
+    ok, reason = evaluate_conditions({"allowed_groups": ["sec"]}, ctx)
+    assert not ok and "group" in reason
+    ok, reason = evaluate_conditions({"allowed_clients": ["claude"]}, ctx)
+    assert not ok and "client" in reason
+
+    good = context_from_now(now=0.0, device_id="dev-1", groups=["sec"], client_id="claude")
+    assert evaluate_conditions({"allowed_devices": ["dev-1"]}, good) == (True, "")
+    assert evaluate_conditions({"allowed_groups": ["sec"]}, good) == (True, "")
+    assert evaluate_conditions({"allowed_clients": ["claude"]}, good) == (True, "")
+
+
+def test_conditional_access_blocks_at_gateway_on_device(store):
+    from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+    from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+    issue_identity(store, agent_id="agent-a", tenant_id="default")
+    create_conditional_policy(store, tenant_id="default", name="managed-only", effect="require", allowed_devices=["dev-managed"])
+
+    async def ok_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")]),
+        policy={},
+        upstream_caller=ok_caller,
+    )
+    client = TestClient(create_gateway_app(settings))
+    message = {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "list_files", "arguments": {}}}
+
+    blocked = client.post("/mcp/filesystem", json=message, headers={"x-agent-device-id": "dev-byod"})
+    assert blocked.json().get("error", {}).get("code") == -32001, blocked.text
+
+    allowed = client.post("/mcp/filesystem", json=message, headers={"x-agent-device-id": "dev-managed"})
+    assert allowed.status_code == 200 and allowed.json()["result"] == {"ok": True}
+
+
+# ── Scoped delegation tokens ─────────────────────────────────────────────────────
+
+
+def test_delegation_token_verifies_and_is_scoped():
+    token, claims = issue_delegation_token(
+        tenant_id="t1", delegator="orchestrator", delegatee="worker", scopes=["read_repo", "list_files"], ttl_seconds=300
+    )
+    verified = verify_delegation_token(token, tenant_id="t1", required_scope="read_repo")
+    assert verified.delegator == "orchestrator" and verified.delegatee == "worker"
+    assert set(verified.scopes) == {"read_repo", "list_files"}
+
+
+def test_delegation_token_rejects_over_scoped_call():
+    token, _ = issue_delegation_token(tenant_id="t1", delegator="o", delegatee="w", scopes=["read_repo"], ttl_seconds=300)
+    with pytest.raises(DelegationTokenError):
+        verify_delegation_token(token, tenant_id="t1", required_scope="delete_repo")
+
+
+def test_delegation_token_rejects_expired():
+    past = datetime.now(timezone.utc) - timedelta(hours=1)
+    token, _ = issue_delegation_token(tenant_id="t1", delegator="o", delegatee="w", scopes=["read_repo"], ttl_seconds=60, at=past)
+    with pytest.raises(DelegationTokenError):
+        verify_delegation_token(token, tenant_id="t1")
+
+
+def test_delegation_token_rejects_tampered_signature():
+    token, _ = issue_delegation_token(tenant_id="t1", delegator="o", delegatee="w", scopes=["read_repo"], ttl_seconds=60)
+    payload, _sig = token.split(".", 1)
+    tampered = f"{payload}.AAAA"
+    with pytest.raises(DelegationTokenError):
+        verify_delegation_token(tampered, tenant_id="t1")
+
+
+def test_delegation_token_rejects_cross_tenant():
+    token, _ = issue_delegation_token(tenant_id="t1", delegator="o", delegatee="w", scopes=["read_repo"], ttl_seconds=60)
+    with pytest.raises(DelegationTokenError):
+        verify_delegation_token(token, tenant_id="t2")
+
+
+def test_delegation_scopeless_token_refused():
+    with pytest.raises(ValueError):
+        issue_delegation_token(tenant_id="t1", delegator="o", delegatee="w", scopes=[], ttl_seconds=60)
+
+
+def test_delegation_propagation_narrows_scope_and_decrements_depth():
+    token, parent = issue_delegation_token(
+        tenant_id="t1", delegator="o", delegatee="w1", scopes=["read_repo", "list_files"], ttl_seconds=300
+    )
+    child_token, child = propagate_delegation_token(token, next_delegatee="w2", scopes=["read_repo"], tenant_id="t1")
+    assert child.scopes == ["read_repo"]
+    assert child.chain[-1] == "w2"
+    assert child.remaining_depth == parent.remaining_depth - 1
+    assert child.exp == parent.exp  # expiry never extended
+    verify_delegation_token(child_token, tenant_id="t1", required_scope="read_repo")
+
+
+def test_delegation_propagation_cannot_broaden_scope():
+    token, _ = issue_delegation_token(tenant_id="t1", delegator="o", delegatee="w1", scopes=["read_repo"], ttl_seconds=300)
+    with pytest.raises(DelegationTokenError):
+        propagate_delegation_token(token, next_delegatee="w2", scopes=["read_repo", "delete_repo"], tenant_id="t1")
+
+
+# ── API surface ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture()
+def client(store):
+    from agent_bom.api.server import app
+
+    return TestClient(app)
+
+
+def test_delegation_api_issue_verify_propagate(client, store):
+    issued = client.post("/v1/identities", json={"agent_id": "orchestrator", "blueprint_id": "developer"})
+    assert issued.status_code == 201, issued.text
+    identity_id = issued.json()["identity"]["identity_id"]
+
+    resp = client.post(
+        f"/v1/identities/{identity_id}/delegations",
+        json={"delegatee": "worker", "scopes": ["read_repo", "list_files"], "ttl_seconds": 300},
+    )
+    assert resp.status_code == 201, resp.text
+    token = resp.json()["token"]
+    assert resp.json()["delegation"]["scopes"] == ["list_files", "read_repo"]
+
+    verified = client.post("/v1/delegations/verify", json={"token": token, "required_scope": "read_repo"})
+    assert verified.status_code == 200 and verified.json()["valid"] is True
+
+    over = client.post("/v1/delegations/verify", json={"token": token, "required_scope": "delete_repo"})
+    assert over.json()["valid"] is False
+
+    prop = client.post("/v1/delegations/propagate", json={"token": token, "next_delegatee": "worker-2", "scopes": ["read_repo"]})
+    assert prop.status_code == 201, prop.text
+    assert prop.json()["delegation"]["scopes"] == ["read_repo"]
+
+
+def test_delegation_api_requires_scopes(client, store):
+    issued = client.post("/v1/identities", json={"agent_id": "o", "blueprint_id": "developer"})
+    identity_id = issued.json()["identity"]["identity_id"]
+    resp = client.post(f"/v1/identities/{identity_id}/delegations", json={"delegatee": "w", "scopes": []})
+    assert resp.status_code == 400
+
+
+def test_conditional_access_api_accepts_device_group_client(client, store):
+    created = client.post(
+        "/v1/conditional-access-policies",
+        json={
+            "name": "managed-sec-eng",
+            "effect": "require",
+            "allowed_devices": ["dev-managed"],
+            "allowed_groups": ["security-eng"],
+            "allowed_clients": ["claude-desktop"],
+        },
+    )
+    assert created.status_code == 201, created.text
+    policy = created.json()["policy"]
+    assert policy["allowed_devices"] == ["dev-managed"]
+    assert policy["allowed_groups"] == ["security-eng"]
+    assert policy["allowed_clients"] == ["claude-desktop"]

--- a/tests/test_mcp_config_distribution.py
+++ b/tests/test_mcp_config_distribution.py
@@ -1,0 +1,158 @@
+"""Served, governed MCP-client-config distribution (#3908)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.mcp_config_store import (
+    InMemoryMcpConfigStore,
+    build_served_mcp_config,
+    create_assignment,
+    set_mcp_config_store,
+)
+
+
+@pytest.fixture()
+def store():
+    s = InMemoryMcpConfigStore()
+    set_mcp_config_store(s)
+    try:
+        yield s
+    finally:
+        set_mcp_config_store(None)
+
+
+@pytest.fixture()
+def client(store):
+    from agent_bom.api.server import app
+
+    return TestClient(app)
+
+
+def _first_connector_id(client) -> str:
+    servers = client.get("/v1/registry").json()["servers"]
+    assert servers, "registry should not be empty"
+    return servers[0]["id"]
+
+
+# ── Composition: reference-only, no secrets ──────────────────────────────────────
+
+
+def test_build_served_config_has_no_secret_values():
+    registry = [
+        {
+            "id": "modelcontextprotocol/github",
+            "name": "GitHub",
+            "transport": "stdio",
+            "publisher": "modelcontextprotocol",
+            "credential_env_vars": ["GITHUB_TOKEN"],
+            "packages": [{"name": "server-github", "ecosystem": "npm"}],
+        }
+    ]
+    assignment = create_assignment(
+        InMemoryMcpConfigStore(),
+        tenant_id="t1",
+        name="dev-config",
+        profile_id="developer",
+        connector_ids=["modelcontextprotocol/github"],
+    )
+    doc = build_served_mcp_config(
+        assignment,
+        registry=registry,
+        profile={"blueprint_id": "developer"},
+        connections=[{"id": "conn-1", "provider": "aws", "display_name": "prod", "has_external_id": True}],
+    )
+    server = doc["mcpServers"]["GitHub"]
+    # Credential is a reference placeholder, never a value.
+    assert server["env"]["GITHUB_TOKEN"]["value"] == "${GITHUB_TOKEN}"
+    assert server["env"]["GITHUB_TOKEN"]["source"] == "reference"
+    # Connection referenced by handle + presence flag only.
+    assert doc["connections"][0]["has_secret"] is True
+    assert doc["connections"][0]["handle"] == "connection:conn-1"
+    # Airtight: the serialized doc contains no obvious secret material.
+    blob = json.dumps(doc)
+    assert "external_id" not in blob
+    assert "role_ref" not in blob
+    assert doc["read_only"] is True
+
+
+# ── API: assign → serve → tenant isolation ───────────────────────────────────────
+
+
+def test_assign_profile_yields_read_only_config_url(client):
+    connector_id = _first_connector_id(client)
+    resp = client.post(
+        "/v1/mcp-config/assignments",
+        json={"name": "sec-analyst", "profile_id": "security_analyst", "connector_ids": [connector_id]},
+    )
+    assert resp.status_code == 201, resp.text
+    config_url = resp.json()["config_url"]
+    assert config_url.endswith("/mcp.json")
+
+    served = client.get(config_url)
+    assert served.status_code == 200, served.text
+    doc = served.json()
+    assert doc["read_only"] is True
+    assert doc["profile"]["blueprint_id"] == "security_analyst"
+    assert list(doc["mcpServers"].keys()), "served config should list the selected connector"
+    # No secret material in the served document.
+    assert "external_id_encrypted" not in json.dumps(doc)
+
+
+def test_serve_rejects_unknown_profile(client):
+    connector_id = _first_connector_id(client)
+    resp = client.post(
+        "/v1/mcp-config/assignments",
+        json={"name": "x", "profile_id": "not-a-profile", "connector_ids": [connector_id]},
+    )
+    assert resp.status_code == 400
+
+
+def test_serve_rejects_unknown_connector(client):
+    resp = client.post(
+        "/v1/mcp-config/assignments",
+        json={"name": "x", "profile_id": "developer", "connector_ids": ["totally/unknown-server"]},
+    )
+    assert resp.status_code == 400
+
+
+def test_revoked_config_404s(client):
+    connector_id = _first_connector_id(client)
+    created = client.post(
+        "/v1/mcp-config/assignments",
+        json={"name": "x", "profile_id": "developer", "connector_ids": [connector_id]},
+    ).json()
+    config_id = created["assignment"]["config_id"]
+    assert client.get(created["config_url"]).status_code == 200
+    assert client.post(f"/v1/mcp-config/assignments/{config_id}/revoke").status_code == 200
+    assert client.get(created["config_url"]).status_code == 404
+
+
+def test_cross_tenant_access_denied(store):
+    # The tenant boundary is enforced at the store: a fetch scoped to a
+    # different tenant is a miss (Postgres additionally enforces this with RLS).
+    assignment = create_assignment(
+        store,
+        tenant_id="tenant-a",
+        name="a-config",
+        profile_id="developer",
+        connector_ids=["modelcontextprotocol/github"],
+    )
+    assert store.get("tenant-a", assignment.config_id) is not None
+    assert store.get("tenant-b", assignment.config_id) is None
+
+
+def test_served_config_route_is_tenant_scoped(client, store):
+    # An assignment stored under a foreign tenant is not served to the request's
+    # (default) tenant — the serve route calls store.get(tenant_id, config_id).
+    foreign = create_assignment(
+        store,
+        tenant_id="some-other-tenant",
+        name="foreign",
+        profile_id="developer",
+        connector_ids=["modelcontextprotocol/github"],
+    )
+    assert client.get(f"/v1/mcp-config/{foreign.config_id}/mcp.json").status_code == 404

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2934,6 +2934,11 @@ export interface ConditionalAccessPolicy {
   allowed_hours_utc: number[];
   allowed_weekdays: number[];
   allowed_source_cidrs: string[];
+  // ABAC device/group/client conditions (evaluated fail-closed alongside the
+  // environment/time/CIDR guardrails).
+  allowed_devices: string[];
+  allowed_groups: string[];
+  allowed_clients: string[];
   updated_at: string;
   description: string;
 }
@@ -3371,4 +3376,94 @@ export interface BlueprintCreateRequest {
   owner_type?: string;
   description?: string;
   composition?: Partial<BlueprintComposition>;
+}
+
+// ── Governance: ABAC device/group/client + delegation + served MCP-config ───────
+
+/** Verified claims of a scoped delegation token (issue/verify/propagate). */
+export interface DelegationClaims {
+  jti: string;
+  tenant_id: string;
+  delegator: string;
+  delegatee: string;
+  scopes: string[];
+  chain: string[];
+  remaining_depth: number;
+  issued_at: number;
+  expires_at: number;
+}
+
+/** Response from issuing/propagating a delegation token. */
+export interface DelegationTokenResponse {
+  schema_version: string;
+  token: string;
+  delegation: DelegationClaims;
+}
+
+/** Response from `POST /v1/delegations/verify`. */
+export interface DelegationVerifyResponse {
+  schema_version: string;
+  valid: boolean;
+  reason?: string;
+  delegation?: DelegationClaims;
+}
+
+/** One tenant-scoped MCP-client-config assignment. */
+export interface McpClientConfigAssignment {
+  config_id: string;
+  tenant_id: string;
+  name: string;
+  profile_id: string;
+  connector_ids: string[];
+  connection_ids: string[];
+  created_at: string;
+  created_by: string;
+  updated_at: string;
+  revoked: boolean;
+  config_url?: string;
+}
+
+/** Response from assigning a profile → one distributable read-only config URL. */
+export interface McpConfigAssignmentResponse {
+  schema_version: string;
+  assignment: McpClientConfigAssignment;
+  config_url: string;
+}
+
+/** One credential reference in a served MCP-client-config — never a secret value. */
+export interface McpServerCredentialReference {
+  value: string;
+  handle: string;
+  source: "reference";
+}
+
+/** The served, read-only `.mcp.json` document. References connectors/secrets by
+ *  handle only; it never embeds secret material. */
+export interface ServedMcpClientConfig {
+  schema_version: string;
+  config_id: string;
+  tenant_id: string;
+  name: string;
+  profile_id: string;
+  profile?: Record<string, unknown> | null;
+  mcpServers: Record<string, {
+    connector_id: string;
+    name: string;
+    transport: string;
+    publisher?: string | null;
+    risk_level?: string | null;
+    packages: unknown[];
+    env: Record<string, McpServerCredentialReference>;
+    credential_references: string[];
+  }>;
+  connections: Array<{
+    connection_id?: string;
+    provider?: string;
+    display_name?: string;
+    has_secret: boolean;
+    handle: string;
+  }>;
+  unknown_connectors: string[];
+  generated_at: string;
+  read_only: boolean;
 }


### PR DESCRIPTION
Closes #3906, Closes #3908. Advances governance epic #3902 (remaining after this: #3907 key broker, #3910 EDR/MDM). Both issues **EXTEND** existing bones.

## #3906 — ABAC device/group/client + scoped delegation token

**ABAC attributes.** `ConditionalAccessPolicy` gains `allowed_devices` / `allowed_groups` / `allowed_clients` conditions alongside the existing environment / time-window / weekday / source-CIDR guardrails. `AccessContext` (gateway path) and `DecisionContext` (proxy declarative-rule engine) carry `device_id` / `groups` / `client_id`, resolved at the gateway from `x-agent-device-id` / `x-agent-groups` / `x-agent-client-id`. All new conditions are **fail-closed**: a policy that requires a device/group/client denies when the request cannot prove the attribute. Enforced at both the gateway (`ConditionalAccessPolicy`) and the shared `proxy_policy.evaluate_conditions` decision point.

**Scoped delegation tokens.** New `agent_bom.api.delegation_token` issues HMAC-signed, expiring delegation tokens for multi-agent handoffs. A token is:
- **scoped** — carries an explicit capability list; a scopeless token is refused (never bearer-all),
- **verifiable** — HMAC-SHA256 over the payload, constant-time compare; tampered payload/signature fails closed; no DB lookup required,
- **expiring** — `exp` claim, rejected fail-closed once past,
- **tenant-bound** — cross-tenant verify is rejected,
- **chain-aware** — records the `delegation_chain` + a depth budget; propagation can only **narrow** scope and never extends expiry or depth.

Routes (identities surface): `POST /v1/identities/{id}/delegations` (issue), `POST /v1/delegations/verify` (receiver validates; over-scoped/expired rejected), `POST /v1/delegations/propagate` (narrow-only). Signed with `AGENT_BOM_DELEGATION_SIGNING_KEY` (per-process ephemeral fallback when unset).

## #3908 — one served, governed MCP-client-config distribution URL

New `McpConfigStore` (in-memory / SQLite / Postgres+RLS, tenant-scoped) persists `profile + connectors` assignments. Assigning a profile yields **one** distributable, read-only `.mcp.json` URL.

- `POST /v1/mcp-config/assignments` (config-gated) → returns `config_url`
- `GET /v1/mcp-config/{config_id}/mcp.json` (read-gated) → the composed `mcpServers` document
- list / get / revoke assignment routes

**Proves no-secrets:** each connector credential is emitted as a `${VAR}` reference placeholder + opaque `connector:<id>:<VAR>` handle; each cloud connection is referenced by `connection:<id>` handle + `has_secret` flag only — mirroring the existing connection-secret model (`CloudConnectionRecord.to_public_dict`). A test asserts the serialized document contains no `external_id` / `role_ref` material. **Tenant-scoped:** `store.get(tenant_id, config_id)`; cross-tenant fetch is a 404 (Postgres additionally enforces FORCE ROW LEVEL SECURITY). Read-only: served by GET; revoke is a separate config-gated write and then 404s.

## Full-stack chain
- Model/policy + dual-backend stores + Postgres tenant RLS.
- Routes RBAC-gated (`read` / `config`) + tenant-gated; OpenAPI regenerated from code (**+8 operations, +7 paths, +1 route module**); count-guard docs updated (`AGENT_CAPABILITY`, `ARCHITECTURE`, `START_HERE`, `docs/README`); DATA_MODEL atlas regenerated.
- `ui/lib/api-types.ts`: extended `ConditionalAccessPolicy` + added delegation / served-config types (type-only, no fenced components).
- Docs: governance reference (`site-docs/reference/configuration.md`) + delegation signing key in `ENTERPRISE_DEPLOYMENT.md`; env var allowlisted.
- Strict mypy for the new modules.

## Verification (all green)
- New tests: `tests/test_governance_abac_delegation.py`, `tests/test_mcp_config_distribution.py` — incl. fail-closed device/group denial, scoped-token verify / reject-expired / reject-over-scoped / reject-tampered / narrow-only propagation, no-secrets-in-served-config + tenant-scoping.
- `pytest` across the governance/identity/gateway/proxy/connector/runtime slice: 164 passed.
- `scripts/check_exception_sanitization.py`: 0 violations (delegation error surfaces use `sanitize_error`).
- `scripts/check-counts.py` + `make preflight`: consistent (OpenAPI regenerated from code).
- `ruff` + `mypy` (strict where configured): clean.
- Confirmed **none** of the fenced UI-polish files were touched.

Security posture: ABAC stays fail-closed; delegation tokens are scoped + verifiable + expiring (not bearer-all); the served MCP-config is read-only, tenant-scoped, and references secrets by handle only; RLS/tenant isolation preserved; existing RBAC reused.

Do not merge — review only.