### PR TITLE
feat(ui): combine dense operator cockpit restyles

### DIFF
--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useRef, useState } from "react";
-import { useVirtualizer } from "@tanstack/react-virtual";
+import { Suspense, useCallback, useEffect, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
@@ -60,6 +59,10 @@ import { PageEmptyState, PageErrorState, PageLoadingState } from "@/components/s
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 import { FIRST_SCAN_ACTIONS } from "@/lib/empty-state-actions";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import { StatStrip } from "@/components/stat-strip";
+import { Collapsible } from "@/components/collapsible";
+import { Drawer } from "@/components/drawer";
 
 // ─── Agents List Helpers ────────────────────────────────────────────────────
 
@@ -194,17 +197,41 @@ function safeDisplayText(value: string): string {
 
 // ─── Agents List View ───────────────────────────────────────────────────────
 
+const CRED_ENV_RE = /key|token|secret|password|credential|auth/i;
+
+function serverCredentialCount(srv: Agent["mcp_servers"][number]): number {
+  if (srv.credential_env_vars?.length) return srv.credential_env_vars.length;
+  return srv.env ? Object.keys(srv.env).filter((k) => CRED_ENV_RE.test(k)).length : 0;
+}
+
+function agentPackageCount(agent: Agent): number {
+  return agent.mcp_servers.reduce((sum, srv) => sum + srv.packages.length, 0);
+}
+
+function agentCredentialCount(agent: Agent): number {
+  return agent.mcp_servers.reduce((sum, srv) => sum + serverCredentialCount(srv), 0);
+}
+
+function ConfiguredPill() {
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em]"
+      style={{ color: "var(--status-success)" }}
+    >
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: "var(--status-success)" }} aria-hidden="true" />
+      configured
+    </span>
+  );
+}
+
 function AgentsList() {
   const [agents, setAgents] = useState<Agent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState("");
-  const [expandedAgent, setExpandedAgent] = useState<string | null>(null);
+  const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [hintDismissed, setHintDismissed] = useState(false);
   const { counts } = useDeploymentContext();
-
-  function toggleCollapse(agentName: string) {
-    setExpandedAgent((current) => (current === agentName ? null : agentName));
-  }
 
   useEffect(() => {
     api.listAgents()
@@ -223,90 +250,187 @@ function AgentsList() {
     !search || a.name.toLowerCase().includes(search.toLowerCase())
   );
 
-  // Row virtualization for the configured-agents list. Enterprise estates
-  // can carry thousands of configured agents; rendering every card flat
-  // produced ~30s page loads and dropped scroll FPS. The virtualizer
-  // mounts only the visible (+ a small overscan) rows and measures each
-  // one so expanded cards still grow naturally. Tracks #1955.
-  const configuredScrollRef = useRef<HTMLDivElement | null>(null);
-  const configuredVirtualizer = useVirtualizer({
-    count: filteredConfigured.length,
-    getScrollElement: () => configuredScrollRef.current,
-    estimateSize: () => 80,
-    overscan: 8,
-    measureElement: (el) => el?.getBoundingClientRect().height ?? 80,
-  });
-  const configuredVirtualItems = configuredVirtualizer.getVirtualItems();
-  const installedScrollRef = useRef<HTMLDivElement | null>(null);
-  const installedVirtualizer = useVirtualizer({
-    count: installedOnly.length,
-    getScrollElement: () => installedScrollRef.current,
-    estimateSize: () => 96,
-    overscan: 8,
-  });
-  const installedVirtualItems = installedVirtualizer.getVirtualItems();
+  const activeAgent = selectedAgent
+    ? configured.find((a) => a.name === selectedAgent) ?? null
+    : null;
+
+  const ecosystemHint =
+    Object.entries(ecosystems)
+      .map(([eco, count]) => `${eco}: ${count}`)
+      .join(", ") || undefined;
+
+  const configuredColumns: DataTableColumn<Agent>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cell: (agent) => (
+        <div className="min-w-0">
+          <div className="truncate font-medium text-[color:var(--foreground)]">{agent.name}</div>
+          {agent.source ? (
+            <div className="truncate text-xs text-[color:var(--text-tertiary)]">{agent.source}</div>
+          ) : null}
+        </div>
+      ),
+    },
+    {
+      key: "type",
+      header: "Type",
+      cell: (agent) => (
+        <span className="font-mono text-xs text-[color:var(--text-secondary)]">{agent.agent_type}</span>
+      ),
+    },
+    {
+      key: "servers",
+      header: "Servers",
+      align: "right",
+      cell: (agent) => <span className="tabular-nums">{agent.mcp_servers.length}</span>,
+    },
+    {
+      key: "packages",
+      header: "Packages",
+      align: "right",
+      cell: (agent) => <span className="tabular-nums">{agentPackageCount(agent)}</span>,
+    },
+    {
+      key: "credentials",
+      header: "Credentials",
+      align: "right",
+      cell: (agent) => {
+        const count = agentCredentialCount(agent);
+        return (
+          <span
+            className="tabular-nums"
+            style={count > 0 ? { color: "var(--status-warn)" } : undefined}
+          >
+            {count}
+          </span>
+        );
+      },
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: () => <ConfiguredPill />,
+    },
+  ];
+
+  const installedColumns: DataTableColumn<Agent>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cell: (agent) => (
+        <span className="font-medium text-[color:var(--text-secondary)]">{agent.name}</span>
+      ),
+    },
+    {
+      key: "type",
+      header: "Type",
+      cell: (agent) => (
+        <span className="font-mono text-xs text-[color:var(--text-tertiary)]">{agent.agent_type}</span>
+      ),
+    },
+    {
+      key: "config",
+      header: "Config path",
+      cell: (agent) => (
+        <span className="truncate font-mono text-xs text-[color:var(--text-tertiary)]">
+          {agent.config_path || "—"}
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: () => (
+        <span
+          className="inline-flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em]"
+          style={{ color: "var(--status-warn)" }}
+        >
+          <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: "var(--status-warn)" }} aria-hidden="true" />
+          not configured
+        </span>
+      ),
+    },
+  ];
 
   return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
+    <div className="space-y-5">
+      <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
-          <p className="text-[color:var(--text-secondary)] text-sm mt-1">
+          <h1 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Agents</h1>
+          <p className="mt-1 text-sm text-[color:var(--text-secondary)]">
             Discovered AI clients/hosts and background agents, with their MCP servers
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/agents/topology"
-            className="flex items-center gap-2 px-3 py-2 bg-[color:var(--surface-elevated)] hover:bg-[color:var(--surface-elevated)] border border-[color:var(--border-subtle)] rounded-lg text-sm text-[color:var(--text-secondary)] transition-colors"
+            className="flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)]"
           >
-            <Network className="w-4 h-4" />
+            <Network className="h-4 w-4" />
             Agent mesh
           </Link>
           <Link
             href="/mesh"
-            className="flex items-center gap-2 px-3 py-2 bg-[color:var(--surface-elevated)] hover:bg-[color:var(--surface-elevated)] border border-[color:var(--border-subtle)] rounded-lg text-sm text-[color:var(--text-secondary)] transition-colors"
+            className="flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)]"
           >
-            <GitBranch className="w-4 h-4" />
+            <GitBranch className="h-4 w-4" />
             Mesh View
           </Link>
         </div>
       </div>
 
