### PR TITLE
feat(integrations): MCP-first ITSM/ticketing connector [WIP]

### DIFF
--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -115,7 +115,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 - **Blast radius + attack-path fusion** — multi-hop exposure paths over one unified `ContextGraph`, from package → finding → MCP server → credentials → connected agents
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not; symbol-level CVE reachability joins CWE/CVE/CPE advisory context when OSV/GHSA carry affected symbols (Python, npm, Go)
 - **Portable outputs** — SARIF, CycloneDX, SPDX, OCSF, HTML, graph, JSON, ZIP evidence bundles, and more
-- **MCP server mode** — 73 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
+- **MCP server mode** — 75 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
 - **VEX generation** — auto-triage with CWE/CVE/CPE-aware reachability (package + function-level when advisory symbols exist)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@
 
 **MCP server mode**
 
-- Advertises 73 MCP tools, 6 resources, and 8 workflow prompts.
+- Advertises 75 MCP tools, 6 resources, and 8 workflow prompts.
 - Registry metadata lives in the committed Smithery manifest and Glama listing; install and liveness checks are in the integration docs.
 
 </details>

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 73 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 75 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -16,8 +16,8 @@ attack paths, compliance tags, and runtime audit chain.
 
 | Area | Shipped today |
 |---|---|
-| MCP security tools | 73 tools, 6 resources, 8 workflow prompts |
-| REST API | 350 operations across 40 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| MCP security tools | 75 tools, 6 resources, 8 workflow prompts |
+| REST API | 357 operations across 41 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["350 REST operations across 40 route modules\nplus 2 WebSocket routes"]
+        R["357 REST operations across 41 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]
@@ -465,7 +465,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (73 tools across core, operator, runtime-catalog, and specialized modules) |
+| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (75 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory + CIS posture |
 | Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor with in-account snapshot/volume cleanup; Azure Managed Disk and GCP Persistent Disk targets share the same bounded lifecycle contract and graph-visible workload-disk model |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 296 |
-| `docs/openapi/v1.json` | component schemas | 78 |
+| `docs/openapi/v1.json` | paths | 300 |
+| `docs/openapi/v1.json` | component schemas | 80 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -237,7 +237,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 73 tools to any MCP-compatible AI assistant. Your agent can run scans,
+Exposes 75 tools to any MCP-compatible AI assistant. Your agent can run scans,
 check packages, query ExposurePaths, ask for deploy decisions, query threat
 intel, inspect runtime posture, run admin-gated Shield actions, and generate
 compliance reports without leaving the chat:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -165,7 +165,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (73 tools)
+## Tool Categories (75 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 73 MCP tools as an MCP server. Any MCP-compatible client can
+agent-bom exposes 75 MCP tools as an MCP server. Any MCP-compatible client can
 connect and get vulnerability scanning, blast radius analysis, compliance
 checks, runtime posture, and supply-chain verification through natural
 conversation.

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,11 +54,11 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (296 paths / 350 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (300 paths / 357 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 
-- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 73 tools
+- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 75 tools
 - [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md) — connect MCP clients
 - [`PYTHON_API.md`](PYTHON_API.md) — Python control-plane client
 - [`PLUGIN_ENTRYPOINTS.md`](PLUGIN_ENTRYPOINTS.md) — opt-in plugin entry-point loader and author contract

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (350 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (357 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the
@@ -102,7 +102,7 @@ scan a repo by URL.
 
 ```bash
 pip install 'agent-bom[mcp-server]'
-agent-bom mcp server                      # stdio MCP server: 73 tools, 6 resources, 8 prompts
+agent-bom mcp server                      # stdio MCP server: 75 tools, 6 resources, 8 prompts
 ```
 
 - MCP server setup + client guides: [`MCP_SERVER.md`](MCP_SERVER.md),

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -3745,6 +3745,97 @@
         "title": "TenantQuotaUpdateRequest",
         "type": "object"
       },
+      "TicketCreate": {
+        "additionalProperties": false,
+        "description": "File a ticket for a finding through a stored connection.\n\nDeliberately carries NO credential, token, or base-URL/link field \u2014 auth and\nendpoint come only from the stored connection.",
+        "properties": {
+          "connection_id": {
+            "default": "",
+            "title": "Connection Id",
+            "type": "string"
+          },
+          "finding": {
+            "additionalProperties": true,
+            "title": "Finding",
+            "type": "object"
+          },
+          "finding_id": {
+            "default": "",
+            "title": "Finding Id",
+            "type": "string"
+          },
+          "issue_type": {
+            "default": "",
+            "title": "Issue Type",
+            "type": "string"
+          },
+          "project": {
+            "default": "",
+            "title": "Project",
+            "type": "string"
+          },
+          "source_url": {
+            "default": "",
+            "maxLength": 2048,
+            "title": "Source Url",
+            "type": "string"
+          }
+        },
+        "title": "TicketCreate",
+        "type": "object"
+      },
+      "TicketingConnectionCreate": {
+        "additionalProperties": false,
+        "description": "Create a connect-once ITSM connection. ``secret`` is write-only.\n\n``transport=mcp`` (primary): ``endpoint`` is the ITSM MCP server URL and\n``secret`` (optional) is its bearer token. ``transport=rest`` +\n``auth_method=api_token``: ``endpoint`` is the site URL, ``secret`` is the\nAPI token, and ``auth_params.email`` is the account email.",
+        "properties": {
+          "auth_method": {
+            "default": "mcp",
+            "title": "Auth Method",
+            "type": "string"
+          },
+          "auth_params": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Auth Params",
+            "type": "object"
+          },
+          "display_name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Display Name",
+            "type": "string"
+          },
+          "endpoint": {
+            "maxLength": 2048,
+            "minLength": 1,
+            "title": "Endpoint",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "secret": {
+            "default": "",
+            "maxLength": 8192,
+            "title": "Secret",
+            "type": "string"
+          },
+          "transport": {
+            "default": "mcp",
+            "title": "Transport",
+            "type": "string"
+          }
+        },
+        "required": [
+          "provider",
+          "display_name",
+          "endpoint"
+        ],
+        "title": "TicketingConnectionCreate",
+        "type": "object"
+      },
       "TracingHealth": {
         "properties": {
           "otlp_endpoint_configured": {
@@ -27612,6 +27703,626 @@
           }
         },
         "summary": "Export Tenant Data"
+      }
+    },
+    "/v1/ticketing/connections": {
+      "get": {
+        "description": "List the tenant's ticketing connections (non-secret metadata only).",
+        "operationId": "list_connections_v1_ticketing_connections_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Connections V1 Ticketing Connections Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Connections",
+        "tags": [
+          "ticketing"
+        ]
+      },
+      "post": {
+        "description": "Create a connect-once ITSM connection for the tenant (seals the secret).",
+        "operationId": "create_connection_v1_ticketing_connections_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TicketingConnectionCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Connection V1 Ticketing Connections Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Connection",
+        "tags": [
+          "ticketing"
+        ]
+      }
+    },
+    "/v1/ticketing/connections/{connection_id}": {
+      "delete": {
+        "description": "Revoke a ticketing connection owned by the tenant.",
+        "operationId": "delete_connection_v1_ticketing_connections__connection_id__delete",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connection_id",
+            "required": true,
+            "schema": {
+              "title": "Connection Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Delete Connection",
+        "tags": [
+          "ticketing"
+        ]
+      },
+      "get": {
+        "description": "Return one ticketing connection's non-secret metadata (tenant-scoped).",
+        "operationId": "get_connection_v1_ticketing_connections__connection_id__get",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "connection_id",
+            "required": true,
+            "schema": {
+              "title": "Connection Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Connection V1 Ticketing Connections  Connection Id  Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Connection",
+        "tags": [
+          "ticketing"
+        ]
+      }
+    },
+    "/v1/ticketing/tickets": {
+      "get": {
+        "description": "List the tenant's filed tickets (finding\u2192ticket links + last status).",
+        "operationId": "list_tickets_v1_ticketing_tickets_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response List Tickets V1 Ticketing Tickets Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "List Tickets",
+        "tags": [
+          "ticketing"
+        ]
+      },
+      "post": {
+        "description": "File a ticket for a finding through the stored connection (idempotent).",
+        "operationId": "create_ticket_v1_ticketing_tickets_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TicketCreate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Create Ticket V1 Ticketing Tickets Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Create Ticket",
+        "tags": [
+          "ticketing"
+        ]
+      }
+    },
+    "/v1/ticketing/tickets/{ticket_id}/sync": {
+      "post": {
+        "description": "Refresh a filed ticket's status from its ITSM, through the connection.",
+        "operationId": "sync_ticket_v1_ticketing_tickets__ticket_id__sync_post",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "ticket_id",
+            "required": true,
+            "schema": {
+              "title": "Ticket Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Sync Ticket V1 Ticketing Tickets  Ticket Id  Sync Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Sync Ticket",
+        "tags": [
+          "ticketing"
+        ]
       }
     },
     "/v1/traces": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2486,6 +2486,89 @@ components:
           title: Schedules
       title: TenantQuotaUpdateRequest
       type: object
+    TicketCreate:
+      additionalProperties: false
+      description: "File a ticket for a finding through a stored connection.\n\nDeliberately\
+        \ carries NO credential, token, or base-URL/link field \u2014 auth and\nendpoint\
+        \ come only from the stored connection."
+      properties:
+        connection_id:
+          default: ''
+          title: Connection Id
+          type: string
+        finding:
+          additionalProperties: true
+          title: Finding
+          type: object
+        finding_id:
+          default: ''
+          title: Finding Id
+          type: string
+        issue_type:
+          default: ''
+          title: Issue Type
+          type: string
+        project:
+          default: ''
+          title: Project
+          type: string
+        source_url:
+          default: ''
+          maxLength: 2048
+          title: Source Url
+          type: string
+      title: TicketCreate
+      type: object
+    TicketingConnectionCreate:
+      additionalProperties: false
+      description: 'Create a connect-once ITSM connection. ``secret`` is write-only.
+
+
+        ``transport=mcp`` (primary): ``endpoint`` is the ITSM MCP server URL and
+
+        ``secret`` (optional) is its bearer token. ``transport=rest`` +
+
+        ``auth_method=api_token``: ``endpoint`` is the site URL, ``secret`` is the
+
+        API token, and ``auth_params.email`` is the account email.'
+      properties:
+        auth_method:
+          default: mcp
+          title: Auth Method
+          type: string
+        auth_params:
+          additionalProperties:
+            type: string
+          title: Auth Params
+          type: object
+        display_name:
+          maxLength: 200
+          minLength: 1
+          title: Display Name
+          type: string
+        endpoint:
+          maxLength: 2048
+          minLength: 1
+          title: Endpoint
+          type: string
+        provider:
+          title: Provider
+          type: string
+        secret:
+          default: ''
+          maxLength: 8192
+          title: Secret
+          type: string
+        transport:
+          default: mcp
+          title: Transport
+          type: string
+      required:
+      - provider
+      - display_name
+      - endpoint
+      title: TicketingConnectionCreate
+      type: object
     TracingHealth:
       properties:
         otlp_endpoint_configured:
@@ -17867,6 +17950,360 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Export Tenant Data
+  /v1/ticketing/connections:
+    get:
+      description: List the tenant's ticketing connections (non-secret metadata only).
+      operationId: list_connections_v1_ticketing_connections_get
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Connections V1 Ticketing Connections Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List Connections
+      tags:
+      - ticketing
+    post:
+      description: Create a connect-once ITSM connection for the tenant (seals the
+        secret).
+      operationId: create_connection_v1_ticketing_connections_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TicketingConnectionCreate'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Create Connection V1 Ticketing Connections Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Create Connection
+      tags:
+      - ticketing
+  /v1/ticketing/connections/{connection_id}:
+    delete:
+      description: Revoke a ticketing connection owned by the tenant.
+      operationId: delete_connection_v1_ticketing_connections__connection_id__delete
+      parameters:
+      - in: path
+        name: connection_id
+        required: true
+        schema:
+          title: Connection Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '204':
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Delete Connection
+      tags:
+      - ticketing
+    get:
+      description: Return one ticketing connection's non-secret metadata (tenant-scoped).
+      operationId: get_connection_v1_ticketing_connections__connection_id__get
+      parameters:
+      - in: path
+        name: connection_id
+        required: true
+        schema:
+          title: Connection Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Connection V1 Ticketing Connections  Connection
+                  Id  Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Connection
+      tags:
+      - ticketing
+  /v1/ticketing/tickets:
+    get:
+      description: "List the tenant's filed tickets (finding\u2192ticket links + last\
+        \ status)."
+      operationId: list_tickets_v1_ticketing_tickets_get
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response List Tickets V1 Ticketing Tickets Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: List Tickets
+      tags:
+      - ticketing
+    post:
+      description: File a ticket for a finding through the stored connection (idempotent).
+      operationId: create_ticket_v1_ticketing_tickets_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TicketCreate'
+        required: true
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Create Ticket V1 Ticketing Tickets Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Create Ticket
+      tags:
+      - ticketing
+  /v1/ticketing/tickets/{ticket_id}/sync:
+    post:
+      description: Refresh a filed ticket's status from its ITSM, through the connection.
+      operationId: sync_ticket_v1_ticketing_tickets__ticket_id__sync_post
+      parameters:
+      - in: path
+        name: ticket_id
+        required: true
+        schema:
+          title: Ticket Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Sync Ticket V1 Ticketing Tickets  Ticket Id  Sync
+                  Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Sync Ticket
+      tags:
+      - ticketing
   /v1/traces:
     post:
       description: 'Ingest OpenTelemetry trace data and flag vulnerable tool calls.

--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   ],
   "name": "agent-bom",
   "title": "agent-bom",
-  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 73 read-first MCP tools for headless security agents.",
+  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 75 read-first MCP tools for headless security agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 73 MCP tools with descriptions and parameters
+- `tools.json` — all 75 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -1314,5 +1314,32 @@
         "desc": "Maximum campaigns to list when campaign_id is omitted (default: 200)"
       }
     ]
+  },
+  {
+    "name": "create_ticket",
+    "description": "File an ITSM ticket for a finding through a stored connect-once connection; no per-action credential.",
+    "arguments": [
+      {"name": "finding", "type": "string", "desc": "Finding or issue as a JSON object"},
+      {"name": "project", "type": "string", "desc": "Target ITSM project or queue key"},
+      {"name": "connection_id", "type": "string", "desc": "Stored ticketing connection id"},
+      {"name": "finding_id", "type": "string", "desc": "Stable finding id for idempotency"},
+      {"name": "issue_type", "type": "string", "desc": "ITSM issue type"},
+      {"name": "source_url", "type": "string", "desc": "Optional agent-bom provenance link"},
+      {"name": "operator_role", "type": "string", "desc": "Authenticated operator role"},
+      {"name": "operator_scopes", "type": "string", "desc": "Comma-separated operator scopes"},
+      {"name": "reason", "type": "string", "desc": "Human audit reason"},
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope"}
+    ]
+  },
+  {
+    "name": "sync_ticket_status",
+    "description": "Refresh a filed ITSM ticket's status through the stored ticketing connection.",
+    "arguments": [
+      {"name": "ticket_id", "type": "string", "desc": "Agent-bom ticket link id"},
+      {"name": "operator_role", "type": "string", "desc": "Authenticated operator role"},
+      {"name": "operator_scopes", "type": "string", "desc": "Comma-separated operator scopes"},
+      {"name": "reason", "type": "string", "desc": "Human audit reason"},
+      {"name": "tenant_id", "type": "string", "desc": "Tenant scope"}
+    ]
   }
 ]

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -449,7 +449,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (73, 6, 8):
+    if (tools, resources, prompts) != (75, 6, 8):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -483,3 +483,8 @@ AGENT_BOM_POSTGRES_IAM_REGION
 # (cli/agents). Boolean intent flag that flips auto-proposed gateway block rules
 # from audit (propose only) to enforce mode; not a scalar config knob.
 AGENT_BOM_ENFORCE_CORRELATED_BLOCKS
+
+# Atlassian OAuth app identity and file-first secret are resolved dynamically
+# by the connect-once Jira integration so credentials can rotate at runtime.
+AGENT_BOM_JIRA_OAUTH_CLIENT_ID
+AGENT_BOM_JIRA_OAUTH_CLIENT_SECRET

--- a/src/agent_bom/api/routes/ticketing.py
+++ b/src/agent_bom/api/routes/ticketing.py
@@ -270,7 +270,7 @@ async def create_ticket(request: Request, body: TicketCreate, _role: Any = _WRIT
             actor=_actor(request),
         )
     except TicketingError as exc:
-        raise HTTPException(status_code=_ERROR_STATUS.get(exc.code, 400), detail=str(exc)) from exc
+        raise HTTPException(status_code=_ERROR_STATUS.get(exc.code, 400), detail=sanitize_error(exc)) from exc
 
 
 @router.get("/ticketing/tickets")
@@ -293,4 +293,4 @@ async def sync_ticket(request: Request, ticket_id: str, _role: Any = _WRITE_DEP)
     try:
         return await sync_ticket_status(tenant_id=tenant_id, ticket_id=ticket_id, actor=_actor(request))
     except TicketingError as exc:
-        raise HTTPException(status_code=_ERROR_STATUS.get(exc.code, 400), detail=str(exc)) from exc
+        raise HTTPException(status_code=_ERROR_STATUS.get(exc.code, 400), detail=sanitize_error(exc)) from exc

--- a/src/agent_bom/api/routes/ticketing.py
+++ b/src/agent_bom/api/routes/ticketing.py
@@ -1,0 +1,296 @@
+"""Per-tenant ITSM ticketing plane — connect once, then file/sync through it.
+
+Manages the stored, encrypted, tenant-scoped ticketing connection and the
+finding→ticket actions that run **through** it. No endpoint ever accepts a
+credential, token, or base URL for an *action*: creating a ticket takes a
+finding + target project and resolves auth/endpoint from the stored connection
+(the platform connect-once invariant). The connection's secret is encrypted at
+rest and never returned.
+
+Endpoints:
+    POST   /v1/ticketing/connections            create a connection (seals the secret once)
+    GET    /v1/ticketing/connections            list this tenant's connections
+    GET    /v1/ticketing/connections/{id}       one connection (non-secret metadata)
+    DELETE /v1/ticketing/connections/{id}       revoke a connection
+    POST   /v1/ticketing/tickets                file a ticket for a finding via a connection
+    GET    /v1/ticketing/tickets                list this tenant's filed tickets
+    POST   /v1/ticketing/tickets/{id}/sync      refresh a ticket's status from its ITSM
+
+The primary transport is MCP-client (agent-bom drives a configured ITSM MCP
+server). A direct-REST Jira adapter (API token / OAuth bearer) is available
+behind the same interface. OAuth 3LO browser connect, ServiceNow REST, and the
+UI action button are tracked follow-ups (see #4004).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent_bom.api.audit_log import log_action
+from agent_bom.api.connection_crypto import ConnectionSecretError, connections_key_configured, encrypt_secret
+from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.rbac import require_authenticated_permission
+from agent_bom.security import sanitize_error, validate_url
+from agent_bom.ticketing.connection_store import get_ticketing_store
+from agent_bom.ticketing.models import (
+    AUTH_API_TOKEN,
+    AUTH_MCP,
+    STATUS_ACTIVE,
+    SUPPORTED_TICKETING_PROVIDERS,
+    TRANSPORT_MCP,
+    TRANSPORT_REST,
+    TicketingConnectionRecord,
+)
+from agent_bom.ticketing.service import TicketingError, create_ticket_for_finding, sync_ticket_status
+
+router = APIRouter(tags=["ticketing"])
+_logger = logging.getLogger(__name__)
+
+_READ_DEP = require_authenticated_permission("read")
+_WRITE_DEP = require_authenticated_permission("scan")
+
+_MAX_AUTH_PARAMS = 20
+_MAX_PARAM_LEN = 1024
+# Connect-time auth methods accepted by this endpoint. OAuth (3LO) is connected
+# through the dedicated browser flow (follow-up), not by posting a token here.
+_ACCEPTED_AUTH_METHODS = (AUTH_MCP, AUTH_API_TOKEN)
+
+# Map a service error code to an HTTP status.
+_ERROR_STATUS = {
+    "no_connection": 409,
+    "ambiguous_connection": 409,
+    "not_found": 404,
+    "missing_project": 400,
+    "missing_finding_id": 400,
+    "secret_unavailable": 503,
+    "transport_error": 502,
+}
+
+
+class TicketingConnectionCreate(BaseModel):
+    """Create a connect-once ITSM connection. ``secret`` is write-only.
+
+    ``transport=mcp`` (primary): ``endpoint`` is the ITSM MCP server URL and
+    ``secret`` (optional) is its bearer token. ``transport=rest`` +
+    ``auth_method=api_token``: ``endpoint`` is the site URL, ``secret`` is the
+    API token, and ``auth_params.email`` is the account email.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    provider: str
+    transport: str = TRANSPORT_MCP
+    auth_method: str = AUTH_MCP
+    display_name: str = Field(min_length=1, max_length=200)
+    endpoint: str = Field(min_length=1, max_length=2048)
+    secret: str = Field(default="", max_length=8192)
+    auth_params: dict[str, str] = Field(default_factory=dict)
+
+
+class TicketCreate(BaseModel):
+    """File a ticket for a finding through a stored connection.
+
+    Deliberately carries NO credential, token, or base-URL/link field — auth and
+    endpoint come only from the stored connection.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    connection_id: str = ""
+    finding_id: str = ""
+    project: str = ""
+    issue_type: str = ""
+    source_url: str = Field(default="", max_length=2048)
+    finding: dict[str, Any] = Field(default_factory=dict)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _tenant(request: Request) -> str:
+    return require_request_tenant_id(request)
+
+
+def _actor(request: Request) -> str:
+    return getattr(request.state, "api_key_name", "") or getattr(request.state, "auth_method", "") or "system"
+
+
+def _validate_auth_params(auth_params: dict[str, str]) -> dict[str, str]:
+    if not auth_params:
+        return {}
+    if len(auth_params) > _MAX_AUTH_PARAMS:
+        raise HTTPException(status_code=400, detail=f"Too many auth_params (max {_MAX_AUTH_PARAMS}).")
+    cleaned: dict[str, str] = {}
+    for key, value in auth_params.items():
+        key_str = str(key).strip()
+        if not key_str:
+            continue
+        value_str = str(value).strip()
+        if len(value_str) > _MAX_PARAM_LEN:
+            raise HTTPException(status_code=400, detail=f"auth_params value too long (max {_MAX_PARAM_LEN}).")
+        cleaned[key_str] = value_str
+    return cleaned
+
+
+@router.post("/ticketing/connections", status_code=201)
+async def create_connection(request: Request, body: TicketingConnectionCreate, _role: Any = _WRITE_DEP) -> dict[str, Any]:
+    """Create a connect-once ITSM connection for the tenant (seals the secret)."""
+    tenant_id = _tenant(request)
+    provider = body.provider.strip().lower()
+    transport = body.transport.strip().lower()
+    auth_method = body.auth_method.strip().lower()
+    if provider not in SUPPORTED_TICKETING_PROVIDERS:
+        raise HTTPException(
+            status_code=400, detail=f"Unsupported provider '{body.provider}'. Use one of: {', '.join(SUPPORTED_TICKETING_PROVIDERS)}."
+        )
+    if transport not in (TRANSPORT_MCP, TRANSPORT_REST):
+        raise HTTPException(status_code=400, detail=f"Unsupported transport '{body.transport}'. Use 'mcp' or 'rest'.")
+    if auth_method not in _ACCEPTED_AUTH_METHODS:
+        raise HTTPException(
+            status_code=400,
+            detail="Unsupported auth_method here. Use 'mcp' or 'api_token'; OAuth (3LO) connects via the dedicated flow.",
+        )
+
+    endpoint = body.endpoint.strip()
+    try:
+        validate_url(endpoint)
+    except Exception as exc:  # noqa: BLE001 - SSRF/format rejection
+        raise HTTPException(status_code=400, detail=f"Invalid endpoint URL: {sanitize_error(exc)}") from exc
+
+    auth_params = _validate_auth_params(body.auth_params)
+    if transport == TRANSPORT_REST and auth_method == AUTH_API_TOKEN:
+        if not auth_params.get("email"):
+            raise HTTPException(status_code=400, detail="A REST api_token connection requires auth_params.email.")
+        if not body.secret.strip():
+            raise HTTPException(status_code=400, detail="A REST api_token connection requires a secret (the API token).")
+
+    secret_encrypted = ""
+    if body.secret.strip():
+        if not connections_key_configured():
+            raise HTTPException(
+                status_code=503,
+                detail="Connection secret encryption is not configured (AGENT_BOM_CONNECTIONS_KEY unset); refusing to store a secret.",
+            )
+        try:
+            secret_encrypted = encrypt_secret(body.secret.strip())
+        except ConnectionSecretError as exc:
+            _logger.warning("Ticketing secret encryption unavailable")
+            raise HTTPException(status_code=503, detail=sanitize_error(exc, generic=True)) from exc
+
+    now = _now()
+    record = TicketingConnectionRecord(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        provider=provider,
+        transport=transport,
+        auth_method=auth_method,
+        display_name=body.display_name.strip(),
+        endpoint=endpoint,
+        secret_encrypted=secret_encrypted,
+        auth_params=auth_params,
+        status=STATUS_ACTIVE,
+        created_at=now,
+        updated_at=now,
+    )
+    get_ticketing_store().put_connection(record)
+    log_action(
+        "ticketing_connection.create",
+        actor=_actor(request),
+        resource=f"ticketing-connection/{record.id}",
+        tenant_id=tenant_id,
+        provider=record.provider,
+        transport=record.transport,
+    )
+    return record.to_public_dict()
+
+
+@router.get("/ticketing/connections")
+async def list_connections(request: Request, _role: Any = _READ_DEP) -> dict[str, Any]:
+    """List the tenant's ticketing connections (non-secret metadata only)."""
+    tenant_id = _tenant(request)
+    records = get_ticketing_store().list_connections(tenant_id)
+    return {
+        "schema_version": "ticketing.connections.v1",
+        "tenant_id": tenant_id,
+        "connections": [r.to_public_dict() for r in records],
+        "count": len(records),
+    }
+
+
+@router.get("/ticketing/connections/{connection_id}")
+async def get_connection(request: Request, connection_id: str, _role: Any = _READ_DEP) -> dict[str, Any]:
+    """Return one ticketing connection's non-secret metadata (tenant-scoped)."""
+    tenant_id = _tenant(request)
+    record = get_ticketing_store().get_connection(tenant_id, connection_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Connection {connection_id} not found")
+    return record.to_public_dict()
+
+
+@router.delete("/ticketing/connections/{connection_id}", status_code=204)
+async def delete_connection(request: Request, connection_id: str, _role: Any = _WRITE_DEP) -> None:
+    """Revoke a ticketing connection owned by the tenant."""
+    tenant_id = _tenant(request)
+    store = get_ticketing_store()
+    record = store.get_connection(tenant_id, connection_id)
+    if record is None:
+        raise HTTPException(status_code=404, detail=f"Connection {connection_id} not found")
+    store.delete_connection(tenant_id, connection_id)
+    log_action(
+        "ticketing_connection.delete",
+        actor=_actor(request),
+        resource=f"ticketing-connection/{connection_id}",
+        tenant_id=tenant_id,
+        provider=record.provider,
+    )
+
+
+@router.post("/ticketing/tickets", status_code=201)
+async def create_ticket(request: Request, body: TicketCreate, _role: Any = _WRITE_DEP) -> dict[str, Any]:
+    """File a ticket for a finding through the stored connection (idempotent)."""
+    tenant_id = _tenant(request)
+    if not body.finding:
+        raise HTTPException(status_code=400, detail="A 'finding' object is required to file a ticket.")
+    try:
+        return await create_ticket_for_finding(
+            tenant_id=tenant_id,
+            connection_id=body.connection_id.strip(),
+            finding=body.finding,
+            project=body.project.strip(),
+            finding_id=body.finding_id.strip(),
+            issue_type=body.issue_type.strip(),
+            source_url=body.source_url.strip(),
+            actor=_actor(request),
+        )
+    except TicketingError as exc:
+        raise HTTPException(status_code=_ERROR_STATUS.get(exc.code, 400), detail=str(exc)) from exc
+
+
+@router.get("/ticketing/tickets")
+async def list_tickets(request: Request, _role: Any = _READ_DEP) -> dict[str, Any]:
+    """List the tenant's filed tickets (finding→ticket links + last status)."""
+    tenant_id = _tenant(request)
+    links = get_ticketing_store().list_ticket_links(tenant_id)
+    return {
+        "schema_version": "ticketing.tickets.v1",
+        "tenant_id": tenant_id,
+        "tickets": [link.to_public_dict() for link in links],
+        "count": len(links),
+    }
+
+
+@router.post("/ticketing/tickets/{ticket_id}/sync")
+async def sync_ticket(request: Request, ticket_id: str, _role: Any = _WRITE_DEP) -> dict[str, Any]:
+    """Refresh a filed ticket's status from its ITSM, through the connection."""
+    tenant_id = _tenant(request)
+    try:
+        return await sync_ticket_status(tenant_id=tenant_id, ticket_id=ticket_id, actor=_actor(request))
+    except TicketingError as exc:
+        raise HTTPException(status_code=_ERROR_STATUS.get(exc.code, 400), detail=str(exc)) from exc

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -935,6 +935,7 @@ from agent_bom.api.routes.scan import router as _scan_router  # noqa: E402
 from agent_bom.api.routes.schedules import router as _schedules_router  # noqa: E402
 from agent_bom.api.routes.scim import router as _scim_router  # noqa: E402
 from agent_bom.api.routes.sources import router as _sources_router  # noqa: E402
+from agent_bom.api.routes.ticketing import router as _ticketing_router  # noqa: E402
 from agent_bom.api.routes.webhooks import router as _webhooks_router  # noqa: E402
 from agent_bom.api.versioning import create_v1_api_router  # noqa: E402
 
@@ -979,6 +980,7 @@ for _router in (
     _scan_router,
     _schedules_router,
     _sources_router,
+    _ticketing_router,
     _webhooks_router,
 ):
     _v1_api_router.include_router(_router)

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -986,7 +986,7 @@ def mcp_server_cmd(
       docs/MCP_WORKFLOWS.md
 
     \b
-    Exposes 73 security tools via MCP protocol, organized behind 8 workflow
+    Exposes 75 security tools via MCP protocol, organized behind 8 workflow
     prompts. Advanced direct tools include skill_scan, skill_verify,
     compliance, and remediate.
 

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (73):
+Tools (75):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     blast_radius        — Look up blast radius for a specific CVE

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1189,6 +1189,15 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
         truncate_response=_truncate_response,
     )
 
+    from agent_bom.mcp_server_ticketing_tools import register_ticketing_tools
+
+    register_ticketing_tools(
+        mcp,
+        write_action=_WRITE_ACTION,
+        execute_tool_async=_execute_tool_async,
+        truncate_response=_truncate_response,
+    )
+
     from agent_bom.mcp_server_operator_tools import register_operator_tools
 
     register_operator_tools(

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -372,6 +372,16 @@ _SERVER_CARD_TOOLS = [
         "description": "List/get NHI access-review campaigns; recomputes and persists overdue status (idempotent write)",
         "annotations": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True},
     },
+    {
+        "name": "create_ticket",
+        "description": "File an ITSM ticket for a finding through a stored connect-once connection; no per-action credential",
+        "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    },
+    {
+        "name": "sync_ticket_status",
+        "description": "Refresh a filed ITSM ticket's status through the stored ticketing connection",
+        "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
+    },
 ]
 
 _TOOL_CAPABILITY_CLASSES = {
@@ -450,6 +460,8 @@ _TOOL_CAPABILITY_CLASSES = {
     "credential_expiry": ["READ", "SECURITY", "AUDIT"],
     "cost_forecast": ["READ", "RUNTIME", "OBSERVABILITY"],
     "cost_allocation": ["READ", "RUNTIME", "OBSERVABILITY"],
+    "create_ticket": ["WRITE", "NETWORK", "INTEGRATION"],
+    "sync_ticket_status": ["WRITE", "NETWORK", "INTEGRATION"],
 }
 
 for _tool in _SERVER_CARD_TOOLS:
@@ -463,12 +475,7 @@ def server_card_tool_names() -> frozenset[str]:
 
 def _is_mcp_tool_decorator(node: ast.expr) -> bool:
     target = node.func if isinstance(node, ast.Call) else node
-    return (
-        isinstance(target, ast.Attribute)
-        and target.attr == "tool"
-        and isinstance(target.value, ast.Name)
-        and target.value.id == "mcp"
-    )
+    return isinstance(target, ast.Attribute) and target.attr == "tool" and isinstance(target.value, ast.Name) and target.value.id == "mcp"
 
 
 def registered_mcp_tool_decorator_names() -> frozenset[str]:

--- a/src/agent_bom/mcp_server_ticketing_tools.py
+++ b/src/agent_bom/mcp_server_ticketing_tools.py
@@ -1,0 +1,87 @@
+"""Ticketing MCP tool registration surface.
+
+Keeps the FastMCP tool decorators for the connect-once ITSM ticketing actions
+out of ``mcp_server.py`` (mirroring ``mcp_server_operator_tools`` /
+``mcp_server_specialized``) while the implementation logic lives in
+:mod:`agent_bom.mcp_tools.ticketing`. Both tools are ``destructiveHint`` writes,
+gated at the dispatch layer by an authenticated admin operator +
+``ticketing:write`` scope. Neither accepts a credential, token, or base URL —
+auth and endpoint are resolved only from the stored, encrypted connection.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated
+
+from pydantic import Field
+
+from agent_bom.mcp_tools.ticketing import create_ticket_impl, sync_ticket_status_impl
+
+
+def register_ticketing_tools(mcp, *, write_action, execute_tool_async, truncate_response) -> None:
+    """Register the ticketing write tools on the FastMCP server."""
+
+    @mcp.tool(annotations=write_action, title="Create ITSM Ticket")
+    async def create_ticket(
+        finding: Annotated[str, Field(description="Finding/issue as a JSON object (the vulnerability details to file).")] = "",
+        project: Annotated[str, Field(description="Target ITSM project/queue key. Uses the connection default if omitted.")] = "",
+        connection_id: Annotated[
+            str, Field(description="Stored ticketing connection id. Uses the tenant's only connection if omitted.")
+        ] = "",
+        finding_id: Annotated[str, Field(description="Stable finding id for idempotency. Derived from the finding if omitted.")] = "",
+        issue_type: Annotated[str, Field(description="ITSM issue type (e.g. Bug). Provider default if omitted.")] = "",
+        source_url: Annotated[str, Field(description="Optional deep link back into agent-bom for provenance.")] = "",
+        operator_role: Annotated[str, Field(description="Operator role for this write action (audit).")] = "viewer",
+        operator_scopes: Annotated[str, Field(description="Comma-separated operator scopes (audit).")] = "",
+        reason: Annotated[str, Field(description="Human audit reason for filing the ticket.")] = "",
+        tenant_id: Annotated[str, Field(description="Tenant scope for the connection and audit logging.")] = "default",
+    ) -> str:
+        """File an ITSM ticket for a finding through a stored connection.
+
+        Connect-once: auth and the ITSM base URL come only from the stored,
+        encrypted connection — no credential or link is passed here. Requires an
+        admin operator + ``ticketing:write`` scope. Idempotent per finding.
+        """
+        return await execute_tool_async(
+            "create_ticket",
+            create_ticket_impl,
+            destructive=True,
+            required_scope="ticketing:write",
+            finding=finding,
+            project=project,
+            connection_id=connection_id,
+            finding_id=finding_id,
+            issue_type=issue_type,
+            source_url=source_url,
+            operator_role=operator_role,
+            operator_scopes=operator_scopes,
+            reason=reason,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=write_action, title="Sync ITSM Ticket Status")
+    async def sync_ticket_status(
+        ticket_id: Annotated[str, Field(description="agent-bom ticket link id returned by create_ticket.")] = "",
+        operator_role: Annotated[str, Field(description="Operator role for this write action (audit).")] = "viewer",
+        operator_scopes: Annotated[str, Field(description="Comma-separated operator scopes (audit).")] = "",
+        reason: Annotated[str, Field(description="Human audit reason for syncing status.")] = "",
+        tenant_id: Annotated[str, Field(description="Tenant scope for the connection and audit logging.")] = "default",
+    ) -> str:
+        """Refresh a filed ticket's status from its ITSM through the connection.
+
+        Requires an admin operator + ``ticketing:write`` scope. Resolves auth and
+        endpoint from the stored connection only.
+        """
+        return await execute_tool_async(
+            "sync_ticket_status",
+            sync_ticket_status_impl,
+            destructive=True,
+            required_scope="ticketing:write",
+            ticket_id=ticket_id,
+            operator_role=operator_role,
+            operator_scopes=operator_scopes,
+            reason=reason,
+            tenant_id=tenant_id,
+            _truncate_response=truncate_response,
+        )

--- a/src/agent_bom/mcp_tools/ticketing.py
+++ b/src/agent_bom/mcp_tools/ticketing.py
@@ -1,0 +1,100 @@
+"""MCP ticketing tools — file a ticket / sync its status through a stored
+connect-once ITSM connection.
+
+Exposes the same connect-once actions to headless MCP clients that the REST plane
+offers. Neither tool accepts a credential, token, or base URL: auth and endpoint
+are resolved only from the stored, encrypted, tenant-scoped connection. The
+tools are ``destructiveHint`` writes, gated at the dispatch layer by an
+authenticated admin operator + ``ticketing:write`` scope, and every action is
+audit-logged by the service.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from agent_bom.mcp_tenant import resolve_mcp_tool_tenant_id
+from agent_bom.security import sanitize_error
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_finding(finding_json: str) -> dict[str, Any]:
+    if not finding_json.strip():
+        return {}
+    try:
+        parsed = json.loads(finding_json)
+    except (ValueError, TypeError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+async def create_ticket_impl(
+    *,
+    finding: str = "",
+    project: str = "",
+    connection_id: str = "",
+    finding_id: str = "",
+    issue_type: str = "",
+    source_url: str = "",
+    operator_role: str = "viewer",
+    operator_scopes: str = "",
+    reason: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+    _authenticated_actor: str = "",
+) -> str:
+    """File a ticket for a finding through the stored ITSM connection."""
+    from agent_bom.ticketing.service import TicketingError, create_ticket_for_finding
+
+    finding_dict = _parse_finding(finding)
+    if not finding_dict:
+        return json.dumps({"error": "A 'finding' JSON object is required to file a ticket.", "status": "rejected"})
+    resolved_tenant = resolve_mcp_tool_tenant_id(tenant_id)
+    actor = (_authenticated_actor or "mcp-operator").strip()
+    try:
+        result = await create_ticket_for_finding(
+            tenant_id=resolved_tenant,
+            connection_id=connection_id.strip(),
+            finding=finding_dict,
+            project=project.strip(),
+            finding_id=finding_id.strip(),
+            issue_type=issue_type.strip(),
+            source_url=source_url.strip(),
+            actor=actor,
+        )
+    except TicketingError as exc:
+        return json.dumps({"error": str(exc), "code": exc.code, "status": "rejected"})
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("MCP create_ticket failed")
+        return json.dumps({"error": sanitize_error(exc), "status": "error"})
+    return _truncate_response(json.dumps(result, indent=2, default=str))
+
+
+async def sync_ticket_status_impl(
+    *,
+    ticket_id: str = "",
+    operator_role: str = "viewer",
+    operator_scopes: str = "",
+    reason: str = "",
+    tenant_id: str = "default",
+    _truncate_response,
+    _authenticated_actor: str = "",
+) -> str:
+    """Refresh a filed ticket's status from its ITSM, through the connection."""
+    from agent_bom.ticketing.service import TicketingError, sync_ticket_status
+
+    if not ticket_id.strip():
+        return json.dumps({"error": "A ticket_id is required.", "status": "rejected"})
+    resolved_tenant = resolve_mcp_tool_tenant_id(tenant_id)
+    actor = (_authenticated_actor or "mcp-operator").strip()
+    try:
+        result = await sync_ticket_status(tenant_id=resolved_tenant, ticket_id=ticket_id.strip(), actor=actor)
+    except TicketingError as exc:
+        return json.dumps({"error": str(exc), "code": exc.code, "status": "rejected"})
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("MCP sync_ticket_status failed")
+        return json.dumps({"error": sanitize_error(exc), "status": "error"})
+    return _truncate_response(json.dumps(result, indent=2, default=str))

--- a/src/agent_bom/ticketing/__init__.py
+++ b/src/agent_bom/ticketing/__init__.py
@@ -1,0 +1,58 @@
+"""Scoped ITSM / ticketing connector (#4004).
+
+Files a ticket for a finding/issue and syncs its status back, through a
+**stored, scoped, encrypted, revocable connection** configured once in the
+Connections hub — never a per-action credential (see the platform invariant in
+`/develop` §11 and `AGENTS.md`). The action call (MCP tool, REST, UI) takes a
+finding/issue reference + a target project only; auth and the base URL are always
+resolved from the stored connection.
+
+The connector is transport-pluggable behind one interface
+(:class:`~agent_bom.ticketing.transport.TicketingTransport`):
+
+* **MCP-client transport (primary)** — agent-bom acts as an MCP *client* of a
+  configured ITSM MCP server (e.g. an Atlassian/Jira MCP server) and routes
+  ``create_ticket`` / ``sync_status`` to that server's tools. Interoperable by
+  design; no hardcoded per-vendor REST for MCP-capable ITSMs.
+* **Direct-REST transport (fallback)** — a verified per-vendor REST adapter
+  (Jira Cloud REST v3 today) for ITSMs without an MCP server. Jira supports
+  OAuth 2.0 (3LO) Bearer *and*, as a secondary fallback, an API token — both
+  entered once at connect time, sealed at rest, and never re-entered.
+
+Our own ``create_ticket`` / ``sync_ticket_status`` MCP tools + REST endpoints
+dispatch to whichever transport the stored connection selected.
+"""
+
+from __future__ import annotations
+
+from agent_bom.ticketing.models import (
+    AUTH_API_TOKEN,
+    AUTH_MCP,
+    AUTH_OAUTH,
+    PROVIDER_GENERIC,
+    PROVIDER_JIRA,
+    PROVIDER_SERVICENOW,
+    SUPPORTED_TICKETING_PROVIDERS,
+    TRANSPORT_MCP,
+    TRANSPORT_REST,
+    TicketDraft,
+    TicketingConnectionRecord,
+    TicketRef,
+    TicketStatus,
+)
+
+__all__ = [
+    "AUTH_API_TOKEN",
+    "AUTH_MCP",
+    "AUTH_OAUTH",
+    "PROVIDER_GENERIC",
+    "PROVIDER_JIRA",
+    "PROVIDER_SERVICENOW",
+    "SUPPORTED_TICKETING_PROVIDERS",
+    "TRANSPORT_MCP",
+    "TRANSPORT_REST",
+    "TicketDraft",
+    "TicketRef",
+    "TicketStatus",
+    "TicketingConnectionRecord",
+]

--- a/src/agent_bom/ticketing/connection_store.py
+++ b/src/agent_bom/ticketing/connection_store.py
@@ -1,0 +1,399 @@
+"""Tenant-scoped persistence for ITSM ticketing connections + ticket links.
+
+Two logical entities, one store (parity with the cloud-connection store's
+backend tiering: in-memory for tests, SQLite for the single-node durable
+default, Postgres with tenant RLS for multi-replica):
+
+* ``ticketing_connections`` — the stored, encrypted, revocable connection
+  (``secret_encrypted`` is the only sensitive column; never returned).
+* ``ticket_links`` — the bidirectional link from a finding to its filed ticket.
+  Its ``UNIQUE (tenant_id, connection_id, dedupe_key)`` is the idempotency guard:
+  a second create for the same finding *claims* the same row instead of filing a
+  duplicate ticket. The tenant_id is part of the key so two tenants filing the
+  same logical finding never collide.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime, timezone
+from typing import Any, Protocol
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+from agent_bom.ticketing.models import TicketingConnectionRecord
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+@dataclass
+class TicketLink:
+    """A finding→ticket link (also the idempotency ledger row)."""
+
+    id: str
+    tenant_id: str
+    connection_id: str
+    dedupe_key: str
+    provider: str
+    status: str = "open"
+    external_id: str = ""
+    key: str = ""
+    url: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+
+    def to_public_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+# ── Store contract ────────────────────────────────────────────────────────────
+
+
+class TicketingStore(Protocol):
+    def init_schema(self) -> None: ...
+    def put_connection(self, record: TicketingConnectionRecord) -> None: ...
+    def get_connection(self, tenant_id: str, connection_id: str) -> TicketingConnectionRecord | None: ...
+    def list_connections(self, tenant_id: str) -> list[TicketingConnectionRecord]: ...
+    def delete_connection(self, tenant_id: str, connection_id: str) -> bool: ...
+    def claim_ticket_link(self, link: TicketLink) -> tuple[bool, TicketLink]: ...
+    def update_ticket_link(self, link: TicketLink) -> None: ...
+    def get_ticket_link(self, tenant_id: str, ticket_id: str) -> TicketLink | None: ...
+    def get_ticket_link_by_dedupe(self, tenant_id: str, connection_id: str, dedupe_key: str) -> TicketLink | None: ...
+    def list_ticket_links(self, tenant_id: str) -> list[TicketLink]: ...
+    def delete_ticket_link(self, tenant_id: str, ticket_id: str) -> bool: ...
+
+
+def _copy_conn(record: TicketingConnectionRecord) -> TicketingConnectionRecord:
+    return replace(record, auth_params=dict(record.auth_params))
+
+
+# ── In-memory backend ─────────────────────────────────────────────────────────
+
+
+class InMemoryTicketingStore:
+    """Dict-backed store for tests and ephemeral runs (tenant-scoped)."""
+
+    def __init__(self) -> None:
+        self._conns: dict[str, TicketingConnectionRecord] = {}
+        self._links: dict[str, TicketLink] = {}
+        self._lock = threading.Lock()
+
+    def init_schema(self) -> None:  # no persistent schema
+        return None
+
+    def put_connection(self, record: TicketingConnectionRecord) -> None:
+        with self._lock:
+            self._conns[record.id] = _copy_conn(record)
+
+    def get_connection(self, tenant_id: str, connection_id: str) -> TicketingConnectionRecord | None:
+        with self._lock:
+            record = self._conns.get(connection_id)
+            if record is None or record.tenant_id != tenant_id:
+                return None
+            return _copy_conn(record)
+
+    def list_connections(self, tenant_id: str) -> list[TicketingConnectionRecord]:
+        with self._lock:
+            rows = [_copy_conn(r) for r in self._conns.values() if r.tenant_id == tenant_id]
+        return sorted(rows, key=lambda r: (r.created_at, r.id))
+
+    def delete_connection(self, tenant_id: str, connection_id: str) -> bool:
+        with self._lock:
+            record = self._conns.get(connection_id)
+            if record is None or record.tenant_id != tenant_id:
+                return False
+            del self._conns[connection_id]
+            return True
+
+    def claim_ticket_link(self, link: TicketLink) -> tuple[bool, TicketLink]:
+        with self._lock:
+            for existing in self._links.values():
+                if (
+                    existing.tenant_id == link.tenant_id
+                    and existing.connection_id == link.connection_id
+                    and existing.dedupe_key == link.dedupe_key
+                ):
+                    return False, replace(existing)
+            self._links[link.id] = replace(link)
+            return True, replace(link)
+
+    def update_ticket_link(self, link: TicketLink) -> None:
+        with self._lock:
+            self._links[link.id] = replace(link)
+
+    def get_ticket_link(self, tenant_id: str, ticket_id: str) -> TicketLink | None:
+        with self._lock:
+            link = self._links.get(ticket_id)
+            if link is None or link.tenant_id != tenant_id:
+                return None
+            return replace(link)
+
+    def get_ticket_link_by_dedupe(self, tenant_id: str, connection_id: str, dedupe_key: str) -> TicketLink | None:
+        with self._lock:
+            for link in self._links.values():
+                if link.tenant_id == tenant_id and link.connection_id == connection_id and link.dedupe_key == dedupe_key:
+                    return replace(link)
+            return None
+
+    def list_ticket_links(self, tenant_id: str) -> list[TicketLink]:
+        with self._lock:
+            rows = [replace(link) for link in self._links.values() if link.tenant_id == tenant_id]
+        return sorted(rows, key=lambda r: (r.created_at, r.id))
+
+    def delete_ticket_link(self, tenant_id: str, ticket_id: str) -> bool:
+        with self._lock:
+            link = self._links.get(ticket_id)
+            if link is None or link.tenant_id != tenant_id:
+                return False
+            del self._links[ticket_id]
+            return True
+
+
+# ── SQLite backend ────────────────────────────────────────────────────────────
+
+_CONN_COLS = (
+    "id, tenant_id, provider, transport, auth_method, display_name, endpoint, "
+    "secret_encrypted, auth_params, status, status_detail, created_at, updated_at"
+)
+_LINK_COLS = "id, tenant_id, connection_id, dedupe_key, provider, status, external_id, key, url, created_at, updated_at"
+
+
+def _row_to_conn(row: Any) -> TicketingConnectionRecord:
+    return TicketingConnectionRecord(
+        id=row[0],
+        tenant_id=row[1],
+        provider=row[2],
+        transport=row[3],
+        auth_method=row[4],
+        display_name=row[5],
+        endpoint=row[6],
+        secret_encrypted=row[7],
+        auth_params=json.loads(row[8]) if row[8] else {},
+        status=row[9],
+        status_detail=row[10],
+        created_at=row[11],
+        updated_at=row[12],
+    )
+
+
+def _row_to_link(row: Any) -> TicketLink:
+    return TicketLink(
+        id=row[0],
+        tenant_id=row[1],
+        connection_id=row[2],
+        dedupe_key=row[3],
+        provider=row[4],
+        status=row[5],
+        external_id=row[6],
+        key=row[7],
+        url=row[8],
+        created_at=row[9],
+        updated_at=row[10],
+    )
+
+
+class SQLiteTicketingStore:
+    """SQLite-backed store (durable single-node default)."""
+
+    def __init__(self, db_path: str = "agent_bom.db") -> None:
+        self._db_path = db_path
+        self._local = threading.local()
+        self._init_db()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self._db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        conn: sqlite3.Connection = self._local.conn
+        return conn
+
+    def init_schema(self) -> None:
+        self._init_db()
+
+    def _init_db(self) -> None:
+        ensure_sqlite_schema_version(self._conn, "ticketing_connections")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ticketing_connections (
+                id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                transport TEXT NOT NULL,
+                auth_method TEXT NOT NULL,
+                display_name TEXT NOT NULL,
+                endpoint TEXT NOT NULL DEFAULT '',
+                secret_encrypted TEXT NOT NULL DEFAULT '',
+                auth_params TEXT NOT NULL DEFAULT '{}',
+                status TEXT NOT NULL DEFAULT 'pending',
+                status_detail TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_ticketing_connections_tenant ON ticketing_connections(tenant_id, created_at)")
+        self._conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS ticket_links (
+                id TEXT PRIMARY KEY,
+                tenant_id TEXT NOT NULL,
+                connection_id TEXT NOT NULL,
+                dedupe_key TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'open',
+                external_id TEXT NOT NULL DEFAULT '',
+                key TEXT NOT NULL DEFAULT '',
+                url TEXT NOT NULL DEFAULT '',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                UNIQUE (tenant_id, connection_id, dedupe_key)
+            )
+            """
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_ticket_links_tenant ON ticket_links(tenant_id, created_at)")
+        self._conn.commit()
+
+    def put_connection(self, record: TicketingConnectionRecord) -> None:
+        self._conn.execute(
+            f"INSERT OR REPLACE INTO ticketing_connections ({_CONN_COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                record.id,
+                record.tenant_id,
+                record.provider,
+                record.transport,
+                record.auth_method,
+                record.display_name,
+                record.endpoint,
+                record.secret_encrypted,
+                json.dumps(record.auth_params),
+                record.status,
+                record.status_detail,
+                record.created_at,
+                record.updated_at,
+            ),
+        )
+        self._conn.commit()
+
+    def get_connection(self, tenant_id: str, connection_id: str) -> TicketingConnectionRecord | None:
+        row = self._conn.execute(
+            f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = ? AND id = ?",
+            (tenant_id, connection_id),
+        ).fetchone()
+        return _row_to_conn(row) if row else None
+
+    def list_connections(self, tenant_id: str) -> list[TicketingConnectionRecord]:
+        rows = self._conn.execute(
+            f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = ? ORDER BY created_at, id",
+            (tenant_id,),
+        ).fetchall()
+        return [_row_to_conn(r) for r in rows]
+
+    def delete_connection(self, tenant_id: str, connection_id: str) -> bool:
+        cursor = self._conn.execute(
+            "DELETE FROM ticketing_connections WHERE tenant_id = ? AND id = ?",
+            (tenant_id, connection_id),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def claim_ticket_link(self, link: TicketLink) -> tuple[bool, TicketLink]:
+        try:
+            self._conn.execute(
+                f"INSERT INTO ticket_links ({_LINK_COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                (
+                    link.id,
+                    link.tenant_id,
+                    link.connection_id,
+                    link.dedupe_key,
+                    link.provider,
+                    link.status,
+                    link.external_id,
+                    link.key,
+                    link.url,
+                    link.created_at,
+                    link.updated_at,
+                ),
+            )
+            self._conn.commit()
+            return True, link
+        except sqlite3.IntegrityError:
+            self._conn.rollback()
+            existing = self.get_ticket_link_by_dedupe(link.tenant_id, link.connection_id, link.dedupe_key)
+            if existing is None:  # pragma: no cover - lost row after conflict
+                raise
+            return False, existing
+
+    def update_ticket_link(self, link: TicketLink) -> None:
+        self._conn.execute(
+            "UPDATE ticket_links SET status=?, external_id=?, key=?, url=?, updated_at=? WHERE tenant_id=? AND id=?",
+            (link.status, link.external_id, link.key, link.url, link.updated_at, link.tenant_id, link.id),
+        )
+        self._conn.commit()
+
+    def get_ticket_link(self, tenant_id: str, ticket_id: str) -> TicketLink | None:
+        row = self._conn.execute(
+            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? AND id = ?",
+            (tenant_id, ticket_id),
+        ).fetchone()
+        return _row_to_link(row) if row else None
+
+    def get_ticket_link_by_dedupe(self, tenant_id: str, connection_id: str, dedupe_key: str) -> TicketLink | None:
+        row = self._conn.execute(
+            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? AND connection_id = ? AND dedupe_key = ?",
+            (tenant_id, connection_id, dedupe_key),
+        ).fetchone()
+        return _row_to_link(row) if row else None
+
+    def list_ticket_links(self, tenant_id: str) -> list[TicketLink]:
+        rows = self._conn.execute(
+            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? ORDER BY created_at, id",
+            (tenant_id,),
+        ).fetchall()
+        return [_row_to_link(r) for r in rows]
+
+    def delete_ticket_link(self, tenant_id: str, ticket_id: str) -> bool:
+        cursor = self._conn.execute(
+            "DELETE FROM ticket_links WHERE tenant_id = ? AND id = ?",
+            (tenant_id, ticket_id),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+
+# ── Factory (mirrors get_connection_store) ────────────────────────────────────
+
+_TICKETING_STORE: TicketingStore | None = None
+
+
+def get_ticketing_store() -> TicketingStore:
+    """Return the process ticketing store, selecting the backend via the factory.
+
+    Postgres → shared SQLite → in-memory, matching every other env-ladder store.
+    """
+    global _TICKETING_STORE
+    if _TICKETING_STORE is not None:
+        return _TICKETING_STORE
+    from agent_bom.storage.base import BackendKind
+    from agent_bom.storage.factory import resolve_backend
+
+    selection = resolve_backend(mode="env")
+    if selection.backend is BackendKind.POSTGRES:
+        from agent_bom.ticketing.postgres_store import PostgresTicketingStore
+
+        _TICKETING_STORE = PostgresTicketingStore()
+    elif selection.backend is BackendKind.SQLITE and selection.sqlite_path:
+        _TICKETING_STORE = SQLiteTicketingStore(selection.sqlite_path)
+    else:
+        _TICKETING_STORE = InMemoryTicketingStore()
+    return _TICKETING_STORE
+
+
+def set_ticketing_store(store: TicketingStore | None) -> None:
+    """Swap the process ticketing store (tests / explicit backend wiring)."""
+    global _TICKETING_STORE
+    _TICKETING_STORE = store

--- a/src/agent_bom/ticketing/connection_store.py
+++ b/src/agent_bom/ticketing/connection_store.py
@@ -281,14 +281,14 @@ class SQLiteTicketingStore:
 
     def get_connection(self, tenant_id: str, connection_id: str) -> TicketingConnectionRecord | None:
         row = self._conn.execute(
-            f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = ? AND id = ?",
+            f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = ? AND id = ?",  # nosec B608 -- fixed internal columns
             (tenant_id, connection_id),
         ).fetchone()
         return _row_to_conn(row) if row else None
 
     def list_connections(self, tenant_id: str) -> list[TicketingConnectionRecord]:
         rows = self._conn.execute(
-            f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = ? ORDER BY created_at, id",
+            f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = ? ORDER BY created_at, id",  # nosec B608 -- fixed internal columns
             (tenant_id,),
         ).fetchall()
         return [_row_to_conn(r) for r in rows]
@@ -304,7 +304,7 @@ class SQLiteTicketingStore:
     def claim_ticket_link(self, link: TicketLink) -> tuple[bool, TicketLink]:
         try:
             self._conn.execute(
-                f"INSERT INTO ticket_links ({_LINK_COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+                f"INSERT INTO ticket_links ({_LINK_COLS}) VALUES (?,?,?,?,?,?,?,?,?,?,?)",  # nosec B608 -- fixed internal columns
                 (
                     link.id,
                     link.tenant_id,
@@ -337,21 +337,21 @@ class SQLiteTicketingStore:
 
     def get_ticket_link(self, tenant_id: str, ticket_id: str) -> TicketLink | None:
         row = self._conn.execute(
-            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? AND id = ?",
+            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? AND id = ?",  # nosec B608 -- fixed internal columns
             (tenant_id, ticket_id),
         ).fetchone()
         return _row_to_link(row) if row else None
 
     def get_ticket_link_by_dedupe(self, tenant_id: str, connection_id: str, dedupe_key: str) -> TicketLink | None:
         row = self._conn.execute(
-            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? AND connection_id = ? AND dedupe_key = ?",
+            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? AND connection_id = ? AND dedupe_key = ?",  # nosec B608 -- fixed internal columns
             (tenant_id, connection_id, dedupe_key),
         ).fetchone()
         return _row_to_link(row) if row else None
 
     def list_ticket_links(self, tenant_id: str) -> list[TicketLink]:
         rows = self._conn.execute(
-            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? ORDER BY created_at, id",
+            f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = ? ORDER BY created_at, id",  # nosec B608 -- fixed internal columns
             (tenant_id,),
         ).fetchall()
         return [_row_to_link(r) for r in rows]

--- a/src/agent_bom/ticketing/factory.py
+++ b/src/agent_bom/ticketing/factory.py
@@ -1,0 +1,46 @@
+"""Build the right transport for a stored connection + its decrypted secret.
+
+The action layer never chooses a transport or handles a credential — it hands the
+stored connection (and the just-decrypted secret) here and gets back a ready
+:class:`~agent_bom.ticketing.transport.TicketingTransport`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from agent_bom.ticketing.jira_rest import JiraRestTransport
+from agent_bom.ticketing.mcp_transport import McpTicketingTransport
+from agent_bom.ticketing.models import (
+    PROVIDER_JIRA,
+    TRANSPORT_MCP,
+    TRANSPORT_REST,
+    TicketingConnectionRecord,
+)
+from agent_bom.ticketing.transport import TicketingTransport, TicketingTransportError
+
+_McpCaller = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+def build_transport(
+    record: TicketingConnectionRecord,
+    secret: str,
+    *,
+    mcp_caller: _McpCaller | None = None,
+    rest_client_factory: Callable[..., Any] | None = None,
+) -> TicketingTransport:
+    """Return a transport for the connection. ``secret`` is already decrypted."""
+    transport = (record.transport or "").strip().lower()
+    if transport == TRANSPORT_MCP:
+        return McpTicketingTransport(record, secret, caller=mcp_caller)
+    if transport == TRANSPORT_REST:
+        provider = (record.provider or "").strip().lower()
+        if provider == PROVIDER_JIRA:
+            if rest_client_factory is not None:
+                return JiraRestTransport(record, secret, client_factory=rest_client_factory)
+            return JiraRestTransport(record, secret)
+        raise TicketingTransportError(
+            f"Direct-REST ticketing for provider '{record.provider}' is not implemented yet; connect it via an ITSM MCP server instead."
+        )
+    raise TicketingTransportError(f"Unsupported ticketing transport '{record.transport}'.")

--- a/src/agent_bom/ticketing/jira_rest.py
+++ b/src/agent_bom/ticketing/jira_rest.py
@@ -1,0 +1,191 @@
+"""Direct Jira Cloud REST v3 transport (fallback when no ITSM MCP server).
+
+Verified against the official Jira Cloud platform REST v3 docs:
+
+* Create issue — ``POST /rest/api/3/issue`` with ``{"fields": {...}}``; the
+  response carries ``id``, ``key``, ``self``.
+  https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issues/
+* Read issue status — ``GET /rest/api/3/issue/{issueIdOrKey}?fields=status``;
+  status is at ``fields.status`` with a ``statusCategory`` whose ``key`` is one
+  of ``new`` / ``indeterminate`` / ``done``.
+  https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-issue-search/
+
+Auth is resolved **only** from the stored connection — never from the caller:
+
+* ``oauth`` (3LO, primary): the site is reached at
+  ``https://api.atlassian.com/ex/jira/{cloudId}`` with an ``Authorization:
+  Bearer <access_token>`` header (the OAuth bundle is the sealed secret).
+  https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
+* ``api_token`` (secondary fallback): Basic auth ``base64(email:api_token)``
+  against the customer site URL (``endpoint``).
+  https://developer.atlassian.com/cloud/jira/platform/basic-auth-for-rest-apis/
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from collections.abc import Callable
+from typing import Any
+
+from agent_bom.security import validate_url
+from agent_bom.ticketing.models import (
+    AUTH_API_TOKEN,
+    AUTH_OAUTH,
+    PROVIDER_JIRA,
+    TicketDraft,
+    TicketingConnectionRecord,
+    TicketRef,
+    TicketStatus,
+)
+from agent_bom.ticketing.transport import TicketingTransport, TicketingTransportError, map_jira_status
+
+# Atlassian-hosted API gateway used with OAuth 2.0 (3LO) access tokens.
+_ATLASSIAN_API_BASE = "https://api.atlassian.com"
+
+
+def _default_client_factory(timeout: float = 15.0) -> Any:
+    from agent_bom.http_client import create_client
+
+    return create_client(timeout=timeout)
+
+
+class JiraRestTransport(TicketingTransport):
+    """Create/read Jira issues over REST using the stored connection's auth."""
+
+    def __init__(
+        self,
+        record: TicketingConnectionRecord,
+        secret: str,
+        *,
+        client_factory: Callable[..., Any] = _default_client_factory,
+    ) -> None:
+        self._record = record
+        self._secret = secret
+        self._client_factory = client_factory
+        self._api_base, self._browse_base, self._headers = self._resolve_auth(record, secret)
+
+    # — auth resolution (from the stored connection only) —
+
+    @staticmethod
+    def _resolve_auth(record: TicketingConnectionRecord, secret: str) -> tuple[str, str, dict[str, str]]:
+        method = (record.auth_method or "").strip().lower()
+        if method == AUTH_OAUTH:
+            bundle = _load_oauth_bundle(secret)
+            access_token = str(bundle.get("access_token") or "").strip()
+            cloud_id = str(record.auth_params.get("cloud_id") or "").strip()
+            if not access_token:
+                raise TicketingTransportError("Jira OAuth connection is missing an access token; reconnect Jira.")
+            if not cloud_id:
+                raise TicketingTransportError("Jira OAuth connection is missing its cloud id; reconnect Jira.")
+            api_base = f"{_ATLASSIAN_API_BASE}/ex/jira/{cloud_id}"
+            browse_base = str(record.auth_params.get("site_url") or record.endpoint or "").rstrip("/")
+            headers = {"Authorization": f"Bearer {access_token}"}
+            return api_base, browse_base, headers
+        if method == AUTH_API_TOKEN:
+            email = str(record.auth_params.get("email") or "").strip()
+            if not email:
+                raise TicketingTransportError("Jira API-token connection is missing its account email.")
+            if not secret:
+                raise TicketingTransportError("Jira API-token connection has no stored token; reconnect Jira.")
+            base = (record.endpoint or "").rstrip("/")
+            if not base:
+                raise TicketingTransportError("Jira API-token connection is missing its site URL.")
+            validate_url(base)
+            auth = base64.b64encode(f"{email}:{secret}".encode()).decode()
+            return base, base, {"Authorization": f"Basic {auth}"}
+        raise TicketingTransportError(f"Unsupported Jira auth method '{record.auth_method}'.")
+
+    def _headers_with_content(self) -> dict[str, str]:
+        return {**self._headers, "Content-Type": "application/json", "Accept": "application/json"}
+
+    # — transport interface —
+
+    async def create_ticket(self, draft: TicketDraft) -> TicketRef:
+        if not draft.project:
+            raise TicketingTransportError("A target Jira project key is required to create an issue.")
+        payload = _issue_payload(draft)
+        url = f"{self._api_base}/rest/api/3/issue"
+        data = await self._request("POST", url, json_body=payload, expected=(200, 201))
+        key = str(data.get("key") or "").strip()
+        issue_id = str(data.get("id") or "").strip()
+        if not key and not issue_id:
+            raise TicketingTransportError("Jira did not return an issue key.")
+        browse = f"{self._browse_base}/browse/{key}" if (self._browse_base and key) else ""
+        return TicketRef(
+            provider=PROVIDER_JIRA,
+            external_id=issue_id or key,
+            key=key,
+            url=browse,
+            status=TicketStatus.OPEN,
+        )
+
+    async def get_status(self, ref: TicketRef) -> TicketStatus:
+        handle = (ref.key or ref.external_id).strip()
+        if not handle:
+            raise TicketingTransportError("A Jira issue key or id is required to read status.")
+        url = f"{self._api_base}/rest/api/3/issue/{handle}?fields=status"
+        data = await self._request("GET", url, expected=(200,))
+        status_obj = (data.get("fields") or {}).get("status") or {}
+        category = status_obj.get("statusCategory") or {}
+        return map_jira_status(str(category.get("key") or ""), str(category.get("name") or ""))
+
+    # — one HTTP round-trip through the shared resilient client —
+
+    async def _request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json_body: dict[str, Any] | None = None,
+        expected: tuple[int, ...],
+    ) -> dict[str, Any]:
+        from agent_bom.http_client import request_with_retry
+
+        kwargs: dict[str, Any] = {"headers": self._headers_with_content(), "max_retries": 2}
+        if json_body is not None:
+            kwargs["json"] = json_body
+        async with self._client_factory(timeout=15.0) as client:
+            resp = await request_with_retry(client, method, url, **kwargs)
+        if resp is None:
+            raise TicketingTransportError("No response from Jira.")
+        if resp.status_code not in expected:
+            raise TicketingTransportError(f"Jira returned HTTP {resp.status_code}.")
+        try:
+            body = resp.json()
+        except Exception as exc:  # noqa: BLE001 - non-JSON body
+            raise TicketingTransportError("Jira returned a non-JSON response.") from exc
+        if not isinstance(body, dict):
+            raise TicketingTransportError("Jira returned an unexpected response shape.")
+        return body
+
+
+def _load_oauth_bundle(secret: str) -> dict[str, Any]:
+    try:
+        bundle = json.loads(secret)
+    except (ValueError, TypeError) as exc:
+        raise TicketingTransportError("Jira OAuth token bundle is malformed; reconnect Jira.") from exc
+    if not isinstance(bundle, dict):
+        raise TicketingTransportError("Jira OAuth token bundle is malformed; reconnect Jira.")
+    return bundle
+
+
+def _issue_payload(draft: TicketDraft) -> dict[str, Any]:
+    """Build the Jira v3 create-issue body (Atlassian Document Format description)."""
+    fields: dict[str, Any] = {
+        "project": {"key": draft.project},
+        "summary": draft.title[:255],
+        "description": {
+            "type": "doc",
+            "version": 1,
+            "content": [{"type": "paragraph", "content": [{"type": "text", "text": draft.description or draft.title}]}],
+        },
+        "issuetype": {"name": draft.issue_type or "Bug"},
+        "labels": [_sanitize_label(label) for label in draft.labels if label],
+    }
+    return {"fields": fields}
+
+
+def _sanitize_label(label: str) -> str:
+    # Jira labels may not contain spaces.
+    return "".join(ch if not ch.isspace() else "-" for ch in str(label))

--- a/src/agent_bom/ticketing/mcp_transport.py
+++ b/src/agent_bom/ticketing/mcp_transport.py
@@ -1,0 +1,149 @@
+"""MCP-client ticketing transport (primary).
+
+agent-bom acts as an MCP *client* of a configured ITSM MCP server (e.g. an
+Atlassian/Jira MCP server, official-remote or self-hosted) and routes
+``create_ticket`` / ``sync_status`` to that server's tools. This reuses the same
+MCP-client machinery agent-bom already uses to introspect servers
+(:mod:`agent_bom.mcp_introspect`) — a ``streamablehttp_client`` + ``ClientSession``
+handshake — with the server's own bearer auth resolved once from the stored
+connection.
+
+The tool names are non-secret connection params (``auth_params.create_tool`` /
+``auth_params.status_tool``); the server's bearer token is the sealed secret. No
+credential is ever taken from the action caller. The actual tool invocation is
+injected behind :class:`_ToolCaller` so tests drive a mock/generic ITSM MCP
+server without a live network.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from agent_bom.ticketing.models import (
+    TicketDraft,
+    TicketingConnectionRecord,
+    TicketRef,
+    TicketStatus,
+)
+from agent_bom.ticketing.transport import TicketingTransport, TicketingTransportError, map_status_token
+
+# A caller invokes one tool on the connected ITSM MCP server and returns the
+# tool result already reduced to a JSON dict (structuredContent, or parsed text).
+_ToolCaller = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
+
+# Default MCP tool names if the connection did not specify its own.
+_DEFAULT_CREATE_TOOL = "create_issue"
+_DEFAULT_STATUS_TOOL = "get_issue"
+
+
+class McpTicketingTransport(TicketingTransport):
+    """Drive a configured ITSM MCP server's create/status tools as a client."""
+
+    def __init__(
+        self,
+        record: TicketingConnectionRecord,
+        secret: str,
+        *,
+        caller: _ToolCaller | None = None,
+    ) -> None:
+        self._record = record
+        self._secret = secret
+        self._create_tool = str(record.auth_params.get("create_tool") or _DEFAULT_CREATE_TOOL)
+        self._status_tool = str(record.auth_params.get("status_tool") or _DEFAULT_STATUS_TOOL)
+        self._caller = caller or _default_caller(record, secret)
+
+    async def create_ticket(self, draft: TicketDraft) -> TicketRef:
+        result = await self._caller(self._create_tool, draft.to_arguments())
+        external_id = _first_str(result, "external_id", "id", "key", "sys_id", "issue_id")
+        key = _first_str(result, "key", "number", "external_id", "id")
+        url = _first_str(result, "url", "link", "self")
+        if not external_id and not key:
+            raise TicketingTransportError("The ITSM MCP server did not return a ticket id.")
+        status_token = _first_str(result, "status", "state")
+        return TicketRef(
+            provider=self._record.provider,
+            external_id=external_id or key,
+            key=key,
+            url=url,
+            status=map_status_token(status_token) if status_token else TicketStatus.OPEN,
+        )
+
+    async def get_status(self, ref: TicketRef) -> TicketStatus:
+        handle = (ref.external_id or ref.key).strip()
+        if not handle:
+            raise TicketingTransportError("A ticket id is required to read status.")
+        result = await self._caller(self._status_tool, {"ticket_id": handle, "key": ref.key, "external_id": ref.external_id})
+        token = _first_str(result, "status", "state")
+        return map_status_token(token) if token else TicketStatus.UNKNOWN
+
+
+def _first_str(data: dict[str, Any], *keys: str) -> str:
+    """First non-empty string value across ``keys`` (case-insensitive keys)."""
+    lowered = {str(k).lower(): v for k, v in data.items()} if isinstance(data, dict) else {}
+    for key in keys:
+        value = lowered.get(key.lower())
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text:
+            return text
+    return ""
+
+
+def _default_caller(record: TicketingConnectionRecord, secret: str) -> _ToolCaller:
+    """Build the real MCP-client caller for the connection's server endpoint.
+
+    Uses ``streamablehttp_client`` + ``ClientSession`` (the transport agent-bom
+    already speaks). The server's bearer token (the sealed secret) is sent as an
+    ``Authorization`` header; nothing is taken from the action caller.
+    """
+
+    endpoint = (record.endpoint or "").strip()
+
+    async def _call(tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+        if not endpoint:
+            raise TicketingTransportError("The ITSM MCP connection has no server endpoint.")
+        try:
+            from mcp import ClientSession
+            from mcp.client.streamable_http import streamablehttp_client
+        except ImportError as exc:  # pragma: no cover - mcp is a core extra
+            raise TicketingTransportError("The MCP client SDK is not installed for the MCP ticketing transport.") from exc
+
+        headers = {"Authorization": f"Bearer {secret}"} if secret else None
+        try:
+            async with streamablehttp_client(endpoint, headers=headers) as (read, write, _get_session_id):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(tool_name, arguments)
+        except TicketingTransportError:
+            raise
+        except Exception as exc:  # noqa: BLE001 - any client/transport failure
+            raise TicketingTransportError(f"ITSM MCP server call '{tool_name}' failed.") from exc
+        if getattr(result, "isError", False):
+            raise TicketingTransportError(f"ITSM MCP server reported an error for '{tool_name}'.")
+        return _reduce_tool_result(result)
+
+    return _call
+
+
+def _reduce_tool_result(result: Any) -> dict[str, Any]:
+    """Reduce an MCP ``CallToolResult`` to a JSON dict.
+
+    Prefers ``structuredContent``; otherwise parses the first JSON text block.
+    """
+    structured = getattr(result, "structuredContent", None)
+    if isinstance(structured, dict):
+        return structured
+    for block in getattr(result, "content", None) or []:
+        text = getattr(block, "text", None)
+        if not text:
+            continue
+        try:
+            parsed = json.loads(text)
+        except (ValueError, TypeError):
+            continue
+        if isinstance(parsed, dict):
+            return parsed
+    return {}

--- a/src/agent_bom/ticketing/models.py
+++ b/src/agent_bom/ticketing/models.py
@@ -1,0 +1,218 @@
+"""Provider-neutral ticketing data model.
+
+These types are the contract every transport (MCP-client or direct-REST) speaks,
+so the service, MCP tools, and REST route never depend on a vendor shape. A
+:class:`TicketingConnectionRecord` is the stored, encrypted, tenant-scoped
+connection through which every action runs — its ``secret_encrypted`` column is
+the only sensitive field and is never returned by the API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from enum import Enum
+from typing import Any
+
+# ── Vocabulary ────────────────────────────────────────────────────────────────
+
+PROVIDER_JIRA = "jira"
+PROVIDER_SERVICENOW = "servicenow"
+PROVIDER_GENERIC = "generic"
+SUPPORTED_TICKETING_PROVIDERS: tuple[str, ...] = (PROVIDER_JIRA, PROVIDER_SERVICENOW, PROVIDER_GENERIC)
+
+# How a connection reaches its ITSM.
+TRANSPORT_MCP = "mcp"  # agent-bom is an MCP client of an ITSM MCP server (primary)
+TRANSPORT_REST = "rest"  # direct per-vendor REST adapter (fallback)
+SUPPORTED_TRANSPORTS: tuple[str, ...] = (TRANSPORT_MCP, TRANSPORT_REST)
+
+# How the stored secret authenticates. All are entered once at connect time and
+# sealed at rest; none is ever re-entered per action.
+AUTH_OAUTH = "oauth"  # OAuth 2.0 (3LO) bearer + refresh bundle (primary for Jira Cloud)
+AUTH_API_TOKEN = "api_token"  # secondary fallback: a scoped API token, sealed once
+AUTH_MCP = "mcp"  # the MCP server's own auth (bearer), sealed once
+SUPPORTED_AUTH_METHODS: tuple[str, ...] = (AUTH_OAUTH, AUTH_API_TOKEN, AUTH_MCP)
+
+# Connection lifecycle status.
+STATUS_PENDING = "pending"
+STATUS_ACTIVE = "active"
+STATUS_ERROR = "error"
+
+
+class TicketStatus(str, Enum):
+    """Canonical, provider-neutral ticket status.
+
+    Every transport maps its vendor status into one of these so the finding's
+    status chip and the API/MCP surface stay vendor-independent.
+    """
+
+    OPEN = "open"
+    IN_PROGRESS = "in_progress"
+    DONE = "done"
+    UNKNOWN = "unknown"
+
+
+# Severity → a generic priority label transports can remap to their own scheme.
+SEVERITY_PRIORITY: dict[str, str] = {
+    "critical": "Highest",
+    "high": "High",
+    "medium": "Medium",
+    "low": "Low",
+    "none": "Lowest",
+    "info": "Lowest",
+}
+
+
+@dataclass(frozen=True)
+class TicketDraft:
+    """Normalized ticket content derived from a finding/issue.
+
+    Transport-neutral: the MCP transport passes these fields as tool arguments and
+    the REST transport renders them into the vendor body. It never carries a
+    credential or base URL — those live only in the stored connection.
+    """
+
+    finding_id: str
+    project: str
+    title: str
+    description: str
+    severity: str = "medium"
+    issue_type: str = ""
+    labels: tuple[str, ...] = ()
+    source_url: str = ""
+
+    @property
+    def priority(self) -> str:
+        return SEVERITY_PRIORITY.get((self.severity or "").strip().lower(), "Medium")
+
+    def to_arguments(self) -> dict[str, Any]:
+        """Argument dict for an MCP ITSM tool (stable, vendor-neutral keys)."""
+        return {
+            "project": self.project,
+            "summary": self.title,
+            "description": self.description,
+            "severity": (self.severity or "").strip().lower(),
+            "priority": self.priority,
+            "issue_type": self.issue_type or "Bug",
+            "labels": list(self.labels),
+            "finding_id": self.finding_id,
+            "source_url": self.source_url,
+        }
+
+    @classmethod
+    def from_finding(
+        cls,
+        finding: dict[str, Any],
+        *,
+        project: str,
+        finding_id: str = "",
+        issue_type: str = "",
+        source_url: str = "",
+    ) -> TicketDraft:
+        """Build a normalized draft from an agent-bom finding/blast-radius dict."""
+        fid = (finding_id or _finding_id(finding)).strip()
+        severity = str(finding.get("severity") or "medium").strip().lower()
+        vuln = str(finding.get("vulnerability_id") or finding.get("cve") or finding.get("id") or "finding").strip()
+        package = str(finding.get("package") or finding.get("component") or "").strip()
+        risk = finding.get("risk_score")
+        title_pkg = f" in {package}" if package else ""
+        if isinstance(risk, (int, float)):
+            title = f"[agent-bom] {vuln}{title_pkg} (risk {float(risk):.1f}/10)"
+        else:
+            title = f"[agent-bom] {vuln}{title_pkg}"
+        description = _describe(finding, vuln=vuln, package=package, severity=severity)
+        labels = ["agent-bom", "security", f"severity-{severity}"]
+        return cls(
+            finding_id=fid,
+            project=project.strip(),
+            title=title[:255],
+            description=description,
+            severity=severity,
+            issue_type=issue_type,
+            labels=tuple(labels),
+            source_url=source_url.strip(),
+        )
+
+
+def _finding_id(finding: dict[str, Any]) -> str:
+    """Stable identifier for dedupe when the caller does not pass one.
+
+    Prefers an explicit id; otherwise a deterministic composite of the
+    vulnerability + package so re-filing the same finding dedupes.
+    """
+    for key in ("finding_id", "id", "vulnerability_id", "cve"):
+        value = str(finding.get(key) or "").strip()
+        if value:
+            package = str(finding.get("package") or finding.get("component") or "").strip()
+            return f"{value}:{package}" if package else value
+    return ""
+
+
+def _describe(finding: dict[str, Any], *, vuln: str, package: str, severity: str) -> str:
+    parts = [
+        f"Vulnerability: {vuln}",
+        f"Package: {package}" if package else "",
+        f"Severity: {severity}",
+    ]
+    risk = finding.get("risk_score")
+    if isinstance(risk, (int, float)):
+        parts.append(f"Risk score: {float(risk):.1f}/10")
+    fix = str(finding.get("fixed_version") or "").strip()
+    if fix:
+        parts.append(f"Fix: upgrade to {fix}")
+    for label, key in (("Affected agents", "affected_agents"), ("Affected servers", "affected_servers")):
+        values = finding.get(key)
+        if isinstance(values, (list, tuple)) and values:
+            parts.append(f"{label}: {', '.join(str(v) for v in values)}")
+    return "\n".join(p for p in parts if p)
+
+
+@dataclass(frozen=True)
+class TicketRef:
+    """A created ticket's provider-side reference + human handle + deep link."""
+
+    provider: str
+    external_id: str  # Jira issue id / ServiceNow sys_id / MCP-returned id
+    key: str = ""  # human handle: Jira key (SEC-123) / ServiceNow number (INC0012)
+    url: str = ""  # deep link to the ticket
+    status: TicketStatus = TicketStatus.OPEN
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "provider": self.provider,
+            "external_id": self.external_id,
+            "key": self.key,
+            "url": self.url,
+            "status": self.status.value,
+        }
+
+
+@dataclass
+class TicketingConnectionRecord:
+    """One stored, encrypted, tenant-scoped ITSM connection (connect-once).
+
+    ``secret_encrypted`` is the Fernet ciphertext of the auth bundle — an OAuth
+    token bundle (access/refresh), an API token, or an MCP-server bearer — and is
+    the only sensitive column. :meth:`to_public_dict` never emits it.
+    ``auth_params`` holds non-secret connection params (Jira cloud id / default
+    project / email; the MCP tool names) and is safe to return.
+    """
+
+    id: str
+    tenant_id: str
+    provider: str  # jira | servicenow | generic
+    transport: str  # mcp | rest
+    auth_method: str  # oauth | api_token | mcp
+    display_name: str
+    endpoint: str  # REST base URL, or the ITSM MCP server URL
+    secret_encrypted: str
+    auth_params: dict[str, str] = field(default_factory=dict)
+    status: str = STATUS_PENDING
+    status_detail: str = ""
+    created_at: str = ""
+    updated_at: str = ""
+
+    def to_public_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data.pop("secret_encrypted", None)
+        data["has_secret"] = bool(self.secret_encrypted)
+        return data

--- a/src/agent_bom/ticketing/oauth.py
+++ b/src/agent_bom/ticketing/oauth.py
@@ -1,0 +1,202 @@
+"""Atlassian OAuth 2.0 (3LO) helpers for the Jira ticketing connection.
+
+Connect-once, OAuth-first: an admin clicks "Connect Jira", authorizes once in
+Atlassian, and agent-bom seals the returned token bundle. No API token is ever
+typed for the OAuth path, and nothing is re-entered per action.
+
+Verified against the official Atlassian 3LO docs:
+https://developer.atlassian.com/cloud/jira/platform/oauth-2-3lo-apps/
+
+* Authorize   ``GET https://auth.atlassian.com/authorize`` (audience=api.atlassian.com)
+* Token       ``POST https://auth.atlassian.com/oauth/token`` (authorization_code / refresh_token)
+* Cloud id    ``GET https://api.atlassian.com/oauth/token/accessible-resources`` (Bearer)
+
+The app's ``client_id`` / ``client_secret`` are operator-configured secrets (env
+or file), never entered by an end user. All HTTP is injectable for tests.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from typing import Any
+from urllib.parse import urlencode
+
+AUTHORIZE_URL = "https://auth.atlassian.com/authorize"
+TOKEN_URL = "https://auth.atlassian.com/oauth/token"
+ACCESSIBLE_RESOURCES_URL = "https://api.atlassian.com/oauth/token/accessible-resources"
+
+# Least-privilege scopes: create issues + read status, plus offline_access so we
+# receive a refresh token (no re-consent for background status sync).
+DEFAULT_SCOPES = ("read:jira-work", "write:jira-work", "read:me", "offline_access")
+
+CLIENT_ID_ENV = "AGENT_BOM_JIRA_OAUTH_CLIENT_ID"
+CLIENT_SECRET_ENV = "AGENT_BOM_JIRA_OAUTH_CLIENT_SECRET"
+
+
+class TicketingOAuthError(RuntimeError):
+    """Raised when the OAuth exchange cannot complete. Never carries a token."""
+
+
+def _resolve_client_id() -> str:
+    from agent_bom.api.secret_source import resolve_secret
+
+    return (resolve_secret(CLIENT_ID_ENV) or os.environ.get(CLIENT_ID_ENV, "")).strip()
+
+
+def _resolve_client_secret() -> str:
+    from agent_bom.api.secret_source import resolve_secret
+
+    return (resolve_secret(CLIENT_SECRET_ENV) or "").strip()
+
+
+def oauth_configured() -> bool:
+    """Whether the Atlassian OAuth app credentials are configured."""
+    from agent_bom.api.secret_source import secret_is_configured
+
+    return bool(_resolve_client_id()) and secret_is_configured(CLIENT_SECRET_ENV)
+
+
+def build_authorize_url(*, redirect_uri: str, state: str, scopes: tuple[str, ...] = DEFAULT_SCOPES) -> str:
+    """Build the Atlassian authorize URL the admin's browser is sent to."""
+    client_id = _resolve_client_id()
+    if not client_id:
+        raise TicketingOAuthError(f"Jira OAuth is not configured ({CLIENT_ID_ENV} unset).")
+    if not redirect_uri:
+        raise TicketingOAuthError("A redirect URI is required to start the Jira OAuth flow.")
+    if not state:
+        raise TicketingOAuthError("An anti-CSRF state value is required to start the Jira OAuth flow.")
+    query = urlencode(
+        {
+            "audience": "api.atlassian.com",
+            "client_id": client_id,
+            "scope": " ".join(scopes),
+            "redirect_uri": redirect_uri,
+            "state": state,
+            "response_type": "code",
+            "prompt": "consent",
+        }
+    )
+    return f"{AUTHORIZE_URL}?{query}"
+
+
+def _default_client_factory(timeout: float = 15.0) -> Any:
+    from agent_bom.http_client import create_client
+
+    return create_client(timeout=timeout)
+
+
+async def exchange_code(
+    *,
+    code: str,
+    redirect_uri: str,
+    client_factory: Callable[..., Any] = _default_client_factory,
+) -> dict[str, Any]:
+    """Exchange an authorization code for a token bundle (access/refresh)."""
+    client_id = _resolve_client_id()
+    client_secret = _resolve_client_secret()
+    if not client_id or not client_secret:
+        raise TicketingOAuthError("Jira OAuth app credentials are not configured.")
+    body = {
+        "grant_type": "authorization_code",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "code": code,
+        "redirect_uri": redirect_uri,
+    }
+    bundle = await _post_token(body, client_factory)
+    if not bundle.get("access_token"):
+        raise TicketingOAuthError("Atlassian token exchange did not return an access token.")
+    return bundle
+
+
+async def refresh_tokens(
+    *,
+    refresh_token: str,
+    client_factory: Callable[..., Any] = _default_client_factory,
+) -> dict[str, Any]:
+    """Refresh an access token using a stored refresh token."""
+    client_id = _resolve_client_id()
+    client_secret = _resolve_client_secret()
+    if not client_id or not client_secret:
+        raise TicketingOAuthError("Jira OAuth app credentials are not configured.")
+    body = {
+        "grant_type": "refresh_token",
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "refresh_token": refresh_token,
+    }
+    return await _post_token(body, client_factory)
+
+
+async def resolve_accessible_resource(
+    *,
+    access_token: str,
+    site_url: str = "",
+    client_factory: Callable[..., Any] = _default_client_factory,
+) -> dict[str, str]:
+    """Resolve the granted site's cloud id + URL from accessible-resources.
+
+    When ``site_url`` is given, the matching resource is chosen; otherwise the
+    first granted resource is used.
+    """
+    from agent_bom.http_client import request_with_retry
+
+    async with client_factory(timeout=15.0) as client:
+        resp = await request_with_retry(
+            client,
+            "GET",
+            ACCESSIBLE_RESOURCES_URL,
+            headers={"Authorization": f"Bearer {access_token}", "Accept": "application/json"},
+            max_retries=2,
+        )
+    if resp is None or resp.status_code != 200:
+        raise TicketingOAuthError("Could not resolve the Jira site from Atlassian accessible-resources.")
+    try:
+        resources = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        raise TicketingOAuthError("Atlassian accessible-resources returned a non-JSON response.") from exc
+    if not isinstance(resources, list) or not resources:
+        raise TicketingOAuthError("The Jira OAuth grant has no accessible Jira sites.")
+    chosen = None
+    wanted = (site_url or "").rstrip("/").lower()
+    for resource in resources:
+        if not isinstance(resource, dict):
+            continue
+        if wanted and str(resource.get("url") or "").rstrip("/").lower() == wanted:
+            chosen = resource
+            break
+    if chosen is None:
+        chosen = next((r for r in resources if isinstance(r, dict)), None)
+    if not chosen or not chosen.get("id"):
+        raise TicketingOAuthError("Atlassian accessible-resources did not include a cloud id.")
+    return {
+        "cloud_id": str(chosen["id"]),
+        "site_url": str(chosen.get("url") or "").rstrip("/"),
+        "site_name": str(chosen.get("name") or ""),
+    }
+
+
+async def _post_token(body: dict[str, str], client_factory: Callable[..., Any]) -> dict[str, Any]:
+    from agent_bom.http_client import request_with_retry
+
+    async with client_factory(timeout=15.0) as client:
+        resp = await request_with_retry(
+            client,
+            "POST",
+            TOKEN_URL,
+            json=body,
+            headers={"Content-Type": "application/json", "Accept": "application/json"},
+            max_retries=2,
+        )
+    if resp is None:
+        raise TicketingOAuthError("No response from the Atlassian token endpoint.")
+    if resp.status_code != 200:
+        raise TicketingOAuthError(f"Atlassian token endpoint returned HTTP {resp.status_code}.")
+    try:
+        bundle = resp.json()
+    except Exception as exc:  # noqa: BLE001
+        raise TicketingOAuthError("Atlassian token endpoint returned a non-JSON response.") from exc
+    if not isinstance(bundle, dict):
+        raise TicketingOAuthError("Atlassian token endpoint returned an unexpected shape.")
+    return bundle

--- a/src/agent_bom/ticketing/postgres_store.py
+++ b/src/agent_bom/ticketing/postgres_store.py
@@ -1,0 +1,219 @@
+"""Postgres-backed ticketing store for multi-replica deployments.
+
+Mirrors :class:`agent_bom.ticketing.connection_store.SQLiteTicketingStore` but on
+shared Postgres with tenant RLS, so the connect-once connection and the ticket
+dedupe ledger stay consistent across control-plane replicas. The
+``secret_encrypted`` column is opaque ciphertext here exactly as in SQLite —
+Postgres never sees the plaintext secret. The ``ticket_links`` unique key does the
+cross-process idempotency claim via ``INSERT ... ON CONFLICT DO NOTHING``.
+"""
+
+from __future__ import annotations
+
+import json
+
+from agent_bom.api.postgres_common import (
+    ConnectionPool,
+    _ensure_tenant_rls,
+    _get_pool,
+    _tenant_connection,
+)
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+from agent_bom.ticketing.connection_store import (
+    _CONN_COLS,
+    _LINK_COLS,
+    TicketLink,
+    _row_to_conn,
+    _row_to_link,
+)
+from agent_bom.ticketing.models import TicketingConnectionRecord
+
+
+class PostgresTicketingStore:
+    """Shared ticketing store backed by Postgres with tenant RLS."""
+
+    def __init__(self, pool: ConnectionPool | None = None) -> None:
+        self._pool = pool or _get_pool()
+        self._init_tables()
+
+    def init_schema(self) -> None:
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "ticketing_connections")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ticketing_connections (
+                    id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    transport TEXT NOT NULL,
+                    auth_method TEXT NOT NULL,
+                    display_name TEXT NOT NULL,
+                    endpoint TEXT NOT NULL DEFAULT '',
+                    secret_encrypted TEXT NOT NULL DEFAULT '',
+                    auth_params TEXT NOT NULL DEFAULT '{}',
+                    status TEXT NOT NULL DEFAULT 'pending',
+                    status_detail TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_ticketing_connections_tenant ON ticketing_connections(tenant_id, created_at)")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS ticket_links (
+                    id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    connection_id TEXT NOT NULL,
+                    dedupe_key TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    status TEXT NOT NULL DEFAULT 'open',
+                    external_id TEXT NOT NULL DEFAULT '',
+                    key TEXT NOT NULL DEFAULT '',
+                    url TEXT NOT NULL DEFAULT '',
+                    created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    UNIQUE (tenant_id, connection_id, dedupe_key)
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_ticket_links_tenant ON ticket_links(tenant_id, created_at)")
+            _ensure_tenant_rls(conn, "ticketing_connections", "tenant_id")
+            _ensure_tenant_rls(conn, "ticket_links", "tenant_id")
+            conn.commit()
+
+    def put_connection(self, record: TicketingConnectionRecord) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                f"""
+                INSERT INTO ticketing_connections ({_CONN_COLS})
+                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (id) DO UPDATE SET
+                    provider = EXCLUDED.provider,
+                    transport = EXCLUDED.transport,
+                    auth_method = EXCLUDED.auth_method,
+                    display_name = EXCLUDED.display_name,
+                    endpoint = EXCLUDED.endpoint,
+                    secret_encrypted = EXCLUDED.secret_encrypted,
+                    auth_params = EXCLUDED.auth_params,
+                    status = EXCLUDED.status,
+                    status_detail = EXCLUDED.status_detail,
+                    updated_at = EXCLUDED.updated_at
+                """,
+                (
+                    record.id,
+                    record.tenant_id,
+                    record.provider,
+                    record.transport,
+                    record.auth_method,
+                    record.display_name,
+                    record.endpoint,
+                    record.secret_encrypted,
+                    json.dumps(record.auth_params),
+                    record.status,
+                    record.status_detail,
+                    record.created_at,
+                    record.updated_at,
+                ),
+            )
+            conn.commit()
+
+    def get_connection(self, tenant_id: str, connection_id: str) -> TicketingConnectionRecord | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = %s AND id = %s",
+                (tenant_id, connection_id),
+            ).fetchone()
+        return _row_to_conn(row) if row else None
+
+    def list_connections(self, tenant_id: str) -> list[TicketingConnectionRecord]:
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = %s ORDER BY created_at, id",
+                (tenant_id,),
+            ).fetchall()
+        return [_row_to_conn(r) for r in rows]
+
+    def delete_connection(self, tenant_id: str, connection_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                "DELETE FROM ticketing_connections WHERE tenant_id = %s AND id = %s",
+                (tenant_id, connection_id),
+            )
+            conn.commit()
+            return bool(cursor.rowcount > 0)
+
+    def claim_ticket_link(self, link: TicketLink) -> tuple[bool, TicketLink]:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                f"""
+                INSERT INTO ticket_links ({_LINK_COLS})
+                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
+                ON CONFLICT (tenant_id, connection_id, dedupe_key) DO NOTHING
+                """,
+                (
+                    link.id,
+                    link.tenant_id,
+                    link.connection_id,
+                    link.dedupe_key,
+                    link.provider,
+                    link.status,
+                    link.external_id,
+                    link.key,
+                    link.url,
+                    link.created_at,
+                    link.updated_at,
+                ),
+            )
+            conn.commit()
+            won = bool(cursor.rowcount == 1)
+        if won:
+            return True, link
+        existing = self.get_ticket_link_by_dedupe(link.tenant_id, link.connection_id, link.dedupe_key)
+        if existing is None:  # pragma: no cover - lost row after conflict
+            return True, link
+        return False, existing
+
+    def update_ticket_link(self, link: TicketLink) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                "UPDATE ticket_links SET status=%s, external_id=%s, key=%s, url=%s, updated_at=%s WHERE tenant_id=%s AND id=%s",
+                (link.status, link.external_id, link.key, link.url, link.updated_at, link.tenant_id, link.id),
+            )
+            conn.commit()
+
+    def get_ticket_link(self, tenant_id: str, ticket_id: str) -> TicketLink | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s AND id = %s",
+                (tenant_id, ticket_id),
+            ).fetchone()
+        return _row_to_link(row) if row else None
+
+    def get_ticket_link_by_dedupe(self, tenant_id: str, connection_id: str, dedupe_key: str) -> TicketLink | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s AND connection_id = %s AND dedupe_key = %s",
+                (tenant_id, connection_id, dedupe_key),
+            ).fetchone()
+        return _row_to_link(row) if row else None
+
+    def list_ticket_links(self, tenant_id: str) -> list[TicketLink]:
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s ORDER BY created_at, id",
+                (tenant_id,),
+            ).fetchall()
+        return [_row_to_link(r) for r in rows]
+
+    def delete_ticket_link(self, tenant_id: str, ticket_id: str) -> bool:
+        with _tenant_connection(self._pool) as conn:
+            cursor = conn.execute(
+                "DELETE FROM ticket_links WHERE tenant_id = %s AND id = %s",
+                (tenant_id, ticket_id),
+            )
+            conn.commit()
+            return bool(cursor.rowcount > 0)

