### PR TITLE
perf(findings): index-backed unfiltered effective-reach sort + trust materialized score

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -78,6 +78,13 @@ _CurrentPageSortKey = tuple[float | str, str | tuple[int, ...], str]
 # uses ingest order.
 _LIST_PAGE_SORTS = ("effective_reach", "cvss", "severity", "ordinal")
 
+# Private per-row slot on the in-memory store carrying the effective-reach
+# composite materialised at ingest (mirrors the SQL ``effective_reach_score``
+# column). The read-path sort trusts this scalar instead of re-deriving
+# ``symbol_reachability_from_payload`` for every row on every request (#4049).
+# Stripped from every returned payload so it never leaks into API output.
+_REACH_SORT_KEY = "__reach_sort__"
+
 
 def _severity_rank(payload: dict[str, Any]) -> int:
     return severity_policy_rank(str(payload.get("severity", "")))
@@ -123,7 +130,16 @@ def _page_signal(row: dict[str, Any], sort: str) -> float:
         return _cvss_value(row)
     if sort == "severity":
         return float(_severity_rank(row))
-    return compute_effective_reach_score(row)  # effective_reach default
+    # effective_reach (default): trust the composite materialised at ingest
+    # (``_REACH_SORT_KEY``) instead of re-deriving it per row on the read path.
+    # Fall back to deriving it for any row that predates materialisation (#4049).
+    cached = row.get(_REACH_SORT_KEY)
+    if cached is not None:
+        try:
+            return float(cached)
+        except (TypeError, ValueError):
+            pass
+    return compute_effective_reach_score(row)
 
 
 def _page_sort_key(sort: str) -> Callable[[dict[str, Any]], float]:
