### PR TITLE
fix: pre-release bug-fixes (combined)

### DIFF
--- a/src/agent_bom/api/routes/identities.py
+++ b/src/agent_bom/api/routes/identities.py
@@ -50,7 +50,9 @@ def _tenant(request: Request) -> str:
 
 
 def _actor(request: Request) -> str:
-    return getattr(getattr(request, "state", None), "actor", None) or "api"
+    return getattr(getattr(request, "state", None), "actor", None) or getattr(
+        getattr(request, "state", None), "api_key_name", None
+    ) or "api"
 
 
 def _emit(event_type: str, *, tenant_id: str, subject_id: str, **payload: object) -> None:

--- a/src/agent_bom/api/routes/mcp_config.py
+++ b/src/agent_bom/api/routes/mcp_config.py
@@ -47,7 +47,9 @@ def _tenant(request: Request) -> str:
 
 
 def _actor(request: Request) -> str:
-    return getattr(getattr(request, "state", None), "actor", None) or "api"
+    return getattr(getattr(request, "state", None), "actor", None) or getattr(
+        getattr(request, "state", None), "api_key_name", None
+    ) or "api"
 
 
 def _str_list(body: dict, key: str, *, max_items: int = 200, max_len: int = 200) -> list[str]:

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -786,7 +786,8 @@ async def pull_trace_connector(request: Request, provider: str, body: dict) -> d
         limit = max(1, min(int(body.get("limit", 50) or 50), 1000))
     except (TypeError, ValueError) as exc:
         raise HTTPException(status_code=400, detail="'limit' must be an integer") from exc
-    screen_content = _screen_content_enabled(bool(body.get("screen_content", False)) or None)
+    raw_screen = body.get("screen_content")
+    screen_content = _screen_content_enabled(None if raw_screen is None else bool(raw_screen))
 
     try:
         otlp = fetch_traces(provider, credentials, limit=limit, include_content=screen_content)

--- a/src/agent_bom/ast_csharp.py
+++ b/src/agent_bom/ast_csharp.py
@@ -25,6 +25,7 @@ from agent_bom.ast_models import (
     _CSharpToolRegistration,
 )
 from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
+from agent_bom.ast_source_mask import mask_line_comments_and_strings
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_nuget_package
 
 if TYPE_CHECKING:
@@ -136,6 +137,7 @@ def _csharp_local_bindings(body: str, import_bindings: Mapping[str, str]) -> dic
 
 
 def _csharp_call_sites(body: str, *, line_offset: int) -> list[_CSharpCallSite]:
+    body = mask_line_comments_and_strings(body)
     sites: list[_CSharpCallSite] = []
     for match in _CS_CALL_RE.finditer(body):
         name = match.group("name")

--- a/src/agent_bom/ast_java.py
+++ b/src/agent_bom/ast_java.py
@@ -25,6 +25,7 @@ from agent_bom.ast_models import (
     _JavaToolRegistration,
 )
 from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
+from agent_bom.ast_source_mask import mask_line_comments_and_strings
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_maven_coord
 
 if TYPE_CHECKING:
