### PR TITLE
feat(scan): scanner coverage — Go reachability, OS/distro breadth, live-K8s

### DIFF
--- a/src/agent_bom/cli/_db.py
+++ b/src/agent_bom/cli/_db.py
@@ -135,6 +135,9 @@ def db_status(db_path: str | None) -> None:
     conn = init_db(db_file)
     try:
         stats = db_stats(conn)
+        from agent_bom.coverage import covered_os_distros
+
+        os_distros = covered_os_distros(conn)
     finally:
         conn.close()
 
@@ -143,6 +146,8 @@ def db_status(db_path: str | None) -> None:
     con.print(f"  Affected ranges : {stats['affected_count']:,}")
     con.print(f"  EPSS scores     : {stats['epss_count']:,}")
     con.print(f"  KEV entries     : {stats['kev_count']:,}")
+    if os_distros:
+        con.print(f"  OS distros      : {', '.join(os_distros)}")
 
     meta = stats.get("sync_meta", {})
     if meta:

--- a/src/agent_bom/coverage.py
+++ b/src/agent_bom/coverage.py
@@ -84,6 +84,25 @@ def record_manifest_parse_warning(*, ecosystem: str, path: str, detail: str) -> 
         pass
 
 
+def covered_os_distros(conn: sqlite3.Connection) -> list[str]:
+    """Return the OS-distro families the local DB actually carries advisories for.
+
+    Reads the distinct ``affected.ecosystem`` values and maps them to human
+    distro labels via :func:`agent_bom.os_advisory.covered_distro_labels`. This is
+    the honest "which distros are active" signal for the scan/DB status surface —
+    derived from the data present, never an aspirational static list, so we never
+    overclaim coverage the DB does not hold.
+    """
+    from agent_bom.os_advisory import covered_distro_labels
+
+    try:
+        rows = conn.execute("SELECT DISTINCT ecosystem FROM affected").fetchall()
+    except sqlite3.Error as exc:  # pragma: no cover - defensive
+        _logger.debug("Could not read OS-distro coverage: %s", exc)
+        return []
+    return covered_distro_labels(str(r[0]) for r in rows if r and r[0])
+
+
 def _release_key(pkg: "Package") -> Optional[tuple[str, str]]:
     """Return ``(family, db_release_key)`` for an OS package with a known release.
 

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -20,6 +20,7 @@ from pathlib import Path
 from typing import Optional
 
 from agent_bom.api.tracing import get_tracer
+from agent_bom.os_advisory import OS_DISTRO_COMPARATOR_FAMILIES
 
 _logger = logging.getLogger(__name__)
 _LOOKUP_TRACER = get_tracer("agent_bom.db.lookup")
@@ -265,7 +266,9 @@ def _version_affected(
 
 
 # Map a (possibly release-suffixed) DB ecosystem to a base family the version
-# comparator understands.
+# comparator understands. The RPM/apk distro families (Red Hat, Rocky, AlmaLinux,
+# openSUSE/SUSE, Wolfi, Chainguard) are contributed by ``os_advisory`` so the
+# routing and comparator maps never drift apart.
 _ECO_FAMILY_TO_COMPARATOR = {
     "debian": "deb",
     "ubuntu": "deb",
@@ -274,6 +277,7 @@ _ECO_FAMILY_TO_COMPARATOR = {
     "apk": "apk",
     "rpm": "rpm",
     "linux": "rpm",
+    **OS_DISTRO_COMPARATOR_FAMILIES,
 }
 
 

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -388,6 +388,7 @@ def _parse_osv_entry(data: dict) -> Optional[tuple[dict, list[dict]]]:
     fixed_version: Optional[str] = None
     affected_rows: list[dict] = []
 
+    from agent_bom.os_advisory import normalize_redhat_ecosystem
     from agent_bom.package_utils import normalize_package_name
 
     for aff in data.get("affected", []):
@@ -396,6 +397,11 @@ def _parse_osv_entry(data: dict) -> Optional[tuple[dict, list[dict]]]:
         pkg_name = pkg.get("name", "")
         if not ecosystem or not pkg_name:
             continue
+
+        # Collapse repo/module-qualified Red Hat ecosystems (``…:8::baseos``,
+        # ``…:10.0``) to a canonical per-major key so a scanned host — which
+        # cannot know a package's originating repo — matches exactly.
+        ecosystem = normalize_redhat_ecosystem(ecosystem)
 
         norm_name = normalize_package_name(pkg_name, ecosystem)
 

--- a/src/agent_bom/db/sync.py
+++ b/src/agent_bom/db/sync.py
@@ -191,6 +191,7 @@ def _normalize_ghsa_db_ecosystem(ecosystem: str) -> str:
     eco = (ecosystem or "").strip().lower()
     return _GHSA_API_TO_DB_ECOSYSTEM.get(eco, eco)
 
+
 # Batch insert size for performance
 _BATCH_SIZE = 500
 
@@ -1529,9 +1530,9 @@ def sync_nvd_incremental(
 ) -> int:
     """Fetch recently modified CVEs from NVD and upsert enrichment into the local DB.
 
