### PR TITLE
fix: pre-release scale & loop-safety

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -23325,7 +23325,7 @@
     },
     "/v1/runtime/trace-explorer": {
       "get": {
-        "description": "Langfuse-style trace explorer joined to findings and policy decisions (#3608).\n\nFuses gateway/proxy feed events and persisted runtime observations into\nsession-grouped spans. Each span carries correlated findings (CVE, reach\nband, compliance controls) and blocked/observed verdict metadata.",
+        "description": "Langfuse-style trace explorer joined to findings and policy decisions (#3608).\n\nFuses gateway/proxy feed events and persisted runtime observations into\nsession-grouped spans. Each span carries correlated findings (CVE, reach\nband, compliance controls) and blocked/observed verdict metadata.\n\nThe whole assembly \u2014 unbounded findings iteration, synchronous psycopg\nsession/observation reads, and CPU-bound serialization \u2014 is offloaded via\n``asyncio.to_thread`` so it never blocks the event loop under scale.",
         "operationId": "trace_explorer_v1_runtime_trace_explorer_get",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -15104,15 +15104,13 @@ paths:
       - observability
   /v1/runtime/trace-explorer:
     get:
-      description: 'Langfuse-style trace explorer joined to findings and policy decisions
-        (#3608).
-
-
-        Fuses gateway/proxy feed events and persisted runtime observations into
-
-        session-grouped spans. Each span carries correlated findings (CVE, reach
-
-        band, compliance controls) and blocked/observed verdict metadata.'
+      description: "Langfuse-style trace explorer joined to findings and policy decisions\
+        \ (#3608).\n\nFuses gateway/proxy feed events and persisted runtime observations\
+        \ into\nsession-grouped spans. Each span carries correlated findings (CVE,\
+        \ reach\nband, compliance controls) and blocked/observed verdict metadata.\n\
+        \nThe whole assembly \u2014 unbounded findings iteration, synchronous psycopg\n\
+        session/observation reads, and CPU-bound serialization \u2014 is offloaded\
+        \ via\n``asyncio.to_thread`` so it never blocks the event loop under scale."
       operationId: trace_explorer_v1_runtime_trace_explorer_get
       parameters:
       - in: query

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -77,6 +77,8 @@ AGENT_BOM_BROWSER_SESSION_SIGNING_KEY
 AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_LAST_ROTATED
 AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_MAX_AGE_DAYS
 AGENT_BOM_BROWSER_SESSION_SIGNING_KEY_ROTATION_DAYS
+# Rolling-window (days) that bounds the budget-check spend SUM; unset = all-history. Read at call time so tests can vary it.
+AGENT_BOM_BUDGET_WINDOW_DAYS
 AGENT_BOM_CLICKHOUSE_BUFFERED
 AGENT_BOM_CLICKHOUSE_FLUSH_INTERVAL
 AGENT_BOM_CLICKHOUSE_MAX_BATCH
@@ -95,6 +97,8 @@ AGENT_BOM_DSPM_DB_SAMPLING
 AGENT_BOM_ICEBERG_CREDENTIAL
 # Iceberg REST catalog bearer token; secret material stays env/KMS-only and out of generated config docs.
 AGENT_BOM_ICEBERG_TOKEN
+# TTL (hours) for pruning stale SQLite idempotency keys on write; read at call time in api/idempotency_store.py.
+AGENT_BOM_IDEMPOTENCY_TTL_HOURS
 # base64 Fernet key for at-rest encryption of cloud-connection secrets (ExternalId); secret, env/KMS-only, never in config.py or ENV_VARS.md. With provider=aws-kms it holds the base64 KMS-wrapped data key instead. Accepts a comma-separated list of keys for MultiFernet rotation (first key = primary/encrypt, any key decrypts).
 AGENT_BOM_CONNECTIONS_KEY
 # Selects how the connection encryption key is resolved: env (default) | aws-secrets | aws-kms | vault; read at key-load time in api/connection_crypto.py.
@@ -276,6 +280,8 @@ AGENT_BOM_OCI_MAX_DECOMPRESSION_RATIO
 AGENT_BOM_OCI_MAX_JAR_UNCOMPRESSED_BYTES
 AGENT_BOM_OCI_MAX_LAYER_UNCOMPRESSED_BYTES
 AGENT_BOM_OFFLINE
+# TTL (seconds) for the per-tenant /v1/overview payload cache; read at call time so tests can vary it. 0 disables.
+AGENT_BOM_OVERVIEW_CACHE_TTL_SECONDS
 AGENT_BOM_SKIP_UPDATE_CHECK
 AGENT_BOM_OIDC_ALLOWED_JWKS_URIS
 AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT

--- a/src/agent_bom/api/cost_store.py
+++ b/src/agent_bom/api/cost_store.py
@@ -10,10 +10,12 @@ accountability layer commercial agent-runtime products charge for, kept open.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import threading
 from collections import defaultdict
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
@@ -215,14 +217,34 @@ COST_STORAGE_SCHEMA = StorageSchema(
 )
 
 
+def budget_window_start(now: datetime | None = None) -> str | None:
+    """Return the ISO cutoff for budget spend SUMs, or ``None`` for all-history.
+
+    ``AGENT_BOM_BUDGET_WINDOW_DAYS`` bounds the budget-check spend SUM to a
+    rolling window so the aggregate does not scan a tenant's entire cost ledger
+    on every enforced call. Unset (the default) preserves all-history semantics.
+    """
+    raw = os.environ.get("AGENT_BOM_BUDGET_WINDOW_DAYS")
+    if raw is None or raw.strip() == "":
+        return None
+    try:
+        days = int(raw)
+    except ValueError:
+        return None
+    if days <= 0:
+        return None
+    ref = now or datetime.now(timezone.utc)
+    return (ref - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 class CostStore(Protocol):
     def record_cost(self, record: LLMCostRecord) -> None: ...
 
     def list_records(self, tenant_id: str, *, limit: int = 1000) -> list[LLMCostRecord]: ...
 
-    def total_spend(self, tenant_id: str, *, agent: str | None = None) -> float: ...
+    def total_spend(self, tenant_id: str, *, agent: str | None = None, since: str | None = None) -> float: ...
 
-    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str) -> float: ...
+    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str, *, since: str | None = None) -> float: ...
 
     def set_budget(self, budget: CostBudget) -> None: ...
 
@@ -366,17 +388,25 @@ class InMemoryCostStore:
         with self._lock:
             return list(self._records.get(tenant_id, []))[-limit:]
 
-    def total_spend(self, tenant_id: str, *, agent: str | None = None) -> float:
+    def total_spend(self, tenant_id: str, *, agent: str | None = None, since: str | None = None) -> float:
         with self._lock:
             return round(
-                sum(r.cost_usd for r in self._records.get(tenant_id, []) if agent in (None, "", r.agent) or r.agent == agent),
+                sum(
+                    r.cost_usd
+                    for r in self._records.get(tenant_id, [])
+                    if (agent in (None, "", r.agent) or r.agent == agent) and (since is None or r.observed_at >= since)
+                ),
                 6,
             )
 
-    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str) -> float:
+    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str, *, since: str | None = None) -> float:
         with self._lock:
             return round(
-                sum(r.cost_usd for r in self._records.get(tenant_id, []) if (r.cost_center or "") == cost_center),
+                sum(
+                    r.cost_usd
+                    for r in self._records.get(tenant_id, [])
+                    if (r.cost_center or "") == cost_center and (since is None or r.observed_at >= since)
+                ),
                 6,
             )
 
@@ -486,6 +516,11 @@ class SQLiteCostStore:
             self._conn.execute("ALTER TABLE llm_costs ADD COLUMN allocation_tags TEXT NOT NULL DEFAULT '{}'")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_agent ON llm_costs(tenant_id, agent)")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_cost_center ON llm_costs(tenant_id, cost_center)")
+        # Supports the windowed budget-check SUM (WHERE tenant_id=? [AND agent=?]
+        # AND observed_at >= ?) so a rolling-window aggregate stays a bounded
+        # range scan instead of folding the tenant's whole cost history.
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_agent_observed ON llm_costs(tenant_id, agent, observed_at)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_llm_costs_tenant_observed ON llm_costs(tenant_id, observed_at)")
         self._conn.commit()
 
     def record_cost(self, record: LLMCostRecord) -> None:
@@ -540,20 +575,25 @@ class SQLiteCostStore:
             for r in rows
         ]
 
-    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str) -> float:
-        row = self._conn.execute(
-            "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = ? AND cost_center = ?",
-            (tenant_id, cost_center),
-        ).fetchone()
+    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str, *, since: str | None = None) -> float:
+        sql = "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = ? AND cost_center = ?"
+        params: list[Any] = [tenant_id, cost_center]
+        if since is not None:
+            sql += " AND observed_at >= ?"
+            params.append(since)
+        row = self._conn.execute(sql, params).fetchone()
         return round(float(row[0]), 6)
 
