### PR TITLE
perf(graph): wire streamed prior-snapshot digest through the persist path

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -21,6 +21,7 @@ from typing import Any, Protocol
 
 from agent_bom.db import graph_store as sqlite_graph_store
 from agent_bom.graph import AttackPath, EntityType, NodeDimensions, NodeStatus, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph.delta_digest import PriorSnapshotDigest
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 
 # Only finding-like nodes (vulnerabilities, misconfigurations, drift) carry a
@@ -159,6 +160,8 @@ class GraphStoreProtocol(Protocol):
         min_severity_rank: int = 0,
         relationship_types: frozenset[str] | None = None,
     ) -> UnifiedGraph: ...
+
+    def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = "") -> PriorSnapshotDigest: ...
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]: ...
 
@@ -1180,6 +1183,58 @@ class SQLiteGraphStore:
                 scan_id=scan_id,
                 entity_types=entity_types,
                 min_severity_rank=min_severity_rank,
+            )
+        finally:
+            conn.close()
+
+    def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = "") -> PriorSnapshotDigest:
+        """Build a bounded :class:`PriorSnapshotDigest` for delta diffing.
+
+        Streams the prior snapshot's node ids (id column only) and the small
+        AGENT-node + attack-path/interaction-risk key sets instead of loading a
+        second full ``UnifiedGraph`` — so peak RSS on the persist path is not
+        doubled by the previous snapshot (#4055 / #4075).
+        """
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
+        conn = self._open_ro_conn()
+        if conn is None:
+            return PriorSnapshotDigest.empty()
+        try:
+            effective_scan_id, _created = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+            if not effective_scan_id:
+                return PriorSnapshotDigest.empty()
+            node_ids: set[str] = set()
+            for row in conn.execute(
+                "SELECT id FROM graph_nodes WHERE tenant_id = ? AND scan_id = ?",
+                (tenant_id, effective_scan_id),
+            ):
+                node_ids.add(row["id"])
+            agent_nodes: dict[str, UnifiedNode] = {
+                node.id: node
+                for node in sqlite_graph_store.iter_graph_nodes(
+                    conn,
+                    tenant_id=tenant_id,
+                    scan_id=effective_scan_id,
+                    entity_types={EntityType.AGENT.value},
+                )
+            }
+            attack_path_keys: set[tuple[str, str]] = set()
+            for row in conn.execute(
+                "SELECT source_node, target_node FROM attack_paths WHERE tenant_id = ? AND scan_id = ?",
+                (tenant_id, effective_scan_id),
+            ):
+                attack_path_keys.add((row["source_node"], row["target_node"]))
+            interaction_risk_keys: set[tuple[str, tuple[str, ...]]] = set()
+            for row in conn.execute(
+                "SELECT pattern, agents FROM interaction_risks WHERE tenant_id = ? AND scan_id = ?",
+                (tenant_id, effective_scan_id),
+            ):
+                interaction_risk_keys.add((row["pattern"], tuple(sorted(json.loads(row["agents"])))))
+            return PriorSnapshotDigest(
+                node_ids=frozenset(node_ids),
+                agent_nodes=agent_nodes,
+                attack_path_keys=frozenset(attack_path_keys),
+                interaction_risk_keys=frozenset(interaction_risk_keys),
             )
         finally:
             conn.close()

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -336,7 +336,8 @@ def _persist_graph_snapshot(
     export all derive from the same persisted graph state.
     """
     from agent_bom.graph.builder import build_unified_graph_from_report
-    from agent_bom.graph.webhooks import compute_delta_alerts, dispatch_delta_alerts
+    from agent_bom.graph.delta_digest import PriorSnapshotDigest
+    from agent_bom.graph.webhooks import compute_delta_alerts_from_digest, dispatch_delta_alerts
 
     tenant_id = job.tenant_id or "default"
     scan_id = report_json.get("scan_id") or job.job_id
@@ -346,16 +347,23 @@ def _persist_graph_snapshot(
 
     tenant_token = set_current_tenant(tenant_id)
     try:
-        previous_graph = None
+        prior_digest = PriorSnapshotDigest.empty()
         graph_store = _get_graph_store()
         previous_scan_id = graph_store.latest_snapshot_id(tenant_id=tenant_id)
         if previous_scan_id and previous_scan_id != scan_id:
-            previous_graph = graph_store.load_graph(tenant_id=tenant_id, scan_id=previous_scan_id)
+            # Bounded prior-snapshot read for delta diffing — never materialise a
+            # second full UnifiedGraph (#4055 / #4075). Backends that predate the
+            # digest primitive fall back to the full load (byte-identical result).
+            digest_reader = getattr(graph_store, "prior_delta_digest", None)
+            if callable(digest_reader):
+                prior_digest = digest_reader(tenant_id=tenant_id, scan_id=previous_scan_id)
+            else:
+                prior_digest = PriorSnapshotDigest.from_graph(graph_store.load_graph(tenant_id=tenant_id, scan_id=previous_scan_id))
         graph_store.save_graph(graph)
     finally:
         reset_current_tenant(tenant_token)
 
-    alerts = compute_delta_alerts(previous_graph, graph)
+    alerts = compute_delta_alerts_from_digest(prior_digest, graph)
     delivery = dispatch_delta_alerts(alerts, product_version=__version__, tenant_id=tenant_id) if alerts else None
     _logger.info(
         "Graph persisted for scan=%s tenant=%s nodes=%d edges=%d delta_alerts=%d delta_delivered=%d",

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -973,6 +973,67 @@ class PostgresGraphStore:
 
             return graph
 
+    def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = ""):
+        """Build a bounded prior-snapshot digest for delta diffing.
+
+        Streams the prior snapshot's node ids via a server-side cursor and loads
+        only the small AGENT-node + attack-path/interaction-risk key sets, so the
+        persist path never materialises a second full ``UnifiedGraph`` just to
+        diff against it (#4055 / #4075).
+        """
+        from agent_bom.graph.delta_digest import PriorSnapshotDigest
+        from agent_bom.graph.types import EntityType
+
+        tenant_id = normalize_graph_tenant_id(tenant_id)
+        effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
+        if not effective_scan_id:
+            return PriorSnapshotDigest.empty()
+
+        node_ids: set[str] = set()
+        agent_nodes: dict[str, Any] = {}
+        attack_path_keys: set[tuple[str, str]] = set()
+        interaction_risk_keys: set[tuple[str, tuple[str, ...]]] = set()
+
+        with _tenant_connection(self._pool) as conn:
+            # Server-side (named) cursor streams node ids without buffering the
+            # whole result set client-side — peak stays bounded by the id set.
+            with conn.cursor(name="prior_delta_digest_ids") as cur:
+                cur.itersize = 5000
+                cur.execute(
+                    "SELECT id FROM graph_nodes WHERE tenant_id = %s AND scan_id = %s",
+                    (tenant_id, effective_scan_id),
+                )
+                for row in cur:
+                    node_ids.add(row[0])
+
+            agent_query = (
+                "SELECT id, entity_type, label, category_uid, class_uid, type_uid, status, risk_score, severity, "
+                "severity_id, first_seen, last_seen, attributes, compliance_tags, data_sources, dimensions "
+                "FROM graph_nodes WHERE tenant_id = %s AND scan_id = %s AND entity_type = %s"
+            )
+            for row in conn.execute(agent_query, (tenant_id, effective_scan_id, EntityType.AGENT.value)).fetchall():
+                node = self._node_from_row(row)
+                agent_nodes[node.id] = node
+
+            for row in conn.execute(
+                "SELECT source_node, target_node FROM attack_paths WHERE tenant_id = %s AND scan_id = %s",
+                (tenant_id, effective_scan_id),
+            ).fetchall():
+                attack_path_keys.add((row[0], row[1]))
+
+            for row in conn.execute(
+                "SELECT pattern, agents FROM interaction_risks WHERE tenant_id = %s AND scan_id = %s",
+                (tenant_id, effective_scan_id),
+            ).fetchall():
+                interaction_risk_keys.add((row[0], tuple(sorted(json.loads(row[1])))))
+
+        return PriorSnapshotDigest(
+            node_ids=frozenset(node_ids),
+            agent_nodes=agent_nodes,
+            attack_path_keys=frozenset(attack_path_keys),
+            interaction_risk_keys=frozenset(interaction_risk_keys),
+        )
+
     def nodes_by_ids(
         self,
         *,

--- a/src/agent_bom/graph/__init__.py
+++ b/src/agent_bom/graph/__init__.py
@@ -16,6 +16,7 @@ from agent_bom.graph.container import (
     LegendEntry,
     UnifiedGraph,
 )
+from agent_bom.graph.delta_digest import PriorSnapshotDigest
 from agent_bom.graph.dependency_reach import (
     PackageReachability,
     ReachabilityReport,
@@ -41,7 +42,12 @@ from agent_bom.graph.severity import (
 )
 from agent_bom.graph.types import EntityType, GraphLayout, GraphSemanticLayer, NodeStatus, RelationshipType
 from agent_bom.graph.util import _now_iso
-from agent_bom.graph.webhooks import compute_delta_alerts, dispatch_delta_alerts, format_alerts_for_siem
+from agent_bom.graph.webhooks import (
+    compute_delta_alerts,
+    compute_delta_alerts_from_digest,
+    dispatch_delta_alerts,
+    format_alerts_for_siem,
+)
 
 __all__ = [
     # Types
@@ -94,6 +100,8 @@ __all__ = [
     # Builder
     "build_unified_graph_from_report",
     "compute_delta_alerts",
+    "compute_delta_alerts_from_digest",
+    "PriorSnapshotDigest",
     "dispatch_delta_alerts",
     "format_alerts_for_siem",
     # Dependency reachability (#1896)

--- a/src/agent_bom/graph/delta_digest.py
+++ b/src/agent_bom/graph/delta_digest.py
@@ -1,0 +1,64 @@
+"""Bounded prior-snapshot digest for graph delta-alert computation.
+
+``compute_delta_alerts`` only needs a handful of facts about the *previous*
+snapshot: the set of node ids (for new-node detection), the agent nodes (for
+removed-agent detection and their event refs), and the attack-path /
+interaction-risk keys. Materialising the whole previous ``UnifiedGraph`` just to
+diff against it holds a second full graph in memory (#4055 / #4075).
+
+:class:`PriorSnapshotDigest` captures exactly those facts and nothing else, so a
+store can build it by streaming the prior snapshot's nodes one at a time — peak
+RSS stays bounded by the id-string set and the (small) agent-node subset rather
+than every node's attributes/dimensions payload.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType
+
+
+@dataclass(frozen=True)
+class PriorSnapshotDigest:
+    """Bounded projection of a previous graph snapshot for delta diffing.
+
+    - ``node_ids``: every prior node id (membership test for new nodes).
+    - ``agent_nodes``: prior AGENT nodes only (removed-agent detection + refs).
+    - ``attack_path_keys``: ``(source, target)`` of each prior attack path.
+    - ``interaction_risk_keys``: ``(pattern, sorted-agents)`` of each prior risk.
+    """
+
+    node_ids: frozenset[str] = frozenset()
+    agent_nodes: Mapping[str, UnifiedNode] = field(default_factory=dict)
+    attack_path_keys: frozenset[tuple[str, str]] = frozenset()
+    interaction_risk_keys: frozenset[tuple[str, tuple[str, ...]]] = frozenset()
+
+    @classmethod
+    def empty(cls) -> PriorSnapshotDigest:
+        """Digest of a non-existent prior snapshot (first scan for a tenant)."""
+        return cls()
+
+    @classmethod
+    def from_graph(cls, graph: object | None) -> PriorSnapshotDigest:
+        """Project a fully materialised ``UnifiedGraph`` into a digest.
+
+        Kept identical to the fields ``compute_delta_alerts`` reads off a full
+        graph so the streamed and in-memory paths produce byte-identical alerts.
+        Accepts ``None`` (no prior snapshot) → empty digest.
+        """
+        if graph is None:
+            return cls.empty()
+        nodes: Mapping[str, UnifiedNode] = graph.nodes  # type: ignore[attr-defined]
+        agent_nodes = {nid: node for nid, node in nodes.items() if node.entity_type == EntityType.AGENT}
+        return cls(
+            node_ids=frozenset(nodes.keys()),
+            agent_nodes=agent_nodes,
+            attack_path_keys=frozenset((p.source, p.target) for p in graph.attack_paths),  # type: ignore[attr-defined]
+            interaction_risk_keys=frozenset(
+                (r.pattern, tuple(sorted(r.agents)))
+                for r in graph.interaction_risks  # type: ignore[attr-defined]
+            ),
+        )

--- a/src/agent_bom/graph/webhooks.py
+++ b/src/agent_bom/graph/webhooks.py
@@ -19,6 +19,8 @@ from typing import Any
 
 from agent_bom.event_normalization import build_event_ref, build_event_relationships
 from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.delta_digest import PriorSnapshotDigest
+from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.severity import SEVERITY_RANK
 from agent_bom.graph.types import EntityType
 from agent_bom.posture_streaming import PostureEvent, WebhookDestination, WebhookOutbox, default_webhook_outbox
@@ -28,15 +30,15 @@ logger = logging.getLogger(__name__)
 
 
 def _graph_node_ref(
-    graph: UnifiedGraph | None,
+    nodes: Mapping[str, UnifiedNode] | None,
     node_id: str,
     *,
     role: str,
 ) -> dict[str, Any] | None:
-    """Resolve one graph node into a canonical event target reference."""
-    if graph is None:
+    """Resolve one node (from a node mapping) into a canonical event target ref."""
+    if nodes is None:
         return None
-    node = graph.nodes.get(node_id)
+    node = nodes.get(node_id)
     if node is None:
         return None
     return build_event_ref(
@@ -54,12 +56,12 @@ def _graph_node_ref(
 
 def _graph_relationships(
     *,
-    graph: UnifiedGraph | None,
+    nodes: Mapping[str, UnifiedNode] | None,
     targets: list[tuple[str, str]],
     source: str = "graph_delta",
 ) -> dict[str, Any] | None:
     """Build an additive canonical relationship envelope for delta alerts."""
-    target_refs = [_graph_node_ref(graph, node_id, role=role) for node_id, role in targets]
+    target_refs = [_graph_node_ref(nodes, node_id, role=role) for node_id, role in targets]
     return build_event_relationships(source=source, targets=[ref for ref in target_refs if ref])
 
 
@@ -83,10 +85,30 @@ def compute_delta_alerts(
 
     Returns a list of alert dicts suitable for SIEM push or webhook delivery.
     Each alert has: type, severity, title, description, node_ids, scan_id.
+
+    Thin wrapper over :func:`compute_delta_alerts_from_digest` — projects the
+    fully materialised ``old_graph`` into a :class:`PriorSnapshotDigest` first.
+    Callers that can stream the prior snapshot (the scan pipeline) should build
+    the digest via a bounded store read and call the digest form directly, so
+    peak RSS is not doubled by a second full graph (#4055 / #4075).
+    """
+    return compute_delta_alerts_from_digest(PriorSnapshotDigest.from_graph(old_graph), new_graph)
+
+
+def compute_delta_alerts_from_digest(
+    prior: PriorSnapshotDigest,
+    new_graph: UnifiedGraph,
+) -> list[dict[str, Any]]:
+    """Compute delta alerts against a bounded prior-snapshot digest.
+
+    Byte-identical to :func:`compute_delta_alerts` on the same underlying
+    snapshots, but the prior side is a :class:`PriorSnapshotDigest` (node ids +
+    agent nodes + path/risk keys) rather than a whole ``UnifiedGraph`` — so the
+    caller never materialises a second full graph just to diff against it.
     """
     alerts: list[dict[str, Any]] = []
 
-    old_nodes = old_graph.nodes if old_graph else {}
+    old_node_ids = prior.node_ids
 
     # ── New critical/high findings ───────────────────────────────────
     # Large control-plane snapshots are usually dominated by unchanged
@@ -94,7 +116,7 @@ def compute_delta_alerts(
     # against the prior snapshot instead of materializing full node-id
     # difference sets or scanning the same delta twice.
     for nid, node in new_graph.nodes.items():
-        if nid in old_nodes:
+        if nid in old_node_ids:
             continue
         if node.entity_type == EntityType.VULNERABILITY and SEVERITY_RANK.get(node.severity, 0) >= 4:
             details = {
@@ -118,7 +140,7 @@ def compute_delta_alerts(
                     "scan_id": new_graph.scan_id,
                     "details": details,
                     "event_relationships": _graph_relationships(
-                        graph=new_graph,
+                        nodes=new_graph.nodes,
                         targets=[(nid, "affected_finding")],
                     ),
                     "attributes": {
@@ -147,16 +169,14 @@ def compute_delta_alerts(
                     "scan_id": new_graph.scan_id,
                     "details": details,
                     "event_relationships": _graph_relationships(
-                        graph=new_graph,
+                        nodes=new_graph.nodes,
                         targets=[(nid, "affected_finding")],
                     ),
                 }
             )
 
     # ── New attack paths with high composite risk ────────────────────
-    old_path_keys = set()
-    if old_graph:
-        old_path_keys = {(p.source, p.target) for p in old_graph.attack_paths}
+    old_path_keys = prior.attack_path_keys
     for path in new_graph.attack_paths:
         if (path.source, path.target) not in old_path_keys and path.composite_risk >= 7.0:
             details = {
@@ -180,7 +200,7 @@ def compute_delta_alerts(
                     "scan_id": new_graph.scan_id,
                     "details": details,
                     "event_relationships": _graph_relationships(
-                        graph=new_graph,
+                        nodes=new_graph.nodes,
                         targets=[
                             (path.source, "path_source"),
                             (path.target, "path_target"),
@@ -195,9 +215,7 @@ def compute_delta_alerts(
             )
 
     # ── New lateral movement risks ───────────────────────────────────
-    old_risk_keys = set()
-    if old_graph:
-        old_risk_keys = {(r.pattern, tuple(sorted(r.agents))) for r in old_graph.interaction_risks}
+    old_risk_keys = prior.interaction_risk_keys
     for risk in new_graph.interaction_risks:
         key = (risk.pattern, tuple(sorted(risk.agents)))
         if key not in old_risk_keys and risk.risk_score >= 7.0:
@@ -222,7 +240,7 @@ def compute_delta_alerts(
                     "scan_id": new_graph.scan_id,
                     "details": details,
                     "event_relationships": _graph_relationships(
-                        graph=new_graph,
+                        nodes=new_graph.nodes,
                         targets=[(node_id, "affected_agent") for node_id in node_ids],
                     ),
                     "attributes": {
@@ -234,8 +252,8 @@ def compute_delta_alerts(
             )
 
     # ── Nodes removed (potential drift) ──────────────────────────────
-    if old_graph:
-        agent_removed = [nid for nid, node in old_nodes.items() if nid not in new_graph.nodes and node.entity_type == EntityType.AGENT]
+    if prior.agent_nodes:
+        agent_removed = [nid for nid in prior.agent_nodes if nid not in new_graph.nodes]
         if agent_removed:
             details = {
                 "node_ids": agent_removed,
@@ -254,7 +272,7 @@ def compute_delta_alerts(
                     "scan_id": new_graph.scan_id,
                     "details": details,
                     "event_relationships": _graph_relationships(
-                        graph=old_graph,
+                        nodes=prior.agent_nodes,
                         targets=[(node_id, "removed_agent") for node_id in agent_removed],
                     ),
                 }

--- a/tests/test_control_plane_contracts.py
+++ b/tests/test_control_plane_contracts.py
@@ -139,7 +139,7 @@ def control_plane_contracts(tmp_path, monkeypatch):
         "agent_bom.graph.builder.build_unified_graph_from_report",
         lambda report_json, scan_id, tenant_id: graphs[scan_id],
     )
-    monkeypatch.setattr("agent_bom.graph.webhooks.compute_delta_alerts", lambda previous, current: [])
+    monkeypatch.setattr("agent_bom.graph.webhooks.compute_delta_alerts_from_digest", lambda prior, current: [])
     monkeypatch.setattr("agent_bom.graph.webhooks.dispatch_delta_alerts", lambda alerts, product_version=None: None)
 
     _persist_graph_snapshot(alpha_job, {"scan_id": "tenant-alpha-scan"})

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2066,7 +2066,7 @@ class TestGraphStoreBackendSelection:
 
         monkeypatch.setattr("agent_bom.api.pipeline._get_graph_store", lambda: recording_graph_store)
         monkeypatch.setattr("agent_bom.graph.builder.build_unified_graph_from_report", lambda report_json, scan_id, tenant_id: persisted)
-        monkeypatch.setattr("agent_bom.graph.webhooks.compute_delta_alerts", lambda previous, current: [])
+        monkeypatch.setattr("agent_bom.graph.webhooks.compute_delta_alerts_from_digest", lambda prior, current: [])
         monkeypatch.setattr(
             "agent_bom.api.postgres_store.set_current_tenant",
             lambda tenant_id: tenant_context.append(("set", tenant_id)) or "tenant-token",

--- a/tests/test_graph_streaming_producer.py
+++ b/tests/test_graph_streaming_producer.py
@@ -1,0 +1,178 @@
+"""Streaming graph producer: bounded prior-snapshot digest for delta alerts.
+
+Wires the #4074 streaming primitives through the production persist path
+(#4075): the delta-alert computation no longer materialises a second full
+``UnifiedGraph`` for the previous snapshot — it streams a bounded
+``PriorSnapshotDigest`` instead. These tests assert the streamed path is
+byte-identical to the old full-load path AND that its peak Python-heap footprint
+is a fraction of the full-load path's on the same snapshot.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+
+import pytest
+
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph import (
+    AttackPath,
+    EntityType,
+    InteractionRisk,
+    RelationshipType,
+    UnifiedEdge,
+    UnifiedGraph,
+    UnifiedNode,
+)
+from agent_bom.graph.delta_digest import PriorSnapshotDigest
+from agent_bom.graph.webhooks import compute_delta_alerts, compute_delta_alerts_from_digest
+
+
+def _prior_graph(scan_id: str = "s1", tenant_id: str = "t") -> UnifiedGraph:
+    """A rich prior snapshot exercising every delta-alert branch."""
+    g = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
+    # Bulk unchanged inventory (dominates the full-load memory cost).
+    for i in range(200):
+        g.add_node(UnifiedNode(id=f"package:p{i}", entity_type=EntityType.PACKAGE, label=f"p{i}"))
+    g.add_node(UnifiedNode(id="agent:kept", entity_type=EntityType.AGENT, label="kept"))
+    g.add_node(UnifiedNode(id="agent:removed", entity_type=EntityType.AGENT, label="removed"))
+    g.add_node(UnifiedNode(id="vuln:OLD", entity_type=EntityType.VULNERABILITY, label="OLD", severity="critical"))
+    g.add_edge(UnifiedEdge(source="agent:kept", target="vuln:OLD", relationship=RelationshipType.VULNERABLE_TO))
+    g.attack_paths.append(AttackPath(source="agent:kept", target="vuln:OLD", hops=["agent:kept", "vuln:OLD"], composite_risk=8.0))
+    g.interaction_risks.append(
+        InteractionRisk(pattern="existing_pattern", agents=["agent:kept", "agent:removed"], risk_score=8.0, description="d")
+    )
+    return g
+
+
+def _new_graph(scan_id: str = "s2", tenant_id: str = "t") -> UnifiedGraph:
+    """A follow-up snapshot with a new vuln, misconfig, path, risk, and a removed agent."""
+    g = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
+    for i in range(200):
+        g.add_node(UnifiedNode(id=f"package:p{i}", entity_type=EntityType.PACKAGE, label=f"p{i}"))
+    g.add_node(UnifiedNode(id="agent:kept", entity_type=EntityType.AGENT, label="kept"))
+    # agent:removed is gone -> removed-agent alert
+    g.add_node(UnifiedNode(id="vuln:OLD", entity_type=EntityType.VULNERABILITY, label="OLD", severity="critical"))
+    g.add_node(
+        UnifiedNode(
+            id="vuln:NEW",
+            entity_type=EntityType.VULNERABILITY,
+            label="NEW",
+            severity="critical",
+            attributes={"cvss_score": 9.8, "is_kev": True, "affected_agent_count": 3},
+        )
+    )
+    g.add_node(UnifiedNode(id="misconfig:NEW", entity_type=EntityType.MISCONFIGURATION, label="MISC", severity="high"))
+    g.attack_paths.append(AttackPath(source="agent:kept", target="vuln:OLD", hops=["agent:kept", "vuln:OLD"], composite_risk=8.0))
+    g.attack_paths.append(AttackPath(source="agent:kept", target="vuln:NEW", hops=["agent:kept", "vuln:NEW"], composite_risk=9.5))
+    g.interaction_risks.append(
+        InteractionRisk(pattern="existing_pattern", agents=["agent:kept", "agent:removed"], risk_score=8.0, description="d")
+    )
+    g.interaction_risks.append(
+        InteractionRisk(pattern="new_pattern", agents=["agent:kept"], risk_score=9.0, description="new", owasp_agentic_tag="AAI01")
+    )
+    return g
+
+
+@pytest.fixture
+def store(tmp_path):
+    return SQLiteGraphStore(db_path=tmp_path / "graph.db")
+
+
+def test_from_graph_projects_exactly_what_delta_needs():
+    prior = PriorSnapshotDigest.from_graph(_prior_graph())
+    assert "package:p0" in prior.node_ids
+    assert prior.node_ids == frozenset(_prior_graph().nodes.keys())
+    # Only AGENT nodes are retained in full (bounded), not the 200 packages.
+    assert set(prior.agent_nodes) == {"agent:kept", "agent:removed"}
+    assert prior.attack_path_keys == frozenset({("agent:kept", "vuln:OLD")})
+    assert prior.interaction_risk_keys == frozenset({("existing_pattern", ("agent:kept", "agent:removed"))})
+
+
+def test_from_graph_none_is_empty():
+    prior = PriorSnapshotDigest.from_graph(None)
+    assert prior == PriorSnapshotDigest.empty()
+    assert prior.node_ids == frozenset()
+    assert prior.agent_nodes == {}
+
+
+def test_digest_alerts_byte_identical_to_full_load(store):
+    """The streamed digest path fires exactly the same alerts as the full-load path."""
+    old = _prior_graph()
+    new = _new_graph()
+    store.save_graph(old)
+
+    # Anchor: in-memory full-graph diff (the historical behaviour).
+    baseline = compute_delta_alerts(old, new)
+    # Old production approach: load the whole prior graph, then diff.
+    full_load = compute_delta_alerts(store.load_graph(tenant_id="t", scan_id="s1"), new)
+    # New production approach: bounded streamed digest, then diff.
+    digest = store.prior_delta_digest(tenant_id="t", scan_id="s1")
+    streamed = compute_delta_alerts_from_digest(digest, new)
+
+    # Every branch must be present so the equality is meaningful.
+    types = {a["type"] for a in baseline}
+    assert types == {"new_vulnerability", "new_misconfiguration", "new_attack_path", "new_interaction_risk", "agent_removed"}
+
+    assert full_load == baseline
+    assert streamed == baseline  # byte-identical, computed via the bounded path
+
+
+def test_prior_delta_digest_matches_from_graph(store):
+    old = _prior_graph()
+    store.save_graph(old)
+
+    streamed = store.prior_delta_digest(tenant_id="t", scan_id="s1")
+    reference = PriorSnapshotDigest.from_graph(store.load_graph(tenant_id="t", scan_id="s1"))
+
+    assert streamed.node_ids == reference.node_ids
+    assert set(streamed.agent_nodes) == set(reference.agent_nodes)
+    assert streamed.attack_path_keys == reference.attack_path_keys
+    assert streamed.interaction_risk_keys == reference.interaction_risk_keys
+
+
+def test_empty_prior_digest_for_missing_snapshot(store):
+    # No snapshot persisted yet -> empty digest, no crash, no alerts suppressed.
+    digest = store.prior_delta_digest(tenant_id="t", scan_id="does-not-exist")
+    assert digest == PriorSnapshotDigest.empty()
+
+
+def test_digest_peak_memory_is_a_fraction_of_full_load(store):
+    """Production-path regression: the bounded digest peak << full load_graph peak.
+
+    Deterministic Python-heap measurement via ``tracemalloc`` (not ru_maxrss,
+    which is platform-variant). ``load_graph`` materialises every node with its
+    attributes/dimensions payload plus edges; the digest holds only id strings
+    and the few agent nodes, so its peak must be a small fraction.
+    """
+    n = 20_000
+    g = UnifiedGraph(scan_id="big", tenant_id="t")
+    for i in range(n):
+        g.add_node(
+            UnifiedNode(
+                id=f"package:p{i}",
+                entity_type=EntityType.PACKAGE,
+                label=f"package-{i}",
+                attributes={"version": f"1.2.{i}", "ecosystem": "pypi", "purl": f"pkg:pypi/p{i}@1.2.{i}"},
+            )
+        )
+    g.add_node(UnifiedNode(id="agent:solo", entity_type=EntityType.AGENT, label="solo"))
+    store.save_graph(g)
+
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    loaded = store.load_graph(tenant_id="t", scan_id="big")
+    _, peak_full = tracemalloc.get_traced_memory()
+    assert len(loaded.nodes) == n + 1
+    del loaded
+    tracemalloc.stop()
+
+    tracemalloc.start()
+    tracemalloc.reset_peak()
+    digest = store.prior_delta_digest(tenant_id="t", scan_id="big")
+    _, peak_digest = tracemalloc.get_traced_memory()
+    assert len(digest.node_ids) == n + 1
+    tracemalloc.stop()
+
+    # The bounded digest must cost well under half the full materialisation.
+    assert peak_digest < peak_full * 0.5, f"digest peak {peak_digest} not < 50% of full-load peak {peak_full}"


### PR DESCRIPTION
## What

Wires the #4074 streaming primitives through the production persist path so the
write-path memory bound is realised end-to-end (#4075). The scan pipeline's
`_persist_graph_snapshot` used to load the **previous** snapshot into a second
full `UnifiedGraph` purely to compute delta alerts — so peak held up to two
materialised graphs. It now diffs against a bounded **`PriorSnapshotDigest`**
streamed from the store instead.

- New `PriorSnapshotDigest` captures exactly what `compute_delta_alerts` needs
  off the prior snapshot: the node-id set (new-node detection), the AGENT nodes
  (removed-agent detection + their event refs), and the attack-path /
  interaction-risk keys — nothing else.
- `compute_delta_alerts(old_graph, new)` is now a thin wrapper over
  `compute_delta_alerts_from_digest(PriorSnapshotDigest.from_graph(old_graph), new)`,
  so existing callers and results are unchanged.
- `prior_delta_digest(...)` added to the graph-store protocol and both real
  backends: SQLite streams the id column + the small agent/path/risk sets;
  Postgres uses a server-side (named) cursor for the id scan. Backends without
  the primitive fall back to a full load (byte-identical result).
- `_persist_graph_snapshot` reads the digest and diffs via
  `compute_delta_alerts_from_digest`.

## Memory result (production persist path, prior-snapshot read)

Deterministic `tracemalloc` Python-heap peak (not `ru_maxrss`, which is
platform-variant per the #4083 lesson), same N, old full-load vs new digest:

| N nodes | old full prior-load peak | new streamed digest peak | reduction |
|--------:|-------------------------:|-------------------------:|----------:|
| 100,000 | 120.3 MiB | 13.2 MiB | **89.0%** (9.1x) |
| 500,000 | 594.1 MiB | 58.6 MiB | **90.1%** (10.1x) |

## Correctness

Graph results are identical — this only bounds memory. A test asserts the
streamed-digest alerts are **byte-identical** to the full-load path across every
branch (new vulnerability / misconfiguration / attack path / interaction risk /
removed agent), and an end-to-end persist→delta smoke confirms the same alerts
fire through the real SQLite store (which uses the bounded path).

## Realised vs deferred

- **Realised (this PR):** the second full prior-snapshot materialisation on the
  production persist path is gone — the biggest remaining doubling of peak RSS
  described in #4075.
- **Already done in #4074:** the freshly-built graph's persist already streams
  (`save_graph` is a thin wrapper over `save_graph_streaming` feeding
  `graph.nodes.values()`), so persisting adds no extra copy — no change needed.
- **Deferred (tracked, out of scope):** streaming `build_unified_graph_from_report`
  itself so the freshly-built graph is never fully materialised. That is the deep
  correlation-builder refactor (cross-entity correlation + attack-path fusion need
  broad visibility) called out in #4075 and is intentionally not attempted here.

Non-negotiables held: persist stays off the request event loop (unchanged),
queries are sargable (`tenant_id, scan_id` keyed), and the empty-prior /
missing-snapshot cases fail closed to an empty digest.

## Verification

- `pytest` touched suites (streaming producer, wave23 delta, graph_api,
  control-plane contracts) — green; broader delta/graph_store/persist sweep 204
  passed.
- `ruff check` + `ruff format --check` + `mypy` on changed files — clean.

Progresses #4075.