### PR TITLE
governance[8/8]: audit-event OTLP-log export + EDR/MDM device-posture ABAC

### DIFF
--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 73 tools, 6 resources, 8 workflow prompts |
-| REST API | 337 operations across 39 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 339 operations across 40 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 73 tools, 6 resources, 8 workflow prompts |
-| REST API | 339 operations across 40 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 339 operations across 39 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["339 REST operations across 40 route modules\nplus 2 WebSocket routes"]
+        R["339 REST operations across 39 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["337 REST operations across 39 route modules\nplus 2 WebSocket routes"]
+        R["339 REST operations across 40 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 286 |
+| `docs/openapi/v1.json` | paths | 288 |
 | `docs/openapi/v1.json` | component schemas | 76 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/OBSERVABILITY_METRICS.md
+++ b/docs/OBSERVABILITY_METRICS.md
@@ -95,6 +95,49 @@ OTLP/HTTP through `src/agent_bom/api/tracing.py`. Recommended exporters:
 Correlate traces with audit entries via the `trace_id` field written to
 every `compliance.report_exported` audit entry.
 
+## Audit-event OTLP log export
+
+The tamper-evident governance/NHI-lifecycle audit chain
+(`src/agent_bom/api/governance_audit_log.py`) can also be exported as OTLP
+**logs** (distinct from the trace spans above) to any OTLP/HTTP collector. Set
+`AGENT_BOM_OTEL_LOGS_ENDPOINT` (the collector's logs endpoint, e.g.
+`https://collector.example.com/v1/logs`) and optional
+`AGENT_BOM_OTEL_LOGS_HEADERS` (comma-separated `key=value` collector-auth
+pairs). When configured, every audit record appended by the lifecycle-cleanup
+loop (JIT-grant expiry, dormant-identity auto-revoke, token-rotation-due) is
+emitted as an OTLP `LogRecord` through `src/agent_bom/siem/otlp_logs.py`:
+
+- **Severity** escalates to `WARN` for revocation/enforcement actions and stays
+  `INFO` for routine notices.
+- **Attributes** carry `governance.tenant_id`, `governance.actor`,
+  `governance.action`, `governance.target_type`/`target_id`, before/after state,
+  and the chain `governance.record_hash` (so a consumer can attribute and verify
+  per tenant). The free-form record `detail` is deliberately **not** exported, so
+  a caller-supplied secret can never leave the process.
+- **Batched + non-blocking:** a `BatchLogRecordProcessor` flushes on a background
+  thread, so export never blocks the request or cleanup path. The endpoint is
+  validated against the outbound URL policy (private/loopback egress is refused
+  unless explicitly opened). Requires the `otel` extra; a graceful no-op
+  otherwise.
+
+`GET /health` reports the export state under `tracing.otlp_logs_export`
+(`disabled` / `pending` / `configured`) so operators can confirm whether audit
+logs are merely available or actively exported.
+
+## Device posture (EDR/MDM) → conditional-access ABAC
+
+EDR (endpoint detection & response) and MDM (mobile device management) systems
+own device managed/compliant/encrypted ground truth. `POST /v1/device-posture`
+ingests those signals — `source` selects the normalizer (`generic` for the
+canonical shape, or a vendor field-mapping such as `crowdstrike` / `intune`) and
+`payload` is the source's already-fetched JSON. This is read-only and agentless:
+no vendor credential is stored here. Normalized, tenant-scoped
+`DeviceSignal`s (`src/agent_bom/device_posture.py`) feed the
+`require_device_managed` / `require_device_compliant` /
+`require_device_disk_encrypted` conditions on a conditional-access policy, which
+fail closed for an unknown or non-compliant device. `GET /v1/device-posture/{id}`
+returns the latest stored signal for a device.
+
 ## Runtime Production Index
 
 `GET /v1/runtime/production-index` returns the security equivalent of a

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (286 paths / 337 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (288 paths / 339 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (337 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (339 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -3663,6 +3663,21 @@
             "title": "Otlp Headers Configured",
             "type": "boolean"
           },
+          "otlp_logs_endpoint_configured": {
+            "default": false,
+            "title": "Otlp Logs Endpoint Configured",
+            "type": "boolean"
+          },
+          "otlp_logs_export": {
+            "default": "disabled",
+            "title": "Otlp Logs Export",
+            "type": "string"
+          },
+          "otlp_logs_headers_configured": {
+            "default": false,
+            "title": "Otlp Logs Headers Configured",
+            "type": "boolean"
+          },
           "w3c_baggage": {
             "default": true,
             "title": "W3C Baggage",
@@ -10148,6 +10163,195 @@
           }
         },
         "summary": "Verify Agent Delegation",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
+    "/v1/device-posture": {
+      "post": {
+        "description": "Ingest EDR/MDM device posture/compliance signals for the caller's tenant.\n\n``source`` selects the normalizer (``generic`` for the canonical shape, or a\nvendor field-mapping such as ``crowdstrike`` / ``intune``); ``payload`` is\nthe source's already-fetched JSON. This is read-only, agentless enrichment \u2014\nno vendor credential is stored here. The normalized signals feed the\n``require_device_managed`` / ``require_device_compliant`` /\n``require_device_disk_encrypted`` conditional-access conditions.",
+        "operationId": "ingest_device_posture_v1_device_posture_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "additionalProperties": true,
+                "title": "Body",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Ingest Device Posture V1 Device Posture Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Ingest Device Posture",
+        "tags": [
+          "identity"
+        ]
+      }
+    },
+    "/v1/device-posture/{device_id}": {
+      "get": {
+        "description": "Return the latest stored posture signal for one device (tenant-scoped).",
+        "operationId": "get_device_posture_v1_device_posture__device_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "device_id",
+            "required": true,
+            "schema": {
+              "title": "Device Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Device Posture V1 Device Posture  Device Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Device Posture",
         "tags": [
           "identity"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2431,6 +2431,18 @@ components:
           default: false
           title: Otlp Headers Configured
           type: boolean
+        otlp_logs_endpoint_configured:
+          default: false
+          title: Otlp Logs Endpoint Configured
+          type: boolean
+        otlp_logs_export:
+          default: disabled
+          title: Otlp Logs Export
+          type: string
+        otlp_logs_headers_configured:
+          default: false
+          title: Otlp Logs Headers Configured
+          type: boolean
         w3c_baggage:
           default: true
           title: W3C Baggage
@@ -6706,6 +6718,120 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Verify Agent Delegation
+      tags:
+      - identity
+  /v1/device-posture:
+    post:
+      description: "Ingest EDR/MDM device posture/compliance signals for the caller's\
+        \ tenant.\n\n``source`` selects the normalizer (``generic`` for the canonical\
+        \ shape, or a\nvendor field-mapping such as ``crowdstrike`` / ``intune``);\
+        \ ``payload`` is\nthe source's already-fetched JSON. This is read-only, agentless\
+        \ enrichment \u2014\nno vendor credential is stored here. The normalized signals\
+        \ feed the\n``require_device_managed`` / ``require_device_compliant`` /\n\
+        ``require_device_disk_encrypted`` conditional-access conditions."
+      operationId: ingest_device_posture_v1_device_posture_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              additionalProperties: true
+              title: Body
+              type: object
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Ingest Device Posture V1 Device Posture Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Ingest Device Posture
+      tags:
+      - identity
+  /v1/device-posture/{device_id}:
+    get:
+      description: Return the latest stored posture signal for one device (tenant-scoped).
+      operationId: get_device_posture_v1_device_posture__device_id__get
+      parameters:
+      - in: path
+        name: device_id
+        required: true
+        schema:
+          title: Device Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Device Posture V1 Device Posture  Device Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Device Posture
       tags:
       - identity
   /v1/discovery/providers:

--- a/docs/schemas/v1/HealthResponse.json
+++ b/docs/schemas/v1/HealthResponse.json
@@ -169,6 +169,21 @@
           "title": "Otlp Headers Configured",
           "type": "boolean"
         },
+        "otlp_logs_endpoint_configured": {
+          "default": false,
+          "title": "Otlp Logs Endpoint Configured",
+          "type": "boolean"
+        },
+        "otlp_logs_export": {
+          "default": "disabled",
+          "title": "Otlp Logs Export",
+          "type": "string"
+        },
+        "otlp_logs_headers_configured": {
+          "default": false,
+          "title": "Otlp Logs Headers Configured",
+          "type": "boolean"
+        },
         "w3c_baggage": {
           "default": true,
           "title": "W3C Baggage",

--- a/docs/schemas/v1/TracingHealth.json
+++ b/docs/schemas/v1/TracingHealth.json
@@ -15,6 +15,21 @@
       "title": "Otlp Headers Configured",
       "type": "boolean"
     },
+    "otlp_logs_endpoint_configured": {
+      "default": false,
+      "title": "Otlp Logs Endpoint Configured",
+      "type": "boolean"
+    },
+    "otlp_logs_export": {
+      "default": "disabled",
+      "title": "Otlp Logs Export",
+      "type": "string"
+    },
+    "otlp_logs_headers_configured": {
+      "default": false,
+      "title": "Otlp Logs Headers Configured",
+      "type": "boolean"
+    },
     "w3c_baggage": {
       "default": true,
       "title": "W3C Baggage",

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -310,6 +310,10 @@ AGENT_BOM_OKTA_ORG_URL  # Okta org base URL for read-only NHI discovery; read in
 AGENT_BOM_ENTITLEMENT_FILE
 AGENT_BOM_OTEL_TRACES_ENDPOINT
 AGENT_BOM_OTEL_TRACES_HEADERS
+# OTLP/HTTP endpoint + optional collector-auth headers for exporting the
+# governance audit chain as OTLP logs; read in siem/otlp_logs.py.
+AGENT_BOM_OTEL_LOGS_ENDPOINT
+AGENT_BOM_OTEL_LOGS_HEADERS
 AGENT_BOM_POSTGRES_URL
 # API posture webhook outbox SQLite path override; deploy-time operator setting.
 AGENT_BOM_POSTURE_WEBHOOK_OUTBOX_DB

--- a/src/agent_bom/api/agent_identity_store.py
+++ b/src/agent_bom/api/agent_identity_store.py
@@ -181,6 +181,13 @@ class AccessContext:
     device_id: str = ""
     groups: list[str] = field(default_factory=list)
     client_id: str = ""
+    # Device posture (ABAC), enriched from EDR/MDM signals
+    # (:mod:`agent_bom.device_posture`). ``None`` means "not supplied / unknown"
+    # — a ``require_device_*`` policy fails closed on an unknown device rather
+    # than waving it through.
+    device_managed: bool | None = None
+    device_compliant: bool | None = None
+    device_disk_encrypted: bool | None = None
     at: datetime | None = None
 
 
@@ -219,6 +226,12 @@ class ConditionalAccessPolicy:
     allowed_devices: list[str] = field(default_factory=list)
     allowed_groups: list[str] = field(default_factory=list)
     allowed_clients: list[str] = field(default_factory=list)
+    # Device-posture conditions (ABAC), evaluated against EDR/MDM-enriched
+    # context. Each defaults off; when set, the request must prove the posture
+    # attribute is True or the condition fails closed (unknown/False → not met).
+    require_device_managed: bool = False
+    require_device_compliant: bool = False
+    require_device_disk_encrypted: bool = False
     updated_at: str = ""
     description: str = ""
 
@@ -262,6 +275,14 @@ class ConditionalAccessPolicy:
             return False
         # Client: exact match against the allowed MCP client applications.
         if self.allowed_clients and (not ctx.client_id or ctx.client_id not in set(self.allowed_clients)):
+            return False
+        # Device posture (EDR/MDM enriched). A required posture attribute must be
+        # proven True; an unknown (None) or False posture fails closed.
+        if self.require_device_managed and ctx.device_managed is not True:
+            return False
+        if self.require_device_compliant and ctx.device_compliant is not True:
+            return False
+        if self.require_device_disk_encrypted and ctx.device_disk_encrypted is not True:
             return False
         return True
 
@@ -1011,6 +1032,21 @@ def _put_grant_any_tenant(store: AgentIdentityStore, grant: AgentJITGrant) -> No
         store.put_jit_grant(grant)
 
 
+def _export_audit_to_otlp(record: Any) -> None:
+    """Fire-and-forget OTLP-log export of a sealed audit record.
+
+    Batched + non-blocking (the OTLP batch processor flushes off-thread) and a
+    strict no-op unless ``AGENT_BOM_OTEL_LOGS_ENDPOINT`` is configured, so the
+    cleanup loop is never blocked or aborted by observability export.
+    """
+    try:
+        from agent_bom.siem.otlp_logs import export_governance_audit_record
+
+        export_governance_audit_record(record)
+    except Exception:  # noqa: BLE001 — export must never abort cleanup
+        _lifecycle_logger.debug("governance audit OTLP export skipped", exc_info=True)
+
+
 def _emit_audit(record_kwargs: dict[str, Any], audit_log: Any) -> None:
     """Append one governance-audit record, tolerating a sink failure."""
     if audit_log is None:
@@ -1019,7 +1055,8 @@ def _emit_audit(record_kwargs: dict[str, Any], audit_log: Any) -> None:
         from agent_bom.api.governance_audit_log import make_governance_audit_record
 
         record = make_governance_audit_record(**record_kwargs)
-        audit_log.append(record)
+        sealed = audit_log.append(record)
+        _export_audit_to_otlp(sealed)
     except Exception:  # noqa: BLE001 — an audit-sink hiccup must not abort cleanup
         _lifecycle_logger.warning(
             "governance audit append failed for action=%s target=%s; "
@@ -1330,6 +1367,9 @@ def create_conditional_policy(
     allowed_devices: list[str] | None = None,
     allowed_groups: list[str] | None = None,
     allowed_clients: list[str] | None = None,
+    require_device_managed: bool = False,
+    require_device_compliant: bool = False,
+    require_device_disk_encrypted: bool = False,
     description: str = "",
 ) -> ConditionalAccessPolicy:
     """Create an active conditional-access policy for ``tenant_id``."""
@@ -1354,6 +1394,9 @@ def create_conditional_policy(
         allowed_devices=list(allowed_devices or []),
         allowed_groups=list(allowed_groups or []),
         allowed_clients=list(allowed_clients or []),
+        require_device_managed=bool(require_device_managed),
+        require_device_compliant=bool(require_device_compliant),
+        require_device_disk_encrypted=bool(require_device_disk_encrypted),
         updated_at=now,
         description=description[:1000],
     )

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -320,6 +320,11 @@ class TracingHealth(BaseModel):
     otlp_export: str = "disabled"
     otlp_endpoint_configured: bool = False
     otlp_headers_configured: bool = False
+    # Audit-event OTLP *log* export (governance chain → OTLP logs), distinct from
+    # the trace-span export above.
+    otlp_logs_export: str = "disabled"
+    otlp_logs_endpoint_configured: bool = False
+    otlp_logs_headers_configured: bool = False
 
 
 class AnalyticsHealth(BaseModel):

--- a/src/agent_bom/api/routes/identities.py
+++ b/src/agent_bom/api/routes/identities.py
@@ -423,6 +423,13 @@ def _str_list(body: dict, key: str, *, max_items: int = 200, max_len: int = 120)
     return [str(v).strip()[:max_len] for v in raw if str(v).strip()][:max_items]
 
 
+def _bool(body: dict, key: str) -> bool:
+    raw = body.get(key, False)
+    if isinstance(raw, bool):
+        return raw
+    return str(raw).strip().lower() in {"true", "1", "yes", "on"}
+
+
 def _int_list(body: dict, key: str, *, lo: int, hi: int) -> list[int]:
     raw = body.get(key, [])
     if raw in (None, ""):
@@ -477,6 +484,9 @@ async def create_conditional_access_policy(request: Request, body: dict) -> dict
         allowed_devices=_str_list(body, "allowed_devices", max_len=200),
         allowed_groups=_str_list(body, "allowed_groups", max_len=120),
         allowed_clients=_str_list(body, "allowed_clients", max_len=200),
+        require_device_managed=_bool(body, "require_device_managed"),
+        require_device_compliant=_bool(body, "require_device_compliant"),
+        require_device_disk_encrypted=_bool(body, "require_device_disk_encrypted"),
         description=str(body.get("description", "") or ""),
     )
     log_action(
@@ -987,3 +997,57 @@ async def get_agent_identity(request: Request, identity_id: str) -> dict[str, ob
     if identity is None or identity.tenant_id != _tenant(request):
         raise HTTPException(status_code=404, detail="Agent identity not found")
     return {"schema_version": "agent.identity.v1", "identity": identity.to_public_dict()}
+
+
+# ── Device posture (EDR/MDM) ingest → ABAC device-attribute enrichment ────────
+
+
+@router.post("/device-posture", status_code=201, dependencies=[_dep("config")])
+async def ingest_device_posture(request: Request, body: dict) -> dict[str, object]:
+    """Ingest EDR/MDM device posture/compliance signals for the caller's tenant.
+
+    ``source`` selects the normalizer (``generic`` for the canonical shape, or a
+    vendor field-mapping such as ``crowdstrike`` / ``intune``); ``payload`` is
+    the source's already-fetched JSON. This is read-only, agentless enrichment —
+    no vendor credential is stored here. The normalized signals feed the
+    ``require_device_managed`` / ``require_device_compliant`` /
+    ``require_device_disk_encrypted`` conditional-access conditions.
+    """
+    from agent_bom.device_posture import get_device_posture_store, ingest_device_signals, list_device_connectors
+
+    source = str(body.get("source", "generic") or "generic").strip().lower()
+    if source not in list_device_connectors():
+        raise HTTPException(status_code=400, detail=f"unknown source '{source}'; available: {list_device_connectors()}")
+    payload = body.get("payload", body)
+    if not isinstance(payload, dict):
+        raise HTTPException(status_code=400, detail="'payload' must be an object")
+    tenant_id = _tenant(request)
+    try:
+        signals = ingest_device_signals(get_device_posture_store(), source, payload, tenant_id=tenant_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
+    log_action(
+        "agent_identity.device_posture_ingested",
+        actor=_actor(request),
+        resource=f"device-posture/{source}",
+        tenant_id=tenant_id,
+        source=source,
+        count=len(signals),
+    )
+    return {
+        "schema_version": "identity.device_posture.v1",
+        "source": source,
+        "ingested": len(signals),
+        "devices": [s.to_public_dict() for s in signals],
+    }
+
+
+@router.get("/device-posture/{device_id}", dependencies=[_dep("read")])
+async def get_device_posture(request: Request, device_id: str) -> dict[str, object]:
+    """Return the latest stored posture signal for one device (tenant-scoped)."""
+    from agent_bom.device_posture import get_device_posture_store
+
+    signal = get_device_posture_store().get(device_id, tenant_id=_tenant(request))
+    if signal is None:
+        raise HTTPException(status_code=404, detail="No device-posture signal for this device")
+    return {"schema_version": "identity.device_posture.v1", "device": signal.to_public_dict()}

--- a/src/agent_bom/api/tracing.py
+++ b/src/agent_bom/api/tracing.py
@@ -25,6 +25,9 @@ class TracingHealthSnapshot(TypedDict):
     otlp_export: str
     otlp_endpoint_configured: bool
     otlp_headers_configured: bool
+    otlp_logs_export: str
+    otlp_logs_endpoint_configured: bool
+    otlp_logs_headers_configured: bool
 
 
 def _random_trace_id() -> str:
@@ -222,6 +225,12 @@ def get_tracing_health() -> TracingHealthSnapshot:
     state = _otel_tracing_state
     if state == "unconfigured" and not endpoint:
         state = "disabled"
+    try:
+        from agent_bom.siem.otlp_logs import audit_otlp_health
+
+        logs_health = audit_otlp_health()
+    except Exception:  # noqa: BLE001 - health probe must never raise
+        logs_health = {"otlp_logs_export": "disabled", "otlp_logs_endpoint_configured": False, "otlp_logs_headers_configured": False}
     return {
         "w3c_trace_context": True,
         "w3c_tracestate": True,
@@ -229,4 +238,7 @@ def get_tracing_health() -> TracingHealthSnapshot:
         "otlp_export": state,
         "otlp_endpoint_configured": bool(endpoint),
         "otlp_headers_configured": bool(headers),
+        "otlp_logs_export": str(logs_health["otlp_logs_export"]),
+        "otlp_logs_endpoint_configured": bool(logs_health["otlp_logs_endpoint_configured"]),
+        "otlp_logs_headers_configured": bool(logs_health["otlp_logs_headers_configured"]),
     }

--- a/src/agent_bom/device_posture.py
+++ b/src/agent_bom/device_posture.py
@@ -1,0 +1,402 @@
+"""EDR/MDM device-posture ingest → ABAC device-attribute enrichment.
+
+Endpoint Detection & Response (EDR) and Mobile Device Management (MDM) systems
+own the ground truth for whether a device is *managed*, *compliant*, and
+*disk-encrypted*. Conditional-access (ABAC) policies
+(:class:`agent_bom.api.agent_identity_store.ConditionalAccessPolicy`, device
+attributes added for #3906) can *require* those postures — but only if the
+signals reach the decision point. This module is that bridge:
+
+    vendor payload  ──normalize──▶  DeviceSignal  ──put──▶  DevicePostureStore
+                                                                    │
+                       AccessContext ◀──apply_device_posture────────┘
+
+**Vendor-neutral by design.** The canonical unit is :class:`DeviceSignal`.
+Concrete adapters normalize a specific source's payload shape into that unit;
+they are pure field-mappers over an *already-fetched* JSON payload (read-only,
+agentless — no live vendor API client and no stored vendor credentials ship
+here). Two adapters are provided as concrete shapes — one EDR (CrowdStrike host
+API) and one MDM (Microsoft Intune ``managedDevices``) — alongside a ``generic``
+adapter that accepts the canonical shape directly, which is the documented
+generic **POST** ingest contract. This is deliberately honest: agent-bom ships a
+generic device-posture ingest plus two documented vendor field-mappings, not a
+fleet of live vendor integrations.
+
+The signals carry no secret material — device id, posture booleans, OS version,
+and last-seen only.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import sqlite3
+import threading
+from dataclasses import asdict, dataclass, field
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from agent_bom.api.agent_identity_store import AccessContext
+
+
+@dataclass
+class DeviceSignal:
+    """A vendor-neutral device posture/compliance signal (no secrets).
+
+    ``managed`` / ``compliant`` / ``disk_encrypted`` are tri-state: ``True`` /
+    ``False`` / ``None`` (unknown / not reported). ABAC ``require_device_*``
+    conditions treat only ``True`` as satisfying — unknown fails closed.
+    """
+
+    tenant_id: str
+    device_id: str
+    source: str  # crowdstrike | intune | jamf | generic | ...
+    managed: bool | None = None
+    compliant: bool | None = None
+    disk_encrypted: bool | None = None
+    os_version: str = ""
+    hostname: str = ""
+    risk_level: str = ""  # low | medium | high | critical | ""
+    last_seen: str = ""  # ISO-8601 when the source last observed the device
+    observed_at: str = ""  # ISO-8601 when agent-bom ingested this signal
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ── Store ────────────────────────────────────────────────────────────────────
+
+
+class DevicePostureStore(Protocol):
+    def put(self, signal: DeviceSignal) -> None: ...
+
+    def get(self, device_id: str, *, tenant_id: str) -> DeviceSignal | None: ...
+
+    def list(self, tenant_id: str, *, limit: int = 500) -> builtins.list[DeviceSignal]: ...
+
+
+class InMemoryDevicePostureStore:
+    """Process-local per-tenant device-posture cache. Ephemeral (lost on restart)."""
+
+    def __init__(self) -> None:
+        # Keyed by the composite (tenant_id, device_id) so a device id can never
+        # cross tenants — enrichment for tenant A never leaks to tenant B.
+        self._by_key: dict[tuple[str, str], DeviceSignal] = {}
+        self._lock = threading.Lock()
+
+    def put(self, signal: DeviceSignal) -> None:
+        with self._lock:
+            self._by_key[(signal.tenant_id, signal.device_id)] = signal
+
+    def get(self, device_id: str, *, tenant_id: str) -> DeviceSignal | None:
+        with self._lock:
+            return self._by_key.get((tenant_id, device_id))
+
+    def list(self, tenant_id: str, *, limit: int = 500) -> builtins.list[DeviceSignal]:
+        with self._lock:
+            rows = [s for (t, _d), s in self._by_key.items() if t == tenant_id]
+        return rows[:limit]
+
+
+class SQLiteDevicePostureStore:
+    """Single-node durable device-posture cache backed by SQLite."""
+
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._lock = threading.Lock()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def _init_db(self) -> None:
+        from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
+        ensure_sqlite_schema_version(self._conn, "device_posture")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS device_posture (
+                tenant_id TEXT NOT NULL,
+                device_id TEXT NOT NULL,
+                source TEXT NOT NULL,
+                observed_at TEXT NOT NULL,
+                data TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, device_id)
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_device_posture_tenant ON device_posture(tenant_id)")
+        self._conn.commit()
+
+    def put(self, signal: DeviceSignal) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                INSERT INTO device_posture (tenant_id, device_id, source, observed_at, data)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(tenant_id, device_id)
+                DO UPDATE SET source=excluded.source, observed_at=excluded.observed_at, data=excluded.data
+                """,
+                (signal.tenant_id, signal.device_id, signal.source, signal.observed_at, json.dumps(asdict(signal), sort_keys=True)),
+            )
+            self._conn.commit()
+
+    def get(self, device_id: str, *, tenant_id: str) -> DeviceSignal | None:
+        row = self._conn.execute(
+            "SELECT data FROM device_posture WHERE tenant_id = ? AND device_id = ?",
+            (tenant_id, device_id),
+        ).fetchone()
+        return DeviceSignal(**json.loads(row[0])) if row else None
+
+    def list(self, tenant_id: str, *, limit: int = 500) -> builtins.list[DeviceSignal]:
+        rows = self._conn.execute(
+            "SELECT data FROM device_posture WHERE tenant_id = ? ORDER BY observed_at DESC LIMIT ?",
+            (tenant_id, limit),
+        ).fetchall()
+        return [DeviceSignal(**json.loads(r[0])) for r in rows]
+
+
+# ── Connectors (vendor-neutral normalizers) ──────────────────────────────────
+
+
+def _as_bool(value: Any) -> bool | None:
+    """Coerce a vendor field to a tri-state bool. Unknown → ``None``."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    text = str(value).strip().lower()
+    if text in {"true", "yes", "1", "compliant", "managed", "encrypted", "enabled", "on"}:
+        return True
+    if text in {"false", "no", "0", "noncompliant", "unmanaged", "notencrypted", "disabled", "off"}:
+        return False
+    return None
+
+
+class DevicePostureConnector(Protocol):
+    source: str
+
+    def normalize(self, payload: dict[str, Any], *, tenant_id: str) -> builtins.list[DeviceSignal]: ...
+
+
+class GenericDevicePostureConnector:
+    """Accept the canonical device-posture shape directly (the POST ingest).
+
+    Expected payload::
+
+        {"signals": [{"device_id": "...", "managed": true, "compliant": true,
+                      "disk_encrypted": true, "os_version": "...",
+                      "hostname": "...", "risk_level": "low",
+                      "last_seen": "...", "attributes": {...}}]}
+    """
+
+    source = "generic"
+
+    def normalize(self, payload: dict[str, Any], *, tenant_id: str) -> builtins.list[DeviceSignal]:
+        out: builtins.list[DeviceSignal] = []
+        for row in payload.get("signals", []) or []:
+            device_id = str(row.get("device_id") or "").strip()
+            if not device_id:
+                continue
+            out.append(
+                DeviceSignal(
+                    tenant_id=tenant_id,
+                    device_id=device_id,
+                    source=str(row.get("source") or self.source),
+                    managed=_as_bool(row.get("managed")),
+                    compliant=_as_bool(row.get("compliant")),
+                    disk_encrypted=_as_bool(row.get("disk_encrypted")),
+                    os_version=str(row.get("os_version") or ""),
+                    hostname=str(row.get("hostname") or ""),
+                    risk_level=str(row.get("risk_level") or ""),
+                    last_seen=str(row.get("last_seen") or ""),
+                    attributes=dict(row.get("attributes") or {}),
+                )
+            )
+        return out
+
+
+class CrowdStrikeConnector:
+    """Normalize a CrowdStrike Falcon host-details payload (EDR).
+
+    Field mapping (``/devices/entities/devices/v2`` ``resources[]``):
+    a reporting sensor ⇒ ``managed``; ``status == "normal"`` and *not* in
+    ``reduced_functionality_mode`` ⇒ ``compliant``.
+    """
+
+    source = "crowdstrike"
+
+    def normalize(self, payload: dict[str, Any], *, tenant_id: str) -> builtins.list[DeviceSignal]:
+        out: builtins.list[DeviceSignal] = []
+        for host in payload.get("resources", []) or []:
+            device_id = str(host.get("device_id") or host.get("id") or "").strip()
+            if not device_id:
+                continue
+            status = str(host.get("status") or "").strip().lower()
+            rfm = _as_bool(host.get("reduced_functionality_mode"))
+            compliant = status in {"normal", ""} and rfm is not True
+            out.append(
+                DeviceSignal(
+                    tenant_id=tenant_id,
+                    device_id=device_id,
+                    source=self.source,
+                    managed=True,  # a host reporting to Falcon is under EDR management
+                    compliant=compliant,
+                    disk_encrypted=_as_bool(host.get("disk_encryption_status")),
+                    os_version=str(host.get("os_version") or ""),
+                    hostname=str(host.get("hostname") or ""),
+                    risk_level=str(host.get("risk_level") or ""),
+                    last_seen=str(host.get("last_seen") or ""),
+                    attributes={"platform": str(host.get("platform_name") or "")},
+                )
+            )
+        return out
+
+
+class IntuneConnector:
+    """Normalize a Microsoft Intune ``managedDevices`` payload (MDM).
+
+    Field mapping (Graph ``deviceManagement/managedDevices`` ``value[]``):
+    ``complianceState == "compliant"`` ⇒ ``compliant``;
+    ``managementState``/``managementAgent`` present ⇒ ``managed``;
+    ``isEncrypted`` ⇒ ``disk_encrypted``.
+    """
+
+    source = "intune"
+
+    def normalize(self, payload: dict[str, Any], *, tenant_id: str) -> builtins.list[DeviceSignal]:
+        out: builtins.list[DeviceSignal] = []
+        for dev in payload.get("value", []) or []:
+            device_id = str(dev.get("id") or "").strip()
+            if not device_id:
+                continue
+            compliance = str(dev.get("complianceState") or "").strip().lower()
+            mgmt_state = str(dev.get("managementState") or dev.get("managementAgent") or "").strip().lower()
+            out.append(
+                DeviceSignal(
+                    tenant_id=tenant_id,
+                    device_id=device_id,
+                    source=self.source,
+                    managed=bool(mgmt_state) and mgmt_state not in {"none", "unmanaged", "discovered"},
+                    compliant=(compliance == "compliant") if compliance else None,
+                    disk_encrypted=_as_bool(dev.get("isEncrypted")),
+                    os_version=str(dev.get("osVersion") or ""),
+                    hostname=str(dev.get("deviceName") or ""),
+                    last_seen=str(dev.get("lastSyncDateTime") or ""),
+                    attributes={"os": str(dev.get("operatingSystem") or "")},
+                )
+            )
+        return out
+
+
+_CONNECTORS: dict[str, type] = {
+    "generic": GenericDevicePostureConnector,
+    "crowdstrike": CrowdStrikeConnector,
+    "intune": IntuneConnector,
+}
+
+
+def create_device_connector(name: str) -> DevicePostureConnector:
+    """Create a device-posture connector by source name."""
+    cls = _CONNECTORS.get(name.strip().lower())
+    if cls is None:
+        raise ValueError(f"Unknown device-posture connector: {name!r}. Available: {list_device_connectors()}")
+    return cls()  # type: ignore[return-value]
+
+
+def list_device_connectors() -> builtins.list[str]:
+    return sorted(_CONNECTORS.keys())
+
+
+# ── ABAC enrichment ──────────────────────────────────────────────────────────
+
+
+def apply_device_posture(store: DevicePostureStore, ctx: "AccessContext", *, tenant_id: str) -> "AccessContext":
+    """Fill ``ctx`` device-posture attributes from the store for its device id.
+
+    A no-op when the request supplied no ``device_id`` or the device is unknown
+    to this tenant — leaving the posture attributes ``None`` so a
+    ``require_device_*`` policy fails closed on an unmanaged / unknown device.
+    Mutates and returns ``ctx``.
+    """
+    if not ctx.device_id:
+        return ctx
+    signal = store.get(ctx.device_id, tenant_id=tenant_id)
+    if signal is None:
+        return ctx
+    ctx.device_managed = signal.managed
+    ctx.device_compliant = signal.compliant
+    ctx.device_disk_encrypted = signal.disk_encrypted
+    return ctx
+
+
+# ── Store singleton ──────────────────────────────────────────────────────────
+
+_DEVICE_POSTURE_STORE: DevicePostureStore | None = None
+_STORE_LOCK = threading.Lock()
+
+
+def get_device_posture_store() -> DevicePostureStore:
+    """Return the process device-posture store, durable by default.
+
+    Node-local durable SQLite by default; in-memory only on the explicit
+    ephemeral opt-out (``AGENT_BOM_EPHEMERAL_STORE``). A shared Postgres tier for
+    multi-replica posture is a tracked follow-up; on a Postgres deployment this
+    falls back to node-local SQLite (each replica caches independently), which is
+    safe because posture is an enrichment cache re-populated on ingest.
+    """
+    global _DEVICE_POSTURE_STORE
+    if _DEVICE_POSTURE_STORE is not None:
+        return _DEVICE_POSTURE_STORE
+    with _STORE_LOCK:
+        if _DEVICE_POSTURE_STORE is None:
+            from agent_bom.api.durable_store import select_backend, sqlite_path
+
+            backend = select_backend()
+            if backend == "memory":
+                _DEVICE_POSTURE_STORE = InMemoryDevicePostureStore()
+            else:
+                _DEVICE_POSTURE_STORE = SQLiteDevicePostureStore(sqlite_path())
+    return _DEVICE_POSTURE_STORE
+
+
+def set_device_posture_store(store: DevicePostureStore | None) -> None:
+    global _DEVICE_POSTURE_STORE
+    with _STORE_LOCK:
+        _DEVICE_POSTURE_STORE = store
+
+
+def ingest_device_signals(
+    store: DevicePostureStore, source: str, payload: dict[str, Any], *, tenant_id: str
+) -> builtins.list[DeviceSignal]:
+    """Normalize a vendor/generic payload and persist every signal. Returns them."""
+    connector = create_device_connector(source)
+    signals = connector.normalize(payload, tenant_id=tenant_id)
+    for signal in signals:
+        store.put(signal)
+    return signals
+
+
+__all__ = [
+    "CrowdStrikeConnector",
+    "DevicePostureConnector",
+    "DevicePostureStore",
+    "DeviceSignal",
+    "GenericDevicePostureConnector",
+    "InMemoryDevicePostureStore",
+    "IntuneConnector",
+    "SQLiteDevicePostureStore",
+    "apply_device_posture",
+    "create_device_connector",
+    "get_device_posture_store",
+    "ingest_device_signals",
+    "list_device_connectors",
+    "set_device_posture_store",
+]

--- a/src/agent_bom/device_posture.py
+++ b/src/agent_bom/device_posture.py
@@ -241,19 +241,35 @@ class CrowdStrikeConnector:
                 continue
             status = str(host.get("status") or "").strip().lower()
             rfm = _as_bool(host.get("reduced_functionality_mode"))
-            compliant = status in {"normal", ""} and rfm is not True
+            last_seen = str(host.get("last_seen") or "")
+            agent_version = str(host.get("agent_version") or "")
+            # Tri-state compliance — a missing/empty status is UNKNOWN, not
+            # compliant. Only assert compliant on an explicit "normal" that is
+            # not in reduced-functionality mode; RFM is a known-bad signal.
+            compliant: bool | None
+            if rfm is True:
+                compliant = False
+            elif status:
+                compliant = status == "normal"
+            else:
+                compliant = None
+            # Only assert managed when the payload actually evidences a reporting
+            # / enrolled sensor (status, a last-seen, or an agent version). A
+            # sparse device_id-only entry leaves managed unknown so a
+            # require_device_managed gate fails closed.
+            managed: bool | None = True if (status or last_seen or agent_version) else None
             out.append(
                 DeviceSignal(
                     tenant_id=tenant_id,
                     device_id=device_id,
                     source=self.source,
-                    managed=True,  # a host reporting to Falcon is under EDR management
+                    managed=managed,
                     compliant=compliant,
                     disk_encrypted=_as_bool(host.get("disk_encryption_status")),
                     os_version=str(host.get("os_version") or ""),
                     hostname=str(host.get("hostname") or ""),
                     risk_level=str(host.get("risk_level") or ""),
-                    last_seen=str(host.get("last_seen") or ""),
+                    last_seen=last_seen,
                     attributes={"platform": str(host.get("platform_name") or "")},
                 )
             )

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -2145,6 +2145,16 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         groups=_request_groups(request),
                         client_id=_request_client_id(request),
                     )
+                    # Enrich the access context with EDR/MDM device posture so a
+                    # require_device_managed/compliant/disk_encrypted policy can
+                    # be evaluated. Unknown devices leave posture None → the
+                    # guardrail fails closed.
+                    try:
+                        from agent_bom.device_posture import apply_device_posture, get_device_posture_store
+
+                        apply_device_posture(get_device_posture_store(), ctx, tenant_id=tenant_id)
+                    except Exception:  # noqa: BLE001 — enrichment must not break the decision path
+                        pass
                     cond_allowed, cond_reason, cond_policy_id = evaluate_conditional_access_for_request(
                         get_agent_identity_store(),
                         tenant_id=tenant_id,

--- a/src/agent_bom/siem/otlp_logs.py
+++ b/src/agent_bom/siem/otlp_logs.py
@@ -1,0 +1,295 @@
+"""Audit-event OTLP **log** export.
+
+The platform already ships OTLP *trace spans* (``api/tracing.py``,
+``output/prometheus.py``) and a full SIEM/OCSF forwarder set (``siem/__init__``,
+``delivery.py``). The one OTLP surface missing was **logs**: exporting the
+tamper-evident governance/audit chain (``api/governance_audit_log.py``) as OTLP
+``LogRecord``s so a SIEM/observability collector receives every NHI
+lifecycle-enforcement action (JIT-grant expiry, dormant-identity revoke, token
+rotation-due) as a first-class log stream — not only as trace spans.
+
+Design (mirrors the existing OTLP *trace* exporter):
+
+* **Same env-driven config style** as ``AGENT_BOM_OTEL_TRACES_*`` — an operator
+  sets ``AGENT_BOM_OTEL_LOGS_ENDPOINT`` (OTLP/HTTP logs endpoint, e.g. a
+  collector's ``/v1/logs``) and optional ``AGENT_BOM_OTEL_LOGS_HEADERS``
+  (comma-separated ``key=value`` collector-auth pairs). Unset ⇒ disabled no-op.
+* **Batched + non-blocking.** A ``BatchLogRecordProcessor`` enqueues records and
+  flushes on a background thread, so ``export`` never blocks the caller's
+  (request / cleanup-loop) path — the same read-path offload discipline the rest
+  of the codebase follows.
+* **Secret-free.** Only the governance record's declared, redacted fields are
+  mapped to attributes (the chain itself never holds secret material); the
+  free-form ``detail`` dict is deliberately *not* forwarded so an accidental
+  secret in a caller-supplied detail can never leave the process.
+* **Tenant-scoped.** Every log record carries ``governance.tenant_id`` and the
+  record's chain ``record_hash``, so a downstream consumer can attribute and
+  verify each event per tenant.
+
+OpenTelemetry is an optional dependency (the ``otel`` extra); every entry point
+degrades to a graceful no-op when it is not installed.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from agent_bom.api.governance_audit_log import GovernanceAuditRecord
+
+logger = logging.getLogger(__name__)
+
+# Env config — mirrors the AGENT_BOM_OTEL_TRACES_* convention used for spans.
+ENDPOINT_ENV = "AGENT_BOM_OTEL_LOGS_ENDPOINT"
+HEADERS_ENV = "AGENT_BOM_OTEL_LOGS_HEADERS"
+
+# Actions that represent a security-relevant revocation/enforcement escalate to
+# WARN; routine "due" notices stay INFO. Kept explicit so the mapping is auditable.
+_WARN_ACTIONS = frozenset(
+    {
+        "identity_dormant_auto_revoke",
+        "jit_grant_expired",
+        "jit_grant_denied_pruned",
+    }
+)
+
+
+def severity_for_action(action: str) -> tuple[Any, str]:
+    """Map a governance action to an OTLP ``(SeverityNumber, severity_text)``.
+
+    Import of the OTel severity enum is deferred so the mapping table itself
+    stays importable without the optional dependency.
+    """
+    from opentelemetry._logs import SeverityNumber
+
+    if action in _WARN_ACTIONS:
+        return SeverityNumber.WARN, "WARN"
+    return SeverityNumber.INFO, "INFO"
+
+
+def audit_record_log_attributes(record: "GovernanceAuditRecord") -> dict[str, Any]:
+    """Return the OTLP-safe, secret-free attribute map for one audit record.
+
+    Only the record's declared governance fields are exported. The free-form
+    ``detail`` dict is intentionally omitted so a caller-supplied secret can
+    never ride out on the log stream.
+    """
+    return {
+        "governance.tenant_id": record.tenant_id,
+        "governance.actor": record.actor,
+        "governance.action": record.action,
+        "governance.target_type": record.target_type,
+        "governance.target_id": record.target_id,
+        "governance.before_state": record.before_state,
+        "governance.after_state": record.after_state,
+        "governance.reason": record.reason,
+        "governance.observed_at": record.observed_at,
+        "governance.action_id": record.action_id,
+        "governance.record_hash": record.record_hash,
+    }
+
+
+def _audit_record_body(record: "GovernanceAuditRecord") -> str:
+    """A concise human-readable log body (no secrets)."""
+    return f"governance {record.action} {record.target_type}:{record.target_id} {record.before_state}->{record.after_state}"
+
+
+def _iso_to_unix_nanos(observed_at: str) -> int | None:
+    from datetime import datetime
+
+    try:
+        dt = datetime.fromisoformat(observed_at)
+    except (ValueError, TypeError):
+        return None
+    return int(dt.timestamp() * 1_000_000_000)
+
+
+class AuditLogOtlpExporter:
+    """Export governance audit records as OTLP logs via an injected provider.
+
+    ``provider`` is an OpenTelemetry ``LoggerProvider``. In production it wraps a
+    ``BatchLogRecordProcessor`` + OTLP HTTP exporter (see
+    :func:`configure_audit_otlp_from_env`); tests inject a provider backed by an
+    in-memory exporter. ``export`` only *enqueues* records with the provider —
+    the batch processor performs the network flush on its own thread — so it is
+    safe to call from a request or the cleanup loop without blocking.
+    """
+
+    def __init__(self, provider: Any) -> None:
+        self._provider = provider
+        self._logger = provider.get_logger("agent_bom.governance_audit")
+
+    def export(self, records: "list[GovernanceAuditRecord]") -> int:
+        """Emit each record as an OTLP LogRecord. Returns the count emitted.
+
+        Never raises for a delivery problem — an emit failure is logged and the
+        remaining records still attempt to export.
+        """
+        emitted = 0
+        for record in records:
+            try:
+                severity_number, severity_text = severity_for_action(record.action)
+                ts = _iso_to_unix_nanos(record.observed_at)
+                self._logger.emit(
+                    timestamp=ts,
+                    observed_timestamp=ts,
+                    severity_number=severity_number,
+                    severity_text=severity_text,
+                    body=_audit_record_body(record),
+                    attributes=audit_record_log_attributes(record),
+                    event_name="governance.audit",
+                )
+                emitted += 1
+            except Exception:  # noqa: BLE001 - export must never abort the caller
+                logger.warning("audit OTLP log emit failed for action=%s", record.action, exc_info=True)
+        return emitted
+
+    def force_flush(self, timeout_millis: int = 5000) -> bool:
+        try:
+            return bool(self._provider.force_flush(timeout_millis))
+        except Exception:  # noqa: BLE001
+            return False
+
+    def shutdown(self) -> None:
+        try:
+            self._provider.shutdown()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def _parse_headers(raw: str) -> dict[str, str]:
+    headers: dict[str, str] = {}
+    for pair in raw.split(","):
+        if "=" not in pair:
+            continue
+        key, value = pair.split("=", 1)
+        if key.strip():
+            headers[key.strip()] = value.strip()
+    return headers
+
+
+def build_audit_otlp_exporter(endpoint: str, headers: dict[str, str] | None = None) -> AuditLogOtlpExporter | None:
+    """Build a batched OTLP-log exporter for ``endpoint``.
+
+    Returns ``None`` when the OpenTelemetry logs packages are unavailable (the
+    ``otel`` extra is not installed) — a graceful no-op, matching the trace path.
+
+    Raises ``RuntimeError`` only when ``endpoint`` is rejected by the outbound
+    URL policy (an actionable misconfiguration, not a transient failure).
+    """
+    from agent_bom import __version__
+    from agent_bom.security import SecurityError, validate_url
+
+    allow_private = os.environ.get("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "").strip().lower() in {"1", "true", "yes", "on"}
+    try:
+        validate_url(endpoint, allowed_schemes=("https", "http") if allow_private else ("https",), allow_private=allow_private)
+    except SecurityError as exc:
+        raise RuntimeError(f"OTLP logs endpoint rejected by outbound URL policy: {exc}") from exc
+
+    try:
+        from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
+        from opentelemetry.sdk._logs import LoggerProvider
+        from opentelemetry.sdk._logs.export import BatchLogRecordProcessor
+        from opentelemetry.sdk.resources import SERVICE_NAME, SERVICE_VERSION, Resource
+    except ImportError:
+        logger.warning(
+            "%s is set but OpenTelemetry log packages are unavailable. Install with: pip install 'agent-bom[otel]'",
+            ENDPOINT_ENV,
+        )
+        return None
+
+    resource = Resource.create({SERVICE_NAME: "agent-bom", SERVICE_VERSION: __version__})
+    provider = LoggerProvider(resource=resource)
+    provider.add_log_record_processor(
+        BatchLogRecordProcessor(OTLPLogExporter(endpoint=endpoint, headers=headers or None))
+    )
+    return AuditLogOtlpExporter(provider=provider)
+
+
+_EXPORTER: AuditLogOtlpExporter | None = None
+_EXPORTER_LOCK = threading.Lock()
+_CONFIGURED = False
+
+
+def configure_audit_otlp_from_env() -> AuditLogOtlpExporter | None:
+    """Return a process-wide audit OTLP-log exporter from env, or ``None``.
+
+    Reads ``AGENT_BOM_OTEL_LOGS_ENDPOINT`` (+ optional
+    ``AGENT_BOM_OTEL_LOGS_HEADERS``). Unset endpoint ⇒ disabled (``None``).
+    Cached after the first successful build so the batch processor / background
+    exporter is created once per process.
+    """
+    global _EXPORTER, _CONFIGURED
+    endpoint = os.environ.get(ENDPOINT_ENV, "").strip()
+    if not endpoint:
+        return None
+    with _EXPORTER_LOCK:
+        if _CONFIGURED and _EXPORTER is not None:
+            return _EXPORTER
+        headers = _parse_headers(os.environ.get(HEADERS_ENV, "").strip())
+        exporter = build_audit_otlp_exporter(endpoint, headers)
+        if exporter is not None:
+            _EXPORTER = exporter
+            _CONFIGURED = True
+        return exporter
+
+
+def set_audit_otlp_exporter(exporter: AuditLogOtlpExporter | None) -> None:
+    """Override the process exporter (tests / explicit wiring)."""
+    global _EXPORTER, _CONFIGURED
+    with _EXPORTER_LOCK:
+        _EXPORTER = exporter
+        _CONFIGURED = exporter is not None
+
+
+def export_governance_audit_record(record: "GovernanceAuditRecord") -> bool:
+    """Fire-and-forget export of one audit record when OTLP logs are configured.
+
+    Non-blocking and failure-tolerant: returns ``True`` when the record was
+    enqueued for export, ``False`` when export is not configured or the emit
+    failed. Safe to call from the audit-append hot path.
+    """
+    # An explicitly-set exporter (programmatic wiring / tests) is used directly;
+    # otherwise fall back to the env-configured singleton.
+    exporter = _EXPORTER if (_CONFIGURED and _EXPORTER is not None) else configure_audit_otlp_from_env()
+    if exporter is None:
+        return False
+    try:
+        return exporter.export([record]) == 1
+    except Exception:  # noqa: BLE001
+        logger.warning("governance audit OTLP export failed", exc_info=True)
+        return False
+
+
+def audit_otlp_health() -> dict[str, Any]:
+    """Operator-facing status of audit OTLP-log export (no secrets)."""
+    endpoint = os.environ.get(ENDPOINT_ENV, "").strip()
+    headers = os.environ.get(HEADERS_ENV, "").strip()
+    if not endpoint:
+        state = "disabled"
+    elif _CONFIGURED and _EXPORTER is not None:
+        state = "configured"
+    else:
+        state = "pending"
+    return {
+        "otlp_logs_export": state,
+        "otlp_logs_endpoint_configured": bool(endpoint),
+        "otlp_logs_headers_configured": bool(headers),
+    }
+
+
+__all__ = [
+    "AuditLogOtlpExporter",
+    "ENDPOINT_ENV",
+    "HEADERS_ENV",
+    "audit_otlp_health",
+    "audit_record_log_attributes",
+    "build_audit_otlp_exporter",
+    "configure_audit_otlp_from_env",
+    "export_governance_audit_record",
+    "set_audit_otlp_exporter",
+    "severity_for_action",
+]

--- a/src/agent_bom/siem/otlp_logs.py
+++ b/src/agent_bom/siem/otlp_logs.py
@@ -212,6 +212,11 @@ def build_audit_otlp_exporter(endpoint: str, headers: dict[str, str] | None = No
 _EXPORTER: AuditLogOtlpExporter | None = None
 _EXPORTER_LOCK = threading.Lock()
 _CONFIGURED = False
+# The endpoint whose env-config attempt already completed. Cached so a build
+# that yields no exporter (e.g. the ``otel`` extra is not installed) is attempted
+# once — not re-run (with its blocking ``validate_url`` → ``socket.getaddrinfo``)
+# on every audit-append. ``None`` = not yet attempted for the current endpoint.
+_ENV_ATTEMPTED_ENDPOINT: str | None = None
 
 
 def configure_audit_otlp_from_env() -> AuditLogOtlpExporter | None:
@@ -222,15 +227,20 @@ def configure_audit_otlp_from_env() -> AuditLogOtlpExporter | None:
     Cached after the first successful build so the batch processor / background
     exporter is created once per process.
     """
-    global _EXPORTER, _CONFIGURED
+    global _EXPORTER, _CONFIGURED, _ENV_ATTEMPTED_ENDPOINT
     endpoint = os.environ.get(ENDPOINT_ENV, "").strip()
     if not endpoint:
         return None
     with _EXPORTER_LOCK:
         if _CONFIGURED and _EXPORTER is not None:
             return _EXPORTER
+        # Already attempted this exact endpoint and it produced no exporter
+        # (otel extra missing): don't re-run the blocking build/URL validation.
+        if _ENV_ATTEMPTED_ENDPOINT == endpoint:
+            return None
         headers = _parse_headers(os.environ.get(HEADERS_ENV, "").strip())
         exporter = build_audit_otlp_exporter(endpoint, headers)
+        _ENV_ATTEMPTED_ENDPOINT = endpoint
         if exporter is not None:
             _EXPORTER = exporter
             _CONFIGURED = True
@@ -239,10 +249,11 @@ def configure_audit_otlp_from_env() -> AuditLogOtlpExporter | None:
 
 def set_audit_otlp_exporter(exporter: AuditLogOtlpExporter | None) -> None:
     """Override the process exporter (tests / explicit wiring)."""
-    global _EXPORTER, _CONFIGURED
+    global _EXPORTER, _CONFIGURED, _ENV_ATTEMPTED_ENDPOINT
     with _EXPORTER_LOCK:
         _EXPORTER = exporter
         _CONFIGURED = exporter is not None
+        _ENV_ATTEMPTED_ENDPOINT = None
 
 
 def export_governance_audit_record(record: "GovernanceAuditRecord") -> bool:

--- a/tests/test_audit_otlp_logs.py
+++ b/tests/test_audit_otlp_logs.py
@@ -32,6 +32,7 @@ from agent_bom.siem.otlp_logs import (  # noqa: E402
     AuditLogOtlpExporter,
     audit_record_log_attributes,
     configure_audit_otlp_from_env,
+    export_governance_audit_record,
     set_audit_otlp_exporter,
     severity_for_action,
 )
@@ -167,6 +168,33 @@ def test_configure_from_env_builds_exporter(monkeypatch):
     assert n == 1
     exporter.shutdown()
     set_audit_otlp_exporter(None)
+
+
+def test_unavailable_exporter_is_attempted_once_not_on_every_append(monkeypatch):
+    # Endpoint set but the build returns None (e.g. the `otel` extra is not
+    # installed). The build path is where the blocking URL/DNS validation
+    # (`validate_url` → `socket.getaddrinfo`) runs under the exporter lock, so it
+    # must be attempted exactly once and cached as a no-op — NOT re-run on every
+    # audit-append call.
+    import agent_bom.siem.otlp_logs as otlp
+
+    monkeypatch.setenv("AGENT_BOM_OTEL_LOGS_ENDPOINT", "https://collector.example.com/v1/logs")
+    monkeypatch.delenv("AGENT_BOM_OTEL_LOGS_HEADERS", raising=False)
+    set_audit_otlp_exporter(None)  # clear cache + reset attempt sentinel
+
+    calls = {"n": 0}
+
+    def _counting_build(endpoint, headers=None):
+        calls["n"] += 1
+        return None  # simulate otel-unavailable no-op
+
+    monkeypatch.setattr(otlp, "build_audit_otlp_exporter", _counting_build)
+    try:
+        results = [export_governance_audit_record(_record()) for _ in range(5)]
+        assert results == [False] * 5  # no exporter → not enqueued
+        assert calls["n"] == 1  # build/validate attempted at most once
+    finally:
+        set_audit_otlp_exporter(None)
 
 
 def test_lifecycle_audit_append_triggers_otlp_export():

--- a/tests/test_audit_otlp_logs.py
+++ b/tests/test_audit_otlp_logs.py
@@ -1,0 +1,202 @@
+"""Audit-event OTLP-log export.
+
+The governance audit chain already ships as hash-chained records; the SIEM/OTel
+layer already exports OTLP *trace spans*. These tests cover the missing half:
+exporting the governance/audit log as OTLP **logs** through the pinned
+OpenTelemetry logs SDK, honoring the same env-driven config style as the trace
+exporter, batched and non-blocking, tenant-scoped, and never leaking secrets.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.api.governance_audit_log import (
+    ACTION_IDENTITY_DORMANT_REVOKE,
+    ACTION_TOKEN_ROTATION_DUE,
+    make_governance_audit_record,
+)
+
+pytest.importorskip("opentelemetry.sdk._logs")
+
+from opentelemetry._logs import SeverityNumber  # noqa: E402
+from opentelemetry.sdk._logs import LoggerProvider  # noqa: E402
+from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor  # noqa: E402
+
+try:  # exporter name churned across otel-sdk releases; support both.
+    from opentelemetry.sdk._logs.export import InMemoryLogRecordExporter as _MemLogExporter
+except ImportError:  # pragma: no cover - older sdk
+    from opentelemetry.sdk._logs.export import InMemoryLogExporter as _MemLogExporter
+
+from agent_bom.siem.otlp_logs import (  # noqa: E402
+    AuditLogOtlpExporter,
+    audit_record_log_attributes,
+    configure_audit_otlp_from_env,
+    set_audit_otlp_exporter,
+    severity_for_action,
+)
+
+
+def _record(**overrides):
+    kwargs = dict(
+        tenant_id="tenant-a",
+        actor="lifecycle-loop",
+        action=ACTION_IDENTITY_DORMANT_REVOKE,
+        target_type="agent_identity",
+        target_id="id-123",
+        reason="dormant 90d",
+        before_state="active",
+        after_state="revoked",
+        observed_at="2026-07-16T00:00:00+00:00",
+        window_key="2026-07-16T00:00:00+00:00",
+    )
+    kwargs.update(overrides)
+    return make_governance_audit_record(**kwargs)
+
+
+def _mem_exporter() -> AuditLogOtlpExporter:
+    exporter = _MemLogExporter()
+    provider = LoggerProvider()
+    provider.add_log_record_processor(SimpleLogRecordProcessor(exporter))
+    return AuditLogOtlpExporter(provider=provider), exporter
+
+
+def _lr(readable):
+    """Normalize across otel-sdk shapes: a finished log exposes its record
+    either directly or under ``.log_record``."""
+    return getattr(readable, "log_record", readable)
+
+
+# ── attribute mapping ────────────────────────────────────────────────────────
+
+
+def test_audit_record_maps_to_otlp_attributes():
+    rec = _record()
+    attrs = audit_record_log_attributes(rec)
+    assert attrs["governance.tenant_id"] == "tenant-a"
+    assert attrs["governance.actor"] == "lifecycle-loop"
+    assert attrs["governance.action"] == ACTION_IDENTITY_DORMANT_REVOKE
+    assert attrs["governance.target_type"] == "agent_identity"
+    assert attrs["governance.target_id"] == "id-123"
+    assert attrs["governance.before_state"] == "active"
+    assert attrs["governance.after_state"] == "revoked"
+    # The record hash ties the exported log back to the tamper-evident chain.
+    assert attrs["governance.record_hash"] == rec.record_hash
+    # Every attribute value is a scalar OTLP-safe type (str/int/float/bool).
+    for value in attrs.values():
+        assert isinstance(value, (str, int, float, bool))
+
+
+def test_severity_escalates_for_revocation():
+    revoke_num, revoke_text = severity_for_action(ACTION_IDENTITY_DORMANT_REVOKE)
+    info_num, _ = severity_for_action(ACTION_TOKEN_ROTATION_DUE)
+    assert revoke_num == SeverityNumber.WARN
+    assert revoke_text == "WARN"
+    assert info_num == SeverityNumber.INFO
+
+
+# ── export round-trip ────────────────────────────────────────────────────────
+
+
+def test_export_emits_well_formed_log_record():
+    exporter, mem = _mem_exporter()
+    rec = _record()
+    n = exporter.export([rec])
+    exporter.force_flush()
+    assert n == 1
+    logs = mem.get_finished_logs()
+    assert len(logs) == 1
+    lr = _lr(logs[0])
+    assert lr.severity_number == SeverityNumber.WARN
+    assert "identity_dormant_auto_revoke" in str(lr.body)
+    attrs = dict(lr.attributes)
+    assert attrs["governance.tenant_id"] == "tenant-a"
+    assert attrs["governance.action"] == ACTION_IDENTITY_DORMANT_REVOKE
+
+
+def test_export_is_tenant_scoped_and_preserves_each_tenant():
+    exporter, mem = _mem_exporter()
+    a = _record(tenant_id="tenant-a", target_id="id-a")
+    b = _record(tenant_id="tenant-b", target_id="id-b")
+    exporter.export([a, b])
+    exporter.force_flush()
+    logs = mem.get_finished_logs()
+    tenants = {dict(_lr(lr).attributes)["governance.tenant_id"] for lr in logs}
+    assert tenants == {"tenant-a", "tenant-b"}
+    assert len(logs) == 2
+
+
+def test_export_never_leaks_secret_material():
+    # A record whose reason/detail carry a token-shaped string must still export
+    # only the declared, secret-free governance attributes.
+    exporter, mem = _mem_exporter()
+    rec = _record(reason="rotate", detail={"token": "sk-super-secret-value", "note": "ok"})
+    exporter.export([rec])
+    exporter.force_flush()
+    lr = _lr(mem.get_finished_logs()[0])
+    blob = str(lr.body) + str(dict(lr.attributes))
+    assert "sk-super-secret-value" not in blob
+
+
+# ── env configuration ────────────────────────────────────────────────────────
+
+
+def test_configure_from_env_disabled_without_endpoint(monkeypatch):
+    monkeypatch.delenv("AGENT_BOM_OTEL_LOGS_ENDPOINT", raising=False)
+    assert configure_audit_otlp_from_env() is None
+
+
+def test_configure_from_env_rejects_disallowed_endpoint(monkeypatch):
+    # A private/loopback endpoint is rejected by the outbound URL policy unless
+    # egress is explicitly opened — never silently exported.
+    monkeypatch.setenv("AGENT_BOM_OTEL_LOGS_ENDPOINT", "http://169.254.169.254/v1/logs")
+    monkeypatch.delenv("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", raising=False)
+    with pytest.raises(RuntimeError):
+        configure_audit_otlp_from_env()
+
+
+def test_configure_from_env_builds_exporter(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_OTEL_LOGS_ENDPOINT", "https://example.com/v1/logs")
+    monkeypatch.setenv("AGENT_BOM_OTEL_LOGS_HEADERS", "authorization=Bearer abc,x-scope=team")
+    set_audit_otlp_exporter(None)  # clear any cached singleton
+    exporter = configure_audit_otlp_from_env()
+    assert isinstance(exporter, AuditLogOtlpExporter)
+    # The batch processor exports off the caller's thread — export() returns
+    # immediately without blocking on the network.
+    n = exporter.export([_record()])
+    assert n == 1
+    exporter.shutdown()
+    set_audit_otlp_exporter(None)
+
+
+def test_lifecycle_audit_append_triggers_otlp_export():
+    # The single audit-append hook (_emit_audit) must fan the sealed record out
+    # to the configured OTLP-log exporter — proving the wiring, not just the unit.
+    from agent_bom.api.agent_identity_store import _emit_audit
+    from agent_bom.api.governance_audit_log import InMemoryGovernanceAuditLog
+
+    exporter, mem = _mem_exporter()
+    # An explicitly-set exporter is honored directly (no env endpoint needed).
+    set_audit_otlp_exporter(exporter)
+    try:
+        _emit_audit(
+            {
+                "tenant_id": "tenant-a",
+                "actor": "cleanup",
+                "action": ACTION_IDENTITY_DORMANT_REVOKE,
+                "target_type": "agent_identity",
+                "target_id": "id-9",
+                "reason": "dormant",
+                "before_state": "active",
+                "after_state": "revoked",
+                "observed_at": "2026-07-16T00:00:00+00:00",
+                "window_key": "2026-07-16T00:00:00+00:00",
+            },
+            InMemoryGovernanceAuditLog(),
+        )
+        exporter.force_flush()
+        logs = mem.get_finished_logs()
+        assert len(logs) == 1
+        assert dict(_lr(logs[0]).attributes)["governance.target_id"] == "id-9"
+    finally:
+        set_audit_otlp_exporter(None)

--- a/tests/test_device_posture.py
+++ b/tests/test_device_posture.py
@@ -64,6 +64,44 @@ def test_crowdstrike_reduced_functionality_is_not_compliant():
     assert sig.compliant is False
 
 
+def test_crowdstrike_sparse_host_is_unknown_not_compliant():
+    # A partial/sparse CrowdStrike payload (device_id only, no status and no
+    # enrollment evidence) must NOT fail open: posture is unknown, not compliant,
+    # and managed is not asserted True — so a require_device_* gate fails closed.
+    conn = create_device_connector("crowdstrike")
+    payload = {"resources": [{"device_id": "cs-sparse"}]}
+    sig = conn.normalize(payload, tenant_id="t")[0]
+    assert sig.compliant is None  # unknown, NOT compliant
+    assert sig.managed is not True  # no enrollment evidence → not asserted managed
+
+    # And it must be denied by a require-compliant policy (fail closed).
+    policy = ConditionalAccessPolicy(
+        policy_id="p1",
+        tenant_id="t",
+        name="require compliant device",
+        effect="require",
+        status="active",
+        created_at="2026-07-16T00:00:00+00:00",
+        require_device_compliant=True,
+    )
+    store = InMemoryDevicePostureStore()
+    store.put(sig)
+    ctx = AccessContext(device_id="cs-sparse")
+    apply_device_posture(store, ctx, tenant_id="t")
+    denied, _reason, _pid = evaluate_conditional_access([policy], ctx)
+    assert denied is False
+
+
+def test_crowdstrike_empty_status_with_enrollment_evidence_is_managed_but_unknown_compliant():
+    # A host that evidences a reporting sensor (last_seen present) but reports no
+    # status is managed=True yet compliant=None (unknown, fails closed).
+    conn = create_device_connector("crowdstrike")
+    payload = {"resources": [{"device_id": "cs-seen", "last_seen": "2026-07-15T12:00:00Z"}]}
+    sig = conn.normalize(payload, tenant_id="t")[0]
+    assert sig.managed is True
+    assert sig.compliant is None
+
+
 def test_intune_mdm_payload_normalizes():
     conn = create_device_connector("intune")
     payload = {

--- a/tests/test_device_posture.py
+++ b/tests/test_device_posture.py
@@ -1,0 +1,339 @@
+"""EDR/MDM device-posture ingest + ABAC device-attribute enrichment.
+
+Device posture/compliance signals from EDR (endpoint detection & response) and
+MDM (mobile device management) sources are normalized to a vendor-neutral
+:class:`DeviceSignal`, persisted per tenant, and surfaced to the
+conditional-access (ABAC) evaluation so a policy can require a *managed* /
+*compliant* / *disk-encrypted* device.
+
+These tests assert: vendor payload → normalized signal round-trip (one EDR, one
+MDM adapter), tenant isolation in the store, and that an ingested signal makes a
+require-compliant conditional-access policy allow/deny correctly.
+"""
+
+from __future__ import annotations
+
+from agent_bom.api.agent_identity_store import (
+    AccessContext,
+    ConditionalAccessPolicy,
+    InMemoryAgentIdentityStore,
+    create_conditional_policy,
+    evaluate_conditional_access,
+)
+from agent_bom.device_posture import (
+    DeviceSignal,
+    InMemoryDevicePostureStore,
+    apply_device_posture,
+    create_device_connector,
+    list_device_connectors,
+)
+
+# ── vendor adapters (round-trip) ─────────────────────────────────────────────
+
+
+def test_crowdstrike_edr_payload_normalizes():
+    conn = create_device_connector("crowdstrike")
+    payload = {
+        "resources": [
+            {
+                "device_id": "cs-abc",
+                "hostname": "laptop-1",
+                "platform_name": "Mac",
+                "os_version": "14.5",
+                "status": "normal",
+                "reduced_functionality_mode": "no",
+                "last_seen": "2026-07-15T12:00:00Z",
+            }
+        ]
+    }
+    signals = conn.normalize(payload, tenant_id="tenant-a")
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.source == "crowdstrike"
+    assert sig.device_id == "cs-abc"
+    assert sig.managed is True  # a reporting CrowdStrike sensor = managed
+    assert sig.compliant is True  # normal + not reduced-functionality
+    assert sig.os_version == "14.5"
+
+
+def test_crowdstrike_reduced_functionality_is_not_compliant():
+    conn = create_device_connector("crowdstrike")
+    payload = {"resources": [{"device_id": "cs-x", "status": "normal", "reduced_functionality_mode": "yes"}]}
+    sig = conn.normalize(payload, tenant_id="t")[0]
+    assert sig.managed is True
+    assert sig.compliant is False
+
+
+def test_intune_mdm_payload_normalizes():
+    conn = create_device_connector("intune")
+    payload = {
+        "value": [
+            {
+                "id": "intune-dev-1",
+                "deviceName": "phone-1",
+                "operatingSystem": "iOS",
+                "osVersion": "17.5",
+                "complianceState": "compliant",
+                "managementState": "managed",
+                "isEncrypted": True,
+                "lastSyncDateTime": "2026-07-15T09:00:00Z",
+            }
+        ]
+    }
+    signals = conn.normalize(payload, tenant_id="tenant-a")
+    assert len(signals) == 1
+    sig = signals[0]
+    assert sig.source == "intune"
+    assert sig.device_id == "intune-dev-1"
+    assert sig.compliant is True
+    assert sig.managed is True
+    assert sig.disk_encrypted is True
+
+
+def test_intune_noncompliant_device():
+    conn = create_device_connector("intune")
+    payload = {"value": [{"id": "d2", "complianceState": "noncompliant", "isEncrypted": False}]}
+    sig = conn.normalize(payload, tenant_id="t")[0]
+    assert sig.compliant is False
+    assert sig.disk_encrypted is False
+
+
+def test_generic_ingest_normalizes_canonical_shape():
+    conn = create_device_connector("generic")
+    payload = {
+        "signals": [
+            {
+                "device_id": "dev-9",
+                "managed": True,
+                "compliant": True,
+                "disk_encrypted": True,
+                "os_version": "13.0",
+                "risk_level": "low",
+            }
+        ]
+    }
+    signals = conn.normalize(payload, tenant_id="tenant-a")
+    assert signals[0].device_id == "dev-9"
+    assert signals[0].compliant is True
+
+
+def test_connectors_are_listed_and_unknown_rejected():
+    names = list_device_connectors()
+    assert {"crowdstrike", "intune", "generic"} <= set(names)
+    import pytest
+
+    with pytest.raises(ValueError):
+        create_device_connector("does-not-exist")
+
+
+# ── store + tenant isolation ─────────────────────────────────────────────────
+
+
+def test_store_is_tenant_scoped():
+    store = InMemoryDevicePostureStore()
+    store.put(DeviceSignal(tenant_id="tenant-a", device_id="dev-1", source="generic", compliant=True))
+    store.put(DeviceSignal(tenant_id="tenant-b", device_id="dev-1", source="generic", compliant=False))
+    a = store.get("dev-1", tenant_id="tenant-a")
+    b = store.get("dev-1", tenant_id="tenant-b")
+    assert a is not None and a.compliant is True
+    assert b is not None and b.compliant is False
+    # A device known to tenant-a is invisible to tenant-c.
+    assert store.get("dev-1", tenant_id="tenant-c") is None
+
+
+def test_store_upsert_keeps_latest():
+    store = InMemoryDevicePostureStore()
+    store.put(DeviceSignal(tenant_id="t", device_id="d", source="crowdstrike", compliant=False))
+    store.put(DeviceSignal(tenant_id="t", device_id="d", source="crowdstrike", compliant=True))
+    got = store.get("d", tenant_id="t")
+    assert got is not None and got.compliant is True
+    assert len(store.list("t")) == 1
+
+
+# ── ABAC enrichment ──────────────────────────────────────────────────────────
+
+
+def test_apply_device_posture_fills_context():
+    store = InMemoryDevicePostureStore()
+    store.put(
+        DeviceSignal(tenant_id="t", device_id="dev-1", source="intune", managed=True, compliant=True, disk_encrypted=True)
+    )
+    ctx = AccessContext(device_id="dev-1")
+    apply_device_posture(store, ctx, tenant_id="t")
+    assert ctx.device_managed is True
+    assert ctx.device_compliant is True
+    assert ctx.device_disk_encrypted is True
+
+
+def test_apply_device_posture_unknown_device_stays_none():
+    store = InMemoryDevicePostureStore()
+    ctx = AccessContext(device_id="ghost")
+    apply_device_posture(store, ctx, tenant_id="t")
+    assert ctx.device_compliant is None
+
+
+def test_require_compliant_policy_denies_noncompliant_device():
+    policy = ConditionalAccessPolicy(
+        policy_id="p1",
+        tenant_id="t",
+        name="require compliant device",
+        effect="require",
+        status="active",
+        created_at="2026-07-16T00:00:00+00:00",
+        require_device_compliant=True,
+    )
+    # Compliant device → allowed.
+    ok, _reason, _pid = evaluate_conditional_access(
+        [policy], AccessContext(device_id="dev-1", device_compliant=True)
+    )
+    assert ok is True
+    # Non-compliant device → denied (fail closed).
+    denied, reason, pid = evaluate_conditional_access(
+        [policy], AccessContext(device_id="dev-2", device_compliant=False)
+    )
+    assert denied is False
+    assert pid == "p1"
+    # Unknown posture (None) → denied (fail closed).
+    unknown, _reason, _pid = evaluate_conditional_access(
+        [policy], AccessContext(device_id="dev-3", device_compliant=None)
+    )
+    assert unknown is False
+
+
+def test_end_to_end_ingest_to_abac():
+    # EDR payload → normalized signal → store → posture into context → policy eval.
+    store = InMemoryDevicePostureStore()
+    conn = create_device_connector("crowdstrike")
+    for sig in conn.normalize({"resources": [{"device_id": "cs-1", "status": "normal"}]}, tenant_id="t"):
+        store.put(sig)
+    ident_store = InMemoryAgentIdentityStore()
+    create_conditional_policy(
+        ident_store,
+        tenant_id="t",
+        name="managed-device guardrail",
+        effect="require",
+        require_device_managed=True,
+    )
+    ctx = AccessContext(device_id="cs-1")
+    apply_device_posture(store, ctx, tenant_id="t")
+    ok, _reason, _pid = evaluate_conditional_access(
+        ident_store.list_conditional_policies("t"), ctx
+    )
+    assert ok is True
+
+
+# ── API route + gateway end-to-end ───────────────────────────────────────────
+
+
+def _client(store):
+    import pytest as _pytest
+
+    _pytest.importorskip("fastapi")
+    from starlette.testclient import TestClient
+
+    from agent_bom import agent_identity
+    from agent_bom.api.agent_identity_store import set_agent_identity_store, verify_token
+    from agent_bom.api.server import app
+
+    set_agent_identity_store(store)
+    agent_identity.set_local_identity_verifier(lambda tok: verify_token(store, tok))
+    return TestClient(app)
+
+
+def test_ingest_route_normalizes_and_persists(monkeypatch):
+    import pytest as _pytest
+
+    _pytest.importorskip("fastapi")
+    from agent_bom.device_posture import get_device_posture_store, set_device_posture_store
+
+    posture = InMemoryDevicePostureStore()
+    set_device_posture_store(posture)
+    ident = InMemoryAgentIdentityStore()
+    try:
+        client = _client(ident)
+        resp = client.post(
+            "/v1/device-posture",
+            json={"source": "intune", "payload": {"value": [{"id": "d1", "complianceState": "compliant", "isEncrypted": True}]}},
+        )
+        assert resp.status_code == 201, resp.text
+        body = resp.json()
+        assert body["ingested"] == 1
+        assert body["devices"][0]["compliant"] is True
+        # Persisted + readable back through the tenant-scoped GET.
+        got = client.get("/v1/device-posture/d1")
+        assert got.status_code == 200
+        assert got.json()["device"]["disk_encrypted"] is True
+        assert get_device_posture_store().get("d1", tenant_id="default") is not None
+    finally:
+        set_device_posture_store(None)
+        from agent_bom.api.agent_identity_store import set_agent_identity_store
+
+        set_agent_identity_store(None)
+
+
+def test_ingest_route_rejects_unknown_source():
+    import pytest as _pytest
+
+    _pytest.importorskip("fastapi")
+    from agent_bom.device_posture import set_device_posture_store
+
+    set_device_posture_store(InMemoryDevicePostureStore())
+    ident = InMemoryAgentIdentityStore()
+    try:
+        client = _client(ident)
+        resp = client.post("/v1/device-posture", json={"source": "nope", "payload": {}})
+        assert resp.status_code == 400
+    finally:
+        set_device_posture_store(None)
+        from agent_bom.api.agent_identity_store import set_agent_identity_store
+
+        set_agent_identity_store(None)
+
+
+def test_gateway_blocks_noncompliant_device_end_to_end():
+    import pytest as _pytest
+
+    _pytest.importorskip("fastapi")
+    from starlette.testclient import TestClient
+
+    from agent_bom import agent_identity
+    from agent_bom.api.agent_identity_store import (
+        issue_identity,
+        set_agent_identity_store,
+        verify_token,
+    )
+    from agent_bom.device_posture import DeviceSignal, InMemoryDevicePostureStore, set_device_posture_store
+    from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+    from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+    ident = InMemoryAgentIdentityStore()
+    set_agent_identity_store(ident)
+    agent_identity.set_local_identity_verifier(lambda tok: verify_token(ident, tok))
+    posture = InMemoryDevicePostureStore()
+    posture.put(DeviceSignal(tenant_id="default", device_id="dev-ok", source="crowdstrike", managed=True, compliant=True))
+    posture.put(DeviceSignal(tenant_id="default", device_id="dev-bad", source="crowdstrike", managed=True, compliant=False))
+    set_device_posture_store(posture)
+    try:
+        issue_identity(ident, agent_id="agent-a", tenant_id="default")
+        create_conditional_policy(ident, tenant_id="default", name="compliant-only", effect="require", require_device_compliant=True)
+
+        async def ok_caller(upstream, message, extra_headers):
+            return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+        settings = GatewaySettings(
+            registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")]),
+            policy={},
+            upstream_caller=ok_caller,
+        )
+        client = TestClient(create_gateway_app(settings))
+        message = {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "list_files", "arguments": {}}}
+
+        blocked = client.post("/mcp/filesystem", json=message, headers={"x-agent-device-id": "dev-bad"})
+        assert blocked.json().get("error", {}).get("code") == -32001, blocked.text
+
+        allowed = client.post("/mcp/filesystem", json=message, headers={"x-agent-device-id": "dev-ok"})
+        assert allowed.status_code == 200 and allowed.json()["result"] == {"ok": True}
+    finally:
+        set_device_posture_store(None)
+        set_agent_identity_store(None)
+        agent_identity.set_local_identity_verifier(None)


### PR DESCRIPTION
## What

Extends the existing SIEM/OTel forwarder layer (already ships OTLP trace spans + Splunk/Datadog/Elastic/OCSF forwarders and the shared `delivery.py` client) with the two governance surfaces `#3910` calls out. Both halves land here.

### 1. Audit-event OTLP **log** export
Today the platform exports OTLP trace *spans* but not logs. This adds a governance audit → OTLP **logs** path:

- `siem/otlp_logs.py` maps each hash-chained governance audit record (`api/governance_audit_log.py`) to an OTLP `LogRecord`:
  - **Severity** escalates to `WARN` for revocation/enforcement actions, `INFO` otherwise.
  - **Attributes** carry `governance.tenant_id`, `actor`, `action`, `target_type`/`target_id`, before/after state, and the chain `record_hash` — so a consumer can attribute and verify per tenant.
  - The free-form record `detail` dict is **not** exported, so a caller-supplied secret can never leave the process.
- **Batched + non-blocking** via `BatchLogRecordProcessor` (background flush) — never blocks the request/cleanup path. Env-driven like the trace exporter: `AGENT_BOM_OTEL_LOGS_ENDPOINT` / `AGENT_BOM_OTEL_LOGS_HEADERS`. Endpoint validated against the outbound URL policy (private/loopback egress refused unless explicitly opened). Graceful no-op without the `otel` extra.
- Wired into the single audit-append hook (`_emit_audit`) so every NHI lifecycle-enforcement action fans out. `/health` reports state under `tracing.otlp_logs_export`.

### 2. EDR/MDM device-posture connectors → conditional-access ABAC
Ties EDR/MDM device signals into the `ConditionalAccessPolicy` device attributes from `#3906`:

- `device_posture.py`: vendor-neutral `DeviceSignal` + tenant-scoped store (in-memory + durable SQLite), a connector interface, and three normalizers — `generic` (the canonical **POST** ingest), `crowdstrike` (EDR) and `intune` (MDM) field-mappings. **Read-only / agentless**: field-mappers over already-fetched JSON; no vendor credential is stored here.
- `ConditionalAccessPolicy` gains `require_device_managed` / `require_device_compliant` / `require_device_disk_encrypted` conditions (fail closed on unknown/false); `AccessContext` carries the enriched posture; the **gateway** resolves posture into the request context before evaluating conditional access.
- `POST /v1/device-posture` ingests signals; `GET /v1/device-posture/{id}` reads the latest — both tenant-scoped.

**Honest scope:** we ship a generic device-posture ingest plus two documented vendor field-mappings (one EDR, one MDM), not a fleet of live vendor integrations. A shared Postgres tier for multi-replica posture is a noted follow-up (falls back to node-local SQLite today, safe because posture is a re-populated enrichment cache).

## Blast radius (aligned in this PR)
model/dataclasses → stores (SQLite/in-memory) → gateway middleware → API routes → `/health` contract → OpenAPI + v1 schemas + DATA_MODEL atlas + REST counts → env-var allowlist → docs (`docs/OBSERVABILITY_METRICS.md`) → tests.

## Verification (all green)
- `pytest tests/test_audit_otlp_logs.py tests/test_device_posture.py` — 24 passed (incl. tenant isolation, secret-free export, env config, and the full EDR→store→ABAC→gateway round-trip).
- Adjacent suites (identity/governance/conditional/lifecycle/tracing/api): 566 passed, 0 regressions.
- `ruff` clean; `mypy` clean on changed files; `make preflight` green; `check-counts` consistent.
- OTLP logs verified empirically against the pinned OpenTelemetry SDK 1.43.0 (`opentelemetry-sdk` + `opentelemetry-exporter-otlp-proto-http`, already in the `otel` extra — no new deps).

Closes #3910.