### PR TITLE
feat(cloud): provider-API deprecation & removal signal

### DIFF
--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -517,3 +517,37 @@ the freshness of the SDK layer is surfaced, never left silent.
     `summary`, alongside the vuln-DB freshness fields.
 - **How to refresh.** Upgrade the matching extra, e.g.
   `pip install -U 'agent-bom[aws]'` (or `[azure]` / `[gcp]` / `[snowflake]`).
+- **Staying current automatically.** Dependabot keeps the provider SDKs on a
+  safe cadence via the `cloud-and-ai-sdks` group in `.github/dependabot.yml`
+  (boto3/botocore are data-driven and backward-compatible, so new provider APIs
+  land through routine bumps).
+
+### 9.1 Provider-API deprecation posture (a legacy-SDK exposure guard)
+
+The freshness check above answers "is my SDK current?". A complementary signal
+answers "does my install still depend on a provider API the vendor has
+*retired*?" A retired API returns errors (for example Azure AD Graph now returns
+HTTP 403), so a check that still routes through it under-covers or fails
+silently.
+
+- **What it checks.** A small, first-party-sourced watchlist of retired /
+  deprecated provider APIs (e.g. the retired **Azure AD Graph API**, the
+  deprecated **oauth2client** auth library), each keyed by the *legacy*
+  distribution that speaks it. The probe is whether that legacy SDK is present
+  in the environment — an **offline, deterministic** check evaluated against the
+  current date.
+- **Honest default is "clear".** agent-bom already uses the modern replacement
+  for every entry (Azure identities/roles via Azure Resource Manager, GCP auth
+  via `google-auth`), so the shipped posture is *clear*. The signal only lights
+  up if a legacy SDK is dragged into the tree — a supply-chain / coverage guard.
+- **Fail-honest gating.** When a retired API is *both* past its removal date and
+  reachable via an installed legacy SDK, it is marked **gated**: a check bound
+  to it must be skipped and reported, never silently passed. The
+  `removed_provider_apis()` helper exposes that skip set for scanners.
+- **Where it shows up.**
+  - `agent-bom doctor` renders a **Cloud API deprecations** section (each API
+    with its status and migration target).
+  - `--agent-mode` scan metadata carries a `deprecations` block (`status`,
+    `removed_count`, `at_risk_count`, `gated`, `warnings`) nested under
+    `cloud_sdk_freshness`; `doctor --agent-mode` emits a
+    `cloud_api_deprecations` section in its envelope.

--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -29,6 +29,7 @@ def doctor_cmd() -> None:
     runtime_checks: list[tuple[str, str, str]] = []
     platform_checks: list[tuple[str, str, str]] = []
     cloud_sdk_checks: list[tuple[str, str, str]] = []
+    cloud_api_checks: list[tuple[str, str, str]] = []
 
     # Python version
     py_ver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
@@ -143,6 +144,26 @@ def doctor_cmd() -> None:
     except Exception:
         cloud_sdk_checks.append(("Cloud SDKs", "freshness check unavailable", "info"))
 
+    # Provider-API deprecation posture — a legacy-SDK exposure guard for
+    # retired/deprecating provider APIs (Azure AD Graph, oauth2client, …).
+    # Honest default is "clear": agent-bom uses the modern replacements, so this
+    # only lights up if a legacy SDK is dragged into the environment.
+    try:
+        from agent_bom.cloud_sdk_freshness import cloud_api_deprecation_posture
+
+        _api_status_map = {"clear": "ok", "at_risk": "warn", "gated": "warn"}
+        for api in cloud_api_deprecation_posture()["apis"]:
+            if api["status"] == "clear":
+                value = f"clear (uses {api['replacement']})"
+            elif api["status"] == "gated":
+                value = f"retired + {api['distribution']} present — checks skipped; migrate to {api['replacement']}"
+            else:
+                when = f" on {api['retirement_date']}" if api["retirement_date"] else ""
+                value = f"deprecating{when} — {api['distribution']} present; migrate to {api['replacement']}"
+            cloud_api_checks.append((api["api"], value, _api_status_map.get(api["status"], "info")))
+    except Exception:
+        cloud_api_checks.append(("Cloud API deprecations", "check unavailable", "info"))
+
     checks = [*core_checks, *runtime_checks, *platform_checks]
     warns = sum(1 for _, _, s in checks if s == "warn")
 
