### PR TITLE
feat(self-posture): operator self-audit UI panel

### DIFF
--- a/ui/app/self-posture/page.tsx
+++ b/ui/app/self-posture/page.tsx
@@ -1,0 +1,287 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import {
+  CheckCircle2,
+  HelpCircle,
+  ShieldAlert,
+  ShieldCheck,
+  ShieldQuestion,
+  ShieldX,
+  XCircle,
+} from "lucide-react";
+
+import { api } from "@/lib/api";
+import type {
+  SelfPostureCheck,
+  SelfPostureOverall,
+  SelfPostureReport,
+  SelfPostureStatus,
+} from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
+import { Collapsible } from "@/components/collapsible";
+import { PageErrorState, PageLoadingState } from "@/components/states/page-state";
+
+// Headless equivalent for agents/CI — the panel is the human surface, this is
+// the same posture from the CLI/API (§11 human + headless parity).
+const HEADLESS_CLI = "agent-bom self-audit";
+const HEADLESS_API = "GET /v1/self-posture";
+
+type Verdict = {
+  label: string;
+  detail: string;
+  icon: typeof ShieldCheck;
+  container: string;
+  badge: string;
+  accent: string;
+};
+
+// Headline verdict derives from the SAME overall_status the API returns
+// (fail > warn > unknown > pass precedence lives in the backend) — never a
+// re-computation on the client.
+const OVERALL_VERDICTS: Record<SelfPostureOverall, Verdict> = {
+  hardened: {
+    label: "Control plane hardened",
+    detail: "Every evaluated control is in its hardened configuration.",
+    icon: ShieldCheck,
+    container: "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)]",
+    badge:
+      "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]",
+    accent: "text-[color:var(--status-success)]",
+  },
+  action_advised: {
+    label: "Action advised",
+    detail: "A weakened setting is in effect — acknowledged or dev-scoped, but worth tightening.",
+    icon: ShieldAlert,
+    container: "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)]",
+    badge:
+      "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--status-warn)]",
+    accent: "text-[color:var(--status-warn)]",
+  },
+  needs_review: {
+    label: "Needs review",
+    detail: "One or more controls could not be evaluated from configuration alone — verify them directly.",
+    icon: ShieldQuestion,
+    container: "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]",
+    badge:
+      "border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)]",
+    accent: "text-[color:var(--text-secondary)]",
+  },
+  at_risk: {
+    label: "At risk",
+    detail: "A control is misconfigured for this deployment mode and weakens posture — fix before relying on it.",
+    icon: ShieldX,
+    container: "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)]",
+    badge:
+      "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--status-danger)]",
+    accent: "text-[color:var(--status-danger)]",
+  },
+};
+
+type ChipMeta = {
+  label: string;
+  icon: typeof CheckCircle2;
+  chip: string;
+};
+
+// Four-way, theme-safe chips. `unknown` is an explicit neutral "not evaluated"
+// state — never rendered as an implied pass.
+const STATUS_CHIPS: Record<SelfPostureStatus, ChipMeta> = {
+  pass: {
+    label: "Pass",
+    icon: CheckCircle2,
+    chip: "border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] text-[color:var(--status-success)]",
+  },
+  fail: {
+    label: "Fail",
+    icon: XCircle,
+    chip: "border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] text-[color:var(--status-danger)]",
+  },
+  warn: {
+    label: "Warn",
+    icon: ShieldAlert,
+    chip: "border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] text-[color:var(--status-warn)]",
+  },
+  unknown: {
+    label: "Not evaluated",
+    icon: HelpCircle,
+    chip: "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-tertiary)]",
+  },
+};
+
+const COUNT_ORDER: Array<{ status: SelfPostureStatus }> = [
+  { status: "fail" },
+  { status: "warn" },
+  { status: "unknown" },
+  { status: "pass" },
+];
+
+function StatusChip({ status }: { status: SelfPostureStatus }) {
+  const meta = STATUS_CHIPS[status];
+  const Icon = meta.icon;
+  return (
+    <span
+      data-testid="posture-check-status"
+      data-status={status}
+      className={`inline-flex shrink-0 items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium ${meta.chip}`}
+    >
+      <Icon className="h-3 w-3" aria-hidden="true" />
+      {meta.label}
+    </span>
+  );
+}
+
+function CheckRow({ check }: { check: SelfPostureCheck }) {
+  const hasRemediation = Boolean(check.remediation && check.remediation.trim());
+  return (
+    <Collapsible
+      data-testid={`posture-check-${check.id}`}
+      title={check.title}
+      defaultOpen={false}
+      actions={<StatusChip status={check.status} />}
+      className="bg-[color:var(--surface)]"
+    >
+      <p className="text-xs leading-5 text-[color:var(--text-secondary)] [overflow-wrap:anywhere]">
+        {check.detail}
+      </p>
+      {hasRemediation && (
+        <div className="mt-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2">
+          <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+            Remediation
+          </div>
+          <p className="mt-1 text-xs leading-5 text-[color:var(--text-secondary)] [overflow-wrap:anywhere]">
+            {check.remediation}
+          </p>
+        </div>
+      )}
+      <p className="mt-3 text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">
+        {check.category} · {check.id}
+      </p>
+    </Collapsible>
+  );
+}
+
+export default function SelfPosturePage() {
+  const [report, setReport] = useState<SelfPostureReport | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    api
+      .getSelfPosture()
+      .then(setReport)
+      .catch((e) => setError(userFacingApiErrorMessage(e, "Self-posture could not be evaluated")))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  if (loading) {
+    return (
+      <PageLoadingState
+        data-testid="self-posture-loading"
+        title="Evaluating control-plane posture…"
+        detail="Reading this instance's own security and governance configuration."
+      />
+    );
+  }
+
+  if (error || !report) {
+    return (
+      <PageErrorState
+        data-testid="self-posture-error"
+        title="Self-posture could not be evaluated"
+        detail={error ?? "No self-posture report was returned by the control plane."}
+        suggestions={[
+          "Confirm you are signed in with read access to this control plane.",
+          "The same posture is available headless for agents and CI.",
+        ]}
+        command={`${HEADLESS_CLI}   # or ${HEADLESS_API}`}
+        action={{ label: "Retry", onClick: load }}
+      />
+    );
+  }
+
+  const verdict = OVERALL_VERDICTS[report.overall_status];
+  const VerdictIcon = verdict.icon;
+
+  return (
+    <div className="space-y-6">
+      <div className="min-w-0">
+        <h1 className="flex items-center gap-2 text-2xl font-bold text-[color:var(--foreground)]">
+          <ShieldCheck className="h-6 w-6 text-[color:var(--accent)]" aria-hidden="true" />
+          Self-Audit
+        </h1>
+        <p className="mt-1 text-sm text-[color:var(--text-tertiary)]">
+          agent-bom&apos;s honest posture of its OWN control plane — read-only, configuration only,
+          never a secret value.
+        </p>
+      </div>
+
+      {/* Overall verdict — derived from the API's overall_status, reconciled
+          with the per-check counts below (§11 one source of truth). */}
+      <section
+        aria-label="Overall self-posture"
+        data-testid="self-posture-headline"
+        data-overall={report.overall_status}
+        className={`rounded-2xl border p-4 ${verdict.container}`}
+      >
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex items-center gap-3">
+            <VerdictIcon className={`h-7 w-7 shrink-0 ${verdict.accent}`} aria-hidden="true" />
+            <div className="min-w-0">
+              <div
+                className={`inline-flex items-center rounded-full border px-3 py-0.5 text-sm font-bold tracking-[0.06em] ${verdict.badge}`}
+              >
+                {verdict.label}
+              </div>
+              <p className="mt-1 max-w-xl text-xs text-[color:var(--text-secondary)]">{verdict.detail}</p>
+            </div>
+          </div>
+          <div className="text-right">
+            <div className="text-[10px] uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+              Deployment
+            </div>
+            <div className="font-mono text-sm font-semibold text-[color:var(--foreground)]">
+              {report.deployment_env}
+            </div>
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap gap-2 border-t border-[color:var(--border-subtle)] pt-3">
+          {COUNT_ORDER.map(({ status }) => (
+            <span
+              key={status}
+              className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2.5 py-0.5 text-[11px] text-[color:var(--text-secondary)]"
+            >
+              <span className="tabular-nums font-semibold text-[color:var(--foreground)]">
+                {report.counts[status]}
+              </span>
+              {STATUS_CHIPS[status].label}
+            </span>
+          ))}
+        </div>
+      </section>
+
+      {/* Individual checks — chip + title always visible; evidence + remediation
+          in collapsible detail (§11 concise, one primary read). */}
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold text-[color:var(--foreground)]">
+          Checks ({report.checks.length})
+        </h2>
+        {report.checks.map((check) => (
+          <CheckRow key={check.id} check={check} />
+        ))}
+      </div>
+
+      <p className="text-[11px] text-[color:var(--text-tertiary)]">
+        Headless equivalent: <code className="text-[color:var(--text-secondary)]">{HEADLESS_CLI}</code>{" "}
+        · <code className="text-[color:var(--text-secondary)]">{HEADLESS_API}</code>
+      </p>
+    </div>
+  );
+}

