### PR TITLE
fix(overview): reconcile exec severity counts to the unified findings spine

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -16522,7 +16522,7 @@
     },
     "/v1/graph/snapshots": {
       "get": {
-        "description": "List persisted scan snapshots ordered by creation time.",
+        "description": "List persisted scan snapshots ordered by creation time.\n\nA snapshot's ``risk_summary`` is a per-scan count of *graph nodes* carrying\neach severity \u2014 a distinct metric from the exec open-finding headline\n(``/v1/overview`` / ``/v1/posture/counts``), which counts deduped findings\nacross the estate. Each row is tagged ``severity_basis: \"graph_nodes\"`` so a\nconsumer never mistakes the graph-node tally for the reconciled exec\nseverity count (#3961).",
         "operationId": "get_graph_snapshots_v1_graph_snapshots_get",
         "parameters": [
           {
@@ -21253,7 +21253,7 @@
     },
     "/v1/posture/counts": {
       "get": {
-        "description": "Aggregate vulnerability counts across all completed scans.\n\nLightweight endpoint used by the dashboard nav to show Critical/High\nbadges without loading full scan payloads.\n\nReturns:\n    {critical, high, medium, low, total, kev, compound_issues}",
+        "description": "Aggregate open-finding severity counts across all completed scans.\n\nLightweight endpoint used by the dashboard nav to show Critical/High\nbadges. Reads the SAME reconciled source of truth as the ``/v1/overview``\nexec headline \u2014 the unified findings spine folded with hub-ingested\nevidence (#3961) \u2014 so the nav badges can never disagree with the overview's\ncritical/high. The CVE-only ``blast_radius`` is used only for the\ncorrelation-based ``compound_issues`` metric, where reachability/exposure\nlives. ``unrated`` is an explicit bucket so the histogram sums to ``total``.\n\nReturns:\n    {critical, high, medium, low, unrated, total, kev, compound_issues, \u2026}",
         "operationId": "get_posture_counts_v1_posture_counts_get",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -10829,7 +10829,12 @@ paths:
       - graph
   /v1/graph/snapshots:
     get:
-      description: List persisted scan snapshots ordered by creation time.
+      description: "List persisted scan snapshots ordered by creation time.\n\nA snapshot's\
+        \ ``risk_summary`` is a per-scan count of *graph nodes* carrying\neach severity\
+        \ \u2014 a distinct metric from the exec open-finding headline\n(``/v1/overview``\
+        \ / ``/v1/posture/counts``), which counts deduped findings\nacross the estate.\
+        \ Each row is tagged ``severity_basis: \"graph_nodes\"`` so a\nconsumer never\
+        \ mistakes the graph-node tally for the reconciled exec\nseverity count (#3961)."
       operationId: get_graph_snapshots_v1_graph_snapshots_get
       parameters:
       - description: Max snapshots
@@ -13806,10 +13811,16 @@ paths:
       - compliance
   /v1/posture/counts:
     get:
-      description: "Aggregate vulnerability counts across all completed scans.\n\n\
-        Lightweight endpoint used by the dashboard nav to show Critical/High\nbadges\
-        \ without loading full scan payloads.\n\nReturns:\n    {critical, high, medium,\
-        \ low, total, kev, compound_issues}"
+      description: "Aggregate open-finding severity counts across all completed scans.\n\
+        \nLightweight endpoint used by the dashboard nav to show Critical/High\nbadges.\
+        \ Reads the SAME reconciled source of truth as the ``/v1/overview``\nexec\
+        \ headline \u2014 the unified findings spine folded with hub-ingested\nevidence\
+        \ (#3961) \u2014 so the nav badges can never disagree with the overview's\n\
+        critical/high. The CVE-only ``blast_radius`` is used only for the\ncorrelation-based\
+        \ ``compound_issues`` metric, where reachability/exposure\nlives. ``unrated``\
+        \ is an explicit bucket so the histogram sums to ``total``.\n\nReturns:\n\
+        \    {critical, high, medium, low, unrated, total, kev, compound_issues, \u2026\
+        }"
       operationId: get_posture_counts_v1_posture_counts_get
       parameters:
       - in: header

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -1760,49 +1760,61 @@ async def get_backpressure_posture() -> dict:
     return describe_backpressure_posture()
 
 
-@router.get("/posture/counts", tags=["compliance"])
-async def get_posture_counts(request: Request) -> dict:
-    """Aggregate vulnerability counts across all completed scans.
+def _compound_issue_count(tenant_jobs: list[Any]) -> int:
+    """Count high-priority compound issues from blast-radius correlation.
 
-    Lightweight endpoint used by the dashboard nav to show Critical/High
-    badges without loading full scan payloads.
-
-    Returns:
-        {critical, high, medium, low, total, kev, compound_issues}
+    A compound issue is a KEV vuln that is also reachable or exposes a
+    credential, or a high-CVSS + high-EPSS vuln — the reachability/exposure
+    correlation that lives in ``blast_radius`` (not a raw severity count).
+    Deduped by vulnerability id across scans.
     """
-    counts: dict[str, Any] = {
-        "critical": 0,
-        "high": 0,
-        "medium": 0,
-        "low": 0,
-        "total": 0,
-        "kev": 0,
-        "compound_issues": 0,
-    }
     seen_ids: set[str] = set()
-    tenant_jobs = _tenant_jobs(request)
-
+    compound = 0
     for job in tenant_jobs:
         if job.status != JobStatus.DONE or not job.result:
             continue
-
-        blast_list = job.result.get("blast_radius", [])
-        for b in blast_list:
+        for b in job.result.get("blast_radius", []):
             vid = b.get("vulnerability_id", "")
             if vid in seen_ids:
                 continue
             seen_ids.add(vid)
-            sev = (b.get("severity") or "").lower()
-            if sev in counts:
-                counts[sev] += 1
-            counts["total"] += 1
-            if b.get("cisa_kev") or b.get("is_kev"):
-                counts["kev"] += 1
-            # Compound issue: KEV + reachable tool, or KEV + exposed cred
-            if (b.get("cisa_kev") or b.get("is_kev")) and (b.get("reachable_tools") or b.get("exposed_credentials")):
-                counts["compound_issues"] += 1
+            is_kev = bool(b.get("cisa_kev") or b.get("is_kev"))
+            if is_kev and (b.get("reachable_tools") or b.get("exposed_credentials")):
+                compound += 1
             elif (b.get("epss_score") or 0) >= 0.3 and (b.get("cvss_score") or 0) >= 7:
-                counts["compound_issues"] += 1
+                compound += 1
+    return compound
+
+
+@router.get("/posture/counts", tags=["compliance"])
+async def get_posture_counts(request: Request) -> dict:
+    """Aggregate open-finding severity counts across all completed scans.
+
+    Lightweight endpoint used by the dashboard nav to show Critical/High
+    badges. Reads the SAME reconciled source of truth as the ``/v1/overview``
+    exec headline — the unified findings spine folded with hub-ingested
+    evidence (#3961) — so the nav badges can never disagree with the overview's
+    critical/high. The CVE-only ``blast_radius`` is used only for the
+    correlation-based ``compound_issues`` metric, where reachability/exposure
+    lives. ``unrated`` is an explicit bucket so the histogram sums to ``total``.
+
+    Returns:
+        {critical, high, medium, low, unrated, total, kev, compound_issues, …}
+    """
+    from agent_bom.api.routes.overview import exec_severity_counts
+
+    tenant_jobs = _tenant_jobs(request)
+    reconciled = exec_severity_counts(request, tenant_jobs)
+    counts: dict[str, Any] = {
+        "critical": reconciled["critical"],
+        "high": reconciled["high"],
+        "medium": reconciled["medium"],
+        "low": reconciled["low"],
+        "unrated": reconciled["unrated"],
+        "total": reconciled["total"],
+        "kev": reconciled["kev"],
+        "compound_issues": _compound_issue_count(tenant_jobs),
+    }
 
     counts.update(_derive_deployment_context(request, tenant_jobs))
     tenant_id = require_request_tenant_id(request)

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2460,8 +2460,20 @@ async def get_graph_snapshots(
     request: Request,
     limit: int = Query(50, ge=1, le=500, description="Max snapshots"),
 ) -> list[dict]:
-    """List persisted scan snapshots ordered by creation time."""
-    return await _graph_store_call(_get_graph_store_or_503().list_snapshots, tenant_id=_tenant(request), limit=limit)
+    """List persisted scan snapshots ordered by creation time.
+
+    A snapshot's ``risk_summary`` is a per-scan count of *graph nodes* carrying
+    each severity — a distinct metric from the exec open-finding headline
+    (``/v1/overview`` / ``/v1/posture/counts``), which counts deduped findings
+    across the estate. Each row is tagged ``severity_basis: "graph_nodes"`` so a
+    consumer never mistakes the graph-node tally for the reconciled exec
+    severity count (#3961).
+    """
+    snapshots = await _graph_store_call(_get_graph_store_or_503().list_snapshots, tenant_id=_tenant(request), limit=limit)
+    for snapshot in snapshots:
+        if isinstance(snapshot, dict) and "risk_summary" in snapshot:
+            snapshot["severity_basis"] = "graph_nodes"
+    return snapshots
 
 
 @router.get("/graph/history", tags=["graph"])

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -600,6 +600,40 @@ def _combined_severity(scan_severity: dict[str, int], hub_severity: dict[str, in
     return merged
 
 
+def _reconciled_exec_counts(estate: dict[str, Any], hub_severity: dict[str, int]) -> dict[str, int]:
+    """The single exec-facing severity source of truth (#3961).
+
+    Both the ``/v1/overview`` headline and ``/v1/posture/counts`` derive their
+    critical/high/… from THIS reconciliation of the unified findings spine
+    (``_estate_rollup``) with hub-ingested evidence, so the two exec surfaces
+    can never report a different open-severity count for the same estate. The
+    honest ``unrated`` bucket is carried through and the buckets sum to
+    ``total`` (no silent drop).
+    """
+    combined = _combined_severity(estate["severity"], hub_severity)
+    return {
+        "critical": combined["critical"],
+        "high": combined["high"],
+        "medium": combined["medium"],
+        "low": combined["low"],
+        "unrated": combined[_UNRATED_KEY],
+        "total": sum(combined.values()),
+        "kev": int(estate.get("kev", 0) or 0),
+        "credential_exposed": int(estate.get("credential_exposed", 0) or 0),
+    }
+
+
+def exec_severity_counts(request: Request, jobs: list[Any]) -> dict[str, int]:
+    """Reconciled exec severity counts for ``jobs`` (unified spine + hub).
+
+    Public entry point shared with ``/v1/posture/counts`` so nav badges and the
+    overview headline read one number. Recomputes the estate rollup and hub
+    snapshot; a caller that already holds them should use
+    ``_reconciled_exec_counts`` directly to avoid a second pass.
+    """
+    return _reconciled_exec_counts(_estate_rollup(jobs), _hub_severity_snapshot(request))
+
+
 def _exec_posture(
     request: Request,
     scan_posture: dict[str, Any],
@@ -707,10 +741,13 @@ def _build_overview(request: Request) -> dict[str, Any]:
     identity = _identity_snapshot(request)
 
     hub_findings = sum(int(hub_severity.get(k, 0) or 0) for k in _HUB_SEVERITY_KEYS)
-    # Headline severity reads the SAME unified spine the coverage lanes read,
-    # folded with hub-ingested evidence — never the CVE-only blast_radius (#3961).
-    headline_critical = estate["severity"]["critical"] + int(hub_severity.get("critical", 0) or 0)
-    headline_high = estate["severity"]["high"] + int(hub_severity.get("high", 0) or 0)
+    # Headline severity reads the SAME reconciled source of truth that
+    # /v1/posture/counts reads — the unified spine folded with hub-ingested
+    # evidence — never the CVE-only blast_radius (#3961). Both exec surfaces
+    # route through ``_reconciled_exec_counts`` so they can never disagree.
+    exec_counts = _reconciled_exec_counts(estate, hub_severity)
+    headline_critical = exec_counts["critical"]
+    headline_high = exec_counts["high"]
     critical_high = headline_critical + headline_high
 
     cloud_accounts = _cloud_account_count(request)

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -272,6 +272,44 @@ def test_demo_estate_graph_snapshots_support_drift_lens(demo_estate_client: Test
     assert body.get("nodes_changed"), "expected at least one changed node in the showcase drift story"
 
 
+def test_demo_estate_exec_severity_counts_reconcile_across_surfaces(
+    demo_estate_client: TestClient,
+) -> None:
+    """Exec-facing severity counts agree across surfaces on one estate (#3961).
+
+    Regression for the exec-read honesty bug: ``/v1/posture/counts`` read the
+    CVE-only ``blast_radius`` while ``/v1/overview`` read the unified findings
+    spine, so a leader saw different critical/high on the same estate (2/10 vs
+    3/12 on the demo estate). Both exec surfaces must now derive from the one
+    reconciled source of truth. The graph snapshot ``risk_summary`` is a
+    *different* metric (graph nodes at risk, per scan) and is explicitly tagged
+    as such so it is never mistaken for the exec headline.
+    """
+    counts = demo_estate_client.get("/v1/posture/counts").json()
+    overview = demo_estate_client.get("/v1/overview").json()
+    headline = overview["headline"]
+
+    # 1. The exec headline and the nav-badge counts are the same number.
+    assert counts["critical"] == headline["critical"], (counts, headline)
+    assert counts["high"] == headline["high"], (counts, headline)
+    assert counts["kev"] == headline["kev"], (counts, headline)
+    # The demo estate carries the non-CVE critical/high that blast_radius missed.
+    assert counts["critical"] >= 3 and counts["high"] >= 12, counts
+
+    # 2. Honest histogram: unrated is an explicit bucket and the buckets sum to
+    #    total — no severity is silently dropped.
+    assert "unrated" in counts, counts
+    bucketed = sum(counts[band] for band in ("critical", "high", "medium", "low", "unrated"))
+    assert bucketed == counts["total"], counts
+
+    # 3. The graph snapshot risk_summary is a distinctly-labeled metric
+    #    (graph-node severity), NOT the reconciled exec headline.
+    snapshots = demo_estate_client.get("/v1/graph/snapshots").json()
+    assert snapshots, "expected persisted demo snapshots"
+    for snapshot in snapshots:
+        assert snapshot.get("severity_basis") == "graph_nodes", snapshot
+
+
 def test_demo_estate_showcase_cloud_hierarchy_and_exposure(demo_estate_client: TestClient) -> None:
     """Showcase graph carries org→account containment and a bastion→PII exposure edge."""
     payload = demo_estate_client.get("/v1/graph", headers=ADMIN).json()

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -455,6 +455,58 @@ def test_overview_headline_reflects_noncve_spine_critical() -> None:
     get_compliance_hub_store().clear("default")
 
 
+def test_posture_counts_reconcile_with_overview_headline() -> None:
+    """/v1/posture/counts and the /v1/overview headline read one source (#3961).
+
+    The nav-badge endpoint used to count the CVE-only ``blast_radius`` while the
+    overview headline reads the unified findings spine, so the two exec surfaces
+    disagreed on the same estate. They must now derive from the same reconciled
+    counts. Here the spine carries a non-CVE critical that ``blast_radius`` never
+    materialises — the exact divergence — and both surfaces must still agree.
+    """
+    _clear_jobs()
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+    from agent_bom.api.server import ScanJob, ScanRequest
+
+    get_compliance_hub_store().clear("default")
+    job = ScanJob(
+        job_id="reconcile-job",
+        tenant_id="default",
+        created_at="2026-02-22T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {
+        "agents": [],
+        "scan_sources": ["agent_discovery"],
+        "blast_radius": [
+            {"vulnerability_id": "CVE-2025-1000", "package": "libcve", "severity": "medium", "risk_score": 4},
+        ],
+        "findings": [
+            {"id": "vuln-cve", "security_domain": "vuln", "severity": "medium", "cve_id": "CVE-2025-1000"},
+            {"id": "mal-1", "security_domain": "aspm", "severity": "critical", "is_malicious": True},
+            {"id": "high-1", "security_domain": "aspm", "severity": "high"},
+            {"id": "weird-1", "security_domain": "aspm", "severity": "tuesday"},
+        ],
+    }
+    _get_store().put(job)
+
+    client = TestClient(app)
+    headline = client.get("/v1/overview", headers=_AUTH_HEADERS).json()["headline"]
+    counts = client.get("/v1/posture/counts", headers=_AUTH_HEADERS).json()
+
+    assert counts["critical"] == headline["critical"] == 1, (counts, headline)
+    assert counts["high"] == headline["high"] == 1, (counts, headline)
+    assert counts["kev"] == headline["kev"], (counts, headline)
+    # The unrecognized "tuesday" severity is not dropped — it lands in unrated,
+    # and the buckets sum to total.
+    assert counts["unrated"] == 1, counts
+    bucketed = sum(counts[b] for b in ("critical", "high", "medium", "low", "unrated"))
+    assert bucketed == counts["total"], counts
+    get_compliance_hub_store().clear("default")
+
+
 def test_overview_compliance_failing_moves_grade() -> None:
     """A failing compliance framework feeds the exec grade (was hardcoded 0) (#3962)."""
     _clear_jobs()


### PR DESCRIPTION
## The bug

Three exec-facing surfaces reported **different** critical/high counts for the same seeded demo estate, so a leader on the single pane saw numbers that did not agree and could not drill to consistent evidence.

| Surface | Before | Derivation |
|---|---|---|
| `GET /v1/posture/counts` | **2 critical / 10 high** | CVE-only `blast_radius`, deduped by `vulnerability_id` — a filtered subset that omits non-CVE findings and CVEs without a computed blast path; no hub-ingested evidence |
| `GET /v1/overview` headline | **3 critical / 12 high** | unified findings spine (`_estate_rollup`) + hub severity snapshot — the honest superset |
| `GET /v1/graph/snapshots` first `risk_summary` | **4 critical / 12 high** | count of **graph nodes** carrying each severity (`graph.stats().severity_counts`) — a per-scan, node-basis metric, not deduped open findings |

## Root-cause divergence

- **posture/counts vs overview**: they claim the *same* metric (open findings by severity) but read *different* sources. posture/counts read the CVE-only `blast_radius`; the overview headline reads the spine + hub. On the demo estate the spine carries a critical and two highs (a non-CVE AISPM finding + a spine-only vuln critical) that `blast_radius` never materialises.
- **graph snapshot**: `risk_summary` genuinely measures something else — graph nodes at risk by severity, per scan (includes severity-bearing non-finding nodes, not deduped across scans). It is not the exec headline.

## Reconciliation

- Added `_reconciled_exec_counts` / `exec_severity_counts` in `routes/overview.py`: one fold of the estate spine + hub severity into the honest five buckets (`unrated` explicit; buckets sum to `total`, no silent drop; preserves the ASPM overlapping-lens model — the all-domain histogram is still deduped once per finding, coverage lanes stay separate).
- **Both** the `/v1/overview` headline and `/v1/posture/counts` now derive critical/high/… from that single helper, so the two exec surfaces can never disagree. `compound_issues` stays on `blast_radius`, where the reachability/exposure correlation actually lives.
- **Graph snapshot**: not forced to lie. `/v1/graph/snapshots` now tags each row `severity_basis: "graph_nodes"` so the node-basis tally is never mistaken for the reconciled exec headline. (`api-types.ts` untouched — the wire field `risk_summary` is unchanged.)

## Before / after (seeded demo estate, `AGENT_BOM_DEMO_ESTATE=1 … serve --allow-insecure-no-auth`)

Before:
```
/v1/posture/counts       -> {'critical': 2, 'high': 10, 'medium': 3, 'total': 15, 'kev': 1}
/v1/overview headline    -> {'critical': 3, 'high': 12, ...}
/v1/graph/snapshots[0]   -> risk_summary {'critical': 4, 'high': 12, 'medium': 4, 'info': 10}
```

After:
```
/v1/posture/counts       -> {'critical': 3, 'high': 12, 'medium': 4, 'low': 0, 'unrated': 0, 'total': 19, 'kev': 1, 'compound_issues': 1}
/v1/overview headline    -> {'critical': 3, 'high': 12, 'critical_high': 15, 'kev': 1, ...}
/v1/graph/snapshots[0]   -> severity_basis 'graph_nodes'  risk_summary {'critical': 4, 'high': 12, 'medium': 4, 'info': 10}
```

posture/counts and the overview headline now agree (3 / 12); the graph snapshot keeps its node-basis tally, now explicitly labeled.

## Tests

- `tests/test_demo_estate_bootstrap.py::test_demo_estate_exec_severity_counts_reconcile_across_surfaces` — on the real seeded estate: overview headline == posture/counts (critical/high/kev), buckets sum to total, and every snapshot carries `severity_basis: "graph_nodes"`.
- `tests/test_overview.py::test_posture_counts_reconcile_with_overview_headline` — fast unit test reproducing the exact divergence (spine has a non-CVE critical absent from `blast_radius`) and asserting the two surfaces agree, with an unrecognized severity landing in `unrated`.

## Verification

- `pytest tests/test_overview.py tests/test_demo_estate_bootstrap.py tests/test_compliance.py tests/test_graph_api.py` → 117 passed.
- `scripts/check-counts.py` ✓ · `make preflight` ✓ (OpenAPI regenerated for the two edited operation descriptions) · `check_exception_sanitization.py` ✓ · ruff + mypy on touched modules ✓.

No new REST routes. No fenced files touched (`trace_connectors.py`, `routes/observability.py`, governance/ABAC/blueprint/cost, `api-types.ts`, `nav.tsx`).

Follow-up to #3961 — extends the spine reconciliation (which unified the overview headline) to the posture/counts nav badges and the graph-snapshot surface that #3961 did not cover.