-  Requires ``NVD_API_KEY`` for practical rate limits. Uses ``lastModStartDate`` /
-  ``lastModEndDate`` windows and stores the end timestamp in sync metadata for
-  the next incremental run.
+    Requires ``NVD_API_KEY`` for practical rate limits. Uses ``lastModStartDate`` /
+    ``lastModEndDate`` windows and stores the end timestamp in sync metadata for
+    the next incremental run.
     """
     import os
     import time

--- a/src/agent_bom/k8s.py
+++ b/src/agent_bom/k8s.py
@@ -147,6 +147,455 @@ def list_namespaces(context: Optional[str] = None) -> list[str]:
         return []
 
 
+# Capabilities whose runtime presence materially widens the host attack surface.
+_DANGEROUS_CAPABILITIES = frozenset({"NET_RAW", "NET_ADMIN", "SYS_ADMIN", "SYS_PTRACE", "SYS_MODULE", "ALL"})
+
+# Durations that mean "no idle timeout" for the kubelet streaming connection.
+_ZERO_DURATIONS = frozenset({"0", "0s", "0m", "0h", "0m0s", "0h0m0s"})
+
+
+def _pod_containers(spec: dict) -> list[dict]:
+    """Return all container specs (containers + initContainers) from a pod spec."""
+    containers = spec.get("containers", []) or []
+    init_containers = spec.get("initContainers", []) or []
+    return [c for c in list(containers) + list(init_containers) if isinstance(c, dict)]
+
+
+def evaluate_pod_security(pods: dict, default_namespace: str = "default") -> list[IaCFinding]:
+    """Evaluate PodSecurity posture across *running* workloads.
+
+    Operates on a parsed ``kubectl get pods -o json`` payload. Only pods in the
+    ``Running`` phase are evaluated — this is a runtime posture check, not a
+    manifest lint, so pending/terminated pods are ignored. Findings mirror the
+    severities and CIS/NIST mappings of the static manifest scanner
+    (:mod:`agent_bom.iac.kubernetes`).
+    """
+    findings: list[IaCFinding] = []
+    for pod in pods.get("items", []) or []:
+        if not isinstance(pod, dict):
+            continue
+        if (pod.get("status", {}) or {}).get("phase") != "Running":
+            continue
+        metadata = pod.get("metadata", {}) or {}
+        name = metadata.get("name", "unknown")
+        ns = metadata.get("namespace", default_namespace)
+        pod_ref = f"k8s://{ns}/{name}"
+        spec = pod.get("spec", {}) or {}
+
+        if spec.get("hostNetwork") is True:
+            findings.append(
+                IaCFinding(
+                    rule_id="K8S-LIVE-008",
+                    severity="high",
+                    title="Running pod uses host network",
+                    message=(
+                        f"Pod '{ns}/{name}' is running with hostNetwork: true. It shares the node's "
+                        "network namespace, allowing traffic sniffing and NetworkPolicy bypass."
+                    ),
+                    file_path=pod_ref,
+                    line_number=1,
+                    category="kubernetes-live",
+                    compliance=["CIS-K8s-5.2.4", "NIST-CM-7"],
+                )
+            )
+        if spec.get("hostPID") is True or spec.get("hostIPC") is True:
+            shared = ", ".join(k for k in ("hostPID", "hostIPC") if spec.get(k) is True)
+            findings.append(
+                IaCFinding(
+                    rule_id="K8S-LIVE-009",
+                    severity="high",
+                    title="Running pod shares host process/IPC namespace",
+                    message=(
+                        f"Pod '{ns}/{name}' is running with {shared}: true. Sharing the host PID/IPC "
+                        "namespace enables container escape and cross-process attacks."
+                    ),
+                    file_path=pod_ref,
+                    line_number=1,
+                    category="kubernetes-live",
+                    compliance=["CIS-K8s-5.2.2", "NIST-CM-7"],
+                )
+            )
+        for vol in spec.get("volumes", []) or []:
+            if isinstance(vol, dict) and vol.get("hostPath"):
+                host_path = (vol.get("hostPath") or {}).get("path", "unknown")
+                findings.append(
+                    IaCFinding(
+                        rule_id="K8S-LIVE-010",
+                        severity="high",
+                        title="Running pod mounts a host path",
+                        message=(
+                            f"Pod '{ns}/{name}' mounts host path '{host_path}' via volume "
+                            f"'{vol.get('name', 'unknown')}'. hostPath mounts break container isolation "
+                            "and can expose or tamper with node files."
+                        ),
+                        file_path=pod_ref,
+                        line_number=1,
+                        category="kubernetes-live",
+                        compliance=["CIS-K8s-5.2.12", "NIST-SC-7"],
+                    )
+                )
+                break
+
+        for container in _pod_containers(spec):
+            cname = container.get("name", "unnamed")
+            sec_ctx = container.get("securityContext", {}) or {}
+
+            if sec_ctx.get("privileged") is True:
+                findings.append(
+                    IaCFinding(
+                        rule_id="K8S-LIVE-007",
+                        severity="critical",
+                        title="Running privileged container",
+                        message=(
+                            f"Container '{cname}' in pod '{ns}/{name}' is running in privileged mode, "
+                            "granting full host access. Remove privileged: true from the workload."
+                        ),
+                        file_path=pod_ref,
+                        line_number=1,
+                        category="kubernetes-live",
+                        compliance=["CIS-K8s-5.2.1", "NIST-AC-6"],
+                        attack_techniques=["T1611"],
+                    )
+                )
+            if sec_ctx.get("runAsUser") == 0 or sec_ctx.get("runAsNonRoot") is False:
+                findings.append(
+                    IaCFinding(
+                        rule_id="K8S-LIVE-011",
+                        severity="high",
+                        title="Running container executes as root",
+                        message=(
+                            f"Container '{cname}' in pod '{ns}/{name}' is running as root "
+                            "(runAsUser: 0 or runAsNonRoot: false). Run as a non-root user to limit "
+                            "exploit impact."
+                        ),
+                        file_path=pod_ref,
+                        line_number=1,
+                        category="kubernetes-live",
+                        compliance=["CIS-K8s-5.2.6", "NIST-AC-6"],
+                    )
+                )
+            if sec_ctx.get("allowPrivilegeEscalation") is True:
+                findings.append(
+                    IaCFinding(
+                        rule_id="K8S-LIVE-012",
+                        severity="high",
+                        title="Running container allows privilege escalation",
+                        message=(
+                            f"Container '{cname}' in pod '{ns}/{name}' allows privilege escalation. "
+                            "Set allowPrivilegeEscalation: false to block setuid-based escalation."
+                        ),
+                        file_path=pod_ref,
+                        line_number=1,
+                        category="kubernetes-live",
+                        compliance=["CIS-K8s-5.2.5", "NIST-AC-6"],
+                    )
+                )
+            add_caps = (sec_ctx.get("capabilities", {}) or {}).get("add", []) or []
+            dangerous = sorted({c.upper() for c in add_caps if isinstance(c, str)} & _DANGEROUS_CAPABILITIES)
+            if dangerous:
+                findings.append(
+                    IaCFinding(
+                        rule_id="K8S-LIVE-013",
+                        severity="critical",
+                        title="Running container adds dangerous capabilities",
+                        message=(
+                            f"Container '{cname}' in pod '{ns}/{name}' adds capabilities {dangerous}. "
+                            "Drop ALL capabilities and add back only what the workload needs."
+                        ),
+                        file_path=pod_ref,
+                        line_number=1,
+                        category="kubernetes-live",
+                        compliance=["CIS-K8s-5.2.8", "NIST-AC-6"],
+                    )
+                )
+
+        if not spec.get("securityContext"):
+            findings.append(
+                IaCFinding(
+                    rule_id="K8S-LIVE-014",
+                    severity="medium",
+                    title="Running pod has no securityContext",
+                    message=(
+                        f"Pod '{ns}/{name}' is running without a pod-level securityContext. Set "
+                        "runAsNonRoot, fsGroup, and seccompProfile to enforce a hardened baseline."
+                    ),
+                    file_path=pod_ref,
+                    line_number=1,
+                    category="kubernetes-live",
+                    compliance=["CIS-K8s-5.2.6", "NIST-AC-6"],
+                )
+            )
+
+    return findings
+
+
+def _rule_has_wildcard(rule: dict) -> bool:
+    """Return True if an RBAC policy rule grants wildcard verbs or resources."""
+    verbs = rule.get("verbs", []) or []
+    resources = rule.get("resources", []) or []
+    return "*" in verbs or "*" in resources
+
+
+def _is_builtin_role(name: str) -> bool:
+    """Built-in roles (cluster-admin, system:*) are expected wildcards."""
+    return name == "cluster-admin" or name == "admin" or name.startswith("system:")
+
+
+def evaluate_rbac(
+    cluster_roles: dict,
+    roles: dict,
+    cluster_role_bindings: dict,
+    default_namespace: str = "default",
+) -> list[IaCFinding]:
+    """Audit live RBAC for over-broad grants.
+
+    Flags ClusterRoleBindings to ``cluster-admin`` and user-defined
+    Cluster/Roles that grant wildcard verbs or resources. Built-in
+    ``cluster-admin`` and ``system:*`` roles are intentionally skipped — their
+    wildcards are expected and cannot be tightened.
+    """
+    findings: list[IaCFinding] = []
+
+    for binding in cluster_role_bindings.get("items", []) or []:
+        if not isinstance(binding, dict):
+            continue
+        role_ref = binding.get("roleRef", {}) or {}
+        if role_ref.get("name") != "cluster-admin":
+            continue
+        metadata = binding.get("metadata", {}) or {}
+        subjects = binding.get("subjects", []) or []
+        subject_names = (
+            ", ".join(
+                f"{s.get('kind', 'Subject')}:{s.get('namespace', '')}/{s.get('name', 'unknown')}".strip("/")
+                for s in subjects
+                if isinstance(s, dict)
+            )
+            or "unknown subject"
+        )
+        binding_name = metadata.get("name", "unknown")
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-006",
+                severity="critical",
+                title="Live cluster-admin RBAC binding detected",
+                message=(
+                    f"ClusterRoleBinding '{binding_name}' grants cluster-admin to {subject_names}. "
+                    "Review live RBAC drift and replace with least-privilege bindings."
+                ),
+                file_path=f"k8s://clusterrolebinding/{binding_name}",
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-5.1.1", "NIST-AC-6"],
+            )
+        )
+
+    for role in cluster_roles.get("items", []) or []:
+        if not isinstance(role, dict):
+            continue
+        name = (role.get("metadata", {}) or {}).get("name", "unknown")
+        if _is_builtin_role(name):
+            continue
+        if any(_rule_has_wildcard(r) for r in (role.get("rules", []) or []) if isinstance(r, dict)):
+            findings.append(
+                IaCFinding(
+                    rule_id="K8S-LIVE-015",
+                    severity="high",
+                    title="ClusterRole grants wildcard permissions",
+                    message=(
+                        f"ClusterRole '{name}' grants wildcard (*) verbs or resources. Wildcard grants "
+                        "violate least-privilege — enumerate the specific verbs/resources required."
+                    ),
+                    file_path=f"k8s://clusterrole/{name}",
+                    line_number=1,
+                    category="kubernetes-live",
+                    compliance=["CIS-K8s-5.1.3", "NIST-AC-6"],
+                )
+            )
+
+    for role in roles.get("items", []) or []:
+        if not isinstance(role, dict):
+            continue
+        metadata = role.get("metadata", {}) or {}
+        name = metadata.get("name", "unknown")
+        ns = metadata.get("namespace", default_namespace)
+        if name.startswith("system:"):
+            continue
+        if any(_rule_has_wildcard(r) for r in (role.get("rules", []) or []) if isinstance(r, dict)):
+            findings.append(
+                IaCFinding(
+                    rule_id="K8S-LIVE-016",
+                    severity="high",
+                    title="Role grants wildcard permissions",
+                    message=(
+                        f"Role '{ns}/{name}' grants wildcard (*) verbs or resources. Wildcard grants "
+                        "violate least-privilege — enumerate the specific verbs/resources required."
+                    ),
+                    file_path=f"k8s://role/{ns}/{name}",
+                    line_number=1,
+                    category="kubernetes-live",
+                    compliance=["CIS-K8s-5.1.3", "NIST-AC-6"],
+                )
+            )
+
+    return findings
+
+
+def evaluate_kubelet_config(node_name: str, kubelet_config: dict) -> list[IaCFinding]:
+    """Evaluate a node's kubelet configuration against CIS Benchmark section 4.2.
+
+    ``kubelet_config`` is the resolved KubeletConfiguration (v1beta1) as returned
+    by the read-only ``/api/v1/nodes/<node>/proxy/configz`` endpoint (the
+    ``kubeletconfig`` object). Only fields present in the resolved config are
+    evaluated; absent optional fields are not fabricated into a pass or fail.
+    """
+    findings: list[IaCFinding] = []
+    node_ref = f"k8s://node/{node_name}"
+
+    anonymous = (kubelet_config.get("authentication", {}) or {}).get("anonymous", {}) or {}
+    if anonymous.get("enabled") is True:
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-020",
+                severity="critical",
+                title="Kubelet allows anonymous authentication",
+                message=(
+                    f"Kubelet on node '{node_name}' has authentication.anonymous.enabled: true. "
+                    "Anonymous requests to the kubelet API can read pod data and exec into containers. "
+                    "Set --anonymous-auth=false."
+                ),
+                file_path=node_ref,
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-4.2.1", "NIST-AC-6"],
+            )
+        )
+
+    if (kubelet_config.get("authorization", {}) or {}).get("mode") == "AlwaysAllow":
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-021",
+                severity="critical",
+                title="Kubelet authorization mode is AlwaysAllow",
+                message=(
+                    f"Kubelet on node '{node_name}' uses authorization.mode: AlwaysAllow, which grants "
+                    "every authenticated request. Set --authorization-mode=Webhook."
+                ),
+                file_path=node_ref,
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-4.2.2", "NIST-AC-6"],
+            )
+        )
+
+    read_only_port = kubelet_config.get("readOnlyPort")
+    if isinstance(read_only_port, int) and read_only_port != 0:
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-022",
+                severity="high",
+                title="Kubelet read-only port is enabled",
+                message=(
+                    f"Kubelet on node '{node_name}' exposes readOnlyPort {read_only_port}. This "
+                    "unauthenticated port leaks pod and node metadata. Set --read-only-port=0."
+                ),
+                file_path=node_ref,
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-4.2.4", "NIST-AC-6"],
+            )
+        )
+
+    idle_timeout = str(kubelet_config.get("streamingConnectionIdleTimeout", "")).strip().lower()
+    if idle_timeout in _ZERO_DURATIONS:
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-023",
+                severity="medium",
+                title="Kubelet streaming connections never time out",
+                message=(
+                    f"Kubelet on node '{node_name}' sets streamingConnectionIdleTimeout to 0 (disabled). "
+                    "Idle exec/attach/port-forward streams are held open indefinitely. Set a non-zero "
+                    "timeout (e.g. 4h)."
+                ),
+                file_path=node_ref,
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-4.2.5", "NIST-AC-12"],
+            )
+        )
+
+    if kubelet_config.get("protectKernelDefaults") is False:
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-024",
+                severity="medium",
+                title="Kubelet does not protect kernel defaults",
+                message=(
+                    f"Kubelet on node '{node_name}' has protectKernelDefaults: false, so it may overwrite "
+                    "hardened kernel sysctls. Set --protect-kernel-defaults=true."
+                ),
+                file_path=node_ref,
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-4.2.6", "NIST-CM-6"],
+            )
+        )
+
+    if kubelet_config.get("makeIPTablesUtilChains") is False:
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-025",
+                severity="low",
+                title="Kubelet does not manage iptables util chains",
+                message=(
+                    f"Kubelet on node '{node_name}' has makeIPTablesUtilChains: false. Enable it so the "
+                    "kubelet maintains the iptables rules that back NetworkPolicy enforcement."
+                ),
+                file_path=node_ref,
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-4.2.7", "NIST-SC-7"],
+            )
+        )
+
+    if kubelet_config.get("rotateCertificates") is False:
+        findings.append(
+            IaCFinding(
+                rule_id="K8S-LIVE-026",
+                severity="medium",
+                title="Kubelet client certificate rotation is disabled",
+                message=(
+                    f"Kubelet on node '{node_name}' has rotateCertificates: false. Long-lived client "
+                    "certificates widen the credential-theft window. Set --rotate-certificates=true."
+                ),
+                file_path=node_ref,
+                line_number=1,
+                category="kubernetes-live",
+                compliance=["CIS-K8s-4.2.10", "NIST-IA-5"],
+            )
+        )
+
+    return findings
+
+
+def _fetch_kubelet_config(node_name: str, context: Optional[str]) -> Optional[dict]:
+    """Fetch a node's resolved kubelet config via the read-only configz proxy.
+
+    Returns the ``kubeletconfig`` object, or ``None`` when the endpoint is
+    unreachable (managed control planes commonly forbid the node proxy). A
+    blocked endpoint is an honest skip — never a fabricated pass.
+    """
+    raw_path = f"/api/v1/nodes/{node_name}/proxy/configz"
+    try:
+        data = _run_kubectl_json(["get", "--raw", raw_path], context=context, timeout=30)
+    except K8sDiscoveryError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    config = data.get("kubeletconfig")
+    return config if isinstance(config, dict) else None
+
+
 def scan_live_cluster_posture(
     namespace: str = "default",
     all_namespaces: bool = False,
@@ -155,8 +604,19 @@ def scan_live_cluster_posture(
     """Inspect runtime Kubernetes posture through the live API via kubectl.
 
     This complements manifest scanning. It does not attempt full policy
