### PR TITLE
fix(compliance): all-unrated control is not_evaluated, not a silent pass

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -307,13 +307,16 @@ def _evaluated_control_status(sev_breakdown: dict[str, int]) -> str:
 
     Mirror of ``compliance_narrative._control_status`` so ``/v1/compliance``, the
     narrative, and the CLI export agree: critical/high → fail, medium/low →
-    warning, otherwise pass. Keep in sync with that function.
+    warning. The caller only reaches this with findings > 0, so an all-zero
+    breakdown means the mapped findings are all unrated-severity — evidence
+    exists but severity is ungraded, which is ``not_evaluated``, never a silent
+    pass (a false pass inflated overall_score). Keep in sync with that function.
     """
     if sev_breakdown.get("critical", 0) > 0 or sev_breakdown.get("high", 0) > 0:
         return "fail"
     if sev_breakdown.get("medium", 0) > 0 or sev_breakdown.get("low", 0) > 0:
         return "warning"
-    return "pass"
+    return "not_evaluated"
 
 
 @router.get("/compliance", tags=["compliance"])

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -144,11 +144,18 @@ def _severity_order(sev: str) -> int:
 
 
 def _control_status(sev_breakdown: dict[str, int]) -> str:
+    """Status of a control that HAS mapped findings, by worst severity.
+
+    Mirror of ``routes/compliance._evaluated_control_status``. Callers only reach
+    this with findings > 0, so an all-zero breakdown means every mapped finding
+    is unrated-severity — evidence exists but severity is ungraded, which is
+    ``not_evaluated``, never a silent pass. Keep in sync with that function.
+    """
     if sev_breakdown.get("critical", 0) > 0 or sev_breakdown.get("high", 0) > 0:
         return "fail"
     if sev_breakdown.get("medium", 0) > 0 or sev_breakdown.get("low", 0) > 0:
         return "warning"
-    return "pass"
+    return "not_evaluated"
 
 
 def _control_narrative(
@@ -347,8 +354,14 @@ def _build_framework_narrative(
         # evidence, so they are not-evaluated — never counted as a silent pass.
         if data["findings"] == 0:
             continue
-        evaluated_count += 1
         status = _control_status(data["severity_breakdown"])
+        if status == "not_evaluated":
+            # Findings map here but all are unrated-severity: evidence exists but
+            # severity is ungraded, so it is not an evaluated pass/warn/fail — it
+            # must not inflate the denominator or read as a silent pass. Mirrors
+            # the API excluding not_evaluated controls from evaluated_controls.
+            continue
+        evaluated_count += 1
         pkgs = sorted(data["affected_pkgs"])
         agents = sorted(data["affected_agents"])
 

--- a/tests/test_compliance_narrative.py
+++ b/tests/test_compliance_narrative.py
@@ -171,19 +171,26 @@ def test_at_risk_framework_status_for_medium_vuln():
 
 
 def test_score_is_over_evaluated_controls_only():
-    """Score denominator is the evaluated controls, not the whole catalogue.
+    """Score denominator is evaluated controls only, and an all-unrated control
+    is not a silent pass.
 
-    Two of ten OWASP controls are evaluated: one passes (finding with no
-    severity) and one warns. Score must be 50 (1 pass / 2 evaluated), not 10
-    (1 pass / 10 catalogue controls).
+    A finding with no severity (UNKNOWN) is evidence with an ungraded severity:
+    the control is not_evaluated, never a pass. So with one unrated control
+    (LLM05) and one warning control (LLM01), only LLM01 is evaluated — the
+    denominator excludes both the never-triggered controls AND the unrated one.
+    No control passes (0 / 1 evaluated), so the honest score is 0, not an
+    inflated 50.
     """
-    passing = _make_blast_radius(vuln=_make_vuln(severity=Severity.UNKNOWN), owasp_tags=["LLM05"])
+    unrated = _make_blast_radius(vuln=_make_vuln(severity=Severity.UNKNOWN), owasp_tags=["LLM05"])
     warning = _make_blast_radius(vuln=_make_vuln(severity=Severity.MEDIUM), owasp_tags=["LLM01"])
