### PR TITLE
fix(formats): enforce CycloneDX reference uniqueness

### DIFF
--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -35,6 +35,37 @@ def _sanitize_bom_ref(raw: str) -> str:
     return re.sub(r"[^a-zA-Z0-9._-]", "-", raw)
 
 
+def _unique_bom_ref_items(items: list[dict]) -> list[dict]:
+    """Return one item per ``bom-ref``, preserving first-observed evidence.
+
+    The same agent, server, tool service, model, or dataset can be discovered
+    through multiple configuration surfaces. CycloneDX requires those arrays
+    to be unique; their graph relationships carry the many-to-many context.
+    """
+    unique: list[dict] = []
+    seen_refs: set[str] = set()
+    for item in items:
+        ref = str(item.get("bom-ref") or "")
+        if ref and ref in seen_refs:
+            continue
+        if ref:
+            seen_refs.add(ref)
+        unique.append(item)
+    return unique
+
+
+def _merge_dependencies(dependencies: list[dict]) -> list[dict]:
+    """Merge repeated graph entries into a stable ref/dependsOn adjacency."""
+    by_ref: dict[str, set[str]] = {}
+    for dependency in dependencies:
+        ref = str(dependency.get("ref") or "")
+        if not ref:
+            continue
+        targets = by_ref.setdefault(ref, set())
+        targets.update(str(target) for target in dependency.get("dependsOn", []) if target)
+    return [{"ref": ref, "dependsOn": sorted(by_ref[ref])} for ref in sorted(by_ref)]
+
+
 def _append_discovery_provenance_properties(properties: list[dict], provenance: dict | None) -> None:
     """Append sanitized discovery provenance as CycloneDX component properties."""
     if not provenance:
@@ -415,9 +446,10 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                     "bom-ref": pkg_ref,
                     "name": pkg.name,
                     "version": pkg.version,
-                    "purl": pkg.purl,
                     "properties": pkg_properties,
                 }
+                if pkg.purl:
+                    pkg_component["purl"] = pkg.purl
                 if pkg.license_expression or pkg.license:
                     lic_val = pkg.license_expression or pkg.license or ""
                     # CycloneDX 1.7: compound expressions (AND/OR/WITH) use
@@ -523,6 +555,13 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
             comp_id += 1
             components.append(comp)
             ml_component_refs.append(ref)
