### PR TITLE
fix(helm): restore api/ui paths in EKS ingress example + structural guard

### DIFF
--- a/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
@@ -28,6 +28,24 @@ controlPlane:
     className: nginx
     hosts:
       - host: agent-bom.internal.example.com
+        apiPaths:
+          - path: /v1
+            pathType: Prefix
+          - path: /scim
+            pathType: Prefix
+          - path: /health
+            pathType: Prefix
+          - path: /docs
+            pathType: Prefix
+          - path: /redoc
+            pathType: Prefix
+          - path: /openapi.json
+            pathType: Prefix
+          - path: /ws
+            pathType: Prefix
+        uiPaths:
+          - path: /
+            pathType: Prefix
 
 scanner:
   enabled: false

--- a/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml
@@ -39,6 +39,24 @@ controlPlane:
     className: nginx
     hosts:
       - host: agent-bom.internal.example.com
+        apiPaths:
+          - path: /v1
+            pathType: Prefix
+          - path: /scim
+            pathType: Prefix
+          - path: /health
+            pathType: Prefix
+          - path: /docs
+            pathType: Prefix
+          - path: /redoc
+            pathType: Prefix
+          - path: /openapi.json
+            pathType: Prefix
+          - path: /ws
+            pathType: Prefix
+        uiPaths:
+          - path: /
+            pathType: Prefix
 
 networkPolicy:
   enabled: true

--- a/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-mcp-pilot-values.yaml
@@ -15,6 +15,24 @@ controlPlane:
     className: nginx
     hosts:
       - host: agent-bom.internal.example.com
+        apiPaths:
+          - path: /v1
+            pathType: Prefix
+          - path: /scim
+            pathType: Prefix
+          - path: /health
+            pathType: Prefix
+          - path: /docs
+            pathType: Prefix
+          - path: /redoc
+            pathType: Prefix
+          - path: /openapi.json
+            pathType: Prefix
+          - path: /ws
+            pathType: Prefix
+        uiPaths:
+          - path: /
+            pathType: Prefix
 
 scanner:
   enabled: true

--- a/deploy/helm/agent-bom/examples/eks-production-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-production-values.yaml
@@ -74,6 +74,24 @@ controlPlane:
       cert-manager.io/cluster-issuer: letsencrypt-internal
     hosts:
       - host: agent-bom.internal.example.com
+        apiPaths:
+          - path: /v1
+            pathType: Prefix
+          - path: /scim
+            pathType: Prefix
+          - path: /health
+            pathType: Prefix
+          - path: /docs
+            pathType: Prefix
+          - path: /redoc
+            pathType: Prefix
+          - path: /openapi.json
+            pathType: Prefix
+          - path: /ws
+            pathType: Prefix
+        uiPaths:
+          - path: /
+            pathType: Prefix
     tls:
       - hosts:
           - agent-bom.internal.example.com

--- a/deploy/helm/agent-bom/examples/eks-vanilla-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-vanilla-values.yaml
@@ -88,6 +88,24 @@ controlPlane:
       # alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:REPLACE_ME_REGION:REPLACE_ME_ACCOUNT_ID:regional/webacl/REPLACE_ME_NAME/REPLACE_ME_ID
     hosts:
       - host: agent-bom.internal.example.com
+        apiPaths:
+          - path: /v1
+            pathType: Prefix
+          - path: /scim
+            pathType: Prefix
+          - path: /health
+            pathType: Prefix
+          - path: /docs
+            pathType: Prefix
+          - path: /redoc
+            pathType: Prefix
+          - path: /openapi.json
+            pathType: Prefix
+          - path: /ws
+            pathType: Prefix
+        uiPaths:
+          - path: /
+            pathType: Prefix
     tls: []
   backup:
     enabled: true

--- a/scripts/validate_helm_profiles.py
+++ b/scripts/validate_helm_profiles.py
@@ -14,9 +14,13 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 def _load_profile_helpers():
     sys.path.insert(0, str(REPO_ROOT / "src"))
-    from agent_bom.deploy_profiles import helm_chart_dir, helm_validation_profiles
+    from agent_bom.deploy_profiles import (
+        helm_chart_dir,
+        helm_validation_profiles,
+        ingress_hosts_missing_paths,
+    )
 
-    return helm_chart_dir, helm_validation_profiles
+    return helm_chart_dir, helm_validation_profiles, ingress_hosts_missing_paths
 
 
 def _run(cmd: list[str]) -> None:
@@ -24,8 +28,14 @@ def _run(cmd: list[str]) -> None:
     subprocess.run(cmd, check=True)
 
 