--- a/src/agent_bom/ticketing/postgres_store.py
+++ b/src/agent_bom/ticketing/postgres_store.py
@@ -88,21 +88,14 @@ class PostgresTicketingStore:
     def put_connection(self, record: TicketingConnectionRecord) -> None:
         with _tenant_connection(self._pool) as conn:
             conn.execute(
-                f"""
-                INSERT INTO ticketing_connections ({_CONN_COLS})
-                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-                ON CONFLICT (id) DO UPDATE SET
-                    provider = EXCLUDED.provider,
-                    transport = EXCLUDED.transport,
-                    auth_method = EXCLUDED.auth_method,
-                    display_name = EXCLUDED.display_name,
-                    endpoint = EXCLUDED.endpoint,
-                    secret_encrypted = EXCLUDED.secret_encrypted,
-                    auth_params = EXCLUDED.auth_params,
-                    status = EXCLUDED.status,
-                    status_detail = EXCLUDED.status_detail,
-                    updated_at = EXCLUDED.updated_at
-                """,
+                (
+                    f"INSERT INTO ticketing_connections ({_CONN_COLS}) "  # nosec B608 -- fixed internal columns
+                    "VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) "
+                    "ON CONFLICT (id) DO UPDATE SET provider = EXCLUDED.provider, transport = EXCLUDED.transport, "
+                    "auth_method = EXCLUDED.auth_method, display_name = EXCLUDED.display_name, endpoint = EXCLUDED.endpoint, "
+                    "secret_encrypted = EXCLUDED.secret_encrypted, auth_params = EXCLUDED.auth_params, status = EXCLUDED.status, "
+                    "status_detail = EXCLUDED.status_detail, updated_at = EXCLUDED.updated_at"
+                ),
                 (
                     record.id,
                     record.tenant_id,
@@ -124,7 +117,7 @@ class PostgresTicketingStore:
     def get_connection(self, tenant_id: str, connection_id: str) -> TicketingConnectionRecord | None:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
-                f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = %s AND id = %s",
+                f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = %s AND id = %s",  # nosec B608 -- fixed internal columns
                 (tenant_id, connection_id),
             ).fetchone()
         return _row_to_conn(row) if row else None
@@ -132,7 +125,7 @@ class PostgresTicketingStore:
     def list_connections(self, tenant_id: str) -> list[TicketingConnectionRecord]:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
-                f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = %s ORDER BY created_at, id",
+                f"SELECT {_CONN_COLS} FROM ticketing_connections WHERE tenant_id = %s ORDER BY created_at, id",  # nosec B608 -- fixed internal columns
                 (tenant_id,),
             ).fetchall()
         return [_row_to_conn(r) for r in rows]
