### PR TITLE
fix(graph): make streamed snapshot retries atomic

### DIFF
--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -603,6 +603,14 @@ class PostgresGraphStore:
             """
 
         with _tenant_connection(self._pool) as conn:
+            # Serialize retries and concurrent writers for one logical
+            # snapshot. Without a transaction-scoped lock, disjoint producers
+            # can interleave their upserts and leave rows that disagree with
+            # whichever graph_snapshots tally commits last.
+            conn.execute(
+                "SELECT pg_advisory_xact_lock(hashtextextended(%s, 0))",
+                (f"{tenant}\x1f{scan}",),
+            )
             previous_row = conn.execute(
                 """
                 SELECT scan_id
@@ -627,6 +635,22 @@ class PostgresGraphStore:
                     (tenant, previous_scan),
                 ).fetchall():
                     previous_edges[(row[0], row[1], row[2])] = row
+
+            # A scan id represents a complete immutable snapshot. A retry is a
+            # replacement, not a merge; remove its old rows inside this same
+            # transaction before consuming the new one-shot producers.
+            for table in (
+                "graph_node_search",
+                "attack_paths",
+                "interaction_risks",
+                "graph_edges",
+                "graph_nodes",
+                "graph_snapshots",
+            ):
+                conn.execute(
+                    f"DELETE FROM {table} WHERE tenant_id = %s AND scan_id = %s",  # nosec B608 - static table list
+                    (tenant, scan),
+                )
 
             # ── Nodes + node-search: single-pass, interleaved bounded batches ──
             # The producer is consumed exactly once; each node contributes one

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -613,7 +613,7 @@ class PostgresGraphStore:
             )
             previous_row = conn.execute(
                 """
-                SELECT scan_id
+                SELECT scan_id, created_at
                 FROM graph_snapshots
                 WHERE tenant_id = %s
                 ORDER BY created_at DESC, scan_id DESC
@@ -622,8 +622,18 @@ class PostgresGraphStore:
                 (tenant,),
             ).fetchone()
             previous_scan = str(previous_row[0]) if previous_row else ""
-            if previous_scan == scan:
-                previous_scan = self.previous_snapshot_id(tenant_id=tenant, before_scan_id=scan)
+            if previous_row and previous_scan == scan:
+                prior_row = conn.execute(
+                    """
+                    SELECT scan_id
+                    FROM graph_snapshots
+                    WHERE tenant_id = %s AND created_at < %s
+                    ORDER BY created_at DESC, scan_id DESC
+                    LIMIT 1
+                    """,
+                    (tenant, previous_row[1]),
+                ).fetchone()
+                previous_scan = str(prior_row[0]) if prior_row else ""
             previous_edges: dict[tuple[str, str, str], Any] = {}
             if previous_scan:
                 for row in conn.execute(

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -675,6 +675,17 @@ def save_graph_streaming(
         ):
             previous_edges[(row["source_id"], row["target_id"], row["relationship"])] = row
 
+    # A scan id is one complete snapshot. Retries/replays must replace that
+    # snapshot atomically; upserts alone would retain rows absent from the
+    # retried producer and make graph_snapshots counts contradict graph rows.
+    # The first DELETE also takes SQLite's write lock, serializing concurrent
+    # writers before any streamed batch is consumed.
+    for table in ("attack_paths", "interaction_risks", "graph_edges", "graph_nodes", "graph_snapshots"):
+        conn.execute(
+            f"DELETE FROM {table} WHERE tenant_id = ? AND scan_id = ?",  # nosec B608 - static table list
+            (tenant, scan),
+        )
+
     # Incrementally accumulated snapshot stats — mirrors UnifiedGraph.stats()
     # (severity_counts only counts truthy severities; node_type_counts is every
     # node) without a second pass over a fully materialised graph.

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -168,6 +168,7 @@ CREATE TABLE IF NOT EXISTS attack_paths (
 
 CREATE INDEX IF NOT EXISTS idx_ap_risk ON attack_paths(composite_risk DESC);
 CREATE INDEX IF NOT EXISTS idx_ap_scan ON attack_paths(scan_id);
+CREATE INDEX IF NOT EXISTS idx_ap_tenant_scan ON attack_paths(tenant_id, scan_id);
 
 -- ── Interaction risks (per scan) ──
 CREATE TABLE IF NOT EXISTS interaction_risks (
@@ -180,6 +181,7 @@ CREATE TABLE IF NOT EXISTS interaction_risks (
     tenant_id       TEXT NOT NULL DEFAULT 'default',
     PRIMARY KEY (pattern, agents, scan_id, tenant_id)
 );
+CREATE INDEX IF NOT EXISTS idx_ir_tenant_scan ON interaction_risks(tenant_id, scan_id);
 
 -- ── Schema version ──
 CREATE TABLE IF NOT EXISTS graph_schema_version (

--- a/tests/test_graph_persist_memory_bound.py
+++ b/tests/test_graph_persist_memory_bound.py
@@ -166,7 +166,11 @@ def test_streamed_persist_is_content_identical_to_full_save(tmp_path: Path, repo
     full_store.save_graph(graph)
     loaded_full = full_store.load_graph(tenant_id="t1", scan_id="s")
 
-    graph2 = build_unified_graph_from_report(report, scan_id="s", tenant_id="t1")
+    # Exercise both persistence implementations with the exact same graph.
+    # Building twice makes the equivalence assertion depend on whether the wall
+    # clock crosses a second between builds because node timestamps are created
+    # at build time; that is input drift, not persistence drift.
+    graph2 = graph
     stream_store = SQLiteGraphStore(tmp_path / "stream.db")
     stream_store.save_graph_streaming(
         scan_id=graph2.scan_id,

--- a/tests/test_graph_store_streamed_persistence.py
+++ b/tests/test_graph_store_streamed_persistence.py
@@ -282,6 +282,28 @@ def test_streaming_replaces_same_scan_without_stale_rows(tmp_path) -> None:
     assert tuple(snapshot) == (1, 0)
 
 
+def test_delta_digest_queries_use_tenant_snapshot_indexes(tmp_path) -> None:
+    """Digest projections must not scan other tenants' path/risk history."""
+    db = tmp_path / "digest-query-plan.db"
+    with gs.open_graph_db(db) as conn:
+        queries = (
+            "SELECT source_node, target_node FROM attack_paths WHERE tenant_id = ? AND scan_id = ?",
+            "SELECT pattern, agents FROM interaction_risks WHERE tenant_id = ? AND scan_id = ?",
+        )
+        plans = [
+            " ".join(
+                row["detail"]
+                for row in conn.execute(
+                    f"EXPLAIN QUERY PLAN {query}",
+                    ("acme", "scan-1"),
+                )
+            )
+            for query in queries
+        ]
+
+    assert all("tenant_id=? AND scan_id=?" in plan for plan in plans), plans
+
+
 def test_iter_graph_edges_dangling_edge_matches_documented_contract(tmp_path) -> None:
     """``iter_graph_edges`` vs ``load_graph`` dangling-edge handling is pinned.
 

--- a/tests/test_graph_store_streamed_persistence.py
+++ b/tests/test_graph_store_streamed_persistence.py
@@ -237,6 +237,51 @@ def test_streaming_stats_count_yields_documented_precondition(tmp_path) -> None:
     assert snap["edge_count"] == 2
 
 
+def test_streaming_replaces_same_scan_without_stale_rows(tmp_path) -> None:
+    """Retrying one scan id replaces, rather than merges, its snapshot."""
+    db = tmp_path / "same-scan-retry.db"
+    with gs.open_graph_db(db) as conn:
+        gs.save_graph_streaming(
+            conn,
+            scan_id="scan-retry",
+            tenant_id="acme",
+            nodes=iter(
+                [
+                    UnifiedNode(id="keep", entity_type=EntityType.PACKAGE, label="keep"),
+                    UnifiedNode(id="stale", entity_type=EntityType.PACKAGE, label="stale"),
+                ]
+            ),
+            edges=iter([UnifiedEdge(source="keep", target="stale", relationship=RelationshipType.DEPENDS_ON)]),
+        )
+        gs.save_graph_streaming(
+            conn,
+            scan_id="scan-retry",
+            tenant_id="acme",
+            nodes=iter([UnifiedNode(id="keep", entity_type=EntityType.PACKAGE, label="updated")]),
+            edges=iter(()),
+        )
+
+        node_ids = {
+            row[0]
+            for row in conn.execute(
+                "SELECT id FROM graph_nodes WHERE tenant_id = ? AND scan_id = ?",
+                ("acme", "scan-retry"),
+            )
+        }
+        edge_count = conn.execute(
+            "SELECT COUNT(*) FROM graph_edges WHERE tenant_id = ? AND scan_id = ?",
+            ("acme", "scan-retry"),
+        ).fetchone()[0]
+        snapshot = conn.execute(
+            "SELECT node_count, edge_count FROM graph_snapshots WHERE tenant_id = ? AND scan_id = ?",
+            ("acme", "scan-retry"),
+        ).fetchone()
+
+    assert node_ids == {"keep"}
+    assert edge_count == 0
+    assert tuple(snapshot) == (1, 0)
+
+
 def test_iter_graph_edges_dangling_edge_matches_documented_contract(tmp_path) -> None:
     """``iter_graph_edges`` vs ``load_graph`` dangling-edge handling is pinned.
 

--- a/tests/test_graph_store_streamed_persistence.py
+++ b/tests/test_graph_store_streamed_persistence.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import textwrap
@@ -302,6 +303,81 @@ def test_delta_digest_queries_use_tenant_snapshot_indexes(tmp_path) -> None:
         ]
 
     assert all("tenant_id=? AND scan_id=?" in plan for plan in plans), plans
