### PR TITLE
fix(graph): persist attack-path analysis status

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260717_02_graph_analysis_status.py
+++ b/deploy/supabase/postgres/alembic/versions/20260717_02_graph_analysis_status.py
@@ -1,0 +1,22 @@
+"""Persist per-snapshot graph-analysis execution status.
+
+Revision ID: 20260717_02
+Revises: 20260717_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260717_02"
+down_revision = "20260717_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS analysis_status JSONB NOT NULL DEFAULT '{}'::jsonb")
+
+
+def downgrade() -> None:
+    op.execute("ALTER TABLE graph_snapshots DROP COLUMN IF EXISTS analysis_status")

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -392,6 +392,7 @@ CREATE TABLE IF NOT EXISTS graph_snapshots (
     node_count   INTEGER DEFAULT 0,
     edge_count   INTEGER DEFAULT 0,
     risk_summary JSONB DEFAULT '{}'::jsonb,
+    analysis_status JSONB NOT NULL DEFAULT '{}'::jsonb,
     PRIMARY KEY (scan_id, tenant_id)
 );
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -17953,6 +17953,52 @@
                     },
                     "stats": {
                       "additionalProperties": true,
+                      "properties": {
+                        "analysis_status": {
+                          "additionalProperties": {
+                            "properties": {
+                              "limits": {
+                                "additionalProperties": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "type": "object"
+                              },
+                              "observed": {
+                                "additionalProperties": {
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "type": "object"
+                              },
+                              "reason_codes": {
+                                "items": {
+                                  "type": "string"
+                                },
+                                "type": "array"
+                              },
+                              "status": {
+                                "enum": [
+                                  "complete",
+                                  "limited",
+                                  "skipped",
+                                  "failed",
+                                  "not_recorded"
+                                ],
+                                "type": "string"
+                              }
+                            },
+                            "required": [
+                              "status",
+                              "reason_codes",
+                              "limits",
+                              "observed"
+                            ],
+                            "type": "object"
+                          },
+                          "type": "object"
+                        }
+                      },
                       "type": "object"
                     },
                     "tenant_id": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -11696,6 +11696,39 @@ paths:
                     type: string
                   stats:
                     additionalProperties: true
+                    properties:
+                      analysis_status:
+                        additionalProperties:
+                          properties:
+                            limits:
+                              additionalProperties:
+                                minimum: 0
+                                type: integer
+                              type: object
+                            observed:
+                              additionalProperties:
+                                minimum: 0
+                                type: integer
+                              type: object
+                            reason_codes:
+                              items:
+                                type: string
+                              type: array
+                            status:
+                              enum:
+                              - complete
+                              - limited
+                              - skipped
+                              - failed
+                              - not_recorded
+                              type: string
+                          required:
+                          - status
+                          - reason_codes
+                          - limits
+                          - observed
+                          type: object
+                        type: object
                     type: object
                   tenant_id:
                     type: string

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -15,7 +15,7 @@ import sqlite3
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Iterable, Iterator
+from collections.abc import Iterable, Iterator, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 from agent_bom.db import graph_store as sqlite_graph_store
 from agent_bom.graph import AttackPath, EntityType, NodeDimensions, NodeStatus, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 
 # Only finding-like nodes (vulnerabilities, misconfigurations, drift) carry a
@@ -162,6 +163,7 @@ class GraphStoreProtocol(Protocol):
         edges: Iterable[UnifiedEdge],
         attack_paths: Iterable[AttackPath] = (),
         interaction_risks: Iterable[Any] = (),
+        analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
         created_at: str = "",
     ) -> dict[str, int]: ...
 
@@ -1153,6 +1155,7 @@ class SQLiteGraphStore:
         edges: Iterable[UnifiedEdge],
         attack_paths: Iterable[AttackPath] = (),
         interaction_risks: Iterable[Any] = (),
+        analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
         created_at: str = "",
     ) -> dict[str, int]:
         """Persist a snapshot from node/edge iterables without materialising a graph.
@@ -1171,6 +1174,7 @@ class SQLiteGraphStore:
                 edges=edges,
                 attack_paths=attack_paths,
                 interaction_risks=interaction_risks,
+                analysis_status=analysis_status,
                 created_at=created_at,
             )
             self._refresh_snapshot_search_index(conn, tenant_id=tenant_id, scan_id=scan_id)
@@ -1392,6 +1396,7 @@ class SQLiteGraphStore:
                 "interaction_risk_count": 0,
                 "max_attack_path_risk": 0.0,
                 "highest_interaction_risk": 0.0,
+                "analysis_status": {},
             }
         try:
             effective_scan_id, _created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
@@ -1406,7 +1411,16 @@ class SQLiteGraphStore:
                     "interaction_risk_count": 0,
                     "max_attack_path_risk": 0.0,
                     "highest_interaction_risk": 0.0,
+                    "analysis_status": {},
                 }
+
+            analysis_row = conn.execute(
+                "SELECT analysis_status FROM graph_snapshots WHERE scan_id = ? AND tenant_id = ?",
+                (effective_scan_id, tenant_id),
+            ).fetchone()
+            analysis_status = analysis_status_map_to_dict(
+                analysis_status_map_from_dict(json.loads((analysis_row[0] if analysis_row else "{}") or "{}"))
+            )
 
             node_where = ["tenant_id = ?", "scan_id = ?"]
             params: list[Any] = [tenant_id, effective_scan_id]
@@ -1514,6 +1528,7 @@ class SQLiteGraphStore:
                 "interaction_risk_count": int((interaction_row[0] if interaction_row else 0) or 0),
                 "max_attack_path_risk": float((attack_row[1] if attack_row else 0.0) or 0.0),
                 "highest_interaction_risk": float((interaction_row[1] if interaction_row else 0.0) or 0.0),
+                "analysis_status": analysis_status,
             }
         finally:
             conn.close()

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -12,9 +12,10 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterable, NoReturn, Protocol
+from typing import TYPE_CHECKING, Any, Iterable, Mapping, NoReturn, Protocol
 
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 
 if TYPE_CHECKING:
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
@@ -230,7 +231,8 @@ class NeptuneGraphStore:
               property('created_at', created_at).
               property('node_count', node_count).
               property('edge_count', edge_count).
-              property('risk_summary_json', risk_summary_json)
+              property('risk_summary_json', risk_summary_json).
+              property('analysis_status_json', analysis_status_json)
             """,
             {
                 "snapshot_key": _graph_key(tenant_id, scan_id, "snapshot"),
@@ -240,6 +242,7 @@ class NeptuneGraphStore:
                 "node_count": len(graph.nodes),
                 "edge_count": len(graph.edges),
                 "risk_summary_json": json.dumps(graph.stats(), sort_keys=True),
+                "analysis_status_json": json.dumps(analysis_status_map_to_dict(graph.analysis_status), sort_keys=True),
             },
         )
 
@@ -252,6 +255,7 @@ class NeptuneGraphStore:
         edges: Iterable[UnifiedEdge],
         attack_paths: Iterable[Any] = (),
         interaction_risks: Iterable[Any] = (),
+        analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
         created_at: str = "",
     ) -> dict[str, int]:
         """Persist a snapshot from node/edge iterables.
@@ -269,6 +273,7 @@ class NeptuneGraphStore:
             graph.add_edge(edge)
         graph.attack_paths.extend(attack_paths)
         graph.interaction_risks.extend(interaction_risks)
+        graph.analysis_status.update(analysis_status or {})
         self.save_graph(graph)
         return {"nodes": len(graph.nodes), "edges": len(graph.edges)}
 
@@ -334,6 +339,12 @@ class NeptuneGraphStore:
         tenant = tenant_id or "default"
         scan = scan_id or self.latest_snapshot_id(tenant_id=tenant)
         graph = UnifiedGraph(scan_id=scan, tenant_id=tenant)
+        snapshot_rows = self._submit(
+            "g.V().hasLabel('abom_snapshot').has('tenant_id', tenant_id).has('scan_id', scan_id).limit(1).valueMap()",
+            {"tenant_id": tenant, "scan_id": scan},
+        )
+        if snapshot_rows:
+            graph.analysis_status = analysis_status_map_from_dict(_json_loads(snapshot_rows[0].get("analysis_status_json"), {}))
         node_rows = self._submit(
             "g.V().hasLabel('abom_node').has('tenant_id', tenant_id).has('scan_id', scan_id).valueMap()",
             {"tenant_id": tenant, "scan_id": scan},
@@ -435,12 +446,7 @@ class NeptuneGraphStore:
             entity_types=entity_types,
             min_severity_rank=min_severity_rank,
         )