@@ -149,11 +142,10 @@ class PostgresTicketingStore:
     def claim_ticket_link(self, link: TicketLink) -> tuple[bool, TicketLink]:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(
-                f"""
-                INSERT INTO ticket_links ({_LINK_COLS})
-                VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s)
-                ON CONFLICT (tenant_id, connection_id, dedupe_key) DO NOTHING
-                """,
+                (
+                    f"INSERT INTO ticket_links ({_LINK_COLS}) VALUES (%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s) "  # nosec B608 -- fixed internal columns
+                    "ON CONFLICT (tenant_id, connection_id, dedupe_key) DO NOTHING"
+                ),
                 (
                     link.id,
                     link.tenant_id,
@@ -188,7 +180,7 @@ class PostgresTicketingStore:
     def get_ticket_link(self, tenant_id: str, ticket_id: str) -> TicketLink | None:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
-                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s AND id = %s",
+                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s AND id = %s",  # nosec B608 -- fixed internal columns
                 (tenant_id, ticket_id),
             ).fetchone()
         return _row_to_link(row) if row else None
@@ -196,7 +188,7 @@ class PostgresTicketingStore:
     def get_ticket_link_by_dedupe(self, tenant_id: str, connection_id: str, dedupe_key: str) -> TicketLink | None:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
-                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s AND connection_id = %s AND dedupe_key = %s",
+                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s AND connection_id = %s AND dedupe_key = %s",  # nosec B608 -- fixed internal columns
                 (tenant_id, connection_id, dedupe_key),
             ).fetchone()
         return _row_to_link(row) if row else None
