### PR TITLE
fix(ui): consume overview.top_risks in the exec top-risk strip

### DIFF
--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -32,6 +32,7 @@ import {
   blastCredentials,
   blastTools,
   buildExposurePathView,
+  buildExecExposurePaths,
 } from "@/lib/dashboard-data";
 import { buildIssueSeverityMatrix } from "@/lib/finding-issue-type";
 import {
@@ -244,12 +245,13 @@ export default function Dashboard() {
     return buildExposurePathView(topRisk, topRisk.scanId);
   }, [topRisk]);
 
-  const exposurePaths = useMemo<ExposurePathView[]>(() => {
-    return [...allBlast]
-      .sort((a, b) => (b.risk_score ?? b.blast_score) - (a.risk_score ?? a.blast_score))
-      .slice(0, 5)
-      .map((blast, index) => buildExposurePathView(blast, blast.scanId, index));
-  }, [allBlast]);
+  // The exec top-risk strip merges the scan-derived blast_radius chain with the
+  // server-reconciled overview.top_risks so it stays populated AND honest for
+  // hub/bulk-ingested estates that never create scan jobs (#4063).
+  const exposurePaths = useMemo<ExposurePathView[]>(
+    () => buildExecExposurePaths(allBlast, overview?.top_risks),
+    [allBlast, overview],
+  );
 
   // Total packages scanned across all jobs
   const totalPackages = useMemo(() => {

--- a/ui/lib/dashboard-data.ts
+++ b/ui/lib/dashboard-data.ts
@@ -7,14 +7,14 @@ import {
   Server,
 } from "lucide-react";
 
-import type { Agent, BlastRadius, ScanJob, ScanResult } from "@/lib/api";
+import type { Agent, BlastRadius, OverviewTopRisk, ScanJob, ScanResult } from "@/lib/api";
 import type {
   EpssDataPoint,
   EpssVsCvssPoint,
   TrendDataPoint,
 } from "@/components/charts";
 import type { ExposurePathView } from "@/components/overview-cockpit";
-import { buildSecurityGraphHref } from "@/lib/attack-paths";
+import { buildFindingsHref, buildSecurityGraphHref } from "@/lib/attack-paths";
 import { severityRank } from "@/lib/severity";
 
 // ─── Shared dashboard aggregation ───────────────────────────────────────────
@@ -271,6 +271,79 @@ export function buildExposurePathView(
       agentName: agents[0],
     }),
   };
