### PR TITLE
fix(graph,governance): honest 501 for unsupported Neptune ops + Postgres-durable governance audit chain

### DIFF
--- a/src/agent_bom/api/governance_audit_log.py
+++ b/src/agent_bom/api/governance_audit_log.py
@@ -307,9 +307,11 @@ def make_governance_audit_record(
 def get_governance_audit_log() -> GovernanceAuditLog:
     """Return the process governance audit log, durable by default.
 
-    Selection mirrors the agent-identity store: Postgres is not yet a backend
-    here (a future PR adds the shared-replica chain), so the durable tier is
-    SQLite and the ephemeral opt-out is in-memory.
+    Selection mirrors the agent-identity store: Postgres (multi-replica, tenant
+    RLS) when configured, node-local durable SQLite otherwise, and in-memory only
+    on an explicit ephemeral opt-out. On a clustered Postgres deployment this
+    keeps the tamper-evident chain a single durable per-tenant chain shared
+    across every replica rather than splitting per-node.
     """
     global _GOVERNANCE_AUDIT_LOG
     if _GOVERNANCE_AUDIT_LOG is not None:
@@ -319,9 +321,11 @@ def get_governance_audit_log() -> GovernanceAuditLog:
     backend = select_backend()
     if backend == "memory":
         _GOVERNANCE_AUDIT_LOG = InMemoryGovernanceAuditLog()
+    elif backend == "postgres":
+        from agent_bom.api.postgres_governance_audit import PostgresGovernanceAuditLog
+
+        _GOVERNANCE_AUDIT_LOG = PostgresGovernanceAuditLog()
     else:
-        # Postgres backend has no dedicated chain table yet; fall back to the
-        # node-local durable SQLite chain rather than dropping the audit trail.
         _GOVERNANCE_AUDIT_LOG = SQLiteGovernanceAuditLog(sqlite_path())
     return _GOVERNANCE_AUDIT_LOG
 

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -441,7 +441,8 @@ class NeptuneGraphStore:
 
     def _unsupported(self, name: str) -> NoReturn:
         raise NeptuneGraphStoreUnsupportedOperationError(
-            f"Neptune graph backend does not yet implement {name}; use SQLite/Postgres for this API surface."
+            f"Neptune graph backend does not yet implement {name}; this backend is experimental "
+            "and partial — use the SQLite or Postgres graph backend for this API surface."
         )
 
     def page_nodes(self, **_kwargs: Any) -> tuple[str, str, list[UnifiedNode], int, str | None]:

--- a/src/agent_bom/api/postgres_governance_audit.py
+++ b/src/agent_bom/api/postgres_governance_audit.py
@@ -1,0 +1,180 @@
+"""Postgres-backed durable governance audit chain for horizontal scaling.
+
+Mirrors :class:`agent_bom.api.governance_audit_log.SQLiteGovernanceAuditLog`
+but stores the NHI lifecycle-enforcement chain in shared Postgres with tenant
+RLS, so on a clustered (multi-replica) control plane the tamper-evident audit
+trail is ONE durable, append-only chain per tenant instead of splitting into a
+node-local SQLite chain per replica.
+
+Design (mirrors :class:`agent_bom.api.postgres_audit.PostgresAuditLog`):
+
+* **Per-tenant hash chain.** Each tenant's records form an independent
+  HMAC-linked chain: ``append`` seals a record against that tenant's current
+  head (the max-``seq`` ``record_hash`` visible under the tenant's RLS session),
+  matching the SQLite/in-memory tamper-evidence contract. This keeps chain
+  integrity tenant-scoped, so a tenant can verify its own chain without seeing
+  any other tenant's rows.
+* **Tenant isolation via FORCE ROW LEVEL SECURITY.** Reads and the head lookup
+  run under the record's tenant session, so a cross-tenant ``get`` returns
+  ``None`` even for a valid ``action_id`` from another tenant.
+* **Idempotent append.** The ``action_id`` is ``UNIQUE``; a second append of the
+  same deterministic action is a no-op (``ON CONFLICT DO NOTHING``) and returns
+  the already-stored canonical record, even across replicas.
+
+This store never holds secret material — only identity ids, statuses, reasons.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Any
+
+from agent_bom.api.governance_audit_log import (
+    GovernanceAuditRecord,
+    _seal_record,
+    _verify_rows,
+)
+from agent_bom.api.postgres_common import (
+    ConnectionPool,
+    _current_tenant,
+    _ensure_tenant_rls,
+    _get_pool,
+    _tenant_connection,
+    bypass_tenant_rls,
+)
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
+
+class PostgresGovernanceAuditLog:
+    """Shared, tenant-scoped, append-only governance audit chain on Postgres."""
+
+    def __init__(self, pool: ConnectionPool | None = None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "governance_audit_log")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS governance_audit_log (
+                    seq         BIGSERIAL PRIMARY KEY,
+                    action_id   TEXT NOT NULL UNIQUE,
+                    tenant_id   TEXT NOT NULL,
+                    action      TEXT NOT NULL,
+                    observed_at TEXT NOT NULL,
+                    record_hash TEXT NOT NULL,
+                    data        TEXT NOT NULL
+                )
+            """)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_governance_audit_tenant "
+                "ON governance_audit_log(tenant_id, seq)"
+            )
+            _ensure_tenant_rls(conn, "governance_audit_log", "tenant_id")
+            conn.commit()
+
+    def _get_within_tenant(self, conn: Any, action_id: str) -> GovernanceAuditRecord | None:
+        row = conn.execute(
+            "SELECT data FROM governance_audit_log WHERE action_id = %s",
+            (action_id,),
+        ).fetchone()
+        return GovernanceAuditRecord(**json.loads(row[0])) if row else None
+
+    def append(self, record: GovernanceAuditRecord) -> GovernanceAuditRecord:
+        # Bind the record's own tenant so the head lookup and RLS WITH CHECK
+        # resolve to that tenant's chain — never the ambient request tenant.
+        token = _current_tenant.set(record.tenant_id)
+        try:
+            with _tenant_connection(self._pool) as conn:
+                existing = self._get_within_tenant(conn, record.action_id)
+                if existing is not None:
+                    return existing
+                head_row = conn.execute(
+                    "SELECT record_hash FROM governance_audit_log "
+                    "WHERE tenant_id = %s ORDER BY seq DESC LIMIT 1",
+                    (record.tenant_id,),
+                ).fetchone()
+                head = str(head_row[0]) if head_row else ""
+                sealed = _seal_record(record, head)
+                conn.execute(
+                    "INSERT INTO governance_audit_log "
+                    "(action_id, tenant_id, action, observed_at, record_hash, data) "
+                    "VALUES (%s, %s, %s, %s, %s, %s) "
+                    "ON CONFLICT (action_id) DO NOTHING",
+                    (
+                        sealed.action_id,
+                        sealed.tenant_id,
+                        sealed.action,
+                        sealed.observed_at,
+                        sealed.record_hash,
+                        json.dumps(asdict(sealed), sort_keys=True),
+                    ),
+                )
+                conn.commit()
+                # A concurrent replica may have won the UNIQUE race between our
+                # existence check and insert; re-read so the canonical row wins.
+                stored = self._get_within_tenant(conn, sealed.action_id)
+                return stored if stored is not None else sealed
+        finally:
+            _current_tenant.reset(token)
+
+    def get(self, action_id: str) -> GovernanceAuditRecord | None:
+        # Scoped to the ambient tenant session: a cross-tenant action_id is
+        # invisible under FORCE ROW LEVEL SECURITY and returns None.
+        with _tenant_connection(self._pool) as conn:
+            return self._get_within_tenant(conn, action_id)
+
+    def list(self, *, tenant_id: str | None = None, limit: int = 500) -> list[GovernanceAuditRecord]:
+        if tenant_id is not None:
+            token = _current_tenant.set(tenant_id)
+            try:
+                with _tenant_connection(self._pool) as conn:
+                    rows = conn.execute(
+                        "SELECT data FROM governance_audit_log WHERE tenant_id = %s "
+                        "ORDER BY seq DESC LIMIT %s",
+                        (tenant_id, limit),
+                    ).fetchall()
+            finally:
+                _current_tenant.reset(token)
+        else:
+            # Cross-tenant listing is a trusted control-plane read; the bypass
+            # activation is itself audit-logged in postgres_common.
+            with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
+                rows = conn.execute(
+                    "SELECT data FROM governance_audit_log ORDER BY seq DESC LIMIT %s",
+                    (limit,),
+                ).fetchall()
+        return [GovernanceAuditRecord(**json.loads(r[0])) for r in rows]
+
+    def head_hash(self) -> str:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT record_hash FROM governance_audit_log "
+                "WHERE tenant_id = %s ORDER BY seq DESC LIMIT 1",
+                (_current_tenant.get(),),
+            ).fetchone()
+        return str(row[0]) if row else ""
+
+    def verify_chain(self, *, max_rows: int = 50_000) -> dict[str, Any]:
+        # Full-estate integrity sweep: read every tenant's rows (trusted bypass),
+        # then verify each tenant's chain independently — a tenant's records link
+        # only to that tenant's prior record, so mixing tenants would false-flag.
+        with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT data FROM governance_audit_log ORDER BY tenant_id ASC, seq ASC LIMIT %s",
+                (max_rows,),
+            ).fetchall()
+        by_tenant: dict[str, list[GovernanceAuditRecord]] = {}
+        for r in rows:
+            record = GovernanceAuditRecord(**json.loads(r[0]))
+            by_tenant.setdefault(record.tenant_id, []).append(record)
+        verified = tampered = 0
+        for chain in by_tenant.values():
+            result = _verify_rows(chain)
+            verified += result["verified"]
+            tampered += result["tampered"]
+        return {"verified": verified, "tampered": tampered, "checked": verified + tampered}
+
+
+__all__ = ["PostgresGovernanceAuditLog"]

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -40,6 +40,7 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from agent_bom.api.graph_store import MAX_NODE_PAGE_OFFSET
+from agent_bom.api.neptune_graph import NeptuneGraphStoreUnsupportedOperationError
 from agent_bom.api.stores import _get_graph_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
