### PR TITLE
perf(hub): atomic + batched ingest write path and sub-linear overview snapshot

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -286,6 +286,8 @@ AGENT_BOM_OCI_MAX_LAYER_UNCOMPRESSED_BYTES
 AGENT_BOM_OFFLINE
 # TTL (seconds) for the per-tenant /v1/overview payload cache; read at call time so tests can vary it. 0 disables.
 AGENT_BOM_OVERVIEW_CACHE_TTL_SECONDS
+# TTL (seconds) for the hub-derived severity cache; read at call time so tests and operators can disable it with 0.
+AGENT_BOM_HUB_OVERVIEW_CACHE_TTL_SECONDS
 AGENT_BOM_SKIP_UPDATE_CHECK
 AGENT_BOM_OIDC_ALLOWED_JWKS_URIS
 AGENT_BOM_OIDC_ALLOW_DEFAULT_TENANT

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -779,9 +779,11 @@ class InMemoryComplianceHubStore:
                 bucket.append(stored)
             total = len(bucket)
         if findings:
+            from agent_bom.api import hub_overview_cache
             from agent_bom.api.findings_count_cache import invalidate_tenant
 
             invalidate_tenant(tenant_id)
+            hub_overview_cache.invalidate_tenant(tenant_id)
         return total
 
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
@@ -856,9 +858,11 @@ class InMemoryComplianceHubStore:
             self._current.pop(tenant_id, None)
             self._current_observations.pop(tenant_id, None)
         if removed:
+            from agent_bom.api import hub_overview_cache
             from agent_bom.api.findings_count_cache import invalidate_tenant
 
             invalidate_tenant(tenant_id)
+            hub_overview_cache.invalidate_tenant(tenant_id)
         return removed
 
     def upsert_current_batch(
@@ -1512,9 +1516,11 @@ class SQLiteComplianceHubStore:
         )
         self._conn.commit()
         if rows:
+            from agent_bom.api import hub_overview_cache
             from agent_bom.api.findings_count_cache import invalidate_tenant
 
             invalidate_tenant(tenant_id)
+            hub_overview_cache.invalidate_tenant(tenant_id)
         with self._ingest_stats_lock:
             self._next_ordinal_by_tenant[tenant_id] = next_ord + len(rows)
             self._finding_count_by_tenant[tenant_id] += new_rows
@@ -1639,9 +1645,11 @@ class SQLiteComplianceHubStore:
         removed = cur.rowcount or 0
         self._reset_ingest_stats(tenant_id)
         if removed:
+            from agent_bom.api import hub_overview_cache
             from agent_bom.api.findings_count_cache import invalidate_tenant
 
             invalidate_tenant(tenant_id)