-    evaluation across the cluster; it inspects live workload, RBAC, and
-    namespace state that static manifests cannot prove.
+    evaluation across the cluster; it inspects live workload, RBAC, namespace,
+    and node/kubelet state that static manifests cannot prove. All access is
+    read-only (``kubectl get`` / read-only ``--raw`` GETs); the scan never
+    mutates or execs into the cluster.
+
+    Check families
+    --------------
+    * Runtime workload health — K8S-LIVE-001..004
+    * Namespace NetworkPolicy coverage — K8S-LIVE-005
+    * RBAC / namespace audit — K8S-LIVE-006, 015, 016
+    * PodSecurity on running workloads — K8S-LIVE-007..014
+    * Node / kubelet CIS configuration — K8S-LIVE-020..026 (skipped honestly
+      when the kubelet configz proxy is forbidden on managed control planes)
     """
     ns_args = ["-A"] if all_namespaces else ["-n", namespace]
     findings: list[IaCFinding] = []
@@ -164,6 +624,9 @@ def scan_live_cluster_posture(
     pods = _run_kubectl_json(["get", "pods", *ns_args, "-o", "json"], context=context, timeout=60)
     network_policies = _run_kubectl_json(["get", "networkpolicies", *ns_args, "-o", "json"], context=context, timeout=30)
     cluster_role_bindings = _run_kubectl_json(["get", "clusterrolebindings", "-o", "json"], context=context, timeout=30)
+    cluster_roles = _run_kubectl_json(["get", "clusterroles", "-o", "json"], context=context, timeout=30)
+    roles = _run_kubectl_json(["get", "roles", *ns_args, "-o", "json"], context=context, timeout=30)
+    nodes = _run_kubectl_json(["get", "nodes", "-o", "json"], context=context, timeout=30)
 
     policy_namespaces = {
         item.get("metadata", {}).get("namespace", namespace)
@@ -270,34 +733,21 @@ def scan_live_cluster_posture(
                 )
             )
 
-    for binding in cluster_role_bindings.get("items", []):
-        metadata = binding.get("metadata", {}) or {}
-        role_ref = binding.get("roleRef", {}) or {}
-        if role_ref.get("name") != "cluster-admin":
+    # PodSecurity on running workloads (K8S-LIVE-007..014).
+    findings.extend(evaluate_pod_security(pods, default_namespace=namespace))
+
+    # RBAC / namespace audit (K8S-LIVE-006, 015, 016).
+    findings.extend(evaluate_rbac(cluster_roles, roles, cluster_role_bindings, default_namespace=namespace))
+
+    # Node / kubelet CIS configuration (K8S-LIVE-020..026). The configz proxy is
+    # commonly forbidden on managed control planes — skip those nodes honestly
+    # instead of fabricating a pass.
+    for node in nodes.get("items", []) or []:
+        node_name = (node.get("metadata", {}) or {}).get("name")
+        if not node_name:
             continue
-        subjects = binding.get("subjects", []) or []
-        subject_names = (
-            ", ".join(
-                f"{subject.get('kind', 'Subject')}:{subject.get('namespace', '')}/{subject.get('name', 'unknown')}".strip("/")
-                for subject in subjects
-            )
-            or "unknown subject"
-        )
-        binding_name = metadata.get("name", "unknown")
-        findings.append(
-            IaCFinding(
-                rule_id="K8S-LIVE-006",
-                severity="critical",
-                title="Live cluster-admin RBAC binding detected",
-                message=(
-                    f"ClusterRoleBinding '{binding_name}' grants cluster-admin to {subject_names}. "
-                    "Review live RBAC drift and replace with least-privilege bindings."
-                ),
-                file_path=f"k8s://clusterrolebinding/{binding_name}",
-                line_number=1,
-                category="kubernetes-live",
-                compliance=["CIS-K8s-5.1.1", "NIST-AC-6"],
-            )
-        )
+        kubelet_config = _fetch_kubelet_config(node_name, context)
+        if kubelet_config is not None:
+            findings.extend(evaluate_kubelet_config(node_name, kubelet_config))
 
     return findings

--- a/src/agent_bom/os_advisory.py
+++ b/src/agent_bom/os_advisory.py
@@ -1,0 +1,194 @@
+"""OS distro → OSV advisory ecosystem resolution and coverage reporting.
+
+Maps a scanned OS package's distro (identified by ``/etc/os-release`` ``ID`` +
+``VERSION_ID``) to the OSV advisory ecosystem key(s) its vulnerabilities live
+under. The per-distro version comparison itself is handled by
+:mod:`agent_bom.version_utils` (rpm EVR, dpkg, apk semantics); this module only
+resolves which ecosystem key(s) to query and how to normalise the keys the OSV
+bulk export stores.
+
+The OSV all-ecosystems bulk export already carries advisories for these distro
+families, so extending coverage is a matter of *routing* installed packages to
+the right ecosystem key — not ingesting a new feed. Alpine (secdb) and Debian
+(security-tracker) additionally have dedicated feeds handled in ``db/sync.py``.
+
+Verified against real OSV bulk-export data (2026-07-16):
+
+======================  ============================================================
+Distro (os-release ID)  OSV ecosystem key(s)
+======================  ============================================================
+rhel / centos / redhat  ``Red Hat:enterprise_linux:<major>`` (bulk export stores it
+                        repo/module-qualified, e.g. ``…:8::baseos`` /
+                        ``…:10.0``; :func:`normalize_redhat_ecosystem` collapses
+                        those to the canonical per-major key at ingest). The live
+                        OSV API is queried with the bare ``Red Hat`` ecosystem,
+                        which it accepts and version-filters via the ``.elN`` tag.
+rocky                   ``Rocky Linux:<major>``  (e.g. ``Rocky Linux:8``)
+almalinux / alma        ``AlmaLinux:<major>``    (e.g. ``AlmaLinux:9``)
+opensuse-leap           ``openSUSE:Leap <ver>`` and ``openSUSE:Leap <ver> NonFree``
+wolfi                   ``Wolfi``
+chainguard              ``Chainguard``
+======================  ============================================================
+
+Deferred (advisory source not in the OSV export / version-compare unverified):
+Amazon Linux (ALAS), Oracle Linux (ELSA), SUSE Linux Enterprise product modules,
+openSUSE Tumbleweed. These need dedicated feeds and are tracked as follow-ups
+rather than shipped as guessed matchers.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+# ── distro os-release ID sets ────────────────────────────────────────────────
+# Values are the lowercased ``/etc/os-release`` ``ID`` fields we route on.
+
+_ROCKY_IDS = frozenset({"rocky"})
+_ALMA_IDS = frozenset({"almalinux", "alma"})
+# CentOS Linux is a bug-for-bug RHEL rebuild, so its packages match Red Hat
+# advisories; CentOS Stream is upstream of RHEL but close enough that the Red Hat
+# advisory set is the best available match (mainstream scanners do the same).
+_RHEL_IDS = frozenset({"rhel", "redhat", "red hat", "centos", "scientific"})
+_OPENSUSE_LEAP_IDS = frozenset({"opensuse-leap", "opensuse", "opensuse-leap-micro"})
+_WOLFI_IDS = frozenset({"wolfi"})
+_CHAINGUARD_IDS = frozenset({"chainguard"})
+
+# Base ecosystem family (the part before the first ``:``, lowercased) → the
+# version comparator key. Consumed by ``db.lookup._ECO_FAMILY_TO_COMPARATOR``.
+OS_DISTRO_COMPARATOR_FAMILIES: dict[str, str] = {
+    "red hat": "rpm",
+    "rocky linux": "rpm",
+    "almalinux": "rpm",
+    "opensuse": "rpm",
+    "suse": "rpm",
+    "wolfi": "apk",
+    "chainguard": "apk",
+}
+
+# Base ecosystem family → human coverage label, in display order. Includes the
+# pre-existing Alpine/Debian/Ubuntu families so a single call reports the full
+# active OS-advisory surface.
+_BASE_TO_LABEL: tuple[tuple[str, str], ...] = (
+    ("alpine", "Alpine"),
+    ("debian", "Debian"),
+    ("ubuntu", "Ubuntu"),
+    ("red hat", "RHEL"),
+    ("rocky linux", "Rocky Linux"),
+    ("almalinux", "AlmaLinux"),
+    ("opensuse", "openSUSE"),
+    ("suse", "SUSE"),
+    ("wolfi", "Wolfi"),
+    ("chainguard", "Chainguard"),
+)
+
+_REDHAT_EL_RE = re.compile(r"^red hat:enterprise_linux:(\d+)(?:[.:].*)?$", re.IGNORECASE)
+
+
+def _major(version: str) -> str:
+    """Return the leading numeric major component of a ``VERSION_ID``."""
+    return (version or "").strip().split(".", 1)[0].strip()
+
+
+def _opensuse_leap_release(version: str) -> str:
+    """Normalise an openSUSE Leap ``VERSION_ID`` (``15.5`` / ``15.5.1``) to ``15.5``."""
+    raw = (version or "").strip()
+    parts = raw.split(".")
+    if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+        return f"{parts[0]}.{parts[1]}"
+    return raw
+
+
+def normalize_redhat_ecosystem(ecosystem: str) -> str:
+    """Collapse a repo/module-qualified Red Hat OSV ecosystem to its per-major key.
+
+    The OSV bulk export keys Red Hat advisories by product *stream*, e.g.
+    ``Red Hat:enterprise_linux:8::baseos``, ``…:8::appstream`` or (RHEL 10+)
+    ``Red Hat:enterprise_linux:10.0``. A scanned host cannot know which repo a
+    package came from, so these are collapsed to a single canonical
+    ``Red Hat:enterprise_linux:<major>`` key that a host resolver can match
+    exactly. Non-``enterprise_linux`` Red Hat products (openshift, ceph, ansible,
+    ``enterprise_linux_ai`` …) are returned unchanged — base-OS scans never match
+    them, and rewriting them could collide unrelated advisories.
+    """
+    if not ecosystem:
+        return ecosystem
+    m = _REDHAT_EL_RE.match(ecosystem.strip())
+    if not m:
+        return ecosystem
+    # Preserve the exported casing of the family prefix for display consistency.
+    return f"Red Hat:enterprise_linux:{m.group(1)}"
+
+
+def rpm_advisory_ecosystems(
+    distro_name: str | None,
+    distro_version: str | None,
+    *,
+    for_local_db: bool,
+) -> list[str]:
+    """Resolve OSV ecosystem key(s) for an rpm package from its distro context.
+
+    Returns an empty list when the distro is unrecognised or its release cannot
+    be determined, so the caller can fall back to its prior behaviour rather than
+    matching against a wrong ecosystem.
+
+    Args:
+        distro_name: lowercased ``/etc/os-release`` ``ID`` (``rhel``/``rocky``/…).
+        distro_version: ``VERSION_ID`` (``8.9`` / ``15.5``).
+        for_local_db: when True, return the canonical key stored in the local DB
+            (Red Hat collapsed to ``Red Hat:enterprise_linux:<major>``); when
+            False, return the key the live OSV API accepts (bare ``Red Hat``).
+    """
+    name = (distro_name or "").strip().lower()
+    major = _major(distro_version or "")
+
+    if name in _ROCKY_IDS and major:
+        return [f"Rocky Linux:{major}"]
+    if name in _ALMA_IDS and major:
+        return [f"AlmaLinux:{major}"]
+    if name in _RHEL_IDS and major:
+        if for_local_db:
+            return [f"Red Hat:enterprise_linux:{major}"]
+        return ["Red Hat"]
+    if name in _OPENSUSE_LEAP_IDS:
+        release = _opensuse_leap_release(distro_version or "")
+        if release:
+            return [f"openSUSE:Leap {release}", f"openSUSE:Leap {release} NonFree"]
+    return []
+
+
+def apk_advisory_ecosystems(distro_name: str | None) -> list[str]:
+    """Resolve OSV ecosystem key(s) for an apk package's non-Alpine distros.
+
+    Wolfi and Chainguard are apk-based, undated rolling distros whose advisories
+    live under version-less ``Wolfi`` / ``Chainguard`` ecosystems. Returns an
+    empty list for Alpine (handled by the caller's existing branch) or an
+    unrecognised distro.
+    """
+    name = (distro_name or "").strip().lower()
+    if name in _WOLFI_IDS:
+        return ["Wolfi"]
+    if name in _CHAINGUARD_IDS:
+        return ["Chainguard"]
+    return []
+
+
+def covered_distro_labels(present_ecosystems: Iterable[str]) -> list[str]:
+    """Map the ecosystem keys present in the local DB to OS-distro coverage labels.
+
+    ``present_ecosystems`` is the set of distinct ``affected.ecosystem`` values
+    (any case, release-suffixed or not). Returns the human labels for the OS
+    distro families that have advisory rows, in a stable display order — the
+    honest "which distros are actually covered" signal for the scan surface.
+    """
+    families = {str(e).split(":", 1)[0].strip().lower() for e in present_ecosystems if e}
+    return [label for base, label in _BASE_TO_LABEL if base in families]
+
+
+__all__ = [
+    "OS_DISTRO_COMPARATOR_FAMILIES",
+    "apk_advisory_ecosystems",
+    "covered_distro_labels",
+    "normalize_redhat_ecosystem",
+    "rpm_advisory_ecosystems",
+]

