### PR TITLE
feat(ui): Operations & Integrations settings — webhooks, SIEM, threat-intel, reports (human↔agent parity)

### DIFF
--- a/ui/app/insights/page.tsx
+++ b/ui/app/insights/page.tsx
@@ -2,7 +2,9 @@ import { redirect } from "next/navigation";
 
 // Deep analytics now live on the dashboard so the app has one home and one
 // source of truth for risk charts. Keep the legacy route as a server redirect
-// for bookmarks and docs links without rendering a duplicate page.
+// for bookmarks and docs links without rendering a duplicate page. The home
+// page has no `tab` param — the analytics view is the dashboard itself — so we
+// redirect to "/" honestly rather than to an anchor that is silently ignored.
 export default function InsightsRedirect() {
-  redirect("/?tab=analytics");
+  redirect("/");
 }

--- a/ui/app/integrations/page.tsx
+++ b/ui/app/integrations/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { Suspense } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FileDown, Loader2, Newspaper, Plug, Webhook } from "lucide-react";
+
+import { WebhooksPanel } from "@/components/integrations/webhooks-panel";
+import { SiemPanel } from "@/components/integrations/siem-panel";
+import { IntelPanel } from "@/components/integrations/intel-panel";
+import { ReportsPanel } from "@/components/integrations/reports-panel";
+
+type IntegrationsTab = "webhooks" | "siem" | "intel" | "reports";
+
+const TABS: { key: IntegrationsTab; label: string; icon: typeof Webhook }[] = [
+  { key: "webhooks", label: "Webhooks", icon: Webhook },
+  { key: "siem", label: "SIEM", icon: Plug },
+  { key: "intel", label: "Threat Intel", icon: Newspaper },
+  { key: "reports", label: "Reports", icon: FileDown },
+];
+
+function isTab(value: string | null): value is IntegrationsTab {
+  return value === "webhooks" || value === "siem" || value === "intel" || value === "reports";
+}
+
+function IntegrationsTabs() {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const raw = searchParams.get("tab");
+  const tab: IntegrationsTab = isTab(raw) ? raw : "webhooks";
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight text-[color:var(--foreground)]">
+          Operations &amp; Integrations
+        </h1>
+        <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-secondary)]">
+          Manage the outbound integrations and operational surfaces that ship with the control plane —
+          webhook subscriptions, SIEM connectors, threat-intel lookups, and async report exports. Every
+          capability here is also available to agents over REST and MCP.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap gap-2 border-b border-[color:var(--border-subtle)] pb-4">
+        {TABS.map((item) => {
+          const Icon = item.icon;
+          const selected = item.key === tab;
+          return (
+            <button
+              key={item.key}
+              type="button"
+              onClick={() => router.replace(`/integrations?tab=${item.key}`)}
+              aria-pressed={selected}
+              className={`inline-flex items-center gap-2 rounded-xl border px-3 py-2 text-sm font-medium transition-colors ${
+                selected
+                  ? "border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] text-[color:var(--accent)]"
+                  : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+              }`}
+            >
+              <Icon className="h-4 w-4" />
+              {item.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {tab === "webhooks" ? <WebhooksPanel /> : null}
+      {tab === "siem" ? <SiemPanel /> : null}
+      {tab === "intel" ? <IntelPanel /> : null}
+      {tab === "reports" ? <ReportsPanel /> : null}
+    </div>
+  );
+}
+
+export default function IntegrationsPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Loader2 className="h-6 w-6 animate-spin text-[color:var(--text-tertiary)]" />
+        </div>
+      }
+    >
+      <IntegrationsTabs />
+    </Suspense>
+  );
+}

