### PR TITLE
fix: three scanner/CLI correctness bugs (malicious remediation, AST skip-dir scope, --agent-mode coverage)

### DIFF
--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -39,7 +39,11 @@ ok "CLI reachable ($version)"
 
 bold "2/5 Curated demo scan (offline JSON)"
 json_out="$tmp/demo-report.json"
-if ! "${AGENT_BOM_BIN[@]}" agents --demo --offline --quiet --no-auto-update-db -f json -o "$json_out"; then
+set +e
+"${AGENT_BOM_BIN[@]}" agents --demo --offline --quiet --no-auto-update-db -f json -o "$json_out"
+scan_rc=$?
+set -e
+if [ "$scan_rc" -ne 0 ] && [ "$scan_rc" -ne 1 ]; then
   fail "demo offline scan failed"
 fi
 [ -s "$json_out" ] || fail "demo JSON report is empty"
@@ -56,13 +60,27 @@ findings = report.get("findings") or report.get("vulnerabilities") or []
 print(len(findings))
 PY
 )"
+if [ "$scan_rc" -eq 1 ]; then
+  python3 - "$json_out" <<'PY' || fail "demo scan exited 1 without a malicious finding"
+import json, sys
+
+report = json.load(open(sys.argv[1]))
+findings = report.get("findings") or []
+if not any(row.get("is_malicious") for row in findings):
+    raise SystemExit(1)
+PY
+fi
 [ "$agents" -gt 0 ] || fail "demo scan returned zero agents"
 [ "$vulns" -gt 0 ] || fail "demo scan returned zero findings"
 ok "demo scan produced ${agents} agent(s) and ${vulns} finding(s)"
 
 bold "3/5 CSV export"
 csv_out="$tmp/demo-report.csv"
-if ! "${AGENT_BOM_BIN[@]}" agents --demo --offline --quiet --no-auto-update-db -f csv -o "$csv_out"; then
+set +e
+"${AGENT_BOM_BIN[@]}" agents --demo --offline --quiet --no-auto-update-db -f csv -o "$csv_out"
+csv_rc=$?
+set -e
+if [ "$csv_rc" -ne 0 ] && [ "$csv_rc" -ne 1 ]; then
   fail "demo CSV export failed"
 fi
 [ -s "$csv_out" ] || fail "demo CSV export is empty"

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -97,7 +97,10 @@ def project_has_analyzable_sources(project_path: str | Path) -> bool:
     for path in project.rglob("*"):
         if not path.is_file():
             continue
