### PR TITLE
fix(overview): make connector/bulk-ingested estates first-class in the exec pane

### DIFF
--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -88,12 +88,7 @@ def _overview_fingerprint(jobs: list[Any], hub_severity: dict[str, int]) -> str:
     """
     parts = []
     for job in jobs:
-        stamp = (
-            getattr(job, "completed_at", None)
-            or getattr(job, "updated_at", None)
-            or getattr(job, "created_at", None)
-            or ""
-        )
+        stamp = getattr(job, "completed_at", None) or getattr(job, "updated_at", None) or getattr(job, "created_at", None) or ""
         status = getattr(job, "status", "")
         parts.append(f"{getattr(job, 'job_id', '')}|{getattr(status, 'value', status)}|{stamp}")
     parts.sort()
@@ -128,6 +123,7 @@ def _reset_overview_cache() -> None:
     """Test hook: drop all cached overview payloads."""
     with _overview_cache_lock:
         _overview_cache.clear()
+
 
 _SEVERITY_KEYS = ("critical", "high", "medium", "low")
 # ``unrated`` is the honest home for findings whose severity the histogram does
@@ -295,15 +291,44 @@ def _rollup_from_summary(result: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _finding_top_risk(row: dict[str, Any]) -> dict[str, Any]:
-    """Build a top-risk strip entry from a unified findings-spine row."""
-    asset = row.get("asset") if isinstance(row.get("asset"), dict) else {}
+def _row_risk_score(row: dict[str, Any]) -> float:
+    """Comparable 0–10 risk for a top-risk entry, spine or hub-ingested.
+
+    Prefers an explicit ``risk_score``; a hub-ingested finding carries no such
+    field, so fall back to its materialised ``effective_reach_score`` (a ~0–100
+    priority signal — the same one ``/v1/findings`` sorts on) scaled to the 0–10
+    band the scan spine uses, so scan and hub risks sort on one scale. Falls back
+    to ``cvss_score`` when neither is present. The result is clamped to [0, 10]
+    so an out-of-range reach never renders an absurd risk (the store's own
+    reach-ordered page already fixes which rows are the top risks).
+    """
     risk = row.get("risk_score")
+    if risk is None:
+        reach = row.get("effective_reach_score")
+        if reach is not None:
+            try:
+                return round(min(10.0, max(0.0, float(reach) / 10.0)), 1)
+            except (TypeError, ValueError):
+                return 0.0
+        try:
+            return round(min(10.0, max(0.0, float(row.get("cvss_score") or 0.0))), 1)
+        except (TypeError, ValueError):
+            return 0.0
+    try:
+        return round(float(risk or 0), 1)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _finding_top_risk(row: dict[str, Any]) -> dict[str, Any]:
+    """Build a top-risk strip entry from a unified findings-spine or hub row."""
+    asset = row.get("asset") if isinstance(row.get("asset"), dict) else {}
+    evidence = row.get("evidence") if isinstance(row.get("evidence"), dict) else {}
     return {
-        "vulnerability_id": str(row.get("cve_id") or row.get("canonical_id") or row.get("id") or ""),
-        "package": row.get("package") or (asset or {}).get("name"),
+        "vulnerability_id": str(row.get("cve_id") or row.get("canonical_id") or row.get("id") or row.get("finding_id") or ""),
+        "package": row.get("package") or (asset or {}).get("name") or (evidence or {}).get("package_name"),
         "severity": (str(row.get("severity") or "").strip().lower() or "low"),
-        "risk_score": round(float(risk or 0), 1),
+        "risk_score": _row_risk_score(row),
         "is_kev": bool(row.get("is_kev") or row.get("cisa_kev")),
         "cvss_score": row.get("cvss_score"),
         "epss_score": row.get("epss_score"),
@@ -664,6 +689,64 @@ def _hub_severity_snapshot(request: Request) -> dict[str, int]:
     return empty
 
 
+_HUB_TOP_RISK_LIMIT = 10
+
+
+def _hub_top_risks(request: Request, *, limit: int = _HUB_TOP_RISK_LIMIT) -> list[dict[str, Any]]:
+    """Top hub-ingested findings for the exec top-risk strip (P0 #1).
+
+    ``_estate_rollup`` walks scan jobs only, so a connector/bulk-ingested estate
+    rendered an empty top-risk strip even with a million open findings that DO
+    move the grade + headline (via ``_hub_severity_snapshot``). This folds the
+    hub finding spine into the strip. It reads a single bounded page ordered by
+    the materialised ``effective_reach_score`` (index-backed on the SQL
+    backends), so it stays sub-linear at million-row scale — it never hydrates
+    the whole ledger (mirrors the #3963 rule that the overview must not fold
+    every hub payload). Degrades to an empty list if the hub store is
+    unavailable so the overview never fails closed on an optional dependency.
+    """
+    if limit <= 0:
+        return []
+    try:
+        from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+        store = get_compliance_hub_store()
+        page = store.list_page(
+            _tenant_id(request),
+            limit=limit,
+            sort="effective_reach",
+            include_total=False,
+        )
+    except Exception:  # pragma: no cover - hub store optional
+        _logger.debug("hub top risks failed", exc_info=True)
+        return []
+    rows = page[0] if isinstance(page, tuple) else page
+    return [_finding_top_risk(row) for row in rows or [] if isinstance(row, dict)]
+
+
+def _merge_top_risks(*groups: list[dict[str, Any]], limit: int = 10) -> list[dict[str, Any]]:
+    """Merge scan + hub top-risk entries: dedupe by id, sort by risk, cap.
+
+    Deduped on ``vulnerability_id`` (keeping the higher-risk occurrence) so a
+    finding present in both the scan spine and the hub ledger is not doubled;
+    keyless entries (no id) are always kept.
+    """
+    best_by_id: dict[str, dict[str, Any]] = {}
+    keyless: list[dict[str, Any]] = []
+    for group in groups:
+        for entry in group:
+            key = str(entry.get("vulnerability_id") or "")
+            if not key:
+                keyless.append(entry)
+                continue
+            existing = best_by_id.get(key)
+            if existing is None or float(entry.get("risk_score") or 0.0) > float(existing.get("risk_score") or 0.0):
+                best_by_id[key] = entry
+    merged = [*best_by_id.values(), *keyless]
+    merged.sort(key=lambda r: float(r.get("risk_score") or 0.0), reverse=True)
+    return merged[:limit]
+
+
 def _combined_severity(scan_severity: dict[str, int], hub_severity: dict[str, int]) -> dict[str, int]:
     """Merge scan + hub-ingested severity into the five reconciled buckets.
 
@@ -851,6 +934,11 @@ def _compose_overview(request: Request, tenant_id: str, jobs: list[Any], hub_sev
     repo_scans = _repo_scan_count(jobs)
     vuln_severity = estate["vuln_severity"]
 
+    # Fold hub-ingested findings into the exec top-risk strip so a
+    # connector/bulk-ingested estate (scan jobs alone) no longer renders an empty
+    # strip while a million open findings drive the grade (P0 #1).
+    top_risks = _merge_top_risks(estate["top_risks"], _hub_top_risks(request))
+
     domains = {
         "cloud": {
             "label": "Cloud posture",
@@ -947,7 +1035,7 @@ def _compose_overview(request: Request, tenant_id: str, jobs: list[Any], hub_sev
         },
         "domains": domains,
         "coverage": coverage,
-        "top_risks": estate["top_risks"],
+        "top_risks": top_risks,
     }
 
 

--- a/src/agent_bom/exec_score.py
+++ b/src/agent_bom/exec_score.py
@@ -382,6 +382,7 @@ def compute_exec_score(
         counts=counts,
         finding_total=finding_total,
         floor_summary=floor_summary,
+        breakdown=breakdown,
     )
 
     return {
@@ -402,6 +403,12 @@ def compute_exec_score(
     }
 
 
+# Severity drivers, in the order they appear in ``DRIVER_ORDER`` — the summary
+# ranks these by grade contribution (not by fixed severity) so the blurb names
+# whichever band actually drives the grade.
+_SEVERITY_DRIVERS: tuple[str, ...] = ("critical", "high", "medium", "low", "unrated")
+
+
 def _build_summary(
     *,
     grade: str,
@@ -409,20 +416,34 @@ def _build_summary(
     counts: Mapping[str, int],
     finding_total: int,
     floor_summary: str | None,
+    breakdown: list[dict[str, Any]],
 ) -> str:
-    """Honest one-line blurb. Never claims 'no vulnerabilities' when total > 0."""
+    """Honest one-line blurb. Never claims 'no vulnerabilities' when total > 0.
+
+    Names the DOMINANT driver of the grade — the severity band with the largest
+    penalty contribution (weight × count) — first, then the next-largest, then
+    the KEV / exposure amplifiers. The old blurb named only critical/high (and
+    surfaced medium/low only when both were zero), so ``1 high + 1,000,000
+    medium`` read as "1 high" — overstating the lone high and hiding the mediums
+    that actually drive the F. Ranking by contribution fixes that generally: a
+    critical-dominant estate still leads with critical, a medium-dominant estate
+    leads with medium.
+    """
     score_txt = f"{grade} · {int(round(score))}%"
     if finding_total > 0:
-        bits: list[str] = []
-        if counts["critical"]:
-            bits.append(f"{counts['critical']} critical")
-        if counts["high"]:
-            bits.append(f"{counts['high']} high")
+        ranked = sorted(
+            (b for b in breakdown if b.get("driver") in _SEVERITY_DRIVERS and int(b.get("count") or 0) > 0),
+            key=lambda b: (float(b.get("contribution") or 0.0), int(b.get("count") or 0)),
+            reverse=True,
+        )
+        # Name the top two contributing bands so the dominant driver leads and a
+        # secondary (e.g. the lone high) still shows for context.
+        bits: list[str] = [f"{int(b['count']):,} {b['driver']}" for b in ranked[:2]]
         if counts["kev"]:
-            bits.append(f"{counts['kev']} KEV")
+            bits.append(f"{counts['kev']:,} KEV")
         if counts["exposure"]:
-            bits.append(f"{counts['exposure']} touch secrets")
-        lead = " · ".join(bits) if bits else f"{finding_total} finding(s)"
+            bits.append(f"{counts['exposure']:,} touch secrets")
+        lead = " · ".join(bits) if bits else f"{finding_total:,} finding(s)"
         return f"{score_txt} — {lead} across connected surfaces."
     # No open findings but still graded: a scan ran (floor present). Explain what
     # graded it instead of asserting a clean "no vulnerabilities / strong" line.

--- a/tests/test_exec_score.py
+++ b/tests/test_exec_score.py
@@ -45,6 +45,33 @@ def test_summary_never_claims_no_vulns_when_counted() -> None:
     assert "3 high" in result["summary"]
 
 
+def test_summary_names_dominant_driver_not_just_highest_severity() -> None:
+    """A lone high must not headline the blurb when a million mediums drive the F.
+
+    Regression for the misleading exec summary (P0-1): the old blurb named only
+    critical/high (medium/low surfaced only when crit+high were both zero), so
+    ``1 high + 1,000,000 medium`` read as "1 high across connected surfaces" —
+    overstating the lone high and hiding the mediums that actually drive the
+    grade. The summary must name the DOMINANT driver (largest grade contribution)
+    first.
+    """
+    result = compute_exec_score(severity=_sev(high=1, medium=1_000_000))
+    summary = result["summary"]
+    # The dominant medium driver is named (with a thousands separator), first.
+    assert "1,000,000 medium" in summary, summary
+    assert summary.index("medium") < summary.index("high"), summary
+    # The lone high is still shown for context, just not as the headline.
+    assert "1 high" in summary, summary
+
+
+def test_summary_leads_with_critical_when_critical_dominates() -> None:
+    """When criticals dominate the contribution, they still lead — general rule."""
+    result = compute_exec_score(severity=_sev(critical=5, medium=3))
+    summary = result["summary"]
+    assert "5 critical" in summary, summary
+    assert summary.index("critical") < summary.index("medium"), summary
+
+
 def test_large_estate_grades_f_without_flooring_at_zero() -> None:
     """A big critical estate is grade F with a very low — but non-zero — score.
 

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -236,6 +236,67 @@ def test_overview_counts_bulk_ingested_findings() -> None:
     get_compliance_hub_store().clear("default")
 
 
+def test_overview_top_risks_include_hub_ingested_findings() -> None:
+    """Hub-ingested findings surface in the exec top-risk strip (P0 #1).
+
+    ``_estate_rollup`` walks scan jobs only, so a pure connector/bulk-ingested
+    estate rendered ``top_risks: []`` even with a million open findings that DO
+    move the grade + headline. The strip must now fold the hub finding spine so
+    the exec pane surfaces real, drillable top risks.
+    """
+    _clear_jobs()
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    get_compliance_hub_store().clear("default")
+    _ingest_hub_findings(
+        [
+            {"finding_id": "H-med-1", "severity": "medium", "cvss_score": 6.5, "title": "m1"},
+            {"finding_id": "H-med-2", "severity": "medium", "cvss_score": 5.0, "title": "m2"},
+            {"finding_id": "H-high-1", "severity": "high", "cvss_score": 8.8, "title": "h1"},
+        ]
+    )
+
+    data = client_get_overview()
+    top = data["top_risks"]
+    assert top, "hub-ingested findings must surface in the exec top-risk strip"
+    ids = {r["vulnerability_id"] for r in top}
+    assert {"H-med-1", "H-med-2", "H-high-1"} & ids, ids
+    for row in top:
+        # Each entry carries the fields the strip drills on (severity + score).
+        assert row["severity"] in {"critical", "high", "medium", "low", "unknown", "unrated"}
+        assert isinstance(row["risk_score"], (int, float))
+
+    get_compliance_hub_store().clear("default")
+
+
+def test_overview_medium_dominant_estate_surfaces_risks_and_honest_summary() -> None:
+    """The audited scenario: mediums dominate a bulk-ingested estate.
+
+    With 1 high + many mediums the posture summary must name the dominant medium
+    driver (not the lone high), and the top-risk strip must be populated — the
+    two exec-read honesty fixes reconciled on one payload.
+    """
+    _clear_jobs()
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    get_compliance_hub_store().clear("default")
+    findings = [{"finding_id": "H-high", "severity": "high", "cvss_score": 8.0, "title": "hi"}]
+    findings += [
+        {"finding_id": f"H-med-{i}", "severity": "medium", "cvss_score": 5.0, "title": f"m{i}"} for i in range(50)
+    ]
+    _ingest_hub_findings(findings)
+
+    data = client_get_overview()
+    summary = str(data["posture"]["summary"]).lower()
+    assert "medium" in summary, summary
+    assert data["top_risks"], "medium-dominant estate must still surface top risks"
+    # Headline + hub count remain coherent with the ingested spine.
+    assert data["headline"]["hub_findings"] == 51
+    assert data["headline"]["high"] == 1
+
+    get_compliance_hub_store().clear("default")
+
+
 def test_overview_hub_findings_do_not_upgrade_failing_scan() -> None:
     """Ingested evidence can only move a scan grade down, never launder it up."""
     _clear_jobs()


### PR DESCRIPTION
## Why

A dogfood read of a **1M-finding connector estate** — all loaded via `POST /v1/findings/bulk`, the product's north-star onboarding path — found the executive overview treats hub-ingested findings as second-class. Two code-confirmed P0s: the exec pane surfaced **no top risks** and a **misleading one-line summary**, even though the grade + headline already fold hub findings.

## Fixes

### 1. Empty top-risk strip for hub-ingested estates (P0)
`_estate_rollup` (`src/agent_bom/api/routes/overview.py`) walks scan **jobs** only. Hub/bulk-ingested findings fold into the grade + headline via `_hub_severity_snapshot`, but never into `top_risks`. At 1M findings: grade F, `hub_findings 1,000,002`, but `top_risks: []`.

**Fix:** `_hub_top_risks` (`overview.py`) reads one **bounded page** of the hub ledger ordered by the materialised `effective_reach_score` (index-backed on the SQL backends → sub-linear at million-row scale; never hydrates the whole ledger, honouring the #3963 rule that the overview must not fold every hub payload), then `_merge_top_risks` dedupes it against the scan top-risks by id and caps at 10. Hub rows carry no `risk_score`, so `_row_risk_score` derives a comparable, clamped 0–10 risk from `effective_reach_score` so scan and hub risks sort on one scale. Entries carry `severity` + `vulnerability_id`, so they drill via the existing findings API (`/v1/findings?severity=…` returns the rows).

### 2. Misleading exec summary (P0-1)
`_build_summary` (`src/agent_bom/exec_score.py` ~415) named only critical/high; medium/low appeared only when crit+high were both zero. With `1 high + 1,000,000 medium` it read `"F · 0% — 1 high across connected surfaces"` — overstating the lone high, hiding the mediums that drive the F.

**Fix:** rank the severity bands by grade **contribution** (weight × count) and name the top two, so the blurb leads with whichever band **dominates** the grade (critical-heavy → critical; medium-dominant → medium). KEV/exposure amplifiers still trail; counts get a thousands separator.

## Before / after `/v1/overview` (1 high + 1M medium, bulk-ingested)

**Before** (live evidence instance):
```
posture.summary : "F · 0% — 1 high across connected surfaces."
top_risks        : []
```

**After** (seeded render, worktree src):
```
posture.summary : "F · 3% — 1,000 medium · 1 high across connected surfaces."
top_risks        : [ {vulnerability_id, severity:"medium", risk_score, cvss_score, …}, … 10 ]
headline         : high 1 · hub_findings 1001   (unchanged — grade/headline basis untouched)
```

## Scope / deferred (honest note)
- **Coverage lanes + domain tiles for hub findings are intentionally NOT folded here.** Live evidence shows the synthetic bulk findings drill by `severity=` (returns 1M) but **not** by `domain=` (returns 0) — they carry no resolvable `security_domain`, so attributing them to a domain lane whose href is `/findings?domain=vuln` would make the tile contradict its own drill (a honesty-reconciliation violation). Exact **per-domain** lane counts at million-row scale require a materialised `security_domain`/lens store aggregate (mirroring the existing `severity` / `applicable_frameworks_csv` denorm columns + backfill across in-memory/SQLite/Postgres) — a larger store/migration workstream. Filed as follow-up; not guessed here.
- Compliance-control mapping for ingested findings (`/v1/compliance` `no_data`) is out of scope and remains honest.

## Verification
- New TDD tests (red→green): `tests/test_exec_score.py::test_summary_names_dominant_driver_not_just_highest_severity`, `::test_summary_leads_with_critical_when_critical_dominates`; `tests/test_overview.py::test_overview_top_risks_include_hub_ingested_findings`, `::test_overview_medium_dominant_estate_surfaces_risks_and_honest_summary`.
- Gates green: `ruff check` + `ruff format --check` + `mypy` on changed files; `pytest -k "overview or exec_score or compliance_hub or findings_bulk or posture_counts"` → **189 passed, 2 skipped**; posture suites → 205 passed.
- Rendered the seeded medium-dominant estate through the full server (`TestClient`) and eyeballed the payload for honesty.