@@ -204,7 +196,7 @@ class PostgresTicketingStore:
     def list_ticket_links(self, tenant_id: str) -> list[TicketLink]:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
-                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s ORDER BY created_at, id",
+                f"SELECT {_LINK_COLS} FROM ticket_links WHERE tenant_id = %s ORDER BY created_at, id",  # nosec B608 -- fixed internal columns
                 (tenant_id,),
             ).fetchall()
         return [_row_to_link(r) for r in rows]

--- a/src/agent_bom/ticketing/service.py
+++ b/src/agent_bom/ticketing/service.py
@@ -21,7 +21,7 @@ from collections.abc import Awaitable, Callable
 from datetime import datetime, timezone
 from typing import Any
 
-from agent_bom.security import sanitize_error
+from agent_bom.security import sanitize_error, sanitize_text
 from agent_bom.ticketing.connection_store import TicketingStore, TicketLink, get_ticketing_store
 from agent_bom.ticketing.factory import build_transport
 from agent_bom.ticketing.models import (
@@ -207,7 +207,7 @@ async def sync_ticket_status(
         status = await transport.get_status(ref)
     except Exception as exc:  # noqa: BLE001
         _audit("ticketing.sync", actor=actor, tenant_id=tenant_id, connection=record, outcome="failure")
-        logger.warning("Ticketing status sync failed for ticket %s", ticket_id)
+        logger.warning("Ticketing status sync failed for ticket %s", sanitize_text(ticket_id, max_len=200))
         raise TicketingError(_safe_detail(exc), code="transport_error") from exc
     finally:
         secret = ""

--- a/src/agent_bom/ticketing/service.py
+++ b/src/agent_bom/ticketing/service.py
@@ -1,0 +1,274 @@
+"""Connect-once ticketing service — file a ticket / sync status through a stored
+connection, never a per-action credential.
+
+The public entry points take a finding/issue reference + a target project only.
+Auth and the base URL are resolved **exclusively** from the stored, encrypted,
+tenant-scoped connection (sealed with the shared ``connection_crypto`` key). A
+call with no stored connection fails with a "connect …first" error — never a
+credential prompt.
+
+Idempotency is a claim-first dedupe on ``(tenant_id, connection_id, dedupe_key)``:
+the first caller claims the ledger row and files the ticket; a concurrent or
+repeat caller for the same finding gets the same ticket back and no second ticket
+is ever created (cross-process safe via the store's unique constraint).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import Awaitable, Callable
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.security import sanitize_error
+from agent_bom.ticketing.connection_store import TicketingStore, TicketLink, get_ticketing_store
+from agent_bom.ticketing.factory import build_transport
+from agent_bom.ticketing.models import (
+    PROVIDER_JIRA,
+    TicketDraft,
+    TicketingConnectionRecord,
+    TicketRef,
+    TicketStatus,
+)
+from agent_bom.ticketing.transport import TicketingTransportError
+
+logger = logging.getLogger(__name__)
+
+_McpCaller = Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]]
+
+
+class TicketingError(RuntimeError):
+    """A ticketing action failed. ``code`` classifies it for the API layer."""
+
+    def __init__(self, message: str, *, code: str = "error") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _resolve_connection(store: TicketingStore, tenant_id: str, connection_id: str) -> TicketingConnectionRecord:
+    """Resolve the connection to act through, else guide the user to connect.
+
+    Never prompts for a credential: if no connection exists for the tenant (or the
+    named one is missing), it raises a "connect first" error.
+    """
+    if connection_id:
+        record = store.get_connection(tenant_id, connection_id)
+        if record is None:
+            raise TicketingError(
+                "No ticketing connection is configured. Connect Jira (or another ITSM) once in the "
+                "Connections hub, then file tickets through it — no credential is entered per action.",
+                code="no_connection",
+            )
+        return record
+    # No explicit id: use the tenant's single connection if unambiguous.
+    connections = store.list_connections(tenant_id)
+    if not connections:
+        raise TicketingError(
+            "No ticketing connection is configured. Connect Jira (or another ITSM) once in the Connections hub first.",
+            code="no_connection",
+        )
+    if len(connections) > 1:
+        raise TicketingError(
+            "Multiple ticketing connections are configured; specify which connection to use.",
+            code="ambiguous_connection",
+        )
+    return connections[0]
+
+
+def _resolve_project(record: TicketingConnectionRecord, project: str) -> str:
+    resolved = (project or "").strip() or str(record.auth_params.get("default_project") or "").strip()
+    if not resolved and record.provider == PROVIDER_JIRA:
+        raise TicketingError(
+            "A target Jira project is required. Pass it, or set a default project on the connection.",
+            code="missing_project",
+        )
+    return resolved
+
+
+def _decrypt(record: TicketingConnectionRecord) -> str:
+    from agent_bom.api.connection_crypto import ConnectionSecretError, decrypt_secret
+
+    if not record.secret_encrypted:
+        return ""
+    try:
+        return decrypt_secret(record.secret_encrypted)
+    except ConnectionSecretError as exc:
+        raise TicketingError(
+            "The ticketing connection secret could not be accessed. Reconnect the ITSM connection.",
+            code="secret_unavailable",
+        ) from exc
+
+
+async def create_ticket_for_finding(
+    *,
+    tenant_id: str,
+    connection_id: str = "",
+    finding: dict[str, Any],
+    project: str = "",
+    finding_id: str = "",
+    issue_type: str = "",
+    source_url: str = "",
+    actor: str = "system",
+    store: TicketingStore | None = None,
+    mcp_caller: _McpCaller | None = None,
+    rest_client_factory: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """File a ticket for ``finding`` through the stored connection (idempotent)."""
+    store = store or get_ticketing_store()
+    record = _resolve_connection(store, tenant_id, connection_id)
+    target_project = _resolve_project(record, project)
+    draft = TicketDraft.from_finding(finding, project=target_project, finding_id=finding_id, issue_type=issue_type, source_url=source_url)
+    if not draft.finding_id:
+        raise TicketingError(
+            "A finding id is required so a repeat request does not create a duplicate ticket.",
+            code="missing_finding_id",
+        )
+
+    now = _now()
+    claim = TicketLink(
+        id=str(uuid.uuid4()),
+        tenant_id=tenant_id,
+        connection_id=record.id,
+        dedupe_key=draft.finding_id,
+        provider=record.provider,
+        status="pending",
+        created_at=now,
+        updated_at=now,
+    )
+    won, link = store.claim_ticket_link(claim)
+    if not won:
+        # Idempotent: a ticket already exists for this finding on this connection.
+        return _result(link, record, deduplicated=True)
+
+    secret = _decrypt(record)
+    try:
+        transport = build_transport(record, secret, mcp_caller=mcp_caller, rest_client_factory=rest_client_factory)
+        ref = await transport.create_ticket(draft)
+    except Exception as exc:  # noqa: BLE001 - roll back the claim so a retry can re-file
+        store.delete_ticket_link(tenant_id, claim.id)
+        _audit("ticketing.create", actor=actor, tenant_id=tenant_id, connection=record, outcome="failure")
+        logger.warning("Ticketing create failed for connection %s", record.id)
+        raise TicketingError(_safe_detail(exc), code="transport_error") from exc
+    finally:
+        secret = ""  # drop the plaintext reference
+
+    link.external_id = ref.external_id
+    link.key = ref.key
+    link.url = ref.url
+    link.status = ref.status.value
+    link.updated_at = _now()
+    store.update_ticket_link(link)
+    _audit(
+        "ticketing.create",
+        actor=actor,
+        tenant_id=tenant_id,
+        connection=record,
+        outcome="success",
+        ticket_key=ref.key or ref.external_id,
+    )
+    return _result(link, record, deduplicated=False)
+
+
+async def sync_ticket_status(
+    *,
+    tenant_id: str,
+    ticket_id: str,
+    actor: str = "system",
+    store: TicketingStore | None = None,
+    mcp_caller: _McpCaller | None = None,
+    rest_client_factory: Callable[..., Any] | None = None,
+) -> dict[str, Any]:
+    """Read the current status of a filed ticket and persist it on the link."""
+    store = store or get_ticketing_store()
+    link = store.get_ticket_link(tenant_id, ticket_id)
+    if link is None:
+        raise TicketingError(f"Ticket '{ticket_id}' not found for this tenant.", code="not_found")
+    record = store.get_connection(tenant_id, link.connection_id)
+    if record is None:
+        raise TicketingError(
+            "The ticketing connection for this ticket was revoked; reconnect the ITSM connection.",
+            code="no_connection",
+        )
+    secret = _decrypt(record)
+    try:
+        transport = build_transport(record, secret, mcp_caller=mcp_caller, rest_client_factory=rest_client_factory)
+        ref = TicketRef(
+            provider=record.provider,
+            external_id=link.external_id,
+            key=link.key,
+            url=link.url,
+            status=_coerce_status(link.status),
+        )
+        status = await transport.get_status(ref)
+    except Exception as exc:  # noqa: BLE001
+        _audit("ticketing.sync", actor=actor, tenant_id=tenant_id, connection=record, outcome="failure")
+        logger.warning("Ticketing status sync failed for ticket %s", ticket_id)
+        raise TicketingError(_safe_detail(exc), code="transport_error") from exc
+    finally:
+        secret = ""
+
+    link.status = status.value
+    link.updated_at = _now()
+    store.update_ticket_link(link)
+    _audit("ticketing.sync", actor=actor, tenant_id=tenant_id, connection=record, outcome="success", ticket_key=link.key)
+    return _result(link, record, deduplicated=False)
+
+
+def _coerce_status(value: str) -> TicketStatus:
+    try:
+        return TicketStatus(value)
+    except ValueError:
+        return TicketStatus.UNKNOWN
+
+
+def _result(link: TicketLink, record: TicketingConnectionRecord, *, deduplicated: bool) -> dict[str, Any]:
+    return {
+        "schema_version": "ticketing.ticket.v1",
+        "ticket": link.to_public_dict(),
+        "connection_id": record.id,
+        "provider": record.provider,
+        "transport": record.transport,
+        "deduplicated": deduplicated,
+        "audit_metadata": {
+            "connect_once": True,
+            "per_action_credential": False,
+            "note": "Filed through a stored, scoped, encrypted connection; no credential was entered for this action.",
+        },
+    }
+
+
+def _safe_detail(exc: Exception) -> str:
+    if isinstance(exc, TicketingTransportError):
+        return sanitize_error(exc, generic=False)
+    return sanitize_error(exc, generic=True)
+
+
+def _audit(
+    action: str,
+    *,
+    actor: str,
+    tenant_id: str,
+    connection: TicketingConnectionRecord,
+    outcome: str,
+    ticket_key: str = "",
+) -> None:
+    try:
+        from agent_bom.api.audit_log import log_action
+
+        log_action(
+            action,
+            actor=actor or "system",
+            resource=f"ticketing-connection/{connection.id}",
+            tenant_id=tenant_id,
+            provider=connection.provider,
+            transport=connection.transport,
+            outcome=outcome,
+            ticket_key=ticket_key,
+        )
+    except Exception:  # noqa: BLE001 - audit must never break the action
+        logger.debug("ticketing audit log failed for %s", action, exc_info=True)

--- a/src/agent_bom/ticketing/transport.py
+++ b/src/agent_bom/ticketing/transport.py
@@ -1,0 +1,101 @@
+"""Pluggable ticketing transport interface + status mapping.
+
+A transport is the only thing that knows *how* to reach an ITSM. Everything
+above it (service, MCP tools, REST route) speaks the neutral model in
+:mod:`agent_bom.ticketing.models`. Two transports implement this interface:
+
+* :class:`~agent_bom.ticketing.mcp_transport.McpTicketingTransport` (primary)
+* :class:`~agent_bom.ticketing.jira_rest.JiraRestTransport` (fallback)
+
+A transport is always constructed from a stored connection + its *already
+decrypted* secret bundle — it never accepts a credential from the action caller.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from agent_bom.ticketing.models import TicketDraft, TicketRef, TicketStatus
+
+
+class TicketingTransportError(RuntimeError):
+    """Raised when an ITSM transport call fails.
+
+    The message is sanitized/curated by the caller before it reaches an API
+    client; it never carries the connection secret or a raw provider token.
+    """
+
+
+class TicketingTransport(ABC):
+    """Create a ticket and read its status through a stored connection."""
+
+    @abstractmethod
+    async def create_ticket(self, draft: TicketDraft) -> TicketRef:
+        """File a ticket for ``draft`` and return its provider reference."""
+
+    @abstractmethod
+    async def get_status(self, ref: TicketRef) -> TicketStatus:
+        """Return the canonical status of a previously created ticket."""
+
+
+# ── Vendor → canonical status mapping ─────────────────────────────────────────
+# Jira Cloud groups every status into a statusCategory whose ``key`` is one of
+# ``new`` / ``indeterminate`` / ``done`` (``undefined`` for un-categorized). We
+# map on the key primarily and fall back to the human category name, since the
+# per-status names are customer-configurable but the category is not.
+_JIRA_CATEGORY_KEY = {
+    "new": TicketStatus.OPEN,
+    "undefined": TicketStatus.OPEN,
+    "indeterminate": TicketStatus.IN_PROGRESS,
+    "done": TicketStatus.DONE,
+    # Some payloads surface color-derived keys; map them defensively too.
+    "in-flight": TicketStatus.IN_PROGRESS,
+    "completed": TicketStatus.DONE,
+}
+_JIRA_CATEGORY_NAME = {
+    "to do": TicketStatus.OPEN,
+    "new": TicketStatus.OPEN,
+    "in progress": TicketStatus.IN_PROGRESS,
+    "done": TicketStatus.DONE,
+}
+
+
+def map_jira_status(category_key: str, category_name: str = "") -> TicketStatus:
+    """Map a Jira ``statusCategory`` (key, then name) to the canonical status."""
+    mapped = _JIRA_CATEGORY_KEY.get((category_key or "").strip().lower())
+    if mapped is not None:
+        return mapped
+    mapped = _JIRA_CATEGORY_NAME.get((category_name or "").strip().lower())
+    return mapped if mapped is not None else TicketStatus.UNKNOWN
+
+
+def map_servicenow_status(display_label: str) -> TicketStatus:
+    """Map a ServiceNow incident ``state`` display label to canonical status.
+
+    Numeric ``state`` values are instance-customizable, so we map on the display
+    label (fetched with ``sysparm_display_value=true``) which is stable and
+    human-meaningful across instances.
+    """
+    label = (display_label or "").strip().lower()
+    if not label:
+        return TicketStatus.UNKNOWN
+    if any(term in label for term in ("resolved", "closed", "complete", "cancel", "done")):
+        return TicketStatus.DONE
+    if any(term in label for term in ("progress", "work", "hold", "pending", "assigned")):
+        return TicketStatus.IN_PROGRESS
+    if any(term in label for term in ("new", "open")):
+        return TicketStatus.OPEN
+    return TicketStatus.UNKNOWN
+
+
+def map_status_token(token: str) -> TicketStatus:
+    """Map a free-form status token (from a generic MCP ITSM tool) to canonical.
+
+    Tries the canonical enum first, then the same heuristics as the vendor maps.
+    """
+    raw = (token or "").strip().lower().replace(" ", "_")
+    for status in TicketStatus:
+        if raw == status.value:
+            return status
+    generic = map_servicenow_status(token)
+    return generic

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -121,7 +121,7 @@ class TestAgentBom:
         assert "quick-audit" in r.output
         assert "gateway-fleet-live-demo" in r.output
         assert "full tool catalog" in r.output
-        assert "Exposes 73 security tools via MCP protocol" in r.output
+        assert "Exposes 75 security tools via MCP protocol" in r.output
         assert "organized behind 8 workflow" in r.output
 
     def test_secrets_help_has_common_output_flags(self):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -265,6 +265,10 @@ def test_server_card_tools_expose_capability_classes():
         # the fresh scan to history and prunes old reports.
         "access_review",
         "diff",
+        # Connect-once ITSM ticketing writes: file a ticket / refresh its status
+        # through a stored connection (no per-action credential).
+        "create_ticket",
+        "sync_ticket_status",
     }
     # Writes that tear down or invalidate state advertise destructiveHint; issuing
     # an identity or granting access creates state and is non-destructive.
@@ -279,6 +283,8 @@ def test_server_card_tools_expose_capability_classes():
         "identity_revoke_jit",
         "ingest_external_scan",
         "diff",
+        "create_ticket",
+        "sync_ticket_status",
     }
     card = build_server_card()
     for tool in card["tools"]:
@@ -341,6 +347,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
     write_tools = [tool["name"] for tool in card["tools"] if tool.get("annotations", {}).get("readOnlyHint") is False]
     assert sorted(write_tools) == [
         "access_review",
+        "create_ticket",
         "diff",
         "identity_grant_jit",
         "identity_issue",
@@ -351,6 +358,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
         "shield_break_glass",
         "shield_start",
         "shield_unblock",
+        "sync_ticket_status",
     ]
     for resource in card["resources"]:
         assert resource["uri"] in docs
@@ -363,7 +371,12 @@ def test_server_card_tool_count_matches_decorators():
     import inspect
     import re
 
-    from agent_bom import mcp_server_operator_tools, mcp_server_runtime_catalog, mcp_server_specialized
+    from agent_bom import (
+        mcp_server_operator_tools,
+        mcp_server_runtime_catalog,
+        mcp_server_specialized,
+        mcp_server_ticketing_tools,
+    )
     from agent_bom.mcp_server import _SERVER_CARD_TOOLS, create_mcp_server
 
     source = (
@@ -371,6 +384,7 @@ def test_server_card_tool_count_matches_decorators():
         + inspect.getsource(mcp_server_operator_tools)
         + inspect.getsource(mcp_server_runtime_catalog)
         + inspect.getsource(mcp_server_specialized)
+        + inspect.getsource(mcp_server_ticketing_tools)
     )
     decorator_count = len(re.findall(r"@mcp\.tool", source))
     card_count = len(_SERVER_CARD_TOOLS)
