### PR TITLE
fix: pre-release self-host fixes — quickstart works out of the box

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,12 @@ RUN addgroup -S abom && adduser -S -G abom abom
 WORKDIR /workspace
 RUN chown abom:abom /workspace
 
+# Pre-create the state dir and hand ownership to abom (uid/gid of the abom
+# user) so a named volume or bind mount at /home/abom/.agent-bom is writable.
+# Without this the mount lands root-owned and abom (non-root) cannot create
+# jobs.db / vulns.db, crash-looping the API.
+RUN mkdir -p /home/abom/.agent-bom && chown -R abom:abom /home/abom
+
 USER abom
 
 ENV PYTHONUNBUFFERED=1

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint preflight preflight-fix docker-build docker-run scan clean build-ui analytics dev check-dupes clean-dupes
+.PHONY: help install test lint preflight preflight-fix docker-build docker-run scan clean build-ui analytics dev check-dupes clean-dupes secrets platform-up fullstack-up
 
 help:  ## Show this help message
 	@echo 'Usage: make [target]'
@@ -76,6 +76,15 @@ docker-compose-up:  ## Start Docker Compose services
 
 docker-compose-down:  ## Stop Docker Compose services
 	docker-compose -f deploy/docker-compose.yml down -v
+
+secrets:  ## Generate the mounted Docker secret files (idempotent; run before platform/fullstack up)
+	python scripts/deploy/hosted_poc_preflight.py --write-secret --skip-compose
+
+platform-up: secrets  ## Bring up the production-shaped platform stack (generates secrets first)
+	docker compose -f deploy/docker-compose.platform.yml up --build -d
+
+fullstack-up: secrets  ## Bring up the dev full-stack (API + UI + Postgres); generates secrets first
+	docker compose -f deploy/docker-compose.fullstack.yml up --build -d
 
 build-ui:  ## Build Next.js dashboard and bundle into package
 	bash scripts/build-ui.sh

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -18,9 +18,11 @@
 #   chmod 0400 deploy/secrets/*
 #
 # Usage (local dev):
-#   cp .env.example .env   # ports / non-secret URL only
-#   # create the secret files above (or: hosted_poc_preflight.py --write-secret --skip-compose)
-#   docker compose -f deploy/docker-compose.fullstack.yml up
+#   # 1. Generate the mounted secret files FIRST — `up` hard-fails without them:
+#   make secrets
+#   #    (equivalent: python scripts/deploy/hosted_poc_preflight.py --write-secret --skip-compose)
+#   # 2. cp .env.example .env   # ports / non-secret URL only
+#   # 3. docker compose -f deploy/docker-compose.fullstack.yml up   (or: make fullstack-up)
 #
 # Then open:
 #   Dashboard  →  http://localhost:3000
@@ -29,8 +31,6 @@
 # For production, swap the postgres service for a managed Postgres/Supabase URL
 # that uses IAM/cert auth when available, or mount AGENT_BOM_POSTGRES_PASSWORD_FILE
 # for the DML-only app role — never the bootstrap/admin role.
-
-version: '3.8'
 
 services:
 
@@ -98,12 +98,14 @@ services:
     build:
       context: ../ui/
       dockerfile: Dockerfile
-      args:
-        # Baked into the Next.js build — must match the publicly reachable API URL
-        NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://localhost:8422}
     image: agentbom/agent-bom-ui:0.95.0
     container_name: agent-bom-ui
     restart: unless-stopped
