### PR TITLE
fix(ui): light-theme-legible toned chips + drawer a11y + empty-state copy

### DIFF
--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -155,7 +155,7 @@ function DiscoveryProvenanceTags({ provenance }: { provenance: DiscoveryProvenan
   return (
     <div className="flex flex-wrap gap-1.5">
       {tags.map((tag) => (
-        <span key={tag} className="rounded border border-sky-900/60 bg-sky-950/30 px-1.5 py-0.5 text-[10px] font-mono text-sky-300">
+        <span key={tag} className="rounded border border-sky-500/30 dark:border-sky-900/60 bg-sky-500/10 dark:bg-sky-950/30 px-1.5 py-0.5 text-[10px] font-mono text-sky-700 dark:text-sky-300">
           {tag}
         </span>
       ))}

--- a/ui/app/blueprints/page.tsx
+++ b/ui/app/blueprints/page.tsx
@@ -19,11 +19,11 @@ import { Collapsible } from "@/components/collapsible";
 function statusTone(status: string): string {
   switch (status) {
     case "approved":
-      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-300";
+      return "border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300";
     case "pending":
-      return "border-amber-900/60 bg-amber-950/30 text-amber-300";
+      return "border-amber-500/30 dark:border-amber-900/60 bg-amber-500/10 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300";
     case "rejected":
-      return "border-red-900/60 bg-red-950/30 text-red-300";
+      return "border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/30 text-red-700 dark:text-red-300";
     default:
       return "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]";
   }
@@ -278,7 +278,7 @@ function BlueprintDrawer({
       headerAside={blueprint ? <StatusPill status={blueprint.approval_status} /> : undefined}
     >
       {error ? (
-        <div className="rounded-lg border border-red-900/60 bg-red-950/30 px-3 py-2 text-sm text-red-300">{error}</div>
+        <div className="rounded-lg border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/30 px-3 py-2 text-sm text-red-700 dark:text-red-300">{error}</div>
       ) : null}
       {!detail ? (
         <div className="text-sm text-[color:var(--text-secondary)]">Loading blueprint…</div>
@@ -356,7 +356,7 @@ function BlueprintDrawer({
                         <button
                           onClick={() => onAction("reject", version.blueprint_id, version.version)}
                           disabled={!canApprove || busy}
-                          className="inline-flex items-center gap-1.5 rounded-lg border border-red-900/60 bg-red-950/30 px-3 py-1.5 text-xs text-red-300 transition hover:bg-red-950/50 disabled:cursor-not-allowed disabled:opacity-60"
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/30 px-3 py-1.5 text-xs text-red-700 dark:text-red-300 transition hover:bg-red-500/10 dark:hover:bg-red-950/50 disabled:cursor-not-allowed disabled:opacity-60"
                         >
                           Reject
                         </button>

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -388,10 +388,10 @@ const CONNECTOR_CATEGORIES: {
 ];
 
 const CONNECTOR_CATEGORY_TONE: Record<ConnectorCategory, string> = {
-  cloud: "border-purple-500/30 bg-purple-500/10 text-purple-200",
-  code: "border-sky-500/30 bg-sky-500/10 text-sky-200",
-  ai: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
-  data: "border-amber-500/30 bg-amber-500/10 text-amber-200",
+  cloud: "border-purple-500/30 bg-purple-500/10 text-purple-700 dark:text-purple-200",
+  code: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200",
+  ai: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
+  data: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200",
 };
 
 const SCHEDULE_OPTIONS = [
@@ -425,14 +425,14 @@ function eventMode(connection: CloudConnectionRecord): {
     return {
       label: "Event-driven",
       detail: `Last event ${formatWhen(connection.last_event_at)}`,
-      tone: "border-cyan-900/60 bg-cyan-950/30 text-cyan-200",
+      tone: "border-cyan-500/30 dark:border-cyan-900/60 bg-cyan-500/10 dark:bg-cyan-950/30 text-cyan-700 dark:text-cyan-200",
     };
   }
   if (connection.scan_interval_minutes) {
     return {
       label: "Scheduled scan",
       detail: `Every ${connection.scan_interval_minutes} min`,
-      tone: "border-amber-900/60 bg-amber-950/30 text-amber-200",
+      tone: "border-amber-500/30 dark:border-amber-900/60 bg-amber-500/10 dark:bg-amber-950/30 text-amber-700 dark:text-amber-200",
     };
   }
   return {
@@ -445,11 +445,11 @@ function eventMode(connection: CloudConnectionRecord): {
 function statusTone(status: string): string {
   switch (status) {
     case "active":
-      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-300";
+      return "border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300";
     case "error":
-      return "border-red-900/60 bg-red-950/30 text-red-300";
+      return "border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/30 text-red-700 dark:text-red-300";
     default:
-      return "border-amber-900/60 bg-amber-950/30 text-amber-300";
+      return "border-amber-500/30 dark:border-amber-900/60 bg-amber-500/10 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300";
   }
 }
 
@@ -752,7 +752,7 @@ export default function ConnectionsPage() {
         title="Connections"
         subtitle="Connect cloud accounts, code, AI, and data sources — read-only, with secrets encrypted at rest."
         scopeChip={
-          <span className="inline-flex items-center rounded-full border border-purple-500/30 bg-purple-500/10 px-2.5 py-0.5 text-[11px] font-medium text-purple-200">
+          <span className="inline-flex items-center rounded-full border border-purple-500/30 bg-purple-500/10 px-2.5 py-0.5 text-[11px] font-medium text-purple-700 dark:text-purple-200">
             {deploymentModeLabel(counts?.deployment_mode)} · brokered read-only
           </span>
         }
@@ -1237,7 +1237,7 @@ function ConnectorTile({
             onClick={() => onConnectCloud(connector.action.type === "cloud" ? connector.action.provider : "")}
             disabled={!canManage}
             aria-label={`Connect ${connector.label}`}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2.5 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-500 hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2.5 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-500 hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Plug className="h-3.5 w-3.5" />
             Connect
@@ -1247,7 +1247,7 @@ function ConnectorTile({
             type="button"
             onClick={onConnectCodingAgent}
             aria-label="Set up coding agent"
-            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2.5 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-500 hover:bg-emerald-500/20"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2.5 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-500 hover:bg-emerald-500/20"
           >
             <Plug className="h-3.5 w-3.5" />
             Set up
@@ -1256,7 +1256,7 @@ function ConnectorTile({
           <Link
             href={connector.action.href}
             aria-label={`Register ${connector.label}`}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1.5 text-xs font-medium text-[color:var(--foreground)] transition hover:border-emerald-600 hover:text-emerald-300"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1.5 text-xs font-medium text-[color:var(--foreground)] transition hover:border-emerald-600 hover:text-emerald-700 dark:hover:text-emerald-300"
           >
             Register
             <ArrowRight className="h-3.5 w-3.5" />
@@ -1300,7 +1300,7 @@ function CodingAgentDrawer({
         </span>
       }
       headerAside={
-        <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-900/60 bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-300">
+        <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
           <Bot className="h-3 w-3" /> 73 MCP tools
         </span>
       }
@@ -1368,7 +1368,7 @@ function CodingAgentDrawer({
           </ul>
         </section>
 
-        <p className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-900/50 bg-emerald-950/20 px-3 py-2 text-[11px] text-emerald-300">
+        <p className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/30 dark:border-emerald-900/50 bg-emerald-500/10 dark:bg-emerald-950/20 px-3 py-2 text-[11px] text-emerald-700 dark:text-emerald-300">
           <Lock className="h-3.5 w-3.5 shrink-0" /> Read-only. The server never
           writes to your cloud, repos, or control-plane data.
         </p>
@@ -1433,7 +1433,7 @@ function FragmentRow({
               </span>
             ) : null}
             {result ? (
-              <span className="inline-flex items-center gap-1 rounded border border-emerald-800/60 bg-emerald-950/20 px-1.5 py-0.5 text-[10px] text-emerald-300">
+              <span className="inline-flex items-center gap-1 rounded border border-emerald-500/30 dark:border-emerald-800/60 bg-emerald-500/10 dark:bg-emerald-950/20 px-1.5 py-0.5 text-[10px] text-emerald-700 dark:text-emerald-300">
                 CIS {formatPassRate(result.cis_benchmark.pass_rate)}
               </span>
             ) : null}
@@ -1504,7 +1504,7 @@ function FragmentRow({
                   ? "Verify the stored read-only credential without running inventory"
                   : "Testing for this provider is unavailable"
               }
-              className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-800/70 bg-emerald-950/20 px-3 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-600 hover:bg-emerald-950/40 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/30 dark:border-emerald-800/70 bg-emerald-500/10 dark:bg-emerald-950/20 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-600 hover:bg-emerald-500/10 dark:hover:bg-emerald-950/40 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <CheckCircle2 className="h-3.5 w-3.5" />
               {isBusy ? "Working…" : "Test"}
@@ -1526,7 +1526,7 @@ function FragmentRow({
               onClick={onDelete}
               disabled={isBusy || !canManage}
               aria-label={`Delete ${connection.display_name}`}
-              className="inline-flex items-center gap-1 rounded-lg border border-red-900/60 bg-red-950/20 px-3 py-1.5 text-xs font-medium text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
+              className="inline-flex items-center gap-1 rounded-lg border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/20 px-3 py-1.5 text-xs font-medium text-red-700 dark:text-red-300 transition hover:bg-red-500/10 dark:hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
             >
               <Trash2 className="h-3.5 w-3.5" />
               Delete
@@ -1587,7 +1587,7 @@ function ConnectionDetailDrawer({
           <button
             onClick={() => onTest(connection)}
             disabled={isBusy || !canManage || !scannable}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-800/70 bg-emerald-950/20 px-3 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-600 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/30 dark:border-emerald-800/70 bg-emerald-500/10 dark:bg-emerald-950/20 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-600 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <CheckCircle2 className="h-3.5 w-3.5" /> {isBusy ? "Working…" : "Test"}
           </button>
@@ -1601,7 +1601,7 @@ function ConnectionDetailDrawer({
           <button
             onClick={() => onDelete(connection)}
             disabled={isBusy || !canManage}
-            className="ml-auto inline-flex items-center gap-1 rounded-lg border border-red-900/60 bg-red-950/20 px-3 py-1.5 text-xs font-medium text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
+            className="ml-auto inline-flex items-center gap-1 rounded-lg border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/20 px-3 py-1.5 text-xs font-medium text-red-700 dark:text-red-300 transition hover:bg-red-500/10 dark:hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-60"
           >
             <Trash2 className="h-3.5 w-3.5" /> Delete
           </button>
@@ -1611,7 +1611,7 @@ function ConnectionDetailDrawer({
       <div className="space-y-3">
         {result ? <ScanResultPanel result={result} /> : null}
         {!result && testResult ? (
-          <div className="rounded-xl border border-emerald-900/60 bg-emerald-950/20 p-3 text-xs text-emerald-200">
+          <div className="rounded-xl border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/20 p-3 text-xs text-emerald-700 dark:text-emerald-200">
             Read-only credential verified. No inventory, CIS, findings, or
             resource writes ran.
           </div>
@@ -1620,17 +1620,17 @@ function ConnectionDetailDrawer({
           <ScanHandoffLinks scanId={handoffScanId} />
         ) : null}
         {scanError ? (
-          <div className="rounded-xl border border-red-900/60 bg-red-950/20 p-3 text-xs text-red-300">
+          <div className="rounded-xl border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/20 p-3 text-xs text-red-700 dark:text-red-300">
             {scanError}
           </div>
         ) : null}
         {scheduleError ? (
-          <div className="rounded-xl border border-red-900/60 bg-red-950/20 p-3 text-xs text-red-300">
+          <div className="rounded-xl border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/20 p-3 text-xs text-red-700 dark:text-red-300">
             {scheduleError}
           </div>
         ) : null}
         {statusDetail ? (
-          <div className="rounded-xl border border-amber-900/60 bg-amber-950/20 p-3 text-xs text-amber-200">
+          <div className="rounded-xl border border-amber-500/30 dark:border-amber-900/60 bg-amber-500/10 dark:bg-amber-950/20 p-3 text-xs text-amber-700 dark:text-amber-200">
             {statusDetail}
           </div>
         ) : null}
@@ -1744,7 +1744,7 @@ function HandoffLink({
   return (
     <Link
       href={href}
-      className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--foreground)] transition hover:border-emerald-700 hover:text-emerald-300"
+      className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5 text-[11px] font-medium text-[var(--foreground)] transition hover:border-emerald-700 hover:text-emerald-700 dark:hover:text-emerald-300"
     >
       <Icon className="h-3.5 w-3.5" />
       {label}
@@ -2095,7 +2095,7 @@ function AddConnectionWizard({
                         <button
                           type="button"
                           onClick={handleRegenerateExternalId}
-                          className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-200 transition hover:border-emerald-500"
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/60 bg-emerald-500/10 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-500"
                         >
                           <RefreshCcw className="h-3 w-3" />
                           Regenerate

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -263,7 +263,7 @@ function LateralPanel({
                   {r.description}
                 </p>
                 {r.owasp_agentic_tag && (
-                  <span className="inline-block mt-1 text-[9px] bg-purple-900/50 text-purple-300 px-1.5 py-0.5 rounded">
+                  <span className="inline-block mt-1 text-[9px] bg-purple-500/10 dark:bg-purple-900/50 text-purple-700 dark:text-purple-300 px-1.5 py-0.5 rounded">
                     {r.owasp_agentic_tag}
                   </span>
                 )}

--- a/ui/app/cost/page.tsx
+++ b/ui/app/cost/page.tsx
@@ -87,7 +87,7 @@ function BudgetPanel({ budget }: { budget: CostReport["budget"] }) {
         </div>
         No spend budget configured. Set one via{" "}
         <code className="rounded bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-xs text-[color:var(--text-secondary)]">
-          POST /v1/observability/costs/budget
+          PUT /v1/observability/costs/budget
         </code>{" "}
         to enable owner-scoped, pre-invocation enforcement at the gateway.
       </div>

--- a/ui/app/drift/page.tsx
+++ b/ui/app/drift/page.tsx
@@ -84,10 +84,10 @@ function IncidentCard({
             <span
               className={`rounded-full px-2 py-0.5 text-xs font-medium ${
                 incident.resolved
-                  ? "bg-emerald-900/60 text-emerald-300"
+                  ? "bg-emerald-500/10 dark:bg-emerald-900/60 text-emerald-700 dark:text-emerald-300"
                   : incident.status === "review"
-                    ? "bg-amber-900/60 text-amber-300"
-                    : "bg-red-900/60 text-red-300"
+                    ? "bg-amber-500/10 dark:bg-amber-900/60 text-amber-700 dark:text-amber-300"
+                    : "bg-red-500/10 dark:bg-red-900/60 text-red-700 dark:text-red-300"
               }`}
             >
               {incident.resolved
@@ -121,7 +121,7 @@ function IncidentCard({
                 setBusy(false);
               }
             }}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20 disabled:opacity-50"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20 disabled:opacity-50"
           >
             {busy ? (
               <Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -964,7 +964,7 @@ function FindingsPage() {
             : "aggregated across completed scans.",
         )}
         scopeChip={
-          <span className="inline-flex items-center rounded-full border border-cyan-500/30 bg-cyan-500/10 px-2.5 py-0.5 text-[11px] font-medium text-cyan-200">
+          <span className="inline-flex items-center rounded-full border border-cyan-500/30 bg-cyan-500/10 px-2.5 py-0.5 text-[11px] font-medium text-cyan-700 dark:text-cyan-200">
             Shared · Engineering &amp; Compliance
           </span>
         }
@@ -995,7 +995,7 @@ function FindingsPage() {
                 <button
                   onClick={handleExportVex}
                   disabled={vexExporting || vexEligibleCount === 0}
-                  className="flex items-center gap-1.5 rounded-lg border border-emerald-900 bg-emerald-950/40 px-3 py-1.5 text-sm font-medium text-emerald-300 transition-colors hover:bg-emerald-950/70 disabled:cursor-not-allowed disabled:opacity-50"
+                  className="flex items-center gap-1.5 rounded-lg border border-emerald-500/30 dark:border-emerald-900 bg-emerald-500/10 dark:bg-emerald-950/40 px-3 py-1.5 text-sm font-medium text-emerald-700 dark:text-emerald-300 transition-colors hover:bg-emerald-500/10 dark:hover:bg-emerald-950/70 disabled:cursor-not-allowed disabled:opacity-50"
                   title={
                     vexEligibleCount > 0
                       ? "Export signed OpenVEX JSON for findings triaged as not_affected"
@@ -1021,7 +1021,7 @@ function FindingsPage() {
       <p className="text-xs text-[color:var(--text-tertiary)]">{lensHint}</p>
 
       {triageError && (
-        <div className="rounded-lg border border-amber-900/60 bg-amber-950/20 px-3 py-2 text-sm text-amber-200">
+        <div className="rounded-lg border border-amber-500/30 dark:border-amber-900/60 bg-amber-500/10 dark:bg-amber-950/20 px-3 py-2 text-sm text-amber-700 dark:text-amber-200">
           {triageError}
         </div>
       )}
@@ -1086,7 +1086,7 @@ function FindingsPage() {
                 {lens === "trust" ? (
                   <a
                     href="/compliance"
-                    className="rounded-full border border-emerald-900/50 bg-emerald-950/30 px-2 py-1 text-emerald-300 hover:bg-emerald-950/50"
+                    className="rounded-full border border-emerald-500/30 dark:border-emerald-900/50 bg-emerald-500/10 dark:bg-emerald-950/30 px-2 py-1 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 dark:hover:bg-emerald-950/50"
                   >
                     Trust center
                   </a>
@@ -1232,7 +1232,7 @@ function FindingsPage() {
                     title={hint}
                     className={`rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ${
                       issueTypeFilter === key
-                        ? "border-cyan-700 bg-cyan-950/40 text-cyan-200"
+                        ? "border-cyan-700 bg-cyan-500/10 dark:bg-cyan-950/40 text-cyan-700 dark:text-cyan-200"
                         : "border-[var(--border-subtle)] text-[var(--text-tertiary)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]"
                     }`}
                   >

--- a/ui/app/fleet/page.tsx
+++ b/ui/app/fleet/page.tsx
@@ -537,7 +537,7 @@ export default function FleetPage() {
                           }}
                           disabled={quarantiningId === agent.agent_id}
                           title="Quarantine this agent and enforce a gateway DENY policy for its identity"
-                          className="flex items-center gap-1.5 rounded-md border border-red-800 bg-red-950/40 px-3 py-1.5 text-xs font-medium text-red-300 transition-colors hover:bg-red-900/40 disabled:opacity-50"
+                          className="flex items-center gap-1.5 rounded-md border border-red-500/30 dark:border-red-800 bg-red-500/10 dark:bg-red-950/40 px-3 py-1.5 text-xs font-medium text-red-700 dark:text-red-300 transition-colors hover:bg-red-500/10 dark:hover:bg-red-900/40 disabled:opacity-50"
                           data-testid="fleet-quarantine-deny"
                         >
                           {quarantiningId === agent.agent_id ? (

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -2357,7 +2357,7 @@ function GraphPageInner() {
               </span>
             )}
             {loadingGraph && (
-              <span className="flex items-center gap-1 rounded-lg border border-sky-500/20 bg-sky-500/10 px-2.5 py-1 text-sky-200">
+              <span className="flex items-center gap-1 rounded-lg border border-sky-500/20 bg-sky-500/10 px-2.5 py-1 text-sky-700 dark:text-sky-200">
                 <Loader2 className="h-3 w-3 animate-spin" />
                 refreshing
               </span>
@@ -2669,7 +2669,7 @@ function GraphPageInner() {
               </div>
             </summary>
             {diffError ? (
-              <div className="mt-3 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+              <div className="mt-3 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-200">
                 {diffError}
               </div>
             ) : loadingDiff && !graphDiff ? (
@@ -3153,11 +3153,11 @@ function MetricCard({
 }) {
   const accentClass =
     accent === "red"
-      ? "border-red-500/20 bg-red-500/10 text-red-200"
+      ? "border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-200"
       : accent === "orange"
-        ? "border-orange-500/20 bg-orange-500/10 text-orange-200"
+        ? "border-orange-500/20 bg-orange-500/10 text-orange-700 dark:text-orange-200"
         : accent === "blue"
-          ? "border-sky-500/20 bg-sky-500/10 text-sky-200"
+          ? "border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-200"
           : "border-[var(--border-subtle)] bg-[var(--surface)]/80 text-[var(--text-secondary)]";
 
   return (
@@ -3485,11 +3485,11 @@ function PathStat({
 }) {
   const toneClass =
     tone === "red"
-      ? "border-red-500/20 bg-red-500/10 text-red-200"
+      ? "border-red-500/20 bg-red-500/10 text-red-700 dark:text-red-200"
       : tone === "amber"
-        ? "border-amber-500/20 bg-amber-500/10 text-amber-200"
+        ? "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-200"
         : tone === "blue"
-          ? "border-sky-500/20 bg-sky-500/10 text-sky-200"
+          ? "border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-200"
           : "border-[var(--border-subtle)] bg-[var(--surface)]/80 text-[var(--text-secondary)]";
 
   return (
@@ -3543,10 +3543,10 @@ function DiffMetric({
 }) {
   const toneClass =
     tone === "green"
-      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-200"
+      ? "border-emerald-500/20 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
       : tone === "amber"
-        ? "border-amber-500/20 bg-amber-500/10 text-amber-200"
-        : "border-sky-500/20 bg-sky-500/10 text-sky-200";
+        ? "border-amber-500/20 bg-amber-500/10 text-amber-700 dark:text-amber-200"
+        : "border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-200";
 
   return (
     <div className={`rounded-xl border px-3 py-2 ${toneClass}`}>

--- a/ui/app/identity/page.tsx
+++ b/ui/app/identity/page.tsx
@@ -48,10 +48,10 @@ function Badge({
   children: React.ReactNode;
 }) {
   const map = {
-    green: "bg-emerald-900/60 text-emerald-300",
-    blue: "bg-blue-900/60 text-blue-300",
-    red: "bg-red-900/60 text-red-300",
-    amber: "bg-amber-900/60 text-amber-300",
+    green: "bg-emerald-500/10 dark:bg-emerald-900/60 text-emerald-700 dark:text-emerald-300",
+    blue: "bg-blue-500/10 dark:bg-blue-900/60 text-blue-700 dark:text-blue-300",
+    red: "bg-red-500/10 dark:bg-red-900/60 text-red-700 dark:text-red-300",
+    amber: "bg-amber-500/10 dark:bg-amber-900/60 text-amber-700 dark:text-amber-300",
     zinc: "bg-[var(--surface-elevated)] text-[var(--text-secondary)]",
   } as const;
   return (

--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -293,7 +293,7 @@ function JobsPageContent() {
                   </p>
                   <Link
                     href="/scan"
-                    className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
+                    className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
                   >
                     <ShieldAlert className="h-3.5 w-3.5" />
                     Run a scan

--- a/ui/app/manifest/page.tsx
+++ b/ui/app/manifest/page.tsx
@@ -54,7 +54,7 @@ function downloadManifest(manifest: AgentBomManifestResponse) {
 
 function ScopeChip({ label }: { label: string }) {
   return (
-    <span className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-0.5 text-[11px] font-medium text-emerald-200">
+    <span className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-200">
       {label}
     </span>
   );
@@ -65,8 +65,8 @@ function BoundaryBadge({ ok, label }: { ok: boolean; label: string }) {
     <span
       className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] ${
         ok
-          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
-          : "border-amber-500/30 bg-amber-500/10 text-amber-200"
+          ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
+          : "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200"
       }`}
     >
       {ok ? <ShieldCheck className="h-3 w-3" /> : <AlertTriangle className="h-3 w-3" />}
@@ -82,9 +82,9 @@ function DriftStatusBadge({ status }: { status: string }) {
     <span
       className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] ${
         needsReview
-          ? "border-amber-500/30 bg-amber-500/10 text-amber-200"
+          ? "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200"
           : aligned
-            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-200"
+            ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
             : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
       }`}
     >
@@ -109,7 +109,7 @@ function EvidenceSourceRow({ source }: { source: AiBomEvidenceSource }) {
       </div>
       <span
         className={`shrink-0 rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${
-          source.active ? "bg-emerald-500/15 text-emerald-300" : "bg-[color:var(--surface)] text-[color:var(--text-tertiary)]"
+          source.active ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300" : "bg-[color:var(--surface)] text-[color:var(--text-tertiary)]"
         }`}
       >
         {source.active ? "Live" : "Off"}
@@ -306,7 +306,7 @@ export default function AgentBomManifestPage() {
       />
 
       {error ? (
-        <Card className="border-red-500/30 bg-red-500/10 !p-3 text-sm text-red-200">{error}</Card>
+        <Card className="border-red-500/30 bg-red-500/10 !p-3 text-sm text-red-700 dark:text-red-200">{error}</Card>
       ) : null}
 
       {/* Top row: sources | inventory metrics — side by side, scroll inside */}
@@ -493,10 +493,10 @@ export default function AgentBomManifestPage() {
                             <span
                               className={`rounded-full px-1.5 py-0.5 text-[10px] ${
                                 row.riskLevel === "high"
-                                  ? "bg-red-500/10 text-red-300"
+                                  ? "bg-red-500/10 text-red-700 dark:text-red-300"
                                   : row.riskLevel === "medium"
-                                    ? "bg-amber-500/10 text-amber-200"
-                                    : "bg-emerald-500/10 text-emerald-200"
+                                    ? "bg-amber-500/10 text-amber-700 dark:text-amber-200"
+                                    : "bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
                               }`}
                             >
                               {row.riskLevel}

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -163,7 +163,7 @@ function MeshToolbar({
                   onClick={() => toggleAgent(key)}
                   className={`max-w-[13rem] truncate rounded-full border px-2.5 py-1 text-[11px] transition ${
                     active
-                      ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-200"
+                      ? "border-emerald-500/50 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
                       : "border-[var(--border-subtle)] bg-[var(--surface)]/70 text-[var(--text-tertiary)] hover:border-[var(--border-strong)] hover:text-[var(--text-secondary)]"
                   }`}
                 >

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -333,7 +333,7 @@ export default function Dashboard() {
         title="Overview"
         subtitle="Exec briefing: posture, open issues, compliance evidence, and live surfaces. Use Findings, Security graph, and Agent mesh for engineer drill-down."
         scopeChip={
-          <span className="inline-flex items-center rounded-full border border-sky-500/30 bg-sky-500/10 px-2.5 py-0.5 text-[11px] font-medium text-sky-200">
+          <span className="inline-flex items-center rounded-full border border-sky-500/30 bg-sky-500/10 px-2.5 py-0.5 text-[11px] font-medium text-sky-700 dark:text-sky-200">
             {deploymentModeLabel(counts?.deployment_mode)} · {countActiveServices(counts?.services)} services live
           </span>
         }

--- a/ui/app/proxy/ProxyDashboard.tsx
+++ b/ui/app/proxy/ProxyDashboard.tsx
@@ -292,7 +292,7 @@ export default function ProxyDashboard() {
             <SetupCard
               title="Hosted runtime feed"
               body="Forward proxy events or audit logs into the API when running agent-bom behind a central service."
-              command="POST /v1/proxy/events or /ws/proxy/metrics"
+              command="POST /v1/proxy/audit or /ws/proxy/metrics"
             />
           </div>
         </div>
@@ -479,7 +479,7 @@ export default function ProxyDashboard() {
                 {status.detectors_active?.map((d) => (
                   <span
                     key={d}
-                    className="text-[11px] px-2.5 py-1 rounded-full bg-emerald-950/50 text-emerald-300 border border-emerald-800/50 font-mono"
+                    className="text-[11px] px-2.5 py-1 rounded-full bg-emerald-500/10 dark:bg-emerald-950/50 text-emerald-700 dark:text-emerald-300 border border-emerald-500/30 dark:border-emerald-800/50 font-mono"
                   >
                     {d}
                   </span>

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/lib/attack-paths";
 import { SecurityGraphInvestigation } from "@/components/security-graph-investigation";
 import type { UnifiedGraphData } from "@/lib/graph-schema";
+import { tonedChipClass } from "@/lib/toned-chip";
 
 const ATTACK_PATH_QUEUE_LIMIT = 75;
 const ATTACK_PATH_QUEUE_PAGE_SIZE = 12;
@@ -536,7 +537,7 @@ function SecurityGraphPageContent() {
                         onClick={() => setSelectedScanId(snapshot.scan_id)}
                         className={`rounded-xl border px-3 py-2 text-left text-xs transition ${
                           selected
-                            ? "border-emerald-700 bg-emerald-950/40 text-emerald-200"
+                            ? "border-emerald-700 bg-emerald-500/10 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-200"
                             : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
                         }`}
                       >
@@ -596,7 +597,7 @@ function SecurityGraphPageContent() {
           <div className="mt-4 flex flex-wrap gap-3 border-t border-red-900/40 pt-4">
             <Link
               href={fullGraphHref}
-              className="inline-flex items-center gap-2 rounded-full border border-red-900/60 bg-red-950/30 px-3 py-1.5 text-xs text-red-200 transition hover:border-red-700"
+              className="inline-flex items-center gap-2 rounded-full border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/30 px-3 py-1.5 text-xs text-red-700 dark:text-red-200 transition hover:border-red-700"
             >
               Retry in full graph
               <GitBranch className="h-3.5 w-3.5" />
@@ -604,7 +605,7 @@ function SecurityGraphPageContent() {
             {hasFocusContext && (
               <Link
                 href={resetFocusHref}
-                className="inline-flex items-center gap-2 rounded-full border border-red-900/60 bg-red-950/30 px-3 py-1.5 text-xs text-red-200 transition hover:border-red-700"
+                className="inline-flex items-center gap-2 rounded-full border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/30 px-3 py-1.5 text-xs text-red-700 dark:text-red-200 transition hover:border-red-700"
               >
                 Clear focus
                 <ArrowRight className="h-3.5 w-3.5" />
@@ -714,9 +715,9 @@ function QuickStat({
 }) {
   const tones = {
     zinc: "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]",
-    red: "border-red-900/60 bg-red-950/20 text-red-200",
-    amber: "border-amber-900/60 bg-amber-950/20 text-amber-200",
-    blue: "border-sky-900/60 bg-sky-950/20 text-sky-200",
+    red: tonedChipClass("danger"),
+    amber: tonedChipClass("warn"),
+    blue: tonedChipClass("low"),
   };
   return (
     <div className={`rounded-2xl border px-4 py-3 ${tones[tone]}`}>

--- a/ui/components/attack-path-card.tsx
+++ b/ui/components/attack-path-card.tsx
@@ -21,14 +21,14 @@ interface AttackPathCardProps {
 }
 
 const NODE_META: Record<AttackPathNode["type"], { icon: LucideIcon; tint: string; ring: string }> = {
-  cve: { icon: Bug, tint: "text-red-300 bg-red-500/12", ring: "border-red-500/25" },
-  package: { icon: Package, tint: "text-amber-300 bg-amber-500/12", ring: "border-amber-500/25" },
-  server: { icon: Server, tint: "text-sky-300 bg-sky-500/12", ring: "border-sky-500/25" },
-  agent: { icon: Bot, tint: "text-emerald-300 bg-emerald-500/12", ring: "border-emerald-500/25" },
-  credential: { icon: KeyRound, tint: "text-fuchsia-300 bg-fuchsia-500/12", ring: "border-fuchsia-500/25" },
-  tool: { icon: Wrench, tint: "text-purple-300 bg-purple-500/12", ring: "border-purple-500/25" },
-  data: { icon: Database, tint: "text-cyan-300 bg-cyan-500/12", ring: "border-cyan-500/25" },
-  identity: { icon: Fingerprint, tint: "text-indigo-300 bg-indigo-500/12", ring: "border-indigo-500/25" },
+  cve: { icon: Bug, tint: "text-red-700 dark:text-red-300 bg-red-500/12", ring: "border-red-500/25" },
+  package: { icon: Package, tint: "text-amber-700 dark:text-amber-300 bg-amber-500/12", ring: "border-amber-500/25" },
+  server: { icon: Server, tint: "text-sky-700 dark:text-sky-300 bg-sky-500/12", ring: "border-sky-500/25" },
+  agent: { icon: Bot, tint: "text-emerald-700 dark:text-emerald-300 bg-emerald-500/12", ring: "border-emerald-500/25" },
+  credential: { icon: KeyRound, tint: "text-fuchsia-700 dark:text-fuchsia-300 bg-fuchsia-500/12", ring: "border-fuchsia-500/25" },
+  tool: { icon: Wrench, tint: "text-purple-700 dark:text-purple-300 bg-purple-500/12", ring: "border-purple-500/25" },
+  data: { icon: Database, tint: "text-cyan-700 dark:text-cyan-300 bg-cyan-500/12", ring: "border-cyan-500/25" },
+  identity: { icon: Fingerprint, tint: "text-indigo-700 dark:text-indigo-300 bg-indigo-500/12", ring: "border-indigo-500/25" },
   entity: {
     icon: ShieldAlert,
     tint: "text-[color:var(--text-secondary)] bg-[color:var(--surface-elevated)]",
@@ -47,9 +47,9 @@ export function AttackPathCard({
 }: AttackPathCardProps) {
   const riskTone =
     riskScore >= 8
-      ? "border-red-500/25 bg-red-500/10 text-red-200"
+      ? "border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-200"
       : riskScore >= 5
-        ? "border-amber-500/25 bg-amber-500/10 text-amber-200"
+        ? "border-amber-500/25 bg-amber-500/10 text-amber-700 dark:text-amber-200"
         : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)]";
 
   const cardBody = (

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -81,7 +81,7 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center px-4 py-10">
-      <div className="max-w-xl rounded-2xl border border-red-900/50 bg-red-950/20 p-6 text-sm text-red-300">{error}</div>
+      <div className="max-w-xl rounded-2xl border border-red-500/30 dark:border-red-900/50 bg-red-500/10 dark:bg-red-950/20 p-6 text-sm text-red-700 dark:text-red-300">{error}</div>
     </div>
   );
 }

--- a/ui/components/cis-benchmark-detail.tsx
+++ b/ui/components/cis-benchmark-detail.tsx
@@ -72,13 +72,13 @@ function statusBadge(status: string): { label: string; className: string; Icon: 
 function severityClass(severity: string): string {
   switch (severity) {
     case "critical":
-      return "text-red-300 border-red-500/40 bg-red-500/10";
+      return "text-red-700 dark:text-red-300 border-red-500/40 bg-red-500/10";
     case "high":
-      return "text-orange-300 border-orange-500/40 bg-orange-500/10";
+      return "text-orange-700 dark:text-orange-300 border-orange-500/40 bg-orange-500/10";
     case "medium":
-      return "text-yellow-300 border-yellow-500/40 bg-yellow-500/10";
+      return "text-yellow-700 dark:text-yellow-300 border-yellow-500/40 bg-yellow-500/10";
     case "low":
-      return "text-sky-300 border-sky-500/40 bg-sky-500/10";
+      return "text-sky-700 dark:text-sky-300 border-sky-500/40 bg-sky-500/10";
     default:
       return "text-[color:var(--text-secondary)] border-[color:var(--border-strong)] bg-[color:var(--surface-muted)]/40";
   }
@@ -121,7 +121,7 @@ function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
         <span>Fix (CLI)</span>
         {check.requires_human_review ? (
           <span
-            className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-300"
+            className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300"
             data-testid="human-review-badge"
           >
             <ShieldAlert className="h-3 w-3" />
@@ -148,7 +148,7 @@ function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
           }
           className={`mt-0.5 inline-flex items-center gap-1 rounded-md border px-2 py-1.5 text-xs transition-colors ${
             check.requires_human_review
-              ? "border-amber-500/40 text-amber-300 hover:bg-amber-500/10"
+              ? "border-amber-500/40 text-amber-700 dark:text-amber-300 hover:bg-amber-500/10"
               : "border-[color:var(--border-strong)] text-[color:var(--text-secondary)] hover:bg-[color:var(--surface-muted)]"
           }`}
         >
@@ -194,7 +194,7 @@ function CheckCard({ check }: { check: CISBenchmarkCheck }) {
               {priorityLabel(check.priority)}
             </span>
             {check.requires_human_review ? (
-              <span className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-300">
+              <span className="inline-flex items-center gap-1 rounded border border-amber-500/40 bg-amber-500/10 px-1.5 py-0.5 text-[11px] font-medium text-amber-700 dark:text-amber-300">
                 <ShieldAlert className="h-3 w-3" />
                 Review
               </span>
@@ -202,7 +202,7 @@ function CheckCard({ check }: { check: CISBenchmarkCheck }) {
             {check.guardrails.map((g) => (
               <span
                 key={g}
-                className="rounded border border-cyan-500/30 bg-cyan-500/10 px-1.5 py-0.5 text-[11px] font-medium text-cyan-300"
+                className="rounded border border-cyan-500/30 bg-cyan-500/10 px-1.5 py-0.5 text-[11px] font-medium text-cyan-700 dark:text-cyan-300"
               >
                 {g}
               </span>

--- a/ui/components/compliance-control-drawer.tsx
+++ b/ui/components/compliance-control-drawer.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Package, Server, X } from "lucide-react";
 
+import { useEscToClose } from "@/hooks/use-esc-to-close";
 import type { ComplianceControl } from "@/lib/api";
 
 function statusLabel(status: ComplianceControl["status"]): string {
@@ -27,6 +28,7 @@ export function ComplianceControlDrawer({
   catalogName?: string | undefined;
   onClose: () => void;
 }) {
+  useEscToClose(true, onClose);
   const name = catalogName ?? control.name;
   const sev = control.severity_breakdown;
 
@@ -56,10 +58,10 @@ export function ComplianceControlDrawer({
               <span
                 className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
                   control.status === "pass"
-                    ? "bg-emerald-500/15 text-emerald-300"
+                    ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
                     : control.status === "warning"
-                      ? "bg-yellow-500/15 text-yellow-300"
-                      : "bg-red-500/15 text-red-300"
+                      ? "bg-yellow-500/15 text-yellow-700 dark:text-yellow-300"
+                      : "bg-red-500/15 text-red-700 dark:text-red-300"
                 }`}
               >
                 {statusLabel(control.status)}
@@ -146,7 +148,7 @@ export function ComplianceControlDrawer({
         <div className="mt-6 flex flex-wrap gap-2 border-t border-[color:var(--border-subtle)] pt-4">
           <Link
             href={`/findings?q=${encodeURIComponent(control.code)}`}
-            className="rounded-lg border border-emerald-700/50 bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-200 transition hover:border-emerald-600"
+            className="rounded-lg border border-emerald-700/50 bg-emerald-500/10 dark:bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-600"
           >
             View findings
           </Link>

--- a/ui/components/coverage-cockpit.tsx
+++ b/ui/components/coverage-cockpit.tsx
@@ -220,7 +220,7 @@ function CoverageCard({
           {actionHref && actionLabel ? (
             <Link
               href={actionHref}
-              className="inline-flex items-center gap-1 rounded-lg border border-emerald-800/50 bg-emerald-950/20 px-2.5 py-1 text-[11px] font-medium text-emerald-300 transition hover:border-emerald-600"
+              className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 dark:border-emerald-800/50 bg-emerald-500/10 dark:bg-emerald-950/20 px-2.5 py-1 text-[11px] font-medium text-emerald-700 dark:text-emerald-300 transition hover:border-emerald-600"
             >
               {actionLabel}
               <ArrowRight className="h-3 w-3" />

--- a/ui/components/demo-estate-label.tsx
+++ b/ui/components/demo-estate-label.tsx
@@ -18,7 +18,7 @@ export function DemoEstateLabel() {
   return (
     <div
       id="demo-estate-watermark"
-      className={`pointer-events-none fixed z-[120] max-w-[min(18rem,calc(100vw-1.5rem))] truncate rounded-full border border-emerald-500/40 bg-[color:var(--surface-elevated)]/95 px-3 py-1 font-medium uppercase tracking-[0.1em] text-emerald-200 shadow-md shadow-black/20 ${
+      className={`pointer-events-none fixed z-[120] max-w-[min(18rem,calc(100vw-1.5rem))] truncate rounded-full border border-emerald-500/40 bg-[color:var(--surface-elevated)]/95 px-3 py-1 font-medium uppercase tracking-[0.1em] text-emerald-700 dark:text-emerald-200 shadow-md shadow-black/20 ${
         captureMode ? "right-5 top-16 text-[11px]" : "bottom-4 right-4 text-[11px]"
       }`}
       aria-hidden="true"

--- a/ui/components/drawer.tsx
+++ b/ui/components/drawer.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useEffect, useState, type ReactNode } from "react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
 import { ChevronLeft, X } from "lucide-react";
+
+const FOCUSABLE_SELECTOR =
+  'a[href],button:not([disabled]),textarea:not([disabled]),input:not([disabled]),select:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
 export type DrawerSize = "sm" | "md" | "lg" | "xl" | "2xl" | "3xl" | "4xl" | "5xl";
 
@@ -52,6 +55,7 @@ export function Drawer({
   children,
 }: DrawerProps) {
   const [entered, setEntered] = useState(false);
+  const panelRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     if (!open) {
@@ -59,13 +63,46 @@ export function Drawer({
       return;
     }
     const raf = requestAnimationFrame(() => setEntered(true));
+    // Restore focus to whatever triggered the drawer once it closes.
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    // Move focus into the panel so screen readers/keyboards land inside the dialog.
+    const focusRaf = requestAnimationFrame(() => panelRef.current?.focus());
+
     const onKey = (event: KeyboardEvent) => {
-      if (event.key === "Escape") onClose();
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+      if (event.key !== "Tab") return;
+      const panel = panelRef.current;
+      if (!panel) return;
+      const focusable = Array.from(
+        panel.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+      ).filter((el) => el.offsetParent !== null || el === panel);
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (!first || !last) {
+        event.preventDefault();
+        panel.focus();
+        return;
+      }
+      const active = document.activeElement;
+      if (event.shiftKey) {
+        if (active === first || active === panel) {
+          event.preventDefault();
+          last.focus();
+        }
+      } else if (active === last) {
+        event.preventDefault();
+        first.focus();
+      }
     };
     document.addEventListener("keydown", onKey);
     return () => {
       cancelAnimationFrame(raf);
+      cancelAnimationFrame(focusRaf);
       document.removeEventListener("keydown", onKey);
+      previouslyFocused?.focus?.();
     };
   }, [open, onClose]);
 
@@ -73,7 +110,7 @@ export function Drawer({
 
   return (
     <div
-      className={`fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm transition-opacity duration-200 ${
+      className={`fixed inset-0 z-[80] flex justify-end bg-black/45 backdrop-blur-sm transition-opacity duration-200 motion-reduce:transition-none ${
         entered ? "opacity-100" : "opacity-0"
       }`}
       role="dialog"
@@ -87,7 +124,9 @@ export function Drawer({
         onClick={onClose}
       />
       <aside
-        className={`relative flex h-full w-full flex-col border-l border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-3 transition-transform duration-200 ease-out ${
+        ref={panelRef}
+        tabIndex={-1}
+        className={`relative flex h-full w-full flex-col border-l border-[color:var(--border-subtle)] bg-[color:var(--surface)] elev-3 outline-none transition-transform duration-200 ease-out motion-reduce:transition-none ${
           SIZE_CLASS[size]
         } ${entered ? "translate-x-0" : "translate-x-full"}`}
       >

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -79,15 +79,15 @@ function PathViewToggle({
 }
 
 const ROLE_META: Record<ExposureEntityRole, { label: string; icon: LucideIcon; tint: string }> = {
-  agent: { label: "Agent", icon: Bot, tint: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200" },
-  server: { label: "Server", icon: Server, tint: "border-sky-500/30 bg-sky-500/10 text-sky-200" },
-  package: { label: "Package", icon: Package, tint: "border-amber-500/30 bg-amber-500/10 text-amber-200" },
-  finding: { label: "Finding", icon: Bug, tint: "border-red-500/30 bg-red-500/10 text-red-200" },
-  credential: { label: "Credential", icon: KeyRound, tint: "border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-200" },
-  tool: { label: "Tool", icon: Wrench, tint: "border-purple-500/30 bg-purple-500/10 text-purple-200" },
-  environment: { label: "Environment", icon: Database, tint: "border-cyan-500/30 bg-cyan-500/10 text-cyan-200" },
-  cluster: { label: "Cluster", icon: Database, tint: "border-indigo-500/30 bg-indigo-500/10 text-indigo-200" },
-  unknown: { label: "Entity", icon: ShieldAlert, tint: "border-slate-500/30 bg-slate-500/10 text-slate-200" },
+  agent: { label: "Agent", icon: Bot, tint: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200" },
+  server: { label: "Server", icon: Server, tint: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200" },
+  package: { label: "Package", icon: Package, tint: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200" },
+  finding: { label: "Finding", icon: Bug, tint: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-200" },
+  credential: { label: "Credential", icon: KeyRound, tint: "border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-200" },
+  tool: { label: "Tool", icon: Wrench, tint: "border-purple-500/30 bg-purple-500/10 text-purple-700 dark:text-purple-200" },
+  environment: { label: "Environment", icon: Database, tint: "border-cyan-500/30 bg-cyan-500/10 text-cyan-700 dark:text-cyan-200" },
+  cluster: { label: "Cluster", icon: Database, tint: "border-indigo-500/30 bg-indigo-500/10 text-indigo-700 dark:text-indigo-200" },
+  unknown: { label: "Entity", icon: ShieldAlert, tint: "border-slate-500/30 bg-slate-500/10 text-slate-700 dark:text-slate-200" },
 };
 
 export function ExposurePathCommandCenter({
@@ -144,11 +144,11 @@ export function ExposurePathCommandCenter({
         <div className="flex flex-wrap items-start justify-between gap-4">
           <div className="min-w-0 flex-1 space-y-2">
             <div className="flex flex-wrap items-center gap-2">
-              <span className="rounded-full border border-red-500/35 bg-red-500/12 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-red-200">
+              <span className="rounded-full border border-red-500/35 bg-red-500/12 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-red-700 dark:text-red-200">
                 {String(path.severity)} risk
               </span>
               {evidence?.isKev ? (
-                <span className="rounded-full border border-amber-500/35 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-200">
+                <span className="rounded-full border border-amber-500/35 bg-amber-500/10 px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-amber-700 dark:text-amber-200">
                   CISA KEV
                 </span>
               ) : null}
@@ -251,7 +251,7 @@ export function ExposurePathCommandCenter({
         <div className="flex flex-wrap gap-2">
           <Link
             href={primaryAction.href}
-            className="inline-flex items-center gap-2 rounded-xl border border-emerald-700/50 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-500 hover:bg-emerald-500/15"
+            className="inline-flex items-center gap-2 rounded-xl border border-emerald-700/50 bg-emerald-500/10 px-4 py-2 text-sm font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-500 hover:bg-emerald-500/15"
           >
             <CheckCircle2 className="h-4 w-4 shrink-0" />
             <span>{primaryAction.title}</span>

--- a/ui/components/exposure-path-neighbor-explorer.tsx
+++ b/ui/components/exposure-path-neighbor-explorer.tsx
@@ -23,14 +23,14 @@ const EXPANDABLE_ROLES: ReadonlySet<ExposureEntityRole> = new Set(["agent", "ser
 const NEIGHBOR_LIMIT = 12;
 
 const ROLE_STYLE: Record<ExposureEntityRole, { icon: LucideIcon; chip: string; accent: string }> = {
-  agent: { icon: Bot, chip: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200", accent: "text-emerald-300" },
-  server: { icon: Server, chip: "border-sky-500/30 bg-sky-500/10 text-sky-200", accent: "text-sky-300" },
-  package: { icon: Package, chip: "border-amber-500/30 bg-amber-500/10 text-amber-200", accent: "text-amber-300" },
-  finding: { icon: Bug, chip: "border-red-500/30 bg-red-500/10 text-red-200", accent: "text-red-300" },
-  credential: { icon: KeyRound, chip: "border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-200", accent: "text-fuchsia-300" },
-  tool: { icon: Wrench, chip: "border-purple-500/30 bg-purple-500/10 text-purple-200", accent: "text-purple-300" },
-  environment: { icon: Database, chip: "border-cyan-500/30 bg-cyan-500/10 text-cyan-200", accent: "text-cyan-300" },
-  cluster: { icon: Database, chip: "border-indigo-500/30 bg-indigo-500/10 text-indigo-200", accent: "text-indigo-300" },
+  agent: { icon: Bot, chip: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200", accent: "text-emerald-300" },
+  server: { icon: Server, chip: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200", accent: "text-sky-300" },
+  package: { icon: Package, chip: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200", accent: "text-amber-300" },
+  finding: { icon: Bug, chip: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-200", accent: "text-red-300" },
+  credential: { icon: KeyRound, chip: "border-fuchsia-500/30 bg-fuchsia-500/10 text-fuchsia-700 dark:text-fuchsia-200", accent: "text-fuchsia-300" },
+  tool: { icon: Wrench, chip: "border-purple-500/30 bg-purple-500/10 text-purple-700 dark:text-purple-200", accent: "text-purple-300" },
+  environment: { icon: Database, chip: "border-cyan-500/30 bg-cyan-500/10 text-cyan-700 dark:text-cyan-200", accent: "text-cyan-300" },
+  cluster: { icon: Database, chip: "border-indigo-500/30 bg-indigo-500/10 text-indigo-700 dark:text-indigo-200", accent: "text-indigo-300" },
   unknown: {
     icon: ShieldAlert,
     chip: "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)]",

--- a/ui/components/exposure-path-strip.tsx
+++ b/ui/components/exposure-path-strip.tsx
@@ -17,11 +17,11 @@ export function ExposurePathStrip({
 }) {
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-[var(--border-subtle)] bg-red-950/15 px-4 py-2 text-sm">
-      <span className="shrink-0 rounded border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-red-200">
+      <span className="shrink-0 rounded border border-red-500/40 bg-red-500/10 px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.14em] text-red-700 dark:text-red-200">
         {path.severity}
       </span>
       {typeof path.riskScore === "number" && Number.isFinite(path.riskScore) && (
-        <span className="shrink-0 rounded border border-orange-500/30 bg-orange-500/10 px-2 py-0.5 font-mono text-[11px] text-orange-200">
+        <span className="shrink-0 rounded border border-orange-500/30 bg-orange-500/10 px-2 py-0.5 font-mono text-[11px] text-orange-700 dark:text-orange-200">
           risk {path.riskScore.toFixed(1)}
         </span>
       )}
@@ -37,7 +37,7 @@ export function ExposurePathStrip({
         <button
           type="button"
           onClick={onAction}
-          className="shrink-0 rounded border border-red-500/30 px-2 py-1 text-xs text-red-200 transition hover:border-red-400 hover:bg-red-500/10"
+          className="shrink-0 rounded border border-red-500/30 px-2 py-1 text-xs text-red-700 dark:text-red-200 transition hover:border-red-400 hover:bg-red-500/10"
         >
           {active ? "Show all" : actionLabel}
         </button>

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -490,7 +490,7 @@ function TriageTab({
         </a>
         <Link
           href={`/findings?cve=${vuln.id}`}
-          className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/40 px-3 py-1.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-950/70"
+          className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 dark:border-emerald-800 bg-emerald-500/10 dark:bg-emerald-950/40 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300 transition-colors hover:bg-emerald-500/10 dark:hover:bg-emerald-950/70"
         >
           Keep this CVE scoped
         </Link>
@@ -506,7 +506,7 @@ function ReachBadges({ vuln }: { vuln: EnrichedVuln }) {
   return (
     <div className="flex flex-wrap items-center gap-2">
       {vuln.effective_reach_band ? (
-        <span className="rounded border border-amber-800/60 bg-amber-950/40 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-300">
+        <span className="rounded border border-amber-500/30 dark:border-amber-800/60 bg-amber-500/10 dark:bg-amber-950/40 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-amber-700 dark:text-amber-300">
           Reach {vuln.effective_reach_band}
           {typeof vuln.effective_reach_score === "number" ? ` (${vuln.effective_reach_score.toFixed(0)})` : ""}
         </span>
@@ -515,8 +515,8 @@ function ReachBadges({ vuln }: { vuln: EnrichedVuln }) {
         <span
           className={`rounded border px-2 py-0.5 text-xs font-medium uppercase tracking-wide ${
             vuln.runtime_evidence.state === "blocked"
-              ? "border-rose-800/60 bg-rose-950/40 text-rose-300"
-              : "border-sky-800/60 bg-sky-950/40 text-sky-300"
+              ? "border-rose-500/30 dark:border-rose-800/60 bg-rose-500/10 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300"
+              : "border-sky-500/30 dark:border-sky-800/60 bg-sky-500/10 dark:bg-sky-950/40 text-sky-700 dark:text-sky-300"
           }`}
         >
           Runtime {vuln.runtime_evidence.state}
@@ -571,7 +571,7 @@ function TriageButton({
 }) {
   const classes =
     tone === "green"
-      ? "border-emerald-800 bg-emerald-950/40 text-emerald-300 hover:bg-emerald-950/70"
+      ? "border-emerald-500/30 dark:border-emerald-800 bg-emerald-500/10 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 dark:hover:bg-emerald-950/70"
       : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)] hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]";
   return (
     <button

--- a/ui/components/first-run-journey.tsx
+++ b/ui/components/first-run-journey.tsx
@@ -124,7 +124,7 @@ export function FirstRunJourney({
                   {step.status === "done" ? (
                     <CheckCircle2 className="h-5 w-5 text-emerald-400" />
                   ) : isCurrent ? (
-                    <span className="flex h-5 w-5 items-center justify-center rounded-full border border-emerald-500 text-[11px] font-semibold text-emerald-300">
+                    <span className="flex h-5 w-5 items-center justify-center rounded-full border border-emerald-500 text-[11px] font-semibold text-emerald-700 dark:text-emerald-300">
                       {index + 1}
                     </span>
                   ) : (
@@ -136,7 +136,7 @@ export function FirstRunJourney({
                     <Icon className="h-4 w-4 text-emerald-400" />
                     {step.title}
                     {step.status === "done" ? (
-                      <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-200">
+                      <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-200">
                         Done
                       </span>
                     ) : null}
@@ -212,7 +212,7 @@ function JourneyAction({
   if (step === "scan") {
     return (
       <div className="mt-3 flex flex-wrap gap-2">
-        <span className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-200">
+        <span className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200">
           <ScanSearch className="h-3.5 w-3.5" />
           Use “Run scan” on your connection below
         </span>

--- a/ui/components/framework-coverage-panel.tsx
+++ b/ui/components/framework-coverage-panel.tsx
@@ -123,13 +123,13 @@ export function FrameworkCoveragePanel({ items, onFocusFramework, cloudCisHref }
           </p>
         </div>
         <div className="flex flex-wrap gap-2 text-xs">
-          <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-emerald-300">
+          <span className="rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2.5 py-1 text-emerald-700 dark:text-emerald-300">
             {summary.passing} passing
           </span>
-          <span className="rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-1 text-yellow-200">
+          <span className="rounded-full border border-yellow-500/30 bg-yellow-500/10 px-2.5 py-1 text-yellow-700 dark:text-yellow-200">
             {summary.warning} warning
           </span>
-          <span className="rounded-full border border-red-500/30 bg-red-500/10 px-2.5 py-1 text-red-300">
+          <span className="rounded-full border border-red-500/30 bg-red-500/10 px-2.5 py-1 text-red-700 dark:text-red-300">
             {summary.failing} failing
           </span>
         </div>
@@ -214,10 +214,10 @@ export function FrameworkCoveragePanel({ items, onFocusFramework, cloudCisHref }
                   <span
                     className={`rounded-full px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide ${
                       tone === "fail"
-                        ? "bg-red-500/15 text-red-300"
+                        ? "bg-red-500/15 text-red-700 dark:text-red-300"
                         : tone === "warning"
-                          ? "bg-yellow-500/15 text-yellow-200"
-                          : "bg-emerald-500/15 text-emerald-300"
+                          ? "bg-yellow-500/15 text-yellow-700 dark:text-yellow-200"
+                          : "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
                     }`}
                   >
                     {tone === "fail" ? "Fail" : tone === "warning" ? "Warn" : "Pass"}

--- a/ui/components/graph-drift-legend.tsx
+++ b/ui/components/graph-drift-legend.tsx
@@ -93,7 +93,7 @@ export function GraphDriftLegend({
           onClick={() => onToggleActive(!active)}
           className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
             active
-              ? "border-sky-500/60 bg-sky-500/15 text-sky-200"
+              ? "border-sky-500/60 bg-sky-500/15 text-sky-700 dark:text-sky-200"
               : "border-[var(--border-subtle)] bg-[var(--surface)]/60 text-[var(--text-secondary)] hover:text-[var(--foreground)]"
           }`}
         >

--- a/ui/components/graph-evaluation-summary.tsx
+++ b/ui/components/graph-evaluation-summary.tsx
@@ -86,15 +86,15 @@ export function GraphEvaluationSummary({ evaluation }: GraphEvaluationSummaryPro
 
 function gradeTone(grade: GraphUxEvaluation["grade"]): string {
   if (grade === "excellent" || grade === "strong") {
-    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-200";
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200";
   }
   if (grade === "usable") {
-    return "border-sky-500/30 bg-sky-500/10 text-sky-200";
+    return "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:text-sky-200";
   }
   if (grade === "weak") {
-    return "border-amber-500/30 bg-amber-500/10 text-amber-200";
+    return "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200";
   }
-  return "border-red-500/30 bg-red-500/10 text-red-200";
+  return "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-200";
 }
 
 function barTone(score: number): string {

--- a/ui/components/graph-state-panels.tsx
+++ b/ui/components/graph-state-panels.tsx
@@ -110,7 +110,7 @@ export function GraphFindingsFallback({
               <button
                 type="button"
                 onClick={onExpandScope}
-                className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-300 hover:bg-emerald-500/20 hover:border-emerald-400 transition-colors"
+                className="mt-3 inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/20 hover:border-emerald-400 transition-colors"
               >
                 Show expanded topology
               </button>
@@ -219,9 +219,9 @@ function FindingRow({
   const osvUrl = getOsvVulnerabilityUrl(data.label);
   const severityClass =
     data.severity === "critical"
-      ? "border-red-500/25 bg-red-500/10 text-red-200"
+      ? "border-red-500/25 bg-red-500/10 text-red-700 dark:text-red-200"
       : data.severity === "high"
-        ? "border-orange-500/25 bg-orange-500/10 text-orange-200"
+        ? "border-orange-500/25 bg-orange-500/10 text-orange-700 dark:text-orange-200"
         : "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)]";
 
   return (
@@ -232,7 +232,7 @@ function FindingRow({
             {severity}
           </span>
           {data.isKev && (
-            <span className="rounded-lg border border-red-500/25 bg-red-500/10 px-2 py-0.5 text-[10px] font-medium tracking-[0.14em] text-red-200">
+            <span className="rounded-lg border border-red-500/25 bg-red-500/10 px-2 py-0.5 text-[10px] font-medium tracking-[0.14em] text-red-700 dark:text-red-200">
               KEV
             </span>
           )}
@@ -256,7 +256,7 @@ function FindingRow({
         </button>
         <Link
           href={buildFindingsHref({ scanId, cve: data.label })}
-          className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/40 px-3 py-1.5 text-xs font-medium text-emerald-300 transition-colors hover:bg-emerald-950/70"
+          className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 dark:border-emerald-800 bg-emerald-500/10 dark:bg-emerald-950/40 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-300 transition-colors hover:bg-emerald-500/10 dark:hover:bg-emerald-950/70"
         >
           <Route className="h-3 w-3" />
           Findings

--- a/ui/components/hitl-approval-queue-panel.tsx
+++ b/ui/components/hitl-approval-queue-panel.tsx
@@ -56,7 +56,7 @@ export function HitlApprovalQueuePanel() {
 
   if (error) {
     return (
-      <div className="rounded-2xl border border-red-900/50 bg-red-950/30 px-4 py-3 text-sm text-red-300">
+      <div className="rounded-2xl border border-red-500/30 dark:border-red-900/50 bg-red-500/10 dark:bg-red-950/30 px-4 py-3 text-sm text-red-700 dark:text-red-300">
         {error}
       </div>
     );
@@ -152,7 +152,7 @@ export function HitlApprovalQueuePanel() {
                         type="button"
                         disabled={busyId === item.item_id}
                         onClick={() => void decide(item.item_id, "approve")}
-                        className="inline-flex items-center gap-1 rounded-lg border border-emerald-800 bg-emerald-950/50 px-2.5 py-1.5 text-xs text-emerald-300 hover:bg-emerald-900/40 disabled:opacity-50"
+                        className="inline-flex items-center gap-1 rounded-lg border border-emerald-500/30 dark:border-emerald-800 bg-emerald-500/10 dark:bg-emerald-950/50 px-2.5 py-1.5 text-xs text-emerald-700 dark:text-emerald-300 hover:bg-emerald-500/10 dark:hover:bg-emerald-900/40 disabled:opacity-50"
                       >
                         <CheckCircle2 className="h-3.5 w-3.5" />
                         Approve
@@ -161,7 +161,7 @@ export function HitlApprovalQueuePanel() {
                         type="button"
                         disabled={busyId === item.item_id}
                         onClick={() => void decide(item.item_id, "deny")}
-                        className="inline-flex items-center gap-1 rounded-lg border border-rose-800 bg-rose-950/50 px-2.5 py-1.5 text-xs text-rose-300 hover:bg-rose-900/40 disabled:opacity-50"
+                        className="inline-flex items-center gap-1 rounded-lg border border-rose-500/30 dark:border-rose-800 bg-rose-500/10 dark:bg-rose-950/50 px-2.5 py-1.5 text-xs text-rose-700 dark:text-rose-300 hover:bg-rose-500/10 dark:hover:bg-rose-900/40 disabled:opacity-50"
                       >
                         <XCircle className="h-3.5 w-3.5" />
                         Deny

--- a/ui/components/integration-required-state.tsx
+++ b/ui/components/integration-required-state.tsx
@@ -48,7 +48,7 @@ export function IntegrationRequiredState({
               {primaryAction ? (
                 <Link
                   href={primaryAction.href}
-                  className="mt-3 inline-flex items-center gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
+                  className="mt-3 inline-flex items-center gap-2 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-sm font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-400 hover:bg-emerald-500/20"
                 >
                   <Play className="h-4 w-4" />
                   {primaryAction.label}

--- a/ui/components/job-pipeline-panel.tsx
+++ b/ui/components/job-pipeline-panel.tsx
@@ -140,11 +140,11 @@ function StatusBanner({
   const done = status === "done";
 
   const tone = failed
-    ? "border-red-500/40 bg-red-500/10 text-red-300"
+    ? "border-red-500/40 bg-red-500/10 text-red-700 dark:text-red-300"
     : active
-      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-300"
+      ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
       : done
-        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-300"
+        ? "border-emerald-500/40 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300"
         : "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
 
   const icon = failed ? (

--- a/ui/components/key-lifecycle-panel.tsx
+++ b/ui/components/key-lifecycle-panel.tsx
@@ -42,13 +42,13 @@ function toIsoOrNull(value: string): string | null {
 function keyStateTone(state: ApiKeyRecord["state"]): string {
   switch (state) {
     case "active":
-      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-300";
+      return "border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300";
     case "rotation_overlap":
-      return "border-sky-900/60 bg-sky-950/30 text-sky-300";
+      return "border-sky-500/30 dark:border-sky-900/60 bg-sky-500/10 dark:bg-sky-950/30 text-sky-700 dark:text-sky-300";
     case "rotated":
-      return "border-amber-900/60 bg-amber-950/30 text-amber-300";
+      return "border-amber-500/30 dark:border-amber-900/60 bg-amber-500/10 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300";
     case "revoked":
-      return "border-red-900/60 bg-red-950/30 text-red-300";
+      return "border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/30 text-red-700 dark:text-red-300";
     case "expired":
     default:
       return "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
@@ -97,13 +97,13 @@ function modeTone(value: string): string {
   switch (value) {
     case "reverse_proxy_oidc":
     case "trusted_proxy":
-      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-300";
+      return "border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300";
     case "oidc_bearer":
     case "saml_sso":
-      return "border-sky-900/60 bg-sky-950/30 text-sky-300";
+      return "border-sky-500/30 dark:border-sky-900/60 bg-sky-500/10 dark:bg-sky-950/30 text-sky-700 dark:text-sky-300";
     case "session_api_key":
     case "api_key":
-      return "border-amber-900/60 bg-amber-950/30 text-amber-300";
+      return "border-amber-500/30 dark:border-amber-900/60 bg-amber-500/10 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300";
     case "no_auth":
     default:
       return "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
@@ -117,11 +117,11 @@ function quotaInputValue(value: number | null | undefined): string {
 function quotaStatusTone(status: string): string {
   switch (status) {
     case "ok":
-      return "border-emerald-900/60 bg-emerald-950/30 text-emerald-300";
+      return "border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 text-emerald-700 dark:text-emerald-300";
     case "near_limit":
-      return "border-amber-900/60 bg-amber-950/30 text-amber-300";
+      return "border-amber-500/30 dark:border-amber-900/60 bg-amber-500/10 dark:bg-amber-950/30 text-amber-700 dark:text-amber-300";
     case "at_limit":
-      return "border-red-900/60 bg-red-950/30 text-red-300";
+      return "border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/30 text-red-700 dark:text-red-300";
     case "unlimited":
     default:
       return "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";
@@ -392,7 +392,7 @@ export function KeyLifecyclePanel({
               setCreateOpen((value) => !value);
               setFormError(null);
             }}
-            className="inline-flex items-center gap-1.5 rounded-xl border border-emerald-900/60 bg-emerald-950/30 px-3 py-2 text-sm text-emerald-300 transition hover:bg-emerald-950/50"
+            className="inline-flex items-center gap-1.5 rounded-xl border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 px-3 py-2 text-sm text-emerald-700 dark:text-emerald-300 transition hover:bg-emerald-500/10 dark:hover:bg-emerald-950/50"
           >
             <Plus className="h-4 w-4" />
             New key
@@ -430,7 +430,7 @@ export function KeyLifecyclePanel({
       ) : null}
 
       {formError ? (
-        <div className="rounded-xl border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-300">{formError}</div>
+        <div className="rounded-xl border border-red-500/30 dark:border-red-900/50 bg-red-500/10 dark:bg-red-950/20 px-4 py-3 text-sm text-red-700 dark:text-red-300">{formError}</div>
       ) : null}
 
       {createOpen ? (
@@ -970,7 +970,7 @@ export function KeyLifecyclePanel({
                                 setRotationTarget(key);
                               }}
                               disabled={!canRotate || busyKeyId === key.key_id}
-                              className="inline-flex items-center gap-1.5 rounded-lg border border-sky-900/60 bg-sky-950/20 px-3 py-1.5 text-xs text-sky-300 transition hover:bg-sky-950/40 disabled:cursor-not-allowed disabled:opacity-40"
+                              className="inline-flex items-center gap-1.5 rounded-lg border border-sky-500/30 dark:border-sky-900/60 bg-sky-500/10 dark:bg-sky-950/20 px-3 py-1.5 text-xs text-sky-700 dark:text-sky-300 transition hover:bg-sky-500/10 dark:hover:bg-sky-950/40 disabled:cursor-not-allowed disabled:opacity-40"
                             >
                               {busyAction === "rotate" && busyKeyId === key.key_id ? (
                                 <Loader2 className="h-3.5 w-3.5 animate-spin" />
@@ -982,7 +982,7 @@ export function KeyLifecyclePanel({
                             <button
                               onClick={() => void handleRevoke(key)}
                               disabled={!canRevoke || busyKeyId === key.key_id}
-                              className="inline-flex items-center gap-1.5 rounded-lg border border-red-900/60 bg-red-950/20 px-3 py-1.5 text-xs text-red-300 transition hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-40"
+                              className="inline-flex items-center gap-1.5 rounded-lg border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/20 px-3 py-1.5 text-xs text-red-700 dark:text-red-300 transition hover:bg-red-500/10 dark:hover:bg-red-950/40 disabled:cursor-not-allowed disabled:opacity-40"
                             >
                               {busyAction === "revoke" && busyKeyId === key.key_id ? (
                                 <Loader2 className="h-3.5 w-3.5 animate-spin" />

--- a/ui/components/large-graph-overview.tsx
+++ b/ui/components/large-graph-overview.tsx
@@ -205,7 +205,7 @@ export function LargeGraphOverview({
     <div className="flex h-full min-h-[72vh] flex-col overflow-hidden rounded-xl border border-[var(--border-subtle)] bg-[var(--background)] shadow-2xl shadow-black/30" data-testid="large-graph-overview">
       <div className="border-b border-[var(--border-subtle)] bg-[var(--background)]/95 p-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-200">
+          <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 dark:bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 dark:text-emerald-200">
             <Network className="h-3.5 w-3.5" />
             Large graph overview
           </span>

--- a/ui/components/lineage-detail.tsx
+++ b/ui/components/lineage-detail.tsx
@@ -296,7 +296,7 @@ export function LineageDetailPanel({
         {data.nodeType === "sharedServer" && (
           <div className="space-y-3">
             {data.sharedBy && (
-              <div className="text-xs px-2 py-1 rounded bg-cyan-900/60 text-cyan-300 border border-cyan-700 font-mono">
+              <div className="text-xs px-2 py-1 rounded bg-cyan-500/10 dark:bg-cyan-900/60 text-cyan-700 dark:text-cyan-300 border border-cyan-700 font-mono">
                 Shared by {data.sharedBy} agents
               </div>
             )}
@@ -566,7 +566,7 @@ export function LineageDetailPanel({
             className={`flex w-full items-center justify-center gap-2 rounded-lg border px-3 py-2 text-xs font-medium transition disabled:cursor-not-allowed disabled:opacity-60 ${
               blastRadiusActive
                 ? "border-violet-400/50 bg-violet-500/20 text-violet-100"
-                : "border-violet-500/30 bg-violet-500/10 text-violet-200 hover:border-violet-400/60 hover:bg-violet-500/20"
+                : "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-200 hover:border-violet-400/60 hover:bg-violet-500/20"
             }`}
           >
             {blastRadiusLoading ? (

--- a/ui/components/lineage-nodes.tsx
+++ b/ui/components/lineage-nodes.tsx
@@ -109,12 +109,12 @@ const RUNTIME_EVIDENCE_CHIP: Record<
   runtime_observed: {
     label: "Observed",
     className:
-      "border-sky-800/70 bg-sky-950/50 text-sky-300",
+      "border-sky-500/30 dark:border-sky-800/70 bg-sky-500/10 dark:bg-sky-950/50 text-sky-700 dark:text-sky-300",
   },
   runtime_blocked: {
     label: "Blocked",
     className:
-      "border-rose-800/70 bg-rose-950/50 text-rose-300",
+      "border-rose-500/30 dark:border-rose-800/70 bg-rose-500/10 dark:bg-rose-950/50 text-rose-700 dark:text-rose-300",
   },
 };
 

--- a/ui/components/login-panel.tsx
+++ b/ui/components/login-panel.tsx
@@ -200,7 +200,7 @@ export function LoginPanel({
             </button>
 
             {shownError ? (
-              <div className="mt-4 rounded-xl border border-red-900/50 bg-red-950/20 px-4 py-2.5 text-sm text-red-300">
+              <div className="mt-4 rounded-xl border border-red-500/30 dark:border-red-900/50 bg-red-500/10 dark:bg-red-950/20 px-4 py-2.5 text-sm text-red-700 dark:text-red-300">
                 {shownError}
               </div>
             ) : null}
@@ -238,7 +238,7 @@ export function LoginPanel({
 
   return (
     <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
-      <div className="max-w-xl rounded-2xl border border-red-900/50 bg-red-950/20 p-6 text-sm text-red-300">
+      <div className="max-w-xl rounded-2xl border border-red-500/30 dark:border-red-900/50 bg-red-500/10 dark:bg-red-950/20 p-6 text-sm text-red-700 dark:text-red-300">
         {userFacingApiErrorMessage(error, "Failed to load auth session")}
       </div>
     </div>

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -214,7 +214,7 @@ const NAV_LINK_ICON_CLASS: Record<string, string> = {
   "/traces": "text-violet-400",
   "/compliance": "text-emerald-400",
   "/governance": "text-amber-400",
-  "/audit": "text-stone-400",
+  "/audit": "text-teal-400",
   "/registry": "text-amber-400",
   "/cost": "text-yellow-400",
   "/jobs": "text-orange-400",

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -603,11 +603,11 @@ function ComplianceSnapshotPanel({
                 <span
                   className={`justify-self-end rounded-full px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide ${
                     tone === "fail"
-                      ? "bg-red-500/15 text-red-300"
+                      ? "bg-red-500/15 text-red-700 dark:text-red-300"
                       : tone === "warn"
-                        ? "bg-yellow-500/15 text-yellow-200"
+                        ? "bg-yellow-500/15 text-yellow-700 dark:text-yellow-200"
                         : tone === "pass"
-                          ? "bg-emerald-500/15 text-emerald-300"
+                          ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
                           : "border border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-tertiary)]"
                   }`}
                 >
@@ -723,7 +723,7 @@ function TopRisksPanel({
         </Link>
         <Link
           href="/compliance"
-          className="rounded-lg border border-emerald-700/50 bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-200"
+          className="rounded-lg border border-emerald-700/50 bg-emerald-500/10 dark:bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200"
         >
           Compliance evidence
         </Link>
@@ -751,10 +751,10 @@ const RISK_NODE_ORDER: ExposurePathView["nodes"][number]["type"][] = [
 ];
 
 function riskScoreTone(score: number): string {
-  if (score >= 9) return "border-red-500/45 bg-red-500/10 text-red-300";
-  if (score >= 7) return "border-orange-500/45 bg-orange-500/10 text-orange-300";
-  if (score >= 4) return "border-yellow-500/45 bg-yellow-500/10 text-yellow-200";
-  return "border-sky-500/45 bg-sky-500/10 text-sky-300";
+  if (score >= 9) return "border-red-500/45 bg-red-500/10 text-red-700 dark:text-red-300";
+  if (score >= 7) return "border-orange-500/45 bg-orange-500/10 text-orange-700 dark:text-orange-300";
+  if (score >= 4) return "border-yellow-500/45 bg-yellow-500/10 text-yellow-700 dark:text-yellow-200";
+  return "border-sky-500/45 bg-sky-500/10 text-sky-700 dark:text-sky-300";
 }
 
 function RiskChainRow({ path, rank }: { path: ExposurePathView; rank: number }) {
@@ -801,7 +801,7 @@ function RiskChainRow({ path, rank }: { path: ExposurePathView; rank: number }) 
         ))}
       </div>
       {hasCredential ? (
-        <span className="hidden shrink-0 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-200 sm:inline">
+        <span className="hidden shrink-0 rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] font-semibold text-amber-700 dark:text-amber-200 sm:inline">
           credential
         </span>
       ) : null}

--- a/ui/components/posture-grade.tsx
+++ b/ui/components/posture-grade.tsx
@@ -23,20 +23,20 @@ export function postureDimensionTone(score: number) {
   if (score >= 80) {
     return {
       label: "strong",
-      badge: "border border-emerald-800 bg-emerald-950/60 text-emerald-300",
+      badge: "border border-emerald-500/30 dark:border-emerald-800 bg-emerald-500/10 dark:bg-emerald-950/60 text-emerald-700 dark:text-emerald-300",
       bar: "bg-emerald-500",
     };
   }
   if (score >= 60) {
     return {
       label: "watch",
-      badge: "border border-yellow-800 bg-yellow-950/60 text-yellow-300",
+      badge: "border border-yellow-500/30 dark:border-yellow-800 bg-yellow-500/10 dark:bg-yellow-950/60 text-yellow-700 dark:text-yellow-300",
       bar: "bg-yellow-500",
     };
   }
   return {
     label: "critical",
-    badge: "border border-red-800 bg-red-950/60 text-red-300",
+    badge: "border border-red-500/30 dark:border-red-800 bg-red-500/10 dark:bg-red-950/60 text-red-700 dark:text-red-300",
     bar: "bg-red-500",
   };
 }

--- a/ui/components/proxy-alert-drawer.tsx
+++ b/ui/components/proxy-alert-drawer.tsx
@@ -2,6 +2,7 @@
 
 import { X } from "lucide-react";
 
+import { useEscToClose } from "@/hooks/use-esc-to-close";
 import type { ProxyAlert } from "@/lib/api";
 import { formatDate } from "@/lib/api";
 import { proxyAlertDetailEntries, proxyAlertSummary } from "@/lib/proxy-alerts";
@@ -21,6 +22,7 @@ export function ProxyAlertDrawer({
   alert: ProxyAlert;
   onClose: () => void;
 }) {
+  useEscToClose(true, onClose);
   const rows = proxyAlertDetailEntries(alert);
 
   return (

--- a/ui/components/ranked-path-list.tsx
+++ b/ui/components/ranked-path-list.tsx
@@ -56,7 +56,7 @@ export function RankedPathList({
             <span
               className={`shrink-0 rounded-md px-2 py-1 text-[10px] font-semibold uppercase tracking-[0.14em] ${
                 row.rank === 1
-                  ? "bg-orange-500/15 text-orange-300"
+                  ? "bg-orange-500/15 text-orange-700 dark:text-orange-300"
                   : "bg-[color:var(--surface)] text-[color:var(--text-tertiary)]"
               }`}
             >

--- a/ui/components/repo-scan-overview-panel.tsx
+++ b/ui/components/repo-scan-overview-panel.tsx
@@ -44,7 +44,7 @@ export function RepoScanOverviewPanel({
         </div>
         <Link
           href={repoGraphHref(scanId)}
-          className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/40 bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-200 hover:border-emerald-500/50"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-700/40 bg-emerald-500/10 dark:bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 hover:border-emerald-500/50"
         >
           <GitBranch className="h-3.5 w-3.5" />
           Open folder graph

--- a/ui/components/role-access.tsx
+++ b/ui/components/role-access.tsx
@@ -70,7 +70,7 @@ export function PermissionDeniedNotice({
       <p className="mt-1.5 text-[13px] leading-6 text-amber-100/90">
         To {action} you need the {neededLabel} role or higher.
       </p>
-      <p className="mt-3 text-[12px] font-semibold uppercase tracking-[0.12em] text-amber-200/90">
+      <p className="mt-3 text-[12px] font-semibold uppercase tracking-[0.12em] text-amber-700 dark:text-amber-200/90">
         {guidance.title}
       </p>
       <ul className="mt-1.5 space-y-1 text-[13px] leading-6 text-amber-100/90">
@@ -121,7 +121,7 @@ export function RolePermissionsPanel({
                   {entry.label}
                 </span>
                 {active ? (
-                  <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-200">
+                  <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-2 py-0.5 text-[10px] font-medium text-emerald-700 dark:text-emerald-200">
                     You
                   </span>
                 ) : null}

--- a/ui/components/scan-result.tsx
+++ b/ui/components/scan-result.tsx
@@ -157,7 +157,7 @@ export function ScanResultView({ id }: { id: string }) {
             type="button"
             onClick={() => void handleExport("json")}
             disabled={exporting}
-            className="inline-flex items-center gap-2 rounded-lg border border-cyan-900/60 bg-cyan-950/30 px-3 py-2 text-sm font-medium text-cyan-200 transition-colors hover:border-cyan-800 hover:bg-cyan-950/50 disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex items-center gap-2 rounded-lg border border-cyan-500/30 dark:border-cyan-900/60 bg-cyan-500/10 dark:bg-cyan-950/30 px-3 py-2 text-sm font-medium text-cyan-700 dark:text-cyan-200 transition-colors hover:border-cyan-500/30 dark:hover:border-cyan-800 hover:bg-cyan-500/10 dark:hover:bg-cyan-950/50 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {exporting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Download className="h-4 w-4" />}
             Export graph JSON
@@ -166,7 +166,7 @@ export function ScanResultView({ id }: { id: string }) {
       </div>
 
       {exportError ? (
-        <div className="rounded-xl border border-red-900/50 bg-red-950/20 px-4 py-3 text-sm text-red-300">
+        <div className="rounded-xl border border-red-500/30 dark:border-red-900/50 bg-red-500/10 dark:bg-red-950/20 px-4 py-3 text-sm text-red-700 dark:text-red-300">
           {exportError}
         </div>
       ) : null}
@@ -239,14 +239,14 @@ export function ScanResultView({ id }: { id: string }) {
             </button>
             <Link
               href={`/scan?id=${id}&view=mesh`}
-              className="flex items-center gap-1.5 text-xs text-cyan-400 hover:text-cyan-300 transition-colors bg-cyan-950/30 border border-cyan-900/50 rounded-lg px-3 py-1.5"
+              className="flex items-center gap-1.5 text-xs text-cyan-400 hover:text-cyan-700 dark:hover:text-cyan-300 transition-colors bg-cyan-500/10 dark:bg-cyan-950/30 border border-cyan-500/30 dark:border-cyan-900/50 rounded-lg px-3 py-1.5"
             >
               <Server className="w-3 h-3" />
               View Mesh
             </Link>
             <Link
               href={`/scan?id=${id}&view=attack-flow`}
-              className="flex items-center gap-1.5 text-xs text-emerald-400 hover:text-emerald-300 transition-colors bg-emerald-950/30 border border-emerald-900/50 rounded-lg px-3 py-1.5"
+              className="flex items-center gap-1.5 text-xs text-emerald-400 hover:text-emerald-700 dark:hover:text-emerald-300 transition-colors bg-emerald-500/10 dark:bg-emerald-950/30 border border-emerald-500/30 dark:border-emerald-900/50 rounded-lg px-3 py-1.5"
             >
               <GitBranch className="w-3 h-3" />
               View Attack Flow

--- a/ui/components/security-graph-investigation.tsx
+++ b/ui/components/security-graph-investigation.tsx
@@ -229,7 +229,7 @@ export function SecurityGraphInvestigation({
             onClick={() => onFocusModeChange(!focusMode)}
             className={`inline-flex items-center gap-2 rounded-lg border px-3 py-1.5 text-xs font-medium transition ${
               focusMode
-                ? "border-emerald-600/50 bg-emerald-500/10 text-emerald-200"
+                ? "border-emerald-600/50 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200"
                 : "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]"
             }`}
           >

--- a/ui/components/service-state-chip.tsx
+++ b/ui/components/service-state-chip.tsx
@@ -8,8 +8,8 @@ import {
 
 const STATE_STYLE: Record<ServiceEntry["state"], string> = {
   locked: "border-[var(--border-subtle)] bg-[var(--surface)]/80 text-[var(--text-secondary)]",
-  connected: "border-amber-500/30 bg-amber-500/10 text-amber-200",
-  live: "border-emerald-500/30 bg-emerald-500/10 text-emerald-200",
+  connected: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-200",
+  live: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-200",
 };
 
 export function ServiceStateChip({

--- a/ui/components/sigma-graph-overview.tsx
+++ b/ui/components/sigma-graph-overview.tsx
@@ -216,7 +216,7 @@ export function SigmaGraphOverview({
     >
       <div className="border-b border-[var(--border-subtle)] bg-[var(--background)]/95 p-3">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-200">
+          <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 dark:bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 dark:text-emerald-200">
             <Sparkles className="h-3.5 w-3.5" />
             WebGL graph overview
           </span>

--- a/ui/components/sso-setup-presets.tsx
+++ b/ui/components/sso-setup-presets.tsx
@@ -14,9 +14,9 @@ import {
 function fieldTone(kind: SsoProviderPreset["fields"][number]["kind"]): string {
   switch (kind) {
     case "secret":
-      return "border-amber-900/50 bg-amber-950/20 text-amber-200";
+      return "border-amber-500/30 dark:border-amber-900/50 bg-amber-500/10 dark:bg-amber-950/20 text-amber-700 dark:text-amber-200";
     case "tenant":
-      return "border-sky-900/50 bg-sky-950/20 text-sky-200";
+      return "border-sky-500/30 dark:border-sky-900/50 bg-sky-500/10 dark:bg-sky-950/20 text-sky-700 dark:text-sky-200";
     case "config":
     default:
       return "border-[var(--border-subtle)] bg-[var(--surface)] text-[var(--text-secondary)]";

--- a/ui/components/topology-detail-drawer.tsx
+++ b/ui/components/topology-detail-drawer.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { Lock, Package, Server, ShieldAlert, Users, Wrench, X } from "lucide-react";
 
+import { useEscToClose } from "@/hooks/use-esc-to-close";
 import type { Agent } from "@/lib/api";
 import {
   serverHasCredentials,
@@ -26,6 +27,7 @@ export function TopologyDetailDrawer({
     | null;
   onClose: () => void;
 }) {
+  useEscToClose(selection !== null, onClose);
   if (!selection) return null;
 
   const agent =
@@ -96,7 +98,7 @@ export function TopologyDetailDrawer({
         </div>
 
         {hasCredentials ? (
-          <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-950/20 px-3 py-2 text-xs text-amber-200">
+          <div className="mb-4 rounded-lg border border-amber-500/30 bg-amber-500/10 dark:bg-amber-950/20 px-3 py-2 text-xs text-amber-700 dark:text-amber-200">
             <Lock className="mr-1.5 inline h-3.5 w-3.5" />
             Credential-backed env vars detected on this service path.
           </div>
@@ -128,7 +130,7 @@ export function TopologyDetailDrawer({
           {selection.kind === "agent" ? (
             <Link
               href={`/agents?name=${encodeURIComponent(selection.name)}`}
-              className="rounded-lg border border-emerald-700/50 bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-200"
+              className="rounded-lg border border-emerald-700/50 bg-emerald-500/10 dark:bg-emerald-950/30 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200"
             >
               Open agent record
             </Link>

--- a/ui/components/trace-explorer-panel.tsx
+++ b/ui/components/trace-explorer-panel.tsx
@@ -60,7 +60,7 @@ export function TraceExplorerPanel() {
 
   if (error) {
     return (
-      <div className="rounded-2xl border border-red-900/50 bg-red-950/30 px-4 py-3 text-sm text-red-300">
+      <div className="rounded-2xl border border-red-500/30 dark:border-red-900/50 bg-red-500/10 dark:bg-red-950/30 px-4 py-3 text-sm text-red-700 dark:text-red-300">
         {error}
       </div>
     );

--- a/ui/hooks/use-esc-to-close.ts
+++ b/ui/hooks/use-esc-to-close.ts
@@ -1,0 +1,19 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * Close an overlay when Escape is pressed. Pass `active` so the listener is only
+ * bound while the overlay is open (custom drawers that early-return null must
+ * still call the hook unconditionally to satisfy the rules of hooks).
+ */
+export function useEscToClose(active: boolean, onClose: () => void): void {
+  useEffect(() => {
+    if (!active) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [active, onClose]);
+}

--- a/ui/lib/toned-chip.ts
+++ b/ui/lib/toned-chip.ts
@@ -1,0 +1,47 @@
+/**
+ * Both-theme legible "toned chip" classes.
+ *
+ * The dark-canvas UI historically styled status/severity chips with
+ * `bg-<hue>-950 text-<hue>-200`, which computes pale-on-pale (≈1.1:1) on the
+ * light surface. Every tone below ships a light pair (`bg-<hue>-500/10
+ * text-<hue>-700 border-<hue>-500/30`, AA ≥ 4.5:1 on the light card) plus a
+ * `dark:`-scoped restore of the original dark treatment. Use this for
+ * semantic status/severity chips instead of hand-rolling color classes.
+ */
+export type ChipTone =
+  // severity
+  | "critical"
+  | "high"
+  | "medium"
+  | "low"
+  | "info"
+  // status
+  | "ok"
+  | "warn"
+  | "danger"
+  | "neutral"
+  // brand
+  | "accent";
+
+const TONE_CLASS: Readonly<Record<ChipTone, string>> = {
+  critical:
+    "border-red-500/30 bg-red-500/10 text-red-700 dark:border-red-500/40 dark:bg-red-950/40 dark:text-red-200",
+  high: "border-orange-500/30 bg-orange-500/10 text-orange-700 dark:border-orange-500/40 dark:bg-orange-950/40 dark:text-orange-200",
+  medium:
+    "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-200",
+  low: "border-sky-500/30 bg-sky-500/10 text-sky-700 dark:border-sky-500/40 dark:bg-sky-950/40 dark:text-sky-200",
+  info: "border-blue-500/30 bg-blue-500/10 text-blue-700 dark:border-blue-500/40 dark:bg-blue-950/40 dark:text-blue-200",
+  ok: "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-200",
+  warn: "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:border-amber-500/40 dark:bg-amber-950/40 dark:text-amber-200",
+  danger:
+    "border-red-500/30 bg-red-500/10 text-red-700 dark:border-red-500/40 dark:bg-red-950/40 dark:text-red-200",
+  neutral:
+    "border-slate-500/30 bg-slate-500/10 text-slate-700 dark:border-slate-500/40 dark:bg-slate-900/50 dark:text-slate-200",
+  accent:
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:border-emerald-500/40 dark:bg-emerald-950/40 dark:text-emerald-200",
+};
+
+/** Both-theme (light + dark) border/bg/text classes for a semantic chip tone. */
+export function tonedChipClass(tone: ChipTone): string {
+  return TONE_CLASS[tone];
+}

--- a/ui/tests/toned-chip.test.ts
+++ b/ui/tests/toned-chip.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { tonedChipClass, type ChipTone } from "@/lib/toned-chip";
+
+const TONES: ChipTone[] = [
+  "critical",
+  "high",
+  "medium",
+  "low",
+  "info",
+  "ok",
+  "warn",
+  "danger",
+  "neutral",
+  "accent",
+];
+
+describe("tonedChipClass", () => {
+  it("emits a light-theme pair and a dark:-scoped pair for every tone", () => {
+    for (const tone of TONES) {
+      const cls = tonedChipClass(tone);
+      // Light theme: a saturated -700 text and a -500 tinted bg (no dark: prefix).
+      expect(cls).toMatch(/(?<!dark:)\btext-[a-z]+-700\b/);
+      expect(cls).toMatch(/(?<!dark:)\bbg-[a-z]+-500\/\d+\b/);
+      // Dark theme: restores the dark-canvas treatment.
+      expect(cls).toMatch(/\bdark:bg-[a-z]+-9\d0(?:\/\d+)?\b/);
+      expect(cls).toMatch(/\bdark:text-[a-z]+-200\b/);
+    }
+  });
+
+  it("never leaves an unguarded dark-only pale-text token (the light-theme bug)", () => {
+    for (const tone of TONES) {
+      const cls = tonedChipClass(tone);
+      // No bare (non-dark:) text-*-200/300 — that was the pale-on-pale defect.
+      expect(cls).not.toMatch(/(?<!dark:)\btext-[a-z]+-(?:200|300)\b/);
+      // No bare (non-dark:) bg-*-900/950 dark panel leaking into light theme.
+      expect(cls).not.toMatch(/(?<!dark:)\bbg-[a-z]+-9\d0(?:\/\d+)?\b/);
+    }
+  });
+});


### PR DESCRIPTION
## Pre-release UI fixes (UI/UX + interop bug-hunts)

Frontend-only. Tokens/`dark:`-scoped classes only, both themes verified, AA (≥4.5:1) text.

### Fix 1 (headline) — light theme shipped broken on dark-tuned chips
Status/severity chips built for the dark canvas (`bg-*-900/950/<opacity>` + `text-*-200/300`) computed **pale-on-pale on the light surface** (e.g. `bg-red-950/20` + `text-red-200` ≈ 1.1:1, effectively invisible).

- New shared **`tonedChipClass(tone)`** helper (`ui/lib/toned-chip.ts`) — semantic tones (severity/status/accent) → both-theme, AA-legible classes; `security-graph` QuickStat migrated to it as the exemplar.
- Codemod migrated **~180 chip literals across ~50 files** to a both-theme pair: light `bg-*-500/10 text-*-700 border-*-500/30`, `dark:`-scoped restore of the original dark panel. Variant chains (`hover:`, etc.) preserved.
- **Before: 186** unguarded pale-on-pale chip literals → **After: 0** (the 50 solid opaque-dark pills, e.g. `bg-emerald-950 text-emerald-300`, are legible in both themes and deliberately left as-is).
- Covers the security-graph moat page (QuickStat tones, selected-snapshot chip, error banner), connections type/mode badges, key-lifecycle admin warning, and the long tail.
- New `toned-chip` test asserts every tone emits a light pair + `dark:` pair; existing `light-theme-token-guard` still passes (no new hardcoded zinc).

### Fix 2 (a11y) — drawer keyboard/focus
- Shared `Drawer`: focus the panel on open, **trap Tab within**, restore focus to the trigger on close, `motion-reduce` on the transitions.
- Three custom drawers (`topology-detail`, `compliance-control`, `proxy-alert`) get **Escape-to-close** via a shared `useEscToClose` hook.

### Fix 3 (interop) — empty-state copy named wrong endpoints
- proxy dashboard: `POST /v1/proxy/events` → **`POST /v1/proxy/audit`** (real ingest route; `/ws/proxy/metrics` kept).
- cost page: `POST /v1/observability/costs/budget` → **`PUT …`** (write route is PUT). Both verified against `src/agent_bom/api/`.

### Fix 4 — nav `/audit` icon tint
- `text-stone-400` (the lone desaturated nav icon) → `text-teal-400` (saturated, no duplicate).

### Skipped (tracked, not dropped)
- **Gateway/proxy design-system restyle** (`GatewayDashboard.tsx` `bg-blue-600` primaries + `PageLaneHeader`): PageLane + accent swap is all-or-nothing and risks scope-creep, so skipped to keep this PR focused. Its chips were still migrated by Fix 1.

### Verify
- `npm run build` clean · `vitest run` 600/600 · `tsc --noEmit` clean · ESLint clean (1 pre-existing unrelated warning) · bundle budget PASS.

From the UI/UX + interop pre-release bug-hunts.