-        return {
-            "scan_id": graph.scan_id,
-            "node_count": len(graph.nodes),
-            "edge_count": len(graph.edges),
-            "severity_counts": graph.stats().get("severity_counts", {}),
-        }
+        return graph.stats()
 
     def _edge_rows(self, *, tenant_id: str, scan_id: str) -> list[Any]:
         return self._submit(
@@ -461,6 +467,7 @@ class NeptuneGraphStore:
             "node_count": int(_first(row.get("node_count"), 0) or 0),
             "edge_count": int(_first(row.get("edge_count"), 0) or 0),
             "risk_summary": _json_loads(row.get("risk_summary_json"), {}),
+            "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(_json_loads(row.get("analysis_status_json"), {}))),
         }
 
     @staticmethod

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -364,6 +364,7 @@ def _persist_graph_snapshot(
             edges=graph.edges,
             attack_paths=graph.attack_paths,
             interaction_risks=graph.interaction_risks,
+            analysis_status=graph.analysis_status,
             created_at=graph.created_at,
         )
     finally:

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -8,7 +8,7 @@ import logging
 import os
 import time
 from datetime import datetime, timedelta, timezone
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Iterator, Mapping, Sequence
 
 if TYPE_CHECKING:
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
@@ -24,6 +24,7 @@ from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMENT_TIMEOUT_MS
 from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, graph_retention_policy, normalize_graph_tenant_id
 from agent_bom.graph import EntityType
+from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 from agent_bom.security import sanitize_text
 
 from .postgres_common import _apply_tenant_session, _ensure_tenant_rls, _get_pool, _tenant_connection, bypass_tenant_rls
@@ -304,6 +305,7 @@ class PostgresGraphStore:
                     node_count INTEGER DEFAULT 0,
                     edge_count INTEGER DEFAULT 0,
                     risk_summary TEXT DEFAULT '{}',
+                    analysis_status TEXT DEFAULT '{}',
                     PRIMARY KEY (scan_id, tenant_id)
                 )
                 """
@@ -341,6 +343,7 @@ class PostgresGraphStore:
             )
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT ''")
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS tool_exposure TEXT DEFAULT '[]'")
+            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS analysis_status TEXT DEFAULT '{}'")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_from TEXT DEFAULT ''")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_to TEXT DEFAULT NULL")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION DEFAULT 1.0")
@@ -529,6 +532,7 @@ class PostgresGraphStore:
             edges=graph.edges,
             attack_paths=graph.attack_paths,
             interaction_risks=graph.interaction_risks,
+            analysis_status=graph.analysis_status,
             created_at=graph.created_at,
         )
 
@@ -541,6 +545,7 @@ class PostgresGraphStore:
         edges: Iterable[Any],
         attack_paths: Iterable[Any] = (),
         interaction_risks: Iterable[Any] = (),
+        analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
         created_at: str = "",
     ) -> dict[str, int]:
         """Persist a snapshot from node/edge iterables without materialising a graph.
@@ -874,13 +879,15 @@ class PostgresGraphStore:
 
             conn.execute(
                 """
-                INSERT INTO graph_snapshots (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary)
-                VALUES (%s, %s, %s, %s, %s, %s)
+                INSERT INTO graph_snapshots
+                    (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary, analysis_status)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (scan_id, tenant_id) DO UPDATE SET
                     created_at = EXCLUDED.created_at,
                     node_count = EXCLUDED.node_count,
                     edge_count = EXCLUDED.edge_count,
-                    risk_summary = EXCLUDED.risk_summary
+                    risk_summary = EXCLUDED.risk_summary,
+                    analysis_status = EXCLUDED.analysis_status
                 """,
                 (
                     scan,
@@ -889,6 +896,7 @@ class PostgresGraphStore:
                     node_count,
                     edge_count,
                     json.dumps(dict(severity_counts)),
+                    json.dumps(analysis_status_map_to_dict(analysis_status or {})),
                 ),
             )
             conn.commit()
@@ -999,10 +1007,12 @@ class PostgresGraphStore:
 
         with _tenant_connection(self._pool) as conn:
             snapshot_row = conn.execute(
-                "SELECT created_at FROM graph_snapshots WHERE scan_id = %s AND tenant_id = %s",
+                "SELECT created_at, analysis_status FROM graph_snapshots WHERE scan_id = %s AND tenant_id = %s",
                 (effective_scan_id, tenant_id),
             ).fetchone()
             graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=str(snapshot_row[0]) if snapshot_row else "")