--- a/src/agent_bom/parsers/os_parsers.py
+++ b/src/agent_bom/parsers/os_parsers.py
@@ -334,9 +334,24 @@ def detect_os_type(root: Path = Path("/")) -> str | None:
                 os_id = line.split("=", 1)[1].strip().strip('"').lower()
                 if os_id in ("debian", "ubuntu", "linuxmint", "pop"):
                     return "deb"
-                if os_id in ("fedora", "rhel", "centos", "rocky", "alma", "almalinux", "ol"):
+                if os_id in (
+                    "fedora",
+                    "rhel",
+                    "centos",
+                    "rocky",
+                    "alma",
+                    "almalinux",
+                    "ol",
+                    "opensuse",
+                    "opensuse-leap",
+                    "opensuse-tumbleweed",
+                    "opensuse-leap-micro",
+                    "sles",
+                    "sled",
+                    "suse",
+                ):
                     return "rpm"
-                if os_id == "alpine":
+                if os_id in ("alpine", "wolfi", "chainguard"):
                     return "apk"
     except OSError:
         pass

--- a/src/agent_bom/reachability_cve.py
+++ b/src/agent_bom/reachability_cve.py
@@ -14,7 +14,20 @@ Two halves already exist in the codebase and this module is the join:
   *symbols* of which *packages* are reachable from a live entrypoint.
 * **Advisory symbols** — some OSV/GHSA advisories carry the affected
   *functions/symbols* under ``affected[].ecosystem_specific.imports`` (the
-  OSV / Go-vulndb ``imports[].{path,symbols}`` shape). Most do not.
+  OSV / Go-vulndb ``imports[].{path,symbols}`` shape). Most do not. The Go
+  vulnerability database (OSV ecosystem ``Go``) is the richest source: nearly
+  every record lists ``imports[].symbols`` (verified against live
+  ``api.osv.dev`` records, e.g. ``GO-2022-0646``). GHSA occasionally lists
+  affected functions in ``database_specific``; the remaining ecosystems carry
+  no symbol data today and stay honestly package-level.
+
+Go module vs import path: an SCA finding — and an OSV ``affected[].package.name``
+— is a *module* (``github.com/aws/aws-sdk-go``), whereas the AST records reach
+against the fully-qualified *import path*
+(``github.com/aws/aws-sdk-go/service/s3/s3crypto``). The reach index therefore
+matches a module finding against any reached sub-package import path on the
+``/`` module boundary, so Go symbol reach actually fires instead of always
+degrading to package-level.
 
 For a vulnerable package we extract the advisory's affected symbols (if
 any) and intersect them with the project's reached symbol set. The result
@@ -122,15 +135,43 @@ class SymbolReachIndex:
     def from_ast_result(cls, result: "ASTAnalysisResult") -> "SymbolReachIndex":
         return cls.from_reaches(result.dependency_symbol_reach)
 
+    def _matching_keys(self, package: str, ecosystem: str) -> list[str]:
+        """Index keys that belong to ``package`` for reach lookups.
+
+        For most ecosystems the reached-symbol key *is* the package name, so
+        this is the exact key. Go is the exception: the AST records
+        ``reach.package`` as the fully-qualified *import path*
+        (``github.com/aws/aws-sdk-go/service/s3/s3crypto``) while an SCA finding
+        and its OSV advisory name the *module*
+        (``github.com/aws/aws-sdk-go``). We therefore also match any indexed
+        import path that is a sub-package of the module, honouring the ``/``
+        module boundary so ``…/aws-sdk-go`` never matches ``…/aws-sdk-goodies``.
+        """
+        eco = normalize_package_ecosystem(ecosystem or "pypi")
+        exact = _pkg_index_key(package, eco)
+        keys = [exact] if exact in self._symbols_by_key else []
+        if eco == "go":
+            prefix = f"{exact}/"
+            keys.extend(key for key in self._symbols_by_key if key != exact and key.startswith(prefix))
+        return keys
+
     def is_package_reached(self, package: str, *, ecosystem: str = "pypi") -> bool:
         """True when any symbol of ``package`` is reached from an entrypoint."""
-        return _pkg_index_key(package, ecosystem) in self._symbols_by_key
+        return bool(self._matching_keys(package, ecosystem))
 
     def symbols_for_package(self, package: str, *, ecosystem: str = "pypi") -> set[str]:
-        return set(self._symbols_by_key.get(_pkg_index_key(package, ecosystem), set()))
+        symbols: set[str] = set()
+        for key in self._matching_keys(package, ecosystem):
+            symbols |= self._symbols_by_key.get(key, set())
+        return symbols
 
     def call_path_for_package(self, package: str, *, ecosystem: str = "pypi") -> tuple[str, ...]:
-        return self._paths_by_key.get(_pkg_index_key(package, ecosystem), ())
+        shortest: tuple[str, ...] = ()
+        for key in self._matching_keys(package, ecosystem):
+            candidate = self._paths_by_key.get(key)
+            if candidate and (not shortest or len(candidate) < len(shortest)):
+                shortest = candidate
+        return shortest
 
     def __bool__(self) -> bool:
         return bool(self._symbols_by_key)

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -43,6 +43,7 @@ from agent_bom.models import Agent, BlastRadius, MCPServer, Package, Severity, V
 from agent_bom.nist_800_53 import tag_blast_radius as tag_nist_800_53
 from agent_bom.nist_ai_rmf import tag_blast_radius as tag_nist_ai_rmf
 from agent_bom.nist_csf import tag_blast_radius as tag_nist_csf
+from agent_bom.os_advisory import apk_advisory_ecosystems, rpm_advisory_ecosystems
 from agent_bom.owasp import tag_blast_radius
 from agent_bom.owasp_agentic import tag_blast_radius as tag_owasp_agentic
 from agent_bom.owasp_mcp import tag_blast_radius as tag_owasp_mcp
@@ -270,8 +271,14 @@ _DEBIAN_OSV_FALLBACKS = ("Debian:11", "Debian:12", "Debian:13", "Debian:14")
 _ALPINE_OSV_FALLBACKS = alpine_osv_fallback_ecosystems()
 
 
-def _osv_ecosystems_for_package(pkg: Package) -> list[str]:
-    """Return one or more OSV ecosystem identifiers for a package."""
+def _resolve_osv_ecosystems(pkg: Package, *, for_local_db: bool) -> list[str]:
+    """Return OSV ecosystem identifier(s) for a package.
+
+    ``for_local_db`` selects the key variant: the local DB stores RPM-distro
+    advisories under a per-major key (e.g. ``Red Hat:enterprise_linux:8``) while
+    the live OSV API is queried with the bare distro ecosystem it accepts
+    (``Red Hat``). Every other ecosystem resolves identically for both paths.
+    """
     eco_key = pkg.ecosystem.lower()
 
     if eco_key == "deb":
@@ -287,6 +294,10 @@ def _osv_ecosystems_for_package(pkg: Package) -> list[str]:
         return list(_DEBIAN_OSV_FALLBACKS)
 
     if eco_key == "apk":
+        # Wolfi/Chainguard are apk-based but use their own version-less ecosystems.
+        non_alpine = apk_advisory_ecosystems(pkg.distro_name)
+        if non_alpine:
+            return non_alpine
         distro_version = (pkg.distro_version or "").strip()
         if distro_version:
             # Alpine advisories are keyed by minor branch (``v3.16``), so a full
@@ -294,13 +305,26 @@ def _osv_ecosystems_for_package(pkg: Package) -> list[str]:
             return [f"Alpine:{alpine_release_branch(distro_version)}"]
         return list(_ALPINE_OSV_FALLBACKS)
 
+    if eco_key == "rpm":
+        # RHEL/CentOS, Rocky, AlmaLinux and openSUSE Leap advisories are carried
+        # by the OSV bulk export under distro-specific ecosystems. Fall back to
+        # the cross-distro "Linux" ecosystem only when the distro is unresolved.
+        distro = rpm_advisory_ecosystems(pkg.distro_name, pkg.distro_version, for_local_db=for_local_db)
+        if distro:
+            return distro
+
     osv_ecosystem = ECOSYSTEM_MAP.get(eco_key)
     return [osv_ecosystem] if osv_ecosystem else []
 
 