@@ -172,6 +193,7 @@ def doctor_cmd() -> None:
                 "runtime": _section(runtime_checks),
                 "platform": _section(platform_checks),
                 "cloud_sdk": _section(cloud_sdk_checks),
+                "cloud_api_deprecations": _section(cloud_api_checks),
                 "capabilities": capabilities,
                 "coverage": coverage,
                 "ready": warns == 0,
@@ -189,6 +211,7 @@ def doctor_cmd() -> None:
     _print_section(console, "Runtime surfaces", runtime_checks)
     _print_section(console, "Platform integrations", platform_checks)
     _print_section(console, "Cloud SDK freshness", cloud_sdk_checks)
+    _print_section(console, "Cloud API deprecations", cloud_api_checks)
 
     # Nothing-silent capability view — every gated feature with its state and
     # unlock path, so a skipped/degraded capability is never silent.

--- a/src/agent_bom/cloud_sdk_freshness.py
+++ b/src/agent_bom/cloud_sdk_freshness.py
@@ -32,9 +32,15 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from datetime import date, datetime, timezone
 from typing import Any
 
 SCHEMA_VERSION = 1
+
+# How far ahead a scheduled retirement is still surfaced as a live "deprecating"
+# signal when a legacy SDK is present. Purely cosmetic today (any not-yet-removed
+# exposed entry warns); kept as a named constant so the horizon is explicit.
+DEPRECATION_HORIZON_DAYS = 365
 
 
 @dataclass(frozen=True)
@@ -257,5 +263,260 @@ def cloud_sdk_freshness_summary(
             for s in posture["sdks"]
             if s["status"] == "outdated"
         ],