+
+
+def test_sqlite_api_retry_rebuilds_search_index_without_stale_rows(tmp_path) -> None:
+    """The API wrapper refreshes its optional search mirror after replacement."""
+    from agent_bom.api.graph_store import SQLiteGraphStore
+
+    db = tmp_path / "api-search-retry.db"
+    store = SQLiteGraphStore(db)
+    store.save_graph_streaming(
+        scan_id="retry",
+        tenant_id="acme",
+        nodes=iter(
+            [
+                UnifiedNode(id="keep", entity_type=EntityType.PACKAGE, label="keep"),
+                UnifiedNode(id="stale", entity_type=EntityType.PACKAGE, label="stale"),
+            ]
+        ),
+        edges=iter(()),
+    )
+    store.save_graph_streaming(
+        scan_id="retry",
+        tenant_id="acme",
+        nodes=iter([UnifiedNode(id="keep", entity_type=EntityType.PACKAGE, label="updated")]),
+        edges=iter(()),
+    )
+
+    with sqlite3.connect(db) as conn:
+        ids = {
+            row[0]
+            for row in conn.execute(
+                "SELECT node_id FROM graph_node_search WHERE tenant_id = ? AND scan_id = ?",
+                ("acme", "retry"),
+            )
+        }
+    assert ids == {"keep"}
+
+
+def test_sqlite_stream_retry_rolls_back_after_flushed_batch(tmp_path, monkeypatch) -> None:
+    """A producer failure restores the prior complete snapshot, including search."""
+    from agent_bom.api.graph_store import SQLiteGraphStore
+
+    monkeypatch.setenv("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", "1")
+    db = tmp_path / "api-rollback.db"
+    store = SQLiteGraphStore(db)
+    store.save_graph_streaming(
+        scan_id="retry",
+        tenant_id="acme",
+        nodes=iter([UnifiedNode(id="original", entity_type=EntityType.PACKAGE, label="original")]),
+        edges=iter(()),
+    )
+
+    def failing_nodes():
+        yield UnifiedNode(id="partial", entity_type=EntityType.PACKAGE, label="partial")
+        raise RuntimeError("producer failed after flush")
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="producer failed after flush"):
+        store.save_graph_streaming(
+            scan_id="retry",
+            tenant_id="acme",
+            nodes=failing_nodes(),
+            edges=iter(()),
+        )
+
+    with sqlite3.connect(db) as conn:
+        graph_ids = {row[0] for row in conn.execute("SELECT id FROM graph_nodes WHERE tenant_id='acme' AND scan_id='retry'")}
+        search_ids = {
+            row[0] for row in conn.execute("SELECT node_id FROM graph_node_search WHERE tenant_id='acme' AND scan_id='retry'")
+        }
+        count = conn.execute(
+            "SELECT node_count FROM graph_snapshots WHERE tenant_id='acme' AND scan_id='retry'"
+        ).fetchone()[0]
+    assert graph_ids == search_ids == {"original"}
+    assert count == 1
 
 
 def test_iter_graph_edges_dangling_edge_matches_documented_contract(tmp_path) -> None:

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -82,8 +82,10 @@ class _RecordingConn:
 class _FakePool:
     def __init__(self, conn):
         self._conn = conn
