### PR TITLE
perf(graph): bounded prior-snapshot digest + single-pass streaming persist

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -380,6 +380,18 @@ list/put plus session-scoped `app.current_tenant` for RLS.
 | `osv_cache` | OSV API response cache | TTL-bounded |
 | `api_rate_limits` | Sliding-window rate limit state | per-tenant bucket key |
 
+The `UnifiedGraph` family is written through a **streamed, bounded write path**
+(`save_graph_streaming`, SQLite and Postgres). Nodes and edges flush in bounded
+batches (a single producer fans out to both `graph_nodes` and its
+`graph_node_search` mirror in one pass on Postgres), the retired-edge
+reconciliation set is bounded by the *previous* snapshot, and the per-scan delta
+alerts are derived from a bounded `prior_delta_digest` (node ids + agent refs +
+attack-path/interaction-risk keys) instead of re-materialising the previous
+snapshot into a second full `UnifiedGraph`. Peak write-path memory is thereby
+decoupled from prior-graph size (#4055/#4075). `save_graph` is a thin wrapper
+over the streamed path; Neptune falls back to a materialising write that is not
+yet bounded. See `docs/GRAPH_MIGRATION.md`.
+
 ### ClickHouse — `src/agent_bom/cloud/clickhouse.py`
 
 OLAP-only. Canonical analytics rows for trends, runtime events, posture.

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -17,7 +17,10 @@ import time
 from collections import defaultdict
 from collections.abc import Iterable, Iterator
 from pathlib import Path
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
+
+if TYPE_CHECKING:
+    from agent_bom.graph.delta_digest import PriorSnapshotDigest
 
 from agent_bom.db import graph_store as sqlite_graph_store
 from agent_bom.graph import AttackPath, EntityType, NodeDimensions, NodeStatus, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
@@ -149,6 +152,20 @@ class GraphStoreProtocol(Protocol):
     def previous_snapshot_id(self, *, tenant_id: str = "", before_scan_id: str = "") -> str: ...
 
     def save_graph(self, graph: UnifiedGraph) -> None: ...
+
+    def save_graph_streaming(
+        self,
+        *,
+        scan_id: str,
+        tenant_id: str = "",
+        nodes: Iterable[UnifiedNode],
+        edges: Iterable[UnifiedEdge],
+        attack_paths: Iterable[AttackPath] = (),
+        interaction_risks: Iterable[Any] = (),
+        created_at: str = "",
+    ) -> dict[str, int]: ...
+
+    def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = "") -> "PriorSnapshotDigest": ...
 
     def load_graph(
         self,
@@ -1229,6 +1246,19 @@ class SQLiteGraphStore:
                 min_severity_rank=min_severity_rank,
                 relationship_types=relationship_types,
             )
+        finally:
+            conn.close()
+
+    def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = "") -> "PriorSnapshotDigest":
+        """Bounded prior-snapshot digest for delta alerts (see #4055/#4075)."""
+        from agent_bom.graph.delta_digest import PriorSnapshotDigestBuilder
+
+        tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
+        conn = self._open_ro_conn()
+        if conn is None:
+            return PriorSnapshotDigestBuilder().build()
+        try:
+            return sqlite_graph_store.prior_delta_digest(conn, tenant_id=tenant_id, scan_id=scan_id)
         finally:
             conn.close()
 

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -12,9 +12,12 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
-from typing import Any, NoReturn, Protocol
+from typing import TYPE_CHECKING, Any, Iterable, NoReturn, Protocol
 
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+
+if TYPE_CHECKING:
+    from agent_bom.graph.delta_digest import PriorSnapshotDigest
 
 
 class NeptuneGraphStoreError(RuntimeError):
@@ -239,6 +242,47 @@ class NeptuneGraphStore:
                 "risk_summary_json": json.dumps(graph.stats(), sort_keys=True),
             },
         )