@@ -135,6 +151,18 @@ def _page_sort_key(sort: str) -> Callable[[dict[str, Any]], float]:
     """
     normalized = sort if sort in _LIST_PAGE_SORTS else "effective_reach"
     return lambda row: -_page_signal(row, normalized)
+
+
+def _strip_reach_sort(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop the private ingest-materialised reach scalar from returned payloads.
+
+    ``hydrate_finding_payloads_memory`` returns fresh dict copies, so popping
+    here never mutates the stored bucket — it just keeps ``_REACH_SORT_KEY`` an
+    internal sort scalar and out of the API response (#4049).
+    """
+    for row in rows:
+        row.pop(_REACH_SORT_KEY, None)
+    return rows
 
 
 def _filter_hub_rows(
@@ -732,6 +760,10 @@ class InMemoryComplianceHubStore:
                     continue
                 slim = normalize_finding_payload_for_store(tenant_id, payload)
                 stored = _redact_finding(slim)
+                # Materialise the effective-reach composite once at ingest so the
+                # read-path sort never re-derives it per row (#4049). Mirrors the
+                # SQL backends materialising the ``effective_reach_score`` column.
+                stored[_REACH_SORT_KEY] = compute_effective_reach_score(stored)
                 finding_id = str(stored.get("id") or "")
                 if finding_id and finding_id in slots:
                     # Refresh payload, keep original ingest position.
@@ -750,7 +782,7 @@ class InMemoryComplianceHubStore:
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
         with self._lock:
             rows = list(self._by_tenant.get(tenant_id, []))
-        return hydrate_finding_payloads_memory(tenant_id, rows)
+        return _strip_reach_sort(hydrate_finding_payloads_memory(tenant_id, rows))
 
     def _guard_sort_ceiling(self, tenant_id: str, row_count: int) -> None:
         """Warn once per tenant when the whole-tenant re-sort ceiling is crossed.
@@ -794,7 +826,7 @@ class InMemoryComplianceHubStore:
             rows = rows[offset:]
         if limit >= 0:
             rows = rows[:limit]
-        return hydrate_finding_payloads_memory(tenant_id, rows), total
+        return _strip_reach_sort(hydrate_finding_payloads_memory(tenant_id, rows)), total
 
     def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
         with self._lock:
@@ -1327,6 +1359,25 @@ class SQLiteComplianceHubStore:
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_severity_cvss "
             "ON compliance_hub_findings(tenant_id, origin, severity_rank, cvss_score DESC, ordinal)"
+        )
+        # Non-origin covering sort indexes so the *unfiltered* default reads
+        # (``WHERE tenant_id=? ORDER BY <col> DESC, ordinal``) ride an ordered
+        # index range scan + LIMIT instead of a temp-B-tree filesort — the
+        # origin-scoped indexes above cannot serve them because ``origin`` is an
+        # unconstrained middle column (#4049). Distinct names + IF NOT EXISTS so
+        # steady-state startup is a no-op (no rebuild); the origin-scoped indexes
+        # are kept for the filtered reads that still need origin equality.
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_reach_all "
+            "ON compliance_hub_findings(tenant_id, effective_reach_score DESC, ordinal)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_cvss_all "
+            "ON compliance_hub_findings(tenant_id, cvss_score DESC, ordinal)"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_severity_all "
+            "ON compliance_hub_findings(tenant_id, severity_rank DESC, ordinal)"
         )
         # Back the scan_id filter with an index (was a per-row json_extract scan).
         # PARTIAL on scan_id != '' so the common no-scan_id rows stay OUT of the

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -351,6 +351,24 @@ class PostgresComplianceHubStore:
                 "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_origin_severity_cvss "
                 "ON compliance_hub_findings(tenant_id, origin, severity_rank, cvss_score DESC, ordinal)"
             )
+            # Non-origin covering sort indexes so the *unfiltered* default reads
+            # (``WHERE tenant_id=? ORDER BY <col> DESC, ordinal``) ride an ordered
+            # index range scan + LIMIT instead of a full-tenant sort — the
+            # origin-scoped indexes cannot serve them (``origin`` is an
+            # unconstrained middle column). Origin-scoped indexes are kept for the
+            # filtered reads that need origin equality (#4049).
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_reach_all "
+                "ON compliance_hub_findings(tenant_id, effective_reach_score DESC, ordinal)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_cvss_all "
+                "ON compliance_hub_findings(tenant_id, cvss_score DESC, ordinal)"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_hub_findings_tenant_severity_all "
+                "ON compliance_hub_findings(tenant_id, severity_rank DESC, ordinal)"
+            )
             # Back the severity GROUP BY (severity_breakdown) with a sargable
             # tenant/severity index so the overview aggregate scans the column
             # instead of decoding every payload (#3963). Partial on non-empty

--- a/tests/test_findings_reach_perf_4049.py
+++ b/tests/test_findings_reach_perf_4049.py
@@ -1,0 +1,234 @@
+"""Read-path perf regressions for #4049.
+
+The unfiltered default (``effective_reach``) findings sort was the slowest 1M-row
+read on the hot path — ~20x the ``cvss`` sort. Two independent causes:
+
+1. In-memory backend re-derived ``symbol_reachability_from_payload`` for every
+   row on every read (``compute_effective_reach_score`` in the sort comparator),
+   even though the composite is already materialised at ingest.
+2. SQL backends only had origin-scoped ``(tenant_id, origin, <col> DESC, ordinal)``
+   sort indexes, so the *unfiltered* ``ORDER BY <col> DESC, ordinal`` fell back to
+   a temp-B-tree filesort (``origin`` is an unconstrained middle column).
+
+These tests pin: the in-memory read trusts the materialised score (no per-row
+re-derivation) with byte-identical ordering, and the SQL unfiltered default sorts
+ride a non-origin index range scan (no filesort) while the origin-scoped indexes
+still serve the filtered reads.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from agent_bom.api import compliance_hub_store as chs
+from agent_bom.api.compliance_hub_store import (
+    InMemoryComplianceHubStore,
+    SQLiteComplianceHubStore,
+    compute_effective_reach_score,
+)
+
+SYMS = (None, "reachable", "unreachable", "unknown")
+
+
+def _findings(count: int, *, origin: str = "bulk_ingest") -> list[dict]:
+    rows: list[dict] = []
+    for i in range(count):
+        sym = SYMS[i % len(SYMS)]
+        base = float((i * 7) % 90)
+        row: dict = {
+            "id": f"{origin}:{i}",
+            "title": f"Finding {i}",
+            "severity": ("critical", "high", "medium", "low")[i % 4],
+            "cvss_score": float(i % 10),
+            "origin": origin,
+            "source": "test_4049",
+            "effective_reach_score": base,
+            "effective_reach": {"composite": base, "band": "med"},
+        }
+        if sym is not None:
+            row["symbol_reachability"] = sym
+        rows.append(row)
+    return rows
+
+
+# ── In-memory: trust the materialised score, no per-row re-derivation ─────────
+
+
+def test_inmemory_read_does_not_rederive_reach_per_row(monkeypatch) -> None:
+    store = InMemoryComplianceHubStore()
+    store.add("t", _findings(500))
+
+    calls = {"n": 0}
+    real = chs.compute_effective_reach_score
+
+    def _counting(payload):
+        calls["n"] += 1
+        return real(payload)
+
+    monkeypatch.setattr(chs, "compute_effective_reach_score", _counting)
+
+    calls["n"] = 0
+    store.list_page("t", limit=50, sort="effective_reach")
+    # The read path must not re-derive the composite per row: the score is
+    # materialised at ingest and trusted on read.
+    assert calls["n"] == 0, f"read re-derived reach {calls['n']} times"
+
+
+def test_inmemory_reach_ordering_unchanged() -> None:
+    """Ordering is byte-identical to sorting by compute_effective_reach_score."""
+    store = InMemoryComplianceHubStore()
+    findings = _findings(400)
+    store.add("t", findings)
+
+    rows, total = store.list_page("t", limit=400, sort="effective_reach")
+    got = [r["id"] for r in rows]
+    assert total == 400
+
+    # Reference order: descending composite, stable on ingest order (ordinal ASC).
+    reference = sorted(
+        enumerate(findings),
+        key=lambda pair: (-compute_effective_reach_score(pair[1]), pair[0]),
+    )
+    expected = [f["id"] for _, f in reference]
+    assert got == expected
+
+
+def test_inmemory_read_does_not_leak_sort_scalar() -> None:
+    store = InMemoryComplianceHubStore()
+    store.add("t", _findings(20))
+    rows, _ = store.list_page("t", limit=20, sort="effective_reach")
+    for row in rows:
+        assert chs._REACH_SORT_KEY not in row, row.keys()
+    # ``list`` must not leak it either.
+    for row in store.list("t"):
+        assert chs._REACH_SORT_KEY not in row
+
+
+def test_inmemory_reach_matches_after_idempotent_refresh() -> None:
+    """A resend of the same finding refreshes the materialised score in place."""
+    store = InMemoryComplianceHubStore()
+    store.add("t", [{"id": "x", "origin": "bulk_ingest", "effective_reach_score": 10.0, "effective_reach": {"composite": 10.0}}])
+    store.add("t", [{"id": "x", "origin": "bulk_ingest", "effective_reach_score": 90.0, "effective_reach": {"composite": 90.0}}])
+    store.add("t", [{"id": "y", "origin": "bulk_ingest", "effective_reach_score": 50.0, "effective_reach": {"composite": 50.0}}])
+    rows, _ = store.list_page("t", limit=10, sort="effective_reach")
+    assert [r["id"] for r in rows] == ["x", "y"]  # x refreshed to 90 > y 50
+
+
+# ── SQLite: unfiltered default sorts ride a non-origin index (no filesort) ────
+
+
+def _seed_sqlite(tmp_path) -> SQLiteComplianceHubStore:
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    store.add("t", _findings(600, origin="bulk_ingest") + _findings(120, origin="scan"))
+    return store
+
+
+def _plan(conn, sql, params) -> str:
+    rows = conn.execute("EXPLAIN QUERY PLAN " + sql, params).fetchall()
+    return " | ".join(r[3] for r in rows)
+
+
+def test_sqlite_unfiltered_reach_uses_index_no_filesort(tmp_path) -> None:
+    store = _seed_sqlite(tmp_path)
+    detail = _plan(
+        store._conn,
+        "SELECT payload FROM compliance_hub_findings WHERE tenant_id=? "
+        "ORDER BY effective_reach_score DESC, ordinal ASC LIMIT 51",
+        ("t",),
+    )
+    assert "TEMP B-TREE" not in detail.upper(), detail
+    assert "idx_hub_findings_tenant_reach_all" in detail, detail
+
+
+def test_sqlite_unfiltered_cvss_uses_index_no_filesort(tmp_path) -> None:
+    store = _seed_sqlite(tmp_path)
+    detail = _plan(
+        store._conn,
+        "SELECT payload FROM compliance_hub_findings WHERE tenant_id=? "
+        "ORDER BY cvss_score DESC, ordinal ASC LIMIT 51",
+        ("t",),
+    )
+    assert "TEMP B-TREE" not in detail.upper(), detail
+    assert "idx_hub_findings_tenant_cvss_all" in detail, detail
+
+
+def test_sqlite_unfiltered_severity_uses_index_no_filesort(tmp_path) -> None:
+    store = _seed_sqlite(tmp_path)
+    detail = _plan(
+        store._conn,
+        "SELECT payload FROM compliance_hub_findings WHERE tenant_id=? "
+        "ORDER BY severity_rank DESC, ordinal ASC LIMIT 51",
+        ("t",),
+    )
+    assert "TEMP B-TREE" not in detail.upper(), detail
+    assert "idx_hub_findings_tenant_severity_all" in detail, detail
+
+
+def test_sqlite_origin_filtered_reach_still_uses_origin_index(tmp_path) -> None:
+    """Adding the non-origin index must NOT regress the filtered read plan."""
+    store = _seed_sqlite(tmp_path)
+    detail = _plan(
+        store._conn,
+        "SELECT payload FROM compliance_hub_findings WHERE tenant_id=? AND origin=? "
+        "ORDER BY effective_reach_score DESC, ordinal ASC LIMIT 51",
+        ("t", "bulk_ingest"),
+    )
+    assert "TEMP B-TREE" not in detail.upper(), detail
+    assert "idx_hub_findings_tenant_origin_reach" in detail, detail
+
+
+def test_sqlite_origin_scoped_scan_filter_not_shadowed(tmp_path) -> None:
+    """Production reads always scope by origin — the new non-origin covering
+    index must not steal the origin+scan filtered plan (it still rides an
+    origin-scoped index, not ``idx_hub_findings_tenant_reach_all``)."""
+    store = _seed_sqlite(tmp_path)
+    detail = _plan(
+        store._conn,
+        "SELECT payload FROM compliance_hub_findings WHERE tenant_id=? AND origin=? "
+        "AND scan_id=? AND scan_id!='' ORDER BY effective_reach_score DESC, ordinal ASC LIMIT 51",
+        ("t", "bulk_ingest", "s1"),
+    )
+    assert "idx_hub_findings_tenant_reach_all" not in detail, detail
+    assert "origin" in detail, detail
+
+
+def test_sqlite_new_indexes_exist(tmp_path) -> None:
+    store = _seed_sqlite(tmp_path)
+    names = {r[0] for r in store._conn.execute("SELECT name FROM sqlite_master WHERE type='index'").fetchall()}
+    assert {
+        "idx_hub_findings_tenant_reach_all",
+        "idx_hub_findings_tenant_cvss_all",
+        "idx_hub_findings_tenant_severity_all",
+    } <= names
+    # The origin-scoped indexes are retained for filtered reads.
+    assert "idx_hub_findings_tenant_origin_reach" in names
+
+
+def test_sqlite_unfiltered_reach_ordering_matches_reference(tmp_path) -> None:
+    findings = _findings(300)
+    sqlite_store = SQLiteComplianceHubStore(str(tmp_path / "o.db"))
+    sqlite_store.add("t", findings)
+    rows, _ = sqlite_store.list_page("t", limit=300, sort="effective_reach")
+    got = [r["id"] for r in rows]
+    reference = sorted(
+        enumerate(findings),
+        key=lambda pair: (-compute_effective_reach_score(pair[1]), pair[0]),
+    )
+    assert got == [f["id"] for _, f in reference]
+
+
+# ── Postgres: mirror the non-origin indexes (mock pool, no live PG) ───────────
+
+
+def test_postgres_creates_non_origin_sort_indexes() -> None:
+    sys.path.insert(0, "tests")
+    from test_postgres_store import MockPool  # noqa: PLC0415
+
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore  # noqa: PLC0415
+
+    pool = MockPool()
+    PostgresComplianceHubStore(pool=pool)
+    issued = " ".join(" ".join(sql.split()) for sql, _ in pool._conn.executed)
+    assert "idx_hub_findings_tenant_reach_all ON compliance_hub_findings(tenant_id, effective_reach_score DESC, ordinal)" in issued
+    assert "idx_hub_findings_tenant_cvss_all ON compliance_hub_findings(tenant_id, cvss_score DESC, ordinal)" in issued
+    assert "idx_hub_findings_tenant_severity_all ON compliance_hub_findings(tenant_id, severity_rank DESC, ordinal)" in issued


### PR DESCRIPTION
## Problem (confirmed @ 1M findings)

The **unfiltered** default (`effective_reach`) findings first page was the slowest 1M-row read on the hot path — an ~20x outlier vs every other sort. Two independent contributors, by backend:

1. **In-memory store** (`InMemoryComplianceHubStore.list_page`). The `effective_reach` sort comparator called `compute_effective_reach_score(row)` **per row on every read**, which re-derived `symbol_reachability_from_payload(payload)` even though the composite is already materialized at ingest. That per-element comparator cost is what made reach ~3.5x the `cvss` sort at 300k and the ~2.04s outlier at 1M.
2. **SQL (SQLite / Postgres)**. All sort indexes were origin-scoped `(tenant_id, origin, <col> DESC, ordinal)`. An unfiltered `WHERE tenant_id=? ORDER BY effective_reach_score DESC, ordinal` can't range-scan them (`origin` is an unconstrained middle column) → temp-B-tree filesort. Same for unfiltered cvss/severity.

## Fix

- **In-memory:** materialize the effective-reach composite **once at ingest** into a private per-row scalar (`__reach_sort__`, mirroring the SQL `effective_reach_score` column) and trust it on the read path. The scalar is stripped from every returned payload (`list` / `list_page`) so API output is byte-for-byte unchanged. Ordering + the `ordinal` tiebreak are preserved exactly (the read now sorts by the value computed from the identical stored payload); a row lacking the scalar falls back to deriving it.
- **SQL (SQLite + Postgres):** add non-origin covering indexes `(tenant_id, <col> DESC, ordinal)` for reach, cvss and severity_rank so the unfiltered default sorts ride an **index range scan + LIMIT** instead of a filesort. Distinct names + `CREATE INDEX IF NOT EXISTS` (no drop) so steady-state startup is a no-op. The origin-scoped indexes are **retained** for filtered reads.

## Verification (before / after, 1M findings, one tenant)

Isolated `ORDER BY … DESC, ordinal LIMIT 51` read (no `include_total`):

| backend | read | before | after |
|---|---|---|---|
| in-memory | reach vs cvss | reach ~3.5x cvss (the ~2.04s outlier at 1M) | reach ≈ cvss (comparator cost gone) |
| SQLite | unfiltered reach | **~1213 ms** (temp-B-tree filesort) | **~0 ms** (index range scan) |

### EXPLAIN QUERY PLAN (SQLite, unfiltered reach)

```
BEFORE: SEARCH compliance_hub_findings USING INDEX idx_hub_findings_tenant_order (tenant_id=?) | USE TEMP B-TREE FOR ORDER BY
AFTER:  SEARCH compliance_hub_findings USING INDEX idx_hub_findings_tenant_reach_all (tenant_id=?)
```

Postgres mirrors the same three DDL statements (asserted via a mock-pool test; no live PG in CI).

## Ordering unchanged

`test_inmemory_reach_ordering_unchanged` and `test_sqlite_unfiltered_reach_ordering_matches_reference` pin that both backends return rows in exactly `descending composite, ordinal ASC` order; `test_inmemory_read_does_not_rederive_reach_per_row` asserts zero per-row re-derivation on the read; `test_inmemory_read_does_not_leak_sort_scalar` asserts the private scalar never leaves the store.

## Blast radius / notes

- Production reads always scope by `origin='bulk_ingest'` and keep using the origin-scoped indexes (`test_sqlite_origin_scoped_scan_filter_not_shadowed` pins that the new covering index does not steal the origin+scan plan). The only shape the new index can shadow is `list_page(scan_id=…, origin=None)` with a 0-match scan — a synthetic path with no production first-page caller (the unfiltered store reads that exist, e.g. the compliance listing, benefit from the new index).
- Index-only + a private in-memory field: no OpenAPI/contract change.
- Three extra SQLite indexes add ~15% to bulk-ingest time at 300k; acceptable for the read-path win and symmetric with the existing origin-scoped set.

Closes #4049