+    environment:
+      # The browser same-origins to this UI; the UI's Node server proxies
+      # /v1,/health,/ws to NEXT_PUBLIC_API_URL, which must be the API
+      # container's in-network DNS name — not the browser's localhost.
+      NEXT_PUBLIC_API_URL: ${NEXT_PUBLIC_API_URL:-http://api:8422}
     ports:
       - "127.0.0.1:${UI_PORT:-3000}:3000"
     networks:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -62,7 +62,10 @@ services:
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:
-      NEXT_PUBLIC_API_URL: http://localhost:8422
+      # The browser same-origins to this UI; the UI's Node server proxies
+      # /v1,/health,/ws to NEXT_PUBLIC_API_URL, which must be the API
+      # container's in-network DNS name — not the browser's localhost.
+      NEXT_PUBLIC_API_URL: http://api:8422
     ports:
       - "127.0.0.1:3000:3000"
     depends_on:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 # ── Profile: PRODUCTION-SHAPED ──────────────────────────────────────────────
 # Production-like platform deployment: self-hosted `agent-bom` control plane
 # with PostgreSQL, using one product split across two images:
@@ -29,10 +27,12 @@ version: "3.8"
 #     Placeholders live at deploy/secrets/*.example for documentation only.
 #
 # Usage:
-#   cp .env.example .env                     # non-secret URL / OIDC issuer only
-#   python scripts/deploy/hosted_poc_preflight.py --write-secret --skip-compose
-#   # or write files manually — see deploy/secrets/README.md
-#   docker compose -f deploy/docker-compose.platform.yml up --build
+#   # 1. Generate the mounted secret files FIRST — `up` hard-fails without them:
+#   make secrets
+#   #    (equivalent: python scripts/deploy/hosted_poc_preflight.py --write-secret --skip-compose;
+#   #     or write files manually — see deploy/secrets/README.md)
+#   # 2. cp .env.example .env                  # non-secret URL / OIDC issuer only
+#   # 3. docker compose -f deploy/docker-compose.platform.yml up --build   (or: make platform-up)
 
 services:
   postgres:
@@ -134,7 +134,10 @@ services:
     ports:
       - "${AGENT_BOM_UI_BIND_HOST:-127.0.0.1}:${UI_PORT:-3000}:3000"
     environment:
-      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://localhost:8422}
+      # The browser same-origins to this UI; the UI's Node server proxies
+      # /v1,/health,/ws to NEXT_PUBLIC_API_URL, which must be the API
+      # container's in-network DNS name — not the browser's localhost.
+      - NEXT_PUBLIC_API_URL=${NEXT_PUBLIC_API_URL:-http://api:8422}
     depends_on:
       api:
         condition: service_healthy

--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -54,24 +54,27 @@ pointing back to it; in the self-hosted tiers both sides live in your account.
 
 ## Tier 1 — Self-hosted anywhere (laptop / VM, fastest)
 
-One command brings up API + UI + Postgres with Docker Compose. Best for trying
-the full product, a single-team pilot, or an air-gapped VM.
+API + UI + Postgres with Docker Compose. Best for trying the full product, a
+single-team pilot, or an air-gapped VM.
+
+**Step 1 — generate the mounted secret files first.** `docker compose up`
+hard-fails with a bare "secret file not found" if you skip this:
 
 ```bash
-cp .env.example .env
-mkdir -p deploy/secrets
-printf '%s' "$(openssl rand -hex 32)" > deploy/secrets/postgres_password
-printf '%s' "$(openssl rand -hex 32)" > deploy/secrets/postgres_app_password
-printf '%s' "$(openssl rand -hex 32)" > deploy/secrets/api_key
-printf '%s' "$(openssl rand -hex 32)" > deploy/secrets/audit_hmac_key
-printf '%s' "$(openssl rand -hex 32)" > deploy/secrets/browser_session_signing_key
-printf '%s' "$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')" \
-  > deploy/secrets/connections_key
-chmod 0400 deploy/secrets/postgres_password deploy/secrets/postgres_app_password \
-  deploy/secrets/api_key deploy/secrets/audit_hmac_key \
-  deploy/secrets/browser_session_signing_key deploy/secrets/connections_key
-docker compose -f deploy/docker-compose.fullstack.yml up
+make secrets            # writes deploy/secrets/* (idempotent)
+# equivalent: python scripts/deploy/hosted_poc_preflight.py --write-secret --skip-compose
 ```
+
+**Step 2 — bring the stack up:**
+
+```bash
+cp .env.example .env    # ports / non-secret URL only
+make fullstack-up       # == docker compose -f deploy/docker-compose.fullstack.yml up --build -d
+```
+
+Prefer to write the secret files by hand? Generate all six with `openssl` /
+Fernet as documented in [`deploy/secrets/README.md`](../deploy/secrets/README.md),
+`chmod 0400` them, then run the compose command above.
 
 Postgres and control-plane secrets are Docker secret files only — never `.env`
 or compose env. The API connects as `agent_bom_app` (DML-only), not the image

--- a/site-docs/deployment/quickstart.md
+++ b/site-docs/deployment/quickstart.md
@@ -23,9 +23,10 @@ audit flow into one graph — no mandatory vendor SaaS.
 ## Ten-minute proof path
 
 ```bash
+# Step 1: generate the mounted secret files FIRST — the production-shaped
+# stack hard-fails with "secret file not found" without them.
+make secrets   # == python scripts/deploy/hosted_poc_preflight.py --write-secret --skip-compose
 cp .env.example .env
-# Generate the mounted files in deploy/secrets/ as documented in
-# deploy/secrets/README.md before starting the production-shaped stack.
 scripts/deploy/install.sh platform-docker
 scripts/deploy/install.sh connect aws       # or azure | gcp | snowflake
 scripts/deploy/install.sh onboard \


### PR DESCRIPTION
The 0.95.0 self-host quickstart did not come up out of the box. Bug-hunt reproduced two P0s on the published images, plus P1/P2 friction. Fixes below, each with the reproduced-break → fixed reasoning.

## Fixes

### P0-1 · Dockerfile: create + chown the state dir (unbricks the API)
`Dockerfile` did `USER abom` (uid 100) but never created/chowned `/home/abom/.agent-bom`. The pilot named volume `agent-bom-pilot-data` (and platform `agent-bom-state`) mounts over that path root-owned → non-root `abom` cannot create `jobs.db`/`vulns.db` → API crash-loops → UI never starts (`depends_on: service_healthy`).
Fix: before `USER abom`, `RUN mkdir -p /home/abom/.agent-bom && chown -R abom:abom /home/abom`. A fresh named volume inherits the (now abom-owned) image mount-point, so the app can write.

### P0-2 · Compose: point the UI at the API service DNS
`ui.NEXT_PUBLIC_API_URL` was `http://localhost:8422` in pilot/fullstack/platform. The UI's Node server (per `ui/next.config.ts`) proxies `/v1,/health,/ws` to that URL from *inside* the compose network — `localhost` there is the UI container itself, so every API call failed. Set it to the API service DNS `http://api:8422` (the `api` service is the canonical compose network alias in all three files).

### P1-1 · Lead the quickstart with secret generation
platform/fullstack need six mounted secret files (only `*.example` committed); `docker compose up` hard-fails with a bare "secret file not found" if skipped. Made secret-gen step 1 in both compose headers and the docs (`docs/DEPLOY_PLATFORM.md`, `site-docs/deployment/quickstart.md`), and added `make secrets` / `make platform-up` / `make fullstack-up` (secrets target runs `hosted_poc_preflight.py --write-secret --skip-compose`).

### P1-2 · Drop the dead fullstack build-arg
`docker-compose.fullstack.yml` passed `NEXT_PUBLIC_API_URL` as `build.args` but `ui/Dockerfile` has no matching `ARG` → silently ignored. Removed it; the P0-2 runtime env is what matters.

### P2 · Remove obsolete `version: '3.8'`
Dropped from fullstack + platform (modern Docker warns on it).

## Verification (built + booted — real repro, then torn down)
Built the API + UI images with the fixes and brought up the pilot stack:
- **P0-1:** `agent-bom-pilot-api` reached `Up (healthy)` on a fresh named volume; `jobs.db` created and owned by `abom` (uid 100) — no crash loop. Pre-fix, the same mount is root-owned and the write fails.
- **P0-2:** from inside the compose network, `http://api:8422/health` returns **HTTP 200** — the exact origin the UI's Node server proxies to. With the old `localhost:8422` the UI server would hit itself (connection refused).
- **Static:** `docker compose -f deploy/docker-compose.{pilot,fullstack,platform}.yml config` all exit 0 with no `version` warning; rendered `ui` env is `http://api:8422` in all three; Dockerfile chown line is immediately before `USER abom`.

## Security defaults confirmed untouched
`AGENT_BOM_NO_AUTH_ROLE=analyst`, file-mounted Docker secrets, non-superuser `agent_bom_app` DB role, loopback (`127.0.0.1`) binds, internal-only Postgres network (`internal: true`), connections_key auto-seed — all intact.

## ⚠️ Overlap note for reconciliation
The in-flight `control-plane-secrets-files` branch also edits `deploy/docker-compose.{fullstack,platform,product}.yml` and `deploy/secrets/`. This PR's compose changes were kept minimal and surgical (only the `ui` `NEXT_PUBLIC_API_URL` line, the dead build-arg removal, the `version:` line, and the header-comment quickstart steps). Please reconcile at merge — no `deploy/secrets/` or Postgres-role changes were made here, and `docker-compose.product.yml` was intentionally left untouched to reduce overlap.