--- a/ui/components/integrations/intel-panel.tsx
+++ b/ui/components/integrations/intel-panel.tsx
@@ -1,0 +1,390 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { FileSearch, Loader2, Newspaper, RefreshCw, Search, ShieldAlert } from "lucide-react";
+
+import {
+  api,
+  formatDate,
+  type IntelAdvisory,
+  type IntelDailyBriefResponse,
+  type IntelMatchResponse,
+  type IntelSource,
+} from "@/lib/api";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import { StatStrip } from "@/components/stat-strip";
+import { PageErrorState } from "@/components/states/page-state";
+import {
+  Field,
+  INPUT_CLASS,
+  InlineNotice,
+  PanelButton,
+  PanelIntro,
+  Pill,
+  errorMessage,
+} from "@/components/integrations/panel-kit";
+
+function severityTone(sev: string): "danger" | "warn" | "neutral" {
+  const s = sev.toLowerCase();
+  if (s === "critical" || s === "high") return "danger";
+  if (s === "medium") return "warn";
+  return "neutral";
+}
+
+export function IntelPanel() {
+  const [sources, setSources] = useState<IntelSource[]>([]);
+  const [query, setQuery] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await api.getIntelSources();
+      setSources(res.sources ?? []);
+    } catch (err) {
+      setLoadError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return sources;
+    return sources.filter(
+      (s) =>
+        s.display_name.toLowerCase().includes(q) ||
+        s.source_id.toLowerCase().includes(q) ||
+        s.kind.toLowerCase().includes(q),
+    );
+  }, [sources, query]);
+
+  const enabledCount = sources.filter((s) => s.enabled).length;
+  const totalRecords = sources.reduce((acc, s) => acc + (s.feed_run?.record_count ?? 0), 0);
+
+  const columns = useMemo<DataTableColumn<IntelSource>[]>(
+    () => [
+      {
+        key: "name",
+        header: "Source",
+        cell: (s) => (
+          <div className="min-w-0">
+            <div className="truncate font-medium text-[color:var(--foreground)]">{s.display_name}</div>
+            <div className="truncate text-xs text-[color:var(--text-tertiary)]">
+              {s.kind} · {s.owner}
+            </div>
+          </div>
+        ),
+      },
+      { key: "tier", header: "Tier", cell: (s) => <Pill tone="neutral">{s.tier}</Pill> },
+      {
+        key: "validation",
+        header: "Validation",
+        cell: (s) =>
+          s.validation_status === "validated" ? (
+            <Pill tone="success">{s.validation_status}</Pill>
+          ) : (
+            <Pill tone="warn">{s.validation_status || "unknown"}</Pill>
+          ),
+      },
+      {
+        key: "records",
+        header: "Records",
+        align: "right",
+        cell: (s) => (
+          <span className="font-mono tabular-nums text-[color:var(--text-secondary)]">
+            {(s.feed_run?.record_count ?? 0).toLocaleString()}
+          </span>
+        ),
+      },
+      {
+        key: "synced",
+        header: "Last synced",
+        cell: (s) => (
+          <span className="text-xs text-[color:var(--text-tertiary)]">
+            {s.feed_run?.last_synced ? formatDate(s.feed_run.last_synced) : "never"}
+          </span>
+        ),
+      },
+    ],
+    [],
+  );
+
+  if (loadError) {
+    return (
+      <PageErrorState
+        title="Could not load threat-intel sources"
+        detail={loadError}
+        action={{ label: "Retry", onClick: () => void load() }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <PanelIntro
+        title="Threat intel"
+        description="Governed intel sources, advisory lookup, a local analyst daily brief, and inventory package matching — all served from the local intel database."
+      >
+        <PanelButton tone="secondary" onClick={() => void load()} title="Refresh">
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </PanelButton>
+      </PanelIntro>
+
+      <StatStrip
+        items={[
+          { label: "Sources", value: sources.length, icon: ShieldAlert },
+          { label: "Enabled", value: enabledCount, accent: "success" },
+          { label: "Indexed records", value: totalRecords.toLocaleString() },
+        ]}
+      />
+
+      <div>
+        <div className="mb-2 flex items-center gap-2">
+          <Search className="h-4 w-4 text-[color:var(--text-tertiary)]" />
+          <input
+            className={INPUT_CLASS}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search sources by name, id, or kind…"
+            data-testid="intel-source-search"
+          />
+        </div>
+        <DataTable
+          rows={filtered}
+          rowKey={(s) => s.source_id}
+          columns={columns}
+          loading={loading}
+          maxHeight="24rem"
+          caption="Threat-intel sources"
+          empty="No sources match your search."
+          data-testid="intel-sources-table"
+        />
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <AdvisoryLookup />
+        <DailyBrief />
+      </div>
+
+      <PackageMatch />
+    </div>
+  );
+}
+
+function AdvisoryLookup() {
+  const [id, setId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [advisory, setAdvisory] = useState<IntelAdvisory | null>(null);
+  const [notFound, setNotFound] = useState(false);
+
+  const lookup = async () => {
+    if (!id.trim()) return;
+    setLoading(true);
+    setError(null);
+    setAdvisory(null);
+    setNotFound(false);
+    try {
+      const res = await api.getIntelAdvisory(id.trim());
+      if (res.found && res.advisory) setAdvisory(res.advisory);
+      else setNotFound(true);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+      <div className="flex items-center gap-2 text-sm font-medium text-[color:var(--foreground)]">
+        <FileSearch className="h-4 w-4" /> Advisory lookup
+      </div>
+      <form
+        className="flex gap-2"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void lookup();
+        }}
+      >
+        <input
+          className={INPUT_CLASS}
+          value={id}
+          onChange={(e) => setId(e.target.value)}
+          placeholder="CVE-2024-3094, GHSA-…, or OSV id"
+          data-testid="intel-advisory-input"
+        />
+        <PanelButton tone="primary" type="submit" disabled={loading || !id.trim()} data-testid="intel-advisory-submit">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+          Look up
+        </PanelButton>
+      </form>
+
+      {error ? <InlineNotice tone="error">{error}</InlineNotice> : null}
+      {notFound ? <InlineNotice tone="info">No advisory found for that identifier.</InlineNotice> : null}
+      {advisory ? (
+        <div className="space-y-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3" data-testid="intel-advisory-result">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="font-mono text-sm font-semibold text-[color:var(--foreground)]">{advisory.id}</span>
+            <Pill tone={severityTone(advisory.severity)}>{advisory.severity || "unknown"}</Pill>
+            {advisory.cvss_score != null ? <Pill tone="neutral">CVSS {advisory.cvss_score}</Pill> : null}
+            {advisory.epss_probability != null ? (
+              <Pill tone="warn">EPSS {(advisory.epss_probability * 100).toFixed(1)}%</Pill>
+            ) : null}
+            {advisory.is_kev ? <Pill tone="danger">KEV</Pill> : null}
+          </div>
+          {advisory.summary ? (
+            <p className="text-sm text-[color:var(--text-secondary)]">{advisory.summary}</p>
+          ) : null}
+          <div className="text-xs text-[color:var(--text-tertiary)]">
+            source {advisory.source || "—"}
+            {advisory.fixed_version ? ` · fixed in ${advisory.fixed_version}` : ""}
+            {advisory.published_at ? ` · published ${formatDate(advisory.published_at)}` : ""}
+            {` · ${advisory.affected?.length ?? 0} affected package(s)`}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function DailyBrief() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [brief, setBrief] = useState<IntelDailyBriefResponse | null>(null);
+
+  const run = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      setBrief(await api.getIntelDailyBrief({}));
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const s = brief?.sections;
+  const rows: { label: string; value: number }[] = s
+    ? [
+        { label: "KEV in last 24h", value: s.kev_last_24h.length },
+        { label: "High-EPSS inventory", value: s.high_epss_inventory.length },
+        { label: "Vendor advisories", value: s.vendor_advisories.length },
+        { label: "IoC telemetry hits", value: s.ioc_telemetry_hits.length },
+        { label: "Campaign matches", value: s.campaign_matches.length },
+        { label: "Ransomware sector matches", value: s.ransomware_sector_matches.length },
+      ]
+    : [];
+
+  return (
+    <div className="space-y-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2 text-sm font-medium text-[color:var(--foreground)]">
+          <Newspaper className="h-4 w-4" /> Daily brief
+        </div>
+        <PanelButton tone="primary" onClick={() => void run()} disabled={loading} data-testid="intel-brief-submit">
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Newspaper className="h-4 w-4" />}
+          Generate
+        </PanelButton>
+      </div>
+      {error ? <InlineNotice tone="error">{error}</InlineNotice> : null}
+      {brief ? (
+        <div className="space-y-2" data-testid="intel-brief-result">
+          <div className="text-xs text-[color:var(--text-tertiary)]">
+            Generated {formatDate(brief.generated_at)}
+          </div>
+          <div className="divide-y divide-[color:var(--border-subtle)] rounded-lg border border-[color:var(--border-subtle)]">
+            {rows.map((r) => (
+              <div key={r.label} className="flex items-center justify-between px-3 py-1.5 text-sm">
+                <span className="text-[color:var(--text-secondary)]">{r.label}</span>
+                <span className="font-mono tabular-nums text-[color:var(--foreground)]">{r.value}</span>
+              </div>
+            ))}
+          </div>
+          {brief.limitations?.length ? (
+            <p className="text-xs text-[color:var(--text-tertiary)]">{brief.limitations[0]}</p>
+          ) : null}
+        </div>
+      ) : (
+        <p className="text-sm text-[color:var(--text-tertiary)]">
+          Generate a local analyst brief (KEV window, high-EPSS inventory) from governed intel sources.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function PackageMatch() {
+  const [ecosystem, setEcosystem] = useState("");
+  const [name, setName] = useState("");
+  const [version, setVersion] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<IntelMatchResponse | null>(null);
+
+  const submit = async () => {
+    if (!ecosystem.trim() || !name.trim()) {
+      setError("Ecosystem and package name are required.");
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.matchIntelPackages([
+        { ecosystem: ecosystem.trim(), name: name.trim(), version: version.trim() || undefined },
+      ]);
+      setResult(res);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5">
+      <div className="flex items-center gap-2 text-sm font-medium text-[color:var(--foreground)]">
+        <ShieldAlert className="h-4 w-4" /> Match a package to advisory intel
+      </div>
+      <form
+        className="grid gap-3 md:grid-cols-4"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void submit();
+        }}
+      >
+        <Field label="Ecosystem">
+          <input className={INPUT_CLASS} value={ecosystem} onChange={(e) => setEcosystem(e.target.value)} placeholder="npm, pypi, …" data-testid="intel-match-ecosystem" />
+        </Field>
+        <Field label="Name">
+          <input className={INPUT_CLASS} value={name} onChange={(e) => setName(e.target.value)} placeholder="package name" data-testid="intel-match-name" />
+        </Field>
+        <Field label="Version (optional)">
+          <input className={INPUT_CLASS} value={version} onChange={(e) => setVersion(e.target.value)} placeholder="1.2.3" />
+        </Field>
+        <div className="flex items-end">
+          <PanelButton tone="primary" type="submit" disabled={loading} className="w-full" data-testid="intel-match-submit">
+            {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Search className="h-4 w-4" />}
+            Match
+          </PanelButton>
+        </div>
+      </form>
+      {error ? <InlineNotice tone="error">{error}</InlineNotice> : null}
+      {result ? (
+        <InlineNotice tone={result.match_count > 0 ? "success" : "info"} data-testid="intel-match-result">
+          {result.matched_packages} of {result.submitted} package(s) matched — {result.match_count} advisory
+          {result.match_count === 1 ? "" : "ies"} found.
+        </InlineNotice>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/components/integrations/panel-kit.tsx
+++ b/ui/components/integrations/panel-kit.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import type { ButtonHTMLAttributes, ReactNode } from "react";
+import { AlertTriangle, CheckCircle2, Info } from "lucide-react";
+
+/** Small shared building blocks for the Operations & Integrations panels so
+ *  each panel stays focused on its own endpoint wiring, not chrome. Tokens
+ *  only — verified against both themes. */
+
+export function PanelIntro({ title, description, children }: { title: string; description: string; children?: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-3 border-b border-[color:var(--border-subtle)] pb-4 lg:flex-row lg:items-end lg:justify-between">
+      <div className="min-w-0">
+        <h2 className="text-lg font-semibold tracking-tight text-[color:var(--foreground)]">{title}</h2>
+        <p className="mt-1 max-w-3xl text-sm text-[color:var(--text-secondary)]">{description}</p>
+      </div>
+      {children ? <div className="flex flex-wrap items-center gap-2">{children}</div> : null}
+    </div>
+  );
+}
+
+type ButtonTone = "primary" | "secondary" | "danger";
+
+const BUTTON_TONE: Record<ButtonTone, string> = {
+  primary:
+    "border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] text-[color:var(--accent)] hover:bg-[color:var(--accent-soft-hover)]",
+  secondary:
+    "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]",
+  danger:
+    "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--severity-critical)] hover:brightness-110",
+};
+
+export function PanelButton({
+  tone = "secondary",
+  className = "",
+  children,
+  ...rest
+}: ButtonHTMLAttributes<HTMLButtonElement> & { tone?: ButtonTone }) {
+  return (
+    <button
+      type={rest.type ?? "button"}
+      className={`inline-flex items-center justify-center gap-1.5 rounded-lg border px-3 py-1.5 text-sm font-medium transition disabled:cursor-not-allowed disabled:opacity-50 ${BUTTON_TONE[tone]} ${className}`}
+      {...rest}
+    >
+      {children}
+    </button>
+  );
+}
+
+type PillTone = "neutral" | "success" | "warn" | "danger" | "accent";
+
+const PILL_TONE: Record<PillTone, string> = {
+  neutral:
+    "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]",
+  success:
+    "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]",
+  warn:
+    "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--status-warn)]",
+  danger:
+    "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--severity-critical)]",
+  accent:
+    "border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] text-[color:var(--accent)]",
+};
+
+export function Pill({ tone = "neutral", children }: { tone?: PillTone; children: ReactNode }) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium ${PILL_TONE[tone]}`}
+    >
+      {children}
+    </span>
+  );
+}
+
+type NoticeTone = "success" | "error" | "info";
+
+const NOTICE_TONE: Record<NoticeTone, { cls: string; Icon: typeof Info }> = {
+  success: {
+    cls: "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]",
+    Icon: CheckCircle2,
+  },
+  error: {
+    cls: "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--severity-critical)]",
+    Icon: AlertTriangle,
+  },
+  info: {
+    cls: "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]",
+    Icon: Info,
+  },
+};
+
+export function InlineNotice({
+  tone,
+  children,
+  "data-testid": testId,
+}: {
+  tone: NoticeTone;
+  children: ReactNode;
+  "data-testid"?: string;
+}) {
+  const { cls, Icon } = NOTICE_TONE[tone];
+  return (
+    <div
+      role="status"
+      data-testid={testId}
+      className={`flex items-start gap-2 rounded-lg border px-3 py-2 text-sm ${cls}`}
+    >
+      <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <div className="min-w-0">{children}</div>
+    </div>
+  );
+}
+
+/** A read-only labeled field used across the panels. Never used for secrets. */
+export function Field({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <label className="flex flex-col gap-1 text-sm">
+      <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-tertiary)]">
+        {label}
+      </span>
+      {children}
+    </label>
+  );
+}
+
+export const INPUT_CLASS =
+  "w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-sm text-[color:var(--foreground)] outline-none transition focus:border-[color:var(--border-strong)] placeholder:text-[color:var(--text-tertiary)]";
+
+export function errorMessage(err: unknown): string {
+  if (err instanceof Error && err.message) return err.message;
+  return "Request failed. Check your permissions and try again.";
+}

--- a/ui/components/integrations/reports-panel.tsx
+++ b/ui/components/integrations/reports-panel.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Download, FileDown, Loader2, Play } from "lucide-react";
+
+import { api, formatDate, type ReportJobRecord, type ReportSort } from "@/lib/api";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import {
+  Field,
+  INPUT_CLASS,
+  InlineNotice,
+  PanelButton,
+  PanelIntro,
+  Pill,
+  errorMessage,
+} from "@/components/integrations/panel-kit";
+
+const SORTS: ReportSort[] = ["effective_reach", "cvss", "severity", "ordinal"];
+const SEVERITIES = ["", "critical", "high", "medium", "low"];
+
+function statusTone(status: string): "success" | "warn" | "danger" | "neutral" {
+  if (status === "done") return "success";
+  if (status === "failed" || status === "cancelled") return "danger";
+  if (status === "pending" || status === "running") return "warn";
+  return "neutral";
+}
+
+function isTerminal(status: string): boolean {
+  return status === "done" || status === "failed" || status === "cancelled";
+}
+
+export function ReportsPanel() {
+  // No server-side list endpoint exists for reports, so we track the jobs
+  // created in this session and poll each until it reaches a terminal state.
+  const [jobs, setJobs] = useState<ReportJobRecord[]>([]);
+  const [sort, setSort] = useState<ReportSort>("effective_reach");
+  const [severity, setSeverity] = useState("");
+  const [creating, setCreating] = useState(false);
+  const [notice, setNotice] = useState<{ tone: "success" | "error" | "info"; text: string } | null>(null);
+  const [downloadingId, setDownloadingId] = useState<string | null>(null);
+  const pollRef = useRef<number | null>(null);
+  // Latest committed jobs, so the interval callback never reads a stale closure.
+  const jobsRef = useRef<ReportJobRecord[]>([]);
+  jobsRef.current = jobs;
+
+  const poll = useCallback(async () => {
+    const pending = jobsRef.current.filter((j) => !isTerminal(j.status));
+    if (pending.length === 0) return;
+    const fresh = await Promise.all(
+      pending.map((j) => api.getReportJob(j.job_id).catch(() => null)),
+    );
+    setJobs((cur) => cur.map((c) => fresh.find((f) => f && f.job_id === c.job_id) ?? c));
+  }, []);
+
+  useEffect(() => {
+    pollRef.current = window.setInterval(() => void poll(), 2500);
+    return () => {
+      if (pollRef.current) window.clearInterval(pollRef.current);
+    };
+  }, [poll]);
+
+  const create = async () => {
+    setCreating(true);
+    setNotice(null);
+    try {
+      const job = await api.createReportJob({
+        format: "ndjson",
+        sort,
+        severity: severity || null,
+      });
+      setJobs((prev) => [job, ...prev]);
+      setNotice({ tone: "success", text: "Report export queued." });
+    } catch (err) {
+      setNotice({ tone: "error", text: errorMessage(err) });
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const download = async (job: ReportJobRecord) => {
+    if (!job.download_token) {
+      setNotice({ tone: "error", text: "Download token unavailable for this report." });
+      return;
+    }
+    setDownloadingId(job.job_id);
+    setNotice(null);
+    try {
+      const blob = await api.downloadReportArtifact(job.job_id, job.download_token);
+      const objectUrl = URL.createObjectURL(blob);
+      const anchor = document.createElement("a");
+      anchor.href = objectUrl;
+      anchor.download = `findings-${job.job_id.slice(0, 8)}.ndjson.gz`;
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      URL.revokeObjectURL(objectUrl);
+    } catch (err) {
+      setNotice({ tone: "error", text: errorMessage(err) });
+    } finally {
+      setDownloadingId(null);
+    }
+  };
+
+  const columns: DataTableColumn<ReportJobRecord>[] = [
+    {
+      key: "job",
+      header: "Job",
+      cell: (j) => <span className="font-mono text-xs text-[color:var(--foreground)]">{j.job_id.slice(0, 8)}…</span>,
+    },
+    { key: "sort", header: "Sort", cell: (j) => <Pill tone="neutral">{j.sort}</Pill> },
+    {
+      key: "severity",
+      header: "Severity",
+      cell: (j) => (j.severity ? <Pill tone="neutral">{j.severity}</Pill> : <span className="text-[color:var(--text-tertiary)]">all</span>),
+    },
+    {
+      key: "status",
+      header: "Status",
+      cell: (j) => (
+        <Pill tone={statusTone(j.status)}>
+          {j.status !== "done" && !isTerminal(j.status) ? (
+            <Loader2 className="h-3 w-3 animate-spin" />
+          ) : null}
+          {j.status}
+        </Pill>
+      ),
+    },
+    {
+      key: "rows",
+      header: "Rows",
+      align: "right",
+      cell: (j) => (
+        <span className="font-mono tabular-nums text-[color:var(--text-secondary)]">
+          {j.row_count != null ? j.row_count.toLocaleString() : "—"}
+        </span>
+      ),
+    },
+    {
+      key: "created",
+      header: "Created",
+      cell: (j) => <span className="text-xs text-[color:var(--text-tertiary)]">{formatDate(j.created_at)}</span>,
+    },
+    {
+      key: "actions",
+      header: "",
+      align: "right",
+      cell: (j) => (
+        <div className="flex justify-end">
+          {j.status === "done" ? (
+            <PanelButton
+              tone="primary"
+              disabled={downloadingId === j.job_id}
+              onClick={() => void download(j)}
+              data-testid={`report-download-${j.job_id.slice(0, 8)}`}
+            >
+              {downloadingId === j.job_id ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Download className="h-3.5 w-3.5" />
+              )}
+              Download
+            </PanelButton>
+          ) : j.status === "failed" ? (
+            <span className="text-xs text-[color:var(--severity-critical)]">{j.error ?? "failed"}</span>
+          ) : (
+            <span className="text-xs text-[color:var(--text-tertiary)]">working…</span>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-5">
+      <PanelIntro
+        title="Reports"
+        description="Queue an async findings export (gzipped NDJSON) streamed from the hub, then poll and download. Exports are quota-enforced per tenant; the download token is sent via header, never in the URL."
+      />
+
+      <form
+        className="space-y-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void create();
+        }}
+      >
+        <div className="grid gap-4 md:grid-cols-3">
+          <Field label="Format">
+            <select className={INPUT_CLASS} value="ndjson" disabled data-testid="report-format-select">
+              <option value="ndjson">NDJSON (gzip)</option>
+            </select>
+          </Field>
+          <Field label="Sort">
+            <select
+              className={INPUT_CLASS}
+              value={sort}
+              onChange={(e) => setSort(e.target.value as ReportSort)}
+              data-testid="report-sort-select"
+            >
+              {SORTS.map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Severity filter">
+            <select
+              className={INPUT_CLASS}
+              value={severity}
+              onChange={(e) => setSeverity(e.target.value)}
+              data-testid="report-severity-select"
+            >
+              {SEVERITIES.map((s) => (
+                <option key={s || "all"} value={s}>
+                  {s || "all severities"}
+                </option>
+              ))}
+            </select>
+          </Field>
+        </div>
+        <PanelButton tone="primary" type="submit" disabled={creating} data-testid="report-create-submit">
+          {creating ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+          Queue export
+        </PanelButton>
+      </form>
+
+      {notice ? <InlineNotice tone={notice.tone} data-testid="report-notice">{notice.text}</InlineNotice> : null}
+
+      <DataTable
+        rows={jobs}
+        rowKey={(j) => j.job_id}
+        columns={columns}
+        maxHeight="28rem"
+        caption="Report export jobs created this session"
+        empty={
+          <span className="inline-flex items-center gap-2">
+            <FileDown className="h-4 w-4" /> No exports yet. Queue one above to generate a downloadable findings report.
+          </span>
+        }
+        data-testid="reports-table"
+      />
+    </div>
+  );
+}

--- a/ui/components/integrations/siem-panel.tsx
+++ b/ui/components/integrations/siem-panel.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { CheckCircle2, Loader2, Plug, RefreshCw, XCircle } from "lucide-react";
+
+import { api, type SiemTestResponse } from "@/lib/api";
+import { useAuthState } from "@/components/auth-provider";
+import { PageErrorState } from "@/components/states/page-state";
+import { StatStrip } from "@/components/stat-strip";
+import {
+  Field,
+  INPUT_CLASS,
+  InlineNotice,
+  PanelButton,
+  PanelIntro,
+  Pill,
+  errorMessage,
+} from "@/components/integrations/panel-kit";
+
+export function SiemPanel() {
+  const { session, hasCapability } = useAuthState();
+  const canTest = !session?.auth_required || hasCapability("policy.manage");
+
+  const [connectors, setConnectors] = useState<string[]>([]);
+  const [formats, setFormats] = useState<string[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
+  const [siemType, setSiemType] = useState("");
+  const [url, setUrl] = useState("");
+  const [token, setToken] = useState("");
+  const [testing, setTesting] = useState(false);
+  const [result, setResult] = useState<SiemTestResponse | null>(null);
+  const [testError, setTestError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const [c, f] = await Promise.all([api.listSiemConnectors(), api.listSiemFormats()]);
+      const list = c.connectors ?? [];
+      setConnectors(list);
+      setFormats(f.formats ?? []);
+      setSiemType((prev) => prev || list[0] || "");
+    } catch (err) {
+      setLoadError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const runTest = async () => {
+    setTesting(true);
+    setResult(null);
+    setTestError(null);
+    try {
+      const res = await api.testSiemConnection(siemType, url.trim(), token.trim() || undefined);
+      // Do not retain the token beyond the request.
+      setToken("");
+      setResult(res);
+    } catch (err) {
+      setTestError(errorMessage(err));
+    } finally {
+      setTesting(false);
+    }
+  };
+
+  if (loadError) {
+    return (
+      <PageErrorState
+        title="Could not load SIEM connectors"
+        detail={loadError}
+        action={{ label: "Retry", onClick: () => void load() }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <PanelIntro
+        title="SIEM connectors"
+        description="Available SIEM connector types and event formats for streaming detections downstream. Run a connectivity test before wiring a destination. Tokens are sent per-test and never stored or displayed."
+      >
+        <PanelButton tone="secondary" onClick={() => void load()} title="Refresh">
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </PanelButton>
+      </PanelIntro>
+
+      <StatStrip
+        items={[
+          { label: "Connector types", value: connectors.length, icon: Plug },
+          { label: "Event formats", value: formats.length },
+        ]}
+      />
+
+      <div className="grid gap-3 md:grid-cols-2">
+        <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-tertiary)]">
+            Connector types
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2" data-testid="siem-connectors">
+            {loading ? (
+              <span className="text-sm text-[color:var(--text-tertiary)]">Loading…</span>
+            ) : connectors.length === 0 ? (
+              <span className="text-sm text-[color:var(--text-tertiary)]">No connectors registered.</span>
+            ) : (
+              connectors.map((c) => (
+                <Pill key={c} tone="accent">
+                  {c}
+                </Pill>
+              ))
+            )}
+          </div>
+        </div>
+        <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-tertiary)]">
+            Event formats
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2" data-testid="siem-formats">
+            {loading ? (
+              <span className="text-sm text-[color:var(--text-tertiary)]">Loading…</span>
+            ) : (
+              formats.map((f) => (
+                <Pill key={f} tone="neutral">
+                  {f}
+                </Pill>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+
+      <form
+        className="space-y-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5"
+        onSubmit={(e) => {
+          e.preventDefault();
+          void runTest();
+        }}
+      >
+        <div className="text-sm font-medium text-[color:var(--foreground)]">Test connectivity</div>
+        <div className="grid gap-4 md:grid-cols-3">
+          <Field label="Connector type">
+            <select
+              className={INPUT_CLASS}
+              value={siemType}
+              onChange={(e) => setSiemType(e.target.value)}
+              data-testid="siem-type-select"
+            >
+              {connectors.map((c) => (
+                <option key={c} value={c}>
+                  {c}
+                </option>
+              ))}
+            </select>
+          </Field>
+          <Field label="Endpoint URL">
+            <input
+              className={INPUT_CLASS}
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              placeholder="https://siem.example.com/services/collector"
+              data-testid="siem-url-input"
+            />
+          </Field>
+          <Field label="Auth token (optional, not stored)">
+            <input
+              className={INPUT_CLASS}
+              type="password"
+              autoComplete="off"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="Sent via header for this test only"
+            />
+          </Field>
+        </div>
+
+        {!canTest ? (
+          <InlineNotice tone="info">Testing a SIEM connector requires an admin (policy management) role.</InlineNotice>
+        ) : null}
+        {testError ? <InlineNotice tone="error">{testError}</InlineNotice> : null}
+        {result ? (
+          <InlineNotice tone={result.healthy ? "success" : "error"} data-testid="siem-test-result">
+            <div className="flex items-center gap-2 font-medium">
+              {result.healthy ? (
+                <CheckCircle2 className="h-4 w-4" />
+              ) : (
+                <XCircle className="h-4 w-4" />
+              )}
+              {result.siem_type || siemType}: {result.healthy ? "healthy" : "unhealthy"}
+            </div>
+            {result.error ? <p className="mt-1 text-xs">{result.error}</p> : null}
+          </InlineNotice>
+        ) : null}
+
+        <PanelButton tone="primary" type="submit" disabled={!canTest || testing || !siemType} data-testid="siem-test-submit">
+          {testing ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plug className="h-4 w-4" />}
+          Run test
+        </PanelButton>
+      </form>
+    </div>
+  );
+}

--- a/ui/components/integrations/webhooks-panel.tsx
+++ b/ui/components/integrations/webhooks-panel.tsx
@@ -1,0 +1,440 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Copy, Loader2, Plus, RefreshCw, Send, Trash2, Power, Webhook } from "lucide-react";
+
+import {
+  api,
+  type WebhookSubscription,
+  type WebhookOutboxResponse,
+} from "@/lib/api";
+import { useAuthState } from "@/components/auth-provider";
+import { DataTable, type DataTableColumn } from "@/components/data-table";
+import { StatStrip } from "@/components/stat-strip";
+import { PageErrorState } from "@/components/states/page-state";
+import {
+  Field,
+  INPUT_CLASS,
+  InlineNotice,
+  PanelButton,
+  PanelIntro,
+  Pill,
+  errorMessage,
+} from "@/components/integrations/panel-kit";
+
+/**
+ * A webhook URL can itself be a secret (Slack-style incoming webhooks embed the
+ * token in the path), which is why the backend redacts it in the audit log. We
+ * mirror that here: the management table shows only origin + a masked path and
+ * the non-reversible `secret_fingerprint` handle — never a full URL or secret.
+ */
+function redactWebhookUrl(raw: string): string {
+  try {
+    const u = new URL(raw);
+    const hasPath = u.pathname && u.pathname !== "/";
+    return `${u.protocol}//${u.host}${hasPath ? "/•••" : ""}`;
+  } catch {
+    return "•••";
+  }
+}
+
+export function WebhooksPanel() {
+  const { session, hasCapability } = useAuthState();
+  const canManage = !session?.auth_required || hasCapability("policy.manage");
+
+  const [subs, setSubs] = useState<WebhookSubscription[]>([]);
+  const [catalog, setCatalog] = useState<string[]>([]);
+  const [outbox, setOutbox] = useState<WebhookOutboxResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [notice, setNotice] = useState<{ tone: "success" | "error"; text: string } | null>(null);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const [showCreate, setShowCreate] = useState(false);
+  const [oneTimeSecret, setOneTimeSecret] = useState<string | null>(null);
+  const [secretCopied, setSecretCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await api.listWebhookSubscriptions(true, 200);
+      setSubs(res.subscriptions ?? []);
+      setCatalog(res.event_catalog ?? []);
+      // Outbox is best-effort observability; a failure here must not blank the panel.
+      const box = await api.listWebhookOutbox(undefined, 50).catch(() => null);
+      setOutbox(box);
+    } catch (err) {
+      setLoadError(errorMessage(err));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const runAction = useCallback(
+    async (id: string, verb: string, fn: () => Promise<unknown>) => {
+      setBusyId(id);
+      setNotice(null);
+      try {
+        await fn();
+        setNotice({ tone: "success", text: `Webhook ${verb}.` });
+        await load();
+      } catch (err) {
+        setNotice({ tone: "error", text: errorMessage(err) });
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [load],
+  );
+
+  const activeCount = subs.filter((s) => s.status === "active").length;
+  const stats = outbox?.stats ?? {};
+
+  const columns = useMemo<DataTableColumn<WebhookSubscription>[]>(
+    () => [
+      {
+        key: "url",
+        header: "Destination",
+        cell: (s) => (
+          <div className="min-w-0">
+            <div className="truncate font-mono text-xs text-[color:var(--foreground)]" title="URL redacted — it may embed a secret token">
+              {redactWebhookUrl(s.url)}
+            </div>
+            {s.description ? (
+              <div className="truncate text-xs text-[color:var(--text-tertiary)]">{s.description}</div>
+            ) : null}
+          </div>
+        ),
+      },
+      {
+        key: "events",
+        header: "Events",
+        cell: (s) =>
+          s.event_types.length === 0 ? (
+            <Pill tone="neutral">all governance events</Pill>
+          ) : (
+            <div className="flex flex-wrap gap-1">
+              {s.event_types.map((e) => (
+                <Pill key={e} tone="neutral">
+                  {e}
+                </Pill>
+              ))}
+            </div>
+          ),
+      },
+      {
+        key: "secret",
+        header: "Secret",
+        cell: (s) => (
+          <span className="font-mono text-xs text-[color:var(--text-tertiary)]">
+            {s.secret_fingerprint ? `${s.secret_fingerprint}…` : "—"}
+          </span>
+        ),
+      },
+      {
+        key: "status",
+        header: "Status",
+        cell: (s) =>
+          s.status === "active" ? <Pill tone="success">active</Pill> : <Pill tone="warn">disabled</Pill>,
+      },
+      {
+        key: "actions",
+        header: "",
+        align: "right",
+        cell: (s) => {
+          const busy = busyId === s.subscription_id;
+          return (
+            <div className="flex justify-end gap-1.5">
+              <PanelButton
+                tone="secondary"
+                disabled={!canManage || busy}
+                title="Send a synthetic test delivery"
+                onClick={() =>
+                  runAction(s.subscription_id, "test enqueued", () =>
+                    api.testWebhookSubscription(s.subscription_id),
+                  )
+                }
+              >
+                {busy ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Send className="h-3.5 w-3.5" />}
+                Test
+              </PanelButton>
+              <PanelButton
+                tone="secondary"
+                disabled={!canManage || busy}
+                onClick={() =>
+                  runAction(
+                    s.subscription_id,
+                    s.status === "active" ? "disabled" : "enabled",
+                    () =>
+                      s.status === "active"
+                        ? api.disableWebhookSubscription(s.subscription_id)
+                        : api.enableWebhookSubscription(s.subscription_id),
+                  )
+                }
+              >
+                <Power className="h-3.5 w-3.5" />
+                {s.status === "active" ? "Disable" : "Enable"}
+              </PanelButton>
+              <PanelButton
+                tone="danger"
+                disabled={!canManage || busy}
+                onClick={() => {
+                  if (!window.confirm("Delete this webhook subscription?")) return;
+                  void runAction(s.subscription_id, "deleted", () =>
+                    api.deleteWebhookSubscription(s.subscription_id),
+                  );
+                }}
+              >
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete
+              </PanelButton>
+            </div>
+          );
+        },
+      },
+    ],
+    [busyId, canManage, runAction],
+  );
+
+  if (loadError) {
+    return (
+      <PageErrorState
+        title="Could not load webhook subscriptions"
+        detail={loadError}
+        action={{ label: "Retry", onClick: () => void load() }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <PanelIntro
+        title="Webhook subscriptions"
+        description="Outbound governance webhooks (budget enforcement, identity lifecycle, JIT grants, conditional-access denials, drift). Deliveries flow through the durable, HMAC-signed outbox."
+      >
+        <PanelButton tone="secondary" onClick={() => void load()} title="Refresh">
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </PanelButton>
+        <PanelButton
+          tone="primary"
+          disabled={!canManage}
+          onClick={() => {
+            setOneTimeSecret(null);
+            setShowCreate((v) => !v);
+          }}
+        >
+          <Plus className="h-4 w-4" />
+          New subscription
+        </PanelButton>
+      </PanelIntro>
+
+      <StatStrip
+        items={[
+          { label: "Subscriptions", value: subs.length, icon: Webhook },
+          { label: "Active", value: activeCount, accent: "success" },
+          { label: "Disabled", value: subs.length - activeCount, accent: activeCount === subs.length ? "neutral" : "warn" },
+          { label: "Outbox pending", value: Number(stats.pending ?? 0), accent: "warn" },
+          { label: "Delivered", value: Number(stats.delivered ?? 0), accent: "success" },
+          { label: "Dead-letter", value: Number(stats.dead_letter ?? 0), accent: "critical" },
+        ]}
+      />
+
+      {notice ? <InlineNotice tone={notice.tone} data-testid="webhook-notice">{notice.text}</InlineNotice> : null}
+      {!canManage ? (
+        <InlineNotice tone="info">
+          Viewing only. Registering, testing, enabling, disabling, or deleting webhooks requires an
+          admin (policy management) role.
+        </InlineNotice>
+      ) : null}
+
+      {oneTimeSecret ? (
+        <InlineNotice tone="success" data-testid="webhook-secret-reveal">
+          <div className="font-medium">Signing secret — shown once</div>
+          <p className="mt-1 text-xs">
+            Store this HMAC signing secret now. It is not retrievable later; the table only ever shows a
+            non-reversible fingerprint.
+          </p>
+          <div className="mt-2 flex items-center gap-2">
+            <code className="min-w-0 flex-1 truncate rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2 py-1 font-mono text-xs text-[color:var(--foreground)]">
+              {oneTimeSecret}
+            </code>
+            <PanelButton
+              tone="secondary"
+              onClick={() => {
+                void navigator.clipboard?.writeText(oneTimeSecret);
+                setSecretCopied(true);
+              }}
+            >
+              {secretCopied ? "Copied" : <><Copy className="h-3.5 w-3.5" /> Copy</>}
+            </PanelButton>
+          </div>
+        </InlineNotice>
+      ) : null}
+
+      {showCreate && canManage ? (
+        <CreateWebhookForm
+          catalog={catalog}
+          onCancel={() => setShowCreate(false)}
+          onCreated={(secret) => {
+            setShowCreate(false);
+            setOneTimeSecret(secret);
+            setSecretCopied(false);
+            setNotice({ tone: "success", text: "Webhook subscription created." });
+            void load();
+          }}
+        />
+      ) : null}
+
+      <DataTable
+        rows={subs}
+        rowKey={(s) => s.subscription_id}
+        columns={columns}
+        loading={loading}
+        maxHeight="32rem"
+        caption="Governance webhook subscriptions"
+        empty="No webhook subscriptions yet. Register a destination to receive governance events."
+        data-testid="webhooks-table"
+      />
+    </div>
+  );
+}
+
+function CreateWebhookForm({
+  catalog,
+  onCancel,
+  onCreated,
+}: {
+  catalog: string[];
+  onCancel: () => void;
+  onCreated: (secret: string) => void;
+}) {
+  const [url, setUrl] = useState("");
+  const [description, setDescription] = useState("");
+  const [signingSecret, setSigningSecret] = useState("");
+  const [allowPrivate, setAllowPrivate] = useState(false);
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleEvent = (e: string) =>
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(e)) next.delete(e);
+      else next.add(e);
+      return next;
+    });
+
+  const submit = async () => {
+    setError(null);
+    if (!url.trim()) {
+      setError("A destination URL is required.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await api.createWebhookSubscription({
+        url: url.trim(),
+        event_types: [...selected],
+        description: description.trim(),
+        signing_secret: signingSecret.trim() || undefined,
+        allow_private_networks: allowPrivate,
+      });
+      // Clear the operator-provided secret from memory immediately.
+      setSigningSecret("");
+      onCreated(res.signing_secret);
+    } catch (err) {
+      setError(errorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      className="space-y-4 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void submit();
+      }}
+    >
+      <div className="grid gap-4 md:grid-cols-2">
+        <Field label="Destination URL">
+          <input
+            className={INPUT_CLASS}
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="https://hooks.example.com/agent-bom"
+            data-testid="webhook-url-input"
+          />
+        </Field>
+        <Field label="Description (optional)">
+          <input
+            className={INPUT_CLASS}
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="Team channel / purpose"
+          />
+        </Field>
+      </div>
+
+      <Field label="Signing secret (optional — leave blank to auto-generate)">
+        <input
+          className={INPUT_CLASS}
+          type="password"
+          autoComplete="off"
+          value={signingSecret}
+          onChange={(e) => setSigningSecret(e.target.value)}
+          placeholder="Provide your own HMAC secret, or leave blank"
+        />
+      </Field>
+
+      <div>
+        <span className="text-[11px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-tertiary)]">
+          Event types ({selected.size === 0 ? "all governance events" : `${selected.size} selected`})
+        </span>
+        <div className="mt-2 flex flex-wrap gap-2">
+          {catalog.map((e) => {
+            const on = selected.has(e);
+            return (
+              <button
+                key={e}
+                type="button"
+                onClick={() => toggleEvent(e)}
+                className={`rounded-full border px-2.5 py-1 text-xs font-medium transition ${
+                  on
+                    ? "border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] text-[color:var(--accent)]"
+                    : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)]"
+                }`}
+              >
+                {e}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <label className="flex items-center gap-2 text-sm text-[color:var(--text-secondary)]">
+        <input type="checkbox" checked={allowPrivate} onChange={(e) => setAllowPrivate(e.target.checked)} />
+        Allow private-network destinations (advanced)
+      </label>
+
+      {error ? <InlineNotice tone="error">{error}</InlineNotice> : null}
+
+      <div className="flex gap-2">
+        <PanelButton tone="primary" type="submit" disabled={submitting} data-testid="webhook-create-submit">
+          {submitting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Plus className="h-4 w-4" />}
+          Create subscription
+        </PanelButton>
+        <PanelButton tone="secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </PanelButton>
+      </div>
+    </form>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -182,11 +182,12 @@ const NAV_GROUPS: NavGroup[] = [
   {
     label: "Operations",
     icon: Cog,
-    desc: "Spend, jobs, and activity",
+    desc: "Spend, jobs, and integrations",
     links: [
       { href: "/cost", label: "AI Spend", icon: DollarSign },
       { href: "/jobs", label: "Scan Jobs", icon: Clock },
       { href: "/activity", label: "Activity", icon: Activity },
+      { href: "/integrations", label: "Integrations", icon: Plug, desc: "Webhooks, SIEM, threat intel, and report exports" },
     ],
   },
 ];
@@ -219,6 +220,7 @@ const NAV_LINK_ICON_CLASS: Record<string, string> = {
   "/cost": "text-yellow-400",
   "/jobs": "text-orange-400",
   "/activity": "text-lime-400",
+  "/integrations": "text-teal-400",
 };
 
 const NAV_GROUP_ICON_CLASS: Record<string, string> = {

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -3467,3 +3467,200 @@ export interface ServedMcpClientConfig {
   generated_at: string;
   read_only: boolean;
 }
+
+// ─── Operations & Integrations ──────────────────────────────────────────────
+// Webhook subscriptions, SIEM connectors, threat-intel, async reports. Each
+// contract mirrors an existing REST surface so the UI reaches human↔agent
+// parity without new backend routes.
+
+/** A governance webhook destination. The signing secret is never returned in
+ *  list/detail views — only a non-reversible `secret_fingerprint` handle. */
+export interface WebhookSubscription {
+  subscription_id: string;
+  tenant_id: string;
+  url: string;
+  event_types: string[];
+  status: string;
+  description: string;
+  created_at: string;
+  updated_at: string;
+  allow_private_networks: boolean;
+  secret_fingerprint: string;
+}
+
+export interface WebhookSubscriptionsResponse {
+  schema_version: string;
+  tenant_id: string;
+  event_catalog: string[];
+  count: number;
+  subscriptions: WebhookSubscription[];
+}
+
+export interface WebhookCreateRequest {
+  url: string;
+  event_types?: string[];
+  description?: string;
+  signing_secret?: string | undefined;
+  allow_private_networks?: boolean;
+}
+
+/** Registration response. `signing_secret` is present ONLY here, exactly once,
+ *  and is unrecoverable afterward (mirrors the API-key one-time reveal). */
+export interface WebhookCreateResponse {
+  schema_version: string;
+  subscription: WebhookSubscription;
+  signing_secret: string;
+  secret_notice: string;
+}
+
+export interface WebhookMutationResponse {
+  schema_version: string;
+  subscription?: WebhookSubscription;
+  deleted?: boolean;
+  queued?: boolean;
+  subscription_id?: string;
+  event_id?: string;
+}
+
+export interface WebhookOutboxResponse {
+  schema_version: string;
+  tenant_id: string;
+  status: string | null;
+  count: number;
+  records: Array<Record<string, unknown>>;
+  stats: Record<string, number>;
+}
+
+export interface SiemConnectorsResponse {
+  connectors: string[];
+}
+
+export interface SiemFormatsResponse {
+  formats: string[];
+}
+
+export interface SiemTestResponse {
+  siem_type: string;
+  healthy: boolean;
+  error?: string;
+}
+
+export interface IntelFeedRun {
+  sync_meta_source: string;
+  last_synced: string | null;
+  record_count: number;
+  status: string;
+  validation_status: string;
+  parse_errors: number;
+  validation_failures: number;
+  cap_hit: boolean;
+}
+
+export interface IntelSource {
+  source_id: string;
+  display_name: string;
+  tier: string;
+  kind: string;
+  validation_status: string;
+  support_status: string;
+  enabled: boolean;
+  owner: string;
+  description: string;
+  feed_run: IntelFeedRun;
+}
+
+export interface IntelSourcesResponse {
+  schema_version: string;
+  sources: IntelSource[];
+  count: number;
+}
+
+export interface IntelAdvisory {
+  id: string;
+  summary: string;
+  severity: string;
+  cvss_score: number | null;
+  cvss_vector: string | null;
+  fixed_version: string | null;
+  source: string;
+  published_at: string | null;
+  modified_at: string | null;
+  epss_probability: number | null;
+  epss_percentile: number | null;
+  is_kev: boolean;
+  kev_date_added: string | null;
+  affected: Array<Record<string, unknown>>;
+  canonical_ids: { cves: string[]; ghsas: string[]; osv: string[]; cwes: string[] };
+  evidence_links: Array<{ label?: string; url: string }>;
+}
+
+export interface IntelAdvisoryResponse {
+  schema_version: string;
+  found: boolean;
+  query: string;
+  advisory: IntelAdvisory | null;
+}
+
+export interface IntelMatchPackageInput {
+  ecosystem: string;
+  name: string;
+  version?: string | undefined;
+}
+
+export interface IntelMatchItem {
+  ecosystem?: string;
+  name?: string;
+  version?: string;
+  match_count: number;
+  advisories?: Array<Record<string, unknown>>;
+  [key: string]: unknown;
+}
+
+export interface IntelMatchResponse {
+  schema_version: string;
+  submitted: number;
+  matched_packages: number;
+  match_count: number;
+  matches: IntelMatchItem[];
+}
+
+export interface IntelDailyBriefResponse {
+  schema_version: string;
+  generated_at: string;
+  inputs: Record<string, unknown>;
+  sections: {
+    kev_last_24h: unknown[];
+    high_epss_inventory: unknown[];
+    vendor_advisories: unknown[];
+    ioc_telemetry_hits: unknown[];
+    campaign_matches: unknown[];
+    ransomware_sector_matches: unknown[];
+  };
+  limitations: string[];
+}
+
+export type ReportSort = "effective_reach" | "cvss" | "severity" | "ordinal";
+
+export interface ReportJobRecord {
+  job_id: string;
+  tenant_id: string;
+  status: JobStatus;
+  format: string;
+  sort: string;
+  severity: string | null;
+  created_at: string;
+  started_at: string | null;
+  completed_at: string | null;
+  row_count: number | null;
+  byte_count: number | null;
+  error: string | null;
+  download_url?: string;
+  download_token?: string;
+  download_token_header?: string;
+}
+
+export interface ReportCreateRequest {
+  format?: "ndjson";
+  sort?: ReportSort;
+  severity?: string | null;
+}

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -123,7 +123,22 @@ import type {
   BlueprintDetailResponse,
   BlueprintVersionResponse,
   BlueprintSeedResponse,
-  BlueprintCreateRequest
+  BlueprintCreateRequest,
+  WebhookSubscriptionsResponse,
+  WebhookCreateRequest,
+  WebhookCreateResponse,
+  WebhookMutationResponse,
+  WebhookOutboxResponse,
+  SiemConnectorsResponse,
+  SiemFormatsResponse,
+  SiemTestResponse,
+  IntelSourcesResponse,
+  IntelAdvisoryResponse,
+  IntelMatchPackageInput,
+  IntelMatchResponse,
+  IntelDailyBriefResponse,
+  ReportJobRecord,
+  ReportCreateRequest
 } from "./api-types";
 export type {
   AccountSummaryResponse,
@@ -335,6 +350,27 @@ export type {
   BlueprintVersionResponse,
   BlueprintSeedResponse,
   BlueprintCreateRequest,
+  WebhookSubscription,
+  WebhookSubscriptionsResponse,
+  WebhookCreateRequest,
+  WebhookCreateResponse,
+  WebhookMutationResponse,
+  WebhookOutboxResponse,
+  SiemConnectorsResponse,
+  SiemFormatsResponse,
+  SiemTestResponse,
+  IntelFeedRun,
+  IntelSource,
+  IntelSourcesResponse,
+  IntelAdvisory,
+  IntelAdvisoryResponse,
+  IntelMatchPackageInput,
+  IntelMatchItem,
+  IntelMatchResponse,
+  IntelDailyBriefResponse,
+  ReportSort,
+  ReportJobRecord,
+  ReportCreateRequest,
 } from "./api-types";
 export type { MitreAtlasCatalogMetadata } from "./api-types";
 
@@ -503,10 +539,10 @@ async function del(path: string): Promise<void> {
   _runInvalidations(path);
 }
 
-async function getBlob(path: string): Promise<Blob> {
+async function getBlob(path: string, headers: Record<string, string> = {}): Promise<Blob> {
   const res = await _doFetch(path, {
     credentials: "include",
-    headers: getSessionAuthHeaders(),
+    headers: { ...getSessionAuthHeaders(), ...headers },
     signal: withTimeout(),
   }, "GET");
   return res.blob();
@@ -1390,6 +1426,74 @@ export const api = {
     get<DriftIncidentsResponse>(`/v1/runtime/drift/incidents?include_resolved=${includeResolved}&limit=${limit}`),
   resolveDriftIncident: (incidentId: string, note?: string) =>
     post<{ resolved: boolean }>(`/v1/runtime/drift/incidents/${encodeURIComponent(incidentId)}/resolve`, { note: note ?? "" }),
+
+  // ── Operations & Integrations: webhook subscriptions ──
+  /** List governance webhook subscriptions for the active tenant. */
+  listWebhookSubscriptions: (includeDisabled = true, limit = 200) =>
+    get<WebhookSubscriptionsResponse>(
+      `/v1/webhooks?include_disabled=${includeDisabled}&limit=${limit}`,
+      { ttlMs: 0 },
+    ),
+  /** Register a governance webhook destination. Returns the signing secret once. */
+  createWebhookSubscription: (body: WebhookCreateRequest) =>
+    post<WebhookCreateResponse>("/v1/webhooks", body),
+  /** Enable a disabled subscription. */
+  enableWebhookSubscription: (id: string) =>
+    post<WebhookMutationResponse>(`/v1/webhooks/${encodeURIComponent(id)}/enable`, {}),
+  /** Disable a subscription without deleting it. */
+  disableWebhookSubscription: (id: string) =>
+    post<WebhookMutationResponse>(`/v1/webhooks/${encodeURIComponent(id)}/disable`, {}),
+  /** Delete a subscription. */
+  deleteWebhookSubscription: (id: string) => del(`/v1/webhooks/${encodeURIComponent(id)}`),
+  /** Enqueue a synthetic test delivery to this destination. */
+  testWebhookSubscription: (id: string) =>
+    post<WebhookMutationResponse>(`/v1/webhooks/${encodeURIComponent(id)}/test`, {}),
+  /** Recent webhook outbox deliveries (observability of the shipped outbox). */
+  listWebhookOutbox: (status?: "pending" | "delivered" | "dead_letter", limit = 50) =>
+    get<WebhookOutboxResponse>(
+      `/v1/posture/webhooks/outbox?limit=${limit}${status ? `&status=${status}` : ""}`,
+      { ttlMs: 0 },
+    ),
+
+  // ── Operations & Integrations: SIEM connectors ──
+  /** List available SIEM connector types. */
+  listSiemConnectors: () => get<SiemConnectorsResponse>("/v1/siem/connectors"),
+  /** List supported SIEM event formats. */
+  listSiemFormats: () => get<SiemFormatsResponse>("/v1/siem/formats"),
+  /** Test SIEM connectivity. The token (if any) is sent via header, never persisted. */
+  testSiemConnection: (siemType: string, url: string, token?: string) =>
+    post<SiemTestResponse>(
+      `/v1/siem/test?siem_type=${encodeURIComponent(siemType)}&url=${encodeURIComponent(url)}`,
+      {},
+      token ? { "X-Siem-Token": token } : {},
+    ),
+
+  // ── Operations & Integrations: threat intel ──
+  /** Canonical threat-intel source and feed-run metadata. */
+  getIntelSources: () => get<IntelSourcesResponse>("/v1/intel/sources", { ttlMs: 0 }),
+  /** Look up one CVE/GHSA/OSV advisory from local intel. */
+  getIntelAdvisory: (advisoryId: string) =>
+    get<IntelAdvisoryResponse>(`/v1/intel/advisories/${encodeURIComponent(advisoryId)}`, { ttlMs: 0 }),
+  /** Match inventory package coordinates to local advisory intel. */
+  matchIntelPackages: (packages: IntelMatchPackageInput[], limit = 100) =>
+    post<IntelMatchResponse>("/v1/intel/match", { packages, limit }),
+  /** Local analyst threat brief from governed intel sources. */
+  getIntelDailyBrief: (body: Record<string, unknown> = {}) =>
+    post<IntelDailyBriefResponse>("/v1/intel/daily-brief", body),
+
+  // ── Operations & Integrations: async reports ──
+  /** Enqueue an async findings export (gzipped NDJSON). */
+  createReportJob: (body: ReportCreateRequest = {}) =>
+    post<ReportJobRecord>("/v1/reports", body),
+  /** Poll async report job status and download metadata. */
+  getReportJob: (jobId: string) =>
+    get<ReportJobRecord>(`/v1/reports/${encodeURIComponent(jobId)}`, { ttlMs: 0 }),
+  /** Download a completed report artifact. The job-scoped token is sent via
+   *  header (kept out of logs/history), never in the URL. */
+  downloadReportArtifact: (jobId: string, token: string) =>
+    getBlob(`/v1/reports/${encodeURIComponent(jobId)}/download`, {
+      "X-Agent-Bom-Download-Token": token,
+    }),
 };
 
 // ─── Threat Framework Catalogs ────────────────────────────────────────────────

--- a/ui/tests/insights-redirect.test.tsx
+++ b/ui/tests/insights-redirect.test.tsx
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { redirectMock } = vi.hoisted(() => ({ redirectMock: vi.fn() }));
+
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+
+import InsightsRedirect from "@/app/insights/page";
+
+describe("insights redirect", () => {
+  it("redirects to the dashboard home honestly (no ignored ?tab suffix)", () => {
+    InsightsRedirect();
+    expect(redirectMock).toHaveBeenCalledWith("/");
+    // The old target used an anchor the home page never reads.
+    expect(redirectMock).not.toHaveBeenCalledWith("/?tab=analytics");
+  });
+});

--- a/ui/tests/integrations-intel-panel.test.tsx
+++ b/ui/tests/integrations-intel-panel.test.tsx
@@ -1,0 +1,128 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { IntelPanel } from "@/components/integrations/intel-panel";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    getIntelSources: vi.fn(),
+    getIntelAdvisory: vi.fn(),
+    matchIntelPackages: vi.fn(),
+    getIntelDailyBrief: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock, formatDate: (s: string) => s }));
+
+const SOURCE = {
+  source_id: "nvd",
+  display_name: "NVD",
+  tier: "authoritative",
+  kind: "cve",
+  validation_status: "validated",
+  support_status: "supported",
+  enabled: true,
+  owner: "nist",
+  description: "",
+  feed_run: {
+    sync_meta_source: "nvd",
+    last_synced: "2026-07-14T00:00:00Z",
+    record_count: 4200,
+    status: "synced",
+    validation_status: "validated",
+    parse_errors: 0,
+    validation_failures: 0,
+    cap_hit: false,
+  },
+};
+
+beforeEach(() => {
+  Object.values(apiMock).forEach((fn) => fn.mockReset());
+  apiMock.getIntelSources.mockResolvedValue({ schema_version: "v1", sources: [SOURCE], count: 1 });
+});
+
+describe("IntelPanel", () => {
+  it("renders sources and filters by search", async () => {
+    render(<IntelPanel />);
+    expect(await screen.findByText("NVD")).toBeInTheDocument();
+    fireEvent.change(screen.getByTestId("intel-source-search"), { target: { value: "zzz-nomatch" } });
+    await waitFor(() => expect(screen.queryByText("NVD")).not.toBeInTheDocument());
+  });
+
+  it("looks up an advisory by id", async () => {
+    apiMock.getIntelAdvisory.mockResolvedValue({
+      schema_version: "v1",
+      found: true,
+      query: "CVE-2024-3094",
+      advisory: {
+        id: "CVE-2024-3094",
+        summary: "backdoor",
+        severity: "critical",
+        cvss_score: 10,
+        cvss_vector: null,
+        fixed_version: "5.6.2",
+        source: "nvd",
+        published_at: "2026-01-01T00:00:00Z",
+        modified_at: null,
+        epss_probability: 0.5,
+        epss_percentile: 0.9,
+        is_kev: true,
+        kev_date_added: "2026-01-02",
+        affected: [{}],
+        canonical_ids: { cves: [], ghsas: [], osv: [], cwes: [] },
+        evidence_links: [],
+      },
+    });
+    render(<IntelPanel />);
+    await screen.findByText("NVD");
+    fireEvent.change(screen.getByTestId("intel-advisory-input"), { target: { value: "CVE-2024-3094" } });
+    fireEvent.click(screen.getByTestId("intel-advisory-submit"));
+    await waitFor(() => expect(apiMock.getIntelAdvisory).toHaveBeenCalledWith("CVE-2024-3094"));
+    const result = await screen.findByTestId("intel-advisory-result");
+    expect(result).toHaveTextContent("CVE-2024-3094");
+    expect(result).toHaveTextContent(/KEV/);
+  });
+
+  it("matches a package against advisory intel", async () => {
+    apiMock.matchIntelPackages.mockResolvedValue({
+      schema_version: "v1",
+      submitted: 1,
+      matched_packages: 1,
+      match_count: 3,
+      matches: [],
+    });
+    render(<IntelPanel />);
+    await screen.findByText("NVD");
+    fireEvent.change(screen.getByTestId("intel-match-ecosystem"), { target: { value: "npm" } });
+    fireEvent.change(screen.getByTestId("intel-match-name"), { target: { value: "left-pad" } });
+    fireEvent.click(screen.getByTestId("intel-match-submit"));
+    await waitFor(() =>
+      expect(apiMock.matchIntelPackages).toHaveBeenCalledWith([
+        { ecosystem: "npm", name: "left-pad", version: undefined },
+      ]),
+    );
+    expect(await screen.findByTestId("intel-match-result")).toHaveTextContent("3 advisor");
+  });
+
+  it("generates a daily brief", async () => {
+    apiMock.getIntelDailyBrief.mockResolvedValue({
+      schema_version: "v1",
+      generated_at: "2026-07-14T00:00:00Z",
+      inputs: {},
+      sections: {
+        kev_last_24h: [{}, {}],
+        high_epss_inventory: [],
+        vendor_advisories: [],
+        ioc_telemetry_hits: [],
+        campaign_matches: [],
+        ransomware_sector_matches: [],
+      },
+      limitations: ["telemetry needed"],
+    });
+    render(<IntelPanel />);
+    await screen.findByText("NVD");
+    fireEvent.click(screen.getByTestId("intel-brief-submit"));
+    await waitFor(() => expect(apiMock.getIntelDailyBrief).toHaveBeenCalled());
+    expect(await screen.findByTestId("intel-brief-result")).toHaveTextContent("KEV in last 24h");
+  });
+});

--- a/ui/tests/integrations-page.test.tsx
+++ b/ui/tests/integrations-page.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import IntegrationsPage from "@/app/integrations/page";
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  useSearchParams: () => new URLSearchParams("tab=siem"),
+}));
+
+vi.mock("@/components/integrations/webhooks-panel", () => ({ WebhooksPanel: () => <div>webhooks panel</div> }));
+vi.mock("@/components/integrations/siem-panel", () => ({ SiemPanel: () => <div>siem panel</div> }));
+vi.mock("@/components/integrations/intel-panel", () => ({ IntelPanel: () => <div>intel panel</div> }));
+vi.mock("@/components/integrations/reports-panel", () => ({ ReportsPanel: () => <div>reports panel</div> }));
+
+describe("IntegrationsPage", () => {
+  it("renders the tab shell and the selected tab's panel", async () => {
+    render(<IntegrationsPage />);
+    expect(await screen.findByRole("heading", { name: /Operations & Integrations/i })).toBeInTheDocument();
+    expect(screen.getByText("siem panel")).toBeInTheDocument();
+    expect(screen.queryByText("webhooks panel")).not.toBeInTheDocument();
+  });
+});

--- a/ui/tests/integrations-reports-panel.test.tsx
+++ b/ui/tests/integrations-reports-panel.test.tsx
@@ -1,0 +1,80 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ReportsPanel } from "@/components/integrations/reports-panel";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    createReportJob: vi.fn(),
+    getReportJob: vi.fn(),
+    downloadReportArtifact: vi.fn(),
+  },
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock, formatDate: (s: string) => s }));
+
+const PENDING = {
+  job_id: "job-abcdef12",
+  tenant_id: "t",
+  status: "pending",
+  format: "ndjson",
+  sort: "effective_reach",
+  severity: null,
+  created_at: "2026-07-14T00:00:00Z",
+  started_at: null,
+  completed_at: null,
+  row_count: null,
+  byte_count: null,
+  error: null,
+};
+
+const DONE = { ...PENDING, status: "done", row_count: 128, download_token: "test", download_token_header: "X-Agent-Bom-Download-Token" };
+
+beforeEach(() => {
+  Object.values(apiMock).forEach((fn) => fn.mockReset());
+  URL.createObjectURL = vi.fn(() => "blob:mock");
+  URL.revokeObjectURL = vi.fn();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("ReportsPanel", () => {
+  it("queues an export and shows the job row", async () => {
+    apiMock.createReportJob.mockResolvedValue(PENDING);
+    render(<ReportsPanel />);
+    fireEvent.change(screen.getByTestId("report-sort-select"), { target: { value: "cvss" } });
+    fireEvent.click(screen.getByTestId("report-create-submit"));
+    await waitFor(() =>
+      expect(apiMock.createReportJob).toHaveBeenCalledWith({ format: "ndjson", sort: "cvss", severity: null }),
+    );
+    expect(await screen.findByText(/job-abcd/)).toBeInTheDocument();
+  });
+
+  it("polls a pending job until it completes", async () => {
+    apiMock.createReportJob.mockResolvedValue(PENDING);
+    apiMock.getReportJob.mockResolvedValue(DONE);
+    render(<ReportsPanel />);
+    fireEvent.click(screen.getByTestId("report-create-submit"));
+    // A pending row appears immediately; the 2.5s poll interval then advances it.
+    expect(await screen.findByText(/job-abcd/)).toBeInTheDocument();
+    await waitFor(
+      () => expect(apiMock.getReportJob).toHaveBeenCalledWith("job-abcdef12"),
+      { timeout: 4000 },
+    );
+    await waitFor(() => expect(screen.getByTestId("reports-table")).toHaveTextContent("done"));
+  });
+
+  it("downloads a completed report using the job-scoped token header", async () => {
+    apiMock.createReportJob.mockResolvedValue(DONE);
+    apiMock.downloadReportArtifact.mockResolvedValue(new Blob(["x"]));
+    render(<ReportsPanel />);
+    fireEvent.click(screen.getByTestId("report-create-submit"));
+    const btn = await screen.findByTestId("report-download-job-abcd");
+    fireEvent.click(btn);
+    await waitFor(() =>
+      expect(apiMock.downloadReportArtifact).toHaveBeenCalledWith("job-abcdef12", "test"),
+    );
+  });
+});

--- a/ui/tests/integrations-siem-panel.test.tsx
+++ b/ui/tests/integrations-siem-panel.test.tsx
@@ -1,0 +1,56 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { SiemPanel } from "@/components/integrations/siem-panel";
+
+const { apiMock, authMock } = vi.hoisted(() => ({
+  apiMock: {
+    listSiemConnectors: vi.fn(),
+    listSiemFormats: vi.fn(),
+    testSiemConnection: vi.fn(),
+  },
+  authMock: { value: { session: { auth_required: true }, hasCapability: (c: string): boolean => c === "policy.manage" } },
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+vi.mock("@/components/auth-provider", () => ({ useAuthState: () => authMock.value }));
+
+beforeEach(() => {
+  Object.values(apiMock).forEach((fn) => fn.mockReset());
+  authMock.value = { session: { auth_required: true }, hasCapability: (c: string): boolean => c === "policy.manage" };
+  apiMock.listSiemConnectors.mockResolvedValue({ connectors: ["splunk", "datadog", "syslog"] });
+  apiMock.listSiemFormats.mockResolvedValue({ formats: ["raw", "ocsf"] });
+});
+
+describe("SiemPanel", () => {
+  it("renders connector types and formats", async () => {
+    render(<SiemPanel />);
+    const connectors = await screen.findByTestId("siem-connectors");
+    expect(connectors).toHaveTextContent("splunk");
+    expect(connectors).toHaveTextContent("syslog");
+    expect(screen.getByTestId("siem-formats")).toHaveTextContent("ocsf");
+  });
+
+  it("runs a connectivity test and shows the healthy result", async () => {
+    apiMock.testSiemConnection.mockResolvedValue({ siem_type: "splunk", healthy: true });
+    render(<SiemPanel />);
+    await screen.findByTestId("siem-connectors");
+
+    fireEvent.change(screen.getByTestId("siem-url-input"), {
+      target: { value: "https://siem.example.com/collector" },
+    });
+    fireEvent.click(screen.getByTestId("siem-test-submit"));
+
+    await waitFor(() => expect(apiMock.testSiemConnection).toHaveBeenCalledTimes(1));
+    expect(apiMock.testSiemConnection.mock.calls[0]![0]).toBe("splunk");
+    expect(apiMock.testSiemConnection.mock.calls[0]![1]).toBe("https://siem.example.com/collector");
+    expect(await screen.findByTestId("siem-test-result")).toHaveTextContent(/healthy/i);
+  });
+
+  it("gates the test action for non-admins", async () => {
+    authMock.value = { session: { auth_required: true }, hasCapability: (): boolean => false };
+    render(<SiemPanel />);
+    await screen.findByTestId("siem-connectors");
+    expect(screen.getByTestId("siem-test-submit")).toBeDisabled();
+  });
+});

--- a/ui/tests/integrations-webhooks-panel.test.tsx
+++ b/ui/tests/integrations-webhooks-panel.test.tsx
@@ -1,0 +1,118 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { WebhooksPanel } from "@/components/integrations/webhooks-panel";
+
+const { apiMock, authMock } = vi.hoisted(() => ({
+  apiMock: {
+    listWebhookSubscriptions: vi.fn(),
+    listWebhookOutbox: vi.fn(),
+    createWebhookSubscription: vi.fn(),
+    enableWebhookSubscription: vi.fn(),
+    disableWebhookSubscription: vi.fn(),
+    deleteWebhookSubscription: vi.fn(),
+    testWebhookSubscription: vi.fn(),
+  },
+  authMock: { value: { session: { auth_required: true }, hasCapability: (c: string): boolean => c === "policy.manage" } },
+}));
+
+vi.mock("@/lib/api", () => ({ api: apiMock }));
+vi.mock("@/components/auth-provider", () => ({ useAuthState: () => authMock.value }));
+
+const SUB = {
+  subscription_id: "wh-1",
+  tenant_id: "t",
+  url: "https://hooks.example.com/team/sensitive-path",
+  event_types: ["drift.detected"],
+  status: "active",
+  description: "Ops channel",
+  created_at: "2026-07-14T00:00:00Z",
+  updated_at: "2026-07-14T00:00:00Z",
+  allow_private_networks: false,
+  secret_fingerprint: "test",
+};
+
+beforeEach(() => {
+  Object.values(apiMock).forEach((fn) => fn.mockReset());
+  authMock.value = { session: { auth_required: true }, hasCapability: (c: string): boolean => c === "policy.manage" };
+  window.confirm = () => true;
+  apiMock.listWebhookSubscriptions.mockResolvedValue({
+    schema_version: "v1",
+    tenant_id: "t",
+    event_catalog: ["drift.detected", "budget.exceeded"],
+    count: 1,
+    subscriptions: [SUB],
+  });
+  apiMock.listWebhookOutbox.mockResolvedValue({
+    schema_version: "v1",
+    tenant_id: "t",
+    status: null,
+    count: 0,
+    records: [],
+    stats: { pending: 2, delivered: 5, dead_letter: 1 },
+  });
+});
+
+describe("WebhooksPanel", () => {
+  it("renders subscriptions and redacts the URL (never shows the secret path)", async () => {
+    render(<WebhooksPanel />);
+    expect(await screen.findByText("https://hooks.example.com/•••")).toBeInTheDocument();
+    // The sensitive path segment must NOT be rendered anywhere.
+    expect(screen.queryByText(/sensitive-path/)).not.toBeInTheDocument();
+    // Only the fingerprint handle is shown.
+    expect(screen.getByText("test…")).toBeInTheDocument();
+  });
+
+  it("creates a subscription and reveals the one-time signing secret", async () => {
+    apiMock.createWebhookSubscription.mockResolvedValue({
+      schema_version: "v1",
+      subscription: SUB,
+      signing_secret: "test",
+      secret_notice: "store now",
+    });
+    render(<WebhooksPanel />);
+    fireEvent.click(await screen.findByRole("button", { name: /New subscription/i }));
+    fireEvent.change(screen.getByTestId("webhook-url-input"), {
+      target: { value: "https://hooks.example.com/new" },
+    });
+    fireEvent.click(screen.getByTestId("webhook-create-submit"));
+
+    await waitFor(() => expect(apiMock.createWebhookSubscription).toHaveBeenCalledTimes(1));
+    expect(apiMock.createWebhookSubscription.mock.calls[0]![0]).toMatchObject({
+      url: "https://hooks.example.com/new",
+    });
+    expect(await screen.findByTestId("webhook-secret-reveal")).toHaveTextContent("test");
+  });
+
+  it("wires enable/disable, test, and delete actions to their endpoints", async () => {
+    apiMock.disableWebhookSubscription.mockResolvedValue({ schema_version: "v1", subscription: SUB });
+    apiMock.testWebhookSubscription.mockResolvedValue({ schema_version: "v1", queued: true });
+    apiMock.deleteWebhookSubscription.mockResolvedValue(undefined);
+
+    render(<WebhooksPanel />);
+    const row = (await screen.findByTestId("webhooks-table")).querySelector("tbody tr")!;
+    const scope = within(row as HTMLElement);
+
+    fireEvent.click(scope.getByRole("button", { name: /Test/i }));
+    await waitFor(() => expect(apiMock.testWebhookSubscription).toHaveBeenCalledWith("wh-1"));
+
+    fireEvent.click(scope.getByRole("button", { name: /Disable/i }));
+    await waitFor(() => expect(apiMock.disableWebhookSubscription).toHaveBeenCalledWith("wh-1"));
+
+    fireEvent.click(scope.getByRole("button", { name: /Delete/i }));
+    await waitFor(() => expect(apiMock.deleteWebhookSubscription).toHaveBeenCalledWith("wh-1"));
+  });
+
+  it("shows an error state when the list fails", async () => {
+    apiMock.listWebhookSubscriptions.mockRejectedValue(new Error("boom"));
+    render(<WebhooksPanel />);
+    expect(await screen.findByText(/Could not load webhook subscriptions/i)).toBeInTheDocument();
+  });
+
+  it("gates management actions for non-admin viewers", async () => {
+    authMock.value = { session: { auth_required: true }, hasCapability: (): boolean => false };
+    render(<WebhooksPanel />);
+    expect(await screen.findByText(/Viewing only/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /New subscription/i })).toBeDisabled();
+  });
+});


### PR DESCRIPTION
**Closes #4014.**

Completes the surface-parity single pane by giving the last P2 orphan backends
(REST-only, no UI) a cohesive human UI, so every capability is usable by humans
**and** agents. Everything lands in one new **Operations & Integrations** settings
section (`/integrations`) — a tabbed page where each panel calls the existing
backend. No backend routes were added or changed.

## Panels → endpoints

- **Webhooks** (`api/routes/webhooks.py`): dense `DataTable` of subscriptions with
  create form, enable/disable/delete/test actions, and outbox delivery stats from
  `/posture/webhooks/outbox`. Wires `GET/POST /v1/webhooks`,
  `POST /v1/webhooks/{id}/{enable,disable,test}`, `DELETE /v1/webhooks/{id}`.
- **SIEM** (`api/routes/enterprise.py`, `governance.py`): configured connector types
  + supported formats, plus a connectivity **Test** action showing the result.
  Wires `GET /v1/siem/connectors`, `GET /v1/siem/formats`, `POST /v1/siem/test`.
- **Threat Intel** (`api/routes/intel.py`): analyst view — sources status table
  (searchable), advisory lookup, a daily-brief panel, and a package match action.
  Wires `GET /v1/intel/sources`, `GET /v1/intel/advisories/{id}`,
  `POST /v1/intel/match`, `POST /v1/intel/daily-brief`.
- **Reports** (`api/routes/reports.py`): create a quota-enforced async export
  (sort/severity), poll status to completion, and download completed artifacts.
  Wires `POST /v1/reports`, `GET /v1/reports/{id}`, `GET /v1/reports/{id}/download`.
- **Insights anchor fix** (`app/insights/page.tsx`): the redirect targeted
  `/?tab=analytics`, but the home page never reads `tab`. Now redirects to `/`
  honestly (analytics live on the dashboard itself).

## Security / accuracy

- **No secret material rendered.** Webhook URLs are redacted (origin + masked path)
  because a webhook URL can itself embed a token; list/detail views show only the
  non-reversible `secret_fingerprint` handle. The signing secret appears once at
  creation (unrecoverable, mirrors the existing API-key one-time reveal). SIEM and
  report tokens are sent per-request via header and never stored or displayed.
- **RBAC.** Webhook/SIEM mutations are gated on `policy.manage` (admin) matching the
  backend; viewers get a read-only notice. The backend remains the enforcement point.
- Real API data only; honest loading / empty / error states via `PageState`.

## Build / test / bundle

- `npm run typecheck` clean · `eslint` clean (only the pre-existing nav warning).
- `npx vitest run`: **615 passed / 122 files** (17 new across the 4 panels + page +
  insights redirect: list render, create/enable/disable/delete/test, empty/error
  states, intel search + lookup + match + brief, reports create+poll+download,
  URL-redaction assertion, RBAC gating).
- `npm run build` clean, `/integrations` route present.
- Bundle budget PASS: 3384.8 KiB / 3456.0 KiB.
- Both themes verified: tokens only (all present in both globals.css blocks), zero
  hardcoded `zinc-*`/hex, composed from the already-both-theme design-system
  primitives (`DataTable`, `StatStrip`, `PageState`).