+def _osv_ecosystems_for_package(pkg: Package) -> list[str]:
+    """Return one or more OSV ecosystem identifiers for a package (live API path)."""
+    return _resolve_osv_ecosystems(pkg, for_local_db=False)
+
+
 def _db_ecosystems_for_package(pkg: Package) -> list[str]:
-    """Return normalized DB ecosystem keys for a package."""
-    return [eco.lower() for eco in _osv_ecosystems_for_package(pkg)]
+    """Return normalized local-DB ecosystem keys for a package."""
+    return [eco.lower() for eco in _resolve_osv_ecosystems(pkg, for_local_db=True)]
 
 
 def _db_covered_ecosystems() -> set[str]:

--- a/src/agent_bom/scanners/registry.py
+++ b/src/agent_bom/scanners/registry.py
@@ -227,6 +227,39 @@ def builtin_scanner_registrations() -> list[ScannerRegistration]:
             standards=("SLSA", "NIST", "SOC2"),
         ),
         _registration(
+            "k8s-live-cluster",
+            "agent_bom.k8s",
+            phase=ScannerPhase.DISCOVERY,
+            run_attr="scan_live_cluster_posture",
+            input_types=("kubeconfig_context", "kubectl"),
+            output_types=("iac_findings",),
+            finding_types=(
+                "kubernetes-live",
+                "pod-security",
+                "rbac-wildcard",
+                "cluster-admin-binding",
+                "kubelet-cis",
+                "network-policy-gap",
+            ),
+            summary=(
+                "Read-only live Kubernetes cluster audit via kubectl: PodSecurity on running "
+                "workloads, RBAC/namespace over-broad grants, and node/kubelet CIS configuration."
+            ),
+            capabilities=ExtensionCapabilities(
+                scan_modes=("cluster", "online"),
+                required_scopes=("kubernetes_cluster_read",),
+                permissions_used=("kubectl_get", "kubelet_configz_read"),
+                outbound_destinations=("kubernetes_api_server",),
+                data_boundary="cluster_state_read_only",
+                network_access=True,
+                guarantees=("read_only", "no_cluster_mutation"),
+            ),
+            failure_mode=ScannerFailureMode.SKIP_WHEN_UNAVAILABLE,
+            skip_when=("kubectl_missing", "cluster_unreachable", "no_cluster_scope"),
+            telemetry_keys=("pods_scanned", "nodes_scanned", "findings_emitted", "duration_ms"),
+            standards=("CIS", "NIST"),
+        ),
+        _registration(
             "cicd-github-actions",
             "agent_bom.github_actions",
             phase=ScannerPhase.DISCOVERY,

--- a/tests/test_k8s.py
+++ b/tests/test_k8s.py
@@ -295,6 +295,9 @@ def test_scan_live_cluster_posture_finds_runtime_gaps(monkeypatch):
                 }
             ]
         },
+        ("get", "clusterroles"): {"items": []},
+        ("get", "roles"): {"items": []},
+        ("get", "nodes"): {"items": []},
     }
 
     def fake_run(cmd, **kwargs):
