### PR TITLE
feat(connect-wizard): AWS Organization StackSet onboarding path

### DIFF
--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -517,3 +517,37 @@ the freshness of the SDK layer is surfaced, never left silent.
     `summary`, alongside the vuln-DB freshness fields.
 - **How to refresh.** Upgrade the matching extra, e.g.
   `pip install -U 'agent-bom[aws]'` (or `[azure]` / `[gcp]` / `[snowflake]`).
+- **Staying current automatically.** Dependabot keeps the provider SDKs on a
+  safe cadence via the `cloud-and-ai-sdks` group in `.github/dependabot.yml`
+  (boto3/botocore are data-driven and backward-compatible, so new provider APIs
+  land through routine bumps).
+
+### 9.1 Provider-API deprecation posture (a legacy-SDK exposure guard)
+
+The freshness check above answers "is my SDK current?". A complementary signal
+answers "does my install still depend on a provider API the vendor has
+*retired*?" A retired API returns errors (for example Azure AD Graph now returns
+HTTP 403), so a check that still routes through it under-covers or fails
+silently.
+
+- **What it checks.** A small, first-party-sourced watchlist of retired /
+  deprecated provider APIs (e.g. the retired **Azure AD Graph API**, the
+  deprecated **oauth2client** auth library), each keyed by the *legacy*
+  distribution that speaks it. The probe is whether that legacy SDK is present
+  in the environment — an **offline, deterministic** check evaluated against the
+  current date.
+- **Honest default is "clear".** agent-bom already uses the modern replacement
+  for every entry (Azure identities/roles via Azure Resource Manager, GCP auth
+  via `google-auth`), so the shipped posture is *clear*. The signal only lights
+  up if a legacy SDK is dragged into the tree — a supply-chain / coverage guard.
+- **Fail-honest gating.** When a retired API is *both* past its removal date and
+  reachable via an installed legacy SDK, it is marked **gated**: a check bound
+  to it must be skipped and reported, never silently passed. The
+  `removed_provider_apis()` helper exposes that skip set for scanners.
+- **Where it shows up.**
+  - `agent-bom doctor` renders a **Cloud API deprecations** section (each API
+    with its status and migration target).
+  - `--agent-mode` scan metadata carries a `deprecations` block (`status`,
+    `removed_count`, `at_risk_count`, `gated`, `warnings`) nested under
+    `cloud_sdk_freshness`; `doctor --agent-mode` emits a
+    `cloud_api_deprecations` section in its envelope.

--- a/src/agent_bom/cli/_doctor.py
+++ b/src/agent_bom/cli/_doctor.py
@@ -29,6 +29,7 @@ def doctor_cmd() -> None:
     runtime_checks: list[tuple[str, str, str]] = []
     platform_checks: list[tuple[str, str, str]] = []
     cloud_sdk_checks: list[tuple[str, str, str]] = []
+    cloud_api_checks: list[tuple[str, str, str]] = []
 
     # Python version
     py_ver = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
@@ -143,6 +144,26 @@ def doctor_cmd() -> None:
     except Exception:
         cloud_sdk_checks.append(("Cloud SDKs", "freshness check unavailable", "info"))
 
+    # Provider-API deprecation posture — a legacy-SDK exposure guard for
+    # retired/deprecating provider APIs (Azure AD Graph, oauth2client, …).
+    # Honest default is "clear": agent-bom uses the modern replacements, so this
+    # only lights up if a legacy SDK is dragged into the environment.
+    try:
+        from agent_bom.cloud_sdk_freshness import cloud_api_deprecation_posture
+
+        _api_status_map = {"clear": "ok", "at_risk": "warn", "gated": "warn"}
+        for api in cloud_api_deprecation_posture()["apis"]:
+            if api["status"] == "clear":
+                value = f"clear (uses {api['replacement']})"
+            elif api["status"] == "gated":
+                value = f"retired + {api['distribution']} present — checks skipped; migrate to {api['replacement']}"
+            else:
+                when = f" on {api['retirement_date']}" if api["retirement_date"] else ""
+                value = f"deprecating{when} — {api['distribution']} present; migrate to {api['replacement']}"
+            cloud_api_checks.append((api["api"], value, _api_status_map.get(api["status"], "info")))
+    except Exception:
+        cloud_api_checks.append(("Cloud API deprecations", "check unavailable", "info"))
+
     checks = [*core_checks, *runtime_checks, *platform_checks]
     warns = sum(1 for _, _, s in checks if s == "warn")
 
@@ -172,6 +193,7 @@ def doctor_cmd() -> None:
                 "runtime": _section(runtime_checks),
                 "platform": _section(platform_checks),
                 "cloud_sdk": _section(cloud_sdk_checks),
+                "cloud_api_deprecations": _section(cloud_api_checks),
                 "capabilities": capabilities,
                 "coverage": coverage,
                 "ready": warns == 0,
@@ -189,6 +211,7 @@ def doctor_cmd() -> None:
     _print_section(console, "Runtime surfaces", runtime_checks)
     _print_section(console, "Platform integrations", platform_checks)
     _print_section(console, "Cloud SDK freshness", cloud_sdk_checks)
+    _print_section(console, "Cloud API deprecations", cloud_api_checks)
 
     # Nothing-silent capability view — every gated feature with its state and
     # unlock path, so a skipped/degraded capability is never silent.

--- a/src/agent_bom/cloud_sdk_freshness.py
+++ b/src/agent_bom/cloud_sdk_freshness.py
@@ -32,9 +32,15 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass
+from datetime import date, datetime, timezone
 from typing import Any
 
 SCHEMA_VERSION = 1