+        self.connection_calls = 0
 
     def connection(self):
+        self.connection_calls += 1
         return self._conn
 
 
@@ -184,3 +186,24 @@ def test_streaming_serializes_and_replaces_same_snapshot(monkeypatch):
         "graph_nodes",
         "graph_snapshots",
     ]
+
+
+def test_same_scan_retry_does_not_checkout_nested_connection(monkeypatch):
+    """A one-connection pool must not deadlock while resolving prior history."""
+    class _RetryConn(_RecordingConn):
+        def execute(self, sql, params=None):
+            low = " ".join(sql.strip().lower().split())
+            if low.startswith("select scan_id") and "order by created_at" in low and "created_at <" not in low:
+                return _FakeCursor([("scan-retry", "2026-07-17T00:00:00+00:00")])
+            if low.startswith("select created_at"):
+                return _FakeCursor([("2026-07-17T00:00:00+00:00",)])
+            if low.startswith("select scan_id") and "created_at <" in low:
+                return _FakeCursor([])
+            return super().execute(sql, params)
+
+    conn = _RetryConn()
+    store = _make_store(conn, monkeypatch)
+
+    store.save_graph_streaming(scan_id="scan-retry", tenant_id="t1", nodes=_nodes(1), edges=iter(()))
+
+    assert store._pool.connection_calls == 1

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -41,15 +41,20 @@ class _RecordingConn:
         self.committed = 0
         self.deleted_tables: list[str] = []
         self.advisory_locks: list[tuple] = []
