### PR TITLE
feat(connections): guided Verify step in the connect wizard

### DIFF
--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -942,12 +942,20 @@ function ConnectionsHub() {
 
   const handleCreated = useCallback(
     (created: CloudConnectionRecord) => {
-      setWizardOpen(false);
+      // The connection now exists; the wizard stays open on its Verify step so the
+      // operator sees the live connectivity/permission check before closing. We
+      // refresh the background list so the new row appears immediately.
       setMessage(`Connected ${created.display_name}.`);
       void refresh();
     },
     [refresh],
   );
+
+  const handleWizardClose = useCallback(() => {
+    setWizardOpen(false);
+    // Pick up any status change from an in-wizard verify / first scan.
+    void refresh();
+  }, [refresh]);
 
   const handleRegisterSource = useCallback(
     (kind: SourceKind) => {
@@ -1445,7 +1453,7 @@ function ConnectionsHub() {
       {wizardOpen ? (
         <AddConnectionWizard
           initialProvider={wizardProvider}
-          onClose={() => setWizardOpen(false)}
+          onClose={handleWizardClose}
           onCreated={handleCreated}
         />
       ) : null}
@@ -3162,6 +3170,9 @@ function buildWizardForm(provider: string): WizardForm {
   };
 }
 
+type WizardStep = 0 | 1 | 2 | 3;
+type VerifyState = "idle" | "running" | "ok" | "error";
+
 function AddConnectionWizard({
   initialProvider,
   onClose,
@@ -3171,7 +3182,7 @@ function AddConnectionWizard({
   onClose: () => void;
   onCreated: (created: CloudConnectionRecord) => void;
 }) {
-  const [step, setStep] = useState<0 | 1 | 2>(0);
+  const [step, setStep] = useState<WizardStep>(0);
   const [form, setForm] = useState<WizardForm>(() =>
     buildWizardForm(initialProvider && providerOption(initialProvider) ? initialProvider : "aws"),
   );
@@ -3179,6 +3190,14 @@ function AddConnectionWizard({
   const [formError, setFormError] = useState<string | null>(null);
   const [generatedExternalId, setGeneratedExternalId] = useState("");
   const [grantMethod, setGrantMethod] = useState<CloudGrantMethod>("cli");
+  // Verify step: the created connection + the live connectivity/permission check
+  // and optional first scan run against the real /test and /scan endpoints.
+  const [createdRecord, setCreatedRecord] = useState<CloudConnectionRecord | null>(null);
+  const [verifyState, setVerifyState] = useState<VerifyState>("idle");
+  const [verifyError, setVerifyError] = useState<string | null>(null);
+  const [scanState, setScanState] = useState<VerifyState>("idle");
+  const [scanError, setScanError] = useState<string | null>(null);
+  const [scanId, setScanId] = useState<string | null>(null);
 
   const provider = useMemo(
     () => providerOption(form.provider) ?? PROVIDER_OPTIONS[0]!,
@@ -3225,7 +3244,7 @@ function AddConnectionWizard({
   }
 
   function goNext() {
-    setStep((current) => (current + 1) as 0 | 1 | 2);
+    setStep((current) => (current === 3 ? current : ((current + 1) as WizardStep)));
   }
 
   function handleRegenerateExternalId() {
@@ -3233,6 +3252,41 @@ function AddConnectionWizard({
     setGeneratedExternalId(value);
     setForm((current) => ({ ...current, external_id: value }));
   }
+
+  const runVerify = useCallback(async (record: CloudConnectionRecord) => {
+    setVerifyState("running");
+    setVerifyError(null);
+    try {
+      await api.testCloudConnection(record.id);
+      setVerifyState("ok");
+    } catch (err) {
+      // Surface the sanitized "why + how to fix" from the API verbatim — never a
+      // fabricated success. A failed verify keeps the connection in error state.
+      setVerifyError(err instanceof Error ? err.message : "Connectivity check failed.");
+      setVerifyState("error");
+    }
+  }, []);
+
+  async function runFirstScan() {
+    if (!createdRecord) return;
+    setScanState("running");
+    setScanError(null);
+    try {
+      const result = await api.scanCloudConnection(createdRecord.id);
+      setScanId(typeof result.scan_id === "string" ? result.scan_id : null);
+      setScanState("ok");
+    } catch (err) {
+      setScanError(err instanceof Error ? err.message : "First scan failed.");
+      setScanState("error");
+    }
+  }
+
+  // Auto-run the real connectivity/permission check on entering the Verify step.
+  useEffect(() => {
+    if (step === 3 && createdRecord && verifyState === "idle") {
+      void runVerify(createdRecord);
+    }
+  }, [step, createdRecord, verifyState, runVerify]);
 
   const providerMeta = cloudProviderMeta(provider.value);
   const deployScript = buildGrantScript(
@@ -3243,6 +3297,9 @@ function AddConnectionWizard({
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    // Only the Details step creates the connection; guard against Enter on
+    // other steps re-submitting (and re-creating) an existing connection.
+    if (step !== 2) return;
     setFormError(null);
 
     const displayName = form.display_name.trim();
@@ -3289,8 +3346,13 @@ function AddConnectionWizard({
     setSubmitting(true);
     try {
       const created = await api.createCloudConnection(payload);
+      // Drop the secret from client state the moment it is persisted.
       setForm((current) => ({ ...current, external_id: "" }));
+      setCreatedRecord(created);
+      // Refresh the background list + toast, but keep the wizard open so the
+      // operator sees the live Verify step before finishing.
       onCreated(created);
+      setStep(3);
     } catch (err) {
       setFormError(err instanceof Error ? err.message : "Failed to create connection.");
     } finally {
@@ -3317,7 +3379,7 @@ function AddConnectionWizard({
             </span>
             <div>
               <h2 className="text-base font-semibold text-[var(--foreground)]">Add cloud account</h2>
-              <p className="text-xs text-[var(--text-secondary)]">Read-only connection · step {step + 1} of 3</p>
+              <p className="text-xs text-[var(--text-secondary)]">Read-only connection · step {step + 1} of 4</p>
             </div>
           </div>
           <button
@@ -3548,23 +3610,117 @@ function AddConnectionWizard({
               </div>
             ) : null}
 
+            {step === 3 ? (
+              <div className="space-y-4">
+                <div>
+                  <h3 className="text-sm font-semibold text-[var(--foreground)]">Verify connectivity</h3>
+                  <p className="mt-1 text-xs text-[var(--text-secondary)]">
+                    We broker a short-lived read-only credential and check access — no inventory, findings, or writes.
+                  </p>
+                </div>
+
+                {verifyState === "running" ? (
+                  <div className="flex items-center gap-2.5 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-3 text-sm text-[var(--text-secondary)]">
+                    <Loader2 className="h-4 w-4 animate-spin text-[var(--text-tertiary)]" />
+                    Verifying read-only access…
+                  </div>
+                ) : null}
+
+                {verifyState === "ok" ? (
+                  <div className="space-y-3 rounded-xl border border-emerald-500/30 dark:border-emerald-800/70 bg-emerald-500/10 dark:bg-emerald-950/20 px-4 py-3">
+                    <p className="flex items-center gap-2 text-sm font-medium text-emerald-700 dark:text-emerald-200">
+                      <CheckCircle2 className="h-4 w-4" />
+                      Read-only access verified
+                    </p>
+                    <p className="text-xs text-[var(--text-secondary)]">
+                      The connection is active. Run a first read-only scan now, or close and scan later from the table.
+                    </p>
+                    {scanState === "ok" ? (
+                      <p className="flex flex-wrap items-center gap-1.5 text-xs text-emerald-700 dark:text-emerald-200">
+                        <ShieldCheck className="h-3.5 w-3.5" />
+                        First scan started{scanId ? ` — ${scanId}` : "."}
+                      </p>
+                    ) : scanState === "error" ? (
+                      <div className="space-y-2">
+                        <p className="flex items-start gap-1.5 text-xs text-red-700 dark:text-red-300">
+                          <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                          <span>{scanError}</span>
+                        </p>
+                        <button
+                          type="button"
+                          onClick={() => void runFirstScan()}
+                          className="inline-flex items-center gap-1.5 rounded-lg border border-emerald-500/40 bg-emerald-500/10 px-3 py-1.5 text-xs font-medium text-emerald-700 dark:text-emerald-200 transition hover:border-emerald-500"
+                        >
+                          <RefreshCcw className="h-3.5 w-3.5" /> Retry scan
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => void runFirstScan()}
+                        disabled={scanState === "running"}
+                        className="inline-flex items-center gap-1.5 rounded-lg bg-emerald-500 px-3 py-1.5 text-xs font-medium text-black transition hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {scanState === "running" ? (
+                          <>
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" /> Starting first scan…
+                          </>
+                        ) : (
+                          <>
+                            <ShieldCheck className="h-3.5 w-3.5" /> Run first scan
+                          </>
+                        )}
+                      </button>
+                    )}
+                  </div>
+                ) : null}
+
+                {verifyState === "error" ? (
+                  <div className="space-y-3 rounded-xl border border-red-500/30 dark:border-red-900/60 bg-red-500/10 dark:bg-red-950/20 px-4 py-3">
+                    <p className="flex items-center gap-2 text-sm font-medium text-red-700 dark:text-red-300">
+                      <AlertTriangle className="h-4 w-4" />
+                      Verification failed
+                    </p>
+                    <p className="text-xs leading-5 text-[var(--text-secondary)]">{verifyError}</p>
+                    <p className="text-[11px] text-[var(--text-tertiary)]">
+                      The connection was saved but is not active. Fix the grant (or its permissions) and retry — nothing
+                      was scanned.
+                    </p>
+                    <button
+                      type="button"
+                      onClick={() => createdRecord && void runVerify(createdRecord)}
+                      className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs font-medium text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+                    >
+                      <RefreshCcw className="h-3.5 w-3.5" /> Retry verification
+                    </button>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+
             {formError ? <p className="text-sm text-red-400">{formError}</p> : null}
           </div>
 
           <div className="flex items-center justify-between gap-3 border-t border-[color:var(--border-subtle)] px-5 py-4">
-            <button
-              type="button"
-              onClick={() => (step === 0 ? onClose() : setStep((s) => (s - 1) as 0 | 1 | 2))}
-              className="inline-flex items-center gap-1.5 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
-            >
-              {step === 0 ? (
-                "Cancel"
-              ) : (
-                <>
-                  <ArrowLeft className="h-4 w-4" /> Back
-                </>
-              )}
-            </button>
+            {step === 3 ? (
+              // The connection already exists; going back would re-create it. Verify
+              // and first-scan actions live in the panel; the footer only closes.
+              <span aria-hidden className="h-9" />
+            ) : (
+              <button
+                type="button"
+                onClick={() => (step === 0 ? onClose() : setStep((s) => (s - 1) as WizardStep))}
+                className="inline-flex items-center gap-1.5 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-2 text-sm text-[var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+              >
+                {step === 0 ? (
+                  "Cancel"
+                ) : (
+                  <>
+                    <ArrowLeft className="h-4 w-4" /> Back
+                  </>
+                )}
+              </button>
+            )}
             {step < 2 ? (
               <button
                 key="wizard-next"
@@ -3574,7 +3730,7 @@ function AddConnectionWizard({
               >
                 Next <ArrowRight className="h-4 w-4" />
               </button>
-            ) : (
+            ) : step === 2 ? (
               <button
                 key="wizard-submit"
                 type="submit"
@@ -3583,6 +3739,15 @@ function AddConnectionWizard({
               >
                 <Plus className="h-4 w-4" />
                 {submitting ? "Connecting…" : "Create connection"}
+              </button>
+            ) : (
+              <button
+                key="wizard-done"
+                type="button"
+                onClick={onClose}
+                className="inline-flex items-center gap-1.5 rounded-xl bg-emerald-500 px-4 py-2 text-sm font-medium text-black transition hover:bg-emerald-400"
+              >
+                Done
               </button>
             )}
           </div>
@@ -3593,7 +3758,7 @@ function AddConnectionWizard({
 }
 
 function StepIndicator({ step }: { step: number }) {
-  const labels = ["Provider", "Setup", "Details"];
+  const labels = ["Provider", "Setup", "Details", "Verify"];
   return (
     <div className="flex items-center gap-2">
       {labels.map((label, index) => (

--- a/ui/e2e/connections-screenshot.spec.ts
+++ b/ui/e2e/connections-screenshot.spec.ts
@@ -133,7 +133,7 @@ test("captures connections page and wizard", async ({ page }, testInfo) => {
   const setupExternalId = (await dialog.getByTestId("wizard-external-id").textContent())?.trim();
   expect(setupExternalId).toMatch(/^[a-f0-9]{32}$/);
   await dialog.getByRole("button", { name: "Next", exact: true }).click();
-  await expect(page.getByText("Read-only connection · step 3 of 3")).toBeVisible();
+  await expect(page.getByText("Read-only connection · step 3 of 4")).toBeVisible();
   await dialog.getByPlaceholder("Production account").fill("Production account");
   await dialog.getByPlaceholder(/arn:aws:iam/).fill("arn:aws:iam::123456789012:role/agent-bom-readonly");
   await expect(dialog.getByTestId("wizard-external-id-details")).toHaveText(setupExternalId!);

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -159,8 +159,33 @@ function openAwsWizard(): HTMLElement {
 }
 
 describe("ConnectionsPage — Connect segment", () => {
-  it("carries one AWS ExternalId from setup through details into create", async () => {
+  const TEST_OK = {
+    schema_version: "cloud.connections.test.v1",
+    connection_id: "conn-1",
+    tenant_id: "tenant-acme",
+    provider: "aws",
+    status: "ok",
+  };
+
+  function fillAwsDetails(wizard: HTMLElement): string {
+    fireEvent.click(within(wizard).getByRole("button", { name: /Next/ }));
+    const setupId = within(wizard).getByTestId("wizard-external-id").textContent!.trim();
+    fireEvent.click(within(wizard).getByRole("button", { name: /Next/ }));
+    fireEvent.change(within(wizard).getByPlaceholderText("Production account"), {
+      target: { value: "Production account" },
+    });
+    fireEvent.change(within(wizard).getByPlaceholderText(/arn:aws:iam/), {
+      target: { value: "arn:aws:iam::123456789012:role/agent-bom-readonly" },
+    });
+    fireEvent.change(within(wizard).getByPlaceholderText("us-east-1, us-west-2"), {
+      target: { value: "us-east-1" },
+    });
+    return setupId;
+  }
+
+  it("carries one AWS ExternalId from setup through details into create + verify", async () => {
     apiMock.createCloudConnection.mockResolvedValue(CREATED_RECORD);
+    apiMock.testCloudConnection.mockResolvedValue(TEST_OK);
 
     render(<ConnectionsPage />);
     await waitForConnectTab();
@@ -205,6 +230,65 @@ describe("ConnectionsPage — Connect segment", () => {
     await waitFor(() =>
       expect(screen.getByText("Connected Production account.")).toBeInTheDocument(),
     );
+
+    // Create advances to Verify (does not close), which auto-runs the real test.
+    await waitFor(() => expect(apiMock.testCloudConnection).toHaveBeenCalledWith("conn-1"));
+    expect(within(wizard).getByRole("heading", { name: "Verify connectivity" })).toBeInTheDocument();
+  });
+
+  it("verify step confirms read-only access and runs the first scan", async () => {
+    apiMock.createCloudConnection.mockResolvedValue(CREATED_RECORD);
+    apiMock.testCloudConnection.mockResolvedValue(TEST_OK);
+    apiMock.scanCloudConnection.mockResolvedValue({
+      schema_version: "cloud.connections.scan.v1",
+      connection_id: "conn-1",
+      tenant_id: "tenant-acme",
+      provider: "aws",
+      scan_id: "abcdef12-3456-7890-abcd-ef1234567890",
+    });
+
+    render(<ConnectionsPage />);
+    await waitForConnectTab();
+
+    const wizard = openAwsWizard();
+    fillAwsDetails(wizard);
+    fireEvent.click(within(wizard).getByRole("button", { name: "Create connection" }));
+
+    await waitFor(() => expect(apiMock.testCloudConnection).toHaveBeenCalledWith("conn-1"));
+    await waitFor(() =>
+      expect(within(wizard).getByText("Read-only access verified")).toBeInTheDocument(),
+    );
+
+    fireEvent.click(within(wizard).getByRole("button", { name: /Run first scan/ }));
+    await waitFor(() => expect(apiMock.scanCloudConnection).toHaveBeenCalledWith("conn-1"));
+    await waitFor(() =>
+      expect(within(wizard).getByText(/First scan started/)).toBeInTheDocument(),
+    );
+  });
+
+  it("verify step surfaces a missing-permission failure honestly (no fake green)", async () => {
+    apiMock.createCloudConnection.mockResolvedValue(CREATED_RECORD);
+    apiMock.testCloudConnection.mockRejectedValue(
+      new Error("AccessDenied: the role is missing sts:AssumeRole for the ExternalId trust policy."),
+    );
+
+    render(<ConnectionsPage />);
+    await waitForConnectTab();
+
+    const wizard = openAwsWizard();
+    fillAwsDetails(wizard);
+    fireEvent.click(within(wizard).getByRole("button", { name: "Create connection" }));
+
+    await waitFor(() => expect(apiMock.testCloudConnection).toHaveBeenCalledWith("conn-1"));
+    await waitFor(() =>
+      expect(within(wizard).getByText(/missing sts:AssumeRole/)).toBeInTheDocument(),
+    );
+
+    // Honest: no success state, and the first scan is NOT offered on a failed verify.
+    expect(within(wizard).queryByText("Read-only access verified")).toBeNull();
+    expect(within(wizard).queryByRole("button", { name: /Run first scan/ })).toBeNull();
+    expect(apiMock.scanCloudConnection).not.toHaveBeenCalled();
+    expect(within(wizard).getByRole("button", { name: /Retry verification/ })).toBeInTheDocument();
   });
 
   it("regenerating the AWS ExternalId updates setup and details together", async () => {


### PR DESCRIPTION
## What

Extends the in-app **Add cloud account** wizard from a 3-step (Provider → Setup → Details) create form into a fully guided **Introduction → Configure → Verify** flow, closing the last gap in the guided connect experience: a real, live connectivity/permission check before the operator leaves the wizard.

Previously the wizard ended at `POST /v1/cloud/connections` (create) and left "did the grant actually work?" to a separate **Test** button on the connections table. Now, on successful create the wizard stays open and advances to a new **Verify** step that:

- **Auto-runs the real read-only check** against `POST /v1/cloud/connections/{id}/test` — brokers a short-lived read-only credential only; no inventory, findings, or writes.
- **On success:** shows *Read-only access verified*, marks the connection active, and offers a **first read-only scan** via `POST /v1/cloud/connections/{id}/scan`, surfacing the returned `scan_id`.
- **On failure:** shows the API's sanitized *why + how to fix* detail **verbatim** with a **Retry verification** action — never a fabricated green. A failed verify offers **no** first scan and leaves the connection in its error state.

Works for all four providers (AWS/GCP/Azure/Snowflake) since the create/test/scan endpoints already support them.

## What it reuses (no new backend, no forked flow)

- `api.createCloudConnection` / `testCloudConnection` / `scanCloudConnection` — the existing per-tenant, RBAC-gated, read-only connection endpoints.
- The existing `buildGrantScript` / ExternalId generation for the read-only setup artifact on the Setup step.
- The existing `AddConnectionWizard` shell, `Drawer`/token styling, and both themes.

## Security / honesty

- The one write-only secret (`external_id`) is dropped from client state the moment the connection is persisted; the Verify and scan steps carry no credentials.
- Verify surfaces the backend's sanitized permission/connectivity detail honestly — no fake success.

## Tests / gates

- Component tests for the Verify step: success + first-scan path, and the **missing-permission failure path** (asserts the honest error renders, no success state, no scan offered/called, Retry present). `vitest` 20/20 green.
- `npm run typecheck`, `npm run lint`, `npm run build`, and `NEXT_EXPORT=1 npm run build` (connections is in the exported UI) all green.

## Deferred (honest follow-up)

- Explicit **baseline vs deep-scan depth** selector in the wizard: the create API carries no depth field and deep-scan is a separate Terraform overlay, so wiring it truthfully is out of scope for this PR and tracked for a follow-up rather than shipped as a half-true toggle.
- SSO provider presets (§B of the issue) are a separate workstream.

addresses #3736 (§A)