### PR TITLE
fix(ci): restore root-logger handlers between tests (xdist stdout pollution → 3.13 failure)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import logging
 import os
 import sys
 import tempfile
@@ -454,8 +455,20 @@ def reset_global_test_state():
     config_auth_snapshot = _snapshot_config_auth()
     output_console_snapshot = _snapshot_output_console()
 
+    # Snapshot root-logger handlers + level. Several CLI/gateway paths call
+    # ``configure_logging``/``logging.basicConfig`` which ``addHandler`` to root
+    # without removing existing ones, so handlers ACCUMULATE across a worker's
+    # tests. A leaked handler (e.g. one writing to stdout) then contaminates a
+    # later test that parses a command's stdout as JSON — an xdist-order flake.
+    # Restore the exact handler set + level on teardown so no test can leak one.
+    root_logger = logging.getLogger()
+    logging_handlers_snapshot = root_logger.handlers[:]
+    logging_level_snapshot = root_logger.level
+
     yield
 
+    root_logger.handlers[:] = logging_handlers_snapshot
+    root_logger.setLevel(logging_level_snapshot)
     _restore_store_singletons(store_singleton_snapshot)
     _restore_config_auth(config_auth_snapshot)
     _restore_output_console(output_console_snapshot)


### PR DESCRIPTION
## Problem
`Test (Python 3.13)` fails on `main` (release-blocker #4083): `tests/test_cli_p1_polish.py::test_mcp_inventory_demo_shows_bundled_inventory` → `json.decoder.JSONDecodeError: Expecting value: line 1 column 5 (char 4)`. It passes in isolation — a cross-test / xdist-order pollution: it `json.loads(result.output)` a CLI command's stdout, and a leaked logging handler contaminates that stdout.

## Root cause
`logging_config.configure_logging` (`root.addHandler(...)`) and `cli/_gateway.py` (`logging.basicConfig`) add handlers to the **root logger without removing existing ones**, so handlers **accumulate across an xdist worker's tests** (`-n 4 --dist loadscope`). A leaked handler writing to stdout corrupts a later test that parses a command's stdout as JSON. The existing `reset_global_test_state` autouse fixture resets resolver/registry/identity/api/store/console/env state — but **not logging handlers**. That was the gap.

## Fix
Extend `reset_global_test_state` to **snapshot the root-logger handlers + level and restore the exact set on teardown**, so no test can leak a handler into another — a root-cause-class fix independent of which test is the polluter.

## Verification
- `test_cli_p1_polish.py` (incl. the victim) passes under `-n 2 --dist loadscope`; victim passes in isolation.
- `ruff` clean on the change (+13 lines, stdlib `logging` only).
- The full-suite xdist worker assignment can't be recreated locally; CI's real matrix confirms.

Closes #4083