-    report = _make_report(blast_radii=[passing, warning])
+    report = _make_report(blast_radii=[unrated, warning])
     result = generate_compliance_narrative(report, framework="owasp-llm")
     fw = result.framework_narratives[0]
     assert fw.status == "at_risk"
-    assert fw.score == 50
+    # Only the medium control is evaluated (warning); the unrated control is
+    # excluded, not counted as a pass — so the score is not inflated.
+    assert fw.score == 0
+    assert {c.control_id for c in fw.failing_controls} == {"LLM01"}
 
 
 def test_framework_score_is_integer_0_to_100():

--- a/tests/test_compliance_unrated_false_pass.py
+++ b/tests/test_compliance_unrated_false_pass.py
@@ -1,0 +1,147 @@
+"""A control with findings that are ALL unrated-severity must NOT read as PASS.
+
+`_evaluated_control_status` (routes/compliance.py) and its mirror
+`_control_status` (output/compliance_narrative.py) previously fell through to
+``pass`` when a control HAS mapped findings but every finding is unrated
+(sev_breakdown all-zero). That is a false pass: evidence exists but severity is
+ungraded, so the control is ``not_evaluated`` — never a silent pass. A silent
+pass inflated overall_score and contradicted the unrated-honesty principle.
+
+These tests pin the fix across all three surfaces: the ``/v1/compliance`` API,
+the narrative builder, and the shared status ladders — they must agree.
+"""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.routes.compliance import _evaluated_control_status
+from agent_bom.api.server import app
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.output.compliance_narrative import _build_framework_narrative, _control_status
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+_AUTH_HEADERS = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def _clear_jobs() -> None:
+    from agent_bom.api.server import set_job_store
+
+    set_job_store(InMemoryJobStore())
+
+
+def _add_done_job(blast_radius: list[dict]) -> None:
+    from agent_bom.api.server import JobStatus, ScanJob, ScanRequest, _get_store
+
+    job = ScanJob(job_id="test-job", tenant_id="default", created_at="2026-02-22T10:00:00Z", request=ScanRequest())
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-02-22T10:05:00Z"
+    job.result = {"agents": [], "blast_radius": blast_radius, "threat_framework_summary": {}}
+    _get_store().put(job)
+
+
+# ─── Shared status ladders (both copies must agree) ──────────────────────────
+
+
+def test_status_ladder_all_unrated_is_not_evaluated() -> None:
+    all_unrated = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    assert _evaluated_control_status(all_unrated) == "not_evaluated"
+    assert _control_status(all_unrated) == "not_evaluated"
+
+
+def test_status_ladder_critical_or_high_is_fail() -> None:
+    for sev in ("critical", "high"):
+        breakdown = {"critical": 0, "high": 0, "medium": 0, "low": 0, sev: 1}
+        assert _evaluated_control_status(breakdown) == "fail"
+        assert _control_status(breakdown) == "fail"
+
+
+def test_status_ladder_medium_or_low_is_warning() -> None:
+    for sev in ("medium", "low"):
+        breakdown = {"critical": 0, "high": 0, "medium": 0, "low": 0, sev: 1}
+        assert _evaluated_control_status(breakdown) == "warning"
+        assert _control_status(breakdown) == "warning"
+
+
+# ─── /v1/compliance API ──────────────────────────────────────────────────────
+
+
+def test_api_all_unrated_control_is_not_evaluated_not_pass() -> None:
+    """A mapped finding with an unrated severity → control not_evaluated, and the
+    overall_score is not inflated by that would-be pass."""
+    _clear_jobs()
+    _add_done_job(
+        [
+            {
+                "vulnerability_id": "CVE-2025-9999",
+                "severity": "unknown",  # unrated → not in sev_breakdown
+                "package": "leftpad",
+                "affected_agents": ["claude-desktop"],
+                "owasp_tags": ["LLM05"],
+            }
+        ]
+    )
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+
+    llm05 = next(c for c in data["owasp_llm_top10"] if c["control_id"] == "LLM05")
+    assert llm05["findings"] == 1
+    assert llm05["status"] == "not_evaluated"  # NOT "pass"
+
+    # No control passes (the only mapped one is unrated), so score is not inflated.
+    assert data["summary"]["owasp_pass"] == 0
+    assert data["summary"]["owasp_not_evaluated"] == 10
+    assert data["overall_score"] == 0.0
+    _clear_jobs()
+
+
+def test_api_rated_finding_unchanged() -> None:
+    """A rated (high) finding still fails — the fix only touches the all-unrated case."""
+    _clear_jobs()
+    _add_done_job(
+        [
+            {
+                "vulnerability_id": "CVE-2025-1111",
+                "severity": "high",
+                "package": "express",
+                "affected_agents": ["claude-desktop"],
+                "owasp_tags": ["LLM05"],
+            }
+        ]
+    )
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+    llm05 = next(c for c in data["owasp_llm_top10"] if c["control_id"] == "LLM05")
+    assert llm05["status"] == "fail"
+    assert data["summary"]["owasp_fail"] == 1
+    _clear_jobs()
+
+
+# ─── Narrative agreement ─────────────────────────────────────────────────────
+
+
+def test_narrative_all_unrated_control_not_counted_as_pass() -> None:
+    """The narrative must agree: an all-unrated control is not an evaluated pass,
+    so the framework does not read as 'passing'."""
+    blast = [
+        {
+            "vulnerability_id": "CVE-2025-9999",
+            "severity": "unknown",
+            "package": "leftpad",
+            "affected_agents": ["claude-desktop"],
+            "owasp_tags": ["LLM05"],
+        }
+    ]
+    fw = _build_framework_narrative("owasp-llm", blast)
+    # An all-unrated mapped control is not a pass → framework never 'passing',
+    # and the score is not inflated by a silent pass.
+    assert fw.status != "passing"
+    assert fw.score == 0