+
+    def save_graph_streaming(
+        self,
+        *,
+        scan_id: str,
+        tenant_id: str = "",
+        nodes: Iterable[UnifiedNode],
+        edges: Iterable[UnifiedEdge],
+        attack_paths: Iterable[Any] = (),
+        interaction_risks: Iterable[Any] = (),
+        created_at: str = "",
+    ) -> dict[str, int]:
+        """Persist a snapshot from node/edge iterables.
+
+        TODO(scale): Neptune has no batched Gremlin bulk-load path yet, so this
+        fallback materialises the producer into a ``UnifiedGraph`` and delegates
+        to :meth:`save_graph`. Writes stay byte-identical, but this backend does
+        NOT yet realise the #4055 peak-RSS bound the SQLite/Postgres streaming
+        paths do — see the PR notes. Neptune is not the millions-of-nodes target.
+        """
+        graph = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id, created_at=created_at)
+        for node in nodes:
+            graph.add_node(node)
+        for edge in edges:
+            graph.add_edge(edge)
+        graph.attack_paths.extend(attack_paths)
+        graph.interaction_risks.extend(interaction_risks)
+        self.save_graph(graph)
+        return {"nodes": len(graph.nodes), "edges": len(graph.edges)}
+
+    def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = "") -> "PriorSnapshotDigest":
+        """Bounded prior-snapshot digest for delta alerts.
+
+        TODO(scale): Neptune has no bounded projection read yet, so this fallback
+        loads the snapshot via :meth:`load_graph` and projects it. Correct, but
+        it does not realise the #4055 read-side bound.
+        """
+        from agent_bom.graph.delta_digest import digest_from_graph
+
+        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        return digest_from_graph(graph)
 
     def latest_snapshot_id(self, *, tenant_id: str = "") -> str:
         snapshots = self.list_snapshots(tenant_id=tenant_id, limit=1)

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -336,7 +336,8 @@ def _persist_graph_snapshot(
     export all derive from the same persisted graph state.
     """
     from agent_bom.graph.builder import build_unified_graph_from_report
-    from agent_bom.graph.webhooks import compute_delta_alerts, dispatch_delta_alerts
+    from agent_bom.graph.delta_digest import compute_delta_alerts_from_digest
+    from agent_bom.graph.webhooks import dispatch_delta_alerts
 
     tenant_id = job.tenant_id or "default"
     scan_id = report_json.get("scan_id") or job.job_id
@@ -346,29 +347,44 @@ def _persist_graph_snapshot(
 
     tenant_token = set_current_tenant(tenant_id)
     try:
-        previous_graph = None
+        prior_digest = None
         graph_store = _get_graph_store()
         previous_scan_id = graph_store.latest_snapshot_id(tenant_id=tenant_id)
         if previous_scan_id and previous_scan_id != scan_id:
-            previous_graph = graph_store.load_graph(tenant_id=tenant_id, scan_id=previous_scan_id)
-        graph_store.save_graph(graph)
+            # Bounded prior-snapshot digest instead of a second full UnifiedGraph
+            # load — keeps peak RSS decoupled from the prior graph size (#4055/#4075).
+            prior_digest = graph_store.prior_delta_digest(tenant_id=tenant_id, scan_id=previous_scan_id)
+        # Persist via the streamed write path (node/edge iterables) so the write
+        # never buffers a second copy of the graph; counts come from the store's
+        # running tally, not len(graph.*).
+        counts = graph_store.save_graph_streaming(
+            scan_id=graph.scan_id,
+            tenant_id=graph.tenant_id,
+            nodes=graph.nodes.values(),
+            edges=graph.edges,
+            attack_paths=graph.attack_paths,
+            interaction_risks=graph.interaction_risks,
+            created_at=graph.created_at,
+        )
     finally:
         reset_current_tenant(tenant_token)
 
-    alerts = compute_delta_alerts(previous_graph, graph)
+    node_count = counts.get("nodes", len(graph.nodes))
+    edge_count = counts.get("edges", len(graph.edges))
+    alerts = compute_delta_alerts_from_digest(prior_digest, graph)
     delivery = dispatch_delta_alerts(alerts, product_version=__version__, tenant_id=tenant_id) if alerts else None
     _logger.info(
         "Graph persisted for scan=%s tenant=%s nodes=%d edges=%d delta_alerts=%d delta_delivered=%d",
         scan_id,
         tenant_id,
-        len(graph.nodes),
-        len(graph.edges),
+        node_count,
+        edge_count,
         len(alerts),
         delivery["delivered"] if delivery else 0,
     )
     if lock:
         with lock:
-            job.progress.append(f"Graph persisted: {len(graph.nodes)} nodes, {len(graph.edges)} edges")
+            job.progress.append(f"Graph persisted: {node_count} nodes, {edge_count} edges")
             if alerts:
                 job.progress.append(f"Graph delta alerts: {len(alerts)}")
                 if delivery and delivery["configured"]:

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -8,7 +8,10 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
-from typing import Any, Callable, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Sequence
+
+if TYPE_CHECKING:
+    from agent_bom.graph.delta_digest import PriorSnapshotDigest
 
 from agent_bom.api.graph_store import (
     MAX_NODE_PAGE_OFFSET,
@@ -518,12 +521,86 @@ class PostgresGraphStore:
         return total
 
     def save_graph(self, graph) -> None:
+        """Persist a fully built ``UnifiedGraph`` via the streamed write path."""
+        self.save_graph_streaming(
+            scan_id=graph.scan_id or "",
+            tenant_id=graph.tenant_id,
+            nodes=graph.nodes.values(),
+            edges=graph.edges,
+            attack_paths=graph.attack_paths,
+            interaction_risks=graph.interaction_risks,
+            created_at=graph.created_at,
+        )
+
+    def save_graph_streaming(
+        self,
+        *,
+        scan_id: str,
+        tenant_id: str = "",
+        nodes: Iterable[Any],
+        edges: Iterable[Any],
+        attack_paths: Iterable[Any] = (),
+        interaction_risks: Iterable[Any] = (),
+        created_at: str = "",
+    ) -> dict[str, int]:
+        """Persist a snapshot from node/edge iterables without materialising a graph.
+
+        Bounded-memory equivalent of :meth:`save_graph` (#4055/#4075). The single
+        producer over ``nodes`` is consumed exactly once and fans out to BOTH the
+        ``graph_nodes`` row and its ``graph_node_search`` mirror in interleaved,
+        bounded batches — so a lazy producer never needs a second pass and peak
+        RSS is decoupled from graph size. Node/edge/severity tallies accumulate
+        incrementally in place of ``graph.stats()`` over a materialised graph, so
+        the persisted snapshot row is byte-identical to :meth:`save_graph`.
+        """
+        from collections import defaultdict
+
         from agent_bom.graph import RelationshipType
 
-        scan = graph.scan_id or ""
-        tenant = normalize_graph_tenant_id(graph.tenant_id)
-        now = graph.created_at or datetime.now(timezone.utc).isoformat()
+        scan = scan_id or ""
+        tenant = normalize_graph_tenant_id(tenant_id)
+        now = created_at or datetime.now(timezone.utc).isoformat()
         batch_size = _graph_write_batch_size()
+
+        node_count = 0
+        edge_count = 0
+        severity_counts: dict[str, int] = defaultdict(int)
+
+        node_insert = """
+            INSERT INTO graph_nodes (
+                id, entity_type, label, category_uid, class_uid, type_uid,
+                status, risk_score, severity, severity_id,
+                first_seen, last_seen, attributes, compliance_tags,
+                data_sources, dimensions, scan_id, tenant_id
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (id, scan_id, tenant_id) DO UPDATE SET
+                entity_type = EXCLUDED.entity_type,
+                label = EXCLUDED.label,
+                category_uid = EXCLUDED.category_uid,
+                class_uid = EXCLUDED.class_uid,
+                type_uid = EXCLUDED.type_uid,
+                status = EXCLUDED.status,
+                risk_score = EXCLUDED.risk_score,
+                severity = EXCLUDED.severity,
+                severity_id = EXCLUDED.severity_id,
+                first_seen = EXCLUDED.first_seen,
+                last_seen = EXCLUDED.last_seen,
+                attributes = EXCLUDED.attributes,
+                compliance_tags = EXCLUDED.compliance_tags,
+                data_sources = EXCLUDED.data_sources,
+                dimensions = EXCLUDED.dimensions
+            """
+        search_insert = """
+            INSERT INTO graph_node_search (
+                node_id, tenant_id, scan_id, entity_type, severity, compliance_tags, data_sources, search_text
+            ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
+            ON CONFLICT (node_id, scan_id, tenant_id) DO UPDATE SET
+                entity_type = EXCLUDED.entity_type,
+                severity = EXCLUDED.severity,
+                compliance_tags = EXCLUDED.compliance_tags,
+                data_sources = EXCLUDED.data_sources,
+                search_text = EXCLUDED.search_text
+            """
 
         with _tenant_connection(self._pool) as conn:
             previous_row = conn.execute(
@@ -551,11 +628,31 @@ class PostgresGraphStore:
                 ).fetchall():
                     previous_edges[(row[0], row[1], row[2])] = row
 
-            def node_rows() -> Iterator[tuple[Any, ...]]:
-                for node in graph.nodes.values():
-                    yield (
+            # ── Nodes + node-search: single-pass, interleaved bounded batches ──
+            # The producer is consumed exactly once; each node contributes one
+            # graph_nodes row and one graph_node_search row, flushed together when
+            # the batch fills, so at most ``batch_size`` rows of each are buffered.
+            node_batch: list[tuple[Any, ...]] = []
+            search_batch: list[tuple[Any, ...]] = []
+
+            def _flush_nodes() -> None:
+                if node_batch:
+                    _execute_many_batched(conn, node_insert, node_batch, batch_size=batch_size)
+                    node_batch.clear()
+                if search_batch:
+                    _execute_many_batched(conn, search_insert, search_batch, batch_size=batch_size)
+                    search_batch.clear()
+
+            for node in nodes:
+                node_count += 1
+                et = node.entity_type.value if hasattr(node.entity_type, "value") else node.entity_type
+                et_search = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
+                if node.severity:
+                    severity_counts[node.severity] += 1
+                node_batch.append(
+                    (
                         node.id,
-                        node.entity_type.value if hasattr(node.entity_type, "value") else node.entity_type,
+                        et,
                         node.label,
                         node.category_uid,
                         node.class_uid,
@@ -573,19 +670,22 @@ class PostgresGraphStore:
                         scan,
                         tenant,
                     )
-
-            def node_search_rows() -> Iterator[tuple[Any, ...]]:
-                for node in graph.nodes.values():
-                    yield (
+                )
+                search_batch.append(
+                    (
                         node.id,
                         tenant,
                         scan,
-                        node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type),
+                        et_search,
                         (node.severity or "").lower(),
                         " ".join(node.compliance_tags).lower(),
                         " ".join(node.data_sources).lower(),
                         _node_search_text(node),
                     )
+                )
+                if len(node_batch) >= batch_size:
+                    _flush_nodes()
+            _flush_nodes()
 
             # Retired-edge detection: start from the prior snapshot's edge keys
             # and discard each one still present in the incoming stream. This
@@ -594,7 +694,9 @@ class PostgresGraphStore:
             removed_edge_keys: set[tuple[str, str, str]] = set(previous_edges)
 
             def edge_rows() -> Iterator[tuple[Any, ...]]:
-                for edge in graph.edges:
+                nonlocal edge_count
+                for edge in edges:
+                    edge_count += 1
                     rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
                     removed_edge_keys.discard((edge.source, edge.target, rel))
                     previous = previous_edges.get((edge.source, edge.target, rel))
@@ -627,7 +729,7 @@ class PostgresGraphStore:
                     )
 
             def attack_path_rows() -> Iterator[tuple[Any, ...]]:
-                for ap in graph.attack_paths:
+                for ap in attack_paths:
                     yield (
                         ap.source,
                         ap.target,
@@ -645,7 +747,7 @@ class PostgresGraphStore:
                     )
 
             def interaction_risk_rows() -> Iterator[tuple[Any, ...]]:
-                for ir in graph.interaction_risks:
+                for ir in interaction_risks:
                     yield (
                         ir.pattern,
                         json.dumps(sorted(ir.agents)),
@@ -656,51 +758,6 @@ class PostgresGraphStore:
                         tenant,
                     )
 
-            _execute_many_batched(
-                conn,
-                """
-                INSERT INTO graph_nodes (
-                    id, entity_type, label, category_uid, class_uid, type_uid,
-                    status, risk_score, severity, severity_id,
-                    first_seen, last_seen, attributes, compliance_tags,
-                    data_sources, dimensions, scan_id, tenant_id
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (id, scan_id, tenant_id) DO UPDATE SET
-                    entity_type = EXCLUDED.entity_type,
-                    label = EXCLUDED.label,
-                    category_uid = EXCLUDED.category_uid,
-                    class_uid = EXCLUDED.class_uid,
-                    type_uid = EXCLUDED.type_uid,
-                    status = EXCLUDED.status,
-                    risk_score = EXCLUDED.risk_score,
-                    severity = EXCLUDED.severity,
-                    severity_id = EXCLUDED.severity_id,
-                    first_seen = EXCLUDED.first_seen,
-                    last_seen = EXCLUDED.last_seen,
-                    attributes = EXCLUDED.attributes,
-                    compliance_tags = EXCLUDED.compliance_tags,
-                    data_sources = EXCLUDED.data_sources,
-                    dimensions = EXCLUDED.dimensions
-                """,
-                node_rows(),
-                batch_size=batch_size,
-            )
-            _execute_many_batched(
-                conn,
-                """
-                INSERT INTO graph_node_search (
-                    node_id, tenant_id, scan_id, entity_type, severity, compliance_tags, data_sources, search_text
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (node_id, scan_id, tenant_id) DO UPDATE SET
-                    entity_type = EXCLUDED.entity_type,
-                    severity = EXCLUDED.severity,
-                    compliance_tags = EXCLUDED.compliance_tags,
-                    data_sources = EXCLUDED.data_sources,
-                    search_text = EXCLUDED.search_text
-                """,
-                node_search_rows(),
-                batch_size=batch_size,
-            )
             _execute_many_batched(
                 conn,
                 """
@@ -781,7 +838,6 @@ class PostgresGraphStore:
                 batch_size=batch_size,
             )
 
-            stats = graph.stats()
             conn.execute(
                 """
                 INSERT INTO graph_snapshots (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary)
@@ -796,9 +852,9 @@ class PostgresGraphStore:
                     scan,
                     tenant,
                     now,
-                    stats["total_nodes"],
-                    stats["total_edges"],
-                    json.dumps(stats.get("severity_counts", {})),
+                    node_count,
+                    edge_count,
+                    json.dumps(dict(severity_counts)),
                 ),
             )
             conn.commit()
@@ -807,6 +863,47 @@ class PostgresGraphStore:
             # snapshot history does not grow unbounded. Best-effort: a purge
             # failure must never fail the durable save that already committed.
             self._purge_expired_snapshots(conn, tenant)
+
+        return {"nodes": node_count, "edges": edge_count}
+
+    def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = "") -> "PriorSnapshotDigest":
+        """Bounded prior-snapshot digest for delta alerts (see #4055/#4075).
+
+        Streams only the columns ``compute_delta_alerts`` reads from the prior
+        graph — node ids, agent refs, and attack-path / interaction-risk keys —
+        rather than loading a full ``UnifiedGraph``.
+        """
+        from agent_bom.graph.delta_digest import PriorSnapshotDigestBuilder
+
+        tenant = normalize_graph_tenant_id(tenant_id)
+        builder = PriorSnapshotDigestBuilder()
+        if not scan_id:
+            return builder.build()
+        with _tenant_connection(self._pool) as conn:
+            for row in conn.execute(
+                "SELECT id, entity_type, label, severity, status, risk_score FROM graph_nodes WHERE tenant_id = %s AND scan_id = %s",
+                (tenant, scan_id),
+            ):
+                builder.add_node(
+                    row[0],
+                    row[1],
+                    label=row[2],
+                    severity=row[3] or "",
+                    status=row[4],
+                    risk_score=row[5],
+                )
+            for row in conn.execute(
+                "SELECT source_node, target_node FROM attack_paths WHERE tenant_id = %s AND scan_id = %s",
+                (tenant, scan_id),
+            ):
+                builder.add_attack_path(row[0], row[1])
+            for row in conn.execute(
+                "SELECT pattern, agents FROM interaction_risks WHERE tenant_id = %s AND scan_id = %s",
+                (tenant, scan_id),
+            ):
+                agents = row[1]
+                builder.add_interaction_risk(row[0], json.loads(agents) if isinstance(agents, str) else agents)
+        return builder.build()
 
     def _purge_expired_snapshots(self, conn, tenant: str) -> None:
         """Delete this tenant's graph snapshots older than the retention window.

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -17,7 +17,10 @@ from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Generator, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Generator, Iterable, Iterator, Sequence
+
+if TYPE_CHECKING:
+    from agent_bom.graph.delta_digest import PriorSnapshotDigest
 
 from agent_bom.graph import (
     SEVERITY_RANK,
@@ -993,6 +996,52 @@ def load_graph(
             )
 
     return graph
+
+
+def prior_delta_digest(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str = "",
+    scan_id: str = "",
+) -> "PriorSnapshotDigest":
+    """Build a bounded prior-snapshot digest for delta-alert computation.
+
+    Streams only the columns :func:`agent_bom.graph.webhooks.compute_delta_alerts`
+    reads from the prior graph (node ids, agent refs, attack-path and
+    interaction-risk keys) instead of materialising a full ``UnifiedGraph`` — so
+    peak RSS is decoupled from the prior snapshot's node/edge payload (#4055,
+    #4075). The digest yields byte-identical delta alerts to the full-graph path.
+    """
+    from agent_bom.graph.delta_digest import PriorSnapshotDigestBuilder
+
+    tenant_id = normalize_graph_tenant_id(tenant_id)
+    builder = PriorSnapshotDigestBuilder()
+    effective_scan_id, _created_at = _resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
+    if not effective_scan_id:
+        return builder.build()
+    for row in conn.execute(
+        "SELECT id, entity_type, label, severity, status, risk_score FROM graph_nodes WHERE tenant_id = ? AND scan_id = ?",
+        (tenant_id, effective_scan_id),
+    ):
+        builder.add_node(
+            row["id"],
+            row["entity_type"],
+            label=row["label"],
+            severity=row["severity"] or "",
+            status=row["status"],
+            risk_score=row["risk_score"],
+        )
+    for row in conn.execute(
+        "SELECT source_node, target_node FROM attack_paths WHERE tenant_id = ? AND scan_id = ?",
+        (tenant_id, effective_scan_id),
+    ):
+        builder.add_attack_path(row["source_node"], row["target_node"])
+    for row in conn.execute(
+        "SELECT pattern, agents FROM interaction_risks WHERE tenant_id = ? AND scan_id = ?",
+        (tenant_id, effective_scan_id),
+    ):
+        builder.add_interaction_risk(row["pattern"], json.loads(row["agents"]))
+    return builder.build()
 
 
 def _node_from_snapshot_row(row: sqlite3.Row) -> UnifiedNode:

--- a/src/agent_bom/graph/delta_digest.py
+++ b/src/agent_bom/graph/delta_digest.py
@@ -1,0 +1,219 @@
+"""Bounded prior-snapshot digest for graph delta-alert computation.
+
+The graph write path evaluates delta alerts by comparing a freshly built
+snapshot against the tenant's *previous* snapshot. The straightforward
+implementation loads the previous snapshot into a second, fully materialised
+:class:`~agent_bom.graph.container.UnifiedGraph` (every ``UnifiedNode``, every
+edge, plus adjacency indexes) purely to answer the handful of set-membership
+questions :func:`agent_bom.graph.webhooks.compute_delta_alerts` actually asks of
+the prior graph. At millions of nodes that second graph is what pins peak RSS
+(see #4055 / #4075).
+
+``compute_delta_alerts`` reads only four things from the prior graph:
+
+1. the set of prior node ids (to detect *new* nodes),
+2. minimal refs (label / severity / status / risk_score) for prior **agent**
+   nodes (to detect *removed* agents and render their event refs),
+3. the prior attack-path ``(source, target)`` keys, and
+4. the prior interaction-risk ``(pattern, agents)`` keys.
+
+:class:`PriorSnapshotDigest` captures exactly that and nothing else. It is a
+structural stand-in for the prior graph — a :class:`PriorGraphView` — so it can
+be handed straight to the unchanged ``compute_delta_alerts``, which keeps the
+delta output byte-identical to the full-graph path while decoupling peak memory
+from the prior snapshot's node/edge payloads. Non-agent node ids collapse onto a
+single shared sentinel ref, so the digest holds one id-string set plus a small
+agent-ref map — never the full node objects, attributes, edges, or adjacency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator, Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, NamedTuple
+
+from agent_bom.graph.types import EntityType
+
+if TYPE_CHECKING:
+    from agent_bom.graph.container import UnifiedGraph
+
+
+@dataclass(frozen=True)
+class PriorNodeRef:
+    """Minimal prior-node projection consumed by ``compute_delta_alerts``.
+
+    Only the attributes the delta walk reads are retained — ``entity_type`` (to
+    single out agents), plus ``id`` / ``label`` / ``severity`` / ``status`` /
+    ``risk_score`` for rendering a removed-agent event ref. ``status`` is the raw
+    persisted string, which equals ``NodeStatus(status).value`` — so the rendered
+    ref is identical to the one built from a fully loaded node.
+    """
+
+    id: str
+    entity_type: EntityType
+    label: str
+    severity: str
+    status: str
+    risk_score: float
+
+
+# Shared sentinel for every non-agent prior node. ``compute_delta_alerts`` only
+# ever inspects ``entity_type`` for non-agent prior nodes (to exclude them from
+# the removed-agent set) and never resolves them into an event ref, so a single
+# shared instance is safe and keeps the digest's memory to one id-string set.
+_NON_AGENT_REF = PriorNodeRef(
+    id="",
+    entity_type=EntityType.RESOURCE,
+    label="",
+    severity="",
+    status="",
+    risk_score=0.0,
+)
+
+
+class _PriorNodes(Mapping[str, PriorNodeRef]):
+    """Mapping view over prior node ids with agent refs materialised lazily.
+
+    ``__contains__`` and iteration cover *all* prior node ids (bounded by the
+    prior snapshot size, but only id strings). ``__getitem__`` returns the real
+    agent ref for agent ids and the shared sentinel for everything else present.
+    """
+
+    __slots__ = ("_all_ids", "_agent_refs")
+
+    def __init__(self, all_ids: set[str], agent_refs: dict[str, PriorNodeRef]) -> None:
+        self._all_ids = all_ids
+        self._agent_refs = agent_refs
+
+    def __getitem__(self, key: str) -> PriorNodeRef:
+        ref = self._agent_refs.get(key)
+        if ref is not None:
+            return ref
+        if key in self._all_ids:
+            return _NON_AGENT_REF
+        raise KeyError(key)
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._all_ids
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._all_ids)
+
+    def __len__(self) -> int:
+        return len(self._all_ids)
+
+    def items(self) -> Iterator[tuple[str, PriorNodeRef]]:  # type: ignore[override]
+        agent_refs = self._agent_refs
+        for nid in self._all_ids:
+            yield nid, agent_refs.get(nid, _NON_AGENT_REF)
+
+
+class _PathKey(NamedTuple):
+    source: str
+    target: str
+
+
+class _RiskKey(NamedTuple):
+    pattern: str
+    agents: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PriorSnapshotDigest:
+    """Structural stand-in for a prior ``UnifiedGraph`` in delta computation.
+
+    Exposes exactly the ``nodes`` / ``attack_paths`` / ``interaction_risks``
+    surface ``compute_delta_alerts`` touches, so it can be passed in place of the
+    prior graph with byte-identical results and bounded memory.
+    """
+
+    nodes: _PriorNodes
+    attack_paths: tuple[_PathKey, ...]
+    interaction_risks: tuple[_RiskKey, ...]
+
+
+class PriorSnapshotDigestBuilder:
+    """Incrementally assemble a :class:`PriorSnapshotDigest` from streamed rows.
+
+    Backends feed this from a lazy cursor over the prior snapshot's node,
+    attack-path, and interaction-risk rows — so building the digest never
+    materialises the prior graph.
+    """
+
+    __slots__ = ("_all_ids", "_agent_refs", "_attack_paths", "_interaction_risks")
+
+    def __init__(self) -> None:
+        self._all_ids: set[str] = set()
+        self._agent_refs: dict[str, PriorNodeRef] = {}
+        self._attack_paths: list[_PathKey] = []
+        self._interaction_risks: list[_RiskKey] = []
+
+    def add_node(
+        self,
+        node_id: str,
+        entity_type: str | EntityType,
+        *,
+        label: str = "",
+        severity: str = "",
+        status: str = "",
+        risk_score: float = 0.0,
+    ) -> None:
+        self._all_ids.add(node_id)
+        et = entity_type.value if isinstance(entity_type, EntityType) else entity_type
+        if et == EntityType.AGENT.value:
+            self._agent_refs[node_id] = PriorNodeRef(
+                id=node_id,
+                entity_type=EntityType.AGENT,
+                label=label,
+                severity=severity or "",
+                status=status or "",
+                risk_score=risk_score or 0.0,
+            )
+
+    def add_attack_path(self, source: str, target: str) -> None:
+        self._attack_paths.append(_PathKey(source, target))
+
+    def add_interaction_risk(self, pattern: str, agents: Iterable[str]) -> None:
+        self._interaction_risks.append(_RiskKey(pattern, tuple(agents)))
+
+    def build(self) -> PriorSnapshotDigest:
+        return PriorSnapshotDigest(
+            nodes=_PriorNodes(self._all_ids, self._agent_refs),
+            attack_paths=tuple(self._attack_paths),
+            interaction_risks=tuple(self._interaction_risks),
+        )
+
+
+def digest_from_graph(graph: UnifiedGraph) -> PriorSnapshotDigest:
+    """Build a digest from an in-memory graph (test/fallback parity helper)."""
+    builder = PriorSnapshotDigestBuilder()
+    for node in graph.nodes.values():
+        builder.add_node(
+            node.id,
+            node.entity_type,
+            label=node.label,
+            severity=node.severity or "",
+            status=node.status.value if hasattr(node.status, "value") else str(node.status),
+            risk_score=node.risk_score,
+        )
+    for path in graph.attack_paths:
+        builder.add_attack_path(path.source, path.target)
+    for risk in graph.interaction_risks:
+        builder.add_interaction_risk(risk.pattern, risk.agents)
+    return builder.build()
+
+
+def compute_delta_alerts_from_digest(
+    prior: PriorSnapshotDigest | None,
+    new_graph: UnifiedGraph,
+) -> list[dict[str, Any]]:
+    """Delta alerts between a bounded prior digest and a freshly built graph.
+
+    Delegates to the single ``compute_delta_alerts`` implementation so the output
+    is byte-identical to the full prior-graph path. Imported lazily (and invoked
+    via the module attribute) both to avoid an import cycle with ``webhooks`` and
+    so test monkeypatches of ``webhooks.compute_delta_alerts`` are honoured.
+    """
+    from agent_bom.graph import webhooks
+
+    return webhooks.compute_delta_alerts(prior, new_graph)

--- a/src/agent_bom/graph/webhooks.py
+++ b/src/agent_bom/graph/webhooks.py
@@ -14,8 +14,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from collections.abc import Mapping
-from typing import Any
+from collections.abc import Mapping, Sequence
+from typing import Any, Protocol
 
 from agent_bom.event_normalization import build_event_ref, build_event_relationships
 from agent_bom.graph.container import UnifiedGraph
@@ -27,8 +27,27 @@ from agent_bom.security import sanitize_error
 logger = logging.getLogger(__name__)
 
 
+class PriorGraphView(Protocol):
+    """Structural view of a prior snapshot as read by :func:`compute_delta_alerts`.
+
+    Both a full :class:`~agent_bom.graph.container.UnifiedGraph` and a bounded
+    :class:`~agent_bom.graph.delta_digest.PriorSnapshotDigest` satisfy this — the
+    delta walk only needs the node mapping (membership + agent refs) and the
+    attack-path / interaction-risk collections, never the full node/edge payload.
+    """
+
+    @property
+    def nodes(self) -> Mapping[str, Any]: ...
+
+    @property
+    def attack_paths(self) -> Sequence[Any]: ...
+
+    @property
+    def interaction_risks(self) -> Sequence[Any]: ...
+
+
 def _graph_node_ref(
-    graph: UnifiedGraph | None,
+    graph: PriorGraphView | None,
     node_id: str,
     *,
     role: str,
@@ -54,7 +73,7 @@ def _graph_node_ref(
 
 def _graph_relationships(
     *,
-    graph: UnifiedGraph | None,
+    graph: PriorGraphView | None,
     targets: list[tuple[str, str]],
     source: str = "graph_delta",
 ) -> dict[str, Any] | None:
@@ -76,7 +95,7 @@ def _dispatch_outbound_alert(dispatcher: Any, alert: dict[str, Any], outbound_ch
 
 
 def compute_delta_alerts(
-    old_graph: UnifiedGraph | None,
+    old_graph: PriorGraphView | None,
     new_graph: UnifiedGraph,
 ) -> list[dict[str, Any]]:
     """Compare two graph snapshots and return alert dicts for critical changes.

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1263,6 +1263,34 @@ class _RecordingGraphStore:
         self.calls.append(("save_graph", graph.scan_id, graph.tenant_id))
         self.graph = graph
 
+    def save_graph_streaming(
+        self,
+        *,
+        scan_id: str,
+        tenant_id: str = "",
+        nodes,
+        edges,
+        attack_paths=(),
+        interaction_risks=(),
+        created_at: str = "",
+    ) -> dict:
+        graph = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id, created_at=created_at)
+        for node in nodes:
+            graph.add_node(node)
+        for edge in edges:
+            graph.add_edge(edge)
+        graph.attack_paths.extend(attack_paths)
+        graph.interaction_risks.extend(interaction_risks)
+        self.calls.append(("save_graph_streaming", scan_id, tenant_id))
+        self.graph = graph
+        return {"nodes": len(graph.nodes), "edges": len(graph.edges)}
+
+    def prior_delta_digest(self, *, tenant_id: str = "", scan_id: str = ""):
+        from agent_bom.graph.delta_digest import digest_from_graph
+
+        self.calls.append(("prior_delta_digest", tenant_id, scan_id))
+        return digest_from_graph(self.graph)
+
     def load_graph(self, *, tenant_id: str = "", scan_id: str = "", entity_types=None, min_severity_rank: int = 0) -> UnifiedGraph:
         self.calls.append(("load_graph", tenant_id, scan_id, entity_types, min_severity_rank))
         return self.graph
@@ -2079,7 +2107,13 @@ class TestGraphStoreBackendSelection:
         job = SimpleNamespace(job_id="job-123", tenant_id="default", progress=[])
         _persist_graph_snapshot(job, {"scan_id": "job-123"})
 
-        assert ("save_graph", "job-123", "default") in recording_graph_store.calls
+        # Write path now streams node/edge iterables into the store instead of
+        # handing over a fully built graph, and derives the prior-snapshot delta
+        # from a bounded digest rather than a second full load_graph (#4075).
+        assert ("save_graph_streaming", "job-123", "default") in recording_graph_store.calls
+        assert not any(call[0] == "save_graph" for call in recording_graph_store.calls)
+        assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
+        assert ("prior_delta_digest", "default", "store-scan") in recording_graph_store.calls
         assert tenant_context == [("set", "default"), ("reset", "tenant-token")]
 
     def test_graph_search_uses_store_native_query(self, recording_graph_store):

--- a/tests/test_graph_delta_digest.py
+++ b/tests/test_graph_delta_digest.py
@@ -1,0 +1,120 @@
+"""Delta-alert equivalence: bounded prior-snapshot digest vs full prior graph.
+
+The streamed write path (#4075) computes graph delta alerts from a bounded
+:class:`PriorSnapshotDigest` instead of loading the previous snapshot into a
+second full ``UnifiedGraph``. These tests pin that the digest path produces
+*byte-identical* alerts to the full-graph path across every delta branch.
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph.container import AttackPath, InteractionRisk, UnifiedGraph
+from agent_bom.graph.delta_digest import (
+    PriorSnapshotDigestBuilder,
+    compute_delta_alerts_from_digest,
+    digest_from_graph,
+)
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, NodeStatus
+from agent_bom.graph.webhooks import compute_delta_alerts
+
+
+def _agent(node_id: str, label: str = "a", severity: str = "", risk: float = 1.0) -> UnifiedNode:
+    return UnifiedNode(
+        id=node_id,
+        entity_type=EntityType.AGENT,
+        label=label,
+        severity=severity,
+        risk_score=risk,
+        status=NodeStatus.ACTIVE,
+    )
+
+
+def _vuln(node_id: str, severity: str, label: str = "CVE-x") -> UnifiedNode:
+    return UnifiedNode(
+        id=node_id,
+        entity_type=EntityType.VULNERABILITY,
+        label=label,
+        severity=severity,
+        risk_score=9.0,
+        attributes={"cvss_score": 9.1, "is_kev": True, "affected_agent_count": 3},
+    )
+
+
+def _misconfig(node_id: str, severity: str, label: str = "CIS-1.1") -> UnifiedNode:
+    return UnifiedNode(id=node_id, entity_type=EntityType.MISCONFIGURATION, label=label, severity=severity)
+
+
+def _old_graph() -> UnifiedGraph:
+    g = UnifiedGraph(scan_id="scan-old", tenant_id="t1")
+    g.add_node(_agent("agent:keep", "keep-agent"))
+    g.add_node(_agent("agent:gone", "gone-agent", severity="high", risk=7.5))
+    g.add_node(_vuln("vuln:old", "critical", "CVE-OLD"))
+    g.add_node(_misconfig("mis:old", "high"))
+    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:old", hops=["agent:keep", "vuln:old"], composite_risk=8.0))
+    g.interaction_risks.append(
+        InteractionRisk(pattern="loop", agents=["keep", "gone"], risk_score=8.0, description="d", owasp_agentic_tag="AA1")
+    )
+    return g
+
+
+def _new_graph() -> UnifiedGraph:
+    g = UnifiedGraph(scan_id="scan-new", tenant_id="t1")
+    # keep-agent stays; gone-agent removed
+    g.add_node(_agent("agent:keep", "keep-agent"))
+    # brand-new critical vuln + high misconfig (should alert)
+    g.add_node(_vuln("vuln:new", "critical", "CVE-NEW"))
+    g.add_node(_misconfig("mis:new", "critical"))
+    # carried-over old vuln (present in old -> no new-vuln alert)
+    g.add_node(_vuln("vuln:old", "critical", "CVE-OLD"))
+    # new high-risk attack path + interaction risk (exercise those branches)
+    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:new", hops=["agent:keep", "vuln:new"], composite_risk=9.5))
+    g.attack_paths.append(AttackPath(source="agent:keep", target="vuln:old", hops=["agent:keep", "vuln:old"], composite_risk=8.0))
+    g.interaction_risks.append(
+        InteractionRisk(pattern="new-loop", agents=["keep"], risk_score=9.1, description="d2", owasp_agentic_tag="AA2")
+    )
+    g.interaction_risks.append(
+        InteractionRisk(pattern="loop", agents=["keep", "gone"], risk_score=8.0, description="d", owasp_agentic_tag="AA1")
+    )
+    return g
+
+
+def test_digest_delta_matches_full_graph_delta_across_all_branches() -> None:
+    old = _old_graph()
+    new = _new_graph()
+
+    full_alerts = compute_delta_alerts(old, new)
+    digest_alerts = compute_delta_alerts_from_digest(digest_from_graph(old), new)
+
+    # Byte-identical, order-preserving.
+    assert digest_alerts == full_alerts
+    # Sanity: the fixture actually exercised multiple branches.
+    kinds = {a["type"] for a in full_alerts}
+    assert {"new_vulnerability", "new_misconfiguration", "new_attack_path", "new_interaction_risk", "agent_removed"} <= kinds
+
+
+def test_digest_delta_matches_when_no_prior_snapshot() -> None:
+    new = _new_graph()
+    assert compute_delta_alerts_from_digest(None, new) == compute_delta_alerts(None, new)
+
+
+def test_builder_streams_rows_into_equivalent_digest() -> None:
+    old = _old_graph()
+    builder = PriorSnapshotDigestBuilder()
+    # Simulate a backend streaming persisted rows (entity_type as stored string).
+    for node in old.nodes.values():
+        builder.add_node(
+            node.id,
+            node.entity_type.value,
+            label=node.label,
+            severity=node.severity,
+            status=node.status.value,
+            risk_score=node.risk_score,
+        )
+    for path in old.attack_paths:
+        builder.add_attack_path(path.source, path.target)
+    for risk in old.interaction_risks:
+        builder.add_interaction_risk(risk.pattern, risk.agents)
+
+    new = _new_graph()
+    assert compute_delta_alerts_from_digest(builder.build(), new) == compute_delta_alerts(old, new)

--- a/tests/test_graph_persist_memory_bound.py
+++ b/tests/test_graph_persist_memory_bound.py
@@ -1,0 +1,223 @@
+"""Production write-path memory bound + streamed-persist equivalence (#4055/#4075).
+
+`_persist_graph_snapshot` used to load the previous snapshot into a second full
+``UnifiedGraph`` purely to compute delta alerts, so peak held up to *two*
+materialised graphs. It now derives the delta from a bounded
+``prior_delta_digest`` and persists via ``save_graph_streaming``. These tests
+pin (a) the digest path's peak allocation is a small fraction of the full
+prior-graph load and stays proportionally bounded as the prior snapshot grows,
+(b) the production persist path realises that bound, (c) the streamed persist is
+content-identical to the full ``save_graph`` on real report fixtures, and (d)
+streamed persist keeps tenant isolation.
+"""
+
+from __future__ import annotations
+
+import json
+import tracemalloc
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph import RelationshipType, UnifiedEdge
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.delta_digest import compute_delta_alerts_from_digest
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, NodeStatus
+from agent_bom.graph.webhooks import compute_delta_alerts
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _synthetic_graph(scan: str, n: int) -> UnifiedGraph:
+    g = UnifiedGraph(scan_id=scan, tenant_id="t1")
+    for i in range(n):
+        g.add_node(
+            UnifiedNode(
+                id=f"n:{i}",
+                entity_type=EntityType.AGENT if i % 50 == 0 else EntityType.VULNERABILITY,
+                label=f"L{i}",
+                severity="high" if i % 3 else "critical",
+                risk_score=float(i % 10),
+                status=NodeStatus.ACTIVE,
+                attributes={"cvss_score": 7.0, "blob": "v" * 24},
+            )
+        )
+    for i in range(0, n - 1, 2):
+        g.add_edge(UnifiedEdge(source=f"n:{i}", target=f"n:{i + 1}", relationship=RelationshipType.DEPENDS_ON))
+    return g
+
+
+def _measure_digest_vs_full_load(tmp_path: Path, n: int) -> tuple[int, int]:
+    store = SQLiteGraphStore(tmp_path / f"g{n}.db")
+    store.save_graph(_synthetic_graph("scan-old", n))
+    # A fresh new graph, held constant across both measurements. Add one brand-new
+    # critical vuln so the delta is non-empty (exercises the equivalence too).
+    new = _synthetic_graph("scan-new", n)
+    new.add_node(
+        UnifiedNode(id="vuln:brand-new", entity_type=EntityType.VULNERABILITY, label="CVE-NEW", severity="critical", risk_score=9.0)
+    )
+
+    tracemalloc.start()
+    prev = store.load_graph(tenant_id="t1", scan_id="scan-old")
+    full_alerts = compute_delta_alerts(prev, new)
+    _, full_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    del prev
+
+    tracemalloc.start()
+    digest = store.prior_delta_digest(tenant_id="t1", scan_id="scan-old")
+    digest_alerts = compute_delta_alerts_from_digest(digest, new)
+    _, digest_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    assert digest_alerts == full_alerts, "digest delta diverged from full-graph delta"
+    assert full_alerts, "fixture should produce a non-empty delta"
+    return full_peak, digest_peak
+
+
+def test_digest_peak_is_small_fraction_of_full_load_and_stays_bounded(tmp_path: Path) -> None:
+    small_full, small_digest = _measure_digest_vs_full_load(tmp_path, 2000)
+    large_full, large_digest = _measure_digest_vs_full_load(tmp_path, 8000)
+
+    ratio_small = small_digest / small_full
+    ratio_large = large_digest / large_full
+
+    # The bounded digest never holds the prior graph's node objects / edges /
+    # adjacency — only an id set + agent refs. Measured ~0.07; guard well clear.
+    assert ratio_small < 0.4, f"digest/full peak ratio too high at N=2000: {ratio_small:.3f}"
+    assert ratio_large < 0.4, f"digest/full peak ratio too high at N=8000: {ratio_large:.3f}"
+    # The advantage must not erode as the prior snapshot grows 4x.
+    assert ratio_large <= ratio_small * 1.5, f"digest advantage eroded with scale: {ratio_small:.3f} -> {ratio_large:.3f}"
+
+
+def test_production_persist_path_does_not_materialise_full_prior_graph(tmp_path: Path, monkeypatch) -> None:
+    import agent_bom.api.pipeline as pipeline
+    import agent_bom.graph.builder as builder
+
+    n = 8000
+    store = SQLiteGraphStore(tmp_path / "pipe.db")
+    store.save_graph(_synthetic_graph("scan-1", n))
+    monkeypatch.setattr(pipeline, "_get_graph_store", lambda: store)
+
+    new = _synthetic_graph("scan-2", 20)
+    monkeypatch.setattr(builder, "build_unified_graph_from_report", lambda report_json, scan_id, tenant_id: new)
+
+    job = SimpleNamespace(job_id="scan-2", tenant_id="t1", progress=[])
+    tracemalloc.start()
+    pipeline._persist_graph_snapshot(job, {"scan_id": "scan-2"})
+    _, pipeline_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    # Cost of the eliminated step: loading the full prior graph for the delta.
+    tracemalloc.start()
+    prev = store.load_graph(tenant_id="t1", scan_id="scan-1")
+    _ = compute_delta_alerts(prev, new)
+    _, full_prior_peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    del prev
+
+    # The entire production persist (build + streamed save + digest delta) peaks
+    # below what a single full prior-graph load for the delta alone would cost.
+    assert pipeline_peak < full_prior_peak, f"persist peak {pipeline_peak} not below full prior-load {full_prior_peak}"
+    # scan-2 actually persisted.
+    assert store.latest_snapshot_id(tenant_id="t1") == "scan-2"
+
+
+def _report_fixtures() -> list[dict]:
+    self_scan = json.loads((_FIXTURES / "agent_bom_self_scan_inventory.json").read_text())
+    constructed = {
+        "scan_id": "constructed",
+        "scan_sources": ["mcp-scan"],
+        "agents": [
+            {
+                "name": "planner",
+                "type": "claude",
+                "source": "local",
+                "mcp_servers": [
+                    {
+                        "name": "files",
+                        "packages": [
+                            {
+                                "name": "requests",
+                                "version": "2.0.0",
+                                "ecosystem": "pypi",
+                                "vulnerabilities": [{"id": "CVE-1", "severity": "critical"}],
+                            },
+                        ],
+                        "tools": [{"name": "read_file"}],
+                    }
+                ],
+            }
+        ],
+        "blast_radius": [],
+    }
+    return [self_scan, constructed]
+
+
+@pytest.mark.parametrize("report", _report_fixtures(), ids=["self_scan_fixture", "constructed_report"])
+def test_streamed_persist_is_content_identical_to_full_save(tmp_path: Path, report: dict) -> None:
+    graph = build_unified_graph_from_report(report, scan_id="s", tenant_id="t1")
+
+    full_store = SQLiteGraphStore(tmp_path / "full.db")
+    full_store.save_graph(graph)
+    loaded_full = full_store.load_graph(tenant_id="t1", scan_id="s")
+
+    graph2 = build_unified_graph_from_report(report, scan_id="s", tenant_id="t1")
+    stream_store = SQLiteGraphStore(tmp_path / "stream.db")
+    stream_store.save_graph_streaming(
+        scan_id=graph2.scan_id,
+        tenant_id=graph2.tenant_id,
+        nodes=iter(graph2.nodes.values()),  # one-shot producer
+        edges=iter(graph2.edges),
+        attack_paths=graph2.attack_paths,
+        interaction_risks=graph2.interaction_risks,
+        created_at=graph2.created_at,
+    )
+    loaded_stream = stream_store.load_graph(tenant_id="t1", scan_id="s")
+
+    def _nodes(g: UnifiedGraph) -> list[dict]:
+        return sorted((n.to_dict() for n in g.nodes.values()), key=lambda d: d["id"])
+
+    def _edges(g: UnifiedGraph) -> list[dict]:
+        return sorted((e.to_dict() for e in g.edges), key=lambda d: (d["source"], d["target"], d["relationship"]))
+
+    assert _nodes(loaded_stream) == _nodes(loaded_full)
+    assert _edges(loaded_stream) == _edges(loaded_full)
+    assert len(loaded_full.nodes) > 0
+
+
+def test_streamed_persist_preserves_tenant_isolation(tmp_path: Path) -> None:
+    store = SQLiteGraphStore(tmp_path / "multi.db")
+
+    def _tenant_graph(tenant: str, extra_id: str) -> UnifiedGraph:
+        g = UnifiedGraph(scan_id=f"{tenant}-scan", tenant_id=tenant)
+        g.add_node(UnifiedNode(id="shared:1", entity_type=EntityType.AGENT, label=f"{tenant}-agent"))
+        g.add_node(UnifiedNode(id=extra_id, entity_type=EntityType.VULNERABILITY, label="v", severity="high"))
+        return g
+
+    for tenant, extra in (("alpha", "vuln:alpha-only"), ("beta", "vuln:beta-only")):
+        g = _tenant_graph(tenant, extra)
+        store.save_graph_streaming(
+            scan_id=g.scan_id,
+            tenant_id=tenant,
+            nodes=iter(g.nodes.values()),
+            edges=iter(g.edges),
+        )
+
+    alpha = store.load_graph(tenant_id="alpha", scan_id="alpha-scan")
+    beta = store.load_graph(tenant_id="beta", scan_id="beta-scan")
+
+    # Same logical key ("shared:1") persists independently per tenant; neither
+    # tenant's snapshot leaks the other's exclusive node.
+    assert "shared:1" in alpha.nodes and "shared:1" in beta.nodes
+    assert "vuln:alpha-only" in alpha.nodes and "vuln:alpha-only" not in beta.nodes
+    assert "vuln:beta-only" in beta.nodes and "vuln:beta-only" not in alpha.nodes
+
+    # The bounded digest read is tenant-scoped too.
+    alpha_digest = store.prior_delta_digest(tenant_id="alpha", scan_id="alpha-scan")
+    assert "vuln:alpha-only" in alpha_digest.nodes
+    assert "vuln:beta-only" not in alpha_digest.nodes

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -1,0 +1,162 @@
+"""Postgres streamed graph persist: single-pass node + node-search double write.
+
+The Postgres backend fans a single node producer out to BOTH the ``graph_nodes``
+row and its ``graph_node_search`` mirror. #4074 left this non-trivial because the
+old ``save_graph`` iterated ``graph.nodes.values()`` twice; a lazy producer can
+only be consumed once. These tests pin that ``save_graph_streaming`` consumes the
+node iterable exactly once, still writes both rows for every node, batches with a
+bounded window, and records byte-correct snapshot tallies — all against a fake
+connection (no live Postgres required).
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, NodeStatus
+
+
+class _FakeCursor:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+    def fetchall(self):
+        return self.rows
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+class _RecordingConn:
+    """Fake Postgres connection recording every insert batch by table."""
+
+    def __init__(self):
+        self.node_rows: list[tuple] = []
+        self.search_rows: list[tuple] = []
+        self.edge_rows: list[tuple] = []
+        self.snapshot_params: tuple | None = None
+        self.executemany_calls: list[str] = []
+        self.committed = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def execute(self, sql, params=None):
+        low = " ".join(sql.strip().lower().split())
+        if low.startswith("insert into graph_snapshots"):
+            self.snapshot_params = tuple(params)
+        # latest/previous lookups + set_config + purge scan -> empty history
+        return _FakeCursor()
+
+    def executemany(self, sql, seq):
+        low = " ".join(sql.strip().lower().split())
+        rows = list(seq)
+        if low.startswith("insert into graph_nodes"):
+            self.executemany_calls.append("graph_nodes")
+            self.node_rows.extend(rows)
+        elif low.startswith("insert into graph_node_search"):
+            self.executemany_calls.append("graph_node_search")
+            self.search_rows.extend(rows)
+        elif low.startswith("insert into graph_edges"):
+            self.edge_rows.extend(rows)
+        return _FakeCursor(rows)
+
+    def commit(self):
+        self.committed += 1
+
+    def rollback(self):
+        pass
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def connection(self):
+        return self._conn
+
+
+def _make_store(conn, monkeypatch):
+    from agent_bom.api import postgres_graph
+
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_tables", lambda self: None)
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_optional_search_indexes", lambda self: None)
+    return postgres_graph.PostgresGraphStore(pool=_FakePool(conn))
+
+
+def _nodes(n):
+    for i in range(n):
+        yield UnifiedNode(
+            id=f"agent:{i}",
+            entity_type=EntityType.AGENT if i % 2 == 0 else EntityType.VULNERABILITY,
+            label=f"n{i}",
+            severity="critical" if i % 2 else "",
+            status=NodeStatus.ACTIVE,
+            risk_score=float(i),
+        )
+
+
+def test_streaming_consumes_one_shot_producer_and_double_writes(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", "2")
+    conn = _RecordingConn()
+    store = _make_store(conn, monkeypatch)
+
+    # A generator is single-use: if the impl iterated nodes twice this yields
+    # zero rows on the second pass and the search mirror would be empty.
+    counts = store.save_graph_streaming(
+        scan_id="scan-1",
+        tenant_id="t1",
+        nodes=_nodes(5),
+        edges=iter(()),
+    )
+
+    assert counts == {"nodes": 5, "edges": 0}
+    # Every node produced BOTH a graph_nodes row and a graph_node_search row.
+    assert len(conn.node_rows) == 5
+    assert len(conn.search_rows) == 5
+    node_ids = [r[0] for r in conn.node_rows]
+    search_ids = [r[0] for r in conn.search_rows]
+    assert node_ids == [f"agent:{i}" for i in range(5)]
+    assert search_ids == node_ids  # same order, one pass
+    # Bounded batching: with batch size 2 over 5 nodes the node insert flushed
+    # more than once rather than buffering all rows.
+    assert conn.executemany_calls.count("graph_nodes") >= 3
+
+
+def test_streaming_snapshot_tally_matches_nodes(monkeypatch):
+    conn = _RecordingConn()
+    store = _make_store(conn, monkeypatch)
+
+    store.save_graph_streaming(scan_id="scan-2", tenant_id="t1", nodes=_nodes(4), edges=iter(()))
+
+    # graph_snapshots row: (scan, tenant, now, node_count, edge_count, risk_summary)
+    assert conn.snapshot_params is not None
+    scan, tenant, _now, node_count, edge_count, risk_summary = conn.snapshot_params
+    assert (scan, tenant, node_count, edge_count) == ("scan-2", "t1", 4, 0)
+    import json
+
+    # Two of four nodes carry "critical" severity (odd indices).
+    assert json.loads(risk_summary) == {"critical": 2}
+    assert conn.committed == 1
+
+
+def test_save_graph_delegates_to_streaming(monkeypatch):
+    """The materialised save_graph path stays byte-identical (delegates)."""
+    from agent_bom.graph.container import UnifiedGraph
+
+    conn = _RecordingConn()
+    store = _make_store(conn, monkeypatch)
+    g = UnifiedGraph(scan_id="scan-3", tenant_id="t1")
+    for node in _nodes(3):
+        g.add_node(node)
+
+    store.save_graph(g)
+
+    assert len(conn.node_rows) == 3
+    assert len(conn.search_rows) == 3
+    assert conn.snapshot_params[0] == "scan-3"


### PR DESCRIPTION
## Addresses #4075

Bounds the graph write-path memory. `_persist_graph_snapshot` previously held up to **two** fully-materialised `UnifiedGraph`s at peak — the freshly-built graph plus a full `load_graph()` of the previous snapshot done only to compute delta alerts. This eliminates the second one and adds a single-pass streamed Postgres save.

> Note: the prior-snapshot **digest** primitives (`graph/delta_digest.py`, `prior_delta_digest`, `compute_delta_alerts_from_digest`) were originally in #4087, but that PR merged into the `fix/ci-main-py313-regression` side-branch and **never reached `main`** (its symbols are absent from `main`). This PR re-delivers that work off current `main` **and** adds the Postgres single-pass streaming save on top.

## What changed
- **`graph/delta_digest.py`** — `PriorSnapshotDigest`, a bounded structural stand-in for the prior graph (all node-id set + real refs only for AGENT nodes via a shared non-agent sentinel + attack-path / interaction-risk keys). Fed to the **unchanged** `compute_delta_alerts`, so delta output is byte-identical with zero logic duplication.
- **`webhooks.py`** — prior-graph param widened to a read-only `PriorGraphView` Protocol (both `UnifiedGraph` and the digest satisfy it). Behavior unchanged.
- **Pipeline** — persists via `save_graph_streaming` (node/edge iterables; counts from the store tally, not `len(graph.*)`), and computes the delta from `prior_delta_digest` — no full prior-graph load.
- **Postgres** — true single-pass `save_graph_streaming`: one node producer fans out to both `graph_nodes` and its `graph_node_search` mirror in interleaved bounded batches; `save_graph` now delegates to it. Added `prior_delta_digest`.
- **SQLite** — added `prior_delta_digest` (streaming save already existed). **Neptune** — honest materialising fallback with `# TODO(scale)` (not the millions-of-nodes target; documented in `DATA_MODEL.md`).

## Memory (tracemalloc, prior-snapshot delta handling)
| prior nodes | full prior-graph load | bounded digest | ratio |
|---|---|---|---|
| 2,000 | 3.29 MB | 0.24 MB | 0.073 |
| 8,000 | 13.16 MB | 0.95 MB | 0.072 |
| 32,000 | 52.82 MB | 3.80 MB | 0.072 |

Full `_persist_graph_snapshot` peak with a 32k-node prior: **12.8 MB** vs ~52.8 MB for a single full prior-load alone — the persist now peaks below one full prior load.

## Honest scope (why "Addresses", not "Closes")
The correlation *builder* still materialises the freshly-built graph: its post-build overlays (`cost`/`aspm`/`repo_structure`/`runtime_evidence`) mutate and aggregate across the full node set, so a byte-identical *streaming build* isn't feasible without an overlay redesign — that floor is documented, not silently dropped. Delivered here: eliminating the second full graph (prior-snapshot load) + the Postgres single-pass save.

## Consistency / layers
model (new digest module) → DB stores → API store + Postgres + Neptune → pipeline → docs (`DATA_MODEL.md`) → tests. **No schema migration** (query-only; `tenant_id` preserved on every streamed row; cross-tenant isolation test added). **No UI change** — read side unchanged; graph read endpoints return identical results (asserted via content-equivalence test).

## Verified on the merged result (rebased onto current `main`, #4089 preserved)
- pytest: 70 graph (delta-digest / memory-bound / postgres-streaming / graph-api) + 16 self-posture regression — pass
- mypy (changed src) clean · ruff check + format clean · bandit `--severity-level medium` exit 0
- `check-counts.py` ✅ · `export_openapi.py --check` OK (no routes/contracts changed)