### PR TITLE
feat(ui): dense restyle of Compliance, Runtime, and Cost onto the design system

### DIFF
--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -31,21 +31,30 @@ import {
   Loader2,
 } from "lucide-react";
 import { ComplianceControlDrawer } from "@/components/compliance-control-drawer";
-import { ComplianceControlRow } from "@/components/compliance-control-row";
-import { isNotEvaluated, postureLabel, statusColor } from "@/components/compliance-status";
+import {
+  isNotEvaluated,
+  postureLabel,
+  statusColor,
+  StatusIcon,
+} from "@/components/compliance-status";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
 import { ComplianceMatrix } from "@/components/compliance-matrix";
 import { CISBenchmarkDetail } from "@/components/cis-benchmark-detail";
-import { FrameworkCoveragePanel, type FrameworkCoverageItem } from "@/components/framework-coverage-panel";
 import { FrameworkIcon } from "@/components/framework-icon";
 import {
   complianceFrameworkSummaries,
+  compliancePassRate,
   controlMatchesQuery,
+  type ComplianceFrameworkSummary,
 } from "@/lib/compliance-frameworks";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
 import { FIRST_EVIDENCE_ACTIONS } from "@/lib/empty-state-actions";
+import { StatStrip, type StatStripItem, type StatAccent } from "@/components/stat-strip";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import { SplitLayout } from "@/components/split-layout";
+import { Collapsible } from "@/components/collapsible";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
@@ -62,52 +71,50 @@ function downloadBlobToFile(blob: Blob, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-// ─── Score Ring ──────────────────────────────────────────────────────────────
+const CONTROL_STATUS_LABEL: Record<string, string> = {
+  pass: "Pass",
+  warning: "Warn",
+  fail: "Fail",
+};
 
-function ScoreRing({ score, status }: { score: number; status: string }) {
-  const r = 54;
-  const circ = 2 * Math.PI * r;
-  // A no-evidence scan has nothing to score. Render a neutral, empty ring with
-  // a "Not evaluated" label rather than a red 0% that reads as "failing".
-  const notEvaluated = isNotEvaluated(status);
-  const offset = notEvaluated ? circ : circ - (score / 100) * circ;
-  const color = notEvaluated
-    ? "var(--text-tertiary)"
-    : status === "pass"
-      ? "#34d399"
-      : status === "warning"
-        ? "#facc15"
-        : "#f87171";
+function statusToAccent(status: string): StatAccent {
+  if (isNotEvaluated(status)) return "neutral";
+  if (status === "pass") return "success";
+  if (status === "warning") return "warn";
+  if (status === "fail") return "critical";
+  return "neutral";
+}
 
+/** Compact three-segment pass/warn/fail bar, token-styled for both themes. */
+function CoverageBar({
+  pass,
+  warn,
+  fail,
+  total,
+}: Pick<ComplianceFrameworkSummary, "pass" | "warn" | "fail" | "total">) {
+  const seg = (n: number) => (total > 0 ? (n / total) * 100 : 0);
   return (
-    <div className="relative w-32 h-32">
-      <svg viewBox="0 0 120 120" className="w-full h-full -rotate-90">
-        <circle cx="60" cy="60" r={r} fill="none" stroke="var(--border-strong)" strokeWidth="8" />
-        <circle
-          cx="60" cy="60" r={r} fill="none"
-          stroke={color} strokeWidth="8"
-          strokeDasharray={circ} strokeDashoffset={offset}
-          strokeLinecap="round"
-          className="transition-all duration-1000"
-        />
-      </svg>
-      <div className="absolute inset-0 flex flex-col items-center justify-center">
-        {notEvaluated ? (
-          <>
-            <span className="text-lg font-bold text-[color:var(--text-secondary)]">—</span>
-            <span className="px-1 text-center text-[9px] leading-tight text-[color:var(--text-tertiary)] uppercase tracking-wider">
-              Not evaluated
-            </span>
-          </>
-        ) : (
-          <>
-            <span className="text-2xl font-bold text-[color:var(--foreground)]">{Math.round(score)}%</span>
-            <span className="text-[10px] text-[color:var(--text-tertiary)] uppercase tracking-wider">Score</span>
-          </>
-        )}
-      </div>
+    <div className="flex h-1.5 w-full min-w-[72px] max-w-[140px] overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
+      {pass > 0 ? (
+        <div style={{ width: `${seg(pass)}%`, backgroundColor: "var(--status-success)" }} />
+      ) : null}
+      {warn > 0 ? (
+        <div style={{ width: `${seg(warn)}%`, backgroundColor: "var(--status-warn)" }} />
+      ) : null}
+      {fail > 0 ? (
+        <div style={{ width: `${seg(fail)}%`, backgroundColor: "var(--status-danger)" }} />
+      ) : null}
     </div>
   );
+}
+
+type CategoryFilter = "all" | "ai" | "governance" | "cloud";
+
+function categoryFor(id: string): "ai" | "governance" | "cloud" {
+  if (id === "cis" || id === "cmmc") return "cloud";
+  if (id === "eu-ai-act" || id === "nist-csf" || id === "iso27001" || id === "soc2")
+    return "governance";
+  return "ai";
 }
 
 // ─── Page ───────────────────────────────────────────────────────────────────
@@ -126,6 +133,7 @@ function CompliancePageContent() {
   // "Cannot connect to the agent-bom API".
   const [errorKind, setErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [viewMode, setViewMode] = useState<"detail" | "heatmap" | "matrix">("detail");
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
   const [controlQuery, setControlQuery] = useState(queryParam);
   const [statusFilter, setStatusFilter] = useState<"all" | "pass" | "warning" | "fail">("all");
   const [exporting, setExporting] = useState(false);
@@ -238,27 +246,20 @@ function CompliancePageContent() {
     [data, hasMcp],
   );
 
-  const frameworkCoverageItems = useMemo((): FrameworkCoverageItem[] => {
-    const categoryFor = (id: string): FrameworkCoverageItem["category"] => {
-      if (id === "cis" || id === "cmmc") return "cloud";
-      if (id === "eu-ai-act" || id === "nist-csf" || id === "iso27001" || id === "soc2") return "governance";
-      return "ai";
-    };
-    return frameworks.map((framework) => ({
-      id: framework.id,
-      label: framework.label,
-      pass: framework.pass,
-      warn: framework.warn,
-      fail: framework.fail,
-      total: framework.total,
-      category: categoryFor(framework.id),
-    }));
-  }, [frameworks]);
+  const visibleFrameworks = useMemo(
+    () =>
+      categoryFilter === "all"
+        ? frameworks
+        : frameworks.filter((framework) => categoryFor(framework.id) === categoryFilter),
+    [frameworks, categoryFilter],
+  );
 
   const selectedSection = useMemo(
     () => detailSections.find((section) => section.id === selectedFrameworkId) ?? detailSections[0],
     [detailSections, selectedFrameworkId],
   );
+
+  const sectionCatalog = selectedSection?.catalog;
 
   const visibleControls = useMemo(() => {
     if (!selectedSection) return [];
@@ -342,226 +343,354 @@ function CompliancePageContent() {
 
   if (!data) return null;
 
-  return (
-    <div className="space-y-5">
-      {/* ── Trust center header ─────────────────────────────────────────── */}
-      <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex items-center gap-5">
-            <ScoreRing score={data.overall_score} status={data.overall_status} />
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">
-                Trust center
-              </p>
-              <h1 className={`text-2xl font-bold ${statusColor(data.overall_status)}`}>
-                {postureLabel(data.overall_status)}
-              </h1>
-              <p className="mt-1 text-sm text-[color:var(--text-tertiary)]">
-                AI supply-chain frameworks plus cloud CIS posture when accounts are connected — not a full CNAPP claim.
-              </p>
-              <div className="mt-2 flex flex-wrap gap-4 text-xs text-[color:var(--text-tertiary)]">
-                <span>
-                  {data.scan_count} scan{data.scan_count !== 1 ? "s" : ""} analyzed
-                </span>
-                {data.latest_scan ? <span>Latest {formatDate(data.latest_scan)}</span> : null}
-                <span>
-                  {frameworks.reduce((total, framework) => total + framework.fail, 0)} failing controls
-                </span>
-              </div>
-            </div>
+  const totalPass = frameworks.reduce((sum, f) => sum + f.pass, 0);
+  const totalWarn = frameworks.reduce((sum, f) => sum + f.warn, 0);
+  const totalFail = frameworks.reduce((sum, f) => sum + f.fail, 0);
+  const evaluatedFrameworks = frameworks.filter((f) => !f.disabled).length;
+  const overallNotEvaluated = isNotEvaluated(data.overall_status);
+
+  const kpis: StatStripItem[] = [
+    {
+      label: "Overall",
+      value: overallNotEvaluated ? "—" : `${Math.round(data.overall_score)}%`,
+      accent: statusToAccent(data.overall_status),
+      hint: postureLabel(data.overall_status),
+    },
+    {
+      label: "Frameworks",
+      value: evaluatedFrameworks,
+      hint: `${frameworks.length} tracked`,
+    },
+    { label: "Passing", value: totalPass, accent: "success" },
+    { label: "Attention", value: totalWarn, accent: "warn", accentThreshold: 0 },
+    { label: "Failing", value: totalFail, accent: "critical", accentThreshold: 0 },
+  ];
+
+  // ── Frameworks master table ────────────────────────────────────────────────
+  const frameworkColumns: DataTableColumn<ComplianceFrameworkSummary>[] = [
+    {
+      key: "label",
+      header: "Framework",
+      cell: (f) => (
+        <div className="flex items-center gap-2">
+          <FrameworkIcon frameworkId={f.id} size={18} />
+          <div className="min-w-0">
+            <div className="truncate font-medium text-[color:var(--foreground)]">{f.shortLabel}</div>
+            <div className="truncate text-[11px] text-[color:var(--text-tertiary)]">{f.label}</div>
           </div>
+        </div>
+      ),
+    },
+    {
+      key: "coverage",
+      header: "Coverage",
+      cell: (f) =>
+        f.disabled ? (
+          <span className="text-[11px] text-[color:var(--text-tertiary)]">
+            {f.disabledReason ?? "Not evaluated"}
+          </span>
+        ) : (
+          <div className="flex items-center gap-2">
+            <CoverageBar pass={f.pass} warn={f.warn} fail={f.fail} total={f.total} />
+            <span className="tabular-nums text-[11px] text-[color:var(--text-tertiary)]">
+              {compliancePassRate(f)}%
+            </span>
+          </div>
+        ),
+    },
+    {
+      key: "fail",
+      header: "Fail",
+      align: "right",
+      sortable: true,
+      width: "4rem",
+      cell: (f) => (
+        <span
+          className={
+            f.fail > 0 ? "font-semibold text-[color:var(--status-danger)]" : "text-[color:var(--text-tertiary)]"
+          }
+        >
+          {f.fail}
+        </span>
+      ),
+    },
+  ];
+
+  const master = (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5">
+        {(["all", "ai", "governance", "cloud"] as const).map((value) => (
           <button
-            onClick={() => void handleExportPack()}
-            disabled={exporting}
-            title="Download a signed evidence pack covering every framework"
-            className="flex items-center gap-1.5 self-start rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100 disabled:opacity-50 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
-            data-testid="compliance-export-pack"
+            key={value}
+            type="button"
+            onClick={() => setCategoryFilter(value)}
+            className={`rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors ${
+              categoryFilter === value
+                ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+            }`}
           >
-            {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
-            {exporting ? "Exporting…" : "Export pack"}
+            {value === "ai" ? "AI" : value}
           </button>
-        </div>
-        {exportError ? (
-          <p className="mt-2 text-right text-xs text-red-400">{exportError}</p>
-        ) : null}
-
-        <FrameworkCoveragePanel
-          items={frameworkCoverageItems}
-          onFocusFramework={(frameworkId) => {
-            setSelectedFrameworkId(frameworkId);
-            setViewMode("detail");
-          }}
-        />
-
-        {(hubPosture && hubPosture.totals.combined > 0) || mitreCatalog || atlasCatalog ? (
-          <details className="mt-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3">
-            <summary className="cursor-pointer text-xs font-medium text-[color:var(--text-secondary)]">
-              Operator & catalog context
-            </summary>
-            <div className="mt-3 space-y-3 text-xs text-[color:var(--text-tertiary)]">
-              {hubPosture && hubPosture.totals.combined > 0 ? (
-                <p>
-                  Compliance hub: {hubPosture.totals.combined.toLocaleString()} findings (
-                  {hubPosture.totals.native.toLocaleString()} native ·{" "}
-                  {hubPosture.totals.hub.toLocaleString()} ingested). Import via{" "}
-                  <code className="rounded bg-[color:var(--surface)] px-1 py-0.5">
-                    POST /v1/compliance/ingest
-                  </code>
-                  .
-                </p>
-              ) : null}
-              {mitreCatalog ? (
-                <p>
-                  MITRE ATT&CK {mitreCatalog.attack_version || "catalog"} ·{" "}
-                  {mitreCatalog.technique_count} techniques · refresh with{" "}
-                  <code className="rounded bg-[color:var(--surface)] px-1 py-0.5">
-                    agent-bom db update-frameworks
-                  </code>
-                  .
-                </p>
-              ) : null}
-              {atlasCatalog ? (
-                <p>
-                  MITRE ATLAS {atlasCatalog.atlas_version || "catalog"} ·{" "}
-                  {atlasCatalog.technique_count} techniques · refresh with{" "}
-                  <code className="rounded bg-[color:var(--surface)] px-1 py-0.5">
-                    agent-bom db update-frameworks --framework atlas
-                  </code>
-                  .
-                </p>
-              ) : null}
-            </div>
-          </details>
-        ) : null}
+        ))}
       </div>
+      <DataTable
+        rows={visibleFrameworks}
+        rowKey={(f) => f.id}
+        columns={frameworkColumns}
+        selectedKey={selectedSection?.id}
+        onRowClick={(f) => {
+          if (f.disabled) return;
+          setSelectedFrameworkId(f.id);
+        }}
+        maxHeight="calc(100vh - 22rem)"
+        caption="Framework coverage"
+        empty="No frameworks in this category."
+        data-testid="compliance-frameworks-table"
+      />
+    </div>
+  );
 
-      {/* ── View Toggle ────────────────────────────────────────────────── */}
-      <div className="flex items-center gap-2">
-        <button
-          onClick={() => setViewMode("detail")}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-            viewMode === "detail"
-              ? "bg-emerald-600 text-white"
-              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
-          }`}
-        >
-          <List className="w-3.5 h-3.5" />
-          Detail
-        </button>
-        <button
-          onClick={() => setViewMode("heatmap")}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-            viewMode === "heatmap"
-              ? "bg-emerald-600 text-white"
-              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
-          }`}
-        >
-          <Grid3X3 className="w-3.5 h-3.5" />
-          Heatmap
-        </button>
-        <button
-          onClick={() => setViewMode("matrix")}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-            viewMode === "matrix"
-              ? "bg-emerald-600 text-white"
-              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
-          }`}
-        >
-          <Scan className="w-3.5 h-3.5" />
-          Matrix
-        </button>
-      </div>
-
-      {/* ── Heatmap View ──────────────────────────────────────────────── */}
-      {viewMode === "heatmap" && <ComplianceHeatmap data={data} />}
-
-      {/* ── Matrix View ───────────────────────────────────────────────── */}
-      {viewMode === "matrix" && <ComplianceMatrix data={data} />}
-
-      {viewMode === "detail" && selectedSection ? (
-      <>
-      <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <div className="flex items-center gap-2">
-              <FrameworkIcon frameworkId={selectedSection.id} size={24} />
-              <h2 className="text-base font-semibold text-[color:var(--foreground)]">
-                {selectedSection.title}
-              </h2>
-            </div>
-            {selectedSection.subtitle ? (
-              <p className="mt-0.5 text-xs text-[color:var(--text-tertiary)]">{selectedSection.subtitle}</p>
-            ) : null}
-            <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
-              {visibleControls.length} of {selectedSection.controls.length} controls shown · click a row for evidence
-            </p>
+  // ── Controls detail table ──────────────────────────────────────────────────
+  const controlColumns: DataTableColumn<ComplianceControl>[] = [
+    {
+      key: "code",
+      header: "Control",
+      cell: (c) => (
+        <div className="min-w-0">
+          <div className="font-mono text-xs font-medium text-[color:var(--foreground)]">{c.code}</div>
+          <div className="truncate text-[11px] text-[color:var(--text-tertiary)]">
+            {sectionCatalog?.[c.code] ?? c.name}
           </div>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <div className="relative min-w-[220px]">
-              <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[color:var(--text-tertiary)]" />
-              <input
-                type="text"
-                value={controlQuery}
-                onChange={(e) => setControlQuery(e.target.value)}
-                placeholder="Search control, package, agent"
-                className="w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface-elevated)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
-              />
-            </div>
-            <div className="flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] p-0.5">
-              {(["all", "fail", "warning", "pass"] as const).map((value) => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => setStatusFilter(value)}
-                  className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                    statusFilter === value
-                      ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
-                      : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
-                  }`}
-                >
-                  {value === "all" ? "All" : value === "pass" ? "Pass" : value === "warning" ? "Warn" : "Fail"}
-                </button>
-              ))}
-            </div>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      width: "6rem",
+      cell: (c) => (
+        <span className="inline-flex items-center gap-1.5">
+          <StatusIcon status={c.status} className="h-3.5 w-3.5" />
+          <span className={`text-xs font-medium ${statusColor(c.status)}`}>
+            {CONTROL_STATUS_LABEL[c.status] ?? c.status}
+          </span>
+        </span>
+      ),
+    },
+    {
+      key: "findings",
+      header: "Findings",
+      align: "right",
+      width: "5rem",
+      cell: (c) => (
+        <span
+          className={
+            c.findings > 0 ? "font-semibold text-[color:var(--foreground)]" : "text-[color:var(--text-tertiary)]"
+          }
+        >
+          {c.findings}
+        </span>
+      ),
+    },
+  ];
+
+  const detail = selectedSection ? (
+    <div className="flex h-full min-h-0 flex-col rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-1">
+      <div className="border-b border-[color:var(--border-subtle)] p-4">
+        <div className="flex items-center gap-2">
+          <FrameworkIcon frameworkId={selectedSection.id} size={22} />
+          <h2 className="text-base font-semibold text-[color:var(--foreground)]">
+            {selectedSection.title}
+          </h2>
+        </div>
+        {selectedSection.subtitle ? (
+          <p className="mt-0.5 text-xs text-[color:var(--text-tertiary)]">{selectedSection.subtitle}</p>
+        ) : null}
+        <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+          {visibleControls.length} of {selectedSection.controls.length} controls shown · click a row for evidence
+        </p>
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="relative min-w-0 flex-1">
+            <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[color:var(--text-tertiary)]" />
+            <input
+              type="text"
+              value={controlQuery}
+              onChange={(e) => setControlQuery(e.target.value)}
+              placeholder="Search control, package, agent"
+              className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
+            />
+          </div>
+          <div className="flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5">
+            {(["all", "fail", "warning", "pass"] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setStatusFilter(value)}
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                  statusFilter === value
+                    ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                    : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+                }`}
+              >
+                {value === "all" ? "All" : value === "pass" ? "Pass" : value === "warning" ? "Warn" : "Fail"}
+              </button>
+            ))}
           </div>
         </div>
       </div>
-
-      <section className="space-y-2">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
         {selectedSection.controls.length === 0 && selectedSection.emptyMessage ? (
           <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
             {selectedSection.emptyMessage}
           </div>
-        ) : visibleControls.length === 0 ? (
-          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
-            No controls match the current filters.
-          </div>
         ) : (
-          visibleControls.map((control) => (
-            <ComplianceControlRow
-              key={control.code}
-              control={control}
-              catalogName={selectedSection.catalog?.[control.code] ?? control.name}
-              onOpen={() =>
-                setSelectedControl({
-                  control,
-                  frameworkLabel: selectedSection.title,
-                  catalog: selectedSection.catalog,
-                })
-              }
-            />
-          ))
+          <DataTable
+            rows={visibleControls}
+            rowKey={(c) => c.code}
+            columns={controlColumns}
+            onRowClick={(control) =>
+              setSelectedControl({
+                control,
+                frameworkLabel: selectedSection.title,
+                catalog: selectedSection.catalog,
+              })
+            }
+            selectedKey={selectedControl?.control.code}
+            caption={`${selectedSection.title} controls`}
+            empty="No controls match the current filters."
+          />
         )}
-      </section>
+      </div>
+    </div>
+  ) : null;
 
-      <details className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]">
-        <summary className="cursor-pointer px-5 py-4 text-sm font-medium text-[color:var(--foreground)]">
-          Cloud CIS benchmark drill-down (AWS / Azure / GCP / Snowflake / Databricks)
-        </summary>
-        <div className="border-t border-[color:var(--border-subtle)] px-2 pb-2">
-          <CISBenchmarkDetail />
+  return (
+    <div className="space-y-5">
+      {/* ── Trust center header ─────────────────────────────────────────── */}
+      <div className="flex flex-col gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">
+            Trust center
+          </p>
+          <h1 className={`text-xl font-bold ${statusColor(data.overall_status)}`}>
+            {postureLabel(data.overall_status)}
+          </h1>
+          <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-[color:var(--text-tertiary)]">
+            <span>
+              {data.scan_count} scan{data.scan_count !== 1 ? "s" : ""} analyzed
+            </span>
+            {data.latest_scan ? <span>Latest {formatDate(data.latest_scan)}</span> : null}
+            <span>{totalFail} failing controls</span>
+            <span>
+              AI supply-chain frameworks + cloud CIS posture when accounts are connected — not a full CNAPP claim.
+            </span>
+          </div>
         </div>
-      </details>
+        <button
+          onClick={() => void handleExportPack()}
+          disabled={exporting}
+          title="Download a signed evidence pack covering every framework"
+          className="flex shrink-0 items-center gap-1.5 self-start rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-sm font-medium text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent-soft-hover)] disabled:opacity-50"
+          data-testid="compliance-export-pack"
+        >
+          {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+          {exporting ? "Exporting…" : "Export pack"}
+        </button>
+      </div>
+      {exportError ? (
+        <p className="text-right text-xs text-[color:var(--status-danger)]">{exportError}</p>
+      ) : null}
+
+      <StatStrip items={kpis} data-testid="compliance-kpi-strip" />
+
+      {/* ── View Toggle ────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5 self-start w-fit">
+        {(
+          [
+            { key: "detail", label: "Detail", icon: List },
+            { key: "heatmap", label: "Heatmap", icon: Grid3X3 },
+            { key: "matrix", label: "Matrix", icon: Scan },
+          ] as const
+        ).map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setViewMode(key)}
+            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              viewMode === key
+                ? "bg-[color:var(--accent-soft)] text-[color:var(--accent)]"
+                : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {viewMode === "heatmap" && <ComplianceHeatmap data={data} />}
+      {viewMode === "matrix" && <ComplianceMatrix data={data} />}
+
+      {viewMode === "detail" ? (
+        <>
+          <SplitLayout
+            masterWidth="24rem"
+            height="calc(100vh - 20rem)"
+            master={master}
+            detail={detail}
+            placeholder="Select a framework to review its controls and evidence."
+            data-testid="compliance-split"
+          />
+
+          <Collapsible
+            title="Cloud CIS benchmark drill-down"
+            subtitle="AWS / Azure / GCP / Snowflake / Databricks"
+            icon={Scan}
+            defaultOpen={false}
+          >
+            <CISBenchmarkDetail />
+          </Collapsible>
+
+          {(hubPosture && hubPosture.totals.combined > 0) || mitreCatalog || atlasCatalog ? (
+            <Collapsible title="Operator & catalog context" defaultOpen={false}>
+              <div className="space-y-3 text-xs text-[color:var(--text-tertiary)]">
+                {hubPosture && hubPosture.totals.combined > 0 ? (
+                  <p>
+                    Compliance hub: {hubPosture.totals.combined.toLocaleString()} findings (
+                    {hubPosture.totals.native.toLocaleString()} native ·{" "}
+                    {hubPosture.totals.hub.toLocaleString()} ingested). Import via{" "}
+                    <code className="rounded bg-[color:var(--surface-muted)] px-1 py-0.5">
+                      POST /v1/compliance/ingest
+                    </code>
+                    .
+                  </p>
+                ) : null}
+                {mitreCatalog ? (
+                  <p>
+                    MITRE ATT&CK {mitreCatalog.attack_version || "catalog"} ·{" "}
+                    {mitreCatalog.technique_count} techniques · refresh with{" "}
+                    <code className="rounded bg-[color:var(--surface-muted)] px-1 py-0.5">
+                      agent-bom db update-frameworks
+                    </code>
+                    .
+                  </p>
+                ) : null}
+                {atlasCatalog ? (
+                  <p>
+                    MITRE ATLAS {atlasCatalog.atlas_version || "catalog"} ·{" "}
+                    {atlasCatalog.technique_count} techniques · refresh with{" "}
+                    <code className="rounded bg-[color:var(--surface-muted)] px-1 py-0.5">
+                      agent-bom db update-frameworks --framework atlas
+                    </code>
+                    .
+                  </p>
+                ) : null}
+              </div>
+            </Collapsible>
+          ) : null}
+        </>
+      ) : null}
 
       {selectedControl ? (
         <ComplianceControlDrawer
@@ -570,8 +699,6 @@ function CompliancePageContent() {
           catalogName={selectedControl.catalog?.[selectedControl.control.code]}
           onClose={() => setSelectedControl(null)}
         />
-      ) : null}
-      </>
       ) : null}
 
       {/* ── Empty state ───────────────────────────────────────────────── */}

--- a/ui/app/cost/page.tsx
+++ b/ui/app/cost/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   DollarSign,
   Activity,
@@ -12,7 +12,6 @@ import {
   Gauge,
   Flame,
   CalendarClock,
-  Building2,
   UserCheck,
 } from "lucide-react";
 import {
@@ -47,6 +46,11 @@ import { PageLaneHeader } from "@/components/page-lane";
 import { ServiceStateBanner, ServiceStateChip } from "@/components/service-state-chip";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { serviceEntry } from "@/lib/service-registry";
+import { StatStrip, type StatStripItem } from "@/components/stat-strip";
+import { DataTable, type DataTableColumn, type SortDirection } from "@/components/data-table";
+import { Collapsible } from "@/components/collapsible";
+import { Drawer } from "@/components/drawer";
+import { useChartTheme } from "@/lib/theme-colors";
 
 function classifyApiErrorKind(err: unknown): ApiOfflineKind {
   if (err instanceof ApiAuthError) return "auth";
@@ -60,148 +64,98 @@ const fmtUsd = (n: number) =>
     : `$${n.toFixed(4)}`;
 const fmtInt = (n: number) => n.toLocaleString();
 
-function StatCard({
-  icon: Icon,
-  label,
-  value,
-  color,
-}: {
-  icon: React.ElementType;
-  label: string;
-  value: string;
-  color: string;
-}) {
-  return (
-    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
-      <div className="mb-1 flex items-center gap-2">
-        <Icon className={`h-4 w-4 ${color}`} />
-        <span className="text-xs text-[var(--text-tertiary)]">{label}</span>
-      </div>
-      <p className="text-2xl font-bold text-[var(--foreground)]">{value}</p>
-    </div>
-  );
+// ─── Budget (owner-scoped) ───────────────────────────────────────────────────
+
+function budgetScopeLabel(budget: CostReport["budget"]): string {
+  if (budget.owner) {
+    return budget.workflow
+      ? `owner ${budget.owner} · ${budget.workflow}`
+      : `owner ${budget.owner}`;
+  }
+  if (budget.agent) return `agent ${budget.agent}`;
+  if (budget.cost_center) return `cost-center ${budget.cost_center}`;
+  return "tenant-wide";
 }
 
-function BudgetBanner({ budget }: { budget: CostReport["budget"] }) {
+function BudgetPanel({ budget }: { budget: CostReport["budget"] }) {
   if (!budget?.configured) {
     return (
-      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4 text-sm text-[var(--text-secondary)]">
-        No spend budget configured for this tenant. Set one via{" "}
-        <code className="rounded bg-[var(--surface-elevated)] px-1.5 py-0.5 text-xs text-[var(--text-secondary)]">
+      <div className="flex h-full flex-col justify-center rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 text-sm text-[color:var(--text-secondary)] elev-1">
+        <div className="mb-1 flex items-center gap-2 text-[color:var(--text-tertiary)]">
+          <Gauge className="h-4 w-4" />
+          <span className="text-[11px] font-medium uppercase tracking-[0.1em]">Budget</span>
+        </div>
+        No spend budget configured. Set one via{" "}
+        <code className="rounded bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-xs text-[color:var(--text-secondary)]">
           POST /v1/observability/costs/budget
         </code>{" "}
-        to enable pre-invocation enforcement at the gateway.
+        to enable owner-scoped, pre-invocation enforcement at the gateway.
       </div>
     );
   }
   const util = budget.utilization ?? 0;
   const pct = Math.min(100, Math.round(util * 100));
   const enforce = budget.mode === "enforce";
-  const barColor = budget.exceeded
-    ? "bg-red-500"
-    : pct >= 80
-      ? "bg-amber-500"
-      : "bg-emerald-500";
+  const tone = budget.exceeded ? "danger" : pct >= 80 ? "warn" : "success";
+  const barVar =
+    tone === "danger"
+      ? "var(--status-danger)"
+      : tone === "warn"
+        ? "var(--status-warn)"
+        : "var(--status-success)";
   return (
     <div
-      className={`rounded-xl border p-4 ${
+      className={`rounded-xl border p-4 elev-1 ${
         budget.exceeded
-          ? "border-red-800/60 bg-red-950/20"
-          : "border-[var(--border-subtle)] bg-[var(--surface)]/40"
+          ? "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)]"
+          : "border-[color:var(--border-subtle)] bg-[color:var(--surface)]"
       }`}
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Gauge
-            className={`h-4 w-4 ${budget.exceeded ? "text-red-400" : "text-emerald-400"}`}
+            className="h-4 w-4"
+            style={{ color: budget.exceeded ? "var(--status-danger)" : "var(--status-success)" }}
           />
-          <span className="text-sm font-medium text-[var(--foreground)]">
-            Budget {budget.agent ? `· agent ${budget.agent}` : "· tenant-wide"}
+          <span className="text-sm font-medium text-[color:var(--foreground)]">
+            Budget · {budgetScopeLabel(budget)}
           </span>
           <span
             className={`rounded-full px-2 py-0.5 text-xs font-medium ${
               enforce
-                ? "bg-emerald-900/60 text-emerald-300"
-                : "bg-[var(--surface-elevated)] text-[var(--text-secondary)]"
+                ? "border border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]"
+                : "border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
             }`}
           >
             {enforce ? "enforce" : "report-only"}
           </span>
           {budget.exceeded && (
-            <span className="rounded-full bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300">
+            <span className="rounded-full border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-2 py-0.5 text-xs font-medium text-[color:var(--status-danger)]">
               exceeded
             </span>
           )}
         </div>
-        <span className="text-sm text-[var(--text-secondary)]">
+        <span className="text-sm text-[color:var(--text-secondary)]">
           {fmtUsd(budget.spend_usd)}{" "}
           {budget.limit_usd != null && <>/ {fmtUsd(budget.limit_usd)}</>}
           {budget.remaining_usd != null && (
-            <span className="ml-2 text-[var(--text-tertiary)]">
+            <span className="ml-2 text-[color:var(--text-tertiary)]">
               ({fmtUsd(Math.max(0, budget.remaining_usd))} left)
             </span>
           )}
         </span>
       </div>
-      <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-[var(--surface-elevated)]">
+      <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
         <div
-          className={`h-full ${barColor} transition-all duration-700`}
-          style={{ width: `${pct}%` }}
+          className="h-full transition-all duration-700"
+          style={{ width: `${pct}%`, backgroundColor: barVar }}
         />
       </div>
     </div>
   );
 }
 
