### PR TITLE
fix(gateway): fail closed on conditional-access evaluation error

### DIFF
--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -562,6 +562,40 @@ def _request_cost_center(request: Request, message: dict[str, Any]) -> str:
     return ""
 
 
+_CONDITIONAL_ACCESS_EVAL_FAILED = "conditional access evaluation failed"
+
+
+def _conditional_access_fail_closed(tenant_id: str) -> tuple[bool, str, str]:
+    """Decide the conditional-access outcome after an evaluation error, fail-closed.
+
+    The primary evaluation (``evaluate_conditional_access_for_request``) raised, so
+    we cannot trust its verdict. A conditional-access ``deny``/``require`` policy
+    that would otherwise block the call MUST NOT be silently bypassed (§7 fail
+    closed). But we also must not turn a flaky store into a blanket outage for
+    tenants that never configured the feature.
+
+    Resolution:
+    - Re-read the tenant's active conditional-access policies with a cheap,
+      independent lookup. If that read succeeds and finds **no** policies, there
+      is no gate to bypass → allow.
+    - If the tenant HAS one or more active conditional-access policies → deny.
+    - If we cannot even determine whether policies exist (the lookup also
+      raised — e.g. the store is unavailable), we cannot prove the gate is empty,
+      so deny. Only a positively-confirmed empty policy set opens the gate.
+
+    Returns ``(allowed, reason, policy_id)`` matching the primary evaluator.
+    """
+    try:
+        from agent_bom.api.agent_identity_store import get_agent_identity_store
+
+        policies = get_agent_identity_store().list_conditional_policies(tenant_id, include_disabled=False, limit=1)
+    except Exception:  # noqa: BLE001 — cannot confirm an empty gate → fail closed
+        return False, _CONDITIONAL_ACCESS_EVAL_FAILED, ""
+    if not policies:
+        return True, "", ""
+    return False, _CONDITIONAL_ACCESS_EVAL_FAILED, ""
+
+
 def _emit_gateway_governance_event(event_type: str, *, tenant_id: str, subject_id: str, payload: dict[str, Any]) -> None:
     """Fan a gateway governance event to subscribed webhooks (best-effort).
 
@@ -2160,8 +2194,8 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                         tenant_id=tenant_id,
                         ctx=ctx,
                     )
-                except Exception:  # noqa: BLE001
-                    cond_allowed, cond_reason, cond_policy_id = True, "", ""
+                except Exception:  # noqa: BLE001 — fail CLOSED: an eval error must not bypass a policy
+                    cond_allowed, cond_reason, cond_policy_id = _conditional_access_fail_closed(tenant_id)
                 if not cond_allowed:
                     allowed, reason, policy_source = False, cond_reason, "conditional_access"
                     if settings.audit_sink is not None:

--- a/tests/test_agent_identity_lifecycle.py
+++ b/tests/test_agent_identity_lifecycle.py
@@ -508,6 +508,73 @@ def test_conditional_access_blocks_at_gateway(store):
     assert allowed.status_code == 200 and allowed.json()["result"] == {"ok": True}
 
 
+def _gateway_client_with_audit(store, audit_events):
+    from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+    from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+
+    async def ok_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    settings = GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")]),
+        policy={},
+        upstream_caller=ok_caller,
+        audit_sink=audit_sink,
+    )
+    return TestClient(create_gateway_app(settings))
+
+
+def test_conditional_access_eval_error_fails_closed_when_policy_exists(store, monkeypatch):
+    """A conditional-access evaluation error must NOT silently open the gate when
+    the tenant has a require/deny policy configured (§7 fail-closed)."""
+    from agent_bom.api import agent_identity_store as ais
+
+    issue_identity(store, agent_id="agent-a", tenant_id="default")
+    # A require-prod policy that would DENY a dev-context request.
+    create_conditional_policy(store, tenant_id="default", name="prod-only", effect="require", allowed_environments=["prod"])
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("conditional-access store unavailable")
+
+    monkeypatch.setattr(ais, "evaluate_conditional_access_for_request", boom)
+
+    audit_events: list[dict] = []
+    client = _gateway_client_with_audit(store, audit_events)
+    message = {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "list_files", "arguments": {}}}
+
+    blocked = client.post("/mcp/filesystem", json=message, headers={"x-agent-environment": "dev"})
+    assert blocked.json().get("error", {}).get("code") == -32001, blocked.text
+    assert blocked.json()["error"]["data"]["policy_source"] == "conditional_access"
+    events = [e for e in audit_events if e.get("action") == "gateway.conditional_access_blocked"]
+    assert events, audit_events
+    assert "fail" in events[0]["reason"].lower()
+
+
+def test_conditional_access_eval_error_allows_when_no_policy(store, monkeypatch):
+    """An eval error for a tenant with NO conditional-access policy has no gate to
+    bypass → allow (don't manufacture denials for tenants not using the feature)."""
+    from agent_bom.api import agent_identity_store as ais
+
+    issue_identity(store, agent_id="agent-a", tenant_id="default")
+    # No conditional-access policy created for the tenant.
+
+    def boom(*args, **kwargs):
+        raise RuntimeError("conditional-access store unavailable")
+
+    monkeypatch.setattr(ais, "evaluate_conditional_access_for_request", boom)
+
+    audit_events: list[dict] = []
+    client = _gateway_client_with_audit(store, audit_events)
+    message = {"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {"name": "list_files", "arguments": {}}}
+
+    allowed = client.post("/mcp/filesystem", json=message, headers={"x-agent-environment": "dev"})
+    assert allowed.status_code == 200 and allowed.json()["result"] == {"ok": True}
+    assert not any(e.get("action") == "gateway.conditional_access_blocked" for e in audit_events)
+
+
 def test_conditional_access_api_crud(client):
     created = client.post(
         "/v1/conditional-access-policies",


### PR DESCRIPTION
## The fail-open (security bug)

The gateway's context-aware / conditional-access (ABAC) decision path swallowed **any** exception from `evaluate_conditional_access_for_request(...)` and set `cond_allowed, cond_reason, cond_policy_id = True, "", ""` — i.e. it **allowed** the request. A `deny`/`require` conditional-access policy that should block the call was therefore silently bypassed on any evaluation error (a store hiccup, a transient DB failure, a bug in a policy predicate). That undermines the fail-closed guarantee for the ABAC layer: an evaluation error must never open a gate a policy would otherwise close.

`src/agent_bom/gateway_server.py` (before):
```python
                except Exception:  # noqa: BLE001
                    cond_allowed, cond_reason, cond_policy_id = True, "", ""
```

## The fix — fail closed, scoped so a flaky store isn't a blanket outage

On an evaluation error we can no longer trust the verdict, so we re-derive it fail-closed via a new helper `_conditional_access_fail_closed(tenant_id)`:

- Re-read the tenant's **active** conditional-access policies with a cheap, independent lookup (`list_conditional_policies(..., limit=1)`).
- Tenant has **no** conditional-access policy → there is no gate to bypass → **allow** (don't manufacture a denial for a tenant not using the feature).
- Tenant **has** one or more active policies → **deny** (fail closed) with reason `conditional access evaluation failed`, and emit the existing `gateway.conditional_access_blocked` audit event + governance event.
- The lookup itself also fails (store unreachable, so we cannot even prove the policy set is empty) → **deny**. Only a positively-confirmed empty policy set opens the gate.

This mirrors the intent of the device-posture enrichment directly above it, which already fails closed. The device-posture enrichment `except` is left untouched — this change is specifically the conditional-access **evaluation** `except`.

### Scoping decision
I kept `evaluate_conditional_access_for_request` as the primary call and put the has-policies re-check in the `except`, rather than blanket-denying on every error. Rationale: a blanket deny would turn a transient store blip into an outage for every tenant, including those that never configured conditional access. The re-check is a single cheap `limit=1` query; if it too fails we still fall through to deny, so the invariant "an eval error never silently bypasses a policy that would deny" holds unconditionally.

## Tests (TDD — red before, green after)

Added to `tests/test_agent_identity_lifecycle.py`:
- `test_conditional_access_eval_error_fails_closed_when_policy_exists` — monkeypatches the evaluator to raise for a tenant with a `require`-prod policy and a dev-context request; asserts the request is **denied** (`-32001`, `policy_source: conditional_access`) and a `gateway.conditional_access_blocked` audit event fires with a "fail" reason. This test **fails on `main`** (request returned `200 ok`).
- `test_conditional_access_eval_error_allows_when_no_policy` — same injected error but no policy configured; asserts the request is still **allowed** (200) and no block is audited.

## Verification
- Red-before / green-after confirmed on the new fail-closed test.
- `pytest tests/test_agent_identity_lifecycle.py tests/test_gateway_policy_hardening.py tests/test_device_posture.py tests/test_governance_abac_delegation.py` → 88 passed.
- Broader gateway sweep (`test_gateway`, `test_gateway_server`, `test_gateway_audit`, `test_gateway_auth_tenant_e2e`, `test_gateway_control_plane_binding`, `test_gateway_drift_enforcement`, `test_gateway_firewall`, `test_fleet_quarantine_gateway_deny`) → 107 passed.
- `ruff check` + `ruff format --check` clean; `mypy src/agent_bom/gateway_server.py` clean.

Closes #4079