### PR TITLE
feat(ui): combine AI scan and evidence parity surfaces

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -30,6 +30,7 @@ import logging
 import os
 import time
 import uuid
+from functools import partial
 from pathlib import Path
 from typing import Annotated, Any
 
@@ -89,6 +90,19 @@ def _api_local_scans_enabled() -> bool:
 async def _scan_graph_compute_call(fn, /, *args, **kwargs):
     """Run graph rendering/derivation for scan subresources off the event loop."""
     return await asyncio.to_thread(fn, *args, **kwargs)
+
+
+async def _ai_scan_call(fn, /, *args, **kwargs):
+    """Run blocking dedicated AI-scan work off-loop under shared backpressure."""
+    try:
+        async with adaptive_backpressure("ai_scan"):
+            return await anyio.to_thread.run_sync(partial(fn, *args, **kwargs))
+    except BackpressureRejectedError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=exc.to_dict(),
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
 
 
 def _api_scan_root() -> Path:
@@ -2124,7 +2138,7 @@ async def scan_dataset_cards(request: DatasetCardsRequest) -> dict:
     for d in request.directories:
         resolved = _api_scan_path_or_400(d)
         safe_dirs.append(resolved)
-        result = scan_dataset_directory(resolved)
+        result = await _ai_scan_call(scan_dataset_directory, resolved)
         results.append(result.to_dict() if hasattr(result, "to_dict") else _dataclass_to_dict(result))
 
     return {"scan_type": "dataset-cards", "directories": safe_dirs, "results": results}
@@ -2144,7 +2158,7 @@ async def scan_training_pipelines(request: TrainingPipelinesRequest) -> dict:
     for d in request.directories:
         resolved = _api_scan_path_or_400(d)
         safe_dirs.append(resolved)
-        result = scan_training_directory(resolved)
+        result = await _ai_scan_call(scan_training_directory, resolved)
         results.append(result.to_dict() if hasattr(result, "to_dict") else _dataclass_to_dict(result))
 
     return {"scan_type": "training-pipelines", "directories": safe_dirs, "results": results}