+        self.sql_calls: list[str] = []
+        self.rolled_back = 0
 
     def __enter__(self):
         return self
 
     def __exit__(self, *args):
+        if args[0] is not None:
+            self.rollback()
         return False
 
     def execute(self, sql, params=None):
         low = " ".join(sql.strip().lower().split())
+        self.sql_calls.append(low)
         if low.startswith("select pg_advisory_xact_lock"):
             self.advisory_locks.append(tuple(params))
         elif low.startswith("delete from"):
@@ -76,7 +81,7 @@ class _RecordingConn:
         self.committed += 1
 
     def rollback(self):
-        pass
+        self.rolled_back += 1
 
 
 class _FakePool:
@@ -207,3 +212,35 @@ def test_same_scan_retry_does_not_checkout_nested_connection(monkeypatch):
     store.save_graph_streaming(scan_id="scan-retry", tenant_id="t1", nodes=_nodes(1), edges=iter(()))
 
     assert store._pool.connection_calls == 1
+
+
+def test_postgres_stream_rolls_back_after_flushed_batch(monkeypatch):
+    """A one-shot producer failure cannot commit a partial replacement."""
+    monkeypatch.setenv("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", "1")
+    conn = _RecordingConn()
+    store = _make_store(conn, monkeypatch)
+
+    def failing_nodes():
+        yield next(_nodes(1))
+        raise RuntimeError("producer failed after flush")
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="producer failed after flush"):
+        store.save_graph_streaming(scan_id="retry", tenant_id="t1", nodes=failing_nodes(), edges=iter(()))
+
+    assert conn.committed == 0
+    assert conn.rolled_back == 1
+    assert conn.snapshot_params is None
+
+
+def test_postgres_writer_lock_precedes_snapshot_reads_and_deletes(monkeypatch):
+    conn = _RecordingConn()
+    store = _make_store(conn, monkeypatch)
+
+    store.save_graph_streaming(scan_id="scan-1", tenant_id="t1", nodes=_nodes(1), edges=iter(()))
+
+    lock_at = next(i for i, sql in enumerate(conn.sql_calls) if sql.startswith("select pg_advisory_xact_lock"))
+    prior_read_at = next(i for i, sql in enumerate(conn.sql_calls) if "from graph_snapshots" in sql and sql.startswith("select"))
+    delete_at = next(i for i, sql in enumerate(conn.sql_calls) if sql.startswith("delete from"))
+    assert lock_at < prior_read_at < delete_at

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -39,6 +39,8 @@ class _RecordingConn:
         self.snapshot_params: tuple | None = None
         self.executemany_calls: list[str] = []
         self.committed = 0
