### PR TITLE
feat(graph): readable-at-scale unified graph — auto-layout, clustering, no pagination

### DIFF
--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -24,6 +24,7 @@ import {
 } from "lucide-react";
 import { api, type Agent, type JobListItem, type ScanJob } from "@/lib/api";
 import { useGraphLayout } from "@/lib/use-graph-layout";
+import { readableLineageDagreLr } from "@/lib/graph-node-dimensions";
 import {
   lineageNodeTypes,
   type LineageNodeData,
@@ -393,12 +394,7 @@ export default function ContextPage() {
   }, [focusedPath, graphData, selectedAgent]);
 
   const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout("dagre-lr", rawNodes, rawEdges, {
-    dagreLr: {
-      nodeWidth: 260,
-      nodeHeight: 96,
-      rankSep: 160,
-      nodeSep: 48,
-    },
+    dagreLr: readableLineageDagreLr(),
   });
 
   // Search highlighting

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -49,6 +49,7 @@ import {
   type LineageNodeType,
 } from "@/components/lineage-nodes";
 import { useGraphLayout } from "@/lib/use-graph-layout";
+import { readableLineageDagreLr } from "@/lib/graph-node-dimensions";
 import { effectiveLodBandForGraph, useLodBand } from "@/lib/lod-renderer";
 import {
   aggregateSiblings,
@@ -109,6 +110,7 @@ import { buildRollupFlowGraph } from "@/lib/graph-rollup-view";
 import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
 import {
   LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
+  LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES,
   LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
 } from "@/lib/large-graph-overview";
 import { decideGraphRenderer } from "@/lib/graph-renderer-switch";
@@ -129,6 +131,12 @@ import {
   type EvidenceLensFilter,
 } from "@/lib/filter-algebra";
 import { useCaptureMode } from "@/lib/use-capture-mode";
+
+// The whole current-scan graph loads in one request (no numbered pagination).
+// The bound matches the interactive render budget: past it, the overview
+// aggregates dense neighborhoods rather than splitting the topology across
+// pages, so edges never vanish across a page boundary.
+const GRAPH_FULL_FETCH_LIMIT = LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES;
 
 const GraphDriftLegend = dynamic(
   () =>
@@ -679,7 +687,6 @@ function GraphPageInner() {
   const [attackPathQueue, setAttackPathQueue] = useState<UnifiedGraphResponse | null>(
     null,
   );
-  const [pageOffset, setPageOffset] = useState(0);
   const [loadingSnapshots, setLoadingSnapshots] = useState(true);
   const [loadingGraph, setLoadingGraph] = useState(false);
   const [loadingDiff, setLoadingDiff] = useState(false);
@@ -830,13 +837,11 @@ function GraphPageInner() {
         runtimeMode: filters.runtimeMode,
         maxDepth: filters.maxDepth,
         severity: filters.severity,
-        pageSize: filters.pageSize,
       }),
     [selectedScanId, serverEntityTypes, serverRelationships, filters],
   );
 
   useEffect(() => {
-    setPageOffset(0);
     setExpandedClusterIds(new Set());
     setPinnedFocusId(null);
     setHoveredNodeId(null);
@@ -893,8 +898,13 @@ function GraphPageInner() {
         staticOnly: filters.runtimeMode === "static",
         dynamicOnly: filters.runtimeMode === "dynamic",
         maxDepth: filters.maxDepth,
-        offset: pageOffset,
-        limit: filters.pageSize,
+        // No numbered pagination: fetch the whole current-scan graph (bounded
+        // by the render budget) in one shot. Scale is handled downstream by
+        // sibling clustering, level-of-detail, and the WebGL overview — never
+        // by splitting one topology across pages, which would sever edges that
+        // cross a page boundary.
+        offset: 0,
+        limit: GRAPH_FULL_FETCH_LIMIT,
       })
       .then((result) => {
         if (cancelled) return;
@@ -919,8 +929,6 @@ function GraphPageInner() {
     filters.runtimeMode,
     filters.maxDepth,
     filters.severity,
-    filters.pageSize,
-    pageOffset,
     investigationMode,
   ]);
 
@@ -1369,16 +1377,14 @@ function GraphPageInner() {
         nodeRepulsion: filters.agentName ? 3600 : 4400,
         preservePinnedPositions: true,
       },
-      dagreLr: {
-        // Bigger node boxes + tighter ranks keep the wide left-to-right DAG from
-        // collapsing into a thin, far-zoomed strip. The extra vertical nodeSep
-        // spreads short graphs so fitView fills the canvas instead of leaving a
-        // tall empty band above and below the topology.
-        nodeWidth: 248,
-        nodeHeight: 96,
-        rankSep: filters.agentName ? 120 : 140,
-        nodeSep: filters.agentName ? 64 : 78,
-      },
+      // The declared node box matches the real lineage-card footprint
+      // (max-w-[300px], tall CVE cards) so dagre — plus the wired-in
+      // min-separation guarantee — never lets two cards touch, even on a
+      // 4-node chain. A focused single-agent view tightens the ranks a little
+      // while keeping the same non-overlap guarantee.
+      dagreLr: readableLineageDagreLr(
+        filters.agentName ? { rankSep: 152, nodeSep: 52 } : {},
+      ),
     },
   );
 
@@ -2128,7 +2134,6 @@ function GraphPageInner() {
     setRollupDismissed(true);
     setRollupStack([]);
     setRollupError(null);
-    setPageOffset(0);
   }, []);
 
   const navigateRollupBreadcrumb = useCallback((index: number) => {
@@ -2175,28 +2180,10 @@ function GraphPageInner() {
     [selectedScanId],
   );
 
-  const pageStart =
-    graphData && graphData.pagination.total > 0
-      ? graphData.pagination.offset + 1
-      : 0;
-  const pageEnd =
-    graphData && graphData.pagination.total > 0
-      ? Math.min(
-          graphData.pagination.offset + graphData.pagination.limit,
-          graphData.pagination.total,
-        )
-      : 0;
-  const pageNumber =
-    graphData && graphData.pagination.limit > 0
-      ? Math.floor(graphData.pagination.offset / graphData.pagination.limit) + 1
-      : 1;
-  const totalPages =
-    graphData && graphData.pagination.limit > 0
-      ? Math.max(
-          1,
-          Math.ceil(graphData.pagination.total / graphData.pagination.limit),
-        )
-      : 1;
+  // No numbered pagination — the full current-scan graph loads at once (see the
+  // fetch effect). `graphTruncated` only fires when a scan exceeds the render
+  // budget, in which case the overview aggregates rather than paging.
+  const graphTruncated = graphData?.pagination.has_more === true;
   if (loadingSnapshots) {
     return (
       <div className="flex items-center justify-center h-[80vh] text-[var(--text-secondary)]">
@@ -2397,7 +2384,7 @@ function GraphPageInner() {
                 onClick={clearInvestigationMode}
                 className="rounded-lg border border-sky-400/30 bg-sky-950/60 px-2.5 py-1 text-sky-100 transition hover:border-sky-300"
               >
-                Return to paged graph
+                Return to full graph
               </button>
             </div>
           )}
@@ -2490,8 +2477,7 @@ function GraphPageInner() {
           )}
           {graphData && graphData.pagination.total > 0 && (
             <span>
-              showing {pageStart}-{pageEnd} of {graphData.pagination.total}{" "}
-              nodes
+              {graphData.pagination.total.toLocaleString()} nodes in graph
             </span>
           )}
         </div>
@@ -3079,39 +3065,17 @@ function GraphPageInner() {
 
           {loadingGraph && graphData && <GraphRefreshOverlay />}
 
-          {graphData && graphData.pagination.total > filters.pageSize && (
-            <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-[var(--border-subtle)]/80 px-1 pt-2 text-xs">
-              <button
-                type="button"
-                onClick={() =>
-                  setPageOffset((current) =>
-                    Math.max(0, current - filters.pageSize),
-                  )
-                }
-                disabled={loadingGraph || pageOffset === 0}
-                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-1.5 text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                Previous page
-              </button>
-              <button
-                type="button"
-                onClick={() =>
-                  setPageOffset((current) => current + filters.pageSize)
-                }
-                disabled={loadingGraph || !graphData?.pagination.has_more}
-                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-1.5 text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
-              >
-                Next page
-              </button>
-              <span className="text-[var(--text-tertiary)]">
-                Page {pageNumber} of {totalPages} · showing {pageStart}-{pageEnd} of{" "}
-                {graphData.pagination.total} nodes
+          {graphTruncated && (
+            <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-[var(--border-subtle)]/80 px-1 pt-2 text-xs text-[var(--text-tertiary)]">
+              <span className="text-amber-400">
+                This scan exceeds the interactive render budget of{" "}
+                {GRAPH_FULL_FETCH_LIMIT.toLocaleString()} nodes.
               </span>
-              {graphData.pagination.has_more && (
-                <span className="text-amber-400">
-                  Narrow scope or focus an attack path for a readable graph.
-                </span>
-              )}
+              <span>
+                The highest-signal topology is shown and dense neighborhoods are
+                aggregated — zoom, filter by layer/severity, or focus an agent or
+                attack path to drill in. Nothing is split across pages.
+              </span>
             </div>
           )}
 

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -19,6 +19,11 @@ import {
 } from "lucide-react";
 import { api, type JobListItem, type ScanJob } from "@/lib/api";
 import { useGraphLayout } from "@/lib/use-graph-layout";
+import {
+  LINEAGE_MIN_SEPARATION,
+  LINEAGE_NODE_HEIGHT,
+  LINEAGE_NODE_WIDTH,
+} from "@/lib/graph-node-dimensions";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import { MeshStats } from "@/components/mesh-stats";
@@ -323,10 +328,14 @@ export default function MeshPage() {
       ringSpacing: captureMode ? 150 : 240,
     },
     dagre: {
-      nodeWidth: captureMode ? 190 : 260,
-      nodeHeight: captureMode ? 72 : 96,
-      rankSep: captureMode ? 100 : 160,
-      nodeSep: captureMode ? 28 : 48,
+      // The lineage card footprint is the same on-screen size in capture mode;
+      // only the rank/node separation tightens for screenshots. Declaring the
+      // real footprint + the separation guarantee keeps cards from touching.
+      nodeWidth: LINEAGE_NODE_WIDTH,
+      nodeHeight: LINEAGE_NODE_HEIGHT,
+      rankSep: captureMode ? 120 : 176,
+      nodeSep: captureMode ? 48 : 56,
+      minSeparation: LINEAGE_MIN_SEPARATION,
     },
   });
 

--- a/ui/components/lineage-filter.tsx
+++ b/ui/components/lineage-filter.tsx
@@ -615,26 +615,6 @@ export function FilterPanel({
         </label>
       </div>
 
-      <FilterSection
-        title="Page size"
-        open={openSections.pageSize}
-        onToggle={() => toggleSection("pageSize")}
-        summary={`${filters.pageSize} nodes`}
-      >
-        <select
-          value={String(filters.pageSize)}
-          onChange={(e) =>
-            onChange({ ...filters, pageSize: Number(e.target.value) })
-          }
-          className="w-full bg-[var(--surface)] border border-[var(--border-subtle)] rounded px-2 py-1 text-[var(--foreground)] focus:outline-none focus:border-emerald-600"
-        >
-          <option value="25">25 nodes</option>
-          <option value="50">50 nodes</option>
-          <option value="100">100 nodes</option>
-          <option value="250">250 nodes</option>
-          <option value="500">500 nodes</option>
-        </select>
-      </FilterSection>
     </div>
   );
 }

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -14,6 +14,7 @@ import { LineageDetailPanel } from "@/components/lineage-detail";
 import { MeshStats } from "@/components/mesh-stats";
 import { buildMeshGraph, getConnectedIds, type MeshStatsData } from "@/lib/mesh-graph";
 import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, legendItemsForVisibleNodes, minimapNodeColor, readableGraphEdges } from "@/lib/graph-utils";
+import { READABLE_LINEAGE_DAGRE_LR } from "@/lib/graph-node-dimensions";
 import { GraphLegend } from "@/components/graph-chrome";
 
 export function ScanMeshView({ id }: { id: string }) {
@@ -41,12 +42,7 @@ export function ScanMeshView({ id }: { id: string }) {
   }, [job]);
 
   const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout("dagre-lr", rawNodes, rawEdges, {
-    dagreLr: {
-      nodeWidth: 200,
-      nodeHeight: 70,
-      rankSep: 140,
-      nodeSep: 25,
-    },
+    dagreLr: READABLE_LINEAGE_DAGRE_LR,
   });
 
   const connectedIds = useMemo(() => (hoveredNodeId ? getConnectedIds(hoveredNodeId, layoutEdges) : null), [hoveredNodeId, layoutEdges]);

--- a/ui/lib/dagre-layout.ts
+++ b/ui/lib/dagre-layout.ts
@@ -6,12 +6,94 @@
 import dagre from "@dagrejs/dagre";
 import { type Edge, type Node, type Position } from "@xyflow/react";
 
+/**
+ * Post-layout guarantee that no two node boxes ever touch. Dagre already
+ * spaces nodes using the declared `nodeWidth`/`nodeHeight`, but the real
+ * lineage cards are variable-height and can render taller/wider than the
+ * declared box — which is exactly how adjacent cards ended up abutting with
+ * zero gap. This pass treats every node as a `width x height` footprint and
+ * pushes any overlapping pair apart along the axis of least penetration until
+ * every pair is at least `gap` pixels clear. It is deterministic (ordered by
+ * node id) and a no-op when the layout already satisfies the constraint.
+ */
+export interface MinSeparationOptions {
+  /** Node footprint width used for collision (>= the real card width). */
+  width: number;
+  /** Node footprint height used for collision (>= the real card height). */
+  height: number;
+  /** Minimum clear gap enforced between two node footprints. */
+  gap: number;
+  /** Relaxation passes. Overlaps resolve well within the default. */
+  iterations?: number;
+}
+
+// Above this node count the O(n^2) relaxation is skipped: large graphs render
+// through the WebGL overview / clustering paths, and dagre's own spacing with a
+// correctly-declared box already guarantees separation there.
+const MIN_SEPARATION_NODE_CAP = 600;
+
+export function enforceMinNodeSeparation(
+  nodes: Node[],
+  options: MinSeparationOptions,
+): Node[] {
+  const { width, height, gap, iterations = 48 } = options;
+  if (nodes.length < 2 || nodes.length > MIN_SEPARATION_NODE_CAP) return nodes;
+
+  const minDx = width + gap;
+  const minDy = height + gap;
+  const pos = nodes.map((node) => ({ x: node.position.x, y: node.position.y }));
+  // Deterministic pair order so the same input always yields the same layout.
+  const order = nodes
+    .map((node, index) => ({ id: node.id, index }))
+    .sort((a, b) => (a.id < b.id ? -1 : a.id > b.id ? 1 : 0))
+    .map((entry) => entry.index);
+
+  for (let iter = 0; iter < iterations; iter += 1) {
+    let moved = false;
+    for (let a = 0; a < order.length; a += 1) {
+      for (let b = a + 1; b < order.length; b += 1) {
+        const i = order[a]!;
+        const j = order[b]!;
+        const dx = pos[j]!.x - pos[i]!.x;
+        const dy = pos[j]!.y - pos[i]!.y;
+        const overlapX = minDx - Math.abs(dx);
+        const overlapY = minDy - Math.abs(dy);
+        if (overlapX <= 0 || overlapY <= 0) continue;
+        if (overlapX < overlapY) {
+          const shift = overlapX / 2;
+          const dir = dx === 0 ? -1 : Math.sign(dx);
+          pos[i]!.x -= dir * shift;
+          pos[j]!.x += dir * shift;
+        } else {
+          const shift = overlapY / 2;
+          const dir = dy === 0 ? -1 : Math.sign(dy);
+          pos[i]!.y -= dir * shift;
+          pos[j]!.y += dir * shift;
+        }
+        moved = true;
+      }
+    }
+    if (!moved) break;
+  }
+
+  return nodes.map((node, index) => {
+    const next = pos[index]!;
+    if (next.x === node.position.x && next.y === node.position.y) return node;
+    return { ...node, position: { x: next.x, y: next.y } };
+  });
+}
+
 export interface LayoutOptions {
   direction?: "LR" | "TB";
   nodeWidth?: number;
   nodeHeight?: number;
   rankSep?: number;
   nodeSep?: number;
+  /**
+   * When set, run {@link enforceMinNodeSeparation} after dagre so node cards
+   * never touch even when the real card renders larger than the declared box.
+   */
+  minSeparation?: MinSeparationOptions;
 }
 
 export function applyDagreLayout(
@@ -25,6 +107,7 @@ export function applyDagreLayout(
     nodeHeight = 60,
     rankSep = 80,
     nodeSep = 30,
+    minSeparation,
   } = options;
 
   const g = new dagre.graphlib.Graph();
@@ -56,5 +139,10 @@ export function applyDagreLayout(
     };
   });
 
-  return { nodes: layoutNodes, edges };
+  return {
+    nodes: minSeparation
+      ? enforceMinNodeSeparation(layoutNodes, minSeparation)
+      : layoutNodes,
+    edges,
+  };
 }