+
+    # Discovery paths overlap by design. Normalize the document-level arrays
+    # once after all builders have contributed so uniqueness applies globally,
+    # not only to package components.
+    components = _unique_bom_ref_items(components)
+    services = _unique_bom_ref_items(services)
+    dependencies = _merge_dependencies(dependencies)
 
     cdx = {
         "bomFormat": "CycloneDX",

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -21,7 +21,7 @@ from agent_bom.asset_provenance import (
     sanitize_discovery_provenance,
 )
 from agent_bom.checksums import cyclonedx_hashes
-from agent_bom.models import AIBOMReport
+from agent_bom.models import AIBOMReport, Vulnerability
 from agent_bom.security import sanitize_launch_command, sanitize_path_label
 from agent_bom.vex import vex_justification_to_cdx
 
@@ -35,22 +35,65 @@ def _sanitize_bom_ref(raw: str) -> str:
     return re.sub(r"[^a-zA-Z0-9._-]", "-", raw)
 
 
-def _unique_bom_ref_items(items: list[dict]) -> list[dict]:
-    """Return one item per ``bom-ref``, preserving first-observed evidence.
+def _merge_properties(current: list[dict], incoming: list[dict]) -> list[dict]:
+    """Merge component properties without dropping later security evidence."""
+    merged = [dict(prop) for prop in current]
+    positions = {str(prop.get("name")): index for index, prop in enumerate(merged)}
+    seen = {(str(prop.get("name")), str(prop.get("value"))) for prop in merged}
+    for prop in incoming:
+        name = str(prop.get("name") or "")
+        value = str(prop.get("value") or "")
+        if (name, value) in seen:
+            continue
+        if name == "agent-bom:tool-count" and name in positions:
+            index = positions[name]
+            try:
+                current_count = int(str(merged[index].get("value") or "0"))
+                incoming_count = int(value)
+            except ValueError:
+                pass
+            else:
+                if incoming_count > current_count:
+                    seen.discard((name, str(merged[index].get("value") or "")))
+                    merged[index] = dict(prop)
+                    seen.add((name, value))
+                continue
+        merged.append(dict(prop))
+        seen.add((name, value))
+        positions.setdefault(name, len(merged) - 1)
+    return merged
+
+
+def _merge_bom_ref_items(items: list[dict]) -> list[dict]:
+    """Return one item per ``bom-ref`` while merging later evidence.
 
     The same agent, server, tool service, model, or dataset can be discovered
     through multiple configuration surfaces. CycloneDX requires those arrays
-    to be unique; their graph relationships carry the many-to-many context.
+    to be unique, but first-observation deduplication must not discard security
+    properties learned from an enriched observation.
     """
     unique: list[dict] = []
-    seen_refs: set[str] = set()
+    by_ref: dict[str, dict] = {}
     for item in items:
         ref = str(item.get("bom-ref") or "")
-        if ref and ref in seen_refs:
+        existing = by_ref.get(ref) if ref else None
+        if existing is not None:
+            existing["properties"] = _merge_properties(
+                list(existing.get("properties", [])),
+                list(item.get("properties", [])),
+            )
+            for key, value in item.items():
+                if key not in existing or existing[key] in (None, "", []):
+                    existing[key] = value
             continue
         if ref:
-            seen_refs.add(ref)
-        unique.append(item)
+            copied = dict(item)
+            if "properties" in copied:
+                copied["properties"] = [dict(prop) for prop in copied["properties"]]
+            by_ref[ref] = copied
+            unique.append(copied)
+        else:
+            unique.append(item)
     return unique
 
 
@@ -64,6 +107,59 @@ def _merge_dependencies(dependencies: list[dict]) -> list[dict]:
         targets = by_ref.setdefault(ref, set())
         targets.update(str(target) for target in dependency.get("dependsOn", []) if target)
     return [{"ref": ref, "dependsOn": sorted(by_ref[ref])} for ref in sorted(by_ref)]
+
+
+def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str) -> dict:
+    """Build one package-scoped CycloneDX vulnerability observation."""
+    ratings: list[dict[str, object]] = []
+    if vuln.cvss_score:
+        ratings.append(
+            {
+                "score": vuln.cvss_score,
+                "severity": vuln.severity.value,
+                "method": "CVSSv3",
+            }
+        )
+    else:
+        ratings.append({"severity": vuln.severity.value})
+    entry: dict = {
+        "id": vuln.id,
+        "description": vuln.summary or f"See {vuln.id} for details",
+        "source": {"name": "OSV", "url": f"https://osv.dev/vulnerability/{vuln.id}"},
+        "ratings": ratings,
+        "affects": [{"ref": pkg_ref}],
+    }
+    if vuln.fixed_version:
+        entry["recommendation"] = f"Upgrade to {vuln.fixed_version}"
+    if vuln.vex_status:
+        state_map = {
+            "affected": "exploitable",
+            "not_affected": "not_affected",
+            "fixed": "resolved",
+            "under_investigation": "in_triage",
+        }
+        analysis: dict[str, str] = {"state": state_map.get(vuln.vex_status, "in_triage")}
+        if vuln.vex_justification:
+            justification = vex_justification_to_cdx(vuln.vex_justification)
+            if justification:
+                analysis["justification"] = justification
+        entry["analysis"] = analysis
+    return entry
+
+
+def _merge_vulnerability_observation(by_id: dict[str, dict], observation: dict) -> None:
+    """Merge a vulnerability ID into one entry with all affected components."""
+    vuln_id = str(observation["id"])
+    existing = by_id.get(vuln_id)
+    if existing is None:
+        by_id[vuln_id] = observation
+        return
+    affected_refs = {
+        str(affected.get("ref"))
+        for affected in [*existing.get("affects", []), *observation.get("affects", [])]
+        if affected.get("ref")
+    }
+    existing["affects"] = [{"ref": ref} for ref in sorted(affected_refs)]
 
 
 def _append_discovery_provenance_properties(properties: list[dict], provenance: dict | None) -> None:
@@ -326,7 +422,7 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
     """
     components = []
     services: list[dict] = []
-    vulnerabilities_cdx = []
+    vulnerabilities_by_id: dict[str, dict] = {}
     dependencies = []
 
     comp_id = 0
@@ -409,6 +505,11 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                 # (and its vulnerabilities) were already emitted via another server.
                 server_deps.append(pkg_ref)
                 bom_ref_map[f"{pkg.ecosystem}:{pkg.name}@{pkg.version}"] = pkg_ref
+                for vuln in pkg.vulnerabilities:
+                    _merge_vulnerability_observation(
+                        vulnerabilities_by_id,
+                        _cyclonedx_vulnerability(vuln, pkg_ref),
+                    )
                 if pkg_ref in seen_component_refs:
                     continue
                 seen_component_refs.add(pkg_ref)
@@ -481,48 +582,6 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
                     pkg_component["externalReferences"] = ext_refs
                 components.append(pkg_component)
 
-                for vuln in pkg.vulnerabilities:
-                    ratings: list[dict[str, object]] = []
-                    if vuln.cvss_score:
-                        ratings.append(
-                            {
-                                "score": vuln.cvss_score,
-                                "severity": vuln.severity.value,
-                                "method": "CVSSv3",
-                            }
-                        )
-                    else:
-                        ratings.append(
-                            {
-                                "severity": vuln.severity.value,
-                            }
-                        )
-                    vuln_entry: dict[str, object] = {
-                        "id": vuln.id,
-                        "description": vuln.summary or f"See {vuln.id} for details",
-                        "source": {"name": "OSV", "url": f"https://osv.dev/vulnerability/{vuln.id}"},
-                        "ratings": ratings,
-                        "affects": [{"ref": pkg_ref}],
-                    }
-                    if vuln.fixed_version:
-                        vuln_entry["recommendation"] = f"Upgrade to {vuln.fixed_version}"
-                    if vuln.vex_status:
-                        _cdx_state_map = {
-                            "affected": "exploitable",
-                            "not_affected": "not_affected",
-                            "fixed": "resolved",
-                            "under_investigation": "in_triage",
-                        }
-                        analysis_dict: dict[str, str] = {
-                            "state": _cdx_state_map.get(vuln.vex_status, "in_triage"),
-                        }
-                        if vuln.vex_justification:
-                            cdx_justification = vex_justification_to_cdx(vuln.vex_justification)
-                            if cdx_justification:
-                                analysis_dict["justification"] = cdx_justification
-                        vuln_entry["analysis"] = analysis_dict
-                    vulnerabilities_cdx.append(vuln_entry)
-
             dependencies.append({"ref": server_ref, "dependsOn": server_deps})
         dependencies.append({"ref": agent_ref, "dependsOn": agent_deps})
 
@@ -559,9 +618,10 @@ def to_cyclonedx(report: AIBOMReport) -> dict:
     # Discovery paths overlap by design. Normalize the document-level arrays
     # once after all builders have contributed so uniqueness applies globally,
     # not only to package components.
-    components = _unique_bom_ref_items(components)
-    services = _unique_bom_ref_items(services)
+    components = _merge_bom_ref_items(components)
+    services = _merge_bom_ref_items(services)
     dependencies = _merge_dependencies(dependencies)
+    vulnerabilities_cdx = [vulnerabilities_by_id[vuln_id] for vuln_id in sorted(vulnerabilities_by_id)]
 
     cdx = {
         "bomFormat": "CycloneDX",

--- a/tests/test_interop_schema_conformance.py
+++ b/tests/test_interop_schema_conformance.py
@@ -170,6 +170,87 @@ def test_cyclonedx_conforms_to_1_7_schema(report: AIBOMReport) -> None:
     )
 
 
+def _shared_server_cyclonedx_report() -> AIBOMReport:
+    """Demo-equivalent overlap: repeated agent/server discovery and a package
+    without a package URL must still produce one strict-valid BOM graph."""
+    no_purl = Package(name="local-plugin", version="1.0", ecosystem="generic", purl=None)
+    left_pkg = Package(name="left", version="1.0", ecosystem="npm", purl="pkg:npm/left@1.0")
+    right_pkg = Package(name="right", version="2.0", ecosystem="npm", purl="pkg:npm/right@2.0")
+    left_server = MCPServer(
+        name="shared-server",
+        command="npx",
+        args=["shared-server"],
+        packages=[no_purl, left_pkg],
+        tools=[MCPTool(name="query", description="read data")],
+    )
+    right_server = MCPServer(
+        name="shared-server",
+        command="npx",
+        args=["shared-server"],
+        packages=[no_purl, right_pkg],
+        tools=[MCPTool(name="query", description="read data")],
+    )
+    first = Agent(
+        name="first",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/first.json",
+        mcp_servers=[left_server],
+    )
+    second = Agent(
+        name="second",
+        agent_type=AgentType.CURSOR,
+        config_path="/tmp/second.json",
+        mcp_servers=[right_server],
+    )
+    return AIBOMReport(
+        agents=[first, second, first],
+        scan_id="c95ee02e-5315-450e-a84d-6dbf17b26b68",
+        tool_version="0.0.0-test",
+        generated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def test_cyclonedx_shared_discovery_is_globally_unique_and_schema_valid() -> None:
+    cdx = to_cyclonedx(_shared_server_cyclonedx_report())
+    _assert_schema_valid(
+        "CycloneDX 1.7 shared discovery",
+        "cyclonedx-1.7.schema.json",
+        Draft7Validator,
+        cdx,
+        registry=_cyclonedx_registry(),
+    )
+
+    component_refs = [component["bom-ref"] for component in cdx["components"]]
+    service_refs = [service["bom-ref"] for service in cdx.get("services", [])]
+    dependency_refs = [dependency["ref"] for dependency in cdx["dependencies"]]
+    assemblies = cdx["compositions"][0]["assemblies"]
+    assert len(component_refs) == len(set(component_refs))
+    assert len(service_refs) == len(set(service_refs))
+    assert len(dependency_refs) == len(set(dependency_refs))
+    assert len(assemblies) == len(set(assemblies))
+
+    local_plugin = next(component for component in cdx["components"] if component["name"] == "local-plugin")
+    assert "purl" not in local_plugin
+
+
+def test_cyclonedx_merges_repeated_dependency_edges_deterministically() -> None:
+    report = _shared_server_cyclonedx_report()
+    first = to_cyclonedx(report)
+    second = to_cyclonedx(report)
+    assert first["dependencies"] == second["dependencies"]
+    assert first["dependencies"] == sorted(first["dependencies"], key=lambda dependency: dependency["ref"])
+    for dependency in first["dependencies"]:
+        assert dependency["dependsOn"] == sorted(set(dependency["dependsOn"]))
+
+    shared = next(dependency for dependency in first["dependencies"] if dependency["ref"].startswith("mcp-server-"))
+    package_names_by_ref = {
+        component["bom-ref"]: component["name"]
+        for component in first["components"]
+        if component["type"] == "library"
+    }
+    assert {package_names_by_ref[ref] for ref in shared["dependsOn"]} == {"local-plugin", "left", "right"}
+
+
 def test_cyclonedx_formulation_is_top_level(report: AIBOMReport) -> None:
     """CDX 1.7 defines ``formulation`` as a top-level BOM array — not a metadata
     field. Nesting it under metadata fails strict validation (regression guard)."""

--- a/tests/test_interop_schema_conformance.py
+++ b/tests/test_interop_schema_conformance.py
@@ -173,22 +173,47 @@ def test_cyclonedx_conforms_to_1_7_schema(report: AIBOMReport) -> None:
 def _shared_server_cyclonedx_report() -> AIBOMReport:
     """Demo-equivalent overlap: repeated agent/server discovery and a package
     without a package URL must still produce one strict-valid BOM graph."""
-    no_purl = Package(name="local-plugin", version="1.0", ecosystem="generic", purl=None)
-    left_pkg = Package(name="left", version="1.0", ecosystem="npm", purl="pkg:npm/left@1.0")
-    right_pkg = Package(name="right", version="2.0", ecosystem="npm", purl="pkg:npm/right@2.0")
+    shared_vuln = Vulnerability(id="CVE-2026-SHARED", summary="shared risk", severity=Severity.HIGH)
+    late_vuln = Vulnerability(id="CVE-2026-LATE", summary="late enrichment", severity=Severity.CRITICAL)
+    left_no_purl = Package(name="local-plugin", version="1.0", ecosystem="generic", purl=None)
+    right_no_purl = Package(
+        name="local-plugin",
+        version="1.0",
+        ecosystem="generic",
+        purl=None,
+        vulnerabilities=[late_vuln],
+    )
+    left_pkg = Package(
+        name="left",
+        version="1.0",
+        ecosystem="npm",
+        purl="pkg:npm/left@1.0",
+        vulnerabilities=[shared_vuln],
+    )
+    right_pkg = Package(
+        name="right",
+        version="2.0",
+        ecosystem="npm",
+        purl="pkg:npm/right@2.0",
+        vulnerabilities=[shared_vuln],
+    )
     left_server = MCPServer(
         name="shared-server",
         command="npx",
         args=["shared-server"],
-        packages=[no_purl, left_pkg],
+        packages=[left_no_purl, left_pkg],
         tools=[MCPTool(name="query", description="read data")],
     )
     right_server = MCPServer(
         name="shared-server",
         command="npx",
         args=["shared-server"],
-        packages=[no_purl, right_pkg],
-        tools=[MCPTool(name="query", description="read data")],
+        packages=[right_no_purl, right_pkg],
+        tools=[
+            MCPTool(name="query", description="read data"),
+            MCPTool(name="admin", description="write data"),
+        ],
+        env={"API_KEY": "test-secret"},
     )
     first = Agent(
         name="first",
@@ -231,6 +256,26 @@ def test_cyclonedx_shared_discovery_is_globally_unique_and_schema_valid() -> Non
 
     local_plugin = next(component for component in cdx["components"] if component["name"] == "local-plugin")
     assert "purl" not in local_plugin
+
+    shared_server = next(component for component in cdx["components"] if component["name"] == "shared-server")
+    properties = shared_server["properties"]
+    assert {prop["value"] for prop in properties if prop["name"] == "agent-bom:has-credentials"} == {"true"}
+    assert {prop["value"] for prop in properties if prop["name"] == "agent-bom:tool-count"} == {"2"}
+    assert {prop["value"].split(":", 1)[0] for prop in properties if prop["name"] == "agent-bom:mcp-tool"} == {
+        "admin",
+        "query",
+    }
+
+    vulnerabilities = {vulnerability["id"]: vulnerability for vulnerability in cdx["vulnerabilities"]}
+    assert set(vulnerabilities) == {"CVE-2026-LATE", "CVE-2026-SHARED"}
+    component_name_by_ref = {component["bom-ref"]: component["name"] for component in cdx["components"]}
+    assert {component_name_by_ref[item["ref"]] for item in vulnerabilities["CVE-2026-LATE"]["affects"]} == {
+        "local-plugin"
+    }
+    assert {component_name_by_ref[item["ref"]] for item in vulnerabilities["CVE-2026-SHARED"]["affects"]} == {
+        "left",
+        "right",
+    }
 
 
 def test_cyclonedx_merges_repeated_dependency_edges_deterministically() -> None:


### PR DESCRIPTION
## Summary

- omit optional CycloneDX package URLs when no PURL exists
- merge document-level component and service `bom-ref` identities across overlapping discovery paths without dropping later credential, tool, provenance, or vulnerability evidence
- merge repeated dependency entries into deterministic, unique adjacency lists so compositions inherit unique assemblies
- merge repeated vulnerability IDs into deterministic entries with every affected component reference

## Root cause

Package components had a local deduplication guard, but agents, servers, services, dependencies, and compositions were appended independently. Optional `purl` was also emitted unconditionally. The offline demo therefore produced null PURLs and repeated references that violate the CycloneDX 1.7 schema.

## Verification

- regression-first shared-server fixture reproduced five strict schema errors before the fix
- `uv run pytest -q tests/test_interop_schema_conformance.py -k 'cyclonedx_shared or cyclonedx_merges'` — 2 passed
- focused CycloneDX/MCP selection — 37 passed, 133 deselected
- `uv run pytest -q tests/test_interop_schema_conformance.py tests/test_aibom_e2e.py tests/test_cyclonedx_vex_justification.py` — 55 passed
- Ruff on changed files
- mypy on `src/agent_bom/output/cyclonedx_fmt.py`
- live offline demo CycloneDX artifact — zero strict-schema errors, 30/30 unique component refs, no null PURLs, and unique services/dependencies/assemblies
- `git diff --check`

## Notes

Overlapping component properties are unioned; security-sensitive credential evidence is preserved and tool counts take the maximum observed value. Vulnerability IDs and affected component references are globally unique. Output ordering remains deterministic.

Closes #4104
Addresses #4095
