### PR TITLE
fix(dspm): retain complete vector scan evidence

### DIFF
--- a/site-docs/architecture/ai-infrastructure.md
+++ b/site-docs/architecture/ai-infrastructure.md
@@ -42,6 +42,7 @@ command should match the system boundary you can actually inspect.
 | Container and GPU images | `agent-bom agents --image <image>` | OS and language packages, CVEs, SBOM-ready package inventory | registry pull credentials when private images are used | image scan does not prove runtime deployment |
 | Kubernetes and GPU workloads | `agent-bom agents --k8s --namespace <ns>` | pod/workload inventory, package paths where available, GPU workload context | kubeconfig or in-cluster service account | depends on Kubernetes permissions and visible namespaces |
 | Cloud and AI platforms | provider-specific scan flags or enterprise preset | read-only cloud, warehouse, model, and AI service inventory | customer-managed provider credentials | provider coverage varies; mark partial evidence honestly |
+| Vector databases | `agent-bom agents -p . --vector-db-scan --format json --output vector-evidence.json` | reachable Qdrant, Weaviate, Chroma, and Milvus posture plus configured Pinecone index metadata | local endpoint access; optional `PINECONE_API_KEY` is read from the process environment and never written to the artifact | local discovery checks loopback defaults; Pinecone evidence is limited to indexes visible to the supplied key |
 | IaC and repo posture | `agent-bom iac scan .` or CI action | Terraform, Kubernetes, Helm, CloudFormation, Dockerfile findings | repository checkout | planned resources are not proof of deployed state |
 | Runtime proxy or gateway | `agent-bom proxy ...` or `agent-bom gateway serve ...` | audit JSONL, policy decisions, runtime alerts, relay metrics | selected MCP traffic path and operator runtime tokens | only selected traffic is governed |
 
@@ -57,6 +58,11 @@ command should match the system boundary you can actually inspect.
 - Prefer read-only credentials for cloud, warehouse, model, and registry scans.
 - Do not imply endpoint, gateway, or proxy rollout unless the runtime command
   path was actually run.
+
+For vector databases, inspect `vector-evidence.json` under `vector_db_scan`,
+then restrict unauthenticated endpoints or narrow the Pinecone key before
+rerunning the same command to produce replacement evidence. The artifact
+contains endpoint and index posture, not vector contents or credential values.
 
 ## Cloud providers
 