+        self.deleted_tables: list[str] = []
+        self.advisory_locks: list[tuple] = []
 
     def __enter__(self):
         return self
@@ -48,6 +50,10 @@ class _RecordingConn:
 
     def execute(self, sql, params=None):
         low = " ".join(sql.strip().lower().split())
+        if low.startswith("select pg_advisory_xact_lock"):
+            self.advisory_locks.append(tuple(params))
+        elif low.startswith("delete from"):
+            self.deleted_tables.append(low.split()[2])
         if low.startswith("insert into graph_snapshots"):
             self.snapshot_params = tuple(params)
         # latest/previous lookups + set_config + purge scan -> empty history
@@ -160,3 +166,21 @@ def test_save_graph_delegates_to_streaming(monkeypatch):
     assert len(conn.node_rows) == 3
     assert len(conn.search_rows) == 3
     assert conn.snapshot_params[0] == "scan-3"
+
+
+def test_streaming_serializes_and_replaces_same_snapshot(monkeypatch):
+    """A retry cannot merge stale rows or race another writer for the scan."""
+    conn = _RecordingConn()
+    store = _make_store(conn, monkeypatch)
+
+    store.save_graph_streaming(scan_id="scan-retry", tenant_id="t1", nodes=_nodes(1), edges=iter(()))
+
+    assert conn.advisory_locks == [("t1\x1fscan-retry",)]
+    assert conn.deleted_tables == [
+        "graph_node_search",
+        "attack_paths",
+        "interaction_risks",
+        "graph_edges",
+        "graph_nodes",
+        "graph_snapshots",
+    ]


### PR DESCRIPTION
## Summary

- replace same-tenant/same-scan graph retries atomically so stale nodes and edges cannot survive a smaller replacement snapshot
- serialize SQLite replacements and use a PostgreSQL transaction advisory lock without a nested pool checkout
- add tenant/snapshot digest indexes and regression coverage for search-index replacement, post-flush rollback, and lock ordering

## Verification

- `uv run pytest -q tests/test_graph_store_streamed_persistence.py tests/test_postgres_graph_streaming.py` (18 passed after rebasing onto current `main`; 85 owning tests passed in the full audit matrix)
- `uv run ruff check src/agent_bom/api/postgres_graph.py src/agent_bom/db/graph_store.py tests/test_graph_store_streamed_persistence.py tests/test_postgres_graph_streaming.py`
- `uv run mypy src/agent_bom/api/postgres_graph.py src/agent_bom/db/graph_store.py`
- PostgreSQL advisory-lock statement executed successfully against the shipped `postgres:16-alpine` image
- two-process SQLite replacement race completed with one coherent snapshot

## Notes

- This is a correctness and concurrency prerequisite for the larger producer-streaming work tracked in #4075; it does not claim that the production graph builder is memory-bounded yet.
- Retry failure is fail-closed at the transaction boundary: the prior coherent snapshot remains intact.

Addresses #4075
Addresses #4095

## CI follow-up

- Full Python 3.11 randomized CI exposed timestamp drift in the equivalence test: two independently built graphs crossed a one-second wall-clock boundary.
- The regression now passes the same graph input through full and streamed persistence, isolating the behavior under test.
- `uv run --python 3.11 pytest -q tests/test_graph_persist_memory_bound.py::test_streamed_persist_is_content_identical_to_full_save tests/test_graph_store_streamed_persistence.py tests/test_postgres_graph_streaming.py` — 20 passed.