+
+# How far ahead a scheduled retirement is still surfaced as a live "deprecating"
+# signal when a legacy SDK is present. Purely cosmetic today (any not-yet-removed
+# exposed entry warns); kept as a named constant so the horizon is explicit.
+DEPRECATION_HORIZON_DAYS = 365
 
 
 @dataclass(frozen=True)
@@ -257,5 +263,260 @@ def cloud_sdk_freshness_summary(
             for s in posture["sdks"]
             if s["status"] == "outdated"
         ],
+        "warnings": [w["message"] for w in posture["warnings"]],
+        # Provider-API retirement posture (Azure AD Graph, oauth2client, …):
+        # a legacy-SDK exposure signal that complements the version-floor check.
+        "deprecations": cloud_api_deprecation_summary(installed=installed),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Provider-API deprecation / removal posture
+# ---------------------------------------------------------------------------
+#
+# The version-floor check above answers "is my SDK current?". This second
+# signal answers a different, complementary question: "does my install still
+# depend on a provider API the vendor has *retired* (or scheduled to retire)?"
+# A retired API returns errors (e.g. Azure AD Graph → HTTP 403), so a check that
+# still routes through it silently under-covers or fails — the same
+# gap-that-looks-like-coverage failure mode.
+#
+# Modeled as a small, deterministic, offline watchlist keyed by the *legacy*
+# distribution that speaks the retired API. agent-bom itself already uses the
+# modern replacement for each entry (Azure identities/roles via Azure Resource
+# Manager, GCP auth via google-auth), so the honest default posture is "clear".
+# The signal fires only when a legacy SDK is actually present in the tree — a
+# supply-chain / coverage guard, evaluated against an injected clock so the
+# removed / deprecating / clear states are all reproducible.
+
+
+@dataclass(frozen=True)
+class ProviderApiDeprecation:
+    """One retired or deprecated provider API on the watchlist.
+
+    Attributes:
+        provider: Provider id (``aws`` / ``azure`` / ``gcp`` / ``snowflake``).
+        api: Human label of the provider API being retired.
+        distribution: The *legacy* PyPI distribution that speaks the retired
+            API — the exposure probe. ``None`` means there is no distinct SDK to
+            detect (the entry is informational only).
+        replacement: The modern SDK/API agent-bom uses instead.
+        retirement_date: ISO ``YYYY-MM-DD`` the API stops working, or ``None``
+            for a deprecation with no scheduled removal date.
+        note: Short, honest description of the impact and agent-bom's posture.
+        reference: Official first-party source URL for the retirement.
+    """
+
+    provider: str
+    api: str
+    distribution: str | None
+    replacement: str
+    retirement_date: str | None
+    note: str
+    reference: str
+
+
+# Real, first-party-sourced entries only. Verified against vendor docs; each
+# carries its source URL. agent-bom uses the modern replacement for all of
+# these, so the shipped posture is "clear" unless a legacy SDK is dragged in.
+PROVIDER_API_DEPRECATIONS: tuple[ProviderApiDeprecation, ...] = (
+    ProviderApiDeprecation(
+        provider="azure",
+        api="Azure AD Graph API (graph.windows.net)",
+        distribution="azure-graphrbac",
+        replacement="Microsoft Graph (azure-identity + msgraph-sdk)",
+        # Extended-access apps lose Azure AD Graph access in early September 2025;
+        # calls then return HTTP 403. Microsoft Entra blog, ref below.
+        retirement_date="2025-09-01",
+        note=(
+            "Azure AD Graph is retired — dependent apps receive HTTP 403. "
+            "agent-bom reads Azure identities/roles via Azure Resource Manager "
+            "(azure-mgmt-authorization), so it is clear unless a legacy "
+            "azure-graphrbac dependency is present."
+        ),
+        reference=("https://techcommunity.microsoft.com/blog/microsoft-entra-blog/important-update-azure-ad-graph-api-retirement/4090534"),
+    ),
+    ProviderApiDeprecation(
+        provider="gcp",
+        api="oauth2client auth library",
+        distribution="oauth2client",
+        replacement="google-auth",
+        # Deprecated by Google in favor of google-auth; no scheduled removal.
+        retirement_date=None,
+        note=(
+            "oauth2client is deprecated by Google in favor of google-auth. "
+            "agent-bom uses google-auth; a transitive oauth2client would be a "
+            "supply-chain and coverage risk."
+        ),
+        reference="https://google-auth.readthedocs.io/en/latest/oauth2client-deprecation.html",
+    ),
+)
+
+
+def _as_date(value: date | datetime | None) -> date:
+    """Normalize an injected reference time to a ``date`` (UTC ``today`` default)."""
+    if value is None:
+        return datetime.now(timezone.utc).date()
+    if isinstance(value, datetime):
+        return value.date()
+    return value
+
+
+def _parse_iso_date(value: str | None) -> date | None:
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None
+
+
+def cloud_api_deprecation_posture(
+    *,
+    now: date | datetime | None = None,
+    installed: Callable[[str], str | None] | Mapping[str, str | None] | None = None,
+    deprecations: Iterable[ProviderApiDeprecation] = PROVIDER_API_DEPRECATIONS,
+    horizon_days: int = DEPRECATION_HORIZON_DAYS,
+) -> dict[str, Any]:
+    """Compute the provider-API deprecation / removal posture.
+
+    For each watchlist entry the ``distribution`` is probed against the
+    installed environment (``exposed``) and the ``retirement_date`` compared to
+    ``now``:
+
+    * ``lifecycle`` is ``removed`` once ``now`` is at or past the retirement
+      date, otherwise ``deprecating`` (a future-dated or undated deprecation).
+    * ``status`` folds in exposure: ``gated`` (removed **and** a legacy SDK is
+      installed — a dependent check must be skipped honestly), ``at_risk``
+      (deprecating and exposed), or ``clear`` (not exposed — agent-bom uses the
+      modern replacement).
+
+    Deterministic for a fixed ``now`` + ``installed``; never raises. Non-blocking
+    — a signal, never a gate on the process exit code.
+    """
+    resolve = _make_resolver(installed)
+    today = _as_date(now)
+
+    apis: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    gated: list[dict[str, Any]] = []
+
+    for dep in deprecations:
+        exposed = dep.distribution is not None and resolve(dep.distribution) is not None
+        retire = _parse_iso_date(dep.retirement_date)
+        removed = retire is not None and today >= retire
+        lifecycle = "removed" if removed else "deprecating"
+
+        days_until = (retire - today).days if retire is not None and not removed else None
+
+        if exposed and removed:
+            status = "gated"
+        elif exposed:
+            status = "at_risk"
+        else:
+            status = "clear"
+
+        entry = {
+            "provider": dep.provider,
+            "api": dep.api,
+            "distribution": dep.distribution,
+            "installed": exposed,
+            "replacement": dep.replacement,
+            "retirement_date": dep.retirement_date,
+            "days_until_retirement": days_until,
+            "lifecycle": lifecycle,
+            "status": status,
+            "reference": dep.reference,
+        }
+
+        if status == "gated":
+            entry["message"] = (
+                f"{dep.api} is retired but reachable via installed {dep.distribution} — "
+                f"checks using it are skipped (not silently passed). Migrate to {dep.replacement}."
+            )
+            warnings.append(
+                {
+                    "code": "api_removed",
+                    "provider": dep.provider,
+                    "api": dep.api,
+                    "distribution": dep.distribution,
+                    "message": entry["message"],
+                    "reference": dep.reference,
+                }
+            )
+            gated.append(entry)
+        elif status == "at_risk":
+            when = f" on {dep.retirement_date}" if dep.retirement_date else ""
+            entry["message"] = (
+                f"{dep.api} is deprecated{when} and reachable via installed {dep.distribution} — "
+                f"migrate to {dep.replacement} before it is removed."
+            )
+            warnings.append(
+                {
+                    "code": "api_deprecating",
+                    "provider": dep.provider,
+                    "api": dep.api,
+                    "distribution": dep.distribution,
+                    "message": entry["message"],
+                    "reference": dep.reference,
+                }
+            )
+        else:
+            entry["message"] = (
+                f"clear of {dep.api} — agent-bom uses {dep.replacement} (no {dep.distribution} in the tree)."
+                if dep.distribution
+                else f"clear of {dep.api} — agent-bom uses {dep.replacement}."
+            )
+
+        apis.append(entry)
+
+    removed_count = sum(1 for a in apis if a["status"] == "gated")
+    at_risk_count = sum(1 for a in apis if a["status"] == "at_risk")
+
+    _ = horizon_days  # reserved: today every not-yet-removed exposed entry warns
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "degraded" if warnings else "ok",
+        "check": "installed-legacy-SDK-vs-provider-API-retirement (offline)",
+        "apis": apis,
+        "warnings": warnings,
+        "gated": gated,
+        "removed_count": removed_count,
+        "at_risk_count": at_risk_count,
+    }
+
+
+def removed_provider_apis(
+    *,
+    now: date | datetime | None = None,
+    installed: Callable[[str], str | None] | Mapping[str, str | None] | None = None,
+    deprecations: Iterable[ProviderApiDeprecation] = PROVIDER_API_DEPRECATIONS,
+) -> dict[str, dict[str, Any]]:
+    """Provider APIs that are retired **and** still reachable via a legacy SDK.
+
+    Returns a mapping ``{api_label: posture_entry}``. A scanner/check bound to
+    one of these APIs must skip it and report the skip honestly, rather than
+    silently passing or emitting an empty result that looks like coverage.
+
+    Empty in a normal agent-bom install (it uses the modern replacements) — this
+    is a guard against a legacy SDK being pulled into the environment.
+    """
+    posture = cloud_api_deprecation_posture(now=now, installed=installed, deprecations=deprecations)
+    return {a["api"]: a for a in posture["gated"]}
+
+
+def cloud_api_deprecation_summary(
+    *,
+    now: date | datetime | None = None,
+    installed: Callable[[str], str | None] | Mapping[str, str | None] | None = None,
+) -> dict[str, Any]:
+    """Compact provider-API deprecation block for ``--agent-mode`` metadata."""
+    posture = cloud_api_deprecation_posture(now=now, installed=installed)
+    return {
+        "status": posture["status"],
+        "removed_count": posture["removed_count"],
+        "at_risk_count": posture["at_risk_count"],
+        "gated": [a["api"] for a in posture["gated"]],
         "warnings": [w["message"] for w in posture["warnings"]],
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import inspect
+import logging
 import os
 import sys
 import tempfile
@@ -454,8 +455,20 @@ def reset_global_test_state():
     config_auth_snapshot = _snapshot_config_auth()
     output_console_snapshot = _snapshot_output_console()
 
+    # Snapshot root-logger handlers + level. Several CLI/gateway paths call
+    # ``configure_logging``/``logging.basicConfig`` which ``addHandler`` to root
+    # without removing existing ones, so handlers ACCUMULATE across a worker's
+    # tests. A leaked handler (e.g. one writing to stdout) then contaminates a
+    # later test that parses a command's stdout as JSON — an xdist-order flake.
+    # Restore the exact handler set + level on teardown so no test can leak one.
+    root_logger = logging.getLogger()
+    logging_handlers_snapshot = root_logger.handlers[:]
+    logging_level_snapshot = root_logger.level
+
     yield
 
+    root_logger.handlers[:] = logging_handlers_snapshot
+    root_logger.setLevel(logging_level_snapshot)
     _restore_store_singletons(store_singleton_snapshot)
     _restore_config_auth(config_auth_snapshot)
     _restore_output_console(output_console_snapshot)

--- a/tests/test_cloud_sdk_freshness.py
+++ b/tests/test_cloud_sdk_freshness.py
@@ -8,12 +8,19 @@ metadata built by ``_agent_mode._summary``.
 
 from __future__ import annotations
 
+from datetime import date, datetime, timezone
+
 from click.testing import CliRunner
 
 from agent_bom.cloud_sdk_freshness import (
+    PROVIDER_API_DEPRECATIONS,
     RECOMMENDED_FLOORS,
+    ProviderApiDeprecation,
+    cloud_api_deprecation_posture,
+    cloud_api_deprecation_summary,
     cloud_sdk_freshness_summary,
     cloud_sdk_posture,
+    removed_provider_apis,
 )
 
 # A fully-fresh install: every anchor distribution comfortably above its floor.
@@ -165,3 +172,161 @@ def test_doctor_renders_cloud_sdk_freshness_section():
     result = CliRunner().invoke(doctor_cmd, [])
     assert result.exit_code == 0, result.output
     assert "Cloud SDK freshness" in result.output
+
+
+# ---------------------------------------------------------------------------
+# Provider-API deprecation / removal posture
+# ---------------------------------------------------------------------------
+
+# A reference "now" comfortably after the Azure AD Graph retirement date so the
+# entry evaluates as removed regardless of when the suite runs.
+AFTER_AZURE_GRAPH = date(2026, 1, 1)
+# A reference "now" before it, for the still-scheduled path.
+BEFORE_AZURE_GRAPH = date(2025, 1, 1)
+
+
+def test_catalog_entries_are_real_and_sourced():
+    # Every shipped entry must carry a provider, a human API label, a
+    # replacement, and an official reference URL — no unsourced/fabricated rows.
+    assert PROVIDER_API_DEPRECATIONS
+    for dep in PROVIDER_API_DEPRECATIONS:
+        assert dep.provider and dep.api and dep.replacement
+        assert dep.reference.startswith("https://")
+
+
+def test_clear_when_no_legacy_sdk_installed():
+    # Nothing legacy in the tree: every retirement is informational (clear),
+    # status ok, no warnings — the honest "we use the modern replacement" state.
+    posture = cloud_api_deprecation_posture(now=AFTER_AZURE_GRAPH, installed={})
+    assert posture["status"] == "ok"
+    assert posture["warnings"] == []
+    assert posture["removed_count"] == 0
+    assert posture["at_risk_count"] == 0
+    assert posture["gated"] == []
+    assert all(a["status"] == "clear" for a in posture["apis"])
+
+
+def test_removed_api_with_legacy_sdk_is_gated():
+    # azure-graphrbac present + past the retirement date → the Azure AD Graph
+    # API is removed AND reachable via a legacy SDK, so it is gated (a check
+    # using it must be skipped honestly, never silently passed).
+    posture = cloud_api_deprecation_posture(
+        now=AFTER_AZURE_GRAPH,
+        installed={"azure-graphrbac": "0.61.1"},
+    )
+    assert posture["status"] == "degraded"
+    assert posture["removed_count"] == 1
+    graph = next(a for a in posture["apis"] if a["distribution"] == "azure-graphrbac")
+    assert graph["status"] == "gated"
+    assert graph["lifecycle"] == "removed"
+    codes = {w["code"] for w in posture["warnings"]}
+    assert "api_removed" in codes
+    assert [g["api"] for g in posture["gated"]] == [graph["api"]]
+
+
+def test_removed_api_without_legacy_sdk_is_clear_not_gated():
+    posture = cloud_api_deprecation_posture(
+        now=AFTER_AZURE_GRAPH,
+        installed={},  # azure-graphrbac absent
+    )
+    graph = next(a for a in posture["apis"] if a["distribution"] == "azure-graphrbac")
+    assert graph["lifecycle"] == "removed"
+    assert graph["status"] == "clear"
+    assert posture["gated"] == []
+
+
+def test_scheduled_future_removal_with_legacy_sdk_is_at_risk_not_gated():
+    posture = cloud_api_deprecation_posture(
+        now=BEFORE_AZURE_GRAPH,
+        installed={"azure-graphrbac": "0.61.1"},
+    )
+    graph = next(a for a in posture["apis"] if a["distribution"] == "azure-graphrbac")
+    assert graph["lifecycle"] == "deprecating"
+    assert graph["status"] == "at_risk"
+    assert posture["at_risk_count"] == 1
+    assert posture["gated"] == []
+    codes = {w["code"] for w in posture["warnings"]}
+    assert "api_deprecating" in codes
+
+
+def test_undated_deprecation_with_legacy_sdk_is_at_risk():
+    # oauth2client has no scheduled removal date → deprecating, not removed.
+    posture = cloud_api_deprecation_posture(
+        now=AFTER_AZURE_GRAPH,
+        installed={"oauth2client": "4.1.3"},
+    )
+    entry = next(a for a in posture["apis"] if a["distribution"] == "oauth2client")
+    assert entry["lifecycle"] == "deprecating"
+    assert entry["status"] == "at_risk"
+
+
+def test_now_accepts_date_and_datetime():
+    as_date = cloud_api_deprecation_posture(now=AFTER_AZURE_GRAPH, installed={})
+    as_dt = cloud_api_deprecation_posture(now=datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc), installed={})
+    assert as_date == as_dt
+
+
+def test_removed_provider_apis_gate_helper():
+    gated = removed_provider_apis(now=AFTER_AZURE_GRAPH, installed={"azure-graphrbac": "0.61.1"})
+    assert set(gated) == {"Azure AD Graph API (graph.windows.net)"}
+    clear = removed_provider_apis(now=AFTER_AZURE_GRAPH, installed={})
+    assert clear == {}
+
+
+def test_custom_future_dated_entry_within_horizon_warns():
+    dep = ProviderApiDeprecation(
+        provider="aws",
+        api="Fake service API",
+        distribution="boto3",
+        replacement="newer boto3",
+        retirement_date="2026-03-01",
+        note="test entry",
+        reference="https://example.com/aws",
+    )
+    posture = cloud_api_deprecation_posture(
+        now=date(2026, 1, 1),
+        installed={"boto3": "1.40.0"},
+        deprecations=[dep],
+    )
+    entry = posture["apis"][0]
+    assert entry["lifecycle"] == "deprecating"
+    assert entry["status"] == "at_risk"
+
+
+def test_default_resolver_never_raises_and_is_json_shaped_deprecations():
+    posture = cloud_api_deprecation_posture()
+    assert posture["schema_version"] == 1
+    assert isinstance(posture["apis"], list) and posture["apis"]
+    assert posture["status"] in {"ok", "degraded"}
+    for entry in posture["apis"]:
+        assert entry["status"] in {"clear", "at_risk", "gated"}
+        assert entry["lifecycle"] in {"removed", "deprecating"}
+
+
+def test_deprecation_summary_trims_and_lists_gated():
+    summary = cloud_api_deprecation_summary(now=AFTER_AZURE_GRAPH, installed={"azure-graphrbac": "0.61.1"})
+    assert summary["status"] == "degraded"
+    assert summary["removed_count"] == 1
+    assert summary["gated"] == ["Azure AD Graph API (graph.windows.net)"]
+    assert summary["warnings"] and "Azure AD Graph" in summary["warnings"][0]
+
+
+def test_sdk_freshness_summary_nests_deprecations_block():
+    summary = cloud_sdk_freshness_summary(installed=FRESH)
+    assert "deprecations" in summary
+    assert summary["deprecations"]["status"] in {"ok", "degraded"}
+
+
+def test_doctor_renders_cloud_api_deprecations_section():
+    from agent_bom.cli._doctor import doctor_cmd
+
+    result = CliRunner().invoke(doctor_cmd, [])
+    assert result.exit_code == 0, result.output
+    assert "Cloud API deprecations" in result.output
+
+
+def test_agent_mode_summary_includes_deprecations():
+    from agent_bom.cli._agent_mode import _summary
+
+    out = _summary({})
+    assert "deprecations" in out["cloud_sdk_freshness"]

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -83,12 +83,14 @@ import { useDemoMode } from "@/hooks/use-demo-mode";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { deploymentModeLabel } from "@/lib/deployment-context";
 import {
+  buildAwsOrgStackSetScript,
   buildGrantScript,
   cloudGrantMethodHint,
   cloudGrantMethodLabel,
   cloudProviderMeta,
   CLOUD_GRANT_METHODS,
   copyTextToClipboard,
+  DEFAULT_AWS_ORG_ROLE_NAME,
   generateConnectionExternalId,
   type CloudGrantMethod,
 } from "@/lib/cloud-connect-wizard";