@@ -535,7 +549,7 @@ def test_refresh_latest_container_keeps_release_code_but_applies_runtime_securit
     workflow = (ROOT / ".github" / "workflows" / "refresh-latest-container.yml").read_text()
 
     assert "main_sha=$MAIN_SHA" in workflow
-    assert "git checkout \"$TAG\"" in workflow
+    assert 'git checkout "$TAG"' in workflow
     assert "Apply current runtime security overlay" in workflow
     assert 'git checkout "${{ steps.release.outputs.main_sha }}" -- \\' in workflow
     assert "deploy/docker/pip-requirements.txt \\" in workflow

--- a/tests/test_fleet_scan.py
+++ b/tests/test_fleet_scan.py
@@ -286,7 +286,13 @@ def test_server_card_tools_count_matches_mcp_tools():
     import inspect
     import re
 
-    from agent_bom import mcp_server, mcp_server_operator_tools, mcp_server_runtime_catalog, mcp_server_specialized
+    from agent_bom import (
+        mcp_server,
+        mcp_server_operator_tools,
+        mcp_server_runtime_catalog,
+        mcp_server_specialized,
+        mcp_server_ticketing_tools,
+    )
     from agent_bom.mcp_server import _SERVER_CARD_TOOLS
 
     source = (
@@ -294,6 +300,7 @@ def test_server_card_tools_count_matches_mcp_tools():
         + inspect.getsource(mcp_server_operator_tools)
         + inspect.getsource(mcp_server_runtime_catalog)
         + inspect.getsource(mcp_server_specialized)
+        + inspect.getsource(mcp_server_ticketing_tools)
     )
     tool_count = len(re.findall(r"@mcp\.tool\(", source))
     card_count = len(_SERVER_CARD_TOOLS)