-        if any(part in _SKIP_DIRS for part in path.parts):
+        # Only consider path components RELATIVE to the scan root — an ancestor
+        # directory of where the user keeps the project (e.g. ~/dev/test/proj,
+        # /ci/build/app) must never disable analysis.
+        if any(part in _SKIP_DIRS for part in path.relative_to(project).parts):
             continue
         if any(skip in path.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue
@@ -129,7 +132,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     # Collect source files
     py_files = []
     for f in sorted(project.rglob("*.py")):
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         # Skip test/fixture/pattern files to avoid false positives
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
@@ -140,7 +143,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     for f in sorted(project.rglob("*")):
         if f.suffix.lower() not in _JS_TS_EXTS:
             continue
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue
@@ -148,7 +151,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
 
     go_files = []
     for f in sorted(project.rglob("*.go")):
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue
@@ -156,7 +159,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
 
     rust_files = []
     for f in sorted(project.rglob("*.rs")):
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue
@@ -164,7 +167,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
 
     java_files = []
     for f in sorted(project.rglob("*.java")):
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue
@@ -172,7 +175,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
 
     csharp_files = []
     for f in sorted(project.rglob("*.cs")):
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue
@@ -180,7 +183,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
 
     ruby_files = []
     for f in sorted(project.rglob("*.rb")):
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue
@@ -188,7 +191,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
 
     php_files = []
     for f in sorted(project.rglob("*.php")):
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue
@@ -196,7 +199,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
 
     swift_files = []
     for f in sorted(project.rglob("*.swift")):
-        if any(part in _SKIP_DIRS for part in f.parts):
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
             continue
         if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
             continue

--- a/src/agent_bom/cli/_agent_mode.py
+++ b/src/agent_bom/cli/_agent_mode.py
@@ -444,3 +444,33 @@ def error_envelope(*, command: str | None, message: str, exit_code: int, error_t
 
 def dumps_envelope(payload: dict[str, Any]) -> str:
     return json.dumps(_redact_sensitive(payload), separators=(",", ":"), sort_keys=True, default=str)
+
+
+def emit_command_envelope(
+    *,
+    command: str,
+    data: dict[str, Any],
+    exit_code: int = 0,
+    summary: dict[str, Any] | None = None,
+    confidence: dict[str, Any] | None = None,
+    error_type: str | None = None,
+) -> None:
+    """Print the stable agent-mode envelope for a non-scan read command.
+
+    A thin wrapper over :func:`command_success_envelope` +
+    :func:`dumps_envelope` so read commands (doctor, capabilities, where,
+    mesh, scanners) emit ONE valid JSON object instead of ANSI when the caller
+    requested ``--agent-mode``. The same credential-redaction barrier applies,
+    so no probed environment value can leak into the serialized payload.
+    """
+    import click
+
+    envelope = command_success_envelope(
+        command=command,
+        data=data,
+        exit_code=exit_code,
+        summary=summary or {},
+        confidence=confidence or {"level": "high", "signals": []},
+        error_type=error_type,
+    )
+    click.echo(dumps_envelope(envelope))

--- a/src/agent_bom/cli/_analysis.py
+++ b/src/agent_bom/cli/_analysis.py
@@ -442,17 +442,45 @@ def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, out
       agent-bom mesh --project .   # project-local discovery only
       agent-bom mesh report.json --format json --output mesh.json
     """
+    from agent_bom.cli._agent_mode import agent_mode_requested, emit_command_envelope
     from agent_bom.output.agent_mesh import build_agent_mesh
 
     con = Console()
+    agent_mode = agent_mode_requested()
 
     try:
-        agents_data, blast_radius, scope_label = _load_mesh_source(scan_file, project_dir)
+        if agent_mode:
+            # Keep stdout carrying ONLY the JSON envelope — silence the live
+            # discovery progress banner that discover_all prints through the
+            # discovery module's console.
+            import io as _io
+
+            from agent_bom import discovery as _discovery
+
+            _prev_console = _discovery.console
+            _discovery.console = Console(file=_io.StringIO(), quiet=True)
+            try:
+                agents_data, blast_radius, scope_label = _load_mesh_source(scan_file, project_dir)
+            finally:
+                _discovery.console = _prev_console
+        else:
+            agents_data, blast_radius, scope_label = _load_mesh_source(scan_file, project_dir)
     except (ValueError, OSError, json.JSONDecodeError) as exc:
+        if agent_mode:
+            emit_command_envelope(
+                command="mesh",
+                data={"error": str(exc)},
+                exit_code=1,
+                error_type="mesh_source_error",
+            )
+            raise SystemExit(1) from exc
         con.print(f"[red]Error loading mesh source:[/red] {exc}")
         raise SystemExit(1) from exc
 
     if not agents_data:
+        if agent_mode:
+            emit_command_envelope(command="mesh", data=build_agent_mesh([], blast_radius))
+            return
         if project_dir:
             con.print("[yellow]No project-local agents discovered.[/yellow] Try [bold]agent-bom mesh[/bold] for machine-wide discovery.")
         else:
@@ -460,6 +488,10 @@ def mesh_cmd(scan_file: Optional[str], project_dir: Optional[str], fmt: str, out
         return
 
     mesh = build_agent_mesh(agents_data, blast_radius)
+
+    if agent_mode:
+        emit_command_envelope(command="mesh", data=mesh)
+        return
 
     if fmt == "json":
         output = json.dumps(mesh, indent=2)

--- a/src/agent_bom/cli/_capabilities.py
+++ b/src/agent_bom/cli/_capabilities.py
@@ -91,4 +91,28 @@ def capabilities_cmd() -> None:
     \b
     No secret values are ever printed — only whether a variable is set.
     """
+    from agent_bom.cli._agent_mode import agent_mode_requested
+
+    if agent_mode_requested():
+        from agent_bom.cli._agent_mode import emit_command_envelope
+
+        capabilities = [
+            {
+                "name": cap.name,
+                "group": cap.group,
+                "state": status.state.value,
+                "does": cap.does,
+                "detail": status.detail,
+                "unlock": cap.unlock if status.state is not State.ON else None,
+            }
+            for cap, status in resolved_capabilities()
+        ]
+        on = sum(1 for cap in capabilities if cap["state"] == "on")
+        emit_command_envelope(
+            command="capabilities",
+            data={"capabilities": capabilities, "coverage": coverage_line()},
+            summary={"total": len(capabilities), "enabled": on},
+        )
+        return
+
     render_capabilities(Console())

--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -143,6 +143,44 @@ def doctor_cmd() -> None:
     except Exception:
         cloud_sdk_checks.append(("Cloud SDKs", "freshness check unavailable", "info"))
 
+    checks = [*core_checks, *runtime_checks, *platform_checks]
+    warns = sum(1 for _, _, s in checks if s == "warn")
+
+    from agent_bom.cli._agent_mode import agent_mode_requested
+
+    if agent_mode_requested():
+        from agent_bom.cli._agent_mode import emit_command_envelope
+
+        def _section(rows: list[tuple[str, str, str]]) -> list[dict[str, str]]:
+            return [{"label": label, "value": value, "status": status} for label, value, status in rows]
+
+        capabilities: list[dict[str, str]] = []
+        coverage = None
+        try:
+            from agent_bom.capabilities import coverage_line, resolved_capabilities
+
+            for cap, status in resolved_capabilities():
+                capabilities.append({"name": cap.name, "state": status.state.value, "detail": status.detail})
+            coverage = coverage_line()
+        except Exception:
+            capabilities = []
+
+        emit_command_envelope(
+            command="doctor",
+            data={
+                "core": _section(core_checks),
+                "runtime": _section(runtime_checks),
+                "platform": _section(platform_checks),
+                "cloud_sdk": _section(cloud_sdk_checks),
+                "capabilities": capabilities,
+                "coverage": coverage,
+                "ready": warns == 0,
+                "warnings": warns,
+            },
+            summary={"warnings": warns, "ready": warns == 0},
+        )
+        return
+
     # Print results
     console.print("  [bold]agent-bom doctor[/bold]")
     console.print()
@@ -171,8 +209,6 @@ def doctor_cmd() -> None:
 
     console.print()
 
-    checks = [*core_checks, *runtime_checks, *platform_checks]
-    warns = sum(1 for _, _, s in checks if s == "warn")
     if warns == 0:
         console.print("  [green]Ready to scan.[/green]")
     else:

--- a/src/agent_bom/cli/_inventory.py
+++ b/src/agent_bom/cli/_inventory.py
@@ -233,7 +233,11 @@ def where(as_json: bool):
 
     current_platform = get_platform()
 
-    if as_json:
+    from agent_bom.cli._agent_mode import agent_mode_requested
+
+    agent_mode = agent_mode_requested()
+
+    if as_json or agent_mode:
         import json as _json
 
         from agent_bom.discovery.coverage import discovery_coverage_summary
@@ -242,6 +246,11 @@ def where(as_json: bool):
         for entry in summary["paths"]:
             path = str(entry["path"])
             entry["expanded"] = str(expand_path(path)) if not path.startswith(".") else path
+        if agent_mode:
+            from agent_bom.cli._agent_mode import emit_command_envelope
+
+            emit_command_envelope(command="where", data=summary)
+            return
         click.echo(_json.dumps(summary, indent=2))
         return
 

--- a/src/agent_bom/cli/_scanner_registry.py
+++ b/src/agent_bom/cli/_scanner_registry.py
@@ -21,6 +21,19 @@ def scanners_cmd(include_planned: bool, output_format: str) -> None:
     summary = scanner_registry_summary()
     warnings = scanner_registry_warnings()
 
+    from agent_bom.cli._agent_mode import agent_mode_requested, emit_command_envelope
+
+    if agent_mode_requested():
+        emit_command_envelope(
+            command="scanners",
+            data={
+                "drivers": [driver.to_dict() for driver in drivers],
+                "summary": summary,
+                "warnings": warnings,
+            },
+        )
+        return
+
     if output_format == "json":
         click.echo(
             json.dumps(

--- a/src/agent_bom/cli/agents/_post.py
+++ b/src/agent_bom/cli/agents/_post.py
@@ -362,7 +362,11 @@ def compute_exit_code(
                 f"Upgrade to --fail-on-severity to enforce."
             )
 
-    if fail_on_malicious and exit_code == 0:
+    # A known-malicious package is a fail-closed BLOCK regardless of the opt-in
+    # --fail-on-malicious flag, mirroring `check`, which always exits 1 on a
+    # malicious verdict. A default scan silently exiting 0 on a typosquat /
+    # dependency-confusion / known-malicious advisory would let it install.
+    if exit_code == 0:
         for br in _active_blast_radii:
             if getattr(br.package, "is_malicious", False):
                 if not quiet:

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -1454,8 +1454,14 @@ def print_remediation_plan(report: AIBOMReport) -> None:
         return
 
     plan = build_remediation_plan(all_cve)
-    fixable = [p for p in plan if p["fix"]]
-    unfixable = [p for p in plan if not p["fix"]]
+    # A malicious package sets fix=None to signal REMOVAL (not a version bump),
+    # so it must be pulled out of the fix-based buckets. Without this it lands in
+    # the "no fix yet — monitor upstream for patches" bucket, which tells the user
+    # to keep a known-malicious dependency and wait — the opposite of the
+    # required "remove immediately" action.
+    malicious = [p for p in plan if p.get("is_malicious")]
+    fixable = [p for p in plan if p["fix"] and not p.get("is_malicious")]
+    unfixable = [p for p in plan if not p["fix"] and not p.get("is_malicious")]
 
     # Totals for percentage calculations
     total_agents = report.total_agents or 1
@@ -1478,6 +1484,22 @@ def print_remediation_plan(report: AIBOMReport) -> None:
         Severity.LOW: "dim",
         Severity.NONE: "white",
     }
+
+    if malicious:
+        _console().print(
+            f"  [red bold]☠ {len(malicious)} MALICIOUS package(s) — remove immediately (do not wait for a patch):[/red bold]\n"
+        )
+        for item in malicious:
+            reason = item.get("reason") or "known malicious package"
+            _console().print(
+                f"    [white on red] MALICIOUS [/white on red] "
+                f"[red bold]Remove {item['package']}@{item['current']}[/red bold] [dim]({reason})[/dim]"
+            )
+            if item.get("command"):
+                _console().print(f"      [dim]$ {item['command']}[/dim]")
+            if item["agents"]:
+                _console().print(f"      [dim]agents:[/dim]  {', '.join(item['agents'][:3])}")
+        _console().print()
 
     if fixable:
         _console().print(f"  [bold]{len(fixable)} fixable upgrade(s) — ordered by grouped blast-radius risk:[/bold]\n")

--- a/tests/test_agent_mode_read_commands.py
+++ b/tests/test_agent_mode_read_commands.py
@@ -1,0 +1,32 @@
+"""`--agent-mode` must emit a valid stable JSON envelope for read commands.
+
+The global `--agent-mode` flag is documented as emitting stable machine-readable
+JSON, but only `scan` and `check` honored it. An automation caller doing
+`agent-bom --agent-mode doctor | json.load` got an ANSI dump and a parse error
+(with exit 0). These tests pin the envelope contract across the common read
+commands.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+READ_COMMANDS = ["doctor", "capabilities", "where", "mesh", "scanners"]
+
+
+@pytest.mark.parametrize("command", READ_COMMANDS)
+def test_agent_mode_emits_parseable_envelope(command: str) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, ["--agent-mode", command])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)  # must be valid JSON, not ANSI
+    assert payload["schema_version"] == "1"
+    assert payload["mode"] == "agent"
+    assert payload["command"] == command
+    assert "data" in payload

--- a/tests/test_ast_cli_gate.py
+++ b/tests/test_ast_cli_gate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from agent_bom.ast_analyzer import project_has_analyzable_sources
+from agent_bom.ast_analyzer import analyze_project, project_has_analyzable_sources
 
 
 def test_project_has_analyzable_sources_php_only(tmp_path: Path) -> None:
@@ -26,3 +26,31 @@ def test_project_has_analyzable_sources_skips_node_modules(tmp_path: Path) -> No
     nested.mkdir(parents=True)
     (nested / "index.ts").write_text("export {}", encoding="utf-8")
     assert project_has_analyzable_sources(tmp_path) is False
+
+
+def test_analyzable_sources_ignores_ancestor_skip_dir_names(tmp_path: Path) -> None:
+    """A project kept under an ancestor dir named like a skip dir is still analyzed.
+
+    The skip list (`build`, `test`, `fixtures`, ...) must only apply to path
+    components RELATIVE to the scan root, never to ancestor directories of where
+    the user happens to keep the project (e.g. ~/dev/test/proj, /ci/build/app).
+    """
+    for ancestor in ("build", "test", "fixtures", "vendor", "env"):
+        project = tmp_path / ancestor / "myapp"
+        project.mkdir(parents=True)
+        (project / "server.py").write_text("def handler():\n    return 1\n", encoding="utf-8")
+        assert project_has_analyzable_sources(project) is True, ancestor
+        result = analyze_project(project)
+        assert result.files_analyzed == 1, ancestor
+
+
+def test_analyze_project_still_skips_tests_subdir_inside_project(tmp_path: Path) -> None:
+    """A `tests/` subtree INSIDE the scan root is still skipped (relative match)."""
+    (tmp_path / "app.py").write_text("def handler():\n    return 1\n", encoding="utf-8")
+    tests_dir = tmp_path / "tests"
+    tests_dir.mkdir()
+    (tests_dir / "helper.py").write_text("def helper():\n    return 2\n", encoding="utf-8")
+
+    assert project_has_analyzable_sources(tmp_path) is True
+    result = analyze_project(tmp_path)
+    assert result.files_analyzed == 1

--- a/tests/test_audit_queue_fixes.py
+++ b/tests/test_audit_queue_fixes.py
@@ -56,6 +56,64 @@ def test_remediation_plan_remove_command_for_malicious_package() -> None:
     assert plan[0]["command"] == "npm uninstall flatmap-stream"
 
 
+def test_remediation_console_renders_remove_not_monitor_for_malicious() -> None:
+    """Console remediation plan must render an explicit REMOVE + MALICIOUS marker
+    for a known-malicious package, never bucket it under 'monitor upstream for
+    patches' (which is only correct for no-fix-yet CVEs)."""
+    import io
+
+    from rich.console import Console
+
+    from agent_bom import output as output_mod
+    from agent_bom.models import AIBOMReport
+    from agent_bom.output.console_render import print_remediation_plan
+
+    report = AIBOMReport(blast_radii=[_malicious_blast_radius()])
+
+    buffer = io.StringIO()
+    original = output_mod.console
+    output_mod.console = Console(file=buffer, force_terminal=False, width=200, no_color=True)
+    try:
+        print_remediation_plan(report)
+    finally:
+        output_mod.console = original
+
+    text = buffer.getvalue()
+    assert "flatmap-stream" in text
+    assert "monitor upstream for patches" not in text
+    assert "MALICIOUS" in text
+    assert "Remove" in text
+
+
+def test_scan_exits_one_on_malicious_package_by_default() -> None:
+    """A known-malicious package must fail the scan (exit 1) even without the
+    opt-in --fail-on-malicious flag, matching `check`'s fail-closed policy. A
+    default scan silently exiting 0 would let a malicious dependency through."""
+    from io import StringIO
+
+    from rich.console import Console
+
+    from agent_bom.cli.agents._context import ScanContext
+    from agent_bom.cli.agents._post import compute_exit_code
+
+    ctx = ScanContext(
+        con=Console(file=StringIO(), force_terminal=False),
+        blast_radii=[_malicious_blast_radius()],
+    )
+    code = compute_exit_code(
+        ctx,
+        fail_on_severity=None,
+        warn_on_severity=None,
+        fail_on_kev=False,
+        fail_if_ai_risk=False,
+        push_url=None,
+        push_api_key=None,
+        quiet=True,
+        fail_on_malicious=False,
+    )
+    assert code == 1
+
+
 def test_forward_fixed_version_rejects_downgrade() -> None:
     assert _forward_fixed_version("0.2.1", "1.2.0", "npm") is None
     assert _forward_fixed_version("1.2.3", "1.2.0", "npm") == "1.2.3"


### PR DESCRIPTION
Three independent, code-confirmed scanner/CLI correctness P1s from the v0.96.3 dogfood audit. Each fix is TDD'd (failing test first) and independently green.

## 1. Malicious package rendered as "remove immediately", not "monitor upstream"
`src/agent_bom/output/console_render.py`

The console remediation plan buckets packages by fix availability. A malicious package sets `fix=None` to signal removal (`build_remediation_plan`, ~L1393-1398), but `print_remediation_plan` bucketed on `p["fix"]` (~L1457-1458) so it fell into the "no fix yet" bucket (~L1544) and printed:

> ⚠ N package(s) have no fix yet — monitor upstream for patches: • <malicious pkg>

i.e. it told the user to KEEP a known-malicious dependency and wait. Machine formats (json/csv/sarif) were already honest (`is_malicious:true`); only the human console was wrong.

- Before: malicious pkg listed under "monitor upstream for patches", no MALICIOUS marker, default scan exits 0.
- After: dedicated `☠ MALICIOUS package(s) — remove immediately` section with a `MALICIOUS` marker + remove command; excluded from the monitor bucket.
- Exit policy: `compute_exit_code` (`src/agent_bom/cli/agents/_post.py` ~L365) now fails closed on any malicious package regardless of the opt-in `--fail-on-malicious`, matching `check`, so a default scan can no longer silently exit 0 on a malicious dependency.

Repro after: `test_remediation_console_renders_remove_not_monitor_for_malicious`, `test_scan_exits_one_on_malicious_package_by_default`.

## 2. AST/reachability no longer disabled by an ancestor dir name
`src/agent_bom/ast_analyzer.py`

`project_has_analyzable_sources` / `analyze_project` (~L100, and 9 collector loops) tested skip-dir names against the ABSOLUTE path components. `_SKIP_DIRS` includes `test`, `tests`, `env`, `build`, `dist`, `fixtures`, `vendor`, so scanning `/ci/build/myapp` or `~/dev/test/proj` silently got NO AST analysis and no warning.

- Before: same project returns analyzable=False under `.../build/proj`, True under `.../fx/proj`.
- After: skip names match only components RELATIVE to the scan root. A project under an ancestor `build`/`test`/`fixtures`/`env`/`vendor` dir IS analyzed; a `tests/` subdir INSIDE the project is still skipped.

Repro after: `test_analyzable_sources_ignores_ancestor_skip_dir_names`, `test_analyze_project_still_skips_tests_subdir_inside_project`.

## 3. `--agent-mode` honored across common read commands
`src/agent_bom/cli/_agent_mode.py`, `_doctor.py`, `_capabilities.py`, `_inventory.py` (where), `_analysis.py` (mesh), `_scanner_registry.py` (scanners)

The global `--agent-mode` flag (`cli/__init__.py` ~L66) is documented "Emit stable machine-readable JSON…", but only `scan`/`check` emitted the envelope. `agent-bom --agent-mode doctor|capabilities|where|mesh|scanners` printed ANSI, so an automation caller piping to `json.load` got a parse error with exit 0.

- After: all five emit the stable envelope (`schema_version` + `command_success` shape, through the existing credential-redaction barrier) via a new `emit_command_envelope` helper. `mesh` silences its live discovery banner so stdout carries only the JSON object.

Repro after: `agent-bom --agent-mode doctor | python3 -c "import json,sys;json.load(sys.stdin)"` succeeds (parametrized over all five in `tests/test_agent_mode_read_commands.py`).

## Verification
- Failing test first for each fix, then the change (red → green).
- Touched suites green: ast (`test_ast_cli_gate`, `test_ast_analyzer`, 67), malicious/remediation/exit-code (`test_audit_queue_fixes`, `test_two_tier_severity`, `test_malicious`, `test_dependency_confusion`, `test_policy_engine`, 104), agent-mode + doctor/capabilities/inventory (54), plus a `-k "scanner or mesh or where or agent_mode"` sweep (511). Final combined sweep of touched suites: 120 passed.
- `ruff check` clean and `mypy` clean on all changed source files.
- Real-process repro confirmed: all five commands pipe cleanly to `json.load`.