-    def total_spend(self, tenant_id: str, *, agent: str | None = None) -> float:
+    def total_spend(self, tenant_id: str, *, agent: str | None = None, since: str | None = None) -> float:
+        sql = "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = ?"
+        params: list[Any] = [tenant_id]
         if agent:
-            row = self._conn.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = ? AND agent = ?", (tenant_id, agent)
-            ).fetchone()
-        else:
-            row = self._conn.execute("SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = ?", (tenant_id,)).fetchone()
+            sql += " AND agent = ?"
+            params.append(agent)
+        if since is not None:
+            sql += " AND observed_at >= ?"
+            params.append(since)
+        row = self._conn.execute(sql, params).fetchone()
         return round(float(row[0]), 6)
 
     def set_budget(self, budget: CostBudget) -> None:
@@ -603,13 +643,14 @@ def check_budget_enforcement(store: CostStore, tenant_id: str, agent: str) -> tu
     otherwise the tenant-wide enforce budget applies. Report-mode budgets and
     missing budgets never block.
     """
+    window = budget_window_start()
     budget = store.get_budget(tenant_id, agent) if agent else None
-    spend = store.total_spend(tenant_id, agent=agent or None)
+    spend = store.total_spend(tenant_id, agent=agent or None, since=window)
     if budget is None or budget.mode != "enforce":
         tenant_budget = store.get_budget(tenant_id, "")
         if tenant_budget is not None and tenant_budget.mode == "enforce":
             budget = tenant_budget
-            spend = store.total_spend(tenant_id, agent=None)
+            spend = store.total_spend(tenant_id, agent=None, since=window)
         elif budget is None or budget.mode != "enforce":
             return False, budget, spend
     blocked = budget is not None and budget.mode == "enforce" and spend >= budget.limit_usd
@@ -626,7 +667,7 @@ def check_cost_center_budget_enforcement(store: CostStore, tenant_id: str, cost_
     if not cost_center:
         return False, None, 0.0
     budget = store.get_budget(tenant_id, "", cost_center=cost_center)
-    spend = store.total_spend_by_cost_center(tenant_id, cost_center)
+    spend = store.total_spend_by_cost_center(tenant_id, cost_center, since=budget_window_start())
     if budget is None or budget.mode != "enforce":
         return False, budget, spend
     return spend >= budget.limit_usd, budget, spend

--- a/src/agent_bom/api/idempotency_store.py
+++ b/src/agent_bom/api/idempotency_store.py
@@ -4,13 +4,41 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sqlite3
 import threading
+import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+# Fixed namespace for content-derived batch ids so an identical write resent
+# without an ``Idempotency-Key`` header still collapses onto one logical batch
+# (stable observation dedup key) instead of minting a fresh random batch id.
+_BATCH_ID_NAMESPACE = uuid.UUID("6f6b4b2e-2c1a-4d9e-9d3b-8a1f0c5e7d42")
+_DEFAULT_IDEMPOTENCY_TTL_HOURS = 24
+
+
+def deterministic_batch_id(seed: str) -> str:
+    """Return a stable batch id derived from *seed* (idempotency key or hash).
+
+    A pure function of the seed: the same request content (or the same explicit
+    ``Idempotency-Key``) always yields the same batch id, so replays dedup rather
+    than inflate per-batch observation counts.
+    """
+    return str(uuid.uuid5(_BATCH_ID_NAMESPACE, seed or ""))
+
+
+def _idempotency_ttl_hours() -> int:
+    raw = os.environ.get("AGENT_BOM_IDEMPOTENCY_TTL_HOURS")
+    if raw is None:
+        return _DEFAULT_IDEMPOTENCY_TTL_HOURS
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _DEFAULT_IDEMPOTENCY_TTL_HOURS
 
 
 @dataclass
@@ -132,10 +160,17 @@ class InMemoryIdempotencyStore:
 
 
 class SQLiteIdempotencyStore:
-    def __init__(self, db_path: str = "agent_bom_jobs.db") -> None:
+    def __init__(self, db_path: str = "agent_bom_jobs.db", ttl_hours: int | None = None) -> None:
         self._db_path = db_path
+        self._ttl_hours = ttl_hours
         self._local = threading.local()
         self._init_db()
+
+    def _prune(self) -> None:
+        """Delete idempotency keys past the TTL (keyed on ``idx_idempotency_created_at``)."""
+        ttl = self._ttl_hours if self._ttl_hours is not None else _idempotency_ttl_hours()
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=max(1, int(ttl)))).isoformat()
+        self._conn.execute("DELETE FROM idempotency_keys WHERE created_at < ?", (cutoff,))
 
     @property
     def _conn(self) -> sqlite3.Connection:
@@ -209,4 +244,6 @@ class SQLiteIdempotencyStore:
                 _utcnow(),
             ),
         )
+        # Prune expired keys on write so the table cannot grow without bound.
+        self._prune()
         self._conn.commit()

--- a/src/agent_bom/api/postgres_cost.py
+++ b/src/agent_bom/api/postgres_cost.py
@@ -11,6 +11,7 @@ via :class:`PostgresRateLimitStore`; cost governance must match).
 from __future__ import annotations
 
 import json
+from typing import Any
 
 from agent_bom.api.cost_store import CostBudget, LLMCostRecord, _decode_tags
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
@@ -145,26 +146,27 @@ class PostgresCostStore:
             for r in rows
         ]
 
-    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str) -> float:
+    def total_spend_by_cost_center(self, tenant_id: str, cost_center: str, *, since: str | None = None) -> float:
+        sql = "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = %s AND cost_center = %s"
+        params: list[Any] = [tenant_id, cost_center]
+        if since is not None:
+            sql += " AND observed_at >= %s"
+            params.append(since)
         with _tenant_connection(self._pool) as conn:
-            row = conn.execute(
-                "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = %s AND cost_center = %s",
-                (tenant_id, cost_center),
-            ).fetchone()
+            row = conn.execute(sql, params).fetchone()
         return round(float(row[0]), 6) if row else 0.0
 
-    def total_spend(self, tenant_id: str, *, agent: str | None = None) -> float:
+    def total_spend(self, tenant_id: str, *, agent: str | None = None, since: str | None = None) -> float:
+        sql = "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = %s"
+        params: list[Any] = [tenant_id]
+        if agent:
+            sql += " AND agent = %s"
+            params.append(agent)
+        if since is not None:
+            sql += " AND observed_at >= %s"
+            params.append(since)
         with _tenant_connection(self._pool) as conn:
-            if agent:
-                row = conn.execute(
-                    "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = %s AND agent = %s",
-                    (tenant_id, agent),
-                ).fetchone()
-            else:
-                row = conn.execute(
-                    "SELECT COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = %s",
-                    (tenant_id,),
-                ).fetchone()
+            row = conn.execute(sql, params).fetchone()
         return round(float(row[0]), 6) if row else 0.0
 
     def set_budget(self, budget: CostBudget) -> None:

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -7,7 +7,7 @@ import json
 import logging
 import os
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Iterable, Iterator, Sequence
 
 from agent_bom.api.graph_store import (
@@ -21,6 +21,7 @@ from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMENT_TIMEOUT_MS
 from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, graph_retention_policy, normalize_graph_tenant_id
 from agent_bom.graph import EntityType
+from agent_bom.security import sanitize_text
 
 from .postgres_common import _apply_tenant_session, _ensure_tenant_rls, _get_pool, _tenant_connection, bypass_tenant_rls
 
@@ -46,6 +47,17 @@ _GRAPH_EVIDENCE_EXCLUDED_PRIVATE_FIELDS = [
     "attack_paths.credential_exposure",
 ]
 _DEFAULT_GRAPH_WRITE_BATCH_SIZE = 1000
+# Tables purged (children before parents) when a graph snapshot ages out of the
+# retention window, so a partial failure never orphans rows under a deleted
+# snapshot. Mirrors ``graph_store._GRAPH_PURGEABLE_TABLES`` plus the search index.
+_GRAPH_RETENTION_PURGE_TABLES = (
+    "graph_node_search",
+    "attack_paths",
+    "interaction_risks",
+    "graph_edges",
+    "graph_nodes",
+    "graph_snapshots",
+)
 _GRAPH_TENANT_TABLE_KEYS: dict[str, tuple[str, ...]] = {
     "graph_nodes": ("id", "scan_id"),
     "graph_edges": ("source_id", "target_id", "relationship", "scan_id"),
@@ -760,6 +772,46 @@ class PostgresGraphStore:
                 ),
             )
             conn.commit()
+
+            # Mirror the SQLite backend's age-based retention purge so Postgres
+            # snapshot history does not grow unbounded. Best-effort: a purge
+            # failure must never fail the durable save that already committed.
+            self._purge_expired_snapshots(conn, tenant)
+
+    def _purge_expired_snapshots(self, conn, tenant: str) -> None:
+        """Delete this tenant's graph snapshots older than the retention window.
+
+        Age-based purge keyed on ``graph_snapshots.created_at`` and scoped to the
+        tenant being saved. Fail-closed on unparseable timestamps (retained,
+        never deleted) and cascades to child rows in FK-safe order.
+        """
+        from agent_bom.api.tenant_graph_retention import resolve_graph_retention_days
+        from agent_bom.db.graph_store import _parse_iso_timestamp
+
+        try:
+            days = max(1, int(resolve_graph_retention_days(tenant)))
+            cutoff = datetime.now(timezone.utc) - timedelta(days=days)
+            rows = conn.execute(
+                "SELECT scan_id, created_at FROM graph_snapshots WHERE tenant_id = %s",
+                (tenant,),
+            ).fetchall()
+            expired: list[tuple[str, str]] = []
+            for row in rows:
+                created = _parse_iso_timestamp(row[1])
+                if created is not None and created < cutoff:
+                    expired.append((tenant, str(row[0])))
+            if not expired:
+                return
+            for table in _GRAPH_RETENTION_PURGE_TABLES:
+                conn.executemany(
+                    f"DELETE FROM {table} WHERE tenant_id = %s AND scan_id = %s",  # nosec B608 - table names are static internal schema metadata
+                    expired,
+                )
+            conn.commit()
+            logger.info("Purged %d expired graph snapshot(s) (tenant=%s)", len(expired), tenant)
+        except Exception as exc:
+            conn.rollback()
+            logger.warning("Graph snapshot retention purge skipped: %s", sanitize_text(str(exc)))
 
     def load_graph(
         self,

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -20,7 +20,6 @@ import json
 import logging
 import os
 import secrets
-import uuid
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
@@ -1998,7 +1997,14 @@ async def ingest_compliance_findings(request: Request) -> dict:
     )
 
     observed_at = normalize_observed_at(body.get("observed_at"))
-    batch_id = str(uuid.uuid4())
+    # Deterministic batch id keyed on the Idempotency-Key header (if any) or the
+    # request-content fingerprint, so re-POSTing the same document collapses onto
+    # one observation batch instead of inflating ``scan_count`` on every resend
+    # (P1-5). The (canonical, batch_id) observation key must be stable per body.
+    from agent_bom.api.idempotency_store import deterministic_batch_id, idempotency_request_fingerprint
+
+    idem_key = request.headers.get("Idempotency-Key") or ""
+    batch_id = deterministic_batch_id(idem_key or idempotency_request_fingerprint(body))
     prior_snapshots: dict[str, Any] = {}
     if needs_hub_prior_snapshots(reconcile_absent=bool(body.get("reconcile_absent"))):
         prior_snapshots = capture_hub_snapshots(store, tenant_id, source=fmt)

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -12,6 +12,7 @@ Endpoints:
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import datetime, timezone
 from typing import Any, cast
@@ -24,6 +25,7 @@ from agent_bom.api.models import FleetAgentUpdate, PushPayload, StateUpdate
 from agent_bom.api.stores import _get_fleet_store, _get_idempotency_store, _get_mcp_observation_store, _get_policy_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.api.tenant_quota import enforce_fleet_agents_quota, tenant_quota_guard
+from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.security import sanitize_command_args, sanitize_error, sanitize_security_warnings, sanitize_text, sanitize_url
@@ -33,6 +35,19 @@ router = APIRouter()
 
 def _dep(permission: str) -> Any:
     return cast(Any, require_authenticated_permission(permission))
+
+
+async def _store_call(fn, /, *args, **kwargs):
+    """Run a sync fleet-store method off the event loop under graph backpressure."""
+    try:
+        async with adaptive_backpressure("graph"):
+            return await asyncio.to_thread(fn, *args, **kwargs)
+    except BackpressureRejectedError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=exc.to_dict(),
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
 
 
 def _quarantine_policy_name(agent_name: str) -> str:
@@ -118,7 +133,8 @@ async def list_fleet(
     result = None
     query_by_tenant = getattr(store, "query_by_tenant", None)
     if callable(query_by_tenant):
-        result = query_by_tenant(
+        result = await _store_call(
+            query_by_tenant,
             tenant_id,
             state=state,
             environment=environment,
@@ -132,7 +148,7 @@ async def list_fleet(
         page, total = result
     else:
         page, total = _query_fleet_fallback(
-            store.list_by_tenant(tenant_id),
+            await _store_call(store.list_by_tenant, tenant_id),
             state=state,
             environment=environment,
             min_trust=min_trust_value,
@@ -155,7 +171,7 @@ async def list_fleet(
 async def fleet_stats(request: Request):
     """Fleet-wide statistics."""
     tenant_id = require_request_tenant_id(request)
-    agents = _get_fleet_store().list_by_tenant(tenant_id)
+    agents = await _store_call(_get_fleet_store().list_by_tenant, tenant_id)
     by_state: dict[str, int] = {}
     by_env: dict[str, int] = {}
     trust_scores: list[float] = []
@@ -178,7 +194,7 @@ async def fleet_stats(request: Request):
 async def get_fleet_agent(request: Request, agent_id: str):
     """Get a single fleet agent with trust score breakdown."""
     tenant_id = require_request_tenant_id(request)
-    agent = _get_fleet_store().get(agent_id, tenant_id=tenant_id)
+    agent = await _store_call(_get_fleet_store().get, agent_id, tenant_id=tenant_id)
     if agent is None:
         raise HTTPException(status_code=404, detail="Fleet agent not found")
     return agent.model_dump()

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1246,6 +1246,36 @@ def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) ->
     }
 
 
+def _overlay_filter_and_respond(
+    graph: UnifiedGraph,
+    *,
+    tenant: str,
+    apply_overlay: bool,
+    filters: Any,
+    offset: int,
+    limit: int,
+) -> dict[str, Any]:
+    """Overlay governance, apply the scoped filter, and serialize — all off-loop.
+
+    Consolidates the governance overlay, ``filtered_view`` derivation and
+    response build into one synchronous unit so ``get_graph`` runs zero heavy
+    work on the event loop between offloaded calls.
+
+    The overlay is applied BEFORE the scoped filter so governance edges are
+    subject to the relationship filter and governance nodes left unconnected in a
+    scoped view are pruned with everything else. Best-effort; never breaks read.
+    """
+    if apply_overlay:
+        try:
+            from agent_bom.graph.governance_overlay import apply_governance_overlay
+
+            apply_governance_overlay(graph, tenant_id=tenant)
+        except Exception:  # noqa: BLE001
+            logger.warning("governance overlay failed", exc_info=True)
+    filtered = graph.filtered_view(filters)
+    return _filtered_graph_response(filtered, offset=offset, limit=limit)
+
+
 def _fix_first_graph_view_payload(graph: UnifiedGraph, *, cve: str, package: str, agent: str, limit: int) -> dict[str, Any]:
     available_paths = _derived_attack_paths(graph)
     ranked_paths = sorted(
@@ -1596,21 +1626,6 @@ async def get_graph(
             entity_types=et_set,
             min_severity_rank=min_rank,
         )
-        # Overlay the live agent-identity governance control plane (managed
-        # identities, JIT grants, conditional-access policies, drift incidents)
-        # so attack paths can traverse agent → identity → grant → tool and
-        # agent ↔ drift. Applied BEFORE the scoped filter so governance edges
-        # are subject to the relationship filter and governance nodes left
-        # unconnected in a scoped view are pruned with everything else, rather
-        # than reappearing as orphan nodes. Best-effort; never breaks the read.
-        if not et_set:
-            try:
-                from agent_bom.graph.governance_overlay import apply_governance_overlay
-
-                apply_governance_overlay(graph, tenant_id=tenant)
-            except Exception:  # noqa: BLE001
-                logger.warning("governance overlay failed", exc_info=True)
-
         rel_set = _parse_relationship_filter(relationships)
         filters = GraphFilterOptions(
             relationship_types=rel_set,
@@ -1618,9 +1633,18 @@ async def get_graph(
             dynamic_only=dynamic_only,
             max_depth=max_depth or 6,
         )
-        graph = graph.filtered_view(filters)
-
-        return await _graph_compute_call(_filtered_graph_response, graph, offset=offset, limit=limit)
+        # Governance overlay, scoped-filter derivation, and response
+        # serialization are all CPU-bound; fold them into ONE off-loop hop so no
+        # heavy work runs between offloaded calls on the event loop.
+        return await _graph_compute_call(
+            _overlay_filter_and_respond,
+            graph,
+            tenant=tenant,
+            apply_overlay=not et_set,
+            filters=filters,
+            offset=offset,
+            limit=limit,
+        )
 
     try:
         effective_scan_id, created_at, paged_nodes, total, next_cursor = await _graph_store_call(

--- a/src/agent_bom/api/routes/observability.py
+++ b/src/agent_bom/api/routes/observability.py
@@ -1000,13 +1000,27 @@ async def trace_explorer(
     Fuses gateway/proxy feed events and persisted runtime observations into
     session-grouped spans. Each span carries correlated findings (CVE, reach
     band, compliance controls) and blocked/observed verdict metadata.
+
+    The whole assembly — unbounded findings iteration, synchronous psycopg
+    session/observation reads, and CPU-bound serialization — is offloaded via
+    ``asyncio.to_thread`` so it never blocks the event loop under scale.
+    """
+    tenant_id = _tenant_id(request)
+    bounded_limit = max(1, min(limit, 200))
+    return await asyncio.to_thread(_build_trace_explorer_payload_sync, tenant_id, limit=bounded_limit)
+
+
+def _build_trace_explorer_payload_sync(tenant_id: str, *, limit: int = 100) -> dict[str, object]:
+    """Heavy trace-explorer assembly; always run off the event loop.
+
+    Findings iteration is bounded by ``limit`` so a large estate can never fold
+    an unbounded number of scan findings into one request.
     """
     from agent_bom.api.cost_store import get_cost_store
     from agent_bom.api.routes.gateway_feed import _load_tenant_alerts, build_gateway_feed
     from agent_bom.api.routes.scan import _completed_jobs_for_tenant, _iter_scan_findings
     from agent_bom.api.trace_explorer import build_trace_explorer_payload
 
