### PR TITLE
feat(ui): first-class UI for the AI/ML supply-chain scans (human↔agent parity)

### DIFF
--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -3,17 +3,25 @@
 :root {
   color-scheme: dark;
   /*
-   * Enterprise-console hierarchy (dark-first):
-   * page < card (--surface) < inset/elevated — each one step brighter,
-   * with borders and secondary text strong enough to read at a glance.
-   * Mint stays the brand accent; severity/status hues are sharpened below.
+   * Enterprise-console hierarchy (dark-first). Four layered surfaces, each one
+   * step brighter, sit on a deep — not pure-black — canvas with a very subtle
+   * radial depth wash:
+   *
+   *   --background        app canvas (deepest)
+   *   --surface-panel     page panels / wells that group cards
+   *   --surface           card (the default content surface)
+   *   --surface-elevated  inset / raised chips, popovers, hovered rows
+   *
+   * Mint/emerald stays the single brand accent (with a small interactive
+   * scale); severity/status hues are semantic and kept separate from it.
    */
-  --background: #181a22;
+  --background: #14161d;
   --foreground: #f4f5f8;
+  --surface-panel: #1b1e27;
   --surface: #22262f;
   --surface-elevated: #2c3140;
   --surface-muted: rgba(72, 78, 94, 0.58);
-  --border-subtle: rgba(110, 118, 138, 0.78);
+  --border-subtle: rgba(110, 118, 138, 0.72);
   --border-strong: rgba(140, 148, 168, 0.92);
   --text-secondary: #d0d4dc;
   --text-tertiary: #a8aebc;
@@ -23,13 +31,40 @@
   --sidebar-width: 240px;
   --sidebar-collapsed-width: 60px;
 
-  /* Mint brand accent */
-  --accent-mint: #34d399;
+  /* Subtle canvas depth — a soft dual spotlight, never a loud gradient. */
+  --app-bg-image:
+    radial-gradient(1200px 620px at 50% -12%, rgba(52, 211, 153, 0.055), transparent 62%),
+    radial-gradient(1000px 560px at 100% 0%, rgba(99, 163, 255, 0.045), transparent 58%);
 
-  /* Text that sits on a bright accent fill (emerald/sky buttons). Near-black
-   * in both themes because the fill stays bright — replaces hardcoded
-   * text-zinc-950 so light theme keeps the same legible contrast (#3966). */
-  --on-accent: #0b0d10;
+  /* Elevation — layered depth so panels read as physical, not flat outlines. */
+  --elevation-1: 0 1px 2px rgba(0, 0, 0, 0.30);
+  --elevation-2: 0 6px 18px -6px rgba(0, 0, 0, 0.46);
+  --elevation-3: 0 18px 44px -12px rgba(0, 0, 0, 0.56);
+
+  /* Radii — one scale for the whole system. */
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
+
+  /* Motion — durations + easing shared by every transition/animation. */
+  --motion-fast: 120ms;
+  --motion-base: 180ms;
+  --motion-slow: 280ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Brand accent scale (mint/emerald) — interactive + selected states. */
+  --accent: #34d399;
+  --accent-strong: #10b981;
+  --accent-soft: rgba(52, 211, 153, 0.14);
+  --accent-soft-hover: rgba(52, 211, 153, 0.22);
+  --accent-border: rgba(52, 211, 153, 0.42);
+  --accent-ring: rgba(52, 211, 153, 0.55);
+  --accent-contrast: #04150f;
+  /* Back-compat alias — existing consumers read --accent-mint. */
+  --accent-mint: var(--accent);
+  --focus-ring: var(--accent-ring);
 
   /* Severity — badges, charts, dots (hex aligned with ui/lib/theme-colors.ts) */
   --severity-critical: #ff6b6b;
@@ -44,11 +79,7 @@
   --severity-low: #6ba3ff;
   --severity-low-bg: rgba(107, 163, 255, 0.15);
   --severity-low-border: rgba(107, 163, 255, 0.48);
-  /* Unrated — findings whose severity is unknown/unscored (issue #3946). Neutral
-   * grey so it never reads as a severity band but is still visibly counted. */
-  --severity-unrated: #9aa3b8;
-  --severity-unrated-bg: rgba(154, 163, 184, 0.14);
-  --severity-unrated-border: rgba(154, 163, 184, 0.46);
+  --severity-none: #8b93a7;
 
   /* Status — success / warn / danger */
   --status-success: #34d399;
@@ -71,21 +102,38 @@
 
 :root[data-theme="light"] {
   color-scheme: light;
-  /* Cool gray canvas — white cards sit clearly above the page */
-  --background: #e4e9f2;
+  /* Cool gray canvas — white cards sit clearly above panels and the page. */
+  --background: #e6eaf1;
   --foreground: #12141a;
+  --surface-panel: #eef2f8;
   --surface: #ffffff;
-  --surface-elevated: #eef2f8;
-  --surface-muted: rgba(190, 198, 212, 0.55);
-  --border-subtle: rgba(130, 145, 168, 0.62);
-  --border-strong: rgba(90, 105, 128, 0.8);
+  --surface-elevated: #f4f7fb;
+  --surface-muted: rgba(190, 198, 212, 0.5);
+  --border-subtle: rgba(130, 145, 168, 0.5);
+  --border-strong: rgba(90, 105, 128, 0.72);
   --text-secondary: #374151;
-  --text-tertiary: #4b5563;
-  --shadow-color: rgba(15, 23, 42, 0.11);
+  --text-tertiary: #55627a;
+  --shadow-color: rgba(15, 23, 42, 0.1);
   --scrollbar-thumb: #9aa3b2;
   --scrollbar-thumb-hover: #7b8596;
 
-  --accent-mint: #059669;
+  --app-bg-image:
+    radial-gradient(1200px 620px at 50% -12%, rgba(5, 150, 105, 0.05), transparent 62%),
+    radial-gradient(1000px 560px at 100% 0%, rgba(37, 99, 235, 0.04), transparent 58%);
+
+  --elevation-1: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --elevation-2: 0 6px 16px -6px rgba(15, 23, 42, 0.12);
+  --elevation-3: 0 18px 40px -12px rgba(15, 23, 42, 0.16);
+
+  --accent: #059669;
+  --accent-strong: #047857;
+  --accent-soft: rgba(5, 150, 105, 0.1);
+  --accent-soft-hover: rgba(5, 150, 105, 0.16);
+  --accent-border: rgba(5, 150, 105, 0.4);
+  --accent-ring: rgba(5, 150, 105, 0.45);
+  --accent-contrast: #ffffff;
+  --accent-mint: var(--accent);
+  --focus-ring: var(--accent-ring);
 
   --severity-critical: #dc2626;
   --severity-critical-bg: rgba(220, 38, 38, 0.1);
@@ -99,9 +147,7 @@
   --severity-low: #2563eb;
   --severity-low-bg: rgba(37, 99, 235, 0.1);
   --severity-low-border: rgba(37, 99, 235, 0.38);
-  --severity-unrated: #64748b;
-  --severity-unrated-bg: rgba(100, 116, 139, 0.1);
-  --severity-unrated-border: rgba(100, 116, 139, 0.36);
+  --severity-none: #64748b;
 
   --status-success: #059669;
   --status-success-bg: rgba(5, 150, 105, 0.1);
@@ -117,13 +163,39 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-elevated: var(--surface-elevated);
+  --color-accent: var(--accent);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 body {
-  background: var(--background);
+  background-color: var(--background);
+  background-image: var(--app-bg-image);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
   color: var(--foreground);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* Numeric-heavy console: tabular figures keep tables/metrics from jittering. */
+.tabular-figures {
+  font-variant-numeric: tabular-nums;
+}
+
+/*
+ * Consistent keyboard focus for interactive elements. `:where()` keeps the
+ * specificity at 0 so any component-level `focus-visible:` utility still wins,
+ * while un-styled controls get a themed ring that follows their border radius.
+ */
+:where(a, button, [role="button"], summary, input, select, textarea):focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--focus-ring);
 }
 
 /* Smooth scrollbar */
@@ -151,18 +223,29 @@ body {
   border-radius: 2px;
 }
 
+/* Elevation utilities — pair with a surface + border for physical depth. */
+.elev-1 {
+  box-shadow: var(--elevation-1);
+}
+.elev-2 {
+  box-shadow: var(--elevation-2);
+}
+.elev-3 {
+  box-shadow: var(--elevation-3);
+}
+
 /* Mobile sidebar slide-in animation */
 @keyframes slide-in-left {
   from { transform: translateX(-100%); }
   to { transform: translateX(0); }
 }
 .animate-slide-in {
-  animation: slide-in-left 0.2s ease-out;
+  animation: slide-in-left var(--motion-base) var(--ease-out);
 }
 
 /* React Flow edge animation refinement */
 .react-flow__edge-path {
-  transition: stroke-opacity 0.2s ease;
+  transition: stroke-opacity var(--motion-base) var(--ease-standard);
 }
 
 /* Fullscreen mode styles */
@@ -181,13 +264,32 @@ body {
   display: none;
 }
 
-/* Card hover effects */
+/* Card hover effect — lifts the border + a hairline ring on hover. */
 .card-hover {
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color var(--motion-fast) var(--ease-standard),
+    box-shadow var(--motion-fast) var(--ease-standard),
+    transform var(--motion-fast) var(--ease-standard);
 }
 .card-hover:hover {
   border-color: var(--border-strong);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-strong) 35%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--border-strong) 35%, transparent),
+    var(--elevation-2);
+}
+
+/* Interactive row — dense list/table rows that respond to hover + selection. */
+.interactive-row {
+  transition:
+    background-color var(--motion-fast) var(--ease-standard),
+    color var(--motion-fast) var(--ease-standard);
+}
+.interactive-row:hover {
+  background-color: var(--surface-elevated);
+}
+.interactive-row[data-selected="true"] {
+  background-color: var(--accent-soft);
+  box-shadow: inset 2px 0 0 0 var(--accent);
 }
 
 /* Stat card gradient backgrounds — driven by severity/status tokens */
