### PR TITLE
fix(security): validate trace-connector URLs to prevent SSRF

### DIFF
--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -772,7 +772,11 @@ async def pull_trace_connector(request: Request, provider: str, body: dict) -> d
     """
     from agent_bom.otel_ingest import parse_otel_traces
     from agent_bom.runtime_correlation import correlate_spans_to_attack_paths
-    from agent_bom.trace_connectors import TraceConnectorError, fetch_traces
+    from agent_bom.trace_connectors import (
+        TraceConnectorError,
+        TraceConnectorValidationError,
+        fetch_traces,
+    )
 
     tenant_id = _tenant_id(request)
     credentials = body.get("credentials") if isinstance(body.get("credentials"), dict) else {}
@@ -786,6 +790,9 @@ async def pull_trace_connector(request: Request, provider: str, body: dict) -> d
 
     try:
         otlp = fetch_traces(provider, credentials, limit=limit, include_content=screen_content)
+    except TraceConnectorValidationError as exc:
+        # Invalid/unsafe caller input (e.g. SSRF-blocked host) — a client error.
+        raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
     except TraceConnectorError as exc:
         # sanitize_error keeps credentials out of the response/logs.
         raise HTTPException(status_code=502, detail=sanitize_error(exc)) from exc

--- a/src/agent_bom/trace_connectors.py
+++ b/src/agent_bom/trace_connectors.py
@@ -39,6 +39,33 @@ class TraceConnectorError(RuntimeError):
     """Raised when a trace connector cannot authenticate or reach its API."""
 
 
+class TraceConnectorValidationError(TraceConnectorError):
+    """Raised when caller-supplied connector input is invalid (bad request).
+
+    Distinct from the base error so the API layer can map it to a 4xx (client
+    error) rather than a 5xx: an unsafe or malformed connector URL is the
+    caller's fault, not an upstream failure.
+    """
+
+
+def _validate_pull_url(url: str) -> None:
+    """Reject unsafe connector base URLs before any server-side request.
+
+    The connector host is caller-supplied, so an unvalidated fetch lets a
+    ``runtime_ingest`` caller point the control plane at internal services or
+    cloud-metadata endpoints (SSRF). ``validate_url`` enforces HTTPS and blocks
+    private / loopback / link-local / reserved / metadata targets (incl. DNS
+    rebinding). The rejection message is static — the raw URL is never echoed —
+    so no caller-controlled value leaks back into the response or logs.
+    """
+    from agent_bom.security import SecurityError, validate_url
+
+    try:
+        validate_url(url, allow_private=False)
+    except SecurityError as exc:
+        raise TraceConnectorValidationError("connector host failed URL validation (must be a public HTTPS endpoint)") from exc
+
+
 class _HttpResponse(Protocol):
     status_code: int
 
@@ -139,6 +166,7 @@ def fetch_langfuse_traces(
     if not host or not public_key or not secret_key:
         raise TraceConnectorError("langfuse connector requires host, public_key and secret_key")
     base = host.rstrip("/")
+    _validate_pull_url(base)
     url = f"{base}/api/public/observations"
     resolved, owns = _client_or_default(client)
     try:
@@ -209,6 +237,7 @@ def fetch_langsmith_traces(
     if not api_key:
         raise TraceConnectorError("langsmith connector requires api_key")
     base = (api_url or "https://api.smith.langchain.com").rstrip("/")
+    _validate_pull_url(base)
     body: dict[str, Any] = {"limit": _bounded_limit(limit), "run_type": "tool"}
     if project:
         body["project_name"] = project
@@ -274,6 +303,7 @@ __all__ = [
     "LANGFUSE",
     "LANGSMITH",
     "TraceConnectorError",
+    "TraceConnectorValidationError",
     "fetch_langfuse_traces",
     "fetch_langsmith_traces",
     "fetch_traces",

--- a/tests/test_trace_attack_path_routes.py
+++ b/tests/test_trace_attack_path_routes.py
@@ -117,3 +117,14 @@ def test_list_trace_connectors_route() -> None:
     assert resp.status_code == 200, resp.text
     names = {c["name"] for c in resp.json()["connectors"]}
     assert {"langfuse", "langsmith"} <= names
+
+
+def test_pull_connector_rejects_ssrf_host_with_400() -> None:
+    # A runtime_ingest caller must not be able to point the control plane at a
+    # cloud-metadata endpoint (SSRF). The guard rejects it as a client error
+    # (400), not a 500/502, and never echoes the raw URL back.
+    client = TestClient(app)
+    body = {"credentials": {"host": "http://169.254.169.254/latest/meta-data", "public_key": "pk", "secret_key": "sk"}}
+    resp = client.post("/v1/traces/connectors/langfuse/pull", json=body, headers=proxy_headers(role="admin"))
+    assert resp.status_code == 400, resp.text
+    assert "169.254.169.254" not in resp.text

--- a/tests/test_trace_connectors.py
+++ b/tests/test_trace_connectors.py
@@ -10,16 +10,30 @@ from typing import Any
 
 import pytest
 
+from agent_bom import security as _security
 from agent_bom.models import Agent, AgentType, BlastRadius, MCPServer, MCPTool, Package, Severity, Vulnerability
 from agent_bom.otel_ingest import parse_otel_traces
 from agent_bom.runtime_correlation import correlate_spans_to_attack_paths
 from agent_bom.trace_connectors import (
     TraceConnectorError,
+    TraceConnectorValidationError,
     fetch_langfuse_traces,
     fetch_langsmith_traces,
     fetch_traces,
     list_trace_connectors,
 )
+
+# Real SSRF guard, captured before the autouse stub replaces it. The mapping
+# tests below use placeholder hosts that don't resolve, so the network-dependent
+# URL validation is stubbed for them; the dedicated SSRF tests restore the real
+# guard to prove unsafe hosts are rejected before any request.
+_REAL_VALIDATE_URL = _security.validate_url
+
+
+@pytest.fixture(autouse=True)
+def _stub_url_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No-op the URL guard so placeholder-host mapping tests stay hermetic."""
+    monkeypatch.setattr("agent_bom.security.validate_url", lambda *a, **k: None)
 
 
 class _FakeResponse:
@@ -111,3 +125,56 @@ def test_missing_credentials_and_http_error_raise() -> None:
         fetch_langsmith_traces(api_key="k", client=_FakeClient({}, status_code=401))
     with pytest.raises(TraceConnectorError):
         fetch_traces("unknown-provider", {"api_key": "k"})
+
+
+# ─── SSRF hardening ──────────────────────────────────────────────────────────
+# The connector host is caller-supplied; without a guard a runtime_ingest caller
+# could make the control plane fetch internal services or cloud metadata (SSRF).
+# These tests restore the real ``validate_url`` guard. Every rejected host is
+# refused on scheme (non-HTTPS) or IP-literal grounds — i.e. before any DNS
+# lookup — so they run offline with no network.
+
+_SSRF_HOSTS = [
+    "http://169.254.169.254/latest/meta-data",  # cloud metadata (link-local)
+    "http://localhost",  # loopback
+    "http://10.0.0.1",  # private RFC1918
+    "http://",  # malformed / no host
+    "https://10.0.0.1",  # private even over https
+]
+
+
+@pytest.mark.parametrize("host", _SSRF_HOSTS)
+def test_langfuse_rejects_unsafe_host_before_any_request(monkeypatch: pytest.MonkeyPatch, host: str) -> None:
+    monkeypatch.setattr("agent_bom.security.validate_url", _REAL_VALIDATE_URL)
+    client = _FakeClient({"data": []})
+    with pytest.raises(TraceConnectorValidationError) as excinfo:
+        fetch_langfuse_traces(host=host, public_key="pk", secret_key="sk", client=client)
+    # Rejected before the HTTP client was ever touched (no network / port scan).
+    assert client.calls == []
+    # The rejection is a bad-request-shaped error and never echoes the raw URL.
+    assert isinstance(excinfo.value, TraceConnectorError)
+    message = str(excinfo.value)
+    assert host not in message
+    assert "169.254" not in message and "10.0.0.1" not in message and "localhost" not in message
+
+
+@pytest.mark.parametrize("api_url", _SSRF_HOSTS)
+def test_langsmith_rejects_unsafe_api_url_before_any_request(monkeypatch: pytest.MonkeyPatch, api_url: str) -> None:
+    monkeypatch.setattr("agent_bom.security.validate_url", _REAL_VALIDATE_URL)
+    client = _FakeClient({"runs": []})
+    with pytest.raises(TraceConnectorValidationError) as excinfo:
+        fetch_langsmith_traces(api_key="ls-key", api_url=api_url, client=client)
+    assert client.calls == []
+    message = str(excinfo.value)
+    assert api_url not in message
+    assert "169.254" not in message and "10.0.0.1" not in message
+
+
+def test_valid_public_https_host_passes_validation(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A public IPv4 literal validates offline (numeric resolution, no DNS) and
+    # lets the (mocked) fetch proceed — behavior is unchanged for safe hosts.
+    monkeypatch.setattr("agent_bom.security.validate_url", _REAL_VALIDATE_URL)
+    client = _FakeClient({"data": [{"id": "o", "traceId": "t", "name": "run_shell"}]})
+    otlp = fetch_langfuse_traces(host="https://93.184.216.34", public_key="pk", secret_key="sk", client=client)
+    assert client.calls, "valid public host must proceed to the HTTP fetch"
+    assert parse_otel_traces(otlp)[0].tool_name == "run_shell"


### PR DESCRIPTION
## The vulnerability (P1 SSRF, release hardening)

`POST /v1/traces/connectors/{provider}/pull` → `trace_connectors.fetch_traces` built the outbound request URL directly from **caller-supplied** credentials:
- Langfuse: `f"{host}/api/public/observations"` from `credentials.host`
- LangSmith: `f"{api_url}/runs/query"` from `credentials.api_url`

Neither URL was validated, so a `runtime_ingest`-role caller could make the control plane fetch an arbitrary URL — `http://169.254.169.254/...` (cloud metadata), loopback, or internal services. That is an authenticated **SSRF / blind port scan**.

## The fix

Apply the codebase's existing guard, `agent_bom.security.validate_url(url, allow_private=False)` — the same one already used on the sibling Jira route "to prevent SSRF". It enforces HTTPS and blocks private / loopback / link-local / reserved / cloud-metadata targets (including DNS-rebinding via resolved-IP checks).

- Both connector base URLs are validated **before** any server-side request (before the HTTP client is even created — no network, no port probe on rejection).
- Rejection raises a new `TraceConnectorValidationError(TraceConnectorError)` with a **static, URL-free** message (the raw URL/exception is never echoed).
- The route maps `TraceConnectorValidationError` → **HTTP 400** (client error), keeping the existing `TraceConnectorError` → 502 mapping for genuine upstream failures.
- Behavior is unchanged for valid public HTTPS hosts.

## Tests

- `tests/test_trace_connectors.py`: parametrized SSRF hosts (`http://169.254.169.254`, `http://localhost`, `http://10.0.0.1`, plain `http://`, `https://10.0.0.1`) are rejected for **both** Langfuse and LangSmith **before any HTTP call** (`client.calls == []`), the error is a `TraceConnectorError`, and the message leaks no raw URL/host. A valid public HTTPS host still proceeds to the (mocked) fetch.
- `tests/test_trace_attack_path_routes.py`: the pull route returns **400** (not 5xx) for a metadata host and does not echo the URL in the body.

No new routes/OpenAPI changes; `check-counts.py` and the exception-sanitization guard stay clean. Backend-only.

Hardens the #4000 native trace connectors.