### PR TITLE
docs: full-stack "Architecture & how it works" in README + tighten ARCHITECTURE

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,25 +55,123 @@
 
 </details>
 
-## How It Works
+## Architecture & how it works
 
-Four beats that match the commands and the sidebar:
+One package, full stack: a **React / Next.js** cockpit and every headless caller
+hit the same **FastAPI** control plane, behind one middleware seam, over the same
+scan pipeline and stores. Everything normalizes into one `Finding` and one
+`ContextGraph`, so posture, blast radius, and enforcement read from a single
+evidence set. Deeper module and surface detail lives in
+[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
-```text
-connect → scan → graph → serve
+**The stack — UI ⇄ API + middleware ⇄ pipeline/enrichment ⇄ stores:**
+
+```mermaid
+flowchart TB
+    UI["React / Next.js UI<br/>exec single-pane · engineer drill"]
+    HL["Headless<br/>CLI · MCP server · agents / CI"]
+    MW["Middleware — one seam for every caller<br/>auth · tenant scope · RLS · rate-limit · audit"]
+    API["FastAPI + uvicorn control plane<br/>REST API · MCP tools"]
+    PIPE["Scan pipeline + scanners<br/>discover · OSV / advisories · reachability · cloud / CIS · IaC"]
+    ENR["Enrichment<br/>NVD CVSS · EPSS · CISA KEV · distro advisories"]
+    ST["Stores<br/>SQLite / Postgres + correlated graph store"]
+
+    UI --> MW
+    HL --> MW
+    MW --> API
+    API --> PIPE --> ENR --> ST
+    API --> ST
 ```
 
-- **connect** — read-only cloud, data, code, and agent sources.
-- **scan** — `agents` / CI.
-- **graph** — `ContextGraph` + blast radius.
-- **serve** — `agent-bom serve`, one pane of glass; the Findings page is a posture queue here, not a product lane.
+**The workflow — one read-only pipeline from source to answer:**
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom flow: connect read-only sources, scan, ContextGraph blast radius, serve as one pane of glass" width="980" />
-  </picture>
-</p>
+```mermaid
+flowchart LR
+    C["connect<br/>read-only · brokered"] --> D["discover<br/>estate · agents · MCP"]
+    D --> S["scan<br/>OSV · advisories · CIS · IaC"]
+    S --> E["enrich<br/>CVSS · EPSS · KEV · reachability"]
+    E --> R["correlate<br/>finding → asset → identity → config"]
+    R --> G["graph<br/>blast radius · attack paths"]
+    G --> X["serve<br/>exec read + engineer drill"]
+```
+
+Every stage is read-only and agentless; the dashboard shows live per-stage
+status rather than a black box.
+
+<details>
+<summary><b>Frontend</b> — the human cockpit</summary>
+
+- **Next.js 16 · React 19 · Tailwind 4** (`ui/`), built with `next build`.
+- **Two altitudes in one pane**: an exec single-pane read (posture, top risks,
+  compliance evidence) that drills to engineer detail (reachability, path, fix).
+- Inventory, findings, graph, compliance, and runtime views all render from the
+  same API — no privileged "UI-only" data path.
+
+</details>
+
+<details>
+<summary><b>Backend</b> — the FastAPI control plane</summary>
+
+- **FastAPI + uvicorn**, pure Python 3.11+ end to end (`src/agent_bom/api/server.py`).
+- The scan pipeline (`src/agent_bom/api/pipeline.py`, `ScanPipeline`) runs on a
+  bounded `ThreadPoolExecutor` — heavy scan/DB work is offloaded **off the event
+  loop** so reads stay responsive.
+- **Stores** scale without a rewrite: SQLite (default / single node) → Postgres
+  (multi-replica), plus a correlated graph store.
+- Headless parity: the **MCP server** and **CLI** expose the same evidence to
+  agents and CI, not just the UI.
+
+</details>
+
+<details>
+<summary><b>Enrichment</b> — from a CVE row to real-world risk</summary>
+
+- Scanners emit raw findings (`src/agent_bom/scanners/` — OSV batch, GHSA, distro
+  and vendor advisories); `src/agent_bom/enrichment.py` layers **NVD CVSS · EPSS ·
+  CISA KEV** and distro advisory data on top.
+- **AST reachability** (`src/agent_bom/reachability_cve.py`) resolves whether a
+  vulnerable symbol is actually reachable — ranking by exploitability, not just CVSS.
+- The result feeds severity, exploitability, and blast-radius scoring.
+- Confidence tiers and the NVD key model are covered in the **Accuracy model**
+  section below.
+
+</details>
+
+<details>
+<summary><b>Correlated graph</b> — the moat</summary>
+
+- `ContextGraph` / `UnifiedGraph` (`src/agent_bom/context_graph.py`) fuses
+  **assets → identities → configs/misconfigs → findings → attack paths** into one
+  connected model.
+- A vulnerable package links to the MCP server that loads it, the tools it
+  exposes, reachable credential references, and the agents that can call it — a
+  reachable blast radius, not an isolated CVE row.
+- Estate-scale `CONTAINS` roll-up keeps it readable and sargable at scale; the
+  full contract is in [docs/graph/CONTRACT.md](docs/graph/CONTRACT.md).
+
+</details>
+
+### Auth & Connections
+
+The honest model — **connect once, then every action runs through the stored
+connection.** There is **never a per-action credential prompt** and no
+"paste your laptop login" to run a scan or push a result.
+
+- **Humans** sign in via **OAuth / OIDC / SAML SSO** (standard providers plus a
+  Snowflake OAuth authorization-code + PKCE flow), with **SCIM** for user and
+  group provisioning (`src/agent_bom/api/{oidc,saml,scim}.py`,
+  `snowflake_oauth.py`).
+- **Agents / CI** authenticate with **scoped API keys / tokens**.
+- **Sources** (AWS, Azure, GCP, Snowflake) are onboarded **once** through
+  **read-only, agentless, brokered connectors** — a single least-privilege
+  managed role per source with **short-lived, brokered credentials** (e.g. AWS
+  `sts:AssumeRole`); connection secrets are **write-only** (encrypted at rest,
+  never read back). Setup and the exact grant per provider live in
+  [docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md); the enterprise auth surface is
+  in [docs/ENTERPRISE.md](docs/ENTERPRISE.md).
+
+Auth, tenant isolation, and audit are enforced once in middleware for the UI,
+agents, and SDKs alike — there is no privileged backdoor.
 
 <details>
 <summary><b>Control-plane architecture</b></summary>

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,7 +93,7 @@ flowchart TB
 
 ---
 
-## 1c. Implementation stack — hermetic and single-language
+## 1b. Implementation stack — hermetic and single-language
 
 With the product mental model in place, the implementation detail: agent-bom is
 pure Python (3.11+) end to end — CLI, FastAPI surface, MCP server, parsers,
@@ -111,7 +111,7 @@ Operational consequences:
 
 ---
 
-## 1b. Data Flow - one scan request
+## 1c. Data Flow - one scan request
 
 A single scan request walks discovery → extraction → scan → finding → graph →
 outputs. The same lower libraries serve the CLI and the API.
@@ -137,7 +137,7 @@ answerable · outputs land in the gate, ticket, or SIEM you already run.
 
 ---
 
-## 1c. Frontend · Backend · Middleware
+## 1d. Frontend · Backend · Middleware
 
 The dashboard is one door into the product, not the only one. The Next.js UI and
 every headless caller hit the same FastAPI surface, behind the same middleware,
@@ -176,7 +176,29 @@ enforced once for the UI, agents, and SDKs alike — there is no privileged
 
 ---
 
-## 1d. Input / Output Formats
+## 1e. Auth & Connections
+
+The identity and connection model is **connect once, act through the stored
+connection** — no surface ever prompts for a per-action credential.
+
+- **Humans** sign in via OAuth / OIDC / SAML SSO (standard providers plus a
+  Snowflake OAuth authorization-code + PKCE flow), with SCIM provisioning —
+  `src/agent_bom/api/{oidc,saml,scim}.py`, `src/agent_bom/api/snowflake_oauth.py`.
+- **Agents / CI** use scoped API keys / tokens.
+- **Sources** (AWS, Azure, GCP, Snowflake) are onboarded once via read-only,
+  agentless, brokered connectors — one least-privilege managed role per source,
+  short-lived brokered credentials (e.g. AWS `sts:AssumeRole`), and write-only
+  secrets (encrypted at rest, never read back). Every scan then runs through that
+  stored connection.
+
+Auth mode, tenant scope, RBAC, and audit are enforced in the shared middleware
+(`src/agent_bom/api/middleware.py`) for every caller. Provider grants and setup
+are in [`CLOUD_CONNECT.md`](CLOUD_CONNECT.md); the enterprise auth surface and
+environment knobs are in [`ENTERPRISE.md`](ENTERPRISE.md).
+
+---
+
+## 1f. Input / Output Formats
 
 agent-bom is format-agnostic on both ends: ingest whatever evidence exists,
 emit whatever the next tool consumes.


### PR DESCRIPTION
## What

Make the README explain the **full stack and how it works** on its own, and tighten the canonical architecture doc — docs-only, every claim grounded in code.

### README — new "Architecture & how it works" section (replaces "How It Works")
- **Stack mermaid diagram** — React/Next.js UI and headless callers (CLI/MCP/agents) ⇄ FastAPI + uvicorn control plane behind one middleware seam (auth · tenant scope · RLS · rate-limit · audit) ⇄ scan pipeline + scanners / OSV enrichment / reachability ⇄ SQLite/Postgres + correlated graph store.
- **Workflow mermaid diagram** of the real pipeline: `connect (read-only) → discover → scan → enrich → correlate → graph → serve`.
- **Collapsible detail** for Frontend, Backend, Enrichment, and the Correlated graph — each pinned to its owning module path (`ui/`, `src/agent_bom/api/server.py`, `api/pipeline.py`, `enrichment.py`, `reachability_cve.py`, `context_graph.py`).
- **Auth & Connections** subsection — the honest model: humans sign in via OAuth/OIDC/SAML SSO (incl. Snowflake OAuth authorization-code + PKCE) with SCIM provisioning; agents/CI use scoped API keys; sources are onboarded **once** via read-only, agentless, brokered connectors (least-privilege managed role, short-lived brokered creds, write-only secrets) and every action runs **through the stored connection** — never a per-action credential prompt.
- Links to `docs/ARCHITECTURE.md`, `docs/CLOUD_CONNECT.md`, `docs/ENTERPRISE.md` for depth rather than re-explaining.

### docs/ARCHITECTURE.md — tightening
- Fixed the duplicate/out-of-order `## 1c` headings (there were two) — now sequential `1a`–`1f` in document order.
- Added a concise **Auth & Connections** subsection matching the README's model, true-to-code (module paths for oidc/saml/scim/snowflake_oauth/middleware).

## Verification
- Stack claims verified against source: FastAPI+uvicorn (`api/server.py`), Next.js 16 / React 19 / Tailwind 4 (`ui/package.json`), scan pipeline offloaded via `ThreadPoolExecutor` off the event loop (`api/pipeline.py`), OSV/GHSA/distro scanners + NVD CVSS/EPSS/CISA KEV enrichment + AST reachability, SQLite/Postgres + graph store, MCP server + CLI, `connect aws|azure|gcp|snowflake` brokered read-only connectors.
- Both mermaid diagrams render clean via `mmdc` (exit 0).
- All doc links resolve to real files.
- No competitor names anywhere.
- `pre-commit` (incl. `release-surface-consistency`) green on the changed files.