### PR TITLE
fix(ui): a11y labels, unique ids, error headings, and legacy deep-link redirects

### DIFF
--- a/ui/app/error.tsx
+++ b/ui/app/error.tsx
@@ -24,16 +24,17 @@ export default function GlobalError({
   }, [error]);
 
   return (
-    <div className="flex flex-col items-center justify-center h-[80vh] gap-4 text-center">
-      <ShieldX className="w-12 h-12 text-red-500" />
-      <h2 className="text-lg font-semibold text-[var(--foreground)]">Something went wrong</h2>
-      <p className="text-sm text-[var(--text-secondary)] max-w-md">{error.message}</p>
+    <main className="flex h-[80vh] flex-col items-center justify-center gap-4 px-6 text-center">
+      <ShieldX className="h-12 w-12 text-red-500" aria-hidden="true" />
+      <h1 className="text-lg font-semibold text-[var(--foreground)]">Something went wrong</h1>
+      <p className="max-w-md text-sm text-[var(--text-secondary)]">{error.message}</p>
       <button
+        type="button"
         onClick={reset}
-        className="px-4 py-2 bg-emerald-600 hover:bg-emerald-500 rounded-md text-sm text-white transition-colors"
+        className="rounded-md bg-emerald-600 px-4 py-2 text-sm text-white transition-colors hover:bg-emerald-500"
       >
         Try again
       </button>
-    </div>
+    </main>
   );
 }

--- a/ui/app/inventory/page.tsx
+++ b/ui/app/inventory/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+// The AI inventory now lives on the AI BOM surface. Keep `/inventory` as a
+// permanent server-side redirect so legacy deep links and bookmarks resolve to
+// the canonical route instead of a 404.
+export default function InventoryRedirect() {
+  redirect("/manifest");
+}

--- a/ui/app/reports/page.tsx
+++ b/ui/app/reports/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+// Report exports are now a tab on the consolidated Integrations surface. Keep
+// `/reports` as a permanent server-side redirect so legacy deep links and
+// bookmarks land on the canonical route instead of a 404.
+export default function ReportsRedirect() {
+  redirect("/integrations?tab=reports");
+}

--- a/ui/app/threat-intel/page.tsx
+++ b/ui/app/threat-intel/page.tsx
@@ -1,0 +1,8 @@
+import { redirect } from "next/navigation";
+
+// Threat-intel lookups are now a tab on the consolidated Integrations surface.
+// Keep `/threat-intel` as a permanent server-side redirect so legacy deep links
+// and bookmarks land on the canonical route instead of a 404.
+export default function ThreatIntelRedirect() {
+  redirect("/integrations?tab=intel");
+}

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -357,8 +357,9 @@ export function FullscreenButton() {
       onClick={toggle}
       className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)] transition-colors backdrop-blur-sm"
       title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
+      aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
     >
-      {isFullscreen ? <Minimize2 className="w-3.5 h-3.5" /> : <Maximize2 className="w-3.5 h-3.5" />}
+      {isFullscreen ? <Minimize2 className="w-3.5 h-3.5" aria-hidden="true" /> : <Maximize2 className="w-3.5 h-3.5" aria-hidden="true" />}
     </button>
   );
 }

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -368,7 +368,7 @@ export function Nav() {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, []);
+  }, [setCollapsed]);
 
   // Filter nav links by search
   const filteredGroups = searchQuery