+        "warnings": [w["message"] for w in posture["warnings"]],
+        # Provider-API retirement posture (Azure AD Graph, oauth2client, …):
+        # a legacy-SDK exposure signal that complements the version-floor check.
+        "deprecations": cloud_api_deprecation_summary(installed=installed),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provider-API deprecation / removal posture
+# ---------------------------------------------------------------------------
+#
+# The version-floor check above answers "is my SDK current?". This second
+# signal answers a different, complementary question: "does my install still
+# depend on a provider API the vendor has *retired* (or scheduled to retire)?"
+# A retired API returns errors (e.g. Azure AD Graph → HTTP 403), so a check that
+# still routes through it silently under-covers or fails — the same
+# gap-that-looks-like-coverage failure mode.
+#
+# Modeled as a small, deterministic, offline watchlist keyed by the *legacy*
+# distribution that speaks the retired API. agent-bom itself already uses the
+# modern replacement for each entry (Azure identities/roles via Azure Resource
+# Manager, GCP auth via google-auth), so the honest default posture is "clear".
+# The signal fires only when a legacy SDK is actually present in the tree — a
+# supply-chain / coverage guard, evaluated against an injected clock so the
+# removed / deprecating / clear states are all reproducible.
+
+
+@dataclass(frozen=True)
+class ProviderApiDeprecation:
+    """One retired or deprecated provider API on the watchlist.
+
+    Attributes:
+        provider: Provider id (``aws`` / ``azure`` / ``gcp`` / ``snowflake``).
+        api: Human label of the provider API being retired.
+        distribution: The *legacy* PyPI distribution that speaks the retired
+            API — the exposure probe. ``None`` means there is no distinct SDK to
+            detect (the entry is informational only).
+        replacement: The modern SDK/API agent-bom uses instead.
+        retirement_date: ISO ``YYYY-MM-DD`` the API stops working, or ``None``
+            for a deprecation with no scheduled removal date.
+        note: Short, honest description of the impact and agent-bom's posture.
+        reference: Official first-party source URL for the retirement.
+    """
+
+    provider: str
+    api: str
+    distribution: str | None
+    replacement: str
+    retirement_date: str | None
+    note: str
+    reference: str
+
+
+# Real, first-party-sourced entries only. Verified against vendor docs; each
+# carries its source URL. agent-bom uses the modern replacement for all of
+# these, so the shipped posture is "clear" unless a legacy SDK is dragged in.
+PROVIDER_API_DEPRECATIONS: tuple[ProviderApiDeprecation, ...] = (
+    ProviderApiDeprecation(
+        provider="azure",
+        api="Azure AD Graph API (graph.windows.net)",
+        distribution="azure-graphrbac",
+        replacement="Microsoft Graph (azure-identity + msgraph-sdk)",
+        # Extended-access apps lose Azure AD Graph access in early September 2025;
+        # calls then return HTTP 403. Microsoft Entra blog, ref below.
+        retirement_date="2025-09-01",
+        note=(
+            "Azure AD Graph is retired — dependent apps receive HTTP 403. "
+            "agent-bom reads Azure identities/roles via Azure Resource Manager "
+            "(azure-mgmt-authorization), so it is clear unless a legacy "
+            "azure-graphrbac dependency is present."
+        ),
+        reference=("https://techcommunity.microsoft.com/blog/microsoft-entra-blog/important-update-azure-ad-graph-api-retirement/4090534"),
+    ),
+    ProviderApiDeprecation(
+        provider="gcp",
+        api="oauth2client auth library",
+        distribution="oauth2client",
+        replacement="google-auth",
+        # Deprecated by Google in favor of google-auth; no scheduled removal.
+        retirement_date=None,
+        note=(
+            "oauth2client is deprecated by Google in favor of google-auth. "
+            "agent-bom uses google-auth; a transitive oauth2client would be a "
+            "supply-chain and coverage risk."
+        ),
+        reference="https://google-auth.readthedocs.io/en/latest/oauth2client-deprecation.html",
+    ),
+)
+
+
+def _as_date(value: date | datetime | None) -> date:
+    """Normalize an injected reference time to a ``date`` (UTC ``today`` default)."""
+    if value is None:
+        return datetime.now(timezone.utc).date()
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+def _parse_iso_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def cloud_api_deprecation_posture(
+    *,
+    now: date | datetime | None = None,
+    installed: Callable[[str], str | None] | Mapping[str, str | None] | None = None,
+    deprecations: Iterable[ProviderApiDeprecation] = PROVIDER_API_DEPRECATIONS,
+    horizon_days: int = DEPRECATION_HORIZON_DAYS,
+) -> dict[str, Any]:
+    """Compute the provider-API deprecation / removal posture.
+
+    For each watchlist entry the ``distribution`` is probed against the
+    installed environment (``exposed``) and the ``retirement_date`` compared to
+    ``now``:
+
+    * ``lifecycle`` is ``removed`` once ``now`` is at or past the retirement
+      date, otherwise ``deprecating`` (a future-dated or undated deprecation).
+    * ``status`` folds in exposure: ``gated`` (removed **and** a legacy SDK is
+      installed — a dependent check must be skipped honestly), ``at_risk``
+      (deprecating and exposed), or ``clear`` (not exposed — agent-bom uses the
+      modern replacement).
+
+    Deterministic for a fixed ``now`` + ``installed``; never raises. Non-blocking
+    — a signal, never a gate on the process exit code.
+    """
+    resolve = _make_resolver(installed)
+    today = _as_date(now)
+
+    apis: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    gated: list[dict[str, Any]] = []
+
+    for dep in deprecations:
+        exposed = dep.distribution is not None and resolve(dep.distribution) is not None
+        retire = _parse_iso_date(dep.retirement_date)
+        removed = retire is not None and today >= retire
+        lifecycle = "removed" if removed else "deprecating"
+
+        days_until = (retire - today).days if retire is not None and not removed else None
+
+        if exposed and removed:
+            status = "gated"
+        elif exposed:
+            status = "at_risk"
+        else:
+            status = "clear"
+
+        entry = {
+            "provider": dep.provider,
+            "api": dep.api,
+            "distribution": dep.distribution,
+            "installed": exposed,
+            "replacement": dep.replacement,
+            "retirement_date": dep.retirement_date,
+            "days_until_retirement": days_until,
+            "lifecycle": lifecycle,
+            "status": status,
+            "reference": dep.reference,
+        }
+
+        if status == "gated":
+            entry["message"] = (
+                f"{dep.api} is retired but reachable via installed {dep.distribution} — "
+                f"checks using it are skipped (not silently passed). Migrate to {dep.replacement}."
+            )
+            warnings.append(
+                {
+                    "code": "api_removed",
+                    "provider": dep.provider,
+                    "api": dep.api,
+                    "distribution": dep.distribution,
+                    "message": entry["message"],
+                    "reference": dep.reference,
+                }
+            )
+            gated.append(entry)
+        elif status == "at_risk":
+            when = f" on {dep.retirement_date}" if dep.retirement_date else ""
+            entry["message"] = (
+                f"{dep.api} is deprecated{when} and reachable via installed {dep.distribution} — "
+                f"migrate to {dep.replacement} before it is removed."
+            )
+            warnings.append(
+                {
+                    "code": "api_deprecating",
+                    "provider": dep.provider,
+                    "api": dep.api,
+                    "distribution": dep.distribution,
+                    "message": entry["message"],
+                    "reference": dep.reference,
+                }
+            )
+        else:
+            entry["message"] = (
+                f"clear of {dep.api} — agent-bom uses {dep.replacement} (no {dep.distribution} in the tree)."
+                if dep.distribution
+                else f"clear of {dep.api} — agent-bom uses {dep.replacement}."
+            )
+
+        apis.append(entry)
+
+    removed_count = sum(1 for a in apis if a["status"] == "gated")
+    at_risk_count = sum(1 for a in apis if a["status"] == "at_risk")
+
+    _ = horizon_days  # reserved: today every not-yet-removed exposed entry warns
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "degraded" if warnings else "ok",
+        "check": "installed-legacy-SDK-vs-provider-API-retirement (offline)",
+        "apis": apis,
+        "warnings": warnings,
+        "gated": gated,
+        "removed_count": removed_count,
+        "at_risk_count": at_risk_count,
+    }
+
+
+def removed_provider_apis(
+    *,
+    now: date | datetime | None = None,
+    installed: Callable[[str], str | None] | Mapping[str, str | None] | None = None,
+    deprecations: Iterable[ProviderApiDeprecation] = PROVIDER_API_DEPRECATIONS,
+) -> dict[str, dict[str, Any]]:
+    """Provider APIs that are retired **and** still reachable via a legacy SDK.
+
+    Returns a mapping ``{api_label: posture_entry}``. A scanner/check bound to
+    one of these APIs must skip it and report the skip honestly, rather than
+    silently passing or emitting an empty result that looks like coverage.
+
+    Empty in a normal agent-bom install (it uses the modern replacements) — this
+    is a guard against a legacy SDK being pulled into the environment.
+    """
+    posture = cloud_api_deprecation_posture(now=now, installed=installed, deprecations=deprecations)
+    return {a["api"]: a for a in posture["gated"]}
+
+
+def cloud_api_deprecation_summary(
+    *,
+    now: date | datetime | None = None,
+    installed: Callable[[str], str | None] | Mapping[str, str | None] | None = None,
+) -> dict[str, Any]:
+    """Compact provider-API deprecation block for ``--agent-mode`` metadata."""
+    posture = cloud_api_deprecation_posture(now=now, installed=installed)
+    return {
+        "status": posture["status"],
+        "removed_count": posture["removed_count"],
+        "at_risk_count": posture["at_risk_count"],
+        "gated": [a["api"] for a in posture["gated"]],
         "warnings": [w["message"] for w in posture["warnings"]],
     }