@@ -1196,6 +1197,8 @@ async def _graph_store_call(fn, /, *args, **kwargs):
             return await asyncio.to_thread(fn, *args, **kwargs)
     except BackpressureRejectedError as exc:
         raise HTTPException(status_code=429, detail=exc.to_dict(), headers={"Retry-After": str(exc.retry_after_seconds)}) from exc
+    except NeptuneGraphStoreUnsupportedOperationError as exc:
+        raise HTTPException(status_code=501, detail=sanitize_error(exc)) from exc
 
 
 async def _graph_compute_call(fn, /, *args, **kwargs):
@@ -1205,6 +1208,8 @@ async def _graph_compute_call(fn, /, *args, **kwargs):
             return await asyncio.to_thread(fn, *args, **kwargs)
     except BackpressureRejectedError as exc:
         raise HTTPException(status_code=429, detail=exc.to_dict(), headers={"Retry-After": str(exc.retry_after_seconds)}) from exc
+    except NeptuneGraphStoreUnsupportedOperationError as exc:
+        raise HTTPException(status_code=501, detail=sanitize_error(exc)) from exc
 
 
 def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) -> dict[str, Any]:

--- a/src/agent_bom/api/routes/inventory_assets.py
+++ b/src/agent_bom/api/routes/inventory_assets.py
@@ -34,9 +34,11 @@ from fastapi import APIRouter, HTTPException, Query, Request
 
 from agent_bom.api import inventory_service
 from agent_bom.api.inventory_service import MAX_PAGE_LIMIT, InventoryError