-function BreakdownTable({
-  title,
-  rows,
-}: {
-  title: string;
-  rows: CostBreakdownRow[];
-}) {
-  const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
-  return (
-    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
-      <h3 className="mb-3 text-sm font-semibold text-[var(--text-secondary)]">{title}</h3>
-      {top.length === 0 ? (
-        <p className="text-sm text-[var(--text-tertiary)]">No cost records yet.</p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
-              <th className="pb-2 font-medium">Name</th>
-              <th className="pb-2 text-right font-medium">Calls</th>
-              <th className="pb-2 text-right font-medium">Tokens (in/out)</th>
-              <th className="pb-2 text-right font-medium">Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {top.map((r) => (
-              <tr
-                key={r.key}
-                className="border-b border-[var(--border-subtle)] last:border-0"
-              >
-                <td className="py-2 font-mono text-xs text-[var(--text-secondary)]">
-                  {r.key || "—"}
-                </td>
-                <td className="py-2 text-right text-[var(--text-secondary)]">
-                  {fmtInt(r.calls)}
-                </td>
-                <td className="py-2 text-right text-[var(--text-tertiary)]">
-                  {fmtInt(r.input_tokens)} / {fmtInt(r.output_tokens)}
-                </td>
-                <td className="py-2 text-right font-medium text-[var(--foreground)]">
-                  {fmtUsd(r.cost_usd)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-    </div>
-  );
-}
+// ─── Forecast & runway ───────────────────────────────────────────────────────
 
 const FORECAST_STATUS: Record<
   string,
@@ -220,18 +174,25 @@ function fmtDays(n: number): string {
   return `${(n * 24).toFixed(1)}h`;
 }
 
+function toneChipClass(tone: "ok" | "warn" | "danger" | "muted"): string {
+  switch (tone) {
+    case "ok":
+      return "border border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]";
+    case "warn":
+      return "border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--status-warn)]";
+    case "danger":
+      return "border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--status-danger)]";
+    default:
+      return "border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]";
+  }
+}
+
 function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
   const status = forecast?.status ?? "insufficient_history";
   const meta = FORECAST_STATUS[status] ?? {
     label: status.replace(/_/g, " "),
     tone: "muted" as const,
   };
-  const toneClass = {
-    ok: "bg-emerald-900/60 text-emerald-300",
-    warn: "bg-amber-900/60 text-amber-300",
-    danger: "bg-red-900/60 text-red-300",
-    muted: "bg-[var(--surface-elevated)] text-[var(--text-secondary)]",
-  }[meta.tone];
 
   const hasRate = forecast?.burn_rate_usd_per_day != null;
   const hasRunway = forecast?.days_remaining != null;
@@ -242,20 +203,22 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
     forecast.days_remaining <= 14;
 
   return (
-    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1">
       <div className="mb-3 flex items-center gap-2">
-        <CalendarClock className="h-4 w-4 text-sky-400" />
-        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
+        <CalendarClock className="h-4 w-4 text-[color:var(--accent)]" />
+        <h3 className="text-sm font-semibold text-[color:var(--foreground)]">
           Forecast &amp; runway
         </h3>
         <span
-          className={`rounded-full px-2 py-0.5 text-xs font-medium ${atRisk ? "bg-amber-900/60 text-amber-300" : toneClass}`}
+          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+            atRisk ? toneChipClass("warn") : toneChipClass(meta.tone)
+          }`}
         >
           {atRisk ? "at risk" : meta.label}
         </span>
       </div>
       {!hasRate && !hasRunway ? (
-        <p className="text-sm text-[var(--text-tertiary)]">
+        <p className="text-sm text-[color:var(--text-tertiary)]">
           {status === "insufficient_history"
             ? "Not enough timestamped spend yet to project a burn rate. A forecast appears once at least two priced LLM calls are recorded."
             : status === "no_budget"
@@ -266,65 +229,50 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
         </p>
       ) : (
         <>
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
-              <div className="mb-1 flex items-center gap-1.5">
-                <Flame className="h-3.5 w-3.5 text-orange-400" />
-                <span className="text-xs text-[var(--text-tertiary)]">Burn / day</span>
-              </div>
-              <p className="text-lg font-bold text-[var(--foreground)]">
-                {forecast?.burn_rate_usd_per_day != null
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            <ForecastStat
+              icon={Flame}
+              label="Burn / day"
+              value={
+                forecast?.burn_rate_usd_per_day != null
                   ? fmtUsd(forecast.burn_rate_usd_per_day)
-                  : "—"}
-              </p>
-              {forecast?.burn_rate_basis && (
-                <p className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">
-                  {forecast.burn_rate_basis.replace(/_/g, " ")}
-                </p>
-              )}
-            </div>
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
-              <div className="mb-1 flex items-center gap-1.5">
-                <Gauge className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
-                <span className="text-xs text-[var(--text-tertiary)]">Runway</span>
-              </div>
-              <p
-                className={`text-lg font-bold ${atRisk ? "text-amber-300" : "text-[var(--foreground)]"}`}
-              >
-                {forecast?.days_remaining != null
-                  ? fmtDays(forecast.days_remaining)
-                  : "—"}
-              </p>
-            </div>
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
-              <div className="mb-1 flex items-center gap-1.5">
-                <CalendarClock className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
-                <span className="text-xs text-[var(--text-tertiary)]">Exhaustion</span>
-              </div>
-              <p className="text-sm font-medium text-[var(--foreground)]">
-                {forecast?.projected_exhaustion_at
+                  : "—"
+              }
+              hint={forecast?.burn_rate_basis?.replace(/_/g, " ")}
+            />
+            <ForecastStat
+              icon={Gauge}
+              label="Runway"
+              value={
+                forecast?.days_remaining != null ? fmtDays(forecast.days_remaining) : "—"
+              }
+              valueClass={atRisk ? "text-[color:var(--status-warn)]" : undefined}
+            />
+            <ForecastStat
+              icon={CalendarClock}
+              label="Exhaustion"
+              value={
+                forecast?.projected_exhaustion_at
                   ? formatDate(forecast.projected_exhaustion_at)
-                  : "—"}
-              </p>
-            </div>
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
-              <div className="mb-1 flex items-center gap-1.5">
-                <TrendingUp className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
-                <span className="text-xs text-[var(--text-tertiary)]">Projected period</span>
-              </div>
-              <p className="text-sm font-medium text-[var(--foreground)]">
-                {forecast?.projected_period_spend_usd != null
+                  : "—"
+              }
+            />
+            <ForecastStat
+              icon={TrendingUp}
+              label="Projected period"
+              value={
+                forecast?.projected_period_spend_usd != null
                   ? fmtUsd(forecast.projected_period_spend_usd)
-                  : "—"}
-              </p>
-              {forecast?.budget_limit_usd != null && (
-                <p className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">
-                  of {fmtUsd(forecast.budget_limit_usd)} cap
-                </p>
-              )}
-            </div>
+                  : "—"
+              }
+              hint={
+                forecast?.budget_limit_usd != null
+                  ? `of ${fmtUsd(forecast.budget_limit_usd)} cap`
+                  : undefined
+              }
+            />
           </div>
-          <p className="mt-3 text-[11px] text-[var(--text-tertiary)]">
+          <p className="mt-3 text-[11px] text-[color:var(--text-tertiary)]">
             Reference only — a forecast never blocks a call; enforcement stays at
             the gateway.
           </p>
@@ -334,122 +282,268 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
   );
 }
 
-function ChargebackPanel({ rows }: { rows: CostBreakdownRow[] }) {
-  const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
-  const total = rows.reduce((sum, r) => sum + r.cost_usd, 0);
+function ForecastStat({
+  icon: Icon,
+  label,
+  value,
+  hint,
+  valueClass,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string;
+  hint?: string | undefined;
+  valueClass?: string | undefined;
+}) {
   return (
-    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
-      <div className="mb-3 flex items-center gap-2">
-        <Building2 className="h-4 w-4 text-violet-400" />
-        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
-          Chargeback by cost-center
-        </h3>
+    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
+      <div className="mb-1 flex items-center gap-1.5">
+        <Icon className="h-3.5 w-3.5 text-[color:var(--text-tertiary)]" />
+        <span className="text-[11px] text-[color:var(--text-tertiary)]">{label}</span>
       </div>
-      {top.length === 0 ? (
-        <p className="text-sm text-[var(--text-tertiary)]">
-          No chargeback allocation recorded. Tag GenAI spans with{" "}
-          <code className="rounded bg-[var(--surface-elevated)] px-1.5 py-0.5 text-xs text-[var(--text-secondary)]">
-            agent.cost_center
-          </code>{" "}
-          (or <code className="text-[var(--text-secondary)]">allocation.tag.*</code>) to attribute
-          spend to a budget unit.
-        </p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
-              <th className="pb-2 font-medium">Cost center</th>
-              <th className="pb-2 text-right font-medium">Calls</th>
-              <th className="pb-2 text-right font-medium">Share</th>
-              <th className="pb-2 text-right font-medium">Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {top.map((r) => {
-              const share = total > 0 ? r.cost_usd / total : 0;
-              return (
-                <tr
-                  key={r.key}
-                  className="border-b border-[var(--border-subtle)] last:border-0"
-                >
-                  <td className="py-2 font-mono text-xs text-[var(--text-secondary)]">
-                    {r.key || "unallocated"}
-                  </td>
-                  <td className="py-2 text-right text-[var(--text-secondary)]">
-                    {fmtInt(r.calls)}
-                  </td>
-                  <td className="py-2 text-right text-[var(--text-tertiary)]">
-                    {(share * 100).toFixed(1)}%
-                  </td>
-                  <td className="py-2 text-right font-medium text-[var(--foreground)]">
-                    {fmtUsd(r.cost_usd)}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      )}
+      <p className={`text-lg font-bold ${valueClass ?? "text-[color:var(--foreground)]"}`}>
+        {value}
+      </p>
+      {hint ? <p className="mt-0.5 text-[11px] text-[color:var(--text-tertiary)]">{hint}</p> : null}
     </div>
   );
 }
 
-function OwnerPanel({ rows }: { rows: CostBreakdownRow[] }) {
-  const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
-  const total = rows.reduce((sum, r) => sum + r.cost_usd, 0);
+// ─── Breakdown (unified, dimension-switched) ─────────────────────────────────
+
+type BreakdownDim = {
+  key: string;
+  label: string;
+  noun: string;
+  rows: CostBreakdownRow[];
+  emptyKey: string;
+  emptyHint: string;
+};
+
+type SortKey = "cost_usd" | "calls" | "key";
+
+function BreakdownExplorer({ report }: { report: CostReport }) {
+  const dims = useMemo<BreakdownDim[]>(
+    () => [
+      { key: "agent", label: "Agent", noun: "agent", rows: report.by_agent, emptyKey: "—", emptyHint: "" },
+      { key: "model", label: "Model", noun: "model", rows: report.by_model, emptyKey: "—", emptyHint: "" },
+      { key: "provider", label: "Provider", noun: "provider", rows: report.by_provider, emptyKey: "—", emptyHint: "" },
+      {
+        key: "owner",
+        label: "Owner",
+        noun: "accountable owner",
+        rows: report.by_owner ?? [],
+        emptyKey: "unattributed",
+        emptyHint:
+          "Approve a governance blueprint listing an agent to attribute its spend to the accountable owner.",
+      },
+      {
+        key: "cost_center",
+        label: "Cost center",
+        noun: "cost-center",
+        rows: report.by_cost_center ?? [],
+        emptyKey: "unallocated",
+        emptyHint:
+          "Tag GenAI spans with agent.cost_center (or allocation.tag.*) to attribute spend to a budget unit.",
+      },
+    ],
+    [report],
+  );
+
+  const [activeKey, setActiveKey] = useState("agent");
+  const [sort, setSort] = useState<{ key: SortKey; direction: SortDirection }>({
+    key: "cost_usd",
+    direction: "desc",
+  });
+  const [selected, setSelected] = useState<CostBreakdownRow | null>(null);
+
+  const active = dims.find((d) => d.key === activeKey) ?? dims[0]!;
+  const total = useMemo(
+    () => active.rows.reduce((sum, r) => sum + r.cost_usd, 0),
+    [active],
+  );
+
+  const sortedRows = useMemo(() => {
+    const rows = [...active.rows];
+    rows.sort((a, b) => {
+      const dir = sort.direction === "asc" ? 1 : -1;
+      if (sort.key === "key") return dir * a.key.localeCompare(b.key);
+      return dir * (a[sort.key] - b[sort.key]);
+    });
+    return rows;
+  }, [active, sort]);
+
+  const cycleSort = (key: string) => {
+    setSort((prev) =>
+      prev.key === key
+        ? { key: key as SortKey, direction: prev.direction === "asc" ? "desc" : "asc" }
+        : { key: key as SortKey, direction: key === "key" ? "asc" : "desc" },
+    );
+  };
+
+  const columns: DataTableColumn<CostBreakdownRow>[] = [
+    {
+      key: "key",
+      header: active.label,
+      sortable: true,
+      cell: (r) => (
+        <span className="font-mono text-xs text-[color:var(--text-secondary)]">
+          {r.key || active.emptyKey}
+        </span>
+      ),
+    },
+    {
+      key: "calls",
+      header: "Calls",
+      align: "right",
+      sortable: true,
+      cell: (r) => fmtInt(r.calls),
+    },
+    {
+      key: "tokens",
+      header: "Tokens (in/out)",
+      align: "right",
+      cell: (r) => (
+        <span className="text-[color:var(--text-tertiary)]">
+          {fmtInt(r.input_tokens)} / {fmtInt(r.output_tokens)}
+        </span>
+      ),
+    },
+    {
+      key: "share",
+      header: "Share",
+      align: "right",
+      cell: (r) => (
+        <span className="text-[color:var(--text-tertiary)]">
+          {(total > 0 ? (r.cost_usd / total) * 100 : 0).toFixed(1)}%
+        </span>
+      ),
+    },
+    {
+      key: "cost_usd",
+      header: "Cost",
+      align: "right",
+      sortable: true,
+      cell: (r) => (
+        <span className="font-medium text-[color:var(--foreground)]">{fmtUsd(r.cost_usd)}</span>
+      ),
+    },
+  ];
+
   return (
-    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
-      <div className="mb-3 flex items-center gap-2">
-        <UserCheck className="h-4 w-4 text-emerald-400" />
-        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
-          Spend by accountable owner
-        </h3>
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-[color:var(--foreground)]">Cost breakdown</h3>
+        <div className="flex flex-wrap items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5">
+          {dims.map((dim) => (
+            <button
+              key={dim.key}
+              type="button"
+              onClick={() => {
+                setActiveKey(dim.key);
+                setSelected(null);
+              }}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                dim.key === activeKey
+                  ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                  : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+              }`}
+            >
+              {dim.label}
+            </button>
+          ))}
+        </div>
       </div>
-      {top.length === 0 ? (
-        <p className="text-sm text-[var(--text-tertiary)]">
-          No owner attribution yet. Approve a governance blueprint whose
-          composition lists an agent to attribute that agent&apos;s spend to its
-          accountable owner.
-        </p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
-              <th className="pb-2 font-medium">Owner</th>
-              <th className="pb-2 text-right font-medium">Calls</th>
-              <th className="pb-2 text-right font-medium">Share</th>
-              <th className="pb-2 text-right font-medium">Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {top.map((r) => {
-              const share = total > 0 ? r.cost_usd / total : 0;
-              return (
-                <tr
-                  key={r.key}
-                  className="border-b border-[var(--border-subtle)] last:border-0"
-                >
-                  <td className="py-2 font-mono text-xs text-[var(--text-secondary)]">
-                    {r.key || "unattributed"}
-                  </td>
-                  <td className="py-2 text-right text-[var(--text-secondary)]">
-                    {fmtInt(r.calls)}
-                  </td>
-                  <td className="py-2 text-right text-[var(--text-tertiary)]">
-                    {(share * 100).toFixed(1)}%
-                  </td>
-                  <td className="py-2 text-right font-medium text-[var(--foreground)]">
-                    {fmtUsd(r.cost_usd)}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      )}
+
+      <DataTable
+        rows={sortedRows}
+        rowKey={(r) => r.key || active.emptyKey}
+        columns={columns}
+        selectedKey={selected ? selected.key || active.emptyKey : undefined}
+        onRowClick={setSelected}
+        sort={sort}
+        onSortChange={cycleSort}
+        maxHeight="26rem"
+        caption={`Spend by ${active.noun}`}
+        empty={
+          active.emptyHint || `No spend recorded by ${active.noun} yet.`
+        }
+        data-testid="cost-breakdown-table"
+      />
+
+      <Drawer
+        open={selected != null}
+        onClose={() => setSelected(null)}
+        eyebrow={`Spend by ${active.label}`}
+        title={selected?.key || active.emptyKey}
+        size="lg"
+        ariaLabel="Cost breakdown detail"
+      >
+        {selected ? (
+          <div className="space-y-4">
+            <StatStrip
+              items={[
+                { label: "Cost", value: fmtUsd(selected.cost_usd), accent: "success" },
+                {
+                  label: "Share",
+                  value: `${(total > 0 ? (selected.cost_usd / total) * 100 : 0).toFixed(1)}%`,
+                },
+                { label: "Calls", value: fmtInt(selected.calls) },
+              ]}
+            />
+            <dl className="grid grid-cols-2 gap-3 text-sm">
+              <DetailStat label="Input tokens" value={fmtInt(selected.input_tokens)} />
+              <DetailStat label="Output tokens" value={fmtInt(selected.output_tokens)} />
+              <DetailStat
+                label="Unpriced calls"
+                value={fmtInt(selected.unpriced_calls)}
+                warn={selected.unpriced_calls > 0}
+              />
+              <DetailStat
+                label="Avg cost / call"
+                value={fmtUsd(selected.calls > 0 ? selected.cost_usd / selected.calls : 0)}
+              />
+            </dl>
+            {selected.unpriced_calls > 0 ? (
+              <p className="rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs text-[color:var(--text-secondary)]">
+                {fmtInt(selected.unpriced_calls)} call
+                {selected.unpriced_calls === 1 ? "" : "s"} lacked a captured price model, so real
+                spend for this {active.noun} may be higher.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </Drawer>
     </div>
   );
 }
+
+function DetailStat({
+  label,
+  value,
+  warn,
+}: {
+  label: string;
+  value: string;
+  warn?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
+      <dt className="text-[11px] uppercase tracking-[0.1em] text-[color:var(--text-tertiary)]">
+        {label}
+      </dt>
+      <dd
+        className={`mt-1 font-mono text-base font-semibold ${
+          warn ? "text-[color:var(--status-warn)]" : "text-[color:var(--foreground)]"
+        }`}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+// ─── Anomalies ───────────────────────────────────────────────────────────────
 
 function AnomalyRow({ a }: { a: CostAnomaly }) {
   const high = a.severity === "high";
@@ -457,27 +551,28 @@ function AnomalyRow({ a }: { a: CostAnomaly }) {
     <div
       className={`rounded-lg border p-3 ${
         high
-          ? "border-red-800/50 bg-red-950/20"
-          : "border-amber-800/40 bg-amber-950/10"
+          ? "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)]"
+          : "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)]"
       }`}
     >
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <ShieldAlert
-            className={`h-4 w-4 ${high ? "text-red-400" : "text-amber-400"}`}
+            className="h-4 w-4"
+            style={{ color: high ? "var(--status-danger)" : "var(--status-warn)" }}
           />
-          <span className="text-sm font-medium text-[var(--foreground)]">
+          <span className="text-sm font-medium text-[color:var(--foreground)]">
             {a.type.replace(/_/g, " ")}
           </span>
-          <span className="font-mono text-xs text-[var(--text-tertiary)]">
+          <span className="font-mono text-xs text-[color:var(--text-tertiary)]">
             {a.agent ?? a.session_id ?? ""}
           </span>
         </div>
-        <span className="font-mono text-xs text-[var(--text-secondary)]">
+        <span className="font-mono text-xs text-[color:var(--text-secondary)]">
           z={a.z_score.toFixed(1)}
         </span>
       </div>
-      <p className="mt-1 text-xs text-[var(--text-secondary)]">
+      <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
         {a.metric} ={" "}
         {typeof a.value === "number" ? a.value.toLocaleString() : a.value} vs
         baseline {a.baseline_median.toLocaleString()} — {a.recommendation}
@@ -486,9 +581,12 @@ function AnomalyRow({ a }: { a: CostAnomaly }) {
   );
 }
 
+// ─── Page ────────────────────────────────────────────────────────────────────
+
 export default function CostPage() {
   const { counts } = useDeploymentContext();
   const aiSpendService = serviceEntry(counts?.services, "ai_spend");
+  const chart = useChartTheme();
   const [report, setReport] = useState<CostReport | null>(null);
   const [anomalies, setAnomalies] = useState<AnomaliesReport | null>(null);
   const [forecast, setForecast] = useState<CostForecast | null>(null);
@@ -552,8 +650,23 @@ export default function CostPage() {
     .map((r) => ({ name: r.key || "—", cost: Number(r.cost_usd.toFixed(4)) }));
   const anomalyCount = anomalies?.anomaly_count ?? 0;
 
+  const kpis: StatStripItem[] = [
+    { label: "Total spend", value: fmtUsd(report.total_cost_usd), icon: DollarSign, accent: "success" },
+    { label: "LLM calls", value: fmtInt(report.total_calls), icon: Activity },
+    { label: "Input tokens", value: fmtInt(report.total_input_tokens), icon: ArrowDownToLine },
+    { label: "Output tokens", value: fmtInt(report.total_output_tokens), icon: ArrowUpFromLine },
+    {
+      label: "Unpriced calls",
+      value: fmtInt(report.unpriced_calls),
+      icon: AlertTriangle,
+      accent: "warn",
+      accentThreshold: 0,
+      hint: report.unpriced_calls > 0 ? "spend may be understated" : undefined,
+    },
+  ];
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <PageLaneHeader
         lane="operations"
         title="AI Spend"
@@ -573,117 +686,67 @@ export default function CostPage() {
         registry={counts?.services}
       />
 
-      <BudgetBanner budget={report.budget} />
+      <StatStrip items={kpis} data-testid="cost-kpi-strip" />
 
-      <ForecastPanel forecast={forecast} />
+      <div className="grid gap-4 lg:grid-cols-2">
+        <BudgetPanel budget={report.budget} />
+        <ForecastPanel forecast={forecast} />
+      </div>
 
       {!hasData ? (
         <PageEmptyState
           title="No cost telemetry yet"
           detail="Cost records appear once agents make priced LLM calls through the proxy or report usage to the cost store."
           icon={DollarSign}
+          data-testid="cost-empty-state"
         />
       ) : (
-        <>
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
-            <StatCard
-              icon={DollarSign}
-              label="Total spend"
-              value={fmtUsd(report.total_cost_usd)}
-              color="text-emerald-400"
-            />
-            <StatCard
-              icon={Activity}
-              label="LLM calls"
-              value={fmtInt(report.total_calls)}
-              color="text-blue-400"
-            />
-            <StatCard
-              icon={ArrowDownToLine}
-              label="Input tokens"
-              value={fmtInt(report.total_input_tokens)}
-              color="text-[var(--text-secondary)]"
-            />
-            <StatCard
-              icon={ArrowUpFromLine}
-              label="Output tokens"
-              value={fmtInt(report.total_output_tokens)}
-              color="text-[var(--text-secondary)]"
-            />
-            <StatCard
-              icon={AlertTriangle}
-              label="Unpriced calls"
-              value={fmtInt(report.unpriced_calls)}
-              color={
-                report.unpriced_calls > 0 ? "text-amber-400" : "text-[var(--text-secondary)]"
-              }
-            />
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+          <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1">
+            <BreakdownExplorer report={report} />
           </div>
-
-          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
+          <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1">
             <div className="mb-3 flex items-center gap-2">
-              <TrendingUp className="h-4 w-4 text-emerald-400" />
-              <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
+              <TrendingUp className="h-4 w-4 text-[color:var(--accent)]" />
+              <h3 className="text-sm font-semibold text-[color:var(--foreground)]">
                 Spend by agent (top 10)
               </h3>
             </div>
-            <ResponsiveContainer width="100%" height={280}>
+            <ResponsiveContainer width="100%" height={300}>
               <BarChart
                 data={agentChart}
                 margin={{ top: 8, right: 8, bottom: 8, left: 8 }}
               >
-                <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-                <XAxis
-                  dataKey="name"
-                  stroke="#71717a"
-                  tick={{ fontSize: 11 }}
-                />
+                <CartesianGrid strokeDasharray="3 3" stroke={chart.grid} />
+                <XAxis dataKey="name" stroke={chart.text} tick={{ fontSize: 11 }} />
                 <YAxis
-                  stroke="#71717a"
+                  stroke={chart.text}
                   tick={{ fontSize: 11 }}
                   tickFormatter={(v) => `$${v}`}
                 />
-                <Tooltip
-                  content={<ChartTooltip />}
-                  cursor={{ fill: "#ffffff08" }}
-                />
+                <Tooltip content={<ChartTooltip />} cursor={{ fill: "var(--surface-muted)" }} />
                 <Bar dataKey="cost" radius={[6, 6, 0, 0]}>
                   {agentChart.map((_, i) => (
-                    <Cell key={i} fill="#34d399" />
+                    <Cell key={i} fill={chart.accent} />
                   ))}
                 </Bar>
               </BarChart>
             </ResponsiveContainer>
           </div>
-
-          <div className="grid gap-4 lg:grid-cols-2">
-            <BreakdownTable title="By model" rows={report.by_model} />
-            <BreakdownTable title="By provider" rows={report.by_provider} />
-          </div>
-
-          <div className="grid gap-4 lg:grid-cols-2">
-            <ChargebackPanel rows={report.by_cost_center ?? []} />
-            <OwnerPanel rows={report.by_owner ?? []} />
-          </div>
-        </>
+        </div>
       )}
 
-      <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
-        <div className="mb-3 flex items-center gap-2">
-          <ShieldAlert className="h-4 w-4 text-amber-400" />
-          <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
-            Cost & behavior anomalies
-          </h3>
-          {anomalyCount > 0 && (
-            <span className="rounded-full bg-amber-900/60 px-2 py-0.5 text-xs font-medium text-amber-300">
-              {anomalyCount}
-            </span>
-          )}
-        </div>
+      <Collapsible
+        title="Cost & behavior anomalies"
+        subtitle="Statistical outliers across cost and call-rate baselines"
+        icon={ShieldAlert}
+        count={anomalyCount}
+        defaultOpen={anomalyCount > 0}
+        data-testid="cost-anomalies"
+      >
         {anomalyCount === 0 ? (
-          <p className="text-sm text-[var(--text-tertiary)]">
-            No statistical anomalies detected across cost or call-rate
-            baselines.
+          <p className="text-sm text-[color:var(--text-tertiary)]">
+            No statistical anomalies detected across cost or call-rate baselines.
           </p>
         ) : (
           <div className="space-y-2">
@@ -695,7 +758,14 @@ export default function CostPage() {
             ))}
           </div>
         )}
-      </div>
+      </Collapsible>
+
+      {hasData && report.by_owner && report.by_owner.length > 0 ? (
+        <p className="flex items-center gap-1.5 text-[11px] text-[color:var(--text-tertiary)]">
+          <UserCheck className="h-3.5 w-3.5" />
+          Owner rollup attributes each agent&apos;s spend to the accountable owner from its governing blueprint. Switch the breakdown to <span className="font-medium text-[color:var(--text-secondary)]">Owner</span> to review chargeback.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -3,17 +3,25 @@
 :root {
   color-scheme: dark;
   /*
-   * Enterprise-console hierarchy (dark-first):
-   * page < card (--surface) < inset/elevated — each one step brighter,
-   * with borders and secondary text strong enough to read at a glance.
-   * Mint stays the brand accent; severity/status hues are sharpened below.
+   * Enterprise-console hierarchy (dark-first). Four layered surfaces, each one
+   * step brighter, sit on a deep — not pure-black — canvas with a very subtle
+   * radial depth wash:
+   *
+   *   --background        app canvas (deepest)
+   *   --surface-panel     page panels / wells that group cards
+   *   --surface           card (the default content surface)
+   *   --surface-elevated  inset / raised chips, popovers, hovered rows
+   *
+   * Mint/emerald stays the single brand accent (with a small interactive
+   * scale); severity/status hues are semantic and kept separate from it.
    */
-  --background: #181a22;
+  --background: #14161d;
   --foreground: #f4f5f8;
+  --surface-panel: #1b1e27;
   --surface: #22262f;
   --surface-elevated: #2c3140;
   --surface-muted: rgba(72, 78, 94, 0.58);
-  --border-subtle: rgba(110, 118, 138, 0.78);
+  --border-subtle: rgba(110, 118, 138, 0.72);
   --border-strong: rgba(140, 148, 168, 0.92);
   --text-secondary: #d0d4dc;
   --text-tertiary: #a8aebc;
@@ -23,13 +31,40 @@
   --sidebar-width: 240px;
   --sidebar-collapsed-width: 60px;
 
-  /* Mint brand accent */
-  --accent-mint: #34d399;
+  /* Subtle canvas depth — a soft dual spotlight, never a loud gradient. */
+  --app-bg-image:
+    radial-gradient(1200px 620px at 50% -12%, rgba(52, 211, 153, 0.055), transparent 62%),
+    radial-gradient(1000px 560px at 100% 0%, rgba(99, 163, 255, 0.045), transparent 58%);
 
-  /* Text that sits on a bright accent fill (emerald/sky buttons). Near-black
-   * in both themes because the fill stays bright — replaces hardcoded
-   * text-zinc-950 so light theme keeps the same legible contrast (#3966). */
-  --on-accent: #0b0d10;
+  /* Elevation — layered depth so panels read as physical, not flat outlines. */
+  --elevation-1: 0 1px 2px rgba(0, 0, 0, 0.30);
+  --elevation-2: 0 6px 18px -6px rgba(0, 0, 0, 0.46);
+  --elevation-3: 0 18px 44px -12px rgba(0, 0, 0, 0.56);
+
+  /* Radii — one scale for the whole system. */
+  --radius-sm: 0.5rem;
+  --radius-md: 0.75rem;
+  --radius-lg: 1rem;
+  --radius-xl: 1.25rem;
+
+  /* Motion — durations + easing shared by every transition/animation. */
+  --motion-fast: 120ms;
+  --motion-base: 180ms;
+  --motion-slow: 280ms;
+  --ease-standard: cubic-bezier(0.2, 0, 0, 1);
+  --ease-out: cubic-bezier(0.16, 1, 0.3, 1);
+
+  /* Brand accent scale (mint/emerald) — interactive + selected states. */
+  --accent: #34d399;
+  --accent-strong: #10b981;
+  --accent-soft: rgba(52, 211, 153, 0.14);
+  --accent-soft-hover: rgba(52, 211, 153, 0.22);
+  --accent-border: rgba(52, 211, 153, 0.42);
+  --accent-ring: rgba(52, 211, 153, 0.55);
+  --accent-contrast: #04150f;
+  /* Back-compat alias — existing consumers read --accent-mint. */
+  --accent-mint: var(--accent);
+  --focus-ring: var(--accent-ring);
 
   /* Severity — badges, charts, dots (hex aligned with ui/lib/theme-colors.ts) */
   --severity-critical: #ff6b6b;
@@ -44,11 +79,7 @@
   --severity-low: #6ba3ff;
   --severity-low-bg: rgba(107, 163, 255, 0.15);
   --severity-low-border: rgba(107, 163, 255, 0.48);
-  /* Unrated — findings whose severity is unknown/unscored (issue #3946). Neutral
-   * grey so it never reads as a severity band but is still visibly counted. */
-  --severity-unrated: #9aa3b8;
-  --severity-unrated-bg: rgba(154, 163, 184, 0.14);
-  --severity-unrated-border: rgba(154, 163, 184, 0.46);
+  --severity-none: #8b93a7;
 
   /* Status — success / warn / danger */
   --status-success: #34d399;
@@ -71,21 +102,38 @@
 
 :root[data-theme="light"] {
   color-scheme: light;
-  /* Cool gray canvas — white cards sit clearly above the page */
-  --background: #e4e9f2;
+  /* Cool gray canvas — white cards sit clearly above panels and the page. */
+  --background: #e6eaf1;
   --foreground: #12141a;
+  --surface-panel: #eef2f8;
   --surface: #ffffff;
-  --surface-elevated: #eef2f8;
-  --surface-muted: rgba(190, 198, 212, 0.55);
-  --border-subtle: rgba(130, 145, 168, 0.62);
-  --border-strong: rgba(90, 105, 128, 0.8);
+  --surface-elevated: #f4f7fb;
+  --surface-muted: rgba(190, 198, 212, 0.5);
+  --border-subtle: rgba(130, 145, 168, 0.5);
+  --border-strong: rgba(90, 105, 128, 0.72);
   --text-secondary: #374151;
-  --text-tertiary: #4b5563;
-  --shadow-color: rgba(15, 23, 42, 0.11);
+  --text-tertiary: #55627a;
+  --shadow-color: rgba(15, 23, 42, 0.1);
   --scrollbar-thumb: #9aa3b2;
   --scrollbar-thumb-hover: #7b8596;
 
-  --accent-mint: #059669;
+  --app-bg-image:
+    radial-gradient(1200px 620px at 50% -12%, rgba(5, 150, 105, 0.05), transparent 62%),
+    radial-gradient(1000px 560px at 100% 0%, rgba(37, 99, 235, 0.04), transparent 58%);
+
+  --elevation-1: 0 1px 2px rgba(15, 23, 42, 0.06);
+  --elevation-2: 0 6px 16px -6px rgba(15, 23, 42, 0.12);
+  --elevation-3: 0 18px 40px -12px rgba(15, 23, 42, 0.16);
+
+  --accent: #059669;
+  --accent-strong: #047857;
+  --accent-soft: rgba(5, 150, 105, 0.1);
+  --accent-soft-hover: rgba(5, 150, 105, 0.16);
+  --accent-border: rgba(5, 150, 105, 0.4);
+  --accent-ring: rgba(5, 150, 105, 0.45);
+  --accent-contrast: #ffffff;
+  --accent-mint: var(--accent);
+  --focus-ring: var(--accent-ring);
 
   --severity-critical: #dc2626;
   --severity-critical-bg: rgba(220, 38, 38, 0.1);
@@ -99,9 +147,7 @@
   --severity-low: #2563eb;
   --severity-low-bg: rgba(37, 99, 235, 0.1);
   --severity-low-border: rgba(37, 99, 235, 0.38);
-  --severity-unrated: #64748b;
-  --severity-unrated-bg: rgba(100, 116, 139, 0.1);
-  --severity-unrated-border: rgba(100, 116, 139, 0.36);
+  --severity-none: #64748b;
 
   --status-success: #059669;
   --status-success-bg: rgba(5, 150, 105, 0.1);
@@ -117,13 +163,39 @@
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
+  --color-surface: var(--surface);
+  --color-surface-elevated: var(--surface-elevated);
+  --color-accent: var(--accent);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
 }
 
 body {
-  background: var(--background);
+  background-color: var(--background);
+  background-image: var(--app-bg-image);
+  background-attachment: fixed;
+  background-repeat: no-repeat;
   color: var(--foreground);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* Numeric-heavy console: tabular figures keep tables/metrics from jittering. */
+.tabular-figures {
+  font-variant-numeric: tabular-nums;
+}
+
+/*
+ * Consistent keyboard focus for interactive elements. `:where()` keeps the
+ * specificity at 0 so any component-level `focus-visible:` utility still wins,
+ * while un-styled controls get a themed ring that follows their border radius.
+ */
+:where(a, button, [role="button"], summary, input, select, textarea):focus-visible {
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  box-shadow:
+    0 0 0 2px var(--background),
+    0 0 0 4px var(--focus-ring);
 }
 
 /* Smooth scrollbar */
@@ -151,18 +223,29 @@ body {
   border-radius: 2px;
 }
 
+/* Elevation utilities — pair with a surface + border for physical depth. */
+.elev-1 {
+  box-shadow: var(--elevation-1);
+}
+.elev-2 {
+  box-shadow: var(--elevation-2);
+}
+.elev-3 {
+  box-shadow: var(--elevation-3);
+}
+
 /* Mobile sidebar slide-in animation */
 @keyframes slide-in-left {
   from { transform: translateX(-100%); }
   to { transform: translateX(0); }
 }
 .animate-slide-in {
-  animation: slide-in-left 0.2s ease-out;
+  animation: slide-in-left var(--motion-base) var(--ease-out);
 }
 
 /* React Flow edge animation refinement */
 .react-flow__edge-path {
-  transition: stroke-opacity 0.2s ease;
+  transition: stroke-opacity var(--motion-base) var(--ease-standard);
 }
 
 /* Fullscreen mode styles */
@@ -181,13 +264,32 @@ body {
   display: none;
 }
 
-/* Card hover effects */
+/* Card hover effect — lifts the border + a hairline ring on hover. */
 .card-hover {
-  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+  transition:
+    border-color var(--motion-fast) var(--ease-standard),
+    box-shadow var(--motion-fast) var(--ease-standard),
+    transform var(--motion-fast) var(--ease-standard);
 }
 .card-hover:hover {
   border-color: var(--border-strong);
-  box-shadow: 0 0 0 1px color-mix(in srgb, var(--border-strong) 35%, transparent);
+  box-shadow:
+    0 0 0 1px color-mix(in srgb, var(--border-strong) 35%, transparent),
+    var(--elevation-2);
+}
+
+/* Interactive row — dense list/table rows that respond to hover + selection. */
+.interactive-row {
+  transition:
+    background-color var(--motion-fast) var(--ease-standard),
+    color var(--motion-fast) var(--ease-standard);
+}
+.interactive-row:hover {
+  background-color: var(--surface-elevated);
+}
+.interactive-row[data-selected="true"] {
+  background-color: var(--accent-soft);
+  box-shadow: inset 2px 0 0 0 var(--accent);
 }
 
 /* Stat card gradient backgrounds — driven by severity/status tokens */
@@ -222,12 +324,24 @@ body {
 
 /* Smooth page transitions */
 main > div {
-  animation: fade-in 0.15s ease-out;
+  animation: fade-in var(--motion-base) var(--ease-out);
 }
 
 @keyframes fade-in {
   from { opacity: 0; transform: translateY(4px); }
   to { opacity: 1; transform: translateY(0); }
+}
+
+/* Respect users who prefer reduced motion — kill transforms/animations. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
 }
 
 /* Drift lens (#3192) — snapshot change-kind rings painted on React Flow node

--- a/ui/app/runtime/page.tsx
+++ b/ui/app/runtime/page.tsx
@@ -32,16 +32,20 @@ function RuntimeTabs() {
   const active = TABS.find((item) => item.key === tab) ?? TABS[0]!;
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 border-b border-[var(--border-subtle)] pb-4 lg:flex-row lg:items-end lg:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-[var(--foreground)]">Runtime</h1>
-          <p className="mt-1 max-w-3xl text-sm text-[var(--text-secondary)]">
+    <div className="space-y-5">
+      <div className="flex flex-col gap-4 border-b border-[color:var(--border-subtle)] pb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Runtime</h1>
+          <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-secondary)]">
             One enforcement surface for MCP proxy telemetry and gateway policy. Switch tabs to review live
             activity, alerts, rollout posture, and audit evidence without hopping between nav entries.
           </p>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div
+          className="flex flex-wrap items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5"
+          role="tablist"
+          aria-label="Runtime surface"
+        >
           {TABS.map((item) => {
             const Icon = item.icon;
             const selected = item.key === tab;
@@ -49,11 +53,13 @@ function RuntimeTabs() {
               <button
                 key={item.key}
                 type="button"
+                role="tab"
+                aria-selected={selected}
                 onClick={() => router.replace(`/runtime?tab=${item.key}`)}
-                className={`inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors ${
+                className={`inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
                   selected
-                    ? "border-emerald-700 bg-emerald-950/40 text-emerald-200"
-                    : "border-[var(--border-subtle)] bg-[var(--background)] text-[var(--text-secondary)] hover:border-[var(--border-subtle)] hover:text-[var(--foreground)]"
+                    ? "bg-[color:var(--accent-soft)] text-[color:var(--accent)]"
+                    : "text-[color:var(--text-tertiary)] hover:text-[color:var(--foreground)]"
                 }`}
               >
                 <Icon className="h-4 w-4" />
@@ -64,7 +70,7 @@ function RuntimeTabs() {
         </div>
       </div>
 
-      <p className="text-xs text-[var(--text-tertiary)]">{active.description}</p>
+      <p className="text-xs text-[color:var(--text-tertiary)]">{active.description}</p>
 
       <RuntimeEmbedProvider>
         {tab === "proxy" ? <ProxyDashboard /> : <GatewayPage />}

--- a/ui/components/collapsible.tsx
+++ b/ui/components/collapsible.tsx
@@ -85,7 +85,7 @@ export function Collapsible({
       className={
         bare
           ? `${className ?? ""}`
-          : `rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] ${className ?? ""}`
+          : `rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-1 ${className ?? ""}`
       }
       data-testid={testId}
     >
@@ -95,10 +95,10 @@ export function Collapsible({
           onClick={() => setOpen((v) => !v)}
           aria-expanded={open}
           aria-controls={panelId}
-          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          className="group flex min-w-0 flex-1 items-center gap-2 rounded-md text-left transition-colors"
         >
           <Chevron
-            className={`${ICON_SIZE.sm} shrink-0 text-[color:var(--text-tertiary)] transition-transform`}
+            className={`${ICON_SIZE.sm} shrink-0 text-[color:var(--text-tertiary)] transition-colors group-hover:text-[color:var(--text-secondary)]`}
             aria-hidden="true"
           />
           {Icon ? (
@@ -110,7 +110,7 @@ export function Collapsible({
           <span className="min-w-0 flex-1">
             <span className="flex min-w-0 items-center gap-2">
               <span
-                className={`truncate font-semibold text-[color:var(--foreground)] ${resolvedTitleClass}`}
+                className={`truncate font-semibold text-[color:var(--foreground)] transition-colors ${resolvedTitleClass}`}
               >
                 {title}
               </span>

--- a/ui/components/data-table.tsx
+++ b/ui/components/data-table.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { ArrowDown, ArrowUp, ChevronsUpDown } from "lucide-react";
+
+import { ICON_SIZE } from "@/lib/icon-sizes";
+
+export type SortDirection = "asc" | "desc";
+
+export type DataTableColumn<T> = {
+  /** Stable key — also used as the sort key when `sortable`. */
+  key: string;
+  /** Header cell content (usually a short label). */
+  header: ReactNode;
+  /** Cell renderer for a row. */
+  cell: (row: T) => ReactNode;
+  /** Text alignment for the column. Defaults to "left". */
+  align?: "left" | "center" | "right";
+  /** Mark the header as a sort control. */
+  sortable?: boolean;
+  /** Fixed column width (e.g. "12rem", "20%"). */
+  width?: string;
+  /** Extra classes applied to both header + body cells. */
+  className?: string;
+};
+
+export type DataTableProps<T> = {
+  columns: DataTableColumn<T>[];
+  rows: T[];
+  /** Stable key per row. */
+  rowKey: (row: T, index: number) => string;
+  /** Click handler — makes rows interactive (hover + keyboard). */
+  onRowClick?: ((row: T) => void) | undefined;
+  /** Key of the currently selected row (accent treatment). */
+  selectedKey?: string | undefined;
+  /** Active sort. When set, headers reflect direction. */
+  sort?: { key: string; direction: SortDirection } | undefined;
+  /** Called with a column key when a sortable header is activated. */
+  onSortChange?: ((key: string) => void) | undefined;
+  /** Show skeleton rows instead of data. */
+  loading?: boolean | undefined;
+  /** Skeleton row count while loading. Defaults to 6. */
+  loadingRows?: number | undefined;
+  /** Rendered in place of the body when there are no rows. */
+  empty?: ReactNode;
+  /** Sticky header while the body scrolls. Defaults to true. */
+  stickyHeader?: boolean | undefined;
+  /** Cap the scroll viewport height (e.g. "28rem"); body scrolls inside. */
+  maxHeight?: string | undefined;
+  /** Accessible caption / summary for screen readers. */
+  caption?: string | undefined;
+  className?: string | undefined;
+  "data-testid"?: string | undefined;
+};
+
+const ALIGN_CLASS = {
+  left: "text-left",
+  center: "text-center",
+  right: "text-right",
+} as const;
+
+/**
+ * Dense, token-styled table — the standard for list surfaces. Sticky header,
+ * row hover + selection, sortable-ready headers, horizontal + vertical scroll
+ * scoped inside its own container, plus loading + empty states. Both themes.
+ *
+ * @example
+ * ```tsx
+ * <DataTable
+ *   rows={findings}
+ *   rowKey={(f) => f.id}
+ *   selectedKey={active?.id}
+ *   onRowClick={setActive}
+ *   sort={{ key: "cvss", direction: "desc" }}
+ *   onSortChange={cycleSort}
+ *   maxHeight="30rem"
+ *   columns={[
+ *     { key: "pkg", header: "Package", cell: (f) => f.pkg },
+ *     { key: "cvss", header: "CVSS", align: "right", sortable: true,
+ *       cell: (f) => f.cvss.toFixed(1) },
+ *   ]}
+ * />
+ * ```
+ */
+export function DataTable<T>({
+  columns,
+  rows,
+  rowKey,
+  onRowClick,
+  selectedKey,
+  sort,
+  onSortChange,
+  loading = false,
+  loadingRows = 6,
+  empty,
+  stickyHeader = true,
+  maxHeight,
+  caption,
+  className,
+  "data-testid": testId,
+}: DataTableProps<T>) {
+  const interactive = typeof onRowClick === "function";
+  const showEmpty = !loading && rows.length === 0;
+
+  return (
+    <div
+      className={`overflow-auto rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-1 ${className ?? ""}`}
+      style={maxHeight ? { maxHeight } : undefined}
+      data-testid={testId}
+    >
+      <table className="w-full border-collapse text-sm">
+        {caption ? <caption className="sr-only">{caption}</caption> : null}
+        <thead
+          className={`${stickyHeader ? "sticky top-0 z-10" : ""} bg-[color:var(--surface-elevated)]`}
+        >
+          <tr className="border-b border-[color:var(--border-subtle)]">
+            {columns.map((column) => {
+              const active = sort?.key === column.key;
+              const align = column.align ?? "left";
+              const head = (
+                <span
+                  className={`inline-flex items-center gap-1 ${
+                    align === "right" ? "flex-row-reverse" : ""
+                  }`}
+                >
+                  <span>{column.header}</span>
+                  {column.sortable ? (
+                    <SortGlyph active={active} direction={sort?.direction} />
+                  ) : null}
+                </span>
+              );
+              return (
+                <th
+                  key={column.key}
+                  scope="col"
+                  aria-sort={
+                    column.sortable
+                      ? active
+                        ? sort?.direction === "asc"
+                          ? "ascending"
+                          : "descending"
+                        : "none"
+                      : undefined
+                  }
+                  style={column.width ? { width: column.width } : undefined}
+                  className={`px-3 py-2 text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-tertiary)] ${ALIGN_CLASS[align]} ${column.className ?? ""}`}
+                >
+                  {column.sortable && onSortChange ? (
+                    <button
+                      type="button"
+                      onClick={() => onSortChange(column.key)}
+                      className={`inline-flex rounded transition-colors hover:text-[color:var(--foreground)] ${
+                        active ? "text-[color:var(--foreground)]" : ""
+                      }`}
+                    >
+                      {head}
+                    </button>
+                  ) : (
+                    head
+                  )}
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {loading
+            ? Array.from({ length: loadingRows }).map((_, rowIndex) => (
+                <tr
+                  key={`skeleton-${rowIndex}`}
+                  className="border-b border-[color:var(--border-subtle)] last:border-b-0"
+                >
+                  {columns.map((column, colIndex) => (
+                    <td key={column.key} className="px-3 py-2.5">
+                      <div
+                        className="h-3 animate-pulse rounded-full bg-[color:var(--surface-muted)]"
+                        style={{ width: `${72 - colIndex * 9}%` }}
+                      />
+                    </td>
+                  ))}
+                </tr>
+              ))
+            : rows.map((row, index) => {
+                const key = rowKey(row, index);
+                const selected = selectedKey != null && key === selectedKey;
+                return (
+                  <tr
+                    key={key}
+                    {...(interactive
+                      ? {
+                          onClick: () => onRowClick?.(row),
+                          onKeyDown: (event) => {
+                            if (event.key === "Enter" || event.key === " ") {
+                              event.preventDefault();
+                              onRowClick?.(row);
+                            }
+                          },
+                          tabIndex: 0,
+                          role: "button",
+                          "aria-pressed": selected,
+                        }
+                      : {})}
+                    data-selected={selected ? "true" : undefined}
+                    className={`interactive-row border-b border-[color:var(--border-subtle)] last:border-b-0 ${
+                      interactive ? "cursor-pointer" : ""
+                    }`}
+                  >
+                    {columns.map((column) => (
+                      <td
+                        key={column.key}
+                        className={`px-3 py-2.5 align-middle text-[color:var(--text-secondary)] ${ALIGN_CLASS[column.align ?? "left"]} ${column.className ?? ""}`}
+                      >
+                        {column.cell(row)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+        </tbody>
+      </table>
+
+      {showEmpty ? (
+        <div className="px-4 py-10 text-center text-sm text-[color:var(--text-tertiary)]">
+          {empty ?? "No records to display."}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SortGlyph({
+  active,
+  direction,
+}: {
+  active: boolean;
+  direction?: SortDirection | undefined;
+}) {
+  if (!active) {
+    return (
+      <ChevronsUpDown
+        className={`${ICON_SIZE.xs} text-[color:var(--text-tertiary)]`}
+        aria-hidden="true"
+      />
+    );
+  }
+  const Glyph = direction === "asc" ? ArrowUp : ArrowDown;
+  return (
+    <Glyph
+      className={`${ICON_SIZE.xs} text-[color:var(--accent)]`}
+      aria-hidden="true"
+    />
+  );
+}

--- a/ui/components/drawer.tsx
+++ b/ui/components/drawer.tsx
@@ -87,7 +87,7 @@ export function Drawer({
         onClick={onClose}
       />
       <aside
-        className={`relative flex h-full w-full flex-col border-l border-[color:var(--border-subtle)] bg-[color:var(--surface)] shadow-2xl transition-transform duration-200 ease-out ${
+        className={`relative flex h-full w-full flex-col border-l border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-3 transition-transform duration-200 ease-out ${
           SIZE_CLASS[size]
         } ${entered ? "translate-x-0" : "translate-x-full"}`}
       >
@@ -97,7 +97,7 @@ export function Drawer({
               <button
                 type="button"
                 onClick={onBack}
-                className="mt-0.5 shrink-0 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-1.5 text-[color:var(--text-secondary)] transition-colors hover:text-[color:var(--foreground)]"
+                className="mt-0.5 shrink-0 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-1.5 text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                 aria-label="Back"
               >
                 <ChevronLeft className="h-4 w-4" />
@@ -122,7 +122,7 @@ export function Drawer({
             <button
               type="button"
               onClick={onClose}
-              className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2 text-[color:var(--text-secondary)] transition-colors hover:text-[color:var(--foreground)]"
+              className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2 text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
               aria-label="Close"
             >
               <X className="h-4 w-4" />

--- a/ui/components/split-layout.tsx
+++ b/ui/components/split-layout.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { MousePointerClick } from "lucide-react";
+
+import { ICON_SIZE } from "@/lib/icon-sizes";
+
+export type SplitLayoutProps = {
+  /** Master pane — the list / index. Owns its own vertical scroll. */
+  master: ReactNode;
+  /** Detail pane — the selected record. Owns its own vertical scroll. */
+  detail: ReactNode;
+  /** Master pane width on md+ screens (e.g. "22rem", "30%"). */
+  masterWidth?: string;
+  /** Shown in the detail pane when `detail` is null/undefined. */
+  placeholder?: ReactNode;
+  /** Place the detail pane on the left instead of the right. */
+  detailFirst?: boolean | undefined;
+  /**
+   * Container height. Panes scroll independently within it — the antidote to
+   * long vertical pages. Defaults to the viewport minus the app shell chrome.
+   */
+  height?: string;
+  className?: string | undefined;
+  "data-testid"?: string | undefined;
+};
+
+/**
+ * Master-detail split. List on one side, detail on the other, each pane with
+ * its OWN internal scroll so the page never grows a single long column. Stacks
+ * vertically on small screens. Token-styled for both themes.
+ *
+ * @example
+ * ```tsx
+ * <SplitLayout
+ *   masterWidth="24rem"
+ *   master={<DataTable rows={rows} onRowClick={setActive} selectedKey={active?.id} … />}
+ *   detail={active ? <FindingDetail finding={active} /> : null}
+ *   placeholder="Select a finding to see evidence and remediation."
+ * />
+ * ```
+ */
+export function SplitLayout({
+  master,
+  detail,
+  masterWidth = "22rem",
+  placeholder,
+  detailFirst = false,
+  height = "calc(100vh - 12rem)",
+  className,
+  "data-testid": testId,
+}: SplitLayoutProps) {
+  const masterPane = (
+    <div
+      className="min-h-0 min-w-0 shrink-0 overflow-y-auto md:basis-[var(--split-master-w)]"
+      style={{ ["--split-master-w" as string]: masterWidth }}
+    >
+      {master}
+    </div>
+  );
+
+  const detailPane = (
+    <div className="min-h-0 min-w-0 flex-1 overflow-y-auto">
+      {detail ?? (
+        <div className="flex h-full min-h-[12rem] items-center justify-center rounded-xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-panel)] p-6 text-center">
+          <div className="flex flex-col items-center gap-2 text-[color:var(--text-tertiary)]">
+            <MousePointerClick className={ICON_SIZE.md} aria-hidden="true" />
+            <p className="max-w-xs text-sm">
+              {placeholder ?? "Select an item to see details."}
+            </p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+
+  return (
+    <div
+      className={`flex min-h-0 flex-col gap-4 md:flex-row md:gap-5 ${
+        detailFirst ? "md:flex-row-reverse" : ""
+      } ${className ?? ""}`}
+      style={{ height }}
+      data-testid={testId}
+    >
+      {masterPane}
+      {detailPane}
+    </div>
+  );
+}

--- a/ui/components/stat-strip.tsx
+++ b/ui/components/stat-strip.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+import Link from "next/link";
+import type { ElementType, ReactNode } from "react";
+
+import { ICON_SIZE } from "@/lib/icon-sizes";
+
+export type StatAccent =
+  | "neutral"
+  | "critical"
+  | "high"
+  | "medium"
+  | "low"
+  | "success"
+  | "warn";
+
+const ACCENT_VALUE: Record<StatAccent, string> = {
+  neutral: "text-[color:var(--foreground)]",
+  critical: "text-[color:var(--severity-critical)]",
+  high: "text-[color:var(--severity-high)]",
+  medium: "text-[color:var(--severity-medium)]",
+  low: "text-[color:var(--severity-low)]",
+  success: "text-[color:var(--status-success)]",
+  warn: "text-[color:var(--status-warn)]",
+};
+
+export type StatStripItem = {
+  label: ReactNode;
+  value: ReactNode;
+  /** Optional secondary line (delta, unit, context). */
+  hint?: ReactNode;
+  accent?: StatAccent;
+  /** Only tint the value when it is a number above this threshold. */
+  accentThreshold?: number;
+  icon?: ElementType;
+  /** Makes the cell a link. */
+  href?: string;
+  /** Makes the cell a button. */
+  onClick?: () => void;
+};
+
+export type StatStripProps = {
+  items: StatStripItem[];
+  className?: string | undefined;
+  "data-testid"?: string | undefined;
+};
+
+/**
+ * Dense KPI row — replaces big, empty stat cards with a single compact strip of
+ * hairline-divided metrics. Wraps on narrow screens, token-styled for both
+ * themes, and each cell can drill in via `href`/`onClick`.
+ *
+ * @example
+ * ```tsx
+ * <StatStrip
+ *   items={[
+ *     { label: "Critical", value: 4, accent: "critical", href: "/findings?sev=critical" },
+ *     { label: "High", value: 12, accent: "high" },
+ *     { label: "Packages", value: 231 },
+ *     { label: "Coverage", value: "92%", accent: "success", hint: "+3 vs last scan" },
+ *   ]}
+ * />
+ * ```
+ */
+export function StatStrip({ items, className, "data-testid": testId }: StatStripProps) {
+  return (
+    <div
+      className={`grid grid-cols-2 gap-px overflow-hidden rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--border-subtle)] elev-1 sm:grid-cols-3 lg:grid-cols-[repeat(auto-fit,minmax(9rem,1fr))] ${className ?? ""}`}
+      data-testid={testId}
+    >
+      {items.map((item, index) => (
+        <StatCell key={typeof item.label === "string" ? item.label : index} item={item} />
+      ))}
+    </div>
+  );
+}
+
+function StatCell({ item }: { item: StatStripItem }) {
+  const {
+    label,
+    value,
+    hint,
+    accent = "neutral",
+    accentThreshold = 0,
+    icon: Icon,
+    href,
+    onClick,
+  } = item;
+
+  const tinted =
+    accent !== "neutral" && (typeof value !== "number" || value > accentThreshold);
+  const valueClass = tinted ? ACCENT_VALUE[accent] : "text-[color:var(--foreground)]";
+
+  const inner = (
+    <>
+      <div className="flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em] text-[color:var(--text-tertiary)]">
+        {Icon ? <Icon className={ICON_SIZE.xs} aria-hidden="true" /> : null}
+        <span className="truncate">{label}</span>
+      </div>
+      <div className={`mt-1 font-mono text-2xl font-semibold tabular-figures ${valueClass}`}>
+        {value}
+      </div>
+      {hint ? (
+        <div className="mt-0.5 truncate text-xs text-[color:var(--text-tertiary)]">{hint}</div>
+      ) : null}
+    </>
+  );
+
+  const base =
+    "block bg-[color:var(--surface)] px-4 py-3 text-left transition-colors";
+
+  if (href) {
+    return (
+      <Link href={href} className={`${base} hover:bg-[color:var(--surface-elevated)]`}>
+        {inner}
+      </Link>
+    );
+  }
+  if (onClick) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className={`${base} w-full hover:bg-[color:var(--surface-elevated)]`}
+      >
+        {inner}
+      </button>
+    );
+  }
+  return <div className={base}>{inner}</div>;
+}

--- a/ui/components/states/page-state.tsx
+++ b/ui/components/states/page-state.tsx
@@ -25,10 +25,14 @@ type PageStateProps = {
 };
 
 const TONE_CLASS: Record<NonNullable<PageStateProps["tone"]>, string> = {
-  neutral: "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)]",
-  warning: "border-amber-500/25 bg-amber-500/10 text-amber-100",
-  danger: "border-red-500/25 bg-red-500/10 text-red-100",
-  success: "border-emerald-500/25 bg-emerald-500/10 text-emerald-100",
+  neutral:
+    "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)]",
+  warning:
+    "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--text-secondary)]",
+  danger:
+    "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--text-secondary)]",
+  success:
+    "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--text-secondary)]",
 };
 
 export function PageState({
@@ -47,7 +51,7 @@ export function PageState({
 
   return (
     <div className="flex min-h-[18rem] items-center justify-center px-4 py-10" data-testid={testId}>
-      <div className={`w-full max-w-2xl rounded-2xl border p-6 shadow-lg ${TONE_CLASS[tone]}`}>
+      <div className={`w-full max-w-2xl rounded-2xl border p-6 elev-2 ${TONE_CLASS[tone]}`}>
         <div className="flex items-start gap-3">
           <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2">
             <Icon className="h-5 w-5 text-[color:var(--text-secondary)]" />
@@ -97,7 +101,7 @@ function PageStateActionButton({ action }: { action: PageStateAction }) {
   const className =
     action.variant === "secondary"
       ? "inline-flex items-center justify-center rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm font-medium text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-      : "inline-flex items-center justify-center rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20";
+      : "inline-flex items-center justify-center rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-sm font-medium text-[color:var(--accent)] transition hover:bg-[color:var(--accent-soft-hover)]";
 
   if (action.href) {
     return (
@@ -133,7 +137,7 @@ export function PageLoadingState({
 }) {
   return (
     <div className="flex min-h-[18rem] items-center justify-center px-4 py-10" data-testid={testId}>
-      <div className="w-full max-w-3xl rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg">
+      <div className="w-full max-w-3xl rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 elev-2">
         <div className="flex items-start gap-3">
           <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2">
             <Loader2 className="h-5 w-5 animate-spin text-[color:var(--text-secondary)]" />

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -33,7 +33,11 @@ const BUDGETS = {
   // `zinc-*` utilities they replace, so the compiled className strings grow a few KiB.
   // Allows 4 KiB for the measured Linux/macOS output variance after adding the
   // blueprint route; both builds remain at roughly 3.3 MiB of emitted client JS.
-  totalClientJsBytes: 3_383_296,
+  // Raised ~8 KiB for the premium design-system foundation: the elevation,
+  // hover, focus-visible, and interactive-state token classes now baked into the
+  // widely-imported shared shells (Collapsible, Drawer, PageState, cards) add a
+  // few KiB of compiled className string literals across every route chunk.
+  totalClientJsBytes: 3_391_488,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };

--- a/ui/tests/cockpits.test.tsx
+++ b/ui/tests/cockpits.test.tsx
@@ -172,9 +172,10 @@ describe("CostPage", () => {
     expect(screen.getByText("Forecast & runway")).toBeInTheDocument();
     expect(screen.getByText("at risk")).toBeInTheDocument();
     expect(screen.getByText("trailing 24h")).toBeInTheDocument();
-    // Chargeback by cost-center panel
-    expect(screen.getByText("Chargeback by cost-center")).toBeInTheDocument();
-    expect(screen.getByText("platform-eng")).toBeInTheDocument();
+    // Cost-center chargeback is now a dimension of the unified breakdown table.
+    fireEvent.click(screen.getByRole("button", { name: "Cost center" }));
+    const table = screen.getByTestId("cost-breakdown-table");
+    expect(within(table).getByText("platform-eng")).toBeInTheDocument();
   });
 });
 

--- a/ui/tests/compliance-page.test.tsx
+++ b/ui/tests/compliance-page.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import CompliancePage from "@/app/compliance/page";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+// CIS drill-down fetches its own benchmark data on mount — stub it so the
+// compliance page test stays focused on the dense framework/control surface.
+vi.mock("@/components/cis-benchmark-detail", () => ({
+  CISBenchmarkDetail: () => <div>cis benchmark</div>,
+}));
+
+const { compliance } = vi.hoisted(() => {
+  const control = (
+    code: string,
+    name: string,
+    status: "pass" | "warning" | "fail",
+    findings: number,
+  ) => ({
+    code,
+    name,
+    findings,
+    status,
+    severity_breakdown: {},
+    affected_packages: [],
+    affected_agents: [],
+  });
+  const emptySummary = Object.fromEntries(
+    [
+      "owasp",
+      "owasp_mcp",
+      "atlas",
+      "nist",
+      "owasp_agentic",
+      "eu_ai_act",
+      "nist_csf",
+      "iso_27001",
+      "soc2",
+      "cis",
+      "cmmc",
+      "nist_800_53",
+      "fedramp",
+      "pci_dss",
+    ].flatMap((k) => [
+      [`${k}_pass`, 0],
+      [`${k}_warn`, 0],
+      [`${k}_fail`, 0],
+    ]),
+  ) as Record<string, number>;
+  return {
+    compliance: {
+      overall_score: 72,
+      overall_status: "warning" as const,
+      scan_count: 3,
+      latest_scan: "2026-07-14T00:00:00Z",
+      has_mcp_context: true,
+      has_agent_context: true,
+      owasp_llm_top10: [
+        control("LLM01", "Prompt Injection", "fail", 4),
+        control("LLM02", "Insecure Output Handling", "pass", 0),
+      ],
+      owasp_mcp_top10: [control("MCP01", "Tool Poisoning", "warning", 1)],
+      mitre_atlas: [],
+      nist_ai_rmf: [],
+      owasp_agentic_top10: [],
+      eu_ai_act: [],
+      nist_csf: [],
+      iso_27001: [],
+      soc2: [],
+      cis_controls: [],
+      cmmc: [],
+      nist_800_53: [],
+      fedramp: [],
+      pci_dss: [],
+      aisvs_benchmark: { checks: [], summary: {} },
+      summary: {
+        ...emptySummary,
+        owasp_pass: 1,
+        owasp_fail: 1,
+        owasp_mcp_warn: 1,
+        aisvs_pass: 0,
+        aisvs_fail: 0,
+        aisvs_error: 0,
+        aisvs_not_applicable: 0,
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      getCompliance: vi.fn().mockResolvedValue(compliance),
+      getFrameworkCatalogs: vi.fn().mockResolvedValue({ frameworks: {} }),
+      getHubPosture: vi
+        .fn()
+        .mockResolvedValue({ totals: { combined: 0, native: 0, hub: 0 } }),
+    },
+  };
+});
+
+describe("CompliancePage (dense restyle)", () => {
+  it("renders KPI strip, frameworks table, and control detail via split layout", async () => {
+    render(<CompliancePage />);
+
+    const strip = await screen.findByTestId("compliance-kpi-strip");
+    expect(within(strip).getByText("Overall")).toBeInTheDocument();
+    expect(within(strip).getByText("Passing")).toBeInTheDocument();
+    expect(within(strip).getByText("Failing")).toBeInTheDocument();
+
+    const table = screen.getByTestId("compliance-frameworks-table");
+    // Short labels appear as the primary framework name.
+    expect(within(table).getByText("LLM")).toBeInTheDocument();
+
+    // The first failing framework (OWASP LLM) is auto-selected, so its
+    // controls render in the detail pane.
+    await waitFor(() =>
+      expect(screen.getByText("Prompt Injection")).toBeInTheDocument(),
+    );
+  });
+
+  it("opens the control drawer when a control row is clicked", async () => {
+    render(<CompliancePage />);
+    await screen.findByTestId("compliance-kpi-strip");
+
+    const injection = await screen.findByText("Prompt Injection");
+    fireEvent.click(injection);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("dialog", { name: /Control details for LLM01/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/ui/tests/cost-page.test.tsx
+++ b/ui/tests/cost-page.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import CostPage from "@/app/cost/page";
+
+vi.mock("@/hooks/use-deployment-context", () => ({
+  useDeploymentContext: () => ({ counts: { services: {} } }),
+}));
+
+const { report, anomalies, forecast } = vi.hoisted(() => {
+  const row = (
+    key: string,
+    cost: number,
+    calls: number,
+    unpriced = 0,
+  ) => ({
+    key,
+    calls,
+    input_tokens: calls * 10,
+    output_tokens: calls * 4,
+    cost_usd: cost,
+    unpriced_calls: unpriced,
+  });
+  return {
+    report: {
+      schema_version: "1",
+      tenant_id: "tenant-a",
+      price_model_captured: {},
+      total_cost_usd: 12.5,
+      total_calls: 100,
+      total_input_tokens: 2000,
+      total_output_tokens: 500,
+      unpriced_calls: 2,
+      by_agent: [row("agent-alpha", 8, 60, 1), row("agent-beta", 4.5, 40)],
+      by_model: [row("gpt-x", 10, 70)],
+      by_provider: [row("openai", 12.5, 100)],
+      by_cost_center: [],
+      by_owner: [row("owner-jane", 12.5, 100)],
+      budget: {
+        configured: true,
+        owner: "owner-jane",
+        mode: "enforce",
+        limit_usd: 100,
+        spend_usd: 12.5,
+        remaining_usd: 87.5,
+        exceeded: false,
+        utilization: 0.125,
+      },
+    },
+    anomalies: {
+      schema_version: "1",
+      tenant_id: "tenant-a",
+      z_threshold: 3,
+      anomaly_count: 0,
+      cost_anomalies: [],
+      behavior_anomalies: [],
+    },
+    forecast: {
+      schema_version: "1",
+      agent: null,
+      now: "2026-07-15T00:00:00Z",
+      status: "ok",
+      current_spend_usd: 12.5,
+      budget_limit_usd: 100,
+      burn_rate_usd_per_day: 1,
+      burn_rate_basis: "trailing_7d",
+      projected_period_spend_usd: 30,
+      period_start: null,
+      period_end: null,
+      days_remaining: 30,
+      projected_exhaustion_at: null,
+    },
+  };
+});
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      getCostReport: vi.fn().mockResolvedValue(report),
+      getCostAnomalies: vi.fn().mockResolvedValue(anomalies),
+      getCostForecast: vi.fn().mockResolvedValue(forecast),
+    },
+  };
+});
+
+describe("CostPage (dense restyle)", () => {
+  it("renders the KPI strip, budget, and a dense breakdown table", async () => {
+    render(<CostPage />);
+
+    const strip = await screen.findByTestId("cost-kpi-strip");
+    expect(within(strip).getByText("Total spend")).toBeInTheDocument();
+    expect(within(strip).getByText("LLM calls")).toBeInTheDocument();
+
+    // Owner-scoped budget in enforce mode.
+    expect(screen.getByText(/owner owner-jane/i)).toBeInTheDocument();
+    expect(screen.getByText("enforce")).toBeInTheDocument();
+
+    // Breakdown DataTable defaults to the agent dimension.
+    const table = screen.getByTestId("cost-breakdown-table");
+    expect(within(table).getByText("agent-alpha")).toBeInTheDocument();
+    expect(within(table).getByText("agent-beta")).toBeInTheDocument();
+  });
+
+  it("switches breakdown dimension to owner and opens a row drawer", async () => {
+    render(<CostPage />);
+    await screen.findByTestId("cost-kpi-strip");
+
+    fireEvent.click(screen.getByRole("button", { name: "Owner" }));
+    const table = screen.getByTestId("cost-breakdown-table");
+    const ownerCell = within(table).getByText("owner-jane");
+    expect(ownerCell).toBeInTheDocument();
+
+    fireEvent.click(ownerCell);
+    await waitFor(() =>
+      expect(screen.getByText("Avg cost / call")).toBeInTheDocument(),
+    );
+  });
+});

--- a/ui/tests/data-table.test.tsx
+++ b/ui/tests/data-table.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+
+type Row = { id: string; pkg: string; cvss: number };
+
+const rows: Row[] = [
+  { id: "a", pkg: "left-pad", cvss: 9.8 },
+  { id: "b", pkg: "log4j", cvss: 10 },
+];
+
+const columns: DataTableColumn<Row>[] = [
+  { key: "pkg", header: "Package", cell: (r) => r.pkg },
+  { key: "cvss", header: "CVSS", align: "right", sortable: true, cell: (r) => r.cvss.toFixed(1) },
+];
+
+describe("DataTable", () => {
+  it("renders headers and row cells", () => {
+    render(<DataTable rows={rows} columns={columns} rowKey={(r) => r.id} />);
+    expect(screen.getByRole("columnheader", { name: /Package/ })).toBeInTheDocument();
+    expect(screen.getByText("left-pad")).toBeInTheDocument();
+    expect(screen.getByText("10.0")).toBeInTheDocument();
+  });
+
+  it("fires onRowClick for pointer and keyboard activation", () => {
+    const onRowClick = vi.fn();
+    render(
+      <DataTable rows={rows} columns={columns} rowKey={(r) => r.id} onRowClick={onRowClick} />,
+    );
+    const firstRow = screen.getByRole("button", { name: /left-pad/ });
+    fireEvent.click(firstRow);
+    fireEvent.keyDown(firstRow, { key: "Enter" });
+    expect(onRowClick).toHaveBeenCalledTimes(2);
+    expect(onRowClick).toHaveBeenCalledWith(rows[0]);
+  });
+
+  it("reflects the active sort on the sortable header", () => {
+    const onSortChange = vi.fn();
+    render(
+      <DataTable
+        rows={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        sort={{ key: "cvss", direction: "desc" }}
+        onSortChange={onSortChange}
+      />,
+    );
+    const header = screen.getByRole("columnheader", { name: /CVSS/ });
+    expect(header).toHaveAttribute("aria-sort", "descending");
+    fireEvent.click(screen.getByRole("button", { name: /CVSS/ }));
+    expect(onSortChange).toHaveBeenCalledWith("cvss");
+  });
+
+  it("marks the selected row via data-selected", () => {
+    render(
+      <DataTable
+        rows={rows}
+        columns={columns}
+        rowKey={(r) => r.id}
+        onRowClick={vi.fn()}
+        selectedKey="b"
+      />,
+    );
+    const selected = screen.getByRole("button", { name: /log4j/ });
+    expect(selected).toHaveAttribute("data-selected", "true");
+    expect(selected).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("shows the empty state when there are no rows", () => {
+    render(
+      <DataTable rows={[]} columns={columns} rowKey={(r) => r.id} empty="Nothing here" />,
+    );
+    expect(screen.getByText("Nothing here")).toBeInTheDocument();
+  });
+
+  it("renders skeleton rows while loading and hides the empty state", () => {
+    const { container } = render(
+      <DataTable
+        rows={[]}
+        columns={columns}
+        rowKey={(r) => r.id}
+        loading
+        loadingRows={3}
+        empty="Nothing here"
+      />,
+    );
+    expect(screen.queryByText("Nothing here")).toBeNull();
+    expect(container.querySelectorAll("tbody tr")).toHaveLength(3);
+  });
+});

--- a/ui/tests/split-layout.test.tsx
+++ b/ui/tests/split-layout.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SplitLayout } from "@/components/split-layout";
+
+describe("SplitLayout", () => {
+  it("renders both master and detail panes", () => {
+    render(
+      <SplitLayout master={<div>list pane</div>} detail={<div>detail pane</div>} />,
+    );
+    expect(screen.getByText("list pane")).toBeInTheDocument();
+    expect(screen.getByText("detail pane")).toBeInTheDocument();
+  });
+
+  it("shows the placeholder when no detail is selected", () => {
+    render(
+      <SplitLayout
+        master={<div>list pane</div>}
+        detail={null}
+        placeholder="Pick a row"
+      />,
+    );
+    expect(screen.getByText("Pick a row")).toBeInTheDocument();
+  });
+
+  it("applies the master width as a CSS custom property", () => {
+    render(
+      <SplitLayout
+        master={<div>list pane</div>}
+        detail={<div>detail pane</div>}
+        masterWidth="30rem"
+      />,
+    );
+    const master = screen.getByText("list pane").parentElement;
+    expect(master?.style.getPropertyValue("--split-master-w")).toBe("30rem");
+  });
+
+  it("reverses pane order when detailFirst is set", () => {
+    const { container } = render(
+      <SplitLayout master={<div>list</div>} detail={<div>detail</div>} detailFirst />,
+    );
+    expect(container.firstChild).toHaveClass("md:flex-row-reverse");
+  });
+});

--- a/ui/tests/stat-strip.test.tsx
+++ b/ui/tests/stat-strip.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { StatStrip } from "@/components/stat-strip";
+
+describe("StatStrip", () => {
+  it("renders each metric's label and value", () => {
+    render(
+      <StatStrip
+        items={[
+          { label: "Critical", value: 4, accent: "critical" },
+          { label: "Coverage", value: "92%", accent: "success", hint: "+3 vs last scan" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("Critical")).toBeInTheDocument();
+    expect(screen.getByText("4")).toBeInTheDocument();
+    expect(screen.getByText("92%")).toBeInTheDocument();
+    expect(screen.getByText("+3 vs last scan")).toBeInTheDocument();
+  });
+
+  it("tints the value only when a numeric value clears the threshold", () => {
+    render(
+      <StatStrip
+        items={[
+          { label: "Zero", value: 0, accent: "critical" },
+          { label: "Some", value: 3, accent: "critical" },
+        ]}
+      />,
+    );
+    expect(screen.getByText("0").className).toContain("var(--foreground)");
+    expect(screen.getByText("3").className).toContain("var(--severity-critical)");
+  });
+
+  it("renders a link cell when href is provided", () => {
+    render(<StatStrip items={[{ label: "High", value: 12, href: "/findings" }]} />);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/findings");
+  });
+
+  it("fires onClick for a button cell", () => {
+    const onClick = vi.fn();
+    render(<StatStrip items={[{ label: "Medium", value: 7, onClick }]} />);
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/tests/theme-readability-tokens.test.ts
+++ b/ui/tests/theme-readability-tokens.test.ts
@@ -11,12 +11,16 @@ describe("theme readability tokens", () => {
   const css = readFileSync(GLOBALS, "utf8");
 
   it("defines dark surface hierarchy and readable secondary text", () => {
-    expect(css).toMatch(/--background:\s*#181a22;/);
+    // Deep, non-flat canvas with a layered panel < card < elevated hierarchy.
+    expect(css).toMatch(/--background:\s*#14161d;/);
+    expect(css).toMatch(/--surface-panel:\s*#1b1e27;/);
     expect(css).toMatch(/--surface:\s*#22262f;/);
     expect(css).toMatch(/--surface-elevated:\s*#2c3140;/);
     expect(css).toMatch(/--text-secondary:\s*#d0d4dc;/);
     expect(css).toMatch(/--text-tertiary:\s*#a8aebc;/);
-    expect(css).toMatch(/--accent-mint:\s*#34d399;/);
+    // Brand accent stays mint; --accent-mint remains as a back-compat alias.
+    expect(css).toMatch(/--accent:\s*#34d399;/);
+    expect(css).toMatch(/--accent-mint:\s*var\(--accent\);/);
   });
 
   it("keeps severity CSS vars aligned with shared chart hex helpers", () => {
@@ -29,7 +33,7 @@ describe("theme readability tokens", () => {
   });
 
   it("defines light-theme severity and surface counterparts", () => {
-    expect(css).toMatch(/:root\[data-theme="light"\][\s\S]*--background:\s*#e4e9f2;/);
+    expect(css).toMatch(/:root\[data-theme="light"\][\s\S]*--background:\s*#e6eaf1;/);
     expect(css).toMatch(/:root\[data-theme="light"\][\s\S]*--severity-critical:\s*#dc2626;/);
     expect(css).toMatch(/:root\[data-theme="light"\][\s\S]*--text-secondary:\s*#374151;/);
   });


### PR DESCRIPTION
> Stacked on #4017 (design-system foundation) — **merge that first**. Base is \`feat/design-system-foundation\`, not \`main\`.

Phase-2 UI restyle: brings Compliance, Runtime, and Cost up to the dense / side-by-side / drawer-driven bar using the shared design-system primitives (\`StatStrip\`, \`DataTable\`, \`SplitLayout\`, \`Collapsible\`, \`Drawer\`, \`PageState\`). Tokens only, both themes, no hardcoded zinc/hex.

## Compliance (`ui/app/compliance/page.tsx`)
Before: big score-ring trust-center card, a stacked framework-coverage list, then a long vertical column of control rows.
After:
- Compact **StatStrip** — overall %, frameworks evaluated, pass / attention / fail.
- Master-detail **SplitLayout**: dense frameworks **DataTable** (category filter, coverage bar, fail count) selects a framework; a controls **DataTable** (code · name · status · findings) fills the detail pane; rows open the existing **compliance-control drawer** (reused).
- Heatmap / matrix views on a token segmented control; CIS drill-down and operator/catalog context moved into **Collapsibles**.
- Export-pack action and honest empty/loading/error states preserved.

## Cost / AI Spend (`ui/app/cost/page.tsx`)
Before: stacked stat cards + four separate breakdown tables (model / provider / cost-center / owner) + agent chart, long vertical page, many dark-only colors.
After:
- **StatStrip** KPI row (spend / calls / tokens / unpriced).
- One dimension-switched dense **DataTable** (agent · model · provider · owner · cost-center), sortable, with a per-row detail **Drawer** (tokens, unpriced, avg cost/call, share).
- Owner-scoped **budget** (set/enforce + exceeded) and **forecast/runway** panels side-by-side; anomalies fold into a **Collapsible**; by_owner rollup retained.
- Chart chrome reads theme tokens via \`useChartTheme\` (no hardcoded hex).

## Runtime (`ui/app/runtime/page.tsx`)
The runtime page is a shell that embeds the proxy and gateway enforcement dashboards. It already delegates dense content, but its tab chrome was a dark-only hardcoded treatment (invisible in light theme). Restyled to a token, both-theme segmented **tablist** (`role="tab"`/`aria-selected`); the embedded proxy/gateway surfaces are untouched (separate scope).

## Verification
- `npm run build` clean; `tsc --noEmit` clean; ESLint clean.
- `npx vitest run` — 111 files / 571 tests green (adds `compliance-page` + `cost-page` tests; updates the cockpits cost test for the unified breakdown).
- `node scripts/check-bundle-budget.mjs` PASS (3308.8 / 3312 KiB).
- Both light + dark reasoned through per surface — every color is a semantic token defined for both themes; light-theme token guard passes.


---
**Closes #3931** (dashboard UX pass — density + IA delivered across every page) and **Closes #4010** (platform-wide UI/UX consistency pass — design-system foundation + all heavy pages restyled dense/side-by-side, both themes).
Remaining scope tracked separately, NOT closed here: #4008 (Connections-hub page merge), #4006 (unified inventory), #4014 (P2 ops/settings UIs), #4009 (retention), #4005 (graph-at-scale).