--- a/tests/test_cloud_sdk_freshness.py
+++ b/tests/test_cloud_sdk_freshness.py
@@ -8,12 +8,19 @@ metadata built by ``_agent_mode._summary``.
 
 from __future__ import annotations
 
+from datetime import date, datetime, timezone
+
 from click.testing import CliRunner
 
 from agent_bom.cloud_sdk_freshness import (
+    PROVIDER_API_DEPRECATIONS,
     RECOMMENDED_FLOORS,
+    ProviderApiDeprecation,
+    cloud_api_deprecation_posture,
+    cloud_api_deprecation_summary,
     cloud_sdk_freshness_summary,
     cloud_sdk_posture,
+    removed_provider_apis,
 )
 
 # A fully-fresh install: every anchor distribution comfortably above its floor.
@@ -165,3 +172,161 @@ def test_doctor_renders_cloud_sdk_freshness_section():
     result = CliRunner().invoke(doctor_cmd, [])
     assert result.exit_code == 0, result.output
     assert "Cloud SDK freshness" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Provider-API deprecation / removal posture
+# ---------------------------------------------------------------------------
+
+# A reference "now" comfortably after the Azure AD Graph retirement date so the
+# entry evaluates as removed regardless of when the suite runs.
+AFTER_AZURE_GRAPH = date(2026, 1, 1)
+# A reference "now" before it, for the still-scheduled path.
+BEFORE_AZURE_GRAPH = date(2025, 1, 1)
+
+
+def test_catalog_entries_are_real_and_sourced():
+    # Every shipped entry must carry a provider, a human API label, a
+    # replacement, and an official reference URL — no unsourced/fabricated rows.
+    assert PROVIDER_API_DEPRECATIONS
+    for dep in PROVIDER_API_DEPRECATIONS:
+        assert dep.provider and dep.api and dep.replacement
+        assert dep.reference.startswith("https://")
+
+
+def test_clear_when_no_legacy_sdk_installed():
+    # Nothing legacy in the tree: every retirement is informational (clear),
+    # status ok, no warnings — the honest "we use the modern replacement" state.
+    posture = cloud_api_deprecation_posture(now=AFTER_AZURE_GRAPH, installed={})
+    assert posture["status"] == "ok"
+    assert posture["warnings"] == []
+    assert posture["removed_count"] == 0
+    assert posture["at_risk_count"] == 0
+    assert posture["gated"] == []
+    assert all(a["status"] == "clear" for a in posture["apis"])
+
+
+def test_removed_api_with_legacy_sdk_is_gated():
+    # azure-graphrbac present + past the retirement date → the Azure AD Graph
+    # API is removed AND reachable via a legacy SDK, so it is gated (a check
+    # using it must be skipped honestly, never silently passed).
+    posture = cloud_api_deprecation_posture(
+        now=AFTER_AZURE_GRAPH,
+        installed={"azure-graphrbac": "0.61.1"},
+    )
+    assert posture["status"] == "degraded"
+    assert posture["removed_count"] == 1
+    graph = next(a for a in posture["apis"] if a["distribution"] == "azure-graphrbac")
+    assert graph["status"] == "gated"
+    assert graph["lifecycle"] == "removed"
+    codes = {w["code"] for w in posture["warnings"]}
+    assert "api_removed" in codes
+    assert [g["api"] for g in posture["gated"]] == [graph["api"]]
+
+
+def test_removed_api_without_legacy_sdk_is_clear_not_gated():
+    posture = cloud_api_deprecation_posture(
+        now=AFTER_AZURE_GRAPH,
+        installed={},  # azure-graphrbac absent
+    )
+    graph = next(a for a in posture["apis"] if a["distribution"] == "azure-graphrbac")
+    assert graph["lifecycle"] == "removed"
+    assert graph["status"] == "clear"
+    assert posture["gated"] == []
+
+
+def test_scheduled_future_removal_with_legacy_sdk_is_at_risk_not_gated():
+    posture = cloud_api_deprecation_posture(
+        now=BEFORE_AZURE_GRAPH,
+        installed={"azure-graphrbac": "0.61.1"},
+    )
+    graph = next(a for a in posture["apis"] if a["distribution"] == "azure-graphrbac")
+    assert graph["lifecycle"] == "deprecating"
+    assert graph["status"] == "at_risk"
+    assert posture["at_risk_count"] == 1
+    assert posture["gated"] == []
+    codes = {w["code"] for w in posture["warnings"]}
+    assert "api_deprecating" in codes
+
+
+def test_undated_deprecation_with_legacy_sdk_is_at_risk():
+    # oauth2client has no scheduled removal date → deprecating, not removed.
+    posture = cloud_api_deprecation_posture(
+        now=AFTER_AZURE_GRAPH,
+        installed={"oauth2client": "4.1.3"},
+    )
+    entry = next(a for a in posture["apis"] if a["distribution"] == "oauth2client")
+    assert entry["lifecycle"] == "deprecating"
+    assert entry["status"] == "at_risk"
+
+
+def test_now_accepts_date_and_datetime():
+    as_date = cloud_api_deprecation_posture(now=AFTER_AZURE_GRAPH, installed={})
+    as_dt = cloud_api_deprecation_posture(now=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc), installed={})
+    assert as_date == as_dt
+
+
+def test_removed_provider_apis_gate_helper():
+    gated = removed_provider_apis(now=AFTER_AZURE_GRAPH, installed={"azure-graphrbac": "0.61.1"})
+    assert set(gated) == {"Azure AD Graph API (graph.windows.net)"}
+    clear = removed_provider_apis(now=AFTER_AZURE_GRAPH, installed={})
+    assert clear == {}
+
+
+def test_custom_future_dated_entry_within_horizon_warns():
+    dep = ProviderApiDeprecation(
+        provider="aws",
+        api="Fake service API",
+        distribution="boto3",
+        replacement="newer boto3",
+        retirement_date="2026-03-01",
+        note="test entry",
+        reference="https://example.com/aws",
+    )
+    posture = cloud_api_deprecation_posture(
+        now=date(2026, 1, 1),
+        installed={"boto3": "1.40.0"},
+        deprecations=[dep],
+    )
+    entry = posture["apis"][0]
+    assert entry["lifecycle"] == "deprecating"
+    assert entry["status"] == "at_risk"
+
+
+def test_default_resolver_never_raises_and_is_json_shaped_deprecations():
+    posture = cloud_api_deprecation_posture()
+    assert posture["schema_version"] == 1
+    assert isinstance(posture["apis"], list) and posture["apis"]
+    assert posture["status"] in {"ok", "degraded"}
+    for entry in posture["apis"]:
+        assert entry["status"] in {"clear", "at_risk", "gated"}
+        assert entry["lifecycle"] in {"removed", "deprecating"}
+
+
+def test_deprecation_summary_trims_and_lists_gated():
+    summary = cloud_api_deprecation_summary(now=AFTER_AZURE_GRAPH, installed={"azure-graphrbac": "0.61.1"})
+    assert summary["status"] == "degraded"
+    assert summary["removed_count"] == 1
+    assert summary["gated"] == ["Azure AD Graph API (graph.windows.net)"]
+    assert summary["warnings"] and "Azure AD Graph" in summary["warnings"][0]
+
+
+def test_sdk_freshness_summary_nests_deprecations_block():
+    summary = cloud_sdk_freshness_summary(installed=FRESH)
+    assert "deprecations" in summary
+    assert summary["deprecations"]["status"] in {"ok", "degraded"}
+
+
+def test_doctor_renders_cloud_api_deprecations_section():
+    from agent_bom.cli._doctor import doctor_cmd
+
+    result = CliRunner().invoke(doctor_cmd, [])
+    assert result.exit_code == 0, result.output
+    assert "Cloud API deprecations" in result.output
+
+
+def test_agent_mode_summary_includes_deprecations():
+    from agent_bom.cli._agent_mode import _summary
+
+    out = _summary({})
+    assert "deprecations" in out["cloud_sdk_freshness"]