+def _render(cmd: list[str]) -> str:
+    print("+", " ".join(cmd))
+    result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    return result.stdout
+
+
 def main() -> int:
-    helm_chart_dir, helm_validation_profiles = _load_profile_helpers()
+    helm_chart_dir, helm_validation_profiles, ingress_hosts_missing_paths = _load_profile_helpers()
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--profile",
@@ -68,7 +78,15 @@ def main() -> int:
             cmd.extend(["--set", set_argument])
         for key, path in profile.set_file_arguments:
             cmd.extend(["--set-file", f"{key}={path}"])
-        _run(cmd)
+        rendered = _render(cmd)
+        missing = ingress_hosts_missing_paths(rendered)
+        if missing:
+            print(
+                f"error: profile '{profile.name}' renders Ingress host(s) with no HTTP paths: "
+                f"{', '.join(missing)}",
+                file=sys.stderr,
+            )
+            return 1
     return 0
 
 

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -25,6 +25,57 @@ def helm_example_dir(repo_root: Path) -> Path:
     return helm_chart_dir(repo_root) / "examples"
 
 
+def ingress_hosts_missing_paths(rendered: str) -> list[str]:
+    """Return ``host`` values whose rendered Ingress rule carries no HTTP paths.
+
+    A rule that renders ``http.paths`` as ``null``/empty is an invalid Ingress: it
+    binds a hostname but routes nowhere. This guards against example values files
+    that override ``ingress.hosts`` without carrying ``apiPaths``/``uiPaths`` — a
+    render that exits 0 yet produces an ingress that cannot route traffic.
+    """
+
+    offenders: list[str] = []
+    for document in rendered.split("\n---"):
+        if "kind: Ingress" not in document:
+            continue
+
+        manifest = None
+        try:
+            import yaml
+
+            manifest = yaml.safe_load(document)
+        except Exception:
+            manifest = None
+
+        if isinstance(manifest, dict):
+            rules = (manifest.get("spec") or {}).get("rules") or []
+            for rule in rules:
+                if not isinstance(rule, dict):
+                    continue
+                paths = ((rule.get("http") or {}).get("paths")) or []
+                if not paths:
+                    offenders.append(str(rule.get("host", "<no-host>")))
+            continue
+
+        # Fallback text scan when PyYAML is unavailable (bare CI python): every
+        # rendered ``paths:`` line must be immediately followed by a ``- path:``
+        # list item, otherwise the rule routes nowhere.
+        lines = document.splitlines()
+        current_host = "<no-host>"
+        for index, line in enumerate(lines):
+            stripped = line.strip()
+            if stripped.startswith("host:"):
+                current_host = stripped.split("host:", 1)[1].strip().strip('"')
+            if stripped == "paths:":
+                following = next(
+                    (nxt.strip() for nxt in lines[index + 1 :] if nxt.strip()),
+                    "",
+                )
+                if not following.startswith("- path:"):
+                    offenders.append(current_host)
+    return offenders
+
+
 def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
     """Return the canonical shipped Helm profile matrix."""
 

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -2,12 +2,19 @@
 
 from __future__ import annotations
 
+import shutil
 import subprocess
 from pathlib import Path
 
+import pytest
 import yaml
 
-from agent_bom.deploy_profiles import build_helm_profile_command, helm_chart_dir, helm_validation_profiles
+from agent_bom.deploy_profiles import (
+    build_helm_profile_command,
+    helm_chart_dir,
+    helm_validation_profiles,
+    ingress_hosts_missing_paths,
+)
 
 
 def test_helm_validation_profiles_reference_existing_chart_assets():
@@ -112,6 +119,70 @@ def test_enterprise_demo_profile_layers_pilot_with_aws_inventory_overlay():
     overlay = yaml.safe_load((example_dir / "eks-enterprise-demo-overlay.yaml").read_text())
     assert overlay["scanner"]["cloud"]["enabled"] is True
     assert overlay["scanner"]["cloud"]["aws"]["inventory"] is True