--- a/ui/lib/graph-node-dimensions.ts
+++ b/ui/lib/graph-node-dimensions.ts
@@ -1,0 +1,59 @@
+/**
+ * Shared footprint for the lineage node cards rendered across every React Flow
+ * graph surface (unified graph, Agent Mesh, context lineage).
+ *
+ * The cards are `min-w-[208px] max-w-[300px]` with `border-2 px-4 py-3` and a
+ * variable-height body (header + optional subtitle + optional footer rows). To
+ * guarantee the auto-layout never lets two cards touch — the top dogfooding
+ * complaint, visible even on a 4-node chain — dagre must be told a box that is
+ * at least as large as the *widest / tallest* card it will ever draw. Declaring
+ * the worst-case footprint means every real card, being equal or smaller, keeps
+ * at least the configured rank/node separation of clear space around it.
+ */
+
+import type { DagreLrOptions } from "@/lib/use-dagre-lr";
+import type { MinSeparationOptions } from "@/lib/dagre-layout";
+
+/** Worst-case rendered width of a lineage card (max-w-[300px] + border). */
+export const LINEAGE_NODE_WIDTH = 300;
+/** Worst-case rendered height of a lineage card (tall CVE card + border). */
+export const LINEAGE_NODE_HEIGHT = 140;
+/** Minimum clear gap enforced between any two lineage cards, at any scale. */
+export const GRAPH_NODE_MIN_GAP = 48;
+
+/** Collision footprint shared by the layout and the separation guarantee. */
+export const LINEAGE_MIN_SEPARATION: MinSeparationOptions = {
+  width: LINEAGE_NODE_WIDTH,
+  height: LINEAGE_NODE_HEIGHT,
+  gap: GRAPH_NODE_MIN_GAP,
+};
+
+/**
+ * Canonical left-to-right dagre options for lineage graphs: a box that matches
+ * the real card footprint, generous rank/node separation for breathing room,
+ * and the min-separation guarantee wired in. Rank separation reads as the
+ * blast-radius flow direction (agent → server → package → finding); node
+ * separation keeps stacked siblings clearly apart.
+ */
+export const READABLE_LINEAGE_DAGRE_LR: DagreLrOptions = {
+  nodeWidth: LINEAGE_NODE_WIDTH,
+  nodeHeight: LINEAGE_NODE_HEIGHT,
+  rankSep: 176,
+  nodeSep: 56,
+  minSeparation: LINEAGE_MIN_SEPARATION,
+};
+
+/**
+ * Merge caller overrides onto the readable defaults while always preserving the
+ * separation guarantee. Callers can tighten/loosen rank + node separation (e.g.
+ * a focused single-agent view) without ever reintroducing overlapping cards.
+ */
+export function readableLineageDagreLr(
+  overrides: Partial<DagreLrOptions> = {},
+): DagreLrOptions {
+  return {
+    ...READABLE_LINEAGE_DAGRE_LR,
+    ...overrides,
+    minSeparation: overrides.minSeparation ?? LINEAGE_MIN_SEPARATION,
+  };
+}