--- a/ui/tests/error-page.test.tsx
+++ b/ui/tests/error-page.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: { reportClientError: vi.fn().mockResolvedValue(undefined) },
+}));
+
+import ErrorBoundary from "@/app/error";
+
+describe("route error boundary", () => {
+  it("renders a top-level heading inside a main landmark", () => {
+    render(<ErrorBoundary error={new Error("boom")} reset={() => {}} />);
+
+    const heading = screen.getByRole("heading", { level: 1, name: /something went wrong/i });
+    expect(heading).toBeInTheDocument();
+    expect(screen.getByRole("main")).toBeInTheDocument();
+    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+});

--- a/ui/tests/graph-chrome.test.tsx
+++ b/ui/tests/graph-chrome.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { GraphEvidenceExportButton, GraphLegend, GraphLegendDock } from "@/components/graph-chrome";
+import { FullscreenButton, GraphEvidenceExportButton, GraphLegend, GraphLegendDock } from "@/components/graph-chrome";
 import { api } from "@/lib/api";
 
 afterEach(() => {
@@ -77,6 +77,14 @@ describe("GraphLegend", () => {
     expect(screen.getByText("Legend")).toBeInTheDocument();
     expect(screen.getAllByText("AI Agent").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Uses").length).toBeGreaterThan(0);
+  });
+});
+
+describe("FullscreenButton", () => {
+  it("exposes an accessible name for the icon-only control", () => {
+    render(<FullscreenButton />);
+
+    expect(screen.getByRole("button", { name: /enter fullscreen/i })).toBeInTheDocument();
   });
 });
 

--- a/ui/tests/legacy-deeplink-redirects.test.tsx
+++ b/ui/tests/legacy-deeplink-redirects.test.tsx
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { redirectMock } = vi.hoisted(() => ({ redirectMock: vi.fn() }));
+
+vi.mock("next/navigation", () => ({ redirect: redirectMock }));
+
+import InventoryRedirect from "@/app/inventory/page";
+import ThreatIntelRedirect from "@/app/threat-intel/page";
+import ReportsRedirect from "@/app/reports/page";
+
+describe("legacy deep-link redirects", () => {
+  beforeEach(() => {
+    redirectMock.mockClear();
+  });
+
+  it("routes /inventory to the AI BOM surface", () => {
+    InventoryRedirect();
+    expect(redirectMock).toHaveBeenCalledWith("/manifest");
+  });
+
+  it("routes /threat-intel to the Integrations intel tab", () => {
+    ThreatIntelRedirect();
+    expect(redirectMock).toHaveBeenCalledWith("/integrations?tab=intel");
+  });
+
+  it("routes /reports to the Integrations reports tab", () => {
+    ReportsRedirect();
+    expect(redirectMock).toHaveBeenCalledWith("/integrations?tab=reports");
+  });
+});


### PR DESCRIPTION
UI-only accessibility and navigation fixes. Each item from an external audit (run against a stale 0.94.2 demo) was reproduced against current `main` first; only what still reproduced was changed.

## Item 1 — nav hook missing-dependency warning — REPRODUCED, fixed
`npx eslint components/nav.tsx` flagged:
`371:6 warning React Hook useEffect has a missing dependency: 'setCollapsed'`
The Cmd/Ctrl+K/B keyboard-shortcut `useEffect` used `setCollapsed` (from the sidebar-layout context, not a known-stable `useState` setter) with an empty dep array. Fixed properly by adding `setCollapsed` to the dependency array — no `eslint-disable`. `setCollapsed` is a stable memoized setter, so behavior is unchanged. Lint is now clean.

## Item 2 — duplicate `agent-bom-bg` ids — ALREADY FIXED (not reproduced)
`grep -rn "agent-bom-bg" ui/` returns no matches anywhere in the UI. The decorative element / gradient id the audit referenced no longer exists on current `main`. No change made — reporting per instructions, no overclaim.

## Item 3 — unlabeled controls on graph / manifest — PARTIALLY REPRODUCED, fixed the one residual
Audited every button on the graph pages (`graph-page-client`, `security-graph`, sigma/large-graph overviews, exposure-path components) and the manifest page. On current `main` these are already labeled — canvases carry `aria-label`, toggles use `aria-pressed`/`role="switch"`, and every other control has visible text.
The one genuine residual: `FullscreenButton` (`components/graph-chrome.tsx`) is icon-only and relied on `title` alone (a weak, inconsistently-exposed accessible name). Added an explicit `aria-label` and `aria-hidden` on the icon. It is used on the graph, mesh, context, security-graph, and attack-flow views.

## Item 4 — runtime error page heading — ALREADY HAS A HEADING; applied a small semantic upgrade
The route error boundary (`app/error.tsx`) already rendered a heading on current `main` (an `<h2>`), so the literal "renders without a proper heading" claim does not reproduce. The shared `PageErrorState` renders only an `<h3>`, so routing through it would have lowered the level. Instead, upgraded `app/error.tsx` to render inside a `<main>` landmark with a top-level `<h1>` and an `aria-hidden` icon (plus `type="button"`), matching the sibling `app/global-error.tsx` pattern for a proper top-level heading + landmark.

## Item 5 — legacy deep-link 404s — REPRODUCED, fixed
`/inventory`, `/threat-intel`, and `/reports` have no route directory under `ui/app/` and 404 today. Redirects follow the existing server-side stub convention (`app/overview/page.tsx` and `app/insights/page.tsx` call `redirect()` from `next/navigation`).

Confirmed route mapping (verified against `nav.tsx` + `app/` structure, not the audit's guesses):
- `/inventory` -> `/manifest` — the "AI inventory" nav group's canonical surface is AI BOM = `/manifest`.
- `/threat-intel` -> `/integrations?tab=intel` — threat-intel lookups live in the Integrations `intel` tab (`components/integrations/intel-panel.tsx`).
- `/reports` -> `/integrations?tab=reports` — report exports live in the Integrations `reports` tab (`components/integrations/reports-panel.tsx`).

The audit had guessed `/manifest`, `/integrations`, and `/audit`; `/inventory` matches, but `/threat-intel` and `/reports` resolve to specific Integrations tabs, and `/reports` is NOT `/audit`.

## Tests
- `tests/legacy-deeplink-redirects.test.tsx` — asserts the three redirect targets.
- `tests/error-page.test.tsx` — asserts the error boundary renders an `<h1>` inside a `main` landmark.
- `tests/graph-chrome.test.tsx` — added an accessible-name assertion for `FullscreenButton`.

## Gates
- `npx eslint` on all changed files: clean, 0 warnings (item-1 warning gone).
- `npx vitest run`: 622 passed (125 files).
- `npm run build` (Turbopack): exit 0; new routes prerendered.

Design tokens and both themes respected; no hardcoded zinc introduced.