+            hub_overview_cache.invalidate_tenant(tenant_id)
         return removed
 
     def upsert_current_batch(

--- a/src/agent_bom/api/hub_ingest.py
+++ b/src/agent_bom/api/hub_ingest.py
@@ -62,25 +62,44 @@ def hub_ingest_store_writes(
     prior_snapshots: dict[str, Any] = {}
     if needs_hub_prior_snapshots(reconcile_absent=reconcile_absent):
         prior_snapshots = capture_hub_snapshots(hub_store, tenant_id, source=source)
-    new_total = hub_store.add(tenant_id, payloads)
-    hub_store.upsert_current_batch(
-        tenant_id,
-        payloads,
-        observed_at=observed_at,
-        batch_id=batch_id,
-        source=source,
-    )
-    reconciled = 0
-    resolved_ids: set[str] = set()
-    if reconcile_absent:
-        present = collect_present_canonical_ids(payloads, source=source)
-        resolved_ids = resolved_canonical_ids(prior_snapshots, present)
-        reconciled = hub_store.reconcile_current_absent(
+
+    # ``present_canonical_ids`` for absent-reconciliation (and the delta
+    # ``resolved_ids`` derived from it) is pure Python — computed before the
+    # write so the atomic seam can run the reconcile inside the same transaction.
+    present: set[str] = collect_present_canonical_ids(payloads, source=source) if reconcile_absent else set()
+
+    atomic = getattr(hub_store, "ingest_batch_atomic", None)
+    if callable(atomic):
+        # Ledger append + current upsert (+ reconcile) commit in ONE transaction
+        # so a mid-batch failure rolls back BOTH — the ledger can no longer
+        # inflate while findings stay invisible (wave-2 residual #1).
+        new_total, reconciled = atomic(
             tenant_id,
-            present_canonical_ids=present,
+            payloads,
             observed_at=observed_at,
-            scope_source=source,
+            batch_id=batch_id,
+            source=source,
+            reconcile_absent=reconcile_absent,
+            present_canonical_ids=present,
         )
+    else:
+        new_total = hub_store.add(tenant_id, payloads)
+        hub_store.upsert_current_batch(
+            tenant_id,
+            payloads,
+            observed_at=observed_at,
+            batch_id=batch_id,
+            source=source,
+        )
+        reconciled = 0
+        if reconcile_absent:
+            reconciled = hub_store.reconcile_current_absent(
+                tenant_id,
+                present_canonical_ids=present,
+                observed_at=observed_at,
+                scope_source=source,
+            )
+    resolved_ids: set[str] = resolved_canonical_ids(prior_snapshots, present) if reconcile_absent else set()
     delta_results = emit_hub_finding_deltas_if_enabled(
         tenant_id=tenant_id,
         hub_store=hub_store,

--- a/src/agent_bom/api/hub_overview_cache.py
+++ b/src/agent_bom/api/hub_overview_cache.py
@@ -1,0 +1,79 @@
+"""Short-lived per-tenant cache for the hub severity histogram (wave-2 residual #3).
+
+The landing-page overview reads the hub-ingested severity breakdown on EVERY
+request — it feeds both the cache fingerprint and the composed payload. The
+underlying ``severity_breakdown`` is an indexed ``GROUP BY`` but still scans the
+whole tenant ledger, so it grows O(rows): ~130ms at 200k, ~360ms at 1M, ~1s at
+2M. That linear cost landed on every ``/v1/overview`` request regardless of the
+payload cache.
+
+This memoises the histogram per tenant. The hub ledger is mutated only by the
+shared ingest body and the hub-clear route, so both invalidate this cache: a
+cached value within TTL is therefore exact (never stale relative to the ledger),
+and the histogram — hence the overview headline — reconciles with the findings
+API by construction (it is the same ``severity_breakdown`` derivation, memoised).
+Between ingests every overview read is O(1); only the first read after an ingest
+pays the scan.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from dataclasses import dataclass
+
+
+def _ttl_seconds() -> float:
+    raw = os.environ.get("AGENT_BOM_HUB_OVERVIEW_CACHE_TTL_SECONDS", "30")
+    try:
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+@dataclass(frozen=True)
+class _Entry:
+    counts: dict[str, int]
+    expires_at: float
+
+
+_lock = threading.Lock()
+_entries: dict[str, _Entry] = {}
+
+
+def get_cached_severity(tenant_id: str) -> dict[str, int] | None:
+    ttl = _ttl_seconds()
+    if ttl <= 0:
+        return None
+    now = time.monotonic()
+    with _lock:
+        entry = _entries.get(tenant_id)
+        if entry is None or entry.expires_at <= now:
+            if entry is not None:
+                _entries.pop(tenant_id, None)
+            return None
+        # Return a copy so callers can mutate their view without corrupting the
+        # shared entry.
+        return dict(entry.counts)
+
+
+def set_cached_severity(tenant_id: str, counts: dict[str, int]) -> None:
+    ttl = _ttl_seconds()
+    if ttl <= 0:
+        return
+    now = time.monotonic()
+    with _lock:
+        _entries[tenant_id] = _Entry(counts=dict(counts), expires_at=now + ttl)
+
+
+def invalidate_tenant(tenant_id: str) -> None:
+    """Drop the cached histogram for a tenant after any hub-ledger mutation."""
+    with _lock:
+        _entries.pop(tenant_id, None)
+
+
+def reset_hub_overview_cache() -> None:
+    """Test helper — never call from production code."""
+    with _lock:
+        _entries.clear()

--- a/src/agent_bom/api/hub_reference_store.py
+++ b/src/agent_bom/api/hub_reference_store.py
@@ -135,10 +135,18 @@ def persist_finding_references_sqlite(conn: sqlite3.Connection, tenant_id: str, 
     return slim
 
 
-def persist_finding_references_postgres(conn: Any, tenant_id: str, payload: Mapping[str, Any]) -> dict[str, Any]:
+def persist_finding_references_postgres(
+    conn: Any, tenant_id: str, payload: Mapping[str, Any], *, ensure_tables: bool = True
+) -> dict[str, Any]:
     if not HUB_REFERENCE_NORMALIZE:
         return dict(payload)
-    ensure_postgres_reference_tables(conn)
+    if ensure_tables:
+        # Callers ingesting a whole batch hoist the two ``CREATE TABLE IF NOT
+        # EXISTS`` probes to once per batch and pass ``ensure_tables=False`` — the
+        # probes are otherwise two round-trips PER ROW, a dominant amplifier on a
+        # connector initial-sync (wave-2 residual #2). The tables are also created
+        # in ``_init_tables`` so batch callers can safely skip the per-row ensure.
+        ensure_postgres_reference_tables(conn)
     slim, intel_blob, framework_blob = extract_reference_blobs(payload)
     now = _now_iso()
     if intel_blob:

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -47,6 +47,18 @@ from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _g
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
 
+def _invalidate_overview_severity(tenant_id: str) -> None:
+    """Drop the memoised /v1/overview severity histogram after a ledger change.
+
+    Any mutation of ``compliance_hub_findings`` (the ``severity_breakdown``
+    source) must invalidate the per-tenant overview cache so the headline never
+    goes stale relative to the ledger (wave-2 residual #3).
+    """
+    from agent_bom.api import hub_overview_cache
+
+    hub_overview_cache.invalidate_tenant(tenant_id)
+
+
 def _migrate_lifecycle_observations_l2_postgres(conn: Any) -> None:
     """Upgrade L1 observation rows (PK on observed_at) to L2 (PK on scan_id)."""
     conn.execute(
@@ -696,6 +708,7 @@ class PostgresComplianceHubStore:
         with _tenant_connection(self._pool) as conn:
             new_rows = self._write_ledger_batch(conn, tenant_id, findings)
             conn.commit()
+        _invalidate_overview_severity(tenant_id)
         return self._bump_tenant_total(tenant_id, new_rows)
 
     def ingest_batch_atomic(
@@ -740,6 +753,7 @@ class PostgresComplianceHubStore:
                     scope_source=source,
                 )
             conn.commit()
+        _invalidate_overview_severity(tenant_id)
         new_total = self._bump_tenant_total(tenant_id, new_rows)
         return new_total, reconciled
 
@@ -861,6 +875,7 @@ class PostgresComplianceHubStore:
             conn.commit()
         removed = cur.rowcount or 0
         self._reset_ingest_stats(tenant_id)
+        _invalidate_overview_severity(tenant_id)
         if removed:
             from agent_bom.api.findings_count_cache import invalidate_tenant
 

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -165,6 +165,28 @@ def _resolve_current_ledger_ordinal_postgres(
     return int(row[0]) if row else _LEDGER_ORDINAL_SENTINEL
 
 
+def _fetch_ledger_ordinals_postgres(
+    conn: Any,
+    tenant_id: str,
+    finding_ids: Sequence[str],
+) -> dict[str, int]:
+    """Bulk variant of :func:`_resolve_current_ledger_ordinal_postgres`.
+
+    One ``= ANY`` lookup on the ledger primary key for a whole batch instead of a
+    per-row point SELECT, so the current-state bulk upsert resolves every ledger
+    ordinal in a single round-trip. Missing pointers simply stay out of the map;
+    the caller falls back to the sort sentinel.
+    """
+    ids = [str(fid) for fid in finding_ids if fid]
+    if not ids:
+        return {}
+    rows = conn.execute(
+        "SELECT finding_id, ordinal FROM compliance_hub_findings WHERE tenant_id = %s AND finding_id = ANY(%s)",
+        (tenant_id, ids),
+    ).fetchall()
+    return {str(finding_id): int(ordinal) for finding_id, ordinal in rows}
+
+
 def _fetch_ledger_payloads_postgres(
     conn: Any,
     tenant_id: str,
@@ -591,33 +613,57 @@ class PostgresComplianceHubStore:
             """
         )
 
-    def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+    def _write_ledger_batch(self, conn: Any, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+        """Append/refresh ledger rows on ``conn`` — no commit, no stats bump.
+
+        Returns the count of genuinely-new rows so the caller can bump the
+        cached tenant total AFTER the shared transaction commits. Bootstraps the
+        ingest-stats counter (a read) inside the same connection. Shared by the
+        committing :meth:`add` and the single-transaction :meth:`ingest_batch_atomic`.
+        """
+        self._bootstrap_ingest_stats(conn, tenant_id)
         if not findings:
-            with _tenant_connection(self._pool) as conn:
-                self._bootstrap_ingest_stats(conn, tenant_id)
-            with self._ingest_stats_lock:
-                if tenant_id in self._finding_count_by_tenant:
-                    return self._finding_count_by_tenant[tenant_id]
-            return self.count(tenant_id)
+            return 0
         now = _now_utc_iso()
         rows_to_insert: list[tuple[str, str, dict[str, Any]]] = []
-        with _tenant_connection(self._pool) as conn:
-            self._bootstrap_ingest_stats(conn, tenant_id)
-            for original in findings:
-                if not isinstance(original, dict):
-                    continue
-                frameworks_csv = _frameworks_csv(original)
-                slim = persist_finding_references_postgres(conn, tenant_id, original)
-                payload = _redact_finding(slim)
-                finding_id = str(payload.get("id") or f"hub-{now}-{id(original)}")
-                rows_to_insert.append((finding_id, frameworks_csv, payload))
-            existing_ids = self._existing_finding_ids(conn, tenant_id, [row[0] for row in rows_to_insert])
-            new_rows = sum(1 for finding_id, _, _ in rows_to_insert if finding_id not in existing_ids)
-            for finding_id, frameworks_csv, payload in rows_to_insert:
-                # Idempotent ingest: a resend of the same (tenant_id, finding_id)
-                # refreshes payload/metadata and keeps the original ``ordinal``
-                # (the BIGSERIAL default only advances on genuine inserts).
-                conn.execute(
+        # Hoist the reference-table existence probe to once per batch (it is
+        # otherwise two CREATE-IF-NOT-EXISTS round-trips per row).
+        ensure_postgres_reference_tables(conn)
+        for original in findings:
+            if not isinstance(original, dict):
+                continue
+            frameworks_csv = _frameworks_csv(original)
+            slim = persist_finding_references_postgres(conn, tenant_id, original, ensure_tables=False)
+            payload = _redact_finding(slim)
+            finding_id = str(payload.get("id") or f"hub-{now}-{id(original)}")
+            rows_to_insert.append((finding_id, frameworks_csv, payload))
+        existing_ids = self._existing_finding_ids(conn, tenant_id, [row[0] for row in rows_to_insert])
+        new_rows = sum(1 for finding_id, _, _ in rows_to_insert if finding_id not in existing_ids)
+        # Idempotent ingest: a resend of the same (tenant_id, finding_id) refreshes
+        # payload/metadata and keeps the original ``ordinal`` (the BIGSERIAL default
+        # only advances on genuine inserts). Batched via ``executemany`` (psycopg
+        # pipelines the round-trips) so a connector initial-sync of millions is not
+        # a per-row execute loop — same SQL, same ON CONFLICT idempotency, same
+        # tenant scope, ~10x the row/s of the per-row loop (wave-2 residual #2).
+        insert_params = [
+            (
+                tenant_id,
+                finding_id,
+                now,
+                str(payload.get("source") or ""),
+                frameworks_csv,
+                encode_hub_payload(payload),
+                compute_effective_reach_score(payload),
+                str(payload.get("origin") or ""),
+                str(payload.get("severity") or ""),
+                _severity_rank(payload),
+                _cvss_value(payload),
+            )
+            for finding_id, frameworks_csv, payload in rows_to_insert
+        ]
+        if insert_params:
+            with conn.cursor() as cur:
+                cur.executemany(
                     """
                     INSERT INTO compliance_hub_findings
                         (tenant_id, finding_id, ingested_at, source, applicable_frameworks_csv, payload,
@@ -634,24 +680,68 @@ class PostgresComplianceHubStore:
                         severity_rank = EXCLUDED.severity_rank,
                         cvss_score = EXCLUDED.cvss_score
                     """,
-                    (
-                        tenant_id,
-                        finding_id,
-                        now,
-                        str(payload.get("source") or ""),
-                        frameworks_csv,
-                        encode_hub_payload(payload),
-                        compute_effective_reach_score(payload),
-                        str(payload.get("origin") or ""),
-                        str(payload.get("severity") or ""),
-                        _severity_rank(payload),
-                        _cvss_value(payload),
-                    ),
+                    insert_params,
+                )
+        return new_rows
+
+    def _bump_tenant_total(self, tenant_id: str, new_rows: int) -> int:
+        """Advance the cached tenant total by ``new_rows`` (called post-commit)."""
+        with self._ingest_stats_lock:
+            if tenant_id in self._finding_count_by_tenant:
+                self._finding_count_by_tenant[tenant_id] += new_rows
+                return self._finding_count_by_tenant[tenant_id]
+        return self.count(tenant_id)
+
+    def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+        with _tenant_connection(self._pool) as conn:
+            new_rows = self._write_ledger_batch(conn, tenant_id, findings)
+            conn.commit()
+        return self._bump_tenant_total(tenant_id, new_rows)
+
+    def ingest_batch_atomic(
+        self,
+        tenant_id: str,
+        findings: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str,
+        reconcile_absent: bool,
+        present_canonical_ids: set[str],
+    ) -> tuple[int, int]:
+        """Ledger append + current upsert (+ reconcile) in ONE transaction.
+
+        Each write method used to open its own tenant connection and commit
+        independently, so a failure between the ledger ``add`` and the
+        current-state upsert left the ledger committed but current-state not:
+        the ledger inflated while the findings stayed invisible (wave-2 residual
+        #1). Threading a single ``_tenant_connection`` through all three writes
+        and committing once makes a mid-batch failure roll BOTH back. The cached
+        tenant total is bumped only after the commit succeeds so a rolled-back
+        batch does not inflate it. Returns ``(new_total, reconciled)``.
+        """
+        with _tenant_connection(self._pool) as conn:
+            new_rows = self._write_ledger_batch(conn, tenant_id, findings)
+            self._write_current_batch(
+                conn,
+                tenant_id,
+                findings,
+                observed_at=observed_at,
+                batch_id=batch_id,
+                source=source,
+            )
+            reconciled = 0
+            if reconcile_absent:
+                reconciled = self._reconcile_current_absent_conn(
+                    conn,
+                    tenant_id,
+                    present_canonical_ids=present_canonical_ids,
+                    observed_at=observed_at,
+                    scope_source=source,
                 )
             conn.commit()
-        with self._ingest_stats_lock:
-            self._finding_count_by_tenant[tenant_id] += new_rows
-            return self._finding_count_by_tenant[tenant_id]
+        new_total = self._bump_tenant_total(tenant_id, new_rows)
+        return new_total, reconciled
 
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
         with _tenant_connection(self._pool) as conn:
@@ -786,6 +876,32 @@ class PostgresComplianceHubStore:
         batch_id: str,
         source: str = "",
     ) -> None:
+        with _tenant_connection(self._pool) as conn:
+            self._write_current_batch(
+                conn,
+                tenant_id,
+                findings,
+                observed_at=observed_at,
+                batch_id=batch_id,
+                source=source,
+            )
+            conn.commit()
+
+    def _write_current_batch(
+        self,
+        conn: Any,
+        tenant_id: str,
+        findings: Sequence[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str = "",
+    ) -> None:
+        """Upsert current-state rows on ``conn`` — no commit.
+
+        Shared by the committing :meth:`upsert_current_batch` and the
+        single-transaction :meth:`ingest_batch_atomic`.
+        """
         from agent_bom.api.finding_lifecycle import (
             apply_observation_to_current,
             lifecycle_metrics,
@@ -796,157 +912,196 @@ class PostgresComplianceHubStore:
         if not clean:
             return
         now = _now_utc_iso()
-        with _tenant_connection(self._pool) as conn:
-            # observed_at is batch-level: ensure its monthly partition exists once
-            # per batch so a backdated bulk import (older than the pre-provisioned
-            # behind=1 window) does not raise a raw CheckViolation -> 500. Out of
-            # the bounded window raises ObservationPartitionRangeError -> 4xx.
-            from agent_bom.api.hub_observations_partition import ensure_observation_partition_for
+        # observed_at is batch-level: ensure its monthly partition exists once
+        # per batch so a backdated bulk import (older than the pre-provisioned
+        # behind=1 window) does not raise a raw CheckViolation -> 500. Out of
+        # the bounded window raises ObservationPartitionRangeError -> 4xx.
+        from agent_bom.api.hub_observations_partition import ensure_observation_partition_for
 
-            ensure_observation_partition_for(conn, observed_at)
-            # Probe the ledger column ONCE per batch/connection — the schema does
-            # not change mid-batch. It was previously an information_schema query
-            # per row, the dominant write-path amplifier at scale.
-            has_ledger_col = _postgres_current_has_ledger_col(conn)
-            payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
-            for payload in clean:
-                canonical = resolve_canonical_id(payload, source=source)
-                metrics = lifecycle_metrics(payload)
-                ledger_finding_id = resolve_ledger_finding_id(payload, canonical_id=canonical)
-                overlay = current_state_overlay(payload) if ledger_finding_id else dict(payload)
-                inserted = conn.execute(
-                    """
-                    INSERT INTO hub_findings_current_observations
-                        (tenant_id, canonical_id, scan_id, observed_at)
-                    VALUES (%s, %s, %s, %s)
-                    ON CONFLICT DO NOTHING
-                    """,
-                    (tenant_id, canonical, batch_id, observed_at),
-                ).rowcount
-                if not inserted:
-                    continue
-                existing_row = conn.execute(
-                    f"""
-                    SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
-                           cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                           updated_at, {payload_select}
-                    FROM hub_findings_current
-                    WHERE tenant_id = %s AND canonical_id = %s
-                    """,  # nosec B608
-                    (tenant_id, canonical),
-                ).fetchone()
-                existing: dict[str, Any] | None
-                if existing_row is None:
-                    existing = None
-                else:
-                    existing = _postgres_current_row_from_db(existing_row, has_ledger_col=has_ledger_col)
-                    existing = _hydrate_postgres_current_rows(conn, tenant_id, [existing])[0]
-                merged = apply_observation_to_current(
-                    existing,
-                    canonical_id=canonical,
-                    observed_at=observed_at,
-                    metrics=metrics,
-                    payload=payload,
-                    updated_at=now,
+        ensure_observation_partition_for(conn, observed_at)
+        # Probe the ledger column ONCE per batch/connection — the schema does
+        # not change mid-batch. It was previously an information_schema query
+        # per row, the dominant write-path amplifier at scale.
+        has_ledger_col = _postgres_current_has_ledger_col(conn)
+        payload_select = "payload, ledger_finding_id" if has_ledger_col else "payload"
+
+        # ── Bulk current-state upsert (wave-2 residual #2) ───────────────────
+        # The per-row loop issued up to four round-trips per finding (observation
+        # insert, existing-current SELECT, ledger-ordinal SELECT, current upsert),
+        # so a connector initial-sync of millions crawled. This batches each of
+        # those into ONE round-trip while preserving the EXACT lifecycle
+        # semantics: the observation ``ON CONFLICT DO NOTHING RETURNING`` yields
+        # precisely the canonicals newly observed this batch (idempotent replay of
+        # the same batch_id returns none), first-occurrence-per-canonical is kept
+        # (later in-batch duplicates were skipped by the observation dedup), the
+        # prior-batch current row still feeds ``apply_observation_to_current``, and
+        # the final upsert is byte-identical SQL.
+        row_meta: list[tuple[str, dict[str, Any], Any, str, dict[str, Any]]] = []
+        obs_params: list[tuple[str, str, str, str]] = []
+        for payload in clean:
+            canonical = resolve_canonical_id(payload, source=source)
+            metrics = lifecycle_metrics(payload)
+            ledger_finding_id = resolve_ledger_finding_id(payload, canonical_id=canonical)
+            overlay = current_state_overlay(payload) if ledger_finding_id else dict(payload)
+            row_meta.append((canonical, payload, metrics, ledger_finding_id or "", overlay))
+            obs_params.append((tenant_id, canonical, batch_id, observed_at))
+
+        inserted_canonicals: set[str] = set()
+        with conn.cursor() as obs_cur:
+            obs_cur.executemany(
+                """
+                INSERT INTO hub_findings_current_observations
+                    (tenant_id, canonical_id, scan_id, observed_at)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT DO NOTHING
+                RETURNING canonical_id
+                """,
+                obs_params,
+                returning=True,
+            )
+            while True:
+                if obs_cur.pgresult is not None and obs_cur.pgresult.ntuples:
+                    inserted_canonicals.update(str(row[0]) for row in obs_cur.fetchall())
+                if not obs_cur.nextset():
+                    break
+        if not inserted_canonicals:
+            return
+
+        # First occurrence per newly-observed canonical, in ingest order — mirrors
+        # the per-row loop that processed the first and skipped later duplicates.
+        to_process: list[tuple[str, dict[str, Any], Any, str, dict[str, Any]]] = []
+        seen_canonical: set[str] = set()
+        for meta in row_meta:
+            canonical = meta[0]
+            if canonical not in inserted_canonicals or canonical in seen_canonical:
+                continue
+            seen_canonical.add(canonical)
+            to_process.append(meta)
+
+        # One SELECT for every prior-batch current row this batch touches, hydrated
+        # in bulk, so ``apply_observation_to_current`` merges against real history.
+        canonical_list = [meta[0] for meta in to_process]
+        existing_rows = conn.execute(
+            f"""
+            SELECT canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                   cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                   updated_at, {payload_select}
+            FROM hub_findings_current
+            WHERE tenant_id = %s AND canonical_id = ANY(%s)
+            """,  # nosec B608
+            (tenant_id, canonical_list),
+        ).fetchall()
+        existing_map: dict[str, dict[str, Any]] = {}
+        if existing_rows:
+            parsed = [_postgres_current_row_from_db(row, has_ledger_col=has_ledger_col) for row in existing_rows]
+            for hydrated in _hydrate_postgres_current_rows(conn, tenant_id, parsed):
+                existing_map[str(hydrated["canonical_id"])] = hydrated
+
+        # One lookup for every ledger ordinal pointer.
+        ordinal_map: dict[str, int] = {}
+        if has_ledger_col:
+            ordinal_map = _fetch_ledger_ordinals_postgres(
+                conn, tenant_id, [meta[3] for meta in to_process if meta[3]]
+            )
+
+        ledger_upsert_params: list[tuple[Any, ...]] = []
+        plain_upsert_params: list[tuple[Any, ...]] = []
+        for canonical, payload, metrics, ledger_finding_id, overlay in to_process:
+            existing = existing_map.get(canonical)
+            merged = apply_observation_to_current(
+                existing,
+                canonical_id=canonical,
+                observed_at=observed_at,
+                metrics=metrics,
+                payload=payload,
+                updated_at=now,
+            )
+            origin_val = str(payload.get("origin") or "")
+            # Canonical ``batch_id or scan_id`` scan filter key (#3926).
+            scan_id_val = str(payload.get("batch_id") or payload.get("scan_id") or "")
+            base = (
+                tenant_id,
+                canonical,
+                merged["first_seen"],
+                merged["last_seen"],
+                merged["status"],
+                merged["severity"],
+                merged["severity_rank"],
+                merged["cvss_score"],
+                merged["effective_reach_score"],
+                merged["scan_count"],
+                merged["resolved_at"],
+                merged["reopened_at"],
+                merged["updated_at"],
+                encode_hub_payload(overlay),
+            )
+            if has_ledger_col:
+                # Materialise the ledger ingest ordinal so ``sort=ordinal`` rides
+                # idx_hub_findings_current_tenant_ordinal instead of a per-row
+                # correlated ledger subquery (#3984).
+                ledger_ordinal_val = ordinal_map.get(ledger_finding_id, _LEDGER_ORDINAL_SENTINEL)
+                ledger_upsert_params.append(
+                    (*base, ledger_finding_id or None, origin_val, scan_id_val, ledger_ordinal_val)
                 )
-                origin_val = str(payload.get("origin") or "")
-                # Canonical ``batch_id or scan_id`` scan filter key (#3926).
-                scan_id_val = str(payload.get("batch_id") or payload.get("scan_id") or "")
-                if has_ledger_col:
-                    # Materialise the ledger ingest ordinal so ``sort=ordinal``
-                    # rides idx_hub_findings_current_tenant_ordinal instead of a
-                    # per-row correlated ledger subquery (#3984).
-                    ledger_ordinal_val = _resolve_current_ledger_ordinal_postgres(conn, tenant_id, ledger_finding_id or "")
-                    conn.execute(
-                        """
-                        INSERT INTO hub_findings_current
-                            (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
-                             cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                             updated_at, payload, ledger_finding_id, origin, scan_id, ledger_ordinal)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)
-                        ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
-                            first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
-                            last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
-                            status = EXCLUDED.status,
-                            severity = EXCLUDED.severity,
-                            severity_rank = EXCLUDED.severity_rank,
-                            cvss_score = EXCLUDED.cvss_score,
-                            effective_reach_score = EXCLUDED.effective_reach_score,
-                            scan_count = EXCLUDED.scan_count,
-                            resolved_at = EXCLUDED.resolved_at,
-                            reopened_at = EXCLUDED.reopened_at,
-                            updated_at = EXCLUDED.updated_at,
-                            payload = EXCLUDED.payload,
-                            ledger_finding_id = EXCLUDED.ledger_finding_id,
-                            origin = EXCLUDED.origin,
-                            scan_id = EXCLUDED.scan_id,
-                            ledger_ordinal = EXCLUDED.ledger_ordinal
-                        """,
-                        (
-                            tenant_id,
-                            canonical,
-                            merged["first_seen"],
-                            merged["last_seen"],
-                            merged["status"],
-                            merged["severity"],
-                            merged["severity_rank"],
-                            merged["cvss_score"],
-                            merged["effective_reach_score"],
-                            merged["scan_count"],
-                            merged["resolved_at"],
-                            merged["reopened_at"],
-                            merged["updated_at"],
-                            encode_hub_payload(overlay),
-                            ledger_finding_id or None,
-                            origin_val,
-                            scan_id_val,
-                            ledger_ordinal_val,
-                        ),
-                    )
-                else:
-                    conn.execute(
-                        """
-                        INSERT INTO hub_findings_current
-                            (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
-                             cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
-                             updated_at, payload, origin, scan_id)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s)
-                        ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
-                            first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
-                            last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
-                            status = EXCLUDED.status,
-                            severity = EXCLUDED.severity,
-                            severity_rank = EXCLUDED.severity_rank,
-                            cvss_score = EXCLUDED.cvss_score,
-                            effective_reach_score = EXCLUDED.effective_reach_score,
-                            scan_count = EXCLUDED.scan_count,
-                            resolved_at = EXCLUDED.resolved_at,
-                            reopened_at = EXCLUDED.reopened_at,
-                            updated_at = EXCLUDED.updated_at,
-                            payload = EXCLUDED.payload,
-                            origin = EXCLUDED.origin,
-                            scan_id = EXCLUDED.scan_id
-                        """,
-                        (
-                            tenant_id,
-                            canonical,
-                            merged["first_seen"],
-                            merged["last_seen"],
-                            merged["status"],
-                            merged["severity"],
-                            merged["severity_rank"],
-                            merged["cvss_score"],
-                            merged["effective_reach_score"],
-                            merged["scan_count"],
-                            merged["resolved_at"],
-                            merged["reopened_at"],
-                            merged["updated_at"],
-                            encode_hub_payload(overlay),
-                            origin_val,
-                            scan_id_val,
-                        ),
-                    )
-            conn.commit()
+            else:
+                plain_upsert_params.append((*base, origin_val, scan_id_val))
+
+        if ledger_upsert_params:
+            with conn.cursor() as up_cur:
+                up_cur.executemany(
+                    """
+                    INSERT INTO hub_findings_current
+                        (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                         cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                         updated_at, payload, ledger_finding_id, origin, scan_id, ledger_ordinal)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s, %s, %s)
+                    ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
+                        first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
+                        last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
+                        status = EXCLUDED.status,
+                        severity = EXCLUDED.severity,
+                        severity_rank = EXCLUDED.severity_rank,
+                        cvss_score = EXCLUDED.cvss_score,
+                        effective_reach_score = EXCLUDED.effective_reach_score,
+                        scan_count = EXCLUDED.scan_count,
+                        resolved_at = EXCLUDED.resolved_at,
+                        reopened_at = EXCLUDED.reopened_at,
+                        updated_at = EXCLUDED.updated_at,
+                        payload = EXCLUDED.payload,
+                        ledger_finding_id = EXCLUDED.ledger_finding_id,
+                        origin = EXCLUDED.origin,
+                        scan_id = EXCLUDED.scan_id,
+                        ledger_ordinal = EXCLUDED.ledger_ordinal
+                    """,
+                    ledger_upsert_params,
+                )
+        if plain_upsert_params:
+            with conn.cursor() as up_cur:
+                up_cur.executemany(
+                    """
+                    INSERT INTO hub_findings_current
+                        (tenant_id, canonical_id, first_seen, last_seen, status, severity, severity_rank,
+                         cvss_score, effective_reach_score, scan_count, resolved_at, reopened_at,
+                         updated_at, payload, origin, scan_id)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s::jsonb, %s, %s)
+                    ON CONFLICT (tenant_id, canonical_id) DO UPDATE SET
+                        first_seen = LEAST(hub_findings_current.first_seen, EXCLUDED.first_seen),
+                        last_seen = GREATEST(hub_findings_current.last_seen, EXCLUDED.last_seen),
+                        status = EXCLUDED.status,
+                        severity = EXCLUDED.severity,
+                        severity_rank = EXCLUDED.severity_rank,
+                        cvss_score = EXCLUDED.cvss_score,
+                        effective_reach_score = EXCLUDED.effective_reach_score,
+                        scan_count = EXCLUDED.scan_count,
+                        resolved_at = EXCLUDED.resolved_at,
+                        reopened_at = EXCLUDED.reopened_at,
+                        updated_at = EXCLUDED.updated_at,
+                        payload = EXCLUDED.payload,
+                        origin = EXCLUDED.origin,
+                        scan_id = EXCLUDED.scan_id
+                    """,
+                    plain_upsert_params,
+                )
 
     def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
         with _tenant_connection(self._pool) as conn:
@@ -1069,6 +1224,31 @@ class PostgresComplianceHubStore:
         observed_at: str,
         scope_source: str | None = None,
     ) -> int:
+        with _tenant_connection(self._pool) as conn:
+            total = self._reconcile_current_absent_conn(
+                conn,
+                tenant_id,
+                present_canonical_ids=present_canonical_ids,
+                observed_at=observed_at,
+                scope_source=scope_source,
+            )
+            conn.commit()
+        return total
+
+    def _reconcile_current_absent_conn(
+        self,
+        conn: Any,
+        tenant_id: str,
+        *,
+        present_canonical_ids: set[str],
+        observed_at: str,
+        scope_source: str | None = None,
+    ) -> int:
+        """Resolve open findings absent from the batch on ``conn`` — no commit.
+
+        Shared by the committing :meth:`reconcile_current_absent` and the
+        single-transaction :meth:`ingest_batch_atomic`.
+        """
         now = _now_utc_iso()
         where = ["tenant_id = %s", "status IN ('open', 'reopened')"]
         params: list[Any] = [tenant_id]
@@ -1077,26 +1257,24 @@ class PostgresComplianceHubStore:
             params.append(scope_source)
         where_sql = " AND ".join(where)
         total = 0
-        with _tenant_connection(self._pool) as conn:
-            rows = conn.execute(
-                f"SELECT canonical_id FROM hub_findings_current WHERE {where_sql}",  # nosec B608
-                tuple(params),
-            ).fetchall()
-            open_ids = {str(row[0]) for row in rows}
-            absent = sorted(open_ids - present_canonical_ids)
-            if not absent:
-                return 0
-            for offset in range(0, len(absent), RECONCILE_ABSENT_CHUNK):
-                chunk = absent[offset : offset + RECONCILE_ABSENT_CHUNK]
-                placeholders = ",".join("%s" for _ in chunk)
-                cur = conn.execute(
-                    f"""
-                    UPDATE hub_findings_current
-                    SET status = 'resolved', resolved_at = %s, updated_at = %s
-                    WHERE {where_sql} AND canonical_id IN ({placeholders})
-                    """,  # nosec B608
-                    (observed_at, now, *params, *chunk),
-                )
-                total += int(cur.rowcount or 0)
-            conn.commit()
+        rows = conn.execute(
+            f"SELECT canonical_id FROM hub_findings_current WHERE {where_sql}",  # nosec B608
+            tuple(params),
+        ).fetchall()
+        open_ids = {str(row[0]) for row in rows}
+        absent = sorted(open_ids - present_canonical_ids)
+        if not absent:
+            return 0
+        for offset in range(0, len(absent), RECONCILE_ABSENT_CHUNK):
+            chunk = absent[offset : offset + RECONCILE_ABSENT_CHUNK]
+            placeholders = ",".join("%s" for _ in chunk)
+            cur = conn.execute(
+                f"""
+                UPDATE hub_findings_current
+                SET status = 'resolved', resolved_at = %s, updated_at = %s
+                WHERE {where_sql} AND canonical_id IN ({placeholders})
+                """,  # nosec B608
+                (observed_at, now, *params, *chunk),
+            )
+            total += int(cur.rowcount or 0)
         return total

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -686,6 +686,17 @@ def _hub_severity_snapshot(request: Request) -> dict[str, int]:
     an optional dependency.
     """
     empty = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+    tenant_id = _tenant_id(request)
+    # Memoise the O(rows) severity GROUP BY per tenant. This snapshot feeds BOTH
+    # the cache fingerprint and the composed payload, so without this it ran the
+    # full-ledger scan on every /v1/overview request (~360ms at 1M). The cache is
+    # invalidated on every hub-ledger mutation (ingest / clear), so a hit is exact
+    # and reconciles with the findings API by construction (wave-2 residual #3).
+    from agent_bom.api import hub_overview_cache
+
+    cached = hub_overview_cache.get_cached_severity(tenant_id)
+    if cached is not None:
+        return cached
     try:
         from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
@@ -693,12 +704,13 @@ def _hub_severity_snapshot(request: Request) -> dict[str, int]:
         breakdown = getattr(store, "severity_breakdown", None)
         if not callable(breakdown):
             return empty
-        counts = breakdown(_tenant_id(request)) or {}
+        counts = breakdown(tenant_id) or {}
     except Exception:  # pragma: no cover - hub store optional
         _logger.debug("hub severity snapshot failed", exc_info=True)
         return empty
     for key, value in counts.items():
         empty[str(key).lower()] = empty.get(str(key).lower(), 0) + int(value or 0)
+    hub_overview_cache.set_cached_severity(tenant_id, empty)
     return empty
 
 

--- a/tests/test_hub_bulk_ingest.py
+++ b/tests/test_hub_bulk_ingest.py
@@ -1,0 +1,191 @@
+"""Bulk (COPY/executemany) Compliance-Hub ingest — correctness + throughput.
+
+Wave-2 residual #2: the Postgres ledger append and current-state upsert were
+per-row round-trips (~1-2k rows/s), too slow for a connector initial-sync of
+millions. The write path now batches both (``executemany`` with pipelined
+round-trips) while preserving EXACT semantics: idempotent ON CONFLICT, tenant
+scope, lifecycle merge, and the observation dedup.
+
+The correctness gate feeds identical batch sequences to the Postgres store and
+the in-memory store (the shared lifecycle reference) and asserts the resulting
+current-state is field-for-field identical. A lenient throughput smoke pins that
+the batched path is no longer a per-row crawl.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="AGENT_BOM_POSTGRES_URL is required for real Postgres bulk-ingest tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_postgres_pool():
+    if not os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        yield
+        return
+    from agent_bom.api import postgres_common
+
+    postgres_common.reset_pool()
+    yield
+    pool = postgres_common._pool
+    if pool is not None:
+        pool.close()
+    postgres_common.reset_pool()
+
+
+def _f(idx: int, *, severity: str = "high", cvss: float = 7.5) -> dict[str, Any]:
+    return {
+        "id": f"f-{idx}",
+        "canonical_id": f"c-{idx}",
+        "severity": severity,
+        "source": "connector",
+        "cvss_score": cvss,
+        "title": f"Finding {idx}",
+    }
+
+
+def _current_snapshot(store: Any, tenant: str) -> dict[str, dict[str, Any]]:
+    """Canonical -> comparable current-state fields (order-independent)."""
+    page, _total, _cursor = store.list_current_page(tenant, limit=10000, sort="ordinal")
+    out: dict[str, dict[str, Any]] = {}
+    for row in page:
+        cid = str(row.get("canonical_id") or row.get("id"))
+        out[cid] = {
+            "severity": row.get("severity"),
+            "status": row.get("status"),
+            "scan_count": row.get("scan_count"),
+            "first_seen": row.get("first_seen"),
+            "last_seen": row.get("last_seen"),
+        }
+    return out
+
+
+def _ingest(store: Any, tenant: str, batch: list[dict[str, Any]], *, observed_at: str, batch_id: str) -> None:
+    store.add(tenant, batch)
+    store.upsert_current_batch(tenant, batch, observed_at=observed_at, batch_id=batch_id, source="connector")
+
+
+# ── Correctness: Postgres bulk path matches the in-memory reference ──────────
+
+
+@pg_only
+def test_bulk_ingest_matches_in_memory_reference_across_lifecycle():
+    from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+    pg = PostgresComplianceHubStore()
+    mem = InMemoryComplianceHubStore()
+
+    # A sequence exercising: fresh insert, re-observe (merge first/last_seen +
+    # scan_count), a NEW finding in a later batch, an in-batch duplicate
+    # canonical, and idempotent replay of a batch_id.
+    batch1 = [_f(1, severity="high"), _f(2, severity="medium"), _f(3, severity="low")]
+    batch2 = [
+        _f(1, severity="critical", cvss=9.8),  # re-observe c-1, escalated
+        _f(4, severity="high"),  # brand new
+        _f(4, severity="high"),  # in-batch duplicate canonical -> deduped
+    ]
+
+    pg_tenant = f"pgbulk-{uuid4().hex}"
+    tok = set_current_tenant(pg_tenant)
+    try:
+        _ingest(pg, pg_tenant, batch1, observed_at="2026-07-14T00:00:00Z", batch_id="b1")
+        _ingest(pg, pg_tenant, batch2, observed_at="2026-07-16T00:00:00Z", batch_id="b2")
+        # Idempotent replay of b2 changes nothing.
+        _ingest(pg, pg_tenant, batch2, observed_at="2026-07-16T00:00:00Z", batch_id="b2")
+        pg_snap = _current_snapshot(pg, pg_tenant)
+        pg_count = pg.count(pg_tenant)
+    finally:
+        reset_current_tenant(tok)
+
+    mem_tenant = "membulk"
+    _ingest(mem, mem_tenant, batch1, observed_at="2026-07-14T00:00:00Z", batch_id="b1")
+    _ingest(mem, mem_tenant, batch2, observed_at="2026-07-16T00:00:00Z", batch_id="b2")
+    _ingest(mem, mem_tenant, batch2, observed_at="2026-07-16T00:00:00Z", batch_id="b2")
+    mem_snap = _current_snapshot(mem, mem_tenant)
+
+    # Canonical id derives from the finding ``id`` (f-N).
+    assert set(pg_snap) == set(mem_snap) == {"f-1", "f-2", "f-3", "f-4"}
+    assert pg_snap == mem_snap, f"pg={pg_snap}\nmem={mem_snap}"
+    # c-1 re-observed twice -> scan_count 2, escalated to critical, first_seen
+    # kept at the earliest, last_seen advanced.
+    assert pg_snap["f-1"]["scan_count"] == 2
+    assert pg_snap["f-1"]["severity"] == "critical"
+    assert pg_snap["f-1"]["first_seen"] == "2026-07-14T00:00:00Z"
+    assert pg_snap["f-1"]["last_seen"] == "2026-07-16T00:00:00Z"
+    # Ledger is idempotent: 4 distinct finding_ids (f-1..f-4), replay adds none.
+    assert pg_count == 4
+
+
+@pg_only
+def test_bulk_ingest_reconcile_absent_matches_reference():
+    from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+    pg = PostgresComplianceHubStore()
+    mem = InMemoryComplianceHubStore()
+
+    first = [_f(1), _f(2), _f(3)]
+    # Second scan of the same source omits c-2 and c-3 -> they resolve.
+    second = [_f(1)]
+
+    def run(store: Any, tenant: str) -> dict[str, dict[str, Any]]:
+        _ingest(store, tenant, first, observed_at="2026-07-14T00:00:00Z", batch_id="b1")
+        store.add(tenant, second)
+        store.upsert_current_batch(tenant, second, observed_at="2026-07-16T00:00:00Z", batch_id="b2", source="connector")
+        store.reconcile_current_absent(
+            tenant, present_canonical_ids={"f-1"}, observed_at="2026-07-16T00:00:00Z", scope_source="connector"
+        )
+        return _current_snapshot(store, tenant)
+
+    pg_tenant = f"pgrec-{uuid4().hex}"
+    tok = set_current_tenant(pg_tenant)
+    try:
+        pg_snap = run(pg, pg_tenant)
+    finally:
+        reset_current_tenant(tok)
+    mem_snap = run(mem, "memrec")
+
+    assert pg_snap == mem_snap
+    assert pg_snap["f-1"]["status"] == "open"
+    assert pg_snap["f-2"]["status"] == "resolved"
+    assert pg_snap["f-3"]["status"] == "resolved"
+
+
+# ── Throughput: batched path is no longer a per-row crawl ────────────────────
+
+
+@pg_only
+def test_bulk_ingest_throughput_is_not_per_row_crawl():
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+    store = PostgresComplianceHubStore()
+    n = 10_000
+    batch = [_f(i) for i in range(n)]
+    tenant = f"pgtput-{uuid4().hex}"
+    tok = set_current_tenant(tenant)
+    try:
+        start = time.perf_counter()
+        store.add(tenant, batch)
+        store.upsert_current_batch(tenant, batch, observed_at="2026-07-16T00:00:00Z", batch_id="b1", source="connector")
+        elapsed = time.perf_counter() - start
+        rows_per_s = n / elapsed
+        # The per-row baseline was ~1-2k rows/s combined; a generous 5k floor
+        # proves the batched path without being machine-flaky.
+        assert rows_per_s > 5000, f"bulk ingest only {rows_per_s:.0f} rows/s (elapsed {elapsed:.2f}s)"
+        assert store.count(tenant) == n
+        assert store.list_current_page(tenant, limit=1, include_total=True)[1] == n
+    finally:
+        reset_current_tenant(tok)

--- a/tests/test_hub_ingest_atomic.py
+++ b/tests/test_hub_ingest_atomic.py
@@ -1,0 +1,250 @@
+"""Batch atomicity for the Compliance-Hub ingest write path (wave-2 residual #1).
+
+``/v1/findings/bulk`` and ``/v1/compliance/ingest`` append the ledger
+(``hub_store.add``) and then upsert current-state (``upsert_current_batch``).
+On the Postgres backend each method opened its OWN tenant connection and
+committed independently, so a failure between them left the ledger committed but
+current-state not — the ledger inflated while the findings stayed invisible.
+
+These tests pin the fix: the ledger append + current upsert (+ reconcile) run in
+a SINGLE transaction. A mid-batch failure rolls back BOTH; the happy path is
+unchanged; an idempotent re-ingest is still exact.
+
+The live-Postgres tests are opt-in (``AGENT_BOM_POSTGRES_URL``); the routing
+test runs everywhere against a fake store.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from uuid import uuid4
+
+import pytest
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="AGENT_BOM_POSTGRES_URL is required for real Postgres atomicity tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_postgres_pool():
+    if not os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        yield
+        return
+    from agent_bom.api import postgres_common
+
+    postgres_common.reset_pool()
+    yield
+    pool = postgres_common._pool
+    if pool is not None:
+        pool.close()
+    postgres_common.reset_pool()
+
+
+def _payload(idx: int, *, severity: str = "high", source: str = "connector") -> dict[str, Any]:
+    return {
+        "id": f"f-{idx}",
+        "canonical_id": f"c-{idx}",
+        "severity": severity,
+        "source": source,
+        "cvss_score": 7.5,
+    }
+
+
+# ── Live Postgres: single-transaction atomicity ──────────────────────────────
+
+
+@pg_only
+def test_atomic_ingest_rolls_back_ledger_when_upsert_fails():
+    """A mid-batch upsert failure leaves NEITHER ledger nor current rows."""
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+    tenant = f"atomic-{uuid4().hex}"
+    token = set_current_tenant(tenant)
+    try:
+        store = PostgresComplianceHubStore()
+        payloads = [_payload(1), _payload(2)]
+
+        boom = RuntimeError("injected upsert failure")
+
+        def _explode(*_a: Any, **_k: Any) -> None:
+            raise boom
+
+        # Fail the current-state write AFTER the ledger insert has run on the
+        # shared connection. If they share one transaction the ledger insert
+        # must roll back too.
+        store._write_current_batch = _explode  # type: ignore[method-assign]
+
+        with pytest.raises(RuntimeError):
+            store.ingest_batch_atomic(
+                tenant,
+                payloads,
+                observed_at="2026-07-16T00:00:00Z",
+                batch_id="batch-1",
+                source="connector",
+                reconcile_absent=False,
+                present_canonical_ids=set(),
+            )
+
+        # DB truth (fresh connection, committed state only): both empty.
+        assert store.count(tenant) == 0
+        assert store.list_current_page(tenant, limit=50)[0] == []
+    finally:
+        reset_current_tenant(token)
+
+
+@pg_only
+def test_atomic_ingest_happy_path_commits_both_and_is_idempotent():
+    """Clean ingest commits ledger + current; a resend is exact (idempotent)."""
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+    tenant = f"atomic-{uuid4().hex}"
+    token = set_current_tenant(tenant)
+    try:
+        store = PostgresComplianceHubStore()
+        payloads = [_payload(1), _payload(2), _payload(3)]
+
+        total, reconciled = store.ingest_batch_atomic(
+            tenant,
+            payloads,
+            observed_at="2026-07-16T00:00:00Z",
+            batch_id="batch-1",
+            source="connector",
+            reconcile_absent=False,
+            present_canonical_ids=set(),
+        )
+        assert total == 3
+        assert reconciled == 0
+        assert store.count(tenant) == 3
+        current, current_total, _ = store.list_current_page(tenant, limit=50)
+        assert len(current) == 3
+        assert current_total == 3
+
+        # Idempotent resend of the identical batch: no new ledger or current rows.
+        total2, _ = store.ingest_batch_atomic(
+            tenant,
+            payloads,
+            observed_at="2026-07-16T00:00:00Z",
+            batch_id="batch-1",
+            source="connector",
+            reconcile_absent=False,
+            present_canonical_ids=set(),
+        )
+        assert total2 == 3
+        assert store.count(tenant) == 3
+        assert store.list_current_page(tenant, limit=50)[1] == 3
+    finally:
+        reset_current_tenant(token)
+
+
+@pg_only
+def test_atomic_ingest_matches_sequential_add_plus_upsert():
+    """The atomic path yields the same rows as the legacy add + upsert calls."""
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+    store = PostgresComplianceHubStore()
+    payloads = [_payload(1), _payload(2)]
+
+    tenant_seq = f"seq-{uuid4().hex}"
+    tok = set_current_tenant(tenant_seq)
+    try:
+        store.add(tenant_seq, payloads)
+        store.upsert_current_batch(
+            tenant_seq, payloads, observed_at="2026-07-16T00:00:00Z", batch_id="b", source="connector"
+        )
+        seq_count = store.count(tenant_seq)
+        seq_current = store.list_current_page(tenant_seq, limit=50)[1]
+    finally:
+        reset_current_tenant(tok)
+
+    tenant_atomic = f"atm-{uuid4().hex}"
+    tok = set_current_tenant(tenant_atomic)
+    try:
+        store.ingest_batch_atomic(
+            tenant_atomic,
+            payloads,
+            observed_at="2026-07-16T00:00:00Z",
+            batch_id="b",
+            source="connector",
+            reconcile_absent=False,
+            present_canonical_ids=set(),
+        )
+        atomic_count = store.count(tenant_atomic)
+        atomic_current = store.list_current_page(tenant_atomic, limit=50)[1]
+    finally:
+        reset_current_tenant(tok)
+
+    assert seq_count == atomic_count == 2
+    assert seq_current == atomic_current == 2
+
+
+# ── Backend-agnostic: shared body routes through the atomic seam ─────────────
+
+
+class _FakeAtomicStore:
+    """Records that the shared ingest body used the atomic single-call seam."""
+
+    def __init__(self) -> None:
+        self.calls: list[dict[str, Any]] = []
+
+    def ingest_batch_atomic(
+        self,
+        tenant_id: str,
+        findings: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str,
+        reconcile_absent: bool,
+        present_canonical_ids: set[str],
+    ) -> tuple[int, int]:
+        self.calls.append(
+            {
+                "tenant_id": tenant_id,
+                "count": len(findings),
+                "batch_id": batch_id,
+                "reconcile_absent": reconcile_absent,
+                "present": set(present_canonical_ids),
+            }
+        )
+        return len(findings), 0
+
+    # Present so ``add``/``upsert_current_batch`` MUST NOT be called on the
+    # happy path; if the body falls back to them the test asserts they went
+    # unused.
+    def add(self, *_a: Any, **_k: Any) -> int:  # pragma: no cover - must not run
+        raise AssertionError("shared body must route through ingest_batch_atomic")
+
+    def upsert_current_batch(self, *_a: Any, **_k: Any) -> None:  # pragma: no cover
+        raise AssertionError("shared body must route through ingest_batch_atomic")
+
+    def reconcile_current_absent(self, *_a: Any, **_k: Any) -> int:  # pragma: no cover
+        raise AssertionError("shared body must route through ingest_batch_atomic")
+
+
+def test_shared_body_uses_atomic_seam_when_available():
+    from agent_bom.api.hub_ingest import hub_ingest_store_writes
+
+    # Delta emission is off by default (no AGENT_BOM_DELTA_STREAM_ENABLED), so
+    # the body never reads the store — it must route the writes through the
+    # atomic single-call seam.
+    store = _FakeAtomicStore()
+    payloads = [_payload(1), _payload(2)]
+    result = hub_ingest_store_writes(
+        store,
+        "tenant-x",
+        payloads,
+        observed_at="2026-07-16T00:00:00Z",
+        batch_id="batch-9",
+        source="connector",
+        reconcile_absent=False,
+    )
+    assert result["new_total"] == 2
+    assert result["reconciled"] == 0
+    assert store.calls and store.calls[0]["batch_id"] == "batch-9"
+    assert store.calls[0]["reconcile_absent"] is False

--- a/tests/test_hub_overview_cache.py
+++ b/tests/test_hub_overview_cache.py
@@ -1,0 +1,163 @@
+"""Sub-linear hub severity snapshot for /v1/overview (wave-2 residual #3).
+
+``_hub_severity_snapshot`` fed the overview headline AND the cache fingerprint,
+so its O(rows) ``severity_breakdown`` GROUP BY ran on every request. It is now
+memoised per tenant and invalidated on every hub-ledger mutation (ingest /
+clear), so repeated overview reads stay O(1) while the counts remain identical
+to the store's live ``severity_breakdown`` truth.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from agent_bom.api import hub_overview_cache
+from agent_bom.api.routes import overview
+
+
+@pytest.fixture(autouse=True)
+def _clean():
+    hub_overview_cache.reset_hub_overview_cache()
+    yield
+    hub_overview_cache.reset_hub_overview_cache()
+
+
+class _CountingStore:
+    def __init__(self, counts: dict[str, int]) -> None:
+        self.counts = counts
+        self.calls = 0
+
+    def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
+        self.calls += 1
+        return dict(self.counts)
+
+
+def _request(tenant: str) -> SimpleNamespace:
+    return SimpleNamespace(tenant=tenant)
+
+
+def test_snapshot_memoised_and_counts_match_store(monkeypatch):
+    store = _CountingStore({"critical": 3, "high": 5, "medium": 0, "low": 0, "info": 0, "unknown": 1})
+    monkeypatch.setattr(overview, "_tenant_id", lambda request: "acme")
+    monkeypatch.setattr(
+        "agent_bom.api.compliance_hub_store.get_compliance_hub_store", lambda: store
+    )
+
+    first = overview._hub_severity_snapshot(_request("acme"))
+    second = overview._hub_severity_snapshot(_request("acme"))
+
+    # Second read is a cache hit — the O(n) GROUP BY ran once.
+    assert store.calls == 1
+    # Counts identical to the store truth, both reads.
+    assert first == second
+    assert first["critical"] == 3
+    assert first["high"] == 5
+    assert first["unknown"] == 1
+
+
+def test_ingest_invalidates_snapshot(monkeypatch):
+    store = _CountingStore({"critical": 1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0})
+    monkeypatch.setattr(overview, "_tenant_id", lambda request: "acme")
+    monkeypatch.setattr(
+        "agent_bom.api.compliance_hub_store.get_compliance_hub_store", lambda: store
+    )
+
+    overview._hub_severity_snapshot(_request("acme"))
+    assert store.calls == 1
+
+    # A hub-ledger mutation invalidates the cache; the next read recomputes.
+    store.counts = {"critical": 9, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+    hub_overview_cache.invalidate_tenant("acme")
+    refreshed = overview._hub_severity_snapshot(_request("acme"))
+    assert store.calls == 2
+    assert refreshed["critical"] == 9
+
+
+def test_ttl_zero_disables_cache(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_HUB_OVERVIEW_CACHE_TTL_SECONDS", "0")
+    store = _CountingStore({"critical": 1, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0})
+    monkeypatch.setattr(overview, "_tenant_id", lambda request: "acme")
+    monkeypatch.setattr(
+        "agent_bom.api.compliance_hub_store.get_compliance_hub_store", lambda: store
+    )
+    overview._hub_severity_snapshot(_request("acme"))
+    overview._hub_severity_snapshot(_request("acme"))
+    # TTL<=0 disables memoisation entirely (every read recomputes).
+    assert store.calls == 2
+
+
+def test_store_add_and_clear_invalidate_overview_cache():
+    """A hub-ledger mutation via ANY store path drops the cached histogram so the
+    next overview read reflects the change (honest counts). Invalidation lives at
+    the store layer so it holds regardless of the caller (ingest route, shared
+    body, or a direct store call)."""
+    from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore
+
+    store = InMemoryComplianceHubStore()
+    seed = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+
+    hub_overview_cache.set_cached_severity("acme", dict(seed))
+    store.add("acme", [{"id": "f-1", "severity": "critical", "source": "connector"}])
+    assert hub_overview_cache.get_cached_severity("acme") is None
+
+    hub_overview_cache.set_cached_severity("acme", dict(seed))
+    store.clear("acme")
+    assert hub_overview_cache.get_cached_severity("acme") is None
+
+
+# ── Live Postgres: cache-hit latency is bounded as rows grow ─────────────────
+
+pg_only = pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="AGENT_BOM_POSTGRES_URL is required for the live overview-latency test",
+)
+
+
+@pg_only
+def test_overview_severity_cache_hit_bounded_and_exact():
+    from agent_bom.api import postgres_common
+    from agent_bom.api.postgres_common import _tenant_connection, reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+    postgres_common.reset_pool()
+    store = PostgresComplianceHubStore()
+    monkey_tenant = f"ovc-{uuid4().hex}"
+    sevs = ["critical", "high", "medium", "low", "info"]
+
+    def chunk(base: int, n: int):
+        return [{"id": f"f-{base + i}", "severity": sevs[(base + i) % 5], "source": "connector"} for i in range(n)]
+
+    tok = set_current_tenant(monkey_tenant)
+    try:
+        loaded = 0
+        target = 300_000
+        while loaded < target:
+            step = min(50_000, target - loaded)
+            with _tenant_connection(store._pool) as conn:
+                store._write_ledger_batch(conn, monkey_tenant, chunk(loaded, step))
+                conn.commit()
+            loaded += step
+
+        truth = store.severity_breakdown(monkey_tenant)
+
+        # Prime the cache (one O(n) scan), then a warm read must be O(1).
+        hub_overview_cache.reset_hub_overview_cache()
+        hub_overview_cache.set_cached_severity(monkey_tenant, truth)
+
+        start = time.perf_counter()
+        for _ in range(50):
+            cached = hub_overview_cache.get_cached_severity(monkey_tenant)
+        warm_ms = (time.perf_counter() - start) / 50 * 1000
+
+        assert cached == truth  # identical to SQL truth
+        # A cache hit is a dict copy — sub-millisecond regardless of row count,
+        # versus a ~360ms GROUP BY at this scale.
+        assert warm_ms < 5.0, f"cache-hit read {warm_ms:.3f} ms is not O(1)"
+    finally:
+        reset_current_tenant(tok)
+        postgres_common.reset_pool()

--- a/tests/test_hub_write_path_scale.py
+++ b/tests/test_hub_write_path_scale.py
@@ -38,12 +38,41 @@ class _FakeCursor:
         return []
 
 
+class _FakeBatchCursor:
+    """Minimal cursor supporting the bulk ``executemany(..., returning=True)``.
+
+    The batched current-state upsert records observations via
+    ``conn.cursor().executemany(... RETURNING canonical_id)``. This fake reports
+    no newly-inserted canonicals (``pgresult=None``, ``nextset()`` False), so the
+    upsert short-circuits after the single ledger-column probe — exactly what the
+    hoist test needs to assert.
+    """
+
+    pgresult = None
+
+    def __enter__(self) -> "_FakeBatchCursor":
+        return self
+
+    def __exit__(self, *_exc: Any) -> None:
+        return None
+
+    def executemany(self, sql: str, params: Any, *, returning: bool = False) -> None:
+        return None
+
+    def fetchall(self) -> list[tuple[Any, ...]]:  # pragma: no cover - guarded by pgresult
+        return []
+
+    def nextset(self) -> bool:
+        return False
+
+
 @dataclass
 class _UpsertConnSpy:
-    """Answers every per-row query so ``upsert_current_batch`` runs end-to-end.
+    """Answers every per-batch query so ``upsert_current_batch`` runs end-to-end.
 
-    Observation INSERT returns rowcount=1 (proceed); the current-row SELECT
-    returns no existing row (treated as a fresh insert). Records executed SQL.
+    Observation writes go through a batched cursor that reports no inserts (so
+    the upsert short-circuits); the partition-ensure + ledger-column probe still
+    run once. Records executed SQL.
     """
 
     executed: list[str] = field(default_factory=list)
@@ -51,6 +80,9 @@ class _UpsertConnSpy:
     def execute(self, sql: str, params: tuple | None = None) -> _FakeCursor:
         self.executed.append(" ".join(sql.split()).lower())
         return _FakeCursor(row=None, rowcount=1)
+
+    def cursor(self) -> _FakeBatchCursor:
+        return _FakeBatchCursor()
 
     def commit(self) -> None:  # pragma: no cover - trivial
         pass


### PR DESCRIPTION
## Summary

Three wave-2 correctness/availability residuals on the Compliance-Hub write+read path. All three landed and are green; each was TDD'd against a real NOSUPERUSER Postgres (`_tenant_connection` + FORCE ROW LEVEL SECURITY enforced).

### 1. Batch atomicity (write path)
The bulk/connector ingest ran the ledger append (`hub_store.add`) and the current-state upsert (`upsert_current_batch`) as **separate tenant connections that each committed independently**, so a failure between them left the ledger committed but current-state not — the ledger inflated while the findings stayed invisible.

**Fix:** thread a single `_tenant_connection` through the ledger append, current upsert and absent-reconcile via a new `ingest_batch_atomic()` and commit once, so a mid-batch failure rolls back **both**. The cached tenant total is bumped only after the commit succeeds. The shared ingest body (`hub_ingest.py`, used by `/v1/findings/bulk` and `/v1/compliance/ingest`) routes through the atomic seam when the store exposes it.

**Repro/test:** injecting a failure into the current-state write leaves neither ledger nor current rows (fresh connection sees committed state only); happy path commits both; idempotent replay stays exact.

### 2. Batched bulk ingest (throughput)
The ledger insert loop and the current-state upsert were per-row round-trips (~1-2k rows/s combined) — too slow for a connector initial-sync of millions.

**Fix:** batch both via psycopg `executemany` (pipelined round-trips), preserving identical `ON CONFLICT` idempotency, tenant scope and lifecycle merge. The observation `ON CONFLICT DO NOTHING RETURNING` yields exactly the canonicals newly observed this batch; existing current rows and ledger ordinals are bulk-fetched once; the reference-table existence probe is hoisted to once per batch (was two `CREATE TABLE IF NOT EXISTS` round-trips **per row**). `executemany` was chosen over COPY-into-staging: it is byte-identical SQL with no `SELECT *` schema-order coupling, and benched within ~30% of COPY.

**Before → after (measured on a NOSUPERUSER Postgres, 20k rows):**

| stage | before | after | speedup |
|---|--:|--:|--:|
| ledger add | 2,719 rows/s | 26,614 rows/s | 9.8x |
| current upsert | 1,934 rows/s | 17,072 rows/s | 8.8x |
| combined end-to-end | ~1,130 rows/s | 10,401 rows/s | 9.2x |

**Correctness:** verified field-for-field identical to the in-memory reference store across insert / merge / in-batch dedup / idempotent replay / reconcile-absent.

### 3. Sub-linear overview snapshot (read path)
`_hub_severity_snapshot` feeds both the overview cache fingerprint and the composed payload, so its `severity_breakdown` GROUP BY ran on **every** `/v1/overview` request. The query is index-backed but still scans the whole tenant ledger, so it grows O(rows): measured **~130ms @ 200k, ~360ms @ 1M, ~1s @ 2M**.

**Fix:** memoise the histogram per tenant (`hub_overview_cache`) and invalidate it on every hub-ledger mutation (`add` / atomic ingest / `clear`, across all three backends — the store layer is the invalidation seam so it holds regardless of caller). The hub ledger is the only `severity_breakdown` source and changes only through those paths, so a cached value within TTL is **exact** (never stale relative to the ledger) and the headline reconciles with the findings API by construction — same derivation, memoised. Numbers are unchanged. Repeated overview reads are now O(1); only the first read after an ingest pays the scan. Warm cache read is sub-millisecond at 300k rows vs the ~360ms GROUP BY.

## Verification
- New tests: `test_hub_ingest_atomic.py`, `test_hub_bulk_ingest.py` (in-memory-oracle equivalence + throughput), `test_hub_overview_cache.py` (memoise + invalidate + live-PG bounded latency).
- Regression sweep (default backend): 125 passed across `test_compliance_hub*`, `test_bulk_ingest_offload`, `test_compliance_ingest_offload`, `test_ingest_idempotency`, `test_overview*`, `test_hub_write_path_scale`. Live-PG store/atomicity/bulk tests green.
- `ruff` + `mypy` clean on all changed files.

## Notes / follow-ups
- COPY-into-staging was benched (~37k vs ~29k rows/s for the ledger) but not adopted — the marginal gain didn't justify the `SELECT *` staging-table schema coupling; `executemany` is the simpler, semantics-preserving win.
- The overview cache defaults to a 30s TTL (`AGENT_BOM_HUB_OVERVIEW_CACHE_TTL_SECONDS`); TTL is a safety expiry only, since invalidation on every ledger mutation keeps it exact.
- Pre-existing (not from this PR): running the full API test suite against a real NOSUPERUSER Postgres surfaces unrelated RLS-policy failures in `audit_log` / `hub_framework_refs` (confirmed identical on `origin/main`); those suites are normally run against the default backend.