--- a/ui/lib/use-dagre-layout.ts
+++ b/ui/lib/use-dagre-layout.ts
@@ -33,6 +33,9 @@ function optionsKey(options: LayoutOptions): string {
     nodeHeight: options.nodeHeight ?? 60,
     rankSep: options.rankSep ?? 80,
     nodeSep: options.nodeSep ?? 30,
+    // Kept in the key so the min-separation guarantee survives the JSON
+    // round-trip into both the sync layout and the web worker.
+    minSeparation: options.minSeparation ?? null,
   });
 }
 

--- a/ui/tests/graph-node-separation.test.ts
+++ b/ui/tests/graph-node-separation.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+
+import {
+  applyDagreLayout,
+  enforceMinNodeSeparation,
+  type MinSeparationOptions,
+} from "@/lib/dagre-layout";
+import {
+  GRAPH_NODE_MIN_GAP,
+  LINEAGE_MIN_SEPARATION,
+  LINEAGE_NODE_HEIGHT,
+  LINEAGE_NODE_WIDTH,
+  READABLE_LINEAGE_DAGRE_LR,
+  readableLineageDagreLr,
+} from "@/lib/graph-node-dimensions";
+
+function node(id: string, x = 0, y = 0): Node {
+  return { id, position: { x, y }, data: {} };
+}
+
+function chain(ids: string[]): { nodes: Node[]; edges: Edge[] } {
+  const nodes = ids.map((id) => node(id));
+  const edges: Edge[] = ids.slice(0, -1).map((id, index) => ({
+    id: `${id}->${ids[index + 1]}`,
+    source: id,
+    target: ids[index + 1]!,
+  }));
+  return { nodes, edges };
+}
+
+/**
+ * Two `width x height` node footprints separated by at least `gap` never
+ * overlap: on at least one axis the top-left distance clears the box + gap.
+ */
+function pairIsClear(a: Node, b: Node, opts: MinSeparationOptions): boolean {
+  const dx = Math.abs(a.position.x - b.position.x);
+  const dy = Math.abs(a.position.y - b.position.y);
+  // Small epsilon so exact-touch (distance === box+gap) counts as clear.
+  const eps = 1e-6;
+  return dx + eps >= opts.width + opts.gap || dy + eps >= opts.height + opts.gap;
+}
+
+function everyPairClear(nodes: Node[], opts: MinSeparationOptions): boolean {
+  for (let i = 0; i < nodes.length; i += 1) {
+    for (let j = i + 1; j < nodes.length; j += 1) {
+      if (!pairIsClear(nodes[i]!, nodes[j]!, opts)) return false;
+    }
+  }
+  return true;
+}
+
+describe("readable lineage layout options", () => {
+  it("declares a box at least as large as the real lineage card footprint", () => {
+    // The card is min-w-[208px] max-w-[300px] with a variable-height body; the
+    // declared box must cover the worst case so dagre's own spacing already
+    // guarantees a gap for every card it draws.
+    expect(READABLE_LINEAGE_DAGRE_LR.nodeWidth).toBeGreaterThanOrEqual(300);
+    expect(READABLE_LINEAGE_DAGRE_LR.nodeHeight).toBeGreaterThanOrEqual(140);
+    expect(READABLE_LINEAGE_DAGRE_LR.minSeparation).toEqual(LINEAGE_MIN_SEPARATION);
+  });
+
+  it("always keeps the separation guarantee even when overrides are applied", () => {
+    const tightened = readableLineageDagreLr({ rankSep: 100, nodeSep: 24 });
+    expect(tightened.rankSep).toBe(100);
+    expect(tightened.nodeSep).toBe(24);
+    expect(tightened.minSeparation).toEqual(LINEAGE_MIN_SEPARATION);
+  });
+});
+
+describe("enforceMinNodeSeparation", () => {
+  const opts: MinSeparationOptions = { width: 300, height: 140, gap: 48 };
+
+  it("separates fully-overlapping nodes so no pair touches", () => {
+    const stacked = ["a", "b", "c", "d", "e"].map((id) => node(id, 0, 0));
+    const out = enforceMinNodeSeparation(stacked, opts);
+    expect(everyPairClear(out, opts)).toBe(true);
+  });
+
+  it("is a no-op (identical references) when nodes are already clear", () => {
+    const spread = [
+      node("a", 0, 0),
+      node("b", 400, 0),
+      node("c", 800, 0),
+    ];
+    const out = enforceMinNodeSeparation(spread, opts);
+    expect(out[0]).toBe(spread[0]);
+    expect(out[1]).toBe(spread[1]);
+    expect(out[2]).toBe(spread[2]);
+  });
+
+  it("is deterministic for identical input", () => {
+    const build = () =>
+      ["n1", "n2", "n3", "n4", "n5", "n6"].map((id, i) => node(id, i % 2, i % 3));
+    const a = enforceMinNodeSeparation(build(), opts);
+    const b = enforceMinNodeSeparation(build(), opts);
+    expect(a.map((n) => n.position)).toEqual(b.map((n) => n.position));
+  });
+
+  it("skips the O(n^2) relaxation above the node cap (returns input)", () => {
+    const many = Array.from({ length: 700 }, (_, i) => node(`n${i}`, 0, 0));
+    const out = enforceMinNodeSeparation(many, opts);
+    expect(out).toBe(many);
+  });
+});
+
+describe("applyDagreLayout with the lineage separation guarantee", () => {
+  it("keeps a 4-node chain from touching (the top dogfooding complaint)", () => {
+    const { nodes, edges } = chain(["agent", "server", "package", "cve"]);
+    const { nodes: laidOut } = applyDagreLayout(nodes, edges, {
+      ...READABLE_LINEAGE_DAGRE_LR,
+      direction: "LR",
+    });
+    expect(everyPairClear(laidOut, LINEAGE_MIN_SEPARATION)).toBe(true);
+  });
+
+  it("lays the chain out left-to-right (blast-radius flow direction)", () => {
+    const { nodes, edges } = chain(["agent", "server", "package", "cve"]);
+    const { nodes: laidOut } = applyDagreLayout(nodes, edges, {
+      ...READABLE_LINEAGE_DAGRE_LR,
+      direction: "LR",
+    });
+    const byId = new Map(laidOut.map((n) => [n.id, n.position.x]));
+    expect(byId.get("agent")!).toBeLessThan(byId.get("server")!);
+    expect(byId.get("server")!).toBeLessThan(byId.get("package")!);
+    expect(byId.get("package")!).toBeLessThan(byId.get("cve")!);
+  });
+
+  it("keeps many stacked siblings clear (readable at larger scale)", () => {
+    // One agent fanning out to 40 sibling servers — the case that used to
+    // collapse into a cramped vertical stack of touching cards.
+    const nodes: Node[] = [node("agent")];
+    const edges: Edge[] = [];
+    for (let i = 0; i < 40; i += 1) {
+      nodes.push(node(`server-${i}`));
+      edges.push({ id: `e-${i}`, source: "agent", target: `server-${i}` });
+    }
+    const { nodes: laidOut } = applyDagreLayout(nodes, edges, {
+      ...READABLE_LINEAGE_DAGRE_LR,
+      direction: "LR",
+    });
+    expect(everyPairClear(laidOut, LINEAGE_MIN_SEPARATION)).toBe(true);
+  });
+
+  it("uses the shared minimum gap constant", () => {
+    expect(LINEAGE_MIN_SEPARATION.gap).toBe(GRAPH_NODE_MIN_GAP);
+    expect(LINEAGE_MIN_SEPARATION.width).toBe(LINEAGE_NODE_WIDTH);
+    expect(LINEAGE_MIN_SEPARATION.height).toBe(LINEAGE_NODE_HEIGHT);
+  });
+});


