### PR TITLE
chore(repo): README self-host + accuracy, Pages concurrency fix, contributor identity cleanup

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,10 +19,6 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: pages
-  cancel-in-progress: true
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -54,6 +50,14 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    # Serialize only real Pages deployments. Keeping this at job level (not the
+    # whole workflow) means build-only validation runs — e.g. the release
+    # workflow calling this with deploy:false — never join the pages group and
+    # so can't cancel an in-progress deploy. cancel-in-progress:false lets a
+    # running production deploy finish instead of being cancelled mid-flight.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
     permissions:
       pages: write
       id-token: write

--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,2 @@
+Wagdy Saad <mohamedsaad018@gmail.com> Cursor Agent <cursoragent@cursor.com>
+Wagdy Saad <mohamedsaad018@gmail.com> Cursor <cursoragent@cursor.com>

--- a/README.md
+++ b/README.md
@@ -139,11 +139,47 @@ Matching mechanics and release evidence:
 
 </details>
 
+## Run It Anywhere
+
+Two ladders: how you consume the shared evidence model, and where you run the
+control plane. You run it in your own boundary — no managed public SaaS in this
+repo yet.
+
+**Surfaces** — one real command each:
+
+- **CLI / CI** — `agent-bom agents -p .` (or the [GitHub Action](https://github.com/marketplace/actions/agent-bom)).
+- **Self-hosted platform** — `pip install 'agent-bom[ui]' && agent-bom serve` — dashboard + API on one host.
+- **Headless** — `agent-bom api` + `agent-bom mcp server` for agents and CI.
+- **Runtime proxy / gateway** — `agent-bom gateway serve` — allow/warn/block audit trail.
+- **Reports / exports** — `agent-bom agents -p . -f sarif -o findings.sarif`.
+
+**Deploy targets** — where the control plane runs, fastest → most-managed:
+
+- **Docker Compose** — fastest; one file, loopback by default → [pilot compose](deploy/docker-compose.pilot.yml)
+- **Helm / Kubernetes** — cluster-native chart → [chart](deploy/helm/agent-bom)
+- **EKS** — opinionated Terraform module → [module](deploy/terraform/platform-eks)
+- **CloudFormation** — one-click AWS stack → [templates](deploy/cloudformation)
+
+<details>
+<summary><b>Local bring-up</b> — Docker Compose in two commands</summary>
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
+docker compose -f docker-compose.pilot.yml up -d
+# Dashboard -> http://localhost:3000
+```
+
+Pilot compose binds to `127.0.0.1` with loopback CORS only. Use
+`docker-compose.platform.yml` or [docs/HOSTED_POC.md](docs/HOSTED_POC.md) before
+sharing a link. Full guides: [Deploy anywhere](docs/DEPLOY_PLATFORM.md).
+
+</details>
+
 ## Start Here
 
 Every lane writes into the same `Finding` and `ContextGraph` model. Pick the
 entry point that matches your role; see [docs/PRODUCT_MAP.md](docs/PRODUCT_MAP.md)
-for ingest lanes, auth boundaries, and surface detail.
+for all entry points, auth boundaries, and surface detail.
 
 | Need | Surface | First action | Main artifact |
 |---|---|---|---|
@@ -151,8 +187,8 @@ for ingest lanes, auth boundaries, and surface detail.
 | Connect cloud and data-estate evidence | Cloud connectors | `agent-bom connect aws` then `agent-bom cloud scan` | assets, CIS findings, graph edges |
 | Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | findings, graph, audit, compliance |
 | Give agents security tools | MCP server | `agent-bom mcp server` | strict MCP tool responses |
-| Govern runtime tool calls | Proxy / gateway | configure proxy or gateway policy | allow/warn/block audit trail |
-| Package evidence for audit | Reports / exports | `agent-bom agents -p . -f html -o report.html` | SARIF, CycloneDX, SPDX, OCSF, compliance bundle |
+| Govern runtime tool calls | Proxy / gateway | `agent-bom gateway serve` | allow/warn/block audit trail |
+| Package evidence for audit | Reports / exports | `agent-bom agents -p . -f html -o report.html` | SARIF, CycloneDX, SPDX, JSON, HTML/PDF, compliance bundle |
 
 | Goal | Command |
 |---|---|
@@ -261,29 +297,18 @@ Snowflake auth defaults to browser SSO (`externalbrowser`); use
 CI. agent-bom authenticates through the Python connector — no `snowsql` session
 needed. Setup and grants: [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md)
 
-**Deploy in your boundary.** OSS CLI, self-hosted API/UI, gated hosted POC, or
-optional Snowflake-native lane — no managed public SaaS in this repo yet.
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
-docker compose -f docker-compose.pilot.yml up -d
-# Dashboard -> http://localhost:3000
-```
-
-Pilot compose binds to `127.0.0.1` with loopback CORS only. Use
-`docker-compose.platform.yml` or [docs/HOSTED_POC.md](docs/HOSTED_POC.md) before
-sharing a link.
-
-- [Deploy anywhere](docs/DEPLOY_PLATFORM.md) · [Helm](deploy/helm/agent-bom) ·
-  [EKS module](deploy/terraform/platform-eks) ·
-  [Docker Hub](https://hub.docker.com/r/agentbom/agent-bom) ·
-  [CloudFormation one-click](deploy/cloudformation)
+**Deploy.** Run in your own boundary — the [Run It Anywhere](#run-it-anywhere)
+ladders above cover Compose, Helm, EKS, and CloudFormation. Full deploy guides:
+[Deploy anywhere](docs/DEPLOY_PLATFORM.md) · [Hosted POC](docs/HOSTED_POC.md) ·
+[Helm](deploy/helm/agent-bom) · [EKS module](deploy/terraform/platform-eks) ·
+[CloudFormation](deploy/cloudformation) ·
+[Docker Hub](https://hub.docker.com/r/agentbom/agent-bom)
 
 **Trust.**
 
 - Read-only discovery by default; no mandatory telemetry.
 - Credential values redacted; env names preserved for explainable exposure paths.
-- Exports: JSON, SARIF, CycloneDX, SPDX, OCSF, Markdown, HTML, compliance bundles.
+- Exports: JSON, SARIF, CycloneDX, SPDX, Parquet, CSV, Markdown, HTML, PDF, compliance bundles.
 - Tenant scope, auth boundaries, and audit evidence on API/runtime paths.
 
 [Threat model](docs/THREAT_MODEL.md) · [Pentest readiness](docs/PENTEST_READINESS.md) ·

--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ repo yet.
 - **Helm / Kubernetes** — cluster-native chart → [chart](deploy/helm/agent-bom)
 - **EKS** — opinionated Terraform module → [module](deploy/terraform/platform-eks)
 - **CloudFormation** — one-click AWS stack → [templates](deploy/cloudformation)
+- **Snowflake (SPCS native app)** — host entirely inside your own Snowflake account → [install guide](docs/snowflake-native-app/INSTALL.md)
 
 <details>
 <summary><b>Local bring-up</b> — Docker Compose in two commands</summary>
@@ -298,10 +299,12 @@ CI. agent-bom authenticates through the Python connector — no `snowsql` sessio
 needed. Setup and grants: [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md)
 
 **Deploy.** Run in your own boundary — the [Run It Anywhere](#run-it-anywhere)
-ladders above cover Compose, Helm, EKS, and CloudFormation. Full deploy guides:
+ladders above cover Compose, Helm, EKS, CloudFormation, and the Snowflake SPCS
+native app. Full deploy guides:
 [Deploy anywhere](docs/DEPLOY_PLATFORM.md) · [Hosted POC](docs/HOSTED_POC.md) ·
 [Helm](deploy/helm/agent-bom) · [EKS module](deploy/terraform/platform-eks) ·
 [CloudFormation](deploy/cloudformation) ·
+[Snowflake native app](docs/snowflake-native-app/INSTALL.md) ·
 [Docker Hub](https://hub.docker.com/r/agentbom/agent-bom)
 
 **Trust.**


### PR DESCRIPTION
Combined repo-polish PR (three independent, non-conflicting changes — folded into one).

## README (`README.md`)
- **New "Run It Anywhere" section** (after How It Works): two tight ladders — **Surfaces** (CLI/CI, self-hosted platform, headless API+MCP, runtime proxy/gateway, reports — one real command each) and **Deploy targets** (Docker Compose → Helm → EKS → CloudFormation, fastest→most-managed, each linked to the real `deploy/…` path). Long compose bring-up in a `<details>`. Old bottom link-dump demoted to a single "full deploy guides" line. Self-host is highlighted + guided instead of buried.
- **Accuracy fixes (verified against `src/agent_bom/cli/`):** removed **OCSF** from scan/report artifacts (it's a runtime-SIEM alert format, not a scan export — not in `SCAN_OUTPUT_FORMATS`); "ingest lanes" → "**entry points**"; proxy/gateway row corrected to the real `agent-bom gateway serve`. All other commands verified to exist.

## GitHub Pages (`.github/workflows/docs.yml`)
- **Fix the recurring concurrency race** that turned `github-pages` red on every release: the release's build-only docs job (`workflow_call`, `deploy:false`) joined the workflow-level `pages` concurrency group and, with `cancel-in-progress: true`, cancelled the standalone Deploy Docs mid-deploy. Moved `concurrency` off the workflow onto the **deploy job only** with `cancel-in-progress: false` (GitHub's recommended Pages pattern) so build-only validation can't cancel a live deploy and real deploys serialize.

## Contributor identity (`.mailmap`)
- Coalesce a stray automated bot contributor identity into the owner via `.mailmap` — **no history rewrite, no force-push**, all SHAs/tags intact. `git shortlog` is clean after. GitHub's Contributors sidebar updates after merge + a cache refresh.

Gates: `make preflight` + `check-counts.py` green; workflow YAML validated. No functional/product code changed.