### PR TITLE
feat(ciem): activate bounded AWS IAM usage evidence

### DIFF
--- a/scripts/provision/aws_readonly_policy.json
+++ b/scripts/provision/aws_readonly_policy.json
@@ -122,7 +122,9 @@
         "iam:GetRole",
         "iam:ListAttachedRolePolicies",
         "iam:ListRolePolicies",
-        "iam:GetRolePolicy"
+        "iam:GetRolePolicy",
+        "iam:GenerateServiceLastAccessedDetails",
+        "iam:GetServiceLastAccessedDetails"
       ],
       "Resource": "*"
     }

--- a/src/agent_bom/cloud/aws_iam_collector.py
+++ b/src/agent_bom/cloud/aws_iam_collector.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Mapping
 
 from agent_bom.cloud.aws_iam_evidence import (
     EvidenceCompleteness,
     IamPrincipalEvidence,
+    IamRoleUsageEvidence,
     IamServiceUsageEvidence,
     NormalizedIamPolicy,
     UsageEvidenceState,
@@ -16,6 +17,9 @@ from agent_bom.cloud.aws_iam_evidence import (
 
 _DENIED_CODES = {"AccessDenied", "AccessDeniedException", "UnauthorizedOperation"}
 _UNSUPPORTED_CODES = {"NotSupported", "NotSupportedException", "UnsupportedOperation"}
+_ACCESS_ADVISOR_PAGE_SIZE = 100
+_ACCESS_ADVISOR_HARD_MAX_POLLS = 10
+_ACCESS_ADVISOR_HARD_MAX_PAGES = 10
 
 
 def _error_code(exc: Exception) -> str:
@@ -104,67 +108,106 @@ def _collect_policies(client: Any, role_name: str) -> tuple[tuple[NormalizedIamP
     return tuple(policies), state
 
 
-def _usage_failure(exc: Exception) -> UsageEvidenceState:
+def _usage_failure(exc: Exception) -> tuple[UsageEvidenceState, str]:
     code = _error_code(exc)
     if code in _DENIED_CODES:
-        return UsageEvidenceState.ACCESS_DENIED
+        return UsageEvidenceState.ACCESS_DENIED, "access_advisor_denied"
     if code in _UNSUPPORTED_CODES:
-        return UsageEvidenceState.NOT_SUPPORTED
-    return UsageEvidenceState.UNAVAILABLE
+        return UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
+    return UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
 
 
 def _collect_access_advisor(
-    client: Any, principal_arn: str, *, max_polls: int
-) -> tuple[tuple[IamServiceUsageEvidence, ...], UsageEvidenceState]:
+    client: Any,
+    principal_arn: str,
+    *,
+    max_polls: int,
+    max_pages: int,
+    collected_at: datetime,
+) -> tuple[tuple[IamServiceUsageEvidence, ...], UsageEvidenceState, str]:
     try:
         started = client.generate_service_last_accessed_details(Arn=principal_arn, Granularity="SERVICE_LEVEL")
         job_id = started.get("JobId")
         if not isinstance(job_id, str) or not job_id:
-            return (), UsageEvidenceState.UNAVAILABLE
+            return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
         response: Mapping[str, Any] = {}
-        for _ in range(max(1, max_polls)):
-            candidate = client.get_service_last_accessed_details(JobId=job_id)
+        poll_budget = min(_ACCESS_ADVISOR_HARD_MAX_POLLS, max(1, max_polls))
+        for _ in range(poll_budget):
+            candidate = client.get_service_last_accessed_details(JobId=job_id, MaxItems=_ACCESS_ADVISOR_PAGE_SIZE)
             if not isinstance(candidate, Mapping):
-                return (), UsageEvidenceState.UNAVAILABLE
+                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
             response = candidate
             if response.get("JobStatus") == "COMPLETED":
                 break
             if response.get("JobStatus") == "FAILED":
-                return (), UsageEvidenceState.UNAVAILABLE
+                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
         else:
-            return (), UsageEvidenceState.PENDING
-        services = response.get("ServicesLastAccessed", [])
-        if not isinstance(services, list):
-            return (), UsageEvidenceState.UNAVAILABLE
-        evidence: list[IamServiceUsageEvidence] = []
-        for service in services:
-            if not isinstance(service, Mapping):
-                continue
-            namespace = service.get("ServiceNamespace")
-            if not isinstance(namespace, str) or not namespace:
-                continue
-            accessed = service.get("LastAuthenticated")
-            region = service.get("LastAuthenticatedRegion")
-            evidence.append(
-                IamServiceUsageEvidence(
-                    service_namespace=namespace,
-                    state=UsageEvidenceState.AVAILABLE,
-                    last_accessed_at=accessed if isinstance(accessed, datetime) else None,
-                    last_accessed_region=region if isinstance(region, str) else None,
-                )
+            return (), UsageEvidenceState.PENDING, "access_advisor_pending"
+
+        pages: list[Mapping[str, Any]] = [response]
+        page_budget = min(_ACCESS_ADVISOR_HARD_MAX_PAGES, max(1, max_pages))
+        while bool(pages[-1].get("IsTruncated")):
+            if len(pages) >= page_budget:
+                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_page_budget_exhausted"
+            marker = pages[-1].get("Marker")
+            if not isinstance(marker, str) or not marker:
+                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
+            candidate = client.get_service_last_accessed_details(
+                JobId=job_id,
+                MaxItems=_ACCESS_ADVISOR_PAGE_SIZE,
+                Marker=marker,
             )
-        return tuple(evidence), UsageEvidenceState.AVAILABLE
+            if not isinstance(candidate, Mapping) or candidate.get("JobStatus") not in {None, "COMPLETED"}:
+                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
+            pages.append(candidate)
+
+        evidence: list[IamServiceUsageEvidence] = []
+        for page in pages:
+            services = page.get("ServicesLastAccessed", [])
+            if not isinstance(services, list):
+                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
+            for service in services:
+                if not isinstance(service, Mapping):
+                    continue
+                namespace = service.get("ServiceNamespace")
+                if not isinstance(namespace, str) or not namespace:
+                    continue
+                accessed = service.get("LastAuthenticated")
+                region = service.get("LastAuthenticatedRegion")
+                evidence.append(
+                    IamServiceUsageEvidence(
+                        service_namespace=namespace,
+                        state=UsageEvidenceState.AVAILABLE,
+                        last_accessed_at=accessed if isinstance(accessed, datetime) else None,
+                        last_accessed_region=region if isinstance(region, str) else None,
+                        collected_at=collected_at,
+                    )
+                )
+        return tuple(evidence), UsageEvidenceState.AVAILABLE, "access_advisor_available"
     except Exception as exc:
-        return (), _usage_failure(exc)
+        state, diagnostic = _usage_failure(exc)
+        return (), state, diagnostic
 
 
-def _role_last_used(client: Any, role_name: str) -> IamServiceUsageEvidence | None:
-    try:
-        response = client.get_role(RoleName=role_name)
-    except Exception:
-        return None
-    role = response.get("Role", {})
-    last_used = role.get("RoleLastUsed", {}) if isinstance(role, Mapping) else {}
+def _role_last_used(
+    client: Any,
+    role_name: str,
+    *,
+    role_snapshot: Mapping[str, Any] | None,
+    collected_at: datetime,
+) -> IamServiceUsageEvidence | None:
+    # AWS ListRoles intentionally omits RoleLastUsed. Reuse a richer caller
+    # snapshot only when it actually contains that field; otherwise GetRole is
+    # required to avoid turning missing telemetry into a false "never used".
+    if role_snapshot is None or "RoleLastUsed" not in role_snapshot:
+        try:
+            response = client.get_role(RoleName=role_name)
+        except Exception:
+            return None
+        role = response.get("Role", {})
+    else:
+        role = role_snapshot
+    last_used = role.get("RoleLastUsed") if isinstance(role, Mapping) else None
     if not isinstance(last_used, Mapping):
         return None
     accessed = last_used.get("LastUsedDate")
@@ -175,6 +218,49 @@ def _role_last_used(client: Any, role_name: str) -> IamServiceUsageEvidence | No
         last_accessed_at=accessed if isinstance(accessed, datetime) else None,
         last_accessed_region=region if isinstance(region, str) else None,
         source="role_last_used",
+        collected_at=collected_at,
+    )
+
+
+def collect_iam_role_usage_evidence(
+    client: Any,
+    *,
+    principal_arn: str,
+    role_name: str,
+    role_snapshot: Mapping[str, Any] | None = None,
+    max_access_advisor_polls: int = 3,
+    max_access_advisor_pages: int = 5,
+    collected_at: datetime | None = None,
+) -> IamRoleUsageEvidence:
+    """Collect usage facts only, with fixed poll/page budgets.
+
+    This entry point intentionally performs no policy-list or policy-document
+    calls. Inventory already owns those reads. A caller may supply a richer
+    ``role_snapshot`` that already contains ``RoleLastUsed``; ordinary
+    ``ListRoles`` snapshots omit it, so the collector falls back to ``GetRole``.
+    """
+    observed_at = collected_at or datetime.now(timezone.utc)
+    usage, usage_state, diagnostic = _collect_access_advisor(
+        client,
+        principal_arn,
+        max_polls=max_access_advisor_polls,
+        max_pages=max_access_advisor_pages,
+        collected_at=observed_at,
+    )
+    role_usage = _role_last_used(
+        client,
+        role_name,
+        role_snapshot=role_snapshot,
+        collected_at=observed_at,
+    )
+    if role_usage is not None:
+        usage = (*usage, role_usage)
+    return IamRoleUsageEvidence(
+        principal_arn=principal_arn,
+        usage_state=usage_state,
+        records=usage,
+        diagnostic=diagnostic,
+        collected_at=observed_at,
     )
 
 
@@ -184,18 +270,22 @@ def collect_iam_role_evidence(
     principal_arn: str,
     role_name: str,
     max_access_advisor_polls: int = 3,
+    max_access_advisor_pages: int = 5,
 ) -> IamPrincipalEvidence:
     """Collect policy and usage facts without interpreting authorization."""
     policies, policy_state = _collect_policies(client, role_name)
 
-    usage, usage_state = _collect_access_advisor(client, principal_arn, max_polls=max_access_advisor_polls)
-    role_usage = _role_last_used(client, role_name)
-    if role_usage is not None:
-        usage = (*usage, role_usage)
+    usage_evidence = collect_iam_role_usage_evidence(
+        client,
+        principal_arn=principal_arn,
+        role_name=role_name,
+        max_access_advisor_polls=max_access_advisor_polls,
+        max_access_advisor_pages=max_access_advisor_pages,
+    )
     return IamPrincipalEvidence(
         principal_arn=principal_arn,
         policies=policies,
-        usage=usage,
+        usage=usage_evidence.records,
         policy_completeness=policy_state,
-        usage_state=usage_state,
+        usage_state=usage_evidence.usage_state,
     )

--- a/src/agent_bom/cloud/aws_iam_evidence.py
+++ b/src/agent_bom/cloud/aws_iam_evidence.py
@@ -158,6 +158,45 @@ class IamServiceUsageEvidence:
             return None
         return self.last_accessed_at is not None
 
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize one non-secret usage observation for inventory output."""
+        return {
+            "service_namespace": self.service_namespace,
+            "state": self.state.value,
+            "observed": self.observed,
+            "last_accessed_at": self.last_accessed_at.isoformat() if self.last_accessed_at else None,
+            "last_accessed_region": self.last_accessed_region,
+            "source": self.source,
+            "collected_at": self.collected_at.isoformat(),
+        }
+
+
+@dataclass(frozen=True)
+class IamRoleUsageEvidence:
+    """Bounded AWS IAM role-usage collection result.
+
+    ``usage_state`` describes whether Access Advisor evidence is complete. Role
+    last-used records may still be present when Access Advisor is denied,
+    pending, or unavailable; callers must not reinterpret those narrower facts
+    as complete service-level usage.
+    """
+
+    principal_arn: str
+    usage_state: UsageEvidenceState
+    records: tuple[IamServiceUsageEvidence, ...] = ()
+    diagnostic: str = "access_advisor_unavailable"
+    collected_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the stable, exception-free AWS inventory representation."""
+        return {
+            "principal_arn": self.principal_arn,
+            "state": self.usage_state.value,
+            "diagnostic": self.diagnostic,
+            "collected_at": self.collected_at.isoformat(),
+            "records": [record.to_dict() for record in self.records],
+        }
+
 
 @dataclass(frozen=True)
 class IamPrincipalEvidence:

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -21,10 +21,13 @@ optional-feature gates (e.g. ``AGENT_BOM_ENABLE_EXTENSION_ENTRYPOINTS``,
 ``AGENT_BOM_DISTRIBUTED_SCANS``).
 
 Trust posture: read-only (``ScanMode.CLOUD_READ_ONLY``), reference-only, and
-agentless. Only ``List*`` / ``Describe*`` / ``Get*Policy*`` APIs are called — no
-write APIs, no object-content reads, no credential exfiltration. Boto3 absence
-or missing credentials degrades to an empty inventory plus a clear status,
-never a crash.
+agentless. Resource discovery uses ``List*`` / ``Describe*`` / ``Get*Policy*``
+APIs; IAM role usage adds the read-only Access Advisor report pair
+``GenerateServiceLastAccessedDetails`` / ``GetServiceLastAccessedDetails`` plus
+``GetRole`` for the role-last-used timestamp that ``ListRoles`` omits. Neither
+path changes IAM or cloud-resource configuration, reads object content, or
+exfiltrates credentials. Boto3 absence or missing credentials degrades to an
+empty inventory plus a clear status, never a crash.
 
 Requires ``boto3``. Install with::
 
@@ -47,6 +50,8 @@ from .aws import (
     _policy_actions_from_document,
     _resolve_account_id,
 )
+from .aws_iam_collector import collect_iam_role_usage_evidence
+from .aws_iam_evidence import IamRoleUsageEvidence, UsageEvidenceState
 from .normalization import sanitize_discovery_warning
 
 logger = logging.getLogger(__name__)
@@ -69,6 +74,12 @@ REGIONS_ENV_VAR = "AGENT_BOM_AWS_REGIONS"
 # Defensive cap so an account with a large enabled-region set can't fan out
 # unbounded without an operator opting into a larger budget.
 _MAX_REGIONS = int(os.environ.get("AGENT_BOM_AWS_MAX_REGIONS", "32") or "32")
+# Access Advisor starts one bounded analysis job per role. Inventory remains
+# complete beyond this cap, but additional roles carry explicit unavailable
+# usage evidence instead of launching an unbounded number of jobs.
+_MAX_IAM_USAGE_ROLES = 100
+_MAX_ACCESS_ADVISOR_POLLS = 3
+_MAX_ACCESS_ADVISOR_PAGES = 5
 
 _TRUTHY = {"1", "true", "yes", "on"}
 
@@ -88,6 +99,7 @@ _AWS_EC2_PERMISSIONS: tuple[str, ...] = (
 )
 _AWS_IAM_PERMISSIONS: tuple[str, ...] = (
     "iam:ListRoles",
+    "iam:GetRole",
     "iam:ListUsers",
     "iam:ListGroups",
     "iam:GetGroup",
@@ -103,6 +115,8 @@ _AWS_IAM_PERMISSIONS: tuple[str, ...] = (
     "iam:GetGroupPolicy",
     "iam:GetPolicy",
     "iam:GetPolicyVersion",
+    "iam:GenerateServiceLastAccessedDetails",
+    "iam:GetServiceLastAccessedDetails",
 )
 _AWS_DATA_PERMISSIONS: tuple[str, ...] = (
     "rds:DescribeDBInstances",
@@ -1266,7 +1280,15 @@ def _discover_iam(
         role_paginator = iam.get_paginator("list_roles")
         for page in role_paginator.paginate():
             for role in page.get("Roles", []):
-                roles.append(_normalize_role(iam, role, account_id=account_id, warnings=warnings))
+                roles.append(
+                    _normalize_role(
+                        iam,
+                        role,
+                        account_id=account_id,
+                        warnings=warnings,
+                        collect_usage=len(roles) < _MAX_IAM_USAGE_ROLES,
+                    )
+                )
     except Exception as exc:  # noqa: BLE001 — one failed IAM list must not sink the scan
         record_discovery_failure(
             exc=exc, resource_type="IAM roles", permission="iam:ListRoles", cloud="aws", warnings=warnings, missing=missing
@@ -1295,7 +1317,14 @@ def _discover_iam(
     return roles, users, groups
 
 
-def _normalize_role(iam: Any, role: dict[str, Any], *, account_id: str | None, warnings: list[str]) -> dict[str, Any]:
+def _normalize_role(
+    iam: Any,
+    role: dict[str, Any],
+    *,
+    account_id: str | None,
+    warnings: list[str],
+    collect_usage: bool = True,
+) -> dict[str, Any]:
     role_name = str(role.get("RoleName", "") or "")
     role_arn = str(role.get("Arn", "") or "")
     policies = _attached_policies(iam, "role", role_name, warnings=warnings)
@@ -1304,6 +1333,21 @@ def _normalize_role(iam: Any, role: dict[str, Any], *, account_id: str | None, w
         role.get("AssumeRolePolicyDocument"),
         account_id=account_id or _account_id_from_arn(role_arn),
     )
+    if collect_usage and role_name and role_arn:
+        usage_evidence = collect_iam_role_usage_evidence(
+            iam,
+            principal_arn=role_arn,
+            role_name=role_name,
+            role_snapshot=role,
+            max_access_advisor_polls=_MAX_ACCESS_ADVISOR_POLLS,
+            max_access_advisor_pages=_MAX_ACCESS_ADVISOR_PAGES,
+        )
+    else:
+        usage_evidence = IamRoleUsageEvidence(
+            principal_arn=role_arn,
+            usage_state=UsageEvidenceState.UNAVAILABLE,
+            diagnostic=("role_collection_budget_exhausted" if not collect_usage else "role_identity_unavailable"),
+        )
     return {
         "principal_type": "iam-role",
         "name": role_name,
@@ -1312,6 +1356,7 @@ def _normalize_role(iam: Any, role: dict[str, Any], *, account_id: str | None, w
         "path": str(role.get("Path", "") or ""),
         "policies": policies,
         "trust_principals": trust_principals,
+        "usage_evidence": usage_evidence.to_dict(),
         "privilege_level": _highest_privilege(policies),
         "created_at": _iso(role.get("CreateDate")),
     }

--- a/tests/test_aws_iam_collector.py
+++ b/tests/test_aws_iam_collector.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
-from agent_bom.cloud.aws_iam_collector import collect_iam_role_evidence
+from agent_bom.cloud.aws_iam_collector import collect_iam_role_evidence, collect_iam_role_usage_evidence
 from agent_bom.cloud.aws_iam_evidence import EvidenceCompleteness, UsageEvidenceState
 
 
@@ -133,3 +133,186 @@ def test_successful_empty_policy_lists_are_complete_evidence() -> None:
 
     assert evidence.policies == ()
     assert evidence.policy_completeness is EvidenceCompleteness.COMPLETE
+
+
+class UsageOnlyClient:
+    def __init__(self) -> None:
+        self.get_calls: list[dict[str, Any]] = []
+        self.generate_calls = 0
+
+    def get_paginator(self, operation: str) -> Paginator:  # pragma: no cover - must never run
+        raise AssertionError(f"usage-only collection attempted policy paginator {operation}")
+
+    def get_role(self, **kwargs: str) -> dict[str, Any]:  # pragma: no cover - role snapshot must win
+        raise AssertionError(f"usage-only collection repeated GetRole: {kwargs}")
+
+    def generate_service_last_accessed_details(self, **kwargs: str) -> dict[str, str]:
+        self.generate_calls += 1
+        return {"JobId": "job-usage"}
+
+    def get_service_last_accessed_details(self, **kwargs: Any) -> dict[str, Any]:
+        self.get_calls.append(kwargs)
+        if kwargs.get("Marker") == "next-page":
+            return {
+                "JobStatus": "COMPLETED",
+                "ServicesLastAccessed": [{"ServiceNamespace": "kms"}],
+                "IsTruncated": False,
+            }
+        return {
+            "JobStatus": "COMPLETED",
+            "ServicesLastAccessed": [
+                {
+                    "ServiceNamespace": "s3",
+                    "LastAuthenticated": datetime(2026, 7, 1, tzinfo=timezone.utc),
+                    "LastAuthenticatedRegion": "us-east-1",
+                }
+            ],
+            "IsTruncated": True,
+            "Marker": "next-page",
+        }
+
+
+_ROLE_SNAPSHOT = {
+    "RoleLastUsed": {
+        "LastUsedDate": datetime(2026, 7, 2, tzinfo=timezone.utc),
+        "Region": "us-west-2",
+    }
+}
+
+
+def test_usage_only_collection_paginates_with_hard_page_size_and_skips_policy_reads() -> None:
+    client = UsageOnlyClient()
+    collected_at = datetime(2026, 7, 17, 16, 0, tzinfo=timezone.utc)
+
+    evidence = collect_iam_role_usage_evidence(
+        client,
+        principal_arn="arn:aws:iam::123456789012:role/scanner",
+        role_name="scanner",
+        role_snapshot=_ROLE_SNAPSHOT,
+        max_access_advisor_polls=2,
+        max_access_advisor_pages=2,
+        collected_at=collected_at,
+    )
+
+    assert evidence.usage_state is UsageEvidenceState.AVAILABLE
+    assert evidence.diagnostic == "access_advisor_available"
+    assert [(item.service_namespace, item.observed, item.source) for item in evidence.records] == [
+        ("s3", True, "access_advisor"),
+        ("kms", False, "access_advisor"),
+        ("*", True, "role_last_used"),
+    ]
+    assert all(item.collected_at == collected_at for item in evidence.records)
+    assert client.generate_calls == 1
+    assert client.get_calls == [
+        {"JobId": "job-usage", "MaxItems": 100},
+        {"JobId": "job-usage", "MaxItems": 100, "Marker": "next-page"},
+    ]
+
+
+def test_usage_only_collection_pending_is_bounded_by_poll_budget() -> None:
+    client = UsageOnlyClient()
+
+    def pending(**kwargs: Any) -> dict[str, Any]:
+        client.get_calls.append(kwargs)
+        return {"JobStatus": "IN_PROGRESS"}
+
+    client.get_service_last_accessed_details = pending  # type: ignore[method-assign]
+    evidence = collect_iam_role_usage_evidence(
+        client,
+        principal_arn="arn:aws:iam::123456789012:role/scanner",
+        role_name="scanner",
+        role_snapshot=_ROLE_SNAPSHOT,
+        max_access_advisor_polls=2,
+    )
+
+    assert evidence.usage_state is UsageEvidenceState.PENDING
+    assert evidence.diagnostic == "access_advisor_pending"
+    assert len(client.get_calls) == 2
+    assert all(item.source == "role_last_used" for item in evidence.records)
+
+
+def test_usage_only_collection_clamps_caller_poll_budget_to_hard_limit() -> None:
+    client = UsageOnlyClient()
+
+    def pending(**kwargs: Any) -> dict[str, Any]:
+        client.get_calls.append(kwargs)
+        return {"JobStatus": "IN_PROGRESS"}
+
+    client.get_service_last_accessed_details = pending  # type: ignore[method-assign]
+    evidence = collect_iam_role_usage_evidence(
+        client,
+        principal_arn="arn:aws:iam::123456789012:role/scanner",
+        role_name="scanner",
+        role_snapshot=_ROLE_SNAPSHOT,
+        max_access_advisor_polls=999,
+    )
+
+    assert evidence.usage_state is UsageEvidenceState.PENDING
+    assert len(client.get_calls) == 10
+
+
+def test_usage_only_collection_discards_truncated_partial_page_at_budget() -> None:
+    client = UsageOnlyClient()
+    evidence = collect_iam_role_usage_evidence(
+        client,
+        principal_arn="arn:aws:iam::123456789012:role/scanner",
+        role_name="scanner",
+        role_snapshot=_ROLE_SNAPSHOT,
+        max_access_advisor_pages=1,
+    )
+
+    assert evidence.usage_state is UsageEvidenceState.UNAVAILABLE
+    assert evidence.diagnostic == "access_advisor_page_budget_exhausted"
+    assert all(item.source == "role_last_used" for item in evidence.records)
+    assert len(client.get_calls) == 1
+
+
+def test_usage_only_collection_clamps_caller_page_budget_to_hard_limit() -> None:
+    client = UsageOnlyClient()
+
+    def truncated(**kwargs: Any) -> dict[str, Any]:
+        client.get_calls.append(kwargs)
+        page = len(client.get_calls)
+        return {
+            "JobStatus": "COMPLETED",
+            "ServicesLastAccessed": [{"ServiceNamespace": f"service-{page}"}],
+            "IsTruncated": True,
+            "Marker": f"page-{page + 1}",
+        }
+
+    client.get_service_last_accessed_details = truncated  # type: ignore[method-assign]
+    evidence = collect_iam_role_usage_evidence(
+        client,
+        principal_arn="arn:aws:iam::123456789012:role/scanner",
+        role_name="scanner",
+        role_snapshot=_ROLE_SNAPSHOT,
+        max_access_advisor_pages=999,
+    )
+
+    assert evidence.usage_state is UsageEvidenceState.UNAVAILABLE
+    assert evidence.diagnostic == "access_advisor_page_budget_exhausted"
+    assert len(client.get_calls) == 10
+
+
+def test_usage_only_collection_sanitizes_denied_and_unknown_failures() -> None:
+    for error, expected_state, expected_diagnostic in (
+        (ProviderError("AccessDenied"), UsageEvidenceState.ACCESS_DENIED, "access_advisor_denied"),
+        (RuntimeError("secret-token=https://user:pass@example.test"), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"),
+    ):
+        client = UsageOnlyClient()
+
+        def failed(**kwargs: str) -> dict[str, str]:
+            raise error
+
+        client.generate_service_last_accessed_details = failed  # type: ignore[method-assign]
+        evidence = collect_iam_role_usage_evidence(
+            client,
+            principal_arn="arn:aws:iam::123456789012:role/scanner",
+            role_name="scanner",
+            role_snapshot=_ROLE_SNAPSHOT,
+        )
+
+        assert evidence.usage_state is expected_state
+        assert evidence.diagnostic == expected_diagnostic
+        assert "secret-token" not in repr(evidence)
+        assert "user:pass" not in repr(evidence.to_dict())

--- a/tests/test_aws_iam_evidence.py
+++ b/tests/test_aws_iam_evidence.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 
 from agent_bom.cloud.aws_iam_evidence import (
     EvidenceCompleteness,
+    IamRoleUsageEvidence,
     IamServiceUsageEvidence,
     UsageEvidenceState,
     normalize_iam_policy_document,
@@ -80,3 +81,22 @@ def test_usage_evidence_preserves_unknown_instead_of_inventing_dormancy() -> Non
     assert denied.observed is None
     assert never_used.observed is False
     assert used.observed is True
+
+
+def test_role_usage_evidence_serializes_provenance_and_stable_diagnostic() -> None:
+    collected_at = datetime(2026, 7, 17, 15, 30, tzinfo=timezone.utc)
+    evidence = IamRoleUsageEvidence(
+        principal_arn="arn:aws:iam::123456789012:role/scanner",
+        usage_state=UsageEvidenceState.ACCESS_DENIED,
+        records=(),
+        diagnostic="access_advisor_denied",
+        collected_at=collected_at,
+    )
+
+    assert evidence.to_dict() == {
+        "principal_arn": "arn:aws:iam::123456789012:role/scanner",
+        "state": "access_denied",
+        "diagnostic": "access_advisor_denied",
+        "collected_at": "2026-07-17T15:30:00+00:00",
+        "records": [],
+    }

--- a/tests/test_aws_inventory_iam_usage.py
+++ b/tests/test_aws_inventory_iam_usage.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_bom.cloud import aws_inventory
+
+
+class _Paginator:
+    def __init__(self, pages: list[dict[str, Any]]) -> None:
+        self.pages = pages
+
+    def paginate(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return self.pages
+
+
+class _InventoryIam:
+    def __init__(self, role_count: int = 1) -> None:
+        self.role_count = role_count
+        self.operations: list[str] = []
+        self.generate_calls = 0
+
+    def get_paginator(self, operation: str) -> _Paginator:
+        self.operations.append(operation)
+        if operation == "list_roles":
+            return _Paginator(
+                [
+                    {
+                        "Roles": [
+                            {
+                                "RoleName": f"role-{index}",
+                                "Arn": f"arn:aws:iam::123456789012:role/role-{index}",
+                            }
+                            for index in range(self.role_count)
+                        ]
+                    }
+                ]
+            )
+        if operation in {"list_groups", "list_users"}:
+            return _Paginator([{"Groups": [], "Users": []}])
+        if operation == "list_attached_role_policies":
+            return _Paginator(
+                [
+                    {
+                        "AttachedPolicies": [
+                            {
+                                "PolicyArn": "arn:aws:iam::123456789012:policy/read-data",
+                                "PolicyName": "read-data",
+                            }
+                        ]
+                    }
+                ]
+            )
+        if operation == "list_role_policies":
+            return _Paginator([{"PolicyNames": ["inline-read"]}])
+        raise AssertionError(operation)
+
+    def get_policy(self, **kwargs: Any) -> dict[str, Any]:
+        self.operations.append("get_policy")
+        return {"Policy": {"DefaultVersionId": "v1"}}
+
+    def get_policy_version(self, **kwargs: Any) -> dict[str, Any]:
+        self.operations.append("get_policy_version")
+        return {"PolicyVersion": {"Document": {"Statement": {"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}}}}
+
+    def get_role_policy(self, **kwargs: Any) -> dict[str, Any]:
+        self.operations.append("get_role_policy")
+        return {"PolicyDocument": {"Statement": {"Effect": "Allow", "Action": "kms:Decrypt", "Resource": "*"}}}
+
+    def get_role(self, **kwargs: Any) -> dict[str, Any]:
+        self.operations.append("get_role")
+        return {
+            "Role": {
+                "RoleName": kwargs["RoleName"],
+                "RoleLastUsed": {
+                    "LastUsedDate": datetime(2026, 7, 1, tzinfo=timezone.utc),
+                    "Region": "us-east-1",
+                },
+            }
+        }
+
+    def generate_service_last_accessed_details(self, **kwargs: Any) -> dict[str, str]:
+        self.generate_calls += 1
+        return {"JobId": f"job-{self.generate_calls}"}
+
+    def get_service_last_accessed_details(self, **kwargs: Any) -> dict[str, Any]:
+        return {
+            "JobStatus": "COMPLETED",
+            "ServicesLastAccessed": [
+                {
+                    "ServiceNamespace": "s3",
+                    "LastAuthenticated": datetime(2026, 7, 2, tzinfo=timezone.utc),
+                    "LastAuthenticatedRegion": "us-east-1",
+                }
+            ],
+            "IsTruncated": False,
+        }
+
+
+class _Session:
+    def __init__(self, iam: _InventoryIam) -> None:
+        self.iam = iam
+
+    def client(self, name: str) -> _InventoryIam:
+        assert name == "iam"
+        return self.iam
+
+
+def test_role_inventory_threads_usage_evidence_without_repeating_policy_reads() -> None:
+    iam = _InventoryIam()
+    role = {
+        "RoleName": "role-0",
+        "Arn": "arn:aws:iam::123456789012:role/role-0",
+    }
+
+    normalized = aws_inventory._normalize_role(iam, role, account_id="123456789012", warnings=[])
+
+    assert normalized["usage_evidence"]["state"] == "available"
+    assert normalized["usage_evidence"]["diagnostic"] == "access_advisor_available"
+    assert [record["service_namespace"] for record in normalized["usage_evidence"]["records"]] == ["s3", "*"]
+    assert iam.operations.count("list_attached_role_policies") == 1
+    assert iam.operations.count("list_role_policies") == 1
+    assert iam.operations.count("get_policy") == 1
+    assert iam.operations.count("get_policy_version") == 1
+    assert iam.operations.count("get_role_policy") == 1
+    assert iam.operations.count("get_role") == 1
+
+
+def test_role_usage_collection_has_an_estate_budget_and_marks_skips_unavailable(monkeypatch: Any) -> None:
+    iam = _InventoryIam(role_count=2)
+    monkeypatch.setattr(aws_inventory, "_MAX_IAM_USAGE_ROLES", 1)
+
+    roles, users, groups = aws_inventory._discover_iam(_Session(iam), account_id="123456789012", warnings=[])
+
+    assert users == []
+    assert groups == []
+    assert [role["usage_evidence"]["state"] for role in roles] == ["available", "unavailable"]
+    assert roles[1]["usage_evidence"]["diagnostic"] == "role_collection_budget_exhausted"
+    assert iam.generate_calls == 1
+
+
+def test_inventory_permission_envelope_declares_only_usage_reads_added_for_ciem() -> None:
+    assert "iam:GetRole" in aws_inventory._AWS_IAM_PERMISSIONS
+    assert "iam:GenerateServiceLastAccessedDetails" in aws_inventory._AWS_IAM_PERMISSIONS
+    assert "iam:GetServiceLastAccessedDetails" in aws_inventory._AWS_IAM_PERMISSIONS
+    assert not any(
+        permission.startswith(("iam:Put", "iam:Create", "iam:Update", "iam:Delete")) for permission in aws_inventory._AWS_IAM_PERMISSIONS
+    )
+
+
+def test_provisioned_readonly_policy_grants_the_bounded_access_advisor_pair() -> None:
+    policy_path = Path(__file__).parent.parent / "scripts" / "provision" / "aws_readonly_policy.json"
+    policy = json.loads(policy_path.read_text(encoding="utf-8"))
+    actions = {action for statement in policy["Statement"] for action in statement.get("Action", []) if isinstance(action, str)}
+
+    assert "iam:GenerateServiceLastAccessedDetails" in actions
+    assert "iam:GetServiceLastAccessedDetails" in actions

--- a/tests/test_discovery_envelope_lock_in.py
+++ b/tests/test_discovery_envelope_lock_in.py
@@ -138,6 +138,13 @@ _READ_VERBS = {
     "watch",
 }
 
+# Provider operations whose leading verb sounds mutating but whose exact API
+# contract is read-only. Keep this at full-action granularity: allowing the
+# generic ``Generate`` verb would weaken the guard for unrelated APIs.
+_READ_ONLY_ACTION_EXCEPTIONS = {
+    "iam:GenerateServiceLastAccessedDetails",  # creates an IAM usage report job; changes no IAM/resource configuration
+}
+
 
 def _extract_verb(perm: str) -> str | None:
     """Pull the trailing verb out of a permission string.
@@ -265,7 +272,7 @@ def test_provider_permissions_are_read_only(module_path: str, scan_mode: ScanMod
         if verb is None:
             # If we can't extract a verb the shape test will catch it.
             continue
-        if verb not in _READ_VERBS:
+        if verb not in _READ_VERBS and perm not in _READ_ONLY_ACTION_EXCEPTIONS:
             write_verbs.append((perm, verb))
     assert not write_verbs, (
         f"{module_path} declares non-read permissions: {write_verbs}. "


### PR DESCRIPTION
## Summary

- add a stable AWS role-usage evidence contract with available, access-denied, pending, and unavailable states
- collect Access Advisor and RoleLastUsed evidence through bounded read-only calls without duplicating existing policy reads
- cap estate, polling, and pagination work while retaining every role with explicit unavailable evidence after the budget
- align the discovery permission envelope and provisioned read-only policy with the exact required IAM actions

## Verification

- 395 affected IAM, inventory, connection, provisioning, and lock-in tests passed
- focused current-main rerun: 86 passed
- Ruff check and format check on changed Python files
- mypy on all changed source files
- exception-sanitization and provider read-only guards
- provisioned policy JSON validation
- `make preflight`
- `git diff --check`

## Notes

- policy reads remain single-pass; usage collection does not call policy APIs
- denied, pending, and unavailable evidence remains unknown and cannot imply an unused role
- graph/governance consumption and resumable pending-job collection are explicit follow-ups

Closes #4126
Addresses #4095