--- a/tests/test_ticketing_core.py
+++ b/tests/test_ticketing_core.py
@@ -413,6 +413,33 @@ async def test_sync_ticket_status_updates_link():
 
 
 @pytest.mark.asyncio
+async def test_sync_ticket_status_sanitizes_ticket_id_in_failure_log(caplog):
+    store = InMemoryTicketingStore()
+    _mcp_connection(store)
+    ticket_id = "ticket-1\r\nforged-log-entry"
+    store.claim_ticket_link(
+        TicketLink(
+            id=ticket_id,
+            tenant_id="t1",
+            connection_id="c1",
+            dedupe_key="finding-1",
+            provider=PROVIDER_JIRA,
+            external_id="1",
+            key="SEC-1",
+        )
+    )
+
+    async def failing_status_caller(tool, args):
+        raise RuntimeError("itsm down")
+
+    with caplog.at_level("WARNING", logger="agent_bom.ticketing.service"), pytest.raises(TicketingError):
+        await sync_ticket_status(tenant_id="t1", ticket_id=ticket_id, store=store, mcp_caller=failing_status_caller)
+
+    assert any("ticket-1 forged-log-entry" in message for message in caplog.messages)
+    assert all("\r" not in message and "\n" not in message for message in caplog.messages)
+
+
+@pytest.mark.asyncio
 async def test_sync_ticket_status_tenant_isolation():
     store = InMemoryTicketingStore()
     _mcp_connection(store)

--- a/tests/test_ticketing_core.py
+++ b/tests/test_ticketing_core.py
@@ -1,0 +1,451 @@
+"""Ticketing connector core tests (#4004).
+
+Covers the connect-once invariant (no per-action credential/link param), the
+transport abstraction (MCP-client primary + Jira REST fallback), claim-first
+idempotency, tenant isolation, and OAuth-first connect helpers. No live network:
+HTTP is mocked via httpx.MockTransport and the MCP transport via an injected
+caller (a mock/generic ITSM MCP server).
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import httpx
+import pytest
+from cryptography.fernet import Fernet
+
+from agent_bom.ticketing.connection_store import (
+    InMemoryTicketingStore,
+    SQLiteTicketingStore,
+    TicketLink,
+)
+from agent_bom.ticketing.jira_rest import JiraRestTransport
+from agent_bom.ticketing.mcp_transport import McpTicketingTransport
+from agent_bom.ticketing.models import (
+    AUTH_API_TOKEN,
+    AUTH_MCP,
+    AUTH_OAUTH,
+    PROVIDER_JIRA,
+    TRANSPORT_MCP,
+    TRANSPORT_REST,
+    TicketDraft,
+    TicketingConnectionRecord,
+    TicketStatus,
+)
+from agent_bom.ticketing.service import TicketingError, create_ticket_for_finding, sync_ticket_status
+from agent_bom.ticketing.transport import map_jira_status, map_servicenow_status
+
+
+@pytest.fixture(autouse=True)
+def _connections_key(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_CONNECTIONS_KEY", Fernet.generate_key().decode("ascii"))
+    from agent_bom.api import connection_crypto
+
+    connection_crypto.reset_key_cache()
+    yield
+    connection_crypto.reset_key_cache()
+
+
+def _seal(plaintext: str) -> str:
+    from agent_bom.api.connection_crypto import encrypt_secret
+
+    return encrypt_secret(plaintext) if plaintext else ""
+
+
+FINDING = {
+    "vulnerability_id": "CVE-2024-9999",
+    "package": "acme-lib",
+    "severity": "high",
+    "risk_score": 8.4,
+    "fixed_version": "2.1.0",
+    "affected_agents": ["agent-a"],
+}
+
+
+def _mock_client_factory(handler):
+    def factory(timeout: float = 15.0):
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    return factory
+
+
+# ── Draft / model ─────────────────────────────────────────────────────────────
+
+
+def test_ticket_draft_from_finding_is_deterministic_and_labelled():
+    draft = TicketDraft.from_finding(FINDING, project="SEC")
+    assert draft.project == "SEC"
+    assert "CVE-2024-9999" in draft.title and "acme-lib" in draft.title
+    assert draft.finding_id == "CVE-2024-9999:acme-lib"
+    assert "severity-high" in draft.labels
+    assert "upgrade to 2.1.0" in draft.description
+
+
+def test_public_dict_never_exposes_secret():
+    record = TicketingConnectionRecord(
+        id="c1",
+        tenant_id="t1",
+        provider=PROVIDER_JIRA,
+        transport=TRANSPORT_REST,
+        auth_method=AUTH_API_TOKEN,
+        display_name="Jira",
+        endpoint="https://x.atlassian.net",
+        secret_encrypted=_seal("super-secret-token"),
+    )
+    public = record.to_public_dict()
+    assert "secret_encrypted" not in public
+    assert public["has_secret"] is True
+    assert "super-secret-token" not in json.dumps(public)
+
+
+# ── Status mapping ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "key,expected",
+    [
+        ("new", TicketStatus.OPEN),
+        ("indeterminate", TicketStatus.IN_PROGRESS),
+        ("done", TicketStatus.DONE),
+        ("bogus", TicketStatus.UNKNOWN),
+    ],
+)
+def test_map_jira_status(key, expected):
+    assert map_jira_status(key) is expected
+
+
+@pytest.mark.parametrize(
+    "label,expected",
+    [
+        ("New", TicketStatus.OPEN),
+        ("In Progress", TicketStatus.IN_PROGRESS),
+        ("Resolved", TicketStatus.DONE),
+        ("Closed", TicketStatus.DONE),
+        ("Cancelled", TicketStatus.DONE),
+    ],
+)
+def test_map_servicenow_status(label, expected):
+    assert map_servicenow_status(label) is expected
+
+
+# ── Jira REST transport (fallback) ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_jira_rest_api_token_create_and_status():
+    calls = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["last"] = request
+        if request.method == "POST":
+            assert request.url.path == "/rest/api/3/issue"
+            assert request.headers["Authorization"].startswith("Basic ")
+            body = json.loads(request.content)
+            assert body["fields"]["project"]["key"] == "SEC"
+            return httpx.Response(201, json={"id": "10001", "key": "SEC-1"})
+        assert request.url.path == "/rest/api/3/issue/SEC-1"
+        return httpx.Response(200, json={"fields": {"status": {"statusCategory": {"key": "indeterminate", "name": "In Progress"}}}})
+
+    record = TicketingConnectionRecord(
+        id="c1",
+        tenant_id="t1",
+        provider=PROVIDER_JIRA,
+        transport=TRANSPORT_REST,
+        auth_method=AUTH_API_TOKEN,
+        display_name="Jira",
+        endpoint="https://acme.atlassian.net",
+        secret_encrypted="",
+        auth_params={"email": "sec@acme.io"},
+    )
+    transport = JiraRestTransport(record, "the-token", client_factory=_mock_client_factory(handler))
+    draft = TicketDraft.from_finding(FINDING, project="SEC")
+    ref = await transport.create_ticket(draft)
+    assert ref.key == "SEC-1"
+    assert ref.url == "https://acme.atlassian.net/browse/SEC-1"
+
+    status = await transport.get_status(ref)
+    assert status is TicketStatus.IN_PROGRESS
+
+
+@pytest.mark.asyncio
+async def test_jira_rest_oauth_uses_atlassian_gateway_and_bearer():
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["url"] = str(request.url)
+        seen["auth"] = request.headers.get("Authorization", "")
+        return httpx.Response(201, json={"id": "20002", "key": "OPS-2"})
+
+    bundle = json.dumps({"access_token": "at-123", "refresh_token": "rt-123"})
+    record = TicketingConnectionRecord(
+        id="c2",
+        tenant_id="t1",
+        provider=PROVIDER_JIRA,
+        transport=TRANSPORT_REST,
+        auth_method=AUTH_OAUTH,
+        display_name="Jira OAuth",
+        endpoint="https://acme.atlassian.net",
+        secret_encrypted="",
+        auth_params={"cloud_id": "cid-9", "site_url": "https://acme.atlassian.net"},
+    )
+    transport = JiraRestTransport(record, bundle, client_factory=_mock_client_factory(handler))
+    ref = await transport.create_ticket(TicketDraft.from_finding(FINDING, project="OPS"))
+    assert "https://api.atlassian.com/ex/jira/cid-9/rest/api/3/issue" in seen["url"]
+    assert seen["auth"] == "Bearer at-123"
+    assert ref.url == "https://acme.atlassian.net/browse/OPS-2"
+
+
+# ── MCP-client transport (primary) ────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mcp_transport_drives_itsm_mcp_server_tools():
+    invoked = []
+
+    async def fake_caller(tool_name: str, arguments: dict) -> dict:
+        invoked.append((tool_name, arguments))
+        if tool_name == "make_issue":
+            return {"key": "JIRA-77", "id": "77", "url": "https://itsm/browse/JIRA-77", "status": "open"}
+        return {"status": "Done"}
+
+    record = TicketingConnectionRecord(
+        id="c3",
+        tenant_id="t1",
+        provider=PROVIDER_JIRA,
+        transport=TRANSPORT_MCP,
+        auth_method=AUTH_MCP,
+        display_name="Jira MCP",
+        endpoint="https://itsm.example/mcp",
+        secret_encrypted="",
+        auth_params={"create_tool": "make_issue", "status_tool": "read_issue"},
+    )
+    transport = McpTicketingTransport(record, "", caller=fake_caller)
+    ref = await transport.create_ticket(TicketDraft.from_finding(FINDING, project="JIRA"))
+    assert invoked[0][0] == "make_issue"
+    assert invoked[0][1]["project"] == "JIRA"
+    assert ref.key == "JIRA-77"
+
+    status = await transport.get_status(ref)
+    assert status is TicketStatus.DONE
+
+
+# ── Store: parity, tenant isolation, dedupe claim ─────────────────────────────
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def store(request, tmp_path):
+    if request.param == "memory":
+        return InMemoryTicketingStore()
+    return SQLiteTicketingStore(str(tmp_path / "ticketing.db"))
+
+
+def _conn(tenant="t1", cid="c1"):
+    return TicketingConnectionRecord(
+        id=cid,
+        tenant_id=tenant,
+        provider=PROVIDER_JIRA,
+        transport=TRANSPORT_MCP,
+        auth_method=AUTH_MCP,
+        display_name="Jira",
+        endpoint="https://itsm/mcp",
+        secret_encrypted="",
+        created_at="2026-07-16T00:00:00Z",
+        updated_at="2026-07-16T00:00:00Z",
+    )
+
+
+def test_store_connection_is_tenant_scoped(store):
+    store.put_connection(_conn(tenant="t1", cid="c1"))
+    assert store.get_connection("t1", "c1") is not None
+    assert store.get_connection("t2", "c1") is None  # cross-tenant read blocked
+    assert store.list_connections("t2") == []
+    assert store.delete_connection("t2", "c1") is False  # cross-tenant delete blocked
+    assert store.delete_connection("t1", "c1") is True
+
+
+def _link(tenant="t1", cid="c1", dedupe="CVE-1", lid="l1"):
+    return TicketLink(
+        id=lid,
+        tenant_id=tenant,
+        connection_id=cid,
+        dedupe_key=dedupe,
+        provider=PROVIDER_JIRA,
+        created_at="2026-07-16T00:00:00Z",
+        updated_at="2026-07-16T00:00:00Z",
+    )
+
+
+def test_claim_ticket_link_dedupes_within_tenant(store):
+    won1, link1 = store.claim_ticket_link(_link(lid="l1"))
+    assert won1 is True
+    won2, link2 = store.claim_ticket_link(_link(lid="l2"))  # same tenant+conn+dedupe
+    assert won2 is False
+    assert link2.id == link1.id  # the second caller gets the first row, no duplicate
+
+
+def test_claim_ticket_link_isolated_across_tenants(store):
+    # Same logical dedupe key for two tenants must both win (tenant_id in the key).
+    won_a, _ = store.claim_ticket_link(_link(tenant="ta", lid="la"))
+    won_b, _ = store.claim_ticket_link(_link(tenant="tb", lid="lb"))
+    assert won_a is True and won_b is True
+    assert store.get_ticket_link("ta", "la") is not None
+    assert store.get_ticket_link("tb", "la") is None  # cross-tenant read blocked
+
+
+# ── Service: connect-once, dedupe, tenant isolation, no-connection guard ───────
+
+
+def _mcp_connection(store, tenant="t1", cid="c1"):
+    record = TicketingConnectionRecord(
+        id=cid,
+        tenant_id=tenant,
+        provider=PROVIDER_JIRA,
+        transport=TRANSPORT_MCP,
+        auth_method=AUTH_MCP,
+        display_name="Jira MCP",
+        endpoint="https://itsm/mcp",
+        secret_encrypted="",
+        auth_params={"create_tool": "create_issue", "status_tool": "get_issue", "default_project": "SEC"},
+        created_at="2026-07-16T00:00:00Z",
+        updated_at="2026-07-16T00:00:00Z",
+    )
+    store.put_connection(record)
+    return record
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_runs_through_stored_connection():
+    store = InMemoryTicketingStore()
+    _mcp_connection(store)
+    calls = []
+
+    async def caller(tool, args):
+        calls.append((tool, args))
+        return {"key": "SEC-100", "id": "100", "url": "https://itsm/browse/SEC-100", "status": "open"}
+
+    result = await create_ticket_for_finding(tenant_id="t1", connection_id="c1", finding=FINDING, store=store, mcp_caller=caller)
+    assert result["deduplicated"] is False
+    assert result["ticket"]["key"] == "SEC-100"
+    assert result["audit_metadata"]["per_action_credential"] is False
+    # persisted + tenant scoped
+    links = store.list_ticket_links("t1")
+    assert len(links) == 1 and links[0].status == "open"
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_is_idempotent_no_duplicate():
+    store = InMemoryTicketingStore()
+    _mcp_connection(store)
+    calls = []
+
+    async def caller(tool, args):
+        calls.append(tool)
+        return {"key": "SEC-1", "id": "1", "status": "open"}
+
+    first = await create_ticket_for_finding(tenant_id="t1", connection_id="c1", finding=FINDING, store=store, mcp_caller=caller)
+    second = await create_ticket_for_finding(tenant_id="t1", connection_id="c1", finding=FINDING, store=store, mcp_caller=caller)
+    assert first["deduplicated"] is False
+    assert second["deduplicated"] is True
+    assert second["ticket"]["id"] == first["ticket"]["id"]
+    assert len(calls) == 1  # provider create invoked exactly once
+    assert len(store.list_ticket_links("t1")) == 1
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_tenant_isolation():
+    store = InMemoryTicketingStore()
+    _mcp_connection(store, tenant="t1", cid="c1")
+
+    async def caller(tool, args):
+        return {"key": "X-1", "id": "1", "status": "open"}
+
+    # Tenant t2 cannot use tenant t1's connection id — guided to connect, not a prompt.
+    with pytest.raises(TicketingError) as exc:
+        await create_ticket_for_finding(tenant_id="t2", connection_id="c1", finding=FINDING, store=store, mcp_caller=caller)
+    assert exc.value.code == "no_connection"
+    assert "Connect" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_without_connection_says_connect_first():
+    store = InMemoryTicketingStore()
+
+    with pytest.raises(TicketingError) as exc:
+        await create_ticket_for_finding(tenant_id="t1", finding=FINDING, store=store)
+    assert exc.value.code == "no_connection"
+    assert "Connect" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_create_ticket_rolls_back_claim_on_provider_failure():
+    store = InMemoryTicketingStore()
+    _mcp_connection(store)
+
+    async def failing_caller(tool, args):
+        raise RuntimeError("itsm down")
+
+    with pytest.raises(TicketingError):
+        await create_ticket_for_finding(tenant_id="t1", connection_id="c1", finding=FINDING, store=store, mcp_caller=failing_caller)
+    # Claim rolled back so a later retry can re-file.
+    assert store.list_ticket_links("t1") == []
+
+
+@pytest.mark.asyncio
+async def test_sync_ticket_status_updates_link():
+    store = InMemoryTicketingStore()
+    _mcp_connection(store)
+
+    async def create_caller(tool, args):
+        return {"key": "SEC-9", "id": "9", "status": "open"}
+
+    created = await create_ticket_for_finding(tenant_id="t1", connection_id="c1", finding=FINDING, store=store, mcp_caller=create_caller)
+    ticket_id = created["ticket"]["id"]
+
+    async def status_caller(tool, args):
+        return {"status": "Done"}
+
+    synced = await sync_ticket_status(tenant_id="t1", ticket_id=ticket_id, store=store, mcp_caller=status_caller)
+    assert synced["ticket"]["status"] == "done"
+    assert store.get_ticket_link("t1", ticket_id).status == "done"
+
+
+@pytest.mark.asyncio
+async def test_sync_ticket_status_tenant_isolation():
+    store = InMemoryTicketingStore()
+    _mcp_connection(store)
+
+    async def create_caller(tool, args):
+        return {"key": "SEC-9", "id": "9", "status": "open"}
+
+    created = await create_ticket_for_finding(tenant_id="t1", connection_id="c1", finding=FINDING, store=store, mcp_caller=create_caller)
+    with pytest.raises(TicketingError) as exc:
+        await sync_ticket_status(tenant_id="t2", ticket_id=created["ticket"]["id"], store=store)
+    assert exc.value.code == "not_found"
+
+
+# ── The connect-once invariant: NO per-action credential/link parameters ──────
+
+
+def test_create_ticket_signature_has_no_credential_or_link_param():
+    params = set(inspect.signature(create_ticket_for_finding).parameters)
+    forbidden = {
+        "token",
+        "api_token",
+        "password",
+        "secret",
+        "credential",
+        "credentials",
+        "auth",
+        "email",
+        "url",
+        "base_url",
+        "jira_url",
+        "endpoint",
+        "link",
+        "site_url",
+    }
+    leaked = params & forbidden
+    assert not leaked, f"create_ticket must resolve auth/base-url from the stored connection only; leaked: {leaked}"

--- a/tests/test_ticketing_oauth.py
+++ b/tests/test_ticketing_oauth.py
@@ -1,0 +1,84 @@
+"""Atlassian OAuth 2.0 (3LO) helper tests for the Jira ticketing connect flow.
+
+Pure/unit level: the authorize URL builder and the token/cloud-id exchanges with
+mocked HTTP. The live browser callback route is a deferred follow-up; these prove
+the connect-once, no-typed-token building blocks.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from agent_bom.ticketing import oauth
+
+
+@pytest.fixture(autouse=True)
+def _oauth_app(monkeypatch):
+    monkeypatch.setenv(oauth.CLIENT_ID_ENV, "client-abc")
+    monkeypatch.setenv(oauth.CLIENT_SECRET_ENV, "shh-secret")
+
+
+def _factory(handler):
+    def factory(timeout: float = 15.0):
+        return httpx.AsyncClient(transport=httpx.MockTransport(handler))
+
+    return factory
+
+
+def test_oauth_configured():
+    assert oauth.oauth_configured() is True
+
+
+def test_build_authorize_url_carries_client_state_scope_redirect():
+    url = oauth.build_authorize_url(redirect_uri="https://cp/cb", state="xyz")
+    assert url.startswith(oauth.AUTHORIZE_URL)
+    assert "client_id=client-abc" in url
+    assert "state=xyz" in url
+    assert "response_type=code" in url
+    assert "offline_access" in url  # refresh token for background status sync
+
+
+def test_build_authorize_url_requires_state():
+    with pytest.raises(oauth.TicketingOAuthError):
+        oauth.build_authorize_url(redirect_uri="https://cp/cb", state="")
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_returns_token_bundle():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert str(request.url) == oauth.TOKEN_URL
+        import json
+
+        body = json.loads(request.content)
+        assert body["grant_type"] == "authorization_code"
+        assert body["client_secret"] == "shh-secret"
+        return httpx.Response(200, json={"access_token": "at", "refresh_token": "rt", "expires_in": 3600})
+
+    bundle = await oauth.exchange_code(code="code-1", redirect_uri="https://cp/cb", client_factory=_factory(handler))
+    assert bundle["access_token"] == "at"
+    assert bundle["refresh_token"] == "rt"
+
+
+@pytest.mark.asyncio
+async def test_exchange_code_rejects_missing_access_token():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json={"token_type": "bearer"})
+
+    with pytest.raises(oauth.TicketingOAuthError):
+        await oauth.exchange_code(code="c", redirect_uri="https://cp/cb", client_factory=_factory(handler))
+
+
+@pytest.mark.asyncio
+async def test_resolve_accessible_resource_picks_cloud_id():
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "api.atlassian.com"
+        assert request.headers["Authorization"] == "Bearer at"
+        return httpx.Response(
+            200,
+            json=[{"id": "cloud-1", "url": "https://acme.atlassian.net", "name": "acme"}],
+        )
+
+    resolved = await oauth.resolve_accessible_resource(access_token="at", client_factory=_factory(handler))
+    assert resolved["cloud_id"] == "cloud-1"
+    assert resolved["site_url"] == "https://acme.atlassian.net"

