### PR TITLE
perf(compliance): bound and reconcile hub reads

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -9877,7 +9877,7 @@
         ]
       },
       "get": {
-        "description": "List compliance-hub findings for the current tenant.\n\nReturns the canonical finding-list envelope (#3666) shared with\n``/v1/findings`` so consumers learn one shape across every finding surface.\nIncludes durable external ingests plus native scan findings projected into\nthe same shape so the list endpoint matches `/hub/posture` totals.\n\nOrdering is ingest-order (``sort=\"ordinal\"``) so the list matches the way\nfindings were imported; pagination is ``limit`` / ``offset``. Keyset\npagination over the same durable hub store is available (keyset-safe sort)\nthrough ``/v1/findings?cursor=`` for scale reads.",
+        "description": "List compliance-hub findings for the current tenant.\n\nReturns the canonical finding-list envelope (#3666) shared with\n``/v1/findings`` so consumers learn one shape across every finding surface.\nIncludes durable external ingests plus native scan findings projected into\nthe same shape so the list endpoint matches `/hub/posture` totals.\n\nOrdering is ingest-order (``sort=\"ordinal\"``) so the list matches the way\nfindings were imported; pagination is ``limit`` / ``offset``. Keyset\npagination over the same durable hub store is available (keyset-safe sort)\nthrough ``/v1/findings?cursor=`` for scale reads.\n\nThe synchronous store read (page fetch + count) runs in a worker thread\nunder adaptive backpressure so a deep page against a large tenant cannot\nblock the event loop and starve ``/health`` (mirrors ``/v1/findings``);\nunder saturation it sheds with ``429 + Retry-After``.",
         "operationId": "list_hub_findings_v1_compliance_hub_findings_get",
         "parameters": [
           {
@@ -9981,7 +9981,7 @@
     },
     "/v1/compliance/hub/posture": {
       "get": {
-        "description": "Aggregate compliance posture across native scans + hub-ingested findings.\n\nReturns per-framework counts, severity breakdown, and source mix\n(native vs external) so the dashboard /compliance page can render a\nsingle posture story across every entry point.",
+        "description": "Aggregate compliance posture across native scans + hub-ingested findings.\n\nReturns per-framework counts, severity breakdown, and source mix\n(native vs external) so the dashboard /compliance page can render a\nsingle posture story across every entry point.\n\nThe synchronous store aggregates (severity GROUP BY, SQL-side framework\ncounts, tenant total) plus the native-job fold run in a worker thread under\nadaptive backpressure so this O(table) read cannot block the event loop and\nstarve ``/health`` (mirrors ``/v1/findings``); under saturation it sheds with\n``429 + Retry-After``.",
         "operationId": "get_hub_posture_v1_compliance_hub_posture_get",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6583,7 +6583,16 @@ paths:
 
         pagination over the same durable hub store is available (keyset-safe sort)
 
-        through ``/v1/findings?cursor=`` for scale reads.'
+        through ``/v1/findings?cursor=`` for scale reads.
+
+
+        The synchronous store read (page fetch + count) runs in a worker thread
+
+        under adaptive backpressure so a deep page against a large tenant cannot
+
+        block the event loop and starve ``/health`` (mirrors ``/v1/findings``);
+
+        under saturation it sheds with ``429 + Retry-After``.'
       operationId: list_hub_findings_v1_compliance_hub_findings_get
       parameters:
       - in: query
@@ -6652,7 +6661,18 @@ paths:
 
         (native vs external) so the dashboard /compliance page can render a
 
-        single posture story across every entry point.'
+        single posture story across every entry point.
+
+
+        The synchronous store aggregates (severity GROUP BY, SQL-side framework
+
+        counts, tenant total) plus the native-job fold run in a worker thread under
+
+        adaptive backpressure so this O(table) read cannot block the event loop and
+
+        starve ``/health`` (mirrors ``/v1/findings``); under saturation it sheds with
+
+        ``429 + Retry-After``.'
       operationId: get_hub_posture_v1_compliance_hub_posture_get
       parameters:
       - in: header

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -190,6 +190,20 @@ def _severity_breakdown_from_rows(rows: Iterable[dict[str, Any]]) -> dict[str, i
     return counts
 
 
+def _severity_breakdown_from_current_rows(rows: Iterable[dict[str, Any]]) -> dict[str, int]:
+    """Per-severity counts over current-state rows.
+
+    Resolves severity the same way :func:`_filter_current_rows` does (top-level
+    column first, then ``payload``) so the buckets match ``list_current_page``'s
+    ``severity=`` COUNT exactly.
+    """
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+    for row in rows:
+        sev = str(row.get("severity") or (row.get("payload") or {}).get("severity") or "unknown").lower()
+        counts[sev] = counts.get(sev, 0) + 1
+    return counts
+
+
 def _framework_slug_counts_from_rows(rows: Iterable[dict[str, Any]]) -> dict[str, int]:
     from agent_bom.compliance_coverage import normalize_framework_slug
 
@@ -277,6 +291,25 @@ class ComplianceHubStore(Protocol):
 
     def severity_breakdown(self, tenant_id: str) -> dict[str, int]:
         """Return per-severity counts for hub findings without loading payloads."""
+        ...
+
+    def current_severity_breakdown(
+        self,
+        tenant_id: str,
+        *,
+        origin: str | None = None,
+        since: str | None = None,
+    ) -> dict[str, int]:
+        """Per-severity counts over CURRENT-STATE rows matching the drill-down.
+
+        Mirrors :meth:`list_current_page`'s COUNT filters (tenant + ``origin``
+        + ``since`` read-window) so the exec headline reconciles EXACTLY with
+        ``/v1/findings`` — a click-through can never disagree with the headline.
+        Unlike :meth:`severity_breakdown` (which scans the append-only ledger,
+        all-origin and unbounded), this reads ``hub_findings_current`` so retired
+        / aged findings that linger in the ledger never inflate the exec numbers.
+        An indexed ``GROUP BY`` — no payload hydration.
+        """
         ...
 
     def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
@@ -839,6 +872,18 @@ class InMemoryComplianceHubStore:
         with self._lock:
             rows = list(self._by_tenant.get(tenant_id, []))
         return _severity_breakdown_from_rows(rows)
+
+    def current_severity_breakdown(
+        self,
+        tenant_id: str,
+        *,
+        origin: str | None = None,
+        since: str | None = None,
+    ) -> dict[str, int]:
+        with self._lock:
+            rows = list(self._current.get(tenant_id, {}).values())
+        rows = _filter_current_rows(rows, severity=None, scan_id=None, origin=origin, since=since)
+        return _severity_breakdown_from_current_rows(rows)
 
     def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
         with self._lock:
@@ -1608,23 +1653,71 @@ class SQLiteComplianceHubStore:
             counts[key] = counts.get(key, 0) + int(count)
         return counts
 
+    def current_severity_breakdown(
+        self,
+        tenant_id: str,
+        *,
+        origin: str | None = None,
+        since: str | None = None,
+    ) -> dict[str, int]:
+        # GROUP BY the materialised ``severity`` column on the current-state
+        # table, applying the SAME tenant/since/origin predicates
+        # ``list_current_page`` counts on, so the exec headline reconciles
+        # exactly with the ``/v1/findings`` drill-down (#3961/#4009).
+        where = ["tenant_id = ?"]
+        params: list[Any] = [tenant_id]
+        if since:
+            where.append("last_seen >= ?")
+            params.append(since)
+        if origin is not None:
+            where.append("origin = ?")
+            params.append(origin)
+        where_sql = " AND ".join(where)
+        rows = self._conn.execute(
+            f"""
+            SELECT LOWER(COALESCE(NULLIF(severity, ''), 'unknown')) AS sev, COUNT(*)
+            FROM hub_findings_current
+            WHERE {where_sql}
+            GROUP BY sev
+            """,  # nosec B608
+            params,
+        ).fetchall()
+        counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+        for sev, count in rows:
+            key = str(sev or "unknown").lower()
+            counts[key] = counts.get(key, 0) + int(count)
+        return counts
+
     def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
         from agent_bom.compliance_coverage import normalize_framework_slug
 
+        # Split + aggregate the denormalised CSV IN SQL via a recursive CTE so
+        # the query returns O(distinct slugs) rows, never the full tenant ledger
+        # pulled into Python (#3963). The handful of raw tokens are then folded
+        # to canonical slugs (alias/underscore normalisation) in Python.
         rows = self._conn.execute(
-            "SELECT applicable_frameworks_csv FROM compliance_hub_findings WHERE tenant_id = ?",
+            """
+            WITH RECURSIVE split(rest, token) AS (
+                SELECT applicable_frameworks_csv || ',', ''
+                  FROM compliance_hub_findings
+                 WHERE tenant_id = ? AND applicable_frameworks_csv <> ''
+                UNION ALL
+                SELECT substr(rest, instr(rest, ',') + 1),
+                       substr(rest, 1, instr(rest, ',') - 1)
+                  FROM split
+                 WHERE rest <> ''
+            )
+            SELECT TRIM(token) AS slug, COUNT(*) AS n
+              FROM split
+             WHERE TRIM(token) <> ''
+             GROUP BY TRIM(token)
+            """,
             (tenant_id,),
         ).fetchall()
         counts: dict[str, int] = {}
-        for (csv_value,) in rows:
-            if not csv_value:
-                continue
-            for slug in str(csv_value).split(","):
-                slug = slug.strip()
-                if not slug:
-                    continue
-                canonical = normalize_framework_slug(slug)
-                counts[canonical] = counts.get(canonical, 0) + 1
+        for slug, n in rows:
+            canonical = normalize_framework_slug(str(slug))
+            counts[canonical] = counts.get(canonical, 0) + int(n)
         return counts
 
     def count(self, tenant_id: str) -> int:

--- a/src/agent_bom/api/finding_cursor.py
+++ b/src/agent_bom/api/finding_cursor.py
@@ -51,6 +51,12 @@ def decode_finding_cursor(cursor: str, *, expected_sort: str) -> tuple[float, st
         sort = str(payload.get("sort") or "")
         if sort != expected_sort:
             raise ValueError("Cursor sort mismatch")
+        if sort == "ordinal":
+            # ``ordinal`` orders by ``ledger_ordinal, first_seen, canonical_id``
+            # but the cursor tuple carries ``last_seen`` — a keyset over it would
+            # filter by a key the ORDER BY never uses, dropping/duplicating rows.
+            # ``ordinal`` therefore paginates by OFFSET only; a cursor is invalid.
+            raise ValueError("ordinal sort does not support cursor pagination; use offset")
         return float(payload.get("primary") or 0.0), str(payload.get("last_seen") or ""), str(payload.get("canonical_id") or "")
     except Exception as exc:
         raise ValueError("Invalid findings cursor") from exc
@@ -59,8 +65,10 @@ def decode_finding_cursor(cursor: str, *, expected_sort: str) -> tuple[float, st
 def cursor_from_current_row(row: dict[str, Any], *, sort: str) -> str:
     normalized = sort if sort in _ALLOWED_SORTS else "effective_reach"
     if normalized == "ordinal":
-        primary = 0.0
-    elif normalized == "cvss":
+        # No keyset cursor is emitted for ordinal (see ``decode_finding_cursor``):
+        # its ORDER BY key is not in the cursor tuple. Callers page by OFFSET.
+        return ""
+    if normalized == "cvss":
         primary = cvss_sort_value(row.get("cvss_score"))
     elif normalized == "severity":
         primary = float(row.get("severity_rank") or 0.0)
@@ -83,12 +91,13 @@ def _cvss_keyset_expr() -> str:
 def sqlite_keyset_clause(sort: str, cursor: str) -> tuple[str, list[Any]]:
     """Return extra WHERE SQL + params for keyset pagination after ``cursor``."""
     normalized = sort if sort in _ALLOWED_SORTS else "effective_reach"
-    primary, last_seen, canonical_id = decode_finding_cursor(cursor, expected_sort=normalized)
     if normalized == "ordinal":
-        return (
-            " AND (last_seen > ? OR (last_seen = ? AND canonical_id > ?))",
-            [last_seen, last_seen, canonical_id],
-        )
+        # Guarded here as well as in ``decode_finding_cursor``: an ordinal keyset
+        # would have to filter on ``ledger_ordinal``/``first_seen`` (the ORDER BY
+        # key), which the cursor tuple does not carry. Reject rather than emit a
+        # predicate that dup/drops rows.
+        raise ValueError("ordinal sort does not support cursor pagination; use offset")
+    primary, last_seen, canonical_id = decode_finding_cursor(cursor, expected_sort=normalized)
     if normalized == "cvss":
         col = _cvss_keyset_expr()
     elif normalized == "severity":
@@ -119,7 +128,9 @@ def row_is_after_cursor(
     row_last = str(row.get("last_seen") or "")
     row_canonical = str(row.get("canonical_id") or "")
     if normalized == "ordinal":
-        return (row_last, row_canonical) > (last_seen, canonical_id)
+        # Ordinal has no keyset cursor (see ``decode_finding_cursor``); it pages
+        # by OFFSET. Reject rather than compare on the wrong (last_seen) key.
+        raise ValueError("ordinal sort does not support cursor pagination; use offset")
     if normalized == "cvss":
         row_primary = cvss_sort_value(row.get("cvss_score"))
     elif normalized == "severity":

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -836,24 +836,65 @@ class PostgresComplianceHubStore:
             counts[key] = counts.get(key, 0) + int(count)
         return counts
 
+    def current_severity_breakdown(
+        self,
+        tenant_id: str,
+        *,
+        origin: str | None = None,
+        since: str | None = None,
+    ) -> dict[str, int]:
+        # GROUP BY the materialised ``severity`` on the current-state table with
+        # the SAME tenant/since/origin predicates ``list_current_page`` counts on,
+        # so the exec headline reconciles exactly with the ``/v1/findings``
+        # drill-down and retired/aged ledger rows never inflate it (#3961/#4009).
+        where = ["tenant_id = %s"]
+        params: list[Any] = [tenant_id]
+        if since:
+            where.append("last_seen >= %s")
+            params.append(since)
+        if origin is not None:
+            where.append("origin = %s")
+            params.append(origin)
+        where_sql = " AND ".join(where)
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                f"""
+                SELECT LOWER(COALESCE(NULLIF(severity, ''), 'unknown')) AS sev, COUNT(*)
+                FROM hub_findings_current
+                WHERE {where_sql}
+                GROUP BY sev
+                """,  # nosec B608
+                tuple(params),
+            ).fetchall()
+        counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
+        for sev, count in rows:
+            key = str(sev or "unknown").lower()
+            counts[key] = counts.get(key, 0) + int(count)
+        return counts
+
     def framework_slug_counts(self, tenant_id: str) -> dict[str, int]:
         from agent_bom.compliance_coverage import normalize_framework_slug
 
+        # Unnest + aggregate the denormalised CSV IN SQL so the query returns
+        # O(distinct slugs) rows instead of pulling every ledger row into Python
+        # to count on the event loop (#3963). Raw tokens are folded to canonical
+        # slugs (alias/underscore normalisation) over the handful of results.
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
-                "SELECT applicable_frameworks_csv FROM compliance_hub_findings WHERE tenant_id = %s",
+                """
+                SELECT TRIM(token) AS slug, COUNT(*) AS n
+                FROM compliance_hub_findings,
+                     unnest(string_to_array(applicable_frameworks_csv, ',')) AS token
+                WHERE tenant_id = %s AND applicable_frameworks_csv <> ''
+                GROUP BY TRIM(token)
+                HAVING TRIM(token) <> ''
+                """,
                 (tenant_id,),
             ).fetchall()
         counts: dict[str, int] = {}
-        for (csv_value,) in rows:
-            if not csv_value:
-                continue
-            for slug in str(csv_value).split(","):
-                slug = slug.strip()
-                if not slug:
-                    continue
-                canonical = normalize_framework_slug(slug)
-                counts[canonical] = counts.get(canonical, 0) + 1
+        for slug, n in rows:
+            canonical = normalize_framework_slug(str(slug))
+            counts[canonical] = counts.get(canonical, 0) + int(n)
         return counts
 
     def count(self, tenant_id: str) -> int:

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -23,6 +23,7 @@ import secrets
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, cast
 
+import anyio.to_thread
 from fastapi import APIRouter, HTTPException, Request
 from fastapi.responses import JSONResponse, PlainTextResponse, StreamingResponse
 
@@ -36,6 +37,7 @@ from agent_bom.api.stores import (
     _get_store,
 )
 from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.security import sanitize_error, sanitize_text
@@ -2074,7 +2076,25 @@ async def list_hub_findings(request: Request, limit: int = 200, offset: int = 0)
     findings were imported; pagination is ``limit`` / ``offset``. Keyset
     pagination over the same durable hub store is available (keyset-safe sort)
     through ``/v1/findings?cursor=`` for scale reads.
+
+    The synchronous store read (page fetch + count) runs in a worker thread
+    under adaptive backpressure so a deep page against a large tenant cannot
+    block the event loop and starve ``/health`` (mirrors ``/v1/findings``);
+    under saturation it sheds with ``429 + Retry-After``.
     """
+    try:
+        async with adaptive_backpressure("compliance"):
+            return await anyio.to_thread.run_sync(_list_hub_findings_impl, request, limit, offset)
+    except BackpressureRejectedError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=exc.to_dict(),
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
+
+
+def _list_hub_findings_impl(request: Request, limit: int, offset: int) -> dict:
+    """Synchronous body of :func:`list_hub_findings` (runs in a worker thread)."""
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
     from agent_bom.api.finding_list_envelope import finding_list_envelope
 
@@ -2114,7 +2134,26 @@ async def get_hub_posture(request: Request) -> dict:
     Returns per-framework counts, severity breakdown, and source mix
     (native vs external) so the dashboard /compliance page can render a
     single posture story across every entry point.
+
+    The synchronous store aggregates (severity GROUP BY, SQL-side framework
+    counts, tenant total) plus the native-job fold run in a worker thread under
+    adaptive backpressure so this O(table) read cannot block the event loop and
+    starve ``/health`` (mirrors ``/v1/findings``); under saturation it sheds with
+    ``429 + Retry-After``.
     """
+    try:
+        async with adaptive_backpressure("compliance"):
+            return await anyio.to_thread.run_sync(_get_hub_posture_impl, request)
+    except BackpressureRejectedError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=exc.to_dict(),
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
+
+
+def _get_hub_posture_impl(request: Request) -> dict:
+    """Synchronous body of :func:`get_hub_posture` (runs in a worker thread)."""
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
     from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS, normalize_framework_slug
 

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -677,20 +677,25 @@ def _identity_snapshot(request: Request) -> dict[str, Any]:
 def _hub_severity_snapshot(request: Request) -> dict[str, int]:
     """Per-severity counts of hub-ingested findings (POST /v1/findings/bulk).
 
-    Reads the same compliance-hub ledger that powers /v1/compliance/hub/posture
-    via the store's indexed ``severity_breakdown`` (a GROUP BY / dict count, no
-    payload hydration) so bulk-ingested evidence contributes to the overview
-    posture + headline instead of being invisible until a scan runs. Tenant
-    scope is owned by the request; the store method is tenant-keyed. Degrades to
-    zeros if the hub store is unavailable so the overview never fails closed on
-    an optional dependency.
+    Reads the CURRENT-STATE table (``hub_findings_current``) with the SAME
+    origin + default read-window predicates that ``/v1/findings`` counts on, via
+    the store's indexed ``current_severity_breakdown`` (a GROUP BY, no payload
+    hydration). This is the exec-read honesty fix (#3961): the headline used to
+    read the append-only ledger (``severity_breakdown`` — all-origin, unbounded,
+    keeping resolved/aged rows forever), so it could exceed and contradict the
+    drill-down. Deriving from current-state within the window makes the headline
+    reconcile EXACTLY with a ``/v1/findings`` click-through.
+
+    Tenant scope is owned by the request; the store method is tenant-keyed.
+    Degrades to zeros if the hub store is unavailable so the overview never fails
+    closed on an optional dependency.
     """
     empty = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0, "unknown": 0}
     tenant_id = _tenant_id(request)
     # Memoise the O(rows) severity GROUP BY per tenant. This snapshot feeds BOTH
     # the cache fingerprint and the composed payload, so without this it ran the
-    # full-ledger scan on every /v1/overview request (~360ms at 1M). The cache is
-    # invalidated on every hub-ledger mutation (ingest / clear), so a hit is exact
+    # full scan on every /v1/overview request (~360ms at 1M). The cache is
+    # invalidated on every hub mutation (ingest / clear), so a hit is exact
     # and reconciles with the findings API by construction (wave-2 residual #3).
     from agent_bom.api import hub_overview_cache
 
@@ -698,13 +703,22 @@ def _hub_severity_snapshot(request: Request) -> dict[str, int]:
     if cached is not None:
         return cached
     try:
+        from agent_bom.api import time_window
         from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
         store = get_compliance_hub_store()
-        breakdown = getattr(store, "severity_breakdown", None)
-        if not callable(breakdown):
-            return empty
-        counts = breakdown(tenant_id) or {}
+        current_breakdown = getattr(store, "current_severity_breakdown", None)
+        if callable(current_breakdown):
+            # Same default read-window ``/v1/findings`` applies (window_days
+            # unset ⇒ server default ≈90d) and the same ``bulk_ingest`` origin
+            # scope, so the headline == the drill-down for the same window.
+            since = time_window.window_since_iso(time_window.normalize_window_days(None))
+            counts = current_breakdown(tenant_id, origin="bulk_ingest", since=since) or {}
+        else:
+            breakdown = getattr(store, "severity_breakdown", None)
+            if not callable(breakdown):
+                return empty
+            counts = breakdown(tenant_id) or {}
     except Exception:  # pragma: no cover - hub store optional
         _logger.debug("hub severity snapshot failed", exc_info=True)
         return empty

--- a/tests/test_api_surface_0943.py
+++ b/tests/test_api_surface_0943.py
@@ -15,18 +15,24 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
 
 import pytest
 from starlette.testclient import TestClient
 
+from agent_bom.api import compliance_hub_store as hub_store_mod
 from agent_bom.api.compliance_hub_store import (
     InMemoryComplianceHubStore,
+    get_compliance_hub_store,
     set_compliance_hub_store,
 )
+from agent_bom.api.findings_count_cache import cache_key, get_cached_total, reset_findings_count_cache
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.server import app
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import set_graph_store, set_job_store
+from agent_bom.api.time_window import normalize_window_days
 from agent_bom.backpressure import _controller_for, reset_backpressure_for_tests
 
 TENANT = "default"
@@ -65,14 +71,26 @@ def _seed_repeated_scans(store: InMemoryJobStore, *, scans: int, findings: list[
     return last_scan_id
 
 
+@contextmanager
+def _client_with_scans_context() -> Iterator[tuple[TestClient, str, int]]:
+    original_hub_store = hub_store_mod._HUB_STORE
+    reset_findings_count_cache()
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    try:
+        job_store = InMemoryJobStore()
+        set_job_store(job_store)
+        findings = _make_findings(106)
+        last_scan_id = _seed_repeated_scans(job_store, scans=6, findings=findings)
+        yield TestClient(app), last_scan_id, len(findings)
+    finally:
+        set_compliance_hub_store(original_hub_store)
+        reset_findings_count_cache()
+
+
 @pytest.fixture
 def client_with_scans():
-    job_store = InMemoryJobStore()
-    set_job_store(job_store)
-    set_compliance_hub_store(InMemoryComplianceHubStore())
-    findings = _make_findings(106)
-    last_scan_id = _seed_repeated_scans(job_store, scans=6, findings=findings)
-    yield TestClient(app), last_scan_id, len(findings)
+    with _client_with_scans_context() as client_state:
+        yield client_state
 
 
 # ── Fix 1: default findings view dedupes across re-scans ─────────────────────
@@ -102,6 +120,39 @@ def test_scan_id_filter_still_returns_that_scan(client_with_scans) -> None:
     assert body["total"] == unique
     assert body["count"] == unique
     assert body["scan_id"] == last_scan_id
+
+
+def test_findings_fixture_ignores_and_restores_unrelated_bulk_state() -> None:
+    unrelated_store = InMemoryComplianceHubStore()
+    set_compliance_hub_store(unrelated_store)
+    unrelated = [{"id": "unrelated:bulk", "severity": "low", "origin": "bulk_ingest"}]
+    unrelated_store.add(TENANT, unrelated)
+    unrelated_store.upsert_current_batch(
+        TENANT,
+        unrelated,
+        observed_at="2026-07-17T00:00:00Z",
+        batch_id="unrelated-batch",
+        source="test_api_surface_0943",
+    )
+    warm = TestClient(app).get("/v1/findings?limit=1000")
+    assert warm.status_code == 200
+    assert warm.json()["total"] == 1
+
+    with _client_with_scans_context() as (client, _last_scan_id, unique):
+        response = client.get("/v1/findings?limit=1000")
+        assert response.status_code == 200
+        assert response.json()["total"] == unique
+
+    assert get_compliance_hub_store() is unrelated_store
+    assert unrelated_store.count(TENANT) == 1
+    restored_cache_key = cache_key(
+        tenant_id=TENANT,
+        severity=None,
+        scan_id=None,
+        origin="bulk_ingest",
+        window_days=normalize_window_days(None),
+    )
+    assert get_cached_total(restored_cache_key) is None
 
 
 # ── Fix 3: invalid sort / severity are rejected ──────────────────────────────

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -18,15 +18,21 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "demo-estate.db"))
     monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(tmp_path / "demo-graph.db"))
 
+    from agent_bom.api import compliance_hub_store as hub_store_mod
     from agent_bom.api import server as api_server
     from agent_bom.api import stores as api_stores
+    from agent_bom.api.compliance_hub_store import set_compliance_hub_store
+    from agent_bom.api.findings_count_cache import reset_findings_count_cache
 
     api_server._runtime_api_key_seeded = False
     api_server._shutting_down = False
     original_job_store = api_stores._store
     original_graph_store = api_stores._graph_store
+    original_hub_store = hub_store_mod._HUB_STORE
     api_stores._store = None
     api_stores._graph_store = None
+    set_compliance_hub_store(None)
+    reset_findings_count_cache()
 
     try:
         with TestClient(api_server.app) as client:
@@ -34,6 +40,8 @@ def demo_estate_client(monkeypatch: pytest.MonkeyPatch, tmp_path):
     finally:
         api_stores._store = original_job_store
         api_stores._graph_store = original_graph_store
+        set_compliance_hub_store(original_hub_store)
+        reset_findings_count_cache()
         # The proxy alert/metric ring buffers and the firewall decision store are
         # process-global; the demo bootstrap seeds them, so clear them here to
         # keep the seeded gateway feed from leaking into later tests.

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -192,14 +192,28 @@ def test_overview_reads_compacted_scan_summary() -> None:
 
 
 def _ingest_hub_findings(findings: list[dict], *, tenant_id: str = "default") -> None:
-    """Append normalized findings straight into the compliance-hub ledger.
+    """Append normalized findings the way POST /v1/findings/bulk persists them.
 
-    Mirrors what POST /v1/findings/bulk persists (hub_store.add) so the overview
-    can be exercised against ingested evidence without a full HTTP round-trip.
+    The real bulk path writes BOTH the append-only ledger (``hub_store.add``,
+    which ``/hub/posture`` + the top-risk strip read) AND the current-state table
+    (``upsert_current_batch``, tagged ``origin=bulk_ingest``, which ``/v1/findings``
+    and the reconciled exec headline read). Seeding only the ledger would leave
+    the current-state empty, so mirror both here.
     """
+    from datetime import datetime, timezone
+
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
-    get_compliance_hub_store().add(tenant_id, findings)
+    store = get_compliance_hub_store()
+    store.add(tenant_id, findings)
+    now = datetime.now(timezone.utc).isoformat()
+    current = []
+    for idx, row in enumerate(findings):
+        payload = dict(row)
+        payload.setdefault("id", str(row.get("finding_id") or row.get("id") or f"hub-{idx}"))
+        payload["origin"] = "bulk_ingest"
+        current.append(payload)
+    store.upsert_current_batch(tenant_id, current, observed_at=now, batch_id="hub-test-batch", source="test")
 
 
 def test_overview_counts_bulk_ingested_findings() -> None:

--- a/tests/test_read_path_compliance_hub.py
+++ b/tests/test_read_path_compliance_hub.py
@@ -1,0 +1,359 @@
+"""Read-path fixes for the compliance-hub / overview surface.
+
+Covers four findings fixed in one coherent change:
+
+- **P1b exec-headline honesty.** The overview / posture ``critical`` & ``high``
+  now derive from the SAME source + semantics as ``/v1/findings``
+  (current-state ``hub_findings_current``, bulk origin, default read-window), so
+  a click-through reconciles exactly. A stale / retired finding that lingers
+  forever in the append-only ledger (``compliance_hub_findings``) no longer
+  inflates the exec headline.
+- **P1a event-loop.** ``/v1/compliance/hub/posture`` offloads its synchronous
+  store work off the loop under adaptive backpressure and sheds with ``429``;
+  the framework count aggregates in SQL instead of pulling every row into
+  Python.
+- **Cross-tenant isolation** of the SQL framework count + current-state
+  severity breakdown.
+- **Empty estate** renders an honest zero headline (buckets sum to total).
+- **P3 ordinal keyset** no longer dup/drops: cursor pagination over
+  ``sort=ordinal`` is rejected explicitly rather than filtering by the wrong
+  key.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import reset_compliance_hub_store
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    from agent_bom.api import hub_overview_cache
+    from agent_bom.api.findings_count_cache import reset_findings_count_cache
+    from agent_bom.api.routes import overview as overview_routes
+    from agent_bom.api.server import set_job_store
+    from agent_bom.api.store import InMemoryJobStore
+
+    # Force fresh reads: no cached overview / severity / count between assertions.
+    monkeypatch.setenv("AGENT_BOM_OVERVIEW_CACHE_TTL_SECONDS", "0")
+    monkeypatch.setenv("AGENT_BOM_HUB_OVERVIEW_CACHE_TTL_SECONDS", "0")
+    reset_compliance_hub_store()
+    set_job_store(InMemoryJobStore())
+    hub_overview_cache.reset_hub_overview_cache()
+    overview_routes._reset_overview_cache()
+    reset_findings_count_cache()
+    yield
+    reset_compliance_hub_store()
+    set_job_store(InMemoryJobStore())
+    hub_overview_cache.reset_hub_overview_cache()
+
+
+def _client(tenant: str = "tenant-alpha", role: str = "admin") -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role=role, tenant=tenant))
+    return client
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _ingest(client: TestClient, findings: list[dict], *, observed_at: str | None = None, source: str = "connector") -> None:
+    body: dict = {"findings": findings, "source": source}
+    if observed_at is not None:
+        body["observed_at"] = observed_at
+    resp = client.post("/v1/findings/bulk", json=body)
+    assert resp.status_code == 201, resp.text
+
+
+def _findings_total(client: TestClient, severity: str) -> int:
+    resp = client.get(f"/v1/findings?severity={severity}")
+    assert resp.status_code == 200, resp.text
+    return int(resp.json()["total"])
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# P1b — exec headline reconciles with the /v1/findings drill-down
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestExecHeadlineReconciliation:
+    def test_overview_headline_equals_findings_drilldown_for_same_window(self) -> None:
+        """overview critical/high == /v1/findings critical/high (reconcile invariant).
+
+        Seeds recent findings PLUS a stale critical + stale high whose
+        ``last_seen`` is well outside the default read-window. The append-only
+        ledger keeps the stale rows forever, so the old ledger-based headline
+        over-counted; the current-state windowed derivation must match the
+        drill-down exactly.
+        """
+        client = _client()
+        # Recent, in-window evidence.
+        _ingest(
+            client,
+            [
+                {"id": "c-1", "severity": "critical"},
+                {"id": "c-2", "severity": "critical"},
+                {"id": "h-1", "severity": "high"},
+                {"id": "m-1", "severity": "medium"},
+            ],
+        )
+        # Stale evidence — outside the default window, lingers in the ledger.
+        stale = (_now() - timedelta(days=400)).isoformat()
+        _ingest(
+            client,
+            [
+                {"id": "c-stale", "severity": "critical"},
+                {"id": "h-stale", "severity": "high"},
+            ],
+            observed_at=stale,
+            source="stale-connector",
+        )
+
+        findings_critical = _findings_total(client, "critical")
+        findings_high = _findings_total(client, "high")
+        # Drill-down is windowed to the recent evidence only.
+        assert findings_critical == 2
+        assert findings_high == 1
+
+        headline = client.get("/v1/overview").json()["headline"]
+        counts = client.get("/v1/posture/counts").json()
+
+        # The reconciliation invariant: click-through matches the headline.
+        assert headline["critical"] == findings_critical
+        assert headline["high"] == findings_high
+        assert counts["critical"] == findings_critical
+        assert counts["high"] == findings_high
+
+    def test_retired_finding_does_not_inflate_exec_headline(self) -> None:
+        """A resolved + aged finding never inflates the exec headline (#3961/#4009).
+
+        The finding is resolved (reconciled absent) AND aged past the window, so
+        it lives only in the append-only ledger. The exec headline must exclude
+        it and reconcile with the (empty) drill-down.
+        """
+        client = _client()
+        from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+        stale = (_now() - timedelta(days=400)).isoformat()
+        _ingest(client, [{"id": "gone-crit", "severity": "critical"}], observed_at=stale, source="dead")
+        # Retire it: reconcile it absent so its current-state status is resolved.
+        get_compliance_hub_store().reconcile_current_absent(
+            "tenant-alpha",
+            present_canonical_ids=set(),
+            observed_at=stale,
+            scope_source="dead",
+        )
+
+        assert _findings_total(client, "critical") == 0
+        headline = client.get("/v1/overview").json()["headline"]
+        assert headline["critical"] == 0
+        # The full-bucket exec counts still sum to total honestly.
+        counts = client.get("/v1/posture/counts").json()
+        assert counts["critical"] == 0
+        assert counts["total"] == sum(counts[k] for k in ("critical", "high", "medium", "low", "unrated"))
+
+    def test_empty_estate_headline_is_honest_zero(self) -> None:
+        """Zero-finding tenant: no NaN, no implied pass, buckets sum to total."""
+        client = _client()
+        headline = client.get("/v1/overview").json()["headline"]
+        assert headline["critical"] == 0 and headline["high"] == 0
+        counts = client.get("/v1/posture/counts").json()
+        for band in ("critical", "high", "medium", "low", "unrated", "total"):
+            assert counts[band] == 0, counts
+        assert counts["total"] == sum(counts[k] for k in ("critical", "high", "medium", "low", "unrated"))
+
+    def test_headline_is_tenant_scoped(self) -> None:
+        """Tenant B's exec headline never leaks tenant A's findings."""
+        a = _client(tenant="tenant-a")
+        b = _client(tenant="tenant-b")
+        _ingest(a, [{"id": "a-crit", "severity": "critical"}])
+        assert a.get("/v1/overview").json()["headline"]["critical"] == 1
+        assert b.get("/v1/overview").json()["headline"]["critical"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# P1a — posture offload + SQL framework counts
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestPostureOffload:
+    def test_posture_sheds_with_429_when_backpressure_opens(self, monkeypatch) -> None:
+        """/v1/compliance/hub/posture offloads off the loop and sheds under load."""
+        from agent_bom.api.routes import compliance as compliance_routes
+        from agent_bom.backpressure import reset_backpressure_for_tests
+
+        monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_COMPLIANCE_P99_MS", "1")
+        monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_COMPLIANCE_MIN_SAMPLES", "1")
+        monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_COMPLIANCE_COOLDOWN_SECONDS", "30")
+        reset_backpressure_for_tests()
+
+        import time
+
+        original = compliance_routes._get_hub_posture_impl
+
+        def _slow(request):
+            time.sleep(0.01)
+            return original(request)
+
+        monkeypatch.setattr(compliance_routes, "_get_hub_posture_impl", _slow)
+        client = _client()
+        try:
+            statuses = {client.get("/v1/compliance/hub/posture").status_code for _ in range(6)}
+        finally:
+            reset_backpressure_for_tests()
+        assert 429 in statuses, statuses
+
+    def test_posture_returns_reconciled_shape(self) -> None:
+        client = _client()
+        _ingest(
+            client,
+            [{"id": "f-1", "severity": "high", "applicable_frameworks": ["soc2", "iso-27001"]}],
+        )
+        body = client.get("/v1/compliance/hub/posture").json()
+        assert body["totals"]["hub"] == 1
+        assert body["framework_counts"]["hub"].get("soc2") == 1
+        assert body["framework_counts"]["hub"].get("iso-27001") == 1
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# Store layer — SQL framework counts + current-state severity breakdown
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+def _seed_ledger(store, tenant: str, rows: list[dict]) -> None:
+    store.add(tenant, rows)
+
+
+def _seed_current(store, tenant: str, finding: dict, *, observed_at: str, source: str = "connector") -> None:
+    store.upsert_current_batch(
+        tenant,
+        [finding],
+        observed_at=observed_at,
+        batch_id=f"b-{finding['id']}",
+        source=source,
+    )
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def store(request):
+    from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, SQLiteComplianceHubStore
+
+    if request.param == "memory":
+        return InMemoryComplianceHubStore()
+    return SQLiteComplianceHubStore(":memory:")
+
+
+class TestFrameworkSlugCountsSql:
+    def test_counts_normalize_and_merge_aliases(self, store) -> None:
+        """Underscore / alias slug variants collapse to one canonical count."""
+        _seed_ledger(
+            store,
+            "t1",
+            [
+                {"id": "f1", "severity": "high", "applicable_frameworks": ["iso_27001", "soc2"]},
+                {"id": "f2", "severity": "low", "applicable_frameworks": ["ISO-27001"]},
+                {"id": "f3", "severity": "low", "applicable_frameworks": []},
+            ],
+        )
+        counts = store.framework_slug_counts("t1")
+        # ``iso_27001`` (underscore) and ``ISO-27001`` (case) fold to one slug.
+        assert counts.get("iso-27001") == 2
+        assert counts.get("soc2") == 1
+
+    def test_framework_counts_are_tenant_scoped(self, store) -> None:
+        _seed_ledger(store, "t1", [{"id": "f1", "severity": "high", "applicable_frameworks": ["soc2"]}])
+        _seed_ledger(store, "t2", [{"id": "f2", "severity": "high", "applicable_frameworks": ["pci-dss"]}])
+        assert store.framework_slug_counts("t1") == {"soc2": 1}
+        assert store.framework_slug_counts("t2") == {"pci-dss": 1}
+
+
+class TestCurrentSeverityBreakdown:
+    def test_matches_list_current_page_count_by_construction(self, store) -> None:
+        """The exec breakdown counts exactly what /v1/findings counts.
+
+        Same table, same tenant/origin/window filters, so the per-severity sum
+        equals ``list_current_page`` COUNT for each band.
+        """
+        now = _now()
+        recent = (now - timedelta(days=1)).isoformat()
+        stale = (now - timedelta(days=400)).isoformat()
+        # bulk origin so both surfaces agree on origin scope.
+        _seed_current(store, "t1", {"id": "r1", "severity": "critical", "origin": "bulk_ingest"}, observed_at=recent)
+        _seed_current(store, "t1", {"id": "r2", "severity": "high", "origin": "bulk_ingest"}, observed_at=recent)
+        _seed_current(store, "t1", {"id": "old", "severity": "critical", "origin": "bulk_ingest"}, observed_at=stale)
+
+        from agent_bom.api import time_window
+
+        since = time_window.window_since_iso(90, now=now)
+        breakdown = store.current_severity_breakdown("t1", origin="bulk_ingest", since=since)
+        # Drill-down COUNT for the same window.
+        _rows, crit_total, _c = store.list_current_page(
+            "t1", limit=100, severity="critical", origin="bulk_ingest", since=since
+        )
+        assert breakdown["critical"] == crit_total == 1
+        assert breakdown["high"] == 1
+
+    def test_current_severity_breakdown_is_tenant_scoped(self, store) -> None:
+        now = _now()
+        recent = (now - timedelta(days=1)).isoformat()
+        _seed_current(store, "t1", {"id": "a", "severity": "critical", "origin": "bulk_ingest"}, observed_at=recent)
+        _seed_current(store, "t2", {"id": "b", "severity": "critical", "origin": "bulk_ingest"}, observed_at=recent)
+        b1 = store.current_severity_breakdown("t1", origin="bulk_ingest", since=None)
+        b2 = store.current_severity_breakdown("t2", origin="bulk_ingest", since=None)
+        assert b1["critical"] == 1
+        assert b2["critical"] == 1
+        # No collision / leak across tenants.
+        assert store.current_severity_breakdown("t3", origin="bulk_ingest", since=None)["critical"] == 0
+
+
+# ═══════════════════════════════════════════════════════════════════════════
+# P3 — ordinal keyset does not dup/drop
+# ═══════════════════════════════════════════════════════════════════════════
+
+
+class TestOrdinalKeyset:
+    def test_ordinal_offset_walk_has_no_dup_or_drop(self, store) -> None:
+        now = _now()
+        recent = (now - timedelta(days=1)).isoformat()
+        for i in range(6):
+            _seed_current(store, "t1", {"id": f"f{i}", "severity": "high", "origin": "bulk_ingest"}, observed_at=recent)
+        seen: list[str] = []
+        offset = 0
+        while True:
+            rows, _total, _cursor = store.list_current_page("t1", limit=2, offset=offset, sort="ordinal")
+            if not rows:
+                break
+            seen.extend(str(r.get("canonical_id") or r.get("id")) for r in rows)
+            offset += 2
+        assert len(seen) == len(set(seen)) == 6
+
+    def test_ordinal_emits_no_cursor(self, store) -> None:
+        """Ordinal paginates by offset only — no broken keyset cursor is handed out."""
+        now = _now()
+        recent = (now - timedelta(days=1)).isoformat()
+        for i in range(4):
+            _seed_current(store, "t1", {"id": f"f{i}", "severity": "high", "origin": "bulk_ingest"}, observed_at=recent)
+        _rows, _total, cursor = store.list_current_page("t1", limit=2, sort="ordinal")
+        assert not cursor
+
+    def test_ordinal_cursor_is_rejected(self) -> None:
+        from agent_bom.api.finding_cursor import decode_finding_cursor, encode_finding_cursor
+
+        crafted = encode_finding_cursor(sort="ordinal", primary=0.0, last_seen="2026-01-01T00:00:00Z", canonical_id="x")
+        with pytest.raises(ValueError):
+            decode_finding_cursor(crafted, expected_sort="ordinal")


### PR DESCRIPTION
## Summary

- offload compliance-hub posture and list reads from the event loop under adaptive backpressure, returning bounded 429 responses under saturation
- aggregate framework and current-state severity counts in SQLite/PostgreSQL instead of hydrating tenant ledgers, and reconcile executive critical/high counts with the same current-state origin/window used by findings drill-downs
- reject invalid ordinal keyset cursors instead of filtering on a key that is not part of ordinal ordering
- isolate compliance-hub stores and the approximate findings-count cache at API/demo fixture boundaries, fixing the order-dependent 109-vs-106 and 22-vs-19 CI failures without weakening intentional approximate-count behavior
- refresh generated OpenAPI descriptions for the offload and saturation contract

## Verification

- focused combined suite — 154 passed
- Python 3.11 xdist/loadscope with the exact failing CI seed 2715805419 — 46 passed
- prior isolation validation under seeds 90210 and 17 — 46 passed each
- Ruff on all changed source/tests — clean
- mypy on all changed production modules and the API fixture regression — clean
- make preflight — passed on current main
- git diff --check — clean

## Notes

The compliance backpressure path fails available with an explicit 429 and Retry-After rather than blocking health and unrelated requests. Optional hub-store read failures retain the existing zero-count degradation behavior. No production-only test hook was added.

Closes #4106
Closes #4130
Addresses #4095