--- a/ui/components/nav.tsx
+++ b/ui/components/nav.tsx
@@ -42,6 +42,7 @@ import {
   Scale,
   Cog,
   ListChecks,
+  ShieldCheck,
 } from "lucide-react";
 import { api } from "@/lib/api";
 import { useAuthState } from "@/components/auth-provider";
@@ -147,6 +148,7 @@ const NAV_GROUPS: NavGroup[] = [
       { href: "/governance", label: "Governance", icon: Eye, capability: "policy.manage" },
       { href: "/drift", label: "Drift", icon: Radar, desc: "Config drift from approved baselines" },
       { href: "/audit", label: "Audit Log", icon: FileText },
+      { href: "/self-posture", label: "Self-Audit", icon: ShieldCheck, desc: "This control plane's own security & governance hardening posture" },
     ],
     secondary: [
       { href: "/blueprints", label: "Blueprints", icon: Boxes },
@@ -211,6 +213,7 @@ const NAV_LINK_ICON_CLASS: Record<string, string> = {
   "/compliance": "text-emerald-400",
   "/governance": "text-amber-400",
   "/audit": "text-teal-400",
+  "/self-posture": "text-emerald-400",
   "/registry": "text-amber-400",
   "/cost": "text-yellow-400",
   "/jobs": "text-orange-400",

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2579,6 +2579,42 @@ export interface GovernanceReport {
   warnings: string[];
 }
 
+// ── Operator self-posture (GET /v1/self-posture) ────────────────────────────
+// agent-bom auditing its OWN control-plane hardening. Honest four-way per-check
+// status; `unknown` is a first-class outcome (never a silent pass). Mirrors
+// agent_bom.self_posture.self_posture — see src/agent_bom/self_posture.py.
+export type SelfPostureStatus = "pass" | "fail" | "warn" | "unknown";
+export type SelfPostureOverall =
+  | "hardened"
+  | "action_advised"
+  | "needs_review"
+  | "at_risk";
+
+export interface SelfPostureCheck {
+  id: string;
+  category: string;
+  title: string;
+  status: SelfPostureStatus;
+  detail: string;
+  remediation?: string;
+}
+
+export interface SelfPostureCounts {
+  pass: number;
+  fail: number;
+  warn: number;
+  unknown: number;
+}
+
+export interface SelfPostureReport {
+  schema_version: number;
+  overall_status: SelfPostureOverall;
+  hardened: boolean;
+  deployment_env: string;
+  counts: SelfPostureCounts;
+  checks: SelfPostureCheck[];
+}
+
 export interface ActivityTimeline {
   account: string;
   discovered_at: string;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -92,6 +92,7 @@ import type {
   EnrichmentPostureResponse,
   GovernanceFinding,
   GovernanceReport,
+  SelfPostureReport,
   ActivityTimeline,
   TraceIngestResponse,
   TraceExplorerResponse,
@@ -314,6 +315,11 @@ export type {
   EnrichmentPostureResponse,
   GovernanceFinding,
   GovernanceReport,
+  SelfPostureStatus,
+  SelfPostureOverall,
+  SelfPostureCheck,
+  SelfPostureCounts,
+  SelfPostureReport,
   ActivityTimeline,
   TraceFlaggedCall,
   TraceIngestResponse,
@@ -1185,6 +1191,9 @@ export const api = {
   getGatewayFeed: (limit = 100) => get<GatewayFeedResponse>(`/v1/gateway/feed?limit=${limit}`),
   getGatewayFeedKpis: () => get<GatewayFeedKpis>("/v1/gateway/feed/kpis"),
   getFirewallStats: () => get<FirewallRuntimeStats>("/v1/firewall/stats"),
+
+  // Operator self-posture — this instance's own control-plane hardening
+  getSelfPosture: () => get<SelfPostureReport>("/v1/self-posture"),
 
   // Governance
   getGovernance: (days = 30) => get<GovernanceReport>(`/v1/governance?days=${days}`),

--- a/ui/tests/self-posture-page.test.tsx
+++ b/ui/tests/self-posture-page.test.tsx
@@ -1,0 +1,135 @@
+import { render, screen, waitFor, within } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import SelfPosturePage from "@/app/self-posture/page";
+import type { SelfPostureReport } from "@/lib/api";
+
+const { apiMock } = vi.hoisted(() => ({
+  apiMock: {
+    getSelfPosture: vi.fn(),
+  },
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => <a href={href}>{children}</a>,
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: apiMock,
+  };
+});
+
+function report(overrides: Partial<SelfPostureReport> = {}): SelfPostureReport {
+  return {
+    schema_version: 1,
+    overall_status: "hardened",
+    hardened: true,
+    deployment_env: "production",
+    counts: { pass: 3, fail: 0, warn: 0, unknown: 0 },
+    checks: [
+      {
+        id: "auth.api_authentication",
+        category: "auth",
+        title: "API authentication enforced",
+        status: "pass",
+        detail: "Unauthenticated API access is disabled.",
+        remediation: "",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+describe("SelfPosturePage", () => {
+  beforeEach(() => {
+    apiMock.getSelfPosture.mockReset();
+  });
+
+  it("shows a loading state while the report resolves", () => {
+    apiMock.getSelfPosture.mockReturnValue(new Promise(() => {}));
+    render(<SelfPosturePage />);
+    expect(screen.getByTestId("self-posture-loading")).toBeInTheDocument();
+  });
+
+  it("renders the hardened headline from the API overall_status", async () => {
+    apiMock.getSelfPosture.mockResolvedValue(report());
+    render(<SelfPosturePage />);
+    const headline = await screen.findByTestId("self-posture-headline");
+    expect(headline).toHaveAttribute("data-overall", "hardened");
+    expect(headline).toHaveTextContent(/hardened/i);
+    // A pass check reads as pass.
+    const check = screen.getByTestId("posture-check-auth.api_authentication");
+    expect(within(check).getByTestId("posture-check-status")).toHaveTextContent(/pass/i);
+  });
+
+  it("reads clearly as a failure when a check is fail (never 'hardened')", async () => {
+    apiMock.getSelfPosture.mockResolvedValue(
+      report({
+        overall_status: "at_risk",
+        hardened: false,
+        counts: { pass: 1, fail: 1, warn: 0, unknown: 0 },
+        checks: [
+          {
+            id: "auth.api_authentication",
+            category: "auth",
+            title: "API authentication enforced",
+            status: "fail",
+            detail: "Unauthenticated API is enabled in production.",
+            remediation: "Unset AGENT_BOM_ALLOW_UNAUTHENTICATED_API.",
+          },
+        ],
+      })
+    );
+    render(<SelfPosturePage />);
+    const headline = await screen.findByTestId("self-posture-headline");
+    expect(headline).toHaveAttribute("data-overall", "at_risk");
+    expect(headline).toHaveTextContent(/at risk/i);
+    expect(headline).not.toHaveTextContent(/hardened/i);
+
+    const chip = within(
+      screen.getByTestId("posture-check-auth.api_authentication")
+    ).getByTestId("posture-check-status");
+    expect(chip).toHaveAttribute("data-status", "fail");
+    expect(chip).toHaveTextContent(/fail/i);
+    expect(chip).not.toHaveTextContent(/pass/i);
+  });
+
+  it("renders an unknown check as an explicit neutral 'not evaluated', never implied pass", async () => {
+    apiMock.getSelfPosture.mockResolvedValue(
+      report({
+        overall_status: "needs_review",
+        hardened: false,
+        counts: { pass: 0, fail: 0, warn: 0, unknown: 1 },
+        checks: [
+          {
+            id: "database.rls_isolation",
+            category: "database",
+            title: "Tenant isolation enforced by the database",
+            status: "unknown",
+            detail: "Configuration alone cannot prove the active role is non-superuser.",
+            remediation: "Verify the active database role against the running database.",
+          },
+        ],
+      })
+    );
+    render(<SelfPosturePage />);
+    await screen.findByTestId("self-posture-headline");
+    const chip = within(
+      screen.getByTestId("posture-check-database.rls_isolation")
+    ).getByTestId("posture-check-status");
+    expect(chip).toHaveAttribute("data-status", "unknown");
+    expect(chip).toHaveTextContent(/not evaluated/i);
+    expect(chip).not.toHaveTextContent(/pass/i);
+  });
+
+  it("shows an error state that points at the CLI/API equivalent", async () => {
+    apiMock.getSelfPosture.mockRejectedValue(new Error("boom"));
+    render(<SelfPosturePage />);
+    await waitFor(() => expect(screen.getByTestId("self-posture-error")).toBeInTheDocument());
+    expect(screen.getByTestId("self-posture-error")).toHaveTextContent(/self-audit/i);
+  });
+});


### PR DESCRIPTION
Addresses #4044 (leg 1 of 3 — self-governance + logs/observability legs remain).

## What changed
UI-only wiring of an **operator self-audit panel** to the existing `GET /v1/self-posture` API (shipped in #4089). agent-bom reporting the security + governance hardening posture of its OWN control plane, as a human surface alongside the existing `agent-bom self-audit` CLI.

- New route `ui/app/self-posture/page.tsx`, added to the **Governance** nav group as "Self-Audit" (nav entry wired — no orphan page). The route maps to no deployment surface, so it is always visible.
- Client + types: `api.getSelfPosture()` and `SelfPosture*` types in `ui/lib/api.ts` / `ui/lib/api-types.ts`, matching the live `PostureCheck.to_dict()` shape and the real response (`overall_status`, `hardened`, `deployment_env`, `counts`, `checks`).
- Overall **verdict headline** derives from the SAME `overall_status` the API returns — `hardened` / `action_advised` / `needs_review` / `at_risk` — not a client re-computation, and is reconciled with the per-check `counts` strip (one source of truth).
- Each check is a collapsible row (reusing shared `Collapsible`) with a **theme-safe four-way status chip**: pass=good, fail=bad, warn=warn, unknown=neutral, mapped to `--status-*` / neutral tokens (no hardcoded colors), legible in light and dark. Evidence + remediation live in the collapsible detail.
- Loading / error states via shared `PageLoadingState` / `PageErrorState`; the error state points at the headless equivalent (`agent-bom self-audit` / `GET /v1/self-posture`) for human + headless parity.

## Honesty (§11)
`unknown` renders as an explicit neutral **"Not evaluated"**, never an implied pass; `fail` reads clearly as a failure; the headline can never show "hardened" while a check is failing because it uses the API's derived `overall_status`.

## No contract change
Backend/API is unchanged — this is pure UI wiring to the existing endpoint. Types were added to `api-types.ts` to match the live response; no field was invented.

## How verified (in worktree `ui/`, reproduced)
- `npm ci` (fresh node_modules) — 0 vulnerabilities
- `npm run typecheck` — pass (tsc --noEmit, clean)
- `npx eslint` on touched files — exit 0
- `npx vitest run tests/self-posture-page.test.tsx` — **5 passed** (hardened headline, at_risk reads failure & never "hardened", unknown rendered as neutral "Not evaluated" not pass, loading, error-with-CLI-pointer)
- `NEXT_EXPORT=1 npm run build` — **exit 0**, `/self-posture` prerendered as static