--- a/src/agent_bom/cli/agents/_cloud.py
+++ b/src/agent_bom/cli/agents/_cloud.py
@@ -554,7 +554,7 @@ def run_benchmarks(
 
             vector_db_results = discover_vector_dbs()
             pinecone_results = discover_pinecone()
-            ctx.vector_db_results = vector_db_results
+            ctx.vector_db_results = [*vector_db_results, *pinecone_results]
             if not vector_db_results and not pinecone_results:
                 con.print("  [dim]No running vector databases found. Set PINECONE_API_KEY to scan Pinecone.[/dim]")
             else:

--- a/src/agent_bom/cli/options_surfaces.py
+++ b/src/agent_bom/cli/options_surfaces.py
@@ -421,7 +421,7 @@ def compliance_options(fn):
                 "--vector-db-scan",
                 "vector_db_scan",
                 is_flag=True,
-                help="Scan for running vector databases (Qdrant, Weaviate, Chroma, Milvus) and assess security",
+                help="Scan Qdrant, Weaviate, Chroma, Milvus, and configured Pinecone indexes for security posture",
             ),
             click.option(
                 "--gpu-scan",

--- a/tests/test_vector_db_evidence_integrity.py
+++ b/tests/test_vector_db_evidence_integrity.py
@@ -1,0 +1,93 @@
+"""Vector-database evidence integrity across CLI context and JSON output."""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+
+from rich.console import Console
+
+from agent_bom.cli.agents._cloud import run_benchmarks
+from agent_bom.cli.agents._context import ScanContext
+from agent_bom.cloud.vector_db import VectorDBResult
+from agent_bom.models import AIBOMReport
+from agent_bom.output.json_fmt import export_json
+
+
+def test_vector_scan_retains_pinecone_in_report_without_api_key(monkeypatch, tmp_path) -> None:
+    api_key = "pcsk-test-secret-must-not-leak"
+    monkeypatch.setenv("PINECONE_API_KEY", api_key)
+    self_hosted = VectorDBResult(
+        db_type="qdrant",
+        host="127.0.0.1",
+        port=6333,
+        is_reachable=True,
+        requires_auth=True,
+        version="1.9.0",
+        collection_count=2,
+        is_loopback=True,
+    )
+    monkeypatch.setattr("agent_bom.cloud.vector_db.discover_vector_dbs", lambda: [self_hosted])
+
+    def _pinecone_get(path: str, supplied_key: str, timeout: int = 3) -> tuple[int, dict]:
+        assert path == "/indexes"
+        assert supplied_key == api_key
+        assert timeout == 3
+        return (
+            200,
+            {
+                "indexes": [
+                    {
+                        "name": "prod-vectors",
+                        "dimension": 1536,
+                        "metric": "cosine",
+                        "spec": {"serverless": {"region": "us-east-1"}},
+                        "status": {"state": "ready", "ready": True},
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr("agent_bom.cloud.vector_db._pinecone_get", _pinecone_get)
+
+    output = StringIO()
+    ctx = ScanContext(con=Console(file=output, force_terminal=False, width=120))
+    run_benchmarks(
+        ctx,
+        skill_only=False,
+        verify_model_hashes=False,
+        project=None,
+        hf_token=None,
+        aws_cis_benchmark=False,
+        aws_region=None,
+        aws_profile=None,
+        snowflake_cis_benchmark=False,
+        snowflake_authenticator=None,
+        azure_cis_benchmark=False,
+        azure_subscription=None,
+        gcp_cis_benchmark=False,
+        gcp_project=None,
+        databricks_security=False,
+        aisvs_flag=False,
+        vector_db_scan=True,
+        gpu_scan_flag=False,
+        gpu_k8s_context=None,
+        no_dcgm_probe=False,
+        smithery_flag=False,
+        smithery_token=None,
+        mcp_registry_flag=False,
+        snyk_flag=False,
+        snyk_token=None,
+        snyk_org=None,
+        cortex_observability=False,
+    )
+
+    report = AIBOMReport(vector_db_scan_data=[result.to_dict() for result in ctx.vector_db_results])
+    report_path = tmp_path / "vector-evidence.json"
+    export_json(report, str(report_path))
+    round_tripped = json.loads(report_path.read_text(encoding="utf-8"))
+
+    assert [item["db_type"] for item in round_tripped["vector_db_scan"]] == ["qdrant", "pinecone"]
+    assert round_tripped["vector_db_scan"][1]["index_name"] == "prod-vectors"
+    assert api_key not in json.dumps(round_tripped)
+    assert api_key not in output.getvalue()


### PR DESCRIPTION
## Summary

- retain Pinecone results alongside self-hosted vector-database findings in the canonical scan context
- prove mixed-provider evidence survives JSON export and readback without exposing `PINECONE_API_KEY`
- align CLI help and documentation with the supported vector providers, first command, artifact, credential boundary, and next step

## Verification

- vector, CLI, and MCP owning suite: 171 passed
- security suite: 68 passed
- export and redaction suite: 8 passed
- focused current-main rerun: 46 passed
- Ruff, Ruff format, and mypy on changed Python files
- exception-sanitization guard
- `uv run mkdocs build --strict`
- `git diff --check`

## Notes

- scanning remains explicit and read-only; the API key is read from process environment only
- vector contents are not read or persisted
- graph crown-jewel correlation remains a separate follow-up

Closes #4127
Addresses #4095