@@ -324,7 +327,22 @@ def test_scan_live_cluster_posture_clean_cluster(monkeypatch):
             "items": [
                 {
                     "metadata": {"name": "api", "namespace": "prod"},
-                    "spec": {"automountServiceAccountToken": False},
+                    "spec": {
+                        "automountServiceAccountToken": False,
+                        "securityContext": {"runAsNonRoot": True, "seccompProfile": {"type": "RuntimeDefault"}},
+                        "containers": [
+                            {
+                                "name": "api",
+                                "securityContext": {
+                                    "privileged": False,
+                                    "runAsNonRoot": True,
+                                    "allowPrivilegeEscalation": False,
+                                    "readOnlyRootFilesystem": True,
+                                    "capabilities": {"drop": ["ALL"]},
+                                },
+                            }
+                        ],
+                    },
                     "status": {
                         "phase": "Running",
                         "containerStatuses": [{"name": "api", "ready": True, "state": {"running": {}}}],
@@ -334,6 +352,9 @@ def test_scan_live_cluster_posture_clean_cluster(monkeypatch):
         },
         ("get", "networkpolicies"): {"items": [{"metadata": {"name": "default-deny", "namespace": "prod"}}]},
         ("get", "clusterrolebindings"): {"items": []},
+        ("get", "clusterroles"): {"items": []},
+        ("get", "roles"): {"items": []},
+        ("get", "nodes"): {"items": []},
     }
 
     def fake_run(cmd, **kwargs):

--- a/tests/test_k8s_live_cluster.py
+++ b/tests/test_k8s_live_cluster.py
@@ -1,0 +1,328 @@
+"""Unit tests for live Kubernetes cluster security checks.
+
+Covers the three read-only check families added to ``agent_bom.k8s``:
+
+* PodSecurity against *running* workloads (``evaluate_pod_security``)
+* namespace / RBAC audit (``evaluate_rbac``)
+* node / kubelet CIS configuration (``evaluate_kubelet_config``)
+
+All checks operate on already-parsed cluster objects (fixture dicts modelled on
+``kubectl get ... -o json`` / kubelet ``configz`` payloads) so no live cluster
+is required.  The kubectl transport is exercised separately in ``test_k8s.py``.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+from agent_bom.k8s import (
+    K8sDiscoveryError,
+    evaluate_kubelet_config,
+    evaluate_pod_security,
+    evaluate_rbac,
+    scan_live_cluster_posture,
+)
+
+# ─── PodSecurity (running workloads) ─────────────────────────────────────────
+
+
+def _pod(spec: dict, name: str = "app", namespace: str = "prod") -> dict:
+    return {
+        "metadata": {"name": name, "namespace": namespace},
+        "spec": spec,
+        "status": {"phase": "Running"},
+    }
+
+
+def test_pod_security_privileged_container():
+    pods = {
+        "items": [
+            _pod(
+                {
+                    "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
+                    "containers": [{"name": "c", "securityContext": {"privileged": True}}],
+                }
+            )
+        ]
+    }
+    findings = evaluate_pod_security(pods)
+    by_id = {f.rule_id: f for f in findings}
+    assert "K8S-LIVE-007" in by_id
+    assert by_id["K8S-LIVE-007"].severity == "critical"
+    assert by_id["K8S-LIVE-007"].category == "kubernetes-live"
+    assert "CIS-K8s-5.2.1" in by_id["K8S-LIVE-007"].compliance
+
+
+def test_pod_security_host_namespaces_and_hostpath():
+    pods = {
+        "items": [
+            _pod(
+                {
+                    "hostNetwork": True,
+                    "hostPID": True,
+                    "hostIPC": True,
+                    "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
+                    "volumes": [{"name": "hp", "hostPath": {"path": "/etc"}}],
+                    "containers": [{"name": "c", "securityContext": {"readOnlyRootFilesystem": True}}],
+                }
+            )
+        ]
+    }
+    ids = {f.rule_id for f in evaluate_pod_security(pods)}
+    assert "K8S-LIVE-008" in ids  # hostNetwork
+    assert "K8S-LIVE-009" in ids  # hostPID / hostIPC
+    assert "K8S-LIVE-010" in ids  # hostPath
+
+
+def test_pod_security_run_as_root_and_priv_escalation_and_caps():
+    pods = {
+        "items": [
+            _pod(
+                {
+                    "securityContext": {"seccompProfile": {"type": "RuntimeDefault"}},
+                    "containers": [
+                        {
+                            "name": "c",
+                            "securityContext": {
+                                "runAsUser": 0,
+                                "allowPrivilegeEscalation": True,
+                                "capabilities": {"add": ["SYS_ADMIN"]},
+                            },
+                        }
+                    ],
+                }
+            )
+        ]
+    }
+    ids = {f.rule_id for f in evaluate_pod_security(pods)}
+    assert "K8S-LIVE-011" in ids  # runAsUser 0
+    assert "K8S-LIVE-012" in ids  # allowPrivilegeEscalation
+    assert "K8S-LIVE-013" in ids  # dangerous capability
+
+
+def test_pod_security_missing_pod_security_context():
+    pods = {"items": [_pod({"containers": [{"name": "c", "securityContext": {"readOnlyRootFilesystem": True}}]})]}
+    ids = {f.rule_id for f in evaluate_pod_security(pods)}
+    assert "K8S-LIVE-014" in ids
+
+
+def test_pod_security_hardened_pod_clean():
+    """A hardened running pod yields no PodSecurity findings."""
+    pods = {
+        "items": [
+            _pod(
+                {
+                    "hostNetwork": False,
+                    "hostPID": False,
+                    "hostIPC": False,
+                    "securityContext": {"runAsNonRoot": True, "seccompProfile": {"type": "RuntimeDefault"}},
+                    "volumes": [{"name": "data", "emptyDir": {}}],
+                    "containers": [
+                        {
+                            "name": "c",
+                            "securityContext": {
+                                "privileged": False,
+                                "runAsNonRoot": True,
+                                "allowPrivilegeEscalation": False,
+                                "readOnlyRootFilesystem": True,
+                                "capabilities": {"drop": ["ALL"]},
+                            },
+                        }
+                    ],
+                }
+            )
+        ]
+    }
+    assert evaluate_pod_security(pods) == []
+
+
+def test_pod_security_skips_non_running_pods():
+    """PodSecurity is a runtime posture check — only running pods are evaluated."""
+    pods = {
+        "items": [
+            {
+                "metadata": {"name": "old", "namespace": "prod"},
+                "spec": {"containers": [{"name": "c", "securityContext": {"privileged": True}}]},
+                "status": {"phase": "Succeeded"},
+            }
+        ]
+    }
+    assert evaluate_pod_security(pods) == []
+
+
+# ─── RBAC / namespace audit ──────────────────────────────────────────────────
+
+
+def test_rbac_cluster_admin_binding():
+    crb = {
+        "items": [
+            {
+                "metadata": {"name": "admin-binding"},
+                "roleRef": {"name": "cluster-admin"},
+                "subjects": [{"kind": "ServiceAccount", "namespace": "prod", "name": "default"}],
+            }
+        ]
+    }
+    findings = evaluate_rbac({"items": []}, {"items": []}, crb)
+    by_id = {f.rule_id: f for f in findings}
+    assert "K8S-LIVE-006" in by_id
+    assert by_id["K8S-LIVE-006"].severity == "critical"
+
+
+def test_rbac_wildcard_cluster_role():
+    cluster_roles = {
+        "items": [
+            {
+                "metadata": {"name": "app-superuser"},
+                "rules": [{"apiGroups": ["*"], "resources": ["*"], "verbs": ["*"]}],
+            }
+        ]
+    }
+    findings = evaluate_rbac(cluster_roles, {"items": []}, {"items": []})
+    by_id = {f.rule_id: f for f in findings}
+    assert "K8S-LIVE-015" in by_id
+    assert by_id["K8S-LIVE-015"].severity == "high"
+    assert "CIS-K8s-5.1.3" in by_id["K8S-LIVE-015"].compliance
+
+
+def test_rbac_wildcard_namespaced_role():
+    roles = {
+        "items": [
+            {
+                "metadata": {"name": "ns-superuser", "namespace": "prod"},
+                "rules": [{"apiGroups": [""], "resources": ["secrets"], "verbs": ["*"]}],
+            }
+        ]
+    }
+    ids = {f.rule_id for f in evaluate_rbac({"items": []}, roles, {"items": []})}
+    assert "K8S-LIVE-016" in ids
+
+
+def test_rbac_ignores_builtin_system_roles():
+    """Built-in cluster-admin and system: roles are expected wildcards — not flagged."""
+    cluster_roles = {
+        "items": [
+            {"metadata": {"name": "cluster-admin"}, "rules": [{"apiGroups": ["*"], "resources": ["*"], "verbs": ["*"]}]},
+            {"metadata": {"name": "system:controller:x"}, "rules": [{"apiGroups": ["*"], "resources": ["*"], "verbs": ["*"]}]},
+        ]
+    }
+    ids = {f.rule_id for f in evaluate_rbac(cluster_roles, {"items": []}, {"items": []})}
+    assert "K8S-LIVE-015" not in ids
+
+
+def test_rbac_least_privilege_role_clean():
+    cluster_roles = {
+        "items": [
+            {
+                "metadata": {"name": "reader"},
+                "rules": [{"apiGroups": [""], "resources": ["pods"], "verbs": ["get", "list", "watch"]}],
+            }
+        ]
+    }
+    assert evaluate_rbac(cluster_roles, {"items": []}, {"items": []}) == []
+
+
+# ─── Node / kubelet configuration (kube-bench-style CIS) ──────────────────────
+
+
+def test_kubelet_anonymous_auth_and_always_allow():
+    cfg = {
+        "authentication": {"anonymous": {"enabled": True}},
+        "authorization": {"mode": "AlwaysAllow"},
+        "readOnlyPort": 10255,
+    }
+    findings = evaluate_kubelet_config("node-1", cfg)
+    by_id = {f.rule_id: f for f in findings}
+    assert by_id["K8S-LIVE-020"].severity == "critical"  # anonymous-auth
+    assert "CIS-K8s-4.2.1" in by_id["K8S-LIVE-020"].compliance
+    assert by_id["K8S-LIVE-021"].severity == "critical"  # AlwaysAllow
+    assert "K8S-LIVE-022" in by_id  # read-only port
+    assert by_id["K8S-LIVE-020"].file_path == "k8s://node/node-1"
+
+
+def test_kubelet_weak_hardening_flags():
+    cfg = {
+        "authentication": {"anonymous": {"enabled": False}},
+        "authorization": {"mode": "Webhook"},
+        "readOnlyPort": 0,
+        "streamingConnectionIdleTimeout": "0",
+        "protectKernelDefaults": False,
+        "makeIPTablesUtilChains": False,
+        "rotateCertificates": False,
+    }
+    ids = {f.rule_id for f in evaluate_kubelet_config("node-1", cfg)}
+    assert "K8S-LIVE-023" in ids  # streaming idle timeout disabled
+    assert "K8S-LIVE-024" in ids  # protectKernelDefaults
+    assert "K8S-LIVE-025" in ids  # makeIPTablesUtilChains
+    assert "K8S-LIVE-026" in ids  # rotateCertificates
+    # Hardened auth/authz/read-only-port must NOT be flagged.
+    assert "K8S-LIVE-020" not in ids
+    assert "K8S-LIVE-021" not in ids
+    assert "K8S-LIVE-022" not in ids
+
+
+def test_kubelet_hardened_config_clean():
+    cfg = {
+        "authentication": {"anonymous": {"enabled": False}},
+        "authorization": {"mode": "Webhook"},
+        "readOnlyPort": 0,
+        "streamingConnectionIdleTimeout": "4h0m0s",
+        "protectKernelDefaults": True,
+        "makeIPTablesUtilChains": True,
+        "rotateCertificates": True,
+    }
+    assert evaluate_kubelet_config("node-1", cfg) == []
+
+
+# ─── Honest no-cluster / unreachable handling ────────────────────────────────
+
+
+def test_scan_live_cluster_no_kubectl(monkeypatch):
+    """No kubectl on PATH → honest error, never a fake clean pass."""
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    with pytest.raises(K8sDiscoveryError):
+        scan_live_cluster_posture(namespace="prod")
+
+
+def test_scan_live_cluster_kubelet_unreachable_skips_not_fails(monkeypatch):
+    """A managed cluster that blocks the kubelet configz proxy must skip node
+    checks honestly (no finding fabricated, scan still completes) rather than
+    crash or emit a false pass."""
+    monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/" + cmd)
+
+    import json
+
+    payloads = {
+        ("get", "pods"): {"items": []},
+        ("get", "networkpolicies"): {"items": []},
+        ("get", "clusterrolebindings"): {"items": []},
+        ("get", "clusterroles"): {"items": []},
+        ("get", "roles"): {"items": []},
+        ("get", "nodes"): {"items": [{"metadata": {"name": "node-1"}}]},
+    }
+
+    def fake_run(cmd, **kwargs):
+        class R:
+            pass
+
+        r = R()
+        r.stderr = ""
+        key = tuple(cmd[1:3])
+        if key == ("get", "--raw"):
+            # kubelet configz blocked (managed control plane)
+            r.returncode = 1
+            r.stdout = ""
+            r.stderr = "Error from server (Forbidden): nodes proxy is forbidden"
+            return r
+        r.returncode = 0
+        r.stdout = json.dumps(payloads[key])
+        return r
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    # Must not raise; kubelet checks are simply skipped.
+    findings = scan_live_cluster_posture(namespace="prod")
+    assert all(not f.rule_id.startswith("K8S-LIVE-02") for f in findings)

--- a/tests/test_os_distro_coverage.py
+++ b/tests/test_os_distro_coverage.py
@@ -1,0 +1,358 @@
+"""OS/distro vulnerability coverage breadth.
+
+Verifies that installed OS packages from the mainstream RPM/apk distros resolve
+to the correct OSV advisory ecosystem key, match a known-vulnerable version with
+the right per-distro version semantics (rpm EVR / apk), do NOT match a patched
+version, and that the coverage surface honestly reports the active distros.
+
+All ecosystem keys and version formats below were checked against the real OSV
+bulk-export data (per-ecosystem ``all.zip``) on 2026-07-16.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from agent_bom.db.lookup import _comparator_ecosystem, lookup_package
+from agent_bom.db.schema import init_db
+from agent_bom.models import Package
+from agent_bom.os_advisory import (
+    apk_advisory_ecosystems,
+    covered_distro_labels,
+    normalize_redhat_ecosystem,
+    rpm_advisory_ecosystems,
+)
+
+# ── pure resolver: rpm distros ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name,version,expected_db",
+    [
+        ("rocky", "8.9", ["Rocky Linux:8"]),
+        ("rocky", "9.3", ["Rocky Linux:9"]),
+        ("almalinux", "8.9", ["AlmaLinux:8"]),
+        ("alma", "9", ["AlmaLinux:9"]),
+        ("rhel", "8.9", ["Red Hat:enterprise_linux:8"]),
+        ("centos", "9", ["Red Hat:enterprise_linux:9"]),
+        ("redhat", "10.0", ["Red Hat:enterprise_linux:10"]),
+    ],
+)
+def test_rpm_resolver_local_db_keys(name, version, expected_db):
+    assert rpm_advisory_ecosystems(name, version, for_local_db=True) == expected_db
+
+
+def test_rpm_resolver_online_rhel_uses_base_ecosystem():
+    # The live OSV API rejects the module-qualified RHEL key; it accepts bare
+    # "Red Hat" and version-filters via the .elN release tag.
+    assert rpm_advisory_ecosystems("rhel", "8.9", for_local_db=False) == ["Red Hat"]
+    # Rocky/Alma keys are identical online and offline (API accepts them as-is).
+    assert rpm_advisory_ecosystems("rocky", "8.9", for_local_db=False) == ["Rocky Linux:8"]
+
+
+def test_rpm_resolver_opensuse_leap_includes_nonfree():
+    assert rpm_advisory_ecosystems("opensuse-leap", "15.5", for_local_db=True) == [
+        "openSUSE:Leap 15.5",
+        "openSUSE:Leap 15.5 NonFree",
+    ]
+
+
+def test_rpm_resolver_unknown_distro_returns_empty():
+    # Amazon Linux / Oracle Linux are NOT in the OSV export — do not guess a key.
+    assert rpm_advisory_ecosystems("amzn", "2023", for_local_db=True) == []
+    assert rpm_advisory_ecosystems("ol", "8.9", for_local_db=True) == []
+    assert rpm_advisory_ecosystems("rocky", "", for_local_db=True) == []
+
+
+# ── pure resolver: apk distros ───────────────────────────────────────────────
+
+
+def test_apk_resolver_wolfi_and_chainguard():
+    assert apk_advisory_ecosystems("wolfi") == ["Wolfi"]
+    assert apk_advisory_ecosystems("chainguard") == ["Chainguard"]
+    assert apk_advisory_ecosystems("alpine") == []  # handled by existing branch
+
+
+# ── Red Hat ingest normalisation ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        ("Red Hat:enterprise_linux:8::baseos", "Red Hat:enterprise_linux:8"),
+        ("Red Hat:enterprise_linux:9::appstream", "Red Hat:enterprise_linux:9"),
+        ("Red Hat:enterprise_linux:10.0", "Red Hat:enterprise_linux:10"),
+        ("Red Hat:enterprise_linux:7::server", "Red Hat:enterprise_linux:7"),
+        # Non enterprise_linux products are left untouched.
+        ("Red Hat:openshift:4.14::el8", "Red Hat:openshift:4.14::el8"),
+        ("Red Hat:enterprise_linux_ai:1.5::el9", "Red Hat:enterprise_linux_ai:1.5::el9"),
+        ("Rocky Linux:8", "Rocky Linux:8"),
+    ],
+)
+def test_normalize_redhat_ecosystem(raw, expected):
+    assert normalize_redhat_ecosystem(raw) == expected
+
+
+# ── comparator family wiring ─────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "stored,expected",
+    [
+        ("red hat:enterprise_linux:8", "rpm"),
+        ("rocky linux:8", "rpm"),
+        ("almalinux:9", "rpm"),
+        ("opensuse:leap 15.5", "rpm"),
+        ("wolfi", "apk"),
+        ("chainguard", "apk"),
+    ],
+)
+def test_new_distros_map_to_correct_comparator(stored, expected):
+    assert _comparator_ecosystem(stored) == expected
+
+
+# ── coverage surface ─────────────────────────────────────────────────────────
+
+
+def test_covered_distro_labels_reports_active_distros():
+    present = {
+        "alpine:v3.18",
+        "debian:12",
+        "ubuntu:22.04",
+        "red hat:enterprise_linux:9",
+        "rocky linux:8",
+        "almalinux:9",
+        "wolfi",
+        "chainguard",
+        "openSUSE:Leap 15.5",
+        "pypi",  # non-OS ecosystem must not appear as a distro label
+    }
+    labels = covered_distro_labels(present)
+    assert labels == [
+        "Alpine",
+        "Debian",
+        "Ubuntu",
+        "RHEL",
+        "Rocky Linux",
+        "AlmaLinux",
+        "openSUSE",
+        "Wolfi",
+        "Chainguard",
+    ]
+
+
+def test_covered_distro_labels_empty_when_no_os_data():
+    assert covered_distro_labels({"pypi", "npm", "maven"}) == []
+
+
+# ── end-to-end DB matching with real ecosystem keys + version formats ─────────
+
+
+@pytest.fixture
+def tmp_db(tmp_path) -> sqlite3.Connection:
+    conn = init_db(tmp_path / "os_distro.db")
+    yield conn
+    conn.close()
+
+
+def _insert(conn, vuln_id, ecosystem, pkg, fixed):
+    conn.execute(
+        "INSERT OR REPLACE INTO vulns(id,summary,severity,cvss_score,source) VALUES (?,?,?,?,'osv')",
+        (vuln_id, f"Test {vuln_id}", "high", 7.5),
+    )
+    conn.execute(
+        "INSERT OR REPLACE INTO affected(vuln_id,ecosystem,package_name,introduced,fixed,last_affected) VALUES (?,?,?,'0',?,'')",
+        (vuln_id, ecosystem, pkg, fixed),
+    )
+    conn.commit()
+
+
+@pytest.mark.parametrize(
+    "os_id,os_ver,ecosystem,pkg,fixed,vuln_ver,patched_ver",
+    [
+        # RHEL: rpm EVR, installed version carries no epoch, OSV fix carries 0:.
+        (
+            "rhel",
+            "8.9",
+            "red hat:enterprise_linux:8",
+            "python-markupsafe",
+            "0:0.23-19.el8",
+            "0.23-18.el8",
+            "0.23-19.el8",
+        ),
+        # Rocky: major-only ecosystem, epoch-1 fix.
+        (
+            "rocky",
+            "8.9",
+            "rocky linux:8",
+            "oci-systemd-hook",
+            "1:0.1.15-2.git2d0b8a3.module+el8.4.0",
+            "0:0.1.15-1.el8",
+            "1:0.1.15-2.git2d0b8a3.module+el8.4.0",
+        ),
+        # AlmaLinux.
+        (
+            "almalinux",
+            "9.3",
+            "almalinux:9",
+            "expat",
+            "0:2.5.0-2.el9_3",
+            "0:2.5.0-1.el9",
+            "0:2.5.0-2.el9_3",
+        ),
+        # Wolfi: apk version semantics (-rN revision).
+        ("wolfi", "", "wolfi", "glibc", "2.38-r5", "2.38-r3", "2.38-r5"),
+    ],
+)
+def test_distro_package_matches_vulnerable_not_patched(tmp_db, os_id, os_ver, ecosystem, pkg, fixed, vuln_ver, patched_ver):
+    _insert(tmp_db, "TEST-2024-0001", ecosystem, pkg, fixed)
+
+    is_rpm = ecosystem.split(":", 1)[0] not in ("wolfi", "chainguard")
+    resolved = rpm_advisory_ecosystems(os_id, os_ver, for_local_db=True) if is_rpm else apk_advisory_ecosystems(os_id)
+    assert resolved, "resolver must produce an ecosystem key for a supported distro"
+    db_eco = resolved[0].lower()
+    assert db_eco == ecosystem  # resolver key must equal the stored DB key
+
+    vulnerable = lookup_package(tmp_db, db_eco, pkg, vuln_ver)
+    assert [m.id for m in vulnerable] == ["TEST-2024-0001"]
+    assert vulnerable[0].fixed_version == fixed
+
+    patched = lookup_package(tmp_db, db_eco, pkg, patched_ver)
+    assert patched == []
+
+
+# ── scanner ecosystem resolver integration ───────────────────────────────────
+
+
+def test_scanner_db_ecosystems_for_rpm_and_apk_packages():
+    from agent_bom.scanners import _db_ecosystems_for_package, _osv_ecosystems_for_package
+
+    rhel_pkg = Package(name="bash", version="4.4.19-8.el8", ecosystem="rpm")
+    rhel_pkg.distro_name = "rhel"
+    rhel_pkg.distro_version = "8.9"
+    assert _db_ecosystems_for_package(rhel_pkg) == ["red hat:enterprise_linux:8"]
+    assert _osv_ecosystems_for_package(rhel_pkg) == ["Red Hat"]
+
+    wolfi_pkg = Package(name="glibc", version="2.38-r5", ecosystem="apk")
+    wolfi_pkg.distro_name = "wolfi"
+    assert _db_ecosystems_for_package(wolfi_pkg) == ["wolfi"]
+
+
+# ── OSV ingest normalises Red Hat repo-qualified ecosystems ──────────────────
+
+
+def test_osv_ingest_collapses_redhat_repo_ecosystems(tmp_db):
+    """A real Red Hat advisory keyed by two repo streams collapses to one per-major
+    key on ingest, so a scanned RHEL host matches it exactly (shape from
+    RHSA/RHBA OSV export, 2026-07-16)."""
+    import json
+
+    from agent_bom.db.sync import _ingest_osv_file
+
+    advisory = {
+        "id": "RHBA-2019:1992",
+        "modified": "2024-01-01T00:00:00Z",
+        "affected": [
+            {
+                "package": {"ecosystem": "Red Hat:enterprise_linux:8::appstream", "name": "cloud-init"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0:18.5-1.el8.4"}]}],
+            },
+            {
+                "package": {"ecosystem": "Red Hat:enterprise_linux:8::baseos", "name": "cloud-init"},
+                "ranges": [{"type": "ECOSYSTEM", "events": [{"introduced": "0"}, {"fixed": "0:18.5-1.el8.4"}]}],
+            },
+        ],
+    }
+    _ingest_osv_file(tmp_db, json.dumps(advisory).encode(), "RHBA-2019:1992.json")
+    tmp_db.commit()
+
+    stored = {r[0] for r in tmp_db.execute("SELECT DISTINCT ecosystem FROM affected").fetchall()}
+    assert stored == {"red hat:enterprise_linux:8"}
+
+    # And a RHEL 8 host with an older cloud-init matches; the patched one does not.
+    resolved = rpm_advisory_ecosystems("rhel", "8.9", for_local_db=True)[0].lower()
+    assert [m.id for m in lookup_package(tmp_db, resolved, "cloud-init", "18.4-1.el8")] == ["RHBA-2019:1992"]
+    assert lookup_package(tmp_db, resolved, "cloud-init", "18.5-1.el8.4") == []
+
+
+def test_covered_os_distros_reads_from_db(tmp_db):
+    from agent_bom.coverage import covered_os_distros
+
+    assert covered_os_distros(tmp_db) == []
+    _insert(tmp_db, "V1", "red hat:enterprise_linux:9", "bash", "0:5.1-1.el9")
+    _insert(tmp_db, "V2", "wolfi", "glibc", "2.38-r5")
+    _insert(tmp_db, "V3", "debian:12", "openssl", "3.0.0-1")
+    _insert(tmp_db, "V4", "pypi", "requests", "2.0.0")  # non-OS: excluded
+    assert covered_os_distros(tmp_db) == ["Debian", "RHEL", "Wolfi"]
+
+
+# ── live-system OS type detection recognises the new distros directly ─────────
+
+
+@pytest.mark.parametrize(
+    "os_id,expected",
+    [
+        ("rocky", "rpm"),
+        ("almalinux", "rpm"),
+        ("opensuse-leap", "rpm"),
+        ("sles", "rpm"),
+        ("wolfi", "apk"),
+        ("chainguard", "apk"),
+    ],
+)
+def test_detect_os_type_new_distros(tmp_path, os_id, expected):
+    from agent_bom.parsers.os_parsers import detect_os_type
+
+    (tmp_path / "etc").mkdir()
+    (tmp_path / "etc" / "os-release").write_text(f'ID={os_id}\nVERSION_ID="1.0"\n')
+    assert detect_os_type(tmp_path) == expected
+
+
+# ── full scanner DB path (freshness gate + resolver + lookup + attach) ────────
+
+
+def test_scanner_local_db_path_attaches_distro_vulns(tmp_path, monkeypatch):
+    """Drive the real ``_scan_packages_local_db`` entry (not just ``lookup_package``)
+    so the freshness gate, resolver, and vuln-attach are all exercised for the new
+    RPM/apk distros."""
+    from datetime import datetime, timezone
+
+    import agent_bom.db.schema as schema
+    import agent_bom.scanners as sc
+
+    db = tmp_path / "scan.db"
+    conn = schema.init_db(db)
+    _insert(conn, "RLSA-1", "rocky linux:8", "python-markupsafe", "0:0.23-19.el8")
+    _insert(conn, "RHSA-1", "red hat:enterprise_linux:9", "bash", "0:5.1.8-6.el9")
+    _insert(conn, "CGA-1", "wolfi", "glibc", "2.38-r5")
+    conn.execute(
+        "INSERT OR REPLACE INTO sync_meta(source,last_synced,record_count) VALUES('osv',?,3)",
+        (datetime.now(timezone.utc).isoformat(),),
+    )
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(schema, "DB_PATH", db)
+
+    def _pkg(name, ver, eco, distro, distro_ver=""):
+        p = Package(name=name, version=ver, ecosystem=eco)
+        p.distro_name = distro
+        p.distro_version = distro_ver
+        return p
+
+    vulnerable = [
+        _pkg("python-markupsafe", "0.23-18.el8", "rpm", "rocky", "8.9"),
+        _pkg("bash", "5.1.8-5.el9", "rpm", "rhel", "9.3"),
+        _pkg("glibc", "2.38-r3", "apk", "wolfi"),
+    ]
+    matched, _ = sc._scan_packages_local_db(vulnerable)
+    assert matched == 3
+    assert [v.id for p in vulnerable for v in p.vulnerabilities] == ["RLSA-1", "RHSA-1", "CGA-1"]
+
+    patched = [
+        _pkg("python-markupsafe", "0.23-19.el8", "rpm", "rocky", "8.9"),
+        _pkg("glibc", "2.38-r5", "apk", "wolfi"),
+    ]
+    assert sc._scan_packages_local_db(patched)[0] == 0
+    assert all(not p.vulnerabilities for p in patched)

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -285,6 +285,124 @@ def test_function_reachable_from_real_ast_analysis(tmp_path: Path) -> None:
     assert classify_reachability(package="requests", advisory=other, index=index).state == PACKAGE_REACHABLE
 
 
+# ── Go module ⇄ import-path join ──────────────────────────────────────────
+#
+# The Go AST records ``reach.package`` as the full *import path*
+# (``github.com/aws/aws-sdk-go/service/s3/s3crypto``) while an SCA finding —
+# and the OSV advisory ``affected[].package.name`` — is the *module*
+# (``github.com/aws/aws-sdk-go``). The two must join or Go symbol reach, the
+# richest advisory-symbol source, is inert.
+
+
+def _go_reach(import_path: str, symbol: str) -> DependencySymbolReach:
+    return DependencySymbolReach(
+        entrypoint="decrypt",
+        package=import_path,
+        module=import_path,
+        symbol=symbol,
+        file_path="main.go",
+        line_number=9,
+        call_path=["decrypt", f"{import_path}.{symbol}"],
+        ecosystem="go",
+    )
+
+
+def _go_osv(import_path: str, symbols: list[str], module: str = "github.com/aws/aws-sdk-go") -> dict:
+    return {
+        "id": "GO-2022-0646",
+        "affected": [
+            {
+                "package": {"ecosystem": "Go", "name": module},
+                "ecosystem_specific": {"imports": [{"path": import_path, "symbols": symbols}]},
+            }
+        ],
+    }
+
+
+def test_go_module_finding_reaches_subpackage_import_symbol() -> None:
+    # Finding is the module; the reached import path is a sub-package of it.
+    index = SymbolReachIndex.from_reaches(
+        [_go_reach("github.com/aws/aws-sdk-go/service/s3/s3crypto", "NewDecryptionClient")]
+    )
+    signal = classify_reachability(
+        package="github.com/aws/aws-sdk-go",
+        advisory=_go_osv("github.com/aws/aws-sdk-go/service/s3/s3crypto", ["NewDecryptionClient", "NewEncryptionClient"]),
+        index=index,
+        ecosystem="go",
+    )
+    assert signal.state == FUNCTION_REACHABLE
+    assert signal.matched_symbols == ("NewDecryptionClient",)
+    assert signal.call_path  # closest sub-package call path is surfaced
+
+
+def test_go_module_package_reachable_when_affected_symbol_not_called() -> None:
+    # A benign symbol of a sub-package is reached; the advisory flags another.
+    index = SymbolReachIndex.from_reaches(
+        [_go_reach("github.com/aws/aws-sdk-go/service/s3", "ListBuckets")]
+    )
+    signal = classify_reachability(
+        package="github.com/aws/aws-sdk-go",
+        advisory=_go_osv("github.com/aws/aws-sdk-go/service/s3/s3crypto", ["NewDecryptionClient"]),
+        index=index,
+        ecosystem="go",
+    )
+    assert signal.state == PACKAGE_REACHABLE
+    assert signal.matched_symbols == ()
+
+
+def test_go_module_prefix_respects_module_boundary() -> None:
+    # A different module that merely shares a string prefix must not match:
+    # ``…/aws-sdk-goodies`` is not a sub-package of ``…/aws-sdk-go``.
+    index = SymbolReachIndex.from_reaches(
+        [_go_reach("github.com/aws/aws-sdk-goodies/crypto", "NewDecryptionClient")]
+    )
+    signal = classify_reachability(
+        package="github.com/aws/aws-sdk-go",
+        advisory=_go_osv("github.com/aws/aws-sdk-go/service/s3/s3crypto", ["NewDecryptionClient"]),
+        index=index,
+        ecosystem="go",
+    )
+    assert signal.state == UNREACHABLE
+
+
+def test_go_function_reachable_from_real_ast_analysis(tmp_path: Path) -> None:
+    (tmp_path / "main.go").write_text(
+        "package main\n\n"
+        'import (\n'
+        '\t"github.com/aws/aws-sdk-go/service/s3/s3crypto"\n'
+        '\t"github.com/mark3labs/mcp-go/server"\n'
+        ")\n\n"
+        "func handleTool(args map[string]any) (any, error) {\n"
+        "\tclient := s3crypto.NewDecryptionClient(nil)\n"
+        "\treturn client, nil\n"
+        "}\n\n"
+        "func main() {\n"
+        '\ts := server.NewMCPServer("demo", "1.0.0")\n'
+        '\ts.AddTool("decrypt", handleTool)\n'
+        "}\n"
+    )
+    result = analyze_project(tmp_path)
+    index = SymbolReachIndex.from_ast_result(result)
+    signal = classify_reachability(
+        package="github.com/aws/aws-sdk-go",
+        advisory=_go_osv("github.com/aws/aws-sdk-go/service/s3/s3crypto", ["NewDecryptionClient"]),
+        index=index,
+        ecosystem="go",
+    )
+    assert signal.state == FUNCTION_REACHABLE
+    assert signal.matched_symbols == ("NewDecryptionClient",)
+
+
+def test_wiring_stamps_go_row_with_realistic_subpackage_import() -> None:
+    br = _python_br(["NewDecryptionClient"], pkg_name="github.com/aws/aws-sdk-go")
+    br.package.ecosystem = "go"
+    go_reach = _go_reach("github.com/aws/aws-sdk-go/service/s3/s3crypto", "NewDecryptionClient")
+    stamped = apply_symbol_reachability_to_blast_radii([br], ASTAnalysisResult(dependency_symbol_reach=[go_reach]))
+    assert stamped == 1
+    assert br.symbol_reachability == FUNCTION_REACHABLE
+    assert br.reachable_affected_symbols == ["NewDecryptionClient"]
+
+
 # ── thin wiring hook ──────────────────────────────────────────────────────
 
 

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -321,9 +321,7 @@ def _go_osv(import_path: str, symbols: list[str], module: str = "github.com/aws/
 
 def test_go_module_finding_reaches_subpackage_import_symbol() -> None:
     # Finding is the module; the reached import path is a sub-package of it.
-    index = SymbolReachIndex.from_reaches(
-        [_go_reach("github.com/aws/aws-sdk-go/service/s3/s3crypto", "NewDecryptionClient")]
-    )
+    index = SymbolReachIndex.from_reaches([_go_reach("github.com/aws/aws-sdk-go/service/s3/s3crypto", "NewDecryptionClient")])
     signal = classify_reachability(
         package="github.com/aws/aws-sdk-go",
         advisory=_go_osv("github.com/aws/aws-sdk-go/service/s3/s3crypto", ["NewDecryptionClient", "NewEncryptionClient"]),
@@ -337,9 +335,7 @@ def test_go_module_finding_reaches_subpackage_import_symbol() -> None:
 
 def test_go_module_package_reachable_when_affected_symbol_not_called() -> None:
     # A benign symbol of a sub-package is reached; the advisory flags another.
-    index = SymbolReachIndex.from_reaches(
-        [_go_reach("github.com/aws/aws-sdk-go/service/s3", "ListBuckets")]
-    )
+    index = SymbolReachIndex.from_reaches([_go_reach("github.com/aws/aws-sdk-go/service/s3", "ListBuckets")])
     signal = classify_reachability(
         package="github.com/aws/aws-sdk-go",
         advisory=_go_osv("github.com/aws/aws-sdk-go/service/s3/s3crypto", ["NewDecryptionClient"]),
@@ -353,9 +349,7 @@ def test_go_module_package_reachable_when_affected_symbol_not_called() -> None:
 def test_go_module_prefix_respects_module_boundary() -> None:
     # A different module that merely shares a string prefix must not match:
     # ``…/aws-sdk-goodies`` is not a sub-package of ``…/aws-sdk-go``.
-    index = SymbolReachIndex.from_reaches(
-        [_go_reach("github.com/aws/aws-sdk-goodies/crypto", "NewDecryptionClient")]
-    )
+    index = SymbolReachIndex.from_reaches([_go_reach("github.com/aws/aws-sdk-goodies/crypto", "NewDecryptionClient")])
     signal = classify_reachability(
         package="github.com/aws/aws-sdk-go",
         advisory=_go_osv("github.com/aws/aws-sdk-go/service/s3/s3crypto", ["NewDecryptionClient"]),
@@ -368,7 +362,7 @@ def test_go_module_prefix_respects_module_boundary() -> None:
 def test_go_function_reachable_from_real_ast_analysis(tmp_path: Path) -> None:
     (tmp_path / "main.go").write_text(
         "package main\n\n"
-        'import (\n'
+        "import (\n"
         '\t"github.com/aws/aws-sdk-go/service/s3/s3crypto"\n'
         '\t"github.com/mark3labs/mcp-go/server"\n'
         ")\n\n"


### PR DESCRIPTION
## Summary

Combines three independently-verified scanner-coverage branches into one coherent PR. All disjoint-file changes; merged cleanly (no code conflicts), with a follow-up formatting normalization against the current `main` ruff config.

### 1. Go-graded reachability (Closes #4070)
Joins Go **module** findings to **sub-package import-path** symbol reachability in `reachability_cve.py`. A CVE reported against a module (e.g. `github.com/aws/aws-sdk-go`) now correctly resolves reachability from reaches recorded on its sub-packages (`…/service/s3/s3crypto`), respecting the **module boundary** (a sibling like `aws-sdk-goodies` sharing a string prefix does not match). Affected-symbol matching distinguishes "the flagged symbol is reached" from "only a benign symbol of the sub-package is reached."

### 2. OS/distro coverage breadth (Closes #4071)
New `os_advisory.py` resolves a scanned OS package's distro (`/etc/os-release` `ID` + `VERSION_ID`) to the OSV ecosystem key(s) it should be matched under, wired through `db/sync.py`, `db/lookup.py`, `scanners/__init__.py`, `parsers/os_parsers.py`, `cli/_db.py`. Landed families beyond the pre-existing Alpine/Debian/Ubuntu: **RHEL/CentOS, Rocky Linux, AlmaLinux, openSUSE (Leap), SUSE, Wolfi, Chainguard**. `coverage.covered_os_distros()` reports the **active** distro surface derived from the advisories actually present in the local DB — an honest signal, never an aspirational static list.

**Deferred (stated honestly, in-code):** Amazon Linux (ALAS) and Oracle Linux (ELSA) — their advisory feeds are not in the OSV bulk export and the version-compare path is unverified, so they need dedicated feeds rather than a silent overclaim.

### 3. Live-cluster Kubernetes scanning (Closes #4072)
Read-only live-cluster security checks in `k8s.py` plus a driver in `scanners/registry.py`. Agentless, read-only against the cluster API (no writes to the target).

**Deferred:** control-plane-file CIS checks (which require host-level file access) are out of scope for the read-only live path.

## Combined-gate result (run on the MERGED tree, not per-branch)

- **Core suites:** `test_reachability_cve.py` + `test_os_distro_coverage.py` + `test_k8s_live_cluster.py` + `test_k8s.py` — **116 passed**.
- **Regression sweep** (`-k "reachab or os_ or distro or k8s or scanner or coverage or advisory or parser"`) — **1435 passed, 2 skipped**.
- **Scanner/registry** (`-k "scanner_registry or scanners"`) — **87 passed, 1 skipped**.
- **mypy** on all 10 changed source files — **no issues found**.
- **ruff check** — all checks passed; **ruff format --check** — all 14 files formatted.
- **check-counts.py** — all counts and versions consistent (MCP 73, detectors 11, dashboard 36, IaC 140, formats 28, REST ops 341, paths 290, routes 39, ws 2).

Zero regressions on the combined tree.

Closes #4070
Closes #4071
Closes #4072