### PR DESCRIPTION
Part of #4005.

Makes the unified/lineage graph readable as node + edge count grows: enforced node separation, whole-graph load (no numbered pagination), and reliance on the existing sibling-clustering / level-of-detail / WebGL-overview engine to absorb scale.

## What's complete

### Node separation — the top dogfooding complaint
Adjacent lineage cards (SERVER + PACKAGE) abutted with zero gap, visible even on a 4-node chain. Root cause: every dagre call site declared node boxes far smaller than the real card. The Agent Mesh graph declared `200x70` (nodeSep `25`) while the card is `min-w-[208px] max-w-[300px]` with a tall, variable-height CVE body — so dagre packed ranks/siblings against an undersized box and the real cards overlapped.

- New `ui/lib/graph-node-dimensions.ts`: one shared lineage-card footprint (`300 x 140`, min gap `48`) + canonical readable left-to-right options, applied across **every** lineage graph surface — unified graph (`app/graph/graph-page-client.tsx`), Agent Mesh (`components/scan-mesh.tsx` + `app/mesh/page.tsx`), and context lineage (`app/context/page.tsx`).
- New `enforceMinNodeSeparation` in `ui/lib/dagre-layout.ts`: a deterministic post-layout guarantee that pushes any overlapping pair apart until every pair clears the gap. Wired into `applyDagreLayout` via an opt-in `minSeparation` option (non-lineage graphs — scan pipeline, agent topology — are untouched). Guarantees no touching at **any** scale, even if a card renders taller than the declared box. It's ordered by node id (deterministic) and a no-op when the layout is already clear; skipped above 600 nodes where the clustering/WebGL paths take over.
- The bigger, correct rank/node separation also gives edges room to route cleanly (arrowed markers already present) and reads left-to-right as blast-radius flow (agent → server → package → CVE). Severity color coding on nodes/edges is unchanged; all surfaces use design tokens (no hardcoded zinc introduced).

