### PR TITLE
chore: map Cursor Agent commits to owner via .mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Wagdy Saad <mohamedsaad018@gmail.com> Cursor Agent <cursoragent@cursor.com>
+Wagdy Saad <mohamedsaad018@gmail.com> Cursor <cursoragent@cursor.com>


### PR DESCRIPTION
## What

Adds a `.mailmap` that coalesces the **Cursor Agent** bot identity into the repo owner so it stops showing up as a separate entry in the GitHub *Contributors* sidebar.

This is the **safe, non-destructive** approach: no history rewrite, no force-push, no rebase. Every commit SHA is unchanged, so the just-published release tags stay valid.

## Identity mapped

Only the Cursor Agent identity is touched. All humans and the `agent-bom` bot are left exactly as-is.

- `Cursor Agent <cursoragent@cursor.com>` (author of 7 commits, plus `Co-authored-by: Cursor` / `Cursor Agent` trailers) → **`Wagdy Saad <mohamedsaad018@gmail.com>`** (the dominant real author in history).

## `.mailmap` lines added

```
Wagdy Saad <mohamedsaad018@gmail.com> Cursor Agent <cursoragent@cursor.com>
Wagdy Saad <mohamedsaad018@gmail.com> Cursor <cursoragent@cursor.com>
```

## Proof — before / after

Before (`git shortlog -sne --all`, excerpt):

```
  3529	Wagdy Saad <mohamedsaad018@gmail.com>
     7	Cursor Agent <cursoragent@cursor.com>
```

After (with `.mailmap` in place):

```
$ git shortlog -sne --all | grep -i cursor
(no output — exit 1)

  3536	Wagdy Saad <mohamedsaad018@gmail.com>   # +7, absorbed the Cursor Agent commits
```

Also verified with mailmap-aware log specifiers (`%aN <%aE>` / `%cN <%cE>`) across `--all`: zero cursor matches on both author and committer sides, and `git check-mailmap "Cursor Agent <cursoragent@cursor.com>"` resolves to `Wagdy Saad <mohamedsaad018@gmail.com>`.

## Note

GitHub honors `.mailmap` for the Contributors graph, but the sidebar is cached — it will update after this merges to the default branch and a cache refresh / next push cycle, not instantly.