### PR DESCRIPTION
## Summary

Extends the cloud SDK freshness lane of #3835 with a **provider-API deprecation & removal signal** — the "scheduled-API-removal gating" checkbox left as a follow-up by #3872.

The existing version-floor check (#3872) answers *"is my SDK current?"*. This adds the complementary question: *"does my install still depend on a provider API the vendor has retired?"* A retired API returns errors (e.g. Azure AD Graph now returns HTTP 403), so a check still routing through it under-covers or fails silently — the same gap-that-looks-like-coverage failure mode.

**Decision (from #3835): SDKs stay local.** Nothing here routes the scan/credential path through an external/cloud MCP — the BYOC/air-gap trust model is preserved. This is a deterministic, **offline** signal.

## What shipped

- **`cloud_sdk_freshness.py`** — new `PROVIDER_API_DEPRECATIONS` watchlist + `cloud_api_deprecation_posture()`:
  - First-party-sourced entries only, each keyed by the *legacy* distribution that speaks the retired API:
    - **Azure AD Graph API** (`graph.windows.net`, `azure-graphrbac`) → Microsoft Graph. Retired; extended-access apps blocked from ~Sept 2025. [Microsoft Entra source](https://techcommunity.microsoft.com/blog/microsoft-entra-blog/important-update-azure-ad-graph-api-retirement/4090534).
    - **oauth2client** → `google-auth`. Deprecated by Google, no scheduled removal. [google-auth source](https://google-auth.readthedocs.io/en/latest/oauth2client-deprecation.html).
  - **Exposure-checked & honest by default.** agent-bom already uses the modern replacement for every entry (Azure roles via ARM `AuthorizationManagementClient`; GCP auth via `google-auth`), so the shipped posture is **clear**. The signal only fires if a legacy SDK is dragged into the tree — a supply-chain / coverage guard.
  - **Fail-honest gating.** A retired API that is *both* past its removal date *and* reachable via an installed legacy SDK is marked **gated** — a dependent check must be skipped and reported, never silently passed. `removed_provider_apis()` exposes the skip set for scanners.
  - **Offline + deterministic + never raises.** Evaluated against an injected clock (`now`); a missing/unparseable input degrades to a readable status.
- **Surfaces (reuse the existing freshness surfaces):**
  - `agent-bom doctor` → new **Cloud API deprecations** section.
  - `doctor --agent-mode` envelope → `cloud_api_deprecations`.
  - scan `--agent-mode` summary → `deprecations` block nested under `cloud_sdk_freshness`.
- **Docs** — `CLOUD_CONNECT.md` §9.1.

## Already covered (no change needed)

- **SDK version-floor freshness** (item 1a) — shipped in #3872.
- **Auto-bump cadence** (item 2) — already handled by the `cloud-and-ai-sdks` Dependabot group in `.github/dependabot.yml` (boto3/botocore/`azure-*`/`google-*`/`snowflake-*`, daily). Documented in §9.

## Deferred (honest)

- **Collector image / sidecar** (`agent-bom-collector`) — balloons (new Dockerfile + a build/publish CI workflow + Helm sidecar wiring). Tracked as the remaining #3835 checkbox; not in this PR. This is why the issue is *addressed*, not closed.
- **Optional cloud-MCP alternative connector** — explicitly a future non-default per the issue.

## Verification

- `pytest tests/test_cloud_sdk_freshness.py` (27) + `tests/test_doctor_cli.py` (3) — green. Covers clear / gated / at-risk / scheduled-future / undated states, the `date`+`datetime` clock injection, the gate helper, the trimmed summary, and all three consumer surfaces.
- **Smoke (real invocations, not just unit tests):** rendered `doctor` shows the Cloud API deprecations section (both entries *clear*); `doctor --agent-mode` envelope carries `cloud_api_deprecations`; scan `--agent-mode` summary carries the nested `deprecations` block; the gated path (`azure-graphrbac` present + now past retirement) produces `status=degraded`, `removed_count=1`, and a populated `removed_provider_apis()` skip set.
- `ruff check` + `ruff format --check`, `mypy` (changed files), `check-counts`, `check_comment_hygiene`, `check_product_surface_contract`, `check_release_consistency` — all clean. No API route or Pydantic model changed; the agent-mode envelope already permits additive `summary` keys.

> Base is `fix/ci-main-py313-regression` (#4085) to inherit the CI fix and keep the diff to a single commit; retarget to `main` once #4085 merges.

Addresses #3835