-      {!loading && agents.length > 0 && (
-        <div className="rounded-xl border border-emerald-900/60 bg-emerald-950/20 p-4">
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
-            <div className="space-y-1">
-              <p className="text-[11px] font-mono uppercase tracking-[0.2em] text-emerald-400">Inventory-first value</p>
-              <h2 className="text-base font-semibold text-[color:var(--foreground)]">See MCP surface area before you deploy proxy</h2>
-              <p className="text-sm leading-6 text-[color:var(--text-secondary)] max-w-3xl">
-                This page is useful on discovery alone. It shows which MCP servers are configured, what transport they use,
-                how many tools they expose, and whether they carry env-backed credentials or risky server state. Proxy and gateway
-                add runtime enforcement later; they are not required for inventory visibility.
-              </p>
-            </div>
-            <div className="grid grid-cols-2 gap-2 text-xs lg:min-w-[280px]">
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
-                <div className="text-[color:var(--text-tertiary)]">Remote MCPs</div>
-                <div className="mt-1 text-sm font-semibold text-blue-400">{remoteServers}</div>
-              </div>
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
-                <div className="text-[color:var(--text-tertiary)]">Servers with credentials</div>
-                <div className="mt-1 text-sm font-semibold text-yellow-400">{serversWithCredentials}</div>
-              </div>
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
-                <div className="text-[color:var(--text-tertiary)]">Blocked or risky</div>
-                <div className="mt-1 text-sm font-semibold text-rose-400">{blockedServers}</div>
-              </div>
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
-                <div className="text-[color:var(--text-tertiary)]">AI clients · background</div>
-                <div className="mt-1 text-sm font-semibold text-emerald-400">
-                  {agentClasses.client} · {agentClasses.background}
-                </div>
-              </div>
-            </div>
-          </div>
+      {!loading && agents.length > 0 && !hintDismissed && (
+        <div className="flex items-start gap-2 rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-xs leading-5 text-[color:var(--text-secondary)]">
+          <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[color:var(--accent)]" />
+          <p className="min-w-0 flex-1">
+            <span className="font-semibold text-[color:var(--foreground)]">Inventory-first:</span> this page is useful on
+            discovery alone — MCP servers, transport, tools, and env-backed credentials. Proxy and gateway add runtime
+            enforcement later; they are not required for visibility.
+          </p>
+          <button
+            type="button"
+            onClick={() => setHintDismissed(true)}
+            aria-label="Dismiss hint"
+            className="shrink-0 rounded p-0.5 text-[color:var(--text-tertiary)] transition-colors hover:text-[color:var(--foreground)]"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
         </div>
+      )}
+
+      {!loading && agents.length > 0 && (
+        <StatStrip
+          data-testid="agents-kpis"
+          items={[
+            {
+              label: "Agents",
+              value: agents.length,
+              icon: Shield,
+              hint: `${configured.length} configured${installedOnly.length > 0 ? ` · ${installedOnly.length} not` : ""}`,
+            },
+            { label: "Servers", value: totalServers, icon: Server, hint: `${remoteServers} remote` },
+            { label: "Packages", value: totalPackages, icon: Package, hint: ecosystemHint },
+            {
+              label: "Credentials",
+              value: totalCredentials,
+              icon: Key,
+              accent: "warn",
+              hint: `${serversWithCredentials} servers`,
+            },
+            {
+              label: "Blocked / risky",
+              value: blockedServers,
+              icon: AlertCircle,
+              accent: "critical",
+            },
+            {
+              label: "Clients · background",
+              value: `${agentClasses.client} · ${agentClasses.background}`,
+              icon: Network,
+            },
+          ]}
+        />
       )}
 
       {!loading && agents.length > 0 && (
@@ -318,7 +442,7 @@ function AgentsList() {
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search agents or agent type"
-              className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:outline-none focus:border-[color:var(--border-strong)]"
+              className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
             />
           </div>
           <p className="text-xs text-[color:var(--text-tertiary)]">
@@ -347,48 +471,6 @@ function AgentsList() {
         />
       )}
 
-      {/* Summary stats bar */}
-      {!loading && agents.length > 0 && (
-        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
-          <div className="bg-[color:var(--surface-muted)] border border-[color:var(--border-subtle)] rounded-lg p-3">
-            <div className="flex items-center gap-1.5 text-[color:var(--text-secondary)] text-xs mb-1">
-              <Shield className="w-3 h-3" /> Agents
-            </div>
-            <div className="text-lg font-semibold text-[color:var(--foreground)]">{agents.length}</div>
-            <div className="text-[10px] text-[color:var(--text-tertiary)] mt-0.5">
-              {configured.length} configured{installedOnly.length > 0 ? `, ${installedOnly.length} not configured` : ""}
-            </div>
-          </div>
-          <div className="bg-[color:var(--surface-muted)] border border-[color:var(--border-subtle)] rounded-lg p-3">
-            <div className="flex items-center gap-1.5 text-[color:var(--text-secondary)] text-xs mb-1">
-              <Server className="w-3 h-3" /> Servers
-            </div>
-            <div className="text-lg font-semibold text-[color:var(--foreground)]">{totalServers}</div>
-            <div className="text-[10px] text-[color:var(--text-tertiary)] mt-0.5">MCP server instances</div>
-          </div>
-          <div className="bg-[color:var(--surface-muted)] border border-[color:var(--border-subtle)] rounded-lg p-3">
-            <div className="flex items-center gap-1.5 text-[color:var(--text-secondary)] text-xs mb-1">
-              <Package className="w-3 h-3" /> Packages
-            </div>
-            <div className="text-lg font-semibold text-[color:var(--foreground)]">{totalPackages}</div>
-            <div className="text-[10px] text-[color:var(--text-tertiary)] mt-0.5">
-              {Object.entries(ecosystems).map(([eco, count]) => `${eco}: ${count}`).join(", ") || "\u2014"}
-            </div>
-          </div>
-          <div className="bg-[color:var(--surface-muted)] border border-[color:var(--border-subtle)] rounded-lg p-3">
-            <div className="flex items-center gap-1.5 text-[color:var(--text-secondary)] text-xs mb-1">
-              <Key className="w-3 h-3" /> Credentials
-            </div>
-            <div className={`text-lg font-semibold ${totalCredentials > 0 ? "text-orange-400" : "text-[color:var(--foreground)]"}`}>
-              {totalCredentials}
-            </div>
-            <div className="text-[10px] text-[color:var(--text-tertiary)] mt-0.5">
-              {totalCredentials > 0 ? "Exposed env vars" : "None detected"}
-            </div>
-          </div>
-        </div>
-      )}
-
       {!loading && !error && agents.length === 0 &&
         (counts && !isDeploymentSurfaceAvailable("agents", counts) ? (
           <DeploymentSurfaceRequiredState surface="agents" counts={counts} detail={error || null} />
@@ -408,245 +490,256 @@ function AgentsList() {
           />
         ))}
 
-      {/* Configured agents — row-virtualized for large estates */}
-      <div
-        ref={configuredScrollRef}
-        data-testid="agents-configured-virtualized"
-        className="max-h-[80vh] overflow-y-auto"
-      >
-        <div
-          style={{ height: `${configuredVirtualizer.getTotalSize()}px`, width: "100%", position: "relative" }}
-        >
-        {configuredVirtualItems.map((virtualRow) => {
-          const agent = filteredConfigured[virtualRow.index];
-          if (!agent) return null;
-          const isExpanded = expandedAgent === agent.name;
-          return (
-          <div
-            key={agent.name}
-            data-index={virtualRow.index}
-            ref={configuredVirtualizer.measureElement}
-            style={{
-              position: "absolute",
-              top: 0,
-              left: 0,
-              right: 0,
-              transform: `translateY(${virtualRow.start}px)`,
-              paddingBottom: "16px",
-            }}
-            className="bg-[color:var(--surface-muted)] border border-[color:var(--border-subtle)] rounded-xl p-5"
-          >
-            <button
-              type="button"
-              onClick={() => toggleCollapse(agent.name)}
-              className="w-full flex items-center justify-between"
-            >
-              <div className="flex items-center gap-2">
-                {isExpanded ? (
-                  <ChevronDown className="w-4 h-4 text-[color:var(--text-tertiary)]" />
-                ) : (
-                  <ChevronRight className="w-4 h-4 text-[color:var(--text-tertiary)]" />
-                )}
-                <h2 className="font-semibold text-[color:var(--foreground)]">{agent.name}</h2>
-                <span className="text-[10px] font-mono bg-emerald-950 border border-emerald-800 text-emerald-400 rounded px-1.5 py-0.5">
-                  configured
-                </span>
-                <span className="text-xs font-mono text-[color:var(--text-tertiary)]">{agent.agent_type}</span>
-                {agent.source && (
-                  <span className="text-xs text-[color:var(--text-tertiary)]">{agent.source}</span>
-                )}
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs font-mono bg-[color:var(--surface-elevated)] border border-[color:var(--border-subtle)] rounded px-2 py-1 text-[color:var(--text-secondary)]">
-                  {agent.mcp_servers.length} server{agent.mcp_servers.length !== 1 ? "s" : ""}
-                </span>
-                <Link
-                  href={`/agents?name=${encodeURIComponent(agent.name)}`}
-                  onClick={(e) => e.stopPropagation()}
-                  className="text-[color:var(--text-tertiary)] hover:text-emerald-400 transition-colors"
-                  title="View agent detail"
-                >
-                  <ArrowRight className="w-4 h-4" />
-                </Link>
-              </div>
-            </button>
-
-            {isExpanded ? (
-              <div className="space-y-2 mt-4">
-                {agent.discovery_provenance ? (
-                  <div className="rounded-lg border border-sky-900/60 bg-sky-950/20 p-3">
-                    <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-300">
-                      <Shield className="h-3.5 w-3.5" />
-                      Asset discovery provenance
-                    </div>
-                    <DiscoveryProvenanceTags provenance={agent.discovery_provenance} />
-                    <div className="mt-2 grid gap-2 text-[11px] text-[color:var(--text-secondary)] sm:grid-cols-2">
-                      {agent.discovery_provenance.source && <span>Source: <span className="text-[color:var(--text-secondary)]">{agent.discovery_provenance.source}</span></span>}
-                      {agent.discovery_provenance.resource_name && (
-                        <span>Resource: <span className="text-[color:var(--text-secondary)]">{agent.discovery_provenance.resource_name}</span></span>
-                      )}
-                      {agent.discovery_provenance.location && <span>Location: <span className="text-[color:var(--text-secondary)]">{agent.discovery_provenance.location}</span></span>}
-                      {agent.discovery_provenance.resource_id && (
-                        <span className="min-w-0 truncate">ID: <span className="font-mono text-[color:var(--text-secondary)]">{agent.discovery_provenance.resource_id}</span></span>
-                      )}
-                    </div>
-                  </div>
-                ) : null}
-                {agent.discovery_envelope ? (
-                  <DiscoveryEnvelopeCard envelope={agent.discovery_envelope} />
-                ) : null}
-                {agent.mcp_servers?.map((srv, j) => (
-                  <div key={j} className="bg-[color:var(--surface-elevated)] border border-[color:var(--border-subtle)] rounded-lg p-3">
-                    <div className="flex items-center justify-between mb-2">
-                      <div className="flex items-center gap-2">
-                        <span className="text-xs font-mono font-semibold text-[color:var(--foreground)]">{srv.name}</span>
-                        {srv.security_blocked && (
-                          <span className="rounded border border-rose-800 bg-rose-950 px-1.5 py-0.5 text-[10px] font-mono text-rose-300">
-                            blocked
-                          </span>
-                        )}
-                        {(srv.credential_env_vars?.length ?? 0) > 0 && (
-                          <span className="rounded border border-yellow-800 bg-yellow-950 px-1.5 py-0.5 text-[10px] font-mono text-yellow-300">
-                            creds
-                          </span>
-                        )}
-                      </div>
-                      <div className="flex items-center gap-2">
-                        {srv.transport && (
-                          <span className="text-xs text-[color:var(--text-tertiary)] font-mono">{srv.transport}</span>
-                        )}
-                      </div>
-                    </div>
-
-                    <DiscoveryProvenanceTags provenance={srv.discovery_provenance} />
-
-                    {srv.command && (
-                      <div className="text-xs font-mono text-[color:var(--text-tertiary)] mb-2">
-                        $ {srv.command} {srv.env ? Object.keys(srv.env).length > 0 ? `[${Object.keys(srv.env).length} env vars]` : "" : ""}
-                      </div>
-                    )}
-
-                    <div className="flex flex-wrap gap-3 text-xs text-[color:var(--text-tertiary)]">
-                      {srv.packages.length > 0 && (
-                        <span className="flex items-center gap-1">
-                          <Package className="w-3 h-3" />
-                          {srv.packages.length} package{srv.packages.length !== 1 ? "s" : ""}
-                        </span>
-                      )}
-                      {srv.tools && srv.tools.length > 0 && (
-                        <span className="flex items-center gap-1">
-                          <Wrench className="w-3 h-3" />
-                          {srv.tools.length} tool{srv.tools.length !== 1 ? "s" : ""}
-                        </span>
-                      )}
-                      {srv.env && Object.keys(srv.env).length > 0 && (
-                        <span className="flex items-center gap-1 text-orange-400">
-                          <Key className="w-3 h-3" />
-                          {Object.keys(srv.env).length} credential{Object.keys(srv.env).length !== 1 ? "s" : ""}
-                        </span>
-                      )}
-                      {srv.security_blocked && (
-                        <span className="flex items-center gap-1 text-rose-400">
-                          <AlertCircle className="w-3 h-3" />
-                          blocked or policy risky
-                        </span>
-                      )}
-                    </div>
-                    {(srv.credential_env_vars?.length ?? 0) > 0 && (
-                      <div className="mt-3">
-                        <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-yellow-400">
-                          Credential-backed env vars
-                        </p>
-                        <div className="flex flex-wrap gap-1.5">
-                          {srv.credential_env_vars?.map((envVar) => (
-                            <span key={envVar} className="rounded border border-yellow-800 bg-yellow-950 px-2 py-0.5 text-[11px] font-mono text-yellow-300">
-                              {envVar}
-                            </span>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ))}
-              </div>
-            ) : null}
+      {/* Configured agents — dense table, row → detail drawer */}
+      {!loading && configured.length > 0 && (
+        <section className="space-y-2">
+          <div className="flex items-baseline justify-between">
+            <h2 className="text-base font-semibold text-[color:var(--foreground)]">Configured agents</h2>
+            <p className="text-xs text-[color:var(--text-tertiary)]">Row → servers, tools, and credentials</p>
           </div>
-        )})}
+          <DataTable<Agent>
+            data-testid="agents-configured-table"
+            columns={configuredColumns}
+            rows={filteredConfigured}
+            rowKey={(agent) => agent.name}
+            onRowClick={(agent) => setSelectedAgent(agent.name)}
+            selectedKey={selectedAgent ?? undefined}
+            maxHeight="34rem"
+            caption="Configured agents with server, package, and credential counts"
+            empty={
+              search
+                ? "No configured agents match the current search."
+                : "No configured agents in this inventory."
+            }
+          />
+        </section>
+      )}
+
+      {/* Installed but not configured */}
+      {!loading && installedOnly.length > 0 && (
+        <Collapsible
+          title="Installed but not configured"
+          icon={AlertCircle}
+          count={installedOnly.length}
+          defaultOpen={false}
+        >
+          <p className="mb-3 text-xs text-[color:var(--text-secondary)]">
+            Binaries detected on PATH. Run setup to configure MCP servers.
+          </p>
+          <DataTable<Agent>
+            data-testid="agents-installed-table"
+            columns={installedColumns}
+            rows={installedOnly}
+            rowKey={(agent, index) => `${agent.name}-${index}`}
+            maxHeight="24rem"
+            caption="Installed but unconfigured agents"
+          />
+        </Collapsible>
+      )}
+
+      <AgentDetailDrawer agent={activeAgent} open={activeAgent != null} onClose={() => setSelectedAgent(null)} />
+    </div>
+  );
+}
+
+function AgentDetailDrawer({
+  agent,
+  open,
+  onClose,
+}: {
+  agent: Agent | null;
+  open: boolean;
+  onClose: () => void;
+}) {
+  if (!agent) return null;
+  const packages = agentPackageCount(agent);
+  const credentials = agentCredentialCount(agent);
+  const tools = agent.mcp_servers.reduce((sum, srv) => sum + (srv.tools?.length ?? 0), 0);
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      eyebrow={agent.agent_type}
+      title={agent.name}
+      subtitle={agent.source ?? agent.config_path}
+      headerAside={<ConfiguredPill />}
+      size="2xl"
+      ariaLabel={`Agent ${agent.name}`}
+      footer={
+        <div className="flex flex-wrap gap-2">
+          <Link
+            href={`/agents?name=${encodeURIComponent(agent.name)}`}
+            className="inline-flex items-center gap-2 rounded-lg bg-[color:var(--accent)] px-3 py-2 text-xs font-medium text-[color:var(--accent-contrast)] transition hover:bg-[color:var(--accent-strong)]"
+          >
+            <ArrowRight className="h-3.5 w-3.5" />
+            Full detail
+          </Link>
+          <Link
+            href={`/agents?name=${encodeURIComponent(agent.name)}&view=lifecycle`}
+            className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+          >
+            <GitBranch className="h-3.5 w-3.5" />
+            Lifecycle graph
+          </Link>
         </div>
-      </div>
-      {!loading && filteredConfigured.length === 0 && configured.length > 0 && (
-        <PageEmptyState
-          title="No configured agents match"
-          detail="The current search filtered out every configured agent in this inventory."
-          icon={Search}
-          suggestions={[
-            "Clear the search to return to the full configured list.",
-            "Search by exact agent name, source, or agent type.",
+      }
+    >
+      <div className="space-y-4" data-testid={`agent-detail-${agent.name}`}>
+        <StatStrip
+          items={[
+            { label: "Servers", value: agent.mcp_servers.length },
+            { label: "Packages", value: packages },
+            { label: "Tools", value: tools },
+            { label: "Credentials", value: credentials, accent: "warn" },
           ]}
         />
-      )}
 
-      {/* Installed but not configured — virtualized for parity with the configured list */}
-      {installedOnly.length > 0 && (
-        <div className="space-y-3">
-          <h2 className="text-sm font-semibold text-[color:var(--text-secondary)] uppercase tracking-widest flex items-center gap-2">
-            <AlertCircle className="w-3.5 h-3.5 text-yellow-500" />
-            Installed but not configured
-          </h2>
-          <div
-            ref={installedScrollRef}
-            data-testid="agents-installed-virtualized"
-            className="max-h-[40vh] overflow-y-auto"
-          >
-            <div
-              style={{ height: `${installedVirtualizer.getTotalSize()}px`, width: "100%", position: "relative" }}
-            >
-            {installedVirtualItems.map((virtualRow) => {
-              const agent = installedOnly[virtualRow.index];
-              if (!agent) return null;
-              return (
-                <div
-                  key={`${agent.name}-${virtualRow.index}`}
-                  data-index={virtualRow.index}
-                  ref={installedVirtualizer.measureElement}
-                  style={{
-                    position: "absolute",
-                    top: 0,
-                    left: 0,
-                    right: 0,
-                    transform: `translateY(${virtualRow.start}px)`,
-                    paddingBottom: "12px",
-                  }}
-                  className="bg-[color:var(--surface-muted)]/50 border border-dashed border-[color:var(--border-subtle)] rounded-xl p-4"
-                >
-                  <div className="flex items-center justify-between">
-                    <div>
-                      <div className="flex items-center gap-2">
-                        <h3 className="font-semibold text-[color:var(--text-secondary)]">{agent.name}</h3>
-                        <span className="text-[10px] font-mono bg-yellow-950 border border-yellow-800 text-yellow-400 rounded px-1.5 py-0.5">
-                          not configured
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-2 mt-0.5">
-                        <span className="text-xs font-mono text-[color:var(--text-tertiary)]">{agent.agent_type}</span>
-                        {agent.config_path && (
-                          <span className="text-xs text-[color:var(--text-tertiary)] font-mono">{agent.config_path}</span>
-                        )}
-                      </div>
-                    </div>
-                    <span className="text-xs text-[color:var(--text-tertiary)]">0 servers</span>
-                  </div>
-                  <p className="text-xs text-[color:var(--text-tertiary)] mt-2">
-                    Binary detected on PATH. Run setup to configure MCP servers.
-                  </p>
-                </div>
-              );
-            })}
+        {agent.discovery_provenance ? (
+          <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3">
+            <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+              <Shield className="h-3.5 w-3.5" />
+              Asset discovery provenance
             </div>
+            <DiscoveryProvenanceTags provenance={agent.discovery_provenance} />
           </div>
+        ) : null}
+
+        {agent.discovery_envelope ? <DiscoveryEnvelopeCard envelope={agent.discovery_envelope} /> : null}
+
+        <div className="space-y-2">
+          <h3 className="flex items-center gap-2 text-sm font-semibold text-[color:var(--foreground)]">
+            <Server className="h-4 w-4 text-[color:var(--text-secondary)]" />
+            MCP servers
+            <span className="text-xs font-normal text-[color:var(--text-tertiary)]">({agent.mcp_servers.length})</span>
+          </h3>
+          {agent.mcp_servers.map((srv, index) => {
+            const credEnv = srv.credential_env_vars ?? [];
+            return (
+              <div
+                key={`${srv.name}-${index}`}
+                className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3"
+              >
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <span className="font-mono text-xs font-semibold text-[color:var(--foreground)]">{srv.name}</span>
+                    {srv.security_blocked && (
+                      <span
+                        className="rounded border px-1.5 py-0.5 text-[10px] font-mono"
+                        style={{
+                          borderColor: "var(--status-danger-border)",
+                          backgroundColor: "var(--status-danger-bg)",
+                          color: "var(--status-danger)",
+                        }}
+                      >
+                        blocked
+                      </span>
+                    )}
+                    {credEnv.length > 0 && (
+                      <span
+                        className="rounded border px-1.5 py-0.5 text-[10px] font-mono"
+                        style={{
+                          borderColor: "var(--status-warn-border)",
+                          backgroundColor: "var(--status-warn-bg)",
+                          color: "var(--status-warn)",
+                        }}
+                      >
+                        creds
+                      </span>
+                    )}
+                  </div>
+                  {srv.transport && (
+                    <span className="font-mono text-xs text-[color:var(--text-tertiary)]">{srv.transport}</span>
+                  )}
+                </div>
+
+                <div className="mt-2">
+                  <DiscoveryProvenanceTags provenance={srv.discovery_provenance} />
+                </div>
+
+                {srv.command && (
+                  <div className="mt-2 flex items-start gap-1.5 font-mono text-xs text-[color:var(--text-tertiary)]">
+                    <TerminalSquare className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span className="break-all">{safeCommandLine(srv.command, srv.args)}</span>
+                  </div>
+                )}
+                {srv.url && (
+                  <div className="mt-2 flex items-start gap-1.5 font-mono text-xs text-[color:var(--text-tertiary)]">
+                    <Link2 className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                    <span className="break-all">{safeDisplayUrl(srv.url)}</span>
+                  </div>
+                )}
+
+                <div className="mt-2 flex flex-wrap gap-3 text-xs text-[color:var(--text-tertiary)]">
+                  {srv.packages.length > 0 && (
+                    <span className="flex items-center gap-1">
+                      <Package className="h-3 w-3" />
+                      {srv.packages.length} package{srv.packages.length !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                  {srv.tools && srv.tools.length > 0 && (
+                    <span className="flex items-center gap-1">
+                      <Wrench className="h-3 w-3" />
+                      {srv.tools.length} tool{srv.tools.length !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                  {credEnv.length > 0 && (
+                    <span className="flex items-center gap-1" style={{ color: "var(--status-warn)" }}>
+                      <Key className="h-3 w-3" />
+                      {credEnv.length} credential{credEnv.length !== 1 ? "s" : ""}
+                    </span>
+                  )}
+                </div>
+
+                {credEnv.length > 0 && (
+                  <div className="mt-3">
+                    <p
+                      className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em]"
+                      style={{ color: "var(--status-warn)" }}
+                    >
+                      Credential-backed env vars
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {credEnv.map((envVar) => (
+                        <span
+                          key={envVar}
+                          className="rounded border px-2 py-0.5 text-[11px] font-mono"
+                          style={{
+                            borderColor: "var(--status-warn-border)",
+                            backgroundColor: "var(--status-warn-bg)",
+                            color: "var(--status-warn)",
+                          }}
+                        >
+                          {envVar}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+
+                {srv.tools && srv.tools.length > 0 && (
+                  <div className="mt-3">
+                    <p className="mb-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                      Tools
+                    </p>
+                    <div className="flex flex-wrap gap-1.5">
+                      {srv.tools.map((tool) => (
+                        <span
+                          key={tool.name}
+                          className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2 py-0.5 text-[11px] text-[color:var(--text-secondary)]"
+                        >
+                          {tool.name}
+                        </span>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
         </div>
-      )}
-    </div>
+      </div>
+    </Drawer>
   );
 }
 

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -31,21 +31,30 @@ import {
   Loader2,
 } from "lucide-react";
 import { ComplianceControlDrawer } from "@/components/compliance-control-drawer";
-import { ComplianceControlRow } from "@/components/compliance-control-row";
-import { isNotEvaluated, postureLabel, statusColor } from "@/components/compliance-status";
+import {
+  isNotEvaluated,
+  postureLabel,
+  statusColor,
+  StatusIcon,
+} from "@/components/compliance-status";
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
 import { ComplianceMatrix } from "@/components/compliance-matrix";
 import { CISBenchmarkDetail } from "@/components/cis-benchmark-detail";
-import { FrameworkCoveragePanel, type FrameworkCoverageItem } from "@/components/framework-coverage-panel";
 import { FrameworkIcon } from "@/components/framework-icon";
 import {
   complianceFrameworkSummaries,
+  compliancePassRate,
   controlMatchesQuery,
+  type ComplianceFrameworkSummary,
 } from "@/lib/compliance-frameworks";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { PageEmptyState, PageLoadingState } from "@/components/states/page-state";
 import { ApiAuthError, ApiForbiddenError } from "@/lib/api-errors";
 import { FIRST_EVIDENCE_ACTIONS } from "@/lib/empty-state-actions";
+import { StatStrip, type StatStripItem, type StatAccent } from "@/components/stat-strip";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import { SplitLayout } from "@/components/split-layout";
+import { Collapsible } from "@/components/collapsible";
 
 function _classifyApiErrorKind(err: unknown): "network" | "auth" | "forbidden" {
   if (err instanceof ApiAuthError) return "auth";
@@ -62,52 +71,50 @@ function downloadBlobToFile(blob: Blob, filename: string) {
   URL.revokeObjectURL(url);
 }
 
-// ─── Score Ring ──────────────────────────────────────────────────────────────
+const CONTROL_STATUS_LABEL: Record<string, string> = {
+  pass: "Pass",
+  warning: "Warn",
+  fail: "Fail",
+};
 
-function ScoreRing({ score, status }: { score: number; status: string }) {
-  const r = 54;
-  const circ = 2 * Math.PI * r;
-  // A no-evidence scan has nothing to score. Render a neutral, empty ring with
-  // a "Not evaluated" label rather than a red 0% that reads as "failing".
-  const notEvaluated = isNotEvaluated(status);
-  const offset = notEvaluated ? circ : circ - (score / 100) * circ;
-  const color = notEvaluated
-    ? "var(--text-tertiary)"
-    : status === "pass"
-      ? "#34d399"
-      : status === "warning"
-        ? "#facc15"
-        : "#f87171";
+function statusToAccent(status: string): StatAccent {
+  if (isNotEvaluated(status)) return "neutral";
+  if (status === "pass") return "success";
+  if (status === "warning") return "warn";
+  if (status === "fail") return "critical";
+  return "neutral";
+}
 
+/** Compact three-segment pass/warn/fail bar, token-styled for both themes. */
+function CoverageBar({
+  pass,
+  warn,
+  fail,
+  total,
+}: Pick<ComplianceFrameworkSummary, "pass" | "warn" | "fail" | "total">) {
+  const seg = (n: number) => (total > 0 ? (n / total) * 100 : 0);
   return (
-    <div className="relative w-32 h-32">
-      <svg viewBox="0 0 120 120" className="w-full h-full -rotate-90">
-        <circle cx="60" cy="60" r={r} fill="none" stroke="var(--border-strong)" strokeWidth="8" />
-        <circle
-          cx="60" cy="60" r={r} fill="none"
-          stroke={color} strokeWidth="8"
-          strokeDasharray={circ} strokeDashoffset={offset}
-          strokeLinecap="round"
-          className="transition-all duration-1000"
-        />
-      </svg>
-      <div className="absolute inset-0 flex flex-col items-center justify-center">
-        {notEvaluated ? (
-          <>
-            <span className="text-lg font-bold text-[color:var(--text-secondary)]">—</span>
-            <span className="px-1 text-center text-[9px] leading-tight text-[color:var(--text-tertiary)] uppercase tracking-wider">
-              Not evaluated
-            </span>
-          </>
-        ) : (
-          <>
-            <span className="text-2xl font-bold text-[color:var(--foreground)]">{Math.round(score)}%</span>
-            <span className="text-[10px] text-[color:var(--text-tertiary)] uppercase tracking-wider">Score</span>
-          </>
-        )}
-      </div>
+    <div className="flex h-1.5 w-full min-w-[72px] max-w-[140px] overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
+      {pass > 0 ? (
+        <div style={{ width: `${seg(pass)}%`, backgroundColor: "var(--status-success)" }} />
+      ) : null}
+      {warn > 0 ? (
+        <div style={{ width: `${seg(warn)}%`, backgroundColor: "var(--status-warn)" }} />
+      ) : null}
+      {fail > 0 ? (
+        <div style={{ width: `${seg(fail)}%`, backgroundColor: "var(--status-danger)" }} />
+      ) : null}
     </div>
   );
+}
+
+type CategoryFilter = "all" | "ai" | "governance" | "cloud";
+
+function categoryFor(id: string): "ai" | "governance" | "cloud" {
+  if (id === "cis" || id === "cmmc") return "cloud";
+  if (id === "eu-ai-act" || id === "nist-csf" || id === "iso27001" || id === "soc2")
+    return "governance";
+  return "ai";
 }
 
 // ─── Page ───────────────────────────────────────────────────────────────────
@@ -126,6 +133,7 @@ function CompliancePageContent() {
   // "Cannot connect to the agent-bom API".
   const [errorKind, setErrorKind] = useState<"network" | "auth" | "forbidden">("network");
   const [viewMode, setViewMode] = useState<"detail" | "heatmap" | "matrix">("detail");
+  const [categoryFilter, setCategoryFilter] = useState<CategoryFilter>("all");
   const [controlQuery, setControlQuery] = useState(queryParam);
   const [statusFilter, setStatusFilter] = useState<"all" | "pass" | "warning" | "fail">("all");
   const [exporting, setExporting] = useState(false);
@@ -238,27 +246,20 @@ function CompliancePageContent() {
     [data, hasMcp],
   );
 
-  const frameworkCoverageItems = useMemo((): FrameworkCoverageItem[] => {
-    const categoryFor = (id: string): FrameworkCoverageItem["category"] => {
-      if (id === "cis" || id === "cmmc") return "cloud";
-      if (id === "eu-ai-act" || id === "nist-csf" || id === "iso27001" || id === "soc2") return "governance";
-      return "ai";
-    };
-    return frameworks.map((framework) => ({
-      id: framework.id,
-      label: framework.label,
-      pass: framework.pass,
-      warn: framework.warn,
-      fail: framework.fail,
-      total: framework.total,
-      category: categoryFor(framework.id),
-    }));
-  }, [frameworks]);
+  const visibleFrameworks = useMemo(
+    () =>
+      categoryFilter === "all"
+        ? frameworks
+        : frameworks.filter((framework) => categoryFor(framework.id) === categoryFilter),
+    [frameworks, categoryFilter],
+  );
 
   const selectedSection = useMemo(
     () => detailSections.find((section) => section.id === selectedFrameworkId) ?? detailSections[0],
     [detailSections, selectedFrameworkId],
   );
+
+  const sectionCatalog = selectedSection?.catalog;
 
   const visibleControls = useMemo(() => {
     if (!selectedSection) return [];
@@ -342,226 +343,354 @@ function CompliancePageContent() {
 
   if (!data) return null;
 
-  return (
-    <div className="space-y-5">
-      {/* ── Trust center header ─────────────────────────────────────────── */}
-      <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-          <div className="flex items-center gap-5">
-            <ScoreRing score={data.overall_score} status={data.overall_status} />
-            <div>
-              <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">
-                Trust center
-              </p>
-              <h1 className={`text-2xl font-bold ${statusColor(data.overall_status)}`}>
-                {postureLabel(data.overall_status)}
-              </h1>
-              <p className="mt-1 text-sm text-[color:var(--text-tertiary)]">
-                AI supply-chain frameworks plus cloud CIS posture when accounts are connected — not a full CNAPP claim.
-              </p>
-              <div className="mt-2 flex flex-wrap gap-4 text-xs text-[color:var(--text-tertiary)]">
-                <span>
-                  {data.scan_count} scan{data.scan_count !== 1 ? "s" : ""} analyzed
-                </span>
-                {data.latest_scan ? <span>Latest {formatDate(data.latest_scan)}</span> : null}
-                <span>
-                  {frameworks.reduce((total, framework) => total + framework.fail, 0)} failing controls
-                </span>
-              </div>
-            </div>
+  const totalPass = frameworks.reduce((sum, f) => sum + f.pass, 0);
+  const totalWarn = frameworks.reduce((sum, f) => sum + f.warn, 0);
+  const totalFail = frameworks.reduce((sum, f) => sum + f.fail, 0);
+  const evaluatedFrameworks = frameworks.filter((f) => !f.disabled).length;
+  const overallNotEvaluated = isNotEvaluated(data.overall_status);
+
+  const kpis: StatStripItem[] = [
+    {
+      label: "Overall",
+      value: overallNotEvaluated ? "—" : `${Math.round(data.overall_score)}%`,
+      accent: statusToAccent(data.overall_status),
+      hint: postureLabel(data.overall_status),
+    },
+    {
+      label: "Frameworks",
+      value: evaluatedFrameworks,
+      hint: `${frameworks.length} tracked`,
+    },
+    { label: "Passing", value: totalPass, accent: "success" },
+    { label: "Attention", value: totalWarn, accent: "warn", accentThreshold: 0 },
+    { label: "Failing", value: totalFail, accent: "critical", accentThreshold: 0 },
+  ];
+
+  // ── Frameworks master table ────────────────────────────────────────────────
+  const frameworkColumns: DataTableColumn<ComplianceFrameworkSummary>[] = [
+    {
+      key: "label",
+      header: "Framework",
+      cell: (f) => (
+        <div className="flex items-center gap-2">
+          <FrameworkIcon frameworkId={f.id} size={18} />
+          <div className="min-w-0">
+            <div className="truncate font-medium text-[color:var(--foreground)]">{f.shortLabel}</div>
+            <div className="truncate text-[11px] text-[color:var(--text-tertiary)]">{f.label}</div>
           </div>
+        </div>
+      ),
+    },
+    {
+      key: "coverage",
+      header: "Coverage",
+      cell: (f) =>
+        f.disabled ? (
+          <span className="text-[11px] text-[color:var(--text-tertiary)]">
+            {f.disabledReason ?? "Not evaluated"}
+          </span>
+        ) : (
+          <div className="flex items-center gap-2">
+            <CoverageBar pass={f.pass} warn={f.warn} fail={f.fail} total={f.total} />
+            <span className="tabular-nums text-[11px] text-[color:var(--text-tertiary)]">
+              {compliancePassRate(f)}%
+            </span>
+          </div>
+        ),
+    },
+    {
+      key: "fail",
+      header: "Fail",
+      align: "right",
+      sortable: true,
+      width: "4rem",
+      cell: (f) => (
+        <span
+          className={
+            f.fail > 0 ? "font-semibold text-[color:var(--status-danger)]" : "text-[color:var(--text-tertiary)]"
+          }
+        >
+          {f.fail}
+        </span>
+      ),
+    },
+  ];
+
+  const master = (
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5">
+        {(["all", "ai", "governance", "cloud"] as const).map((value) => (
           <button
-            onClick={() => void handleExportPack()}
-            disabled={exporting}
-            title="Download a signed evidence pack covering every framework"
-            className="flex items-center gap-1.5 self-start rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-sm font-medium text-emerald-700 transition-colors hover:bg-emerald-100 disabled:opacity-50 dark:border-emerald-800 dark:bg-emerald-950/40 dark:text-emerald-300 dark:hover:bg-emerald-900/40"
-            data-testid="compliance-export-pack"
+            key={value}
+            type="button"
+            onClick={() => setCategoryFilter(value)}
+            className={`rounded-md px-2.5 py-1 text-xs font-medium capitalize transition-colors ${
+              categoryFilter === value
+                ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+            }`}
           >
-            {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
-            {exporting ? "Exporting…" : "Export pack"}
+            {value === "ai" ? "AI" : value}
           </button>
-        </div>
-        {exportError ? (
-          <p className="mt-2 text-right text-xs text-red-400">{exportError}</p>
-        ) : null}
-
-        <FrameworkCoveragePanel
-          items={frameworkCoverageItems}
-          onFocusFramework={(frameworkId) => {
-            setSelectedFrameworkId(frameworkId);
-            setViewMode("detail");
-          }}
-        />
-
-        {(hubPosture && hubPosture.totals.combined > 0) || mitreCatalog || atlasCatalog ? (
-          <details className="mt-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3">
-            <summary className="cursor-pointer text-xs font-medium text-[color:var(--text-secondary)]">
-              Operator & catalog context
-            </summary>
-            <div className="mt-3 space-y-3 text-xs text-[color:var(--text-tertiary)]">
-              {hubPosture && hubPosture.totals.combined > 0 ? (
-                <p>
-                  Compliance hub: {hubPosture.totals.combined.toLocaleString()} findings (
-                  {hubPosture.totals.native.toLocaleString()} native ·{" "}
-                  {hubPosture.totals.hub.toLocaleString()} ingested). Import via{" "}
-                  <code className="rounded bg-[color:var(--surface)] px-1 py-0.5">
-                    POST /v1/compliance/ingest
-                  </code>
-                  .
-                </p>
-              ) : null}
-              {mitreCatalog ? (
-                <p>
-                  MITRE ATT&CK {mitreCatalog.attack_version || "catalog"} ·{" "}
-                  {mitreCatalog.technique_count} techniques · refresh with{" "}
-                  <code className="rounded bg-[color:var(--surface)] px-1 py-0.5">
-                    agent-bom db update-frameworks
-                  </code>
-                  .
-                </p>
-              ) : null}
-              {atlasCatalog ? (
-                <p>
-                  MITRE ATLAS {atlasCatalog.atlas_version || "catalog"} ·{" "}
-                  {atlasCatalog.technique_count} techniques · refresh with{" "}
-                  <code className="rounded bg-[color:var(--surface)] px-1 py-0.5">
-                    agent-bom db update-frameworks --framework atlas
-                  </code>
-                  .
-                </p>
-              ) : null}
-            </div>
-          </details>
-        ) : null}
+        ))}
       </div>
+      <DataTable
+        rows={visibleFrameworks}
+        rowKey={(f) => f.id}
+        columns={frameworkColumns}
+        selectedKey={selectedSection?.id}
+        onRowClick={(f) => {
+          if (f.disabled) return;
+          setSelectedFrameworkId(f.id);
+        }}
+        maxHeight="calc(100vh - 22rem)"
+        caption="Framework coverage"
+        empty="No frameworks in this category."
+        data-testid="compliance-frameworks-table"
+      />
+    </div>
+  );
 
-      {/* ── View Toggle ────────────────────────────────────────────────── */}
-      <div className="flex items-center gap-2">
-        <button
-          onClick={() => setViewMode("detail")}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-            viewMode === "detail"
-              ? "bg-emerald-600 text-white"
-              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
-          }`}
-        >
-          <List className="w-3.5 h-3.5" />
-          Detail
-        </button>
-        <button
-          onClick={() => setViewMode("heatmap")}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-            viewMode === "heatmap"
-              ? "bg-emerald-600 text-white"
-              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
-          }`}
-        >
-          <Grid3X3 className="w-3.5 h-3.5" />
-          Heatmap
-        </button>
-        <button
-          onClick={() => setViewMode("matrix")}
-          className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium transition-colors ${
-            viewMode === "matrix"
-              ? "bg-emerald-600 text-white"
-              : "bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] border border-[color:var(--border-strong)]"
-          }`}
-        >
-          <Scan className="w-3.5 h-3.5" />
-          Matrix
-        </button>
-      </div>
-
-      {/* ── Heatmap View ──────────────────────────────────────────────── */}
-      {viewMode === "heatmap" && <ComplianceHeatmap data={data} />}
-
-      {/* ── Matrix View ───────────────────────────────────────────────── */}
-      {viewMode === "matrix" && <ComplianceMatrix data={data} />}
-
-      {viewMode === "detail" && selectedSection ? (
-      <>
-      <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">
-        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-          <div>
-            <div className="flex items-center gap-2">
-              <FrameworkIcon frameworkId={selectedSection.id} size={24} />
-              <h2 className="text-base font-semibold text-[color:var(--foreground)]">
-                {selectedSection.title}
-              </h2>
-            </div>
-            {selectedSection.subtitle ? (
-              <p className="mt-0.5 text-xs text-[color:var(--text-tertiary)]">{selectedSection.subtitle}</p>
-            ) : null}
-            <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
-              {visibleControls.length} of {selectedSection.controls.length} controls shown · click a row for evidence
-            </p>
+  // ── Controls detail table ──────────────────────────────────────────────────
+  const controlColumns: DataTableColumn<ComplianceControl>[] = [
+    {
+      key: "code",
+      header: "Control",
+      cell: (c) => (
+        <div className="min-w-0">
+          <div className="font-mono text-xs font-medium text-[color:var(--foreground)]">{c.code}</div>
+          <div className="truncate text-[11px] text-[color:var(--text-tertiary)]">
+            {sectionCatalog?.[c.code] ?? c.name}
           </div>
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
-            <div className="relative min-w-[220px]">
-              <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[color:var(--text-tertiary)]" />
-              <input
-                type="text"
-                value={controlQuery}
-                onChange={(e) => setControlQuery(e.target.value)}
-                placeholder="Search control, package, agent"
-                className="w-full rounded-lg border border-[color:var(--border-strong)] bg-[color:var(--surface-elevated)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
-              />
-            </div>
-            <div className="flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] p-0.5">
-              {(["all", "fail", "warning", "pass"] as const).map((value) => (
-                <button
-                  key={value}
-                  type="button"
-                  onClick={() => setStatusFilter(value)}
-                  className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-                    statusFilter === value
-                      ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
-                      : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
-                  }`}
-                >
-                  {value === "all" ? "All" : value === "pass" ? "Pass" : value === "warning" ? "Warn" : "Fail"}
-                </button>
-              ))}
-            </div>
+        </div>
+      ),
+    },
+    {
+      key: "status",
+      header: "Status",
+      width: "6rem",
+      cell: (c) => (
+        <span className="inline-flex items-center gap-1.5">
+          <StatusIcon status={c.status} className="h-3.5 w-3.5" />
+          <span className={`text-xs font-medium ${statusColor(c.status)}`}>
+            {CONTROL_STATUS_LABEL[c.status] ?? c.status}
+          </span>
+        </span>
+      ),
+    },
+    {
+      key: "findings",
+      header: "Findings",
+      align: "right",
+      width: "5rem",
+      cell: (c) => (
+        <span
+          className={
+            c.findings > 0 ? "font-semibold text-[color:var(--foreground)]" : "text-[color:var(--text-tertiary)]"
+          }
+        >
+          {c.findings}
+        </span>
+      ),
+    },
+  ];
+
+  const detail = selectedSection ? (
+    <div className="flex h-full min-h-0 flex-col rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-1">
+      <div className="border-b border-[color:var(--border-subtle)] p-4">
+        <div className="flex items-center gap-2">
+          <FrameworkIcon frameworkId={selectedSection.id} size={22} />
+          <h2 className="text-base font-semibold text-[color:var(--foreground)]">
+            {selectedSection.title}
+          </h2>
+        </div>
+        {selectedSection.subtitle ? (
+          <p className="mt-0.5 text-xs text-[color:var(--text-tertiary)]">{selectedSection.subtitle}</p>
+        ) : null}
+        <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+          {visibleControls.length} of {selectedSection.controls.length} controls shown · click a row for evidence
+        </p>
+        <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+          <div className="relative min-w-0 flex-1">
+            <Search className="absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[color:var(--text-tertiary)]" />
+            <input
+              type="text"
+              value={controlQuery}
+              onChange={(e) => setControlQuery(e.target.value)}
+              placeholder="Search control, package, agent"
+              className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
+            />
+          </div>
+          <div className="flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5">
+            {(["all", "fail", "warning", "pass"] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                onClick={() => setStatusFilter(value)}
+                className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                  statusFilter === value
+                    ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                    : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+                }`}
+              >
+                {value === "all" ? "All" : value === "pass" ? "Pass" : value === "warning" ? "Warn" : "Fail"}
+              </button>
+            ))}
           </div>
         </div>
       </div>
-
-      <section className="space-y-2">
+      <div className="min-h-0 flex-1 overflow-y-auto p-3">
         {selectedSection.controls.length === 0 && selectedSection.emptyMessage ? (
           <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
             {selectedSection.emptyMessage}
           </div>
-        ) : visibleControls.length === 0 ? (
-          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
-            No controls match the current filters.
-          </div>
         ) : (
-          visibleControls.map((control) => (
-            <ComplianceControlRow
-              key={control.code}
-              control={control}
-              catalogName={selectedSection.catalog?.[control.code] ?? control.name}
-              onOpen={() =>
-                setSelectedControl({
-                  control,
-                  frameworkLabel: selectedSection.title,
-                  catalog: selectedSection.catalog,
-                })
-              }
-            />
-          ))
+          <DataTable
+            rows={visibleControls}
+            rowKey={(c) => c.code}
+            columns={controlColumns}
+            onRowClick={(control) =>
+              setSelectedControl({
+                control,
+                frameworkLabel: selectedSection.title,
+                catalog: selectedSection.catalog,
+              })
+            }
+            selectedKey={selectedControl?.control.code}
+            caption={`${selectedSection.title} controls`}
+            empty="No controls match the current filters."
+          />
         )}
-      </section>
+      </div>
+    </div>
+  ) : null;
 
-      <details className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]">
-        <summary className="cursor-pointer px-5 py-4 text-sm font-medium text-[color:var(--foreground)]">
-          Cloud CIS benchmark drill-down (AWS / Azure / GCP / Snowflake / Databricks)
-        </summary>
-        <div className="border-t border-[color:var(--border-subtle)] px-2 pb-2">
-          <CISBenchmarkDetail />
+  return (
+    <div className="space-y-5">
+      {/* ── Trust center header ─────────────────────────────────────────── */}
+      <div className="flex flex-col gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1 lg:flex-row lg:items-center lg:justify-between">
+        <div className="min-w-0">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-[color:var(--text-tertiary)]">
+            Trust center
+          </p>
+          <h1 className={`text-xl font-bold ${statusColor(data.overall_status)}`}>
+            {postureLabel(data.overall_status)}
+          </h1>
+          <div className="mt-1 flex flex-wrap gap-x-4 gap-y-1 text-xs text-[color:var(--text-tertiary)]">
+            <span>
+              {data.scan_count} scan{data.scan_count !== 1 ? "s" : ""} analyzed
+            </span>
+            {data.latest_scan ? <span>Latest {formatDate(data.latest_scan)}</span> : null}
+            <span>{totalFail} failing controls</span>
+            <span>
+              AI supply-chain frameworks + cloud CIS posture when accounts are connected — not a full CNAPP claim.
+            </span>
+          </div>
         </div>
-      </details>
+        <button
+          onClick={() => void handleExportPack()}
+          disabled={exporting}
+          title="Download a signed evidence pack covering every framework"
+          className="flex shrink-0 items-center gap-1.5 self-start rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-sm font-medium text-[color:var(--accent)] transition-colors hover:bg-[color:var(--accent-soft-hover)] disabled:opacity-50"
+          data-testid="compliance-export-pack"
+        >
+          {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
+          {exporting ? "Exporting…" : "Export pack"}
+        </button>
+      </div>
+      {exportError ? (
+        <p className="text-right text-xs text-[color:var(--status-danger)]">{exportError}</p>
+      ) : null}
+
+      <StatStrip items={kpis} data-testid="compliance-kpi-strip" />
+
+      {/* ── View Toggle ────────────────────────────────────────────────── */}
+      <div className="flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5 self-start w-fit">
+        {(
+          [
+            { key: "detail", label: "Detail", icon: List },
+            { key: "heatmap", label: "Heatmap", icon: Grid3X3 },
+            { key: "matrix", label: "Matrix", icon: Scan },
+          ] as const
+        ).map(({ key, label, icon: Icon }) => (
+          <button
+            key={key}
+            type="button"
+            onClick={() => setViewMode(key)}
+            className={`flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
+              viewMode === key
+                ? "bg-[color:var(--accent-soft)] text-[color:var(--accent)]"
+                : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+
+      {viewMode === "heatmap" && <ComplianceHeatmap data={data} />}
+      {viewMode === "matrix" && <ComplianceMatrix data={data} />}
+
+      {viewMode === "detail" ? (
+        <>
+          <SplitLayout
+            masterWidth="24rem"
+            height="calc(100vh - 20rem)"
+            master={master}
+            detail={detail}
+            placeholder="Select a framework to review its controls and evidence."
+            data-testid="compliance-split"
+          />
+
+          <Collapsible
+            title="Cloud CIS benchmark drill-down"
+            subtitle="AWS / Azure / GCP / Snowflake / Databricks"
+            icon={Scan}
+            defaultOpen={false}
+          >
+            <CISBenchmarkDetail />
+          </Collapsible>
+
+          {(hubPosture && hubPosture.totals.combined > 0) || mitreCatalog || atlasCatalog ? (
+            <Collapsible title="Operator & catalog context" defaultOpen={false}>
+              <div className="space-y-3 text-xs text-[color:var(--text-tertiary)]">
+                {hubPosture && hubPosture.totals.combined > 0 ? (
+                  <p>
+                    Compliance hub: {hubPosture.totals.combined.toLocaleString()} findings (
+                    {hubPosture.totals.native.toLocaleString()} native ·{" "}
+                    {hubPosture.totals.hub.toLocaleString()} ingested). Import via{" "}
+                    <code className="rounded bg-[color:var(--surface-muted)] px-1 py-0.5">
+                      POST /v1/compliance/ingest
+                    </code>
+                    .
+                  </p>
+                ) : null}
+                {mitreCatalog ? (
+                  <p>
+                    MITRE ATT&CK {mitreCatalog.attack_version || "catalog"} ·{" "}
+                    {mitreCatalog.technique_count} techniques · refresh with{" "}
+                    <code className="rounded bg-[color:var(--surface-muted)] px-1 py-0.5">
+                      agent-bom db update-frameworks
+                    </code>
+                    .
+                  </p>
+                ) : null}
+                {atlasCatalog ? (
+                  <p>
+                    MITRE ATLAS {atlasCatalog.atlas_version || "catalog"} ·{" "}
+                    {atlasCatalog.technique_count} techniques · refresh with{" "}
+                    <code className="rounded bg-[color:var(--surface-muted)] px-1 py-0.5">
+                      agent-bom db update-frameworks --framework atlas
+                    </code>
+                    .
+                  </p>
+                ) : null}
+              </div>
+            </Collapsible>
+          ) : null}
+        </>
+      ) : null}
 
       {selectedControl ? (
         <ComplianceControlDrawer
@@ -570,8 +699,6 @@ function CompliancePageContent() {
           catalogName={selectedControl.catalog?.[selectedControl.control.code]}
           onClose={() => setSelectedControl(null)}
         />
-      ) : null}
-      </>
       ) : null}
 
       {/* ── Empty state ───────────────────────────────────────────────── */}

--- a/ui/app/cost/page.tsx
+++ b/ui/app/cost/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   DollarSign,
   Activity,
@@ -12,7 +12,6 @@ import {
   Gauge,
   Flame,
   CalendarClock,
-  Building2,
   UserCheck,
 } from "lucide-react";
 import {
@@ -47,6 +46,11 @@ import { PageLaneHeader } from "@/components/page-lane";
 import { ServiceStateBanner, ServiceStateChip } from "@/components/service-state-chip";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { serviceEntry } from "@/lib/service-registry";
+import { StatStrip, type StatStripItem } from "@/components/stat-strip";
+import { DataTable, type DataTableColumn, type SortDirection } from "@/components/data-table";
+import { Collapsible } from "@/components/collapsible";
+import { Drawer } from "@/components/drawer";
+import { useChartTheme } from "@/lib/theme-colors";
 
 function classifyApiErrorKind(err: unknown): ApiOfflineKind {
   if (err instanceof ApiAuthError) return "auth";
@@ -60,148 +64,98 @@ const fmtUsd = (n: number) =>
     : `$${n.toFixed(4)}`;
 const fmtInt = (n: number) => n.toLocaleString();
 
-function StatCard({
-  icon: Icon,
-  label,
-  value,
-  color,
-}: {
-  icon: React.ElementType;
-  label: string;
-  value: string;
-  color: string;
-}) {
-  return (
-    <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-4">
-      <div className="mb-1 flex items-center gap-2">
-        <Icon className={`h-4 w-4 ${color}`} />
-        <span className="text-xs text-[var(--text-tertiary)]">{label}</span>
-      </div>
-      <p className="text-2xl font-bold text-[var(--foreground)]">{value}</p>
-    </div>
-  );
+// ─── Budget (owner-scoped) ───────────────────────────────────────────────────
+
+function budgetScopeLabel(budget: CostReport["budget"]): string {
+  if (budget.owner) {
+    return budget.workflow
+      ? `owner ${budget.owner} · ${budget.workflow}`
+      : `owner ${budget.owner}`;
+  }
+  if (budget.agent) return `agent ${budget.agent}`;
+  if (budget.cost_center) return `cost-center ${budget.cost_center}`;
+  return "tenant-wide";
 }
 
-function BudgetBanner({ budget }: { budget: CostReport["budget"] }) {
+function BudgetPanel({ budget }: { budget: CostReport["budget"] }) {
   if (!budget?.configured) {
     return (
-      <div className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-4 text-sm text-[var(--text-secondary)]">
-        No spend budget configured for this tenant. Set one via{" "}
-        <code className="rounded bg-[var(--surface-elevated)] px-1.5 py-0.5 text-xs text-[var(--text-secondary)]">
+      <div className="flex h-full flex-col justify-center rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 text-sm text-[color:var(--text-secondary)] elev-1">
+        <div className="mb-1 flex items-center gap-2 text-[color:var(--text-tertiary)]">
+          <Gauge className="h-4 w-4" />
+          <span className="text-[11px] font-medium uppercase tracking-[0.1em]">Budget</span>
+        </div>
+        No spend budget configured. Set one via{" "}
+        <code className="rounded bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-xs text-[color:var(--text-secondary)]">
           POST /v1/observability/costs/budget
         </code>{" "}
-        to enable pre-invocation enforcement at the gateway.
+        to enable owner-scoped, pre-invocation enforcement at the gateway.
       </div>
     );
   }
   const util = budget.utilization ?? 0;
   const pct = Math.min(100, Math.round(util * 100));
   const enforce = budget.mode === "enforce";
-  const barColor = budget.exceeded
-    ? "bg-red-500"
-    : pct >= 80
-      ? "bg-amber-500"
-      : "bg-emerald-500";
+  const tone = budget.exceeded ? "danger" : pct >= 80 ? "warn" : "success";
+  const barVar =
+    tone === "danger"
+      ? "var(--status-danger)"
+      : tone === "warn"
+        ? "var(--status-warn)"
+        : "var(--status-success)";
   return (
     <div
-      className={`rounded-xl border p-4 ${
+      className={`rounded-xl border p-4 elev-1 ${
         budget.exceeded
-          ? "border-red-800/60 bg-red-950/20"
-          : "border-[var(--border-subtle)] bg-[var(--surface)]/40"
+          ? "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)]"
+          : "border-[color:var(--border-subtle)] bg-[color:var(--surface)]"
       }`}
     >
       <div className="flex flex-wrap items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <Gauge
-            className={`h-4 w-4 ${budget.exceeded ? "text-red-400" : "text-emerald-400"}`}
+            className="h-4 w-4"
+            style={{ color: budget.exceeded ? "var(--status-danger)" : "var(--status-success)" }}
           />
-          <span className="text-sm font-medium text-[var(--foreground)]">
-            Budget {budget.agent ? `· agent ${budget.agent}` : "· tenant-wide"}
+          <span className="text-sm font-medium text-[color:var(--foreground)]">
+            Budget · {budgetScopeLabel(budget)}
           </span>
           <span
             className={`rounded-full px-2 py-0.5 text-xs font-medium ${
               enforce
-                ? "bg-emerald-900/60 text-emerald-300"
-                : "bg-[var(--surface-elevated)] text-[var(--text-secondary)]"
+                ? "border border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]"
+                : "border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
             }`}
           >
             {enforce ? "enforce" : "report-only"}
           </span>
           {budget.exceeded && (
-            <span className="rounded-full bg-red-900/60 px-2 py-0.5 text-xs font-medium text-red-300">
+            <span className="rounded-full border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-2 py-0.5 text-xs font-medium text-[color:var(--status-danger)]">
               exceeded
             </span>
           )}
         </div>
-        <span className="text-sm text-[var(--text-secondary)]">
+        <span className="text-sm text-[color:var(--text-secondary)]">
           {fmtUsd(budget.spend_usd)}{" "}
           {budget.limit_usd != null && <>/ {fmtUsd(budget.limit_usd)}</>}
           {budget.remaining_usd != null && (
-            <span className="ml-2 text-[var(--text-tertiary)]">
+            <span className="ml-2 text-[color:var(--text-tertiary)]">
               ({fmtUsd(Math.max(0, budget.remaining_usd))} left)
             </span>
           )}
         </span>
       </div>
-      <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-[var(--surface-elevated)]">
+      <div className="mt-3 h-2.5 overflow-hidden rounded-full bg-[color:var(--surface-muted)]">
         <div
-          className={`h-full ${barColor} transition-all duration-700`}
-          style={{ width: `${pct}%` }}
+          className="h-full transition-all duration-700"
+          style={{ width: `${pct}%`, backgroundColor: barVar }}
         />
       </div>
     </div>
   );
 }
 
-function BreakdownTable({
-  title,
-  rows,
-}: {
-  title: string;
-  rows: CostBreakdownRow[];
-}) {
-  const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
-  return (
-    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
-      <h3 className="mb-3 text-sm font-semibold text-[var(--text-secondary)]">{title}</h3>
-      {top.length === 0 ? (
-        <p className="text-sm text-[var(--text-tertiary)]">No cost records yet.</p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
-              <th className="pb-2 font-medium">Name</th>
-              <th className="pb-2 text-right font-medium">Calls</th>
-              <th className="pb-2 text-right font-medium">Tokens (in/out)</th>
-              <th className="pb-2 text-right font-medium">Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {top.map((r) => (
-              <tr
-                key={r.key}
-                className="border-b border-[var(--border-subtle)] last:border-0"
-              >
-                <td className="py-2 font-mono text-xs text-[var(--text-secondary)]">
-                  {r.key || "—"}
-                </td>
-                <td className="py-2 text-right text-[var(--text-secondary)]">
-                  {fmtInt(r.calls)}
-                </td>
-                <td className="py-2 text-right text-[var(--text-tertiary)]">
-                  {fmtInt(r.input_tokens)} / {fmtInt(r.output_tokens)}
-                </td>
-                <td className="py-2 text-right font-medium text-[var(--foreground)]">
-                  {fmtUsd(r.cost_usd)}
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
-    </div>
-  );
-}
+// ─── Forecast & runway ───────────────────────────────────────────────────────
 
 const FORECAST_STATUS: Record<
   string,
@@ -220,18 +174,25 @@ function fmtDays(n: number): string {
   return `${(n * 24).toFixed(1)}h`;
 }
 
+function toneChipClass(tone: "ok" | "warn" | "danger" | "muted"): string {
+  switch (tone) {
+    case "ok":
+      return "border border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]";
+    case "warn":
+      return "border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--status-warn)]";
+    case "danger":
+      return "border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--status-danger)]";
+    default:
+      return "border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]";
+  }
+}
+
 function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
   const status = forecast?.status ?? "insufficient_history";
   const meta = FORECAST_STATUS[status] ?? {
     label: status.replace(/_/g, " "),
     tone: "muted" as const,
   };
-  const toneClass = {
-    ok: "bg-emerald-900/60 text-emerald-300",
-    warn: "bg-amber-900/60 text-amber-300",
-    danger: "bg-red-900/60 text-red-300",
-    muted: "bg-[var(--surface-elevated)] text-[var(--text-secondary)]",
-  }[meta.tone];
 
   const hasRate = forecast?.burn_rate_usd_per_day != null;
   const hasRunway = forecast?.days_remaining != null;
@@ -242,20 +203,22 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
     forecast.days_remaining <= 14;
 
   return (
-    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1">
       <div className="mb-3 flex items-center gap-2">
-        <CalendarClock className="h-4 w-4 text-sky-400" />
-        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
+        <CalendarClock className="h-4 w-4 text-[color:var(--accent)]" />
+        <h3 className="text-sm font-semibold text-[color:var(--foreground)]">
           Forecast &amp; runway
         </h3>
         <span
-          className={`rounded-full px-2 py-0.5 text-xs font-medium ${atRisk ? "bg-amber-900/60 text-amber-300" : toneClass}`}
+          className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+            atRisk ? toneChipClass("warn") : toneChipClass(meta.tone)
+          }`}
         >
           {atRisk ? "at risk" : meta.label}
         </span>
       </div>
       {!hasRate && !hasRunway ? (
-        <p className="text-sm text-[var(--text-tertiary)]">
+        <p className="text-sm text-[color:var(--text-tertiary)]">
           {status === "insufficient_history"
             ? "Not enough timestamped spend yet to project a burn rate. A forecast appears once at least two priced LLM calls are recorded."
             : status === "no_budget"
@@ -266,65 +229,50 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
         </p>
       ) : (
         <>
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
-              <div className="mb-1 flex items-center gap-1.5">
-                <Flame className="h-3.5 w-3.5 text-orange-400" />
-                <span className="text-xs text-[var(--text-tertiary)]">Burn / day</span>
-              </div>
-              <p className="text-lg font-bold text-[var(--foreground)]">
-                {forecast?.burn_rate_usd_per_day != null
+          <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+            <ForecastStat
+              icon={Flame}
+              label="Burn / day"
+              value={
+                forecast?.burn_rate_usd_per_day != null
                   ? fmtUsd(forecast.burn_rate_usd_per_day)
-                  : "—"}
-              </p>
-              {forecast?.burn_rate_basis && (
-                <p className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">
-                  {forecast.burn_rate_basis.replace(/_/g, " ")}
-                </p>
-              )}
-            </div>
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
-              <div className="mb-1 flex items-center gap-1.5">
-                <Gauge className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
-                <span className="text-xs text-[var(--text-tertiary)]">Runway</span>
-              </div>
-              <p
-                className={`text-lg font-bold ${atRisk ? "text-amber-300" : "text-[var(--foreground)]"}`}
-              >
-                {forecast?.days_remaining != null
-                  ? fmtDays(forecast.days_remaining)
-                  : "—"}
-              </p>
-            </div>
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
-              <div className="mb-1 flex items-center gap-1.5">
-                <CalendarClock className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
-                <span className="text-xs text-[var(--text-tertiary)]">Exhaustion</span>
-              </div>
-              <p className="text-sm font-medium text-[var(--foreground)]">
-                {forecast?.projected_exhaustion_at
+                  : "—"
+              }
+              hint={forecast?.burn_rate_basis?.replace(/_/g, " ")}
+            />
+            <ForecastStat
+              icon={Gauge}
+              label="Runway"
+              value={
+                forecast?.days_remaining != null ? fmtDays(forecast.days_remaining) : "—"
+              }
+              valueClass={atRisk ? "text-[color:var(--status-warn)]" : undefined}
+            />
+            <ForecastStat
+              icon={CalendarClock}
+              label="Exhaustion"
+              value={
+                forecast?.projected_exhaustion_at
                   ? formatDate(forecast.projected_exhaustion_at)
-                  : "—"}
-              </p>
-            </div>
-            <div className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/50 p-3">
-              <div className="mb-1 flex items-center gap-1.5">
-                <TrendingUp className="h-3.5 w-3.5 text-[var(--text-secondary)]" />
-                <span className="text-xs text-[var(--text-tertiary)]">Projected period</span>
-              </div>
-              <p className="text-sm font-medium text-[var(--foreground)]">
-                {forecast?.projected_period_spend_usd != null
+                  : "—"
+              }
+            />
+            <ForecastStat
+              icon={TrendingUp}
+              label="Projected period"
+              value={
+                forecast?.projected_period_spend_usd != null
                   ? fmtUsd(forecast.projected_period_spend_usd)
-                  : "—"}
-              </p>
-              {forecast?.budget_limit_usd != null && (
-                <p className="mt-0.5 text-[11px] text-[var(--text-tertiary)]">
-                  of {fmtUsd(forecast.budget_limit_usd)} cap
-                </p>
-              )}
-            </div>
+                  : "—"
+              }
+              hint={
+                forecast?.budget_limit_usd != null
+                  ? `of ${fmtUsd(forecast.budget_limit_usd)} cap`
+                  : undefined
+              }
+            />
           </div>
-          <p className="mt-3 text-[11px] text-[var(--text-tertiary)]">
+          <p className="mt-3 text-[11px] text-[color:var(--text-tertiary)]">
             Reference only — a forecast never blocks a call; enforcement stays at
             the gateway.
           </p>
@@ -334,122 +282,268 @@ function ForecastPanel({ forecast }: { forecast: CostForecast | null }) {
   );
 }
 
-function ChargebackPanel({ rows }: { rows: CostBreakdownRow[] }) {
-  const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
-  const total = rows.reduce((sum, r) => sum + r.cost_usd, 0);
+function ForecastStat({
+  icon: Icon,
+  label,
+  value,
+  hint,
+  valueClass,
+}: {
+  icon: React.ElementType;
+  label: string;
+  value: string;
+  hint?: string | undefined;
+  valueClass?: string | undefined;
+}) {
   return (
-    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
-      <div className="mb-3 flex items-center gap-2">
-        <Building2 className="h-4 w-4 text-violet-400" />
-        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
-          Chargeback by cost-center
-        </h3>
+    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
+      <div className="mb-1 flex items-center gap-1.5">
+        <Icon className="h-3.5 w-3.5 text-[color:var(--text-tertiary)]" />
+        <span className="text-[11px] text-[color:var(--text-tertiary)]">{label}</span>
       </div>
-      {top.length === 0 ? (
-        <p className="text-sm text-[var(--text-tertiary)]">
-          No chargeback allocation recorded. Tag GenAI spans with{" "}
-          <code className="rounded bg-[var(--surface-elevated)] px-1.5 py-0.5 text-xs text-[var(--text-secondary)]">
-            agent.cost_center
-          </code>{" "}
-          (or <code className="text-[var(--text-secondary)]">allocation.tag.*</code>) to attribute
-          spend to a budget unit.
-        </p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
-              <th className="pb-2 font-medium">Cost center</th>
-              <th className="pb-2 text-right font-medium">Calls</th>
-              <th className="pb-2 text-right font-medium">Share</th>
-              <th className="pb-2 text-right font-medium">Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {top.map((r) => {
-              const share = total > 0 ? r.cost_usd / total : 0;
-              return (
-                <tr
-                  key={r.key}
-                  className="border-b border-[var(--border-subtle)] last:border-0"
-                >
-                  <td className="py-2 font-mono text-xs text-[var(--text-secondary)]">
-                    {r.key || "unallocated"}
-                  </td>
-                  <td className="py-2 text-right text-[var(--text-secondary)]">
-                    {fmtInt(r.calls)}
-                  </td>
-                  <td className="py-2 text-right text-[var(--text-tertiary)]">
-                    {(share * 100).toFixed(1)}%
-                  </td>
-                  <td className="py-2 text-right font-medium text-[var(--foreground)]">
-                    {fmtUsd(r.cost_usd)}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      )}
+      <p className={`text-lg font-bold ${valueClass ?? "text-[color:var(--foreground)]"}`}>
+        {value}
+      </p>
+      {hint ? <p className="mt-0.5 text-[11px] text-[color:var(--text-tertiary)]">{hint}</p> : null}
     </div>
   );
 }
 
-function OwnerPanel({ rows }: { rows: CostBreakdownRow[] }) {
-  const top = [...rows].sort((a, b) => b.cost_usd - a.cost_usd).slice(0, 12);
-  const total = rows.reduce((sum, r) => sum + r.cost_usd, 0);
+// ─── Breakdown (unified, dimension-switched) ─────────────────────────────────
+
+type BreakdownDim = {
+  key: string;
+  label: string;
+  noun: string;
+  rows: CostBreakdownRow[];
+  emptyKey: string;
+  emptyHint: string;
+};
+
+type SortKey = "cost_usd" | "calls" | "key";
+
+function BreakdownExplorer({ report }: { report: CostReport }) {
+  const dims = useMemo<BreakdownDim[]>(
+    () => [
+      { key: "agent", label: "Agent", noun: "agent", rows: report.by_agent, emptyKey: "—", emptyHint: "" },
+      { key: "model", label: "Model", noun: "model", rows: report.by_model, emptyKey: "—", emptyHint: "" },
+      { key: "provider", label: "Provider", noun: "provider", rows: report.by_provider, emptyKey: "—", emptyHint: "" },
+      {
+        key: "owner",
+        label: "Owner",
+        noun: "accountable owner",
+        rows: report.by_owner ?? [],
+        emptyKey: "unattributed",
+        emptyHint:
+          "Approve a governance blueprint listing an agent to attribute its spend to the accountable owner.",
+      },
+      {
+        key: "cost_center",
+        label: "Cost center",
+        noun: "cost-center",
+        rows: report.by_cost_center ?? [],
+        emptyKey: "unallocated",
+        emptyHint:
+          "Tag GenAI spans with agent.cost_center (or allocation.tag.*) to attribute spend to a budget unit.",
+      },
+    ],
+    [report],
+  );
+
+  const [activeKey, setActiveKey] = useState("agent");
+  const [sort, setSort] = useState<{ key: SortKey; direction: SortDirection }>({
+    key: "cost_usd",
+    direction: "desc",
+  });
+  const [selected, setSelected] = useState<CostBreakdownRow | null>(null);
+
+  const active = dims.find((d) => d.key === activeKey) ?? dims[0]!;
+  const total = useMemo(
+    () => active.rows.reduce((sum, r) => sum + r.cost_usd, 0),
+    [active],
+  );
+
+  const sortedRows = useMemo(() => {
+    const rows = [...active.rows];
+    rows.sort((a, b) => {
+      const dir = sort.direction === "asc" ? 1 : -1;
+      if (sort.key === "key") return dir * a.key.localeCompare(b.key);
+      return dir * (a[sort.key] - b[sort.key]);
+    });
+    return rows;
+  }, [active, sort]);
+
+  const cycleSort = (key: string) => {
+    setSort((prev) =>
+      prev.key === key
+        ? { key: key as SortKey, direction: prev.direction === "asc" ? "desc" : "asc" }
+        : { key: key as SortKey, direction: key === "key" ? "asc" : "desc" },
+    );
+  };
+
+  const columns: DataTableColumn<CostBreakdownRow>[] = [
+    {
+      key: "key",
+      header: active.label,
+      sortable: true,
+      cell: (r) => (
+        <span className="font-mono text-xs text-[color:var(--text-secondary)]">
+          {r.key || active.emptyKey}
+        </span>
+      ),
+    },
+    {
+      key: "calls",
+      header: "Calls",
+      align: "right",
+      sortable: true,
+      cell: (r) => fmtInt(r.calls),
+    },
+    {
+      key: "tokens",
+      header: "Tokens (in/out)",
+      align: "right",
+      cell: (r) => (
+        <span className="text-[color:var(--text-tertiary)]">
+          {fmtInt(r.input_tokens)} / {fmtInt(r.output_tokens)}
+        </span>
+      ),
+    },
+    {
+      key: "share",
+      header: "Share",
+      align: "right",
+      cell: (r) => (
+        <span className="text-[color:var(--text-tertiary)]">
+          {(total > 0 ? (r.cost_usd / total) * 100 : 0).toFixed(1)}%
+        </span>
+      ),
+    },
+    {
+      key: "cost_usd",
+      header: "Cost",
+      align: "right",
+      sortable: true,
+      cell: (r) => (
+        <span className="font-medium text-[color:var(--foreground)]">{fmtUsd(r.cost_usd)}</span>
+      ),
+    },
+  ];
+
   return (
-    <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
-      <div className="mb-3 flex items-center gap-2">
-        <UserCheck className="h-4 w-4 text-emerald-400" />
-        <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
-          Spend by accountable owner
-        </h3>
+    <div className="space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <h3 className="text-sm font-semibold text-[color:var(--foreground)]">Cost breakdown</h3>
+        <div className="flex flex-wrap items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5">
+          {dims.map((dim) => (
+            <button
+              key={dim.key}
+              type="button"
+              onClick={() => {
+                setActiveKey(dim.key);
+                setSelected(null);
+              }}
+              className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                dim.key === activeKey
+                  ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                  : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+              }`}
+            >
+              {dim.label}
+            </button>
+          ))}
+        </div>
       </div>
-      {top.length === 0 ? (
-        <p className="text-sm text-[var(--text-tertiary)]">
-          No owner attribution yet. Approve a governance blueprint whose
-          composition lists an agent to attribute that agent&apos;s spend to its
-          accountable owner.
-        </p>
-      ) : (
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b border-[var(--border-subtle)] text-left text-xs text-[var(--text-tertiary)]">
-              <th className="pb-2 font-medium">Owner</th>
-              <th className="pb-2 text-right font-medium">Calls</th>
-              <th className="pb-2 text-right font-medium">Share</th>
-              <th className="pb-2 text-right font-medium">Cost</th>
-            </tr>
-          </thead>
-          <tbody>
-            {top.map((r) => {
-              const share = total > 0 ? r.cost_usd / total : 0;
-              return (
-                <tr
-                  key={r.key}
-                  className="border-b border-[var(--border-subtle)] last:border-0"
-                >
-                  <td className="py-2 font-mono text-xs text-[var(--text-secondary)]">
-                    {r.key || "unattributed"}
-                  </td>
-                  <td className="py-2 text-right text-[var(--text-secondary)]">
-                    {fmtInt(r.calls)}
-                  </td>
-                  <td className="py-2 text-right text-[var(--text-tertiary)]">
-                    {(share * 100).toFixed(1)}%
-                  </td>
-                  <td className="py-2 text-right font-medium text-[var(--foreground)]">
-                    {fmtUsd(r.cost_usd)}
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      )}
+
+      <DataTable
+        rows={sortedRows}
+        rowKey={(r) => r.key || active.emptyKey}
+        columns={columns}
+        selectedKey={selected ? selected.key || active.emptyKey : undefined}
+        onRowClick={setSelected}
+        sort={sort}
+        onSortChange={cycleSort}
+        maxHeight="26rem"
+        caption={`Spend by ${active.noun}`}
+        empty={
+          active.emptyHint || `No spend recorded by ${active.noun} yet.`
+        }
+        data-testid="cost-breakdown-table"
+      />
+
+      <Drawer
+        open={selected != null}
+        onClose={() => setSelected(null)}
+        eyebrow={`Spend by ${active.label}`}
+        title={selected?.key || active.emptyKey}
+        size="lg"
+        ariaLabel="Cost breakdown detail"
+      >
+        {selected ? (
+          <div className="space-y-4">
+            <StatStrip
+              items={[
+                { label: "Cost", value: fmtUsd(selected.cost_usd), accent: "success" },
+                {
+                  label: "Share",
+                  value: `${(total > 0 ? (selected.cost_usd / total) * 100 : 0).toFixed(1)}%`,
+                },
+                { label: "Calls", value: fmtInt(selected.calls) },
+              ]}
+            />
+            <dl className="grid grid-cols-2 gap-3 text-sm">
+              <DetailStat label="Input tokens" value={fmtInt(selected.input_tokens)} />
+              <DetailStat label="Output tokens" value={fmtInt(selected.output_tokens)} />
+              <DetailStat
+                label="Unpriced calls"
+                value={fmtInt(selected.unpriced_calls)}
+                warn={selected.unpriced_calls > 0}
+              />
+              <DetailStat
+                label="Avg cost / call"
+                value={fmtUsd(selected.calls > 0 ? selected.cost_usd / selected.calls : 0)}
+              />
+            </dl>
+            {selected.unpriced_calls > 0 ? (
+              <p className="rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs text-[color:var(--text-secondary)]">
+                {fmtInt(selected.unpriced_calls)} call
+                {selected.unpriced_calls === 1 ? "" : "s"} lacked a captured price model, so real
+                spend for this {active.noun} may be higher.
+              </p>
+            ) : null}
+          </div>
+        ) : null}
+      </Drawer>
     </div>
   );
 }
+
+function DetailStat({
+  label,
+  value,
+  warn,
+}: {
+  label: string;
+  value: string;
+  warn?: boolean;
+}) {
+  return (
+    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
+      <dt className="text-[11px] uppercase tracking-[0.1em] text-[color:var(--text-tertiary)]">
+        {label}
+      </dt>
+      <dd
+        className={`mt-1 font-mono text-base font-semibold ${
+          warn ? "text-[color:var(--status-warn)]" : "text-[color:var(--foreground)]"
+        }`}
+      >
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+// ─── Anomalies ───────────────────────────────────────────────────────────────
 
 function AnomalyRow({ a }: { a: CostAnomaly }) {
   const high = a.severity === "high";
@@ -457,27 +551,28 @@ function AnomalyRow({ a }: { a: CostAnomaly }) {
     <div
       className={`rounded-lg border p-3 ${
         high
-          ? "border-red-800/50 bg-red-950/20"
-          : "border-amber-800/40 bg-amber-950/10"
+          ? "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)]"
+          : "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)]"
       }`}
     >
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
           <ShieldAlert
-            className={`h-4 w-4 ${high ? "text-red-400" : "text-amber-400"}`}
+            className="h-4 w-4"
+            style={{ color: high ? "var(--status-danger)" : "var(--status-warn)" }}
           />
-          <span className="text-sm font-medium text-[var(--foreground)]">
+          <span className="text-sm font-medium text-[color:var(--foreground)]">
             {a.type.replace(/_/g, " ")}
           </span>
-          <span className="font-mono text-xs text-[var(--text-tertiary)]">
+          <span className="font-mono text-xs text-[color:var(--text-tertiary)]">
             {a.agent ?? a.session_id ?? ""}
           </span>
         </div>
-        <span className="font-mono text-xs text-[var(--text-secondary)]">
+        <span className="font-mono text-xs text-[color:var(--text-secondary)]">
           z={a.z_score.toFixed(1)}
         </span>
       </div>
-      <p className="mt-1 text-xs text-[var(--text-secondary)]">
+      <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
         {a.metric} ={" "}
         {typeof a.value === "number" ? a.value.toLocaleString() : a.value} vs
         baseline {a.baseline_median.toLocaleString()} — {a.recommendation}
@@ -486,9 +581,12 @@ function AnomalyRow({ a }: { a: CostAnomaly }) {
   );
 }
 
+// ─── Page ────────────────────────────────────────────────────────────────────
+
 export default function CostPage() {
   const { counts } = useDeploymentContext();
   const aiSpendService = serviceEntry(counts?.services, "ai_spend");
+  const chart = useChartTheme();
   const [report, setReport] = useState<CostReport | null>(null);
   const [anomalies, setAnomalies] = useState<AnomaliesReport | null>(null);
   const [forecast, setForecast] = useState<CostForecast | null>(null);
@@ -552,8 +650,23 @@ export default function CostPage() {
     .map((r) => ({ name: r.key || "—", cost: Number(r.cost_usd.toFixed(4)) }));
   const anomalyCount = anomalies?.anomaly_count ?? 0;
 
+  const kpis: StatStripItem[] = [
+    { label: "Total spend", value: fmtUsd(report.total_cost_usd), icon: DollarSign, accent: "success" },
+    { label: "LLM calls", value: fmtInt(report.total_calls), icon: Activity },
+    { label: "Input tokens", value: fmtInt(report.total_input_tokens), icon: ArrowDownToLine },
+    { label: "Output tokens", value: fmtInt(report.total_output_tokens), icon: ArrowUpFromLine },
+    {
+      label: "Unpriced calls",
+      value: fmtInt(report.unpriced_calls),
+      icon: AlertTriangle,
+      accent: "warn",
+      accentThreshold: 0,
+      hint: report.unpriced_calls > 0 ? "spend may be understated" : undefined,
+    },
+  ];
+
   return (
-    <div className="space-y-6">
+    <div className="space-y-5">
       <PageLaneHeader
         lane="operations"
         title="AI Spend"
@@ -573,117 +686,67 @@ export default function CostPage() {
         registry={counts?.services}
       />
 
-      <BudgetBanner budget={report.budget} />
+      <StatStrip items={kpis} data-testid="cost-kpi-strip" />
 
-      <ForecastPanel forecast={forecast} />
+      <div className="grid gap-4 lg:grid-cols-2">
+        <BudgetPanel budget={report.budget} />
+        <ForecastPanel forecast={forecast} />
+      </div>
 
       {!hasData ? (
         <PageEmptyState
           title="No cost telemetry yet"
           detail="Cost records appear once agents make priced LLM calls through the proxy or report usage to the cost store."
           icon={DollarSign}
+          data-testid="cost-empty-state"
         />
       ) : (
-        <>
-          <div className="grid grid-cols-2 gap-4 md:grid-cols-5">
-            <StatCard
-              icon={DollarSign}
-              label="Total spend"
-              value={fmtUsd(report.total_cost_usd)}
-              color="text-emerald-400"
-            />
-            <StatCard
-              icon={Activity}
-              label="LLM calls"
-              value={fmtInt(report.total_calls)}
-              color="text-blue-400"
-            />
-            <StatCard
-              icon={ArrowDownToLine}
-              label="Input tokens"
-              value={fmtInt(report.total_input_tokens)}
-              color="text-[var(--text-secondary)]"
-            />
-            <StatCard
-              icon={ArrowUpFromLine}
-              label="Output tokens"
-              value={fmtInt(report.total_output_tokens)}
-              color="text-[var(--text-secondary)]"
-            />
-            <StatCard
-              icon={AlertTriangle}
-              label="Unpriced calls"
-              value={fmtInt(report.unpriced_calls)}
-              color={
-                report.unpriced_calls > 0 ? "text-amber-400" : "text-[var(--text-secondary)]"
-              }
-            />
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.4fr)_minmax(0,1fr)]">
+          <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1">
+            <BreakdownExplorer report={report} />
           </div>
-
-          <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
+          <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1">
             <div className="mb-3 flex items-center gap-2">
-              <TrendingUp className="h-4 w-4 text-emerald-400" />
-              <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
+              <TrendingUp className="h-4 w-4 text-[color:var(--accent)]" />
+              <h3 className="text-sm font-semibold text-[color:var(--foreground)]">
                 Spend by agent (top 10)
               </h3>
             </div>
-            <ResponsiveContainer width="100%" height={280}>
+            <ResponsiveContainer width="100%" height={300}>
               <BarChart
                 data={agentChart}
                 margin={{ top: 8, right: 8, bottom: 8, left: 8 }}
               >
-                <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-                <XAxis
-                  dataKey="name"
-                  stroke="#71717a"
-                  tick={{ fontSize: 11 }}
-                />
+                <CartesianGrid strokeDasharray="3 3" stroke={chart.grid} />
+                <XAxis dataKey="name" stroke={chart.text} tick={{ fontSize: 11 }} />
                 <YAxis
-                  stroke="#71717a"
+                  stroke={chart.text}
                   tick={{ fontSize: 11 }}
                   tickFormatter={(v) => `$${v}`}
                 />
-                <Tooltip
-                  content={<ChartTooltip />}
-                  cursor={{ fill: "#ffffff08" }}
-                />
+                <Tooltip content={<ChartTooltip />} cursor={{ fill: "var(--surface-muted)" }} />
                 <Bar dataKey="cost" radius={[6, 6, 0, 0]}>
                   {agentChart.map((_, i) => (
-                    <Cell key={i} fill="#34d399" />
+                    <Cell key={i} fill={chart.accent} />
                   ))}
                 </Bar>
               </BarChart>
             </ResponsiveContainer>
           </div>
-
-          <div className="grid gap-4 lg:grid-cols-2">
-            <BreakdownTable title="By model" rows={report.by_model} />
-            <BreakdownTable title="By provider" rows={report.by_provider} />
-          </div>
-
-          <div className="grid gap-4 lg:grid-cols-2">
-            <ChargebackPanel rows={report.by_cost_center ?? []} />
-            <OwnerPanel rows={report.by_owner ?? []} />
-          </div>
-        </>
+        </div>
       )}
 
-      <div className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--surface)]/40 p-5">
-        <div className="mb-3 flex items-center gap-2">
-          <ShieldAlert className="h-4 w-4 text-amber-400" />
-          <h3 className="text-sm font-semibold text-[var(--text-secondary)]">
-            Cost & behavior anomalies
-          </h3>
-          {anomalyCount > 0 && (
-            <span className="rounded-full bg-amber-900/60 px-2 py-0.5 text-xs font-medium text-amber-300">
-              {anomalyCount}
-            </span>
-          )}
-        </div>
+      <Collapsible
+        title="Cost & behavior anomalies"
+        subtitle="Statistical outliers across cost and call-rate baselines"
+        icon={ShieldAlert}
+        count={anomalyCount}
+        defaultOpen={anomalyCount > 0}
+        data-testid="cost-anomalies"
+      >
         {anomalyCount === 0 ? (
-          <p className="text-sm text-[var(--text-tertiary)]">
-            No statistical anomalies detected across cost or call-rate
-            baselines.
+          <p className="text-sm text-[color:var(--text-tertiary)]">
+            No statistical anomalies detected across cost or call-rate baselines.
           </p>
         ) : (
           <div className="space-y-2">
@@ -695,7 +758,14 @@ export default function CostPage() {
             ))}
           </div>
         )}
-      </div>
+      </Collapsible>
+
+      {hasData && report.by_owner && report.by_owner.length > 0 ? (
+        <p className="flex items-center gap-1.5 text-[11px] text-[color:var(--text-tertiary)]">
+          <UserCheck className="h-3.5 w-3.5" />
+          Owner rollup attributes each agent&apos;s spend to the accountable owner from its governing blueprint. Switch the breakdown to <span className="font-medium text-[color:var(--text-secondary)]">Owner</span> to review chargeback.
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/ui/app/runtime/page.tsx
+++ b/ui/app/runtime/page.tsx
@@ -32,16 +32,20 @@ function RuntimeTabs() {
   const active = TABS.find((item) => item.key === tab) ?? TABS[0]!;
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-4 border-b border-[var(--border-subtle)] pb-4 lg:flex-row lg:items-end lg:justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-[var(--foreground)]">Runtime</h1>
-          <p className="mt-1 max-w-3xl text-sm text-[var(--text-secondary)]">
+    <div className="space-y-5">
+      <div className="flex flex-col gap-4 border-b border-[color:var(--border-subtle)] pb-4 lg:flex-row lg:items-end lg:justify-between">
+        <div className="min-w-0">
+          <h1 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Runtime</h1>
+          <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-secondary)]">
             One enforcement surface for MCP proxy telemetry and gateway policy. Switch tabs to review live
             activity, alerts, rollout posture, and audit evidence without hopping between nav entries.
           </p>
         </div>
-        <div className="flex flex-wrap gap-2">
+        <div
+          className="flex flex-wrap items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5"
+          role="tablist"
+          aria-label="Runtime surface"
+        >
           {TABS.map((item) => {
             const Icon = item.icon;
             const selected = item.key === tab;
@@ -49,11 +53,13 @@ function RuntimeTabs() {
               <button
                 key={item.key}
                 type="button"
+                role="tab"
+                aria-selected={selected}
                 onClick={() => router.replace(`/runtime?tab=${item.key}`)}
-                className={`inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors ${
+                className={`inline-flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors ${
                   selected
-                    ? "border-emerald-700 bg-emerald-950/40 text-emerald-200"
-                    : "border-[var(--border-subtle)] bg-[var(--background)] text-[var(--text-secondary)] hover:border-[var(--border-subtle)] hover:text-[var(--foreground)]"
+                    ? "bg-[color:var(--accent-soft)] text-[color:var(--accent)]"
+                    : "text-[color:var(--text-tertiary)] hover:text-[color:var(--foreground)]"
                 }`}
               >
                 <Icon className="h-4 w-4" />
@@ -64,7 +70,7 @@ function RuntimeTabs() {
         </div>
       </div>
 
-      <p className="text-xs text-[var(--text-tertiary)]">{active.description}</p>
+      <p className="text-xs text-[color:var(--text-tertiary)]">{active.description}</p>
 
       <RuntimeEmbedProvider>
         {tab === "proxy" ? <ProxyDashboard /> : <GatewayPage />}

--- a/ui/app/sources/page.tsx
+++ b/ui/app/sources/page.tsx
@@ -6,14 +6,12 @@ import {
   Activity,
   ArrowRight,
   CalendarClock,
-  Cloud,
   FileCheck2,
   Plus,
   Radio,
   RefreshCcw,
   ServerCog,
   Shield,
-  ShieldCheck,
   Workflow,
 } from "lucide-react";
 
@@ -33,6 +31,11 @@ import { useDemoMode } from "@/hooks/use-demo-mode";
 import { ServiceStateBanner, ServiceStateChip } from "@/components/service-state-chip";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { serviceEntry } from "@/lib/service-registry";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import { StatStrip } from "@/components/stat-strip";
+import { Collapsible } from "@/components/collapsible";
+import { Drawer } from "@/components/drawer";
+import { PageEmptyState } from "@/components/states/page-state";
 
 type IngestMode = "Direct scan" | "Read-only connector" | "Pushed ingest" | "Runtime" | "Imported artifact";
 
@@ -49,12 +52,6 @@ interface FormState {
   description: string;
   owner: string;
   connector_name: string;
-}
-
-interface ScheduleFormState {
-  source_id: string;
-  name: string;
-  cron_expression: string;
 }
 
 const SOURCE_KIND_OPTIONS: KindOption[] = [
@@ -152,11 +149,16 @@ const DEFAULT_FORM_STATE: FormState = {
   connector_name: "",
 };
 
-const DEFAULT_SCHEDULE_FORM_STATE: ScheduleFormState = {
-  source_id: "",
-  name: "",
-  cron_expression: "0 * * * *",
-};
+const SCHEDULABLE_KINDS = new Set<SourceKind>([
+  "scan.repo",
+  "scan.image",
+  "scan.iac",
+  "scan.cloud",
+  "scan.mcp_config",
+  "connector.cloud_read_only",
+  "connector.registry",
+  "connector.warehouse",
+]);
 
 const OPERATING_SURFACES = [
   {
@@ -202,32 +204,51 @@ function formatShortId(value: string, head = 10, tail = 6): string {
 
 const PROVIDER_SCAN_MODE_PREVIEW = 3;
 
-function toneForMode(mode: IngestMode): string {
-  switch (mode) {
-    case "Direct scan":
-      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-400";
-    case "Read-only connector":
-      return "border-sky-900/60 bg-sky-950/30 text-sky-400";
-    case "Pushed ingest":
-      return "border-amber-900/60 bg-amber-950/30 text-amber-400";
-    case "Runtime":
-      return "border-violet-900/60 bg-violet-950/30 text-violet-400";
-    case "Imported artifact":
-      return "border-fuchsia-900/60 bg-fuchsia-950/30 text-fuchsia-400";
-  }
+/** Mode dot colors — token-only so both themes track. */
+const MODE_DOT: Record<IngestMode, string> = {
+  "Direct scan": "var(--status-success)",
+  "Read-only connector": "var(--severity-low)",
+  "Pushed ingest": "var(--status-warn)",
+  Runtime: "var(--severity-high)",
+  "Imported artifact": "var(--text-tertiary)",
+};
+
+const STATUS_TONE: Record<string, string> = {
+  healthy: "var(--status-success)",
+  done: "var(--status-success)",
+  active: "var(--status-success)",
+  degraded: "var(--status-warn)",
+  paused: "var(--status-warn)",
+  pending: "var(--status-warn)",
+  disabled: "var(--text-tertiary)",
+  error: "var(--status-danger)",
+  failed: "var(--status-danger)",
+};
+
+function statusTone(status: string): string {
+  return STATUS_TONE[status.toLowerCase()] ?? "var(--accent)";
 }
 
-function toneForStatus(status: string): string {
-  switch (status) {
-    case "healthy":
-      return "text-emerald-400";
-    case "degraded":
-      return "text-amber-400";
-    case "disabled":
-      return "text-[var(--text-secondary)]";
-    default:
-      return "text-sky-400";
-  }
+function ModeChip({ mode }: { mode: IngestMode }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-0.5 text-[11px] font-medium text-[color:var(--text-secondary)]">
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: MODE_DOT[mode] }} aria-hidden="true" />
+      {mode}
+    </span>
+  );
+}
+
+function StatusPill({ status }: { status: string }) {
+  const tone = statusTone(status);
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 text-[11px] font-medium uppercase tracking-[0.1em]"
+      style={{ color: tone }}
+    >
+      <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: tone }} aria-hidden="true" />
+      {status}
+    </span>
+  );
 }
 
 function formatMode(value: string): string {
@@ -265,12 +286,14 @@ export default function SourcesPage() {
   const [syncingFleet, setSyncingFleet] = useState(false);
   const [fleetSyncSummary, setFleetSyncSummary] = useState<string | null>(null);
   const [formState, setFormState] = useState<FormState>(DEFAULT_FORM_STATE);
-  const [scheduleForm, setScheduleForm] = useState<ScheduleFormState>(DEFAULT_SCHEDULE_FORM_STATE);
   const [submitting, setSubmitting] = useState(false);
   const [submittingSchedule, setSubmittingSchedule] = useState(false);
   const [formMessage, setFormMessage] = useState<string | null>(null);
   const [busySourceId, setBusySourceId] = useState<string | null>(null);
   const [busyScheduleId, setBusyScheduleId] = useState<string | null>(null);
+  const [selectedSourceId, setSelectedSourceId] = useState<string | null>(null);
+  const [scheduleName, setScheduleName] = useState("");
+  const [scheduleCron, setScheduleCron] = useState("0 * * * *");
 
   const connectorNames = useMemo(
     () => connectorHealth.map((connector) => connector.connector).sort((left, right) => left.localeCompare(right)),
@@ -287,23 +310,25 @@ export default function SourcesPage() {
   );
   const providerSummary = useMemo(() => summarizeProviders(providerContracts), [providerContracts]);
   const sourceIndex = useMemo(() => new Map(sources.map((source) => [source.source_id, source])), [sources]);
-  const schedulableSources = useMemo(
-    () =>
-      sources.filter((source) =>
-        ["scan.repo", "scan.image", "scan.iac", "scan.cloud", "scan.mcp_config", "connector.cloud_read_only", "connector.registry", "connector.warehouse"].includes(
-          source.kind
-        )
-      ),
-    [sources]
-  );
   const scheduleCounts = useMemo(() => {
-    const counts = new Map<string, number>();
+    const map = new Map<string, number>();
     for (const schedule of schedules) {
       const linkedSourceId = typeof schedule.scan_config?.source_id === "string" ? String(schedule.scan_config.source_id) : "";
       if (!linkedSourceId) continue;
-      counts.set(linkedSourceId, (counts.get(linkedSourceId) ?? 0) + 1);
+      map.set(linkedSourceId, (map.get(linkedSourceId) ?? 0) + 1);
     }
-    return counts;
+    return map;
+  }, [schedules]);
+  const schedulesBySource = useMemo(() => {
+    const map = new Map<string, ScanSchedule[]>();
+    for (const schedule of schedules) {
+      const linkedSourceId = typeof schedule.scan_config?.source_id === "string" ? String(schedule.scan_config.source_id) : "";
+      if (!linkedSourceId) continue;
+      const list = map.get(linkedSourceId) ?? [];
+      list.push(schedule);
+      map.set(linkedSourceId, list);
+    }
+    return map;
   }, [schedules]);
   const roleSummary = session?.role_summary ?? null;
   const roleLabel = roleSummary?.display_name ?? session?.role ?? "Unknown";
@@ -311,12 +336,10 @@ export default function SourcesPage() {
   const canRunScans = hasCapability("scan.run");
   const canManageFleet = hasCapability("fleet.manage");
 
+  const selectedSource = selectedSourceId ? sourceIndex.get(selectedSourceId) ?? null : null;
+
   function updateForm<K extends keyof FormState>(field: K, value: FormState[K]) {
     setFormState((current) => ({ ...current, [field]: value }));
-  }
-
-  function updateScheduleForm<K extends keyof ScheduleFormState>(field: K, value: ScheduleFormState[K]) {
-    setScheduleForm((current) => ({ ...current, [field]: value }));
   }
 
   async function refreshControlPlane() {
@@ -452,6 +475,7 @@ export default function SourcesPage() {
       } else {
         await api.deleteSource(sourceId);
         setFormMessage("Source deleted.");
+        setSelectedSourceId(null);
       }
       await refreshControlPlane();
     } catch (err) {
@@ -461,36 +485,26 @@ export default function SourcesPage() {
     }
   }
 
-  async function handleCreateSchedule(event: React.FormEvent<HTMLFormElement>) {
+  async function handleCreateSchedule(event: React.FormEvent<HTMLFormElement>, source: SourceRecord) {
     event.preventDefault();
     setFormMessage(null);
 
-    const source = sourceIndex.get(scheduleForm.source_id);
-    if (!source) {
-      setFormMessage("Choose a source to schedule.");
-      return;
-    }
-
-    if (!scheduleForm.cron_expression.trim()) {
+    if (!scheduleCron.trim()) {
       setFormMessage("Cron expression is required.");
       return;
     }
 
-    const name = scheduleForm.name.trim() || `${source.display_name} recurring run`;
+    const name = scheduleName.trim() || `${source.display_name} recurring run`;
     setSubmittingSchedule(true);
     try {
       await api.createSchedule({
         name,
-        cron_expression: scheduleForm.cron_expression.trim(),
+        cron_expression: scheduleCron.trim(),
         enabled: true,
         scan_config: { source_id: source.source_id },
       });
       setFormMessage(`Created schedule ${name}.`);
-      setScheduleForm({
-        source_id: source.source_id,
-        name: "",
-        cron_expression: scheduleForm.cron_expression,
-      });
+      setScheduleName("");
       await refreshControlPlane();
     } catch (err) {
       setFormMessage(err instanceof Error ? err.message : "Failed to create schedule.");
@@ -518,12 +532,59 @@ export default function SourcesPage() {
     }
   }
 
+  const columns: DataTableColumn<SourceRecord>[] = [
+    {
+      key: "name",
+      header: "Name",
+      cell: (source) => {
+        const option = SOURCE_KIND_OPTIONS.find((entry) => entry.value === source.kind);
+        return (
+          <div className="min-w-0">
+            <div className="truncate font-medium text-[color:var(--foreground)]">{source.display_name}</div>
+            <div className="truncate text-xs text-[color:var(--text-tertiary)]">{option?.label ?? source.kind}</div>
+          </div>
+        );
+      },
+    },
+    {
+      key: "kind",
+      header: "Kind",
+      cell: (source) => {
+        const option = SOURCE_KIND_OPTIONS.find((entry) => entry.value === source.kind);
+        return <ModeChip mode={option?.mode ?? "Direct scan"} />;
+      },
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (source) => <StatusPill status={source.status} />,
+    },
+    {
+      key: "last_run",
+      header: "Last run",
+      cell: (source) => <span className="text-xs">{formatWhen(source.last_run_at)}</span>,
+    },
+    {
+      key: "schedule",
+      header: "Schedule",
+      align: "right",
+      cell: (source) => <span className="tabular-nums">{scheduleCounts.get(source.source_id) ?? 0}</span>,
+    },
+    {
+      key: "connector",
+      header: "Connector",
+      cell: (source) => (
+        <span className="truncate text-xs text-[color:var(--text-secondary)]">{source.connector_name || "—"}</span>
+      ),
+    },
+  ];
+
   return (
     <div className="space-y-5">
       <header className="flex flex-wrap items-start justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-semibold tracking-tight text-[var(--foreground)]">Data sources</h1>
-          <p className="mt-1 text-sm text-[var(--text-secondary)]">
+          <h1 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">Data sources</h1>
+          <p className="mt-1 text-sm text-[color:var(--text-secondary)]">
             Register scan targets, review connector health, and manage schedules.
           </p>
           <div className="mt-2">
@@ -538,7 +599,7 @@ export default function SourcesPage() {
         <div className="flex flex-wrap gap-2">
           <button
             onClick={() => refreshControlPlane()}
-            className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+            className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
           >
             <RefreshCcw className="h-4 w-4" />
             Refresh
@@ -547,7 +608,7 @@ export default function SourcesPage() {
             <button
               onClick={handleFleetSync}
               disabled={syncingFleet || !canManageFleet}
-              className="inline-flex items-center gap-2 rounded-lg bg-emerald-500 px-3 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-2 rounded-lg bg-[color:var(--accent)] px-3 py-2 text-sm font-medium text-[color:var(--accent-contrast)] transition hover:bg-[color:var(--accent-strong)] disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Activity className="h-4 w-4" />
               {syncingFleet ? "Syncing…" : "Fleet sync"}
@@ -558,272 +619,104 @@ export default function SourcesPage() {
 
       {isDemoMode && <DemoConnectCard />}
 
-      <ServiceStateBanner
-        serviceId="data_sources"
-        entry={dataSourcesService}
-        registry={counts?.services}
+      <ServiceStateBanner serviceId="data_sources" entry={dataSourcesService} registry={counts?.services} />
+
+      <StatStrip
+        data-testid="sources-kpis"
+        items={[
+          {
+            label: "Auth mode",
+            value: session?.auth_method ?? (authLoading ? "…" : "Unknown"),
+            hint: session ? `${roleLabel} · ${session.tenant_id}` : "Control plane owns auth",
+          },
+          {
+            label: "Registered sources",
+            value: loading ? "…" : sourceCount,
+          },
+          {
+            label: "Connector health",
+            value: loading ? "…" : `${healthyConnectors}/${connectorHealth.length || 0}`,
+            accent: connectorHealth.length > 0 && healthyConnectors === connectorHealth.length ? "success" : "neutral",
+          },
+          {
+            label: "Schedules",
+            value: loading ? "…" : schedules.length,
+            hint: schedules[0]?.next_run ? `Next ${formatWhen(schedules[0].next_run)}` : "None yet",
+          },
+        ]}
       />
 
-      <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-        <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          <MetricCard
-            icon={ShieldCheck}
-            label="Auth mode"
-            value={session?.auth_method ?? (authLoading ? "Loading…" : "Unknown")}
-            detail={
-              session
-                ? `${roleLabel} · tenant ${session.tenant_id} · ${session.recommended_ui_mode}`
-                : "API/control plane owns auth and tenant scope"
-            }
-          />
-          <MetricCard
+      {(fleetSyncSummary || formMessage || error) && (
+        <div className="space-y-1 text-sm">
+          {fleetSyncSummary ? <p className="text-[color:var(--status-success)]">{fleetSyncSummary}</p> : null}
+          {formMessage ? <p className="text-[color:var(--accent)]">{formMessage}</p> : null}
+          {error ? <p className="text-[color:var(--status-danger)]">{error}</p> : null}
+        </div>
+      )}
+
+      {!loading && sources.length === 0 ? (
+        isDemoMode ? (
+          <PageEmptyState
+            title="No demo sources registered"
+            detail="Explore New Scan or Scan Jobs with sample data to see how registered sources drive evidence."
             icon={ServerCog}
-            label="Registered sources"
-            value={loading ? "Loading…" : String(sourceCount)}
-            detail={sources[0]?.updated_at ? `Last update ${formatWhen(sources[0].updated_at)}` : "No source registry records yet"}
+            actions={[
+              { label: "New Scan", href: "/scan" },
+              { label: "Scan Jobs", href: "/jobs", variant: "secondary" },
+            ]}
           />
-          <MetricCard
-            icon={Cloud}
-            label="Connector health"
-            value={loading ? "Loading…" : `${healthyConnectors}/${connectorHealth.length || 0}`}
-            detail="Read-only integrations checked through backend health routes"
+        ) : (
+          <PageEmptyState
+            title="No registered sources yet"
+            detail="Register a scan target or connector-backed source to test, run, and schedule it from the control plane."
+            icon={ServerCog}
           />
-          <MetricCard
-            icon={CalendarClock}
-            label="Schedules"
-            value={loading ? "Loading…" : String(schedules.length)}
-            detail={schedules[0]?.next_run ? `Next run ${formatWhen(schedules[0].next_run)}` : "No persisted schedules yet"}
-          />
-        </div>
-
-        {fleetSyncSummary ? <p className="mt-4 text-sm text-emerald-400">{fleetSyncSummary}</p> : null}
-        {formMessage ? <p className="mt-2 text-sm text-emerald-400">{formMessage}</p> : null}
-        {error ? <p className="mt-2 text-sm text-red-400">{error}</p> : null}
-      </section>
-
-      {roleSummary && !isDemoMode ? (
-        <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 shadow-lg shadow-black/5">
-          <div className="flex items-start gap-3">
-            <span className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-2.5">
-              <Shield className="h-5 w-5 text-emerald-400" />
-            </span>
-            <div>
-              <h2 className="text-base font-semibold text-[var(--foreground)]">{roleSummary.display_name} access in this tenant</h2>
-              <p className="mt-1 text-sm text-[var(--text-secondary)]">{roleSummary.description}</p>
-            </div>
+        )
+      ) : (
+        <section className="space-y-2">
+          <div className="flex items-baseline justify-between">
+            <h2 className="text-base font-semibold text-[color:var(--foreground)]">Source registry</h2>
+            <p className="text-xs text-[color:var(--text-tertiary)]">Row → detail, evidence, and actions</p>
           </div>
-
-          <div className="mt-5 grid gap-4 lg:grid-cols-3">
-            <AccessList title="Can see" items={roleSummary.can_see} tone="text-sky-300" />
-            <AccessList title="Can do" items={roleSummary.can_do} tone="text-emerald-300" />
-            <AccessList title="Blocked from" items={roleSummary.cannot_do} tone="text-amber-300" />
-          </div>
+          <DataTable<SourceRecord>
+            data-testid="sources-table"
+            columns={columns}
+            rows={sources}
+            rowKey={(source) => source.source_id}
+            onRowClick={(source) => setSelectedSourceId(source.source_id)}
+            selectedKey={selectedSourceId ?? undefined}
+            loading={loading}
+            maxHeight="32rem"
+            caption="Registered data sources with status, last run, schedule count, and connector"
+          />
         </section>
-      ) : null}
+      )}
 
-      <details className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
-        <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--foreground)] [&::-webkit-details-marker]:hidden">
-          Provider trust contracts
-          {providerContracts ? (
-            <span className="ml-2 text-xs font-normal text-[var(--text-tertiary)]">
-              {providerSummary.total} providers · v{providerContracts.contract_version}
-            </span>
-          ) : null}
-        </summary>
-        <div className="space-y-4 border-t border-[color:var(--border-subtle)] p-4">
-          <p className="text-sm text-[var(--text-secondary)]">
-            Backend provider registry: scan modes, declared permissions, and read-only guarantees.
-          </p>
-
-          <div className="grid gap-3 md:grid-cols-4">
-            <ContractStat label="Providers" value={loading ? "Loading…" : String(providerSummary.total)} />
-            <ContractStat label="Read-only" value={loading ? "Loading…" : `${providerSummary.readOnly}/${providerSummary.total}`} />
-            <ContractStat label="Scope-zero modes" value={loading ? "Loading…" : String(providerSummary.scopeZero)} />
-            <ContractStat label="Declared permissions" value={loading ? "Loading…" : String(providerSummary.permissionCount)} />
-          </div>
-
-          {providerContracts?.warnings?.length ? (
-            <div className="rounded-xl border border-amber-900/60 bg-amber-950/20 p-3 text-xs leading-5 text-amber-200">
-              {providerContracts.warnings.slice(0, 2).join(" · ")}
-            </div>
-          ) : null}
-
-          <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
-            {!providerContracts && !loading ? (
-              <div className="rounded-xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
-                Provider contracts are unavailable from the API.
-              </div>
-            ) : (
-              (providerContracts?.providers ?? []).slice(0, 12).map((provider) => (
-                <ProviderContractCard key={provider.name} provider={provider} />
-              ))
-            )}
-          </div>
-        </div>
-      </details>
-
-      <div className="grid gap-5 xl:grid-cols-[minmax(0,1.2fr)_minmax(0,0.8fr)]">
-        <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-          <h2 className="text-base font-semibold text-[var(--foreground)]">Source registry</h2>
-          <p className="mt-1 text-sm text-[var(--text-secondary)]">Persisted sources with status, last run, and evidence links.</p>
-
-          <div className="mt-4 space-y-3">
-            {sources.length === 0 && !loading ? (
-              <div className="rounded-xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
-                {isDemoMode ? (
-                  <>
-                    No demo sources registered. Explore{" "}
-                    <Link href="/scan" className="text-emerald-400 hover:text-emerald-300">New Scan</Link>
-                    {" "}or{" "}
-                    <Link href="/jobs" className="text-emerald-400 hover:text-emerald-300">Scan Jobs</Link>
-                    {" "}with sample data.
-                  </>
-                ) : (
-                  "No registered sources yet. Create one to test and run from the control plane."
-                )}
-              </div>
-            ) : (
-              sources.map((source) => {
-                const option = SOURCE_KIND_OPTIONS.find((entry) => entry.value === source.kind);
-                const isBusy = busySourceId === source.source_id;
-                return (
-                  <div
-                    key={source.source_id}
-                    data-testid={`source-workflow-${source.source_id}`}
-                    className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4"
-                  >
-                    <div className="flex flex-wrap items-start justify-between gap-3">
-                      <div>
-                        <div className={`inline-flex rounded-full border px-2.5 py-1 text-[11px] font-medium ${toneForMode(option?.mode ?? "Direct scan")}`}>
-                          {option?.mode ?? source.kind}
-                        </div>
-                        <h3 className="mt-3 text-sm font-semibold text-[var(--foreground)]">{source.display_name}</h3>
-                        <p className="mt-1 text-xs text-[var(--text-secondary)]">{option?.label ?? source.kind}</p>
-                      </div>
-                      <div className="text-right">
-                        <p className={`text-[11px] uppercase tracking-[0.18em] ${toneForStatus(source.status)}`}>{source.status}</p>
-                        <p className="mt-1 text-[11px] text-[var(--text-tertiary)]">{source.enabled ? "Enabled" : "Disabled"}</p>
-                      </div>
-                    </div>
-
-                    {source.description ? <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">{source.description}</p> : null}
-
-                    <div className="mt-3 grid gap-2 text-xs text-[var(--text-secondary)] sm:grid-cols-2">
-                      <span>Owner: {source.owner || "Unassigned"}</span>
-                      <span>Credential mode: {source.credential_mode}</span>
-                      <span>Connector: {source.connector_name || "—"}</span>
-                      <span>Last tested: {formatWhen(source.last_tested_at)}</span>
-                      <span>Last run: {formatWhen(source.last_run_at)}</span>
-                      <span className="min-w-0 sm:col-span-2">
-                        Last job:{" "}
-                        {source.last_job_id ? (
-                          <Link
-                            href={`/scan?id=${encodeURIComponent(source.last_job_id)}`}
-                            className="inline-block max-w-full truncate font-mono text-emerald-300 hover:text-emerald-200"
-                            title={source.last_job_id}
-                          >
-                            {formatShortId(source.last_job_id)}
-                          </Link>
-                        ) : (
-                          "—"
-                        )}
-                      </span>
-                      <span>Schedules: {scheduleCounts.get(source.source_id) ?? 0}</span>
-                    </div>
-
-                    {source.last_test_message ? (
-                      <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">{source.last_test_message}</p>
-                    ) : null}
-
-                    <div className="mt-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-3">
-                      <div className="flex items-start gap-2">
-                        <FileCheck2 className="mt-0.5 h-4 w-4 text-emerald-400" />
-                        <div>
-                          <p className="text-xs font-semibold text-[var(--foreground)]">Evidence workflow</p>
-                          <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">
-                            {source.last_job_id
-                              ? "Open the completed job surfaces created from this source."
-                              : "Run this source to create findings, graph, and compliance evidence."}
-                          </p>
-                        </div>
-                      </div>
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {[
-                          { target: "jobs" as const, label: "Jobs" },
-                          { target: "findings" as const, label: "Findings" },
-                          { target: "graph" as const, label: "Graph" },
-                          { target: "compliance" as const, label: "Compliance" },
-                        ].map((link) => (
-                          <Link
-                            key={link.target}
-                            href={sourceEvidenceHref(source, link.target)}
-                            aria-disabled={link.target !== "jobs" && !source.last_job_id}
-                            className={`rounded-lg border px-2.5 py-1.5 text-[11px] font-medium transition ${
-                              link.target !== "jobs" && !source.last_job_id
-                                ? "pointer-events-none border-[color:var(--border-subtle)] text-[var(--text-tertiary)] opacity-60"
-                                : "border-[color:var(--border-subtle)] text-[var(--foreground)] hover:border-[color:var(--border-strong)]"
-                            }`}
-                          >
-                            {link.label}
-                          </Link>
-                        ))}
-                      </div>
-                    </div>
-
-                    <div className="mt-4 flex flex-wrap gap-2">
-                      <button
-                        onClick={() => runSourceAction(source.source_id, "test")}
-                        disabled={isBusy || !canManageSources}
-                        className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        {isBusy ? "Working…" : "Test"}
-                      </button>
-                      <button
-                        onClick={() => runSourceAction(source.source_id, "run")}
-                        disabled={isBusy || !source.enabled || !canRunScans}
-                        className="rounded-xl bg-emerald-500 px-3 py-2 text-xs font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Run now
-                      </button>
-                      <button
-                        onClick={() => runSourceAction(source.source_id, "delete")}
-                        disabled={isBusy || !canManageSources}
-                        className="rounded-xl border border-red-900/60 bg-red-950/20 px-3 py-2 text-xs font-medium text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
-                      >
-                        Delete
-                      </button>
-                    </div>
-                  </div>
-                );
-              })
-            )}
-          </div>
-        </section>
-
-        <div className="space-y-5">
-          {!isDemoMode && (
-          <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-            <h2 className="text-base font-semibold text-[var(--foreground)]">Create source</h2>
-            <p className="mt-1 text-sm text-[var(--text-secondary)]">Register a new scan target or connector-backed source.</p>
-
-            <form className="mt-4 space-y-4" onSubmit={handleCreateSource}>
+      {!isDemoMode && (
+        <div className="grid gap-4 xl:grid-cols-2">
+          <Collapsible title="Create source" icon={Plus} defaultOpen={sources.length === 0}>
+            <form className="space-y-4" onSubmit={handleCreateSource}>
               <label className="block">
-                <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Display name</span>
+                <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                  Display name
+                </span>
                 <input
                   value={formState.display_name}
                   onChange={(event) => updateForm("display_name", event.target.value)}
-                  className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                  className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--accent-border)]"
                   placeholder="AWS production account"
                 />
               </label>
 
               <div className="grid gap-4 sm:grid-cols-2">
                 <label className="block">
-                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Kind</span>
+                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                    Kind
+                  </span>
                   <select
                     value={formState.kind}
                     onChange={(event) => updateForm("kind", event.target.value as SourceKind)}
-                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                    className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--accent-border)]"
                   >
                     {SOURCE_KIND_OPTIONS.map((option) => (
                       <option key={option.value} value={option.value}>
@@ -834,11 +727,13 @@ export default function SourcesPage() {
                 </label>
 
                 <label className="block">
-                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Owner</span>
+                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                    Owner
+                  </span>
                   <input
                     value={formState.owner}
                     onChange={(event) => updateForm("owner", event.target.value)}
-                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                    className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--accent-border)]"
                     placeholder="platform-security"
                   />
                 </label>
@@ -846,11 +741,13 @@ export default function SourcesPage() {
 
               {selectedKind.mode === "Read-only connector" ? (
                 <label className="block">
-                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Connector name</span>
+                  <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                    Connector name
+                  </span>
                   <select
                     value={formState.connector_name}
                     onChange={(event) => updateForm("connector_name", event.target.value)}
-                    className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                    className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--accent-border)]"
                   >
                     <option value="">Choose connector…</option>
                     {connectorNames.map((connector) => (
@@ -863,243 +760,421 @@ export default function SourcesPage() {
               ) : null}
 
               <label className="block">
-                <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Description</span>
+                <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                  Description
+                </span>
                 <textarea
                   value={formState.description}
                   onChange={(event) => updateForm("description", event.target.value)}
-                  rows={3}
-                  className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
+                  rows={2}
+                  className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--accent-border)]"
                   placeholder={selectedKind.detail}
                 />
               </label>
 
-              <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-xs leading-5 text-[var(--text-secondary)]">
-                <div className={`inline-flex rounded-full border px-2.5 py-1 font-medium ${toneForMode(selectedKind.mode)}`}>{selectedKind.mode}</div>
-                <p className="mt-3">{selectedKind.detail}</p>
+              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3 text-xs leading-5 text-[color:var(--text-secondary)]">
+                <ModeChip mode={selectedKind.mode} />
+                <p className="mt-2">{selectedKind.detail}</p>
               </div>
 
               <button
                 type="submit"
                 disabled={submitting || !canManageSources}
-                className="inline-flex items-center gap-2 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+                className="inline-flex items-center gap-2 rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--accent-contrast)] transition hover:bg-[color:var(--accent-strong)] disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <Plus className="h-4 w-4" />
                 {submitting ? "Creating…" : "Create source"}
               </button>
             </form>
-          </section>
-          )}
+          </Collapsible>
 
-          {!isDemoMode && (
-          <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-            <h2 className="text-base font-semibold text-[var(--foreground)]">Connector health</h2>
-            <div className="mt-4 space-y-3">
-              {connectorHealth.length === 0 && !loading ? (
-                <div className="rounded-xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[var(--text-secondary)]">
-                  No connector health state loaded yet.
-                </div>
-              ) : (
-                connectorHealth.map((connector) => (
-                  <div key={connector.connector} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+          <Collapsible
+            title="Connector health"
+            count={connectorHealth.length}
+            defaultOpen={false}
+            scrollMaxHeight="20rem"
+          >
+            {connectorHealth.length === 0 && !loading ? (
+              <p className="text-sm text-[color:var(--text-secondary)]">No connector health state loaded yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {connectorHealth.map((connector) => (
+                  <div
+                    key={connector.connector}
+                    className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3"
+                  >
                     <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <h3 className="text-sm font-semibold text-[var(--foreground)]">{connector.connector}</h3>
-                        <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">{connector.message}</p>
+                      <div className="min-w-0">
+                        <h3 className="text-sm font-semibold text-[color:var(--foreground)]">{connector.connector}</h3>
+                        <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)]">{connector.message}</p>
                       </div>
-                      <span className={`text-[11px] uppercase tracking-[0.18em] ${toneForStatus(connector.state)}`}>{connector.state}</span>
+                      <StatusPill status={connector.state} />
                     </div>
                   </div>
-                ))
-              )}
+                ))}
+              </div>
+            )}
+          </Collapsible>
+        </div>
+      )}
+
+      <Collapsible
+        title="Provider trust contracts"
+        subtitle={
+          providerContracts ? `${providerSummary.total} providers · v${providerContracts.contract_version}` : undefined
+        }
+        defaultOpen={false}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-[color:var(--text-secondary)]">
+            Backend provider registry: scan modes, declared permissions, and read-only guarantees.
+          </p>
+
+          <StatStrip
+            items={[
+              { label: "Providers", value: loading ? "…" : providerSummary.total },
+              { label: "Read-only", value: loading ? "…" : `${providerSummary.readOnly}/${providerSummary.total}` },
+              { label: "Scope-zero modes", value: loading ? "…" : providerSummary.scopeZero },
+              { label: "Declared permissions", value: loading ? "…" : providerSummary.permissionCount },
+            ]}
+          />
+
+          {providerContracts?.warnings?.length ? (
+            <div className="rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] p-3 text-xs leading-5 text-[color:var(--text-secondary)]">
+              {providerContracts.warnings.slice(0, 2).join(" · ")}
             </div>
-          </section>
-          )}
+          ) : null}
 
-          {!isDemoMode && (
-          <section className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-            <h2 className="text-base font-semibold text-[var(--foreground)]">Schedules</h2>
-            <p className="mt-1 text-sm text-[var(--text-secondary)]">Recurring scans bound to registered sources.</p>
+          <div className="grid gap-3 lg:grid-cols-2 xl:grid-cols-3">
+            {!providerContracts && !loading ? (
+              <div className="rounded-lg border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-sm text-[color:var(--text-secondary)]">
+                Provider contracts are unavailable from the API.
+              </div>
+            ) : (
+              (providerContracts?.providers ?? []).slice(0, 12).map((provider) => (
+                <ProviderContractCard key={provider.name} provider={provider} />
+              ))
+            )}
+          </div>
+        </div>
+      </Collapsible>
 
-            <div className="mt-4 space-y-3">
-              <form className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4" onSubmit={handleCreateSchedule}>
-                <div className="grid gap-4 md:grid-cols-3">
-                  <label className="block">
-                    <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Source</span>
-                    <select
-                      aria-label="Schedule source"
-                      value={scheduleForm.source_id}
-                      onChange={(event) => updateScheduleForm("source_id", event.target.value)}
-                      className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
-                    >
-                      <option value="">Choose source…</option>
-                      {schedulableSources.map((source) => (
-                        <option key={source.source_id} value={source.source_id}>
-                          {source.display_name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                  <label className="block">
-                    <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Name</span>
-                    <input
-                      aria-label="Schedule name"
-                      value={scheduleForm.name}
-                      onChange={(event) => updateScheduleForm("name", event.target.value)}
-                      className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
-                      placeholder="Nightly cloud posture"
-                    />
-                  </label>
-                  <label className="block">
-                    <span className="mb-2 block text-xs font-medium uppercase tracking-[0.18em] text-[var(--text-tertiary)]">Cron</span>
-                    <input
-                      aria-label="Schedule cron"
-                      value={scheduleForm.cron_expression}
-                      onChange={(event) => updateScheduleForm("cron_expression", event.target.value)}
-                      className="w-full rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 font-mono text-sm text-[var(--foreground)] outline-none transition focus:border-emerald-500"
-                      placeholder="0 * * * *"
-                    />
-                  </label>
-                </div>
-                <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
-                  <p className="min-w-0 flex-1 text-xs leading-5 text-[var(--text-secondary)]">
-                    Schedules persist in the control plane and run queued scans with the linked <code>source_id</code>, not browser state.
-                  </p>
-                  <button
-                    type="submit"
-                    disabled={submittingSchedule || schedulableSources.length === 0 || !canManageSources}
-                    className="inline-flex shrink-0 items-center gap-2 self-start rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60 sm:self-auto"
-                  >
-                    <CalendarClock className="h-4 w-4" />
-                    {submittingSchedule ? "Creating…" : "Create schedule"}
-                  </button>
-                </div>
-              </form>
+      {roleSummary && !isDemoMode ? (
+        <Collapsible title={`${roleSummary.display_name} access in this tenant`} icon={Shield} defaultOpen={false}>
+          <p className="text-sm text-[color:var(--text-secondary)]">{roleSummary.description}</p>
+          <div className="mt-4 grid gap-4 lg:grid-cols-3">
+            <AccessList title="Can see" items={roleSummary.can_see} />
+            <AccessList title="Can do" items={roleSummary.can_do} />
+            <AccessList title="Blocked from" items={roleSummary.cannot_do} />
+          </div>
+        </Collapsible>
+      ) : null}
 
-              {schedules.length === 0 && !loading ? (
-                <div className="rounded-2xl border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
-                  <p className="text-sm text-[var(--text-secondary)]">No scan schedules yet.</p>
-                  <Link href="/scan" className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-emerald-400">
-                    Open New Scan
-                    <ArrowRight className="h-4 w-4" />
-                  </Link>
-                </div>
-              ) : (
-                schedules.map((schedule) => {
-                  const linkedSourceId = typeof schedule.scan_config?.source_id === "string" ? String(schedule.scan_config.source_id) : "";
-                  const linkedSource = linkedSourceId ? sourceIndex.get(linkedSourceId) : null;
-                  const isBusy = busyScheduleId === schedule.schedule_id;
-                  return (
-                  <div key={schedule.schedule_id} className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      {!isDemoMode && (
+        <Collapsible title="Related operating surfaces" defaultOpen={false}>
+          <div className="grid gap-3 xl:grid-cols-2">
+            {OPERATING_SURFACES.map((surface) => {
+              const Icon = surface.icon;
+              return (
+                <Link key={surface.title} href={surface.href}>
+                  <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 transition-colors hover:border-[color:var(--border-strong)]">
                     <div className="flex items-start justify-between gap-3">
-                      <div>
-                        <h3 className="text-sm font-semibold text-[var(--foreground)]">{schedule.name}</h3>
-                        <p className="mt-1 font-mono text-xs text-[var(--text-secondary)]">{schedule.cron_expression}</p>
-                        <p className="mt-2 text-xs text-[var(--text-secondary)]">
-                          Source: {linkedSource?.display_name ?? (linkedSourceId || "Unlinked control-plane schedule")}
+                      <div className="flex items-center gap-3">
+                        <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-2">
+                          <Icon className="h-4 w-4 text-[color:var(--accent)]" />
+                        </span>
+                        <div>
+                          <p className="text-sm font-semibold text-[color:var(--foreground)]">{surface.title}</p>
+                          <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)]">{surface.summary}</p>
+                        </div>
+                      </div>
+                      <ArrowRight className="mt-1 h-4 w-4 text-[color:var(--text-tertiary)]" />
+                    </div>
+                    <div className="mt-4 text-[11px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                      {surface.status}
+                    </div>
+                  </div>
+                </Link>
+              );
+            })}
+          </div>
+        </Collapsible>
+      )}
+
+      <SourceDrawer
+        source={selectedSource}
+        open={selectedSource != null}
+        onClose={() => setSelectedSourceId(null)}
+        schedules={selectedSource ? schedulesBySource.get(selectedSource.source_id) ?? [] : []}
+        busySourceId={busySourceId}
+        busyScheduleId={busyScheduleId}
+        canManageSources={canManageSources}
+        canRunScans={canRunScans}
+        onSourceAction={runSourceAction}
+        onScheduleAction={runScheduleAction}
+        onCreateSchedule={handleCreateSchedule}
+        submittingSchedule={submittingSchedule}
+        scheduleName={scheduleName}
+        scheduleCron={scheduleCron}
+        onScheduleNameChange={setScheduleName}
+        onScheduleCronChange={setScheduleCron}
+      />
+    </div>
+  );
+}
+
+function SourceDrawer({
+  source,
+  open,
+  onClose,
+  schedules,
+  busySourceId,
+  busyScheduleId,
+  canManageSources,
+  canRunScans,
+  onSourceAction,
+  onScheduleAction,
+  onCreateSchedule,
+  submittingSchedule,
+  scheduleName,
+  scheduleCron,
+  onScheduleNameChange,
+  onScheduleCronChange,
+}: {
+  source: SourceRecord | null;
+  open: boolean;
+  onClose: () => void;
+  schedules: ScanSchedule[];
+  busySourceId: string | null;
+  busyScheduleId: string | null;
+  canManageSources: boolean;
+  canRunScans: boolean;
+  onSourceAction: (sourceId: string, action: "test" | "run" | "delete") => void;
+  onScheduleAction: (scheduleId: string, action: "toggle" | "delete") => void;
+  onCreateSchedule: (event: React.FormEvent<HTMLFormElement>, source: SourceRecord) => void;
+  submittingSchedule: boolean;
+  scheduleName: string;
+  scheduleCron: string;
+  onScheduleNameChange: (value: string) => void;
+  onScheduleCronChange: (value: string) => void;
+}) {
+  if (!source) return null;
+  const option = SOURCE_KIND_OPTIONS.find((entry) => entry.value === source.kind);
+  const mode = option?.mode ?? "Direct scan";
+  const isBusy = busySourceId === source.source_id;
+  const schedulable = SCHEDULABLE_KINDS.has(source.kind);
+
+  const meta: [string, React.ReactNode][] = [
+    ["Owner", source.owner || "Unassigned"],
+    ["Credential mode", source.credential_mode],
+    ["Connector", source.connector_name || "—"],
+    ["Enabled", source.enabled ? "Enabled" : "Disabled"],
+    ["Last tested", formatWhen(source.last_tested_at)],
+    ["Last run", formatWhen(source.last_run_at)],
+  ];
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      eyebrow={mode}
+      title={source.display_name}
+      subtitle={option?.label ?? source.kind}
+      headerAside={<StatusPill status={source.status} />}
+      size="2xl"
+      ariaLabel={`Source ${source.display_name}`}
+      footer={
+        <div className="flex flex-wrap gap-2">
+          <button
+            onClick={() => onSourceAction(source.source_id, "test")}
+            disabled={isBusy || !canManageSources}
+            className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isBusy ? "Working…" : "Test"}
+          </button>
+          <button
+            onClick={() => onSourceAction(source.source_id, "run")}
+            disabled={isBusy || !source.enabled || !canRunScans}
+            className="rounded-lg bg-[color:var(--accent)] px-3 py-2 text-xs font-medium text-[color:var(--accent-contrast)] transition hover:bg-[color:var(--accent-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Run now
+          </button>
+          <button
+            onClick={() => onSourceAction(source.source_id, "delete")}
+            disabled={isBusy || !canManageSources}
+            className="rounded-lg border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-3 py-2 text-xs font-medium text-[color:var(--status-danger)] transition hover:border-[color:var(--status-danger)] disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            Delete
+          </button>
+        </div>
+      }
+    >
+      <div className="space-y-5" data-testid={`source-detail-${source.source_id}`}>
+        {source.description ? (
+          <p className="text-sm leading-6 text-[color:var(--text-secondary)]">{source.description}</p>
+        ) : null}
+
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-3 text-sm">
+          {meta.map(([label, value]) => (
+            <div key={label} className="min-w-0">
+              <dt className="text-[11px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">{label}</dt>
+              <dd className="mt-0.5 truncate text-[color:var(--text-secondary)]">{value}</dd>
+            </div>
+          ))}
+          <div className="col-span-2 min-w-0">
+            <dt className="text-[11px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Last job</dt>
+            <dd className="mt-0.5">
+              {source.last_job_id ? (
+                <Link
+                  href={`/scan?id=${encodeURIComponent(source.last_job_id)}`}
+                  className="inline-block max-w-full truncate font-mono text-[color:var(--accent)] hover:underline"
+                  title={source.last_job_id}
+                >
+                  {formatShortId(source.last_job_id)}
+                </Link>
+              ) : (
+                <span className="text-[color:var(--text-secondary)]">—</span>
+              )}
+            </dd>
+          </div>
+        </dl>
+
+        {source.last_test_message ? (
+          <p className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3 text-xs leading-5 text-[color:var(--text-secondary)]">
+            {source.last_test_message}
+          </p>
+        ) : null}
+
+        <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+          <div className="flex items-start gap-2">
+            <FileCheck2 className="mt-0.5 h-4 w-4 text-[color:var(--accent)]" />
+            <div>
+              <p className="text-xs font-semibold text-[color:var(--foreground)]">Evidence workflow</p>
+              <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)]">
+                {source.last_job_id
+                  ? "Open the completed job surfaces created from this source."
+                  : "Run this source to create findings, graph, and compliance evidence."}
+              </p>
+            </div>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {[
+              { target: "jobs" as const, label: "Jobs" },
+              { target: "findings" as const, label: "Findings" },
+              { target: "graph" as const, label: "Graph" },
+              { target: "compliance" as const, label: "Compliance" },
+            ].map((link) => {
+              const disabled = link.target !== "jobs" && !source.last_job_id;
+              return (
+                <Link
+                  key={link.target}
+                  href={sourceEvidenceHref(source, link.target)}
+                  aria-disabled={disabled}
+                  className={`rounded-lg border px-2.5 py-1.5 text-[11px] font-medium transition ${
+                    disabled
+                      ? "pointer-events-none border-[color:var(--border-subtle)] text-[color:var(--text-tertiary)] opacity-60"
+                      : "border-[color:var(--border-subtle)] text-[color:var(--foreground)] hover:border-[color:var(--border-strong)]"
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-sm font-semibold text-[color:var(--foreground)]">Schedules</h3>
+          <div className="mt-3 space-y-2">
+            {schedules.length === 0 ? (
+              <p className="text-xs text-[color:var(--text-secondary)]">No schedules bound to this source yet.</p>
+            ) : (
+              schedules.map((schedule) => {
+                const isScheduleBusy = busyScheduleId === schedule.schedule_id;
+                return (
+                  <div
+                    key={schedule.schedule_id}
+                    className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        <p className="truncate text-sm font-medium text-[color:var(--foreground)]">{schedule.name}</p>
+                        <p className="mt-0.5 font-mono text-xs text-[color:var(--text-secondary)]">
+                          {schedule.cron_expression}
                         </p>
                       </div>
-                      <span className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
-                        {schedule.enabled ? "Enabled" : "Paused"}
-                      </span>
+                      <StatusPill status={schedule.enabled ? "active" : "paused"} />
                     </div>
-                    <div className="mt-3 grid gap-2 text-xs text-[var(--text-secondary)] sm:grid-cols-2">
-                      <span>Next run: {formatWhen(schedule.next_run)}</span>
-                      <span>Last run: {formatWhen(schedule.last_run)}</span>
+                    <div className="mt-2 grid grid-cols-2 gap-2 text-xs text-[color:var(--text-secondary)]">
+                      <span>Next: {formatWhen(schedule.next_run)}</span>
+                      <span>Last: {formatWhen(schedule.last_run)}</span>
                     </div>
-                    <div className="mt-4 flex flex-wrap gap-2">
+                    <div className="mt-3 flex flex-wrap gap-2">
                       <button
-                        onClick={() => runScheduleAction(schedule.schedule_id, "toggle")}
-                        disabled={isBusy || !canManageSources}
-                        className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={() => onScheduleAction(schedule.schedule_id, "toggle")}
+                        disabled={isScheduleBusy || !canManageSources}
+                        className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-xs font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:cursor-not-allowed disabled:opacity-60"
                       >
-                        {isBusy ? "Working…" : schedule.enabled ? "Pause" : "Enable"}
+                        {isScheduleBusy ? "Working…" : schedule.enabled ? "Pause" : "Enable"}
                       </button>
                       <button
-                        onClick={() => runScheduleAction(schedule.schedule_id, "delete")}
-                        disabled={isBusy || !canManageSources}
-                        className="rounded-xl border border-red-900/60 bg-red-950/20 px-3 py-2 text-xs font-medium text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
+                        onClick={() => onScheduleAction(schedule.schedule_id, "delete")}
+                        disabled={isScheduleBusy || !canManageSources}
+                        className="rounded-lg border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-3 py-1.5 text-xs font-medium text-[color:var(--status-danger)] transition hover:border-[color:var(--status-danger)] disabled:cursor-not-allowed disabled:opacity-60"
                       >
                         Delete
                       </button>
                     </div>
                   </div>
-                  );
-                })
-              )}
-            </div>
-          </section>
-          )}
-        </div>
-      </div>
+                );
+              })
+            )}
 
-      {!isDemoMode && (
-      <details className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]">
-        <summary className="cursor-pointer list-none px-4 py-3 text-sm font-semibold text-[var(--foreground)] [&::-webkit-details-marker]:hidden">
-          Related operating surfaces
-        </summary>
-        <div className="grid gap-3 border-t border-[color:var(--border-subtle)] p-4 xl:grid-cols-2">
-          {OPERATING_SURFACES.map((surface) => {
-            const Icon = surface.icon;
-            return (
-              <Link key={surface.title} href={surface.href}>
-                <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 transition-colors hover:border-[color:var(--border-strong)]">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="flex items-center gap-3">
-                      <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-2">
-                        <Icon className="h-4 w-4 text-emerald-400" />
-                      </span>
-                      <div>
-                        <p className="text-sm font-semibold text-[var(--foreground)]">{surface.title}</p>
-                        <p className="mt-1 text-xs leading-5 text-[var(--text-secondary)]">{surface.summary}</p>
-                      </div>
-                    </div>
-                    <ArrowRight className="mt-1 h-4 w-4 text-[var(--text-tertiary)]" />
-                  </div>
-                  <div className="mt-4 text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{surface.status}</div>
+            {schedulable ? (
+              <form
+                className="rounded-lg border border-dashed border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3"
+                onSubmit={(event) => onCreateSchedule(event, source)}
+              >
+                <div className="grid gap-3 sm:grid-cols-2">
+                  <label className="block">
+                    <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+                      Name
+                    </span>
+                    <input
+                      aria-label="Schedule name"
+                      value={scheduleName}
+                      onChange={(event) => onScheduleNameChange(event.target.value)}
+                      className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--accent-border)]"
+                      placeholder="Nightly posture"
+                    />
+                  </label>
+                  <label className="block">
+                    <span className="mb-1.5 block text-[11px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+                      Cron
+                    </span>
+                    <input
+                      aria-label="Schedule cron"
+                      value={scheduleCron}
+                      onChange={(event) => onScheduleCronChange(event.target.value)}
+                      className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 font-mono text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--accent-border)]"
+                      placeholder="0 * * * *"
+                    />
+                  </label>
                 </div>
-              </Link>
-            );
-          })}
-        </div>
-      </details>
-      )}
-    </div>
-  );
-}
-
-function MetricCard({
-  icon: Icon,
-  label,
-  value,
-  detail,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  value: string;
-  detail: string;
-}) {
-  return (
-    <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
-      <div className="flex items-center gap-3">
-        <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-2">
-          <Icon className="h-4 w-4 text-emerald-400" />
-        </span>
-        <div>
-          <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{label}</p>
-          <p className="mt-1 text-lg font-semibold text-[var(--foreground)]">{value}</p>
+                <button
+                  type="submit"
+                  disabled={submittingSchedule || !canManageSources}
+                  className="mt-3 inline-flex items-center gap-2 rounded-lg bg-[color:var(--accent)] px-4 py-2 text-sm font-medium text-[color:var(--accent-contrast)] transition hover:bg-[color:var(--accent-strong)] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <CalendarClock className="h-4 w-4" />
+                  {submittingSchedule ? "Creating…" : "Create schedule"}
+                </button>
+              </form>
+            ) : null}
+          </div>
         </div>
       </div>
-      <p className="mt-3 text-xs leading-5 text-[var(--text-secondary)]">{detail}</p>
-    </div>
-  );
-}
-
-function ContractStat({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
-      <p className="text-[11px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">{label}</p>
-      <p className="mt-1 text-lg font-semibold text-[var(--foreground)]">{value}</p>
-    </div>
+    </Drawer>
   );
 }
 
@@ -1113,18 +1188,27 @@ function ProviderContractCard({ provider }: { provider: DiscoveryProviderContrac
   const extraModeCount = scanModes.length - previewModes.length;
 
   return (
-    <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
       <div className="flex items-start justify-between gap-3">
-        <div>
-          <h3 className="text-sm font-semibold text-[var(--foreground)]">{provider.name}</h3>
-          <p className="mt-1 font-mono text-[11px] text-[var(--text-tertiary)]">{provider.source}</p>
+        <div className="min-w-0">
+          <h3 className="truncate text-sm font-semibold text-[color:var(--foreground)]">{provider.name}</h3>
+          <p className="mt-1 truncate font-mono text-[11px] text-[color:var(--text-tertiary)]">{provider.source}</p>
         </div>
         <span
-          className={`rounded-full border px-2.5 py-1 text-[11px] font-medium ${
+          className="shrink-0 rounded-full border px-2.5 py-1 text-[11px] font-medium"
+          style={
             trust.supports_scope_zero
-              ? "border-emerald-900 bg-emerald-950/40 text-emerald-300"
-              : "border-[var(--border-subtle)] bg-[var(--background)]/60 text-[var(--text-secondary)]"
-          }`}
+              ? {
+                  borderColor: "var(--status-success-border)",
+                  backgroundColor: "var(--status-success-bg)",
+                  color: "var(--status-success)",
+                }
+              : {
+                  borderColor: "var(--border-subtle)",
+                  backgroundColor: "var(--surface)",
+                  color: "var(--text-secondary)",
+                }
+          }
         >
           {trust.supports_scope_zero ? "scope-zero" : "direct pull"}
         </span>
@@ -1132,13 +1216,16 @@ function ProviderContractCard({ provider }: { provider: DiscoveryProviderContrac
 
       <div className="mt-3 flex max-h-14 flex-wrap gap-1.5 overflow-hidden">
         {previewModes.map((mode) => (
-          <span key={mode} className="rounded border border-sky-900/60 bg-sky-950/30 px-2 py-0.5 text-[10px] font-mono text-sky-300">
+          <span
+            key={mode}
+            className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-0.5 text-[10px] font-mono text-[color:var(--text-secondary)]"
+          >
             {formatMode(mode)}
           </span>
         ))}
         {extraModeCount > 0 ? (
           <span
-            className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-0.5 text-[10px] font-medium text-[var(--text-tertiary)]"
+            className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-0.5 text-[10px] font-medium text-[color:var(--text-tertiary)]"
             title={scanModes.slice(PROVIDER_SCAN_MODE_PREVIEW).map(formatMode).join(", ")}
           >
             +{extraModeCount} mode{extraModeCount === 1 ? "" : "s"}
@@ -1146,27 +1233,27 @@ function ProviderContractCard({ provider }: { provider: DiscoveryProviderContrac
         ) : null}
       </div>
 
-      <div className="mt-4 grid gap-2 text-xs text-[var(--text-secondary)] sm:grid-cols-2">
+      <div className="mt-4 grid gap-2 text-xs text-[color:var(--text-secondary)] sm:grid-cols-2">
         <span>Read-only: {trust.read_only ? "yes" : "no"}</span>
         <span>Agentless: {trust.agentless ? "yes" : "no"}</span>
         <span>Redaction: {formatMode(trust.redaction_status)}</span>
         <span>Residency: {formatMode(trust.data_residency)}</span>
       </div>
 
-      <div className="mt-4 space-y-2 text-xs text-[var(--text-secondary)]">
+      <div className="mt-4 space-y-2 text-xs text-[color:var(--text-secondary)]">
         <div>
-          <span className="text-[var(--text-tertiary)]">Permissions used: </span>
-          <span className="text-[var(--foreground)]">{permissions.length}</span>
+          <span className="text-[color:var(--text-tertiary)]">Permissions used: </span>
+          <span className="text-[color:var(--foreground)]">{permissions.length}</span>
           {permissions.length > 0 ? (
-            <span className="ml-1 font-mono text-[11px] text-[var(--text-secondary)]">
+            <span className="ml-1 font-mono text-[11px] text-[color:var(--text-secondary)]">
               {permissions.slice(0, 3).join(", ")}
               {permissions.length > 3 ? ` +${permissions.length - 3}` : ""}
             </span>
           ) : null}
         </div>
         <div>
-          <span className="text-[var(--text-tertiary)]">Network: </span>
-          <span className="font-mono text-[11px] text-[var(--text-secondary)]">
+          <span className="text-[color:var(--text-tertiary)]">Network: </span>
+          <span className="font-mono text-[11px] text-[color:var(--text-secondary)]">
             {destinations.length ? destinations.slice(0, 3).join(", ") : "none"}
             {destinations.length > 3 ? ` +${destinations.length - 3}` : ""}
           </span>
@@ -1176,14 +1263,14 @@ function ProviderContractCard({ provider }: { provider: DiscoveryProviderContrac
   );
 }
 
-function AccessList({ title, items, tone }: { title: string; items: string[]; tone: string }) {
+function AccessList({ title, items }: { title: string; items: string[] }) {
   return (
-    <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
-      <p className={`text-xs uppercase tracking-[0.18em] ${tone}`}>{title}</p>
+    <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4">
+      <p className="text-xs uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">{title}</p>
       {items.length === 0 ? (
-        <p className="mt-3 text-sm text-[var(--text-secondary)]">No additional access in this category.</p>
+        <p className="mt-3 text-sm text-[color:var(--text-secondary)]">No additional access in this category.</p>
       ) : (
-        <ul className="mt-3 space-y-2 text-sm text-[var(--text-secondary)]">
+        <ul className="mt-3 space-y-2 text-sm text-[color:var(--text-secondary)]">
           {items.map((item) => (
             <li key={item}>{item}</li>
           ))}

--- a/ui/tests/agents-page.test.tsx
+++ b/ui/tests/agents-page.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import AgentsPage from "@/app/agents/page";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    listAgents: vi.fn(),
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  usePathname: () => "/agents",
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    href,
+    children,
+    title,
+    className,
+    onClick,
+  }: {
+    href: string;
+    children: React.ReactNode;
+    title?: string;
+    className?: string;
+    onClick?: (e: React.MouseEvent) => void;
+  }) => (
+    <a href={href} title={title} className={className} onClick={onClick}>
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock("@/hooks/use-deployment-context", () => ({
+  useDeploymentContext: () => ({ counts: undefined }),
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, api: apiMock };
+});
+
+const AGENTS = [
+  {
+    name: "Cursor",
+    agent_type: "ide",
+    agent_class: "client",
+    source: "config",
+    config_path: "/home/u/.cursor/mcp.json",
+    status: "configured",
+    mcp_servers: [
+      {
+        name: "github",
+        transport: "stdio",
+        command: "npx github-mcp",
+        args: [],
+        packages: [
+          { name: "left-pad", version: "1.0.0", ecosystem: "npm" },
+          { name: "requests", version: "2.0.0", ecosystem: "pypi" },
+        ],
+        tools: [{ name: "create_issue" }, { name: "list_repos" }],
+        credential_env_vars: ["GITHUB_TOKEN"],
+        env: { GITHUB_TOKEN: "x" },
+        security_blocked: false,
+      },
+    ],
+  },
+  {
+    name: "ClaudeDesktop",
+    agent_type: "desktop",
+    agent_class: "client",
+    source: "config",
+    config_path: "/home/u/.claude/config.json",
+    status: "configured",
+    mcp_servers: [
+      {
+        name: "filesystem",
+        transport: "sse",
+        url: "https://mcp.example.com/fs",
+        packages: [],
+        tools: [],
+        credential_env_vars: [],
+        env: {},
+        security_blocked: true,
+      },
+    ],
+  },
+  {
+    name: "SomeBinary",
+    agent_type: "cli",
+    status: "installed-not-configured",
+    config_path: "/usr/local/bin/somebinary",
+    mcp_servers: [],
+  },
+];
+
+beforeEach(() => {
+  apiMock.listAgents.mockReset();
+  apiMock.listAgents.mockResolvedValue({ agents: AGENTS });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AgentsPage list view", () => {
+  it("renders KPIs and a dense configured-agents table", async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => expect(screen.getByTestId("agents-configured-table")).toBeInTheDocument());
+    expect(screen.getByTestId("agents-kpis")).toBeInTheDocument();
+
+    const table = within(screen.getByTestId("agents-configured-table"));
+    expect(table.getByText("Cursor")).toBeInTheDocument();
+    expect(table.getByText("ClaudeDesktop")).toBeInTheDocument();
+    // installed-not-configured agent is not in the configured table
+    expect(table.queryByText("SomeBinary")).not.toBeInTheDocument();
+  });
+
+  it("filters configured agents by search", async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => expect(screen.getByTestId("agents-configured-table")).toBeInTheDocument());
+    fireEvent.change(screen.getByPlaceholderText("Search agents or agent type"), {
+      target: { value: "cursor" },
+    });
+
+    const table = within(screen.getByTestId("agents-configured-table"));
+    expect(table.getByText("Cursor")).toBeInTheDocument();
+    expect(table.queryByText("ClaudeDesktop")).not.toBeInTheDocument();
+  });
+
+  it("opens an agent detail drawer with servers, tools, and credentials", async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => expect(screen.getByTestId("agents-configured-table")).toBeInTheDocument());
+    fireEvent.click(within(screen.getByTestId("agents-configured-table")).getByText("Cursor"));
+
+    const detail = within(screen.getByTestId("agent-detail-Cursor"));
+    expect(detail.getByText("github")).toBeInTheDocument();
+    expect(detail.getByText("create_issue")).toBeInTheDocument();
+    expect(detail.getByText("GITHUB_TOKEN")).toBeInTheDocument();
+
+    const dialog = within(screen.getByRole("dialog"));
+    expect(dialog.getByRole("link", { name: "Full detail" })).toHaveAttribute("href", "/agents?name=Cursor");
+    expect(dialog.getByRole("link", { name: "Lifecycle graph" })).toHaveAttribute(
+      "href",
+      "/agents?name=Cursor&view=lifecycle"
+    );
+  });
+
+  it("lists installed-but-not-configured agents in a collapsible table", async () => {
+    render(<AgentsPage />);
+
+    await waitFor(() => expect(screen.getByTestId("agents-configured-table")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Installed but not configured"));
+    expect(within(screen.getByTestId("agents-installed-table")).getByText("SomeBinary")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/cockpits.test.tsx
+++ b/ui/tests/cockpits.test.tsx
@@ -172,9 +172,10 @@ describe("CostPage", () => {
     expect(screen.getByText("Forecast & runway")).toBeInTheDocument();
     expect(screen.getByText("at risk")).toBeInTheDocument();
     expect(screen.getByText("trailing 24h")).toBeInTheDocument();
-    // Chargeback by cost-center panel
-    expect(screen.getByText("Chargeback by cost-center")).toBeInTheDocument();
-    expect(screen.getByText("platform-eng")).toBeInTheDocument();
+    // Cost-center chargeback is now a dimension of the unified breakdown table.
+    fireEvent.click(screen.getByRole("button", { name: "Cost center" }));
+    const table = screen.getByTestId("cost-breakdown-table");
+    expect(within(table).getByText("platform-eng")).toBeInTheDocument();
   });
 });
 

--- a/ui/tests/compliance-page.test.tsx
+++ b/ui/tests/compliance-page.test.tsx
@@ -1,0 +1,140 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import CompliancePage from "@/app/compliance/page";
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(""),
+}));
+
+// CIS drill-down fetches its own benchmark data on mount — stub it so the
+// compliance page test stays focused on the dense framework/control surface.
+vi.mock("@/components/cis-benchmark-detail", () => ({
+  CISBenchmarkDetail: () => <div>cis benchmark</div>,
+}));
+
+const { compliance } = vi.hoisted(() => {
+  const control = (
+    code: string,
+    name: string,
+    status: "pass" | "warning" | "fail",
+    findings: number,
+  ) => ({
+    code,
+    name,
+    findings,
+    status,
+    severity_breakdown: {},
+    affected_packages: [],
+    affected_agents: [],
+  });
+  const emptySummary = Object.fromEntries(
+    [
+      "owasp",
+      "owasp_mcp",
+      "atlas",
+      "nist",
+      "owasp_agentic",
+      "eu_ai_act",
+      "nist_csf",
+      "iso_27001",
+      "soc2",
+      "cis",
+      "cmmc",
+      "nist_800_53",
+      "fedramp",
+      "pci_dss",
+    ].flatMap((k) => [
+      [`${k}_pass`, 0],
+      [`${k}_warn`, 0],
+      [`${k}_fail`, 0],
+    ]),
+  ) as Record<string, number>;
+  return {
+    compliance: {
+      overall_score: 72,
+      overall_status: "warning" as const,
+      scan_count: 3,
+      latest_scan: "2026-07-14T00:00:00Z",
+      has_mcp_context: true,
+      has_agent_context: true,
+      owasp_llm_top10: [
+        control("LLM01", "Prompt Injection", "fail", 4),
+        control("LLM02", "Insecure Output Handling", "pass", 0),
+      ],
+      owasp_mcp_top10: [control("MCP01", "Tool Poisoning", "warning", 1)],
+      mitre_atlas: [],
+      nist_ai_rmf: [],
+      owasp_agentic_top10: [],
+      eu_ai_act: [],
+      nist_csf: [],
+      iso_27001: [],
+      soc2: [],
+      cis_controls: [],
+      cmmc: [],
+      nist_800_53: [],
+      fedramp: [],
+      pci_dss: [],
+      aisvs_benchmark: { checks: [], summary: {} },
+      summary: {
+        ...emptySummary,
+        owasp_pass: 1,
+        owasp_fail: 1,
+        owasp_mcp_warn: 1,
+        aisvs_pass: 0,
+        aisvs_fail: 0,
+        aisvs_error: 0,
+        aisvs_not_applicable: 0,
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      getCompliance: vi.fn().mockResolvedValue(compliance),
+      getFrameworkCatalogs: vi.fn().mockResolvedValue({ frameworks: {} }),
+      getHubPosture: vi
+        .fn()
+        .mockResolvedValue({ totals: { combined: 0, native: 0, hub: 0 } }),
+    },
+  };
+});
+
+describe("CompliancePage (dense restyle)", () => {
+  it("renders KPI strip, frameworks table, and control detail via split layout", async () => {
+    render(<CompliancePage />);
+
+    const strip = await screen.findByTestId("compliance-kpi-strip");
+    expect(within(strip).getByText("Overall")).toBeInTheDocument();
+    expect(within(strip).getByText("Passing")).toBeInTheDocument();
+    expect(within(strip).getByText("Failing")).toBeInTheDocument();
+
+    const table = screen.getByTestId("compliance-frameworks-table");
+    // Short labels appear as the primary framework name.
+    expect(within(table).getByText("LLM")).toBeInTheDocument();
+
+    // The first failing framework (OWASP LLM) is auto-selected, so its
+    // controls render in the detail pane.
+    await waitFor(() =>
+      expect(screen.getByText("Prompt Injection")).toBeInTheDocument(),
+    );
+  });
+
+  it("opens the control drawer when a control row is clicked", async () => {
+    render(<CompliancePage />);
+    await screen.findByTestId("compliance-kpi-strip");
+
+    const injection = await screen.findByText("Prompt Injection");
+    fireEvent.click(injection);
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole("dialog", { name: /Control details for LLM01/i }),
+      ).toBeInTheDocument(),
+    );
+  });
+});

--- a/ui/tests/cost-page.test.tsx
+++ b/ui/tests/cost-page.test.tsx
@@ -1,0 +1,120 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import CostPage from "@/app/cost/page";
+
+vi.mock("@/hooks/use-deployment-context", () => ({
+  useDeploymentContext: () => ({ counts: { services: {} } }),
+}));
+
+const { report, anomalies, forecast } = vi.hoisted(() => {
+  const row = (
+    key: string,
+    cost: number,
+    calls: number,
+    unpriced = 0,
+  ) => ({
+    key,
+    calls,
+    input_tokens: calls * 10,
+    output_tokens: calls * 4,
+    cost_usd: cost,
+    unpriced_calls: unpriced,
+  });
+  return {
+    report: {
+      schema_version: "1",
+      tenant_id: "tenant-a",
+      price_model_captured: {},
+      total_cost_usd: 12.5,
+      total_calls: 100,
+      total_input_tokens: 2000,
+      total_output_tokens: 500,
+      unpriced_calls: 2,
+      by_agent: [row("agent-alpha", 8, 60, 1), row("agent-beta", 4.5, 40)],
+      by_model: [row("gpt-x", 10, 70)],
+      by_provider: [row("openai", 12.5, 100)],
+      by_cost_center: [],
+      by_owner: [row("owner-jane", 12.5, 100)],
+      budget: {
+        configured: true,
+        owner: "owner-jane",
+        mode: "enforce",
+        limit_usd: 100,
+        spend_usd: 12.5,
+        remaining_usd: 87.5,
+        exceeded: false,
+        utilization: 0.125,
+      },
+    },
+    anomalies: {
+      schema_version: "1",
+      tenant_id: "tenant-a",
+      z_threshold: 3,
+      anomaly_count: 0,
+      cost_anomalies: [],
+      behavior_anomalies: [],
+    },
+    forecast: {
+      schema_version: "1",
+      agent: null,
+      now: "2026-07-15T00:00:00Z",
+      status: "ok",
+      current_spend_usd: 12.5,
+      budget_limit_usd: 100,
+      burn_rate_usd_per_day: 1,
+      burn_rate_basis: "trailing_7d",
+      projected_period_spend_usd: 30,
+      period_start: null,
+      period_end: null,
+      days_remaining: 30,
+      projected_exhaustion_at: null,
+    },
+  };
+});
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      getCostReport: vi.fn().mockResolvedValue(report),
+      getCostAnomalies: vi.fn().mockResolvedValue(anomalies),
+      getCostForecast: vi.fn().mockResolvedValue(forecast),
+    },
+  };
+});
+
+describe("CostPage (dense restyle)", () => {
+  it("renders the KPI strip, budget, and a dense breakdown table", async () => {
+    render(<CostPage />);
+
+    const strip = await screen.findByTestId("cost-kpi-strip");
+    expect(within(strip).getByText("Total spend")).toBeInTheDocument();
+    expect(within(strip).getByText("LLM calls")).toBeInTheDocument();
+
+    // Owner-scoped budget in enforce mode.
+    expect(screen.getByText(/owner owner-jane/i)).toBeInTheDocument();
+    expect(screen.getByText("enforce")).toBeInTheDocument();
+
+    // Breakdown DataTable defaults to the agent dimension.
+    const table = screen.getByTestId("cost-breakdown-table");
+    expect(within(table).getByText("agent-alpha")).toBeInTheDocument();
+    expect(within(table).getByText("agent-beta")).toBeInTheDocument();
+  });
+
+  it("switches breakdown dimension to owner and opens a row drawer", async () => {
+    render(<CostPage />);
+    await screen.findByTestId("cost-kpi-strip");
+
+    fireEvent.click(screen.getByRole("button", { name: "Owner" }));
+    const table = screen.getByTestId("cost-breakdown-table");
+    const ownerCell = within(table).getByText("owner-jane");
+    expect(ownerCell).toBeInTheDocument();
+
+    fireEvent.click(ownerCell);
+    await waitFor(() =>
+      expect(screen.getByText("Avg cost / call")).toBeInTheDocument(),
+    );
+  });
+});

--- a/ui/tests/sources-page.test.tsx
+++ b/ui/tests/sources-page.test.tsx
@@ -242,25 +242,40 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
+async function openSourceDrawer(displayName: string) {
+  await waitFor(() => expect(screen.getByTestId("sources-table")).toBeInTheDocument());
+  await waitFor(() => expect(screen.getByText(displayName)).toBeInTheDocument());
+  fireEvent.click(screen.getByText(displayName));
+}
+
 describe("SourcesPage", () => {
-  it("renders linked schedule state from the control plane", async () => {
+  it("renders sources in a dense table and expands the provider-contracts collapsible", async () => {
     render(<SourcesPage />);
 
-    await waitFor(() => expect(screen.getByText("Nightly cloud posture")).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByTestId("sources-table")).toBeInTheDocument());
+    const table = within(screen.getByTestId("sources-table"));
+    expect(table.getByText("AWS production account")).toBeInTheDocument();
+    expect(table.getByText("Jira inventory")).toBeInTheDocument();
+
     expect(apiMock.listDiscoveryProviders).toHaveBeenCalled();
     fireEvent.click(screen.getByText("Provider trust contracts"));
     expect(screen.getAllByText("aws").length).toBeGreaterThan(0);
     expect(screen.getByText("scope-zero")).toBeInTheDocument();
     expect(screen.getAllByText("snowflake").length).toBeGreaterThan(0);
-    expect(screen.getByText("Nightly cloud posture")).toBeInTheDocument();
-    expect(screen.getByText("Source: AWS production account")).toBeInTheDocument();
-    expect(screen.getByText("Schedules: 1")).toBeInTheDocument();
-    const workflow = within(screen.getByTestId("source-workflow-src-1"));
-    expect(workflow.getByText("Evidence workflow")).toBeInTheDocument();
-    expect(workflow.getByRole("link", { name: "Jobs" })).toHaveAttribute("href", "/jobs?q=src-1");
-    expect(workflow.getByRole("link", { name: "Findings" })).toHaveAttribute("href", "/findings?scan=job-prod-cloud");
-    expect(workflow.getByRole("link", { name: "Graph" })).toHaveAttribute("href", "/security-graph?scan=job-prod-cloud");
-    expect(workflow.getByRole("link", { name: "Compliance" })).toHaveAttribute("href", "/compliance?scan=job-prod-cloud");
+  });
+
+  it("opens a source drawer with evidence links and its bound schedule", async () => {
+    render(<SourcesPage />);
+
+    await openSourceDrawer("AWS production account");
+
+    const detail = within(screen.getByTestId("source-detail-src-1"));
+    expect(detail.getByText("Evidence workflow")).toBeInTheDocument();
+    expect(detail.getByRole("link", { name: "Jobs" })).toHaveAttribute("href", "/jobs?q=src-1");
+    expect(detail.getByRole("link", { name: "Findings" })).toHaveAttribute("href", "/findings?scan=job-prod-cloud");
+    expect(detail.getByRole("link", { name: "Graph" })).toHaveAttribute("href", "/security-graph?scan=job-prod-cloud");
+    expect(detail.getByRole("link", { name: "Compliance" })).toHaveAttribute("href", "/compliance?scan=job-prod-cloud");
+    expect(detail.getByText("Nightly cloud posture")).toBeInTheDocument();
   });
 
   it("shortens long last_job_id links and keeps the full id in title", async () => {
@@ -295,13 +310,14 @@ describe("SourcesPage", () => {
 
     render(<SourcesPage />);
 
-    await waitFor(() => expect(screen.getByTestId("source-workflow-src-long")).toBeInTheDocument());
-    const jobLink = within(screen.getByTestId("source-workflow-src-long")).getByRole("link", { name: /…/ });
+    await openSourceDrawer("Long job source");
+    const detail = within(screen.getByTestId("source-detail-src-long"));
+    const jobLink = detail.getByRole("link", { name: /…/ });
     expect(jobLink).toHaveAttribute("title", longJobId);
     expect(jobLink.textContent).not.toBe(longJobId);
   });
 
-  it("creates a schedule bound to a source_id", async () => {
+  it("creates a schedule bound to a source_id from the drawer", async () => {
     apiMock.createSchedule.mockResolvedValue({
       schedule_id: "sched-2",
       name: "Recurring AWS run",
@@ -318,9 +334,8 @@ describe("SourcesPage", () => {
 
     render(<SourcesPage />);
 
-    await waitFor(() => expect(screen.getByRole("heading", { name: "Schedules" })).toBeInTheDocument());
+    await openSourceDrawer("AWS production account");
 
-    fireEvent.change(screen.getByLabelText("Schedule source"), { target: { value: "src-1" } });
     fireEvent.change(screen.getByLabelText("Schedule name"), { target: { value: "Recurring AWS run" } });
     fireEvent.change(screen.getByLabelText("Schedule cron"), { target: { value: "15 * * * *" } });
     fireEvent.click(screen.getByRole("button", { name: "Create schedule" }));
@@ -335,7 +350,7 @@ describe("SourcesPage", () => {
     );
   });
 
-  it("toggles and deletes schedules through the backend API", async () => {
+  it("toggles and deletes schedules through the backend API from the drawer", async () => {
     apiMock.toggleSchedule.mockResolvedValue({
       schedule_id: "sched-1",
       name: "Nightly cloud posture",
@@ -353,16 +368,13 @@ describe("SourcesPage", () => {
 
     render(<SourcesPage />);
 
-    await waitFor(() => expect(screen.getByText("Nightly cloud posture")).toBeInTheDocument());
+    await openSourceDrawer("AWS production account");
+    const detail = within(screen.getByTestId("source-detail-src-1"));
 
-    const scheduleCard = screen.getByText("Nightly cloud posture").closest("div.rounded-2xl");
-    expect(scheduleCard).not.toBeNull();
-    const scheduleActions = within(scheduleCard as HTMLElement);
-
-    fireEvent.click(scheduleActions.getByRole("button", { name: "Pause" }));
+    fireEvent.click(detail.getByRole("button", { name: "Pause" }));
     await waitFor(() => expect(apiMock.toggleSchedule).toHaveBeenCalledWith("sched-1"));
 
-    fireEvent.click(scheduleActions.getByRole("button", { name: "Delete" }));
+    fireEvent.click(detail.getByRole("button", { name: "Delete" }));
     await waitFor(() => expect(apiMock.deleteSchedule).toHaveBeenCalledWith("sched-1"));
   });
 });


### PR DESCRIPTION
## Summary

- Combine the Data Sources + Agents dense side-by-side redesign with the Compliance, Runtime, and Cost cockpit restyle.
- Keep both original signed commits intact on the refreshed design-system foundation.
- Consolidate the presentation-only UI queue without mixing functional scan or governance behavior.

Supersedes #4019 and #4022.

## Verification

- Exact toolchain: Node 24.18.0 / npm 10.9.7
- TypeScript typecheck
- Vitest: 5 files, 16 tests
- Next.js production build: 36 static routes
- Bundle budget: 3288.3 KiB / 3456.0 KiB
- ESLint: 0 errors; one pre-existing nav hook warning from the base branch
- git diff --check

## Notes

#4017 merged before publication. This branch was rebased onto that fresh main tree, so the PR targets main directly without duplicating the foundation changes.



---
**Closes #3931** (dashboard UX pass — density + IA delivered across every page) and **Closes #4010** (platform-wide UI/UX consistency pass — every heavy page restyled dense/side-by-side onto the design system, both themes).
Still open, NOT closed here: #4008 (Connections-hub page merge) · #4006 (unified inventory) · #4009 (retention) · #4005 (graph-at-scale).