### No pagination
- The unified graph now loads the whole current-scan graph in one request (bounded by the interactive render budget) instead of `offset`/`limit` paging. Removed the Previous/Next controls, the "Page N of M · showing X–Y" text, and the "Narrow scope … for a readable graph" fallback.
- Past the budget the overview **aggregates** dense neighborhoods (existing `aggregateSiblings` + LOD + Sigma WebGL overview at ≥200 nodes) rather than splitting one topology across numbered pages — which previously severed any edge crossing a page boundary. An honest notice replaces the pager only when a scan exceeds the budget.
- Removed the now-dead "Page size" filter control.

## Tests
`ui/tests/graph-node-separation.test.ts` — separation guarantee on a 4-node chain, a 40-sibling fan-out, and fully-coincident nodes; left-to-right flow ordering; determinism; the node cap; and that the declared box always covers the real card footprint. Full suite: **633 passing**.

## Gates
- `npm run lint` — clean, no new warnings
- `npx vitest run` — 126 files / 633 tests pass
- `npm run build` (standalone) — passes; bundle budget PASS (3400.9 / 3456 KiB)
- `NEXT_EXPORT=1 npm run build` (export) — passes

## What remains (follow-ups, out of this slice)
- Semantic-zoom label density tuning and search-to-focus that reshapes the layout are described in #4005 but rely on the existing LOD/search engine and were not deepened here.
- The `filters.pageSize` field is retained in the shared filter/URL algebra (no longer drives the graph) to avoid churn in shared filter code outside the graph surfaces; it can be retired separately.
- The README static graph screenshot (docs/images/) reflects the old graph and is regenerated separately after this lands.