+from agent_bom.api.neptune_graph import NeptuneGraphStoreUnsupportedOperationError
 from agent_bom.api.stores import _get_graph_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
+from agent_bom.security import sanitize_error
 
 logger = logging.getLogger(__name__)
 router = APIRouter()
@@ -53,6 +55,11 @@ async def _store_call(fn, /, *args, **kwargs):
             detail=exc.to_dict(),
             headers={"Retry-After": str(exc.retry_after_seconds)},
         ) from exc
+    except NeptuneGraphStoreUnsupportedOperationError as exc:
+        # The experimental Neptune backend implements only a partial
+        # GraphStoreProtocol surface; surface an honest 501 (not a generic 500)
+        # naming the unsupported operation and steering to SQLite/Postgres.
+        raise HTTPException(status_code=501, detail=sanitize_error(exc)) from exc
 
 
 def _tenant(request: Request) -> str:

--- a/tests/test_neptune_unsupported_501.py
+++ b/tests/test_neptune_unsupported_501.py
@@ -1,0 +1,129 @@
+"""Honest 501 (not a generic 500) when the experimental Neptune graph backend
+hits an unsupported GraphStoreProtocol operation.
+
+The Neptune adapter implements only a partial protocol surface (snapshots +
+``load_graph`` + ``snapshot_stats``); the ~16 read/traversal ops raise
+``NeptuneGraphStoreUnsupportedOperationError``. The route wrappers used to catch
+only backpressure, so under ``AGENT_BOM_GRAPH_BACKEND=neptune`` these surfaced as
+opaque 500s. They must degrade honestly: HTTP 501 Not Implemented with a
+sanitized message that names the unsupported op and steers to SQLite/Postgres —
+no stack trace, URL, or filesystem path leaked. SQLite/Postgres backends are
+unaffected.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.neptune_graph import NeptuneGraphStore
+from agent_bom.api.server import app
+from agent_bom.api.stores import set_graph_store
+
+
+class _EmptyGremlinClient:
+    """Gremlin-compatible client that returns no rows for every query.
+
+    Lets the real ``NeptuneGraphStore`` run its genuine code path: the supported
+    snapshot/``load_graph``/``snapshot_stats`` ops return empty results, while the
+    unsupported read/traversal ops raise the real unsupported-operation error.
+    """
+
+    def submit(self, query: str, bindings: dict[str, Any] | None = None) -> list[Any]:
+        return []
+
+
+@pytest.fixture
+def neptune_client(monkeypatch):
+    # The adapter is fail-closed: it refuses to construct unless the operator has
+    # explicitly opted into the experimental backend.
+    monkeypatch.setenv("AGENT_BOM_GRAPH_BACKEND", "neptune")
+    monkeypatch.setenv("AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH", "1")
+    monkeypatch.setenv("AGENT_BOM_NEPTUNE_ENDPOINT", "wss://neptune.example.invalid:8182/gremlin")
+    set_graph_store(NeptuneGraphStore(client=_EmptyGremlinClient()))
+    try:
+        yield TestClient(app)
+    finally:
+        set_graph_store(None)
+
+
+@pytest.fixture
+def sqlite_client():
+    # None forces re-selection of the default durable SQLite backend.
+    set_graph_store(None)
+    try:
+        yield TestClient(app)
+    finally:
+        set_graph_store(None)
+
+
+# (method, path, op-name-fragment) — each endpoint's first store interaction is
+# an unsupported Neptune op, so each must return 501 (not 500).
+_UNSUPPORTED_ENDPOINTS = [
+    ("GET", "/v1/inventory/assets", "page_nodes"),
+    ("GET", "/v1/inventory/assets/agent:a", "node_context"),
+    ("GET", "/v1/graph/attack-paths?limit=5", "attack_paths"),
+    ("GET", "/v1/graph/impact?node=agent:a", "impact_of"),
+    ("GET", "/v1/graph/search?q=agent", "search_nodes"),
+    ("GET", "/v1/graph/node/agent:a/neighbors", "node_context"),
+    ("GET", "/v1/graph/history?limit=10", "graph_history"),
+    ("GET", "/v1/graph/evidence-manifest", "evidence_manifest"),
+    ("GET", "/v1/graph/compliance", "compliance_summary"),
+]
+
+
+@pytest.mark.parametrize("method,path,op", _UNSUPPORTED_ENDPOINTS)
+def test_unsupported_neptune_op_returns_501(neptune_client, method, path, op):
+    resp = neptune_client.request(method, path)
+    assert resp.status_code == 501, (path, resp.status_code, resp.text)
+
+    body = resp.json()
+    detail = body.get("detail")
+    assert isinstance(detail, str), body
+    # Names the unsupported op and the backend, steering to SQLite/Postgres.
+    assert op in detail
+    assert "Neptune" in detail
+    assert "experimental" in detail
+    assert "SQLite" in detail and "Postgres" in detail
+
+
+@pytest.mark.parametrize("method,path,op", _UNSUPPORTED_ENDPOINTS)
+def test_501_detail_is_sanitized(neptune_client, method, path, op):
+    """The 501 message must not leak a stack trace, URL, or filesystem path."""
+    resp = neptune_client.request(method, path)
+    assert resp.status_code == 501
+    detail = resp.json()["detail"]
+    assert "Traceback" not in detail
+    assert "http://" not in detail and "https://" not in detail
+    # sanitize_error collapses any absolute path to a placeholder token.
+    assert "/Users/" not in detail
+    assert ".py" not in detail
+
+
+def test_query_traversal_endpoint_returns_501(neptune_client):
+    """POST /v1/graph/query (traverse_subgraph) also degrades to 501."""
+    resp = neptune_client.post(
+        "/v1/graph/query",
+        json={"roots": ["agent:a"], "max_depth": 2},
+    )
+    assert resp.status_code == 501, resp.text
+    # The handler resolves roots then traverses; whichever unsupported op it hits
+    # first (nodes_by_ids / traverse_subgraph) must degrade honestly, not 500.
+    detail = resp.json()["detail"]
+    assert "Neptune" in detail and "experimental" in detail
+
+
+def test_supported_neptune_op_is_unaffected(neptune_client):
+    """snapshot_stats IS implemented, so /v1/inventory/summary stays 200."""
+    resp = neptune_client.get("/v1/inventory/summary")
+    assert resp.status_code == 200, resp.text
+
+
+@pytest.mark.parametrize("method,path,op", _UNSUPPORTED_ENDPOINTS)
+def test_sqlite_backend_never_501(sqlite_client, method, path, op):
+    """The default SQLite backend implements every op — it must never 501/500."""
+    resp = sqlite_client.request(method, path)
+    assert resp.status_code != 501, (path, resp.text)
+    assert resp.status_code < 500, (path, resp.status_code, resp.text)

--- a/tests/test_postgres_governance_audit.py
+++ b/tests/test_postgres_governance_audit.py
@@ -1,0 +1,293 @@
+"""PostgresGovernanceAuditLog — clustered, tenant-scoped, tamper-evident chain.
+
+Uses a functional in-memory fake pool that persists the ``governance_audit_log``
+table and honours the exact SQL + FORCE ROW LEVEL SECURITY session the store
+issues (``set_config('app.tenant_id' / 'app.bypass_rls')``). The tests prove the
+properties that matter for a multi-replica control plane:
+
+* the HMAC-linked chain appends, reads, and integrity-verifies on Postgres;
+* tenant isolation holds — a cross-tenant ``get`` is denied and each tenant has
+  its own verifiable chain;
+* two store instances over one backend see each other's writes (no per-node
+  divergence);
+* append is idempotent on the deterministic ``action_id``;
+* backend selection follows the configured store.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agent_bom.api.governance_audit_log import (
+    ACTION_IDENTITY_DORMANT_REVOKE,
+    InMemoryGovernanceAuditLog,
+    SQLiteGovernanceAuditLog,
+    make_governance_audit_record,
+    set_governance_audit_log,
+)
+from agent_bom.api.postgres_governance_audit import PostgresGovernanceAuditLog
+
+# ─── Functional fake Postgres with RLS ───────────────────────────────────────
+
+
+class _FakeCursor:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+    def fetchall(self):
+        return self.rows
+
+
+class _FakeConnection:
+    """Minimal Postgres-shaped engine for one governance_audit_log table.
+
+    Enforces tenant RLS the way FORCE ROW LEVEL SECURITY does: a normally-scoped
+    session only sees its own tenant's rows; a bypass session sees all rows.
+    """
+
+    def __init__(self, state):
+        self._state = state  # shared across connections from one pool
+        self.tenant = "default"
+        self.bypass = False
+
+    def _visible(self):
+        rows = self._state["rows"]
+        if self.bypass:
+            return list(rows)
+        return [r for r in rows if r["tenant_id"] == self.tenant]
+
+    def execute(self, sql, params=None):
+        s = " ".join(sql.lower().split())
+        params = params or ()
+
+        if "set_config('app.tenant_id'" in s:
+            self.tenant = params[0]
+            return _FakeCursor()
+        if "set_config('app.bypass_rls'" in s:
+            self.bypass = params[0] == "1"
+            return _FakeCursor()
+        if "set_config('statement_timeout'" in s:
+            return _FakeCursor()
+
+        if s.startswith("insert into governance_audit_log"):
+            action_id, tenant_id, action, observed_at, record_hash, data = params
+            rows = self._state["rows"]
+            if any(r["action_id"] == action_id for r in rows):
+                return _FakeCursor()  # ON CONFLICT DO NOTHING
+            self._state["seq"] += 1
+            rows.append(
+                {
+                    "seq": self._state["seq"],
+                    "action_id": action_id,
+                    "tenant_id": tenant_id,
+                    "action": action,
+                    "observed_at": observed_at,
+                    "record_hash": record_hash,
+                    "data": data,
+                }
+            )
+            return _FakeCursor()
+
+        if "from governance_audit_log where action_id" in s:
+            match = [r for r in self._visible() if r["action_id"] == params[0]]
+            return _FakeCursor([(match[0]["data"],)] if match else [])
+
+        if "select record_hash from governance_audit_log where tenant_id" in s:
+            rows = sorted(
+                (r for r in self._visible() if r["tenant_id"] == params[0]),
+                key=lambda r: r["seq"],
+                reverse=True,
+            )
+            return _FakeCursor([(rows[0]["record_hash"],)] if rows else [])
+
+        if "select data from governance_audit_log where tenant_id" in s:
+            rows = sorted(
+                (r for r in self._visible() if r["tenant_id"] == params[0]),
+                key=lambda r: r["seq"],
+                reverse=True,
+            )[: params[1]]
+            return _FakeCursor([(r["data"],) for r in rows])
+
+        if "order by tenant_id asc, seq asc" in s:
+            rows = sorted(self._visible(), key=lambda r: (r["tenant_id"], r["seq"]))[: params[0]]
+            return _FakeCursor([(r["data"],) for r in rows])
+
+        if s.startswith("select data from governance_audit_log order by seq desc"):
+            rows = sorted(self._visible(), key=lambda r: r["seq"], reverse=True)[: params[0]]
+            return _FakeCursor([(r["data"],) for r in rows])
+
+        # DDL, RLS helpers, schema-version bookkeeping → no-op.
+        return _FakeCursor()
+
+    def commit(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        pass
+
+
+class _FakePool:
+    def __init__(self):
+        self._state = {"rows": [], "seq": 0}
+
+    def connection(self):
+        return _FakeConnection(self._state)
+
+
+def _rec(tenant, target, window, action=ACTION_IDENTITY_DORMANT_REVOKE):
+    return make_governance_audit_record(
+        tenant_id=tenant,
+        actor="cleanup-loop",
+        action=action,
+        target_type="agent_identity",
+        target_id=target,
+        reason="dormant beyond retention",
+        before_state="active",
+        after_state="revoked",
+        observed_at="2026-07-15T00:00:00Z",
+        window_key=window,
+    )
+
+
+# ─── Tests ───────────────────────────────────────────────────────────────────
+
+
+def test_append_read_and_chain_verifies():
+    store = PostgresGovernanceAuditLog(pool=_FakePool())
+    a = store.append(_rec("acme", "id-1", "w1"))
+    b = store.append(_rec("acme", "id-2", "w2"))
+
+    # Chain links: second record's prev_hash is the first record's hash.
+    assert a.prev_hash == ""
+    assert b.prev_hash == a.record_hash
+
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+
+    token = set_current_tenant("acme")
+    try:
+        got = store.get(a.action_id)
+    finally:
+        reset_current_tenant(token)
+    assert got is not None and got.action_id == a.action_id
+
+    result = store.verify_chain()
+    assert result["tampered"] == 0
+    assert result["verified"] == 2
+
+
+def test_idempotent_append():
+    store = PostgresGovernanceAuditLog(pool=_FakePool())
+    rec = _rec("acme", "id-1", "w1")
+    first = store.append(rec)
+    second = store.append(_rec("acme", "id-1", "w1"))  # same deterministic action_id
+
+    assert first.action_id == second.action_id
+    assert first.record_hash == second.record_hash
+    assert len(store.list(tenant_id="acme")) == 1
+    assert store.verify_chain()["checked"] == 1
+
+
+def test_tenant_isolation_get_denied_cross_tenant():
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+
+    store = PostgresGovernanceAuditLog(pool=_FakePool())
+    acme = store.append(_rec("acme", "id-a", "w1"))
+    globex = store.append(_rec("globex", "id-b", "w1"))
+
+    token = set_current_tenant("acme")
+    try:
+        assert store.get(acme.action_id) is not None
+        # globex's record is invisible under acme's RLS session.
+        assert store.get(globex.action_id) is None
+    finally:
+        reset_current_tenant(token)
+
+    # list is tenant-scoped.
+    assert [r.tenant_id for r in store.list(tenant_id="acme")] == ["acme"]
+    assert [r.tenant_id for r in store.list(tenant_id="globex")] == ["globex"]
+
+
+def test_per_tenant_chains_both_verify():
+    store = PostgresGovernanceAuditLog(pool=_FakePool())
+    store.append(_rec("acme", "id-a1", "w1"))
+    store.append(_rec("acme", "id-a2", "w2"))
+    store.append(_rec("globex", "id-b1", "w1"))
+
+    result = store.verify_chain()
+    assert result["tampered"] == 0
+    assert result["verified"] == 3
+
+
+def test_shared_pool_is_cluster_consistent():
+    """Two store instances over one backend must see each other's writes."""
+    pool = _FakePool()
+    node_a = PostgresGovernanceAuditLog(pool=pool)
+    node_b = PostgresGovernanceAuditLog(pool=pool)
+
+    rec_a = node_a.append(_rec("acme", "id-a", "w1"))
+    # node_b, a different replica, appends onto node_a's head — one chain.
+    rec_b = node_b.append(_rec("acme", "id-b", "w2"))
+
+    assert rec_b.prev_hash == rec_a.record_hash
+    assert len(node_b.list(tenant_id="acme")) == 2
+    assert node_b.verify_chain()["tampered"] == 0
+
+
+def test_tamper_is_detected():
+    pool = _FakePool()
+    store = PostgresGovernanceAuditLog(pool=pool)
+    store.append(_rec("acme", "id-a", "w1"))
+    store.append(_rec("acme", "id-b", "w2"))
+
+    # Corrupt a persisted row's payload after the fact.
+    row = pool._state["rows"][0]
+    tampered = json.loads(row["data"])
+    tampered["reason"] = "silently rewritten"
+    row["data"] = json.dumps(tampered, sort_keys=True)
+
+    assert store.verify_chain()["tampered"] >= 1
+
+
+def test_backend_selection_prefers_postgres(monkeypatch):
+    from agent_bom.api import governance_audit_log as mod
+
+    set_governance_audit_log(None)
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgres://agent_bom_app@localhost/test")
+    monkeypatch.setattr(
+        "agent_bom.api.postgres_governance_audit._get_pool",
+        lambda: _FakePool(),
+    )
+    try:
+        log = mod.get_governance_audit_log()
+        assert isinstance(log, PostgresGovernanceAuditLog)
+    finally:
+        set_governance_audit_log(None)
+
+
+def test_backend_selection_memory_and_sqlite(monkeypatch, tmp_path):
+    from agent_bom.api import governance_audit_log as mod
+
+    # Ephemeral opt-out → in-memory.
+    set_governance_audit_log(None)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    monkeypatch.setenv("AGENT_BOM_EPHEMERAL_STORE", "1")
+    try:
+        assert isinstance(mod.get_governance_audit_log(), InMemoryGovernanceAuditLog)
+    finally:
+        set_governance_audit_log(None)
+
+    # Default → durable SQLite.
+    monkeypatch.delenv("AGENT_BOM_EPHEMERAL_STORE", raising=False)
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "cp.db"))
+    set_governance_audit_log(None)
+    try:
+        assert isinstance(mod.get_governance_audit_log(), SQLiteGovernanceAuditLog)
+    finally:
+        set_governance_audit_log(None)


