### PR TITLE
fix(governance): tenant-scoped audit chain (isolation + integrity)

### DIFF
--- a/src/agent_bom/api/governance_audit_log.py
+++ b/src/agent_bom/api/governance_audit_log.py
@@ -9,21 +9,46 @@ is detectable by ``verify_chain``.
 
 Three properties are load-bearing for determinism and replay-safety:
 
-1. **Deterministic record id.** ``action_id`` is derived from stable inputs
-   (``target identity`` + ``action`` + ``window key``), never a fresh
-   ``uuid4()``. Re-running the same cleanup over the same state yields the same
-   id, so an idempotent ``append`` is a no-op rather than a duplicate row.
+1. **Deterministic, tenant-scoped record id.** ``action_id`` is derived from
+   stable inputs (``tenant_id`` + ``target identity`` + ``action`` + ``window
+   key``), never a fresh ``uuid4()``. Re-running the same cleanup over the same
+   state yields the same id, so an idempotent ``append`` is a no-op rather than
+   a duplicate row. Folding ``tenant_id`` into the id means two tenants acting
+   on a same-named target never derive the same id.
 
 2. **Injected timestamp.** The acting time is always passed in by the caller
    (``observed_at``); this module never calls ``time.time()`` / ``datetime.now``
    inside its logic, matching the runtime incident-feedback convention.
 
-3. **Idempotent append.** ``append`` is keyed on ``action_id``: a second append
-   of the same action returns the already-stored record and does not extend the
-   chain, so the cleanup loop is safe to run twice over identical state.
+3. **Idempotent append.** ``append`` dedups on the composite
+   ``(tenant_id, action_id)``: a second append of the same action returns the
+   already-stored record and does not extend the chain, so the cleanup loop is
+   safe to run twice over identical state.
+
+4. **Per-tenant hash chains.** Each tenant owns an independent chain: a new
+   record's ``prev_hash`` links to that tenant's head only, and ``verify_chain``
+   walks each tenant's rows in isolation. One tenant's appends can never extend,
+   fork, or invalidate another tenant's chain, and a dropped/collided row in one
+   tenant cannot mask itself behind another tenant's "verified" count.
 
 This store never holds secret material — it records identity ids, statuses, and
 reasons only, never token hashes or secrets.
+
+**Concurrency & scope (honest).** The SQLite/in-memory backends serialize
+seal+insert with an in-process lock, and the composite ``UNIQUE(tenant_id,
+action_id)`` makes a lost in-process race collapse to the stored row rather than
+a duplicate — so a single process (any number of threads) never forks a chain.
+Cross-*process* serialization for those backends relies on that unique
+constraint plus single-writer operation, so they are **not** safe for multiple
+concurrent writers against one shared chain (multi-replica). The Postgres
+backend (:class:`agent_bom.api.postgres_governance_audit.PostgresGovernanceAuditLog`)
+IS the multi-replica tier: it keeps one shared, tenant-RLS-scoped chain per
+tenant and gets cross-writer idempotency from the same composite
+``UNIQUE(tenant_id, action_id)`` plus ``ON CONFLICT (tenant_id, action_id) DO
+NOTHING`` — a replica that loses the insert race re-reads the canonical row. It
+does not take a cross-node lock, so two replicas can still seal against the same
+head and land two rows for one tenant; that is caught (reported ``tampered``) by
+``verify_chain`` rather than silently corrupting another tenant's chain.
 """
 
 from __future__ import annotations
@@ -55,17 +80,23 @@ _VALID_ACTIONS = frozenset(
 )
 
 
-def derive_action_id(*, target_id: str, action: str, window_key: str) -> str:
-    """Return a deterministic, collision-resistant id for one lifecycle action.
+def derive_action_id(*, tenant_id: str, target_id: str, action: str, window_key: str) -> str:
+    """Return a deterministic, collision-resistant, tenant-scoped action id.
 
-    The id is a SHA-256 over the stable triple ``(target_id, action,
+    The id is a SHA-256 over the stable tuple ``(tenant_id, action, target_id,
     window_key)``. ``window_key`` is a caller-chosen stable token for the
     enforcement occasion — typically the target's terminal state timestamp (an
     expired grant's ``expires_at``, a revoked identity's ``revoked_at``) — so the
     same transition over the same state always derives the same id, and a *new*
     transition (a later re-deprovision after re-activation) derives a new one.
+
+    ``tenant_id`` is folded into the digest so two tenants performing the same
+    logical action on a same-named target derive *different* ids and can never
+    collide on the composite ``UNIQUE(tenant_id, action_id)`` constraint.
     """
