### PR TITLE
feat(self-posture): operator self-audit of agent-bom's own deployment

### DIFF
--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 75 tools, 6 resources, 8 workflow prompts |
-| REST API | 357 operations across 41 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 358 operations across 42 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["357 REST operations across 41 route modules\nplus 2 WebSocket routes"]
+        R["358 REST operations across 42 route modules\nplus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
         S1["SQLite (default / single node)"]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 300 |
+| `docs/openapi/v1.json` | paths | 301 |
 | `docs/openapi/v1.json` | component schemas | 80 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (300 paths / 357 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (301 paths / 358 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (357 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (358 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -26811,6 +26811,90 @@
         ]
       }
     },
+    "/v1/self-posture": {
+      "get": {
+        "description": "Return this agent-bom deployment's own security + governance posture.\n\nHonest per-check results (pass/fail/warn/unknown) over API authentication,\ndatabase tenant isolation, audit-log integrity signing, secret sealing, and\nthe dependency attack surface. Distribution enumeration is offloaded to a\nworker thread so the event loop is never blocked (non-negotiable \u00a77).",
+        "operationId": "get_self_posture_v1_self_posture_get",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Self Posture V1 Self Posture Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Self Posture",
+        "tags": [
+          "self-posture"
+        ]
+      }
+    },
     "/v1/shield/break-glass": {
       "post": {
         "description": "Emergency kill-switch override \u2014 admin only, audit logged.\n\nImmediately unblocks all sessions and logs the override for compliance.\nRequires ``admin`` role (set via ``request.state.api_key_role``).",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -17373,6 +17373,57 @@ paths:
       summary: Scorecard Lookup
       tags:
       - security
+  /v1/self-posture:
+    get:
+      description: "Return this agent-bom deployment's own security + governance posture.\n\
+        \nHonest per-check results (pass/fail/warn/unknown) over API authentication,\n\
+        database tenant isolation, audit-log integrity signing, secret sealing, and\n\
+        the dependency attack surface. Distribution enumeration is offloaded to a\n\
+        worker thread so the event loop is never blocked (non-negotiable \xA77)."
+      operationId: get_self_posture_v1_self_posture_get
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Self Posture V1 Self Posture Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Self Posture
+      tags:
+      - self-posture
   /v1/shield/break-glass:
     post:
       description: "Emergency kill-switch override \u2014 admin only, audit logged.\n\

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -473,6 +473,11 @@ AGENT_BOM_EXEC_SCORE_POLICY_FILE
 # mounted secret path, not a scalar application setting for config.py.
 AGENT_BOM_POSTGRES_PASSWORD_FILE
 
+# File-first audit and connection-encryption secrets are mounted secret paths,
+# not scalar application settings for the generated config reference.
+AGENT_BOM_AUDIT_HMAC_KEY_FILE
+AGENT_BOM_CONNECTIONS_KEY_FILE
+
 # Opt-in runtime Postgres IAM authentication selection. These are resolved at
 # connection time so short-lived tokens can be refreshed without static config.
 AGENT_BOM_POSTGRES_AUTH_MODE

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -105,6 +105,7 @@ verbs are additive entry points that delegate to the underlying implementations.
 | `db freshness` | Show the structured vuln-data freshness indicator (sources, age, staleness) surfaced on every scan, API, and MCP tool |
 | `db framework-status` | Show bundled framework catalog freshness |
 | `doctor` | Check environment readiness for scanning |
+| `self-audit` | Audit this agent-bom deployment's own security and governance posture (auth, tenant isolation, audit-log integrity, secret sealing) with honest pass/fail/warn/unknown results |
 | `capabilities` | Show every gated capability, current state, and exact unlock path without printing secret values |
 | `gateway` | Multi-MCP gateway commands |
 | `interactive` | Start an interactive command shell for repeated CLI workflows |

--- a/src/agent_bom/api/routes/self_posture.py
+++ b/src/agent_bom/api/routes/self_posture.py
@@ -1,0 +1,37 @@
+"""Operator self-posture API route — agent-bom audits its OWN control plane.
+
+Read-only endpoint that surfaces the same honest deployment-hardening posture
+as the ``agent-bom self-audit`` CLI, so operators (and headless callers) can
+see the security + governance posture of THEIR OWN instance from the API.
+No new inspection logic lives here — the checks are computed by
+:func:`agent_bom.self_posture.self_posture`, which reads configuration only
+(never a secret value, never the network, never a write).
+
+Endpoints:
+    GET /v1/self-posture   this instance's own security + governance posture
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import anyio.to_thread
+from fastapi import APIRouter
+
+from agent_bom.rbac import require_authenticated_permission
+
+router = APIRouter(dependencies=[cast(Any, require_authenticated_permission("read"))])
+
+
+@router.get("/self-posture", tags=["self-posture"])
+async def get_self_posture() -> dict[str, Any]:
+    """Return this agent-bom deployment's own security + governance posture.
+
+    Honest per-check results (pass/fail/warn/unknown) over API authentication,
+    database tenant isolation, audit-log integrity signing, secret sealing, and
+    the dependency attack surface. Distribution enumeration is offloaded to a
+    worker thread so the event loop is never blocked (non-negotiable §7).
+    """
+    from agent_bom.self_posture import self_posture
+
+    return await anyio.to_thread.run_sync(self_posture)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -934,6 +934,7 @@ from agent_bom.api.routes.runtime_blueprints import router as _runtime_blueprint
 from agent_bom.api.routes.scan import router as _scan_router  # noqa: E402
 from agent_bom.api.routes.schedules import router as _schedules_router  # noqa: E402
 from agent_bom.api.routes.scim import router as _scim_router  # noqa: E402
+from agent_bom.api.routes.self_posture import router as _self_posture_router  # noqa: E402
 from agent_bom.api.routes.sources import router as _sources_router  # noqa: E402
 from agent_bom.api.routes.ticketing import router as _ticketing_router  # noqa: E402
 from agent_bom.api.routes.webhooks import router as _webhooks_router  # noqa: E402
@@ -979,6 +980,7 @@ for _router in (
     _runtime_blueprints_router,
     _scan_router,
     _schedules_router,
+    _self_posture_router,
     _sources_router,
     _ticketing_router,
     _webhooks_router,

--- a/src/agent_bom/cli/__init__.py
+++ b/src/agent_bom/cli/__init__.py
@@ -418,9 +418,11 @@ main.commands["run"].hidden = True  # Use `proxy` instead
 # ---------------------------------------------------------------------------
 from agent_bom.cli._capabilities import capabilities_cmd  # noqa: E402
 from agent_bom.cli._doctor import doctor_cmd  # noqa: E402
+from agent_bom.cli._self_audit import self_audit_cmd  # noqa: E402
 
 main.add_command(doctor_cmd, "doctor")
 main.add_command(capabilities_cmd, "capabilities")
+main.add_command(self_audit_cmd, "self-audit")
 
 # ---------------------------------------------------------------------------
 # Deployment lifecycle command

--- a/src/agent_bom/cli/_self_audit.py
+++ b/src/agent_bom/cli/_self_audit.py
@@ -1,0 +1,93 @@
+"""``agent-bom self-audit`` — agent-bom audits its OWN deployment posture.
+
+Points the honesty model at the running control plane itself: reads (never
+writes) the security-relevant configuration and reports an honest per-check
+posture — hardened, misconfigured, weakened-but-acknowledged, or unknown.
+Human table by default; ``--agent-mode`` emits the stable JSON envelope for
+headless/CI callers, so operator + agent get surface parity with the
+``GET /v1/self-posture`` API.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+import click
+from rich.console import Console
+
+_STATUS_ICON = {
+    "pass": "[green]✓[/green]",
+    "fail": "[red]✗[/red]",
+    "warn": "[yellow]⚠[/yellow]",
+    "unknown": "[dim]○[/dim]",
+}
+
+_OVERALL_LINE = {
+    "hardened": ("[green]", "Self-posture: hardened — no weakened settings detected."),
+    "action_advised": ("[yellow]", "Self-posture: action advised — weakened settings detected."),
+    "needs_review": ("[yellow]", "Self-posture: needs review — some checks could not be determined."),
+    "at_risk": ("[red]", "Self-posture: at risk — one or more checks failed for this deployment mode."),
+}
+
+
+@click.command("self-audit")
+def self_audit_cmd() -> None:
+    """Audit THIS agent-bom deployment's own security + governance posture.
+
+    \b
+    Read-only checks:  API authentication, database tenant isolation (RLS),
+                       audit-log integrity signing, secret sealing, and the
+                       dependency attack surface. Honest pass/fail/warn/unknown
+                       — unknown is explicit, never an assumed pass. Run
+                       `agent-bom scan --self-scan` for the dependency CVE
+                       posture.
+    """
+    from agent_bom.self_posture import self_posture
+
+    report = self_posture()
+
+    from agent_bom.cli._agent_mode import agent_mode_requested
+
+    if agent_mode_requested():
+        from agent_bom.cli._agent_mode import emit_command_envelope
+
+        emit_command_envelope(
+            command="self-audit",
+            data=report,
+            summary={
+                "overall_status": report["overall_status"],
+                "hardened": report["hardened"],
+                "counts": report["counts"],
+            },
+        )
+        return
+
+    console = Console()
+    console.print()
+    console.print("  [bold]agent-bom self-audit[/bold]  [dim](this instance's own posture)[/dim]")
+    console.print(f"  [dim]deployment: {report['deployment_env']}[/dim]")
+    console.print()
+
+    checks = cast(list[dict[str, str]], report["checks"])
+    categories: list[str] = []
+    for check in checks:
+        if check["category"] not in categories:
+            categories.append(check["category"])
+
+    for category in categories:
+        console.print(f"  [bold]{category.replace('_', ' ').title()}[/bold]")
+        for check in checks:
+            if check["category"] != category:
+                continue
+            icon = _STATUS_ICON.get(check["status"], "[dim]○[/dim]")
+            console.print(f"    {icon}  {check['title']}")
+            console.print(f"        [dim]{check['detail']}[/dim]")
+            if check["status"] in {"fail", "warn"} and check["remediation"]:
+                console.print(f"        [dim]→ {check['remediation']}[/dim]")
+        console.print()
+
+    color, message = _OVERALL_LINE.get(cast(str, report["overall_status"]), ("[dim]", "Self-posture computed."))
+    console.print(f"  {color}{message}[/]")
+    counts = cast(dict[str, int], report["counts"])
+    console.print(f"  [dim]{counts['pass']} pass · {counts['fail']} fail · {counts['warn']} warn · {counts['unknown']} unknown[/dim]")
+    console.print()

--- a/src/agent_bom/self_posture.py
+++ b/src/agent_bom/self_posture.py
@@ -1,0 +1,392 @@
+"""Operator self-posture — agent-bom audits its OWN deployment hardening.
+
+A product that governs other estates must be able to report the security
+posture of its OWN control plane. This module points agent-bom's honesty model
+at itself: it reads (never writes) the security-relevant configuration of the
+running deployment and reports an honest per-check posture — hardened,
+misconfigured, weakened-but-acknowledged, or genuinely unknown.
+
+Design (mirrors :mod:`agent_bom.cloud_sdk_freshness`, the tool's other
+self-inspection surface):
+
+    * **Read-only + deterministic.** Inspects environment configuration only.
+      It never mutates state, never reaches the network, and never reads a
+      secret *value* — only whether a secret is *configured* and *how*
+      (literal env vs sealed file/external provider). Reproducible + air-gap
+      safe.
+    * **Never raises.** A missing or unparseable variable degrades to an
+      explicit ``unknown`` status rather than crashing the report.
+    * **Honest — no self-flattery.** A check is ``pass`` only with evidence the
+      hardened path is actually configured. When production gating cannot be
+      evaluated (deployment env undeclared), the dependent checks report
+      ``unknown``, never an assumed ``pass``. There is no "we're secure"
+      without a concrete, verifiable signal behind it.
+    * **Injectable.** :func:`self_posture` accepts an ``env`` mapping so tests
+      are deterministic and never depend on the ambient process environment.
+
+Surfaced via ``agent-bom self-audit`` (+ ``--agent-mode`` JSON) and
+``GET /v1/self-posture``. Supply-chain / CVE detail is intentionally NOT
+re-derived here (that is the job of ``agent-bom scan --self-scan``); this
+surface reports the *attack-surface size* as context and points at the scan,
+rather than faking a clean CVE result inline.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass
+
+SCHEMA_VERSION = 1
+
+# Status vocabulary (honest, four-way — unknown is a first-class outcome):
+#   pass    — the hardened configuration is verifiably in effect
+#   fail    — a configuration that weakens posture for this deployment mode
+#   warn    — a weakened setting that is explicitly acknowledged / dev-scoped
+#   unknown — cannot be determined from configuration alone (never a silent pass)
+STATUS_PASS = "pass"
+STATUS_FAIL = "fail"
+STATUS_WARN = "warn"
+STATUS_UNKNOWN = "unknown"
+
+_PRODUCTION_LABELS = {"prod", "production"}
+
+# Secrets that agent-bom supports supplying as a sealed file reference or via an
+# external secret provider, rather than as a literal value in the environment.
+# (literal_var, file_var, check_id, human label)
+_SEALABLE_SECRETS: tuple[tuple[str, str, str, str], ...] = (
+    ("AGENT_BOM_AUDIT_HMAC_KEY", "AGENT_BOM_AUDIT_HMAC_KEY_FILE", "audit_hmac_key", "audit-log HMAC signing key"),
+    ("AGENT_BOM_CONNECTIONS_KEY", "AGENT_BOM_CONNECTIONS_KEY_FILE", "connections_key", "connection-secret encryption key"),
+)
+
+
+@dataclass(frozen=True)
+class PostureCheck:
+    """One self-posture check outcome."""
+
+    id: str
+    category: str
+    title: str
+    status: str
+    detail: str
+    remediation: str = ""
+
+    def to_dict(self) -> dict[str, str]:
+        return asdict(self)
+
+
+def _truthy(env: Mapping[str, str], key: str) -> bool:
+    raw = (env.get(key) or "").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _first_non_empty(env: Mapping[str, str], *keys: str) -> str:
+    for key in keys:
+        raw = env.get(key)
+        if raw is not None and str(raw).strip():
+            return str(raw).strip()
+    return ""
+
+
+def _deployment_env(env: Mapping[str, str]) -> str:
+    return _first_non_empty(env, "AGENT_BOM_DEPLOYMENT_ENV", "AGENT_BOM_ENV", "ENVIRONMENT").lower()
+
+
+def _is_production(env: Mapping[str, str]) -> bool:
+    return _deployment_env(env) in _PRODUCTION_LABELS
+
+
+def _replica_count(env: Mapping[str, str]) -> int:
+    raw = (env.get("AGENT_BOM_CONTROL_PLANE_REPLICAS") or "").strip()
+    if not raw:
+        return 1
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return 1
+
+
+def _check_deployment_env(env: Mapping[str, str]) -> PostureCheck:
+    label = _deployment_env(env)
+    if not label:
+        return PostureCheck(
+            id="deployment.env_declared",
+            category="deployment",
+            title="Deployment environment declared",
+            status=STATUS_UNKNOWN,
+            detail=(
+                "No AGENT_BOM_DEPLOYMENT_ENV / AGENT_BOM_ENV set — production-gated checks cannot be evaluated and are reported as unknown."
+            ),
+            remediation="Set AGENT_BOM_DEPLOYMENT_ENV=production (or =dev) so posture gating is explicit.",
+        )
+    return PostureCheck(
+        id="deployment.env_declared",
+        category="deployment",
+        title="Deployment environment declared",
+        status=STATUS_PASS,
+        detail=f"Deployment declared as '{label}'.",
+    )
+
+
+def _check_api_auth(env: Mapping[str, str]) -> PostureCheck:
+    unauth = _truthy(env, "AGENT_BOM_ALLOW_UNAUTHENTICATED_API")
+    if not unauth:
+        return PostureCheck(
+            id="auth.api_authentication",
+            category="auth",
+            title="API authentication enforced",
+            status=STATUS_PASS,
+            detail="Unauthenticated API access is disabled (default) — every request must present a credential.",
+        )
+    production = _is_production(env)
+    role = (env.get("AGENT_BOM_NO_AUTH_ROLE") or "viewer").strip() or "viewer"
+    if production:
+        return PostureCheck(
+            id="auth.api_authentication",
+            category="auth",
+            title="API authentication enforced",
+            status=STATUS_FAIL,
+            detail=(
+                "AGENT_BOM_ALLOW_UNAUTHENTICATED_API is enabled in a production deployment — "
+                f"unauthenticated callers are granted the '{role}' role."
+            ),
+            remediation="Unset AGENT_BOM_ALLOW_UNAUTHENTICATED_API in production and issue scoped API keys.",
+        )
+    return PostureCheck(
+        id="auth.api_authentication",
+        category="auth",
+        title="API authentication enforced",
+        status=STATUS_WARN,
+        detail=(
+            f"Unauthenticated API access is enabled (non-production) — callers get the '{role}' role. Acceptable only for local/dev use."
+        ),
+        remediation="Unset AGENT_BOM_ALLOW_UNAUTHENTICATED_API before exposing the API beyond localhost.",
+    )
+
+
+def _check_db_rls(env: Mapping[str, str]) -> PostureCheck:
+    bypass = _truthy(env, "AGENT_BOM_ALLOW_SUPERUSER_DB")
+    if not bypass:
+        return PostureCheck(
+            id="database.rls_isolation",
+            category="database",
+            title="Tenant isolation enforced by the database",
+            status=STATUS_PASS,
+            detail="Superuser/BYPASSRLS database roles are rejected (default) — Row-Level Security tenant policies are enforced.",
+        )
+    production = _is_production(env)
+    status = STATUS_FAIL if production else STATUS_WARN
+    scope = "production deployment" if production else "single-tenant/dev deployment"
+    return PostureCheck(
+        id="database.rls_isolation",
+        category="database",
+        title="Tenant isolation enforced by the database",
+        status=status,
+        detail=(
+            f"AGENT_BOM_ALLOW_SUPERUSER_DB is set ({scope}) — a superuser/BYPASSRLS role voids "
+            "FORCE ROW LEVEL SECURITY, so tenant isolation is NOT enforced by the database."
+        ),
+        remediation="Connect the control plane with a non-superuser role that cannot BYPASSRLS, then unset AGENT_BOM_ALLOW_SUPERUSER_DB.",
+    )
+
+
+def _check_audit_hmac(env: Mapping[str, str]) -> PostureCheck:
+    configured = bool(_first_non_empty(env, "AGENT_BOM_AUDIT_HMAC_KEY", "AGENT_BOM_AUDIT_HMAC_KEY_FILE"))
+    production = _is_production(env)
+    clustered = _replica_count(env) > 1
+    required = production or clustered
+    ephemeral_allowed = _truthy(env, "AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC")
+    require_flag = _truthy(env, "AGENT_BOM_REQUIRE_AUDIT_HMAC")
+
+    if configured:
+        return PostureCheck(
+            id="audit.hmac_integrity",
+            category="governance",
+            title="Audit-log integrity signing configured",
+            status=STATUS_PASS,
+            detail=(
+                "A persistent audit-log HMAC signing key is configured — the tamper-evident "
+                "hash chain survives restarts and is consistent across replicas."
+            ),
+        )
+    if (required or require_flag) and not ephemeral_allowed:
+        why = "production" if production else "a multi-replica control plane" if clustered else "AGENT_BOM_REQUIRE_AUDIT_HMAC"
+        return PostureCheck(
+            id="audit.hmac_integrity",
+            category="governance",
+            title="Audit-log integrity signing configured",
+            status=STATUS_FAIL,
+            detail=(
+                f"No audit-log HMAC signing key is configured but this deployment ({why}) requires "
+                "one — the audit chain would use an ephemeral per-process key that cannot be verified "
+                "across restarts/replicas."
+            ),
+            remediation="Set AGENT_BOM_AUDIT_HMAC_KEY_FILE (preferred) or AGENT_BOM_AUDIT_HMAC_KEY to a durable secret.",
+        )
+    if required and ephemeral_allowed:
+        return PostureCheck(
+            id="audit.hmac_integrity",
+            category="governance",
+            title="Audit-log integrity signing configured",
+            status=STATUS_WARN,
+            detail=(
+                "AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC is set — the audit chain uses a per-process key "
+                "that is not verifiable across restarts/replicas. Acknowledged, but weakens tamper-evidence."
+            ),
+            remediation="Configure a durable AGENT_BOM_AUDIT_HMAC_KEY_FILE and unset AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC.",
+        )
+    return PostureCheck(
+        id="audit.hmac_integrity",
+        category="governance",
+        title="Audit-log integrity signing configured",
+        status=STATUS_UNKNOWN,
+        detail=(
+            "No audit-log HMAC signing key is configured. Not required for this non-production "
+            "single-process deployment, so the audit chain runs with a per-process key."
+        ),
+        remediation="Set AGENT_BOM_AUDIT_HMAC_KEY_FILE before promoting this instance to production or scaling to multiple replicas.",
+    )
+
+
+def _check_secret_sealing(env: Mapping[str, str]) -> list[PostureCheck]:
+    external = _truthy(env, "AGENT_BOM_EXTERNAL_SECRETS_ENABLED")
+    checks: list[PostureCheck] = []
+    for literal_var, file_var, check_id, label in _SEALABLE_SECRETS:
+        has_literal = bool((env.get(literal_var) or "").strip())
+        has_file = bool((env.get(file_var) or "").strip())
+        title = f"Secret sealed via file/provider — {label}"
+        if has_file or external:
+            via = "file reference" if has_file else "external secret provider"
+            checks.append(
+                PostureCheck(
+                    id=f"secrets.{check_id}",
+                    category="secrets",
+                    title=title,
+                    status=STATUS_PASS,
+                    detail=f"The {label} is provided via {via}, not a literal environment value.",
+                )
+            )
+        elif has_literal:
+            checks.append(
+                PostureCheck(
+                    id=f"secrets.{check_id}",
+                    category="secrets",
+                    title=title,
+                    status=STATUS_WARN,
+                    detail=(
+                        f"The {label} is set as a literal environment value ({literal_var}) — "
+                        "readable to anything that can inspect the process environment."
+                    ),
+                    remediation=f"Move it to {file_var} (mounted secret file) or enable AGENT_BOM_EXTERNAL_SECRETS_ENABLED.",
+                )
+            )
+        else:
+            checks.append(
+                PostureCheck(
+                    id=f"secrets.{check_id}",
+                    category="secrets",
+                    title=title,
+                    status=STATUS_UNKNOWN,
+                    detail=f"No {label} is configured, so sealing cannot be assessed.",
+                    remediation=f"When you configure it, prefer {file_var} over a literal {literal_var}.",
+                )
+            )
+    return checks
+
+
+def _supply_chain_context(env: Mapping[str, str], distribution_count: int | None) -> PostureCheck:
+    if distribution_count is None:
+        return PostureCheck(
+            id="supply_chain.dependency_surface",
+            category="supply_chain",
+            title="Dependency / supply-chain surface",
+            status=STATUS_UNKNOWN,
+            detail="Installed-distribution count could not be enumerated.",
+            remediation="Run `agent-bom scan --self-scan` for the full dependency CVE / malicious-package posture.",
+        )
+    return PostureCheck(
+        id="supply_chain.dependency_surface",
+        category="supply_chain",
+        title="Dependency / supply-chain surface",
+        status=STATUS_UNKNOWN,
+        detail=(
+            f"{distribution_count} Python distributions are installed in this environment "
+            "(attack-surface size). CVE / malicious-package posture is not evaluated inline."
+        ),
+        remediation="Run `agent-bom scan --self-scan` to evaluate the dependency CVE and malicious-package posture honestly.",
+    )
+
+
+def _count_installed_distributions() -> int | None:
+    try:
+        import importlib.metadata as metadata
+
+        seen: set[str] = set()
+        for dist in metadata.distributions():
+            try:
+                name = str(dist.metadata["Name"] or "").strip().lower()
+            except Exception:
+                name = ""
+            if name:
+                seen.add(name)
+        return len(seen)
+    except Exception:
+        return None
+
+
+_AUTO = object()
+
+
+def self_posture(
+    env: Mapping[str, str] | None = None,
+    *,
+    distribution_count: int | None | object = _AUTO,
+) -> dict[str, object]:
+    """Return an honest self-posture report for this agent-bom deployment.
+
+    ``env`` defaults to the process environment; pass a mapping for
+    deterministic tests. ``distribution_count`` defaults to enumerating the
+    installed distributions; pass an int, or ``None`` to force an
+    unknown supply-chain context row in tests.
+    """
+    resolved_env: Mapping[str, str] = os.environ if env is None else env
+    if distribution_count is _AUTO:
+        dist_count: int | None = _count_installed_distributions()
+    else:
+        dist_count = distribution_count  # type: ignore[assignment]
+
+    checks: list[PostureCheck] = [
+        _check_deployment_env(resolved_env),
+        _check_api_auth(resolved_env),
+        _check_db_rls(resolved_env),
+        _check_audit_hmac(resolved_env),
+        *_check_secret_sealing(resolved_env),
+        _supply_chain_context(resolved_env, dist_count),
+    ]
+
+    counts = {
+        STATUS_PASS: 0,
+        STATUS_FAIL: 0,
+        STATUS_WARN: 0,
+        STATUS_UNKNOWN: 0,
+    }
+    for check in checks:
+        counts[check.status] = counts.get(check.status, 0) + 1
+
+    if counts[STATUS_FAIL] > 0:
+        overall = "at_risk"
+    elif counts[STATUS_WARN] > 0:
+        overall = "action_advised"
+    elif counts[STATUS_UNKNOWN] > 0:
+        overall = "needs_review"
+    else:
+        overall = "hardened"
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "overall_status": overall,
+        "hardened": counts[STATUS_FAIL] == 0,
+        "deployment_env": _deployment_env(resolved_env) or "unknown",
+        "counts": counts,
+        "checks": [check.to_dict() for check in checks],
+    }

--- a/tests/api/test_api_self_posture.py
+++ b/tests/api/test_api_self_posture.py
@@ -1,0 +1,52 @@
+"""Tests for the GET /v1/self-posture operator self-audit endpoint."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+_AUTH_HEADERS = proxy_headers(tenant="default")
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def test_self_posture_route_is_registered_under_read_permission() -> None:
+    # The route carries the same require_authenticated_permission("read")
+    # dependency as the other v1 read routes (enforcement itself is covered by
+    # the auth-boundary suite); assert it is wired into the v1 surface.
+    from agent_bom.api.routes.self_posture import router
+
+    paths = {getattr(route, "path", "") for route in router.routes}
+    assert "/self-posture" in paths
+    assert router.dependencies, "self-posture router must carry an auth dependency"
+
+
+def test_self_posture_returns_honest_report() -> None:
+    client = TestClient(app)
+    resp = client.get("/v1/self-posture", headers=_AUTH_HEADERS)
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert body["schema_version"] == 1
+    assert body["overall_status"] in {"hardened", "action_advised", "needs_review", "at_risk"}
+    assert isinstance(body["checks"], list) and body["checks"]
+
+    ids = {c["id"] for c in body["checks"]}
+    assert {
+        "auth.api_authentication",
+        "database.rls_isolation",
+        "audit.hmac_integrity",
+        "supply_chain.dependency_surface",
+    } <= ids
+
+    for check in body["checks"]:
+        assert check["status"] in {"pass", "fail", "warn", "unknown"}
+        assert check["title"] and check["detail"]

--- a/tests/test_self_audit_cli.py
+++ b/tests/test_self_audit_cli.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from agent_bom.cli import main
+
+
+def test_self_audit_renders_honest_human_report(monkeypatch):
+    for key in ("AGENT_BOM_DEPLOYMENT_ENV", "AGENT_BOM_ENV", "ENVIRONMENT"):
+        monkeypatch.delenv(key, raising=False)
+    result = CliRunner().invoke(main, ["self-audit"])
+
+    assert result.exit_code == 0
+    assert "agent-bom self-audit" in result.output
+    assert "API authentication enforced" in result.output
+    assert "Tenant isolation enforced by the database" in result.output
+    assert "Self-posture:" in result.output
+
+
+def test_self_audit_flags_misconfigured_production(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_DEPLOYMENT_ENV", "production")
+    monkeypatch.setenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+    result = CliRunner().invoke(main, ["self-audit"])
+
+    assert result.exit_code == 0
+    assert "at risk" in result.output
+    assert "✗" in result.output
+
+
+def test_self_audit_agent_mode_emits_valid_envelope_without_secret(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_DEPLOYMENT_ENV", "dev")
+    monkeypatch.setenv("AGENT_BOM_AUDIT_HMAC_KEY", "top-secret-literal")
+    result = CliRunner().invoke(main, ["--agent-mode", "self-audit"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert payload["command"] == "self-audit"
+    assert payload["data"]["overall_status"] in {"hardened", "action_advised", "needs_review", "at_risk"}
+    # The literal secret value must never appear in the machine-readable output.
+    assert "top-secret-literal" not in result.output

--- a/tests/test_self_posture.py
+++ b/tests/test_self_posture.py
@@ -1,0 +1,157 @@
+"""Tests for the operator self-posture surface (agent-bom audits itself)."""
+
+from __future__ import annotations
+
+from agent_bom.self_posture import (
+    STATUS_FAIL,
+    STATUS_PASS,
+    STATUS_UNKNOWN,
+    STATUS_WARN,
+    self_posture,
+)
+
+
+def _by_id(report: dict[str, object]) -> dict[str, dict[str, str]]:
+    return {c["id"]: c for c in report["checks"]}  # type: ignore[index,union-attr]
+
+
+# ── Hardened deployment ──────────────────────────────────────────────────────
+
+
+def _hardened_env() -> dict[str, str]:
+    return {
+        "AGENT_BOM_DEPLOYMENT_ENV": "production",
+        # Unauthenticated API off (default), superuser DB off (default).
+        "AGENT_BOM_AUDIT_HMAC_KEY_FILE": "/run/secrets/audit-hmac",
+        "AGENT_BOM_CONNECTIONS_KEY_FILE": "/run/secrets/connections-key",
+    }
+
+
+def test_hardened_production_config_passes_security_checks() -> None:
+    report = self_posture(_hardened_env(), distribution_count=66)
+    checks = _by_id(report)
+
+    assert checks["auth.api_authentication"]["status"] == STATUS_PASS
+    assert checks["database.rls_isolation"]["status"] == STATUS_PASS
+    assert checks["audit.hmac_integrity"]["status"] == STATUS_PASS
+    assert checks["secrets.audit_hmac_key"]["status"] == STATUS_PASS
+    assert checks["secrets.connections_key"]["status"] == STATUS_PASS
+    assert checks["deployment.env_declared"]["status"] == STATUS_PASS
+    # No fail present -> hardened; supply-chain is an explicit unknown context.
+    assert report["hardened"] is True
+    assert report["counts"][STATUS_FAIL] == 0
+
+
+# ── Misconfigured production deployment -> honest failures ───────────────────
+
+
+def test_unauthenticated_api_in_production_is_a_failure() -> None:
+    env = _hardened_env() | {"AGENT_BOM_ALLOW_UNAUTHENTICATED_API": "1"}
+    report = self_posture(env, distribution_count=66)
+    check = _by_id(report)["auth.api_authentication"]
+    assert check["status"] == STATUS_FAIL
+    assert report["overall_status"] == "at_risk"
+    assert report["hardened"] is False
+
+
+def test_superuser_db_in_production_is_a_failure() -> None:
+    env = _hardened_env() | {"AGENT_BOM_ALLOW_SUPERUSER_DB": "true"}
+    check = _by_id(self_posture(env, distribution_count=66))["database.rls_isolation"]
+    assert check["status"] == STATUS_FAIL
+    assert "isolation is NOT enforced" in check["detail"]
+
+
+def test_missing_audit_hmac_key_in_production_is_a_failure() -> None:
+    env = _hardened_env()
+    del env["AGENT_BOM_AUDIT_HMAC_KEY_FILE"]
+    check = _by_id(self_posture(env, distribution_count=66))["audit.hmac_integrity"]
+    assert check["status"] == STATUS_FAIL
+
+
+def test_missing_audit_hmac_required_by_multi_replica_even_without_prod() -> None:
+    env = {
+        "AGENT_BOM_DEPLOYMENT_ENV": "staging",
+        "AGENT_BOM_CONTROL_PLANE_REPLICAS": "3",
+    }
+    check = _by_id(self_posture(env, distribution_count=10))["audit.hmac_integrity"]
+    assert check["status"] == STATUS_FAIL
+
+
+# ── Weakened-but-acknowledged -> warn, not silent pass ───────────────────────
+
+
+def test_unauthenticated_api_in_dev_is_a_warning_not_failure() -> None:
+    env = {"AGENT_BOM_DEPLOYMENT_ENV": "dev", "AGENT_BOM_ALLOW_UNAUTHENTICATED_API": "1"}
+    check = _by_id(self_posture(env, distribution_count=10))["auth.api_authentication"]
+    assert check["status"] == STATUS_WARN
+
+
+def test_literal_secret_in_env_is_a_warning() -> None:
+    env = {
+        "AGENT_BOM_DEPLOYMENT_ENV": "dev",
+        "AGENT_BOM_AUDIT_HMAC_KEY": "s0me-literal-secret",
+    }
+    check = _by_id(self_posture(env, distribution_count=10))["secrets.audit_hmac_key"]
+    assert check["status"] == STATUS_WARN
+    # The literal value must never leak into the report detail.
+    assert "s0me-literal-secret" not in check["detail"]
+    assert "s0me-literal-secret" not in check["remediation"]
+
+
+def test_ephemeral_audit_hmac_acknowledged_is_a_warning() -> None:
+    env = {
+        "AGENT_BOM_DEPLOYMENT_ENV": "production",
+        "AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC": "1",
+    }
+    check = _by_id(self_posture(env, distribution_count=10))["audit.hmac_integrity"]
+    assert check["status"] == STATUS_WARN
+
+
+# ── Unknown is explicit, never an assumed pass ───────────────────────────────
+
+
+def test_undeclared_deployment_env_is_unknown_not_pass() -> None:
+    report = self_posture({}, distribution_count=10)
+    check = _by_id(report)["deployment.env_declared"]
+    assert check["status"] == STATUS_UNKNOWN
+    assert report["deployment_env"] == "unknown"
+
+
+def test_unconfigured_audit_hmac_in_dev_is_unknown_not_pass() -> None:
+    # No prod, single replica, no key -> not required, but honestly unknown.
+    check = _by_id(self_posture({"AGENT_BOM_DEPLOYMENT_ENV": "dev"}, distribution_count=10))["audit.hmac_integrity"]
+    assert check["status"] == STATUS_UNKNOWN
+
+
+def test_unconfigured_secret_is_unknown_not_pass() -> None:
+    check = _by_id(self_posture({"AGENT_BOM_DEPLOYMENT_ENV": "dev"}, distribution_count=10))["secrets.audit_hmac_key"]
+    assert check["status"] == STATUS_UNKNOWN
+
+
+def test_supply_chain_is_context_only_never_a_fake_pass() -> None:
+    report = self_posture(_hardened_env(), distribution_count=66)
+    check = _by_id(report)["supply_chain.dependency_surface"]
+    assert check["status"] == STATUS_UNKNOWN
+    assert "66" in check["detail"]
+    assert "self-scan" in check["remediation"]
+
+    unknown = self_posture(_hardened_env(), distribution_count=None)
+    assert _by_id(unknown)["supply_chain.dependency_surface"]["status"] == STATUS_UNKNOWN
+
+
+def test_overall_status_precedence_fail_over_warn() -> None:
+    env = _hardened_env() | {
+        "AGENT_BOM_ALLOW_UNAUTHENTICATED_API": "1",  # fail (prod)
+        "AGENT_BOM_ALLOW_EPHEMERAL_AUDIT_HMAC": "1",
+    }
+    assert self_posture(env, distribution_count=10)["overall_status"] == "at_risk"
+
+
+def test_never_raises_on_garbage_replica_count() -> None:
+    env = {
+        "AGENT_BOM_DEPLOYMENT_ENV": "production",
+        "AGENT_BOM_CONTROL_PLANE_REPLICAS": "not-a-number",
+        "AGENT_BOM_AUDIT_HMAC_KEY_FILE": "/x",
+    }
+    report = self_posture(env, distribution_count=10)
+    assert report["overall_status"] in {"hardened", "needs_review", "action_advised", "at_risk"}


### PR DESCRIPTION
## Why

A security + governance product must be able to govern itself. Today agent-bom dogfoods the *scanner* (CI self-scan workflows) but the *operator* of a deployment has no first-class way to see the security + governance posture of their OWN control plane. This adds that surface — agent-bom pointed at itself.

## What

A new operator self-audit surface that reads (never writes) the security-relevant configuration of the running deployment and reports an honest per-check posture:

- **API authentication** — is unauthenticated API access disabled?
- **Database tenant isolation** — is a superuser/BYPASSRLS role voiding RLS?
- **Audit-log integrity** — is a durable HMAC signing key configured (production/multi-replica gated)?
- **Secret sealing** — are secrets provided via file/provider vs a literal env value?
- **Dependency attack surface** — context only, pointing at `scan --self-scan`.

Surfaces, with human + headless parity:

- `agent-bom self-audit` CLI, plus `--agent-mode` JSON envelope
- `GET /v1/self-posture` API route (read permission; distribution enumeration offloaded off the event loop)
- shared, injectable, never-raises `agent_bom.self_posture` core (mirrors the `cloud_sdk_freshness` self-inspection pattern)

## Honesty (no self-flattery)

- A check is `pass` only with a verifiable signal that the hardened path is configured.
- When production gating can't be evaluated (deployment env undeclared), dependent checks report an explicit `unknown` — never an assumed pass.
- Supply-chain is context-only (attack-surface size + a pointer to the real self-scan), never a faked inline clean CVE result.
- Secret *values* are never read or emitted; only whether a secret is configured and how.
- Production misconfig fails (`at_risk`); the same setting in dev warns; overall status follows fail > warn > unknown > hardened.

## Tests

- `tests/test_self_posture.py` — hardened config passes; misconfigured production (unauth API, superuser DB, missing audit HMAC, multi-replica) fails; dev-scoped weakening warns; undeclared env / unconfigured secret is explicit `unknown`; secret value never leaks; never raises on garbage input.
- `tests/test_self_audit_cli.py` — human report renders honestly, production misconfig flagged, agent-mode envelope is valid JSON with no secret leak.
- `tests/api/test_api_self_posture.py` — endpoint returns an honest report; route carries the read-permission dependency.

## Verification

- `pytest` (new + adjacent auth-boundary / capabilities / surface-parity suites): green
- `ruff check` + `ruff format --check` + `mypy` on changed files: green
- `scripts/export_openapi.py --check`, `scripts/check-counts.py` (REST ops 358, route modules 42), `check_cli_reference_alignment`, `check_product_surface_contract`: green
- Smoke: ran `agent-bom self-audit` against the local tree in default, misconfigured-production, and `--agent-mode` modes — honest posture in each.

## Scope / deferrals

- UI surface (operator self-posture panel) deferred to a follow-up; CLI + API + agent-mode land here.
- Broader self-governance blueprint + unified in-product logs/observability (the other two legs of the issue) remain follow-ups.

Stacked on the CI-regression fix branch to inherit its green CI; the 3 inherited commits drop out of this diff once that merges.

Addresses #4044.