@@ -3190,6 +3192,9 @@ function AddConnectionWizard({
   const [formError, setFormError] = useState<string | null>(null);
   const [generatedExternalId, setGeneratedExternalId] = useState("");
   const [grantMethod, setGrantMethod] = useState<CloudGrantMethod>("cli");
+  // AWS onboarding scope: a single account, or the whole AWS Organization via a
+  // CloudFormation StackSet (deploy once, every member account auto-enrolls).
+  const [awsScope, setAwsScope] = useState<"account" | "organization">("account");
   // Verify step: the created connection + the live connectivity/permission check
   // and optional first scan run against the real /test and /scan endpoints.
   const [createdRecord, setCreatedRecord] = useState<CloudConnectionRecord | null>(null);
@@ -3232,6 +3237,7 @@ function AddConnectionWizard({
     setForm((current) => {
       if (current.provider === value) return current;
       setGeneratedExternalId("");
+      setAwsScope("account");
       return {
         ...current,
         provider: value,
@@ -3293,6 +3299,11 @@ function AddConnectionWizard({
     provider.value,
     grantMethod,
     isAws ? generatedExternalId || undefined : undefined,
+  );
+  const isOrgScope = isAws && awsScope === "organization";
+  const orgStackSetScript = buildAwsOrgStackSetScript(
+    generatedExternalId || undefined,
+    DEFAULT_AWS_ORG_ROLE_NAME,
   );
 
   async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
@@ -3440,22 +3451,87 @@ function AddConnectionWizard({
                   Grant read-only access
                 </p>
                 <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-4 text-xs leading-6 text-[var(--text-secondary)]">
-                  <p className="text-[var(--foreground)]">
-                    Run this in your {provider.label} to create the read-only grant, then paste the{" "}
-                    {provider.roleField.label.toLowerCase()} in the next step.
-                  </p>
-                  <div className="mt-4 space-y-2">
-                    <GrantMethodPicker method={grantMethod} onChange={setGrantMethod} provider={provider.value} />
-                    <div className="flex flex-wrap items-center justify-between gap-2">
-                      <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">
-                        {cloudGrantMethodLabel(grantMethod)} grant script
-                      </p>
-                      {deployScript ? <CopyTextButton text={deployScript} label="Copy script" /> : null}
+                  {isAws ? (
+                    <div
+                      role="group"
+                      aria-label="AWS onboarding scope"
+                      className="mb-3 grid grid-cols-2 gap-1 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-1"
+                    >
+                      {(["account", "organization"] as const).map((scope) => {
+                        const active = awsScope === scope;
+                        return (
+                          <button
+                            key={scope}
+                            type="button"
+                            aria-pressed={active}
+                            onClick={() => setAwsScope(scope)}
+                            className={`rounded-lg px-2.5 py-1.5 text-[11px] font-medium transition ${
+                              active
+                                ? "bg-emerald-500 text-black"
+                                : "text-[var(--text-secondary)] hover:text-[var(--foreground)]"
+                            }`}
+                          >
+                            {scope === "account" ? "Single account" : "Whole organization"}
+                          </button>
+                        );
+                      })}
                     </div>
-                    <pre className="max-h-40 overflow-auto rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2.5 font-mono text-[10px] leading-5 text-[var(--foreground)]">
-                      {deployScript || provider.cli}
-                    </pre>
-                  </div>
+                  ) : null}
+                  <p className="text-[var(--foreground)]">
+                    {isOrgScope ? (
+                      "Deploy one CloudFormation StackSet from your AWS Organization management (or delegated-admin) account. It mints the read-only role in every member account and auto-enrolls new ones — then paste this management account's role ARN in the next step."
+                    ) : (
+                      <>
+                        Run this in your {provider.label} to create the read-only grant, then paste the{" "}
+                        {provider.roleField.label.toLowerCase()} in the next step.
+                      </>
+                    )}
+                  </p>
+                  {isOrgScope ? (
+                    <div className="mt-4 space-y-2" data-testid="wizard-org-explainer">
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">
+                          Organization StackSet
+                        </p>
+                        <CopyTextButton text={orgStackSetScript} label="Copy StackSet" />
+                      </div>
+                      <pre
+                        data-testid="wizard-org-stackset"
+                        className="max-h-52 overflow-auto rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2.5 font-mono text-[10px] leading-5 text-[var(--foreground)]"
+                      >
+                        {orgStackSetScript}
+                      </pre>
+                      <ul className="space-y-1 text-[11px] text-[var(--text-secondary)]">
+                        <li className="flex items-start gap-1.5">
+                          <CheckCircle2 className="mt-0.5 h-3 w-3 shrink-0 text-emerald-400" />
+                          Deploy once from the management account or a delegated admin — every member account gets the
+                          same read-only <code className="font-mono">agent-bom-readonly</code> role.
+                        </li>
+                        <li className="flex items-start gap-1.5">
+                          <CheckCircle2 className="mt-0.5 h-3 w-3 shrink-0 text-emerald-400" />
+                          New accounts added to the org or OU auto-enroll automatically — no per-account onboarding.
+                        </li>
+                        <li className="flex items-start gap-1.5">
+                          <Lock className="mt-0.5 h-3 w-3 shrink-0 text-emerald-400" />
+                          Read-only least-privilege (SecurityAudit / ViewOnlyAccess), assumed via short-lived STS with
+                          this ExternalId — no static keys, no per-action credentials.
+                        </li>
+                      </ul>
+                    </div>
+                  ) : (
+                    <div className="mt-4 space-y-2">
+                      <GrantMethodPicker method={grantMethod} onChange={setGrantMethod} provider={provider.value} />
+                      <div className="flex flex-wrap items-center justify-between gap-2">
+                        <p className="text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">
+                          {cloudGrantMethodLabel(grantMethod)} grant script
+                        </p>
+                        {deployScript ? <CopyTextButton text={deployScript} label="Copy script" /> : null}
+                      </div>
+                      <pre className="max-h-40 overflow-auto rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-2.5 font-mono text-[10px] leading-5 text-[var(--foreground)]">
+                        {deployScript || provider.cli}
+                      </pre>
+                    </div>
+                  )}
                   {isAws ? (
                     <div className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-lg border border-emerald-900/50 bg-emerald-950/20 px-2.5 py-2">
                       <div className="min-w-0">

--- a/ui/lib/cloud-connect-wizard.ts
+++ b/ui/lib/cloud-connect-wizard.ts
@@ -403,6 +403,67 @@ export function buildCloudShellGrantScript(provider: string, externalId?: string
   return `${header}${body}`;
 }
 
+/**
+ * Consistent read-only role name minted in every member account by the org
+ * StackSet — the same name the org fan-out assumes per account
+ * (`AGENT_BOM_AWS_ORG_ROLE_NAME`, default `agent-bom-readonly` in
+ * `src/agent_bom/cloud/aws_organizations.py`). Keep the two in lockstep.
+ */
+export const DEFAULT_AWS_ORG_ROLE_NAME = "agent-bom-readonly";
+
+/**
+ * Whole-AWS-Organization onboarding via a CloudFormation StackSet — the
+ * org-scale path (deploy ONCE from the management / delegated-admin account,
+ * every member account gets an identical read-only role, and new accounts
+ * auto-enroll) instead of onboarding accounts one at a time.
+ *
+ * Mirrors the commands in `deploy/cloudformation/README.md` and deploys the
+ * shipped `deploy/cloudformation/agent-bom-readonly-role.yaml` template. The
+ * ExternalId round-trips into the StackSet parameters so the SAME value the
+ * wizard stores guards every per-account AssumeRole. Read-only only
+ * (SecurityAudit / ViewOnlyAccess), short-lived STS, no static keys.
+ */
+export function buildAwsOrgStackSetScript(
+  externalId?: string,
+  roleName: string = DEFAULT_AWS_ORG_ROLE_NAME,
+): string {
+  const eid = (externalId ?? "").trim() || "<EXTERNAL_ID>";
+  const name = roleName.trim() || DEFAULT_AWS_ORG_ROLE_NAME;
+  return [
+    `# agent-bom read-only role across your WHOLE AWS Organization (CloudFormation StackSet).`,
+    `# Run from the org MANAGEMENT account (or a delegated StackSets admin) with`,
+    `# service-managed StackSets trusted access enabled. Deploy ONCE — every member`,
+    `# account gets an identical read-only "${name}" role and new accounts auto-enroll.`,
+    `# Never onboard accounts one by one.`,
+    `EXTERNAL_ID=${eid}`,
+    `ROLE_NAME=${name}`,
+    `CONTROL_PLANE_PRINCIPAL_ARN=<CONTROL_PLANE_PRINCIPAL_ARN>  # the identity agent-bom assumes from`,
+    `ROOT_OU_ID=<ROOT_OR_TARGET_OU_ID>                          # org root r-xxxx or an ou-xxxx-... id`,
+    ``,
+    `# 1. Create the StackSet (service-managed, auto-deploy to new accounts).`,
+    `aws cloudformation create-stack-set \\`,
+    `  --stack-set-name "$ROLE_NAME" \\`,
+    `  --template-body file://deploy/cloudformation/agent-bom-readonly-role.yaml \\`,
+    `  --permission-model SERVICE_MANAGED \\`,
+    `  --auto-deployment Enabled=true,RetainStacksOnAccountRemoval=false \\`,
+    `  --capabilities CAPABILITY_NAMED_IAM \\`,
+    `  --parameters ParameterKey=ExternalId,ParameterValue="$EXTERNAL_ID" \\`,
+    `               ParameterKey=TrustedPrincipalArn,ParameterValue="$CONTROL_PLANE_PRINCIPAL_ARN" \\`,
+    `               ParameterKey=RoleName,ParameterValue="$ROLE_NAME"`,
+    ``,
+    `# 2. Roll it out to every account under the org root / target OU.`,
+    `aws cloudformation create-stack-instances \\`,
+    `  --stack-set-name "$ROLE_NAME" \\`,
+    `  --deployment-targets OrganizationalUnitIds="\${ROOT_OU_ID}" \\`,
+    `  --regions us-east-1 \\`,
+    `  --operation-preferences MaxConcurrentPercentage=100,FailureTolerancePercentage=20`,
+    ``,
+    `# 3. Register THIS management account's ${name} role ARN in the next step.`,
+    `#    agent-bom enumerates the org and assumes the same read-only role in each`,
+    `#    member account (short-lived STS + this ExternalId) — read-only, no keys.`,
+  ].join("\n");
+}
+
 export function buildGrantScript(
   provider: string,
   method: CloudGrantMethod,

--- a/ui/tests/cloud-connect-wizard.test.ts
+++ b/ui/tests/cloud-connect-wizard.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  buildAwsOrgStackSetScript,
   buildCliGrantScript,
   buildCloudShellGrantScript,
   buildGrantScript,
   buildTerraformDeployScript,
   cloudGrantMethodLabel,
   cloudProviderMeta,
+  DEFAULT_AWS_ORG_ROLE_NAME,
   generateConnectionExternalId,
 } from "@/lib/cloud-connect-wizard";
 
@@ -83,6 +85,36 @@ describe("cloud-connect-wizard", () => {
     expect(buildGrantScript("aws", "cli")).toContain("aws iam create-policy");
     expect(buildGrantScript("aws", "cloudshell")).toContain("CloudShell");
     expect(cloudGrantMethodLabel("cli")).toBe("CLI");
+  });
+
+  it("builds an org-wide CloudFormation StackSet grant (deploy once, auto-enroll)", () => {
+    // The org-scale path: one StackSet from the management account mints an
+    // identical read-only role in every member account and auto-enrolls new ones,
+    // instead of onboarding accounts one by one.
+    const script = buildAwsOrgStackSetScript("abc123");
+    expect(DEFAULT_AWS_ORG_ROLE_NAME).toBe("agent-bom-readonly");
+    // StackSet create + rollout commands, matching deploy/cloudformation/README.md.
+    expect(script).toContain("aws cloudformation create-stack-set");
+    expect(script).toContain("aws cloudformation create-stack-instances");
+    expect(script).toContain("--permission-model SERVICE_MANAGED");
+    expect(script).toContain("--auto-deployment Enabled=true");
+    expect(script).toContain('OrganizationalUnitIds="${ROOT_OU_ID}"');
+    expect(script).toContain("CAPABILITY_NAMED_IAM");
+    // The consistent role name the org fan-out assumes in each account.
+    expect(script).toContain("agent-bom-readonly");
+    // The ExternalId round-trips into the StackSet parameters.
+    expect(script).toContain("EXTERNAL_ID=abc123");
+    expect(script).toContain("ParameterKey=ExternalId");
+    // Points at the shipped template.
+    expect(script).toContain("deploy/cloudformation/agent-bom-readonly-role.yaml");
+    // Honest: register the management account's role ARN afterwards.
+    expect(script.toLowerCase()).toContain("management");
+  });
+
+  it("defaults the StackSet role name and falls back to a placeholder ExternalId", () => {
+    const script = buildAwsOrgStackSetScript();
+    expect(script).toContain("ROLE_NAME=agent-bom-readonly");
+    expect(script).toContain("EXTERNAL_ID=<EXTERNAL_ID>");
   });
 
   it("generates high-entropy external IDs for AWS trust policies", () => {

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -309,6 +309,43 @@ describe("ConnectionsPage — Connect segment", () => {
     expect(within(wizard).getByTestId("wizard-external-id-details").textContent!.trim()).toBe(regeneratedId);
   });
 
+  it("offers an org-wide StackSet path on the AWS setup step (deploy once, auto-enroll)", async () => {
+    render(<ConnectionsPage />);
+    await waitForConnectTab();
+
+    const wizard = openAwsWizard();
+    fireEvent.click(within(wizard).getByRole("button", { name: /Next/ }));
+
+    // Single-account is the default; the CLI grant script is shown.
+    expect(within(wizard).getByText(/aws iam create-role/)).toBeInTheDocument();
+    const setupId = within(wizard).getByTestId("wizard-external-id").textContent!.trim();
+
+    // Switch to the whole-organization scope.
+    fireEvent.click(within(wizard).getByRole("button", { name: /Whole organization/i }));
+
+    // The StackSet artifact is surfaced with the same ExternalId + consistent role.
+    const stackSet = within(wizard).getByTestId("wizard-org-stackset");
+    expect(stackSet.textContent).toContain("aws cloudformation create-stack-set");
+    expect(stackSet.textContent).toContain("--auto-deployment Enabled=true");
+    expect(stackSet.textContent).toContain("OrganizationalUnitIds");
+    expect(stackSet.textContent).toContain("agent-bom-readonly");
+    expect(stackSet.textContent).toContain(`EXTERNAL_ID=${setupId}`);
+
+    // Honest copy: read-only, every member account, new accounts auto-enroll.
+    const explainer = within(wizard).getByTestId("wizard-org-explainer").textContent ?? "";
+    expect(explainer).toMatch(/every member account/i);
+    expect(explainer).toMatch(/auto-enroll|automatically/i);
+    expect(explainer).toMatch(/read-only/i);
+    expect(explainer).toMatch(/management account|delegated admin/i);
+
+    // The single-account CLI grant script is hidden while in org scope.
+    expect(within(wizard).queryByText(/aws iam create-role/)).toBeNull();
+
+    // The ExternalId still carries into Details unchanged (management-account role).
+    fireEvent.click(within(wizard).getByRole("button", { name: /Next/ }));
+    expect(within(wizard).getByTestId("wizard-external-id-details").textContent!.trim()).toBe(setupId);
+  });
+
   it("maps provider-specific GCP fields to role_ref / external_id / auth_params", async () => {
     apiMock.createCloudConnection.mockResolvedValue({ ...CREATED_RECORD, provider: "gcp" });
 


### PR DESCRIPTION
## What

Adds a **Whole organization (StackSet)** scope to the AWS path of the guided connect wizard (`ui/app/connections/page.tsx`), alongside the existing single-account grant. It surfaces the org-scale onboarding the leaders make one-click, without inventing backend.

On the AWS **Setup** step, a compact segmented toggle offers **Single account** (default, unchanged) vs **Whole organization**. Choosing the org scope:

- Surfaces the **CloudFormation StackSet** artifact — `create-stack-set` (`--permission-model SERVICE_MANAGED`, `--auto-deployment Enabled=true`) then `create-stack-instances` targeting the org root / OU — pre-filled with the generated **ExternalId** and the consistent **`agent-bom-readonly`** role name.
- Explains the model honestly: deploy **once** from the management (or delegated-admin) account, the read-only role is minted in **every member account** and **new accounts auto-enroll**; read-only least-privilege (SecurityAudit / ViewOnlyAccess), short-lived STS, **no static keys, no per-action credentials**.
- The ExternalId carries into the **Details** step unchanged; the user registers the management account's role ARN and the existing **Verify** step runs the real connect `/test`.

## Reuses (no new backend)

- **StackSet template**: deploys the shipped `deploy/cloudformation/agent-bom-readonly-role.yaml`; commands mirror `deploy/cloudformation/README.md`.
- **Org fan-out**: the role name matches the fan-out default (`AGENT_BOM_AWS_ORG_ROLE_NAME` → `agent-bom-readonly` in `src/agent_bom/cloud/aws_organizations.py`), so what the StackSet creates is exactly what `discover_organization` → `assume_account_session` assumes per account.
- **Emit / ExternalId / Verify**: reuses the wizard's ExternalId generation and the connect `/test` verify step — the flow is not forked.

## Honest deferral

Org-wide fan-out **scanning** is enabled by the control-plane env flag `AGENT_BOM_AWS_ORG_INVENTORY` (a server setting), not a per-connection field. This PR provisions the estate-wide read-only role and registers the management-account connection; it does **not** add a per-connection "org mode" backend field (that would be inventing backend). Wiring org-mode as a first-class connection attribute is a tight follow-up if desired.

## Tests / gates

- `ui/tests/cloud-connect-wizard.test.ts` — new `buildAwsOrgStackSetScript` unit tests (StackSet + rollout commands, ExternalId round-trip, role name, template path, default fallbacks).
- `ui/tests/connections-page.test.tsx` — new component test: renders the wizard, toggles Whole organization, asserts the StackSet artifact + honest copy render, the single-account grant is hidden, and the ExternalId carries into Details.
- Green: `vitest` (touched), `typecheck`, `lint`, `npm run build`, and the release gate `NEXT_EXPORT=1 npm run build` (exit 0, `/connections` statically exported). Tokens not `zinc-*`, both themes.

Stacked on #4085 (CI fix) to keep this diff scoped; retarget to `main` once that merges.

addresses #3736