-    digest = hashlib.sha256(f"{action}\x1f{target_id}\x1f{window_key}".encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(
+        f"{tenant_id}\x1f{action}\x1f{target_id}\x1f{window_key}".encode("utf-8")
+    ).hexdigest()
     return f"gov_{digest[:32]}"
 
 
@@ -106,9 +137,9 @@ class GovernanceAuditLog(Protocol):
 
     def list(self, *, tenant_id: str | None = None, limit: int = 500) -> list[GovernanceAuditRecord]: ...
 
-    def head_hash(self) -> str: ...
+    def head_hash(self, tenant_id: str | None = None) -> str: ...
 
-    def verify_chain(self, *, max_rows: int = 50_000) -> dict[str, Any]: ...
+    def verify_chain(self, *, tenant_id: str | None = None, max_rows: int = 50_000) -> dict[str, Any]: ...
 
 
 def _seal_record(record: GovernanceAuditRecord, prev_hash: str) -> GovernanceAuditRecord:
@@ -119,44 +150,53 @@ def _seal_record(record: GovernanceAuditRecord, prev_hash: str) -> GovernanceAud
 
 
 class InMemoryGovernanceAuditLog:
-    """Process-local append-only chain. Lost on restart; used for tests/ephemeral."""
+    """Process-local per-tenant append-only chains. Lost on restart; ephemeral."""
 
     def __init__(self) -> None:
-        self._by_id: dict[str, GovernanceAuditRecord] = {}
-        self._order: list[str] = []
-        self._head: str = ""
+        # Dedup key is the composite (tenant_id, action_id) so a caller-supplied
+        # pre-built id can never cross tenants.
+        self._by_key: dict[tuple[str, str], GovernanceAuditRecord] = {}
+        self._order: list[GovernanceAuditRecord] = []  # global insertion order
+        self._heads: dict[str, str] = {}  # tenant_id -> that tenant's chain head
         self._lock = threading.Lock()
 
     def append(self, record: GovernanceAuditRecord) -> GovernanceAuditRecord:
         with self._lock:
-            existing = self._by_id.get(record.action_id)
+            key = (record.tenant_id, record.action_id)
+            existing = self._by_key.get(key)
             if existing is not None:
                 return existing
-            sealed = _seal_record(record, self._head)
-            self._by_id[sealed.action_id] = sealed
-            self._order.append(sealed.action_id)
-            self._head = sealed.record_hash
+            prev = self._heads.get(record.tenant_id, "")
+            sealed = _seal_record(record, prev)
+            self._by_key[key] = sealed
+            self._order.append(sealed)
+            self._heads[sealed.tenant_id] = sealed.record_hash
             return sealed
 
     def get(self, action_id: str) -> GovernanceAuditRecord | None:
         with self._lock:
-            return self._by_id.get(action_id)
+            for record in self._order:
+                if record.action_id == action_id:
+                    return record
+            return None
 
     def list(self, *, tenant_id: str | None = None, limit: int = 500) -> list[GovernanceAuditRecord]:
         with self._lock:
-            rows = [self._by_id[aid] for aid in self._order]
+            rows = list(self._order)
         if tenant_id is not None:
             rows = [r for r in rows if r.tenant_id == tenant_id]
         return list(reversed(rows))[:limit]
 
-    def head_hash(self) -> str:
+    def head_hash(self, tenant_id: str | None = None) -> str:
         with self._lock:
-            return self._head
+            if tenant_id is not None:
+                return self._heads.get(tenant_id, "")
+            return _combined_head(self._heads)
 
-    def verify_chain(self, *, max_rows: int = 50_000) -> dict[str, Any]:
+    def verify_chain(self, *, tenant_id: str | None = None, max_rows: int = 50_000) -> dict[str, Any]:
         with self._lock:
-            rows = [self._by_id[aid] for aid in self._order[:max_rows]]
-        return _verify_rows(rows)
+            rows = list(self._order[:max_rows])
+        return _verify_rows_grouped(rows, tenant_id=tenant_id)
 
 
 class SQLiteGovernanceAuditLog:
@@ -176,33 +216,65 @@ class SQLiteGovernanceAuditLog:
         conn: sqlite3.Connection = self._local.conn
         return conn
 
+    _TABLE_DDL = """
+        CREATE TABLE IF NOT EXISTS governance_audit_log (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT,
+            action_id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            action TEXT NOT NULL,
+            observed_at TEXT NOT NULL,
+            record_hash TEXT NOT NULL,
+            data TEXT NOT NULL,
+            UNIQUE(tenant_id, action_id)
+        )
+    """
+
     def _init_db(self) -> None:
         ensure_sqlite_schema_version(self._conn, "governance_audit_log")
-        self._conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS governance_audit_log (
-                seq INTEGER PRIMARY KEY AUTOINCREMENT,
-                action_id TEXT NOT NULL UNIQUE,
-                tenant_id TEXT NOT NULL,
-                action TEXT NOT NULL,
-                observed_at TEXT NOT NULL,
-                record_hash TEXT NOT NULL,
-                data TEXT NOT NULL
-            )
-            """
-        )
+        self._migrate_unique_constraint()
+        self._conn.execute(self._TABLE_DDL)
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_governance_audit_tenant ON governance_audit_log(tenant_id, seq)")
         self._conn.commit()
 
+    def _migrate_unique_constraint(self) -> None:
+        """Idempotently rebuild an old single-column ``UNIQUE(action_id)`` table.
+
+        Earlier schema declared ``action_id TEXT NOT NULL UNIQUE`` — a *global*
+        uniqueness that silently dropped a second tenant's legitimately distinct
+        row. Rebuild it to composite ``UNIQUE(tenant_id, action_id)`` in place,
+        preserving ``seq`` (chain order) and every row's original bytes. A no-op
+        when the table is absent or already migrated.
+        """
+        row = self._conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type='table' AND name='governance_audit_log'"
+        ).fetchone()
+        if row is None:
+            return  # fresh install — CREATE TABLE below builds the new shape
+        normalized = (row[0] or "").replace(" ", "").lower()
+        if "unique(tenant_id,action_id)" in normalized:
+            return  # already migrated
+        if "action_idtextnotnullunique" not in normalized:
+            return  # unrecognized shape — leave it untouched rather than guess
+        # Rebuild preserving seq so per-tenant chain order is stable.
+        self._conn.execute("ALTER TABLE governance_audit_log RENAME TO governance_audit_log_legacy")
+        self._conn.execute(self._TABLE_DDL)
+        self._conn.execute(
+            "INSERT INTO governance_audit_log (seq, action_id, tenant_id, action, observed_at, record_hash, data) "
+            "SELECT seq, action_id, tenant_id, action, observed_at, record_hash, data FROM governance_audit_log_legacy"
+        )
+        self._conn.execute("DROP TABLE governance_audit_log_legacy")
+        self._conn.commit()
+
     def append(self, record: GovernanceAuditRecord) -> GovernanceAuditRecord:
-        # Serialize seal+insert so two threads can't read the same head and fork
-        # the chain (read-modify-write race). The UNIQUE action_id makes a second
-        # append of the same action a no-op even across processes/replicas.
+        # Serialize seal+insert so two threads can't read the same tenant head
+        # and fork that tenant's chain (read-modify-write race). The composite
+        # UNIQUE(tenant_id, action_id) makes a lost race collapse to the stored
+        # row rather than a duplicate.
         with self._lock:
-            existing = self.get(record.action_id)
+            existing = self._get_scoped(record.tenant_id, record.action_id)
             if existing is not None:
                 return existing
-            head = self.head_hash()
+            head = self.head_hash(record.tenant_id)
             sealed = _seal_record(record, head)
             try:
                 self._conn.execute(
@@ -219,15 +291,25 @@ class SQLiteGovernanceAuditLog:
                 )
                 self._conn.commit()
             except sqlite3.IntegrityError:
-                # Lost a race on the UNIQUE action_id — the other writer's row is
-                # canonical; return it rather than duplicating.
+                # Lost a race on UNIQUE(tenant_id, action_id) — the other writer's
+                # row is canonical; return it rather than duplicating.
                 self._conn.rollback()
-                stored = self.get(record.action_id)
+                stored = self._get_scoped(record.tenant_id, record.action_id)
                 return stored if stored is not None else sealed
             return sealed
 
+    def _get_scoped(self, tenant_id: str, action_id: str) -> GovernanceAuditRecord | None:
+        row = self._conn.execute(
+            "SELECT data FROM governance_audit_log WHERE tenant_id = ? AND action_id = ?",
+            (tenant_id, action_id),
+        ).fetchone()
+        return GovernanceAuditRecord(**json.loads(row[0])) if row else None
+
     def get(self, action_id: str) -> GovernanceAuditRecord | None:
-        row = self._conn.execute("SELECT data FROM governance_audit_log WHERE action_id = ?", (action_id,)).fetchone()
+        row = self._conn.execute(
+            "SELECT data FROM governance_audit_log WHERE action_id = ? ORDER BY seq ASC LIMIT 1",
+            (action_id,),
+        ).fetchone()
         return GovernanceAuditRecord(**json.loads(row[0])) if row else None
 
     def list(self, *, tenant_id: str | None = None, limit: int = 500) -> list[GovernanceAuditRecord]:
@@ -243,18 +325,39 @@ class SQLiteGovernanceAuditLog:
             ).fetchall()
         return [GovernanceAuditRecord(**json.loads(r[0])) for r in rows]
 
-    def head_hash(self) -> str:
-        row = self._conn.execute("SELECT record_hash FROM governance_audit_log ORDER BY seq DESC LIMIT 1").fetchone()
-        return str(row[0]) if row else ""
+    def head_hash(self, tenant_id: str | None = None) -> str:
+        if tenant_id is not None:
+            row = self._conn.execute(
+                "SELECT record_hash FROM governance_audit_log WHERE tenant_id = ? ORDER BY seq DESC LIMIT 1",
+                (tenant_id,),
+            ).fetchone()
+            return str(row[0]) if row else ""
+        # No tenant → a combined fingerprint over every tenant's head, so callers
+        # can cheaply detect "did any chain move" without conflating tenants.
+        rows = self._conn.execute(
+            "SELECT g.tenant_id, g.record_hash FROM governance_audit_log g "
+            "JOIN (SELECT tenant_id, MAX(seq) AS m FROM governance_audit_log GROUP BY tenant_id) t "
+            "ON g.tenant_id = t.tenant_id AND g.seq = t.m"
+        ).fetchall()
+        return _combined_head({str(r[0]): str(r[1]) for r in rows})
 
-    def verify_chain(self, *, max_rows: int = 50_000) -> dict[str, Any]:
-        rows = self._conn.execute("SELECT data FROM governance_audit_log ORDER BY seq ASC LIMIT ?", (max_rows,)).fetchall()
+    def verify_chain(self, *, tenant_id: str | None = None, max_rows: int = 50_000) -> dict[str, Any]:
+        if tenant_id is not None:
+            rows = self._conn.execute(
+                "SELECT data FROM governance_audit_log WHERE tenant_id = ? ORDER BY seq ASC LIMIT ?",
+                (tenant_id, max_rows),
+            ).fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT data FROM governance_audit_log ORDER BY seq ASC LIMIT ?",
+                (max_rows,),
+            ).fetchall()
         records = [GovernanceAuditRecord(**json.loads(r[0])) for r in rows]
-        return _verify_rows(records)
+        return _verify_rows_grouped(records, tenant_id=tenant_id)
 
 
 def _verify_rows(rows: list[GovernanceAuditRecord]) -> dict[str, Any]:
-    """Walk the chain in order, re-deriving each MAC. Never raises."""
+    """Walk one tenant's chain in order, re-deriving each MAC. Never raises."""
     verified = 0
     tampered = 0
     prev = ""
@@ -267,6 +370,42 @@ def _verify_rows(rows: list[GovernanceAuditRecord]) -> dict[str, Any]:
             tampered += 1
         prev = record.record_hash or prev
     return {"verified": verified, "tampered": tampered, "checked": verified + tampered}
+
+
+def _verify_rows_grouped(
+    rows: list[GovernanceAuditRecord], *, tenant_id: str | None = None
+) -> dict[str, Any]:
+    """Verify each tenant's chain independently and sum the results.
+
+    ``rows`` must be in global ``seq`` order; grouping preserves that order per
+    tenant so every chain is walked from its own genesis (``prev_hash == ""``).
+    With ``tenant_id`` set, only that tenant's chain is verified.
+    """
+    by_tenant: dict[str, list[GovernanceAuditRecord]] = {}
+    for record in rows:
+        if tenant_id is not None and record.tenant_id != tenant_id:
+            continue
+        by_tenant.setdefault(record.tenant_id, []).append(record)
+    verified = 0
+    tampered = 0
+    for tenant_rows in by_tenant.values():
+        result = _verify_rows(tenant_rows)
+        verified += result["verified"]
+        tampered += result["tampered"]
+    return {"verified": verified, "tampered": tampered, "checked": verified + tampered}
+
+
+def _combined_head(heads: dict[str, str]) -> str:
+    """Deterministic fingerprint over every tenant's chain head.
+
+    Returns ``""`` when no chain exists. Any tenant's head advancing changes the
+    fingerprint, so a no-op sweep leaves it unchanged — without pretending the
+    tenants share one chain.
+    """
+    if not heads:
+        return ""
+    joined = "\x1f".join(f"{tenant}={head}" for tenant, head in sorted(heads.items()))
+    return hashlib.sha256(joined.encode("utf-8")).hexdigest()
 
 
 _GOVERNANCE_AUDIT_LOG: GovernanceAuditLog | None = None
@@ -290,7 +429,9 @@ def make_governance_audit_record(
     if action not in _VALID_ACTIONS:
         raise ValueError(f"unknown governance action {action!r}; expected one of {sorted(_VALID_ACTIONS)}")
     return GovernanceAuditRecord(
-        action_id=derive_action_id(target_id=target_id, action=action, window_key=window_key),
+        action_id=derive_action_id(
+            tenant_id=tenant_id, target_id=target_id, action=action, window_key=window_key
+        ),
         tenant_id=tenant_id,
         actor=actor[:120],
         action=action,

--- a/src/agent_bom/api/postgres_governance_audit.py
+++ b/src/agent_bom/api/postgres_governance_audit.py
@@ -17,9 +17,12 @@ Design (mirrors :class:`agent_bom.api.postgres_audit.PostgresAuditLog`):
 * **Tenant isolation via FORCE ROW LEVEL SECURITY.** Reads and the head lookup
   run under the record's tenant session, so a cross-tenant ``get`` returns
   ``None`` even for a valid ``action_id`` from another tenant.
-* **Idempotent append.** The ``action_id`` is ``UNIQUE``; a second append of the
-  same deterministic action is a no-op (``ON CONFLICT DO NOTHING``) and returns
-  the already-stored canonical record, even across replicas.
+* **Idempotent append.** ``(tenant_id, action_id)`` is ``UNIQUE``; a second
+  append of the same deterministic action is a no-op (``ON CONFLICT (tenant_id,
+  action_id) DO NOTHING``) and returns the already-stored canonical record, even
+  across replicas. The composite (rather than a global ``UNIQUE(action_id)``)
+  means two tenants' independent actions can never collide, so no tenant's row is
+  silently dropped.
 
 This store never holds secret material — only identity ids, statuses, reasons.
 """
@@ -32,8 +35,9 @@ from typing import Any
 
 from agent_bom.api.governance_audit_log import (
     GovernanceAuditRecord,
+    _combined_head,
     _seal_record,
-    _verify_rows,
+    _verify_rows_grouped,
 )
 from agent_bom.api.postgres_common import (
     ConnectionPool,
@@ -59,7 +63,7 @@ class PostgresGovernanceAuditLog:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS governance_audit_log (
                     seq         BIGSERIAL PRIMARY KEY,
-                    action_id   TEXT NOT NULL UNIQUE,
+                    action_id   TEXT NOT NULL,
                     tenant_id   TEXT NOT NULL,
                     action      TEXT NOT NULL,
                     observed_at TEXT NOT NULL,
@@ -67,6 +71,20 @@ class PostgresGovernanceAuditLog:
                     data        TEXT NOT NULL
                 )
             """)
+            # Migrate away the old GLOBAL UNIQUE(action_id) if a pre-tenant-scope
+            # table exists (Postgres auto-names an inline column unique
+            # <table>_<column>_key); idempotent no-op on fresh installs.
+            conn.execute(
+                "ALTER TABLE governance_audit_log "
+                "DROP CONSTRAINT IF EXISTS governance_audit_log_action_id_key"
+            )
+            # Tenant-scoped uniqueness — the ON CONFLICT arbiter and the
+            # defense-in-depth against a caller crossing tenants with a pre-built
+            # id. Idempotent for both fresh and migrated tables.
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS uq_governance_audit_tenant_action "
+                "ON governance_audit_log(tenant_id, action_id)"
+            )
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_governance_audit_tenant "
                 "ON governance_audit_log(tenant_id, seq)"
@@ -101,7 +119,7 @@ class PostgresGovernanceAuditLog:
                     "INSERT INTO governance_audit_log "
                     "(action_id, tenant_id, action, observed_at, record_hash, data) "
                     "VALUES (%s, %s, %s, %s, %s, %s) "
-                    "ON CONFLICT (action_id) DO NOTHING",
+                    "ON CONFLICT (tenant_id, action_id) DO NOTHING",
                     (
                         sealed.action_id,
                         sealed.tenant_id,
@@ -147,34 +165,54 @@ class PostgresGovernanceAuditLog:
                 ).fetchall()
         return [GovernanceAuditRecord(**json.loads(r[0])) for r in rows]
 
-    def head_hash(self) -> str:
-        with _tenant_connection(self._pool) as conn:
-            row = conn.execute(
-                "SELECT record_hash FROM governance_audit_log "
-                "WHERE tenant_id = %s ORDER BY seq DESC LIMIT 1",
-                (_current_tenant.get(),),
-            ).fetchone()
-        return str(row[0]) if row else ""
-
-    def verify_chain(self, *, max_rows: int = 50_000) -> dict[str, Any]:
-        # Full-estate integrity sweep: read every tenant's rows (trusted bypass),
-        # then verify each tenant's chain independently — a tenant's records link
-        # only to that tenant's prior record, so mixing tenants would false-flag.
+    def head_hash(self, tenant_id: str | None = None) -> str:
+        if tenant_id is not None:
+            token = _current_tenant.set(tenant_id)
+            try:
+                with _tenant_connection(self._pool) as conn:
+                    row = conn.execute(
+                        "SELECT record_hash FROM governance_audit_log "
+                        "WHERE tenant_id = %s ORDER BY seq DESC LIMIT 1",
+                        (tenant_id,),
+                    ).fetchone()
+            finally:
+                _current_tenant.reset(token)
+            return str(row[0]) if row else ""
+        # No tenant → a combined fingerprint over every tenant's head, so callers
+        # can cheaply detect "did any chain move" without conflating tenants
+        # (trusted control-plane read via the audited RLS bypass).
         with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
             rows = conn.execute(
-                "SELECT data FROM governance_audit_log ORDER BY tenant_id ASC, seq ASC LIMIT %s",
-                (max_rows,),
+                "SELECT g.tenant_id, g.record_hash FROM governance_audit_log g "
+                "JOIN (SELECT tenant_id, MAX(seq) AS m FROM governance_audit_log GROUP BY tenant_id) t "
+                "ON g.tenant_id = t.tenant_id AND g.seq = t.m"
             ).fetchall()
-        by_tenant: dict[str, list[GovernanceAuditRecord]] = {}
-        for r in rows:
-            record = GovernanceAuditRecord(**json.loads(r[0]))
-            by_tenant.setdefault(record.tenant_id, []).append(record)
-        verified = tampered = 0
-        for chain in by_tenant.values():
-            result = _verify_rows(chain)
-            verified += result["verified"]
-            tampered += result["tampered"]
-        return {"verified": verified, "tampered": tampered, "checked": verified + tampered}
+        return _combined_head({str(r[0]): str(r[1]) for r in rows})
+
+    def verify_chain(self, *, tenant_id: str | None = None, max_rows: int = 50_000) -> dict[str, Any]:
+        # A tenant's records link only to that tenant's prior record, so each
+        # chain is verified in isolation; mixing tenants would false-flag.
+        if tenant_id is not None:
+            token = _current_tenant.set(tenant_id)
+            try:
+                with _tenant_connection(self._pool) as conn:
+                    rows = conn.execute(
+                        "SELECT data FROM governance_audit_log WHERE tenant_id = %s "
+                        "ORDER BY seq ASC LIMIT %s",
+                        (tenant_id, max_rows),
+                    ).fetchall()
+            finally:
+                _current_tenant.reset(token)
+        else:
+            # Full-estate sweep: read every tenant's rows under the audited bypass,
+            # ordered so each tenant's rows stay in seq order for the grouped walk.
+            with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
+                rows = conn.execute(
+                    "SELECT data FROM governance_audit_log ORDER BY tenant_id ASC, seq ASC LIMIT %s",
+                    (max_rows,),
+                ).fetchall()
+        records = [GovernanceAuditRecord(**json.loads(r[0])) for r in rows]
+        return _verify_rows_grouped(records, tenant_id=tenant_id)
 
 
 __all__ = ["PostgresGovernanceAuditLog"]

--- a/tests/api/test_governance_audit_log.py
+++ b/tests/api/test_governance_audit_log.py
@@ -1,0 +1,212 @@
+"""Tenant-scoped governance audit chain: isolation + integrity.
+
+These tests pin the invariants that a single, global audit chain violated:
+
+* Two tenants performing the *same* logical lifecycle action on a same-named
+  target must not collide — neither row may be silently dropped, and each
+  tenant's chain must verify independently.
+* Concurrent same-tenant appends must not fork the chain (two rows sharing one
+  ``prev_hash``), which ``verify_chain`` would report as tampered.
+* Appending an identical action twice remains an idempotent no-op.
+* An existing DB written under the old single-column ``UNIQUE(action_id)``
+  schema migrates to the composite ``UNIQUE(tenant_id, action_id)`` without
+  data loss, and new appends keep verifying.
+
+Every behavioural test runs against *both* the in-memory and SQLite backends so
+the two implementations cannot drift apart.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.api.governance_audit_log import (
+    GovernanceAuditRecord,
+    InMemoryGovernanceAuditLog,
+    SQLiteGovernanceAuditLog,
+    _seal_record,
+    make_governance_audit_record,
+)
+
+T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def audit(request, tmp_path):
+    if request.param == "memory":
+        return InMemoryGovernanceAuditLog()
+    return SQLiteGovernanceAuditLog(str(tmp_path / "gov.db"))
+
+
+def _rec(
+    tenant: str,
+    *,
+    target: str = "jit_1",
+    action: str = "jit_grant_expired",
+    window: str = "w1",
+) -> GovernanceAuditRecord:
+    return make_governance_audit_record(
+        tenant_id=tenant,
+        actor="system",
+        action=action,
+        target_type="jit_grant",
+        target_id=target,
+        reason="expired",
+        before_state="active",
+        after_state="revoked",
+        observed_at=T0.isoformat(),
+        window_key=window,
+    )
+
+
+def test_cross_tenant_same_action_both_persist(audit):
+    """Same (action, target_id, window_key) for two tenants must not collide."""
+    acme = _rec("acme")
+    globex = _rec("globex")
+    # tenant is folded into the derived id, so the two ids differ.
+    assert acme.action_id != globex.action_id
+
+    audit.append(acme)
+    audit.append(globex)
+
+    acme_rows = audit.list(tenant_id="acme")
+    globex_rows = audit.list(tenant_id="globex")
+    assert len(acme_rows) == 1
+    assert len(globex_rows) == 1
+    assert acme_rows[0].tenant_id == "acme"
+    assert globex_rows[0].tenant_id == "globex"
+    # Neither tenant's row was dropped.
+    assert len(audit.list()) == 2
+
+    result = audit.verify_chain()
+    assert result["tampered"] == 0
+    assert result["verified"] == 2
+
+
+def test_cross_tenant_chains_are_independent(audit):
+    """Each tenant is its own chain: a per-tenant verify sees only its rows."""
+    audit.append(_rec("acme", target="a", window="1"))
+    audit.append(_rec("globex", target="b", window="1"))
+    audit.append(_rec("acme", target="a", window="2"))
+
+    assert audit.verify_chain(tenant_id="acme")["verified"] == 2
+    assert audit.verify_chain(tenant_id="acme")["tampered"] == 0
+    assert audit.verify_chain(tenant_id="globex")["verified"] == 1
+    assert audit.verify_chain(tenant_id="globex")["tampered"] == 0
+    # A tenant's head is scoped to that tenant.
+    assert audit.head_hash("acme") != audit.head_hash("globex")
+    assert audit.head_hash("acme") == audit.list(tenant_id="acme")[0].record_hash
+
+
+def test_concurrent_same_tenant_append_no_fork(audit):
+    """Threads racing appends must not fork the chain; dups stay idempotent."""
+    recs = [_rec("acme", target=f"t{i}", window=str(i)) for i in range(20)]
+
+    def worker(rec: GovernanceAuditRecord) -> None:
+        audit.append(rec)
+
+    threads = [threading.Thread(target=worker, args=(r,)) for r in recs * 3]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Exactly the 20 distinct actions persisted (true duplicates deduped).
+    assert len(audit.list(tenant_id="acme")) == 20
+    result = audit.verify_chain()
+    assert result["tampered"] == 0
+    assert result["verified"] == 20
+
+
+def test_idempotent_append_is_noop(audit):
+    rec = _rec("acme")
+    first = audit.append(rec)
+    second = audit.append(rec)
+    assert first.record_hash == second.record_hash
+    assert len(audit.list()) == 1
+    assert audit.verify_chain()["tampered"] == 0
+
+
+def _old_schema_ddl() -> str:
+    # The pre-fix schema: single-column global UNIQUE(action_id).
+    return """
+        CREATE TABLE governance_audit_log (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT,
+            action_id TEXT NOT NULL UNIQUE,
+            tenant_id TEXT NOT NULL,
+            action TEXT NOT NULL,
+            observed_at TEXT NOT NULL,
+            record_hash TEXT NOT NULL,
+            data TEXT NOT NULL
+        )
+    """
+
+
+def test_migration_from_old_single_column_unique(tmp_path):
+    db = str(tmp_path / "legacy.db")
+    conn = sqlite3.connect(db)
+    conn.execute(_old_schema_ddl())
+    # Seed a valid single-tenant chain the old way (one global chain == that
+    # tenant's chain when only one tenant is present).
+    prev = ""
+    seeded = []
+    for i in range(3):
+        sealed = _seal_record(_rec("acme", target=f"t{i}", window=str(i)), prev)
+        conn.execute(
+            "INSERT INTO governance_audit_log (action_id, tenant_id, action, observed_at, record_hash, data) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                sealed.action_id,
+                sealed.tenant_id,
+                sealed.action,
+                sealed.observed_at,
+                sealed.record_hash,
+                json.dumps(asdict(sealed), sort_keys=True),
+            ),
+        )
+        seeded.append(sealed.action_id)
+        prev = sealed.record_hash
+    conn.commit()
+    conn.close()
+
+    # Reopen with the new code — migration runs in _init_db.
+    log = SQLiteGovernanceAuditLog(db)
+
+    # No data loss.
+    rows = log.list(tenant_id="acme")
+    assert len(rows) == 3
+    assert {r.action_id for r in rows} == set(seeded)
+    # Legacy single-tenant chain still verifies clean.
+    assert log.verify_chain()["tampered"] == 0
+
+    # Schema is now the composite unique.
+    sql = log._conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='governance_audit_log'"
+    ).fetchone()[0]
+    normalized = sql.replace(" ", "").lower()
+    assert "unique(tenant_id,action_id)" in normalized
+
+    # New appends chain onto the migrated head and stay verifiable.
+    log.append(_rec("acme", target="t9", window="9"))
+    assert len(log.list(tenant_id="acme")) == 4
+    assert log.verify_chain()["tampered"] == 0
+
+    # Migration is idempotent: reopening again is a no-op with no data loss.
+    reopened = SQLiteGovernanceAuditLog(db)
+    assert len(reopened.list(tenant_id="acme")) == 4
+    assert reopened.verify_chain()["tampered"] == 0
+
+
+def test_public_get_still_resolves_by_action_id(audit):
+    rec = _rec("acme")
+    audit.append(rec)
+    fetched = audit.get(rec.action_id)
+    assert fetched is not None
+    assert fetched.tenant_id == "acme"
+    assert audit.get("gov_does_not_exist") is None

--- a/tests/test_nhi_lifecycle_enforcement.py
+++ b/tests/test_nhi_lifecycle_enforcement.py
@@ -213,11 +213,14 @@ def test_set_and_read_quota(store):
 
 
 def test_action_id_deterministic():
-    a = derive_action_id(target_id="jit_1", action="jit_grant_expired", window_key="2026-01-01T00:00:00")
-    b = derive_action_id(target_id="jit_1", action="jit_grant_expired", window_key="2026-01-01T00:00:00")
-    c = derive_action_id(target_id="jit_1", action="jit_grant_expired", window_key="2026-02-01T00:00:00")
+    a = derive_action_id(tenant_id="t1", target_id="jit_1", action="jit_grant_expired", window_key="2026-01-01T00:00:00")
+    b = derive_action_id(tenant_id="t1", target_id="jit_1", action="jit_grant_expired", window_key="2026-01-01T00:00:00")
+    c = derive_action_id(tenant_id="t1", target_id="jit_1", action="jit_grant_expired", window_key="2026-02-01T00:00:00")
+    # Same inputs but a different tenant derives a different id (no collision).
+    d = derive_action_id(tenant_id="t2", target_id="jit_1", action="jit_grant_expired", window_key="2026-01-01T00:00:00")
     assert a == b
     assert a != c
+    assert a != d
     assert a.startswith("gov_")
 
 

--- a/tests/test_postgres_governance_audit.py
+++ b/tests/test_postgres_governance_audit.py
@@ -75,8 +75,9 @@ class _FakeConnection:
         if s.startswith("insert into governance_audit_log"):
             action_id, tenant_id, action, observed_at, record_hash, data = params
             rows = self._state["rows"]
-            if any(r["action_id"] == action_id for r in rows):
-                return _FakeCursor()  # ON CONFLICT DO NOTHING
+            # ON CONFLICT (tenant_id, action_id) DO NOTHING — composite arbiter.
+            if any(r["action_id"] == action_id and r["tenant_id"] == tenant_id for r in rows):
+                return _FakeCursor()
             self._state["seq"] += 1
             rows.append(
                 {
@@ -104,12 +105,20 @@ class _FakeConnection:
             return _FakeCursor([(rows[0]["record_hash"],)] if rows else [])
 
         if "select data from governance_audit_log where tenant_id" in s:
+            # list() reads DESC; verify_chain(tenant_id=...) reads ASC.
             rows = sorted(
                 (r for r in self._visible() if r["tenant_id"] == params[0]),
                 key=lambda r: r["seq"],
-                reverse=True,
+                reverse="desc" in s,
             )[: params[1]]
             return _FakeCursor([(r["data"],) for r in rows])
+
+        if "group by tenant_id" in s and "max(seq)" in s:
+            # Combined head: the last record_hash per tenant (head_hash() no-arg).
+            latest: dict[str, str] = {}
+            for r in sorted(self._visible(), key=lambda r: r["seq"]):
+                latest[r["tenant_id"]] = r["record_hash"]
+            return _FakeCursor([(t, h) for t, h in latest.items()])
 
         if "order by tenant_id asc, seq asc" in s:
             rows = sorted(self._visible(), key=lambda r: (r["tenant_id"], r["seq"]))[: params[0]]
@@ -222,6 +231,49 @@ def test_per_tenant_chains_both_verify():
     result = store.verify_chain()
     assert result["tampered"] == 0
     assert result["verified"] == 3
+
+
+def test_cross_tenant_same_action_both_persist():
+    """Two tenants, identical (action, target_id, window_key): neither dropped.
+
+    Pre-fix a global UNIQUE(action_id) + tenant-blind derive collapsed these to
+    one id, silently dropping the second tenant's row while verify_chain still
+    reported healthy. Tenant-folded ids + composite unique keep both.
+    """
+    store = PostgresGovernanceAuditLog(pool=_FakePool())
+    acme = store.append(_rec("acme", "id-shared", "w1"))
+    globex = store.append(_rec("globex", "id-shared", "w1"))
+
+    assert acme.action_id != globex.action_id
+    assert [r.tenant_id for r in store.list(tenant_id="acme")] == ["acme"]
+    assert [r.tenant_id for r in store.list(tenant_id="globex")] == ["globex"]
+    # Each tenant is a genesis chain of its own.
+    assert acme.prev_hash == ""
+    assert globex.prev_hash == ""
+    result = store.verify_chain()
+    assert result["verified"] == 2
+    assert result["tampered"] == 0
+
+
+def test_verify_chain_and_head_hash_are_tenant_scoped():
+    store = PostgresGovernanceAuditLog(pool=_FakePool())
+    store.append(_rec("acme", "id-a1", "w1"))
+    a2 = store.append(_rec("acme", "id-a2", "w2"))
+    store.append(_rec("globex", "id-b1", "w1"))
+
+    # Per-tenant verify sees only that tenant's rows.
+    assert store.verify_chain(tenant_id="acme") == {"verified": 2, "tampered": 0, "checked": 2}
+    assert store.verify_chain(tenant_id="globex") == {"verified": 1, "tampered": 0, "checked": 1}
+
+    # Per-tenant head is that tenant's latest record_hash; tenants differ.
+    assert store.head_hash("acme") == a2.record_hash
+    assert store.head_hash("acme") != store.head_hash("globex")
+
+    # No-arg head fingerprints all chains and is stable across a no-op append.
+    combined = store.head_hash()
+    assert combined
+    store.append(_rec("acme", "id-a2", "w2"))  # idempotent duplicate
+    assert store.head_hash() == combined
 
 
 def test_shared_pool_is_cluster_consistent():


### PR DESCRIPTION
## Problem

The NHI lifecycle **governance audit log** kept a single **global** hash chain and a **global** `UNIQUE(action_id)`. `derive_action_id` hashed only `(target_id, action, window_key)` — no tenant.

1. **Cross-tenant silent drop.** Two tenants performing the same logical action on a same-named target derive the **identical** `action_id`. Tenant B's legitimate row hits the global unique and is silently dropped by `append`'s dedup — yet `verify_chain` still returns `{verified: N, tampered: 0}`. A missing audit row reported as healthy.
2. **Concurrent chain fork.** One global chain means concurrent appends read the same head and fork it (two rows sharing one `prev_hash`), which `verify_chain` then reports as `tampered`.

## Fix (applied identically to SQLite, in-memory, and Postgres)

- **Tenant-scoped identity + uniqueness.** `derive_action_id` folds `tenant_id` into the SHA-256 input. Every backend uses composite `UNIQUE(tenant_id, action_id)`; `append` dedups on `(tenant_id, action_id)`. Cross-tenant actions never collide; a pre-built id can't cross tenants.
- **Per-tenant chains.** `prev_hash` links to the acting tenant's head only. `head_hash(tenant_id)` returns that tenant's head; `verify_chain(tenant_id=...)` walks one tenant. No-tenant `head_hash()` fingerprints all tenant heads; no-tenant `verify_chain()` verifies every tenant's chain by grouping (shared `_verify_rows_grouped` / `_combined_head` helpers). The `GovernanceAuditLog` Protocol gains optional `tenant_id` params; all three backends implement them.
- **Concurrency.** SQLite/in-memory serialize seal+insert with an in-process lock and collapse a lost race to the stored row via the composite unique. **Postgres** keeps one shared per-tenant chain and gets cross-writer idempotency from the composite unique + `ON CONFLICT (tenant_id, action_id) DO NOTHING` (re-reads the canonical row on a lost race).
- **Idempotent migrations.** SQLite rebuilds an old single-column `UNIQUE(action_id)` table in place to the composite unique, preserving `seq` and every row's bytes. Postgres drops the old auto-named `governance_audit_log_action_id_key` constraint (`IF EXISTS`) and creates the composite unique **index** (`IF NOT EXISTS`) — the repo's idempotent-DDL convention. Both no-op once migrated.

## Honest scope

SQLite / in-memory remain **single-writer** (not multi-replica safe). **Postgres** is the multi-replica tier — one shared, tenant-RLS-scoped chain per tenant — but takes **no cross-node lock**, so two replicas can still seal against the same head; that is **caught** (reported `tampered`) by `verify_chain` rather than silently corrupting another tenant's chain. No cross-node advisory lock is claimed.

## Tests

New `tests/api/test_governance_audit_log.py`, parametrized over **in-memory + SQLite**:
- `test_cross_tenant_same_action_both_persist` — both rows persist; per-tenant `list`; `verify_chain` both verified, 0 tampered. **(failed before, passes after)**
- `test_cross_tenant_chains_are_independent` — per-tenant `verify_chain` / `head_hash` scoped. **(failed before — no `tenant_id` kwarg)**
- `test_migration_from_old_single_column_unique` — old-schema DB migrates without data loss; composite unique present; new appends verify; reopening idempotent. **(failed before, passes after)**
- `test_concurrent_same_tenant_append_no_fork`, `test_idempotent_append_is_noop`, `test_public_get_still_resolves_by_action_id`.

**Postgres** (`tests/test_postgres_governance_audit.py`, existing functional fake-pool harness with FORCE-RLS semantics — extended, not scaffolded):
- `test_cross_tenant_same_action_both_persist` — same `(action, target_id, window_key)`, two tenants: neither dropped, distinct ids, each a genesis chain, both verify.
- `test_verify_chain_and_head_hash_are_tenant_scoped` — `verify_chain(tenant_id=...)` and `head_hash(tenant_id)` scoped; no-arg combined head stable across an idempotent append.
- Fake updated to composite `ON CONFLICT`, ASC/DESC ordering, and the combined-head query.

Note: the Postgres harness is an in-memory functional fake (no real PG / testcontainers in the repo), so the concurrent-no-fork and real DDL-migration paths are not exercised against a live server; the tenant-grouping integrity logic is shared and unit-tested via the in-memory/SQLite params, and the composite `ON CONFLICT` / ordering are modeled in the fake.

Existing `test_action_id_deterministic` updated to pass `tenant_id` and assert cross-tenant ids differ.

## Gates
- `uv run mypy src/ --ignore-missing-imports --disable-error-code import-untyped` → **0 errors** (707 files).
- `uv run ruff check src/` and changed tests → clean.
- `pytest` governance/NHI/postgres-governance → 43 passed.
- `make preflight` → green (no route contract changed).