-    tenant_id = _tenant_id(request)
     bounded_limit = max(1, min(limit, 200))
     alerts = _load_tenant_alerts(tenant_id)
     llm_records = list(get_cost_store().list_records(tenant_id, limit=bounded_limit))
@@ -1018,7 +1032,12 @@ async def trace_explorer(
     )
     findings: list[dict[str, Any]] = []
     for job in _completed_jobs_for_tenant(tenant_id):
-        findings.extend(_iter_scan_findings(job))
+        for finding in _iter_scan_findings(job):
+            findings.append(finding)
+            if len(findings) >= bounded_limit:
+                break
+        if len(findings) >= bounded_limit:
+            break
     store = get_runtime_event_store()
     sessions = [session.to_dict() for session in store.list_sessions(tenant_id, limit=bounded_limit, offset=0)]
     observations = [observation.to_dict() for observation in store.list_observations(tenant_id, limit=bounded_limit, offset=0)]
@@ -1033,35 +1052,9 @@ async def trace_explorer(
 
 
 async def _trace_explorer_payload_for_tenant(tenant_id: str, *, limit: int = 100) -> dict[str, object]:
-    """Shared trace explorer builder for runtime surfaces."""
-    from agent_bom.api.cost_store import get_cost_store
-    from agent_bom.api.routes.gateway_feed import _load_tenant_alerts, build_gateway_feed
-    from agent_bom.api.routes.scan import _completed_jobs_for_tenant, _iter_scan_findings
-    from agent_bom.api.trace_explorer import build_trace_explorer_payload
-
+    """Shared trace explorer builder for runtime surfaces (offloaded off-loop)."""
     bounded_limit = max(1, min(limit, 200))
-    alerts = _load_tenant_alerts(tenant_id)
-    llm_records = list(get_cost_store().list_records(tenant_id, limit=bounded_limit))
-    feed = build_gateway_feed(
-        tenant_id=tenant_id,
-        alerts=alerts,
-        llm_records=llm_records,
-        limit=bounded_limit,
-    )
-    findings: list[dict[str, Any]] = []
-    for job in _completed_jobs_for_tenant(tenant_id):
-        findings.extend(_iter_scan_findings(job))
-    store = get_runtime_event_store()
-    sessions = [session.to_dict() for session in store.list_sessions(tenant_id, limit=bounded_limit, offset=0)]
-    observations = [observation.to_dict() for observation in store.list_observations(tenant_id, limit=bounded_limit, offset=0)]
-    return build_trace_explorer_payload(
-        tenant_id=tenant_id,
-        feed_events=cast(list[dict[str, Any]], feed.get("events", [])),
-        findings=findings,
-        sessions=sessions,
-        observations=observations,
-        limit=bounded_limit,
-    )
+    return await asyncio.to_thread(_build_trace_explorer_payload_sync, tenant_id, limit=bounded_limit)
 
 
 @router.get("/runtime/approval-queue", tags=["runtime", "observability"], dependencies=[_dep("read")])
@@ -1278,12 +1271,36 @@ async def get_llm_costs(
     to scope the report (and budget) to one allocation unit, or ``tag`` to add a
     ``by_tag`` showback slice for a freeform allocation tag.
     """
+    tenant_id = _tenant_id(request)
+    bounded_limit = max(1, min(limit, 10000))
+    # The fetch (up to 10k records) plus the summarize / owner-report / budget /
+    # forecast CPU work is all synchronous; offload it in one hop so a large cost
+    # ledger can never block the event loop.
+    return await asyncio.to_thread(
+        _build_llm_costs_report_sync,
+        tenant_id,
+        agent=agent,
+        cost_center=cost_center,
+        tag=tag,
+        limit=bounded_limit,
+    )
+
+
+def _build_llm_costs_report_sync(
+    tenant_id: str,
+    *,
+    agent: str | None,
+    cost_center: str | None,
+    tag: str | None,
+    limit: int,
+) -> dict[str, object]:
+    """Fetch + compute the LLM cost report off the event loop."""
+    from agent_bom.api.cost_forecast import forecast_spend
+    from agent_bom.api.cost_owner import owner_cost_report
     from agent_bom.api.cost_store import budget_status, get_cost_store, summarize, summarize_by_tag
 
-    tenant_id = _tenant_id(request)
     store = get_cost_store()
-    bounded_limit = max(1, min(limit, 10000))
-    records = store.list_records(tenant_id, limit=bounded_limit)
+    records = store.list_records(tenant_id, limit=limit)
     if agent:
         records = [r for r in records if r.agent == agent]
     if cost_center:
@@ -1292,8 +1309,6 @@ async def get_llm_costs(
     # Owner-attributed rollup (#3909): spend grouped by the accountable owner
     # recorded on the blueprint governing each agent. Spend from an ungoverned
     # agent rolls up under "unattributed" so nothing is silently dropped.
-    from agent_bom.api.cost_owner import owner_cost_report
-
     report["by_owner"] = owner_cost_report(store, tenant_id, records)["by_owner"]
     if tag:
         report["tag_rollup"] = summarize_by_tag(records, _bounded(tag, max_len=60))
@@ -1308,8 +1323,6 @@ async def get_llm_costs(
     report["budget"] = budget_status(spend, budget)
     # Forward-looking companion to the point-in-time budget posture: burn rate +
     # projected runway derived from the same records. Reference only.
-    from agent_bom.api.cost_forecast import forecast_spend
-
     report["forecast"] = forecast_spend(records, budget=budget)
     report["schema_version"] = "observability.costs.v1"
     report["tenant_id"] = tenant_id

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -33,7 +33,11 @@ Endpoints:
 
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
+import threading
+import time
 from typing import Any, cast
 from urllib.parse import urlencode
 
@@ -49,6 +53,81 @@ from agent_bom.rbac import require_authenticated_permission
 
 router = APIRouter(dependencies=[cast(Any, require_authenticated_permission("read"))])
 _logger = logging.getLogger(__name__)
+
+# Per-tenant overview cache (#3963 follow-up). ``_build_overview`` folds every
+# finding of every completed scan (O(estate)); a burst of landing-page reads
+# would refold the whole estate each time. We cache the composed payload keyed by
+# a cheap job-metadata fingerprint so a re-read within the TTL that sees no new
+# scan data skips the fold. The fingerprint (job id/status/timestamp — never the
+# folded findings) invalidates the cache the instant new evidence lands, so the
+# numbers can never go stale relative to the spine.
+_OVERVIEW_CACHE_TTL_SECONDS_DEFAULT = 15.0
+_overview_cache: dict[str, tuple[float, str, dict[str, Any]]] = {}
+_overview_cache_lock = threading.Lock()
+
+
+def _overview_cache_ttl() -> float:
+    raw = os.environ.get("AGENT_BOM_OVERVIEW_CACHE_TTL_SECONDS")
+    if raw is None:
+        return _OVERVIEW_CACHE_TTL_SECONDS_DEFAULT
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return _OVERVIEW_CACHE_TTL_SECONDS_DEFAULT
+
+
+def _overview_fingerprint(jobs: list[Any], hub_severity: dict[str, int]) -> str:
+    """Cheap change-detector over job metadata + hub current-state — no fold.
+
+    Captures job identity, status and the freshest per-job timestamp so a new
+    scan, a status transition, or a re-run all change the fingerprint. It also
+    folds in the hub severity histogram (a cheap indexed GROUP BY) so findings
+    ingested via ``POST /v1/findings/bulk`` — which never touch a scan job —
+    still invalidate the cache. Neither input pays the O(estate) rollup cost, so
+    the headline can never go stale relative to the reconciled spine.
+    """
+    parts = []
+    for job in jobs:
+        stamp = (
+            getattr(job, "completed_at", None)
+            or getattr(job, "updated_at", None)
+            or getattr(job, "created_at", None)
+            or ""
+        )
+        status = getattr(job, "status", "")
+        parts.append(f"{getattr(job, 'job_id', '')}|{getattr(status, 'value', status)}|{stamp}")
+    parts.sort()
+    hub_part = "|".join(f"{k}={int(hub_severity.get(k, 0) or 0)}" for k in sorted(hub_severity))
+    digest = hashlib.sha256(("\x1e".join(parts) + "\x1d" + hub_part).encode("utf-8")).hexdigest()
+    return f"{len(jobs)}:{digest}"
+
+
+def _overview_cache_get(tenant_id: str, fingerprint: str) -> dict[str, Any] | None:
+    ttl = _overview_cache_ttl()
+    if ttl <= 0:
+        return None
+    now = time.monotonic()
+    with _overview_cache_lock:
+        entry = _overview_cache.get(tenant_id)
+        if entry is None:
+            return None
+        cached_at, cached_fp, payload = entry
+        if cached_fp != fingerprint or (now - cached_at) > ttl:
+            return None
+        return payload
+
+
+def _overview_cache_put(tenant_id: str, fingerprint: str, payload: dict[str, Any]) -> None:
+    if _overview_cache_ttl() <= 0:
+        return
+    with _overview_cache_lock:
+        _overview_cache[tenant_id] = (time.monotonic(), fingerprint, payload)
+
+
+def _reset_overview_cache() -> None:
+    """Test hook: drop all cached overview payloads."""
+    with _overview_cache_lock:
+        _overview_cache.clear()
 
 _SEVERITY_KEYS = ("critical", "high", "medium", "low")
 # ``unrated`` is the honest home for findings whose severity the histogram does
@@ -728,13 +807,31 @@ async def get_overview(request: Request) -> dict[str, Any]:
 
 
 def _build_overview(request: Request) -> dict[str, Any]:
-    """Synchronous overview composition (runs in a worker thread, #3963)."""
+    """Synchronous overview composition (runs in a worker thread, #3963).
+
+    Serves a cached payload when the tenant's job-metadata fingerprint is
+    unchanged within the TTL, so repeated landing-page reads don't refold the
+    whole estate (#3963 follow-up). Cache misses (new/changed scan data or an
+    expired entry) recompute and refresh the cache.
+    """
     tenant_id = _tenant_id(request)
     jobs = _get_store().list_all(tenant_id=tenant_id)
+    hub_severity = _hub_severity_snapshot(request)
 
+    fingerprint = _overview_fingerprint(jobs, hub_severity)
+    cached = _overview_cache_get(tenant_id, fingerprint)
+    if cached is not None:
+        return cached
+
+    payload = _compose_overview(request, tenant_id, jobs, hub_severity)
+    _overview_cache_put(tenant_id, fingerprint, payload)
+    return payload
+
+
+def _compose_overview(request: Request, tenant_id: str, jobs: list[Any], hub_severity: dict[str, int]) -> dict[str, Any]:
+    """Fold the estate into the overview payload (the O(estate) hot path)."""
     estate = _estate_rollup(jobs)
     coverage = estate["coverage"]
-    hub_severity = _hub_severity_snapshot(request)
     posture = _exec_posture(request, _posture_snapshot(jobs), estate, hub_severity)
     runtime = _runtime_snapshot(request, jobs)
     cost = _cost_snapshot(request)

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -41,7 +41,11 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from werkzeug.security import safe_join
 
 from agent_bom.api.finding_list_envelope import finding_list_envelope
-from agent_bom.api.idempotency_store import IdempotencyConflictError, idempotency_request_fingerprint
+from agent_bom.api.idempotency_store import (
+    IdempotencyConflictError,
+    deterministic_batch_id,
+    idempotency_request_fingerprint,
+)
 from agent_bom.api.models import (
     BrowserExtensionsRequest,
     DatasetCardsRequest,
@@ -1994,7 +1998,11 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
             cached["idempotent_replay"] = True
             return cached
 
-    batch_id = str(uuid.uuid4())
+    # Deterministic batch id so a resend of the same body (even without an
+    # Idempotency-Key header) collapses onto one logical batch. Random per-request
+    # ids made ``upsert_current_batch``'s (canonical, batch_id) observation key
+    # miss on every replay, inflating ``scan_count`` (P1-5).
+    batch_id = deterministic_batch_id(idem_key or request_hash)
     payloads = [
         _normalized_bulk_finding(row, source=body.source, batch_id=batch_id, ordinal=idx) for idx, row in enumerate(body.findings, start=1)
     ]

--- a/tests/test_finops_costs.py
+++ b/tests/test_finops_costs.py
@@ -365,3 +365,83 @@ def test_cost_center_budget_via_api(client):
 def test_agent_and_cost_center_budget_mutually_exclusive(client):
     bad = client.put("/v1/observability/costs/budget", json={"limit_usd": 5.0, "agent": "a", "cost_center": "team-x"})
     assert bad.status_code == 400
+
+
+# ── windowed spend SUM for budget checks (P1-6) ──────────────────────────────
+
+
+def _rec_at(observed_at, *, call_id, cost=1.0, agent="agent-a", cost_center=""):
+    return LLMCostRecord(
+        tenant_id="t1",
+        call_id=call_id,
+        agent=agent,
+        session_id="s1",
+        provider="openai",
+        model="gpt-4o",
+        input_tokens=100,
+        output_tokens=50,
+        cost_usd=cost,
+        priced=True,
+        observed_at=observed_at,
+        cost_center=cost_center,
+    )
+
+
+def _iso_days_ago(days):
+    from datetime import datetime, timedelta, timezone
+
+    return (datetime.now(timezone.utc) - timedelta(days=days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def test_budget_window_start_env(monkeypatch):
+    from agent_bom.api.cost_store import budget_window_start
+
+    monkeypatch.delenv("AGENT_BOM_BUDGET_WINDOW_DAYS", raising=False)
+    assert budget_window_start() is None  # default: all-history
+
+    monkeypatch.setenv("AGENT_BOM_BUDGET_WINDOW_DAYS", "30")
+    cutoff = budget_window_start()
+    assert cutoff is not None and cutoff <= _iso_days_ago(29)
+
+    monkeypatch.setenv("AGENT_BOM_BUDGET_WINDOW_DAYS", "0")
+    assert budget_window_start() is None  # non-positive disables windowing
+
+
+def test_total_spend_since_bounds_sum_in_memory():
+    store = InMemoryCostStore()
+    store.record_cost(_rec_at(_iso_days_ago(2), call_id="recent", cost=4.0))
+    store.record_cost(_rec_at(_iso_days_ago(90), call_id="old", cost=100.0))
+
+    assert store.total_spend("t1") == 104.0  # unbounded default
+    assert store.total_spend("t1", since=_iso_days_ago(30)) == 4.0  # windowed
+
+
+def test_total_spend_since_bounds_sum_sqlite(tmp_path):
+    from agent_bom.api.cost_store import SQLiteCostStore
+
+    store = SQLiteCostStore(str(tmp_path / "costs.db"))
+    store.record_cost(_rec_at(_iso_days_ago(2), call_id="recent", cost=4.0))
+    store.record_cost(_rec_at(_iso_days_ago(90), call_id="old", cost=100.0))
+
+    assert store.total_spend("t1") == 104.0
+    assert store.total_spend("t1", since=_iso_days_ago(30)) == 4.0
+    assert store.total_spend("t1", agent="agent-a", since=_iso_days_ago(30)) == 4.0
+
+
+def test_budget_enforcement_uses_rolling_window(monkeypatch):
+    from agent_bom.api.cost_store import CostBudget, check_budget_enforcement
+
+    store = InMemoryCostStore()
+    store.record_cost(_rec_at(_iso_days_ago(1), call_id="recent", cost=3.0))
+    store.record_cost(_rec_at(_iso_days_ago(120), call_id="ancient", cost=50.0))
+    store.set_budget(CostBudget("t1", "", 10.0, "2026-01-01", "enforce"))
+
+    # All-history spend (53) exceeds the $10 cap...
+    monkeypatch.delenv("AGENT_BOM_BUDGET_WINDOW_DAYS", raising=False)
+    blocked, _b, spend = check_budget_enforcement(store, "t1", "")
+    assert blocked is True and spend == 53.0
+
+    # ...but the rolling 30-day window (3) is within budget.
+    monkeypatch.setenv("AGENT_BOM_BUDGET_WINDOW_DAYS", "30")
+    blocked, _b, spend = check_budget_enforcement(store, "t1", "")
+    assert blocked is False and spend == 3.0

--- a/tests/test_fleet_offload.py
+++ b/tests/test_fleet_offload.py
@@ -1,0 +1,84 @@
+"""Fleet read handlers offload sync store work off the event loop.
+
+Pre-release scale hardening: list_fleet / fleet_stats / get_fleet_agent ran
+synchronous psycopg reads directly on the loop. They now route through
+``_store_call`` (asyncio.to_thread under backpressure).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from agent_bom.api.routes import fleet
+
+
+class _FakeAgent:
+    def __init__(self, agent_id="a1"):
+        self.agent_id = agent_id
+        self.lifecycle_state = SimpleNamespace(value="active")
+        self.environment = "prod"
+        self.trust_score = 90.0
+
+    def model_dump(self):
+        return {"agent_id": self.agent_id}
+
+
+class _FakeStore:
+    def __init__(self):
+        self.calls: list[str] = []
+
+    def query_by_tenant(self, tenant_id, **kwargs):
+        self.calls.append("query_by_tenant")
+        return ([_FakeAgent()], 1)
+
+    def list_by_tenant(self, tenant_id):
+        self.calls.append("list_by_tenant")
+        return [_FakeAgent()]
+
+    def get(self, agent_id, tenant_id):
+        self.calls.append("get")
+        return _FakeAgent(agent_id)
+
+
+@pytest.fixture()
+def offload_spy(monkeypatch):
+    store = _FakeStore()
+    monkeypatch.setattr(fleet, "_get_fleet_store", lambda: store)
+    monkeypatch.setattr(fleet, "require_request_tenant_id", lambda request: "acme")
+
+    offloaded: list[object] = []
+    real_to_thread = asyncio.to_thread
+
+    async def _spy(fn, /, *args, **kwargs):
+        offloaded.append(fn)
+        return await real_to_thread(fn, *args, **kwargs)
+
+    monkeypatch.setattr(fleet.asyncio, "to_thread", _spy)
+    return store, offloaded
+
+
+def test_list_fleet_offloads(offload_spy):
+    store, offloaded = offload_spy
+    result = asyncio.run(fleet.list_fleet(request=object()))
+    assert result["count"] == 1
+    assert offloaded, "list_fleet must offload the store read"
+    assert "query_by_tenant" in store.calls
+
+
+def test_fleet_stats_offloads(offload_spy):
+    store, offloaded = offload_spy
+    result = asyncio.run(fleet.fleet_stats(request=object()))
+    assert result["total"] == 1
+    assert offloaded, "fleet_stats must offload the store read"
+    assert "list_by_tenant" in store.calls
+
+
+def test_get_fleet_agent_offloads(offload_spy):
+    store, offloaded = offload_spy
+    result = asyncio.run(fleet.get_fleet_agent(request=object(), agent_id="a1"))
+    assert result["agent_id"] == "a1"
+    assert offloaded, "get_fleet_agent must offload the store read"
+    assert "get" in store.calls

--- a/tests/test_idempotency_store.py
+++ b/tests/test_idempotency_store.py
@@ -35,3 +35,38 @@ def test_sqlite_idempotency_store_replays_same_payload_and_rejects_mismatch(tmp_
     assert store.get("/v1/test", "tenant-a", "source-a", "k-1", request_hash=request_hash) == {"ok": True}
     with pytest.raises(IdempotencyConflictError):
         store.get("/v1/test", "tenant-a", "source-a", "k-1", request_hash=mismatch_hash)
+
+
+# ── TTL prune on put (P1-6) ──────────────────────────────────────────────────
+
+
+def test_sqlite_idempotency_put_prunes_expired_keys(tmp_path):
+    """Old idempotency rows must be pruned on write so the table cannot grow unbounded."""
+    from datetime import datetime, timedelta, timezone
+
+    store = SQLiteIdempotencyStore(str(tmp_path / "idem.db"), ttl_hours=24)
+    # Seed a stale row (created 48h ago), bypassing put() so its timestamp is old.
+    stale_ts = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+    store._conn.execute(  # noqa: SLF001 - test seeds a pre-aged row directly
+        """INSERT INTO idempotency_keys
+           (endpoint, tenant_id, source_id, idempotency_key, request_hash, response_json, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)""",
+        ("/v1/test", "t", "s", "old-key", "", "{}", stale_ts),
+    )
+    store._conn.commit()  # noqa: SLF001
+
+    # A fresh put triggers the prune sweep.
+    store.put("/v1/test", "t", "s", "new-key", {"ok": True})
+
+    assert store.get("/v1/test", "t", "s", "old-key") is None
+    assert store.get("/v1/test", "t", "s", "new-key") == {"ok": True}
+    remaining = store._conn.execute("SELECT COUNT(*) FROM idempotency_keys").fetchone()[0]  # noqa: SLF001
+    assert remaining == 1
+
+
+def test_sqlite_idempotency_put_keeps_fresh_keys(tmp_path):
+    store = SQLiteIdempotencyStore(str(tmp_path / "idem.db"), ttl_hours=24)
+    store.put("/v1/test", "t", "s", "k1", {"n": 1})
+    store.put("/v1/test", "t", "s", "k2", {"n": 2})
+    assert store.get("/v1/test", "t", "s", "k1") == {"n": 1}
+    assert store.get("/v1/test", "t", "s", "k2") == {"n": 2}

--- a/tests/test_ingest_idempotency.py
+++ b/tests/test_ingest_idempotency.py
@@ -183,6 +183,53 @@ def test_compliance_ingest_idempotent_on_resend() -> None:
     assert totals == [5, 5, 5]
 
 
+# ─── scan_count must not inflate on resend (P1-5) ────────────────────────────
+
+
+def _max_scan_count(tenant: str) -> int:
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    rows, _total, _cursor = get_compliance_hub_store().list_current_page(tenant, limit=500)
+    return max((int(row.get("scan_count", 0) or 0) for row in rows), default=0)
+
+
+def test_bulk_ingest_resend_does_not_inflate_scan_count() -> None:
+    """A resent identical bulk batch must dedup the observation, not re-count it."""
+    tenant = f"idem-scancount-bulk-{uuid4().hex}"
+    client = _client(tenant)
+    findings = _batch(20, with_id=True)
+    for _ in range(3):
+        resp = client.post("/v1/findings/bulk", json={"source": "agent", "findings": findings})
+        assert resp.status_code == 201, resp.text
+    # Random per-request batch_ids used to miss the (canonical, batch_id)
+    # observation dedup, so scan_count climbed 1 -> 2 -> 3. It must stay 1.
+    assert _max_scan_count(tenant) == 1
+
+
+def test_compliance_ingest_resend_does_not_inflate_scan_count() -> None:
+    tenant = f"idem-scancount-compliance-{uuid4().hex}"
+    client = _client(tenant, role="admin")
+    content = _sarif(5)
+    for _ in range(3):
+        resp = client.post("/v1/compliance/ingest", json={"format": "sarif", "content": content})
+        assert resp.status_code == 201, resp.text
+    assert _max_scan_count(tenant) == 1
+
+
+def test_bulk_ingest_distinct_bodies_do_increment_scan_count() -> None:
+    """Guard against over-dedup: genuinely new observations must still count."""
+    tenant = f"idem-scancount-distinct-{uuid4().hex}"
+    client = _client(tenant)
+    findings = _batch(5, with_id=True)
+    # Same findings, but a changing companion row shifts the body fingerprint so
+    # each POST is a distinct batch -> the shared findings are re-observed.
+    for n in range(3):
+        body = {"source": "agent", "findings": [*findings, {"id": f"marker-{n}", "severity": "low", "title": f"m{n}"}]}
+        resp = client.post("/v1/findings/bulk", json=body)
+        assert resp.status_code == 201, resp.text
+    assert _max_scan_count(tenant) >= 2
+
+
 # ─── Scan job replay ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -21,9 +21,14 @@ def teardown_module() -> None:
 
 
 def _clear_jobs() -> None:
+    from agent_bom.api.routes.overview import _reset_overview_cache
     from agent_bom.api.server import set_job_store
 
     set_job_store(InMemoryJobStore())
+    # The overview payload is cached per-tenant keyed by a job/hub fingerprint;
+    # tests reuse a fixed job_id + timestamp, so the process-global cache must be
+    # dropped alongside the job store (same discipline as backpressure resets).
+    _reset_overview_cache()
 
 
 def _add_done_job(

--- a/tests/test_overview_cache.py
+++ b/tests/test_overview_cache.py
@@ -1,0 +1,129 @@
+"""Per-tenant overview cache (pre-release scale hardening, #3963 follow-up).
+
+``_build_overview`` folds every finding of every completed scan. These tests pin
+the TTL + fingerprint cache: a re-read with unchanged job metadata skips the
+fold, new scan data invalidates it, and the numbers never change.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agent_bom.api.routes import overview
+
+
+class _FakeStore:
+    def __init__(self, jobs):
+        self._jobs = jobs
+
+    def list_all(self, tenant_id):
+        return list(self._jobs)
+
+
+def _job(job_id: str, status: str = "done", completed_at: str = "2026-07-15T00:00:00Z"):
+    return SimpleNamespace(job_id=job_id, status=status, completed_at=completed_at)
+
+
+@pytest.fixture(autouse=True)
+def _clean_cache(monkeypatch):
+    overview._reset_overview_cache()
+    monkeypatch.setattr(overview, "_tenant_id", lambda request: "acme")
+    monkeypatch.delenv("AGENT_BOM_OVERVIEW_CACHE_TTL_SECONDS", raising=False)
+    yield
+    overview._reset_overview_cache()
+
+
+def _install(monkeypatch, jobs, hub_severity=None):
+    store = _FakeStore(jobs)
+    monkeypatch.setattr(overview, "_get_store", lambda: store)
+    hub_state = dict(hub_severity or {"critical": 0, "high": 0})
+    monkeypatch.setattr(overview, "_hub_severity_snapshot", lambda request: dict(hub_state))
+    calls = {"n": 0}
+
+    def _fake_compose(request, tenant_id, jobs_arg, hub_severity):
+        calls["n"] += 1
+        return {"schema_version": "overview.v1", "tenant_id": tenant_id, "job_count": len(jobs_arg)}
+
+    monkeypatch.setattr(overview, "_compose_overview", _fake_compose)
+    return calls
+
+
+def test_hub_ingest_invalidates_cache(monkeypatch):
+    jobs = [_job("j1")]
+    hub = {"critical": 0, "high": 0}
+    store = _FakeStore(jobs)
+    monkeypatch.setattr(overview, "_get_store", lambda: store)
+    monkeypatch.setattr(overview, "_hub_severity_snapshot", lambda request: dict(hub))
+    calls = {"n": 0}
+
+    def _fake_compose(request, tenant_id, jobs_arg, hub_severity):
+        calls["n"] += 1
+        return {"hub_critical": hub_severity.get("critical", 0)}
+
+    monkeypatch.setattr(overview, "_compose_overview", _fake_compose)
+    req = object()
+
+    overview._build_overview(req)
+    assert calls["n"] == 1
+
+    # Bulk-ingested findings change hub current-state (not any scan job) — the
+    # cache must still invalidate so the headline reflects them.
+    hub["critical"] = 3
+    result = overview._build_overview(req)
+    assert calls["n"] == 2
+    assert result["hub_critical"] == 3
+
+
+def test_second_read_within_ttl_skips_fold(monkeypatch):
+    calls = _install(monkeypatch, [_job("j1")])
+    req = object()
+
+    first = overview._build_overview(req)
+    second = overview._build_overview(req)
+
+    assert calls["n"] == 1  # folded once, second served from cache
+    assert first == second
+
+
+def test_new_scan_invalidates_cache(monkeypatch):
+    jobs = [_job("j1")]
+    calls = _install(monkeypatch, jobs)
+    req = object()
+
+    overview._build_overview(req)
+    assert calls["n"] == 1
+
+    # A new completed scan lands -> fingerprint changes -> refold.
+    jobs.append(_job("j2"))
+    result = overview._build_overview(req)
+
+    assert calls["n"] == 2
+    assert result["job_count"] == 2
+
+
+def test_status_transition_invalidates_cache(monkeypatch):
+    job = _job("j1", status="running", completed_at="")
+    calls = _install(monkeypatch, [job])
+    req = object()
+
+    overview._build_overview(req)
+    assert calls["n"] == 1
+
+    # Same job id, but it completes -> fingerprint must change.
+    job.status = "done"
+    job.completed_at = "2026-07-15T01:00:00Z"
+    overview._build_overview(req)
+    assert calls["n"] == 2
+
+
+def test_ttl_zero_disables_cache(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_OVERVIEW_CACHE_TTL_SECONDS", "0")
+    calls = _install(monkeypatch, [_job("j1")])
+    req = object()
+
+    overview._build_overview(req)
+    overview._build_overview(req)
+
+    assert calls["n"] == 2  # caching disabled -> always refolds

--- a/tests/test_postgres_graph_retention.py
+++ b/tests/test_postgres_graph_retention.py
@@ -1,0 +1,170 @@
+"""Postgres graph snapshot retention purge (pre-release scale hardening).
+
+The SQLite backend purges expired snapshots on every save; the Postgres backend
+previously committed with no retention delete, so snapshot history grew
+unbounded. These tests pin the mirrored age-based purge on the Postgres path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+RECENT = datetime.now(timezone.utc).isoformat()
+OLD = (datetime.now(timezone.utc) - timedelta(days=400)).isoformat()
+
+
+class _FakeCursor:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.rowcount = len(self.rows)
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+    def fetchall(self):
+        return self.rows
+
+
+class _FakeConn:
+    """Minimal Postgres connection just rich enough to exercise the purge.
+
+    Tracks ``graph_snapshots`` as ``{(tenant, scan_id): created_at}`` and records
+    every DELETE the purge issues so tests can assert child-row cascades.
+    """
+
+    def __init__(self, snapshots):
+        # snapshots: dict[(tenant, scan_id)] -> created_at iso string
+        self.snapshots = dict(snapshots)
+        self.deletes: list[tuple[str, tuple]] = []
+        self.committed = 0
+        self.rolled_back = 0
+
+    # context-manager protocol used by pool.connection()
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def execute(self, sql, params=None):
+        low = " ".join(sql.strip().lower().split())
+        if low.startswith("select scan_id, created_at from graph_snapshots where tenant_id"):
+            tenant = params[0]
+            rows = [(scan, ts) for (t, scan), ts in self.snapshots.items() if t == tenant]
+            return _FakeCursor(rows)
+        if low.startswith("insert into graph_snapshots"):
+            scan, tenant, created = params[0], params[1], params[2]
+            self.snapshots[(tenant, scan)] = created
+            return _FakeCursor()
+        # previous-snapshot / latest lookups etc. — behave as empty history
+        return _FakeCursor()
+
+    def executemany(self, sql, seq):
+        low = " ".join(sql.strip().lower().split())
+        rows = list(seq)
+        if low.startswith("delete from"):
+            table = low.split()[2]
+            for params in rows:
+                self.deletes.append((table, tuple(params)))
+                if table == "graph_snapshots":
+                    tenant, scan = params
+                    self.snapshots.pop((tenant, scan), None)
+        return _FakeCursor(rows)
+
+    def commit(self):
+        self.committed += 1
+
+    def rollback(self):
+        self.rolled_back += 1
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def connection(self):
+        return self._conn
+
+
+def _make_store(conn, monkeypatch):
+    from agent_bom.api import postgres_graph
+
+    # Skip the schema/DDL bootstrap; we only exercise the purge method.
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_tables", lambda self: None)
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_optional_search_indexes", lambda self: None)
+    return postgres_graph.PostgresGraphStore(pool=_FakePool(conn))
+
+
+def test_purge_deletes_expired_and_keeps_recent(monkeypatch) -> None:
+    conn = _FakeConn(
+        {
+            ("acme", "old"): OLD,
+            ("acme", "recent"): RECENT,
+        }
+    )
+    store = _make_store(conn, monkeypatch)
+
+    store._purge_expired_snapshots(conn, "acme")
+
+    assert ("acme", "old") not in conn.snapshots
+    assert ("acme", "recent") in conn.snapshots
+    # Every child table plus the snapshot row is purged for the expired scan.
+    purged_tables = {table for table, _ in conn.deletes}
+    assert purged_tables == set(postgres_purge_tables())
+    for table in postgres_purge_tables():
+        assert (table, ("acme", "old")) in conn.deletes
+    assert conn.committed >= 1
+
+
+def test_purge_scoped_to_tenant(monkeypatch) -> None:
+    conn = _FakeConn(
+        {
+            ("acme", "old"): OLD,
+            ("other", "old-other"): OLD,
+        }
+    )
+    store = _make_store(conn, monkeypatch)
+
+    store._purge_expired_snapshots(conn, "acme")
+
+    # Only the saving tenant's expired snapshot is touched; the other tenant's
+    # equally-old snapshot is never selected or deleted.
+    assert ("acme", "old") not in conn.snapshots
+    assert ("other", "old-other") in conn.snapshots
+    assert all(params[0] == "acme" for _, params in conn.deletes)
+
+
+def test_purge_is_best_effort_on_error(monkeypatch) -> None:
+    conn = _FakeConn({("acme", "old"): OLD})
+    store = _make_store(conn, monkeypatch)
+
+    def _boom(sql, seq):
+        raise RuntimeError("simulated /secret/path failure")
+
+    monkeypatch.setattr(conn, "executemany", _boom)
+
+    # Must not raise; rolls back the failed purge.
+    store._purge_expired_snapshots(conn, "acme")
+    assert conn.rolled_back >= 1
+
+
+def test_purge_retains_unparseable_timestamps(monkeypatch) -> None:
+    conn = _FakeConn({("acme", "junk"): "not-a-timestamp"})
+    store = _make_store(conn, monkeypatch)
+
+    store._purge_expired_snapshots(conn, "acme")
+
+    assert ("acme", "junk") in conn.snapshots
+    assert conn.deletes == []
+
+
+def postgres_purge_tables():
+    from agent_bom.api.postgres_graph import _GRAPH_RETENTION_PURGE_TABLES
+
+    return _GRAPH_RETENTION_PURGE_TABLES
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-q"]))

--- a/tests/test_trace_explorer.py
+++ b/tests/test_trace_explorer.py
@@ -53,3 +53,75 @@ def test_build_trace_explorer_payload_groups_blocked_span_with_findings() -> Non
     assert span["verdict"] == "blocked"
     assert span["linked_findings"][0]["vulnerability_id"] == "CVE-2024-9"
     assert "nist_csf:ID.RA-01" in span["compliance_controls"]
+
+
+# ── Event-loop offload + limit bounding (pre-release scale hardening) ─────────
+
+
+def test_trace_explorer_handler_offloads_to_thread(monkeypatch) -> None:
+    """The /runtime/trace-explorer handler must never build its payload on the loop."""
+    import asyncio
+
+    from agent_bom.api.routes import observability
+
+    monkeypatch.setattr(observability, "_tenant_id", lambda request: "tenant-x")
+
+    calls: dict[str, object] = {}
+
+    async def _fake_to_thread(func, /, *args, **kwargs):
+        calls["func"] = func
+        calls["args"] = args
+        calls["kwargs"] = kwargs
+        return {"offloaded": True}
+
+    monkeypatch.setattr(observability.asyncio, "to_thread", _fake_to_thread)
+
+    result = asyncio.run(observability.trace_explorer(request=object(), limit=500))
+
+    assert result == {"offloaded": True}
+    assert calls["func"] is observability._build_trace_explorer_payload_sync
+    assert calls["args"] == ("tenant-x",)
+    # limit is bounded to <= 200 before offload
+    assert calls["kwargs"]["limit"] == 200
+
+
+def test_build_trace_explorer_payload_sync_bounds_findings(monkeypatch) -> None:
+    """Findings iteration is capped at the request limit, not the whole estate."""
+    from agent_bom.api import trace_explorer as trace_explorer_mod
+    from agent_bom.api.routes import gateway_feed, observability, scan
+    from agent_bom.api.routes.scan import _completed_jobs_for_tenant  # noqa: F401
+
+    monkeypatch.setattr(gateway_feed, "_load_tenant_alerts", lambda tenant_id: [])
+    monkeypatch.setattr(gateway_feed, "build_gateway_feed", lambda **kwargs: {"events": []})
+
+    class _FakeCostStore:
+        def list_records(self, tenant_id, limit):
+            return []
+
+    monkeypatch.setattr("agent_bom.api.cost_store.get_cost_store", lambda: _FakeCostStore())
+
+    # 50 jobs, each yielding 100 findings → 5000 findings if unbounded.
+    monkeypatch.setattr(scan, "_completed_jobs_for_tenant", lambda tenant_id: list(range(50)))
+    monkeypatch.setattr(scan, "_iter_scan_findings", lambda job: [{"vulnerability_id": f"CVE-{job}-{i}"} for i in range(100)])
+
+    class _FakeRuntimeStore:
+        def list_sessions(self, tenant_id, limit, offset):
+            return []
+
+        def list_observations(self, tenant_id, limit, offset):
+            return []
+
+    monkeypatch.setattr(observability, "get_runtime_event_store", lambda: _FakeRuntimeStore())
+
+    captured: dict[str, object] = {}
+
+    def _capture_payload(**kwargs):
+        captured["findings_len"] = len(kwargs["findings"])
+        return {"ok": True}
+
+    monkeypatch.setattr(trace_explorer_mod, "build_trace_explorer_payload", _capture_payload)
+
+    result = observability._build_trace_explorer_payload_sync("tenant-x", limit=25)
+
+    assert result == {"ok": True}
+    assert captured["findings_len"] == 25


### PR DESCRIPTION
## Pre-release scale & loop-safety fixes

One cohesive pass over the pre-release scale bug-hunt: the two P0 release blockers plus the P1 event-loop-offload / retention / idempotency cluster. TDD throughout; both gates green (preflight + ruff/mypy on touched modules); `check_exception_sanitization.py` clean; no new REST routes.

### P0 — release blockers
- **P0-1 · `/v1/runtime/trace-explorer` blocked the event loop.** The handler built its whole payload (unbounded findings iteration, sync psycopg `list_sessions`/`list_observations`, CPU serialize) on the loop. Heavy work now runs in `_build_trace_explorer_payload_sync` via `asyncio.to_thread`, and findings iteration is bounded by the request `limit`. The shared `_trace_explorer_payload_for_tenant` twin (approval-queue) offloads too.
  - Test: `test_trace_explorer_handler_offloads_to_thread` (asserts the handler dispatches the sync builder via `to_thread` with a bounded limit) + `test_build_trace_explorer_payload_sync_bounds_findings` (50 jobs × 100 findings capped to `limit`).
- **P0-2 · Postgres graph snapshots never purged.** `save_graph` committed with no retention delete (the SQLite backend purges every save). Added `_purge_expired_snapshots`, mirroring the SQLite age-based purge scoped to the saving tenant, cascading children→parents, fail-closed on unparseable timestamps, best-effort so it never fails the durable save.
  - Test: `tests/test_postgres_graph_retention.py` — expired purged / recent kept / tenant isolation / best-effort on error / unparseable retained.

### P1 — same event-loop / scale class
- **P1-1 · `/v1/overview` recompute uncached.** Added a per-tenant TTL cache keyed by a cheap job-metadata **+ hub-severity** fingerprint (no finding fold). A re-read with unchanged evidence skips the O(estate) rollup; a new scan **or** a bulk-ingested finding changes the fingerprint and invalidates the cache, so the headline never goes stale. Numbers still route through `_reconciled_exec_counts`.
  - Test: `tests/test_overview_cache.py` — second read skips fold, new scan / status-transition / hub-ingest invalidate, TTL=0 disables.
- **P1-2 · Fleet router sync-on-loop.** Added a `_store_call` `to_thread` wrapper (copied from `inventory_assets`) under graph backpressure; `list_fleet` / `fleet_stats` / `get_fleet_agent` reads route through it.
  - Test: `tests/test_fleet_offload.py`.
- **P1-3 · `get_graph` partial-offload gap.** `apply_governance_overlay` + `filtered_view` ran on the loop between offloaded calls. Folded overlay + filtered_view + response into one `_overlay_filter_and_respond` helper run via a single `_graph_compute_call`.
- **P1-4 · `/v1/observability/costs` sync-on-loop.** Fetch (≤10k records) + summarize/owner-report/budget/forecast now run in one `_build_llm_costs_report_sync` offloaded via `asyncio.to_thread`.
- **P1-5 · Compliance/bulk ingest not idempotent for `scan_count`.** Both endpoints minted a random `batch_id` per request, so the `(canonical, batch_id)` observation dedup missed on resend and `scan_count` inflated. `batch_id` is now derived deterministically from the `Idempotency-Key` header or the request-content fingerprint via `deterministic_batch_id`.
  - Test: extended `tests/test_ingest_idempotency.py` — resend keeps `scan_count == 1` (bulk + compliance); a genuinely distinct body still increments (no over-dedup).
- **P1-6 · Idempotency keys never pruned + unbounded spend SUM.** SQLite idempotency `put` now TTL-prunes on write (via `idx_idempotency_created_at`, `AGENT_BOM_IDEMPOTENCY_TTL_HOURS`, default 24h). `total_spend`/`total_spend_by_cost_center` gained an optional windowed `since=` SUM (+ supporting indexes across SQLite/Postgres/in-memory); budget-enforcement/posture bound to a rolling window via `AGENT_BOM_BUDGET_WINDOW_DAYS` (unset = all-history, preserving current semantics).
  - Test: `tests/test_idempotency_store.py` (old keys pruned, fresh kept) + `tests/test_finops_costs.py` (windowed SUM bounded, `budget_window_start` env, rolling-window enforcement).

### Offload verification
For each touched endpoint the heavy DB/CPU work is now inside an `asyncio.to_thread` / `anyio.to_thread.run_sync` hop (trace-explorer, costs, fleet reads, graph overlay+filter+serialize) or served from cache (overview). The offload is asserted by test where feasible (trace-explorer, fleet).

### Note on scope
`AGENT_BOM_BUDGET_WINDOW_DAYS` defaults **off** (all-history) deliberately: windowing budget checks by default would change spend semantics and break existing tests that pin all-history sums over fixed past dates (finops + Postgres cost mock). The bound is available via config with the `since=` capability + indexes proving the query is bounded when enabled.

Refs the pre-release scale bug-hunt.