@@ -157,6 +158,7 @@ def _java_import_bindings(source: str, maven_map: Mapping[str, str]) -> dict[str
 
 
 def _java_call_sites(body: str, *, line_offset: int) -> list[_JavaCallSite]:
+    body = mask_line_comments_and_strings(body)
     sites: list[_JavaCallSite] = []
     for match in _JAVA_CALL_RE.finditer(body):
         name = match.group("name")

--- a/src/agent_bom/ast_ruby.py
+++ b/src/agent_bom/ast_ruby.py
@@ -25,6 +25,7 @@ from agent_bom.ast_models import (
     _RubyToolRegistration,
 )
 from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
+from agent_bom.ast_source_mask import mask_line_comments_and_strings
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_verified_ruby_gem
 
 if TYPE_CHECKING:
@@ -127,6 +128,7 @@ def _ruby_local_bindings(body: str, import_bindings: Mapping[str, str]) -> dict[
 
 
 def _ruby_call_sites(body: str, *, line_offset: int) -> list[_RubyCallSite]:
+    body = mask_line_comments_and_strings(body, hash_comments=True)
     sites: list[_RubyCallSite] = []
     for match in _RUBY_CALL_RE.finditer(body):
         name = match.group("name")

--- a/src/agent_bom/ast_rust.py
+++ b/src/agent_bom/ast_rust.py
@@ -25,6 +25,7 @@ from agent_bom.ast_models import (
     _RustToolRegistration,
 )
 from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
+from agent_bom.ast_source_mask import mask_line_comments_and_strings
 from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol, is_external_rust_crate
 
 if TYPE_CHECKING:
@@ -82,6 +83,7 @@ def _rust_use_bindings(source: str) -> dict[str, str]:
 
 
 def _rust_call_sites(body: str, *, line_offset: int) -> list[_RustCallSite]:
+    body = mask_line_comments_and_strings(body)
     sites: list[_RustCallSite] = []
     for match in _RUST_CALL_RE.finditer(body):
         name = match.group("name")

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -23,6 +23,7 @@ from agent_bom.asset_provenance import (
 from agent_bom.checksums import cyclonedx_hashes
 from agent_bom.models import AIBOMReport
 from agent_bom.security import sanitize_launch_command, sanitize_path_label
+from agent_bom.vex import vex_justification_to_cdx
 
 
 def _sanitize_bom_ref(raw: str) -> str:
@@ -484,7 +485,9 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                             "state": _cdx_state_map.get(vuln.vex_status, "in_triage"),
                         }
                         if vuln.vex_justification:
-                            analysis_dict["justification"] = vuln.vex_justification
+                            cdx_justification = vex_justification_to_cdx(vuln.vex_justification)
+                            if cdx_justification:
+                                analysis_dict["justification"] = cdx_justification
                         vuln_entry["analysis"] = analysis_dict
                     vulnerabilities_cdx.append(vuln_entry)
 

--- a/src/agent_bom/vex.py
+++ b/src/agent_bom/vex.py
@@ -101,6 +101,37 @@ _CDX_JUSTIFICATION_TO_VEX: dict[str, VexJustification] = {
     "protected_by_mitigating_control": VexJustification.INLINE_MITIGATIONS_ALREADY_EXIST,
 }
 
+# Inverse of _CDX_JUSTIFICATION_TO_VEX: OpenVEX justification -> CycloneDX
+# ``impactAnalysisJustification`` enum member. The forward map is many-to-one
+# (several CDX members collapse onto one OpenVEX value), so this picks a single
+# canonical CDX member per OpenVEX justification. Used when emitting CycloneDX
+# ``analysis.justification`` — the OpenVEX vocabulary is not a valid CDX enum
+# member and would produce a schema-invalid document.
+_VEX_JUSTIFICATION_TO_CDX: dict[VexJustification, str] = {
+    VexJustification.COMPONENT_NOT_PRESENT: "requires_dependency",
+    VexJustification.VULNERABLE_CODE_NOT_PRESENT: "code_not_present",
+    VexJustification.VULNERABLE_CODE_NOT_IN_EXECUTE_PATH: "code_not_reachable",
+    VexJustification.VULNERABLE_CODE_CANNOT_BE_CONTROLLED_BY_ADVERSARY: "requires_configuration",
+    VexJustification.INLINE_MITIGATIONS_ALREADY_EXIST: "protected_by_mitigating_control",
+}
+
+
+def vex_justification_to_cdx(justification: str | None) -> str | None:
+    """Translate an OpenVEX justification string to a CycloneDX enum member.
+
+    Returns ``None`` when the input is empty or is not a recognized OpenVEX
+    justification, so callers omit ``analysis.justification`` rather than emit a
+    value CycloneDX rejects.
+    """
+    if not justification:
+        return None
+    try:
+        vex_value = VexJustification(justification)
+    except ValueError:
+        return None
+    return _VEX_JUSTIFICATION_TO_CDX.get(vex_value)
+
+
 _CSAF_STATUS_TO_VEX: dict[str, VexStatus] = {
     "fixed": VexStatus.FIXED,
     "known_not_affected": VexStatus.NOT_AFFECTED,

--- a/tests/test_ast_reach_masking.py
+++ b/tests/test_ast_reach_masking.py
@@ -1,0 +1,72 @@
+"""Compiled-language reachability must mask comments + string literals (bug-fix).
+
+The Rust/Java/Ruby/C# call-site extractors ran ``finditer`` over RAW source, so a
+dependency symbol mentioned only inside a ``//``/``#`` comment or a string
+literal was emitted as a real call site — a reachability over-claim that flips a
+non-reachable CVE to ``function_reachable``. Each extractor must mask comments +
+strings first, exactly like the PHP/Swift analyzers. A real call must still be
+captured.
+"""
+
+from __future__ import annotations
+
+from agent_bom.ast_csharp import _csharp_call_sites
+from agent_bom.ast_java import _java_call_sites
+from agent_bom.ast_ruby import _ruby_call_sites
+from agent_bom.ast_rust import _rust_call_sites
+
+
+def _names(fn, body: str) -> set[str]:
+    return {site.name for site in fn(body, line_offset=0)}
+
+
+# --------------------------------------------------------------------------- #
+# Rust                                                                        #
+# --------------------------------------------------------------------------- #
+def test_rust_real_call_captured() -> None:
+    assert "client.request" in _names(_rust_call_sites, "client.request(url);")
+
+
+def test_rust_comment_and_string_mentions_masked() -> None:
+    body = '// client.request(secret)\nlet note = "client.request(secret)";\n'
+    assert _names(_rust_call_sites, body) == set()
+
+
+def test_rust_block_comment_mention_masked() -> None:
+    assert _names(_rust_call_sites, "/* client.request(x) */") == set()
+
+
+# --------------------------------------------------------------------------- #
+# Java                                                                        #
+# --------------------------------------------------------------------------- #
+def test_java_real_call_captured() -> None:
+    assert "client.execute" in _names(_java_call_sites, "client.execute(req);")
+
+
+def test_java_comment_and_string_mentions_masked() -> None:
+    body = '// client.execute(secret)\nString s = "client.execute(secret)";\n'
+    assert _names(_java_call_sites, body) == set()
+
+
+# --------------------------------------------------------------------------- #
+# Ruby (# comments)                                                           #
+# --------------------------------------------------------------------------- #
+def test_ruby_real_call_captured() -> None:
+    assert "client.get" in _names(_ruby_call_sites, "client.get(url)")
+
+
+def test_ruby_comment_and_string_mentions_masked() -> None:
+    body = '# client.get(secret)\ns = "client.get(secret)"\n'
+    assert _names(_ruby_call_sites, body) == set()
+
+
+# --------------------------------------------------------------------------- #
+# C#                                                                          #
+# --------------------------------------------------------------------------- #
+def test_csharp_real_call_captured() -> None:
+    assert "client.Send" in _names(_csharp_call_sites, "client.Send(req);")
+
+
+def test_csharp_comment_and_string_mentions_masked() -> None:
+    body = '// client.Send(secret)\nvar s = "client.Send(secret)";\n'
+    assert _names(_csharp_call_sites, body) == set()

--- a/tests/test_cyclonedx_vex_justification.py
+++ b/tests/test_cyclonedx_vex_justification.py
@@ -1,0 +1,149 @@
+"""CycloneDX VEX ``analysis.justification`` must use the CDX enum (bug-fix).
+
+A VEX-suppressed (``not_affected``) finding carries an OpenVEX-vocabulary
+``vex_justification`` (e.g. ``vulnerable_code_not_present``). That vocabulary is
+DISJOINT from CycloneDX's ``impactAnalysisJustification`` enum
+(``code_not_present``, ``code_not_reachable``, ...). Emitting the raw OpenVEX
+value produces a ``analysis`` object that a CDX 1.7 validator rejects
+(``analysis`` is ``additionalProperties: false``). The exporter must translate to
+the CDX enum via the inverse of ``vex._CDX_JUSTIFICATION_TO_VEX``, omitting the
+justification when no valid mapping exists (keeping the ``state``).
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from agent_bom.models import (
+    Agent,
+    AgentType,
+    AIBOMReport,
+    BlastRadius,
+    MCPServer,
+    MCPTool,
+    Package,
+    Severity,
+    Vulnerability,
+)
+from agent_bom.output.cyclonedx_fmt import to_cyclonedx
+from agent_bom.vex import VexJustification
+
+jsonschema = pytest.importorskip("jsonschema")
+from jsonschema import Draft201909Validator  # noqa: E402
+from referencing import Registry, Resource  # noqa: E402
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+# The valid CycloneDX 1.7 impactAnalysisJustification enum == the forward-map keys.
+_CDX_JUSTIFICATION_ENUM = {
+    "code_not_present",
+    "code_not_reachable",
+    "requires_configuration",
+    "requires_dependency",
+    "requires_environment",
+    "protected_by_compiler",
+    "protected_at_runtime",
+    "protected_at_perimeter",
+    "protected_by_mitigating_control",
+}
+
+
+def _cyclonedx_registry() -> Registry:
+    resources = []
+    for name in (
+        "cyclonedx-1.7.schema.json",
+        "spdx.schema.json",
+        "jsf-0.82.schema.json",
+        "cryptography-defs.schema.json",
+    ):
+        path = _FIXTURES / name
+        if not path.exists():
+            continue
+        schema = json.loads(path.read_text())
+        uri = schema.get("$id") or schema.get("id")
+        if uri:
+            resources.append((uri, Resource.from_contents(schema)))
+    return Registry().with_resources(resources)
+
+
+def _report_with_vex(justification: str) -> AIBOMReport:
+    vuln = Vulnerability(
+        id="CVE-2026-0001",
+        summary="RCE in flask",
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        vex_status="not_affected",
+        vex_justification=justification,
+    )
+    pkg = Package(
+        name="flask",
+        version="0.12.2",
+        ecosystem="pypi",
+        purl="pkg:pypi/flask@0.12.2",
+        vulnerabilities=[vuln],
+        is_direct=True,
+    )
+    server = MCPServer(name="db-server", packages=[pkg], tools=[MCPTool(name="query", description="sql")])
+    agent = Agent(
+        name="claude-desktop",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/cd.json",
+        mcp_servers=[server],
+        version="1.0",
+    )
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[server],
+        affected_agents=[agent],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    br.calculate_risk_score()
+    return AIBOMReport(
+        agents=[agent],
+        blast_radii=[br],
+        scan_sources=["agent_discovery"],
+        scan_id="3c249b23-4088-4c46-911d-1d4daf950e47",
+        tool_version="0.0.0-test",
+        generated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _analysis_blocks(cdx: dict) -> list[dict]:
+    return [v["analysis"] for v in cdx.get("vulnerabilities", []) if "analysis" in v]
+
+
+@pytest.mark.parametrize("justification", [j.value for j in VexJustification])
+def test_openvex_justification_maps_to_cdx_enum(justification: str) -> None:
+    cdx = to_cyclonedx(_report_with_vex(justification))
+    blocks = _analysis_blocks(cdx)
+    assert blocks, "not_affected finding should emit an analysis block"
+    for analysis in blocks:
+        assert analysis["state"] == "not_affected"
+        if "justification" in analysis:
+            assert analysis["justification"] in _CDX_JUSTIFICATION_ENUM
+
+
+def test_unknown_justification_is_omitted_not_passed_through() -> None:
+    cdx = to_cyclonedx(_report_with_vex("some_bespoke_reason"))
+    for analysis in _analysis_blocks(cdx):
+        assert "justification" not in analysis
+        assert analysis["state"] == "not_affected"
+
+
+@pytest.mark.parametrize("justification", [j.value for j in VexJustification])
+def test_cyclonedx_with_vex_validates_against_1_7_schema(justification: str) -> None:
+    schema_path = _FIXTURES / "cyclonedx-1.7.schema.json"
+    if not schema_path.exists():
+        pytest.skip("vendored CDX 1.7 schema unavailable")
+    schema = json.loads(schema_path.read_text())
+    cdx = to_cyclonedx(_report_with_vex(justification))
+    validator = Draft201909Validator(schema, registry=_cyclonedx_registry())
+    errors = sorted(validator.iter_errors(cdx), key=lambda e: list(e.path))
+    rendered = "\n".join(f"  - {'/'.join(str(p) for p in e.path)}: {e.message}" for e in errors[:20])
+    assert not errors, f"CDX with VEX justification={justification} not schema-valid:\n{rendered}"

--- a/tests/test_governance_audit_actor.py
+++ b/tests/test_governance_audit_actor.py
@@ -1,0 +1,65 @@
+"""Governance audit actor attribution (pre-release bug-fix).
+
+The identity/delegation/JIT/conditional-access/access-review and mcp-config
+lifecycle routes seal an ``actor`` into the signed audit chain and fan it out to
+governance webhooks. ``request.state.actor`` is never populated in ``src/`` — the
+auth middleware sets ``request.state.api_key_name`` — so the ``_actor`` helper
+must fall back to ``api_key_name`` before the ``"api"`` sentinel, exactly like
+``routes/blueprints.py``. Otherwise every governance action records a blank
+``actor="api"``, destroying the accountability the surface exists to provide.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent_bom.api.audit_log import InMemoryAuditLog, log_action, set_audit_log
+from agent_bom.api.routes import identities as identities_routes
+from agent_bom.api.routes import mcp_config as mcp_config_routes
+
+
+def _request(api_key_name: str | None = None, actor: str | None = None) -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(api_key_name=api_key_name, actor=actor))
+
+
+def test_identities_actor_prefers_api_key_name() -> None:
+    assert identities_routes._actor(_request(api_key_name="ci-token")) == "ci-token"
+
+
+def test_mcp_config_actor_prefers_api_key_name() -> None:
+    assert mcp_config_routes._actor(_request(api_key_name="ci-token")) == "ci-token"
+
+
+def test_actor_prefers_explicit_actor_over_api_key_name() -> None:
+    req = _request(api_key_name="ci-token", actor="alice@corp")
+    assert identities_routes._actor(req) == "alice@corp"
+    assert mcp_config_routes._actor(req) == "alice@corp"
+
+
+def test_actor_falls_back_to_api_sentinel_when_unset() -> None:
+    req = _request()
+    assert identities_routes._actor(req) == "api"
+    assert mcp_config_routes._actor(req) == "api"
+
+
+def test_governance_audit_records_api_key_name_and_chain_verifies() -> None:
+    """Identity + mcp-config actions seal the real actor and the chain verifies."""
+    store = InMemoryAuditLog()
+    set_audit_log(store)
+
+    req = _request(api_key_name="ci-token")
+    identity_actor = identities_routes._actor(req)
+    mcp_actor = mcp_config_routes._actor(req)
+
+    log_action("agent_identity.issue", actor=identity_actor, resource="agent-1", tenant_id="default")
+    log_action("mcp_config.assign", actor=mcp_actor, resource="cfg-1", tenant_id="default")
+
+    entries = store.list_entries(limit=10, tenant_id="default")
+    actors = {e.action: e.actor for e in entries}
+    assert actors["agent_identity.issue"] == "ci-token"
+    assert actors["mcp_config.assign"] == "ci-token"
+    assert "api" not in actors.values()
+
+    verified, tampered = store.verify_integrity(tenant_id="default")
+    assert tampered == 0
+    assert verified >= 2

--- a/tests/test_trace_pull_screen_content.py
+++ b/tests/test_trace_pull_screen_content.py
@@ -1,0 +1,58 @@
+"""Trace-connector pull honors an explicit ``screen_content`` opt-out (bug-fix).
+
+``POST /v1/traces/connectors/{provider}/pull`` collapsed the tri-state
+``screen_content`` body flag with ``bool(...) or None``, turning an explicit
+``false`` into ``None`` and letting the deployment default
+(``AGENT_BOM_TRACE_CONTENT_SCREENING``) override a caller's explicit opt-out. The
+push path already threads the tri-state through correctly; the pull path must
+match: ``false`` respected, absent → default, ``true`` → screened.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import agent_bom.api.routes.observability as obs
+
+
+def _request() -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(tenant_id="default"))
+
+
+def _call_pull(monkeypatch: Any, body: dict, *, default_on: bool) -> dict:
+    monkeypatch.setattr(obs, "_tenant_id", lambda request: "default")
+    monkeypatch.setattr(obs, "_blast_radius_views_for_tenant", lambda tenant_id: [])
+    monkeypatch.setattr(obs, "_nhi_by_credential_for_tenant", lambda tenant_id: {})
+    # Deployment default for content screening.
+    monkeypatch.setattr(
+        "agent_bom.config.trace_content_screening_enabled", lambda: default_on
+    )
+    # Stub the connector fetch + screening so we observe only the resolved flag.
+    monkeypatch.setattr("agent_bom.trace_connectors.fetch_traces", lambda *a, **k: {"spans": []})
+    monkeypatch.setattr(obs, "_screen_trace_content_events", lambda body, *, tenant_id: [{"detector": "x"}])
+    return asyncio.run(obs.pull_trace_connector(_request(), "langfuse", body))
+
+
+def test_pull_screen_content_false_respected_when_default_on(monkeypatch: Any) -> None:
+    result = _call_pull(monkeypatch, {"credentials": {"k": "v"}, "screen_content": False}, default_on=True)
+    assert result["content_screened"] is False
+    assert result["content_findings"] == []
+
+
+def test_pull_screen_content_absent_uses_default_on(monkeypatch: Any) -> None:
+    result = _call_pull(monkeypatch, {"credentials": {"k": "v"}}, default_on=True)
+    assert result["content_screened"] is True
+    assert result["content_findings"]
+
+
+def test_pull_screen_content_absent_uses_default_off(monkeypatch: Any) -> None:
+    result = _call_pull(monkeypatch, {"credentials": {"k": "v"}}, default_on=False)
+    assert result["content_screened"] is False
+
+
+def test_pull_screen_content_true_screens_when_default_off(monkeypatch: Any) -> None:
+    result = _call_pull(monkeypatch, {"credentials": {"k": "v"}, "screen_content": True}, default_on=False)
+    assert result["content_screened"] is True
+    assert result["content_findings"]


### PR DESCRIPTION
Combined pre-release bug-fix PR from the pre-release bug-hunt lanes. **Kept open to fold in additional confirmed fixes** before finalizing.

## Fixes in this PR

### 1. Governance audit records `actor="api"` for identity/delegation/mcp-config actions (accountability)
`routes/identities.py` and `routes/mcp_config.py` `_actor()` returned `request.state.actor or "api"`, but `request.state.actor` is never set in `src/` — auth middleware sets `request.state.api_key_name`. So every identity issue/rotate/revoke, JIT grant/approve/deny/revoke, delegation issue/propagate, conditional-access change, access-review decision, and mcp-config action sealed a blank `actor="api"` into the signed audit chain + governance webhooks.
- Both `_actor()` now mirror `routes/blueprints.py`: `state.actor` → `state.api_key_name` → `"api"`.

### 2. `screen_content=false` silently ignored on trace-connector pull
`routes/observability.py` pull path used `bool(body.get("screen_content", False)) or None`, collapsing an explicit `false` to `None` → resolved to the deployment default, overriding a caller's explicit opt-out when `AGENT_BOM_TRACE_CONTENT_SCREENING=1`.
- Now threads the tri-state through directly (mirrors the push path): `None` only when absent.

### 3. CycloneDX exported a schema-invalid `analysis.justification`
`output/cyclonedx_fmt.py` passed the OpenVEX-vocabulary `vex_justification` through raw; that vocabulary is disjoint from CycloneDX's `impactAnalysisJustification` enum, and `analysis` is `additionalProperties:false`, so any `not_affected` finding with a justification produced a doc a 1.7 validator rejects.
- New `vex.vex_justification_to_cdx()` (inverse of `_CDX_JUSTIFICATION_TO_VEX`) translates to a valid CDX enum member; omits the justification when no mapping exists (keeps the `state`).

### 4. Reachability over-claim: Rust/Java/Ruby/C# didn't mask comments/strings
`ast_rust.py`, `ast_java.py`, `ast_ruby.py`, `ast_csharp.py` ran call-site `finditer` over raw source, so a dependency symbol appearing only in a comment or string literal was emitted as a real reach (+reachability), flipping amber→red.
- Each `_*_call_sites` now masks with `mask_line_comments_and_strings` before extraction (Ruby with `hash_comments=True`), exactly like the PHP/Swift analyzers.

## Tests (TDD, all added test-first then made green)
- `tests/test_governance_audit_actor.py` — actor prefers api_key_name for both routes; end-to-end audit-chain records the real actor and integrity still verifies.
- `tests/test_trace_pull_screen_content.py` — pull respects explicit `false`, absent → default, `true` → screened.
- `tests/test_cyclonedx_vex_justification.py` — every VEX justification maps to a valid CDX enum member (or is absent) and the doc validates against the vendored 1.7 schema.
- `tests/test_ast_reach_masking.py` — per-language: comment/string-only mentions not reachable; real calls still captured.

## Gates
- New tests: 29 passed. `-k` regression selection: 374 passed, 4 skipped. Interop/ast/vex/cyclonedx suites green.
- `check_exception_sanitization.py` → 0 · `check-counts.py` → consistent · `make preflight` → green · `ruff` + `mypy` on touched modules → clean.

_Kept open — more fixes may be folded in before finalizing._