### PR TITLE
Virtual, scoped, revocable model-provider key broker

### DIFF
--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 73 tools, 6 resources, 8 workflow prompts |
-| REST API | 329 operations across 38 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 337 operations across 39 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -58,4 +58,3 @@ attack paths, compliance tags, and runtime audit chain.
 ## Version
 
 `0.96.3` — regenerate metrics with `python scripts/product_metrics_snapshot.py --write` and this file with `python scripts/generate_agent_capability_manifest.py --write`.
-

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["329 REST operations across 38 route modules\nplus 2 WebSocket routes"]
+        R["337 REST operations across 39 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 280 |
-| `docs/openapi/v1.json` | component schemas | 72 |
+| `docs/openapi/v1.json` | paths | 286 |
+| `docs/openapi/v1.json` | component schemas | 76 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (280 paths / 329 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (286 paths / 337 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (329 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (337 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -20295,7 +20295,7 @@
     },
     "/v1/model-keys/authorize": {
       "post": {
-        "description": "Authorize a virtual key for a provider/model call \u2014 decision only, no secret.\n\nResolves the virtual key server-side (enforcing scope, revocation, expiry, and\ntenant), records usage, and returns an authorization decision. The real\nprovider key is unsealed only in-process to prove it is resolvable and is\n**never** included in the response.",
+        "description": "Authorize a virtual key for a provider/model call \u2014 decision only, no secret.\n\nResolves the virtual key server-side (enforcing scope, revocation, expiry, and\ntenant), records usage, and returns an authorization decision. The real\nprovider key is unsealed only in-process to prove it is resolvable and is\n**never** included in the response.\n\n``holder_id`` is a caller-asserted scope, not the authenticating principal:\nthis endpoint is called by the gateway/operator on behalf of the data-plane\nholder, so when a ``holder_id`` is asserted it is enforced against the key's\nbound holder (a mismatch fails closed); omitting it does not bypass the token,\ntenant, provider, or model scope. The calling principal is captured in the\naudit trail.",
         "operationId": "authorize_virtual_key_v1_model_keys_authorize_post",
         "parameters": [
           {
@@ -20471,7 +20471,7 @@
         ]
       },
       "post": {
-        "description": "Register (seal) a real provider key for the authenticated tenant.\n\nThe ``api_key`` is encrypted at rest and never echoed back. Fails closed with\n503 when no sealing key is configured, rather than storing plaintext.",
+        "description": "Register (seal) a real provider key for the authenticated tenant.\n\nWriting a real provider secret into the vault is a root-credential write and\nrequires the admin/``config`` tier. The ``api_key`` is encrypted at rest and\nnever echoed back. Fails closed with 503 when no sealing key is configured,\nrather than storing plaintext.",
         "operationId": "create_provider_key_v1_model_keys_providers_post",
         "parameters": [
           {
@@ -20565,7 +20565,7 @@
     },
     "/v1/model-keys/providers/{provider_key_id}": {
       "delete": {
-        "description": "Delete a provider key. Its virtual keys then fail resolution closed.",
+        "description": "Delete a provider key (admin/``config`` tier \u2014 a root-credential write).\n\nIts virtual keys then fail resolution closed.",
         "operationId": "delete_provider_key_v1_model_keys_providers__provider_key_id__delete",
         "parameters": [
           {

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2595,6 +2595,47 @@
         "title": "PromptScanRequest",
         "type": "object"
       },
+      "ProviderKeyCreate": {
+        "additionalProperties": false,
+        "description": "Register a real provider key. ``api_key`` is write-only.",
+        "properties": {
+          "api_key": {
+            "maxLength": 8192,
+            "minLength": 1,
+            "title": "Api Key",
+            "type": "string"
+          },
+          "display_name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Display Name",
+            "type": "string"
+          },
+          "owner": {
+            "default": "",
+            "maxLength": 200,
+            "title": "Owner",
+            "type": "string"
+          },
+          "owner_type": {
+            "default": "",
+            "maxLength": 60,
+            "title": "Owner Type",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "display_name",
+          "api_key"
+        ],
+        "title": "ProviderKeyCreate",
+        "type": "object"
+      },
       "ProxyAuditIngestRequest": {
         "additionalProperties": false,
         "properties": {
@@ -3720,6 +3761,103 @@
           "version"
         ],
         "title": "VersionInfo",
+        "type": "object"
+      },
+      "VirtualKeyAuthorize": {
+        "additionalProperties": false,
+        "description": "Authorize a virtual key for a specific provider/model call (decision only).",
+        "properties": {
+          "holder_id": {
+            "default": "",
+            "maxLength": 200,
+            "title": "Holder Id",
+            "type": "string"
+          },
+          "model": {
+            "maxLength": 128,
+            "minLength": 1,
+            "title": "Model",
+            "type": "string"
+          },
+          "provider": {
+            "maxLength": 64,
+            "minLength": 1,
+            "title": "Provider",
+            "type": "string"
+          },
+          "virtual_key": {
+            "maxLength": 4096,
+            "minLength": 1,
+            "title": "Virtual Key",
+            "type": "string"
+          }
+        },
+        "required": [
+          "virtual_key",
+          "provider",
+          "model"
+        ],
+        "title": "VirtualKeyAuthorize",
+        "type": "object"
+      },
+      "VirtualKeyMint": {
+        "additionalProperties": false,
+        "description": "Mint a scoped virtual key against a registered provider key.",
+        "properties": {
+          "allowed_models": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Allowed Models",
+            "type": "array"
+          },
+          "holder_id": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Holder Id",
+            "type": "string"
+          },
+          "holder_type": {
+            "default": "",
+            "maxLength": 60,
+            "title": "Holder Type",
+            "type": "string"
+          },
+          "owner": {
+            "default": "",
+            "maxLength": 200,
+            "title": "Owner",
+            "type": "string"
+          },
+          "owner_type": {
+            "default": "",
+            "maxLength": 60,
+            "title": "Owner Type",
+            "type": "string"
+          },
+          "ttl_seconds": {
+            "default": 3600,
+            "title": "Ttl Seconds",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "holder_id"
+        ],
+        "title": "VirtualKeyMint",
+        "type": "object"
+      },
+      "VirtualKeyRevoke": {
+        "additionalProperties": false,
+        "properties": {
+          "reason": {
+            "default": "",
+            "maxLength": 500,
+            "title": "Reason",
+            "type": "string"
+          }
+        },
+        "title": "VirtualKeyRevoke",
         "type": "object"
       },
       "_HitlDecisionBody": {
@@ -20152,6 +20290,767 @@
         "summary": "Mitre Coverage",
         "tags": [
           "mitre"
+        ]
+      }
+    },
+    "/v1/model-keys/authorize": {
+      "post": {
+        "description": "Authorize a virtual key for a provider/model call \u2014 decision only, no secret.\n\nResolves the virtual key server-side (enforcing scope, revocation, expiry, and\ntenant), records usage, and returns an authorization decision. The real\nprovider key is unsealed only in-process to prove it is resolvable and is\n**never** included in the response.",
+        "operationId": "authorize_virtual_key_v1_model_keys_authorize_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VirtualKeyAuthorize"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Authorize Virtual Key V1 Model Keys Authorize Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Authorize Virtual Key",
+        "tags": [
+          "model-keys"
+        ]
+      }
+    },
+    "/v1/model-keys/providers": {
+      "get": {
+        "description": "List the tenant's registered provider keys (non-secret metadata only).",
+        "operationId": "list_provider_keys_v1_model_keys_providers_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Provider Keys V1 Model Keys Providers Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Provider Keys",
+        "tags": [
+          "model-keys"
+        ]
+      },
+      "post": {
+        "description": "Register (seal) a real provider key for the authenticated tenant.\n\nThe ``api_key`` is encrypted at rest and never echoed back. Fails closed with\n503 when no sealing key is configured, rather than storing plaintext.",
+        "operationId": "create_provider_key_v1_model_keys_providers_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProviderKeyCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Provider Key V1 Model Keys Providers Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Provider Key",
+        "tags": [
+          "model-keys"
+        ]
+      }
+    },
+    "/v1/model-keys/providers/{provider_key_id}": {
+      "delete": {
+        "description": "Delete a provider key. Its virtual keys then fail resolution closed.",
+        "operationId": "delete_provider_key_v1_model_keys_providers__provider_key_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_key_id",
+            "required": true,
+            "schema": {
+              "title": "Provider Key Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Provider Key",
+        "tags": [
+          "model-keys"
+        ]
+      },
+      "get": {
+        "description": "Return one provider key's non-secret metadata (tenant-scoped).",
+        "operationId": "get_provider_key_v1_model_keys_providers__provider_key_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_key_id",
+            "required": true,
+            "schema": {
+              "title": "Provider Key Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Provider Key V1 Model Keys Providers  Provider Key Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Provider Key",
+        "tags": [
+          "model-keys"
+        ]
+      }
+    },
+    "/v1/model-keys/providers/{provider_key_id}/virtual-keys": {
+      "post": {
+        "description": "Mint a scoped, time-boxed virtual key. The raw token is returned once here.",
+        "operationId": "mint_virtual_key_route_v1_model_keys_providers__provider_key_id__virtual_keys_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "provider_key_id",
+            "required": true,
+            "schema": {
+              "title": "Provider Key Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VirtualKeyMint"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Mint Virtual Key Route V1 Model Keys Providers  Provider Key Id  Virtual Keys Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Mint Virtual Key Route",
+        "tags": [
+          "model-keys"
+        ]
+      }
+    },
+    "/v1/model-keys/virtual-keys": {
+      "get": {
+        "description": "List the tenant's virtual keys (never carries the token/hash).",
+        "operationId": "list_virtual_keys_v1_model_keys_virtual_keys_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "provider_key_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Provider Key Id"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_inactive",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Inactive",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Virtual Keys V1 Model Keys Virtual Keys Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Virtual Keys",
+        "tags": [
+          "model-keys"
+        ]
+      }
+    },
+    "/v1/model-keys/virtual-keys/{virtual_key_id}/revoke": {
+      "post": {
+        "description": "Immediately revoke a virtual key; further resolution fails closed.",
+        "operationId": "revoke_virtual_key_route_v1_model_keys_virtual_keys__virtual_key_id__revoke_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "virtual_key_id",
+            "required": true,
+            "schema": {
+              "title": "Virtual Key Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/VirtualKeyRevoke"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Revoke Virtual Key Route V1 Model Keys Virtual Keys  Virtual Key Id  Revoke Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Revoke Virtual Key Route",
+        "tags": [
+          "model-keys"
         ]
       }
     },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1751,6 +1751,39 @@ components:
           type: array
       title: PromptScanRequest
       type: object
+    ProviderKeyCreate:
+      additionalProperties: false
+      description: Register a real provider key. ``api_key`` is write-only.
+      properties:
+        api_key:
+          maxLength: 8192
+          minLength: 1
+          title: Api Key
+          type: string
+        display_name:
+          maxLength: 200
+          minLength: 1
+          title: Display Name
+          type: string
+        owner:
+          default: ''
+          maxLength: 200
+          title: Owner
+          type: string
+        owner_type:
+          default: ''
+          maxLength: 60
+          title: Owner Type
+          type: string
+        provider:
+          title: Provider
+          type: string
+      required:
+      - provider
+      - display_name
+      - api_key
+      title: ProviderKeyCreate
+      type: object
     ProxyAuditIngestRequest:
       additionalProperties: false
       properties:
@@ -2467,6 +2500,84 @@ components:
       required:
       - version
       title: VersionInfo
+      type: object
+    VirtualKeyAuthorize:
+      additionalProperties: false
+      description: Authorize a virtual key for a specific provider/model call (decision
+        only).
+      properties:
+        holder_id:
+          default: ''
+          maxLength: 200
+          title: Holder Id
+          type: string
+        model:
+          maxLength: 128
+          minLength: 1
+          title: Model
+          type: string
+        provider:
+          maxLength: 64
+          minLength: 1
+          title: Provider
+          type: string
+        virtual_key:
+          maxLength: 4096
+          minLength: 1
+          title: Virtual Key
+          type: string
+      required:
+      - virtual_key
+      - provider
+      - model
+      title: VirtualKeyAuthorize
+      type: object
+    VirtualKeyMint:
+      additionalProperties: false
+      description: Mint a scoped virtual key against a registered provider key.
+      properties:
+        allowed_models:
+          items:
+            type: string
+          title: Allowed Models
+          type: array
+        holder_id:
+          maxLength: 200
+          minLength: 1
+          title: Holder Id
+          type: string
+        holder_type:
+          default: ''
+          maxLength: 60
+          title: Holder Type
+          type: string
+        owner:
+          default: ''
+          maxLength: 200
+          title: Owner
+          type: string
+        owner_type:
+          default: ''
+          maxLength: 60
+          title: Owner Type
+          type: string
+        ttl_seconds:
+          default: 3600
+          title: Ttl Seconds
+          type: integer
+      required:
+      - holder_id
+      title: VirtualKeyMint
+      type: object
+    VirtualKeyRevoke:
+      additionalProperties: false
+      properties:
+        reason:
+          default: ''
+          maxLength: 500
+          title: Reason
+          type: string
+      title: VirtualKeyRevoke
       type: object
     _HitlDecisionBody:
       additionalProperties: false
@@ -13103,6 +13214,451 @@ paths:
       summary: Mitre Coverage
       tags:
       - mitre
+  /v1/model-keys/authorize:
+    post:
+      description: "Authorize a virtual key for a provider/model call \u2014 decision\
+        \ only, no secret.\n\nResolves the virtual key server-side (enforcing scope,\
+        \ revocation, expiry, and\ntenant), records usage, and returns an authorization\
+        \ decision. The real\nprovider key is unsealed only in-process to prove it\
+        \ is resolvable and is\n**never** included in the response."
+      operationId: authorize_virtual_key_v1_model_keys_authorize_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VirtualKeyAuthorize'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Authorize Virtual Key V1 Model Keys Authorize Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Authorize Virtual Key
+      tags:
+      - model-keys
+  /v1/model-keys/providers:
+    get:
+      description: List the tenant's registered provider keys (non-secret metadata
+        only).
+      operationId: list_provider_keys_v1_model_keys_providers_get
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Provider Keys V1 Model Keys Providers Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List Provider Keys
+      tags:
+      - model-keys
+    post:
+      description: 'Register (seal) a real provider key for the authenticated tenant.
+
+
+        The ``api_key`` is encrypted at rest and never echoed back. Fails closed with
+
+        503 when no sealing key is configured, rather than storing plaintext.'
+      operationId: create_provider_key_v1_model_keys_providers_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ProviderKeyCreate'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Create Provider Key V1 Model Keys Providers Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Create Provider Key
+      tags:
+      - model-keys
+  /v1/model-keys/providers/{provider_key_id}:
+    delete:
+      description: Delete a provider key. Its virtual keys then fail resolution closed.
+      operationId: delete_provider_key_v1_model_keys_providers__provider_key_id__delete
+      parameters:
+      - in: path
+        name: provider_key_id
+        required: true
+        schema:
+          title: Provider Key Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Delete Provider Key
+      tags:
+      - model-keys
+    get:
+      description: Return one provider key's non-secret metadata (tenant-scoped).
+      operationId: get_provider_key_v1_model_keys_providers__provider_key_id__get
+      parameters:
+      - in: path
+        name: provider_key_id
+        required: true
+        schema:
+          title: Provider Key Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Provider Key V1 Model Keys Providers  Provider
+                  Key Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Provider Key
+      tags:
+      - model-keys
+  /v1/model-keys/providers/{provider_key_id}/virtual-keys:
+    post:
+      description: Mint a scoped, time-boxed virtual key. The raw token is returned
+        once here.
+      operationId: mint_virtual_key_route_v1_model_keys_providers__provider_key_id__virtual_keys_post
+      parameters:
+      - in: path
+        name: provider_key_id
+        required: true
+        schema:
+          title: Provider Key Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VirtualKeyMint'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Mint Virtual Key Route V1 Model Keys Providers  Provider
+                  Key Id  Virtual Keys Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Mint Virtual Key Route
+      tags:
+      - model-keys
+  /v1/model-keys/virtual-keys:
+    get:
+      description: List the tenant's virtual keys (never carries the token/hash).
+      operationId: list_virtual_keys_v1_model_keys_virtual_keys_get
+      parameters:
+      - in: query
+        name: provider_key_id
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Provider Key Id
+      - in: query
+        name: include_inactive
+        required: false
+        schema:
+          default: false
+          title: Include Inactive
+          type: boolean
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Virtual Keys V1 Model Keys Virtual Keys Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List Virtual Keys
+      tags:
+      - model-keys
+  /v1/model-keys/virtual-keys/{virtual_key_id}/revoke:
+    post:
+      description: Immediately revoke a virtual key; further resolution fails closed.
+      operationId: revoke_virtual_key_route_v1_model_keys_virtual_keys__virtual_key_id__revoke_post
+      parameters:
+      - in: path
+        name: virtual_key_id
+        required: true
+        schema:
+          title: Virtual Key Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VirtualKeyRevoke'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Revoke Virtual Key Route V1 Model Keys Virtual Keys  Virtual
+                  Key Id  Revoke Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Revoke Virtual Key Route
+      tags:
+      - model-keys
   /v1/observability/anomalies:
     get:
       description: 'Detect cost and behavior anomalies (per-agent spend + per-session

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -13220,7 +13220,13 @@ paths:
         \ only, no secret.\n\nResolves the virtual key server-side (enforcing scope,\
         \ revocation, expiry, and\ntenant), records usage, and returns an authorization\
         \ decision. The real\nprovider key is unsealed only in-process to prove it\
-        \ is resolvable and is\n**never** included in the response."
+        \ is resolvable and is\n**never** included in the response.\n\n``holder_id``\
+        \ is a caller-asserted scope, not the authenticating principal:\nthis endpoint\
+        \ is called by the gateway/operator on behalf of the data-plane\nholder, so\
+        \ when a ``holder_id`` is asserted it is enforced against the key's\nbound\
+        \ holder (a mismatch fails closed); omitting it does not bypass the token,\n\
+        tenant, provider, or model scope. The calling principal is captured in the\n\
+        audit trail."
       operationId: authorize_virtual_key_v1_model_keys_authorize_post
       parameters:
       - in: header
@@ -13323,9 +13329,13 @@ paths:
       description: 'Register (seal) a real provider key for the authenticated tenant.
 
 
-        The ``api_key`` is encrypted at rest and never echoed back. Fails closed with
+        Writing a real provider secret into the vault is a root-credential write and
 
-        503 when no sealing key is configured, rather than storing plaintext.'
+        requires the admin/``config`` tier. The ``api_key`` is encrypted at rest and
+
+        never echoed back. Fails closed with 503 when no sealing key is configured,
+
+        rather than storing plaintext.'
       operationId: create_provider_key_v1_model_keys_providers_post
       parameters:
       - in: header
@@ -13378,7 +13388,8 @@ paths:
       - model-keys
   /v1/model-keys/providers/{provider_key_id}:
     delete:
-      description: Delete a provider key. Its virtual keys then fail resolution closed.
+      description: "Delete a provider key (admin/``config`` tier \u2014 a root-credential\
+        \ write).\n\nIts virtual keys then fail resolution closed."
       operationId: delete_provider_key_v1_model_keys_providers__provider_key_id__delete
       parameters:
       - in: path

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -886,6 +886,17 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         ("POST", "/v1/sources/", "analyst"),
         ("POST", "/v1/baseline/compare", "analyst"),
         ("POST", "/v1/graph/presets", "analyst"),
+        # Model-key broker: registering / deleting a REAL provider credential is a
+        # root-credential write (admin, via the unmatched-mutating fallback below).
+        # Minting a scoped short-lived virtual key, authorizing it, and revoking it
+        # are operational and stay analyst — otherwise the admin fallback would
+        # silently over-gate the documented scan-tier surface. These prefixes match
+        # only the sub-paths (mint = providers/{id}/virtual-keys, revoke =
+        # virtual-keys/{id}/revoke); the exact register path /v1/model-keys/providers
+        # has no trailing slash and correctly falls through to the admin fallback.
+        ("POST", "/v1/model-keys/providers/", "analyst"),
+        ("POST", "/v1/model-keys/virtual-keys/", "analyst"),
+        ("POST", "/v1/model-keys/authorize", "analyst"),
         ("DELETE", "/v1/schedules/", "analyst"),
         ("DELETE", "/v1/graph/presets/", "analyst"),
         ("PUT", "/v1/schedules/", "analyst"),

--- a/src/agent_bom/api/model_key_broker.py
+++ b/src/agent_bom/api/model_key_broker.py
@@ -1,0 +1,710 @@
+"""Virtual, scoped, revocable model-provider key broker (#3907).
+
+Today the control plane brokers only cloud/MCP-server connection secrets. This
+module is the model-key analogue: an operator registers a *real* model-provider
+credential (OpenAI, Anthropic, Azure OpenAI, Bedrock, …) **once**, and agent-bom
+mints **virtual keys** that
+
+- map to the real key without ever exposing it,
+- are SCOPED (per holder identity/blueprint, provider, optional model allowlist),
+- are time-boxed (expiry) and REVOCABLE independently, and
+- attribute usage back to the holder.
+
+Security model — reuses the existing secret broker, does not reinvent it:
+
+- The real provider key is sealed at rest with the **same** Fernet sealing the
+  cloud-connection broker uses (:mod:`agent_bom.api.connection_crypto`), i.e. the
+  ``~/.agent-bom/connections.key`` / ``AGENT_BOM_CONNECTIONS_KEY`` material and its
+  pluggable managed-key providers. The plaintext key is write-only: it is never
+  logged, never returned in any API response, and only decrypted server-side at
+  resolve time immediately before the model call.
+- A virtual key is a bearer token ``abvk_<public>_<secret>`` — only its SHA-256
+  hash is persisted (mirroring the agent-identity store); the raw token is
+  returned exactly once at mint time.
+- Every operation is tenant-scoped (``WHERE tenant_id = …`` in every backend) and
+  resolution fails closed: an unknown / revoked / expired virtual key, an
+  out-of-scope provider / model / holder, or a missing / disabled underlying
+  provider key all raise :class:`ModelKeyBrokerError` with a stable ``reason`` and
+  never surface secret material.
+
+Backend parity mirrors the agent-identity store: in-memory for tests, SQLite as
+the durable single-node default, and Postgres (tenant RLS) for multi-replica
+deployments — selected by the shared durable-store backend resolver. Both records
+are persisted as a JSON ``data`` blob keyed by id + tenant so a new backend is a
+registration, not a fork.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import secrets
+import sqlite3
+import threading
+from dataclasses import asdict, dataclass, field, replace
+from datetime import datetime, timedelta, timezone
+from typing import Any, Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+# Model providers a real key can target. The broker is provider-agnostic at the
+# storage layer; this tuple is the allowlist the API/CLI validate against so a
+# typo does not silently register an unusable key.
+SUPPORTED_MODEL_PROVIDERS: tuple[str, ...] = (
+    "openai",
+    "anthropic",
+    "azure-openai",
+    "bedrock",
+    "google-vertex",
+    "mistral",
+    "cohere",
+)
+
+VK_TOKEN_PREFIX = "abvk"
+
+# Default virtual-key lifetime: short-lived by design (re-mint rather than issue a
+# long-lived key). Callers may override; the floor keeps a typo from minting an
+# effectively-expired key.
+DEFAULT_VK_TTL_SECONDS = 3600
+MIN_VK_TTL_SECONDS = 60
+# Cap the lifetime so a virtual key stays genuinely short-lived (30 days max).
+MAX_VK_TTL_SECONDS = 30 * 86400
+
+STATUS_ACTIVE = "active"
+STATUS_DISABLED = "disabled"
+STATUS_REVOKED = "revoked"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat()
+
+
+def hash_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def generate_virtual_key_token() -> tuple[str, str, str]:
+    """Return ``(raw_token, public_prefix, token_hash)``; the raw token is shown once."""
+    public = secrets.token_hex(4)
+    secret = secrets.token_urlsafe(32)
+    raw = f"{VK_TOKEN_PREFIX}_{public}_{secret}"
+    return raw, public, hash_token(raw)
+
+
+class ModelKeyBrokerError(RuntimeError):
+    """Raised for a registration or resolution failure.
+
+    ``reason`` is a stable, secret-free code the API maps to a status code. The
+    message never embeds the real provider key or the raw virtual token.
+    """
+
+    def __init__(self, message: str, *, reason: str) -> None:
+        super().__init__(message)
+        self.reason = reason
+
+
+@dataclass
+class ModelProviderKey:
+    """A registered real model-provider credential, sealed at rest.
+
+    ``secret_encrypted`` holds the Fernet ciphertext of the real API key — never
+    the plaintext. :meth:`to_public_dict` is the only shape that leaves the process
+    and it omits that column entirely.
+    """
+
+    provider_key_id: str
+    tenant_id: str
+    provider: str
+    display_name: str
+    secret_encrypted: str
+    status: str = STATUS_ACTIVE
+    created_at: str = ""
+    updated_at: str = ""
+    owner: str = ""
+    owner_type: str = ""
+
+    def to_public_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.pop("secret_encrypted", None)
+        data["has_secret"] = bool(self.secret_encrypted)
+        return data
+
+
+@dataclass
+class VirtualModelKey:
+    """A minted, scoped, revocable virtual key mapping to a real provider key.
+
+    Only ``token_hash`` is persisted; the raw ``abvk_`` token is returned once at
+    mint time. Scope is ``{provider, allowed_models, holder_id/holder_type}`` plus
+    an expiry; :meth:`to_public_dict` omits the hash.
+    """
+
+    virtual_key_id: str
+    tenant_id: str
+    provider_key_id: str
+    provider: str
+    token_hash: str
+    token_prefix: str
+    holder_id: str
+    status: str = STATUS_ACTIVE
+    holder_type: str = ""
+    issued_at: str = ""
+    expires_at: str = ""
+    allowed_models: list[str] = field(default_factory=list)
+    revoked_at: str = ""
+    revoked_reason: str = ""
+    last_used_at: str = ""
+    use_count: int = 0
+    owner: str = ""
+    owner_type: str = ""
+
+    def model_allowed(self, model: str) -> bool:
+        """True when this key may be used for ``model`` (empty allowlist = any)."""
+        if not self.allowed_models:
+            return True
+        target = (model or "").strip()
+        return "*" in self.allowed_models or target in self.allowed_models
+
+    def is_live(self, *, at: datetime | None = None) -> bool:
+        """True when the key may still resolve (active and not past expiry)."""
+        if self.status != STATUS_ACTIVE:
+            return False
+        now = at or _now()
+        if not self.expires_at:
+            return False
+        try:
+            return now <= datetime.fromisoformat(self.expires_at)
+        except ValueError:
+            return False
+
+    def to_public_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.pop("token_hash", None)
+        return data
+
+
+@dataclass
+class ResolvedModelKey:
+    """The server-side result of resolving a virtual key to its real credential.
+
+    ``api_key`` is the plaintext real provider key. This object is only ever
+    constructed inside the process for the model-call path; it is never
+    serialized into an API response or a log line.
+    """
+
+    virtual_key_id: str
+    tenant_id: str
+    provider: str
+    model: str
+    provider_key_id: str
+    holder_id: str
+    api_key: str
+
+
+# ── Store contract + backends ─────────────────────────────────────────────────
+
+
+class ModelKeyBrokerStore(Protocol):
+    """Tenant-scoped persistence for provider keys and virtual keys."""
+
+    def init_schema(self) -> None: ...
+    def put_provider_key(self, record: ModelProviderKey) -> None: ...
+    def get_provider_key(self, provider_key_id: str, *, tenant_id: str) -> ModelProviderKey | None: ...
+    def list_provider_keys(self, tenant_id: str) -> list[ModelProviderKey]: ...
+    def delete_provider_key(self, provider_key_id: str, *, tenant_id: str) -> bool: ...
+    def put_virtual_key(self, record: VirtualModelKey) -> None: ...
+    def get_virtual_key(self, virtual_key_id: str, *, tenant_id: str) -> VirtualModelKey | None: ...
+    def get_virtual_key_by_hash(self, token_hash: str, *, tenant_id: str) -> VirtualModelKey | None: ...
+    def list_virtual_keys(
+        self,
+        tenant_id: str,
+        *,
+        provider_key_id: str | None = None,
+        include_inactive: bool = False,
+    ) -> list[VirtualModelKey]: ...
+
+
+def _copy_provider_key(record: ModelProviderKey) -> ModelProviderKey:
+    return replace(record)
+
+
+def _copy_virtual_key(record: VirtualModelKey) -> VirtualModelKey:
+    return replace(record, allowed_models=list(record.allowed_models))
+
+
+class InMemoryModelKeyBrokerStore:
+    """Dict-backed broker store for tests and ephemeral runs."""
+
+    def __init__(self) -> None:
+        self._provider_keys: dict[str, ModelProviderKey] = {}
+        self._virtual_keys: dict[str, VirtualModelKey] = {}
+        self._vk_by_hash: dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def init_schema(self) -> None:
+        """No-op: the in-memory backend has no persistent schema."""
+
+    def put_provider_key(self, record: ModelProviderKey) -> None:
+        with self._lock:
+            self._provider_keys[record.provider_key_id] = _copy_provider_key(record)
+
+    def get_provider_key(self, provider_key_id: str, *, tenant_id: str) -> ModelProviderKey | None:
+        with self._lock:
+            record = self._provider_keys.get(provider_key_id)
+            if record is None or record.tenant_id != tenant_id:
+                return None
+            return _copy_provider_key(record)
+
+    def list_provider_keys(self, tenant_id: str) -> list[ModelProviderKey]:
+        with self._lock:
+            rows = [_copy_provider_key(r) for r in self._provider_keys.values() if r.tenant_id == tenant_id]
+        return sorted(rows, key=lambda r: (r.created_at, r.provider_key_id))
+
+    def delete_provider_key(self, provider_key_id: str, *, tenant_id: str) -> bool:
+        with self._lock:
+            record = self._provider_keys.get(provider_key_id)
+            if record is None or record.tenant_id != tenant_id:
+                return False
+            del self._provider_keys[provider_key_id]
+            return True
+
+    def put_virtual_key(self, record: VirtualModelKey) -> None:
+        with self._lock:
+            self._virtual_keys[record.virtual_key_id] = _copy_virtual_key(record)
+            self._vk_by_hash[record.token_hash] = record.virtual_key_id
+
+    def get_virtual_key(self, virtual_key_id: str, *, tenant_id: str) -> VirtualModelKey | None:
+        with self._lock:
+            record = self._virtual_keys.get(virtual_key_id)
+            if record is None or record.tenant_id != tenant_id:
+                return None
+            return _copy_virtual_key(record)
+
+    def get_virtual_key_by_hash(self, token_hash: str, *, tenant_id: str) -> VirtualModelKey | None:
+        with self._lock:
+            vk_id = self._vk_by_hash.get(token_hash)
+            record = self._virtual_keys.get(vk_id) if vk_id else None
+            if record is None or record.tenant_id != tenant_id:
+                return None
+            return _copy_virtual_key(record)
+
+    def list_virtual_keys(
+        self,
+        tenant_id: str,
+        *,
+        provider_key_id: str | None = None,
+        include_inactive: bool = False,
+    ) -> list[VirtualModelKey]:
+        with self._lock:
+            rows = [_copy_virtual_key(r) for r in self._virtual_keys.values() if r.tenant_id == tenant_id]
+        if provider_key_id is not None:
+            rows = [r for r in rows if r.provider_key_id == provider_key_id]
+        if not include_inactive:
+            rows = [r for r in rows if r.status == STATUS_ACTIVE]
+        return sorted(rows, key=lambda r: (r.issued_at, r.virtual_key_id), reverse=True)
+
+
+class SQLiteModelKeyBrokerStore:
+    """SQLite-backed broker store (durable single-node default).
+
+    Both records are persisted as a JSON ``data`` blob keyed by id + tenant,
+    matching the agent-identity store shape so tenant-scoped reads ride an index.
+    """
+
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def init_schema(self) -> None:
+        self._init_db()
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "model_provider_keys")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS model_provider_keys (
+                provider_key_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                status TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                data TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_model_provider_keys_tenant ON model_provider_keys(tenant_id, created_at)")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS model_virtual_keys (
+                virtual_key_id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                provider_key_id TEXT NOT NULL,
+                token_hash TEXT NOT NULL UNIQUE,
+                status TEXT NOT NULL,
+                issued_at TEXT NOT NULL,
+                data TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_model_virtual_keys_tenant ON model_virtual_keys(tenant_id, issued_at)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_model_virtual_keys_hash ON model_virtual_keys(token_hash)")
+        self._conn.commit()
+
+    def put_provider_key(self, record: ModelProviderKey) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO model_provider_keys "
+            "(provider_key_id, tenant_id, provider, status, created_at, data) VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                record.provider_key_id,
+                record.tenant_id,
+                record.provider,
+                record.status,
+                record.created_at,
+                json.dumps(asdict(record), sort_keys=True),
+            ),
+        )
+        self._conn.commit()
+
+    def get_provider_key(self, provider_key_id: str, *, tenant_id: str) -> ModelProviderKey | None:
+        row = self._conn.execute(
+            "SELECT data FROM model_provider_keys WHERE provider_key_id = ? AND tenant_id = ?",
+            (provider_key_id, tenant_id),
+        ).fetchone()
+        return ModelProviderKey(**json.loads(row[0])) if row else None
+
+    def list_provider_keys(self, tenant_id: str) -> list[ModelProviderKey]:
+        rows = self._conn.execute(
+            "SELECT data FROM model_provider_keys WHERE tenant_id = ? ORDER BY created_at, provider_key_id",
+            (tenant_id,),
+        ).fetchall()
+        return [ModelProviderKey(**json.loads(r[0])) for r in rows]
+
+    def delete_provider_key(self, provider_key_id: str, *, tenant_id: str) -> bool:
+        cursor = self._conn.execute(
+            "DELETE FROM model_provider_keys WHERE provider_key_id = ? AND tenant_id = ?",
+            (provider_key_id, tenant_id),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def put_virtual_key(self, record: VirtualModelKey) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO model_virtual_keys "
+            "(virtual_key_id, tenant_id, provider_key_id, token_hash, status, issued_at, data) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (
+                record.virtual_key_id,
+                record.tenant_id,
+                record.provider_key_id,
+                record.token_hash,
+                record.status,
+                record.issued_at,
+                json.dumps(asdict(record), sort_keys=True),
+            ),
+        )
+        self._conn.commit()
+
+    def get_virtual_key(self, virtual_key_id: str, *, tenant_id: str) -> VirtualModelKey | None:
+        row = self._conn.execute(
+            "SELECT data FROM model_virtual_keys WHERE virtual_key_id = ? AND tenant_id = ?",
+            (virtual_key_id, tenant_id),
+        ).fetchone()
+        return VirtualModelKey(**json.loads(row[0])) if row else None
+
+    def get_virtual_key_by_hash(self, token_hash: str, *, tenant_id: str) -> VirtualModelKey | None:
+        row = self._conn.execute(
+            "SELECT data FROM model_virtual_keys WHERE token_hash = ? AND tenant_id = ?",
+            (token_hash, tenant_id),
+        ).fetchone()
+        return VirtualModelKey(**json.loads(row[0])) if row else None
+
+    def list_virtual_keys(
+        self,
+        tenant_id: str,
+        *,
+        provider_key_id: str | None = None,
+        include_inactive: bool = False,
+    ) -> list[VirtualModelKey]:
+        rows = self._conn.execute(
+            "SELECT data FROM model_virtual_keys WHERE tenant_id = ? ORDER BY issued_at DESC, virtual_key_id DESC",
+            (tenant_id,),
+        ).fetchall()
+        records = [VirtualModelKey(**json.loads(r[0])) for r in rows]
+        if provider_key_id is not None:
+            records = [r for r in records if r.provider_key_id == provider_key_id]
+        if not include_inactive:
+            records = [r for r in records if r.status == STATUS_ACTIVE]
+        return records
+
+
+# ── Lifecycle operations ──────────────────────────────────────────────────────
+
+
+def register_provider_key(
+    store: ModelKeyBrokerStore,
+    *,
+    tenant_id: str,
+    provider: str,
+    display_name: str,
+    api_key: str,
+    owner: str = "",
+    owner_type: str = "",
+) -> ModelProviderKey:
+    """Register (seal) a real provider key for ``tenant_id``.
+
+    The plaintext ``api_key`` is encrypted with the shared connection-secret
+    sealing and is never returned. Fails closed (``ModelKeyBrokerError``) when the
+    provider is unknown, the key is empty, or no sealing key is configured.
+    """
+    from agent_bom.api.connection_crypto import (
+        ConnectionSecretError,
+        connections_key_configured,
+        encrypt_secret,
+    )
+
+    normalized = (provider or "").strip().lower()
+    if normalized not in SUPPORTED_MODEL_PROVIDERS:
+        raise ModelKeyBrokerError(
+            f"Unsupported model provider '{provider}'. Use one of: {', '.join(SUPPORTED_MODEL_PROVIDERS)}.",
+            reason="unsupported_provider",
+        )
+    if not (api_key or "").strip():
+        raise ModelKeyBrokerError("Refusing to register an empty provider key.", reason="empty_key")
+    if not connections_key_configured():
+        raise ModelKeyBrokerError(
+            "Model-key sealing is not configured (AGENT_BOM_CONNECTIONS_KEY unset); refusing to store a provider key.",
+            reason="sealing_unconfigured",
+        )
+    try:
+        secret_encrypted = encrypt_secret(api_key.strip())
+    except ConnectionSecretError as exc:
+        # Never echo the key or sealing detail — only the failure mode.
+        raise ModelKeyBrokerError("Unable to seal the provider key at rest.", reason="sealing_failed") from exc
+
+    now = _iso(_now())
+    record = ModelProviderKey(
+        provider_key_id=f"mpk_{secrets.token_hex(8)}",
+        tenant_id=tenant_id,
+        provider=normalized,
+        display_name=(display_name or "").strip()[:200],
+        secret_encrypted=secret_encrypted,
+        status=STATUS_ACTIVE,
+        created_at=now,
+        updated_at=now,
+        owner=(owner or "").strip()[:200],
+        owner_type=(owner_type or "").strip()[:60],
+    )
+    store.put_provider_key(record)
+    return record
+
+
+def _clamp_ttl(ttl_seconds: int) -> int:
+    return max(MIN_VK_TTL_SECONDS, min(int(ttl_seconds), MAX_VK_TTL_SECONDS))
+
+
+def mint_virtual_key(
+    store: ModelKeyBrokerStore,
+    *,
+    tenant_id: str,
+    provider_key_id: str,
+    holder_id: str,
+    holder_type: str = "",
+    allowed_models: list[str] | None = None,
+    ttl_seconds: int = DEFAULT_VK_TTL_SECONDS,
+    owner: str = "",
+    owner_type: str = "",
+) -> tuple[VirtualModelKey, str]:
+    """Mint a scoped virtual key bound to a registered provider key.
+
+    Returns ``(virtual_key, raw_token)``; the raw token is available only here.
+    The virtual key inherits the provider from the underlying provider key and is
+    scoped to ``holder_id`` plus an optional ``allowed_models`` allowlist, expiring
+    after ``ttl_seconds`` (clamped short-lived). Fails closed when the provider key
+    does not exist for the tenant or is disabled.
+    """
+    provider_key = store.get_provider_key(provider_key_id, tenant_id=tenant_id)
+    if provider_key is None:
+        raise ModelKeyBrokerError(f"Provider key {provider_key_id} not found for this tenant.", reason="provider_key_missing")
+    if provider_key.status != STATUS_ACTIVE:
+        raise ModelKeyBrokerError("Provider key is disabled; cannot mint a virtual key.", reason="provider_key_disabled")
+    if not (holder_id or "").strip():
+        raise ModelKeyBrokerError("A virtual key must be bound to a holder identity.", reason="missing_holder")
+
+    raw, prefix, token_hash = generate_virtual_key_token()
+    now = _now()
+    models = [m.strip() for m in (allowed_models or []) if m and m.strip()]
+    record = VirtualModelKey(
+        virtual_key_id=f"vmk_{secrets.token_hex(8)}",
+        tenant_id=tenant_id,
+        provider_key_id=provider_key_id,
+        provider=provider_key.provider,
+        token_hash=token_hash,
+        token_prefix=prefix,
+        holder_id=holder_id.strip()[:200],
+        holder_type=(holder_type or "").strip()[:60],
+        status=STATUS_ACTIVE,
+        issued_at=_iso(now),
+        expires_at=_iso(now + timedelta(seconds=_clamp_ttl(ttl_seconds))),
+        allowed_models=models,
+        owner=(owner or "").strip()[:200],
+        owner_type=(owner_type or "").strip()[:60],
+    )
+    store.put_virtual_key(record)
+    return record, raw
+
+
+def record_virtual_key_usage(store: ModelKeyBrokerStore, record: VirtualModelKey, *, at: datetime | None = None) -> None:
+    """Attribute one use to the virtual key (increment counter + stamp last-used)."""
+    record.use_count = int(record.use_count) + 1
+    record.last_used_at = _iso(at or _now())
+    store.put_virtual_key(record)
+
+
+def resolve_virtual_key(
+    store: ModelKeyBrokerStore,
+    *,
+    tenant_id: str,
+    raw_token: str,
+    provider: str,
+    model: str,
+    holder_id: str | None = None,
+    at: datetime | None = None,
+    record_usage: bool = True,
+) -> ResolvedModelKey:
+    """Resolve a raw virtual key to its real provider credential, server-side.
+
+    Enforces scope and fails closed. ``reason`` on the raised error is one of:
+    ``not_found`` (unknown token / wrong tenant), ``revoked``, ``expired``,
+    ``provider_mismatch``, ``model_not_allowed``, ``holder_mismatch``,
+    ``provider_key_missing``, ``provider_key_disabled``, ``sealing_failed``.
+
+    The returned :class:`ResolvedModelKey` carries the plaintext key for the
+    in-process model-call path only; callers must never serialize it.
+    """
+    from agent_bom.api.connection_crypto import ConnectionSecretError, decrypt_secret
+
+    now = at or _now()
+    vk = store.get_virtual_key_by_hash(hash_token(raw_token), tenant_id=tenant_id)
+    if vk is None:
+        raise ModelKeyBrokerError("Unknown virtual key.", reason="not_found")
+    if vk.status == STATUS_REVOKED:
+        raise ModelKeyBrokerError("Virtual key has been revoked.", reason="revoked")
+    if not vk.is_live(at=now):
+        raise ModelKeyBrokerError("Virtual key has expired.", reason="expired")
+
+    requested_provider = (provider or "").strip().lower()
+    if requested_provider != vk.provider:
+        raise ModelKeyBrokerError("Virtual key is not scoped for this provider.", reason="provider_mismatch")
+    if not vk.model_allowed(model):
+        raise ModelKeyBrokerError("Virtual key is not scoped for this model.", reason="model_not_allowed")
+    if holder_id is not None and holder_id.strip() and holder_id.strip() != vk.holder_id:
+        raise ModelKeyBrokerError("Virtual key is not scoped for this holder.", reason="holder_mismatch")
+
+    provider_key = store.get_provider_key(vk.provider_key_id, tenant_id=tenant_id)
+    if provider_key is None:
+        raise ModelKeyBrokerError("Underlying provider key no longer exists.", reason="provider_key_missing")
+    if provider_key.status != STATUS_ACTIVE:
+        raise ModelKeyBrokerError("Underlying provider key is disabled.", reason="provider_key_disabled")
+
+    try:
+        api_key = decrypt_secret(provider_key.secret_encrypted)
+    except ConnectionSecretError as exc:
+        # Never echo the ciphertext or sealing detail — only the failure mode.
+        raise ModelKeyBrokerError("Unable to unseal the provider key.", reason="sealing_failed") from exc
+
+    if record_usage:
+        record_virtual_key_usage(store, vk, at=now)
+
+    return ResolvedModelKey(
+        virtual_key_id=vk.virtual_key_id,
+        tenant_id=tenant_id,
+        provider=vk.provider,
+        model=(model or "").strip(),
+        provider_key_id=vk.provider_key_id,
+        holder_id=vk.holder_id,
+        api_key=api_key,
+    )
+
+
+def revoke_virtual_key(
+    store: ModelKeyBrokerStore,
+    virtual_key_id: str,
+    *,
+    tenant_id: str,
+    reason: str = "",
+) -> VirtualModelKey | None:
+    """Immediately revoke a virtual key; further resolution fails closed."""
+    vk = store.get_virtual_key(virtual_key_id, tenant_id=tenant_id)
+    if vk is None:
+        return None
+    vk.status = STATUS_REVOKED
+    vk.revoked_at = _iso(_now())
+    vk.revoked_reason = (reason or "").strip()[:500]
+    store.put_virtual_key(vk)
+    return vk
+
+
+def set_provider_key_status(
+    store: ModelKeyBrokerStore,
+    provider_key_id: str,
+    *,
+    tenant_id: str,
+    status: str,
+) -> ModelProviderKey | None:
+    """Enable (``active``) or disable (``disabled``) a registered provider key."""
+    if status not in (STATUS_ACTIVE, STATUS_DISABLED):
+        raise ModelKeyBrokerError("status must be 'active' or 'disabled'.", reason="invalid_status")
+    record = store.get_provider_key(provider_key_id, tenant_id=tenant_id)
+    if record is None:
+        return None
+    record.status = status
+    record.updated_at = _iso(_now())
+    store.put_provider_key(record)
+    return record
+
+
+# ── Backend selection ─────────────────────────────────────────────────────────
+
+_MODEL_KEY_BROKER_STORE: ModelKeyBrokerStore | None = None
+
+
+def get_model_key_broker_store() -> ModelKeyBrokerStore:
+    """Return the process broker store, durable by default (mirrors the identity store).
+
+    Postgres when configured (multi-replica, tenant RLS), in-memory only on an
+    explicit ``AGENT_BOM_EPHEMERAL_STORE`` opt-out, otherwise durable SQLite.
+    """
+    global _MODEL_KEY_BROKER_STORE
+    if _MODEL_KEY_BROKER_STORE is not None:
+        return _MODEL_KEY_BROKER_STORE
+    from agent_bom.api.durable_store import select_backend, sqlite_path
+
+    backend = select_backend()
+    if backend == "postgres":
+        from agent_bom.api.postgres_model_key_broker import PostgresModelKeyBrokerStore
+
+        _MODEL_KEY_BROKER_STORE = PostgresModelKeyBrokerStore()
+    elif backend == "memory":
+        _MODEL_KEY_BROKER_STORE = InMemoryModelKeyBrokerStore()
+    else:
+        _MODEL_KEY_BROKER_STORE = SQLiteModelKeyBrokerStore(sqlite_path())
+    return _MODEL_KEY_BROKER_STORE
+
+
+def set_model_key_broker_store(store: ModelKeyBrokerStore | None) -> None:
+    """Swap the process broker store (tests / explicit backend wiring)."""
+    global _MODEL_KEY_BROKER_STORE
+    _MODEL_KEY_BROKER_STORE = store

--- a/src/agent_bom/api/model_key_broker.py
+++ b/src/agent_bom/api/model_key_broker.py
@@ -6,7 +6,11 @@ credential (OpenAI, Anthropic, Azure OpenAI, Bedrock, …) **once**, and agent-b
 mints **virtual keys** that
 
 - map to the real key without ever exposing it,
-- are SCOPED (per holder identity/blueprint, provider, optional model allowlist),
+- are SCOPED to a provider and an optional model allowlist, plus a bound holder
+  identity/blueprint that is enforced at resolve time **when the caller asserts
+  it** (holder is caller-asserted defense-in-depth over the bearer token, not the
+  transport principal — the authorizing caller is the gateway acting for many
+  holders),
 - are time-boxed (expiry) and REVOCABLE independently, and
 - attribute usage back to the holder.
 

--- a/src/agent_bom/api/postgres_model_key_broker.py
+++ b/src/agent_bom/api/postgres_model_key_broker.py
@@ -1,0 +1,185 @@
+"""Postgres-backed model-provider key broker store for horizontal scaling.
+
+Mirrors :class:`agent_bom.api.model_key_broker.SQLiteModelKeyBrokerStore` but
+stores sealed provider keys and minted virtual keys in shared Postgres with
+tenant RLS, so registrations and virtual keys stay consistent across every
+control-plane replica instead of diverging on node-local SQLite (or vanishing on
+an in-memory restart).
+
+Security properties carried over verbatim from the SQLite store:
+- the real provider key is stored only as Fernet ciphertext inside the JSON
+  ``data`` blob (``secret_encrypted``); the plaintext is never persisted,
+- virtual keys are stored only by SHA-256 ``token_hash``; the raw ``abvk_`` token
+  is never persisted,
+- tenant isolation is enforced by Postgres FORCE ROW LEVEL SECURITY *and* every
+  query additionally filters ``tenant_id`` so resolution is fail-closed across
+  tenants.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+
+from agent_bom.api.model_key_broker import (
+    STATUS_ACTIVE,
+    ModelProviderKey,
+    VirtualModelKey,
+)
+from agent_bom.api.postgres_common import (
+    ConnectionPool,
+    _ensure_tenant_rls,
+    _get_pool,
+    _tenant_connection,
+)
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
+
+class PostgresModelKeyBrokerStore:
+    """Shared provider-key + virtual-key broker store backed by Postgres."""
+
+    def __init__(self, pool: ConnectionPool | None = None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def init_schema(self) -> None:
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "model_provider_keys")
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS model_provider_keys (
+                    provider_key_id TEXT PRIMARY KEY,
+                    tenant_id       TEXT NOT NULL,
+                    provider        TEXT NOT NULL,
+                    status          TEXT NOT NULL,
+                    created_at      TEXT NOT NULL,
+                    data            TEXT NOT NULL
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS model_virtual_keys (
+                    virtual_key_id  TEXT PRIMARY KEY,
+                    tenant_id       TEXT NOT NULL,
+                    provider_key_id TEXT NOT NULL,
+                    token_hash      TEXT NOT NULL UNIQUE,
+                    status          TEXT NOT NULL,
+                    issued_at       TEXT NOT NULL,
+                    data            TEXT NOT NULL
+                )
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_model_provider_keys_tenant ON model_provider_keys(tenant_id, created_at)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_model_virtual_keys_tenant ON model_virtual_keys(tenant_id, issued_at)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_model_virtual_keys_hash ON model_virtual_keys(token_hash)")
+            _ensure_tenant_rls(conn, "model_provider_keys", "tenant_id")
+            _ensure_tenant_rls(conn, "model_virtual_keys", "tenant_id")
+            conn.commit()
+
+    # ── provider keys ─────────────────────────────────────────────────────────
+
+    def put_provider_key(self, record: ModelProviderKey) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO model_provider_keys (provider_key_id, tenant_id, provider, status, created_at, data)
+                VALUES (%s, %s, %s, %s, %s, %s)
+                ON CONFLICT (provider_key_id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    data = EXCLUDED.data
+                """,
+                (
+                    record.provider_key_id,
+                    record.tenant_id,
+                    record.provider,
+                    record.status,
+                    record.created_at,
+                    json.dumps(asdict(record), sort_keys=True),
+                ),
+            )
+            conn.commit()
+
+    def get_provider_key(self, provider_key_id: str, *, tenant_id: str) -> ModelProviderKey | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data FROM model_provider_keys WHERE provider_key_id = %s AND tenant_id = %s",
+                (provider_key_id, tenant_id),
+            ).fetchone()
+        return ModelProviderKey(**json.loads(row[0])) if row else None
+
+    def list_provider_keys(self, tenant_id: str) -> list[ModelProviderKey]:
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT data FROM model_provider_keys WHERE tenant_id = %s ORDER BY created_at, provider_key_id",
+                (tenant_id,),
+            ).fetchall()
+        return [ModelProviderKey(**json.loads(r[0])) for r in rows]
+
+    def delete_provider_key(self, provider_key_id: str, *, tenant_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                "DELETE FROM model_provider_keys WHERE provider_key_id = %s AND tenant_id = %s",
+                (provider_key_id, tenant_id),
+            )
+            conn.commit()
+            return bool(cursor.rowcount)
+
+    # ── virtual keys ──────────────────────────────────────────────────────────
+
+    def put_virtual_key(self, record: VirtualModelKey) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """
+                INSERT INTO model_virtual_keys
+                    (virtual_key_id, tenant_id, provider_key_id, token_hash, status, issued_at, data)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (virtual_key_id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    data = EXCLUDED.data
+                """,
+                (
+                    record.virtual_key_id,
+                    record.tenant_id,
+                    record.provider_key_id,
+                    record.token_hash,
+                    record.status,
+                    record.issued_at,
+                    json.dumps(asdict(record), sort_keys=True),
+                ),
+            )
+            conn.commit()
+
+    def get_virtual_key(self, virtual_key_id: str, *, tenant_id: str) -> VirtualModelKey | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data FROM model_virtual_keys WHERE virtual_key_id = %s AND tenant_id = %s",
+                (virtual_key_id, tenant_id),
+            ).fetchone()
+        return VirtualModelKey(**json.loads(row[0])) if row else None
+
+    def get_virtual_key_by_hash(self, token_hash: str, *, tenant_id: str) -> VirtualModelKey | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data FROM model_virtual_keys WHERE token_hash = %s AND tenant_id = %s",
+                (token_hash, tenant_id),
+            ).fetchone()
+        return VirtualModelKey(**json.loads(row[0])) if row else None
+
+    def list_virtual_keys(
+        self,
+        tenant_id: str,
+        *,
+        provider_key_id: str | None = None,
+        include_inactive: bool = False,
+    ) -> list[VirtualModelKey]:
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT data FROM model_virtual_keys WHERE tenant_id = %s ORDER BY issued_at DESC, virtual_key_id DESC",
+                (tenant_id,),
+            ).fetchall()
+        records = [VirtualModelKey(**json.loads(r[0])) for r in rows]
+        if provider_key_id is not None:
+            records = [r for r in records if r.provider_key_id == provider_key_id]
+        if not include_inactive:
+            records = [r for r in records if r.status == STATUS_ACTIVE]
+        return records

--- a/src/agent_bom/api/routes/model_keys.py
+++ b/src/agent_bom/api/routes/model_keys.py
@@ -15,9 +15,20 @@ Security contract (identical posture to the connection broker):
       ``/authorize`` endpoint validates scope + revocation + expiry and returns an
       authorization DECISION (provider, holder, provider-key id) — never the real
       key. It is the only surface that touches the real key, and it strips it.
-    - Every endpoint is tenant-scoped and RBAC-gated. Reads require ``read``;
-      mutations (register / mint / revoke / delete / authorize) require ``scan``.
-    - Every mutation is audit-logged (secret-free).
+    - Holder scope is **caller-asserted**, not derived from the transport
+      principal: ``/authorize`` is called by the gateway/operator acting on behalf
+      of many data-plane holders (agents / blueprints), so the authenticating
+      principal is that gateway, not the holder the key was minted for. When the
+      caller asserts a ``holder_id`` it is enforced at resolve time (a mismatch
+      fails closed with ``holder_mismatch``); omitting it does not bypass the
+      token, tenant, provider, or model scope — holder is defense-in-depth on top
+      of the bearer token, which remains the primary secret.
+    - Every endpoint is tenant-scoped and RBAC-gated. Reads require ``read``.
+      Minting, authorizing, and revoking a virtual key require ``scan`` (analyst).
+      Registering or deleting a **real provider credential** is a root-credential
+      write and requires ``config`` (admin).
+    - Every mutation is audit-logged (secret-free), attributed to the calling
+      principal.
 
 Endpoints:
     POST   /v1/model-keys/providers                          register a real provider key
@@ -60,6 +71,10 @@ _logger = logging.getLogger(__name__)
 
 _READ_DEP = require_authenticated_permission("read")
 _SCAN_DEP = require_authenticated_permission("scan")
+# Writing or deleting a real provider credential in the vault is a root-credential
+# write, gated at the admin/config tier (as other root-credential/config writes
+# are). Minting/authorizing/revoking scoped virtual keys stays at ``scan``.
+_CONFIG_DEP = require_authenticated_permission("config")
 
 _MAX_ALLOWED_MODELS = 50
 _MAX_MODEL_LEN = 128
@@ -119,6 +134,8 @@ class VirtualKeyAuthorize(BaseModel):
     virtual_key: str = Field(min_length=1, max_length=4096)
     provider: str = Field(min_length=1, max_length=64)
     model: str = Field(min_length=1, max_length=_MAX_MODEL_LEN)
+    # Optional caller-asserted holder identity. When present it is enforced at
+    # resolve time (a mismatch fails closed); it is NOT the transport principal.
     holder_id: str = Field(default="", max_length=200)
 
 
@@ -141,11 +158,13 @@ def _validate_models(models: list[str]) -> list[str]:
 
 
 @router.post("/model-keys/providers", status_code=201)
-async def create_provider_key(request: Request, body: ProviderKeyCreate, _role: Any = _SCAN_DEP) -> dict[str, Any]:
+async def create_provider_key(request: Request, body: ProviderKeyCreate, _role: Any = _CONFIG_DEP) -> dict[str, Any]:
     """Register (seal) a real provider key for the authenticated tenant.
 
-    The ``api_key`` is encrypted at rest and never echoed back. Fails closed with
-    503 when no sealing key is configured, rather than storing plaintext.
+    Writing a real provider secret into the vault is a root-credential write and
+    requires the admin/``config`` tier. The ``api_key`` is encrypted at rest and
+    never echoed back. Fails closed with 503 when no sealing key is configured,
+    rather than storing plaintext.
     """
     tenant_id = _tenant(request)
     try:
@@ -197,8 +216,11 @@ async def get_provider_key(request: Request, provider_key_id: str, _role: Any = 
 
 
 @router.delete("/model-keys/providers/{provider_key_id}", status_code=204)
-async def delete_provider_key(request: Request, provider_key_id: str, _role: Any = _SCAN_DEP) -> None:
-    """Delete a provider key. Its virtual keys then fail resolution closed."""
+async def delete_provider_key(request: Request, provider_key_id: str, _role: Any = _CONFIG_DEP) -> None:
+    """Delete a provider key (admin/``config`` tier — a root-credential write).
+
+    Its virtual keys then fail resolution closed.
+    """
     tenant_id = _tenant(request)
     deleted = get_model_key_broker_store().delete_provider_key(provider_key_id, tenant_id=tenant_id)
     if not deleted:
@@ -307,6 +329,13 @@ async def authorize_virtual_key(request: Request, body: VirtualKeyAuthorize, _ro
     tenant), records usage, and returns an authorization decision. The real
     provider key is unsealed only in-process to prove it is resolvable and is
     **never** included in the response.
+
+    ``holder_id`` is a caller-asserted scope, not the authenticating principal:
+    this endpoint is called by the gateway/operator on behalf of the data-plane
+    holder, so when a ``holder_id`` is asserted it is enforced against the key's
+    bound holder (a mismatch fails closed); omitting it does not bypass the token,
+    tenant, provider, or model scope. The calling principal is captured in the
+    audit trail.
     """
     tenant_id = _tenant(request)
     try:

--- a/src/agent_bom/api/routes/model_keys.py
+++ b/src/agent_bom/api/routes/model_keys.py
@@ -1,0 +1,353 @@
+"""Per-tenant model-provider key broker plane (#3907).
+
+The model-key analogue of the cloud-connection broker. An operator registers a
+*real* model-provider credential (OpenAI, Anthropic, Azure OpenAI, Bedrock, …)
+**once**; agent-bom then mints **virtual keys** that map to it without ever
+exposing it, are scoped (holder + optional model allowlist), time-boxed, and
+independently revocable. Usage is attributed to the holding virtual key.
+
+Security contract (identical posture to the connection broker):
+    - The real provider key is write-only: sealed at rest with the shared
+      connection-secret crypto and **never** returned in any response or log.
+    - A virtual key's raw ``abvk_`` token is returned exactly once at mint time;
+      only its hash is stored.
+    - Resolution to the real key happens **server-side** only. The public
+      ``/authorize`` endpoint validates scope + revocation + expiry and returns an
+      authorization DECISION (provider, holder, provider-key id) — never the real
+      key. It is the only surface that touches the real key, and it strips it.
+    - Every endpoint is tenant-scoped and RBAC-gated. Reads require ``read``;
+      mutations (register / mint / revoke / delete / authorize) require ``scan``.
+    - Every mutation is audit-logged (secret-free).
+
+Endpoints:
+    POST   /v1/model-keys/providers                          register a real provider key
+    GET    /v1/model-keys/providers                          list registered provider keys
+    GET    /v1/model-keys/providers/{id}                     one provider key (non-secret)
+    DELETE /v1/model-keys/providers/{id}                     delete a provider key
+    POST   /v1/model-keys/providers/{id}/virtual-keys        mint a scoped virtual key
+    GET    /v1/model-keys/virtual-keys                        list virtual keys
+    POST   /v1/model-keys/virtual-keys/{id}/revoke           revoke a virtual key
+    POST   /v1/model-keys/authorize                          authorize a virtual key (decision only)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent_bom.api.audit_log import log_action
+from agent_bom.api.model_key_broker import (
+    DEFAULT_VK_TTL_SECONDS,
+    MAX_VK_TTL_SECONDS,
+    MIN_VK_TTL_SECONDS,
+    SUPPORTED_MODEL_PROVIDERS,
+    ModelKeyBrokerError,
+    get_model_key_broker_store,
+    mint_virtual_key,
+    register_provider_key,
+    resolve_virtual_key,
+    revoke_virtual_key,
+)
+from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.rbac import require_authenticated_permission
+from agent_bom.security import sanitize_error
+
+router = APIRouter(tags=["model-keys"])
+_logger = logging.getLogger(__name__)
+
+_READ_DEP = require_authenticated_permission("read")
+_SCAN_DEP = require_authenticated_permission("scan")
+
+_MAX_ALLOWED_MODELS = 50
+_MAX_MODEL_LEN = 128
+
+# Resolution-failure reason -> HTTP status. Unknown/wrong-tenant is a 404; scope,
+# revocation, and expiry are 403 (the caller is authenticated but not authorized
+# for this call); a broken underlying provider key is a 409/502.
+_RESOLVE_STATUS: dict[str, int] = {
+    "not_found": 404,
+    "revoked": 403,
+    "expired": 403,
+    "provider_mismatch": 403,
+    "model_not_allowed": 403,
+    "holder_mismatch": 403,
+    "provider_key_missing": 409,
+    "provider_key_disabled": 409,
+    "sealing_failed": 502,
+}
+
+
+class ProviderKeyCreate(BaseModel):
+    """Register a real provider key. ``api_key`` is write-only."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str
+    display_name: str = Field(min_length=1, max_length=200)
+    api_key: str = Field(min_length=1, max_length=8192)
+    owner: str = Field(default="", max_length=200)
+    owner_type: str = Field(default="", max_length=60)
+
+
+class VirtualKeyMint(BaseModel):
+    """Mint a scoped virtual key against a registered provider key."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    holder_id: str = Field(min_length=1, max_length=200)
+    holder_type: str = Field(default="", max_length=60)
+    allowed_models: list[str] = Field(default_factory=list)
+    ttl_seconds: int = DEFAULT_VK_TTL_SECONDS
+    owner: str = Field(default="", max_length=200)
+    owner_type: str = Field(default="", max_length=60)
+
+
+class VirtualKeyRevoke(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    reason: str = Field(default="", max_length=500)
+
+
+class VirtualKeyAuthorize(BaseModel):
+    """Authorize a virtual key for a specific provider/model call (decision only)."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    virtual_key: str = Field(min_length=1, max_length=4096)
+    provider: str = Field(min_length=1, max_length=64)
+    model: str = Field(min_length=1, max_length=_MAX_MODEL_LEN)
+    holder_id: str = Field(default="", max_length=200)
+
+
+def _tenant(request: Request) -> str:
+    return require_request_tenant_id(request)
+
+
+def _actor(request: Request) -> str:
+    return getattr(request.state, "api_key_name", "") or getattr(request.state, "auth_method", "") or "system"
+
+
+def _validate_models(models: list[str]) -> list[str]:
+    cleaned = [m.strip() for m in models if m and m.strip()]
+    if len(cleaned) > _MAX_ALLOWED_MODELS:
+        raise HTTPException(status_code=400, detail=f"Too many allowed_models (max {_MAX_ALLOWED_MODELS}).")
+    for model in cleaned:
+        if len(model) > _MAX_MODEL_LEN:
+            raise HTTPException(status_code=400, detail=f"allowed_models entry too long (max {_MAX_MODEL_LEN}).")
+    return cleaned
+
+
+@router.post("/model-keys/providers", status_code=201)
+async def create_provider_key(request: Request, body: ProviderKeyCreate, _role: Any = _SCAN_DEP) -> dict[str, Any]:
+    """Register (seal) a real provider key for the authenticated tenant.
+
+    The ``api_key`` is encrypted at rest and never echoed back. Fails closed with
+    503 when no sealing key is configured, rather than storing plaintext.
+    """
+    tenant_id = _tenant(request)
+    try:
+        record = register_provider_key(
+            get_model_key_broker_store(),
+            tenant_id=tenant_id,
+            provider=body.provider,
+            display_name=body.display_name,
+            api_key=body.api_key,
+            owner=body.owner,
+            owner_type=body.owner_type,
+        )
+    except ModelKeyBrokerError as exc:
+        status = 503 if exc.reason in ("sealing_unconfigured", "sealing_failed") else 400
+        raise HTTPException(status_code=status, detail=sanitize_error(exc, generic=False)) from exc
+
+    log_action(
+        "model_key.provider.register",
+        actor=_actor(request),
+        resource=f"model-provider-key/{record.provider_key_id}",
+        tenant_id=tenant_id,
+        provider=record.provider,
+    )
+    return record.to_public_dict()
+
+
+@router.get("/model-keys/providers")
+async def list_provider_keys(request: Request, _role: Any = _READ_DEP) -> dict[str, Any]:
+    """List the tenant's registered provider keys (non-secret metadata only)."""
+    tenant_id = _tenant(request)
+    records = get_model_key_broker_store().list_provider_keys(tenant_id)
+    return {
+        "schema_version": "model_keys.providers.v1",
+        "tenant_id": tenant_id,
+        "provider_keys": [r.to_public_dict() for r in records],
+        "count": len(records),
+        "supported_providers": list(SUPPORTED_MODEL_PROVIDERS),
+    }
+
+
+@router.get("/model-keys/providers/{provider_key_id}")
+async def get_provider_key(request: Request, provider_key_id: str, _role: Any = _READ_DEP) -> dict[str, Any]:
+    """Return one provider key's non-secret metadata (tenant-scoped)."""
+    tenant_id = _tenant(request)
+    record = get_model_key_broker_store().get_provider_key(provider_key_id, tenant_id=tenant_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Provider key {provider_key_id} not found")
+    return record.to_public_dict()
+
+
+@router.delete("/model-keys/providers/{provider_key_id}", status_code=204)
+async def delete_provider_key(request: Request, provider_key_id: str, _role: Any = _SCAN_DEP) -> None:
+    """Delete a provider key. Its virtual keys then fail resolution closed."""
+    tenant_id = _tenant(request)
+    deleted = get_model_key_broker_store().delete_provider_key(provider_key_id, tenant_id=tenant_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail=f"Provider key {provider_key_id} not found")
+    log_action(
+        "model_key.provider.delete",
+        actor=_actor(request),
+        resource=f"model-provider-key/{provider_key_id}",
+        tenant_id=tenant_id,
+    )
+
+
+@router.post("/model-keys/providers/{provider_key_id}/virtual-keys", status_code=201)
+async def mint_virtual_key_route(
+    request: Request,
+    provider_key_id: str,
+    body: VirtualKeyMint,
+    _role: Any = _SCAN_DEP,
+) -> dict[str, Any]:
+    """Mint a scoped, time-boxed virtual key. The raw token is returned once here."""
+    tenant_id = _tenant(request)
+    if not (MIN_VK_TTL_SECONDS <= body.ttl_seconds <= MAX_VK_TTL_SECONDS):
+        raise HTTPException(
+            status_code=400,
+            detail=f"ttl_seconds must be between {MIN_VK_TTL_SECONDS} and {MAX_VK_TTL_SECONDS}.",
+        )
+    allowed_models = _validate_models(body.allowed_models)
+    try:
+        vk, raw_token = mint_virtual_key(
+            get_model_key_broker_store(),
+            tenant_id=tenant_id,
+            provider_key_id=provider_key_id,
+            holder_id=body.holder_id,
+            holder_type=body.holder_type,
+            allowed_models=allowed_models,
+            ttl_seconds=body.ttl_seconds,
+            owner=body.owner,
+            owner_type=body.owner_type,
+        )
+    except ModelKeyBrokerError as exc:
+        status = 404 if exc.reason == "provider_key_missing" else 409 if exc.reason == "provider_key_disabled" else 400
+        raise HTTPException(status_code=status, detail=sanitize_error(exc, generic=False)) from exc
+
+    log_action(
+        "model_key.virtual.mint",
+        actor=_actor(request),
+        resource=f"model-virtual-key/{vk.virtual_key_id}",
+        tenant_id=tenant_id,
+        provider=vk.provider,
+        holder_id=vk.holder_id,
+    )
+    # The raw token is surfaced exactly once, alongside the non-secret record.
+    return {
+        "schema_version": "model_keys.virtual_key.v1",
+        "virtual_key": raw_token,
+        "virtual_key_record": vk.to_public_dict(),
+    }
+
+
+@router.get("/model-keys/virtual-keys")
+async def list_virtual_keys(
+    request: Request,
+    provider_key_id: str | None = None,
+    include_inactive: bool = False,
+    _role: Any = _READ_DEP,
+) -> dict[str, Any]:
+    """List the tenant's virtual keys (never carries the token/hash)."""
+    tenant_id = _tenant(request)
+    records = get_model_key_broker_store().list_virtual_keys(tenant_id, provider_key_id=provider_key_id, include_inactive=include_inactive)
+    return {
+        "schema_version": "model_keys.virtual_keys.v1",
+        "tenant_id": tenant_id,
+        "virtual_keys": [r.to_public_dict() for r in records],
+        "count": len(records),
+    }
+
+
+@router.post("/model-keys/virtual-keys/{virtual_key_id}/revoke")
+async def revoke_virtual_key_route(
+    request: Request,
+    virtual_key_id: str,
+    body: VirtualKeyRevoke,
+    _role: Any = _SCAN_DEP,
+) -> dict[str, Any]:
+    """Immediately revoke a virtual key; further resolution fails closed."""
+    tenant_id = _tenant(request)
+    vk = revoke_virtual_key(get_model_key_broker_store(), virtual_key_id, tenant_id=tenant_id, reason=body.reason)
+    if vk is None:
+        raise HTTPException(status_code=404, detail=f"Virtual key {virtual_key_id} not found")
+    log_action(
+        "model_key.virtual.revoke",
+        actor=_actor(request),
+        resource=f"model-virtual-key/{vk.virtual_key_id}",
+        tenant_id=tenant_id,
+        provider=vk.provider,
+        outcome="revoked",
+    )
+    return {"schema_version": "model_keys.virtual_key.v1", "virtual_key_record": vk.to_public_dict()}
+
+
+@router.post("/model-keys/authorize")
+async def authorize_virtual_key(request: Request, body: VirtualKeyAuthorize, _role: Any = _SCAN_DEP) -> dict[str, Any]:
+    """Authorize a virtual key for a provider/model call — decision only, no secret.
+
+    Resolves the virtual key server-side (enforcing scope, revocation, expiry, and
+    tenant), records usage, and returns an authorization decision. The real
+    provider key is unsealed only in-process to prove it is resolvable and is
+    **never** included in the response.
+    """
+    tenant_id = _tenant(request)
+    try:
+        resolved = resolve_virtual_key(
+            get_model_key_broker_store(),
+            tenant_id=tenant_id,
+            raw_token=body.virtual_key,
+            provider=body.provider,
+            model=body.model,
+            holder_id=body.holder_id or None,
+        )
+    except ModelKeyBrokerError as exc:
+        status = _RESOLVE_STATUS.get(exc.reason, 403)
+        log_action(
+            "model_key.virtual.authorize",
+            actor=_actor(request),
+            resource="model-virtual-key/authorize",
+            tenant_id=tenant_id,
+            provider=(body.provider or "").strip().lower(),
+            outcome="denied",
+            reason=exc.reason,
+        )
+        raise HTTPException(status_code=status, detail=sanitize_error(exc, generic=False)) from exc
+
+    log_action(
+        "model_key.virtual.authorize",
+        actor=_actor(request),
+        resource=f"model-virtual-key/{resolved.virtual_key_id}",
+        tenant_id=tenant_id,
+        provider=resolved.provider,
+        model=resolved.model,
+        holder_id=resolved.holder_id,
+        outcome="authorized",
+    )
+    # Decision only — the real key (resolved.api_key) is deliberately omitted.
+    return {
+        "schema_version": "model_keys.authorize.v1",
+        "authorized": True,
+        "virtual_key_id": resolved.virtual_key_id,
+        "provider": resolved.provider,
+        "model": resolved.model,
+        "provider_key_id": resolved.provider_key_id,
+        "holder_id": resolved.holder_id,
+    }

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -902,6 +902,7 @@ from agent_bom.api.routes.intel import router as _intel_router  # noqa: E402
 from agent_bom.api.routes.inventory_assets import router as _inventory_assets_router  # noqa: E402
 from agent_bom.api.routes.mcp_config import router as _mcp_config_router  # noqa: E402
 from agent_bom.api.routes.mitre import router as _mitre_router  # noqa: E402
+from agent_bom.api.routes.model_keys import router as _model_keys_router  # noqa: E402
 from agent_bom.api.routes.observability import infra_router as _observability_infra_router  # noqa: E402
 from agent_bom.api.routes.observability import router as _observability_router  # noqa: E402
 from agent_bom.api.routes.overview import router as _overview_router  # noqa: E402
@@ -947,6 +948,7 @@ for _router in (
     _inventory_assets_router,
     _mcp_config_router,
     _mitre_router,
+    _model_keys_router,
     _observability_router,
     _overview_router,
     _plugins_router,

--- a/tests/api/test_api_auth_boundary.py
+++ b/tests/api/test_api_auth_boundary.py
@@ -203,6 +203,24 @@ def test_read_shaped_posts_stay_viewer_reachable() -> None:
     assert middleware._required_role("POST", "/v1/auth/keys") == "admin"
 
 
+def test_model_keys_rbac_tiers_split_root_writes_from_minting() -> None:
+    """Root provider-credential writes are admin-tier; minting/authorizing/revoking are analyst-tier.
+
+    Registering or deleting a real provider secret is a root-credential write and
+    must require ``admin``. Minting a scoped, short-lived virtual key, authorizing
+    it, and revoking it are operational and stay at ``analyst`` — otherwise the
+    unmatched-mutating-route admin fallback silently over-gates them.
+    """
+    middleware = APIKeyMiddleware(app, api_key="")
+    # Root-credential writes -> admin.
+    assert middleware._required_role("POST", "/v1/model-keys/providers") == "admin"
+    assert middleware._required_role("DELETE", "/v1/model-keys/providers/mpk_abc123") == "admin"
+    # Minting / authorizing / revoking -> analyst.
+    assert middleware._required_role("POST", "/v1/model-keys/providers/mpk_abc123/virtual-keys") == "analyst"
+    assert middleware._required_role("POST", "/v1/model-keys/virtual-keys/vmk_abc123/revoke") == "analyst"
+    assert middleware._required_role("POST", "/v1/model-keys/authorize") == "analyst"
+
+
 def test_head_inherits_get_route_role() -> None:
     """A HEAD request must inherit the required role of the matching GET route.
 

--- a/tests/test_model_key_broker.py
+++ b/tests/test_model_key_broker.py
@@ -1,0 +1,296 @@
+"""Tests for the virtual, scoped, revocable model-provider key broker (#3907).
+
+Covers the store (CRUD + tenant isolation, both in-memory and SQLite), the
+at-rest sealing of the real provider key (reusing the connection-secret crypto),
+and the register -> mint -> resolve -> revoke lifecycle including scope
+enforcement (provider / model / holder), fail-closed on revoked / expired /
+disabled, tenant isolation on resolve, and the guarantee that a real provider
+key never appears in any store public dict, virtual key, or resolution error.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from cryptography.fernet import Fernet
+
+from agent_bom.api import connection_crypto
+from agent_bom.api.model_key_broker import (
+    SUPPORTED_MODEL_PROVIDERS,
+    InMemoryModelKeyBrokerStore,
+    ModelKeyBrokerError,
+    SQLiteModelKeyBrokerStore,
+    generate_virtual_key_token,
+    mint_virtual_key,
+    register_provider_key,
+    resolve_virtual_key,
+    revoke_virtual_key,
+)
+
+_REAL_KEY = "sk-super-secret-real-openai-key-DO-NOT-LEAK"
+_TEST_FERNET = Fernet.generate_key().decode("ascii")
+
+
+@pytest.fixture(autouse=True)
+def _sealing_key() -> Iterator[None]:
+    """Configure the at-rest sealing key the broker reuses from the connection crypto."""
+    prior = os.environ.get(connection_crypto.CONNECTIONS_KEY_ENV)
+    prior_file = os.environ.get(f"{connection_crypto.CONNECTIONS_KEY_ENV}_FILE")
+    prior_provider = os.environ.get(connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV)
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = _TEST_FERNET
+    os.environ.pop(f"{connection_crypto.CONNECTIONS_KEY_ENV}_FILE", None)
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV, None)
+    connection_crypto.reset_key_cache()
+    try:
+        yield
+    finally:
+        for name, value in (
+            (connection_crypto.CONNECTIONS_KEY_ENV, prior),
+            (f"{connection_crypto.CONNECTIONS_KEY_ENV}_FILE", prior_file),
+            (connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV, prior_provider),
+        ):
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        connection_crypto.reset_key_cache()
+
+
+def _stores() -> Iterator[InMemoryModelKeyBrokerStore | SQLiteModelKeyBrokerStore]:
+    yield InMemoryModelKeyBrokerStore()
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        yield SQLiteModelKeyBrokerStore(path)
+    finally:
+        os.unlink(path)
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def store(request: pytest.FixtureRequest) -> Iterator[object]:
+    if request.param == "memory":
+        yield InMemoryModelKeyBrokerStore()
+    else:
+        fd, path = tempfile.mkstemp(suffix=".db")
+        os.close(fd)
+        try:
+            yield SQLiteModelKeyBrokerStore(path)
+        finally:
+            os.unlink(path)
+
+
+# ── sealing / registration ──────────────────────────────────────────────────
+
+
+def test_register_seals_real_key_and_never_returns_it(store: object) -> None:
+    pk = register_provider_key(
+        store,
+        tenant_id="t-alpha",
+        provider="openai",
+        display_name="prod-openai",
+        api_key=_REAL_KEY,
+    )
+    # The stored ciphertext is not the plaintext.
+    assert _REAL_KEY not in pk.secret_encrypted
+    assert pk.secret_encrypted
+    # The public dict never carries the secret, only a boolean.
+    public = pk.to_public_dict()
+    assert "secret_encrypted" not in public
+    assert _REAL_KEY not in str(public)
+    assert public["has_secret"] is True
+    assert public["provider"] == "openai"
+
+
+def test_register_fails_closed_without_sealing_key(store: object) -> None:
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_ENV, None)
+    connection_crypto.reset_key_cache()
+    with pytest.raises(ModelKeyBrokerError):
+        register_provider_key(
+            store,
+            tenant_id="t-alpha",
+            provider="openai",
+            display_name="x",
+            api_key=_REAL_KEY,
+        )
+
+
+def test_register_rejects_unknown_provider(store: object) -> None:
+    with pytest.raises(ModelKeyBrokerError):
+        register_provider_key(store, tenant_id="t-alpha", provider="not-a-provider", display_name="x", api_key=_REAL_KEY)
+    # Sanity: the tuple is what the route validates against.
+    assert "openai" in SUPPORTED_MODEL_PROVIDERS
+    assert "anthropic" in SUPPORTED_MODEL_PROVIDERS
+
+
+# ── mint / resolve lifecycle ─────────────────────────────────────────────────
+
+
+def test_mint_returns_raw_token_once_and_hashes_at_rest(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="anthropic", display_name="x", api_key=_REAL_KEY)
+    vk, raw = mint_virtual_key(
+        store,
+        tenant_id="t",
+        provider_key_id=pk.provider_key_id,
+        holder_id="agent-1",
+        holder_type="agent_identity",
+        allowed_models=["claude-opus-4"],
+    )
+    assert raw.startswith("abvk_")
+    # Only a hash is stored; the raw token is not persisted.
+    assert vk.token_hash and vk.token_hash != raw
+    assert raw not in str(vk.to_public_dict())
+    assert "token_hash" not in vk.to_public_dict()
+    assert vk.provider == "anthropic"
+    assert vk.status == "active"
+
+
+def test_resolve_maps_virtual_to_real_key_within_scope(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    _vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="agent-1", allowed_models=["gpt-4o"])
+    resolved = resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="gpt-4o")
+    assert resolved.api_key == _REAL_KEY
+    assert resolved.provider == "openai"
+    assert resolved.provider_key_id == pk.provider_key_id
+
+
+def test_resolve_rejects_out_of_scope_provider(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    _vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="a")
+    with pytest.raises(ModelKeyBrokerError) as exc:
+        resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="anthropic", model="claude-opus-4")
+    assert exc.value.reason == "provider_mismatch"
+
+
+def test_resolve_rejects_out_of_scope_model(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    _vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="a", allowed_models=["gpt-4o"])
+    with pytest.raises(ModelKeyBrokerError) as exc:
+        resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="gpt-3.5-turbo")
+    assert exc.value.reason == "model_not_allowed"
+
+
+def test_empty_model_allowlist_permits_any_model(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    _vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="a", allowed_models=[])
+    resolved = resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="anything-goes")
+    assert resolved.api_key == _REAL_KEY
+
+
+def test_resolve_rejects_out_of_scope_holder(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    _vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="agent-1")
+    with pytest.raises(ModelKeyBrokerError) as exc:
+        resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="gpt-4o", holder_id="agent-2")
+    assert exc.value.reason == "holder_mismatch"
+
+
+# ── revocation + expiry fail closed ──────────────────────────────────────────
+
+
+def test_revoked_virtual_key_fails_closed(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="a")
+    revoke_virtual_key(store, vk.virtual_key_id, tenant_id="t", reason="compromised")
+    with pytest.raises(ModelKeyBrokerError) as exc:
+        resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="gpt-4o")
+    assert exc.value.reason == "revoked"
+
+
+def test_expired_virtual_key_fails_closed(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    _vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="a", ttl_seconds=60)
+    future = datetime.now(timezone.utc) + timedelta(seconds=120)
+    with pytest.raises(ModelKeyBrokerError) as exc:
+        resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="gpt-4o", at=future)
+    assert exc.value.reason == "expired"
+
+
+def test_deleting_provider_key_fails_resolution_closed(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    _vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="a")
+    assert store.delete_provider_key(pk.provider_key_id, tenant_id="t") is True
+    with pytest.raises(ModelKeyBrokerError) as exc:
+        resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="gpt-4o")
+    assert exc.value.reason == "provider_key_missing"
+
+
+# ── tenant isolation ─────────────────────────────────────────────────────────
+
+
+def test_tenant_b_cannot_resolve_tenant_a_virtual_key(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t-alpha", provider="openai", display_name="x", api_key=_REAL_KEY)
+    _vk, raw = mint_virtual_key(store, tenant_id="t-alpha", provider_key_id=pk.provider_key_id, holder_id="a")
+    with pytest.raises(ModelKeyBrokerError) as exc:
+        resolve_virtual_key(store, tenant_id="t-beta", raw_token=raw, provider="openai", model="gpt-4o")
+    assert exc.value.reason == "not_found"
+
+
+def test_provider_and_virtual_key_lists_are_tenant_scoped(store: object) -> None:
+    pk_a = register_provider_key(store, tenant_id="t-alpha", provider="openai", display_name="a", api_key=_REAL_KEY)
+    register_provider_key(store, tenant_id="t-beta", provider="anthropic", display_name="b", api_key=_REAL_KEY)
+    mint_virtual_key(store, tenant_id="t-alpha", provider_key_id=pk_a.provider_key_id, holder_id="a")
+
+    assert {p.tenant_id for p in store.list_provider_keys("t-alpha")} == {"t-alpha"}
+    assert {v.tenant_id for v in store.list_virtual_keys("t-alpha")} == {"t-alpha"}
+    assert store.list_virtual_keys("t-beta") == []
+    # Tenant B cannot fetch tenant A's provider key by id.
+    assert store.get_provider_key(pk_a.provider_key_id, tenant_id="t-beta") is None
+
+
+def test_mint_rejects_provider_key_from_another_tenant(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t-alpha", provider="openai", display_name="x", api_key=_REAL_KEY)
+    with pytest.raises(ModelKeyBrokerError):
+        mint_virtual_key(store, tenant_id="t-beta", provider_key_id=pk.provider_key_id, holder_id="a")
+
+
+# ── usage attribution + no-leak error ────────────────────────────────────────
+
+
+def test_resolve_records_usage_attribution(store: object) -> None:
+    pk = register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    vk, raw = mint_virtual_key(store, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="agent-1")
+    resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="gpt-4o")
+    resolve_virtual_key(store, tenant_id="t", raw_token=raw, provider="openai", model="gpt-4o")
+    refreshed = store.get_virtual_key(vk.virtual_key_id, tenant_id="t")
+    assert refreshed is not None
+    assert refreshed.use_count == 2
+    assert refreshed.last_used_at
+
+
+def test_unknown_token_error_never_contains_secret(store: object) -> None:
+    register_provider_key(store, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+    with pytest.raises(ModelKeyBrokerError) as exc:
+        resolve_virtual_key(store, tenant_id="t", raw_token="abvk_deadbeef_nope", provider="openai", model="gpt-4o")
+    assert exc.value.reason == "not_found"
+    assert _REAL_KEY not in str(exc.value)
+
+
+def test_generate_token_shape() -> None:
+    raw, prefix, token_hash = generate_virtual_key_token()
+    assert raw.startswith("abvk_")
+    assert prefix in raw
+    assert token_hash and token_hash not in raw
+
+
+def test_sqlite_backend_persists_across_instances() -> None:
+    fd, path = tempfile.mkstemp(suffix=".db")
+    os.close(fd)
+    try:
+        s1 = SQLiteModelKeyBrokerStore(path)
+        pk = register_provider_key(s1, tenant_id="t", provider="openai", display_name="x", api_key=_REAL_KEY)
+        _vk, raw = mint_virtual_key(s1, tenant_id="t", provider_key_id=pk.provider_key_id, holder_id="a")
+        # A fresh store instance on the same file resolves the same virtual key.
+        s2 = SQLiteModelKeyBrokerStore(path)
+        resolved = resolve_virtual_key(s2, tenant_id="t", raw_token=raw, provider="openai", model="gpt-4o")
+        assert resolved.api_key == _REAL_KEY
+        # The raw provider key must not be stored in plaintext anywhere in the DB file.
+        with sqlite3.connect(path) as conn:
+            for (data,) in conn.execute("SELECT data FROM model_provider_keys").fetchall():
+                assert _REAL_KEY not in data
+    finally:
+        os.unlink(path)

--- a/tests/test_model_keys_api.py
+++ b/tests/test_model_keys_api.py
@@ -1,0 +1,259 @@
+"""API tests for the model-provider key broker plane (#3907).
+
+Covers RBAC (auth required, viewer read-only), the register -> mint -> authorize
+-> revoke lifecycle over HTTP, tenant scoping, and the two hard security
+guarantees: the real provider key never appears in ANY response (register, list,
+get, mint, or authorize), and revocation blocks further authorization.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from cryptography.fernet import Fernet
+from starlette.testclient import TestClient
+
+from agent_bom.api import connection_crypto
+from agent_bom.api.model_key_broker import InMemoryModelKeyBrokerStore, set_model_key_broker_store
+
+PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
+_TEST_FERNET = Fernet.generate_key().decode("ascii")
+_REAL_KEY = "sk-real-provider-secret-DO-NOT-LEAK-xyz"
+
+
+def _headers(role: str = "admin", tenant: str = "tenant-alpha") -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": role,
+        "X-Agent-Bom-Tenant-ID": tenant,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _env() -> Iterator[None]:
+    prior = {
+        "AGENT_BOM_TRUST_PROXY_AUTH": os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH"),
+        "AGENT_BOM_TRUST_PROXY_AUTH_SECRET": os.environ.get("AGENT_BOM_TRUST_PROXY_AUTH_SECRET"),
+        connection_crypto.CONNECTIONS_KEY_ENV: os.environ.get(connection_crypto.CONNECTIONS_KEY_ENV),
+        f"{connection_crypto.CONNECTIONS_KEY_ENV}_FILE": os.environ.get(f"{connection_crypto.CONNECTIONS_KEY_ENV}_FILE"),
+        connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV: os.environ.get(connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV),
+    }
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = _TEST_FERNET
+    os.environ.pop(f"{connection_crypto.CONNECTIONS_KEY_ENV}_FILE", None)
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV, None)
+    connection_crypto.reset_key_cache()
+    set_model_key_broker_store(InMemoryModelKeyBrokerStore())
+    try:
+        yield
+    finally:
+        for name, value in prior.items():
+            if value is None:
+                os.environ.pop(name, None)
+            else:
+                os.environ[name] = value
+        connection_crypto.reset_key_cache()
+        set_model_key_broker_store(None)
+
+
+def _app() -> Any:
+    from agent_bom.api.server import app
+
+    return app
+
+
+def _register(client: TestClient, tenant: str = "tenant-alpha") -> dict[str, Any]:
+    resp = client.post(
+        "/v1/model-keys/providers",
+        json={"provider": "openai", "display_name": "prod-openai", "api_key": _REAL_KEY},
+        headers=_headers(tenant=tenant),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def _mint(client: TestClient, provider_key_id: str, tenant: str = "tenant-alpha", **body: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"holder_id": "agent-1", "allowed_models": ["gpt-4o"]}
+    payload.update(body)
+    resp = client.post(
+        f"/v1/model-keys/providers/{provider_key_id}/virtual-keys",
+        json=payload,
+        headers=_headers(tenant=tenant),
+    )
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+# ── auth / RBAC ──────────────────────────────────────────────────────────────
+
+
+def test_requires_authentication() -> None:
+    client = TestClient(_app())
+    assert client.get("/v1/model-keys/providers").status_code == 401
+    assert (
+        client.post(
+            "/v1/model-keys/providers",
+            json={"provider": "openai", "display_name": "x", "api_key": _REAL_KEY},
+        ).status_code
+        == 401
+    )
+
+
+def test_viewer_can_list_but_not_register() -> None:
+    client = TestClient(_app())
+    pk = _register(client)
+    assert client.get("/v1/model-keys/providers", headers=_headers(role="viewer")).status_code == 200
+    resp = client.post(
+        "/v1/model-keys/providers",
+        json={"provider": "openai", "display_name": "x", "api_key": _REAL_KEY},
+        headers=_headers(role="viewer"),
+    )
+    assert resp.status_code == 403
+    # Viewer cannot mint either.
+    assert (
+        client.post(
+            f"/v1/model-keys/providers/{pk['provider_key_id']}/virtual-keys",
+            json={"holder_id": "a"},
+            headers=_headers(role="viewer"),
+        ).status_code
+        == 403
+    )
+
+
+# ── no-secret guarantees ─────────────────────────────────────────────────────
+
+
+def test_register_response_never_contains_real_key() -> None:
+    client = TestClient(_app())
+    body = _register(client)
+    assert _REAL_KEY not in str(body)
+    assert "secret_encrypted" not in body
+    assert "api_key" not in body
+    assert body["has_secret"] is True
+    assert body["provider"] == "openai"
+
+
+def test_list_and_get_never_contain_real_key() -> None:
+    client = TestClient(_app())
+    pk = _register(client)
+    listed = client.get("/v1/model-keys/providers", headers=_headers()).json()
+    got = client.get(f"/v1/model-keys/providers/{pk['provider_key_id']}", headers=_headers()).json()
+    for body in (listed, got):
+        assert _REAL_KEY not in str(body)
+        assert "secret_encrypted" not in str(body)
+
+
+def test_mint_returns_virtual_token_not_real_key() -> None:
+    client = TestClient(_app())
+    pk = _register(client)
+    minted = _mint(client, pk["provider_key_id"])
+    assert minted["virtual_key"].startswith("abvk_")
+    assert _REAL_KEY not in str(minted)
+    assert "token_hash" not in str(minted["virtual_key_record"])
+    assert minted["virtual_key_record"]["provider"] == "openai"
+
+
+def test_authorize_returns_decision_without_real_key() -> None:
+    client = TestClient(_app())
+    pk = _register(client)
+    raw = _mint(client, pk["provider_key_id"])["virtual_key"]
+    resp = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-4o"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["authorized"] is True
+    assert body["provider"] == "openai"
+    assert _REAL_KEY not in str(body)
+    assert "api_key" not in str(body)
+    assert "secret" not in str(body).lower()
+
+
+# ── scope + revocation over HTTP ─────────────────────────────────────────────
+
+
+def test_authorize_rejects_out_of_scope_model() -> None:
+    client = TestClient(_app())
+    pk = _register(client)
+    raw = _mint(client, pk["provider_key_id"], allowed_models=["gpt-4o"])["virtual_key"]
+    resp = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-3.5-turbo"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 403
+
+
+def test_revoke_blocks_further_authorization() -> None:
+    client = TestClient(_app())
+    pk = _register(client)
+    minted = _mint(client, pk["provider_key_id"])
+    raw = minted["virtual_key"]
+    vk_id = minted["virtual_key_record"]["virtual_key_id"]
+
+    ok = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-4o"},
+        headers=_headers(),
+    )
+    assert ok.status_code == 200
+
+    revoked = client.post(f"/v1/model-keys/virtual-keys/{vk_id}/revoke", json={"reason": "rotate"}, headers=_headers())
+    assert revoked.status_code == 200
+    assert revoked.json()["virtual_key_record"]["status"] == "revoked"
+
+    denied = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-4o"},
+        headers=_headers(),
+    )
+    assert denied.status_code == 403
+
+
+# ── tenant isolation over HTTP ───────────────────────────────────────────────
+
+
+def test_tenant_b_cannot_see_or_authorize_tenant_a_keys() -> None:
+    client = TestClient(_app())
+    pk = _register(client, tenant="tenant-alpha")
+    raw = _mint(client, pk["provider_key_id"], tenant="tenant-alpha")["virtual_key"]
+
+    # Tenant B lists nothing and 404s on tenant A's provider key.
+    b_list = client.get("/v1/model-keys/providers", headers=_headers(tenant="tenant-beta")).json()
+    assert b_list["count"] == 0
+    assert client.get(f"/v1/model-keys/providers/{pk['provider_key_id']}", headers=_headers(tenant="tenant-beta")).status_code == 404
+    # Tenant B cannot authorize tenant A's virtual key even with the raw token.
+    denied = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-4o"},
+        headers=_headers(tenant="tenant-beta"),
+    )
+    assert denied.status_code == 404
+
+
+def test_register_unsupported_provider_rejected() -> None:
+    client = TestClient(_app())
+    resp = client.post(
+        "/v1/model-keys/providers",
+        json={"provider": "definitely-not-real", "display_name": "x", "api_key": _REAL_KEY},
+        headers=_headers(),
+    )
+    assert resp.status_code == 400
+
+
+def test_register_fails_closed_without_sealing_key() -> None:
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_ENV, None)
+    connection_crypto.reset_key_cache()
+    client = TestClient(_app())
+    resp = client.post(
+        "/v1/model-keys/providers",
+        json={"provider": "openai", "display_name": "x", "api_key": _REAL_KEY},
+        headers=_headers(),
+    )
+    assert resp.status_code == 503

--- a/tests/test_model_keys_api.py
+++ b/tests/test_model_keys_api.py
@@ -237,6 +237,99 @@ def test_tenant_b_cannot_see_or_authorize_tenant_a_keys() -> None:
     assert denied.status_code == 404
 
 
+# ── RBAC tier split: root-credential writes are admin, minting is analyst ─────
+
+
+def test_analyst_can_mint_revoke_authorize_but_not_register_or_delete() -> None:
+    """register/delete of a real provider key are admin-tier; mint/authorize/revoke stay analyst-tier."""
+    client = TestClient(_app())
+    # Admin provisions the real provider credential.
+    pk = _register(client)
+    pk_id = pk["provider_key_id"]
+
+    # Analyst (scan tier) may NOT write a new real provider secret.
+    denied_register = client.post(
+        "/v1/model-keys/providers",
+        json={"provider": "openai", "display_name": "x", "api_key": _REAL_KEY},
+        headers=_headers(role="analyst"),
+    )
+    assert denied_register.status_code == 403, denied_register.text
+
+    # Analyst CAN mint a scoped virtual key against the admin-provisioned root key.
+    minted = client.post(
+        f"/v1/model-keys/providers/{pk_id}/virtual-keys",
+        json={"holder_id": "agent-1", "allowed_models": ["gpt-4o"]},
+        headers=_headers(role="analyst"),
+    )
+    assert minted.status_code == 201, minted.text
+    raw = minted.json()["virtual_key"]
+    vk_id = minted.json()["virtual_key_record"]["virtual_key_id"]
+
+    # Analyst CAN authorize (resolve) it.
+    authorized = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-4o"},
+        headers=_headers(role="analyst"),
+    )
+    assert authorized.status_code == 200, authorized.text
+
+    # Analyst CAN revoke it.
+    revoked = client.post(
+        f"/v1/model-keys/virtual-keys/{vk_id}/revoke",
+        json={"reason": "rotate"},
+        headers=_headers(role="analyst"),
+    )
+    assert revoked.status_code == 200, revoked.text
+
+    # Analyst may NOT delete the real provider credential (admin-tier root write).
+    denied_delete = client.delete(f"/v1/model-keys/providers/{pk_id}", headers=_headers(role="analyst"))
+    assert denied_delete.status_code == 403, denied_delete.text
+
+    # Admin may delete it.
+    assert client.delete(f"/v1/model-keys/providers/{pk_id}", headers=_headers(role="admin")).status_code == 204
+
+
+# ── holder scope is a caller-asserted scope enforced at resolve ───────────────
+
+
+def test_holder_scope_enforced_against_asserted_holder() -> None:
+    """A virtual key bound to holder A is denied when the caller asserts a different holder.
+
+    Holder scope is caller-asserted (the authorizing principal is the gateway/operator,
+    not the data-plane holder), so an asserted mismatching holder must fail closed while
+    the correct holder — and an unasserted holder — pass.
+    """
+    client = TestClient(_app())
+    pk = _register(client)
+    raw = _mint(client, pk["provider_key_id"], holder_id="agent-A")["virtual_key"]
+
+    # Asserting a DIFFERENT holder must be denied (holder_mismatch -> 403).
+    mismatched = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-4o", "holder_id": "agent-B"},
+        headers=_headers(),
+    )
+    assert mismatched.status_code == 403, mismatched.text
+
+    # Asserting the bound holder is authorized.
+    matched = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-4o", "holder_id": "agent-A"},
+        headers=_headers(),
+    )
+    assert matched.status_code == 200, matched.text
+    assert matched.json()["holder_id"] == "agent-A"
+
+    # Omitting the holder does not bypass the other scopes; it authorizes on
+    # token + tenant + provider + model scope (holder is defense-in-depth).
+    unasserted = client.post(
+        "/v1/model-keys/authorize",
+        json={"virtual_key": raw, "provider": "openai", "model": "gpt-4o"},
+        headers=_headers(),
+    )
+    assert unasserted.status_code == 200, unasserted.text
+
+
 def test_register_unsupported_provider_rejected() -> None:
     client = TestClient(_app())
     resp = client.post(


### PR DESCRIPTION
## What

Adds a **virtual, scoped, revocable model-provider key broker** — the model-key analogue of the existing cloud/MCP connection-secret broker. An operator registers a *real* model-provider credential (OpenAI, Anthropic, Azure OpenAI, Bedrock, Google Vertex, Mistral, Cohere) **once**, and agent-bom mints **virtual keys** that:

- **map** to the real key without ever exposing it,
- are **scoped** — bound to a holder (agent identity / blueprint), a provider, and an optional model allowlist,
- are **time-boxed** (expiry) and **independently revocable**,
- **attribute usage** back to the holding virtual key (use counter + last-used).

## Design

**Real key is write-only and sealed.** Registration encrypts the provider key with the *same* sealing the connection broker already uses (`connection_crypto` — `AGENT_BOM_CONNECTIONS_KEY` / `connections.key` and its pluggable managed-key providers: env / AWS Secrets / AWS KMS / Vault). The plaintext is never logged, never returned in any API response, and only decrypted **server-side** at resolve time.

**Virtual keys are bearer tokens** `abvk_<public>_<secret>` — only the SHA-256 hash is persisted (mirroring the agent-identity store); the raw token is returned exactly once at mint.

**Resolution fails closed.** `resolve_virtual_key(...)` is the in-process primitive that returns the real key to the model-call path. It rejects, with a stable secret-free `reason`, any: unknown / wrong-tenant token (`not_found`), `revoked`, `expired`, `provider_mismatch`, `model_not_allowed`, `holder_mismatch`, or a missing / disabled underlying provider key.

**The `/authorize` endpoint returns a decision only.** It resolves server-side (proving the real key is unsealable, enforcing scope + revocation + expiry + tenant, recording usage) and returns `{authorized, provider, provider_key_id, holder_id, ...}` — the real key is deliberately stripped. No public surface ever returns the real key.

**Every op is tenant-scoped** (`WHERE tenant_id = %s` in every backend, plus Postgres FORCE RLS) and **audit-logged** (secret-free, error text routed through `sanitize_error`).

## What it reuses from the existing broker

- `connection_crypto.encrypt_secret` / `decrypt_secret` / `connections_key_configured` — identical at-rest sealing, no new crypto.
- The agent-identity store's durable-by-default backend parity + JSON `data`-blob shape: **in-memory** (tests), **SQLite** (single-node durable default), **Postgres + tenant RLS** (multi-replica), selected via `durable_store.select_backend()`.
- The cloud-connection routes' control-plane style: RBAC (`read` for reads, `scan` for mutations), `require_request_tenant_id`, `log_action`, write-only-secret + `to_public_dict()` no-secret responses.

## API (`/v1/model-keys`)

| Method | Path | Perm |
|---|---|---|
| POST | `/model-keys/providers` | scan |
| GET | `/model-keys/providers` · `/{id}` | read |
| DELETE | `/model-keys/providers/{id}` | scan |
| POST | `/model-keys/providers/{id}/virtual-keys` | scan |
| GET | `/model-keys/virtual-keys` | read |
| POST | `/model-keys/virtual-keys/{id}/revoke` | scan |
| POST | `/model-keys/authorize` | scan |

## Tests (TDD, written first)

`tests/test_model_key_broker.py` (36, in-memory + SQLite parametrized) and `tests/test_model_keys_api.py` (11) cover: register→mint→resolve→revoke lifecycle; scope enforcement (out-of-scope provider / model / holder rejected); revoked + expired fail closed; deleted provider key fails resolution closed; **tenant isolation** (tenant B cannot resolve/list/mint against tenant A); real key never in any store dict, virtual-key record, API response, resolution error, or the SQLite file; usage attribution.

## Verification

- `pytest` new + neighboring (cloud-connections, agent-identity): **156 passed**
- `ruff check` / `ruff format`: clean · `mypy` on changed files: clean
- `scripts/check-counts.py`: pass (routes 38→39, ops 329→337, paths 280→286) · `export_openapi.py --check`: pass · data-model atlas regenerated · exception-sanitization guard: pass

## Blast radius

model→store (3 backends)→service→API→OpenAPI contract→docs counts→tests. **Deferred (noted):** UI surface for the broker and wiring `resolve_virtual_key` into a live model-proxy call path are follow-ups; this PR lands the complete backend + API slice end-to-end. No new dependencies. `resolve_virtual_key` returns the real key **in-process only**; the API never does.

Closes #3907