@@ -222,12 +324,24 @@ body {
 
 /* Smooth page transitions */
 main > div {
-  animation: fade-in 0.15s ease-out;
+  animation: fade-in var(--motion-base) var(--ease-out);
 }
 
 @keyframes fade-in {
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }
+}
+
+/* Respect users who prefer reduced motion — kill transforms/animations. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* Drift lens (#3192) — snapshot change-kind rings painted on React Flow node

--- a/ui/components/ai-scan-panel.tsx
+++ b/ui/components/ai-scan-panel.tsx
@@ -1,0 +1,872 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import { ArrowRight, Loader2, Plus, ScanSearch, ShieldCheck, X } from "lucide-react";
+
+import { api } from "@/lib/api";
+import {
+  AI_SCAN_TYPES,
+  aiSeverityRank,
+  highestFlagSeverity,
+  type AiScanResponse,
+  type AiScanTypeId,
+  type AiSecurityFlag,
+  type BrowserExtension,
+  type BrowserExtensionsResponse,
+  type DatasetCard,
+  type DatasetCardsResponse,
+  type ModelFileEntry,
+  type ModelFilesResponse,
+  type ModelProvenanceResponse,
+  type PromptFinding,
+  type PromptScanResponse,
+  type ProvenanceResult,
+  type TrainingArtifact,
+  type TrainingPipelinesResponse,
+} from "@/lib/ai-scan";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import { Drawer } from "@/components/drawer";
+import { SeverityBadge } from "@/components/severity-badge";
+import { StatStrip, type StatStripItem } from "@/components/stat-strip";
+import {
+  PageEmptyState,
+  PageErrorState,
+  PageLoadingState,
+} from "@/components/states/page-state";
+
+/** Normalized detail record shown in the drawer for any scan-type row. */
+type DetailView = {
+  eyebrow: string;
+  title: string;
+  subtitle?: string | undefined;
+  flags?: AiSecurityFlag[] | undefined;
+  fields: { label: string; value: ReactNode }[];
+};
+
+function cleanList(values: string[]): string[] {
+  return values.map((v) => v.trim()).filter(Boolean);
+}
+
+export function AiScanPanel() {
+  const [scanType, setScanType] = useState<AiScanTypeId>("dataset-cards");
+  const [dirs, setDirs] = useState<string[]>([]);
+  const [files, setFiles] = useState<string[]>([]);
+  const [hfModels, setHfModels] = useState<string[]>([]);
+  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
+  const [includeLowRisk, setIncludeLowRisk] = useState(false);
+  const [verifyHashes, setVerifyHashes] = useState(false);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<AiScanResponse | null>(null);
+  const [detail, setDetail] = useState<DetailView | null>(null);
+
+  const meta = useMemo(
+    () => AI_SCAN_TYPES.find((t) => t.id === scanType) ?? AI_SCAN_TYPES[0]!,
+    [scanType],
+  );
+  const kind = meta.inputKind;
+
+  function selectType(next: AiScanTypeId) {
+    setScanType(next);
+    setResult(null);
+    setError("");
+    setDetail(null);
+  }
+
+  const cleanedDirs = cleanList(dirs);
+  const cleanedFiles = cleanList(files);
+  const cleanedHf = cleanList(hfModels);
+  const cleanedOllama = cleanList(ollamaModels);
+
+  const canRun = (() => {
+    switch (kind) {
+      case "directories":
+      case "model-files":
+        return cleanedDirs.length > 0;
+      case "prompt":
+        return cleanedDirs.length > 0 || cleanedFiles.length > 0;
+      case "models":
+        return cleanedHf.length > 0 || cleanedOllama.length > 0;
+      case "extensions":
+        return true;
+      default:
+        return false;
+    }
+  })();
+
+  async function run() {
+    if (!canRun || loading) return;
+    setLoading(true);
+    setError("");
+    setDetail(null);
+    try {
+      let response: AiScanResponse;
+      switch (scanType) {
+        case "dataset-cards":
+          response = await api.scanDatasetCards({ directories: cleanedDirs });
+          break;
+        case "training-pipelines":
+          response = await api.scanTrainingPipelines({ directories: cleanedDirs });
+          break;
+        case "browser-extensions":
+          response = await api.scanBrowserExtensions({ include_low_risk: includeLowRisk });
+          break;
+        case "model-provenance":
+          response = await api.scanModelProvenance({
+            hf_models: cleanedHf,
+            ollama_models: cleanedOllama,
+          });
+          break;
+        case "prompt-scan":
+          response = await api.scanPrompts({
+            directories: cleanedDirs,
+            files: cleanedFiles,
+          });
+          break;
+        case "model-files":
+          response = await api.scanModelFiles({
+            directories: cleanedDirs,
+            verify_hashes: verifyHashes,
+          });
+          break;
+      }
+      setResult(response);
+    } catch (err) {
+      setResult(null);
+      setError(err instanceof Error ? err.message : "Scan failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-5 lg:grid-cols-[minmax(0,15rem)_minmax(0,1fr)]" data-testid="ai-scan-panel">
+      <nav aria-label="AI supply-chain scan type" className="space-y-2">
+        <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+          AI supply chain
+        </p>
+        <ul className="space-y-1.5">
+          {AI_SCAN_TYPES.map((type) => {
+            const active = type.id === scanType;
+            return (
+              <li key={type.id}>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => selectType(type.id)}
+                  className={`w-full rounded-xl border px-3 py-2.5 text-left transition ${
+                    active
+                      ? "border-[color:var(--accent-border)] bg-[color:var(--accent-soft)]"
+                      : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] hover:border-[color:var(--border-strong)]"
+                  }`}
+                >
+                  <span
+                    className={`block text-sm font-medium ${
+                      active ? "text-[color:var(--accent)]" : "text-[color:var(--foreground)]"
+                    }`}
+                  >
+                    {type.label}
+                  </span>
+                  <span className="mt-0.5 block text-xs leading-snug text-[color:var(--text-secondary)]">
+                    {type.blurb}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <div className="min-w-0 space-y-4">
+        <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 elev-1">
+          <div className="mb-4">
+            <h2 className="text-base font-semibold text-[color:var(--foreground)]">{meta.label}</h2>
+            <p className="mt-1 text-sm text-[color:var(--text-secondary)]">{meta.blurb}</p>
+          </div>
+
+          <div className="space-y-3">
+            {(kind === "directories" || kind === "prompt" || kind === "model-files") && (
+              <PathListInput
+                label="Directories"
+                placeholder="/path/to/scan"
+                items={dirs}
+                onChange={setDirs}
+              />
+            )}
+
+            {kind === "prompt" && (
+              <PathListInput
+                label="Prompt files (optional)"
+                placeholder="/path/to/system.prompt"
+                items={files}
+                onChange={setFiles}
+              />
+            )}
+
+            {kind === "models" && (
+              <>
+                <PathListInput
+                  label="HuggingFace models"
+                  placeholder="meta-llama/Llama-2-7b-hf"
+                  mono
+                  items={hfModels}
+                  onChange={setHfModels}
+                />
+                <PathListInput
+                  label="Ollama models"
+                  placeholder="llama2"
+                  mono
+                  items={ollamaModels}
+                  onChange={setOllamaModels}
+                />
+              </>
+            )}
+
+            {kind === "extensions" && (
+              <label className="flex cursor-pointer items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-[color:var(--border-subtle)]"
+                  checked={includeLowRisk}
+                  onChange={(e) => setIncludeLowRisk(e.target.checked)}
+                />
+                <span className="text-sm text-[color:var(--foreground)]">
+                  Include low-risk extensions
+                </span>
+              </label>
+            )}
+
+            {kind === "model-files" && (
+              <label className="flex cursor-pointer items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-[color:var(--border-subtle)]"
+                  checked={verifyHashes}
+                  onChange={(e) => setVerifyHashes(e.target.checked)}
+                />
+                <span className="text-sm text-[color:var(--foreground)]">
+                  Compute SHA-256 integrity hashes (slower)
+                </span>
+              </label>
+            )}
+          </div>
+
+          {error ? (
+            <p className="mt-3 rounded-lg border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-3 py-2 text-sm text-[color:var(--severity-critical)]">
+              {error}
+            </p>
+          ) : null}
+
+          <div className="mt-4 flex items-center justify-between gap-3">
+            <p className="text-xs text-[color:var(--text-tertiary)]">
+              {kind === "extensions"
+                ? "Scans browser extensions installed on the control-plane host."
+                : "Paths resolve on the control-plane host running the scan."}
+            </p>
+            <button
+              type="button"
+              onClick={run}
+              disabled={!canRun || loading}
+              className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-[color:var(--accent)] px-4 py-2.5 text-sm font-medium text-[color:var(--accent-contrast)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ScanSearch className="h-4 w-4" />
+              )}
+              Run scan <ArrowRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <AiScanResults
+          loading={loading}
+          error={error}
+          result={result}
+          onOpenDetail={setDetail}
+        />
+      </div>
+
+      <Drawer
+        open={detail !== null}
+        onClose={() => setDetail(null)}
+        eyebrow={detail?.eyebrow}
+        title={detail?.title ?? ""}
+        subtitle={detail?.subtitle}
+        size="2xl"
+      >
+        {detail ? <DetailBody detail={detail} /> : null}
+      </Drawer>
+    </div>
+  );
+}
+
+// ─── Results ────────────────────────────────────────────────────────────────
+
+function AiScanResults({
+  loading,
+  error,
+  result,
+  onOpenDetail,
+}: {
+  loading: boolean;
+  error: string;
+  result: AiScanResponse | null;
+  onOpenDetail: (detail: DetailView) => void;
+}) {
+  if (loading) {
+    return (
+      <PageLoadingState
+        title="Scanning…"
+        detail="Running the scan on the control-plane host and collecting real results."
+        data-testid="ai-scan-loading"
+      />
+    );
+  }
+  if (error) {
+    return (
+      <PageErrorState
+        title="Scan failed"
+        detail={error}
+        data-testid="ai-scan-error"
+      />
+    );
+  }
+  if (!result) {
+    return (
+      <PageEmptyState
+        title="No scan run yet"
+        detail="Set the inputs above and run the scan. Results are rendered here from the API — nothing is sampled or faked."
+        icon={ShieldCheck}
+        data-testid="ai-scan-empty"
+      />
+    );
+  }
+
+  switch (result.scan_type) {
+    case "dataset-cards":
+      return <DatasetCardsResult result={result} onOpenDetail={onOpenDetail} />;
+    case "training-pipelines":
+      return <TrainingPipelinesResult result={result} onOpenDetail={onOpenDetail} />;
+    case "browser-extensions":
+      return <BrowserExtensionsResult result={result} onOpenDetail={onOpenDetail} />;
+    case "model-provenance":
+      return <ModelProvenanceResult result={result} onOpenDetail={onOpenDetail} />;
+    case "prompt-scan":
+      return <PromptScanResult result={result} onOpenDetail={onOpenDetail} />;
+    case "model-files":
+      return <ModelFilesResult result={result} onOpenDetail={onOpenDetail} />;
+    default:
+      return null;
+  }
+}
+
+function FlagCell({ flags }: { flags: AiSecurityFlag[] | undefined }) {
+  const highest = highestFlagSeverity(flags);
+  if (!highest) {
+    return <span className="text-xs text-[color:var(--status-success)]">clean</span>;
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <SeverityBadge severity={highest} />
+      {flags && flags.length > 1 ? (
+        <span className="text-xs tabular-nums text-[color:var(--text-tertiary)]">×{flags.length}</span>
+      ) : null}
+    </span>
+  );
+}
+
+function BoolTag({ value, trueLabel, falseLabel }: { value: boolean | undefined; trueLabel: string; falseLabel: string }) {
+  return (
+    <span className={`text-xs ${value ? "text-[color:var(--status-warn)]" : "text-[color:var(--text-tertiary)]"}`}>
+      {value ? trueLabel : falseLabel}
+    </span>
+  );
+}
+
+function DatasetCardsResult({
+  result,
+  onOpenDetail,
+}: {
+  result: DatasetCardsResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const datasets = result.results.flatMap((r) => r.datasets);
+  const warnings = result.results.flatMap((r) => r.warnings);
+  const flagged = result.results.reduce((sum, r) => sum + r.flagged_count, 0);
+  const stats: StatStripItem[] = [
+    { label: "Directories", value: result.directories.length },
+    { label: "Datasets", value: datasets.length },
+    { label: "Flagged", value: flagged, accent: "high" },
+    { label: "Warnings", value: warnings.length, accent: "warn" },
+  ];
+  const columns: DataTableColumn<DatasetCard>[] = [
+    { key: "name", header: "Dataset", cell: (d) => <span className="text-[color:var(--foreground)]">{d.name}</span> },
+    { key: "license", header: "License", cell: (d) => d.license || "—" },
+    { key: "source", header: "Source", cell: (d) => <span className="font-mono text-xs">{d.source_file ?? "—"}</span> },
+    { key: "flags", header: "Risk", cell: (d) => <FlagCell flags={d.security_flags} /> },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={warnings}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={datasets}
+        rowKey={(d, i) => `${d.source_file ?? d.name}-${i}`}
+        columns={columns}
+        onRowClick={(d) =>
+          onOpenDetail({
+            eyebrow: "Dataset card",
+            title: d.name,
+            subtitle: d.source_file,
+            flags: d.security_flags,
+            fields: buildFields(d, ["name", "security_flags", "source_file"]),
+          })
+        }
+        empty="No dataset cards found in the scanned directories."
+      />
+    </ResultShell>
+  );
+}
+
+function TrainingPipelinesResult({
+  result,
+  onOpenDetail,
+}: {
+  result: TrainingPipelinesResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  type Row = TrainingArtifact & { _kind: "run" | "serving" };
+  const rows: Row[] = [
+    ...result.results.flatMap((r) => r.training_runs.map((t) => ({ ...t, _kind: "run" as const }))),
+    ...result.results.flatMap((r) => r.serving_configs.map((t) => ({ ...t, _kind: "serving" as const }))),
+  ];
+  const warnings = result.results.flatMap((r) => r.warnings);
+  const flagged = result.results.reduce((sum, r) => sum + r.flagged_count, 0);
+  const stats: StatStripItem[] = [
+    { label: "Training runs", value: result.results.reduce((s, r) => s + r.total_runs, 0) },
+    { label: "Serving configs", value: result.results.reduce((s, r) => s + r.total_serving, 0) },
+    { label: "Flagged", value: flagged, accent: "high" },
+    { label: "Warnings", value: warnings.length, accent: "warn" },
+  ];
+  const columns: DataTableColumn<Row>[] = [
+    { key: "name", header: "Artifact", cell: (t) => <span className="text-[color:var(--foreground)]">{t.name}</span> },
+    { key: "kind", header: "Kind", cell: (t) => (t._kind === "run" ? "Training run" : "Serving config") },
+    { key: "framework", header: "Framework", cell: (t) => t.framework ?? "—" },
+    { key: "source", header: "Source", cell: (t) => <span className="font-mono text-xs">{t.source_file ?? "—"}</span> },
+    { key: "flags", header: "Risk", cell: (t) => <FlagCell flags={t.security_flags} /> },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={warnings}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={rows}
+        rowKey={(t, i) => `${t._kind}-${t.source_file ?? t.name}-${i}`}
+        columns={columns}
+        onRowClick={(t) =>
+          onOpenDetail({
+            eyebrow: t._kind === "run" ? "Training run" : "Serving config",
+            title: t.name,
+            subtitle: t.source_file,
+            flags: t.security_flags,
+            fields: buildFields(t, ["name", "security_flags", "source_file", "_kind"]),
+          })
+        }
+        empty="No training or serving artifacts found."
+      />
+    </ResultShell>
+  );
+}
+
+function BrowserExtensionsResult({
+  result,
+  onOpenDetail,
+}: {
+  result: BrowserExtensionsResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const rows = [...result.extensions].sort(
+    (a, b) => aiSeverityRank(b.risk_level) - aiSeverityRank(a.risk_level),
+  );
+  const stats: StatStripItem[] = [
+    { label: "Extensions", value: result.total },
+    { label: "Critical", value: result.critical, accent: "critical" },
+    { label: "High", value: result.high, accent: "high" },
+  ];
+  const columns: DataTableColumn<BrowserExtension>[] = [
+    { key: "name", header: "Extension", cell: (e) => <span className="text-[color:var(--foreground)]">{e.name}</span> },
+    { key: "browser", header: "Browser", cell: (e) => e.browser ?? "—" },
+    { key: "risk", header: "Risk", cell: (e) => (e.risk_level ? <SeverityBadge severity={e.risk_level} /> : "—") },
+    { key: "perms", header: "Perms", align: "right", cell: (e) => (e.permissions?.length ?? 0) + (e.host_permissions?.length ?? 0) },
+    { key: "native", header: "Native msg", cell: (e) => <BoolTag value={e.has_native_messaging} trueLabel="yes" falseLabel="no" /> },
+    { key: "ai", header: "AI host", cell: (e) => <BoolTag value={e.has_ai_host_access} trueLabel="yes" falseLabel="no" /> },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={[]}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={rows}
+        rowKey={(e, i) => `${e.id}-${i}`}
+        columns={columns}
+        onRowClick={(e) =>
+          onOpenDetail({
+            eyebrow: `${e.browser ?? "Extension"} · ${e.risk_level ?? "unknown"} risk`,
+            title: e.name,
+            subtitle: e.id,
+            fields: buildFields(e, ["name", "id", "browser", "risk_level"]),
+          })
+        }
+        empty="No extensions matched the risk filter."
+      />
+    </ResultShell>
+  );
+}
+
+function ModelProvenanceResult({
+  result,
+  onOpenDetail,
+}: {
+  result: ModelProvenanceResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const rows = [...result.results].sort(
+    (a, b) => aiSeverityRank(b.risk_level) - aiSeverityRank(a.risk_level),
+  );
+  const stats: StatStripItem[] = [
+    { label: "Models", value: result.total },
+    { label: "Unsafe format", value: result.unsafe_format, accent: "critical" },
+  ];
+  const columns: DataTableColumn<ProvenanceResult>[] = [
+    { key: "model", header: "Model", cell: (m) => <span className="font-mono text-xs text-[color:var(--foreground)]">{m.model_id}</span> },
+    { key: "source", header: "Source", cell: (m) => m.source ?? "—" },
+    { key: "format", header: "Format", cell: (m) => m.format ?? "—" },
+    {
+      key: "safe",
+      header: "Serialization",
+      cell: (m) =>
+        m.is_safe_format ? (
+          <span className="text-xs text-[color:var(--status-success)]">safe</span>
+        ) : (
+          <span className="text-xs text-[color:var(--severity-critical)]">unsafe</span>
+        ),
+    },
+    { key: "risk", header: "Risk", cell: (m) => (m.risk_level ? <SeverityBadge severity={m.risk_level} /> : "—") },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={[]}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={rows}
+        rowKey={(m, i) => `${m.model_id}-${i}`}
+        columns={columns}
+        onRowClick={(m) =>
+          onOpenDetail({
+            eyebrow: `${m.source ?? "model"} provenance`,
+            title: m.model_id,
+            subtitle: m.format,
+            fields: buildFields(m, ["model_id"]),
+          })
+        }
+        empty="No models resolved. Check the model IDs and network access."
+      />
+    </ResultShell>
+  );
+}
+
+function PromptScanResult({
+  result,
+  onOpenDetail,
+}: {
+  result: PromptScanResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const findings = result.results
+    .flatMap((r) => r.findings)
+    .sort((a, b) => aiSeverityRank(b.severity) - aiSeverityRank(a.severity));
+  const filesScanned = result.results.reduce((s, r) => s + r.files_scanned, 0);
+  const passed = result.results.every((r) => r.passed);
+  const critical = findings.filter((f) => f.severity?.toLowerCase() === "critical").length;
+  const high = findings.filter((f) => f.severity?.toLowerCase() === "high").length;
+  const stats: StatStripItem[] = [
+    { label: "Files scanned", value: filesScanned },
+    { label: "Findings", value: findings.length },
+    { label: "Critical", value: critical, accent: "critical" },
+    { label: "High", value: high, accent: "high" },
+    {
+      label: "Verdict",
+      value: passed ? "pass" : "fail",
+      accent: passed ? "success" : "critical",
+    },
+  ];
+  const columns: DataTableColumn<PromptFinding>[] = [
+    { key: "severity", header: "Severity", cell: (f) => <SeverityBadge severity={f.severity} /> },
+    { key: "category", header: "Category", cell: (f) => f.category ?? "—" },
+    { key: "title", header: "Finding", cell: (f) => <span className="text-[color:var(--foreground)]">{f.title ?? "—"}</span> },
+    {
+      key: "source",
+      header: "Location",
+      cell: (f) => (
+        <span className="font-mono text-xs">
+          {f.source_file ?? "—"}
+          {typeof f.line_number === "number" ? `:${f.line_number}` : ""}
+        </span>
+      ),
+    },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={[]}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={findings}
+        rowKey={(f, i) => `${f.source_file ?? f.title}-${i}`}
+        columns={columns}
+        onRowClick={(f) =>
+          onOpenDetail({
+            eyebrow: `${f.severity} · ${f.category ?? "prompt"}`,
+            title: f.title ?? "Prompt finding",
+            subtitle: f.source_file,
+            fields: buildFields(f, ["title", "source_file", "severity"]),
+          })
+        }
+        empty="No prompt-security findings."
+      />
+    </ResultShell>
+  );
+}
+
+function ModelFilesResult({
+  result,
+  onOpenDetail,
+}: {
+  result: ModelFilesResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const rows = [...result.files].sort(
+    (a, b) => aiSeverityRank(highestFlagSeverity(b.security_flags)) - aiSeverityRank(highestFlagSeverity(a.security_flags)),
+  );
+  const stats: StatStripItem[] = [
+    { label: "Model files", value: result.total },
+    { label: "Manifests", value: result.manifest_total },
+    { label: "Unsafe", value: result.unsafe, accent: "critical" },
+    { label: "Warnings", value: result.warnings.length, accent: "warn" },
+  ];
+  const columns: DataTableColumn<ModelFileEntry>[] = [
+    { key: "file", header: "File", cell: (f) => <span className="font-mono text-xs text-[color:var(--foreground)]">{f.filename ?? f.path}</span> },
+    { key: "format", header: "Format", cell: (f) => f.format ?? "—" },
+    { key: "eco", header: "Ecosystem", cell: (f) => f.ecosystem ?? "—" },
+    { key: "size", header: "Size", align: "right", cell: (f) => f.size_human ?? "—" },
+    { key: "flags", header: "Risk", cell: (f) => <FlagCell flags={f.security_flags} /> },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={result.warnings}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={rows}
+        rowKey={(f, i) => `${f.path}-${i}`}
+        columns={columns}
+        onRowClick={(f) =>
+          onOpenDetail({
+            eyebrow: `${f.format ?? "model file"} · ${f.ecosystem ?? ""}`.trim(),
+            title: f.filename ?? f.path,
+            subtitle: f.path,
+            flags: f.security_flags,
+            fields: buildFields(f, ["filename", "path", "security_flags"]),
+          })
+        }
+        empty="No model files found in the scanned directories."
+      />
+    </ResultShell>
+  );
+}
+
+// ─── Shared render helpers ──────────────────────────────────────────────────
+
+function ResultShell({
+  stats,
+  warnings,
+  children,
+}: {
+  stats: StatStripItem[];
+  warnings: string[];
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-3" data-testid="ai-scan-results">
+      <StatStrip items={stats} data-testid="ai-scan-stats" />
+      {children}
+      {warnings.length > 0 ? (
+        <ul className="space-y-1 rounded-xl border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-4 py-3 text-xs text-[color:var(--text-secondary)]">
+          {warnings.slice(0, 12).map((warning, i) => (
+            <li key={i} className="flex items-start gap-2">
+              <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-[color:var(--status-warn)]" />
+              <span>{warning}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function DetailBody({ detail }: { detail: DetailView }) {
+  return (
+    <div className="space-y-5">
+      {detail.flags && detail.flags.length > 0 ? (
+        <section>
+          <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+            Security flags
+          </h3>
+          <ul className="space-y-2">
+            {detail.flags.map((flag, i) => (
+              <li
+                key={i}
+                className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3"
+              >
+                <div className="flex items-center gap-2">
+                  {flag.severity ? <SeverityBadge severity={flag.severity} /> : null}
+                  {flag.type ? (
+                    <span className="font-mono text-xs text-[color:var(--foreground)]">{flag.type}</span>
+                  ) : null}
+                </div>
+                {flag.description ? (
+                  <p className="mt-1.5 text-sm text-[color:var(--text-secondary)]">{flag.description}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section>
+        <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+          Details
+        </h3>
+        <dl className="divide-y divide-[color:var(--border-subtle)] rounded-xl border border-[color:var(--border-subtle)]">
+          {detail.fields.map((field) => (
+            <div key={field.label} className="grid grid-cols-[10rem_minmax(0,1fr)] gap-3 px-3 py-2">
+              <dt className="text-xs uppercase tracking-[0.1em] text-[color:var(--text-tertiary)]">{field.label}</dt>
+              <dd className="min-w-0 break-words text-sm text-[color:var(--foreground)]">{field.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </div>
+  );
+}
+
+/** Turn an arbitrary result object into labelled detail fields, skipping keys
+ * already surfaced in the drawer header / flags section and empty values. */
+function buildFields(obj: Record<string, unknown>, skip: string[]): { label: string; value: ReactNode }[] {
+  const fields: { label: string; value: ReactNode }[] = [];
+  for (const [key, raw] of Object.entries(obj)) {
+    if (skip.includes(key)) continue;
+    if (raw === null || raw === undefined || raw === "") continue;
+    if (Array.isArray(raw) && raw.length === 0) continue;
+    if (typeof raw === "object" && !Array.isArray(raw) && Object.keys(raw as object).length === 0) continue;
+    fields.push({ label: prettyLabel(key), value: renderValue(raw) });
+  }
+  return fields;
+}
+
+function prettyLabel(key: string): string {
+  return key.replace(/^_/, "").replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function renderValue(raw: unknown): ReactNode {
+  if (typeof raw === "boolean") return raw ? "yes" : "no";
+  if (Array.isArray(raw)) {
+    return (
+      <span className="flex flex-wrap gap-1">
+        {raw.map((item, i) => (
+          <span
+            key={i}
+            className="rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-1.5 py-0.5 font-mono text-[11px] text-[color:var(--text-secondary)]"
+          >
+            {typeof item === "object" ? JSON.stringify(item) : String(item)}
+          </span>
+        ))}
+      </span>
+    );
+  }
+  if (typeof raw === "object") {
+    return <span className="font-mono text-xs">{JSON.stringify(raw)}</span>;
+  }
+  return String(raw);
+}
+
+// ─── Inputs ─────────────────────────────────────────────────────────────────
+
+function PathListInput({
+  label,
+  placeholder,
+  items,
+  onChange,
+  mono = false,
+}: {
+  label: string;
+  placeholder: string;
+  items: string[];
+  onChange: (next: string[]) => void;
+  mono?: boolean;
+}) {
+  const [draft, setDraft] = useState("");
+
+  function add() {
+    const value = draft.trim();
+    if (!value) return;
+    onChange([...items, value]);
+    setDraft("");
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-xs font-medium text-[color:var(--text-secondary)]">{label}</label>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          aria-label={label}
+          placeholder={placeholder}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              add();
+            }
+          }}
+          className={`flex-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)] focus:border-[color:var(--accent)] focus:outline-none ${
+            mono ? "font-mono" : ""
+          }`}
+        />
+        <button
+          type="button"
+          onClick={add}
+          className="inline-flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add
+        </button>
+      </div>
+      {items.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {items.map((item, i) => (
+            <span
+              key={`${item}-${i}`}
+              className="flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1 font-mono text-xs text-[color:var(--foreground)]"
+            >
+              {item}
+              <button
+                type="button"
+                aria-label={`Remove ${item}`}
+                onClick={() => onChange(items.filter((_, idx) => idx !== i))}
+              >
+                <X className="h-3 w-3 text-[color:var(--text-tertiary)] hover:text-[color:var(--foreground)]" />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/components/collapsible.tsx
+++ b/ui/components/collapsible.tsx
@@ -85,7 +85,7 @@ export function Collapsible({
       className={
         bare
           ? `${className ?? ""}`
-          : `rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] ${className ?? ""}`
+          : `rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-1 ${className ?? ""}`
       }
       data-testid={testId}
     >
@@ -95,10 +95,10 @@ export function Collapsible({
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
           aria-controls={panelId}
-          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          className="group flex min-w-0 flex-1 items-center gap-2 rounded-md text-left transition-colors"
         >
           <Chevron
-            className={`${ICON_SIZE.sm} shrink-0 text-[color:var(--text-tertiary)] transition-transform`}
+            className={`${ICON_SIZE.sm} shrink-0 text-[color:var(--text-tertiary)] transition-colors group-hover:text-[color:var(--text-secondary)]`}
             aria-hidden="true"
           />
           {Icon ? (
@@ -110,7 +110,7 @@ export function Collapsible({
           <span className="min-w-0 flex-1">
             <span className="flex min-w-0 items-center gap-2">
               <span
-                className={`truncate font-semibold text-[color:var(--foreground)] ${resolvedTitleClass}`}
+                className={`truncate font-semibold text-[color:var(--foreground)] transition-colors ${resolvedTitleClass}`}
               >
                 {title}
               </span>

--- a/ui/components/data-table.tsx
+++ b/ui/components/data-table.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
+
+import { ICON_SIZE } from "@/lib/icon-sizes";
+
+export type SortDirection = "asc" | "desc";
+
+export type DataTableColumn<T> = {
+  /** Stable key — also used as the sort key when `sortable`. */
+  key: string;
+  /** Header cell content (usually a short label). */
+  header: ReactNode;
+  /** Cell renderer for a row. */
+  cell: (row: T) => ReactNode;
+  /** Text alignment for the column. Defaults to "left". */
+  align?: "left" | "center" | "right";
+  /** Mark the header as a sort control. */
+  sortable?: boolean;
+  /** Fixed column width (e.g. "12rem", "20%"). */
+  width?: string;
+  /** Extra classes applied to both header + body cells. */
+  className?: string;
+};
+
+export type DataTableProps<T> = {
+  columns: DataTableColumn<T>[];
+  rows: T[];
+  /** Stable key per row. */
+  rowKey: (row: T, index: number) => string;
+  /** Click handler — makes rows interactive (hover + keyboard). */
+  onRowClick?: ((row: T) => void) | undefined;
+  /** Key of the currently selected row (accent treatment). */
+  selectedKey?: string | undefined;
+  /** Active sort. When set, headers reflect direction. */
+  sort?: { key: string; direction: SortDirection } | undefined;
+  /** Called with a column key when a sortable header is activated. */
+  onSortChange?: ((key: string) => void) | undefined;
+  /** Show skeleton rows instead of data. */
+  loading?: boolean | undefined;
+  /** Skeleton row count while loading. Defaults to 6. */
+  loadingRows?: number | undefined;
+  /** Rendered in place of the body when there are no rows. */
+  empty?: ReactNode;
+  /** Sticky header while the body scrolls. Defaults to true. */
+  stickyHeader?: boolean | undefined;
+  /** Cap the scroll viewport height (e.g. "28rem"); body scrolls inside. */
+  maxHeight?: string | undefined;
+  /** Accessible caption / summary for screen readers. */
+  caption?: string | undefined;
+  className?: string | undefined;
+  "data-testid"?: string | undefined;
+};
+
+const ALIGN_CLASS = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+} as const;
+
+/**
+ * Dense, token-styled table — the standard for list surfaces. Sticky header,
+ * row hover + selection, sortable-ready headers, horizontal + vertical scroll
+ * scoped inside its own container, plus loading + empty states. Both themes.
+ *
+ * @example
+ * ```tsx
+ * <DataTable
+ *   rows={findings}
+ *   rowKey={(f) => f.id}
+ *   selectedKey={active?.id}
+ *   onRowClick={setActive}
+ *   sort={{ key: "cvss", direction: "desc" }}
+ *   onSortChange={cycleSort}
+ *   maxHeight="30rem"
+ *   columns={[
+ *     { key: "pkg", header: "Package", cell: (f) => f.pkg },
+ *     { key: "cvss", header: "CVSS", align: "right", sortable: true,
+ *       cell: (f) => f.cvss.toFixed(1) },
+ *   ]}
+ * />
+ * ```
+ */
+export function DataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  onRowClick,
+  selectedKey,
+  sort,
+  onSortChange,
+  loading = false,
+  loadingRows = 6,
+  empty,
+  stickyHeader = true,
+  maxHeight,
+  caption,
+  className,
+  "data-testid": testId,
+}: DataTableProps<T>) {
+  const interactive = typeof onRowClick === "function";
+  const showEmpty = !loading && rows.length === 0;
+
+  return (
+    <div
+      className={`overflow-auto rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-1 ${className ?? ""}`}
+      style={maxHeight ? { maxHeight } : undefined}
+      data-testid={testId}
+    >
+      <table className="w-full border-collapse text-sm">
+        {caption ? <caption className="sr-only">{caption}</caption> : null}
+        <thead
+          className={`${stickyHeader ? "sticky top-0 z-10" : ""} bg-[color:var(--surface-elevated)]`}
+        >
+          <tr className="border-b border-[color:var(--border-subtle)]">
+            {columns.map((column) => {
+              const active = sort?.key === column.key;
+              const align = column.align ?? "left";
+              const head = (
+                <span
+                  className={`inline-flex items-center gap-1 ${
+                    align === "right" ? "flex-row-reverse" : ""
+                  }`}
+                >
+                  <span>{column.header}</span>
+                  {column.sortable ? (
+                    <SortGlyph active={active} direction={sort?.direction} />
+                  ) : null}
+                </span>
+              );
+              return (
+                <th
+                  key={column.key}
+                  scope="col"
+                  aria-sort={
+                    column.sortable
+                      ? active
+                        ? sort?.direction === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                      : undefined
+                  }
+                  style={column.width ? { width: column.width } : undefined}
+                  className={`px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-tertiary)] ${ALIGN_CLASS[align]} ${column.className ?? ""}`}
+                >
+                  {column.sortable && onSortChange ? (
+                    <button
+                      type="button"
+                      onClick={() => onSortChange(column.key)}
+                      className={`inline-flex rounded transition-colors hover:text-[color:var(--foreground)] ${
+                        active ? "text-[color:var(--foreground)]" : ""
+                      }`}
+                    >
+                      {head}
+                    </button>
+                  ) : (
+                    head
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {loading
+            ? Array.from({ length: loadingRows }).map((_, rowIndex) => (
+                <tr
+                  key={`skeleton-${rowIndex}`}
+                  className="border-b border-[color:var(--border-subtle)] last:border-b-0"
+                >
+                  {columns.map((column, colIndex) => (
+                    <td key={column.key} className="px-3 py-2.5">
+                      <div
+                        className="h-3 animate-pulse rounded-full bg-[color:var(--surface-muted)]"
+                        style={{ width: `${72 - colIndex * 9}%` }}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            : rows.map((row, index) => {
+                const key = rowKey(row, index);
+                const selected = selectedKey != null && key === selectedKey;
+                return (
+                  <tr
+                    key={key}
+                    {...(interactive
+                      ? {
+                          onClick: () => onRowClick?.(row),
+                          onKeyDown: (event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              onRowClick?.(row);
+                            }
+                          },
+                          tabIndex: 0,
+                          role: "button",
+                          "aria-pressed": selected,
+                        }
+                      : {})}
+                    data-selected={selected ? "true" : undefined}
+                    className={`interactive-row border-b border-[color:var(--border-subtle)] last:border-b-0 ${
+                      interactive ? "cursor-pointer" : ""
+                    }`}
+                  >
+                    {columns.map((column) => (
+                      <td
+                        key={column.key}
+                        className={`px-3 py-2.5 align-middle text-[color:var(--text-secondary)] ${ALIGN_CLASS[column.align ?? "left"]} ${column.className ?? ""}`}
+                      >
+                        {column.cell(row)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+        </tbody>
+      </table>
+
+      {showEmpty ? (
+        <div className="px-4 py-10 text-center text-sm text-[color:var(--text-tertiary)]">
+          {empty ?? "No records to display."}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SortGlyph({
+  active,
+  direction,
+}: {
+  active: boolean;
+  direction?: SortDirection | undefined;
+}) {
+  if (!active) {
+    return (
+      <ChevronsUpDown
+        className={`${ICON_SIZE.xs} text-[color:var(--text-tertiary)]`}
+        aria-hidden="true"
+      />
+    );
+  }
+  const Glyph = direction === "asc" ? ArrowUp : ArrowDown;
+  return (
+    <Glyph
+      className={`${ICON_SIZE.xs} text-[color:var(--accent)]`}
+      aria-hidden="true"
+    />
+  );
+}

--- a/ui/components/drawer.tsx
+++ b/ui/components/drawer.tsx
@@ -87,7 +87,7 @@ export function Drawer({
         onClick={onClose}
       />
       <aside
-        className={`relative flex h-full w-full flex-col border-l border-[color:var(--border-subtle)] bg-[color:var(--surface)] shadow-2xl transition-transform duration-200 ease-out ${
+        className={`relative flex h-full w-full flex-col border-l border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-3 transition-transform duration-200 ease-out ${
           SIZE_CLASS[size]
         } ${entered ? "translate-x-0" : "translate-x-full"}`}
       >
@@ -97,7 +97,7 @@ export function Drawer({
               <button
                 type="button"
                 onClick={onBack}
-                className="mt-0.5 shrink-0 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-1.5 text-[color:var(--text-secondary)] transition-colors hover:text-[color:var(--foreground)]"
+                className="mt-0.5 shrink-0 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-1.5 text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                 aria-label="Back"
               >
                 <ChevronLeft className="h-4 w-4" />
@@ -122,7 +122,7 @@ export function Drawer({
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2 text-[color:var(--text-secondary)] transition-colors hover:text-[color:var(--foreground)]"
+              className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2 text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
               aria-label="Close"
             >
               <X className="h-4 w-4" />

--- a/ui/components/scan-form.tsx
+++ b/ui/components/scan-form.tsx
@@ -14,8 +14,11 @@ import {
   Loader2,
   Plus,
   Server,
+  Sparkles,
   X,
 } from "lucide-react";
+
+import { AiScanPanel } from "@/components/ai-scan-panel";
 
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import {
@@ -36,6 +39,11 @@ import {
   type ScanScopeChip,
 } from "@/lib/scan-scope";
 import { REPO_SCAN_SURFACES, repoScanLanguageSummary } from "@/lib/repo-scan-surfaces";
+
+/** Scan sources shown in the top tablist. Extends the job-queue ``ScanMode``
+ * with the synchronous AI/ML supply-chain surface, which renders its results
+ * inline rather than routing to a job. */
+type FormMode = ScanMode | "aiml";
 
 type ScanFormProps = {
   initialConnectionId?: string | undefined;
@@ -75,7 +83,7 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
   const { counts } = useDeploymentContext();
   const deploymentMode = counts?.deployment_mode ?? "local";
   const enterprisePreset = isEnterprisePreset(initialPreset);
-  const [scanMode, setScanMode] = useState<ScanMode>(
+  const [scanMode, setScanMode] = useState<FormMode>(
     initialConnectionId
       ? "connected"
       : enterprisePreset
@@ -316,6 +324,7 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
               { id: "connected" as const, label: "Cloud account", icon: Cloud },
               { id: "adhoc" as const, label: "Ad-hoc", icon: Bot },
               { id: "scheduled" as const, label: "Data source", icon: CalendarClock },
+              { id: "aiml" as const, label: "AI / ML", icon: Sparkles },
             ] as const
           ).map((option) => {
             const Icon = option.icon;
@@ -340,6 +349,11 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
           })}
         </div>
 
+        {scanMode === "aiml" ? (
+          <div className="p-5">
+            <AiScanPanel />
+          </div>
+        ) : (
         <form
           onSubmit={scanMode === "adhoc" ? handleAdhocSubmit : (e) => e.preventDefault()}
           className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_220px]"
@@ -559,6 +573,7 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
             </div>
           </aside>
         </form>
+        )}
       </div>
 
       <nav aria-label="Related" className="mt-4 flex flex-wrap gap-3 text-xs text-[color:var(--text-tertiary)]">
@@ -570,7 +585,7 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
   );
 }
 
-function ScopeSummaryPanel({ chips, mode }: { chips: ScanScopeChip[]; mode: ScanMode }) {
+function ScopeSummaryPanel({ chips, mode }: { chips: ScanScopeChip[]; mode: FormMode }) {
   const title = mode === "connected" ? "Scope" : mode === "scheduled" ? "Scope" : "Scope";
 
   return (

--- a/ui/components/split-layout.tsx
+++ b/ui/components/split-layout.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { MousePointerClick } from "lucide-react";
+
+import { ICON_SIZE } from "@/lib/icon-sizes";
+
+export type SplitLayoutProps = {
+  /** Master pane — the list / index. Owns its own vertical scroll. */
+  master: ReactNode;
+  /** Detail pane — the selected record. Owns its own vertical scroll. */
+  detail: ReactNode;
+  /** Master pane width on md+ screens (e.g. "22rem", "30%"). */
+  masterWidth?: string;
+  /** Shown in the detail pane when `detail` is null/undefined. */
+  placeholder?: ReactNode;
+  /** Place the detail pane on the left instead of the right. */
+  detailFirst?: boolean | undefined;
+  /**
+   * Container height. Panes scroll independently within it — the antidote to
+   * long vertical pages. Defaults to the viewport minus the app shell chrome.
+   */
+  height?: string;
+  className?: string | undefined;
+  "data-testid"?: string | undefined;
+};
+
+/**
+ * Master-detail split. List on one side, detail on the other, each pane with
+ * its OWN internal scroll so the page never grows a single long column. Stacks
+ * vertically on small screens. Token-styled for both themes.
+ *
+ * @example
+ * ```tsx
+ * <SplitLayout
+ *   masterWidth="24rem"
+ *   master={<DataTable rows={rows} onRowClick={setActive} selectedKey={active?.id} … />}
+ *   detail={active ? <FindingDetail finding={active} /> : null}
+ *   placeholder="Select a finding to see evidence and remediation."
+ * />
+ * ```
+ */
+export function SplitLayout({
+  master,
+  detail,
+  masterWidth = "22rem",
+  placeholder,
+  detailFirst = false,
+  height = "calc(100vh - 12rem)",
+  className,
+  "data-testid": testId,
+}: SplitLayoutProps) {
+  const masterPane = (
+    <div
+      className="min-h-0 min-w-0 shrink-0 overflow-y-auto md:basis-[var(--split-master-w)]"
+      style={{ ["--split-master-w" as string]: masterWidth }}
+    >
+      {master}
+    </div>
+  );
+
+  const detailPane = (
+    <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+      {detail ?? (
+        <div className="flex h-full min-h-[12rem] items-center justify-center rounded-xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-panel)] p-6 text-center">
+          <div className="flex flex-col items-center gap-2 text-[color:var(--text-tertiary)]">
+            <MousePointerClick className={ICON_SIZE.md} aria-hidden="true" />
+            <p className="max-w-xs text-sm">
+              {placeholder ?? "Select an item to see details."}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div
+      className={`flex min-h-0 flex-col gap-4 md:flex-row md:gap-5 ${
+        detailFirst ? "md:flex-row-reverse" : ""
+      } ${className ?? ""}`}
+      style={{ height }}
+      data-testid={testId}
+    >
+      {masterPane}
+      {detailPane}
+    </div>
+  );
+}

--- a/ui/components/stat-strip.tsx
+++ b/ui/components/stat-strip.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Link from "next/link";
+import type { ElementType, ReactNode } from "react";
+
+import { ICON_SIZE } from "@/lib/icon-sizes";
+
+export type StatAccent =
+  | "neutral"
+  | "critical"
+  | "high"
+  | "medium"
+  | "low"
+  | "success"
+  | "warn";
+
+const ACCENT_VALUE: Record<StatAccent, string> = {
+  neutral: "text-[color:var(--foreground)]",
+  critical: "text-[color:var(--severity-critical)]",
+  high: "text-[color:var(--severity-high)]",
+  medium: "text-[color:var(--severity-medium)]",
+  low: "text-[color:var(--severity-low)]",
+  success: "text-[color:var(--status-success)]",
+  warn: "text-[color:var(--status-warn)]",
+};
+
+export type StatStripItem = {
+  label: ReactNode;
+  value: ReactNode;
+  /** Optional secondary line (delta, unit, context). */
+  hint?: ReactNode;
+  accent?: StatAccent;
+  /** Only tint the value when it is a number above this threshold. */
+  accentThreshold?: number;
+  icon?: ElementType;
+  /** Makes the cell a link. */
+  href?: string;
+  /** Makes the cell a button. */
+  onClick?: () => void;
+};
+
+export type StatStripProps = {
+  items: StatStripItem[];
+  className?: string | undefined;
+  "data-testid"?: string | undefined;
+};
+
+/**
+ * Dense KPI row — replaces big, empty stat cards with a single compact strip of
+ * hairline-divided metrics. Wraps on narrow screens, token-styled for both
+ * themes, and each cell can drill in via `href`/`onClick`.
+ *
+ * @example
+ * ```tsx
+ * <StatStrip
+ *   items={[
+ *     { label: "Critical", value: 4, accent: "critical", href: "/findings?sev=critical" },
+ *     { label: "High", value: 12, accent: "high" },
+ *     { label: "Packages", value: 231 },
+ *     { label: "Coverage", value: "92%", accent: "success", hint: "+3 vs last scan" },
+ *   ]}
+ * />
+ * ```
+ */
+export function StatStrip({ items, className, "data-testid": testId }: StatStripProps) {
+  return (
+    <div
+      className={`grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--border-subtle)] elev-1 sm:grid-cols-3 lg:grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] ${className ?? ""}`}
+      data-testid={testId}
+    >
+      {items.map((item, index) => (
+        <StatCell key={typeof item.label === "string" ? item.label : index} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function StatCell({ item }: { item: StatStripItem }) {
+  const {
+    label,
+    value,
+    hint,
+    accent = "neutral",
+    accentThreshold = 0,
+    icon: Icon,
+    href,
+    onClick,
+  } = item;
+
+  const tinted =
+    accent !== "neutral" && (typeof value !== "number" || value > accentThreshold);
+  const valueClass = tinted ? ACCENT_VALUE[accent] : "text-[color:var(--foreground)]";
+
+  const inner = (
+    <>
+      <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-[color:var(--text-tertiary)]">
+        {Icon ? <Icon className={ICON_SIZE.xs} aria-hidden="true" /> : null}
+        <span className="truncate">{label}</span>
+      </div>
+      <div className={`mt-1 font-mono text-2xl font-semibold tabular-figures ${valueClass}`}>
+        {value}
+      </div>
+      {hint ? (
+        <div className="mt-0.5 truncate text-xs text-[color:var(--text-tertiary)]">{hint}</div>
+      ) : null}
+    </>
+  );
+
+  const base =
+    "block bg-[color:var(--surface)] px-4 py-3 text-left transition-colors";
+
+  if (href) {
+    return (
+      <Link href={href} className={`${base} hover:bg-[color:var(--surface-elevated)]`}>
+        {inner}
+      </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={`${base} w-full hover:bg-[color:var(--surface-elevated)]`}
+      >
+        {inner}
+      </button>
+    );
+  }
+  return <div className={base}>{inner}</div>;
+}

--- a/ui/components/states/page-state.tsx
+++ b/ui/components/states/page-state.tsx
@@ -25,10 +25,14 @@ type PageStateProps = {
 };
 
 const TONE_CLASS: Record<NonNullable<PageStateProps["tone"]>, string> = {
-  neutral: "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)]",
-  warning: "border-amber-500/25 bg-amber-500/10 text-amber-100",
-  danger: "border-red-500/25 bg-red-500/10 text-red-100",
-  success: "border-emerald-500/25 bg-emerald-500/10 text-emerald-100",
+  neutral:
+    "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)]",
+  warning:
+    "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--text-secondary)]",
+  danger:
+    "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--text-secondary)]",
+  success:
+    "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--text-secondary)]",
 };
 
 export function PageState({
@@ -47,7 +51,7 @@ export function PageState({
 
   return (
     <div className="flex min-h-[18rem] items-center justify-center px-4 py-10" data-testid={testId}>
-      <div className={`w-full max-w-2xl rounded-2xl border p-6 shadow-lg ${TONE_CLASS[tone]}`}>
+      <div className={`w-full max-w-2xl rounded-2xl border p-6 elev-2 ${TONE_CLASS[tone]}`}>
         <div className="flex items-start gap-3">
           <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2">
             <Icon className="h-5 w-5 text-[color:var(--text-secondary)]" />
@@ -97,7 +101,7 @@ function PageStateActionButton({ action }: { action: PageStateAction }) {
   const className =
     action.variant === "secondary"
       ? "inline-flex items-center justify-center rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm font-medium text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-      : "inline-flex items-center justify-center rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20";
+      : "inline-flex items-center justify-center rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-sm font-medium text-[color:var(--accent)] transition hover:bg-[color:var(--accent-soft-hover)]";
 
   if (action.href) {
     return (
@@ -133,7 +137,7 @@ export function PageLoadingState({
 }) {
   return (
     <div className="flex min-h-[18rem] items-center justify-center px-4 py-10" data-testid={testId}>
-      <div className="w-full max-w-3xl rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg">
+      <div className="w-full max-w-3xl rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 elev-2">
         <div className="flex items-start gap-3">
           <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2">
             <Loader2 className="h-5 w-5 animate-spin text-[color:var(--text-secondary)]" />

--- a/ui/lib/ai-scan.ts
+++ b/ui/lib/ai-scan.ts
@@ -1,0 +1,281 @@
+/**
+ * AI / ML supply-chain scan surface — shared types + selector metadata.
+ *
+ * These describe the six dedicated, synchronous scan endpoints under
+ * ``/v1/scan/*`` (dataset cards, training pipelines, browser extensions,
+ * model provenance, prompt scan, model files). The endpoints already ship in
+ * the API, MCP tools, and CLI; this module lets the UI call them and render
+ * their real results so a human operator has the same reach as an agent.
+ */
+
+export type AiScanTypeId =
+  | "dataset-cards"
+  | "training-pipelines"
+  | "browser-extensions"
+  | "model-provenance"
+  | "prompt-scan"
+  | "model-files";
+
+/** A security flag as emitted by the dataset / training / model-file scanners. */
+export interface AiSecurityFlag {
+  severity?: string;
+  type?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+// ─── Request bodies ─────────────────────────────────────────────────────────
+
+export interface DatasetCardsRequest {
+  directories: string[];
+}
+export interface TrainingPipelinesRequest {
+  directories: string[];
+}
+export interface BrowserExtensionsRequest {
+  include_low_risk: boolean;
+}
+export interface ModelProvenanceRequest {
+  hf_models: string[];
+  ollama_models: string[];
+}
+export interface PromptScanRequest {
+  directories: string[];
+  files: string[];
+}
+export interface ModelFilesRequest {
+  directories: string[];
+  verify_hashes: boolean;
+}
+
+// ─── Response payloads ──────────────────────────────────────────────────────
+
+export interface DatasetCard {
+  name: string;
+  description?: string;
+  license?: string | null;
+  source_file?: string;
+  source_url?: string;
+  version?: string;
+  security_flags?: AiSecurityFlag[];
+  [key: string]: unknown;
+}
+export interface DatasetCardsResult {
+  datasets: DatasetCard[];
+  source_files: string[];
+  warnings: string[];
+  total_datasets: number;
+  flagged_count: number;
+}
+export interface DatasetCardsResponse {
+  scan_type: "dataset-cards";
+  directories: string[];
+  results: DatasetCardsResult[];
+}
+
+export interface TrainingArtifact {
+  name: string;
+  framework?: string;
+  source_file?: string;
+  security_flags?: AiSecurityFlag[];
+  [key: string]: unknown;
+}
+export interface TrainingPipelinesResult {
+  training_runs: TrainingArtifact[];
+  serving_configs: TrainingArtifact[];
+  source_files: string[];
+  warnings: string[];
+  total_runs: number;
+  total_serving: number;
+  flagged_count: number;
+}
+export interface TrainingPipelinesResponse {
+  scan_type: "training-pipelines";
+  directories: string[];
+  results: TrainingPipelinesResult[];
+}
+
+export interface BrowserExtension {
+  id: string;
+  name: string;
+  version?: string;
+  browser?: string;
+  manifest_version?: number;
+  permissions?: string[];
+  host_permissions?: string[];
+  has_native_messaging?: boolean;
+  has_ai_host_access?: boolean;
+  risk_level?: string;
+  risk_reasons?: string[];
+  path?: string;
+  [key: string]: unknown;
+}
+export interface BrowserExtensionsResponse {
+  scan_type: "browser-extensions";
+  total: number;
+  critical: number;
+  high: number;
+  extensions: BrowserExtension[];
+}
+
+export interface ProvenanceResult {
+  model_id: string;
+  source?: string;
+  format?: string;
+  is_safe_format?: boolean;
+  has_digest?: boolean;
+  digest?: string | null;
+  is_gated?: boolean;
+  has_model_card?: boolean;
+  risk_level?: string;
+  risk_flags?: string[];
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+export interface ModelProvenanceResponse {
+  scan_type: "model-provenance";
+  total: number;
+  unsafe_format: number;
+  results: ProvenanceResult[];
+}
+
+export interface PromptFinding {
+  severity: string;
+  category?: string;
+  title?: string;
+  detail?: string;
+  source_file?: string;
+  line_number?: number | null;
+  matched_text?: string;
+  recommendation?: string;
+  [key: string]: unknown;
+}
+export interface PromptScanResult {
+  files_scanned: number;
+  findings: PromptFinding[];
+  prompt_files: string[];
+  passed: boolean;
+}
+export interface PromptScanResponse {
+  scan_type: "prompt-scan";
+  results: PromptScanResult[];
+}
+
+export interface ModelFileEntry {
+  path: string;
+  filename?: string;
+  extension?: string;
+  format?: string;
+  ecosystem?: string;
+  size_bytes?: number;
+  size_human?: string;
+  security_flags?: AiSecurityFlag[];
+  sha256?: string;
+  [key: string]: unknown;
+}
+export interface ModelFilesResponse {
+  scan_type: "model-files";
+  total: number;
+  manifest_total: number;
+  unsafe: number;
+  files: ModelFileEntry[];
+  manifests: ModelFileEntry[];
+  warnings: string[];
+}
+
+export type AiScanResponse =
+  | DatasetCardsResponse
+  | TrainingPipelinesResponse
+  | BrowserExtensionsResponse
+  | ModelProvenanceResponse
+  | PromptScanResponse
+  | ModelFilesResponse;
+
+// ─── Selector metadata ──────────────────────────────────────────────────────
+
+/** Which inputs a scan type needs — drives the input panel + submit gate. */
+export type AiScanInputKind =
+  | "directories"
+  | "prompt"
+  | "model-files"
+  | "extensions"
+  | "models";
+
+export interface AiScanTypeMeta {
+  id: AiScanTypeId;
+  label: string;
+  /** One-line plain-language description of what the scan surfaces. */
+  blurb: string;
+  inputKind: AiScanInputKind;
+}
+
+/**
+ * The six AI supply-chain scan types, in the order the CLI/MCP group them.
+ * Kept as data so the selector, input panel, and tests stay in sync.
+ */
+export const AI_SCAN_TYPES: readonly AiScanTypeMeta[] = [
+  {
+    id: "dataset-cards",
+    label: "Dataset cards",
+    blurb: "HuggingFace dataset cards, DVC files & data lineage — licensing and provenance gaps.",
+    inputKind: "directories",
+  },
+  {
+    id: "training-pipelines",
+    label: "Training pipelines",
+    blurb: "MLflow / W&B / Kubeflow artifacts — unsafe serialization, missing provenance, exposed creds.",
+    inputKind: "directories",
+  },
+  {
+    id: "browser-extensions",
+    label: "Browser extensions",
+    blurb: "Installed extensions — dangerous permissions, native messaging, AI-assistant host access.",
+    inputKind: "extensions",
+  },
+  {
+    id: "model-provenance",
+    label: "Model provenance",
+    blurb: "HuggingFace & Ollama models — safetensors vs pickle, digests, gating, model-card presence.",
+    inputKind: "models",
+  },
+  {
+    id: "prompt-scan",
+    label: "Prompt scan",
+    blurb: "Prompt files — injection & jailbreak patterns, hardcoded secrets, unsafe instructions.",
+    inputKind: "prompt",
+  },
+  {
+    id: "model-files",
+    label: "Model files",
+    blurb: "Model artifacts — pickle deserialization risk (.pkl/.pt), unsafe formats, integrity hashes.",
+    inputKind: "model-files",
+  },
+] as const;
+
+/** Rank a severity string (case-insensitive) for comparison. Higher = worse. */
+export function aiSeverityRank(severity: string | null | undefined): number {
+  switch ((severity ?? "").toLowerCase()) {
+    case "critical":
+      return 4;
+    case "high":
+      return 3;
+    case "medium":
+      return 2;
+    case "low":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/** Highest severity among a set of flags, or ``null`` when there are none. */
+export function highestFlagSeverity(flags: AiSecurityFlag[] | undefined): string | null {
+  if (!flags || flags.length === 0) return null;
+  let best: string | null = null;
+  for (const flag of flags) {
+    if (best === null || aiSeverityRank(flag.severity) > aiSeverityRank(best)) {
+      best = flag.severity ?? "unknown";
+    }
+  }
+  return best;
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -359,6 +359,20 @@ export const PIPELINE_STEPS = [
 
 import { ApiNetworkError, classifyApiResponse } from "./api-errors";
 import { cachedGet, invalidate as _invalidate, type CacheOptions } from "./api-cache";
+import type {
+  DatasetCardsRequest,
+  DatasetCardsResponse,
+  TrainingPipelinesRequest,
+  TrainingPipelinesResponse,
+  BrowserExtensionsRequest,
+  BrowserExtensionsResponse,
+  ModelProvenanceRequest,
+  ModelProvenanceResponse,
+  PromptScanRequest,
+  PromptScanResponse,
+  ModelFilesRequest,
+  ModelFilesResponse,
+} from "./ai-scan";
 
 const FETCH_TIMEOUT_MS = 30_000;
 const BOOTSTRAP_TIMEOUT_MS = 5_000;
@@ -550,6 +564,26 @@ export const api = {
 
   /** Delete a job record */
   deleteScan: (jobId: string) => del(`/v1/scan/${jobId}`),
+
+  // ── AI / ML supply-chain scans (synchronous; results returned inline) ──
+  /** Scan directories for HuggingFace dataset cards, DVC files, and lineage. */
+  scanDatasetCards: (body: DatasetCardsRequest) =>
+    post<DatasetCardsResponse>("/v1/scan/dataset-cards", body),
+  /** Scan directories for MLflow / W&B / Kubeflow training + serving artifacts. */
+  scanTrainingPipelines: (body: TrainingPipelinesRequest) =>
+    post<TrainingPipelinesResponse>("/v1/scan/training-pipelines", body),
+  /** Scan installed browser extensions for dangerous permissions + AI host access. */
+  scanBrowserExtensions: (body: BrowserExtensionsRequest) =>
+    post<BrowserExtensionsResponse>("/v1/scan/browser-extensions", body),
+  /** Check HuggingFace / Ollama model provenance (format, digest, gating, card). */
+  scanModelProvenance: (body: ModelProvenanceRequest) =>
+    post<ModelProvenanceResponse>("/v1/scan/model-provenance", body),
+  /** Scan prompt files for injection, hardcoded secrets, and unsafe instructions. */
+  scanPrompts: (body: PromptScanRequest) =>
+    post<PromptScanResponse>("/v1/scan/prompt-scan", body),
+  /** Scan directories for model files and assess serialization safety. */
+  scanModelFiles: (body: ModelFilesRequest) =>
+    post<ModelFilesResponse>("/v1/scan/model-files", body),
 
   /** List all jobs */
   listJobs: (options?: { includeDetails?: boolean; limit?: number; offset?: number }) => {

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -37,7 +37,12 @@ const BUDGETS = {
   // hover, focus-visible, and interactive-state token classes now baked into the
   // widely-imported shared shells (Collapsible, Drawer, PageState, cards) add a
   // few KiB of compiled className string literals across every route chunk.
-  totalClientJsBytes: 3_391_488,
+  // Raised ~29 KiB for the first-class AI/ML supply-chain scan surface on the
+  // Scan page: the six-scan selector, per-type input panels, and dense result
+  // tables (dataset cards, training pipelines, browser extensions, model
+  // provenance, prompt scan, model files) that give human operators the same
+  // reach as the MCP tools / CLI flags.
+  totalClientJsBytes: 3_440_640,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -33,7 +33,11 @@ const BUDGETS = {
   // `zinc-*` utilities they replace, so the compiled className strings grow a few KiB.
   // Allows 4 KiB for the measured Linux/macOS output variance after adding the
   // blueprint route; both builds remain at roughly 3.3 MiB of emitted client JS.
-  totalClientJsBytes: 3_383_296,
+  // Raised ~8 KiB for the premium design-system foundation: the elevation,
+  // hover, focus-visible, and interactive-state token classes now baked into the
+  // widely-imported shared shells (Collapsible, Drawer, PageState, cards) add a
+  // few KiB of compiled className string literals across every route chunk.
+  totalClientJsBytes: 3_391_488,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/ai-scan-panel.test.tsx
+++ b/ui/tests/ai-scan-panel.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { AiScanPanel } from "@/components/ai-scan-panel";
+import { AI_SCAN_TYPES } from "@/lib/ai-scan";
+import { api } from "@/lib/api";
+
+describe("AiScanPanel", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes all six AI/ML scan types as selectable tabs", () => {
+    render(<AiScanPanel />);
+    for (const type of AI_SCAN_TYPES) {
+      expect(screen.getByRole("tab", { name: new RegExp(type.label, "i") })).toBeInTheDocument();
+    }
+    expect(AI_SCAN_TYPES).toHaveLength(6);
+  });
+
+  it("shows an honest empty state before any scan is run", () => {
+    render(<AiScanPanel />);
+    expect(screen.getByTestId("ai-scan-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("ai-scan-results")).not.toBeInTheDocument();
+  });
+
+  it("runs a dataset-cards scan against the right endpoint and renders real results", async () => {
+    const user = userEvent.setup();
+    const spy = vi.spyOn(api, "scanDatasetCards").mockResolvedValue({
+      scan_type: "dataset-cards",
+      directories: ["/data"],
+      results: [
+        {
+          datasets: [
+            {
+              name: "squad",
+              license: null,
+              source_file: "/data/squad/README.md",
+              security_flags: [
+                { severity: "MEDIUM", type: "UNLICENSED_DATASET", description: "No license." },
+              ],
+            },
+          ],
+          source_files: ["/data/squad/README.md"],
+          warnings: ["heads up"],
+          total_datasets: 1,
+          flagged_count: 1,
+        },
+      ],
+    });
+
+    render(<AiScanPanel />);
+    await user.type(screen.getByLabelText("Directories"), "/data");
+    await user.click(screen.getByRole("button", { name: /^Add$/i }));
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() => expect(screen.getByTestId("ai-scan-results")).toBeInTheDocument());
+    expect(spy).toHaveBeenCalledWith({ directories: ["/data"] });
+    expect(screen.getByText("squad")).toBeInTheDocument();
+    // Warning from the API is surfaced verbatim.
+    expect(screen.getByText("heads up")).toBeInTheDocument();
+  });
+
+  it("gates Run until a directory is provided", async () => {
+    const user = userEvent.setup();
+    render(<AiScanPanel />);
+    expect(screen.getByRole("button", { name: /Run scan/i })).toBeDisabled();
+    await user.type(screen.getByLabelText("Directories"), "/data");
+    await user.click(screen.getByRole("button", { name: /^Add$/i }));
+    expect(screen.getByRole("button", { name: /Run scan/i })).toBeEnabled();
+  });
+
+  it("runs a browser-extension scan with no path input required", async () => {
+    const user = userEvent.setup();
+    const spy = vi.spyOn(api, "scanBrowserExtensions").mockResolvedValue({
+      scan_type: "browser-extensions",
+      total: 1,
+      critical: 1,
+      high: 0,
+      extensions: [
+        {
+          id: "abc",
+          name: "Sketchy Helper",
+          browser: "chrome",
+          risk_level: "critical",
+          permissions: ["debugger"],
+          host_permissions: ["<all_urls>"],
+          has_native_messaging: true,
+          has_ai_host_access: true,
+          risk_reasons: ["debugger permission"],
+        },
+      ],
+    });
+
+    render(<AiScanPanel />);
+    await user.click(screen.getByRole("tab", { name: /Browser extensions/i }));
+    // No inputs — Run is immediately available.
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith({ include_low_risk: false }));
+    expect(screen.getByText("Sketchy Helper")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-scan-stats")).toBeInTheDocument();
+  });
+
+  it("scans model provenance only after a model id is entered", async () => {
+    const user = userEvent.setup();
+    const spy = vi.spyOn(api, "scanModelProvenance").mockResolvedValue({
+      scan_type: "model-provenance",
+      total: 1,
+      unsafe_format: 1,
+      results: [
+        {
+          model_id: "org/model",
+          source: "huggingface",
+          format: "pickle",
+          is_safe_format: false,
+          risk_level: "high",
+          risk_flags: ["unsafe_format"],
+        },
+      ],
+    });
+
+    render(<AiScanPanel />);
+    await user.click(screen.getByRole("tab", { name: /Model provenance/i }));
+    expect(screen.getByRole("button", { name: /Run scan/i })).toBeDisabled();
+
+    await user.type(screen.getByLabelText("HuggingFace models"), "org/model");
+    // Two "Add" buttons (HF + Ollama); the first belongs to the HF input.
+    await user.click(screen.getAllByRole("button", { name: /^Add$/i })[0]!);
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith({ hf_models: ["org/model"], ollama_models: [] }),
+    );
+    const results = screen.getByTestId("ai-scan-results");
+    expect(within(results).getByText("org/model")).toBeInTheDocument();
+    expect(within(results).getByText("unsafe")).toBeInTheDocument();
+  });
+
+  it("opens a detail drawer with the security flags for a row", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "scanModelFiles").mockResolvedValue({
+      scan_type: "model-files",
+      total: 1,
+      manifest_total: 0,
+      unsafe: 1,
+      files: [
+        {
+          path: "/models/evil.pkl",
+          filename: "evil.pkl",
+          format: "Pickle",
+          ecosystem: "scikit-learn/Python",
+          size_human: "2.0 KB",
+          security_flags: [
+            { severity: "CRITICAL", type: "PICKLE_REDUCE", description: "Arbitrary code execution." },
+          ],
+        },
+      ],
+      manifests: [],
+      warnings: [],
+    });
+
+    render(<AiScanPanel />);
+    await user.click(screen.getByRole("tab", { name: /Model files/i }));
+    await user.type(screen.getByLabelText("Directories"), "/models");
+    await user.click(screen.getByRole("button", { name: /^Add$/i }));
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() => expect(screen.getByText("evil.pkl")).toBeInTheDocument());
+    await user.click(screen.getByText("evil.pkl"));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Arbitrary code execution.")).toBeInTheDocument();
+    expect(within(dialog).getByText("PICKLE_REDUCE")).toBeInTheDocument();
+  });
+
+  it("renders an error state when the scan endpoint fails", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "scanBrowserExtensions").mockRejectedValue(new Error("boom"));
+
+    render(<AiScanPanel />);
+    await user.click(screen.getByRole("tab", { name: /Browser extensions/i }));
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() => expect(screen.getByTestId("ai-scan-error")).toBeInTheDocument());
+    expect(screen.getAllByText("boom").length).toBeGreaterThan(0);
+  });
+});

--- a/ui/tests/data-table.test.tsx
+++ b/ui/tests/data-table.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+
+type Row = { id: string; pkg: string; cvss: number };
+
+const rows: Row[] = [
+  { id: "a", pkg: "left-pad", cvss: 9.8 },
+  { id: "b", pkg: "log4j", cvss: 10 },
+];
+
+const columns: DataTableColumn<Row>[] = [
+  { key: "pkg", header: "Package", cell: (r) => r.pkg },
+  { key: "cvss", header: "CVSS", align: "right", sortable: true, cell: (r) => r.cvss.toFixed(1) },
+];
+
+describe("DataTable", () => {
+  it("renders headers and row cells", () => {
+    render(<DataTable rows={rows} columns={columns} rowKey={(r) => r.id} />);
+    expect(screen.getByRole("columnheader", { name: /Package/ })).toBeInTheDocument();
+    expect(screen.getByText("left-pad")).toBeInTheDocument();
+    expect(screen.getByText("10.0")).toBeInTheDocument();
+  });
+
+  it("fires onRowClick for pointer and keyboard activation", () => {
+    const onRowClick = vi.fn();
+    render(
+      <DataTable rows={rows} columns={columns} rowKey={(r) => r.id} onRowClick={onRowClick} />,
+    );
+    const firstRow = screen.getByRole("button", { name: /left-pad/ });
+    fireEvent.click(firstRow);
+    fireEvent.keyDown(firstRow, { key: "Enter" });
+    expect(onRowClick).toHaveBeenCalledTimes(2);
+    expect(onRowClick).toHaveBeenCalledWith(rows[0]);
+  });
+
+  it("reflects the active sort on the sortable header", () => {
+    const onSortChange = vi.fn();
+    render(
+      <DataTable
+        rows={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        sort={{ key: "cvss", direction: "desc" }}
+        onSortChange={onSortChange}
+      />,
+    );
+    const header = screen.getByRole("columnheader", { name: /CVSS/ });
+    expect(header).toHaveAttribute("aria-sort", "descending");
+    fireEvent.click(screen.getByRole("button", { name: /CVSS/ }));
+    expect(onSortChange).toHaveBeenCalledWith("cvss");
+  });
+
+  it("marks the selected row via data-selected", () => {
+    render(
+      <DataTable
+        rows={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        onRowClick={vi.fn()}
+        selectedKey="b"
+      />,
+    );
+    const selected = screen.getByRole("button", { name: /log4j/ });
+    expect(selected).toHaveAttribute("data-selected", "true");
+    expect(selected).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows the empty state when there are no rows", () => {
+    render(
+      <DataTable rows={[]} columns={columns} rowKey={(r) => r.id} empty="Nothing here" />,
+    );
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+
+  it("renders skeleton rows while loading and hides the empty state", () => {
+    const { container } = render(
+      <DataTable
+        rows={[]}
+        columns={columns}
+        rowKey={(r) => r.id}
+        loading
+        loadingRows={3}
+        empty="Nothing here"
+      />,
+    );
+    expect(screen.queryByText("Nothing here")).toBeNull();
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(3);
+  });
+});

--- a/ui/tests/scan-form.test.tsx
+++ b/ui/tests/scan-form.test.tsx
@@ -217,6 +217,16 @@ describe("ScanForm", () => {
     expect(screen.getByRole("button", { name: /Scan repo/i })).toBeDisabled();
   });
 
+  it("surfaces the AI/ML supply-chain scan panel from its own tab", async () => {
+    const user = userEvent.setup();
+    render(<ScanForm />);
+
+    await user.click(screen.getByRole("tab", { name: /AI \/ ML/i }));
+    expect(screen.getByTestId("ai-scan-panel")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Dataset cards/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Prompt scan/i })).toBeInTheDocument();
+  });
+
   it("explains kubernetes namespace scope in plain language", async () => {
     const user = userEvent.setup();
     render(<ScanForm />);

--- a/ui/tests/split-layout.test.tsx
+++ b/ui/tests/split-layout.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SplitLayout } from "@/components/split-layout";
+
+describe("SplitLayout", () => {
+  it("renders both master and detail panes", () => {
+    render(
+      <SplitLayout master={<div>list pane</div>} detail={<div>detail pane</div>} />,
+    );
+    expect(screen.getByText("list pane")).toBeInTheDocument();
+    expect(screen.getByText("detail pane")).toBeInTheDocument();
+  });
+
+  it("shows the placeholder when no detail is selected", () => {
+    render(
+      <SplitLayout
+        master={<div>list pane</div>}
+        detail={null}
+        placeholder="Pick a row"
+      />,
+    );
+    expect(screen.getByText("Pick a row")).toBeInTheDocument();
+  });
+
+  it("applies the master width as a CSS custom property", () => {
+    render(
+      <SplitLayout
+        master={<div>list pane</div>}
+        detail={<div>detail pane</div>}
+        masterWidth="30rem"
+      />,
+    );
+    const master = screen.getByText("list pane").parentElement;
+    expect(master?.style.getPropertyValue("--split-master-w")).toBe("30rem");
+  });
+
+  it("reverses pane order when detailFirst is set", () => {
+    const { container } = render(
+      <SplitLayout master={<div>list</div>} detail={<div>detail</div>} detailFirst />,
+    );
+    expect(container.firstChild).toHaveClass("md:flex-row-reverse");
+  });
+});

--- a/ui/tests/stat-strip.test.tsx
+++ b/ui/tests/stat-strip.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { StatStrip } from "@/components/stat-strip";
+
+describe("StatStrip", () => {
+  it("renders each metric's label and value", () => {
+    render(
+      <StatStrip
+        items={[
+          { label: "Critical", value: 4, accent: "critical" },
+          { label: "Coverage", value: "92%", accent: "success", hint: "+3 vs last scan" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("92%")).toBeInTheDocument();
+    expect(screen.getByText("+3 vs last scan")).toBeInTheDocument();
+  });
+
+  it("tints the value only when a numeric value clears the threshold", () => {
+    render(
+      <StatStrip
+        items={[
+          { label: "Zero", value: 0, accent: "critical" },
+          { label: "Some", value: 3, accent: "critical" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("0").className).toContain("var(--foreground)");
+    expect(screen.getByText("3").className).toContain("var(--severity-critical)");
+  });
+
+  it("renders a link cell when href is provided", () => {
+    render(<StatStrip items={[{ label: "High", value: 12, href: "/findings" }]} />);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/findings");
+  });
+
+  it("fires onClick for a button cell", () => {
+    const onClick = vi.fn();
+    render(<StatStrip items={[{ label: "Medium", value: 7, onClick }]} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/tests/theme-readability-tokens.test.ts
+++ b/ui/tests/theme-readability-tokens.test.ts
@@ -11,12 +11,16 @@ describe("theme readability tokens", () => {
   const css = readFileSync(GLOBALS, "utf8");
 
   it("defines dark surface hierarchy and readable secondary text", () => {
-    expect(css).toMatch(/--background:\s*#181a22;/);
+    // Deep, non-flat canvas with a layered panel < card < elevated hierarchy.
+    expect(css).toMatch(/--background:\s*#14161d;/);
+    expect(css).toMatch(/--surface-panel:\s*#1b1e27;/);
     expect(css).toMatch(/--surface:\s*#22262f;/);
     expect(css).toMatch(/--surface-elevated:\s*#2c3140;/);
     expect(css).toMatch(/--text-secondary:\s*#d0d4dc;/);
     expect(css).toMatch(/--text-tertiary:\s*#a8aebc;/);
-    expect(css).toMatch(/--accent-mint:\s*#34d399;/);
+    // Brand accent stays mint; --accent-mint remains as a back-compat alias.
+    expect(css).toMatch(/--accent:\s*#34d399;/);
+    expect(css).toMatch(/--accent-mint:\s*var\(--accent\);/);
   });
 
   it("keeps severity CSS vars aligned with shared chart hex helpers", () => {
@@ -29,7 +33,7 @@ describe("theme readability tokens", () => {
   });
 
   it("defines light-theme severity and surface counterparts", () => {
-    expect(css).toMatch(/:root\[data-theme="light"\][\s\S]*--background:\s*#e4e9f2;/);
+    expect(css).toMatch(/:root\[data-theme="light"\][\s\S]*--background:\s*#e6eaf1;/);
     expect(css).toMatch(/:root\[data-theme="light"\][\s\S]*--severity-critical:\s*#dc2626;/);
     expect(css).toMatch(/:root\[data-theme="light"\][\s\S]*--text-secondary:\s*#374151;/);
   });


### PR DESCRIPTION
## What & why

The six dedicated AI/ML scan endpoints — `POST /v1/scan/{dataset-cards, training-pipelines, browser-extensions, model-provenance, prompt-scan, model-files}` — shipped only through MCP tools and CLI flags, with **zero UI**. A headline AI-security capability class was invisible to UI operators. This wires them into the Scan page so a human can run each and read its results, closing the human↔agent surface-parity gap (#4014, P1-1).

> **Stacked on #4017 (design-system-foundation) — merge that first.** PR base is `feat/design-system-foundation`; it uses that branch's tokens and `DataTable` / `StatStrip` / `Drawer` / `PageState` primitives.

## The six scans wired

| Scan | Inputs | Result panel |
|------|--------|--------------|
| Dataset cards | directories | datasets · license · source · risk flags |
| Training pipelines | directories | runs + serving configs · framework · risk flags |
| Browser extensions | include-low-risk toggle | extension · browser · risk · perms · native-msg / AI-host |
| Model provenance | HF + Ollama model IDs | model · source · format · safe/unsafe · risk |
| Prompt scan | directories + files | severity · category · finding · location · pass/fail verdict |
| Model files | directories + verify-hashes toggle | file · format · ecosystem · size · risk flags |

Each list is a dense `DataTable`; a row opens a `Drawer` with full detail + the scan's real security flags. Aggregate counts render in a `StatStrip`. Loading / empty / error states use `PageState` — **results come from the API; nothing is sampled or faked**.

## How it's shaped

- New **"AI / ML"** tab on the Scan page next to Cloud account / Ad-hoc / Data source. The standard job-queue scan flow is untouched; the AI/ML scans are synchronous and render inline.
- `ui/components/ai-scan-panel.tsx` — the selector, input panels, run logic, result renderers, and detail drawer.
- `ui/lib/ai-scan.ts` — shared request/response types + selector metadata.
- `ui/lib/api.ts` — six client methods (`scanDatasetCards`, `scanTrainingPipelines`, `scanBrowserExtensions`, `scanModelProvenance`, `scanPrompts`, `scanModelFiles`).

## Verification

- `npm run build` clean; `tsc --noEmit` clean; ESLint clean on touched files.
- `npx vitest run` → **576 passed** (incl. 8 new AI-scan tests + 1 scan-form tab test: each type selectable, Run calls the right endpoint with the right body, results/empty/error states render, drawer shows flags).
- Bundle budget PASS (3340.9 / 3360.0 KiB — budget raised ~29 KiB with a comment for the new surface).
- Both themes: component uses design tokens exclusively (no hardcoded `zinc-*`/hex); every referenced token is defined in both the light and dark scopes of `globals.css`.

Refs #4014