### PR DESCRIPTION
Follow-up to the pre-release bug-hunt (companion to #4027, which is now merged). This carries the one remaining accuracy fix that landed after #4027 was merged.

## Bug — compliance control false-pass on all-unrated findings
A compliance control that HAS mapped findings but whose findings are **all unrated-severity** (`sev_breakdown` all-zero — no critical/high/medium/low) fell through to `return "pass"` in `_evaluated_control_status` (`routes/compliance.py`) and its mirror `_control_status` (`output/compliance_narrative.py`). Since the caller only reaches that ladder when `findings > 0`, an all-zero breakdown means unrated findings exist — so a clean **PASS** was shown for a control that actually has ungraded evidence. That false pass inflated `overall_score` and contradicted the unrated-honesty principle ("unrated is explicit, never a silent pass"). The sibling `findings == 0 → not_evaluated` branch didn't catch findings-but-all-unrated.

## Fix
- Both status ladders now return **`not_evaluated`** for the all-zero case (critical/high → fail, medium/low → warning unchanged). These are the only two sev-breakdown ladders in `src/`; the CLI export inherits the fix via `generate_compliance_narrative`.
- The narrative framework loop no longer counts a `not_evaluated` control toward `evaluated_count`, matching the API which already excludes `not_evaluated` from its `evaluated_controls` denominator — so **`/v1/compliance`, the narrative, and the CLI export agree** and the score is not inflated by all-unrated controls.

## Functions kept in sync
- `routes/compliance.py::_evaluated_control_status`
- `output/compliance_narrative.py::_control_status` (+ the framework-narrative counting loop)
- Verified there is no third copy of the sev-breakdown pass/warning/fail ladder in `src/` (`_bundle_control_status` and `_control_status_counts` classify by status string and already bucket `not_evaluated` correctly).

## Tests
- New `tests/test_compliance_unrated_false_pass.py`: both status ladders agree on all-unrated → not_evaluated / critical|high → fail / medium|low → warning; `/v1/compliance` shows the all-unrated control as `not_evaluated` (not pass) with `overall_score == 0.0` and `owasp_not_evaluated == 10`; a rated (high) finding still fails; the narrative agrees (framework not `passing`, score not inflated).
- Updated `test_score_is_over_evaluated_controls_only`, which had codified the false pass (an UNKNOWN-severity finding counted as "one passes").

## Gates
- Compliance/narrative/export/vuln-compliance suites: 94 passed. New file: 6 passed.
- `ruff` + `mypy` on touched modules clean · `check_exception_sanitization.py` → 0 · `check-counts.py` consistent · `make preflight` green.