--- a/tests/test_ticketing_route.py
+++ b/tests/test_ticketing_route.py
@@ -1,0 +1,206 @@
+"""API + MCP surface tests for the ticketing connector (#4004).
+
+Proves the REST plane enforces auth/RBAC, seals the secret (never returned),
+files a ticket through the stored connection with no per-action credential, and
+that the MCP tools are registered with no credential/link parameter.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from cryptography.fernet import Fernet
+from starlette.testclient import TestClient
+
+from agent_bom.api import connection_crypto
+from agent_bom.ticketing.connection_store import InMemoryTicketingStore, set_ticketing_store
+from agent_bom.ticketing.models import PROVIDER_JIRA, TicketRef, TicketStatus
+
+PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
+_TEST_KEY = Fernet.generate_key().decode("ascii")
+
+
+def _headers(role: str = "admin", tenant: str = "tenant-alpha") -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": role,
+        "X-Agent-Bom-Tenant-ID": tenant,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch) -> Iterator[None]:
+    # Keep the route tests hermetic: the endpoint SSRF check does live DNS, which
+    # would reject an unresolvable test host. SSRF logic is covered elsewhere.
+    monkeypatch.setattr("agent_bom.api.routes.ticketing.validate_url", lambda *a, **k: None)
+    prior = {
+        k: os.environ.get(k)
+        for k in (
+            "AGENT_BOM_TRUST_PROXY_AUTH",
+            "AGENT_BOM_TRUST_PROXY_AUTH_SECRET",
+            connection_crypto.CONNECTIONS_KEY_ENV,
+            f"{connection_crypto.CONNECTIONS_KEY_ENV}_FILE",
+            connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV,
+        )
+    }
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+    os.environ[connection_crypto.CONNECTIONS_KEY_ENV] = _TEST_KEY
+    os.environ.pop(f"{connection_crypto.CONNECTIONS_KEY_ENV}_FILE", None)
+    os.environ.pop(connection_crypto.CONNECTIONS_KEY_PROVIDER_ENV, None)
+    connection_crypto.reset_key_cache()
+    set_ticketing_store(InMemoryTicketingStore())
+    try:
+        yield
+    finally:
+        for key, value in prior.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        connection_crypto.reset_key_cache()
+        set_ticketing_store(None)
+
+
+def _app() -> Any:
+    from agent_bom.api.server import app
+
+    return app
+
+
+def _mcp_conn_body() -> dict[str, Any]:
+    return {
+        "provider": "jira",
+        "transport": "mcp",
+        "auth_method": "mcp",
+        "display_name": "Jira MCP",
+        "endpoint": "https://itsm.example.com/mcp",
+        "secret": "server-bearer-token",
+        "auth_params": {"create_tool": "create_issue", "status_tool": "get_issue", "default_project": "SEC"},
+    }
+
+
+FINDING = {"vulnerability_id": "CVE-2024-1", "package": "acme", "severity": "high", "risk_score": 7.0}
+
+
+def test_api_requires_authentication() -> None:
+    client = TestClient(_app())
+    assert client.get("/v1/ticketing/connections").status_code == 401
+    assert client.post("/v1/ticketing/connections", json=_mcp_conn_body()).status_code == 401
+
+
+def test_api_rejects_underprivileged_role() -> None:
+    client = TestClient(_app())
+    resp = client.post("/v1/ticketing/connections", json=_mcp_conn_body(), headers=_headers(role="viewer"))
+    assert resp.status_code == 403
+
+
+def test_create_connection_seals_secret_and_never_returns_it() -> None:
+    client = TestClient(_app())
+    resp = client.post("/v1/ticketing/connections", json=_mcp_conn_body(), headers=_headers())
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert "secret" not in body and "secret_encrypted" not in body
+    assert body["has_secret"] is True
+    assert "server-bearer-token" not in resp.text
+
+
+def test_create_connection_rejects_unknown_body_field() -> None:
+    client = TestClient(_app())
+    bad = _mcp_conn_body()
+    bad["api_token"] = "should-not-be-here"  # per-action/extra credential field forbidden
+    resp = client.post("/v1/ticketing/connections", json=bad, headers=_headers())
+    assert resp.status_code == 422
+
+
+def test_create_ticket_body_forbids_credential_fields() -> None:
+    client = TestClient(_app())
+    resp = client.post(
+        "/v1/ticketing/tickets",
+        json={"connection_id": "x", "finding": FINDING, "token": "nope"},
+        headers=_headers(),
+    )
+    assert resp.status_code == 422  # extra="forbid" rejects a credential field
+
+
+def test_create_ticket_without_connection_says_connect_first() -> None:
+    client = TestClient(_app())
+    resp = client.post("/v1/ticketing/tickets", json={"finding": FINDING}, headers=_headers())
+    assert resp.status_code == 409
+    assert "Connect" in resp.json()["detail"]
+
+
+def test_create_ticket_through_stored_connection(monkeypatch) -> None:
+    client = TestClient(_app())
+    created = client.post("/v1/ticketing/connections", json=_mcp_conn_body(), headers=_headers())
+    connection_id = created.json()["id"]
+
+    class _FakeTransport:
+        async def create_ticket(self, draft):
+            assert draft.project == "SEC"
+            return TicketRef(
+                provider=PROVIDER_JIRA, external_id="100", key="SEC-100", url="https://itsm/browse/SEC-100", status=TicketStatus.OPEN
+            )
+
+        async def get_status(self, ref):
+            return TicketStatus.DONE
+
+    monkeypatch.setattr("agent_bom.ticketing.service.build_transport", lambda *a, **k: _FakeTransport())
+
+    resp = client.post(
+        "/v1/ticketing/tickets",
+        json={"connection_id": connection_id, "finding": FINDING},
+        headers=_headers(),
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["ticket"]["key"] == "SEC-100"
+    assert body["deduplicated"] is False
+    assert body["audit_metadata"]["per_action_credential"] is False
+
+    ticket_id = body["ticket"]["id"]
+    synced = client.post(f"/v1/ticketing/tickets/{ticket_id}/sync", headers=_headers())
+    assert synced.status_code == 200
+    assert synced.json()["ticket"]["status"] == "done"
+
+
+def test_tickets_and_connections_are_tenant_scoped(monkeypatch) -> None:
+    client = TestClient(_app())
+    client.post("/v1/ticketing/connections", json=_mcp_conn_body(), headers=_headers(tenant="tenant-alpha"))
+    # A different tenant sees none of tenant-alpha's connections.
+    other = client.get("/v1/ticketing/connections", headers=_headers(tenant="tenant-beta"))
+    assert other.status_code == 200
+    assert other.json()["count"] == 0
+
+
+def test_mcp_tools_registered_without_credential_params() -> None:
+    import asyncio
+
+    from agent_bom.mcp_server import create_mcp_server
+    from agent_bom.mcp_server_metadata import server_card_tool_names
+
+    names = server_card_tool_names()
+    assert "create_ticket" in names and "sync_ticket_status" in names
+
+    mcp = create_mcp_server()
+    tools = {t.name: t for t in asyncio.run(mcp.list_tools())}
+    assert "create_ticket" in tools and "sync_ticket_status" in tools
+    props = set(tools["create_ticket"].inputSchema.get("properties", {}))
+    forbidden = {
+        "token",
+        "api_token",
+        "password",
+        "secret",
+        "credential",
+        "auth",
+        "email",
+        "base_url",
+        "jira_url",
+        "endpoint",
+        "site_url",
+        "url",
+    }
+    assert not (props & forbidden), f"MCP create_ticket leaked credential/link params: {props & forbidden}"

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -2529,7 +2529,7 @@ function CodingAgentDrawer({ open, onClose }: { open: boolean; onClose: () => vo
       }
       headerAside={
         <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-          <Bot className="h-3 w-3" /> 73 MCP tools
+          <Bot className="h-3 w-3" /> 75 MCP tools
         </span>
       }
     >

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -391,7 +391,7 @@ describe("ConnectionsPage — Connect segment", () => {
 
     const drawer = await screen.findByRole("dialog", { name: /Connect a coding agent/ });
     expect(within(drawer).getByText("agent-bom mcp-server")).toBeInTheDocument();
-    expect(within(drawer).getByText(/73 MCP tools/)).toBeInTheDocument();
+    expect(within(drawer).getByText(/75 MCP tools/)).toBeInTheDocument();
   });
 
   it("syncs the segmented tab to the URL", async () => {


### PR DESCRIPTION
## MCP-first ITSM / ticketing connector

Adds an MCP-first ITSM/ticketing connector so agent-bom can file and sync tickets for findings by driving a configured ITSM/Jira MCP server as the primary transport. Connect once; every action runs through the stored, scoped, revocable connection with no per-action credentials.

### Landed
- **MCP-first transport** — agent-bom drives a configured ITSM/Jira MCP server as the primary transport (`ticketing/mcp_transport.py`, `transport.py`, `factory.py`).
- **Connect-once model** — stored, scoped connection (`connection_store.py` / `postgres_store.py`); `create_ticket` / `sync_status` resolve auth from the stored connection, never from a per-action credential/token/link param. Enforced by invariant tests (route + service + MCP tool schema).
- **MCP tools** — `create_ticket` / `sync_status` exposed as MCP tools, classified WRITE (not `readOnlyHint`), registered without credential params.
- **REST** — `api/routes/ticketing.py` surfaces the same actions; OpenAPI contract + count gates regenerated and consistent.
- Tenant isolation + dedupe/idempotency + no-connection fail-closed guard covered by tests.

### Deferred (not in this PR)
- Direct-REST Jira path (scaffolding present in `jira_rest.py`, not the primary path)
- OAuth 3LO flow
- ServiceNow provider
- UI / Connections-hub surface

### Verification
- Ticketing suites, MCP catalog-drift + tool-impl, deployment, fleet-scan, core: green (481 tests across touched suites)
- `ruff check`, `ruff format --check`, `mypy` on changed files: green
- `scripts/check-counts.py` and `export_openapi.py --check`: consistent (75 MCP tools, 348 REST ops, 294 paths, 40 route modules)

addresses #4004