+}
+
+const CVE_ID_PATTERN = /^CVE-\d{4}-\d{4,}$/i;
+
+/**
+ * Build an exec exposure-path row from the API's authoritative `overview.top_risks`
+ * (#4063). Hub/bulk-ingested findings never create scan jobs, so the scan-derived
+ * `blast_radius` path leaves the strip empty for a pure bulk estate even though
+ * `/v1/overview` returns correct, worst-first `top_risks`. This maps that server-
+ * reconciled entry into the same `ExposurePathView` the scan path renders.
+ *
+ * The drill lands on real finding ROWS, never an empty security-graph snapshot a
+ * scan-less estate has no data for: a CVE-shaped id drills the exact CVE
+ * (`/findings?cve=…`, provably non-empty — the row is why this risk exists); any
+ * other id (GHSA, canonical, synthetic) would return 0 under a `?cve=` filter, so
+ * fall back to the severity band the finding provably belongs to.
+ */
+export function buildTopRiskExposurePath(
+  risk: OverviewTopRisk,
+  index?: number,
+): ExposurePathView {
+  const severity = (risk.severity || "").trim().toLowerCase();
+  const nodes: ExposurePathView["nodes"] = [
+    severity
+      ? { type: "cve", label: risk.vulnerability_id, severity }
+      : { type: "cve", label: risk.vulnerability_id },
+  ];
+  if (risk.package) nodes.push({ type: "package", label: risk.package });
+  const agent = risk.affected_agents?.[0];
+  if (agent) nodes.push({ type: "agent", label: agent });
+
+  const href = CVE_ID_PATTERN.test(risk.vulnerability_id)
+    ? buildFindingsHref({ cve: risk.vulnerability_id })
+    : severity && severity !== "unrated"
+      ? `/findings?severity=${encodeURIComponent(severity)}`
+      : "/findings";
+
+  const baseKey = `${risk.vulnerability_id}:${risk.package ?? "unknown"}`;
+  return {
+    key: index === undefined ? baseKey : `${baseKey}:${index}`,
+    nodes,
+    riskScore: risk.risk_score ?? 0,
+    href,
+  };
+}
+
+/**
+ * Assemble the exec top-risk strip from BOTH sources so it stays populated and
+ * honest across estate shapes (#4063). Scan-derived `blast_radius` rows carry the
+ * richest chain (server/credential hops) plus the scan→graph drill, so they lead;
+ * the server-reconciled `overview.top_risks` — the authoritative source that also
+ * covers hub/bulk-ingested findings, which never create scan jobs — contributes
+ * any risk not already represented by a scan blast. Deduped by `vulnerability_id`
+ * so scan and hub are never double-counted; ranked worst-first and capped.
+ */
+export function buildExecExposurePaths(
+  allBlast: (BlastRadius & { scanId?: string })[],
+  topRisks: OverviewTopRisk[] | null | undefined,
+  limit = 5,
+): ExposurePathView[] {
+  const blastRanked = [...allBlast].sort(
+    (a, b) => (b.risk_score ?? b.blast_score) - (a.risk_score ?? a.blast_score),
+  );
+  const blastViews = blastRanked.map((blast, index) =>
+    buildExposurePathView(blast, blast.scanId, index),
+  );
+  const covered = new Set(blastRanked.map((b) => b.vulnerability_id).filter(Boolean));
+  const topRiskViews = (topRisks ?? [])
+    .filter((r) => r.vulnerability_id && !covered.has(r.vulnerability_id))
+    .map((risk, index) => buildTopRiskExposurePath(risk, blastViews.length + index));
+  return [...blastViews, ...topRiskViews]
+    .sort((a, b) => b.riskScore - a.riskScore)
+    .slice(0, limit);
 }
 
 export function aggregateCompoundIssues(allBlast: BlastRadius[]): CompoundIssue[] {

--- a/ui/tests/dashboard-data.test.ts
+++ b/ui/tests/dashboard-data.test.ts
@@ -1,7 +1,25 @@
 import { describe, expect, it } from "vitest";
 
-import { buildExposurePathView } from "@/lib/dashboard-data";
-import type { BlastRadius } from "@/lib/api";
+import {
+  buildExposurePathView,
+  buildExecExposurePaths,
+  buildTopRiskExposurePath,
+} from "@/lib/dashboard-data";
+import type { BlastRadius, OverviewTopRisk } from "@/lib/api";
+
+function makeTopRisk(overrides: Partial<OverviewTopRisk> = {}): OverviewTopRisk {
+  return {
+    vulnerability_id: "CVE-2026-9001",
+    package: "requests",
+    severity: "critical",
+    risk_score: 9.4,
+    is_kev: false,
+    cvss_score: 9.8,
+    epss_score: 0.7,
+    affected_agents: ["Ingest Bot"],
+    ...overrides,
+  };
+}
 
 function makeBlast(overrides: Partial<BlastRadius> = {}): BlastRadius {
   return {
@@ -55,5 +73,96 @@ describe("buildExposurePathView", () => {
     expect(view.href).toBe(
       "/security-graph?scan=scan-1&cve=CVE-2026-0002&agent=Claude+Desktop",
     );
+  });
+});
+
+describe("buildTopRiskExposurePath", () => {
+  it("maps an OverviewTopRisk into a CVE→package→agent chain (#4063)", () => {
+    const view = buildTopRiskExposurePath(makeTopRisk(), 0);
+    expect(view.riskScore).toBe(9.4);
+    expect(view.key).toBe("CVE-2026-9001:requests:0");
+    expect(view.nodes).toEqual([
+      { type: "cve", label: "CVE-2026-9001", severity: "critical" },
+      { type: "package", label: "requests" },
+      { type: "agent", label: "Ingest Bot" },
+    ]);
+  });
+
+  it("drills a CVE-shaped risk to the finding rows for that CVE", () => {
+    const view = buildTopRiskExposurePath(makeTopRisk());
+    // Must land on real finding rows — not an empty security-graph snapshot for a
+    // bulk estate that has no scan (#4063 / avoids the #4059 self-contradiction).
+    expect(view.href).toBe("/findings?cve=CVE-2026-9001");
+  });
+
+  it("drills a non-CVE id by severity so the target is never empty", () => {
+    const view = buildTopRiskExposurePath(
+      makeTopRisk({ vulnerability_id: "GHSA-xxxx-yyyy-zzzz", severity: "high" }),
+    );
+    // A non-CVE id filtered as ?cve= would return 0 rows; fall back to the
+    // severity band the finding provably belongs to.
+    expect(view.href).toBe("/findings?severity=high");
+  });
+
+  it("omits absent package/agent hops and keys without an index", () => {
+    const view = buildTopRiskExposurePath(
+      makeTopRisk({ package: null, affected_agents: [] }),
+    );
+    expect(view.key).toBe("CVE-2026-9001:unknown");
+    expect(view.nodes).toEqual([
+      { type: "cve", label: "CVE-2026-9001", severity: "critical" },
+    ]);
+  });
+});
+
+describe("buildExecExposurePaths", () => {
+  it("populates the strip from overview.top_risks for a bulk estate with no scans (#4063)", () => {
+    const paths = buildExecExposurePaths(
+      [],
+      [
+        makeTopRisk({ vulnerability_id: "CVE-2026-1000", risk_score: 6.0 }),
+        makeTopRisk({ vulnerability_id: "CVE-2026-2000", risk_score: 9.9 }),
+      ],
+    );
+    // Worst-first, and each carries a working finding-row drill (not an empty
+    // security-graph snapshot the scan-less estate has no data for).
+    expect(paths.map((p) => p.nodes[0]!.label)).toEqual(["CVE-2026-2000", "CVE-2026-1000"]);
+    expect(paths[0]!.href).toBe("/findings?cve=CVE-2026-2000");
+  });
+
+  it("keeps the scan-derived path (rich hops + scan→graph drill) for a scan estate", () => {
+    const paths = buildExecExposurePaths(
+      [{ ...makeBlast(), scanId: "scan-xyz" }],
+      // The same CVE appears in top_risks (server folds the scan in) — must NOT
+      // double-count, and the richer scan row (with scanId graph drill) wins.
+      [makeTopRisk({ vulnerability_id: "CVE-2026-0002" })],
+    );
+    expect(paths).toHaveLength(1);
+    expect(paths[0]!.href).toBe(
+      "/security-graph?scan=scan-xyz&cve=CVE-2026-0002&package=flask&agent=Claude+Desktop",
+    );
+  });
+
+  it("merges hub-only risks alongside scan blasts, deduped and ranked", () => {
+    const paths = buildExecExposurePaths(
+      [{ ...makeBlast({ vulnerability_id: "CVE-2026-0002", risk_score: 5.0 }), scanId: "s1" }],
+      [
+        makeTopRisk({ vulnerability_id: "CVE-2026-0002", risk_score: 9.9 }), // dup of scan
+        makeTopRisk({ vulnerability_id: "CVE-2026-7777", risk_score: 8.0 }), // hub-only
+      ],
+    );
+    const labels = paths.map((p) => p.nodes[0]!.label);
+    expect(labels).toContain("CVE-2026-0002");
+    expect(labels).toContain("CVE-2026-7777");
+    // Deduped: the scan CVE appears exactly once (scan row wins, hub dup dropped).
+    expect(labels.filter((l) => l === "CVE-2026-0002")).toHaveLength(1);
+    // Hub-only risk drills to real finding rows.
+    const hub = paths.find((p) => p.nodes[0]!.label === "CVE-2026-7777");
+    expect(hub!.href).toBe("/findings?cve=CVE-2026-7777");
+  });
+
+  it("returns an empty strip when there are genuinely no risks", () => {
+    expect(buildExecExposurePaths([], [])).toEqual([]);
+    expect(buildExecExposurePaths([], null)).toEqual([]);
   });
 });

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -3,7 +3,8 @@ import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
 
 import { OverviewCockpit } from "@/components/overview-cockpit";
-import type { OverviewResponse } from "@/lib/api";
+import { buildExecExposurePaths } from "@/lib/dashboard-data";
+import type { OverviewResponse, OverviewTopRisk } from "@/lib/api";
 
 function domain(
   label: string,
@@ -129,6 +130,41 @@ describe("OverviewCockpit", () => {
     expect(screen.queryByText("Data sources")).not.toBeInTheDocument();
     expect(screen.getByText(/3 of 4 operational lanes active/i)).toBeInTheDocument();
     expect(screen.getByText(/2 connected/i)).toBeInTheDocument();
+  });
+
+  it("renders the top-risk strip from overview.top_risks for a bulk estate with no scans (#4063)", () => {
+    // A hub/bulk-ingested estate has no scan jobs, so the scan-derived blast path
+    // is empty. The strip must still populate from the server-reconciled
+    // top_risks and each row must drill to real finding rows.
+    const topRisks: OverviewTopRisk[] = [
+      { vulnerability_id: "CVE-2026-5555", package: "urllib3", severity: "critical", risk_score: 9.6, is_kev: true, cvss_score: 9.8, epss_score: 0.6, affected_agents: ["Ingest Bot"] },
+      { vulnerability_id: "CVE-2026-4444", package: "lodash", severity: "high", risk_score: 7.1, is_kev: false, cvss_score: 7.5, epss_score: 0.2, affected_agents: [] },
+    ];
+    const exposurePaths = buildExecExposurePaths([], topRisks);
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        topPath={null}
+        exposurePaths={exposurePaths}
+        critical={1}
+        high={1}
+      />,
+    );
+
+    expect(screen.getByText("CVE-2026-5555")).toBeInTheDocument();
+    expect(screen.getByText("urllib3")).toBeInTheDocument();
+    expect(screen.getByText("CVE-2026-4444")).toBeInTheDocument();
+    // Worst-first row drills to the exact CVE's finding rows (non-empty target).
+    const worst = screen.getByText("CVE-2026-5555").closest("a");
+    expect(worst).toHaveAttribute("href", "/findings?cve=CVE-2026-5555");
+  });
+
+  it("shows an honest empty strip when there are genuinely no risks (#4063)", () => {
+    render(<OverviewCockpit {...baseProps} topPath={null} exposurePaths={[]} critical={0} high={0} />);
+    expect(
+      screen.getByText(/Run a scan to correlate CVEs, packages, agents, and credentials/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/CVE-/)).not.toBeInTheDocument();
   });
 
   it("surfaces risk themes and links into findings / compliance", () => {


### PR DESCRIPTION
## Problem

The exec cockpit top-risk strip (`ui/components/overview-cockpit.tsx` `TopRisksPanel`, fed by `ui/app/page.tsx` `exposurePaths`) derived its rows **entirely client-side** from scan jobs' `blast_radius` (`allBlast`). Hub/bulk-ingested findings (via `POST /v1/findings/bulk`) never create scan jobs, so for a pure connector/bulk estate `allBlast` is empty and the strip renders **empty** — even though `/v1/overview` now returns a correct, worst-first `top_risks` list (fixed in #4059 / #4064). The backend honesty fix was therefore invisible in-product for exactly the estates it targets.

## Fix

New pure helper `buildExecExposurePaths(allBlast, overview.top_risks)` merges both sources:

- The scan-derived `blast_radius` chain (richest hops: server/credential, plus the scan→graph drill) **leads**, so scan estates do not regress.
- The server-reconciled `overview.top_risks` — the authoritative source that also covers hub/bulk findings — contributes any risk **not already represented** by a scan blast, deduped by `vulnerability_id` so scan + hub are never double-counted.
- Ranked worst-first, capped at 5.

Each `top_risks`-derived row drills to **real finding rows**, never an empty security-graph snapshot a scan-less estate has no data for:
- a CVE-shaped id → `/findings?cve=…` (provably non-empty — the row is why the risk exists);
- any other id (GHSA / canonical / synthetic) → `/findings?severity=…` (the band the finding provably belongs to), avoiding the drill-to-0 self-contradiction the backend fix already removed.

Honest empty state preserved when there are genuinely no risks.

### Before / After

| Estate | Before | After |
| --- | --- | --- |
| Bulk / connector (no scans) | strip **empty** despite open CVEs | strip **populated** worst-first from `overview.top_risks`, each row drilling to real finding rows |
| Scan estate | scan `blast_radius` chain | unchanged (leads); hub-only risks appended, deduped |

## Verify

- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm run test:run` ✅ (129 files / 672 tests) — new: 8 mapper/merge unit tests + 2 strip render tests (bulk-estate populated with working drill hrefs; honest empty state)
- `npm run build` ✅
- `NEXT_EXPORT=1 npm run build` ✅ (static-export release gate)

Both themes: rows render through the existing token-styled `RiskChainRow` (no new colors).

Closes #4063