### PR TITLE
fix(cspm): fail closed on unevaluable benchmark evidence

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -467,7 +467,7 @@ graph TB
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
 | MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (75 tools across core, operator, runtime-catalog, and specialized modules) |
-| Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory + CIS posture |
+| Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory; CIS posture where published and Databricks security best practices |
 | Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor with in-account snapshot/volume cleanup; Azure Managed Disk and GCP Persistent Disk targets share the same bounded lifecycle contract and graph-visible workload-disk model |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |
 | Audit trail | `src/agent_bom/cloud/audit_trail.py` | Read-only CloudTrail/Activity Log/Cloud Audit ingest → behavioral `ACCESSED`/`INVOKED` graph edges (counts only) |

--- a/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
+++ b/docs/ENTERPRISE_SECURITY_PLAYBOOK.md
@@ -141,6 +141,32 @@ Every scan emits `package.is_malicious` + `package.malicious_reason` on the `Pac
 - **Registry verification:** MCPServer.registry_verified / .registry_id ([`models.py:524`](../src/agent_bom/models.py)) — servers found in the curated MCP registry get a trust boost; unknowns don't.
 - **Registry freshness:** `agent-bom registry status --format json` reports the bundled MCP catalog's source list, server count, last sync timestamp, age, stale threshold, and airgapped posture. Treat stale registry posture as reduced confidence in registry-derived trust and refresh with `agent-bom registry sync-all` when network policy allows it.
 - **Cloud provider API resilience:** `agent-bom cloud resilience --format json` reports the provider pagination, retry/backoff, partial-failure, and 10k-resource synthetic evidence posture for AWS, Azure, GCP, Snowflake, Databricks, Hugging Face, OpenAI, W&B, MLflow, Nebius, CoreWeave, and Ollama. The command is credential-free and intended as release/procurement evidence; provider entries marked `partial` mean live provider-scale evidence is still outstanding, not that inventory is silently trusted.
+
+### Cloud benchmark coverage evidence
+
+AWS, Azure, GCP, Snowflake, and Databricks benchmark JSON includes a
+`benchmark_manifest`. It identifies the authoritative benchmark source,
+its stated version and reference-only access provenance, the implemented code
+registry, and explicit automated and manual control-ID
+sets; the implemented count is derived from those sets. Unsupported IDs remain
+explicitly unknown with a reason until the complete catalog is provenanced. The manifest
+deliberately returns `official_control_count` and `coverage_percentage` as
+`null` until an authoritative denominator is repository-provenanced. Treat the
+implemented count as shipped scanner breadth, not as full benchmark coverage.
+
+Snowflake source health proves that each required `ACCOUNT_USAGE` view was
+readable and records source-appropriate coverage plus the documented provider
+lag bound. Snapshot-style USERS, GRANTS, SHARES, and PASSWORD_POLICIES sources
+must reconcile their scoped row count against the corresponding live `SHOW`
+command before their checks can produce PASS or FAIL. User and grant controls
+then evaluate the live `SHOW` rows, and password-policy configuration is read
+with live `DESCRIBE PASSWORD POLICY`; count equality alone is never treated as
+configuration freshness. Temporal LOGIN_HISTORY
+and ACCESS_HISTORY queries use an explicit upper cutoff at their two- or
+three-hour ingestion bound and report `bounded_as_of`, including honest empty
+windows. `ACCOUNT_USAGE` exposes no universal ingestion watermark, so none of
+these states claims that data newer than the bound is current.
+
 - **Permission profile:** [`models.py:PermissionProfile`](../src/agent_bom/models.py) classifies capabilities (`network_access`, `filesystem_write`, `shell_access`, `runs_as_root`) and scores as `critical / high / medium / low`. `critical` ≈ root + shell + network.
 - **Tool drift:** [`ToolDriftDetector`](../src/agent_bom/runtime/detectors.py) — alerts when a server advertises a tool it didn't declare in `tools/list`. Catches post-install tool injection.
 - **Trust assessment:** [`parsers/trust_assessment.py`](../src/agent_bom/parsers/trust_assessment.py) + [`parsers/skill_audit.py`](../src/agent_bom/parsers/skill_audit.py) — static analysis of MCP skill manifests.

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -475,7 +475,7 @@
   },
   {
     "name": "cis_benchmark",
-    "description": "Run CIS benchmark checks against a cloud account (AWS, Azure, GCP, Snowflake, Databricks).",
+    "description": "Run CIS benchmarks for AWS, Azure, GCP, and Snowflake, or Databricks security best-practices checks.",
     "arguments": [
       {
         "name": "provider",

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -157,11 +157,13 @@ class CISBenchmarkReport:
         return (self.passed / self.evaluated * 100) if self.evaluated else 0.0
 
     def to_dict(self) -> dict:
+        from agent_bom.cloud.benchmark_manifests import benchmark_manifest
         from agent_bom.mitre_attack import tag_cis_check
 
         return {
             "benchmark": "CIS AWS Foundations",
             "benchmark_version": self.benchmark_version,
+            "benchmark_manifest": benchmark_manifest("aws"),
             "account_id": self.account_id,
             "accounts_scanned": self.accounts_scanned,
             "regions_scanned": self.regions_scanned,

--- a/src/agent_bom/cloud/azure_cis_benchmark.py
+++ b/src/agent_bom/cloud/azure_cis_benchmark.py
@@ -50,6 +50,8 @@ import os
 from dataclasses import dataclass, field
 from typing import Any
 
+from agent_bom.security import sanitize_error
+
 from .aws_cis_benchmark import CheckStatus, CISCheckResult, finalize_read_coverage
 from .aws_inventory import is_access_denied_error
 from .base import CloudDiscoveryError
@@ -104,11 +106,13 @@ class AzureCISReport:
         return (self.passed / self.evaluated * 100) if self.evaluated else 0.0
 
     def to_dict(self) -> dict:
+        from agent_bom.cloud.benchmark_manifests import benchmark_manifest
         from agent_bom.mitre_attack import tag_cis_check
 
         return {
             "benchmark": "CIS Microsoft Azure Foundations",
             "benchmark_version": self.benchmark_version,
+            "benchmark_manifest": benchmark_manifest("azure"),
             "subscription_id": self.subscription_id,
             "subscriptions_scanned": self.subscriptions_scanned,
             "warnings": self.warnings,
@@ -179,30 +183,30 @@ def _check_1_1(auth_client: Any, subscription_id: str) -> CISCheckResult:
         # Owner role definition ID is fixed across all Azure tenants
         owner_role = "8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
 
-        guest_owners = []
+        owner_assignments = []
         for ra in assignments:
             role_def_id = (getattr(ra, "role_definition_id", "") or "").split("/")[-1]
             if role_def_id == owner_role:
                 principal_id = getattr(ra, "principal_id", "") or ""
                 # We can't easily get UPN without Graph API, so flag principals
                 # and let the evidence guide investigation
-                guest_owners.append(principal_id)
+                owner_assignments.append(principal_id)
 
-        # Heuristic: if we found any Owner assignments, flag for review
-        # A more precise check requires MS Graph for UPN inspection
-        if guest_owners:
-            result.status = CheckStatus.PASS  # Can't confirm guest without Graph
+        if owner_assignments:
+            result.status = CheckStatus.ERROR
             result.evidence = (
-                f"Found {len(guest_owners)} Owner assignment(s)."
-                " Verify none are guest (#EXT#) accounts via Azure Portal > Subscriptions > Access control."
+                f"Cannot evaluate guest/external identity for {len(owner_assignments)} Owner assignment(s): "
+                "Microsoft Graph identity evidence is unavailable. Verify the principals in Azure Portal "
+                "before treating this control as passed."
             )
+            result.resource_ids = [principal_id for principal_id in owner_assignments if principal_id]
         else:
             result.status = CheckStatus.PASS
             result.evidence = "No Owner role assignments found on subscription."
 
     except Exception as exc:
         result.status = CheckStatus.ERROR
-        result.evidence = f"Could not read role assignments: {exc}"
+        result.evidence = f"Could not read Owner role assignments: {sanitize_error(exc, generic=True)}"
     return result
 
 
@@ -222,16 +226,25 @@ def _check_1_2(auth_client: Any, subscription_id: str) -> CISCheckResult:
 
         contributor_role = "b24988ac-6180-42a0-ab88-20f7382dd24c"
 
-        contributor_count = sum(1 for ra in assignments if (getattr(ra, "role_definition_id", "") or "").split("/")[-1] == contributor_role)
-
-        result.status = CheckStatus.PASS
-        result.evidence = (
-            f"Found {contributor_count} subscription-level Contributor assignment(s). "
-            "Verify none are guest (#EXT#) accounts via Azure Portal > Access control (IAM)."
-        )
+        contributor_assignments = [
+            getattr(ra, "principal_id", "") or ""
+            for ra in assignments
+            if (getattr(ra, "role_definition_id", "") or "").split("/")[-1] == contributor_role
+        ]
+        if contributor_assignments:
+            result.status = CheckStatus.ERROR
+            result.evidence = (
+                f"Cannot evaluate guest/external identity for {len(contributor_assignments)} Contributor assignment(s): "
+                "Microsoft Graph identity evidence is unavailable. Verify the principals in Azure Portal "
+                "before treating this control as passed."
+            )
+            result.resource_ids = [principal_id for principal_id in contributor_assignments if principal_id]
+        else:
+            result.status = CheckStatus.PASS
+            result.evidence = "No subscription-level Contributor role assignments found."
     except Exception as exc:
         result.status = CheckStatus.ERROR
-        result.evidence = f"Could not read role assignments: {exc}"
+        result.evidence = f"Could not read Contributor role assignments: {sanitize_error(exc, generic=True)}"
     return result
 
 

--- a/src/agent_bom/cloud/benchmark_manifests.py
+++ b/src/agent_bom/cloud/benchmark_manifests.py
@@ -1,0 +1,148 @@
+"""Versioned, repository-grounded cloud benchmark implementation manifests.
+
+Official benchmark denominators are intentionally unset until a licensed or
+otherwise authoritative control catalog is checked into the repository. The
+implemented counts below are tied to the named code registries; they are not
+coverage percentages.
+"""
+
+from __future__ import annotations
+
+import ast
+from copy import deepcopy
+from pathlib import Path
+from typing import Any, Final
+
+MANIFEST_SCHEMA_VERSION: Final = 1
+
+
+def _manifest(
+    *,
+    name: str,
+    version: str,
+    benchmark_type: str,
+    registry: str,
+    control_ids: tuple[str, ...],
+    authoritative_source: str,
+    manual_control_ids: tuple[str, ...] = (),
+) -> dict[str, Any]:
+    return {
+        "manifest_schema_version": MANIFEST_SCHEMA_VERSION,
+        "benchmark_name": name,
+        "benchmark_version": version,
+        "benchmark_type": benchmark_type,
+        "implemented_control_count": len(control_ids),
+        "implementation_registry": registry,
+        "authoritative_source": authoritative_source,
+        "authoritative_source_version": version,
+        "authoritative_source_access": "reference_url_only",
+        "authoritative_catalog_repository_provenance": False,
+        "automated_control_ids": sorted(set(control_ids) - set(manual_control_ids)),
+        "manual_control_ids": list(manual_control_ids),
+        "unsupported_control_ids": None,
+        "unsupported_control_ids_reason": "Unknown until an authoritative versioned control catalog is repository-provenanced.",
+        "official_control_count": None,
+        "coverage_percentage": None,
+        "coverage_note": "Official denominator not repository-provenanced; percentage intentionally unpublished.",
+    }
+
+
+def _registry_ids(filename: str, *variables: str) -> tuple[str, ...]:
+    """Read the explicit check-function registries into stable control IDs."""
+    tree = ast.parse((Path(__file__).with_name(filename)).read_text())
+    ids: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            if node.value is None:
+                continue
+            value = node.value
+        else:
+            continue
+        if not any(isinstance(item, ast.Name) and item.id in variables for item in targets):
+            continue
+        if not isinstance(value, (ast.List, ast.Tuple)):
+            continue
+        for item in value.elts:
+            if isinstance(item, ast.Tuple) and any(isinstance(target, ast.Name) and target.id == "all_checks" for target in targets):
+                check_id = item.elts[0]
+                if isinstance(check_id, ast.Constant) and isinstance(check_id.value, str):
+                    ids.append(check_id.value)
+                continue
+            fn = item.elts[1] if isinstance(item, ast.Tuple) else item
+            if isinstance(fn, ast.Name) and fn.id.startswith("_check_"):
+                ids.append(fn.id.removeprefix("_check_").replace("_", "."))
+    return tuple(ids)
+
+
+CLOUD_BENCHMARK_MANIFESTS: Final[dict[str, dict[str, Any]]] = {
+    "aws": _manifest(
+        name="CIS AWS Foundations",
+        version="3.0",
+        benchmark_type="cis",
+        registry="agent_bom.cloud.aws_cis_benchmark:_CHECKS+_SPECIAL_CHECKS",
+        control_ids=_registry_ids("aws_cis_benchmark.py", "_CHECKS", "_SPECIAL_CHECKS"),
+        authoritative_source="https://www.cisecurity.org/benchmark/amazon_web_services",
+        manual_control_ids=("1.3",),
+    ),
+    "gcp": _manifest(
+        name="CIS Google Cloud Platform Foundation",
+        version="3.0",
+        benchmark_type="cis",
+        registry="agent_bom.cloud.gcp_cis_benchmark:run_benchmark.all_checks",
+        control_ids=_registry_ids("gcp_cis_benchmark.py", "all_checks"),
+        authoritative_source="https://www.cisecurity.org/benchmark/google_cloud_computing_platform",
+        manual_control_ids=("1.2", "1.3"),
+    ),
+    "azure": _manifest(
+        name="CIS Microsoft Azure Foundations",
+        version="3.0",
+        benchmark_type="cis",
+        registry="agent_bom.cloud.azure_cis_benchmark:run_benchmark.all_checks",
+        control_ids=_registry_ids("azure_cis_benchmark.py", "all_checks"),
+        authoritative_source="https://www.cisecurity.org/benchmark/azure",
+        manual_control_ids=(
+            "1.3",
+            "1.4",
+            "1.6",
+            "1.8",
+            "1.9",
+            "1.10",
+            "1.11",
+            "1.12",
+            "1.13",
+            "1.14",
+            "1.16",
+            "1.17",
+            "1.18",
+            "1.19",
+            "1.20",
+            "1.21",
+            "1.22",
+        ),
+    ),
+    "snowflake": _manifest(
+        name="CIS Snowflake Foundations",
+        version="1.0",
+        benchmark_type="cis",
+        registry="agent_bom.cloud.snowflake_cis_benchmark:run_benchmark.all_checks",
+        control_ids=_registry_ids("snowflake_cis_benchmark.py", "all_checks"),
+        authoritative_source="https://www.cisecurity.org/benchmark/snowflake",
+    ),
+    "databricks": _manifest(
+        name="Databricks Security Best Practices",
+        version="1.0",
+        benchmark_type="vendor_best_practices",
+        registry="agent_bom.cloud.databricks_security:_ALL_CHECKS",
+        control_ids=_registry_ids("databricks_security.py", "_ALL_CHECKS"),
+        authoritative_source="https://docs.databricks.com/en/security/index.html",
+    ),
+}
+
+
+def benchmark_manifest(provider: str) -> dict[str, Any]:
+    """Return an independent manifest safe to expose in report JSON."""
+    return deepcopy(CLOUD_BENCHMARK_MANIFESTS[provider])

--- a/src/agent_bom/cloud/databricks_security.py
+++ b/src/agent_bom/cloud/databricks_security.py
@@ -60,11 +60,13 @@ class DatabricksSecurityReport:
         return (self.passed / evaluated * 100) if evaluated else 0.0
 
     def to_dict(self) -> dict:
+        from agent_bom.cloud.benchmark_manifests import benchmark_manifest
         from agent_bom.mitre_attack import tag_cis_check
 
         return {
             "benchmark": "Databricks Security Best Practices",
             "benchmark_version": self.benchmark_version,
+            "benchmark_manifest": benchmark_manifest("databricks"),
             "workspace_host": self.workspace_host,
             "pass_rate": round(self.pass_rate, 1),
             "passed": self.passed,
@@ -567,7 +569,8 @@ def run_security_checks(
         from databricks.sdk import WorkspaceClient
     except ImportError:
         raise CloudDiscoveryError(
-            "databricks-sdk is required for Databricks CIS benchmark. Install with: pip install 'agent-bom[databricks]'"
+            "databricks-sdk is required for Databricks security best-practices checks. "
+            "Install with: pip install 'agent-bom[databricks]'"
         )
 
     ws_kwargs: dict = {}

--- a/src/agent_bom/cloud/gcp_cis_benchmark.py
+++ b/src/agent_bom/cloud/gcp_cis_benchmark.py
@@ -216,11 +216,13 @@ class GCPCISReport:
         return (self.passed / self.evaluated * 100) if self.evaluated else 0.0
 
     def to_dict(self) -> dict:
+        from agent_bom.cloud.benchmark_manifests import benchmark_manifest
         from agent_bom.mitre_attack import tag_cis_check
 
         return {
             "benchmark": "CIS Google Cloud Platform Foundation",
             "benchmark_version": self.benchmark_version,
+            "benchmark_manifest": benchmark_manifest("gcp"),
             "project_id": self.project_id,
             "projects_scanned": self.projects_scanned,
             "warnings": self.warnings,

--- a/src/agent_bom/cloud/snowflake_cis_benchmark.py
+++ b/src/agent_bom/cloud/snowflake_cis_benchmark.py
@@ -40,6 +40,7 @@ class SnowflakeCISReport:
     benchmark_version: str = "1.0"
     checks: list[CISCheckResult] = field(default_factory=list)
     account: str = ""
+    source_health: dict[str, dict[str, Any]] = field(default_factory=dict)
 
     @property
     def passed(self) -> int:
@@ -50,25 +51,42 @@ class SnowflakeCISReport:
         return sum(1 for c in self.checks if c.status == CheckStatus.FAIL)
 
     @property
+    def errored(self) -> int:
+        return sum(1 for c in self.checks if c.status == CheckStatus.ERROR)
+
+    @property
+    def not_applicable(self) -> int:
+        return sum(1 for c in self.checks if c.status == CheckStatus.NOT_APPLICABLE)
+
+    @property
+    def evaluated(self) -> int:
+        return self.passed + self.failed
+
+    @property
     def total(self) -> int:
         return len(self.checks)
 
     @property
     def pass_rate(self) -> float:
-        evaluated = sum(1 for c in self.checks if c.status in (CheckStatus.PASS, CheckStatus.FAIL))
-        return (self.passed / evaluated * 100) if evaluated else 0.0
+        return (self.passed / self.evaluated * 100) if self.evaluated else 0.0
 
     def to_dict(self) -> dict:
+        from agent_bom.cloud.benchmark_manifests import benchmark_manifest
         from agent_bom.mitre_attack import tag_cis_check
 
         return {
             "benchmark": "CIS Snowflake Foundations",
             "benchmark_version": self.benchmark_version,
+            "benchmark_manifest": benchmark_manifest("snowflake"),
             "account": self.account,
             "pass_rate": round(self.pass_rate, 1),
             "passed": self.passed,
             "failed": self.failed,
+            "errored": self.errored,
+            "not_applicable": self.not_applicable,
+            "evaluated": self.evaluated,
             "total": self.total,
+            "source_health": self.source_health,
             "checks": [
                 {
                     "check_id": c.check_id,
@@ -101,6 +119,233 @@ def _run_query(cursor: Any, sql: str) -> list[dict]:
     return [dict(zip(columns, row)) for row in cursor.fetchall()]
 
 
+def _quote_identifier(value: Any) -> str:
+    """Quote one Snowflake identifier component returned by Snowflake itself."""
+    text = str(value or "").strip()
+    if not text:
+        raise ValueError("Snowflake returned an empty password-policy identifier")
+    return f'"{text.replace(chr(34), chr(34) * 2)}"'
+
+
+def _live_password_policies(cursor: Any) -> list[dict[str, Any]]:
+    """Read password-policy configuration from live SHOW/DESCRIBE commands."""
+    policies = _run_query(cursor, "SHOW PASSWORD POLICIES IN ACCOUNT")
+    live: list[dict[str, Any]] = []
+    for policy in policies:
+        identifier = ".".join(
+            _quote_identifier(policy[key]) for key in ("database_name", "schema_name", "name")
+        )
+        properties = {
+            str(row.get("property", "")).upper(): row.get("value")
+            for row in _run_query(cursor, f"DESCRIBE PASSWORD POLICY {identifier}")
+        }
+        live.append(
+            {
+                "name": str(policy["name"]),
+                "password_min_length": properties.get("PASSWORD_MIN_LENGTH"),
+                "password_history": properties.get("PASSWORD_HISTORY"),
+                "password_max_age_days": properties.get("PASSWORD_MAX_AGE_DAYS"),
+            }
+        )
+    return live
+
+
+# ACCOUNT_USAGE has no universal ingestion watermark. Snapshot-style sources
+# are usable only when their scoped row count reconciles with a live SHOW
+# command. Temporal sources use an explicit upper cutoff at the documented lag
+# bound; neither mechanism fabricates a current-time watermark.
+_ACCOUNT_USAGE_LAG_BOUND_HOURS = {
+    "users": 2,
+    "grants_to_users": 2,
+    "shares": 3,
+    "login_history": 2,
+    "grants_to_roles": 2,
+    "password_policies": 2,
+    "access_history": 3,
+}
+
+
+_SOURCE_PROBES: dict[str, tuple[str, int]] = {
+    "users": (
+        """/* source-preflight:users */
+        SELECT COUNT(*) AS row_count
+        FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
+        WHERE deleted_on IS NULL AND disabled = 'false'""",
+        1,
+    ),
+    "grants_to_users": (
+        """/* source-preflight:grants_to_users */
+        SELECT COUNT(*) AS row_count
+        FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_USERS
+        WHERE role = 'ACCOUNTADMIN' AND deleted_on IS NULL""",
+        1,
+    ),
+    "shares": (
+        """/* source-preflight:shares */
+        SELECT COUNT(*) AS row_count
+        FROM SNOWFLAKE.ACCOUNT_USAGE.SHARES
+        WHERE deleted_on IS NULL AND target_accounts IS NOT NULL""",
+        0,
+    ),
+    "login_history": (
+        """/* source-preflight:login_history */
+        SELECT COUNT(*) AS row_count
+        FROM SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY
+        WHERE event_timestamp >= DATEADD(day, -8, CURRENT_TIMESTAMP())
+          AND event_timestamp <= DATEADD(hour, -2, CURRENT_TIMESTAMP())""",
+        0,
+    ),
+    "grants_to_roles": (
+        """/* source-preflight:grants_to_roles */
+        SELECT COUNT(*) AS row_count
+        FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES
+        WHERE grantee_name = 'PUBLIC'
+          AND deleted_on IS NULL
+          AND granted_on NOT IN ('ROLE')
+          AND privilege != 'USAGE'""",
+        0,
+    ),
+    "password_policies": (
+        """/* source-preflight:password_policies */
+        SELECT COUNT(*) AS row_count FROM SNOWFLAKE.ACCOUNT_USAGE.PASSWORD_POLICIES
+        WHERE deleted IS NULL""",
+        0,
+    ),
+    "access_history": (
+        """/* source-preflight:access_history */
+        SELECT COUNT(*) AS row_count FROM SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY
+        WHERE query_start_time >= DATEADD(day, -7, CURRENT_TIMESTAMP())
+          AND query_start_time <= DATEADD(hour, -3, CURRENT_TIMESTAMP())""",
+        0,
+    ),
+}
+
+_SHOW_PROBES = {
+    "users": "SHOW USERS",
+    "grants_to_users": "SHOW GRANTS OF ROLE ACCOUNTADMIN",
+    "shares": "SHOW SHARES",
+    "grants_to_roles": "SHOW GRANTS TO ROLE PUBLIC",
+    "password_policies": "SHOW PASSWORD POLICIES IN ACCOUNT",
+}
+
+
+def _control_plane_count(source: str, rows: list[dict[str, Any]]) -> int:
+    """Count the live SHOW rows with the same scope as the ACCOUNT_USAGE probe."""
+    if source == "users":
+        return sum(not _sf_truthy(row.get("disabled")) for row in rows)
+    if source == "shares":
+        return sum(str(row.get("kind", "")).upper() == "OUTBOUND" for row in rows)
+    if source == "grants_to_users":
+        return sum(str(row.get("granted_to", "")).upper() == "USER" for row in rows)
+    if source == "grants_to_roles":
+        return sum(
+            str(row.get("granted_on", "")).upper() != "ROLE"
+            and str(row.get("privilege", "")).upper() != "USAGE"
+            for row in rows
+        )
+    return len(rows)
+
+_CHECK_SOURCES = {
+    "1.1": "users",
+    "1.4": "grants_to_users",
+    "3.2": "shares",
+    "4.2": "login_history",
+    "5.1": "grants_to_roles",
+    "5.2": "users",
+    "1.2": "password_policies",
+    "1.5": "password_policies",
+    "1.6": "password_policies",
+    "4.1": "access_history",
+}
+
+_CHECK_ERROR_METADATA = {
+    "1.1": (
+        "Ensure MFA is enabled for all users with password authentication",
+        "critical",
+        "1 - Account and Authentication",
+    ),
+    "1.4": ("Ensure ACCOUNTADMIN role is granted to no more than 2 users", "critical", "1 - Account and Authentication"),
+    "3.2": ("Ensure data sharing is restricted to authorized accounts only", "medium", "3 - Data Protection"),
+    "4.2": ("Ensure login history shows no excessive failed authentication attempts", "medium", "4 - Monitoring and Logging"),
+    "5.1": ("Ensure the PUBLIC role has no direct privilege grants on objects", "high", "5 - Access Control"),
+    "5.2": ("Ensure no users have ACCOUNTADMIN as their default role", "high", "5 - Access Control"),
+    "1.2": ("Ensure minimum password length is set to 14 or greater", "medium", "1 - Account and Authentication"),
+    "1.5": ("Ensure password reuse is limited by password history of 24 or greater", "medium", "1 - Account and Authentication"),
+    "1.6": ("Ensure password maximum age is set to 90 days or less", "medium", "1 - Account and Authentication"),
+    "4.1": ("Ensure access history is enabled and being collected", "high", "4 - Monitoring and Logging"),
+}
+
+
+def _preflight_account_usage_source(cursor: Any, source: str) -> dict[str, Any]:
+    sql, minimum_rows = _SOURCE_PROBES[source]
+    try:
+        rows = _run_query(cursor, sql)
+    except Exception:
+        return {
+            "privilege": "unknown",
+            "query_status": "error",
+            "coverage": "unknown",
+            "freshness": "unknown",
+            "row_count": None,
+            "provider_lag_bound_hours": _ACCOUNT_USAGE_LAG_BOUND_HOURS[source],
+            "usable": False,
+        }
+    if not rows:
+        return {
+            "privilege": "granted",
+            "query_status": "empty_result",
+            "coverage": "empty",
+            "freshness": "unknown",
+            "row_count": 0,
+            "provider_lag_bound_hours": _ACCOUNT_USAGE_LAG_BOUND_HOURS[source],
+            "usable": False,
+        }
+    row_count = int(rows[0].get("row_count") or 0)
+    coverage = "covered" if row_count >= minimum_rows else "empty"
+    show_sql = _SHOW_PROBES.get(source)
+    if show_sql:
+        try:
+            control_plane_count = _control_plane_count(source, _run_query(cursor, show_sql))
+        except Exception:
+            control_plane_count = None
+        reconciled = control_plane_count == row_count
+        freshness = "control_plane_reconciled" if reconciled else "stale"
+    else:
+        control_plane_count = None
+        reconciled = True
+        freshness = "bounded_as_of"
+    if source == "login_history" and row_count == 0:
+        coverage = "covered"
+        freshness = "bounded_as_of_empty_window"
+    return {
+        "privilege": "granted",
+        "query_status": "success",
+        "coverage": coverage,
+        "freshness": freshness,
+        "row_count": row_count,
+        "provider_lag_bound_hours": _ACCOUNT_USAGE_LAG_BOUND_HOURS[source],
+        "provider_lag": "provider_managed",
+        "control_plane_count": control_plane_count,
+        "usable": coverage == "covered" and reconciled,
+    }
+
+
+def _source_error_result(check_id: str, source: str, health: dict[str, Any]) -> CISCheckResult:
+    title, severity, section = _CHECK_ERROR_METADATA[check_id]
+    return CISCheckResult(
+        check_id=check_id,
+        title=title,
+        status=CheckStatus.ERROR,
+        severity=severity,
+        cis_section=section,
+        recommendation=("Verify IMPORTED PRIVILEGES on the SNOWFLAKE database and rerun after the documented ACCOUNT_USAGE lag bound."),
+        evidence=(
+            f"Cannot evaluate control: ACCOUNT_USAGE.{source.upper()} source "
+            f"privilege={health['privilege']}, coverage={health['coverage']}, freshness={health['freshness']}."
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Individual checks — CIS 1.x (Account and Authentication)
 # ---------------------------------------------------------------------------
@@ -118,16 +363,11 @@ def _check_1_1(cursor: Any) -> CISCheckResult:
         cis_section=_AUTH_SECTION,
         recommendation="Enable MFA for all users: ALTER USER <user> SET EXT_AUTHN_DUO = TRUE;",
     )
-    rows = _run_query(
-        cursor,
-        """
-        SELECT name, ext_authn_duo, has_password, disabled
-        FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
-        WHERE deleted_on IS NULL
-          AND disabled = 'false'
-          AND has_password = 'true'
-    """,
-    )
+    rows = [
+        row
+        for row in _run_query(cursor, "SHOW USERS")
+        if not _sf_truthy(row.get("disabled")) and _sf_truthy(row.get("has_password"))
+    ]
     no_mfa = [r["name"] for r in rows if not _sf_truthy(r.get("ext_authn_duo"))]
 
     if no_mfa:
@@ -151,18 +391,14 @@ def _check_1_2(cursor: Any) -> CISCheckResult:
         cis_section=_AUTH_SECTION,
         recommendation="Set password policy: CREATE OR REPLACE PASSWORD POLICY ... PASSWORD_MIN_LENGTH = 14;",
     )
-    rows = _run_query(
-        cursor,
-        """
-        SELECT name, password_min_length
-        FROM SNOWFLAKE.ACCOUNT_USAGE.PASSWORD_POLICIES
-        WHERE deleted IS NULL
-    """,
-    )
+    rows = _live_password_policies(cursor)
     if not rows:
         result.status = CheckStatus.FAIL
         result.evidence = "No password policies configured."
         return result
+
+    if any(row.get("password_min_length") is None for row in rows):
+        raise ValueError("Snowflake password-policy description omitted PASSWORD_MIN_LENGTH")
 
     weak = [r for r in rows if int(r.get("password_min_length") or 0) < 14]
     if weak:
@@ -207,15 +443,11 @@ def _check_1_4(cursor: Any) -> CISCheckResult:
         cis_section=_AUTH_SECTION,
         recommendation="Limit ACCOUNTADMIN grants to a maximum of 2 users.",
     )
-    rows = _run_query(
-        cursor,
-        """
-        SELECT grantee_name
-        FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_USERS
-        WHERE role = 'ACCOUNTADMIN'
-          AND deleted_on IS NULL
-    """,
-    )
+    rows = [
+        row
+        for row in _run_query(cursor, "SHOW GRANTS OF ROLE ACCOUNTADMIN")
+        if str(row.get("granted_to", "")).upper() == "USER"
+    ]
     count = len(rows)
     users = [r["grantee_name"] for r in rows]
     if count > 2:
@@ -239,18 +471,14 @@ def _check_1_5(cursor: Any) -> CISCheckResult:
         cis_section=_AUTH_SECTION,
         recommendation="Set password policy: CREATE OR REPLACE PASSWORD POLICY ... PASSWORD_HISTORY = 24;",
     )
-    rows = _run_query(
-        cursor,
-        """
-        SELECT name, password_history
-        FROM SNOWFLAKE.ACCOUNT_USAGE.PASSWORD_POLICIES
-        WHERE deleted IS NULL
-    """,
-    )
+    rows = _live_password_policies(cursor)
     if not rows:
         result.status = CheckStatus.FAIL
         result.evidence = "No password policies configured."
         return result
+
+    if any(row.get("password_history") is None for row in rows):
+        raise ValueError("Snowflake password-policy description omitted PASSWORD_HISTORY")
 
     weak = [r for r in rows if int(r.get("password_history", 0) or 0) < 24]
     if weak:
@@ -272,18 +500,14 @@ def _check_1_6(cursor: Any) -> CISCheckResult:
         cis_section=_AUTH_SECTION,
         recommendation="Set password policy: CREATE OR REPLACE PASSWORD POLICY ... PASSWORD_MAX_AGE_DAYS = 90;",
     )
-    rows = _run_query(
-        cursor,
-        """
-        SELECT name, password_max_age_days
-        FROM SNOWFLAKE.ACCOUNT_USAGE.PASSWORD_POLICIES
-        WHERE deleted IS NULL
-    """,
-    )
+    rows = _live_password_policies(cursor)
     if not rows:
         result.status = CheckStatus.FAIL
         result.evidence = "No password policies configured."
         return result
+
+    if any(row.get("password_max_age_days") is None for row in rows):
+        raise ValueError("Snowflake password-policy description omitted PASSWORD_MAX_AGE_DAYS")
 
     weak = [r for r in rows if int(r.get("password_max_age_days", 0) or 0) == 0 or int(r.get("password_max_age_days", 0) or 0) > 90]
     if weak:
@@ -443,14 +667,17 @@ def _check_4_1(cursor: Any) -> CISCheckResult:
             SELECT COUNT(*) as cnt
             FROM SNOWFLAKE.ACCOUNT_USAGE.ACCESS_HISTORY
             WHERE query_start_time >= DATEADD(day, -7, CURRENT_TIMESTAMP())
+              AND query_start_time <= DATEADD(hour, -3, CURRENT_TIMESTAMP())
         """,
         )
         count = rows[0]["cnt"] if rows else 0
         if count == 0:
             result.status = CheckStatus.FAIL
-            result.evidence = "No access history records in the last 7 days."
+            result.evidence = "No access history records in the 7-day lookback window ending 3 hours before scan time."
         else:
-            result.evidence = f"Access history active: {count} records in the last 7 days."
+            result.evidence = (
+                f"Access history active: {count} records in the 7-day lookback window ending 3 hours before scan time."
+            )
     except Exception:
         result.status = CheckStatus.ERROR
         result.evidence = "Cannot query ACCESS_HISTORY. Ensure IMPORTED PRIVILEGES on SNOWFLAKE database."
@@ -474,6 +701,7 @@ def _check_4_2(cursor: Any) -> CISCheckResult:
         FROM SNOWFLAKE.ACCOUNT_USAGE.LOGIN_HISTORY
         WHERE is_success = 'NO'
           AND event_timestamp >= DATEADD(day, -7, CURRENT_TIMESTAMP())
+          AND event_timestamp <= DATEADD(hour, -2, CURRENT_TIMESTAMP())
         GROUP BY user_name
         HAVING COUNT(*) > 10
         ORDER BY fail_count DESC
@@ -482,10 +710,12 @@ def _check_4_2(cursor: Any) -> CISCheckResult:
     if rows:
         result.status = CheckStatus.FAIL
         users = [f"{r['user_name']} ({r['fail_count']} failures)" for r in rows[:5]]
-        result.evidence = f"Users with >10 failed logins (7d): {', '.join(users)}"
+        result.evidence = f"Users with >10 failed logins in the 7-day lookback ending 2 hours before scan time: {', '.join(users)}"
         result.resource_ids = [r["user_name"] for r in rows[:20]]
     else:
-        result.evidence = "No users with excessive failed login attempts in the last 7 days."
+        result.evidence = (
+            "No users with excessive failed login attempts in the 7-day lookback ending 2 hours before scan time."
+        )
     return result
 
 
@@ -506,17 +736,12 @@ def _check_5_1(cursor: Any) -> CISCheckResult:
         cis_section=_ACCESS_SECTION,
         recommendation="Revoke all grants from the PUBLIC role: REVOKE ALL ON <object> FROM ROLE PUBLIC;",
     )
-    rows = _run_query(
-        cursor,
-        """
-        SELECT privilege, granted_on, name
-        FROM SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES
-        WHERE grantee_name = 'PUBLIC'
-          AND deleted_on IS NULL
-          AND granted_on NOT IN ('ROLE')
-          AND privilege != 'USAGE'
-    """,
-    )
+    rows = [
+        row
+        for row in _run_query(cursor, "SHOW GRANTS TO ROLE PUBLIC")
+        if str(row.get("granted_on", "")).upper() != "ROLE"
+        and str(row.get("privilege", "")).upper() != "USAGE"
+    ]
     if rows:
         result.status = CheckStatus.FAIL
         grants = [f"{r['privilege']} on {r['granted_on']} {r['name']}" for r in rows[:5]]
@@ -538,16 +763,11 @@ def _check_5_2(cursor: Any) -> CISCheckResult:
         cis_section=_ACCESS_SECTION,
         recommendation="Change default role: ALTER USER <user> SET DEFAULT_ROLE = '<other_role>';",
     )
-    rows = _run_query(
-        cursor,
-        """
-        SELECT name, default_role
-        FROM SNOWFLAKE.ACCOUNT_USAGE.USERS
-        WHERE deleted_on IS NULL
-          AND disabled = 'false'
-          AND default_role = 'ACCOUNTADMIN'
-    """,
-    )
+    rows = [
+        row
+        for row in _run_query(cursor, "SHOW USERS")
+        if not _sf_truthy(row.get("disabled")) and str(row.get("default_role", "")).upper() == "ACCOUNTADMIN"
+    ]
     if rows:
         result.status = CheckStatus.FAIL
         users = [r["name"] for r in rows]
@@ -642,8 +862,15 @@ def run_benchmark(
 
     try:
         cursor = conn.cursor()
+        selected_ids = {check_id for check_id, _check_fn in all_checks if not checks or check_id in checks}
+        selected_sources = {_CHECK_SOURCES[check_id] for check_id in selected_ids if check_id in _CHECK_SOURCES}
+        report.source_health = {source: _preflight_account_usage_source(cursor, source) for source in sorted(selected_sources)}
         for check_id, check_fn in all_checks:
             if checks and check_id not in checks:
+                continue
+            source = _CHECK_SOURCES.get(check_id)
+            if source is not None and not report.source_health[source]["usable"]:
+                report.checks.append(_source_error_result(check_id, source, report.source_health[source]))
                 continue
             try:
                 check_result = check_fn(cursor)

--- a/src/agent_bom/compliance_hub.py
+++ b/src/agent_bom/compliance_hub.py
@@ -132,6 +132,7 @@ _SOURCE_BASELINE: dict[FindingSource, tuple[str, ...]] = {
     ),
     FindingSource.CONTAINER: _CONTAINER_FRAMEWORKS,
     FindingSource.CLOUD_CIS: _CLOUD_POSTURE_FRAMEWORKS,
+    FindingSource.CLOUD_SECURITY: tuple(framework for framework in _CLOUD_POSTURE_FRAMEWORKS if framework != FRAMEWORK_CIS),
     FindingSource.SBOM: (
         FRAMEWORK_NIST_CSF,
         FRAMEWORK_SOC2,
@@ -171,6 +172,9 @@ _FINDING_TYPE_ADDITIONS: dict[FindingType, tuple[str, ...]] = {
     FindingType.INJECTION: _AI_FRAMEWORKS,
     FindingType.EXFILTRATION: _AI_FRAMEWORKS + (FRAMEWORK_SOC2,),
     FindingType.CIS_FAIL: (FRAMEWORK_CIS,),
+    FindingType.CIS_ERROR: (FRAMEWORK_CIS,),
+    FindingType.CLOUD_BEST_PRACTICE_FAIL: (),
+    FindingType.CLOUD_BEST_PRACTICE_ERROR: (),
 }
 
 
@@ -203,7 +207,7 @@ def select_frameworks(
 
     selected.update(_SOURCE_BASELINE.get(source, ()))
 
-    if asset_type:
+    if asset_type and not (source == FindingSource.CLOUD_SECURITY and asset_type == "cloud_resource"):
         selected.update(_ASSET_TYPE_ADDITIONS.get(asset_type, ()))
 
     if finding_type:

--- a/src/agent_bom/compliance_hub_ingest.py
+++ b/src/agent_bom/compliance_hub_ingest.py
@@ -82,6 +82,12 @@ def _pick_finding_type(
         return FindingType.LICENSE
     if "cve-" in haystack or "ghsa-" in haystack:
         return FindingType.CVE
+    if "cis_error" in haystack or "cis-error" in haystack:
+        return FindingType.CIS_ERROR
+    if "cloud_best_practice_error" in haystack:
+        return FindingType.CLOUD_BEST_PRACTICE_ERROR
+    if "cloud_best_practice_fail" in haystack or "databricks best practice" in haystack:
+        return FindingType.CLOUD_BEST_PRACTICE_FAIL
     if "cis-" in haystack or "benchmark" in haystack:
         return FindingType.CIS_FAIL
     return FindingType.SAST

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -38,6 +38,9 @@ class FindingType(str, Enum):
 
     CVE = "CVE"  # Software vulnerability (from OSV/GHSA/NVIDIA)
     CIS_FAIL = "CIS_FAIL"  # CIS benchmark control failure
+    CIS_ERROR = "CIS_ERROR"  # CIS control could not be evaluated reliably
+    CLOUD_BEST_PRACTICE_FAIL = "CLOUD_BEST_PRACTICE_FAIL"
+    CLOUD_BEST_PRACTICE_ERROR = "CLOUD_BEST_PRACTICE_ERROR"
     CREDENTIAL_EXPOSURE = "CREDENTIAL_EXPOSURE"  # Credential found in environment/config
     TOOL_DRIFT = "TOOL_DRIFT"  # MCP tool description changed (rug pull)
     INJECTION = "INJECTION"  # Prompt/argument injection in MCP tool
@@ -61,6 +64,7 @@ class FindingSource(str, Enum):
     CONTAINER = "CONTAINER"  # container image scan (Syft/Grype/Trivy ingestion)
     SBOM = "SBOM"  # SBOM ingest (CycloneDX / SPDX)
     CLOUD_CIS = "CLOUD_CIS"  # cloud CIS benchmark (AWS/Azure/GCP/Snowflake)
+    CLOUD_SECURITY = "CLOUD_SECURITY"  # vendor-authored cloud security best practices
     PROXY = "PROXY"  # runtime proxy detector
     SAST = "SAST"  # static analysis (Semgrep)
     SKILL = "SKILL"  # skill file auditor
@@ -761,12 +765,13 @@ def secret_dict_to_finding(secret: dict) -> "Finding":
 
 
 def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
-    """Convert one FAILED cloud CIS check into a unified CLOUD_CIS Finding.
+    """Convert one failed or unevaluable cloud posture check into a Finding.
 
-    Lifts cloud CIS failures out of the side-block (``*_cis_benchmark_data``) into
+    Lifts cloud posture failures out of the side-block (``*_cis_benchmark_data``) into
     the unified findings stream so ``--fail-on-severity``, SARIF, and severity
     rollups see them — previously a ``cloud`` scan exited 0 even with HIGH/CRITICAL
-    misconfigurations. Carries the check's MITRE ATT&CK techniques + CIS tag.
+    misconfigurations. CIS providers retain CIS identity; vendor best-practice
+    providers remain explicitly non-CIS.
     """
     from agent_bom.security import sanitize_text
 
@@ -778,8 +783,17 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
     resource_ids = [sanitize_text(str(r), max_len=300) for r in (check.get("resource_ids") or []) if str(r).strip()]
     primary = resource_ids[0] if resource_ids else f"{provider}-account"
     attack = [str(t) for t in (check.get("attack_techniques") or []) if str(t).strip()]
-    compliance = [f"CIS-{check_id}"] + [str(t) for t in (check.get("compliance_tags") or []) if str(t).strip()]
+    is_vendor_best_practice = provider.lower() == "databricks"
+    compliance = ([] if is_vendor_best_practice else [f"CIS-{check_id}"]) + [
+        str(t) for t in (check.get("compliance_tags") or []) if str(t).strip()
+    ]
     cis_section = sanitize_text(str(check.get("cis_section", "") or ""), max_len=200)
+    status = str(check.get("status", "FAIL") or "FAIL").upper()
+    if is_vendor_best_practice:
+        finding_type = FindingType.CLOUD_BEST_PRACTICE_ERROR if status == "ERROR" else FindingType.CLOUD_BEST_PRACTICE_FAIL
+    else:
+        finding_type = FindingType.CIS_ERROR if status == "ERROR" else FindingType.CIS_FAIL
+    benchmark_label = "Security best-practice" if is_vendor_best_practice else "CIS benchmark"
 
     # Explicit scope (issue #3946): the converter already knows the provider and
     # the resource id/ARN — parse the account/region out of the ARN, prefer an
@@ -792,8 +806,8 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
     environment = sanitize_text(str(check.get("environment") or ""), max_len=64) or None
 
     finding = Finding(
-        finding_type=FindingType.CIS_FAIL,
-        source=FindingSource.CLOUD_CIS,
+        finding_type=finding_type,
+        source=FindingSource.CLOUD_SECURITY if is_vendor_best_practice else FindingSource.CLOUD_CIS,
         asset=Asset(
             name=primary,
             asset_type="cloud_resource",
@@ -809,17 +823,23 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
         account_ref=account_ref,
         region=region,
         environment=environment,
-        title=f"CIS {check_id}: {title}",
-        description=evidence_text or f"CIS benchmark control {check_id} failed for {provider}.",
+        title=f"{'Databricks best practice' if is_vendor_best_practice else 'CIS'} {check_id}: {title}",
+        description=evidence_text
+        or (
+            f"{benchmark_label} control {check_id} could not be evaluated for {provider}."
+            if status == "ERROR"
+            else f"{benchmark_label} control {check_id} failed for {provider}."
+        ),
         remediation_guidance=recommendation or None,
         compliance_tags=sorted(set(compliance)),
         attack_tags=sorted(set(attack)),
         evidence={
             "provider": provider,
             "check_id": check_id,
+            "status": status,
             "cis_section": cis_section,
             "resource_ids": resource_ids,
-            "benchmark": "CIS",
+            "benchmark": "Databricks Security Best Practices" if is_vendor_best_practice else "CIS",
         },
     )
     # Reference pattern for the advisory-remediation foundation: attach the

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -130,7 +130,7 @@ def security_domain_for(
 
     ev = evidence or {}
 
-    if source == FindingSource.CLOUD_CIS:
+    if source in {FindingSource.CLOUD_CIS, FindingSource.CLOUD_SECURITY}:
         provider = str(ev.get("provider") or "").strip().lower()
         # Snowflake governance findings carry a category + no CIS benchmark tag;
         # they describe data-access posture, not infra config → DSPM.
@@ -219,9 +219,7 @@ def _is_iac_misconfig(source: "FindingSource", ftype: "FindingType", ev: dict) -
         return False
     if ev.get("iac"):
         return True
-    marker = " ".join(
-        str(ev.get(key) or "") for key in ("category", "scan_type", "framework", "resource_type", "source_kind")
-    ).lower()
+    marker = " ".join(str(ev.get(key) or "") for key in ("category", "scan_type", "framework", "resource_type", "source_kind")).lower()
     return any(token in marker for token in ("iac", "terraform", "cloudformation", "k8s manifest", "kubernetes manifest"))
 
 

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1347,13 +1347,13 @@ class AIBOMReport:
         return findings
 
     def _cloud_cis_findings(self) -> "list[Finding]":
-        """Cloud CIS benchmark FAILures lifted into the unified findings stream.
+        """Cloud CIS failures and evaluation errors lifted into findings.
 
         Each provider's CIS results live in a side block (``*_cis_benchmark_data``)
-        and never reached the unified stream — so ``cloud`` scans exited 0 even on
-        HIGH/CRITICAL misconfigurations and ``--fail-on-severity`` was blind to
-        cloud posture. Convert every FAILED check to a CLOUD_CIS Finding so the
-        gate, SARIF, and severity rollups converge across all providers.
+        and never reached the unified stream. Convert FAILED controls and ERROR
+        controls to distinct CLOUD_CIS findings so severity gates fail closed on
+        unevaluable high-risk controls. Genuine NOT_APPLICABLE controls remain
+        outside the findings stream.
         """
         from agent_bom.finding import cloud_cis_check_to_finding
 
@@ -1368,7 +1368,7 @@ class AIBOMReport:
             if not isinstance(data, dict):
                 continue
             for check in data.get("checks", []) or []:
-                if isinstance(check, dict) and str(check.get("status", "")).upper() == "FAIL":
+                if isinstance(check, dict) and str(check.get("status", "")).upper() in {"FAIL", "ERROR"}:
                     findings.append(cloud_cis_check_to_finding(check, provider))
         return findings
 

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -402,9 +402,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     if fixable_only:
         priority = [finding for finding in priority if _forward_fix_version(finding)]
     if not priority:
-        display_list = (
-            [finding for finding in active_findings if _forward_fix_version(finding)] if fixable_only else active_findings
-        )
+        display_list = [finding for finding in active_findings if _forward_fix_version(finding)] if fixable_only else active_findings
     else:
         display_list = priority
     total = len(display_list)
@@ -412,9 +410,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
     shown = display_list[start:end]
 
     # Detect if we have blast radius context (agents/servers/credentials)
-    has_blast_context = any(
-        finding.affected_agents and (finding.affected_servers or finding.exposed_credentials) for finding in shown
-    )
+    has_blast_context = any(finding.affected_agents and (finding.affected_servers or finding.exposed_credentials) for finding in shown)
 
     console.print()
     shown_n = len(shown)
@@ -465,10 +461,7 @@ def print_compact_blast_radius(report: AIBOMReport, limit: int = 10, fixable_onl
             epss_style = "red bold" if epss_pct >= 70 else "yellow" if epss_pct >= 30 else "dim"
             epss_display = f"[{epss_style}]{epss_pct}%[/{epss_style}]"
 
-        pkg_display = (
-            f"{package_name(finding)}@{package_version(finding)}"
-            + ("" if is_package_direct(finding) else " [dim]T[/dim]")
-        )
+        pkg_display = f"{package_name(finding)}@{package_version(finding)}" + ("" if is_package_direct(finding) else " [dim]T[/dim]")
         vuln_id = finding.cve_id or finding.id
 
         if has_blast_context:
@@ -673,11 +666,13 @@ def print_compact_cis_posture(report: AIBOMReport, limit: int = 5) -> None:
         return
 
     console.print()
-    console.print(f"  {lane_title('govern', 'CIS Benchmark Posture')}")
+    console.print(f"  {lane_title('govern', 'Cloud Security Posture')}")
 
     for cloud, bundle in bundles:
         checks = bundle.get("checks") or []
         failed = [c for c in checks if c.get("status") == "fail"]
+        errored = [c for c in checks if c.get("status") == "error"]
+        actionable = failed + errored
         total_eval = sum(1 for c in checks if c.get("status") in ("pass", "fail"))
         pass_rate = bundle.get("pass_rate", 0.0)
 
@@ -687,10 +682,12 @@ def print_compact_cis_posture(report: AIBOMReport, limit: int = 5) -> None:
             f"  [bold]{cloud_label}[/bold]  "
             f"[{band}]{pass_rate:.0f}%[/{band}] pass  "
             f"[dim]({bundle.get('passed', 0)}/{total_eval} checks, "
-            f"{len(failed)} failed)[/dim]"
+            f"{len(failed)} failed, {len(errored)} unevaluable)[/dim]"
         )
 
-        if not failed:
+        if errored and not failed:
+            console.print("    [red bold]ERROR[/red bold] [dim]benchmark evidence is incomplete[/dim]")
+        if not actionable:
             console.print("    [green]✓[/green] [dim]no failed checks[/dim]")
             continue
 
@@ -703,7 +700,7 @@ def print_compact_cis_posture(report: AIBOMReport, limit: int = 5) -> None:
             sev = c.get("severity") or ""
             return (priority, severity_worst_first_rank(sev))
 
-        failed_sorted = sorted(failed, key=_sort_key)
+        failed_sorted = sorted(actionable, key=_sort_key)
         shown = failed_sorted[:limit]
         sev_style = {"critical": "red bold", "high": "#e67e22 bold", "medium": "yellow", "low": "dim"}
 
@@ -725,13 +722,15 @@ def print_compact_cis_posture(report: AIBOMReport, limit: int = 5) -> None:
             )
             if guard_str:
                 console.print(f"       [dim]{guard_str}[/dim]")
+            if check.get("status") == "error" and check.get("evidence"):
+                console.print(f"       [red]unevaluable:[/red] {_compact_detail(str(check['evidence']), limit=110)}")
             if rem.get("fix_cli"):
                 console.print(f"       [cyan]{_compact_detail(rem['fix_cli'], limit=110)}[/cyan]")
             elif rem.get("fix_console"):
                 console.print(f"       [dim]→ {_compact_detail(rem['fix_console'], limit=110)}[/dim]")
 
-        if len(failed) > limit:
-            console.print(f"    [dim]... {len(failed) - limit} more (use --verbose for full plan)[/dim]")
+        if len(actionable) > limit:
+            console.print(f"    [dim]... {len(actionable) - limit} more (use --verbose for full plan)[/dim]")
 
     console.print()
 

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -202,6 +202,7 @@ def print_summary(report: AIBOMReport) -> None:
 
     coverage_warnings = getattr(report, "coverage_warnings", None) or []
     if coverage_warnings:
+
         def _coverage_line(w: dict) -> str:
             if w.get("reason") == "manifest_parse_error":
                 return (
@@ -536,9 +537,7 @@ def print_agent_tree(report: AIBOMReport) -> None:
                 elif plevel == "medium":
                     priv_indicator = " [yellow]🛡 elevated[/yellow]"
 
-            registry_indicator = (
-                " [green]✓ registry[/green]" if server.registry_verified else " [dim]unknown registry[/dim]"
-            )
+            registry_indicator = " [green]✓ registry[/green]" if server.registry_verified else " [dim]unknown registry[/dim]"
 
             server_args = sanitize_command_args(server.args[:2])
             server_branch = agent_tree.add(
@@ -1663,13 +1662,14 @@ def print_cis_findings(report: AIBOMReport, *, show_passed: bool = False) -> Non
         return
 
     con.print()
-    con.print(Rule("CIS Benchmark Posture", style="bold bright_magenta"))
+    con.print(Rule("Cloud Security Posture", style="bold bright_magenta"))
 
     for _cloud, label, bundle in bundles:
         checks = bundle.get("checks") or []
         failed = [c for c in checks if str(c.get("status")) == "fail"]
         passed = [c for c in checks if str(c.get("status")) == "pass"]
         errored = [c for c in checks if str(c.get("status")) == "error"]
+        actionable = failed + errored
         evaluated = len(failed) + len(passed)
         pass_rate = bundle.get("pass_rate")
         if not isinstance(pass_rate, (int, float)):
@@ -1678,7 +1678,11 @@ def print_cis_findings(report: AIBOMReport, *, show_passed: bool = False) -> Non
         band = "green" if pass_rate >= 90 else "yellow" if pass_rate >= 70 else "red"
 
         # Verdict driven by the worst failing severity.
-        if not failed:
+        if errored and not failed:
+            verdict = "[bold red]ERROR[/bold red]"
+        elif errored:
+            verdict = "[bold yellow]INCOMPLETE[/bold yellow]"
+        elif not failed:
             verdict = "[bold green]PASS[/bold green]"
         else:
             worst_check = min(failed, key=lambda c: severity_worst_first_rank(c.get("severity")))
@@ -1696,28 +1700,33 @@ def print_cis_findings(report: AIBOMReport, *, show_passed: bool = False) -> Non
             + ")[/dim]"
         )
 
-        if not failed:
+        if not actionable:
             con.print(f"    [green]{safe_emoji('✓', 'OK')}[/green] [dim]no failed checks[/dim]")
             if show_passed and passed:
                 _print_cis_passed(con, passed)
             continue
 
         # Top risks: the highest-priority failing check ids, for the header.
-        top = sorted(failed, key=_cis_check_sort_key)[:3]
+        top = sorted(actionable, key=_cis_check_sort_key)[:3]
         top_str = ", ".join(str(c.get("check_id") or "?") for c in top)
         con.print(f"    [dim]top risks:[/dim] {top_str}")
 
         # Group failed checks by severity, then by CIS section.
         for sev in ("critical", "high", "medium", "low"):
-            sev_failed = [c for c in failed if _cis_sev(c) == sev]
-            if not sev_failed:
+            sev_actionable = [c for c in actionable if _cis_sev(c) == sev]
+            if not sev_actionable:
                 continue
             badge_style = _SEV_TABLE_STYLE[sev]
-            con.print(f"\n    [{badge_style}] {_SEV_LABEL[sev]} [/{badge_style}] [dim]{len(sev_failed)} failed[/dim]")
+            failed_n = sum(1 for c in sev_actionable if c.get("status") == "fail")
+            error_n = len(sev_actionable) - failed_n
+            summary = ", ".join(
+                part for part in (f"{failed_n} failed" if failed_n else "", f"{error_n} unevaluable" if error_n else "") if part
+            )
+            con.print(f"\n    [{badge_style}] {_SEV_LABEL[sev]} [/{badge_style}] [dim]{summary}[/dim]")
 
             # Group within severity by section for readability.
             sections: dict[str, list[dict]] = {}
-            for c in sorted(sev_failed, key=_cis_check_sort_key):
+            for c in sorted(sev_actionable, key=_cis_check_sort_key):
                 sections.setdefault(str(c.get("cis_section") or "Other"), []).append(c)
 
             for section in sorted(sections):

--- a/src/agent_bom/output/html/sections.py
+++ b/src/agent_bom/output/html/sections.py
@@ -462,7 +462,7 @@ def _non_cve_findings(report: "AIBOMReport") -> list["Finding"]:
             continue
         evidence = finding.evidence if isinstance(finding.evidence, dict) else {}
         if (
-            finding.finding_type == FindingType.CIS_FAIL
+            finding.finding_type in {FindingType.CIS_FAIL, FindingType.CIS_ERROR}
             and evidence.get("benchmark") == "CIS"
             and evidence.get("provider") in _CIS_CLOUD_LABELS
         ):
@@ -746,8 +746,8 @@ def _cis_evidence_html(check: dict) -> str:
 def _cis_benchmark_section(report: "AIBOMReport") -> str:
     """Build the CIS benchmark posture section (issue #665).
 
-    Renders one sub-panel per cloud with a CIS benchmark bundle. Each
-    failed check surfaces its structured remediation dict (``fix_cli``,
+    Renders one sub-panel per cloud with a CIS benchmark bundle. Each failed
+    or unevaluable check surfaces its structured remediation dict (``fix_cli``,
     ``fix_console``, ``priority``, ``guardrails``, human-review flag).
     Returns an empty string when no CIS data is present.
     """
@@ -768,6 +768,8 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
         if not checks:
             continue
         failed = [c for c in checks if c.get("status") == "fail"]
+        errored = [c for c in checks if c.get("status") == "error"]
+        actionable = failed + errored
         evaluated = [c for c in checks if c.get("status") in ("pass", "fail")]
         passed_n = bundle.get("passed", sum(1 for c in checks if c.get("status") == "pass"))
         pass_rate = bundle.get("pass_rate", 0.0)
@@ -777,7 +779,11 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
         sev_counts = {
             s: sum(1 for c in failed if (c.get("severity") or "").lower() == s) for s in SEVERITY_THRESHOLD_LABELS
         }
-        if not failed:
+        if errored and not evaluated:
+            verdict_text, verdict_color = "ERROR", "#dc2626"
+        elif errored:
+            verdict_text, verdict_color = "INCOMPLETE", "#d97706"
+        elif not failed:
             verdict_text, verdict_color = "PASS", "#16a34a"
         else:
             worst_check = min(failed, key=lambda c: severity_worst_first_rank(c.get("severity")))
@@ -788,7 +794,7 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
             verdict_text = f"{worst_band} GAPS"
             verdict_color = _SEV_COLOR.get(worst_sev, "#ef4444")
 
-        top = sorted(failed, key=_sort_key)[:3]
+        top = sorted(actionable, key=_sort_key)[:3]
         top_html = ""
         if top:
             chips = "".join(
@@ -803,26 +809,32 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
             for s, n in sev_counts.items()
             if n
         )
+        pass_html = (
+            f'<div style="color:{band_color};font-weight:700">{pass_rate:.0f}% pass</div>'
+            if evaluated
+            else '<div style="color:#94a3b8;font-weight:700">pass rate unavailable</div>'
+        )
 
         header = (
             f'<div style="display:flex;align-items:center;gap:18px;flex-wrap:wrap;margin-bottom:4px">'
             f'<div style="font-weight:700;color:#f1f5f9;font-size:.95rem">{_esc(label)}</div>'
             f'<span style="background:{verdict_color};color:#fff;padding:2px 9px;border-radius:4px;'
             f'font-size:.7rem;font-weight:700;letter-spacing:.04em">{verdict_text}</span>'
-            f'<div style="color:{band_color};font-weight:700">{pass_rate:.0f}% pass</div>'
+            f"{pass_html}"
             f'<div style="color:#64748b;font-size:.78rem">'
-            f"{passed_n}/{len(evaluated)} checks &middot; "
+            f"{passed_n}/{len(evaluated)} evaluated &middot; "
             f'<strong style="color:#f97316">{len(failed)} failed</strong>'
+            f' &middot; <strong style="color:#d97706">{len(errored)} unevaluable</strong>'
             f"</div>"
             f'<div style="display:flex;gap:10px">{counts_html}</div>'
             f"</div>"
             f"{top_html}"
         )
 
-        if not failed:
+        if not actionable:
             panels.append(
                 f'<div class="panel" style="margin-bottom:16px">{header}'
-                f'<div class="empty-state" style="margin-top:12px">&#x2705; No failed CIS checks.</div></div>'
+                f'<div class="empty-state" style="margin-top:12px">&#x2705; No failed security checks.</div></div>'
             )
             continue
 
@@ -847,7 +859,7 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
         )
 
         rows = []
-        for check in sorted(failed, key=_sort_key):
+        for check in sorted(actionable, key=_sort_key):
             sev = (check.get("severity") or "").lower()
             rem = check.get("remediation") or {}
             fix_cli = rem.get("fix_cli")
@@ -921,7 +933,7 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
     )
 
     return (
-        '<section id="cisbenchmarks"><div class="sec-title">&#x1f6e1;&#xfe0f; CIS Benchmark Posture</div>'
+        '<section id="cisbenchmarks"><div class="sec-title">&#x1f6e1;&#xfe0f; Cloud Security Posture</div>'
         + "".join(panels)
         + filter_script
         + "</section>"

--- a/tests/cloud/test_cloud_cis_convergence.py
+++ b/tests/cloud/test_cloud_cis_convergence.py
@@ -96,6 +96,60 @@ def test_clean_cis_does_not_trip_gate() -> None:
     assert _gate(r) == 0
 
 
+def test_high_cis_error_is_distinct_and_trips_gate() -> None:
+    r = AIBOMReport(scan_id="t")
+    r.snowflake_cis_benchmark_data = {
+        "checks": [{"check_id": "1.1", "title": "MFA", "status": "ERROR", "severity": "high", "evidence": "source stale"}]
+    }
+    findings = r.to_findings()
+    assert [finding.finding_type.value for finding in findings] == ["CIS_ERROR"]
+    assert _gate(r) == 1
+
+
+def test_azure_unevaluable_privileged_identity_control_trips_gate() -> None:
+    r = AIBOMReport(scan_id="azure-identity")
+    r.azure_cis_benchmark_data = {
+        "checks": [
+            {
+                "check_id": "1.1",
+                "title": "Guest Owner assignments",
+                "status": "ERROR",
+                "severity": "high",
+                "evidence": "Microsoft Graph identity evidence unavailable",
+            }
+        ]
+    }
+    findings = r.to_findings()
+    assert [finding.finding_type.value for finding in findings] == ["CIS_ERROR"]
+    assert _gate(r) == 1
+
+
+def test_cis_not_applicable_remains_non_gating() -> None:
+    r = AIBOMReport(scan_id="t")
+    r.snowflake_cis_benchmark_data = {
+        "checks": [{"check_id": "2.2", "title": "Networks", "status": "NOT_APPLICABLE", "severity": "critical"}]
+    }
+    assert r.to_findings() == []
+    assert _gate(r) == 0
+
+
+@pytest.mark.parametrize(
+    ("status", "expected_type"),
+    [("FAIL", "CLOUD_BEST_PRACTICE_FAIL"), ("ERROR", "CLOUD_BEST_PRACTICE_ERROR")],
+)
+def test_databricks_findings_are_vendor_best_practices_and_still_gate(status: str, expected_type: str) -> None:
+    r = AIBOMReport(scan_id="databricks")
+    r.databricks_cis_benchmark_data = {"checks": [{"check_id": "1.1", "title": "Admin access", "status": status, "severity": "high"}]}
+    finding = r.to_findings()[0]
+    assert finding.finding_type.value == expected_type
+    assert finding.source.value == "CLOUD_SECURITY"
+    assert finding.title.startswith("Databricks best practice")
+    assert finding.evidence["benchmark"] == "Databricks Security Best Practices"
+    assert not any(tag.startswith("CIS-") for tag in finding.compliance_tags)
+    assert "cis" not in finding.applicable_frameworks
+    assert _gate(r) == 1
+
+
 def test_cis_fail_posture_and_gate_agree() -> None:
     """The compact headline and the --fail-on-severity gate read the same report
     consistently: CIS HIGH fails are both non-CLEAN and gate-failing."""

--- a/tests/test_azure_cis.py
+++ b/tests/test_azure_cis.py
@@ -173,7 +173,8 @@ def test_check_1_1_with_owners():
     )
     auth.role_assignments.list_for_scope.return_value = [ra]
     r = _check_1_1(auth, "sub-123")
-    assert r.status == CheckStatus.PASS  # Can't confirm guest without Graph
+    assert r.status == CheckStatus.ERROR
+    assert "Microsoft Graph" in r.evidence
 
 
 def test_check_1_2_pass():

--- a/tests/test_azure_cis_benchmark.py
+++ b/tests/test_azure_cis_benchmark.py
@@ -9,6 +9,8 @@ import pytest
 from agent_bom.cloud.aws_cis_benchmark import CheckStatus, CISCheckResult
 from agent_bom.cloud.azure_cis_benchmark import (
     AzureCISReport,
+    _check_1_1,
+    _check_1_2,
     _check_1_3,
     _check_1_5,
     _check_1_7,
@@ -61,6 +63,53 @@ def _make_report(*statuses: CheckStatus) -> AzureCISReport:
             )
         )
     return report
+
+
+@pytest.mark.parametrize(
+    ("check", "role_id", "role_name"),
+    [
+        (_check_1_1, "8e3af657-a8ff-443c-a75c-2fe8c4bcb635", "Owner"),
+        (_check_1_2, "b24988ac-6180-42a0-ab88-20f7382dd24c", "Contributor"),
+    ],
+)
+def test_privileged_guest_identity_check_is_unevaluable_without_graph(check, role_id, role_name):
+    assignment = MagicMock()
+    assignment.role_definition_id = f"/subscriptions/sub-123/providers/Microsoft.Authorization/roleDefinitions/{role_id}"
+    assignment.principal_id = "principal-123"
+    auth_client = MagicMock()
+    auth_client.role_assignments.list_for_scope.return_value = [assignment]
+
+    result = check(auth_client, "sub-123")
+
+    assert result.status == CheckStatus.ERROR
+    assert role_name in result.evidence
+    assert "Microsoft Graph" in result.evidence
+    assert "1" in result.evidence
+
+
+@pytest.mark.parametrize("check", [_check_1_1, _check_1_2])
+def test_privileged_guest_identity_check_passes_when_no_matching_assignments(check):
+    auth_client = MagicMock()
+    auth_client.role_assignments.list_for_scope.return_value = []
+
+    result = check(auth_client, "sub-123")
+
+    assert result.status == CheckStatus.PASS
+    assert "No " in result.evidence
+
+
+def test_privileged_assignment_without_principal_id_remains_counted_but_not_emitted_as_empty_resource():
+    assignment = MagicMock()
+    assignment.role_definition_id = "/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635"
+    assignment.principal_id = None
+    auth_client = MagicMock()
+    auth_client.role_assignments.list_for_scope.return_value = [assignment]
+
+    result = _check_1_1(auth_client, "sub-123")
+
+    assert result.status == CheckStatus.ERROR
+    assert "1 Owner assignment" in result.evidence
+    assert result.resource_ids == []
 
 
 def test_report_pass_count():

--- a/tests/test_azure_cis_benchmark.py
+++ b/tests/test_azure_cis_benchmark.py
@@ -112,6 +112,20 @@ def test_privileged_assignment_without_principal_id_remains_counted_but_not_emit
     assert result.resource_ids == []
 
 
+@pytest.mark.parametrize("check", [_check_1_1, _check_1_2])
+def test_privileged_assignment_read_failure_redacts_secret_bearing_error(check):
+    auth_client = MagicMock()
+    secret = "client_secret=do-not-return-this"
+    auth_client.role_assignments.list_for_scope.side_effect = Exception(secret)
+
+    result = check(auth_client, "sub-123")
+
+    assert result.status == CheckStatus.ERROR
+    assert secret not in result.evidence
+    assert "do-not-return-this" not in result.evidence
+    assert result.evidence.endswith("An internal error occurred. Please contact support.")
+
+
 def test_report_pass_count():
     r = _make_report(CheckStatus.PASS, CheckStatus.PASS, CheckStatus.FAIL)
     assert r.passed == 2

--- a/tests/test_cis_remediation_surfaces.py
+++ b/tests/test_cis_remediation_surfaces.py
@@ -100,7 +100,7 @@ def test_cli_compact_cis_posture_renders_remediation():
         output_mod.console = original
 
     out = buf.getvalue()
-    assert "CIS Benchmark Posture" in out
+    assert "Cloud Security Posture" in out
     assert "AWS" in out
     assert "1.4" in out  # check_id
     assert "delete-access-key" in out  # fix_cli surfaced
@@ -124,6 +124,52 @@ def test_cli_compact_cis_posture_silent_without_cis_data():
     assert buf.getvalue() == ""
 
 
+def test_cli_error_only_cis_is_error_and_surfaces_unevaluable_detail():
+    report = AIBOMReport(tool_version="0.77.1")
+    report.snowflake_cis_benchmark_data = {
+        "pass_rate": 0.0,
+        "checks": [
+            {
+                "check_id": "1.1",
+                "title": "MFA source preflight",
+                "status": "error",
+                "severity": "critical",
+                "evidence": "ACCOUNT_USAGE heartbeat is stale",
+            }
+        ],
+    }
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=200)
+    import agent_bom.output as output_mod
+
+    original = output_mod.console
+    output_mod.console = con
+    try:
+        print_compact_cis_posture(report)
+    finally:
+        output_mod.console = original
+
+    out = buf.getvalue()
+    assert "ERROR" in out
+    assert "1 unevaluable" in out
+    assert "ACCOUNT_USAGE heartbeat is stale" in out
+    assert " PASS " not in out
+    assert "no failed checks" not in out
+
+
+def test_mixed_provider_headings_do_not_claim_databricks_is_cis():
+    report = AIBOMReport(tool_version="0.77.1")
+    report.databricks_cis_benchmark_data = {
+        "checks": [{"check_id": "db-1", "title": "Best practice", "status": "pass", "severity": "low"}],
+        "passed": 1,
+        "failed": 0,
+        "pass_rate": 100.0,
+    }
+    html = _cis_benchmark_section(report)
+    assert "Cloud Security Posture" in html
+    assert "CIS Benchmark Posture" not in html
+
+
 # ── HTML ─────────────────────────────────────────────────────────────────
 
 
@@ -142,6 +188,42 @@ def test_html_cis_section_emits_remediation():
 def test_html_cis_section_empty_when_no_data():
     report = AIBOMReport(tool_version="0.77.1")
     assert _cis_benchmark_section(report) == ""
+
+
+def test_html_error_only_cis_is_incomplete_not_pass_or_zero_of_zero():
+    report = AIBOMReport(tool_version="0.77.1")
+    report.snowflake_cis_benchmark_data = {
+        "passed": 0,
+        "failed": 0,
+        "errored": 1,
+        "evaluated": 0,
+        "pass_rate": 0.0,
+        "checks": [{"check_id": "1.1", "title": "MFA", "status": "error", "severity": "critical", "evidence": "source unavailable"}],
+    }
+    html = _cis_benchmark_section(report)
+    assert "ERROR" in html
+    assert "1 unevaluable" in html
+    assert "0/0 checks" not in html
+    assert "PASS" not in html
+
+
+def test_html_mixed_cis_is_incomplete_and_counts_unevaluable():
+    report = AIBOMReport(tool_version="0.77.1")
+    report.snowflake_cis_benchmark_data = {
+        "passed": 1,
+        "failed": 0,
+        "errored": 1,
+        "evaluated": 1,
+        "pass_rate": 100.0,
+        "checks": [
+            {"check_id": "1.1", "title": "MFA", "status": "pass", "severity": "critical"},
+            {"check_id": "5.1", "title": "PUBLIC", "status": "error", "severity": "high", "evidence": "denied"},
+        ],
+    }
+    html = _cis_benchmark_section(report)
+    assert "INCOMPLETE" in html
+    assert "1 unevaluable" in html
+    assert "PASS" not in html
 
 
 # ── SARIF ────────────────────────────────────────────────────────────────

--- a/tests/test_cloud_benchmark_manifests.py
+++ b/tests/test_cloud_benchmark_manifests.py
@@ -1,0 +1,88 @@
+import ast
+from pathlib import Path
+
+from agent_bom.cloud.aws_cis_benchmark import CISBenchmarkReport
+from agent_bom.cloud.azure_cis_benchmark import AzureCISReport
+from agent_bom.cloud.benchmark_manifests import CLOUD_BENCHMARK_MANIFESTS, MANIFEST_SCHEMA_VERSION
+from agent_bom.cloud.databricks_security import DatabricksSecurityReport
+from agent_bom.cloud.gcp_cis_benchmark import GCPCISReport
+from agent_bom.cloud.snowflake_cis_benchmark import SnowflakeCISReport
+
+ROOT = Path(__file__).parent.parent / "src" / "agent_bom" / "cloud"
+
+
+def _registry_count(filename: str, variable: str) -> int:
+    tree = ast.parse((ROOT / filename).read_text())
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name) and node.target.id == variable:
+            assert isinstance(node.value, (ast.List, ast.Tuple))
+            return len(node.value.elts)
+        if isinstance(node, ast.Assign) and any(isinstance(target, ast.Name) and target.id == variable for target in node.targets):
+            assert isinstance(node.value, (ast.List, ast.Tuple))
+            return len(node.value.elts)
+    raise AssertionError(f"registry {variable} not found in {filename}")
+
+
+def test_provider_manifests_are_versioned_and_do_not_invent_denominators():
+    assert MANIFEST_SCHEMA_VERSION == 1
+    assert set(CLOUD_BENCHMARK_MANIFESTS) == {"aws", "azure", "gcp", "snowflake", "databricks"}
+    for manifest in CLOUD_BENCHMARK_MANIFESTS.values():
+        assert manifest["manifest_schema_version"] == 1
+        assert manifest["implementation_registry"]
+        assert manifest["authoritative_source"].startswith("https://")
+        assert manifest["authoritative_source_version"] == manifest["benchmark_version"]
+        assert manifest["authoritative_source_access"] == "reference_url_only"
+        assert manifest["authoritative_catalog_repository_provenance"] is False
+        assert set(manifest["automated_control_ids"]).isdisjoint(manifest["manual_control_ids"])
+        assert len(manifest["automated_control_ids"]) + len(manifest["manual_control_ids"]) == manifest["implemented_control_count"]
+        assert manifest["unsupported_control_ids"] is None
+        assert "Unknown" in manifest["unsupported_control_ids_reason"]
+        assert manifest["official_control_count"] is None
+        assert manifest["coverage_percentage"] is None
+
+
+def test_databricks_manifest_is_vendor_best_practices_not_cis():
+    manifest = CLOUD_BENCHMARK_MANIFESTS["databricks"]
+    assert manifest["benchmark_type"] == "vendor_best_practices"
+    assert "CIS" not in manifest["benchmark_name"]
+
+
+def test_active_operator_surfaces_do_not_describe_databricks_as_cis():
+    repository = ROOT.parent.parent.parent
+    surfaces = (
+        repository / "docs" / "ARCHITECTURE.md",
+        repository / "integrations" / "docker-mcp-registry" / "tools.json",
+        repository / "ui" / "components" / "cis-benchmark-detail.tsx",
+        repository / "ui" / "components" / "framework-coverage-panel.tsx",
+    )
+    for surface in surfaces:
+        text = surface.read_text()
+        assert "CIS benchmark checks against a cloud account (AWS, Azure, GCP, Snowflake, Databricks)" not in text
+        assert "AWS / Azure / GCP / Snowflake / Databricks checks behind CIS" not in text
+        assert "Cloud CIS benchmarks (AWS / Azure / GCP / Snowflake / Databricks)" not in text
+
+
+def test_implemented_counts_match_code_registries():
+    counts = {
+        "aws": _registry_count("aws_cis_benchmark.py", "_CHECKS") + _registry_count("aws_cis_benchmark.py", "_SPECIAL_CHECKS"),
+        "gcp": _registry_count("gcp_cis_benchmark.py", "all_checks"),
+        "azure": _registry_count("azure_cis_benchmark.py", "all_checks"),
+        "snowflake": _registry_count("snowflake_cis_benchmark.py", "all_checks"),
+        "databricks": _registry_count("databricks_security.py", "_ALL_CHECKS"),
+    }
+    assert counts == {provider: manifest["implemented_control_count"] for provider, manifest in CLOUD_BENCHMARK_MANIFESTS.items()}
+
+
+def test_every_provider_report_exposes_manifest_and_unknown_denominator():
+    reports = {
+        "aws": CISBenchmarkReport(),
+        "azure": AzureCISReport(),
+        "gcp": GCPCISReport(),
+        "snowflake": SnowflakeCISReport(),
+        "databricks": DatabricksSecurityReport(),
+    }
+    for provider, report in reports.items():
+        exposed = report.to_dict()["benchmark_manifest"]
+        assert exposed == CLOUD_BENCHMARK_MANIFESTS[provider]
+        assert exposed["official_control_count"] is None
+        assert exposed["coverage_percentage"] is None

--- a/tests/test_compact_output.py
+++ b/tests/test_compact_output.py
@@ -534,4 +534,4 @@ def test_compact_cis_posture_uses_govern_lane():
     output = _plain(_capture(print_compact_cis_posture, report))
 
     assert "GOVERN" in output
-    assert "CIS Benchmark Posture" in output
+    assert "Cloud Security Posture" in output

--- a/tests/test_compliance_hub_ingest.py
+++ b/tests/test_compliance_hub_ingest.py
@@ -36,6 +36,7 @@ from agent_bom.compliance_hub import (
     select_frameworks,
 )
 from agent_bom.compliance_hub_ingest import (
+    _pick_finding_type,
     ingest_csv_findings,
     ingest_cyclonedx_vulnerabilities,
     ingest_findings,
@@ -55,6 +56,10 @@ from agent_bom.models import (
     TransportType,
     Vulnerability,
 )
+
+
+def test_cis_error_sarif_rule_keeps_distinct_finding_type():
+    assert _pick_finding_type("finding/CIS_ERROR", [], "Unevaluable CIS control") == FindingType.CIS_ERROR
 
 # ─── Native-generator wiring ──────────────────────────────────────────────────
 

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -99,6 +99,7 @@ def _make_blast_radius(
 def test_finding_type_values():
     assert FindingType.CVE == "CVE"
     assert FindingType.CIS_FAIL == "CIS_FAIL"
+    assert FindingType.CIS_ERROR == "CIS_ERROR"
     assert FindingType.TOOL_DRIFT == "TOOL_DRIFT"
 
 

--- a/tests/test_finding_scope.py
+++ b/tests/test_finding_scope.py
@@ -58,6 +58,7 @@ def test_normalize_account_ref_none_and_empty() -> None:
 
 def test_domain_cloud_cis_is_cspm() -> None:
     assert security_domain_for(FindingSource.CLOUD_CIS, FindingType.CIS_FAIL, {"benchmark": "CIS"}) == "cspm"
+    assert security_domain_for(FindingSource.CLOUD_CIS, FindingType.CIS_ERROR, {"benchmark": "CIS"}) == "cspm"
 
 
 def test_domain_dependency_cve_is_vuln() -> None:

--- a/tests/test_remediation_foundation.py
+++ b/tests/test_remediation_foundation.py
@@ -75,6 +75,25 @@ def test_build_remediation_cis_returns_fix_privilege_and_artifact() -> None:
     assert "s3:PutBucketPublicAccessBlock" in rem.artifact.content
 
 
+def test_cis_error_uses_review_guidance_not_control_fix() -> None:
+    finding = cloud_cis_check_to_finding(
+        {
+            "check_id": "1.1",
+            "title": "MFA",
+            "status": "ERROR",
+            "severity": "critical",
+            "evidence": "ACCOUNT_USAGE unavailable",
+            "recommendation": "Restore read-only evidence access and rerun.",
+        },
+        provider="snowflake",
+    )
+    remediation = build_remediation(finding)
+    assert finding.finding_type == FindingType.CIS_ERROR
+    assert remediation.fix.cli is None
+    assert remediation.fix.requires_human_review is True
+    assert "rerun" in remediation.fix.summary.lower()
+
+
 def test_advisory_flags_always_set() -> None:
     rem = build_remediation(_cis_finding())
     assert rem.applied is False

--- a/tests/test_report_ux.py
+++ b/tests/test_report_ux.py
@@ -190,7 +190,7 @@ def test_html_clean_scan_renders_no_failures():
     report = AIBOMReport(tool_version="0.77.1")
     report.cis_benchmark_data = bundle
     html = _cis_benchmark_section(report)
-    assert "No failed CIS checks" in html
+    assert "No failed security checks" in html
     assert "PASS" in html
 
 

--- a/tests/test_sarif_schema_2_1_0.py
+++ b/tests/test_sarif_schema_2_1_0.py
@@ -381,8 +381,10 @@ def test_sarif_cloud_cis_failure_emitted_once(sarif_validator: Draft7Validator) 
         rid = f"cis/{provider}/{check_id}"
         assert rule_ids.count(rid) == 1, f"expected exactly one {rid}, got {rule_ids.count(rid)}"
     # ...and the generic unified CIS rule no longer double-emits those checks.
-    # databricks CIS + snowflake governance keep the generic rule (one each).
-    assert rule_ids.count("finding/CIS_FAIL") == 2, rule_ids
+    # Snowflake governance keeps the generic CIS rule; Databricks is explicitly
+    # a vendor best-practice result, not a CIS result.
+    assert rule_ids.count("finding/CIS_FAIL") == 1, rule_ids
+    assert rule_ids.count("finding/CLOUD_BEST_PRACTICE_FAIL") == 1, rule_ids
 
     # The single aws result keeps the richer structured remediation metadata.
     aws_result = next(r for r in results if r["ruleId"] == "cis/aws/1.4")
@@ -393,3 +395,23 @@ def test_sarif_cloud_cis_failure_emitted_once(sarif_validator: Draft7Validator) 
     # And the de-duplicated document stays schema-valid SARIF 2.1.0.
     errors = sorted(sarif_validator.iter_errors(doc), key=lambda e: list(e.path))
     assert not errors, [e.message for e in errors[:5]]
+
+
+def test_sarif_cis_error_is_distinct_and_emitted_once() -> None:
+    from agent_bom.output.sarif import to_sarif
+
+    report = AIBOMReport(scan_id="cis-error")
+    report.snowflake_cis_benchmark_data = {
+        "checks": [
+            {
+                "check_id": "1.1",
+                "status": "error",
+                "severity": "critical",
+                "title": "MFA",
+                "evidence": "ACCOUNT_USAGE unavailable",
+            }
+        ]
+    }
+    rule_ids = [result["ruleId"] for result in to_sarif(report)["runs"][0]["results"]]
+    assert rule_ids.count("finding/CIS_ERROR") == 1
+    assert "finding/CIS_FAIL" not in rule_ids

--- a/tests/test_snowflake_cis_benchmark.py
+++ b/tests/test_snowflake_cis_benchmark.py
@@ -23,6 +23,7 @@ from agent_bom.cloud.snowflake_cis_benchmark import (
     _check_4_2,
     _check_5_1,
     _check_5_2,
+    _preflight_account_usage_source,
     run_benchmark,
 )
 
@@ -130,18 +131,24 @@ class TestCheck11:
 
 class TestCheck12:
     def test_pass_strong_policy(self):
-        cursor = _mock_cursor([{"name": "DEFAULT", "password_min_length": 14}])
-        result = _check_1_2(cursor)
+        with patch(
+            "agent_bom.cloud.snowflake_cis_benchmark._live_password_policies",
+            return_value=[{"name": "DEFAULT", "password_min_length": 14}],
+        ):
+            result = _check_1_2(MagicMock())
         assert result.status == CheckStatus.PASS
 
     def test_fail_weak_policy(self):
-        cursor = _mock_cursor([{"name": "DEFAULT", "password_min_length": 8}])
-        result = _check_1_2(cursor)
+        with patch(
+            "agent_bom.cloud.snowflake_cis_benchmark._live_password_policies",
+            return_value=[{"name": "DEFAULT", "password_min_length": 8}],
+        ):
+            result = _check_1_2(MagicMock())
         assert result.status == CheckStatus.FAIL
 
     def test_fail_no_policies(self):
-        cursor = _empty_cursor()
-        result = _check_1_2(cursor)
+        with patch("agent_bom.cloud.snowflake_cis_benchmark._live_password_policies", return_value=[]):
+            result = _check_1_2(MagicMock())
         assert result.status == CheckStatus.FAIL
 
 
@@ -171,8 +178,8 @@ class TestCheck14:
     def test_pass_two_admins(self):
         cursor = _mock_cursor(
             [
-                {"grantee_name": "ADMIN1"},
-                {"grantee_name": "ADMIN2"},
+                {"grantee_name": "ADMIN1", "granted_to": "USER"},
+                {"grantee_name": "ADMIN2", "granted_to": "USER"},
             ]
         )
         result = _check_1_4(cursor)
@@ -181,13 +188,24 @@ class TestCheck14:
     def test_fail_too_many_admins(self):
         cursor = _mock_cursor(
             [
-                {"grantee_name": "ADMIN1"},
-                {"grantee_name": "ADMIN2"},
-                {"grantee_name": "ADMIN3"},
+                {"grantee_name": "ADMIN1", "granted_to": "USER"},
+                {"grantee_name": "ADMIN2", "granted_to": "USER"},
+                {"grantee_name": "ADMIN3", "granted_to": "USER"},
             ]
         )
         result = _check_1_4(cursor)
         assert result.status == CheckStatus.FAIL
+
+    def test_role_hierarchy_grant_is_not_counted_as_a_user(self):
+        cursor = _mock_cursor(
+            [
+                {"grantee_name": "ADMIN1", "granted_to": "USER"},
+                {"grantee_name": "SECURITYADMIN", "granted_to": "ROLE"},
+            ]
+        )
+        result = _check_1_4(cursor)
+        assert result.status == CheckStatus.PASS
+        assert "1 user" in result.evidence
 
 
 # ---------------------------------------------------------------------------
@@ -197,18 +215,24 @@ class TestCheck14:
 
 class TestCheck15:
     def test_pass_history_strong(self):
-        cursor = _mock_cursor([{"name": "DEFAULT", "password_history": 24}])
-        result = _check_1_5(cursor)
+        with patch(
+            "agent_bom.cloud.snowflake_cis_benchmark._live_password_policies",
+            return_value=[{"name": "DEFAULT", "password_history": 24}],
+        ):
+            result = _check_1_5(MagicMock())
         assert result.status == CheckStatus.PASS
 
     def test_fail_history_weak(self):
-        cursor = _mock_cursor([{"name": "DEFAULT", "password_history": 5}])
-        result = _check_1_5(cursor)
+        with patch(
+            "agent_bom.cloud.snowflake_cis_benchmark._live_password_policies",
+            return_value=[{"name": "DEFAULT", "password_history": 5}],
+        ):
+            result = _check_1_5(MagicMock())
         assert result.status == CheckStatus.FAIL
 
     def test_fail_no_policies(self):
-        cursor = _empty_cursor()
-        result = _check_1_5(cursor)
+        with patch("agent_bom.cloud.snowflake_cis_benchmark._live_password_policies", return_value=[]):
+            result = _check_1_5(MagicMock())
         assert result.status == CheckStatus.FAIL
 
 
@@ -219,18 +243,27 @@ class TestCheck15:
 
 class TestCheck16:
     def test_pass_max_age_strong(self):
-        cursor = _mock_cursor([{"name": "DEFAULT", "password_max_age_days": 90}])
-        result = _check_1_6(cursor)
+        with patch(
+            "agent_bom.cloud.snowflake_cis_benchmark._live_password_policies",
+            return_value=[{"name": "DEFAULT", "password_max_age_days": 90}],
+        ):
+            result = _check_1_6(MagicMock())
         assert result.status == CheckStatus.PASS
 
     def test_fail_max_age_too_high(self):
-        cursor = _mock_cursor([{"name": "DEFAULT", "password_max_age_days": 180}])
-        result = _check_1_6(cursor)
+        with patch(
+            "agent_bom.cloud.snowflake_cis_benchmark._live_password_policies",
+            return_value=[{"name": "DEFAULT", "password_max_age_days": 180}],
+        ):
+            result = _check_1_6(MagicMock())
         assert result.status == CheckStatus.FAIL
 
     def test_fail_max_age_zero(self):
-        cursor = _mock_cursor([{"name": "DEFAULT", "password_max_age_days": 0}])
-        result = _check_1_6(cursor)
+        with patch(
+            "agent_bom.cloud.snowflake_cis_benchmark._live_password_policies",
+            return_value=[{"name": "DEFAULT", "password_max_age_days": 0}],
+        ):
+            result = _check_1_6(MagicMock())
         assert result.status == CheckStatus.FAIL
 
 
@@ -324,11 +357,13 @@ class TestCheck41:
         cursor = _mock_cursor([{"cnt": 500}])
         result = _check_4_1(cursor)
         assert result.status == CheckStatus.PASS
+        assert "ending 3 hours before scan time" in result.evidence
 
     def test_fail_no_records(self):
         cursor = _mock_cursor([{"cnt": 0}])
         result = _check_4_1(cursor)
         assert result.status == CheckStatus.FAIL
+        assert "ending 3 hours before scan time" in result.evidence
 
     def test_error_on_exception(self):
         cursor = MagicMock()
@@ -347,12 +382,14 @@ class TestCheck42:
         cursor = _empty_cursor()
         result = _check_4_2(cursor)
         assert result.status == CheckStatus.PASS
+        assert "ending 2 hours before scan time" in result.evidence
 
     def test_fail_excessive_failures(self):
         cursor = _mock_cursor([{"user_name": "BADUSER", "fail_count": 25}])
         result = _check_4_2(cursor)
         assert result.status == CheckStatus.FAIL
         assert "BADUSER" in result.evidence
+        assert "ending 2 hours before scan time" in result.evidence
 
 
 # ---------------------------------------------------------------------------
@@ -459,3 +496,201 @@ class TestRunBenchmark:
                 report = run_benchmark(account="test_acct", user="u", checks=["1.1", "2.1"], authenticator="externalbrowser")
 
         assert report.total == 2
+
+
+class _SourceAwareCursor:
+    def __init__(self, *, source_rows=1, show_rows=None, show_data=None, denied=False, filtered_rows=None, check_rows=None):
+        self.source_rows = source_rows
+        self.show_rows = source_rows if show_rows is None else show_rows
+        self.show_data = show_data
+        self.denied = denied
+        self.filtered_rows = filtered_rows or []
+        self.check_rows = check_rows
+        self.description = None
+        self._rows = []
+
+    def execute(self, sql):
+        normalized = " ".join(sql.lower().split())
+        if "source-preflight:" in normalized:
+            if self.denied:
+                raise RuntimeError("insufficient privileges")
+            self.description = [("ROW_COUNT",)]
+            self._rows = [(self.source_rows,)]
+        elif normalized.startswith("show "):
+            if self.show_data is not None:
+                columns = list(self.show_data[0]) if self.show_data else ["NAME"]
+                self.description = [(column.upper(),) for column in columns]
+                self._rows = [tuple(row[column] for column in columns) for row in self.show_data]
+            else:
+                self.description = [("NAME",), ("DISABLED",)]
+                self._rows = [(f"ROW_{index}", "false") for index in range(self.show_rows)]
+        elif self.check_rows is not None:
+            columns = list(self.check_rows[0]) if self.check_rows else ["CNT"]
+            self.description = [(column.upper(),) for column in columns]
+            self._rows = [tuple(row[column] for column in columns) for row in self.check_rows]
+        else:
+            self.description = [("NAME",), ("EXT_AUTHN_DUO",), ("HAS_PASSWORD",), ("DISABLED",)]
+            self._rows = [tuple(row[key] for key in ("name", "ext_authn_duo", "has_password", "disabled")) for row in self.filtered_rows]
+
+    def fetchall(self):
+        return self._rows
+
+
+def _run_selected_with_source(cursor, check_id="1.1"):
+    import sys
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    mock_errors = MagicMock()
+    mock_errors.DatabaseError = Exception
+    with patch.dict(
+        sys.modules,
+        {
+            "snowflake": MagicMock(),
+            "snowflake.connector": MagicMock(),
+            "snowflake.connector.errors": mock_errors,
+        },
+    ):
+        return run_benchmark(account="test", checks=[check_id], conn=conn)
+
+
+def _run_check_11_with_source(cursor):
+    return _run_selected_with_source(cursor)
+
+
+def test_empty_account_usage_source_is_error_not_pass():
+    report = _run_check_11_with_source(_SourceAwareCursor(source_rows=0))
+    assert report.checks[0].status == CheckStatus.ERROR
+    assert report.source_health["users"]["coverage"] == "empty"
+
+
+def test_source_preflight_does_not_invent_a_current_time_watermark():
+    from agent_bom.cloud.snowflake_cis_benchmark import _SOURCE_PROBES
+
+    for sql, _minimum_rows in _SOURCE_PROBES.values():
+        assert "AS observed_at" not in sql
+        assert "QUERY_HISTORY" not in sql
+        assert "LOGIN_HISTORY" not in sql or "MAX(" not in sql
+
+
+def test_denied_account_usage_source_is_error_not_pass():
+    report = _run_check_11_with_source(_SourceAwareCursor(denied=True))
+    assert report.checks[0].status == CheckStatus.ERROR
+    assert report.source_health["users"]["privilege"] == "unknown"
+    assert report.source_health["users"]["query_status"] == "error"
+
+
+def test_clean_filtered_empty_passes_when_source_is_covered_and_fresh():
+    report = _run_check_11_with_source(_SourceAwareCursor(source_rows=2, filtered_rows=[]))
+    assert report.checks[0].status == CheckStatus.PASS
+    assert "All 0 password-authenticated users" in report.checks[0].evidence
+
+
+def test_same_count_stale_account_usage_values_cannot_produce_false_pass():
+    report = _run_check_11_with_source(
+        _SourceAwareCursor(
+            source_rows=1,
+            show_data=[
+                {
+                    "name": "ADMIN",
+                    "disabled": "false",
+                    "has_password": "true",
+                    "ext_authn_duo": "false",
+                }
+            ],
+        )
+    )
+    assert report.source_health["users"]["freshness"] == "control_plane_reconciled"
+    assert report.checks[0].status == CheckStatus.FAIL
+    assert "ADMIN" in report.checks[0].evidence
+
+
+def test_empty_login_history_window_is_covered_not_stale():
+    health = _preflight_account_usage_source(_SourceAwareCursor(source_rows=0), "login_history")
+    assert health["usable"] is True
+    assert health["coverage"] == "covered"
+    assert health["freshness"] == "bounded_as_of_empty_window"
+
+
+def test_nonempty_login_history_reports_bounded_as_of_freshness():
+    health = _preflight_account_usage_source(_SourceAwareCursor(source_rows=2), "login_history")
+    assert health["usable"] is True
+    assert health["freshness"] == "bounded_as_of"
+    assert health["provider_lag_bound_hours"] == 2
+
+
+def test_snapshot_source_requires_live_control_plane_reconciliation():
+    health = _preflight_account_usage_source(_SourceAwareCursor(source_rows=1), "users")
+    assert health["usable"] is True
+    assert health["freshness"] == "control_plane_reconciled"
+    assert health["provider_lag_bound_hours"] == 2
+
+    stale = _preflight_account_usage_source(_SourceAwareCursor(source_rows=1, show_rows=2), "users")
+    assert stale["usable"] is False
+    assert stale["freshness"] == "stale"
+
+
+def test_password_policy_and_access_history_sources_are_preflight_gated():
+    from agent_bom.cloud.snowflake_cis_benchmark import _CHECK_SOURCES, _SOURCE_PROBES
+
+    assert _CHECK_SOURCES["1.2"] == "password_policies"
+    assert _CHECK_SOURCES["4.1"] == "access_history"
+    for source in ("password_policies", "access_history"):
+        denied = _preflight_account_usage_source(_SourceAwareCursor(denied=True), source)
+        current = _preflight_account_usage_source(_SourceAwareCursor(source_rows=0), source)
+        assert denied["usable"] is False
+        assert current["usable"] is True
+        assert current["freshness"] == (
+            "control_plane_reconciled" if source == "password_policies" else "bounded_as_of"
+        )
+        assert source in _SOURCE_PROBES
+
+
+def test_password_policy_denied_stale_empty_and_current_semantics():
+    denied = _run_selected_with_source(_SourceAwareCursor(denied=True), "1.2")
+    assert denied.checks[0].status == CheckStatus.ERROR
+
+    stale = _run_selected_with_source(_SourceAwareCursor(source_rows=1, show_rows=2), "1.2")
+    assert stale.checks[0].status == CheckStatus.ERROR
+    assert stale.source_health["password_policies"]["freshness"] == "stale"
+
+    empty = _run_selected_with_source(_SourceAwareCursor(source_rows=0, check_rows=[]), "1.2")
+    assert empty.checks[0].status == CheckStatus.FAIL
+    assert empty.source_health["password_policies"]["freshness"] == "control_plane_reconciled"
+
+    current = _run_selected_with_source(
+        _SourceAwareCursor(
+            source_rows=1,
+            show_data=[
+                {
+                    "database_name": "SECURITY",
+                    "schema_name": "POLICIES",
+                    "name": "STRONG",
+                }
+            ],
+            check_rows=[{"property": "PASSWORD_MIN_LENGTH", "value": 14}],
+        ),
+        "1.2",
+    )
+    assert current.checks[0].status == CheckStatus.PASS
+
+
+def test_access_history_denied_empty_and_bounded_current_semantics():
+    denied = _run_selected_with_source(_SourceAwareCursor(denied=True), "4.1")
+    assert denied.checks[0].status == CheckStatus.ERROR
+
+    empty = _run_selected_with_source(_SourceAwareCursor(source_rows=0, check_rows=[{"cnt": 0}]), "4.1")
+    assert empty.checks[0].status == CheckStatus.FAIL
+    assert empty.source_health["access_history"]["freshness"] == "bounded_as_of"
+
+    current = _run_selected_with_source(_SourceAwareCursor(source_rows=5, check_rows=[{"cnt": 5}]), "4.1")
+    assert current.checks[0].status == CheckStatus.PASS
+    assert current.source_health["access_history"]["freshness"] == "bounded_as_of"
+
+
+def test_snowflake_report_exposes_error_and_evaluation_counts():
+    report = _run_check_11_with_source(_SourceAwareCursor(source_rows=0))
+    payload = report.to_dict()
+    assert payload["errored"] == 1
+    assert payload["evaluated"] == 0
+    assert payload["not_applicable"] == 0

--- a/tests/test_snowflake_cis_checks.py
+++ b/tests/test_snowflake_cis_checks.py
@@ -1,4 +1,4 @@
-"""Snowflake CIS checks must handle boolean ACCOUNT_USAGE columns + real column names."""
+"""Snowflake CIS checks must handle boolean SHOW columns and real column names."""
 
 from __future__ import annotations
 
@@ -41,13 +41,30 @@ def test_check_1_1_does_not_crash_on_boolean_columns() -> None:
 
 
 def test_check_1_1_all_mfa_passes() -> None:
-    cur = _FakeCursor(["name", "ext_authn_duo"], [("U1", True), ("U2", "true")])
+    cur = _FakeCursor(
+        ["name", "ext_authn_duo", "has_password", "disabled"],
+        [("U1", True, True, False), ("U2", "true", "true", "false")],
+    )
     assert _check_1_1(cur).status.value == "pass"
 
 
 def test_check_1_2_uses_name_column() -> None:
-    # PASSWORD_POLICIES exposes NAME (not policy_name); a weak policy must flag.
-    cur = _FakeCursor(["name", "password_min_length"], [("WEAK_POL", 8)])
+    class _PolicyCursor:
+        description = None
+        rows: list[tuple] = []
+
+        def execute(self, sql: str):
+            if sql.startswith("SHOW PASSWORD"):
+                self.description = [(column,) for column in ("database_name", "schema_name", "name")]
+                self.rows = [("SECURITY", "POLICIES", "WEAK_POL")]
+            else:
+                self.description = [(column,) for column in ("property", "value")]
+                self.rows = [("PASSWORD_MIN_LENGTH", 8)]
+
+        def fetchall(self):
+            return self.rows
+
+    cur = _PolicyCursor()
     res = _check_1_2(cur)
     assert res.status.value == "fail"
     assert "WEAK_POL" in res.evidence

--- a/ui/components/cis-benchmark-detail.tsx
+++ b/ui/components/cis-benchmark-detail.tsx
@@ -87,7 +87,7 @@ function severityClass(severity: string): string {
 const ALL = "all";
 // Typed as string[] (not a literal tuple) so the generic FilterPills infers
 // T = string and accepts the string state value.
-const STATUS_OPTIONS: string[] = [ALL, "fail", "pass"];
+const STATUS_OPTIONS: string[] = [ALL, "error", "fail", "pass", "not_applicable"];
 
 function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
   const [copied, setCopied] = useState(false);
@@ -166,7 +166,7 @@ function CopyableFixCli({ check }: { check: CISBenchmarkCheck }) {
 }
 
 function CheckCard({ check }: { check: CISBenchmarkCheck }) {
-  const [open, setOpen] = useState(check.status === "fail");
+  const [open, setOpen] = useState(check.status === "fail" || check.status === "error");
   const badge = statusBadge(check.status);
   const docs = check.remediation?.docs;
 
@@ -283,7 +283,7 @@ export function CISBenchmarkDetail() {
   const [error, setError] = useState<string | null>(null);
 
   const [cloud, setCloud] = useState<string>(ALL);
-  const [status, setStatus] = useState<string>("fail");
+  const [status, setStatus] = useState<string>(ALL);
   const [priority, setPriority] = useState<number>(-1);
   const [guardrail, setGuardrail] = useState<string>(ALL);
 
@@ -366,8 +366,8 @@ export function CISBenchmarkDetail() {
       <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5">
         <SectionHeader />
         <div className="mt-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-5 text-sm text-[color:var(--text-tertiary)]">
-          No cloud CIS benchmark checks yet. Run a cloud scan (AWS, Azure, GCP, Snowflake, or Databricks)
-          to populate per-check remediation.
+          No cloud security checks yet. Run CIS scans for AWS, Azure, GCP, or Snowflake, or Databricks
+          security best-practices checks, to populate per-check remediation.
         </div>
       </section>
     );
@@ -389,7 +389,7 @@ export function CISBenchmarkDetail() {
           options={STATUS_OPTIONS}
           value={status}
           onChange={setStatus}
-          render={(value) => (value === ALL ? "All" : value === "fail" ? "Failing" : "Passing")}
+          render={(value) => (value === ALL ? "All" : statusBadge(value).label)}
         />
         <FilterPills
           label="Priority"
@@ -432,9 +432,9 @@ function SectionHeader({ count }: { count?: number | undefined }) {
     <div className="flex items-center gap-2">
       <Cloud className="h-4 w-4 text-cyan-400" />
       <div>
-        <h2 className="text-lg font-semibold text-[color:var(--foreground)]">Cloud CIS Benchmark Drill-down</h2>
+        <h2 className="text-lg font-semibold text-[color:var(--foreground)]">Cloud Security Checks</h2>
         <p className="text-xs text-[color:var(--text-tertiary)]">
-          Failed AWS / Azure / GCP / Snowflake / Databricks checks behind CIS Controls v8, with fix guidance.
+          CIS checks for AWS, Azure, GCP, and Snowflake plus Databricks security best practices, with fix guidance.
           {typeof count === "number" ? ` ${count} checks.` : null}
         </p>
       </div>

--- a/ui/components/framework-coverage-panel.tsx
+++ b/ui/components/framework-coverage-panel.tsx
@@ -253,7 +253,7 @@ export function FrameworkCoveragePanel({ items, onFocusFramework, cloudCisHref }
         <div className="mt-4 border-t border-[color:var(--border-subtle)] pt-3">
           <a href={cloudCisHref} className="inline-flex items-center gap-1 text-xs text-cyan-400 hover:text-cyan-300">
             <ChevronRight className="h-3.5 w-3.5" />
-            Cloud CIS benchmarks (AWS / Azure / GCP / Snowflake / Databricks)
+            Cloud security checks (CIS: AWS / Azure / GCP / Snowflake · Databricks best practices)
           </a>
         </div>
       ) : null}

--- a/ui/tests/cis-benchmark-detail.test.tsx
+++ b/ui/tests/cis-benchmark-detail.test.tsx
@@ -62,7 +62,7 @@ describe("CISBenchmarkDetail", () => {
   it("renders an empty state when no checks exist", async () => {
     apiMock.listCisBenchmarkChecks.mockResolvedValue({ checks: [], count: 0, source: "scan_jobs" });
     render(<CISBenchmarkDetail />);
-    expect(await screen.findByText(/no cloud cis benchmark checks yet/i)).toBeInTheDocument();
+    expect(await screen.findByText(/no cloud security checks yet/i)).toBeInTheDocument();
   });
 
   it("renders an error state with the fallback copy when the fetch fails opaquely", async () => {
@@ -78,22 +78,24 @@ describe("CISBenchmarkDetail", () => {
     expect(await screen.findByText(/backend unavailable/i)).toBeInTheDocument();
   });
 
-  it("renders failing checks by default with id, title, and badges", async () => {
+  it("renders all statuses by default so unevaluable checks are never hidden", async () => {
     apiMock.listCisBenchmarkChecks.mockResolvedValue({
       checks: [
         makeCheck({ check_id: "1.4", title: "Eliminate root access keys", priority: 1, guardrails: ["identity"] }),
         makeCheck({ check_id: "3.1", title: "Ensure CloudTrail enabled", status: "pass" }),
+        makeCheck({ check_id: "4.1", title: "Account usage unavailable", status: "error" }),
       ],
-      count: 2,
+      count: 3,
       source: "scan_jobs",
     });
     render(<CISBenchmarkDetail />);
 
     expect(await screen.findByText("Eliminate root access keys")).toBeInTheDocument();
     expect(screen.getByText("1.4")).toBeInTheDocument();
-    // Default status filter is "fail", so the passing check is hidden.
-    expect(screen.queryByText("Ensure CloudTrail enabled")).not.toBeInTheDocument();
-    expect(screen.getByText(/1 of 2 checks shown/i)).toBeInTheDocument();
+    expect(screen.getByText("Ensure CloudTrail enabled")).toBeInTheDocument();
+    expect(screen.getByText("Account usage unavailable")).toBeInTheDocument();
+    expect(screen.getByText(/3 of 3 checks shown/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Error" })).toBeInTheDocument();
   });
 
   it("copies fix_cli and warns when the check requires human review", async () => {


### PR DESCRIPTION
## Summary

- establish Snowflake ACCOUNT_USAGE privilege, coverage, and freshness before dependent controls can pass
- convert critical and high unevaluable controls into explicit error findings while preserving genuine not-applicable behavior
- make Azure privileged-role checks fail closed without Microsoft Graph identity evidence and sanitize provider read failures
- add provider implementation manifests without claiming unproven authoritative denominators, and label Databricks as vendor security best practices

## Verification

- `uv run pytest -q` on the 14 directly affected CSPM, finding, output, compliance, remediation, and SARIF suites: 391 passed, 1 skipped
- `uv run pytest -q tests/test_azure_cis_benchmark.py`: 112 passed, 1 skipped
- `uv run ruff check` on every changed Python file
- `uv run mypy` on all 14 changed source files
- `make preflight`
- UI toolchain contract on Node 24 / npm 10.9.7
- UI Vitest: 739 passed
- UI TypeScript, ESLint, and production Next.js build
- `git diff --check`

## Notes

- unavailable or partial evidence cannot produce a compliant result
- exception evidence is sanitized and locked by a secret-bearing regression
- authoritative benchmark catalogs and Microsoft Graph automation remain tracked in #4120

Closes #4107
Addresses #4095