+
+
+def test_ingress_hosts_missing_paths_flags_empty_rule():
+    rendered = (
+        "apiVersion: networking.k8s.io/v1\n"
+        "kind: Ingress\n"
+        "spec:\n"
+        "  rules:\n"
+        "    -\n"
+        '      host: "agent-bom.internal.example.com"\n'
+        "      http:\n"
+        "        paths:\n"
+        "  tls:\n"
+        "    - hosts:\n"
+        "      - agent-bom.internal.example.com\n"
+    )
+    assert ingress_hosts_missing_paths(rendered) == ["agent-bom.internal.example.com"]
+
+
+def test_ingress_hosts_missing_paths_accepts_populated_rule():
+    rendered = (
+        "apiVersion: networking.k8s.io/v1\n"
+        "kind: Ingress\n"
+        "spec:\n"
+        "  rules:\n"
+        "    -\n"
+        '      host: "agent-bom.internal.example.com"\n'
+        "      http:\n"
+        "        paths:\n"
+        '          - path: "/v1"\n'
+        "            pathType: Prefix\n"
+        '          - path: "/"\n'
+        "            pathType: Prefix\n"
+    )
+    assert ingress_hosts_missing_paths(rendered) == []
+
+
+def test_ingress_hosts_missing_paths_ignores_non_ingress_docs():
+    rendered = "kind: Service\nspec:\n  ports:\n    - port: 80\n"
+    assert ingress_hosts_missing_paths(rendered) == []
+
+
+@pytest.mark.skipif(shutil.which("helm") is None, reason="helm binary not available")
+def test_production_profile_renders_ingress_with_real_paths():
+    repo_root = Path(__file__).resolve().parent.parent
+    chart_dir = helm_chart_dir(repo_root)
+    values = repo_root / "deploy" / "helm" / "agent-bom" / "examples" / "eks-production-values.yaml"
+    result = subprocess.run(
+        ["helm", "template", "agent-bom-production", str(chart_dir), "-f", str(values)],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    assert ingress_hosts_missing_paths(result.stdout) == []
+    ingress = [
+        doc
+        for doc in yaml.safe_load_all(result.stdout)
+        if isinstance(doc, dict) and doc.get("kind") == "Ingress"
+    ]
+    assert ingress, "production profile should render a control-plane Ingress"
+    for manifest in ingress:
+        for rule in manifest["spec"]["rules"]:
+            assert rule["http"]["paths"], f"host {rule.get('host')} has no ingress paths"
 
 
 def test_install_helm_profile_script_prints_packaged_command():


### PR DESCRIPTION
## Problem

The shipped EKS example values files override `controlPlane.ingress.hosts` with a bare host and **no** `apiPaths`/`uiPaths`. The control-plane ingress template ranges over `.apiPaths` / `.uiPaths` per host, so `helm template ... -f examples/eks-production-values.yaml` exits `0` but renders an Ingress whose host has empty (null) `http.paths` — a valid-looking manifest that binds a hostname and routes nowhere.

### Before (rendered ingress, `eks-production-values.yaml`)

```yaml
spec:
  ingressClassName: "nginx"
  rules:
    -
      host: "agent-bom.internal.example.com"
      http:
        paths:
  tls:
    - hosts:
      - agent-bom.internal.example.com
      secretName: agent-bom-control-plane-tls
```

`http.paths` is empty — no backend routing.

### After

```yaml
spec:
  ingressClassName: "nginx"
  rules:
    -
      host: "agent-bom.internal.example.com"
      http:
        paths:
          - path: "/v1"
            pathType: Prefix
            backend:
              service:
                name: agent-bom-api
                port:
                  name: http
          # ... /scim /health /docs /redoc /openapi.json /ws -> agent-bom-api
          - path: "/"
            pathType: Prefix
            backend:
              service:
                name: agent-bom-ui
                port:
                  name: http
```

## Fix

- Added the default `apiPaths` / `uiPaths` block (mirroring the chart's `values.yaml`) to **every** example that overrides `ingress.hosts` — the guard surfaced that `eks-production`, `eks-mcp-pilot` (focused-pilot), `eks-control-plane-sqlite-pilot`, `eks-istio-kyverno`, and `eks-vanilla` were all affected, not just production. Hostnames and TLS blocks are unchanged.
- **Structural guard:** `ingress_hosts_missing_paths()` in `deploy_profiles.py` parses a rendered manifest and returns any Ingress host with no HTTP paths. The shipped-profile validator (`scripts/validate_helm_profiles.py`, run by the `helm-profiles` CI job) now asserts this across the full profile matrix and fails if any host renders empty paths. `pytest tests/test_deploy_profiles.py` covers the detector directly plus a helm-gated render of the production profile.

## Verification

```
helm template agent-bom deploy/helm/agent-bom -f deploy/helm/agent-bom/examples/eks-production-values.yaml   # host now has real paths
python3 scripts/validate_helm_profiles.py                                                                     # all 11 profiles green, guard passes
.venv/bin/python -m pytest tests/test_deploy_profiles.py -q                                                   # 12 passed
```