+            if snapshot_row:
+                graph.analysis_status = analysis_status_map_from_dict(json.loads(snapshot_row[1] or "{}"))
 
             query = (
                 "SELECT id, entity_type, label, category_uid, class_uid, type_uid, status, risk_score, severity, severity_id, "
@@ -1562,7 +1572,7 @@ class PostgresGraphStore:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 f"""
-                SELECT scan_id, created_at, node_count, edge_count, risk_summary
+                SELECT scan_id, created_at, node_count, edge_count, risk_summary, analysis_status
                 FROM graph_snapshots
                 {where}
                 ORDER BY created_at DESC
@@ -1577,6 +1587,7 @@ class PostgresGraphStore:
                     "node_count": row[2],
                     "edge_count": row[3],
                     "risk_summary": json.loads(row[4]),
+                    "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(json.loads(row[5] or "{}"))),
                 }
                 for row in rows
             ]
@@ -1788,6 +1799,7 @@ class PostgresGraphStore:
                 "interaction_risk_count": 0,
                 "max_attack_path_risk": 0.0,
                 "highest_interaction_risk": 0.0,
+                "analysis_status": {},
             }
 
         node_where = ["tenant_id = %s", "scan_id = %s"]
@@ -1802,6 +1814,13 @@ class PostgresGraphStore:
         where_sql = " AND ".join(node_where)
 
         with _tenant_connection(self._pool) as conn:
+            analysis_row = conn.execute(
+                "SELECT analysis_status FROM graph_snapshots WHERE scan_id = %s AND tenant_id = %s",
+                (effective_scan_id, tenant_id),
+            ).fetchone()
+            analysis_status = analysis_status_map_to_dict(
+                analysis_status_map_from_dict(json.loads((analysis_row[0] if analysis_row else "{}") or "{}"))
+            )
             # Unfiltered node/edge totals are already materialised on the snapshot
             # row at write time. Re-deriving the edge count here re-scans
             # graph_edges with a double id-membership subquery (~seconds at 500k
@@ -1880,6 +1899,7 @@ class PostgresGraphStore:
                 "interaction_risk_count": int((interaction_row[0] if interaction_row else 0) or 0),
                 "max_attack_path_risk": float((attack_row[1] if attack_row else 0.0) or 0.0),
                 "highest_interaction_risk": float((interaction_row[1] if interaction_row else 0.0) or 0.0),
+                "analysis_status": analysis_status,
             }
 
     def page_nodes(

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -162,7 +162,34 @@ _ATTACK_PATHS_OPENAPI_RESPONSE: dict[str, Any] = {
                             "additionalProperties": True,
                         },
                     },
-                    "stats": {"type": "object", "additionalProperties": True},
+                    "stats": {
+                        "type": "object",
+                        "properties": {
+                            "analysis_status": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "required": ["status", "reason_codes", "limits", "observed"],
+                                    "properties": {
+                                        "status": {
+                                            "type": "string",
+                                            "enum": ["complete", "limited", "skipped", "failed", "not_recorded"],
+                                        },
+                                        "reason_codes": {"type": "array", "items": {"type": "string"}},
+                                        "limits": {
+                                            "type": "object",
+                                            "additionalProperties": {"type": "integer", "minimum": 0},
+                                        },
+                                        "observed": {
+                                            "type": "object",
+                                            "additionalProperties": {"type": "integer", "minimum": 0},
+                                        },
+                                    },
+                                },
+                            }
+                        },
+                        "additionalProperties": True,
+                    },
                     "pagination": {"type": "object", "additionalProperties": True},
                 },
             }

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -17,7 +17,7 @@ from collections import defaultdict
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Generator, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Generator, Iterable, Iterator, Mapping, Sequence
 
 if TYPE_CHECKING:
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
@@ -34,6 +34,12 @@ from agent_bom.graph import (
     UnifiedGraph,
     UnifiedNode,
     _now_iso,
+)
+from agent_bom.graph.analysis import (
+    GraphAnalysisStatus,
+    analysis_status_map_from_dict,
+    analysis_status_map_to_dict,
+    not_recorded_analysis_status,
 )
 from agent_bom.security import sanitize_text
 
@@ -144,6 +150,7 @@ CREATE TABLE IF NOT EXISTS graph_snapshots (
     edge_count      INTEGER DEFAULT 0,
     risk_summary    TEXT DEFAULT '{}',
     node_type_counts TEXT DEFAULT NULL,
+    analysis_status TEXT DEFAULT '{}',
     PRIMARY KEY (scan_id, tenant_id)
 );
 CREATE INDEX IF NOT EXISTS idx_gs_recent ON graph_snapshots(tenant_id, created_at DESC);
@@ -318,6 +325,8 @@ def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) 
     snapshot_columns = {row["name"] for row in conn.execute("PRAGMA table_info(graph_snapshots)").fetchall()}
     if "node_type_counts" not in snapshot_columns:
         conn.execute("ALTER TABLE graph_snapshots ADD COLUMN node_type_counts TEXT DEFAULT NULL")
+    if "analysis_status" not in snapshot_columns:
+        conn.execute("ALTER TABLE graph_snapshots ADD COLUMN analysis_status TEXT DEFAULT '{}'")
     if backfill_legacy_tenants:
         _backfill_empty_tenant_ids(conn)
     conn.commit()
@@ -622,6 +631,7 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
         edges=graph.edges,
         attack_paths=graph.attack_paths,
         interaction_risks=graph.interaction_risks,
+        analysis_status=graph.analysis_status,
     )
 
 
@@ -634,6 +644,7 @@ def save_graph_streaming(
     edges: Iterable[UnifiedEdge],
     attack_paths: Iterable[AttackPath] = (),
     interaction_risks: Iterable[InteractionRisk] = (),
+    analysis_status: Mapping[str, GraphAnalysisStatus] | None = None,
     created_at: str = "",
 ) -> dict[str, int]:
     """Persist a graph snapshot from streamed node/edge iterables.
@@ -856,8 +867,8 @@ def save_graph_streaming(
     conn.execute(
         """
         INSERT OR REPLACE INTO graph_snapshots
-            (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary, node_type_counts)
-        VALUES (?, ?, ?, ?, ?, ?, ?)
+            (scan_id, tenant_id, created_at, node_count, edge_count, risk_summary, node_type_counts, analysis_status)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             scan,
@@ -867,6 +878,7 @@ def save_graph_streaming(
             edge_count,
             json.dumps(dict(severity_counts)),
             json.dumps(dict(type_counts)),
+            json.dumps(analysis_status_map_to_dict(analysis_status or {})),
         ),
     )
 
@@ -912,6 +924,16 @@ def load_graph(
     graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=created_at)
     if not effective_scan_id:
         return graph
+
+    snapshot_row = conn.execute(
+        "SELECT analysis_status FROM graph_snapshots WHERE tenant_id = ? AND scan_id = ?",
+        (tenant_id, effective_scan_id),
+    ).fetchone()
+    if snapshot_row is not None:
+        raw_status = json.loads(snapshot_row["analysis_status"] or "{}")
+        graph.analysis_status = analysis_status_map_from_dict(raw_status)
+        if not graph.analysis_status:
+            graph.analysis_status["attack_path_fusion"] = not_recorded_analysis_status()
 
     query = "SELECT * FROM graph_nodes WHERE tenant_id = ? AND scan_id = ?"
     params: list[Any] = [tenant_id, effective_scan_id]
@@ -1372,7 +1394,7 @@ def list_snapshots(
     params.append(limit)
     rows = conn.execute(
         f"""\
-        SELECT scan_id, created_at, node_count, edge_count, risk_summary
+        SELECT scan_id, created_at, node_count, edge_count, risk_summary, analysis_status
         FROM graph_snapshots
         {where}
         ORDER BY created_at DESC LIMIT ?
@@ -1386,6 +1408,7 @@ def list_snapshots(
             "node_count": r["node_count"],
             "edge_count": r["edge_count"],
             "risk_summary": json.loads(r["risk_summary"]),
+            "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(json.loads(r["analysis_status"] or "{}"))),
         }
         for r in rows
     ]

--- a/src/agent_bom/graph/__init__.py
+++ b/src/agent_bom/graph/__init__.py
@@ -5,6 +5,7 @@ Re-exports everything from submodules so consumers can do::
     from agent_bom.graph import UnifiedGraph, EntityType, SEVERITY_RANK
 """
 
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.builder import build_unified_graph_from_report
 from agent_bom.graph.compat import EDGE_KIND_TO_RELATIONSHIP, NODE_KIND_TO_ENTITY
 from agent_bom.graph.container import (
@@ -50,6 +51,8 @@ __all__ = [
     "GraphSemanticLayer",
     "NodeStatus",
     "GraphLayout",
+    "GraphAnalysisState",
+    "GraphAnalysisStatus",
     "OCSFSeverity",
     "SEMANTIC_CLUSTER_KINDS",
     # Severity

--- a/src/agent_bom/graph/analysis.py
+++ b/src/agent_bom/graph/analysis.py
@@ -1,0 +1,84 @@
+"""Typed execution status for snapshot-wide graph analyses."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Mapping
+
+
+class GraphAnalysisState(str, Enum):
+    COMPLETE = "complete"
+    LIMITED = "limited"
+    SKIPPED = "skipped"
+    FAILED = "failed"
+    NOT_RECORDED = "not_recorded"
+
+
+@dataclass(frozen=True, slots=True)
+class GraphAnalysisStatus:
+    """Secret-safe, serializable status for one graph analyzer."""
+
+    status: GraphAnalysisState
+    reason_codes: tuple[str, ...] = ()
+    limits: Mapping[str, int] = field(default_factory=dict)
+    observed: Mapping[str, int] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "reason_codes": list(self.reason_codes),
+            "limits": {str(key): int(value) for key, value in self.limits.items()},
+            "observed": {str(key): int(value) for key, value in self.observed.items()},
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> GraphAnalysisStatus:
+        try:
+            state = GraphAnalysisState(str(data.get("status", "not_recorded")))
+        except ValueError:
+            state = GraphAnalysisState.NOT_RECORDED
+        return cls(
+            status=state,
+            reason_codes=tuple(str(code) for code in data.get("reason_codes", ()) if isinstance(code, str) and code),
+            limits=_integer_mapping(data.get("limits")),
+            observed=_integer_mapping(data.get("observed")),
+        )
+
+
+def _integer_mapping(value: Any) -> dict[str, int]:
+    if not isinstance(value, Mapping):
+        return {}
+    result: dict[str, int] = {}
+    for key, candidate in value.items():
+        if isinstance(candidate, bool):
+            continue
+        try:
+            result[str(key)] = int(candidate)
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def analysis_status_map_to_dict(statuses: Mapping[str, GraphAnalysisStatus]) -> dict[str, dict[str, Any]]:
+    return {str(name): status.to_dict() for name, status in sorted(statuses.items())}
+
+
+def analysis_status_map_from_dict(value: Any) -> dict[str, GraphAnalysisStatus]:
+    if not isinstance(value, Mapping):
+        value = {}
+    statuses = {
+        str(name): GraphAnalysisStatus.from_dict(payload)
+        for name, payload in value.items()
+        if isinstance(payload, Mapping)
+    }
+    if "attack_path_fusion" not in statuses:
+        statuses["attack_path_fusion"] = not_recorded_analysis_status()
+    return statuses
+
+
+def not_recorded_analysis_status() -> GraphAnalysisStatus:
+    return GraphAnalysisStatus(
+        status=GraphAnalysisState.NOT_RECORDED,
+        reason_codes=("legacy_snapshot",),
+    )

--- a/src/agent_bom/graph/attack_path_fusion.py
+++ b/src/agent_bom/graph/attack_path_fusion.py
@@ -30,7 +30,9 @@ capped, and the number of returned paths is capped after ranking + dedup.
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.container import AttackPath, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
@@ -46,6 +48,22 @@ _MAX_NODES = 5000  # node budget: skip fusion on graphs larger than this
 _MAX_VISITED_PER_ENTRY = 2000  # per-entry traversal node budget
 _MAX_ENTRIES = 200  # cap distinct internet-exposed entry points walked
 _MAX_PATHS = 50  # ranked fused chains returned / materialised
+
+_ANALYZER = "attack_path_fusion"
+_LIMITS = {
+    "max_nodes": _MAX_NODES,
+    "max_visited_per_entry": _MAX_VISITED_PER_ENTRY,
+    "max_entries": _MAX_ENTRIES,
+    "max_depth": _MAX_DEPTH,
+    "max_paths": _MAX_PATHS,
+}
+
+
+@dataclass(slots=True)
+class _FusionComputation:
+    paths: list[AttackPath]
+    status: GraphAnalysisStatus
+
 
 # Edges an attacker can traverse moving *forward* from an internet entry toward
 # data. All are already present in the unified graph (inventory + both overlays).
@@ -165,8 +183,22 @@ def compute_fused_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     collecting the *highest-scoring* chain that terminates at each reachable
     crown-jewel data store, then ranks + dedups + caps the result.
     """
+    return _compute_fused_attack_paths(graph).paths
+
+
+def _compute_fused_attack_paths(graph: UnifiedGraph) -> _FusionComputation:
+    """Compute paths together with an honest snapshot-wide execution status."""
+    node_count = len(graph.nodes)
+    base_observed = {"node_count": node_count}
     if not graph.nodes:
-        return []
+        return _FusionComputation(
+            [],
+            GraphAnalysisStatus(
+                status=GraphAnalysisState.COMPLETE,
+                limits=_LIMITS,
+                observed={**base_observed, "entry_count": 0, "evaluated_entry_count": 0, "candidate_path_count": 0, "result_count": 0},
+            ),
+        )
     if len(graph.nodes) > _MAX_NODES:
         # Capped, NOT "no attack paths". Log a signal so a large real estate that
         # skipped fusion is not silently read as "flagship found nothing".
@@ -176,33 +208,71 @@ def compute_fused_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
             len(graph.nodes),
             _MAX_NODES,
         )
-        return []
+        return _FusionComputation(
+            [],
+            GraphAnalysisStatus(
+                status=GraphAnalysisState.SKIPPED,
+                reason_codes=("node_cap_exceeded",),
+                limits=_LIMITS,
+                observed={**base_observed, "entry_count": 0, "evaluated_entry_count": 0, "candidate_path_count": 0, "result_count": 0},
+            ),
+        )
 
     entries = [n for n in graph.nodes.values() if _is_entry(n)]
+    entry_count = len(entries)
     if not entries:
-        return []
+        return _FusionComputation(
+            [],
+            GraphAnalysisStatus(
+                status=GraphAnalysisState.COMPLETE,
+                limits=_LIMITS,
+                observed={**base_observed, "entry_count": 0, "evaluated_entry_count": 0, "candidate_path_count": 0, "result_count": 0},
+            ),
+        )
     # Deterministic, bounded set of footholds.
     entries.sort(key=lambda n: (-n.risk_score, n.id))
     entries = entries[:_MAX_ENTRIES]
+    reason_codes: set[str] = set()
+    if entry_count > _MAX_ENTRIES:
+        reason_codes.add("entry_cap_reached")
 
     # Best chain (by score) per (entry, jewel) pair, deduped across entries.
     best_by_pair: dict[tuple[str, str], tuple[float, AttackPath]] = {}
 
     for entry in entries:
-        _walk_from_entry(graph, entry, best_by_pair)
+        reason_codes.update(_walk_from_entry(graph, entry, best_by_pair))
 
     paths = [ap for _score, ap in best_by_pair.values()]
     paths.sort(key=lambda p: (p.composite_risk, len(p.hops)), reverse=True)
-    return paths[:_MAX_PATHS]
+    candidate_path_count = len(paths)
+    if candidate_path_count > _MAX_PATHS:
+        reason_codes.add("path_cap_reached")
+    paths = paths[:_MAX_PATHS]
+    return _FusionComputation(
+        paths,
+        GraphAnalysisStatus(
+            status=GraphAnalysisState.LIMITED if reason_codes else GraphAnalysisState.COMPLETE,
+            reason_codes=tuple(sorted(reason_codes)),
+            limits=_LIMITS,
+            observed={
+                **base_observed,
+                "entry_count": entry_count,
+                "evaluated_entry_count": len(entries),
+                "candidate_path_count": candidate_path_count,
+                "result_count": len(paths),
+            },
+        ),
+    )
 
 
 def _walk_from_entry(
     graph: UnifiedGraph,
     entry: UnifiedNode,
     best_by_pair: dict[tuple[str, str], tuple[float, AttackPath]],
-) -> None:
+) -> set[str]:
     """Bounded DFS from a single entry, recording best chain per crown jewel."""
     visited_budget = {"n": 0}
+    limit_reasons: set[str] = set()
 
     def dfs(
         node_id: str,
@@ -215,6 +285,7 @@ def _walk_from_entry(
         cred_exposure: list[str],
     ) -> None:
         if visited_budget["n"] >= _MAX_VISITED_PER_ENTRY:
+            limit_reasons.add("visit_cap_reached")
             return
         visited_budget["n"] += 1
         node = graph.nodes.get(node_id)
@@ -242,6 +313,8 @@ def _walk_from_entry(
             # A data store can also be a transit hop, so keep exploring.
 
         if len(hops) > _MAX_DEPTH:
+            if any(_rel(edge) in _TRAVERSABLE_RELS and edge.target not in on_path for edge in graph.adjacency.get(node_id, [])):
+                limit_reasons.add("depth_cap_reached")
             return
 
         for edge in graph.adjacency.get(node_id, []):
@@ -274,6 +347,7 @@ def _walk_from_entry(
             on_path.discard(nxt)
 
     dfs(entry.id, [entry.id], [], [], {entry.id}, _node_boost(entry), [], [])
+    return limit_reasons
 
 
 def apply_attack_path_fusion(graph: UnifiedGraph) -> dict[str, object]:
@@ -283,13 +357,16 @@ def apply_attack_path_fusion(graph: UnifiedGraph) -> dict[str, object]:
     re-run does not duplicate them. Other attack paths (lateral, governance) are
     preserved. Returns counts. Never raises into the builder.
     """
-    fused = compute_fused_attack_paths(graph)
+    computation = _compute_fused_attack_paths(graph)
+    fused = computation.paths
     # Drop any prior fusion output, keep everything else.
     graph.attack_paths = [p for p in graph.attack_paths if not _is_fusion_path(p)]
     graph.attack_paths.extend(fused)
+    graph.analysis_status[_ANALYZER] = computation.status
     result: dict[str, object] = {
         "fused_attack_paths": len(fused),
         "max_fused_risk": int(round(max((p.composite_risk for p in fused), default=0.0))),
+        "analysis_status": computation.status.to_dict(),
     }
     # Surface the node-budget cap so 0 paths on a large estate reads as "skipped"
     # rather than "genuinely none".

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1073,7 +1073,14 @@ def build_unified_graph_from_report(
 
         apply_attack_path_fusion(graph)
     except Exception:  # noqa: BLE001
-        _logger.warning("attack-path fusion failed", exc_info=True)
+        from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
+
+        graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
+            status=GraphAnalysisState.FAILED,
+            reason_codes=("analysis_error",),
+            observed={"node_count": len(graph.nodes), "result_count": 0},
+        )
+        _logger.warning("attack-path fusion failed: analysis_error")
 
     # Cost (FinOps) fusion: attach LLM spend to agent/resource nodes, roll it up
     # the CONTAINS hierarchy, and flag nodes that are BOTH high-cost AND

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -7,6 +7,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
@@ -102,6 +103,7 @@ class UnifiedGraph:
 
     attack_paths: list[AttackPath] = field(default_factory=list)
     interaction_risks: list[InteractionRisk] = field(default_factory=list)
+    analysis_status: dict[str, GraphAnalysisStatus] = field(default_factory=dict)
 
     scan_id: str = ""
     tenant_id: str = ""
@@ -456,7 +458,12 @@ class UnifiedGraph:
         incoming edges, or both. The returned edges always preserve their
         original orientation in the canonical graph.
         """
-        sub = UnifiedGraph(scan_id=self.scan_id, tenant_id=self.tenant_id, created_at=self.created_at)
+        sub = UnifiedGraph(
+            scan_id=self.scan_id,
+            tenant_id=self.tenant_id,
+            created_at=self.created_at,
+            analysis_status=dict(self.analysis_status),
+        )
         if not roots:
             return sub, {}, False
 
@@ -590,6 +597,7 @@ class UnifiedGraph:
             "interaction_risk_count": len(self.interaction_risks),
             "max_attack_path_risk": max((p.composite_risk for p in self.attack_paths), default=0.0),
             "highest_interaction_risk": max((r.risk_score for r in self.interaction_risks), default=0.0),
+            "analysis_status": analysis_status_map_to_dict(self.analysis_status),
         }
 
     # ── Serialisation ────────────────────────────────────────────────────
@@ -603,6 +611,7 @@ class UnifiedGraph:
             "edges": [e.to_dict() for e in self.edges],
             "attack_paths": [p.to_dict() for p in self.attack_paths],
             "interaction_risks": [r.to_dict() for r in self.interaction_risks],
+            "analysis_status": analysis_status_map_to_dict(self.analysis_status),
             "stats": self.stats(),
         }
 
@@ -612,6 +621,7 @@ class UnifiedGraph:
             scan_id=data.get("scan_id", ""),
             tenant_id=data.get("tenant_id", ""),
             created_at=data.get("created_at", ""),
+            analysis_status=analysis_status_map_from_dict(data.get("analysis_status", {})),
         )
         for nd in data.get("nodes", []):
             graph.add_node(UnifiedNode.from_dict(nd))
@@ -749,7 +759,12 @@ class UnifiedGraph:
             keep_ids.add(edge.source)
             keep_ids.add(edge.target)
 
-        pruned = UnifiedGraph(scan_id=sub.scan_id, tenant_id=sub.tenant_id, created_at=sub.created_at)
+        pruned = UnifiedGraph(
+            scan_id=sub.scan_id,
+            tenant_id=sub.tenant_id,
+            created_at=sub.created_at,
+            analysis_status=dict(sub.analysis_status),
+        )
         for node_id in keep_ids:
             node = sub.nodes.get(node_id)
             if node:
@@ -764,7 +779,12 @@ class UnifiedGraph:
         node_filter: Any = None,
         edge_filter: Any = None,
     ) -> UnifiedGraph:
-        sub = UnifiedGraph(scan_id=self.scan_id, tenant_id=self.tenant_id, created_at=self.created_at)
+        sub = UnifiedGraph(
+            scan_id=self.scan_id,
+            tenant_id=self.tenant_id,
+            created_at=self.created_at,
+            analysis_status=dict(self.analysis_status),
+        )
         if edge_filter and not node_filter:
             matching_edges = [e for e in self.edges if edge_filter(e)]
             referenced_ids = set()

--- a/tests/test_attack_path_fusion.py
+++ b/tests/test_attack_path_fusion.py
@@ -100,6 +100,17 @@ def test_kill_chain_produces_one_ranked_fused_path():
     assert path.summary.startswith("Internet-exposed public-ec2")
 
 
+def test_complete_fusion_records_snapshot_analysis_status():
+    g = _kill_chain_graph()
+
+    stats = apply_attack_path_fusion(g)
+
+    assert stats["analysis_status"]["status"] == "complete"
+    assert stats["analysis_status"]["reason_codes"] == []
+    assert stats["analysis_status"]["observed"]["result_count"] == 1
+    assert g.analysis_status["attack_path_fusion"].status.value == "complete"
+
+
 def test_benign_graph_produces_no_fused_paths():
     assert compute_fused_attack_paths(_benign_graph()) == []
 
@@ -195,6 +206,23 @@ def test_returned_path_count_is_capped():
     assert len(paths) == _MAX_PATHS
 
 
+def test_path_cap_records_limited_snapshot_analysis_status():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    for i in range(_MAX_PATHS + 20):
+        eid = f"entry{i}"
+        did = f"data_store:{i}"
+        g.add_node(UnifiedNode(id=eid, entity_type=EntityType.CLOUD_RESOURCE, label=f"e{i}", attributes={"internet_exposed": True}))
+        g.add_node(UnifiedNode(id=did, entity_type=EntityType.DATA_STORE, label=f"d{i}", attributes={"data_sensitivity": "sensitive"}))
+        g.add_edge(UnifiedEdge(source=eid, target=did, relationship=RelationshipType.STORES))
+
+    stats = apply_attack_path_fusion(g)
+
+    assert stats["analysis_status"]["status"] == "limited"
+    assert "path_cap_reached" in stats["analysis_status"]["reason_codes"]
+    assert stats["analysis_status"]["observed"]["candidate_path_count"] == _MAX_PATHS + 20
+    assert len(g.attack_paths) == _MAX_PATHS
+
+
 def test_apply_materialises_and_is_idempotent():
     g = _kill_chain_graph()
     stats = apply_attack_path_fusion(g)
@@ -274,3 +302,6 @@ def test_oversized_graph_surfaces_skipped_signal():
     assert stats["fused_attack_paths"] == 0
     assert stats["skipped"] is True
     assert "node_cap_exceeded" in stats["skipped_reason"]
+    assert stats["analysis_status"]["status"] == "skipped"
+    assert stats["analysis_status"]["reason_codes"] == ["node_cap_exceeded"]
+    assert g.analysis_status["attack_path_fusion"].status.value == "skipped"

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -34,6 +34,7 @@ from agent_bom.graph import (
     UnifiedGraph,
     UnifiedNode,
 )
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 
 
 def _build_persisted_graph(db, scan_id="test-scan-001"):
@@ -1272,6 +1273,7 @@ class _RecordingGraphStore:
         edges,
         attack_paths=(),
         interaction_risks=(),
+        analysis_status=None,
         created_at: str = "",
     ) -> dict:
         graph = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id, created_at=created_at)
@@ -1281,6 +1283,7 @@ class _RecordingGraphStore:
             graph.add_edge(edge)
         graph.attack_paths.extend(attack_paths)
         graph.interaction_risks.extend(interaction_risks)
+        graph.analysis_status.update(analysis_status or {})
         self.calls.append(("save_graph_streaming", scan_id, tenant_id))
         self.graph = graph
         return {"nodes": len(graph.nodes), "edges": len(graph.edges)}
@@ -1653,10 +1656,14 @@ class TestGraphStoreBackendSelection:
         attack_path_item = schema["paths"]["/v1/graph/attack-paths"]["get"]["responses"]["200"]["content"]["application/json"]["schema"][
             "properties"
         ]["attack_paths"]["items"]
+        analysis_schema = schema["paths"]["/v1/graph/attack-paths"]["get"]["responses"]["200"]["content"]["application/json"]["schema"][
+            "properties"
+        ]["stats"]["properties"]["analysis_status"]["additionalProperties"]
 
         assert fix_first_card["properties"]["exposure_path"]["required"][:5] == ["id", "label", "summary", "riskScore", "severity"]
         assert "affectedAgents" in attack_path_item["properties"]["exposure_path"]["properties"]
         assert "exposedCredentials" in attack_path_item["properties"]["exposure_path"]["properties"]
+        assert analysis_schema["properties"]["status"]["enum"] == ["complete", "limited", "skipped", "failed", "not_recorded"]
 
     def test_graph_routes_use_pluggable_store(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-1"))
@@ -1671,10 +1678,18 @@ class TestGraphStoreBackendSelection:
                 tool_exposure=["run_shell"],
             )
         )
+        recording_graph_store.graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
+            status=GraphAnalysisState.LIMITED,
+            reason_codes=("path_cap_reached",),
+            limits={"max_paths": 50},
+            observed={"candidate_path_count": 80, "result_count": 50},
+        )
         client = TestClient(app)
 
         response = client.get("/v1/graph")
+        attack_path_response = client.get("/v1/graph/attack-paths")
         assert response.status_code == 200
+        assert attack_path_response.status_code == 200
         body = response.json()
         assert body["scan_id"] == "store-scan"
         assert body["attack_paths"][0]["summary"] == "agent-a reaches CVE-2026-1"
@@ -1682,6 +1697,8 @@ class TestGraphStoreBackendSelection:
         assert body["attack_paths"][0]["exposure_path"]["source"]["id"] == "agent:a"
         assert body["attack_paths"][0]["exposure_path"]["target"]["id"] == "vuln:cve"
         assert body["attack_paths"][0]["exposure_path"]["severity"] == "high"
+        assert body["stats"]["analysis_status"]["attack_path_fusion"]["status"] == "limited"
+        assert attack_path_response.json()["stats"]["analysis_status"]["attack_path_fusion"]["status"] == "limited"
         assert any(call[0] == "latest_snapshot_id" for call in recording_graph_store.calls)
         assert any(call[0] == "page_nodes" for call in recording_graph_store.calls)
 
@@ -1778,7 +1795,9 @@ class TestGraphStoreBackendSelection:
 
     def test_fix_first_graph_view_derives_paths_when_snapshot_has_topology_but_no_path_rows(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
-        recording_graph_store.graph.add_node(UnifiedNode(id="pkg:npm:form-data", entity_type=EntityType.PACKAGE, label="form-data"))
+        recording_graph_store.graph.add_node(
+            UnifiedNode(id="pkg:npm:form-data", entity_type=EntityType.PACKAGE, label="form-data")
+        )
         recording_graph_store.graph.add_node(UnifiedNode(id="cred:aws", entity_type=EntityType.CREDENTIAL, label="AWS_SECRET_ACCESS_KEY"))
         recording_graph_store.graph.add_node(UnifiedNode(id="tool:shell", entity_type=EntityType.TOOL, label="run_shell"))
         recording_graph_store.graph.add_node(
@@ -2553,9 +2572,7 @@ class TestGraphStoreBackendSelection:
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
         recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
         recording_graph_store.graph.add_node(UnifiedNode(id="server:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
-        recording_graph_store.graph.add_node(
-            UnifiedNode(id="pkg:npm:form-data", entity_type=EntityType.PACKAGE, label="form-data")
-        )
+        recording_graph_store.graph.add_node(UnifiedNode(id="pkg:npm:form-data", entity_type=EntityType.PACKAGE, label="form-data"))
         recording_graph_store.graph.add_node(
             UnifiedNode(
                 id="vuln:cve",

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -1545,3 +1545,19 @@ class TestEdgeEvidenceMerge:
         assert kept.evidence.get("data_source") == "package-path"
         # Conflict on existing key: kept side wins (no overwrite).
         assert kept.evidence.get("is_direct") is True
+
+
+def test_attack_path_analysis_failure_is_recorded_without_exception_text(monkeypatch):
+    import agent_bom.graph.attack_path_fusion as fusion
+
+    def fail(_graph):
+        raise RuntimeError("secret-bearing analyzer detail")
+
+    monkeypatch.setattr(fusion, "apply_attack_path_fusion", fail)
+
+    g = build_unified_graph_from_report({"agents": []}, scan_id="failed-analysis", tenant_id="tenant-a")
+
+    status = g.analysis_status["attack_path_fusion"].to_dict()
+    assert status["status"] == "failed"
+    assert status["reason_codes"] == ["analysis_error"]
+    assert "secret-bearing" not in str(status)

--- a/tests/test_graph_store_streamed_persistence.py
+++ b/tests/test_graph_store_streamed_persistence.py
@@ -19,7 +19,10 @@ import subprocess
 import sys
 import textwrap
 
+import pytest
+
 from agent_bom.db import graph_store as gs
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.container import AttackPath, InteractionRisk, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
@@ -39,6 +42,12 @@ def _sample_graph(scan_id: str) -> UnifiedGraph:
         AttackPath(source="agent:a", target="vuln:v", hops=["agent:a", "server:s", "pkg:p", "vuln:v"], composite_risk=8.5)
     )
     g.interaction_risks.append(InteractionRisk(pattern="shared-cred", agents=["agent:a"], risk_score=7.0, description="x"))
+    g.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
+        status=GraphAnalysisState.LIMITED,
+        reason_codes=("path_cap_reached",),
+        limits={"max_paths": 50},
+        observed={"candidate_path_count": 72, "result_count": 50},
+    )
     return g
 
 
@@ -52,7 +61,8 @@ def _snapshot_rows(conn, scan_id: str, tenant_id: str) -> dict[str, list]:
         "attack_paths": rows("SELECT * FROM attack_paths WHERE tenant_id=? AND scan_id=? ORDER BY source_node,target_node"),
         "interaction_risks": rows("SELECT * FROM interaction_risks WHERE tenant_id=? AND scan_id=? ORDER BY pattern"),
         "snapshot": rows(
-            "SELECT node_count, edge_count, risk_summary, node_type_counts FROM graph_snapshots WHERE tenant_id=? AND scan_id=?"
+            "SELECT node_count, edge_count, risk_summary, node_type_counts, analysis_status "
+            "FROM graph_snapshots WHERE tenant_id=? AND scan_id=?"
         ),
     }
 
@@ -78,6 +88,7 @@ def test_streaming_persist_matches_save_graph(tmp_path) -> None:
             edges=iter(streamed.edges),
             attack_paths=iter(streamed.attack_paths),
             interaction_risks=iter(streamed.interaction_risks),
+            analysis_status=streamed.analysis_status,
         )
         rows_b = _snapshot_rows(conn, "s1", "acme")
 
@@ -144,6 +155,83 @@ def test_streaming_load_iterators_match_load_graph(tmp_path) -> None:
     assert sorted((e.source, e.target, e.relationship.value) for e in streamed_edges) == sorted(
         (e.source, e.target, e.relationship.value) for e in full.edges
     )
+    assert full.analysis_status["attack_path_fusion"].status is GraphAnalysisState.LIMITED
+    assert full.analysis_status["attack_path_fusion"].reason_codes == ("path_cap_reached",)
+
+
+def test_analysis_status_is_tenant_isolated(tmp_path) -> None:
+    db = tmp_path / "tenant-status.db"
+    with gs.open_graph_db(db) as conn:
+        for tenant, state in (
+            ("tenant-a", GraphAnalysisState.COMPLETE),
+            ("tenant-b", GraphAnalysisState.SKIPPED),
+        ):
+            graph = UnifiedGraph(scan_id="shared-scan", tenant_id=tenant)
+            graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
+                status=state,
+                reason_codes=("node_cap_exceeded",) if state is GraphAnalysisState.SKIPPED else (),
+            )
+            gs.save_graph(conn, graph)
+
+        tenant_a = gs.load_graph(conn, tenant_id="tenant-a", scan_id="shared-scan")
+        tenant_b = gs.load_graph(conn, tenant_id="tenant-b", scan_id="shared-scan")
+
+    assert tenant_a.analysis_status["attack_path_fusion"].status is GraphAnalysisState.COMPLETE
+    assert tenant_b.analysis_status["attack_path_fusion"].status is GraphAnalysisState.SKIPPED
+
+
+def test_legacy_snapshot_analysis_status_is_not_recorded(tmp_path) -> None:
+    from agent_bom.api.graph_store import SQLiteGraphStore
+
+    db = tmp_path / "legacy-status.db"
+    with gs.open_graph_db(db) as conn:
+        graph = _sample_graph("legacy-scan")
+        gs.save_graph(conn, graph)
+        conn.execute(
+            "UPDATE graph_snapshots SET analysis_status = '{}' WHERE tenant_id = ? AND scan_id = ?",
+            ("acme", "legacy-scan"),
+        )
+        conn.commit()
+
+        loaded = gs.load_graph(conn, tenant_id="acme", scan_id="legacy-scan")
+
+    status = loaded.analysis_status["attack_path_fusion"]
+    assert status.status is GraphAnalysisState.NOT_RECORDED
+    assert status.reason_codes == ("legacy_snapshot",)
+    api_status = SQLiteGraphStore(db).snapshot_stats(tenant_id="acme", scan_id="legacy-scan")
+    assert api_status["analysis_status"]["attack_path_fusion"]["status"] == "not_recorded"
+
+
+def test_analysis_status_retry_rollback_preserves_prior_snapshot(tmp_path) -> None:
+    db = tmp_path / "status-rollback.db"
+    with gs.open_graph_db(db) as conn:
+        original = _sample_graph("retry-scan")
+        original.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(status=GraphAnalysisState.COMPLETE)
+        gs.save_graph(conn, original)
+
+        def failing_nodes():
+            yield UnifiedNode(id="replacement", entity_type=EntityType.AGENT, label="replacement")
+            raise RuntimeError("producer failed after flush")
+
+        with pytest.raises(RuntimeError, match="producer failed after flush"):
+            gs.save_graph_streaming(
+                conn,
+                scan_id="retry-scan",
+                tenant_id="acme",
+                nodes=failing_nodes(),
+                edges=(),
+                analysis_status={
+                    "attack_path_fusion": GraphAnalysisStatus(
+                        status=GraphAnalysisState.FAILED,
+                        reason_codes=("analysis_error",),
+                    )
+                },
+            )
+        conn.rollback()
+        loaded = gs.load_graph(conn, tenant_id="acme", scan_id="retry-scan")
+
+    assert "replacement" not in loaded.nodes
+    assert loaded.analysis_status["attack_path_fusion"].status is GraphAnalysisState.COMPLETE
 
 
 def test_streaming_snapshot_stats_are_golden_and_match_unified_graph_stats(tmp_path) -> None:
@@ -370,12 +458,8 @@ def test_sqlite_stream_retry_rolls_back_after_flushed_batch(tmp_path, monkeypatc
 
     with sqlite3.connect(db) as conn:
         graph_ids = {row[0] for row in conn.execute("SELECT id FROM graph_nodes WHERE tenant_id='acme' AND scan_id='retry'")}
-        search_ids = {
-            row[0] for row in conn.execute("SELECT node_id FROM graph_node_search WHERE tenant_id='acme' AND scan_id='retry'")
-        }
-        count = conn.execute(
-            "SELECT node_count FROM graph_snapshots WHERE tenant_id='acme' AND scan_id='retry'"
-        ).fetchone()[0]
+        search_ids = {row[0] for row in conn.execute("SELECT node_id FROM graph_node_search WHERE tenant_id='acme' AND scan_id='retry'")}
+        count = conn.execute("SELECT node_count FROM graph_snapshots WHERE tenant_id='acme' AND scan_id='retry'").fetchone()[0]
     assert graph_ids == search_ids == {"original"}
     assert count == 1
 

--- a/tests/test_neptune_graph_store.py
+++ b/tests/test_neptune_graph_store.py
@@ -7,6 +7,7 @@ import pytest
 from agent_bom.api import stores as api_stores
 from agent_bom.api.neptune_graph import NeptuneGraphConfig, NeptuneGraphStore, NeptuneGraphStoreConfigError
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 
 
 class FakeGremlinClient:
@@ -57,6 +58,12 @@ def test_neptune_graph_store_writes_graph_with_tenant_scan_bindings() -> None:
     graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="Agent A"))
     graph.add_node(UnifiedNode(id="server:a", entity_type=EntityType.SERVER, label="Server A"))
     graph.add_edge(UnifiedEdge(source="agent:a", target="server:a", relationship=RelationshipType.USES))
+    graph.analysis_status["attack_path_fusion"] = GraphAnalysisStatus(
+        status=GraphAnalysisState.SKIPPED,
+        reason_codes=("node_cap_exceeded",),
+        limits={"max_nodes": 5000},
+        observed={"node_count": 5001},
+    )
 
     store.save_graph(graph)
 
@@ -71,6 +78,7 @@ def test_neptune_graph_store_writes_graph_with_tenant_scan_bindings() -> None:
     assert edge_call["target_key"] == "tenant-a|scan-1|server:a"
     assert snapshot_call["node_count"] == 2
     assert snapshot_call["edge_count"] == 1
+    assert json.loads(snapshot_call["analysis_status_json"])["attack_path_fusion"]["status"] == "skipped"
 
 
 def test_neptune_graph_store_reads_snapshots_graph_and_active_edges() -> None:
@@ -90,6 +98,18 @@ def test_neptune_graph_store_reads_snapshots_graph_and_active_edges() -> None:
             "node_count": [1],
             "edge_count": [1],
             "risk_summary_json": ['{"severity_counts": {}}'],
+            "analysis_status_json": [
+                json.dumps(
+                    {
+                        "attack_path_fusion": {
+                            "status": "limited",
+                            "reason_codes": ["path_cap_reached"],
+                            "limits": {"max_paths": 50},
+                            "observed": {"candidate_path_count": 75, "result_count": 50},
+                        }
+                    }
+                )
+            ],
         }
     ]
     client.nodes = [_node_record(node), _node_record(UnifiedNode(id="server:a", entity_type=EntityType.SERVER, label="Server A"))]
@@ -103,6 +123,9 @@ def test_neptune_graph_store_reads_snapshots_graph_and_active_edges() -> None:
     assert sorted(graph.nodes) == ["agent:a", "server:a"]
     assert [(item.source, item.target, item.relationship) for item in graph.edges] == [("agent:a", "server:a", RelationshipType.USES)]
     assert active_edges[0]["valid_from"] == "2026-05-14T00:00:00Z"
+    status = graph.analysis_status["attack_path_fusion"]
+    assert status.status is GraphAnalysisState.LIMITED
+    assert status.reason_codes == ("path_cap_reached",)
 
 
 def test_neptune_backend_selection_is_explicit_and_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -11,6 +11,7 @@ connection (no live Postgres required).
 
 from __future__ import annotations
 
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.types import EntityType, NodeStatus
 
@@ -145,16 +146,35 @@ def test_streaming_snapshot_tally_matches_nodes(monkeypatch):
     conn = _RecordingConn()
     store = _make_store(conn, monkeypatch)
 
-    store.save_graph_streaming(scan_id="scan-2", tenant_id="t1", nodes=_nodes(4), edges=iter(()))
+    store.save_graph_streaming(
+        scan_id="scan-2",
+        tenant_id="t1",
+        nodes=_nodes(4),
+        edges=iter(()),
+        analysis_status={
+            "attack_path_fusion": GraphAnalysisStatus(
+                status=GraphAnalysisState.SKIPPED,
+                reason_codes=("node_cap_exceeded",),
+                limits={"max_nodes": 5000},
+                observed={"node_count": 5001},
+            )
+        },
+    )
 
-    # graph_snapshots row: (scan, tenant, now, node_count, edge_count, risk_summary)
+    # graph_snapshots row: counts plus serialized analysis execution state.
     assert conn.snapshot_params is not None
-    scan, tenant, _now, node_count, edge_count, risk_summary = conn.snapshot_params
+    scan, tenant, _now, node_count, edge_count, risk_summary, analysis_status = conn.snapshot_params
     assert (scan, tenant, node_count, edge_count) == ("scan-2", "t1", 4, 0)
     import json
 
     # Two of four nodes carry "critical" severity (odd indices).
     assert json.loads(risk_summary) == {"critical": 2}
+    assert json.loads(analysis_status)["attack_path_fusion"] == {
+        "status": "skipped",
+        "reason_codes": ["node_cap_exceeded"],
+        "limits": {"max_nodes": 5000},
+        "observed": {"node_count": 5001},
+    }
     assert conn.committed == 1
 
 
@@ -195,6 +215,7 @@ def test_streaming_serializes_and_replaces_same_snapshot(monkeypatch):
 
 def test_same_scan_retry_does_not_checkout_nested_connection(monkeypatch):
     """A one-connection pool must not deadlock while resolving prior history."""
+
     class _RetryConn(_RecordingConn):
         def execute(self, sql, params=None):
             low = " ".join(sql.strip().lower().split())

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -12,6 +12,7 @@ VERSIONS_DIR = ALEMBIC_DIR / "versions"
 BASELINE = VERSIONS_DIR / "20260416_01_control_plane_baseline.py"
 GRAPH_HOT_PATH_INDEXES = VERSIONS_DIR / "20260513_01_graph_hot_path_indexes.py"
 POSTGRES_STORE_PARITY = VERSIONS_DIR / "20260717_01_postgres_store_parity.py"
+GRAPH_ANALYSIS_STATUS = VERSIONS_DIR / "20260717_02_graph_analysis_status.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
 
 
@@ -79,3 +80,10 @@ def test_postgres_store_parity_migration_is_idempotent_and_chained():
     assert "ALTER TABLE %s DROP CONSTRAINT %I" in sql
     assert "n.nspname = current_schema()" not in sql
     assert "ALTER TABLE IF EXISTS cloud_connections ADD COLUMN IF NOT EXISTS last_scan_id" in sql
+
+
+def test_graph_analysis_status_migration_is_idempotent_and_chained():
+    sql = GRAPH_ANALYSIS_STATUS.read_text()
+    assert re.search(r'revision\s*=\s*"20260717_02"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260717_01"', sql)
+    assert "ADD COLUMN IF NOT EXISTS analysis_status JSONB NOT NULL" in sql

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -141,6 +141,11 @@ def test_graph_tables_have_rls_policies():
         assert f"CREATE POLICY {table}_tenant_isolation ON {table}" in SQL
 
 
+def test_graph_snapshot_analysis_status_is_in_baseline():
+    assert "analysis_status" in _columns_for("graph_snapshots")
+    assert "analysis_status JSONB NOT NULL DEFAULT '{}'::jsonb" in SQL
+
+
 def test_graph_edges_has_versioning_columns():
     """graph_edges baseline must define the schema-v3 versioning + provenance
     columns. Regression: these were only created by the app bootstrap in

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -18,6 +18,7 @@ import { AlertTriangle, Layers, Loader2, Radar, Route, ShieldAlert } from "lucid
 
 import { AttackPathCard } from "@/components/attack-path-card";
 import { GraphEvaluationSummary } from "@/components/graph-evaluation-summary";
+import { GraphAnalysisStatusBanner } from "@/components/graph-analysis-status";
 import {
   GraphEvidenceExportButton,
   FullscreenButton,
@@ -409,6 +410,7 @@ function emptyGraphResponse(scanId: string): UnifiedGraphResponse {
       interaction_risk_count: 0,
       max_attack_path_risk: 0,
       highest_interaction_risk: 0,
+      analysis_status: {},
     },
     pagination: {
       total: 0,
@@ -2267,6 +2269,10 @@ function GraphPageInner() {
           </div>
 
           <div className="flex flex-wrap items-center gap-2 xl:justify-end">
+            <GraphAnalysisStatusBanner
+              status={graphData?.stats.analysis_status?.attack_path_fusion}
+              compact
+            />
             {flow.summary && (
               <>
                 <MetricCard value={flow.summary.agents} label="agents" />

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -27,6 +27,7 @@ import { DeployGatePanel } from "@/components/deploy-gate-panel";
 import { ExposurePathLens } from "@/components/exposure-path-lens";
 import { Collapsible } from "@/components/collapsible";
 import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
+import { GraphAnalysisStatusBanner, graphAnalysisStatusCopy } from "@/components/graph-analysis-status";
 import {
   api,
   formatDate,
@@ -326,6 +327,30 @@ function SecurityGraphPageContent() {
   );
 
   const emptyGraphState = useMemo(() => {
+    const analysis = graphData?.stats.analysis_status?.attack_path_fusion;
+    const executionCopy = graphAnalysisStatusCopy(analysis);
+    if (analysis?.status === "skipped" || analysis?.status === "failed") {
+      return {
+        title: executionCopy.label,
+        detail: executionCopy.detail,
+        suggestions: [
+          "Run a fresh scan after reviewing the recorded analysis limit or failure.",
+          "Open the full graph to inspect the inventory and findings that did persist.",
+          "Do not treat this snapshot as proof that no attack paths exist.",
+        ],
+      };
+    }
+    if (analysis?.status === "limited") {
+      return {
+        title: "No paths in the retained partial result",
+        detail: executionCopy.detail,
+        suggestions: [
+          "Review the recorded execution limits before relying on this result.",
+          "Open the full graph to inspect topology outside the retained path set.",
+          "Run a narrower or higher-capacity scan for complete path coverage.",
+        ],
+      };
+    }
     if (hasFocusContext) {
       return {
         title: "No attack paths matched the current focus",
@@ -348,7 +373,7 @@ function SecurityGraphPageContent() {
         "Check the vulnerabilities page if you need fix context before the next scan completes.",
       ],
     };
-  }, [focusLabel, hasFocusContext]);
+  }, [focusLabel, graphData?.stats.analysis_status, hasFocusContext]);
 
   const graphErrorState = useMemo(() => {
     const detail = graphLoadError ?? "The graph API did not return attack-path data for this snapshot.";
@@ -642,6 +667,9 @@ function SecurityGraphPageContent() {
         </section>
       ) : attackPaths.length === 0 ? (
         <section className="rounded-3xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
+          <div className="mb-4">
+            <GraphAnalysisStatusBanner status={graphData?.stats.analysis_status?.attack_path_fusion} />
+          </div>
           <GraphEmptyState
             title={emptyGraphState.title}
             detail={emptyGraphState.detail}

--- a/ui/components/graph-analysis-status.tsx
+++ b/ui/components/graph-analysis-status.tsx
@@ -1,0 +1,102 @@
+import { AlertTriangle, CheckCircle2, CircleHelp, Gauge, XCircle } from "lucide-react";
+
+import type { GraphAnalysisStatus } from "@/lib/graph-schema";
+import { tonedChipClass } from "@/lib/toned-chip";
+
+const REASON_LABELS: Readonly<Record<string, string>> = {
+  node_cap_exceeded: "estate exceeded the analysis node cap",
+  entry_cap_reached: "entry-point evaluation was capped",
+  visit_cap_reached: "path traversal visit budget was reached",
+  depth_cap_reached: "path traversal depth was capped",
+  path_cap_reached: "additional candidate paths were omitted",
+  analysis_error: "analysis failed before completion",
+  legacy_snapshot: "this snapshot predates execution-status tracking",
+};
+
+export function graphAnalysisStatusCopy(status: GraphAnalysisStatus | undefined): {
+  label: string;
+  detail: string;
+  tone: "ok" | "warn" | "danger" | "neutral";
+} {
+  if (!status || status.status === "not_recorded") {
+    return {
+      label: "Analysis status unavailable",
+      detail: "This snapshot does not prove whether attack-path analysis completed. Run a fresh scan for a verified result.",
+      tone: "neutral",
+    };
+  }
+  if (status.status === "complete") {
+    return {
+      label: "Attack-path analysis complete",
+      detail: "The persisted snapshot records a complete attack-path analysis run.",
+      tone: "ok",
+    };
+  }
+  const reasons = status.reason_codes.map((code) => REASON_LABELS[code] ?? code.replaceAll("_", " ")).join("; ");
+  if (status.status === "limited") {
+    return {
+      label: "Attack-path analysis limited",
+      detail: `Results are partial: ${reasons || "an execution limit was reached"}.`,
+      tone: "warn",
+    };
+  }
+  if (status.status === "skipped") {
+    return {
+      label: "Attack-path analysis skipped",
+      detail: `No complete result is available: ${reasons || "analysis did not run"}.`,
+      tone: "danger",
+    };
+  }
+  return {
+    label: "Attack-path analysis failed",
+    detail: `The snapshot was preserved, but attack-path analysis did not complete: ${reasons || "analysis error"}.`,
+    tone: "danger",
+  };
+}
+
+export function GraphAnalysisStatusBanner({
+  status,
+  compact = false,
+}: {
+  status?: GraphAnalysisStatus | undefined;
+  compact?: boolean;
+}) {
+  const copy = graphAnalysisStatusCopy(status);
+  const Icon =
+    status?.status === "complete"
+      ? CheckCircle2
+      : status?.status === "limited"
+        ? Gauge
+        : status?.status === "failed"
+          ? XCircle
+          : status?.status === "skipped"
+            ? AlertTriangle
+            : CircleHelp;
+
+  if (compact) {
+    return (
+      <span
+        data-testid="graph-analysis-status"
+        className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-xs ${tonedChipClass(copy.tone)}`}
+        title={copy.detail}
+      >
+        <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+        {copy.label}
+      </span>
+    );
+  }
+
+  return (
+    <div
+      data-testid="graph-analysis-status"
+      className={`flex items-start gap-3 rounded-2xl border p-3 ${tonedChipClass(copy.tone)}`}
+      role={copy.tone === "danger" ? "alert" : "status"}
+    >
+      <Icon className="mt-0.5 h-4 w-4 shrink-0" aria-hidden="true" />
+      <div>
+        <p className="text-xs font-semibold">{copy.label}</p>
+        <p className="mt-1 text-xs opacity-90">{copy.detail}</p>
+      </div>
+    </div>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -116,6 +116,7 @@ export interface GraphSnapshot {
   node_count: number;
   edge_count: number;
   risk_summary: Record<string, number>;
+  analysis_status?: import("./graph-schema").GraphStats["analysis_status"] | undefined;
 }
 
 export interface GraphAttackPath extends AttackPath {

--- a/ui/lib/graph-schema.ts
+++ b/ui/lib/graph-schema.ts
@@ -384,6 +384,20 @@ export interface InteractionRisk {
   owasp_agentic_tag?: string;
 }
 
+export type GraphAnalysisState =
+  | "complete"
+  | "limited"
+  | "skipped"
+  | "failed"
+  | "not_recorded";
+
+export interface GraphAnalysisStatus {
+  status: GraphAnalysisState;
+  reason_codes: string[];
+  limits: Record<string, number>;
+  observed: Record<string, number>;
+}
+
 export interface GraphStats {
   total_nodes: number;
   total_edges: number;
@@ -394,6 +408,7 @@ export interface GraphStats {
   interaction_risk_count: number;
   max_attack_path_risk: number;
   highest_interaction_risk: number;
+  analysis_status?: Record<string, GraphAnalysisStatus>;
 }
 
 export interface UnifiedGraphData {

--- a/ui/tests/graph-analysis-status.test.tsx
+++ b/ui/tests/graph-analysis-status.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GraphAnalysisStatusBanner, graphAnalysisStatusCopy } from "@/components/graph-analysis-status";
+
+describe("GraphAnalysisStatusBanner", () => {
+  it("does not present a skipped large-estate analysis as no paths", () => {
+    const status = {
+      status: "skipped" as const,
+      reason_codes: ["node_cap_exceeded"],
+      limits: { max_nodes: 5000 },
+      observed: { node_count: 5001 },
+    };
+
+    const { container } = render(<GraphAnalysisStatusBanner status={status} />);
+
+    expect(screen.getByRole("alert")).toHaveTextContent("Attack-path analysis skipped");
+    expect(screen.getByText(/estate exceeded the analysis node cap/)).toBeInTheDocument();
+    expect(graphAnalysisStatusCopy(status).detail).not.toMatch(/no attack paths/i);
+    expect(container.firstElementChild).toHaveClass("text-red-700", "dark:text-red-200");
+  });
+
+  it("marks capped results as partial", () => {
+    render(
+      <GraphAnalysisStatusBanner
+        status={{
+          status: "limited",
+          reason_codes: ["path_cap_reached"],
+          limits: { max_paths: 50 },
+          observed: { candidate_path_count: 80, result_count: 50 },
+        }}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Results are partial");
+  });
+
+  it("labels legacy snapshots as unverified", () => {
+    render(<GraphAnalysisStatusBanner />);
+    expect(screen.getByText("Analysis status unavailable")).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

- persist typed complete, limited, skipped, failed, or legacy-not-recorded attack-path analysis state across SQLite, PostgreSQL, Neptune, streamed writes, snapshot lists, and graph responses
- record deterministic node, entry, visit, depth, and path limits so capped analysis cannot be presented as an empty clean result
- surface incomplete analysis honestly in Security Graph and the full graph view, including actionable large-estate guidance
- add tenant-isolation, legacy-row, rollback, API-contract, failure-redaction, and backend round-trip regressions

## Verification

- uv run pytest -q tests/test_attack_path_fusion.py tests/test_graph_builder.py tests/test_graph_store_streamed_persistence.py tests/test_postgres_graph_streaming.py tests/test_graph_api.py tests/test_postgres_migrations.py tests/test_postgres_schema.py tests/test_neptune_graph_store.py — 225 passed
- uv run ruff check on all changed Python source and test files
- uv run mypy on all changed Python source files — clean
- make preflight — passed
- UI toolchain contract — Node 24.18.0, npm 10.9.7
- UI Vitest — 135 files, 742 tests passed
- UI TypeScript and ESLint — clean
- UI production build — 48 static routes generated

## Notes

This makes the current 5,000-node fusion bound explicit and durable; it does not claim the analysis itself is yet sub-linear or raise that bound. Legacy snapshots are labeled unverified instead of being treated as complete.

Closes #4125
Addresses #4095