### PR DESCRIPTION
## Summary

Two backend completeness fixes from the surface-parity / completeness audit (#4014): honest degradation for the partial Neptune graph backend, and a durable HA governance audit chain on clustered Postgres. No new REST routes; backend + tests only.

## Fix 1 — Neptune graph backend: honest 501, not generic 500

The experimental, opt-in Neptune adapter (`AGENT_BOM_GRAPH_BACKEND=neptune` + `AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH=1`) implements only a partial `GraphStoreProtocol` surface; ~16 read/traversal ops (`page_nodes`, `search_nodes`, `bfs_paths`, `impact_of`, `traverse_subgraph`, `attack_paths*`, `node_context`, `compliance_summary`, `graph_history`, `evidence_manifest`, `save/list/delete_preset`, …) raise `NeptuneGraphStoreUnsupportedOperationError`. The `/v1/graph/*` and `/v1/inventory/*` route wrappers caught only backpressure, so these surfaced as opaque **500**s.

- The three store-call wrappers (`routes/graph.py` `_graph_store_call` / `_graph_compute_call`, `routes/inventory_assets.py` `_store_call`) — through which **all** graph/inventory store access flows — now also catch the unsupported-op error and return an honest **HTTP 501 Not Implemented** with a `sanitize_error`-cleaned message that names the operation and steers to SQLite/Postgres.
- Gremlin traversals are intentionally **not** implemented (out of scope); this only makes the degradation honest.
- The Neptune message was reworded (`SQLite/Postgres` → `SQLite or Postgres`) so `sanitize_error`'s path-stripping regex doesn't mangle the steering text.

## Fix 2 — Governance audit log: Postgres-backed durable chain (HA)

`governance_audit_log.py` fell back to node-local SQLite even on clustered Postgres, splitting the tamper-evident NHI lifecycle-enforcement trail per replica. New `PostgresGovernanceAuditLog` (in `postgres_governance_audit.py`), selected via the shared `durable_store.select_backend()` path (in-memory / SQLite / **Postgres+tenant-RLS**), mirroring the agent-identity / `PostgresAuditLog` conventions:

- **Per-tenant HMAC chain** — `append` seals each record against that tenant's current head (RLS-scoped), preserving the tamper-evident contract.
- **Tenant isolation** via idempotent DDL + `FORCE ROW LEVEL SECURITY`; a cross-tenant `get` returns `None`.
- **Idempotent append** on the deterministic `action_id` (`UNIQUE` + `ON CONFLICT DO NOTHING`), safe across replicas.
- `verify_chain` does a trusted full-estate sweep, verifying each tenant's chain independently.

On clustered Postgres the chain is one durable, shared, per-tenant chain instead of diverging per node.

## Tests

- `tests/test_neptune_unsupported_501.py` — real `NeptuneGraphStore` + empty Gremlin client; parametrized `/v1/graph/*` + `/v1/inventory/*` endpoints return **501 (not 500)** with a sanitized, op-naming message (no stack/URL/path leak); a supported op (`snapshot_stats` → `/v1/inventory/summary`) stays 200; the default SQLite backend never 501/500s.
- `tests/test_postgres_governance_audit.py` — functional fake pool honouring the store's SQL + RLS session: append/read/integrity-verify, tenant isolation, per-tenant chains, cluster consistency across two store instances, idempotency, tamper detection, and backend selection (memory / SQLite / Postgres).

## Gates

- `pytest -k "neptune or graph_backend or governance_audit or audit_log or inventory"` → 466 passed, 3 skipped; new suites → 37 passed.
- `check_exception_sanitization.py` → 0 · `check-counts.py` → consistent (no routes) · `make preflight` → green · ruff + mypy on touched modules → clean.
- `git diff --stat origin/main`: backend + tests only; none of the #4011 / hardening / exec-count / UI fenced files.

Refs #4014.