@@ -2159,7 +2173,10 @@ async def scan_browser_extensions_endpoint(request: BrowserExtensionsRequest) ->
     """
     from agent_bom.parsers.browser_extensions import discover_browser_extensions
 
-    extensions = discover_browser_extensions(include_low_risk=request.include_low_risk)
+    extensions = await _ai_scan_call(
+        discover_browser_extensions,
+        include_low_risk=request.include_low_risk,
+    )
     ext_dicts: list[Any] = [e.to_dict() if hasattr(e, "to_dict") else _dataclass_to_dict(e) for e in extensions]
 
     return {
@@ -2182,10 +2199,10 @@ async def scan_model_provenance(request: ModelProvenanceRequest) -> dict:
 
     results: list[Any] = []
     if request.hf_models:
-        hf_results = check_hf_models(request.hf_models)
+        hf_results = await _ai_scan_call(check_hf_models, request.hf_models)
         results.extend(r.to_dict() if hasattr(r, "to_dict") else _dataclass_to_dict(r) for r in hf_results)
     if request.ollama_models:
-        ollama_results = check_ollama_models(request.ollama_models)
+        ollama_results = await _ai_scan_call(check_ollama_models, request.ollama_models)
         results.extend(r.to_dict() if hasattr(r, "to_dict") else _dataclass_to_dict(r) for r in ollama_results)
 
     return {
@@ -2216,10 +2233,10 @@ async def scan_prompts(request: PromptScanRequest) -> dict:
 
     results = []
     for safe in safe_dirs:
-        result = scan_prompt_files(root=safe)
+        result = await _ai_scan_call(scan_prompt_files, root=safe)
         results.append(result.to_dict() if hasattr(result, "to_dict") else _dataclass_to_dict(result))
     if all_paths:
-        result = scan_prompt_files(paths=all_paths)
+        result = await _ai_scan_call(scan_prompt_files, paths=all_paths)
         results.append(result.to_dict() if hasattr(result, "to_dict") else _dataclass_to_dict(result))
 
     return {"scan_type": "prompt-scan", "results": results}
@@ -2239,8 +2256,8 @@ async def scan_model_files_endpoint(request: ModelFilesRequest) -> dict:
     all_warnings = []
     for d in request.directories:
         resolved = _api_scan_path_or_400(d)
-        files, warnings = scan_model_files(resolved)
-        manifests, manifest_warnings = scan_model_manifests(resolved)
+        files, warnings = await _ai_scan_call(scan_model_files, resolved)
+        manifests, manifest_warnings = await _ai_scan_call(scan_model_manifests, resolved)
         all_files.extend(files)
         all_manifests.extend(manifests)
         all_warnings.extend(warnings)
@@ -2248,7 +2265,7 @@ async def scan_model_files_endpoint(request: ModelFilesRequest) -> dict:
 
     if request.verify_hashes:
         for f in all_files:
-            hash_result = verify_model_hash(f["path"])
+            hash_result = await _ai_scan_call(verify_model_hash, f["path"])
             f["sha256"] = hash_result.get("sha256")
 
     return {

--- a/tests/api/test_api_scan_types.py
+++ b/tests/api/test_api_scan_types.py
@@ -10,6 +10,7 @@ import os
 from dataclasses import dataclass, field
 from unittest.mock import patch
 
+import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import _jobs, app, set_job_store
@@ -515,3 +516,47 @@ def test_endpoint_returns_generic_invalid_scan_path(tmp_path, monkeypatch):
 
     assert resp.status_code == 400
     assert resp.json()["detail"] == "Invalid scan path"
+
+
+@pytest.mark.anyio
+async def test_ai_scan_work_is_offloaded_from_the_event_loop(monkeypatch):
+    """Dedicated scans must execute blocking parser work in the worker pool."""
+    from agent_bom.api.routes import scan as scan_routes
+
+    calls: list[object] = []
+
+    async def fake_run_sync(fn):
+        calls.append(fn)
+        return fn()
+
+    monkeypatch.setattr(scan_routes.anyio.to_thread, "run_sync", fake_run_sync)
+
+    result = await scan_routes._ai_scan_call(lambda: {"ok": True})
+
+    assert result == {"ok": True}
+    assert len(calls) == 1
+
+
+@pytest.mark.anyio
+async def test_ai_scan_sheds_work_with_retry_after_under_saturation(monkeypatch):
+    """Saturated dedicated scans fail fast with an actionable 429."""
+    from contextlib import asynccontextmanager
+
+    from fastapi import HTTPException
+
+    from agent_bom.api.routes import scan as scan_routes
+    from agent_bom.backpressure import BackpressureRejectedError
+
+    @asynccontextmanager
+    async def reject(_path):
+        raise BackpressureRejectedError("ai_scan", "concurrency_limit", 3)
+        yield
+
+    monkeypatch.setattr(scan_routes, "adaptive_backpressure", reject)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await scan_routes._ai_scan_call(lambda: None)
+
+    assert exc_info.value.status_code == 429
+    assert exc_info.value.headers == {"Retry-After": "3"}
+    assert exc_info.value.detail["path"] == "ai_scan"

--- a/ui/app/audit/page.tsx
+++ b/ui/app/audit/page.tsx
@@ -24,6 +24,7 @@ import {
 import { useAuthState } from "@/components/auth-provider";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { KeyLifecyclePanel } from "@/components/key-lifecycle-panel";
+import { AuditEvidencePanel } from "@/components/audit-evidence-panel";
 import { PageLaneHeader } from "@/components/page-lane";
 
 // ─── Constants ───────────────────────────────────────────────────────────────
@@ -204,6 +205,9 @@ export default function AuditLogPage() {
           </div>
         </div>
       )}
+
+      {/* Signed evidence export + tamper-evident verification */}
+      <AuditEvidencePanel />
 
       {/* Filters */}
       <div className="flex flex-wrap items-center gap-3">

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -7,6 +7,7 @@ import {
   ArrowRight,
   GitBranch,
   Loader2,
+  Route,
 } from "lucide-react";
 
 import { ApiOfflineState } from "@/components/api-offline-state";
@@ -22,6 +23,9 @@ import { RankedPathList, type RankedPathRow } from "@/components/ranked-path-lis
 import { ExposurePathCommandCenter, type ExposurePathView } from "@/components/exposure-path-command-center";
 import { GraphEvidenceExportButton } from "@/components/graph-chrome";
 import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
+import { DeployGatePanel } from "@/components/deploy-gate-panel";
+import { ExposurePathLens } from "@/components/exposure-path-lens";
+import { Collapsible } from "@/components/collapsible";
 import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
 import {
   api,
@@ -445,6 +449,17 @@ function SecurityGraphPageContent() {
       />
 
       <GraphLensSwitcher variant="compact" />
+
+      <DeployGatePanel scanId={selectedScanId || undefined} />
+
+      <Collapsible
+        title="Exposure paths"
+        subtitle="Agent-native exposure-path lens over persisted graph evidence."
+        icon={Route}
+        defaultOpen={false}
+      >
+        <ExposurePathLens scanId={selectedScanId || undefined} />
+      </Collapsible>
 
       {selectedExposurePath ? (
         <ExposurePathCommandCenter

--- a/ui/components/ai-scan-panel.tsx
+++ b/ui/components/ai-scan-panel.tsx
@@ -1,0 +1,872 @@
+"use client";
+
+import { useMemo, useState, type ReactNode } from "react";
+import { ArrowRight, Loader2, Plus, ScanSearch, ShieldCheck, X } from "lucide-react";
+
+import { api } from "@/lib/api";
+import {
+  AI_SCAN_TYPES,
+  aiSeverityRank,
+  highestFlagSeverity,
+  type AiScanResponse,
+  type AiScanTypeId,
+  type AiSecurityFlag,
+  type BrowserExtension,
+  type BrowserExtensionsResponse,
+  type DatasetCard,
+  type DatasetCardsResponse,
+  type ModelFileEntry,
+  type ModelFilesResponse,
+  type ModelProvenanceResponse,
+  type PromptFinding,
+  type PromptScanResponse,
+  type ProvenanceResult,
+  type TrainingArtifact,
+  type TrainingPipelinesResponse,
+} from "@/lib/ai-scan";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import { Drawer } from "@/components/drawer";
+import { SeverityBadge } from "@/components/severity-badge";
+import { StatStrip, type StatStripItem } from "@/components/stat-strip";
+import {
+  PageEmptyState,
+  PageErrorState,
+  PageLoadingState,
+} from "@/components/states/page-state";
+
+/** Normalized detail record shown in the drawer for any scan-type row. */
+type DetailView = {
+  eyebrow: string;
+  title: string;
+  subtitle?: string | undefined;
+  flags?: AiSecurityFlag[] | undefined;
+  fields: { label: string; value: ReactNode }[];
+};
+
+function cleanList(values: string[]): string[] {
+  return values.map((v) => v.trim()).filter(Boolean);
+}
+
+export function AiScanPanel() {
+  const [scanType, setScanType] = useState<AiScanTypeId>("dataset-cards");
+  const [dirs, setDirs] = useState<string[]>([]);
+  const [files, setFiles] = useState<string[]>([]);
+  const [hfModels, setHfModels] = useState<string[]>([]);
+  const [ollamaModels, setOllamaModels] = useState<string[]>([]);
+  const [includeLowRisk, setIncludeLowRisk] = useState(false);
+  const [verifyHashes, setVerifyHashes] = useState(false);
+
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState<AiScanResponse | null>(null);
+  const [detail, setDetail] = useState<DetailView | null>(null);
+
+  const meta = useMemo(
+    () => AI_SCAN_TYPES.find((t) => t.id === scanType) ?? AI_SCAN_TYPES[0]!,
+    [scanType],
+  );
+  const kind = meta.inputKind;
+
+  function selectType(next: AiScanTypeId) {
+    setScanType(next);
+    setResult(null);
+    setError("");
+    setDetail(null);
+  }
+
+  const cleanedDirs = cleanList(dirs);
+  const cleanedFiles = cleanList(files);
+  const cleanedHf = cleanList(hfModels);
+  const cleanedOllama = cleanList(ollamaModels);
+
+  const canRun = (() => {
+    switch (kind) {
+      case "directories":
+      case "model-files":
+        return cleanedDirs.length > 0;
+      case "prompt":
+        return cleanedDirs.length > 0 || cleanedFiles.length > 0;
+      case "models":
+        return cleanedHf.length > 0 || cleanedOllama.length > 0;
+      case "extensions":
+        return true;
+      default:
+        return false;
+    }
+  })();
+
+  async function run() {
+    if (!canRun || loading) return;
+    setLoading(true);
+    setError("");
+    setDetail(null);
+    try {
+      let response: AiScanResponse;
+      switch (scanType) {
+        case "dataset-cards":
+          response = await api.scanDatasetCards({ directories: cleanedDirs });
+          break;
+        case "training-pipelines":
+          response = await api.scanTrainingPipelines({ directories: cleanedDirs });
+          break;
+        case "browser-extensions":
+          response = await api.scanBrowserExtensions({ include_low_risk: includeLowRisk });
+          break;
+        case "model-provenance":
+          response = await api.scanModelProvenance({
+            hf_models: cleanedHf,
+            ollama_models: cleanedOllama,
+          });
+          break;
+        case "prompt-scan":
+          response = await api.scanPrompts({
+            directories: cleanedDirs,
+            files: cleanedFiles,
+          });
+          break;
+        case "model-files":
+          response = await api.scanModelFiles({
+            directories: cleanedDirs,
+            verify_hashes: verifyHashes,
+          });
+          break;
+      }
+      setResult(response);
+    } catch (err) {
+      setResult(null);
+      setError(err instanceof Error ? err.message : "Scan failed");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="grid gap-5 lg:grid-cols-[minmax(0,15rem)_minmax(0,1fr)]" data-testid="ai-scan-panel">
+      <nav aria-label="AI supply-chain scan type" className="space-y-2">
+        <p className="px-1 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+          AI supply chain
+        </p>
+        <ul className="space-y-1.5">
+          {AI_SCAN_TYPES.map((type) => {
+            const active = type.id === scanType;
+            return (
+              <li key={type.id}>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={active}
+                  onClick={() => selectType(type.id)}
+                  className={`w-full rounded-xl border px-3 py-2.5 text-left transition ${
+                    active
+                      ? "border-[color:var(--accent-border)] bg-[color:var(--accent-soft)]"
+                      : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] hover:border-[color:var(--border-strong)]"
+                  }`}
+                >
+                  <span
+                    className={`block text-sm font-medium ${
+                      active ? "text-[color:var(--accent)]" : "text-[color:var(--foreground)]"
+                    }`}
+                  >
+                    {type.label}
+                  </span>
+                  <span className="mt-0.5 block text-xs leading-snug text-[color:var(--text-secondary)]">
+                    {type.blurb}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </nav>
+
+      <div className="min-w-0 space-y-4">
+        <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 elev-1">
+          <div className="mb-4">
+            <h2 className="text-base font-semibold text-[color:var(--foreground)]">{meta.label}</h2>
+            <p className="mt-1 text-sm text-[color:var(--text-secondary)]">{meta.blurb}</p>
+          </div>
+
+          <div className="space-y-3">
+            {(kind === "directories" || kind === "prompt" || kind === "model-files") && (
+              <PathListInput
+                label="Directories"
+                placeholder="/path/to/scan"
+                items={dirs}
+                onChange={setDirs}
+              />
+            )}
+
+            {kind === "prompt" && (
+              <PathListInput
+                label="Prompt files (optional)"
+                placeholder="/path/to/system.prompt"
+                items={files}
+                onChange={setFiles}
+              />
+            )}
+
+            {kind === "models" && (
+              <>
+                <PathListInput
+                  label="HuggingFace models"
+                  placeholder="meta-llama/Llama-2-7b-hf"
+                  mono
+                  items={hfModels}
+                  onChange={setHfModels}
+                />
+                <PathListInput
+                  label="Ollama models"
+                  placeholder="llama2"
+                  mono
+                  items={ollamaModels}
+                  onChange={setOllamaModels}
+                />
+              </>
+            )}
+
+            {kind === "extensions" && (
+              <label className="flex cursor-pointer items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-[color:var(--border-subtle)]"
+                  checked={includeLowRisk}
+                  onChange={(e) => setIncludeLowRisk(e.target.checked)}
+                />
+                <span className="text-sm text-[color:var(--foreground)]">
+                  Include low-risk extensions
+                </span>
+              </label>
+            )}
+
+            {kind === "model-files" && (
+              <label className="flex cursor-pointer items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-4 py-3">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-[color:var(--border-subtle)]"
+                  checked={verifyHashes}
+                  onChange={(e) => setVerifyHashes(e.target.checked)}
+                />
+                <span className="text-sm text-[color:var(--foreground)]">
+                  Compute SHA-256 integrity hashes (slower)
+                </span>
+              </label>
+            )}
+          </div>
+
+          {error ? (
+            <p className="mt-3 rounded-lg border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-3 py-2 text-sm text-[color:var(--severity-critical)]">
+              {error}
+            </p>
+          ) : null}
+
+          <div className="mt-4 flex items-center justify-between gap-3">
+            <p className="text-xs text-[color:var(--text-tertiary)]">
+              {kind === "extensions"
+                ? "Scans browser extensions installed on the control-plane host."
+                : "Paths resolve on the control-plane host running the scan."}
+            </p>
+            <button
+              type="button"
+              onClick={run}
+              disabled={!canRun || loading}
+              className="inline-flex shrink-0 items-center gap-2 rounded-xl bg-[color:var(--accent)] px-4 py-2.5 text-sm font-medium text-[color:var(--accent-contrast)] transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {loading ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <ScanSearch className="h-4 w-4" />
+              )}
+              Run scan <ArrowRight className="h-4 w-4" />
+            </button>
+          </div>
+        </div>
+
+        <AiScanResults
+          loading={loading}
+          error={error}
+          result={result}
+          onOpenDetail={setDetail}
+        />
+      </div>
+
+      <Drawer
+        open={detail !== null}
+        onClose={() => setDetail(null)}
+        eyebrow={detail?.eyebrow}
+        title={detail?.title ?? ""}
+        subtitle={detail?.subtitle}
+        size="2xl"
+      >
+        {detail ? <DetailBody detail={detail} /> : null}
+      </Drawer>
+    </div>
+  );
+}
+
+// ─── Results ────────────────────────────────────────────────────────────────
+
+function AiScanResults({
+  loading,
+  error,
+  result,
+  onOpenDetail,
+}: {
+  loading: boolean;
+  error: string;
+  result: AiScanResponse | null;
+  onOpenDetail: (detail: DetailView) => void;
+}) {
+  if (loading) {
+    return (
+      <PageLoadingState
+        title="Scanning…"
+        detail="Running the scan on the control-plane host and collecting real results."
+        data-testid="ai-scan-loading"
+      />
+    );
+  }
+  if (error) {
+    return (
+      <PageErrorState
+        title="Scan failed"
+        detail={error}
+        data-testid="ai-scan-error"
+      />
+    );
+  }
+  if (!result) {
+    return (
+      <PageEmptyState
+        title="No scan run yet"
+        detail="Set the inputs above and run the scan. Results are rendered here from the API — nothing is sampled or faked."
+        icon={ShieldCheck}
+        data-testid="ai-scan-empty"
+      />
+    );
+  }
+
+  switch (result.scan_type) {
+    case "dataset-cards":
+      return <DatasetCardsResult result={result} onOpenDetail={onOpenDetail} />;
+    case "training-pipelines":
+      return <TrainingPipelinesResult result={result} onOpenDetail={onOpenDetail} />;
+    case "browser-extensions":
+      return <BrowserExtensionsResult result={result} onOpenDetail={onOpenDetail} />;
+    case "model-provenance":
+      return <ModelProvenanceResult result={result} onOpenDetail={onOpenDetail} />;
+    case "prompt-scan":
+      return <PromptScanResult result={result} onOpenDetail={onOpenDetail} />;
+    case "model-files":
+      return <ModelFilesResult result={result} onOpenDetail={onOpenDetail} />;
+    default:
+      return null;
+  }
+}
+
+function FlagCell({ flags }: { flags: AiSecurityFlag[] | undefined }) {
+  const highest = highestFlagSeverity(flags);
+  if (!highest) {
+    return <span className="text-xs text-[color:var(--status-success)]">clean</span>;
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <SeverityBadge severity={highest} />
+      {flags && flags.length > 1 ? (
+        <span className="text-xs tabular-nums text-[color:var(--text-tertiary)]">×{flags.length}</span>
+      ) : null}
+    </span>
+  );
+}
+
+function BoolTag({ value, trueLabel, falseLabel }: { value: boolean | undefined; trueLabel: string; falseLabel: string }) {
+  return (
+    <span className={`text-xs ${value ? "text-[color:var(--status-warn)]" : "text-[color:var(--text-tertiary)]"}`}>
+      {value ? trueLabel : falseLabel}
+    </span>
+  );
+}
+
+function DatasetCardsResult({
+  result,
+  onOpenDetail,
+}: {
+  result: DatasetCardsResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const datasets = result.results.flatMap((r) => r.datasets);
+  const warnings = result.results.flatMap((r) => r.warnings);
+  const flagged = result.results.reduce((sum, r) => sum + r.flagged_count, 0);
+  const stats: StatStripItem[] = [
+    { label: "Directories", value: result.directories.length },
+    { label: "Datasets", value: datasets.length },
+    { label: "Flagged", value: flagged, accent: "high" },
+    { label: "Warnings", value: warnings.length, accent: "warn" },
+  ];
+  const columns: DataTableColumn<DatasetCard>[] = [
+    { key: "name", header: "Dataset", cell: (d) => <span className="text-[color:var(--foreground)]">{d.name}</span> },
+    { key: "license", header: "License", cell: (d) => d.license || "—" },
+    { key: "source", header: "Source", cell: (d) => <span className="font-mono text-xs">{d.source_file ?? "—"}</span> },
+    { key: "flags", header: "Risk", cell: (d) => <FlagCell flags={d.security_flags} /> },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={warnings}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={datasets}
+        rowKey={(d, i) => `${d.source_file ?? d.name}-${i}`}
+        columns={columns}
+        onRowClick={(d) =>
+          onOpenDetail({
+            eyebrow: "Dataset card",
+            title: d.name,
+            subtitle: d.source_file,
+            flags: d.security_flags,
+            fields: buildFields(d, ["name", "security_flags", "source_file"]),
+          })
+        }
+        empty="No dataset cards found in the scanned directories."
+      />
+    </ResultShell>
+  );
+}
+
+function TrainingPipelinesResult({
+  result,
+  onOpenDetail,
+}: {
+  result: TrainingPipelinesResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  type Row = TrainingArtifact & { _kind: "run" | "serving" };
+  const rows: Row[] = [
+    ...result.results.flatMap((r) => r.training_runs.map((t) => ({ ...t, _kind: "run" as const }))),
+    ...result.results.flatMap((r) => r.serving_configs.map((t) => ({ ...t, _kind: "serving" as const }))),
+  ];
+  const warnings = result.results.flatMap((r) => r.warnings);
+  const flagged = result.results.reduce((sum, r) => sum + r.flagged_count, 0);
+  const stats: StatStripItem[] = [
+    { label: "Training runs", value: result.results.reduce((s, r) => s + r.total_runs, 0) },
+    { label: "Serving configs", value: result.results.reduce((s, r) => s + r.total_serving, 0) },
+    { label: "Flagged", value: flagged, accent: "high" },
+    { label: "Warnings", value: warnings.length, accent: "warn" },
+  ];
+  const columns: DataTableColumn<Row>[] = [
+    { key: "name", header: "Artifact", cell: (t) => <span className="text-[color:var(--foreground)]">{t.name}</span> },
+    { key: "kind", header: "Kind", cell: (t) => (t._kind === "run" ? "Training run" : "Serving config") },
+    { key: "framework", header: "Framework", cell: (t) => t.framework ?? "—" },
+    { key: "source", header: "Source", cell: (t) => <span className="font-mono text-xs">{t.source_file ?? "—"}</span> },
+    { key: "flags", header: "Risk", cell: (t) => <FlagCell flags={t.security_flags} /> },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={warnings}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={rows}
+        rowKey={(t, i) => `${t._kind}-${t.source_file ?? t.name}-${i}`}
+        columns={columns}
+        onRowClick={(t) =>
+          onOpenDetail({
+            eyebrow: t._kind === "run" ? "Training run" : "Serving config",
+            title: t.name,
+            subtitle: t.source_file,
+            flags: t.security_flags,
+            fields: buildFields(t, ["name", "security_flags", "source_file", "_kind"]),
+          })
+        }
+        empty="No training or serving artifacts found."
+      />
+    </ResultShell>
+  );
+}
+
+function BrowserExtensionsResult({
+  result,
+  onOpenDetail,
+}: {
+  result: BrowserExtensionsResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const rows = [...result.extensions].sort(
+    (a, b) => aiSeverityRank(b.risk_level) - aiSeverityRank(a.risk_level),
+  );
+  const stats: StatStripItem[] = [
+    { label: "Extensions", value: result.total },
+    { label: "Critical", value: result.critical, accent: "critical" },
+    { label: "High", value: result.high, accent: "high" },
+  ];
+  const columns: DataTableColumn<BrowserExtension>[] = [
+    { key: "name", header: "Extension", cell: (e) => <span className="text-[color:var(--foreground)]">{e.name}</span> },
+    { key: "browser", header: "Browser", cell: (e) => e.browser ?? "—" },
+    { key: "risk", header: "Risk", cell: (e) => (e.risk_level ? <SeverityBadge severity={e.risk_level} /> : "—") },
+    { key: "perms", header: "Perms", align: "right", cell: (e) => (e.permissions?.length ?? 0) + (e.host_permissions?.length ?? 0) },
+    { key: "native", header: "Native msg", cell: (e) => <BoolTag value={e.has_native_messaging} trueLabel="yes" falseLabel="no" /> },
+    { key: "ai", header: "AI host", cell: (e) => <BoolTag value={e.has_ai_host_access} trueLabel="yes" falseLabel="no" /> },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={[]}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={rows}
+        rowKey={(e, i) => `${e.id}-${i}`}
+        columns={columns}
+        onRowClick={(e) =>
+          onOpenDetail({
+            eyebrow: `${e.browser ?? "Extension"} · ${e.risk_level ?? "unknown"} risk`,
+            title: e.name,
+            subtitle: e.id,
+            fields: buildFields(e, ["name", "id", "browser", "risk_level"]),
+          })
+        }
+        empty="No extensions matched the risk filter."
+      />
+    </ResultShell>
+  );
+}
+
+function ModelProvenanceResult({
+  result,
+  onOpenDetail,
+}: {
+  result: ModelProvenanceResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const rows = [...result.results].sort(
+    (a, b) => aiSeverityRank(b.risk_level) - aiSeverityRank(a.risk_level),
+  );
+  const stats: StatStripItem[] = [
+    { label: "Models", value: result.total },
+    { label: "Unsafe format", value: result.unsafe_format, accent: "critical" },
+  ];
+  const columns: DataTableColumn<ProvenanceResult>[] = [
+    { key: "model", header: "Model", cell: (m) => <span className="font-mono text-xs text-[color:var(--foreground)]">{m.model_id}</span> },
+    { key: "source", header: "Source", cell: (m) => m.source ?? "—" },
+    { key: "format", header: "Format", cell: (m) => m.format ?? "—" },
+    {
+      key: "safe",
+      header: "Serialization",
+      cell: (m) =>
+        m.is_safe_format ? (
+          <span className="text-xs text-[color:var(--status-success)]">safe</span>
+        ) : (
+          <span className="text-xs text-[color:var(--severity-critical)]">unsafe</span>
+        ),
+    },
+    { key: "risk", header: "Risk", cell: (m) => (m.risk_level ? <SeverityBadge severity={m.risk_level} /> : "—") },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={[]}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={rows}
+        rowKey={(m, i) => `${m.model_id}-${i}`}
+        columns={columns}
+        onRowClick={(m) =>
+          onOpenDetail({
+            eyebrow: `${m.source ?? "model"} provenance`,
+            title: m.model_id,
+            subtitle: m.format,
+            fields: buildFields(m, ["model_id"]),
+          })
+        }
+        empty="No models resolved. Check the model IDs and network access."
+      />
+    </ResultShell>
+  );
+}
+
+function PromptScanResult({
+  result,
+  onOpenDetail,
+}: {
+  result: PromptScanResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const findings = result.results
+    .flatMap((r) => r.findings)
+    .sort((a, b) => aiSeverityRank(b.severity) - aiSeverityRank(a.severity));
+  const filesScanned = result.results.reduce((s, r) => s + r.files_scanned, 0);
+  const passed = result.results.every((r) => r.passed);
+  const critical = findings.filter((f) => f.severity?.toLowerCase() === "critical").length;
+  const high = findings.filter((f) => f.severity?.toLowerCase() === "high").length;
+  const stats: StatStripItem[] = [
+    { label: "Files scanned", value: filesScanned },
+    { label: "Findings", value: findings.length },
+    { label: "Critical", value: critical, accent: "critical" },
+    { label: "High", value: high, accent: "high" },
+    {
+      label: "Verdict",
+      value: passed ? "pass" : "fail",
+      accent: passed ? "success" : "critical",
+    },
+  ];
+  const columns: DataTableColumn<PromptFinding>[] = [
+    { key: "severity", header: "Severity", cell: (f) => <SeverityBadge severity={f.severity} /> },
+    { key: "category", header: "Category", cell: (f) => f.category ?? "—" },
+    { key: "title", header: "Finding", cell: (f) => <span className="text-[color:var(--foreground)]">{f.title ?? "—"}</span> },
+    {
+      key: "source",
+      header: "Location",
+      cell: (f) => (
+        <span className="font-mono text-xs">
+          {f.source_file ?? "—"}
+          {typeof f.line_number === "number" ? `:${f.line_number}` : ""}
+        </span>
+      ),
+    },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={[]}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={findings}
+        rowKey={(f, i) => `${f.source_file ?? f.title}-${i}`}
+        columns={columns}
+        onRowClick={(f) =>
+          onOpenDetail({
+            eyebrow: `${f.severity} · ${f.category ?? "prompt"}`,
+            title: f.title ?? "Prompt finding",
+            subtitle: f.source_file,
+            fields: buildFields(f, ["title", "source_file", "severity"]),
+          })
+        }
+        empty="No prompt-security findings."
+      />
+    </ResultShell>
+  );
+}
+
+function ModelFilesResult({
+  result,
+  onOpenDetail,
+}: {
+  result: ModelFilesResponse;
+  onOpenDetail: (d: DetailView) => void;
+}) {
+  const rows = [...result.files].sort(
+    (a, b) => aiSeverityRank(highestFlagSeverity(b.security_flags)) - aiSeverityRank(highestFlagSeverity(a.security_flags)),
+  );
+  const stats: StatStripItem[] = [
+    { label: "Model files", value: result.total },
+    { label: "Manifests", value: result.manifest_total },
+    { label: "Unsafe", value: result.unsafe, accent: "critical" },
+    { label: "Warnings", value: result.warnings.length, accent: "warn" },
+  ];
+  const columns: DataTableColumn<ModelFileEntry>[] = [
+    { key: "file", header: "File", cell: (f) => <span className="font-mono text-xs text-[color:var(--foreground)]">{f.filename ?? f.path}</span> },
+    { key: "format", header: "Format", cell: (f) => f.format ?? "—" },
+    { key: "eco", header: "Ecosystem", cell: (f) => f.ecosystem ?? "—" },
+    { key: "size", header: "Size", align: "right", cell: (f) => f.size_human ?? "—" },
+    { key: "flags", header: "Risk", cell: (f) => <FlagCell flags={f.security_flags} /> },
+  ];
+  return (
+    <ResultShell stats={stats} warnings={result.warnings}>
+      <DataTable
+        data-testid="ai-scan-table"
+        rows={rows}
+        rowKey={(f, i) => `${f.path}-${i}`}
+        columns={columns}
+        onRowClick={(f) =>
+          onOpenDetail({
+            eyebrow: `${f.format ?? "model file"} · ${f.ecosystem ?? ""}`.trim(),
+            title: f.filename ?? f.path,
+            subtitle: f.path,
+            flags: f.security_flags,
+            fields: buildFields(f, ["filename", "path", "security_flags"]),
+          })
+        }
+        empty="No model files found in the scanned directories."
+      />
+    </ResultShell>
+  );
+}
+
+// ─── Shared render helpers ──────────────────────────────────────────────────
+
+function ResultShell({
+  stats,
+  warnings,
+  children,
+}: {
+  stats: StatStripItem[];
+  warnings: string[];
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-3" data-testid="ai-scan-results">
+      <StatStrip items={stats} data-testid="ai-scan-stats" />
+      {children}
+      {warnings.length > 0 ? (
+        <ul className="space-y-1 rounded-xl border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-4 py-3 text-xs text-[color:var(--text-secondary)]">
+          {warnings.slice(0, 12).map((warning, i) => (
+            <li key={i} className="flex items-start gap-2">
+              <span className="mt-1.5 h-1 w-1 shrink-0 rounded-full bg-[color:var(--status-warn)]" />
+              <span>{warning}</span>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}
+
+function DetailBody({ detail }: { detail: DetailView }) {
+  return (
+    <div className="space-y-5">
+      {detail.flags && detail.flags.length > 0 ? (
+        <section>
+          <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+            Security flags
+          </h3>
+          <ul className="space-y-2">
+            {detail.flags.map((flag, i) => (
+              <li
+                key={i}
+                className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3"
+              >
+                <div className="flex items-center gap-2">
+                  {flag.severity ? <SeverityBadge severity={flag.severity} /> : null}
+                  {flag.type ? (
+                    <span className="font-mono text-xs text-[color:var(--foreground)]">{flag.type}</span>
+                  ) : null}
+                </div>
+                {flag.description ? (
+                  <p className="mt-1.5 text-sm text-[color:var(--text-secondary)]">{flag.description}</p>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+
+      <section>
+        <h3 className="mb-2 text-[11px] font-semibold uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+          Details
+        </h3>
+        <dl className="divide-y divide-[color:var(--border-subtle)] rounded-xl border border-[color:var(--border-subtle)]">
+          {detail.fields.map((field) => (
+            <div key={field.label} className="grid grid-cols-[10rem_minmax(0,1fr)] gap-3 px-3 py-2">
+              <dt className="text-xs uppercase tracking-[0.1em] text-[color:var(--text-tertiary)]">{field.label}</dt>
+              <dd className="min-w-0 break-words text-sm text-[color:var(--foreground)]">{field.value}</dd>
+            </div>
+          ))}
+        </dl>
+      </section>
+    </div>
+  );
+}
+
+/** Turn an arbitrary result object into labelled detail fields, skipping keys
+ * already surfaced in the drawer header / flags section and empty values. */
+function buildFields(obj: Record<string, unknown>, skip: string[]): { label: string; value: ReactNode }[] {
+  const fields: { label: string; value: ReactNode }[] = [];
+  for (const [key, raw] of Object.entries(obj)) {
+    if (skip.includes(key)) continue;
+    if (raw === null || raw === undefined || raw === "") continue;
+    if (Array.isArray(raw) && raw.length === 0) continue;
+    if (typeof raw === "object" && !Array.isArray(raw) && Object.keys(raw as object).length === 0) continue;
+    fields.push({ label: prettyLabel(key), value: renderValue(raw) });
+  }
+  return fields;
+}
+
+function prettyLabel(key: string): string {
+  return key.replace(/^_/, "").replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
+function renderValue(raw: unknown): ReactNode {
+  if (typeof raw === "boolean") return raw ? "yes" : "no";
+  if (Array.isArray(raw)) {
+    return (
+      <span className="flex flex-wrap gap-1">
+        {raw.map((item, i) => (
+          <span
+            key={i}
+            className="rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-1.5 py-0.5 font-mono text-[11px] text-[color:var(--text-secondary)]"
+          >
+            {typeof item === "object" ? JSON.stringify(item) : String(item)}
+          </span>
+        ))}
+      </span>
+    );
+  }
+  if (typeof raw === "object") {
+    return <span className="font-mono text-xs">{JSON.stringify(raw)}</span>;
+  }
+  return String(raw);
+}
+
+// ─── Inputs ─────────────────────────────────────────────────────────────────
+
+function PathListInput({
+  label,
+  placeholder,
+  items,
+  onChange,
+  mono = false,
+}: {
+  label: string;
+  placeholder: string;
+  items: string[];
+  onChange: (next: string[]) => void;
+  mono?: boolean;
+}) {
+  const [draft, setDraft] = useState("");
+
+  function add() {
+    const value = draft.trim();
+    if (!value) return;
+    onChange([...items, value]);
+    setDraft("");
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="block text-xs font-medium text-[color:var(--text-secondary)]">{label}</label>
+      <div className="flex gap-2">
+        <input
+          type="text"
+          aria-label={label}
+          placeholder={placeholder}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              add();
+            }
+          }}
+          className={`flex-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)] focus:border-[color:var(--accent)] focus:outline-none ${
+            mono ? "font-mono" : ""
+          }`}
+        />
+        <button
+          type="button"
+          onClick={add}
+          className="inline-flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+        >
+          <Plus className="h-3.5 w-3.5" />
+          Add
+        </button>
+      </div>
+      {items.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {items.map((item, i) => (
+            <span
+              key={`${item}-${i}`}
+              className="flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1 font-mono text-xs text-[color:var(--foreground)]"
+            >
+              {item}
+              <button
+                type="button"
+                aria-label={`Remove ${item}`}
+                onClick={() => onChange(items.filter((_, idx) => idx !== i))}
+              >
+                <X className="h-3 w-3 text-[color:var(--text-tertiary)] hover:text-[color:var(--foreground)]" />
+              </button>
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/components/audit-evidence-panel.tsx
+++ b/ui/components/audit-evidence-panel.tsx
@@ -1,0 +1,286 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Download,
+  FileCheck2,
+  Loader2,
+  ShieldAlert,
+  ShieldCheck,
+} from "lucide-react";
+
+import {
+  api,
+  type AuditExportPacket,
+  type AuditExportVerifyResult,
+} from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
+
+type VerifyState = {
+  result: AuditExportVerifyResult;
+  /** Round-trip verification of a freshly-exported packet vs. a pasted one. */
+  source: "export" | "paste";
+};
+
+function downloadPacket(packet: AuditExportPacket): void {
+  if (typeof window === "undefined" || typeof URL.createObjectURL !== "function") {
+    return;
+  }
+  const blob = new Blob([JSON.stringify(packet, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = "agent-bom-audit-export.json";
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
+}
+
+/** Extract a `{ payload, signature }` packet from a pasted export blob. */
+function parsePacket(raw: string, signatureField: string): AuditExportPacket | { error: string } {
+  const trimmed = raw.trim();
+  if (!trimmed) return { error: "Paste an exported audit packet to verify." };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed);
+  } catch {
+    // Not JSON — treat the raw text as the payload, needs an explicit signature.
+    if (!signatureField.trim()) return { error: "Add the export signature to verify raw text." };
+    return { payload: trimmed, signature: signatureField.trim() };
+  }
+  if (
+    parsed &&
+    typeof parsed === "object" &&
+    "payload" in parsed &&
+    "signature" in parsed &&
+    typeof (parsed as { signature: unknown }).signature === "string"
+  ) {
+    const wrapper = parsed as { payload: unknown; signature: string };
+    return { payload: wrapper.payload, signature: wrapper.signature };
+  }
+  if (!signatureField.trim()) {
+    return { error: "This looks like a bare export body — add its signature to verify." };
+  }
+  return { payload: parsed, signature: signatureField.trim() };
+}
+
+/**
+ * Human UI for the signed audit evidence surface (P1-2, #4014): download a
+ * tamper-evident export and verify one round-trip (PASS/FAIL) — GRC evidence
+ * that the log has not been altered, without exposing HMAC key material.
+ */
+export function AuditEvidencePanel() {
+  const [exporting, setExporting] = useState(false);
+  const [lastExport, setLastExport] = useState<AuditExportPacket | null>(null);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  const [pasteValue, setPasteValue] = useState("");
+  const [signatureValue, setSignatureValue] = useState("");
+  const [verifying, setVerifying] = useState(false);
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const [verifyState, setVerifyState] = useState<VerifyState | null>(null);
+
+  async function runExport() {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const packet = await api.exportAuditPacket();
+      setLastExport(packet);
+      downloadPacket(packet);
+      // Round-trip: prove the freshly-signed packet verifies clean.
+      const result = await api.verifyAuditPacket(packet.payload, packet.signature);
+      setVerifyState({ result, source: "export" });
+      setVerifyError(null);
+    } catch (err) {
+      setExportError(userFacingApiErrorMessage(err, "Audit export failed"));
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  async function runVerify() {
+    const packet = parsePacket(pasteValue, signatureValue);
+    if ("error" in packet) {
+      setVerifyError(packet.error);
+      setVerifyState(null);
+      return;
+    }
+    setVerifying(true);
+    setVerifyError(null);
+    try {
+      const result = await api.verifyAuditPacket(packet.payload, packet.signature);
+      setVerifyState({ result, source: "paste" });
+    } catch (err) {
+      setVerifyState(null);
+      setVerifyError(userFacingApiErrorMessage(err, "Audit verification failed"));
+    } finally {
+      setVerifying(false);
+    }
+  }
+
+  return (
+    <section
+      aria-label="Audit evidence export and verification"
+      className="grid gap-3 md:grid-cols-2"
+    >
+      {/* Export */}
+      <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+        <div className="flex items-center gap-2">
+          <Download className="h-4 w-4 text-[color:var(--accent)]" aria-hidden="true" />
+          <h2 className="text-sm font-semibold text-[color:var(--foreground)]">Export signed evidence</h2>
+        </div>
+        <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+          Download a JSON evidence packet with its detached HMAC signature for auditors.
+        </p>
+        <button
+          type="button"
+          onClick={() => void runExport()}
+          disabled={exporting}
+          className="mt-3 inline-flex items-center gap-2 rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-sm font-medium text-[color:var(--accent)] transition hover:bg-[color:var(--accent-soft-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {exporting ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Download className="h-4 w-4" aria-hidden="true" />
+          )}
+          Export &amp; verify
+        </button>
+
+        {exportError && (
+          <p
+            role="alert"
+            className="mt-3 rounded-lg border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-3 py-2 text-xs text-[color:var(--status-danger)]"
+          >
+            {exportError}
+          </p>
+        )}
+
+        {lastExport && !exportError && (
+          <div className="mt-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-xs">
+            <div className="text-[10px] uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+              Signature
+            </div>
+            <code className="mt-0.5 block truncate font-mono text-[11px] text-[color:var(--text-secondary)]">
+              {lastExport.signature ? `${lastExport.signature.slice(0, 32)}…` : "not provided by server"}
+            </code>
+          </div>
+        )}
+      </div>
+
+      {/* Verify */}
+      <div className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+        <div className="flex items-center gap-2">
+          <FileCheck2 className="h-4 w-4 text-[color:var(--accent)]" aria-hidden="true" />
+          <h2 className="text-sm font-semibold text-[color:var(--foreground)]">Verify an export</h2>
+        </div>
+        <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+          Paste an exported packet to confirm the log is tamper-evident and unaltered.
+        </p>
+
+        <label htmlFor="audit-verify-packet" className="sr-only">
+          Exported audit packet
+        </label>
+        <textarea
+          id="audit-verify-packet"
+          value={pasteValue}
+          onChange={(event) => setPasteValue(event.target.value)}
+          rows={4}
+          placeholder='{"payload": …, "signature": "…"}'
+          className="mt-2 w-full resize-y rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 font-mono text-[11px] text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--accent-border)] focus:outline-none"
+        />
+        <label htmlFor="audit-verify-signature" className="sr-only">
+          Signature (only needed for a bare export body)
+        </label>
+        <input
+          id="audit-verify-signature"
+          value={signatureValue}
+          onChange={(event) => setSignatureValue(event.target.value)}
+          placeholder="Signature (optional — only for a bare export body)"
+          className="mt-2 w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 font-mono text-[11px] text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--accent-border)] focus:outline-none"
+        />
+        <div className="mt-2 flex flex-wrap items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void runVerify()}
+            disabled={verifying}
+            className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm font-medium text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)] disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {verifying ? (
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <ShieldCheck className="h-4 w-4" aria-hidden="true" />
+            )}
+            Verify
+          </button>
+          {lastExport && (
+            <button
+              type="button"
+              onClick={() => {
+                setPasteValue(JSON.stringify(lastExport, null, 2));
+                setSignatureValue("");
+                setVerifyError(null);
+              }}
+              className="text-xs text-[color:var(--accent)] underline-offset-2 hover:underline"
+            >
+              Fill from last export
+            </button>
+          )}
+        </div>
+
+        {verifyError && (
+          <p
+            role="alert"
+            className="mt-3 rounded-lg border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-3 py-2 text-xs text-[color:var(--status-danger)]"
+          >
+            {verifyError}
+          </p>
+        )}
+
+        {verifyState && !verifyError && (
+          <div
+            data-testid="audit-verify-result"
+            data-valid={verifyState.result.valid ? "true" : "false"}
+            className={`mt-3 flex items-start gap-3 rounded-lg border px-3 py-2.5 ${
+              verifyState.result.valid
+                ? "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)]"
+                : "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)]"
+            }`}
+          >
+            {verifyState.result.valid ? (
+              <ShieldCheck
+                className="mt-0.5 h-5 w-5 shrink-0 text-[color:var(--status-success)]"
+                aria-hidden="true"
+              />
+            ) : (
+              <ShieldAlert
+                className="mt-0.5 h-5 w-5 shrink-0 text-[color:var(--status-danger)]"
+                aria-hidden="true"
+              />
+            )}
+            <div className="min-w-0">
+              <div
+                className={`text-sm font-bold tracking-[0.12em] ${
+                  verifyState.result.valid
+                    ? "text-[color:var(--status-success)]"
+                    : "text-[color:var(--status-danger)]"
+                }`}
+              >
+                {verifyState.result.valid ? "PASS" : "FAIL"}
+              </div>
+              <p className="mt-0.5 text-xs text-[color:var(--text-secondary)]">
+                {verifyState.result.valid
+                  ? "Signature matches — the exported log is intact and tamper-evident."
+                  : "Signature mismatch — the packet has been altered or the signature is wrong."}
+                {verifyState.source === "export" ? " (fresh export round-trip)" : ""}
+              </p>
+              <p className="mt-0.5 text-[10px] text-[color:var(--text-tertiary)]">
+                {verifyState.result.payload_bytes.toLocaleString()} bytes verified
+              </p>
+            </div>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/ui/components/audit-evidence-panel.tsx
+++ b/ui/components/audit-evidence-panel.tsx
@@ -20,7 +20,16 @@ type VerifyState = {
   result: AuditExportVerifyResult;
   /** Round-trip verification of a freshly-exported packet vs. a pasted one. */
   source: "export" | "paste";
+  tamperedEntries: number;
 };
+
+function reportedTamperedEntries(payload: unknown): number {
+  if (!payload || typeof payload !== "object") return 0;
+  const integrity = (payload as { integrity?: unknown }).integrity;
+  if (!integrity || typeof integrity !== "object") return 0;
+  const value = (integrity as { tampered?: unknown }).tampered;
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
 
 function downloadPacket(packet: AuditExportPacket): void {
   if (typeof window === "undefined" || typeof URL.createObjectURL !== "function") {
@@ -90,7 +99,11 @@ export function AuditEvidencePanel() {
       downloadPacket(packet);
       // Round-trip: prove the freshly-signed packet verifies clean.
       const result = await api.verifyAuditPacket(packet.payload, packet.signature);
-      setVerifyState({ result, source: "export" });
+      setVerifyState({
+        result,
+        source: "export",
+        tamperedEntries: reportedTamperedEntries(packet.payload),
+      });
       setVerifyError(null);
     } catch (err) {
       setExportError(userFacingApiErrorMessage(err, "Audit export failed"));
@@ -110,7 +123,11 @@ export function AuditEvidencePanel() {
     setVerifyError(null);
     try {
       const result = await api.verifyAuditPacket(packet.payload, packet.signature);
-      setVerifyState({ result, source: "paste" });
+      setVerifyState({
+        result,
+        source: "paste",
+        tamperedEntries: reportedTamperedEntries(packet.payload),
+      });
     } catch (err) {
       setVerifyState(null);
       setVerifyError(userFacingApiErrorMessage(err, "Audit verification failed"));
@@ -237,17 +254,19 @@ export function AuditEvidencePanel() {
           </p>
         )}
 
-        {verifyState && !verifyError && (
+        {verifyState && !verifyError && (() => {
+          const verifiedIntact = verifyState.result.valid && verifyState.tamperedEntries === 0;
+          return (
           <div
             data-testid="audit-verify-result"
-            data-valid={verifyState.result.valid ? "true" : "false"}
+            data-valid={verifiedIntact ? "true" : "false"}
             className={`mt-3 flex items-start gap-3 rounded-lg border px-3 py-2.5 ${
-              verifyState.result.valid
+              verifiedIntact
                 ? "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)]"
                 : "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)]"
             }`}
           >
-            {verifyState.result.valid ? (
+            {verifiedIntact ? (
               <ShieldCheck
                 className="mt-0.5 h-5 w-5 shrink-0 text-[color:var(--status-success)]"
                 aria-hidden="true"
@@ -261,17 +280,19 @@ export function AuditEvidencePanel() {
             <div className="min-w-0">
               <div
                 className={`text-sm font-bold tracking-[0.12em] ${
-                  verifyState.result.valid
+                  verifiedIntact
                     ? "text-[color:var(--status-success)]"
                     : "text-[color:var(--status-danger)]"
                 }`}
               >
-                {verifyState.result.valid ? "PASS" : "FAIL"}
+                {verifiedIntact ? "PASS" : "FAIL"}
               </div>
               <p className="mt-0.5 text-xs text-[color:var(--text-secondary)]">
-                {verifyState.result.valid
+                {verifiedIntact
                   ? "Signature matches — the exported log is intact and tamper-evident."
-                  : "Signature mismatch — the packet has been altered or the signature is wrong."}
+                  : verifyState.result.valid
+                    ? `Signature matches, but the payload reports tampered entries (${verifyState.tamperedEntries}).`
+                    : "Signature mismatch — the packet has been altered or the signature is wrong."}
                 {verifyState.source === "export" ? " (fresh export round-trip)" : ""}
               </p>
               <p className="mt-0.5 text-[10px] text-[color:var(--text-tertiary)]">
@@ -279,7 +300,8 @@ export function AuditEvidencePanel() {
               </p>
             </div>
           </div>
-        )}
+          );
+        })()}
       </div>
     </section>
   );

--- a/ui/components/deploy-gate-panel.tsx
+++ b/ui/components/deploy-gate-panel.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Ban,
+  CheckCircle2,
+  Loader2,
+  Rocket,
+  ShieldAlert,
+  ShieldQuestion,
+} from "lucide-react";
+
+import { api, type DeployDecision, type GraphDeployDecisionResponse } from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
+
+type Verdict = {
+  label: string;
+  detail: string;
+  icon: typeof CheckCircle2;
+  container: string;
+  badge: string;
+  accent: string;
+};
+
+const VERDICTS: Record<DeployDecision, Verdict> = {
+  allow: {
+    label: "GO",
+    detail: "No blocking exposure path reaches this candidate — safe to ship.",
+    icon: CheckCircle2,
+    container:
+      "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)]",
+    badge:
+      "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]",
+    accent: "text-[color:var(--status-success)]",
+  },
+  warn: {
+    label: "REVIEW",
+    detail: "A material exposure path was found — review the evidence before shipping.",
+    icon: ShieldQuestion,
+    container: "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)]",
+    badge:
+      "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--status-warn)]",
+    accent: "text-[color:var(--status-warn)]",
+  },
+  block: {
+    label: "BLOCK",
+    detail: "A high-risk exposure path reaches this candidate — do not deploy.",
+    icon: Ban,
+    container:
+      "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)]",
+    badge:
+      "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--status-danger)]",
+    accent: "text-[color:var(--status-danger)]",
+  },
+};
+
+function severityToken(severity: string): string {
+  const value = severity.toLowerCase();
+  if (value === "critical") return "text-[color:var(--severity-critical)]";
+  if (value === "high") return "text-[color:var(--severity-high)]";
+  if (value === "medium") return "text-[color:var(--severity-medium)]";
+  if (value === "low") return "text-[color:var(--severity-low)]";
+  return "text-[color:var(--text-secondary)]";
+}
+
+/**
+ * "Should I deploy this agent/component?" gate — the exec answer over the
+ * MCP-only /v1/graph/should-i-deploy surface. Renders GO / REVIEW / BLOCK from
+ * the allow/warn/block decision with the reasons and exposure it found.
+ */
+export function DeployGatePanel({ scanId }: { scanId?: string | undefined }) {
+  const [candidate, setCandidate] = useState("");
+  const [result, setResult] = useState<GraphDeployDecisionResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmed = candidate.trim();
+
+  async function runGate() {
+    if (!trimmed) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await api.graphShouldIDeploy({
+        candidate: trimmed,
+        scanId: scanId || undefined,
+      });
+      setResult(response);
+    } catch (err) {
+      setResult(null);
+      setError(userFacingApiErrorMessage(err, "Deploy gate could not be evaluated"));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const verdict = result ? VERDICTS[result.decision] : null;
+  const VerdictIcon = verdict?.icon ?? Rocket;
+
+  return (
+    <section
+      aria-label="Should I deploy gate"
+      className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <Rocket className="h-4 w-4 text-[color:var(--accent)]" aria-hidden="true" />
+            <h2 className="text-sm font-semibold text-[color:var(--foreground)]">Should I deploy?</h2>
+          </div>
+          <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+            Check an agent, service, image, or package against this snapshot&apos;s exposure paths.
+          </p>
+        </div>
+      </div>
+
+      <form
+        className="mt-3 flex flex-wrap items-center gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          void runGate();
+        }}
+      >
+        <label htmlFor="deploy-gate-candidate" className="sr-only">
+          Deploy candidate
+        </label>
+        <input
+          id="deploy-gate-candidate"
+          value={candidate}
+          onChange={(event) => setCandidate(event.target.value)}
+          placeholder="agent:claude-desktop, service:payments-api, pkg@1.2.3…"
+          className="min-w-0 flex-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--accent-border)] focus:outline-none"
+        />
+        <button
+          type="submit"
+          disabled={loading || !trimmed}
+          className="inline-flex shrink-0 items-center gap-2 rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-sm font-medium text-[color:var(--accent)] transition hover:bg-[color:var(--accent-soft-hover)] disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {loading ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <ShieldAlert className="h-4 w-4" aria-hidden="true" />
+          )}
+          Run gate
+        </button>
+      </form>
+
+      {error && (
+        <p
+          role="alert"
+          className="mt-3 rounded-lg border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-3 py-2 text-xs text-[color:var(--status-danger)]"
+        >
+          {error}
+        </p>
+      )}
+
+      {result && verdict && (
+        <div
+          data-testid="deploy-gate-verdict"
+          data-decision={result.decision}
+          className={`mt-4 rounded-2xl border p-4 ${verdict.container}`}
+        >
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <div className="flex items-center gap-3">
+              <VerdictIcon className={`h-7 w-7 shrink-0 ${verdict.accent}`} aria-hidden="true" />
+              <div className="min-w-0">
+                <div
+                  className={`inline-flex items-center rounded-full border px-3 py-0.5 text-sm font-bold tracking-[0.14em] ${verdict.badge}`}
+                >
+                  {verdict.label}
+                </div>
+                <p className="mt-1 max-w-xl text-xs text-[color:var(--text-secondary)]">{verdict.detail}</p>
+              </div>
+            </div>
+            <div className="text-right">
+              <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                Max path risk
+              </div>
+              <div className={`font-mono text-2xl font-semibold ${verdict.accent}`}>
+                {result.maxRisk.toFixed(1)}
+              </div>
+              <div className="text-[10px] text-[color:var(--text-tertiary)]">
+                warn ≥ {result.thresholds.warnRisk} · block ≥ {result.thresholds.blockRisk}
+              </div>
+            </div>
+          </div>
+
+          {result.reasons.length > 0 && (
+            <ul className="mt-3 space-y-1.5 border-t border-[color:var(--border-subtle)] pt-3 text-xs text-[color:var(--text-secondary)]">
+              {result.reasons.map((reason) => (
+                <li key={reason} className="flex items-start gap-2">
+                  <span className="mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full bg-[color:var(--text-tertiary)]" />
+                  <span className="[overflow-wrap:anywhere]">{reason}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className="mt-3 border-t border-[color:var(--border-subtle)] pt-3">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+              Matched exposure paths ({result.matchedPathCount})
+            </div>
+            {result.matchedPaths.length === 0 ? (
+              <p className="mt-2 text-xs text-[color:var(--text-secondary)]">
+                No exposure path in this snapshot reaches the candidate.
+              </p>
+            ) : (
+              <ul className="mt-2 space-y-2">
+                {result.matchedPaths.slice(0, 5).map((path) => (
+                  <li
+                    key={path.id}
+                    className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2"
+                  >
+                    <div className="flex items-center justify-between gap-3">
+                      <span className="min-w-0 truncate text-xs font-medium text-[color:var(--foreground)]">
+                        {path.label || path.id}
+                      </span>
+                      <span className="shrink-0 font-mono text-xs text-[color:var(--text-secondary)]">
+                        <span className={severityToken(path.severity)}>{path.severity}</span>{" "}
+                        · {path.riskScore.toFixed(1)}
+                      </span>
+                    </div>
+                    {path.findings.length > 0 && (
+                      <div className="mt-1 flex flex-wrap gap-1">
+                        {path.findings.slice(0, 4).map((finding) => (
+                          <span
+                            key={finding}
+                            className="rounded border border-[color:var(--border-subtle)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--text-tertiary)]"
+                          >
+                            {finding}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/ui/components/deploy-gate-panel.tsx
+++ b/ui/components/deploy-gate-panel.tsx
@@ -22,7 +22,9 @@ type Verdict = {
   accent: string;
 };
 
-const VERDICTS: Record<DeployDecision, Verdict> = {
+type DisplayDecision = DeployDecision | "insufficient-evidence";
+
+const VERDICTS: Record<DisplayDecision, Verdict> = {
   allow: {
     label: "GO",
     detail: "No blocking exposure path reaches this candidate — safe to ship.",
@@ -51,6 +53,15 @@ const VERDICTS: Record<DeployDecision, Verdict> = {
     badge:
       "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--status-danger)]",
     accent: "text-[color:var(--status-danger)]",
+  },
+  "insufficient-evidence": {
+    label: "INSUFFICIENT EVIDENCE",
+    detail: "No matching exposure evidence was returned — gather or refresh graph data before shipping.",
+    icon: ShieldQuestion,
+    container: "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)]",
+    badge:
+      "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--status-warn)]",
+    accent: "text-[color:var(--status-warn)]",
   },
 };
 
@@ -94,7 +105,12 @@ export function DeployGatePanel({ scanId }: { scanId?: string | undefined }) {
     }
   }
 
-  const verdict = result ? VERDICTS[result.decision] : null;
+  const displayDecision: DisplayDecision | null = result
+    ? result.matchedPathCount === 0 && result.matchedPaths.length === 0
+      ? "insufficient-evidence"
+      : result.decision
+    : null;
+  const verdict = displayDecision ? VERDICTS[displayDecision] : null;
   const VerdictIcon = verdict?.icon ?? Rocket;
 
   return (
@@ -157,7 +173,7 @@ export function DeployGatePanel({ scanId }: { scanId?: string | undefined }) {
       {result && verdict && (
         <div
           data-testid="deploy-gate-verdict"
-          data-decision={result.decision}
+          data-decision={displayDecision}
           className={`mt-4 rounded-2xl border p-4 ${verdict.container}`}
         >
           <div className="flex flex-wrap items-center justify-between gap-3">
@@ -177,7 +193,7 @@ export function DeployGatePanel({ scanId }: { scanId?: string | undefined }) {
                 Max path risk
               </div>
               <div className={`font-mono text-2xl font-semibold ${verdict.accent}`}>
-                {result.maxRisk.toFixed(1)}
+                {displayDecision === "insufficient-evidence" ? "—" : result.maxRisk.toFixed(1)}
               </div>
               <div className="text-[10px] text-[color:var(--text-tertiary)]">
                 warn ≥ {result.thresholds.warnRisk} · block ≥ {result.thresholds.blockRisk}
@@ -202,7 +218,7 @@ export function DeployGatePanel({ scanId }: { scanId?: string | undefined }) {
             </div>
             {result.matchedPaths.length === 0 ? (
               <p className="mt-2 text-xs text-[color:var(--text-secondary)]">
-                No exposure path in this snapshot reaches the candidate.
+                No matching path evidence is available for this candidate.
               </p>
             ) : (
               <ul className="mt-2 space-y-2">

--- a/ui/components/exposure-path-lens.tsx
+++ b/ui/components/exposure-path-lens.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Loader2, Route } from "lucide-react";
+
+import {
+  api,
+  type GraphExposureEntityRef,
+  type GraphExposurePath,
+  type GraphExposurePathsResponse,
+} from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
+import {
+  ExposurePathCommandCenter,
+  type ExposurePathView,
+} from "@/components/exposure-path-command-center";
+import {
+  exposurePathKey,
+  normalizeExposureSeverity,
+  pathDisplayTitle,
+  type ExposureEntityRef,
+  type ExposureEntityRole,
+  type ExposurePath,
+} from "@/lib/exposure-path";
+import { PageErrorState, PageEmptyState } from "@/components/states/page-state";
+import { StatStrip } from "@/components/stat-strip";
+
+const EXPOSURE_PATH_LIMIT = 25;
+
+const KNOWN_ROLES = new Set<ExposureEntityRole>([
+  "agent",
+  "server",
+  "package",
+  "finding",
+  "credential",
+  "tool",
+  "environment",
+  "cluster",
+  "unknown",
+]);
+
+function toRole(role: string): ExposureEntityRole {
+  const value = role.toLowerCase() as ExposureEntityRole;
+  return KNOWN_ROLES.has(value) ? value : "unknown";
+}
+
+function toEntityRef(ref: GraphExposureEntityRef): ExposureEntityRef {
+  return {
+    id: ref.id,
+    label: ref.label,
+    role: toRole(ref.role),
+    severity: ref.severity,
+    riskScore: ref.riskScore,
+  };
+}
+
+/** Map the MCP/REST ExposurePath payload onto the UI's shared ExposurePath shape. */
+export function toUiExposurePath(path: GraphExposurePath): ExposurePath {
+  const hops = path.hops.map(toEntityRef);
+  const affectedAgents = hops.filter((hop) => hop.role === "agent").map((hop) => hop.label);
+  const affectedServers = hops.filter((hop) => hop.role === "server").map((hop) => hop.label);
+  return {
+    id: path.id,
+    rank: path.rank,
+    label: path.label,
+    summary: path.summary,
+    riskScore: path.riskScore,
+    severity: normalizeExposureSeverity(path.severity),
+    source: toEntityRef(path.source),
+    target: toEntityRef(path.target),
+    hops,
+    relationships: path.relationships.map((rel) => ({
+      id: rel.id,
+      source: rel.source,
+      target: rel.target,
+      relationship: rel.relationship,
+      confidence: rel.confidence,
+    })),
+    nodeIds: path.nodeIds,
+    edgeIds: path.edgeIds,
+    findings: path.findings,
+    affectedAgents,
+    affectedServers,
+    reachableTools: path.reachableTools,
+    exposedCredentials: path.exposedCredentials,
+    provenance: path.provenance,
+  };
+}
+
+/**
+ * ExposurePath lens for the security-graph page. Renders the agent-native
+ * /v1/graph/exposure-paths queue (a distinct view from the ranked attack paths)
+ * and reuses the shared ExposurePathCommandCenter Path/Graph/List rendering.
+ */
+export function ExposurePathLens({ scanId }: { scanId?: string | undefined }) {
+  const [response, setResponse] = useState<GraphExposurePathsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const [view, setView] = useState<ExposurePathView>("path");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.getGraphExposurePaths({
+        scanId: scanId || undefined,
+        limit: EXPOSURE_PATH_LIMIT,
+      });
+      setResponse(data);
+    } catch (err) {
+      setResponse(null);
+      setError(userFacingApiErrorMessage(err, "Failed to load exposure paths"));
+    } finally {
+      setLoading(false);
+    }
+  }, [scanId]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const paths = useMemo(() => (response?.paths ?? []).map(toUiExposurePath), [response]);
+
+  const selectedPath = useMemo(() => {
+    if (paths.length === 0) return null;
+    return paths.find((path) => exposurePathKey(path) === selectedKey) ?? paths[0]!;
+  }, [paths, selectedKey]);
+
+  const highestRisk = useMemo(
+    () => paths.reduce((max, path) => Math.max(max, path.riskScore), 0),
+    [paths],
+  );
+
+  if (loading) {
+    return (
+      <section
+        aria-label="Exposure paths"
+        className="flex items-center justify-center rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] py-12"
+      >
+        <Loader2 className="h-5 w-5 animate-spin text-[color:var(--text-tertiary)]" aria-hidden="true" />
+        <span className="ml-2 text-xs text-[color:var(--text-secondary)]">Loading exposure paths…</span>
+      </section>
+    );
+  }
+
+  if (error) {
+    return (
+      <PageErrorState
+        title="Cannot load exposure paths"
+        detail={error}
+        action={{ label: "Retry", onClick: () => void load() }}
+        data-testid="exposure-path-lens-error"
+      />
+    );
+  }
+
+  if (paths.length === 0) {
+    return (
+      <PageEmptyState
+        icon={Route}
+        title="No exposure paths for this snapshot"
+        detail={
+          response?.message ||
+          "No agent-to-vulnerability exposure path currently reaches a credential exposure or reachable tool in this scan."
+        }
+        suggestions={[
+          "Run a fresh scan so the graph can rebuild exposure evidence.",
+          "Lower the risk filter to inspect lower-risk exposure paths.",
+        ]}
+        data-testid="exposure-path-lens-empty"
+      />
+    );
+  }
+
+  return (
+    <section aria-label="Exposure paths" className="space-y-3" data-testid="exposure-path-lens">
+      <StatStrip
+        items={[
+          { label: "Exposure paths", value: response?.count ?? paths.length },
+          { label: "Total in snapshot", value: response?.total ?? paths.length },
+          { label: "Highest risk", value: highestRisk.toFixed(1), accent: "critical" },
+        ]}
+      />
+
+      <div className="grid gap-3 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)]">
+        <ul className="space-y-1.5" aria-label="Exposure path queue">
+          {paths.map((path) => {
+            const key = exposurePathKey(path);
+            const active = selectedPath ? exposurePathKey(selectedPath) === key : false;
+            return (
+              <li key={key}>
+                <button
+                  type="button"
+                  onClick={() => setSelectedKey(key)}
+                  aria-pressed={active}
+                  className={`w-full rounded-xl border px-3 py-2 text-left transition ${
+                    active
+                      ? "border-[color:var(--accent-border)] bg-[color:var(--accent-soft)]"
+                      : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] hover:border-[color:var(--border-strong)]"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="min-w-0 truncate text-xs font-medium text-[color:var(--foreground)]">
+                      {pathDisplayTitle(path)}
+                    </span>
+                    <span className="shrink-0 font-mono text-xs text-[color:var(--text-secondary)]">
+                      {path.riskScore.toFixed(1)}
+                    </span>
+                  </div>
+                  <div className="mt-0.5 text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+                    {String(path.severity)} · {Math.max(0, path.hops.length - 1)} hops
+                  </div>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+
+        {selectedPath && (
+          <ExposurePathCommandCenter
+            path={selectedPath}
+            scanId={scanId || undefined}
+            view={view}
+            onViewChange={setView}
+          />
+        )}
+      </div>
+    </section>
+  );
+}

--- a/ui/components/scan-form.tsx
+++ b/ui/components/scan-form.tsx
@@ -14,8 +14,11 @@ import {
   Loader2,
   Plus,
   Server,
+  Sparkles,
   X,
 } from "lucide-react";
+
+import { AiScanPanel } from "@/components/ai-scan-panel";
 
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import {
@@ -36,6 +39,11 @@ import {
   type ScanScopeChip,
 } from "@/lib/scan-scope";
 import { REPO_SCAN_SURFACES, repoScanLanguageSummary } from "@/lib/repo-scan-surfaces";
+
+/** Scan sources shown in the top tablist. Extends the job-queue ``ScanMode``
+ * with the synchronous AI/ML supply-chain surface, which renders its results
+ * inline rather than routing to a job. */
+type FormMode = ScanMode | "aiml";
 
 type ScanFormProps = {
   initialConnectionId?: string | undefined;
@@ -75,7 +83,7 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
   const { counts } = useDeploymentContext();
   const deploymentMode = counts?.deployment_mode ?? "local";
   const enterprisePreset = isEnterprisePreset(initialPreset);
-  const [scanMode, setScanMode] = useState<ScanMode>(
+  const [scanMode, setScanMode] = useState<FormMode>(
     initialConnectionId
       ? "connected"
       : enterprisePreset
@@ -316,6 +324,7 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
               { id: "connected" as const, label: "Cloud account", icon: Cloud },
               { id: "adhoc" as const, label: "Ad-hoc", icon: Bot },
               { id: "scheduled" as const, label: "Data source", icon: CalendarClock },
+              { id: "aiml" as const, label: "AI / ML", icon: Sparkles },
             ] as const
           ).map((option) => {
             const Icon = option.icon;
@@ -340,6 +349,11 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
           })}
         </div>
 
+        {scanMode === "aiml" ? (
+          <div className="p-5">
+            <AiScanPanel />
+          </div>
+        ) : (
         <form
           onSubmit={scanMode === "adhoc" ? handleAdhocSubmit : (e) => e.preventDefault()}
           className="grid gap-0 lg:grid-cols-[minmax(0,1fr)_220px]"
@@ -559,6 +573,7 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
             </div>
           </aside>
         </form>
+        )}
       </div>
 
       <nav aria-label="Related" className="mt-4 flex flex-wrap gap-3 text-xs text-[color:var(--text-tertiary)]">
@@ -570,7 +585,7 @@ export function ScanForm({ initialConnectionId, initialPreset }: ScanFormProps) 
   );
 }
 
-function ScopeSummaryPanel({ chips, mode }: { chips: ScanScopeChip[]; mode: ScanMode }) {
+function ScopeSummaryPanel({ chips, mode }: { chips: ScanScopeChip[]; mode: FormMode }) {
   const title = mode === "connected" ? "Scope" : mode === "scheduled" ? "Scope" : "Scope";
 
   return (

--- a/ui/lib/ai-scan.ts
+++ b/ui/lib/ai-scan.ts
@@ -1,0 +1,281 @@
+/**
+ * AI / ML supply-chain scan surface — shared types + selector metadata.
+ *
+ * These describe the six dedicated, synchronous scan endpoints under
+ * ``/v1/scan/*`` (dataset cards, training pipelines, browser extensions,
+ * model provenance, prompt scan, model files). The endpoints already ship in
+ * the API, MCP tools, and CLI; this module lets the UI call them and render
+ * their real results so a human operator has the same reach as an agent.
+ */
+
+export type AiScanTypeId =
+  | "dataset-cards"
+  | "training-pipelines"
+  | "browser-extensions"
+  | "model-provenance"
+  | "prompt-scan"
+  | "model-files";
+
+/** A security flag as emitted by the dataset / training / model-file scanners. */
+export interface AiSecurityFlag {
+  severity?: string;
+  type?: string;
+  description?: string;
+  [key: string]: unknown;
+}
+
+// ─── Request bodies ─────────────────────────────────────────────────────────
+
+export interface DatasetCardsRequest {
+  directories: string[];
+}
+export interface TrainingPipelinesRequest {
+  directories: string[];
+}
+export interface BrowserExtensionsRequest {
+  include_low_risk: boolean;
+}
+export interface ModelProvenanceRequest {
+  hf_models: string[];
+  ollama_models: string[];
+}
+export interface PromptScanRequest {
+  directories: string[];
+  files: string[];
+}
+export interface ModelFilesRequest {
+  directories: string[];
+  verify_hashes: boolean;
+}
+
+// ─── Response payloads ──────────────────────────────────────────────────────
+
+export interface DatasetCard {
+  name: string;
+  description?: string;
+  license?: string | null;
+  source_file?: string;
+  source_url?: string;
+  version?: string;
+  security_flags?: AiSecurityFlag[];
+  [key: string]: unknown;
+}
+export interface DatasetCardsResult {
+  datasets: DatasetCard[];
+  source_files: string[];
+  warnings: string[];
+  total_datasets: number;
+  flagged_count: number;
+}
+export interface DatasetCardsResponse {
+  scan_type: "dataset-cards";
+  directories: string[];
+  results: DatasetCardsResult[];
+}
+
+export interface TrainingArtifact {
+  name: string;
+  framework?: string;
+  source_file?: string;
+  security_flags?: AiSecurityFlag[];
+  [key: string]: unknown;
+}
+export interface TrainingPipelinesResult {
+  training_runs: TrainingArtifact[];
+  serving_configs: TrainingArtifact[];
+  source_files: string[];
+  warnings: string[];
+  total_runs: number;
+  total_serving: number;
+  flagged_count: number;
+}
+export interface TrainingPipelinesResponse {
+  scan_type: "training-pipelines";
+  directories: string[];
+  results: TrainingPipelinesResult[];
+}
+
+export interface BrowserExtension {
+  id: string;
+  name: string;
+  version?: string;
+  browser?: string;
+  manifest_version?: number;
+  permissions?: string[];
+  host_permissions?: string[];
+  has_native_messaging?: boolean;
+  has_ai_host_access?: boolean;
+  risk_level?: string;
+  risk_reasons?: string[];
+  path?: string;
+  [key: string]: unknown;
+}
+export interface BrowserExtensionsResponse {
+  scan_type: "browser-extensions";
+  total: number;
+  critical: number;
+  high: number;
+  extensions: BrowserExtension[];
+}
+
+export interface ProvenanceResult {
+  model_id: string;
+  source?: string;
+  format?: string;
+  is_safe_format?: boolean;
+  has_digest?: boolean;
+  digest?: string | null;
+  is_gated?: boolean;
+  has_model_card?: boolean;
+  risk_level?: string;
+  risk_flags?: string[];
+  metadata?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+export interface ModelProvenanceResponse {
+  scan_type: "model-provenance";
+  total: number;
+  unsafe_format: number;
+  results: ProvenanceResult[];
+}
+
+export interface PromptFinding {
+  severity: string;
+  category?: string;
+  title?: string;
+  detail?: string;
+  source_file?: string;
+  line_number?: number | null;
+  matched_text?: string;
+  recommendation?: string;
+  [key: string]: unknown;
+}
+export interface PromptScanResult {
+  files_scanned: number;
+  findings: PromptFinding[];
+  prompt_files: string[];
+  passed: boolean;
+}
+export interface PromptScanResponse {
+  scan_type: "prompt-scan";
+  results: PromptScanResult[];
+}
+
+export interface ModelFileEntry {
+  path: string;
+  filename?: string;
+  extension?: string;
+  format?: string;
+  ecosystem?: string;
+  size_bytes?: number;
+  size_human?: string;
+  security_flags?: AiSecurityFlag[];
+  sha256?: string;
+  [key: string]: unknown;
+}
+export interface ModelFilesResponse {
+  scan_type: "model-files";
+  total: number;
+  manifest_total: number;
+  unsafe: number;
+  files: ModelFileEntry[];
+  manifests: ModelFileEntry[];
+  warnings: string[];
+}
+
+export type AiScanResponse =
+  | DatasetCardsResponse
+  | TrainingPipelinesResponse
+  | BrowserExtensionsResponse
+  | ModelProvenanceResponse
+  | PromptScanResponse
+  | ModelFilesResponse;
+
+// ─── Selector metadata ──────────────────────────────────────────────────────
+
+/** Which inputs a scan type needs — drives the input panel + submit gate. */
+export type AiScanInputKind =
+  | "directories"
+  | "prompt"
+  | "model-files"
+  | "extensions"
+  | "models";
+
+export interface AiScanTypeMeta {
+  id: AiScanTypeId;
+  label: string;
+  /** One-line plain-language description of what the scan surfaces. */
+  blurb: string;
+  inputKind: AiScanInputKind;
+}
+
+/**
+ * The six AI supply-chain scan types, in the order the CLI/MCP group them.
+ * Kept as data so the selector, input panel, and tests stay in sync.
+ */
+export const AI_SCAN_TYPES: readonly AiScanTypeMeta[] = [
+  {
+    id: "dataset-cards",
+    label: "Dataset cards",
+    blurb: "HuggingFace dataset cards, DVC files & data lineage — licensing and provenance gaps.",
+    inputKind: "directories",
+  },
+  {
+    id: "training-pipelines",
+    label: "Training pipelines",
+    blurb: "MLflow / W&B / Kubeflow artifacts — unsafe serialization, missing provenance, exposed creds.",
+    inputKind: "directories",
+  },
+  {
+    id: "browser-extensions",
+    label: "Browser extensions",
+    blurb: "Installed extensions — dangerous permissions, native messaging, AI-assistant host access.",
+    inputKind: "extensions",
+  },
+  {
+    id: "model-provenance",
+    label: "Model provenance",
+    blurb: "HuggingFace & Ollama models — safetensors vs pickle, digests, gating, model-card presence.",
+    inputKind: "models",
+  },
+  {
+    id: "prompt-scan",
+    label: "Prompt scan",
+    blurb: "Prompt files — injection & jailbreak patterns, hardcoded secrets, unsafe instructions.",
+    inputKind: "prompt",
+  },
+  {
+    id: "model-files",
+    label: "Model files",
+    blurb: "Model artifacts — pickle deserialization risk (.pkl/.pt), unsafe formats, integrity hashes.",
+    inputKind: "model-files",
+  },
+] as const;
+
+/** Rank a severity string (case-insensitive) for comparison. Higher = worse. */
+export function aiSeverityRank(severity: string | null | undefined): number {
+  switch ((severity ?? "").toLowerCase()) {
+    case "critical":
+      return 4;
+    case "high":
+      return 3;
+    case "medium":
+      return 2;
+    case "low":
+      return 1;
+    default:
+      return 0;
+  }
+}
+
+/** Highest severity among a set of flags, or ``null`` when there are none. */
+export function highestFlagSeverity(flags: AiSecurityFlag[] | undefined): string | null {
+  if (!flags || flags.length === 0) return null;
+  let best: string | null = null;
+  for (const flag of flags) {
+    if (best === null || aiSeverityRank(flag.severity) > aiSeverityRank(best)) {
+      best = flag.severity ?? "unknown";
+    }
+  }
+  return best;
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -527,6 +527,92 @@ export {
 } from "./api-errors";
 export { invalidate as invalidateApiCache, clearCache as _clearApiCacheForTests } from "./api-cache";
 
+// ─── Surface-parity types (#4014) ─────────────────────────────────────────────
+// Human UIs for three flagship API/MCP-only surfaces: signed audit export/verify
+// (P1-2), the "should I deploy" gate, and the ExposurePath lens (P1-3). Response
+// shapes mirror the backend contracts in api/routes/enterprise.py + routes/graph.py.
+
+/** Signed audit evidence packet: JSON body + its detached HMAC signature header. */
+export interface AuditExportPacket {
+  /** The export body returned by GET /v1/audit/export. */
+  payload: unknown;
+  /** X-Agent-Bom-Audit-Export-Signature header value (empty if the server omitted it). */
+  signature: string;
+}
+
+/** Result of POST /v1/audit/export/verify — tamper-evident PASS/FAIL, no key material. */
+export interface AuditExportVerifyResult {
+  valid: boolean;
+  payload_bytes: number;
+}
+
+export interface GraphExposureEntityRef {
+  id: string;
+  label: string;
+  role: string;
+  severity?: string | undefined;
+  riskScore?: number | undefined;
+}
+
+export interface GraphExposureRelationshipRef {
+  id: string;
+  source: string;
+  target: string;
+  relationship: string;
+  confidence?: number | undefined;
+}
+
+/** One ranked ExposurePath as returned by the MCP-compatible REST surface. */
+export interface GraphExposurePath {
+  id: string;
+  rank?: number | undefined;
+  label: string;
+  summary?: string | undefined;
+  riskScore: number;
+  severity: string;
+  source: GraphExposureEntityRef;
+  target: GraphExposureEntityRef;
+  hops: GraphExposureEntityRef[];
+  relationships: GraphExposureRelationshipRef[];
+  nodeIds: string[];
+  edgeIds: string[];
+  findings: string[];
+  reachableTools: string[];
+  exposedCredentials: string[];
+  provenance?: { source: string; scanId?: string | undefined } | undefined;
+}
+
+export interface GraphExposurePathsResponse {
+  schema_version: string;
+  tool: string;
+  tenant_id: string;
+  scan_id: string;
+  created_at?: string | null | undefined;
+  count: number;
+  total: number;
+  filters: { limit: number; min_risk: number };
+  paths: GraphExposurePath[];
+  message?: string | undefined;
+}
+
+export type DeployDecision = "allow" | "warn" | "block";
+
+/** allow/warn/block deploy gate decision from POST /v1/graph/should-i-deploy. */
+export interface GraphDeployDecisionResponse {
+  schema_version: string;
+  tool: string;
+  tenant_id: string;
+  scan_id: string;
+  candidate: { value: string };
+  decision: DeployDecision;
+  maxRisk: number;
+  thresholds: { warnRisk: number; blockRisk: number };
+  reasons: string[];
+  matchedPathCount: number;
+  matchedPaths: GraphExposurePath[];
+  provenance?: { source: string; basis: string } | undefined;
+}
+
 // ─── API functions ────────────────────────────────────────────────────────────
 
 export const api = {
@@ -712,6 +798,36 @@ export const api = {
     if (filters?.limit != null) params.set("limit", String(filters.limit));
     const qs = params.toString();
     return get<UnifiedGraphResponse>(`/v1/graph/attack-paths${qs ? `?${qs}` : ""}`);
+  },
+
+  /** Ranked ExposurePath queue (agent-native lens) over REST — GET /v1/graph/exposure-paths */
+  getGraphExposurePaths: (filters?: {
+    scanId?: string | undefined;
+    limit?: number | undefined;
+    minRisk?: number | undefined;
+  }) => {
+    const params = new URLSearchParams();
+    if (filters?.scanId) params.set("scan_id", filters.scanId);
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.minRisk != null) params.set("min_risk", String(filters.minRisk));
+    const qs = params.toString();
+    return get<GraphExposurePathsResponse>(`/v1/graph/exposure-paths${qs ? `?${qs}` : ""}`);
+  },
+
+  /** "Should I deploy" gate — POST /v1/graph/should-i-deploy → GO/REVIEW/BLOCK decision */
+  graphShouldIDeploy: (body: {
+    candidate: string;
+    scanId?: string | undefined;
+    limit?: number | undefined;
+    warnRisk?: number | undefined;
+    blockRisk?: number | undefined;
+  }) => {
+    const payload: Record<string, unknown> = { candidate: body.candidate };
+    if (body.scanId) payload.scan_id = body.scanId;
+    if (body.limit != null) payload.limit = body.limit;
+    if (body.warnRisk != null) payload.warnRisk = body.warnRisk;
+    if (body.blockRisk != null) payload.blockRisk = body.blockRisk;
+    return post<GraphDeployDecisionResponse>("/v1/graph/should-i-deploy", payload);
   },
 
   /** Run a bounded root-centered graph traversal */
@@ -1175,6 +1291,39 @@ export const api = {
   },
   getAuditIntegrity: (limit = 1000) => get<AuditIntegrityResponse>(`/v1/audit/integrity?limit=${limit}`),
   getAuditLog: (limit?: number) => get<{ entries: AuditEntry[] }>(`/v1/audit?limit=${limit ?? 10}`),
+
+  /**
+   * Download a signed audit evidence packet (GET /v1/audit/export). Returns the
+   * JSON body together with its detached HMAC signature (response header) so the
+   * caller can persist a self-contained, tamper-evident evidence file.
+   */
+  exportAuditPacket: async (filters?: {
+    action?: string | undefined;
+    resource?: string | undefined;
+    since?: string | undefined;
+    limit?: number | undefined;
+    offset?: number | undefined;
+  }): Promise<AuditExportPacket> => {
+    const params = new URLSearchParams();
+    params.set("format", "json");
+    if (filters?.action) params.set("action", filters.action);
+    if (filters?.resource) params.set("resource", filters.resource);
+    if (filters?.since) params.set("since", filters.since);
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.offset != null) params.set("offset", String(filters.offset));
+    const res = await _doFetch(
+      `/v1/audit/export?${params.toString()}`,
+      { credentials: "include", headers: getSessionAuthHeaders(), signal: withTimeout() },
+      "GET",
+    );
+    const signature = res.headers.get("X-Agent-Bom-Audit-Export-Signature") ?? "";
+    const payload = (await res.json()) as unknown;
+    return { payload, signature };
+  },
+
+  /** Verify a signed audit export packet without returning HMAC key material. */
+  verifyAuditPacket: (payload: unknown, signature: string) =>
+    post<AuditExportVerifyResult>("/v1/audit/export/verify", { payload, signature }),
 
   // ── Cost / FinOps cockpit ──
   getCostReport: (filters?: { agent?: string; costCenter?: string; tag?: string }) => {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -359,6 +359,20 @@ export const PIPELINE_STEPS = [
 
 import { ApiNetworkError, classifyApiResponse } from "./api-errors";
 import { cachedGet, invalidate as _invalidate, type CacheOptions } from "./api-cache";
+import type {
+  DatasetCardsRequest,
+  DatasetCardsResponse,
+  TrainingPipelinesRequest,
+  TrainingPipelinesResponse,
+  BrowserExtensionsRequest,
+  BrowserExtensionsResponse,
+  ModelProvenanceRequest,
+  ModelProvenanceResponse,
+  PromptScanRequest,
+  PromptScanResponse,
+  ModelFilesRequest,
+  ModelFilesResponse,
+} from "./ai-scan";
 
 const FETCH_TIMEOUT_MS = 30_000;
 const BOOTSTRAP_TIMEOUT_MS = 5_000;
@@ -550,6 +564,26 @@ export const api = {
 
   /** Delete a job record */
   deleteScan: (jobId: string) => del(`/v1/scan/${jobId}`),
+
+  // ── AI / ML supply-chain scans (synchronous; results returned inline) ──
+  /** Scan directories for HuggingFace dataset cards, DVC files, and lineage. */
+  scanDatasetCards: (body: DatasetCardsRequest) =>
+    post<DatasetCardsResponse>("/v1/scan/dataset-cards", body),
+  /** Scan directories for MLflow / W&B / Kubeflow training + serving artifacts. */
+  scanTrainingPipelines: (body: TrainingPipelinesRequest) =>
+    post<TrainingPipelinesResponse>("/v1/scan/training-pipelines", body),
+  /** Scan installed browser extensions for dangerous permissions + AI host access. */
+  scanBrowserExtensions: (body: BrowserExtensionsRequest) =>
+    post<BrowserExtensionsResponse>("/v1/scan/browser-extensions", body),
+  /** Check HuggingFace / Ollama model provenance (format, digest, gating, card). */
+  scanModelProvenance: (body: ModelProvenanceRequest) =>
+    post<ModelProvenanceResponse>("/v1/scan/model-provenance", body),
+  /** Scan prompt files for injection, hardcoded secrets, and unsafe instructions. */
+  scanPrompts: (body: PromptScanRequest) =>
+    post<PromptScanResponse>("/v1/scan/prompt-scan", body),
+  /** Scan directories for model files and assess serialization safety. */
+  scanModelFiles: (body: ModelFilesRequest) =>
+    post<ModelFilesResponse>("/v1/scan/model-files", body),
 
   /** List all jobs */
   listJobs: (options?: { includeDetails?: boolean; limit?: number; offset?: number }) => {

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -38,6 +38,7 @@ const BUDGETS = {
   // premium design-system foundation's shared-shell token classes): the near-term
   // queue of UI PRs is legitimate feature work, not bloat, and needs room.
   // The first-class AI/ML scan surface stays within that measured phase allowance.
+  // Audit evidence, deploy-gate, and exposure-path parity also remain within it.
   totalClientJsBytes: 3_538_944,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -37,6 +37,7 @@ const BUDGETS = {
   // active UX/IA polish + feature phase (nav IA, graph, governance surfaces, and the
   // premium design-system foundation's shared-shell token classes): the near-term
   // queue of UI PRs is legitimate feature work, not bloat, and needs room.
+  // The first-class AI/ML scan surface stays within that measured phase allowance.
   totalClientJsBytes: 3_538_944,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,

--- a/ui/tests/ai-scan-panel.test.tsx
+++ b/ui/tests/ai-scan-panel.test.tsx
@@ -1,0 +1,189 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+import { AiScanPanel } from "@/components/ai-scan-panel";
+import { AI_SCAN_TYPES } from "@/lib/ai-scan";
+import { api } from "@/lib/api";
+
+describe("AiScanPanel", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("exposes all six AI/ML scan types as selectable tabs", () => {
+    render(<AiScanPanel />);
+    for (const type of AI_SCAN_TYPES) {
+      expect(screen.getByRole("tab", { name: new RegExp(type.label, "i") })).toBeInTheDocument();
+    }
+    expect(AI_SCAN_TYPES).toHaveLength(6);
+  });
+
+  it("shows an honest empty state before any scan is run", () => {
+    render(<AiScanPanel />);
+    expect(screen.getByTestId("ai-scan-empty")).toBeInTheDocument();
+    expect(screen.queryByTestId("ai-scan-results")).not.toBeInTheDocument();
+  });
+
+  it("runs a dataset-cards scan against the right endpoint and renders real results", async () => {
+    const user = userEvent.setup();
+    const spy = vi.spyOn(api, "scanDatasetCards").mockResolvedValue({
+      scan_type: "dataset-cards",
+      directories: ["/data"],
+      results: [
+        {
+          datasets: [
+            {
+              name: "squad",
+              license: null,
+              source_file: "/data/squad/README.md",
+              security_flags: [
+                { severity: "MEDIUM", type: "UNLICENSED_DATASET", description: "No license." },
+              ],
+            },
+          ],
+          source_files: ["/data/squad/README.md"],
+          warnings: ["heads up"],
+          total_datasets: 1,
+          flagged_count: 1,
+        },
+      ],
+    });
+
+    render(<AiScanPanel />);
+    await user.type(screen.getByLabelText("Directories"), "/data");
+    await user.click(screen.getByRole("button", { name: /^Add$/i }));
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() => expect(screen.getByTestId("ai-scan-results")).toBeInTheDocument());
+    expect(spy).toHaveBeenCalledWith({ directories: ["/data"] });
+    expect(screen.getByText("squad")).toBeInTheDocument();
+    // Warning from the API is surfaced verbatim.
+    expect(screen.getByText("heads up")).toBeInTheDocument();
+  });
+
+  it("gates Run until a directory is provided", async () => {
+    const user = userEvent.setup();
+    render(<AiScanPanel />);
+    expect(screen.getByRole("button", { name: /Run scan/i })).toBeDisabled();
+    await user.type(screen.getByLabelText("Directories"), "/data");
+    await user.click(screen.getByRole("button", { name: /^Add$/i }));
+    expect(screen.getByRole("button", { name: /Run scan/i })).toBeEnabled();
+  });
+
+  it("runs a browser-extension scan with no path input required", async () => {
+    const user = userEvent.setup();
+    const spy = vi.spyOn(api, "scanBrowserExtensions").mockResolvedValue({
+      scan_type: "browser-extensions",
+      total: 1,
+      critical: 1,
+      high: 0,
+      extensions: [
+        {
+          id: "abc",
+          name: "Sketchy Helper",
+          browser: "chrome",
+          risk_level: "critical",
+          permissions: ["debugger"],
+          host_permissions: ["<all_urls>"],
+          has_native_messaging: true,
+          has_ai_host_access: true,
+          risk_reasons: ["debugger permission"],
+        },
+      ],
+    });
+
+    render(<AiScanPanel />);
+    await user.click(screen.getByRole("tab", { name: /Browser extensions/i }));
+    // No inputs — Run is immediately available.
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() => expect(spy).toHaveBeenCalledWith({ include_low_risk: false }));
+    expect(screen.getByText("Sketchy Helper")).toBeInTheDocument();
+    expect(screen.getByTestId("ai-scan-stats")).toBeInTheDocument();
+  });
+
+  it("scans model provenance only after a model id is entered", async () => {
+    const user = userEvent.setup();
+    const spy = vi.spyOn(api, "scanModelProvenance").mockResolvedValue({
+      scan_type: "model-provenance",
+      total: 1,
+      unsafe_format: 1,
+      results: [
+        {
+          model_id: "org/model",
+          source: "huggingface",
+          format: "pickle",
+          is_safe_format: false,
+          risk_level: "high",
+          risk_flags: ["unsafe_format"],
+        },
+      ],
+    });
+
+    render(<AiScanPanel />);
+    await user.click(screen.getByRole("tab", { name: /Model provenance/i }));
+    expect(screen.getByRole("button", { name: /Run scan/i })).toBeDisabled();
+
+    await user.type(screen.getByLabelText("HuggingFace models"), "org/model");
+    // Two "Add" buttons (HF + Ollama); the first belongs to the HF input.
+    await user.click(screen.getAllByRole("button", { name: /^Add$/i })[0]!);
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() =>
+      expect(spy).toHaveBeenCalledWith({ hf_models: ["org/model"], ollama_models: [] }),
+    );
+    const results = screen.getByTestId("ai-scan-results");
+    expect(within(results).getByText("org/model")).toBeInTheDocument();
+    expect(within(results).getByText("unsafe")).toBeInTheDocument();
+  });
+
+  it("opens a detail drawer with the security flags for a row", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "scanModelFiles").mockResolvedValue({
+      scan_type: "model-files",
+      total: 1,
+      manifest_total: 0,
+      unsafe: 1,
+      files: [
+        {
+          path: "/models/evil.pkl",
+          filename: "evil.pkl",
+          format: "Pickle",
+          ecosystem: "scikit-learn/Python",
+          size_human: "2.0 KB",
+          security_flags: [
+            { severity: "CRITICAL", type: "PICKLE_REDUCE", description: "Arbitrary code execution." },
+          ],
+        },
+      ],
+      manifests: [],
+      warnings: [],
+    });
+
+    render(<AiScanPanel />);
+    await user.click(screen.getByRole("tab", { name: /Model files/i }));
+    await user.type(screen.getByLabelText("Directories"), "/models");
+    await user.click(screen.getByRole("button", { name: /^Add$/i }));
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() => expect(screen.getByText("evil.pkl")).toBeInTheDocument());
+    await user.click(screen.getByText("evil.pkl"));
+
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText("Arbitrary code execution.")).toBeInTheDocument();
+    expect(within(dialog).getByText("PICKLE_REDUCE")).toBeInTheDocument();
+  });
+
+  it("renders an error state when the scan endpoint fails", async () => {
+    const user = userEvent.setup();
+    vi.spyOn(api, "scanBrowserExtensions").mockRejectedValue(new Error("boom"));
+
+    render(<AiScanPanel />);
+    await user.click(screen.getByRole("tab", { name: /Browser extensions/i }));
+    await user.click(screen.getByRole("button", { name: /Run scan/i }));
+
+    await waitFor(() => expect(screen.getByTestId("ai-scan-error")).toBeInTheDocument());
+    expect(screen.getAllByText("boom").length).toBeGreaterThan(0);
+  });
+});

--- a/ui/tests/audit-evidence-panel.test.tsx
+++ b/ui/tests/audit-evidence-panel.test.tsx
@@ -63,6 +63,25 @@ describe("AuditEvidencePanel", () => {
     expect(result).toHaveTextContent("FAIL");
   });
 
+  it("renders FAIL when a valid signature covers an audit payload that reports tampering", async () => {
+    apiMock.verifyAuditPacket.mockResolvedValue({ valid: true, payload_bytes: 96 });
+
+    render(<AuditEvidencePanel />);
+    const wrapper = JSON.stringify({
+      payload: { entries: [], integrity: { verified: 3, tampered: 1 } },
+      signature: SIGNATURE,
+    });
+    fireEvent.change(screen.getByLabelText("Exported audit packet"), {
+      target: { value: wrapper },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    const result = await screen.findByTestId("audit-verify-result");
+    expect(result).toHaveAttribute("data-valid", "false");
+    expect(result).toHaveTextContent("FAIL");
+    expect(result).toHaveTextContent("reports tampered entries");
+  });
+
   it("rejects an empty verify without calling the endpoint", async () => {
     render(<AuditEvidencePanel />);
     fireEvent.click(screen.getByRole("button", { name: "Verify" }));

--- a/ui/tests/audit-evidence-panel.test.tsx
+++ b/ui/tests/audit-evidence-panel.test.tsx
@@ -1,0 +1,72 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AuditEvidencePanel } from "@/components/audit-evidence-panel";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    exportAuditPacket: vi.fn(),
+    verifyAuditPacket: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+
+const SIGNATURE = "a".repeat(64);
+
+beforeEach(() => {
+  apiMock.exportAuditPacket.mockReset();
+  apiMock.verifyAuditPacket.mockReset();
+  // jsdom lacks object URLs; stub so the download path does not throw.
+  (URL as unknown as { createObjectURL: () => string }).createObjectURL = vi.fn(() => "blob:x");
+  (URL as unknown as { revokeObjectURL: () => void }).revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("AuditEvidencePanel", () => {
+  it("exports a signed packet and verifies the fresh round-trip as PASS", async () => {
+    const packet = { payload: { entries: [], integrity: { verified: 3 } }, signature: SIGNATURE };
+    apiMock.exportAuditPacket.mockResolvedValue(packet);
+    apiMock.verifyAuditPacket.mockResolvedValue({ valid: true, payload_bytes: 128 });
+
+    render(<AuditEvidencePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Export & verify" }));
+
+    await waitFor(() => expect(apiMock.exportAuditPacket).toHaveBeenCalled());
+    await waitFor(() =>
+      expect(apiMock.verifyAuditPacket).toHaveBeenCalledWith(packet.payload, SIGNATURE),
+    );
+
+    const result = await screen.findByTestId("audit-verify-result");
+    expect(result).toHaveAttribute("data-valid", "true");
+    expect(result).toHaveTextContent("PASS");
+  });
+
+  it("verifies a pasted packet and renders FAIL when the signature does not match", async () => {
+    apiMock.verifyAuditPacket.mockResolvedValue({ valid: false, payload_bytes: 64 });
+
+    render(<AuditEvidencePanel />);
+    const wrapper = JSON.stringify({ payload: { entries: [] }, signature: SIGNATURE });
+    fireEvent.change(screen.getByLabelText("Exported audit packet"), {
+      target: { value: wrapper },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+
+    await waitFor(() =>
+      expect(apiMock.verifyAuditPacket).toHaveBeenCalledWith({ entries: [] }, SIGNATURE),
+    );
+    const result = await screen.findByTestId("audit-verify-result");
+    expect(result).toHaveAttribute("data-valid", "false");
+    expect(result).toHaveTextContent("FAIL");
+  });
+
+  it("rejects an empty verify without calling the endpoint", async () => {
+    render(<AuditEvidencePanel />);
+    fireEvent.click(screen.getByRole("button", { name: "Verify" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("Paste an exported audit packet");
+    expect(apiMock.verifyAuditPacket).not.toHaveBeenCalled();
+  });
+});

--- a/ui/tests/deploy-gate-panel.test.tsx
+++ b/ui/tests/deploy-gate-panel.test.tsx
@@ -100,6 +100,23 @@ describe("DeployGatePanel", () => {
     expect(verdict).toHaveTextContent("CVE-2024-1");
   });
 
+  it("renders INSUFFICIENT EVIDENCE instead of GO for an empty graph result", async () => {
+    const response = decisionResponse("allow", 0);
+    response.matchedPathCount = 0;
+    response.matchedPaths = [];
+    response.reasons = [];
+    apiMock.graphShouldIDeploy.mockResolvedValue(response);
+    render(<DeployGatePanel scanId="scan-1" />);
+
+    fireEvent.change(screen.getByLabelText("Deploy candidate"), { target: { value: "svc:x" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run gate" }));
+
+    const verdict = await screen.findByTestId("deploy-gate-verdict");
+    expect(verdict).toHaveAttribute("data-decision", "insufficient-evidence");
+    expect(verdict).toHaveTextContent("INSUFFICIENT EVIDENCE");
+    expect(verdict).not.toHaveTextContent("safe to ship");
+  });
+
   it("does not call the endpoint with an empty candidate", () => {
     render(<DeployGatePanel />);
     expect(screen.getByRole("button", { name: "Run gate" })).toBeDisabled();

--- a/ui/tests/deploy-gate-panel.test.tsx
+++ b/ui/tests/deploy-gate-panel.test.tsx
@@ -1,0 +1,107 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DeployGatePanel } from "@/components/deploy-gate-panel";
+import type { DeployDecision, GraphDeployDecisionResponse } from "@/lib/api";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    graphShouldIDeploy: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+
+function decisionResponse(decision: DeployDecision, maxRisk: number): GraphDeployDecisionResponse {
+  return {
+    schema_version: "v1",
+    tool: "should_i_deploy",
+    tenant_id: "default",
+    scan_id: "scan-1",
+    candidate: { value: "agent:claude-desktop" },
+    decision,
+    maxRisk,
+    thresholds: { warnRisk: 40, blockRisk: 80 },
+    reasons: [`Top matched exposure path risk is ${maxRisk} for agent:claude-desktop.`],
+    matchedPathCount: 1,
+    matchedPaths: [
+      {
+        id: "p1",
+        label: "claude-desktop → left-pad → CVE-2024-1",
+        summary: "",
+        riskScore: maxRisk,
+        severity: "high",
+        source: { id: "agent:claude-desktop", label: "claude-desktop", role: "agent" },
+        target: { id: "cve", label: "CVE-2024-1", role: "finding" },
+        hops: [],
+        relationships: [],
+        nodeIds: [],
+        edgeIds: [],
+        findings: ["CVE-2024-1"],
+        reachableTools: [],
+        exposedCredentials: [],
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  apiMock.graphShouldIDeploy.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("DeployGatePanel", () => {
+  it("calls the deploy-gate endpoint with the candidate and scan id and renders GO", async () => {
+    apiMock.graphShouldIDeploy.mockResolvedValue(decisionResponse("allow", 12));
+    render(<DeployGatePanel scanId="scan-1" />);
+
+    fireEvent.change(screen.getByLabelText("Deploy candidate"), {
+      target: { value: "agent:claude-desktop" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "Run gate" }));
+
+    await waitFor(() =>
+      expect(apiMock.graphShouldIDeploy).toHaveBeenCalledWith({
+        candidate: "agent:claude-desktop",
+        scanId: "scan-1",
+      }),
+    );
+    const verdict = await screen.findByTestId("deploy-gate-verdict");
+    expect(verdict).toHaveAttribute("data-decision", "allow");
+    expect(verdict).toHaveTextContent("GO");
+  });
+
+  it("renders REVIEW for a warn decision", async () => {
+    apiMock.graphShouldIDeploy.mockResolvedValue(decisionResponse("warn", 55));
+    render(<DeployGatePanel scanId="scan-1" />);
+
+    fireEvent.change(screen.getByLabelText("Deploy candidate"), { target: { value: "svc:x" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run gate" }));
+
+    const verdict = await screen.findByTestId("deploy-gate-verdict");
+    expect(verdict).toHaveAttribute("data-decision", "warn");
+    expect(verdict).toHaveTextContent("REVIEW");
+    expect(verdict).toHaveTextContent("55.0");
+  });
+
+  it("renders BLOCK for a block decision with matched exposure paths", async () => {
+    apiMock.graphShouldIDeploy.mockResolvedValue(decisionResponse("block", 91));
+    render(<DeployGatePanel scanId="scan-1" />);
+
+    fireEvent.change(screen.getByLabelText("Deploy candidate"), { target: { value: "svc:x" } });
+    fireEvent.click(screen.getByRole("button", { name: "Run gate" }));
+
+    const verdict = await screen.findByTestId("deploy-gate-verdict");
+    expect(verdict).toHaveAttribute("data-decision", "block");
+    expect(verdict).toHaveTextContent("BLOCK");
+    expect(verdict).toHaveTextContent("CVE-2024-1");
+  });
+
+  it("does not call the endpoint with an empty candidate", () => {
+    render(<DeployGatePanel />);
+    expect(screen.getByRole("button", { name: "Run gate" })).toBeDisabled();
+  });
+});

--- a/ui/tests/exposure-path-lens.test.tsx
+++ b/ui/tests/exposure-path-lens.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ExposurePathLens } from "@/components/exposure-path-lens";
+import type { GraphExposurePathsResponse } from "@/lib/api";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    getGraphExposurePaths: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+function response(paths: GraphExposurePathsResponse["paths"]): GraphExposurePathsResponse {
+  return {
+    schema_version: "v1",
+    tool: "exposure_paths",
+    tenant_id: "default",
+    scan_id: "scan-1",
+    count: paths.length,
+    total: paths.length,
+    filters: { limit: 25, min_risk: 0 },
+    paths,
+  };
+}
+
+beforeEach(() => {
+  apiMock.getGraphExposurePaths.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("ExposurePathLens", () => {
+  it("loads and renders exposure paths for the snapshot", async () => {
+    apiMock.getGraphExposurePaths.mockResolvedValue(
+      response([
+        {
+          id: "p1",
+          rank: 1,
+          label: "claude-desktop → left-pad → CVE-2024-1",
+          summary: "Reachable package inherits agent exposure.",
+          riskScore: 88.5,
+          severity: "critical",
+          source: { id: "agent:claude-desktop", label: "claude-desktop", role: "agent" },
+          target: { id: "finding:cve", label: "CVE-2024-1", role: "finding" },
+          hops: [
+            { id: "agent:claude-desktop", label: "claude-desktop", role: "agent" },
+            { id: "pkg:left-pad", label: "left-pad", role: "package" },
+            { id: "finding:cve", label: "CVE-2024-1", role: "finding" },
+          ],
+          relationships: [
+            { id: "e1", source: "agent:claude-desktop", target: "pkg:left-pad", relationship: "depends_on" },
+          ],
+          nodeIds: ["agent:claude-desktop", "pkg:left-pad", "finding:cve"],
+          edgeIds: ["e1"],
+          findings: ["CVE-2024-1"],
+          reachableTools: [],
+          exposedCredentials: [],
+        },
+      ]),
+    );
+
+    render(<ExposurePathLens scanId="scan-1" />);
+
+    await waitFor(() =>
+      expect(apiMock.getGraphExposurePaths).toHaveBeenCalledWith({ scanId: "scan-1", limit: 25 }),
+    );
+    expect(await screen.findByTestId("exposure-path-lens")).toBeInTheDocument();
+    expect(screen.getByText("Total in snapshot")).toBeInTheDocument();
+    expect(screen.getAllByText(/88\.5/).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /left-pad/ })).toBeInTheDocument();
+  });
+
+  it("renders the empty state when no exposure paths exist", async () => {
+    apiMock.getGraphExposurePaths.mockResolvedValue({
+      ...response([]),
+      message: "0 paths means no agent-to-vulnerability ExposurePath reaches a credential exposure.",
+    });
+
+    render(<ExposurePathLens scanId="scan-1" />);
+
+    expect(await screen.findByTestId("exposure-path-lens-empty")).toBeInTheDocument();
+    expect(screen.getByText(/No exposure paths for this snapshot/)).toBeInTheDocument();
+  });
+
+  it("renders an error state when the endpoint fails", async () => {
+    apiMock.getGraphExposurePaths.mockRejectedValue(new Error("boom"));
+
+    render(<ExposurePathLens scanId="scan-1" />);
+
+    expect(await screen.findByTestId("exposure-path-lens-error")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/scan-form.test.tsx
+++ b/ui/tests/scan-form.test.tsx
@@ -217,6 +217,16 @@ describe("ScanForm", () => {
     expect(screen.getByRole("button", { name: /Scan repo/i })).toBeDisabled();
   });
 
+  it("surfaces the AI/ML supply-chain scan panel from its own tab", async () => {
+    const user = userEvent.setup();
+    render(<ScanForm />);
+
+    await user.click(screen.getByRole("tab", { name: /AI \/ ML/i }));
+    expect(screen.getByTestId("ai-scan-panel")).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Dataset cards/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Prompt scan/i })).toBeInTheDocument();
+  });
+
   it("explains kubernetes namespace scope in plain language", async () => {
     const user = userEvent.setup();
     render(<ScanForm />);


### PR DESCRIPTION
## Summary

- Combine first-class AI/ML supply-chain scan UI with audit export/verify, should-I-deploy, and exposure-path human surfaces.
- Fail closed when a signed audit payload reports tampered entries or when the deploy gate has no matching graph evidence.
- Move blocking dedicated scan work off the event loop and shed saturated requests with 429 + Retry-After.

Supersedes #4020 and #4021.

## Root cause

The original sibling PRs were built independently on the same foundation. Their bundle-budget edits conflicted, and the UI treated signature validity as proof of an intact audit chain while treating an empty graph as safe-to-ship evidence. The scan endpoints also called blocking parser, filesystem, model-network, and hashing work directly from async handlers.

## Verification

- Observed red tests: valid signature + tampered payload rendered PASS; empty graph rendered GO; no offload helper existed.
- Exact toolchain: Node 24.18.0 / npm 10.9.7
- UI typecheck; Vitest: 5 files, 30 tests
- API scan types: 29 passed
- Ruff clean on touched backend/test modules
- Next.js production build: 36 static routes
- Bundle budget: 3366.5 KiB / 3456.0 KiB
- make preflight
- ESLint: 0 errors; one pre-existing nav hook warning from the base branch
- git diff --check

## Failure behavior

- Audit verification requires both a valid signature and zero payload-reported tampering.
- No matching graph evidence is INSUFFICIENT EVIDENCE, never GO.
- Saturated dedicated scans return 429 with Retry-After instead of starving unrelated API traffic.

## Notes

#4017 merged before publication. This branch was rebased onto that fresh main tree, so the PR targets main directly without duplicating the foundation changes.



---
Delivers **#4014** P1 surface-parity: AI/ML scan UI (P1-1) + audit export/verify & should-I-deploy gate & exposure-path lens (P1-2/P1-3). #4014 stays open for its remaining P2 ops/settings UIs.
