### PR TITLE
ci(docs): scope Pages concurrency to the deploy job

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -54,6 +50,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Serialize only real Pages deployments. Keeping this at job level (not the
+    # whole workflow) means build-only validation runs — e.g. the release
+    # workflow calling this with deploy:false — never join the pages group and
+    # so can't cancel an in-progress deploy. cancel-in-progress:false lets a
+    # running production deploy finish instead of being cancelled mid-flight.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Problem

The `github-pages` environment went red after the v0.96.2 release. Root cause is a concurrency race, not a broken docs build (the mkdocs `--strict` build passed in every recent run):

- `.github/workflows/docs.yml` declared `concurrency: group: pages, cancel-in-progress: true` at the **workflow level**.
- `.github/workflows/release.yml` calls `docs.yml` via `workflow_call` with `deploy: false` — purely to validate the docs build during a release. That build-only invocation still joined the shared `pages` concurrency group.
- When a release commit lands, the push-triggered standalone **Deploy Docs** run and the tag-triggered **Release** run start almost simultaneously. The Release's build-only docs invocation becomes a "higher priority waiting request for pages" and, because of `cancel-in-progress: true`, cancels the standalone run **mid-deploy**.
- The cancelled deploy leaves the `github-pages` deployment in an `error` state, and the Release never redeploys (it runs with `deploy: false`), so Pages stays red until the next docs change.

This reproduced exactly on the v0.96.2 landing: standalone Deploy Docs run cancelled with `Canceling since a higher priority waiting request for pages exists`, Pages deployment for the release sha left in `error`.

## Fix

- Move the `concurrency` block from the workflow level onto the `deploy` job only.
- Set `cancel-in-progress: false`.

Effects:
- Build-only validation (release `deploy:false`) no longer joins the `pages` group, so it can never cancel an in-progress deploy.
- Real deployments still serialize on `group: pages`, and a running production deploy is allowed to finish instead of being cancelled.

This is GitHub's recommended Pages concurrency pattern. No change to the docs build itself.