### PR TITLE
feat(kspm): add native evidence-aware transport

### DIFF
--- a/src/agent_bom/k8s.py
+++ b/src/agent_bom/k8s.py
@@ -17,13 +17,56 @@ from __future__ import annotations
 import json
 import shutil
 import subprocess
+from dataclasses import dataclass, field
+from enum import Enum
 from typing import Optional
 
 from agent_bom.iac.models import IaCFinding
+from agent_bom.k8s_transport import K8sReadTransport, K8sTransportError, select_k8s_transport
 
 
 class K8sDiscoveryError(Exception):
     """Raised when kubectl discovery fails."""
+
+
+class CollectorState(str, Enum):
+    """Execution state for one live Kubernetes evidence collector."""
+
+    EXECUTED = "executed"
+    SKIPPED = "skipped"
+    UNEVALUABLE = "unevaluable"
+    FAILED = "failed"
+
+
+class K8sPostureStatus(str, Enum):
+    """Aggregate completeness of a live Kubernetes posture run."""
+
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class K8sCollectorEvidence:
+    """Auditable execution evidence for one read-only collector."""
+
+    collector_id: str
+    state: CollectorState
+    object_count: int = 0
+    pages: int = 0
+    truncated: bool = False
+    message: str = ""
+    transport: str = ""
+
+
+@dataclass
+class K8sPostureResult:
+    """Findings plus explicit collection completeness for a posture run."""
+
+    findings: list[IaCFinding] = field(default_factory=list)
+    collectors: list[K8sCollectorEvidence] = field(default_factory=list)
+    status: K8sPostureStatus = K8sPostureStatus.FAILED
+    transport: str = ""
 
 
 def _kubectl_available() -> bool:
@@ -451,10 +494,10 @@ def evaluate_rbac(
 def evaluate_kubelet_config(node_name: str, kubelet_config: dict) -> list[IaCFinding]:
     """Evaluate a node's kubelet configuration against CIS Benchmark section 4.2.
 
-    ``kubelet_config`` is the resolved KubeletConfiguration (v1beta1) as returned
-    by the read-only ``/api/v1/nodes/<node>/proxy/configz`` endpoint (the
-    ``kubeletconfig`` object). Only fields present in the resolved config are
-    evaluated; absent optional fields are not fabricated into a pass or fail.
+    ``kubelet_config`` is the resolved KubeletConfiguration (v1beta1) returned
+    by the fine-grained ``/api/v1/nodes/<node>/configz`` subresource. Only
+    fields present in the resolved config are evaluated; absent optional fields
+    are not fabricated into a pass or fail.
     """
     findings: list[IaCFinding] = []
     node_ref = f"k8s://node/{node_name}"
@@ -586,188 +629,394 @@ def evaluate_kubelet_config(node_name: str, kubelet_config: dict) -> list[IaCFin
     return findings
 
 
-def _fetch_kubelet_config(node_name: str, context: Optional[str]) -> Optional[dict]:
-    """Fetch a node's resolved kubelet config via the read-only configz proxy.
+_POSTURE_RESOURCES = (
+    "pods",
+    "networkpolicies",
+    "clusterrolebindings",
+    "clusterroles",
+    "roles",
+    "nodes",
+)
 
-    Returns the ``kubeletconfig`` object, or ``None`` when the endpoint is
-    unreachable (managed control planes commonly forbid the node proxy). A
-    blocked endpoint is an honest skip — never a fabricated pass.
+
+def _collector_state_for_error(exc: K8sTransportError) -> CollectorState:
+    if exc.status_code in {401, 403, 404}:
+        return CollectorState.UNEVALUABLE
+    return CollectorState.FAILED
+
+
+def _kubelet_endpoint(node: dict) -> tuple[str, int] | None:
+    """Return a node-advertised kubelet HTTPS endpoint, if present."""
+    status = node.get("status", {}) or {}
+    raw_addresses = status.get("addresses", []) or []
+    by_type = {
+        item.get("type"): item.get("address")
+        for item in raw_addresses
+        if isinstance(item, dict) and isinstance(item.get("address"), str) and item.get("address")
+    }
+    host = next(
+        (
+            by_type[address_type]
+            for address_type in ("InternalDNS", "Hostname", "InternalIP", "ExternalDNS", "ExternalIP")
+            if by_type.get(address_type)
+        ),
+        None,
+    )
+    endpoint = (status.get("daemonEndpoints", {}) or {}).get("kubeletEndpoint", {}) or {}
+    port = endpoint.get("Port", endpoint.get("port"))
+    if not host or not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65_535:
+        return None
+    return str(host), port
+
+
+def _posture_status(collectors: list[K8sCollectorEvidence]) -> K8sPostureStatus:
+    primary = [collector for collector in collectors if collector.collector_id in _POSTURE_RESOURCES]
+    if primary and all(collector.state is not CollectorState.EXECUTED for collector in primary):
+        return K8sPostureStatus.FAILED
+    if any(collector.state in {CollectorState.UNEVALUABLE, CollectorState.FAILED} or collector.truncated for collector in collectors):
+        return K8sPostureStatus.PARTIAL
+    return K8sPostureStatus.COMPLETE
+
+
+def scan_live_cluster_posture_with_evidence(
+    namespace: str = "default",
+    all_namespaces: bool = False,
+    context: Optional[str] = None,
+    *,
+    enable_nodes_configz: bool = False,
+    transport: K8sReadTransport | None = None,
+) -> K8sPostureResult:
+    """Inspect live Kubernetes posture with explicit collection evidence.
+
+    This complements manifest scanning. It does not attempt full policy
+    evaluation across the cluster; it inspects live workload, RBAC, namespace,
+    and optional node/kubelet state that static manifests cannot prove. The
+    in-cluster path uses the mounted service-account token and CA directly;
+    kubectl is retained only as a workstation fallback. All access is GET-only.
+
+    Direct kubelet ``/configz`` is separately opt-in because older clusters do
+    not map it to the fine-grained ``nodes/configz`` authorization subresource.
+    The collector never falls back to ``nodes/proxy``; unavailable config is
+    recorded as unevaluable.
     """
-    raw_path = f"/api/v1/nodes/{node_name}/proxy/configz"
+    findings: list[IaCFinding] = []
+    collectors: list[K8sCollectorEvidence] = []
+    payloads: dict[str, dict] = {}
+    owns_transport = transport is None
+
+    if transport is None:
+        try:
+            transport = select_k8s_transport(
+                context=context,
+            )
+        except K8sTransportError as exc:
+            collectors.extend(
+                K8sCollectorEvidence(
+                    collector_id=resource,
+                    state=CollectorState.FAILED,
+                    message=str(exc),
+                )
+                for resource in _POSTURE_RESOURCES
+            )
+            collectors.append(
+                K8sCollectorEvidence(
+                    collector_id="kubelet_configz",
+                    state=CollectorState.SKIPPED,
+                    message="nodes/configz collection was not started",
+                )
+            )
+            return K8sPostureResult(
+                findings=[],
+                collectors=collectors,
+                status=K8sPostureStatus.FAILED,
+                transport="unavailable",
+            )
+
+    transport_name = transport.name
     try:
-        data = _run_kubectl_json(["get", "--raw", raw_path], context=context, timeout=30)
-    except K8sDiscoveryError:
-        return None
-    if not isinstance(data, dict):
-        return None
-    config = data.get("kubeletconfig")
-    return config if isinstance(config, dict) else None
+        for resource in _POSTURE_RESOURCES:
+            resource_namespace = namespace if resource in {"pods", "networkpolicies", "roles"} else None
+            try:
+                read = transport.list_resource(
+                    resource,
+                    namespace=resource_namespace,
+                    all_namespaces=all_namespaces,
+                )
+            except K8sTransportError as exc:
+                collectors.append(
+                    K8sCollectorEvidence(
+                        collector_id=resource,
+                        state=_collector_state_for_error(exc),
+                        message=str(exc),
+                        transport=transport_name,
+                    )
+                )
+                continue
+            payloads[resource] = read.data
+            collectors.append(
+                K8sCollectorEvidence(
+                    collector_id=resource,
+                    state=CollectorState.EXECUTED,
+                    object_count=read.object_count,
+                    pages=read.pages,
+                    truncated=read.truncated,
+                    message="collection reached its configured bound" if read.truncated else "",
+                    transport=transport_name,
+                )
+            )
+
+        pods = payloads.get("pods", {"items": []})
+        network_policies = payloads.get("networkpolicies", {"items": []})
+        cluster_role_bindings = payloads.get("clusterrolebindings", {"items": []})
+        cluster_roles = payloads.get("clusterroles", {"items": []})
+        roles = payloads.get("roles", {"items": []})
+        nodes = payloads.get("nodes", {"items": []})
+
+        policy_namespaces = {
+            item.get("metadata", {}).get("namespace", namespace)
+            for item in network_policies.get("items", [])
+            if isinstance(item, dict) and item.get("metadata", {}).get("namespace")
+        }
+        namespaces_with_pods: set[str] = set()
+
+        if "pods" in payloads:
+            for pod in pods.get("items", []):
+                if not isinstance(pod, dict):
+                    continue
+                metadata = pod.get("metadata", {})
+                pod_name = metadata.get("name", "unknown")
+                pod_ns = metadata.get("namespace", namespace)
+                namespaces_with_pods.add(pod_ns)
+                pod_ref = f"k8s://{pod_ns}/{pod_name}"
+                spec = pod.get("spec", {}) or {}
+                status = pod.get("status", {}) or {}
+                phase = status.get("phase", "Unknown")
+
+                if phase != "Running":
+                    findings.append(
+                        IaCFinding(
+                            rule_id="K8S-LIVE-001",
+                            severity="medium",
+                            title="Live pod not running",
+                            message=(
+                                f"Pod '{pod_ns}/{pod_name}' is currently in phase '{phase}'. "
+                                "Investigate runtime drift, crash loops, or image/config rollout health."
+                            ),
+                            file_path=pod_ref,
+                            line_number=1,
+                            category="kubernetes-live",
+                            compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
+                        )
+                    )
+
+                container_statuses = status.get("containerStatuses", []) or []
+                for container_status in container_statuses:
+                    waiting = (container_status.get("state", {}) or {}).get("waiting", {}) or {}
+                    if waiting.get("reason") == "CrashLoopBackOff":
+                        findings.append(
+                            IaCFinding(
+                                rule_id="K8S-LIVE-002",
+                                severity="high",
+                                title="Live pod is crash looping",
+                                message=(
+                                    f"Pod '{pod_ns}/{pod_name}' container "
+                                    f"'{container_status.get('name', 'unknown')}' is in CrashLoopBackOff. "
+                                    "Runtime drift or bad rollout is already impacting availability."
+                                ),
+                                file_path=pod_ref,
+                                line_number=1,
+                                category="kubernetes-live",
+                                compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
+                            )
+                        )
+                    if not container_status.get("ready", False):
+                        findings.append(
+                            IaCFinding(
+                                rule_id="K8S-LIVE-003",
+                                severity="medium",
+                                title="Live pod container not ready",
+                                message=(
+                                    f"Pod '{pod_ns}/{pod_name}' container "
+                                    f"'{container_status.get('name', 'unknown')}' is not ready. "
+                                    "Live readiness drift may bypass assumptions in static manifests."
+                                ),
+                                file_path=pod_ref,
+                                line_number=1,
+                                category="kubernetes-live",
+                                compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
+                            )
+                        )
+
+                automount = spec.get("automountServiceAccountToken")
+                if automount is not False:
+                    explicit = automount is True
+                    detail = (
+                        "service-account token auto-mount explicitly enabled."
+                        if explicit
+                        else "service-account token auto-mount left at the Kubernetes default (enabled)."
+                    )
+                    findings.append(
+                        IaCFinding(
+                            rule_id="K8S-LIVE-004",
+                            severity="medium" if explicit else "low",
+                            title="Live pod mounts service-account token",
+                            message=(
+                                f"Pod '{pod_ns}/{pod_name}' is running with {detail} "
+                                "Set automountServiceAccountToken: false unless the workload needs Kubernetes API access."
+                            ),
+                            file_path=pod_ref,
+                            line_number=1,
+                            category="kubernetes-live",
+                            compliance=["CIS-K8s-5.1.6", "NIST-AC-6"],
+                        )
+                    )
+
+            findings.extend(evaluate_pod_security(pods, default_namespace=namespace))
+
+        # NetworkPolicy absence is only evaluable when both inputs completed.
+        if "pods" in payloads and "networkpolicies" in payloads:
+            for ns in sorted(namespaces_with_pods):
+                if ns not in policy_namespaces:
+                    findings.append(
+                        IaCFinding(
+                            rule_id="K8S-LIVE-005",
+                            severity="high",
+                            title="Namespace lacks live NetworkPolicy coverage",
+                            message=(
+                                f"Namespace '{ns}' has running pods but no live NetworkPolicy objects. "
+                                "This is a runtime posture gap even if manifests exist elsewhere in Git."
+                            ),
+                            file_path=f"k8s://namespace/{ns}",
+                            line_number=1,
+                            category="kubernetes-live",
+                            compliance=["CIS-K8s-5.3.2", "NIST-SC-7"],
+                        )
+                    )
+
+        # Each RBAC input remains independently useful when another read is denied.
+        findings.extend(
+            evaluate_rbac(
+                cluster_roles if "clusterroles" in payloads else {"items": []},
+                roles if "roles" in payloads else {"items": []},
+                cluster_role_bindings if "clusterrolebindings" in payloads else {"items": []},
+                default_namespace=namespace,
+            )
+        )
+
+        if not enable_nodes_configz:
+            collectors.append(
+                K8sCollectorEvidence(
+                    collector_id="kubelet_configz",
+                    state=CollectorState.SKIPPED,
+                    message="nodes/configz collection is opt-in and disabled",
+                    transport=transport_name,
+                )
+            )
+        elif "nodes" not in payloads:
+            collectors.append(
+                K8sCollectorEvidence(
+                    collector_id="kubelet_configz",
+                    state=CollectorState.UNEVALUABLE,
+                    message="nodes/configz requires successful node inventory",
+                    transport=transport_name,
+                )
+            )
+        else:
+            config_count = 0
+            config_errors: list[K8sTransportError] = []
+            node_items = nodes.get("items", []) or []
+            for node in node_items:
+                if not isinstance(node, dict):
+                    continue
+                node_name = (node.get("metadata", {}) or {}).get("name")
+                if not node_name:
+                    continue
+                endpoint = _kubelet_endpoint(node)
+                if endpoint is None:
+                    config_errors.append(
+                        K8sTransportError(
+                            "Node does not advertise an evaluable kubelet HTTPS endpoint",
+                            status_code=404,
+                            reason="unavailable",
+                        )
+                    )
+                    continue
+                kubelet_host, kubelet_port = endpoint
+                try:
+                    data = transport.get_kubelet_json(
+                        kubelet_host,
+                        kubelet_port,
+                        "/configz",
+                        timeout=30,
+                    )
+                except K8sTransportError as exc:
+                    config_errors.append(exc)
+                    continue
+                config = data.get("kubeletconfig", data)
+                if not isinstance(config, dict) or not config:
+                    config_errors.append(K8sTransportError("nodes/configz returned no evaluable configuration", reason="invalid_json"))
+                    continue
+                config_count += 1
+                findings.extend(evaluate_kubelet_config(str(node_name), config))
+
+            if config_errors:
+                config_state = (
+                    CollectorState.FAILED
+                    if any(_collector_state_for_error(error) is CollectorState.FAILED for error in config_errors)
+                    else CollectorState.UNEVALUABLE
+                )
+                message = f"{len(config_errors)} node config read(s) were not evaluable"
+            else:
+                config_state = CollectorState.EXECUTED
+                message = ""
+            collectors.append(
+                K8sCollectorEvidence(
+                    collector_id="kubelet_configz",
+                    state=config_state,
+                    object_count=config_count,
+                    pages=config_count,
+                    message=message,
+                    transport=transport_name,
+                )
+            )
+    finally:
+        if owns_transport:
+            transport.close()
+
+    return K8sPostureResult(
+        findings=findings,
+        collectors=collectors,
+        status=_posture_status(collectors),
+        transport=transport_name,
+    )
 
 
 def scan_live_cluster_posture(
     namespace: str = "default",
     all_namespaces: bool = False,
     context: Optional[str] = None,
+    *,
+    enable_nodes_configz: bool = False,
 ) -> list[IaCFinding]:
-    """Inspect runtime Kubernetes posture through the live API via kubectl.
+    """Compatibility wrapper returning findings while failing on total outage.
 
-    This complements manifest scanning. It does not attempt full policy
-    evaluation across the cluster; it inspects live workload, RBAC, namespace,
-    and node/kubelet state that static manifests cannot prove. All access is
-    read-only (``kubectl get`` / read-only ``--raw`` GETs); the scan never
-    mutates or execs into the cluster.
-
-    Check families
-    --------------
-    * Runtime workload health — K8S-LIVE-001..004
-    * Namespace NetworkPolicy coverage — K8S-LIVE-005
-    * RBAC / namespace audit — K8S-LIVE-006, 015, 016
-    * PodSecurity on running workloads — K8S-LIVE-007..014
-    * Node / kubelet CIS configuration — K8S-LIVE-020..026 (skipped honestly
-      when the kubelet configz proxy is forbidden on managed control planes)
+    Call :func:`scan_live_cluster_posture_with_evidence` when partial and
+    unevaluable collector states must be rendered or persisted.
     """
-    ns_args = ["-A"] if all_namespaces else ["-n", namespace]
-    findings: list[IaCFinding] = []
-
-    pods = _run_kubectl_json(["get", "pods", *ns_args, "-o", "json"], context=context, timeout=60)
-    network_policies = _run_kubectl_json(["get", "networkpolicies", *ns_args, "-o", "json"], context=context, timeout=30)
-    cluster_role_bindings = _run_kubectl_json(["get", "clusterrolebindings", "-o", "json"], context=context, timeout=30)
-    cluster_roles = _run_kubectl_json(["get", "clusterroles", "-o", "json"], context=context, timeout=30)
-    roles = _run_kubectl_json(["get", "roles", *ns_args, "-o", "json"], context=context, timeout=30)
-    nodes = _run_kubectl_json(["get", "nodes", "-o", "json"], context=context, timeout=30)
-
-    policy_namespaces = {
-        item.get("metadata", {}).get("namespace", namespace)
-        for item in network_policies.get("items", [])
-        if item.get("metadata", {}).get("namespace")
-    }
-    namespaces_with_pods: set[str] = set()
-
-    for pod in pods.get("items", []):
-        metadata = pod.get("metadata", {})
-        pod_name = metadata.get("name", "unknown")
-        pod_ns = metadata.get("namespace", namespace)
-        namespaces_with_pods.add(pod_ns)
-        pod_ref = f"k8s://{pod_ns}/{pod_name}"
-        spec = pod.get("spec", {}) or {}
-        status = pod.get("status", {}) or {}
-        phase = status.get("phase", "Unknown")
-
-        if phase != "Running":
-            findings.append(
-                IaCFinding(
-                    rule_id="K8S-LIVE-001",
-                    severity="medium",
-                    title="Live pod not running",
-                    message=(
-                        f"Pod '{pod_ns}/{pod_name}' is currently in phase '{phase}'. "
-                        "Investigate runtime drift, crash loops, or image/config rollout health."
-                    ),
-                    file_path=pod_ref,
-                    line_number=1,
-                    category="kubernetes-live",
-                    compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
-                )
-            )
-
-        container_statuses = status.get("containerStatuses", []) or []
-        for container_status in container_statuses:
-            waiting = (container_status.get("state", {}) or {}).get("waiting", {}) or {}
-            if waiting.get("reason") == "CrashLoopBackOff":
-                findings.append(
-                    IaCFinding(
-                        rule_id="K8S-LIVE-002",
-                        severity="high",
-                        title="Live pod is crash looping",
-                        message=(
-                            f"Pod '{pod_ns}/{pod_name}' container '{container_status.get('name', 'unknown')}' "
-                            "is in CrashLoopBackOff. Runtime drift or bad rollout is already impacting availability."
-                        ),
-                        file_path=pod_ref,
-                        line_number=1,
-                        category="kubernetes-live",
-                        compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
-                    )
-                )
-            if not container_status.get("ready", False):
-                findings.append(
-                    IaCFinding(
-                        rule_id="K8S-LIVE-003",
-                        severity="medium",
-                        title="Live pod container not ready",
-                        message=(
-                            f"Pod '{pod_ns}/{pod_name}' container '{container_status.get('name', 'unknown')}' "
-                            "is not ready. Live readiness drift may bypass assumptions in static manifests."
-                        ),
-                        file_path=pod_ref,
-                        line_number=1,
-                        category="kubernetes-live",
-                        compliance=["CIS-K8s-5.7.4", "NIST-SI-4"],
-                    )
-                )
-
-        automount = spec.get("automountServiceAccountToken")
-        if automount is not False:
-            # An explicit opt-in is an intentional choice (medium); leaving the
-            # field unset inherits Kubernetes' on-by-default behaviour, which is
-            # nearly every normal pod — flag it as low-severity signal rather
-            # than drowning the report in MEDIUMs. We still emit it (not
-            # suppress) because a mounted token on a broadly-privileged
-            # service account remains a real exposure.
-            explicit = automount is True
-            if explicit:
-                detail = "service-account token auto-mount explicitly enabled."
-            else:
-                detail = "service-account token auto-mount left at the Kubernetes default (enabled)."
-            findings.append(
-                IaCFinding(
-                    rule_id="K8S-LIVE-004",
-                    severity="medium" if explicit else "low",
-                    title="Live pod mounts service-account token",
-                    message=(
-                        f"Pod '{pod_ns}/{pod_name}' is running with {detail} "
-                        "Set automountServiceAccountToken: false unless the workload needs Kubernetes API access."
-                    ),
-                    file_path=pod_ref,
-                    line_number=1,
-                    category="kubernetes-live",
-                    compliance=["CIS-K8s-5.1.6", "NIST-AC-6"],
-                )
-            )
-
-    for ns in sorted(namespaces_with_pods):
-        if ns not in policy_namespaces:
-            findings.append(
-                IaCFinding(
-                    rule_id="K8S-LIVE-005",
-                    severity="high",
-                    title="Namespace lacks live NetworkPolicy coverage",
-                    message=(
-                        f"Namespace '{ns}' has running pods but no live NetworkPolicy objects. "
-                        "This is a runtime posture gap even if manifests exist elsewhere in Git."
-                    ),
-                    file_path=f"k8s://namespace/{ns}",
-                    line_number=1,
-                    category="kubernetes-live",
-                    compliance=["CIS-K8s-5.3.2", "NIST-SC-7"],
-                )
-            )
-
-    # PodSecurity on running workloads (K8S-LIVE-007..014).
-    findings.extend(evaluate_pod_security(pods, default_namespace=namespace))
-
-    # RBAC / namespace audit (K8S-LIVE-006, 015, 016).
-    findings.extend(evaluate_rbac(cluster_roles, roles, cluster_role_bindings, default_namespace=namespace))
-
-    # Node / kubelet CIS configuration (K8S-LIVE-020..026). The configz proxy is
-    # commonly forbidden on managed control planes — skip those nodes honestly
-    # instead of fabricating a pass.
-    for node in nodes.get("items", []) or []:
-        node_name = (node.get("metadata", {}) or {}).get("name")
-        if not node_name:
-            continue
-        kubelet_config = _fetch_kubelet_config(node_name, context)
-        if kubelet_config is not None:
-            findings.extend(evaluate_kubelet_config(node_name, kubelet_config))
-
-    return findings
+    result = scan_live_cluster_posture_with_evidence(
+        namespace=namespace,
+        all_namespaces=all_namespaces,
+        context=context,
+        enable_nodes_configz=enable_nodes_configz,
+    )
+    if result.status is not K8sPostureStatus.COMPLETE:
+        details = next(
+            (
+                collector.message
+                for collector in result.collectors
+                if collector.state in {CollectorState.UNEVALUABLE, CollectorState.FAILED} and collector.message
+            ),
+            "collection incomplete",
+        )
+        raise K8sDiscoveryError(details)
+    return result.findings

--- a/src/agent_bom/k8s.py
+++ b/src/agent_bom/k8s.py
@@ -19,10 +19,12 @@ import shutil
 import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
+from math import ceil
+from time import monotonic
 from typing import Optional
 
 from agent_bom.iac.models import IaCFinding
-from agent_bom.k8s_transport import K8sReadTransport, K8sTransportError, select_k8s_transport
+from agent_bom.k8s_transport import K8sReadTransport, K8sTransportError, select_k8s_transport, validate_kubelet_endpoint
 
 
 class K8sDiscoveryError(Exception):
@@ -637,6 +639,9 @@ _POSTURE_RESOURCES = (
     "roles",
     "nodes",
 )
+MAX_CONFIGZ_NODES = 100
+MAX_CONFIGZ_BUDGET_SECONDS = 60
+MAX_CONFIGZ_REQUEST_SECONDS = 30
 
 
 def _collector_state_for_error(exc: K8sTransportError) -> CollectorState:
@@ -654,19 +659,15 @@ def _kubelet_endpoint(node: dict) -> tuple[str, int] | None:
         for item in raw_addresses
         if isinstance(item, dict) and isinstance(item.get("address"), str) and item.get("address")
     }
-    host = next(
-        (
-            by_type[address_type]
-            for address_type in ("InternalDNS", "Hostname", "InternalIP", "ExternalDNS", "ExternalIP")
-            if by_type.get(address_type)
-        ),
-        None,
-    )
+    host = by_type.get("InternalIP")
     endpoint = (status.get("daemonEndpoints", {}) or {}).get("kubeletEndpoint", {}) or {}
     port = endpoint.get("Port", endpoint.get("port"))
-    if not host or not isinstance(port, int) or isinstance(port, bool) or not 1 <= port <= 65_535:
+    if not host or not isinstance(port, int) or isinstance(port, bool):
         return None
-    return str(host), port
+    try:
+        return validate_kubelet_endpoint(str(host), port)
+    except K8sTransportError:
+        return None
 
 
 def _posture_status(collectors: list[K8sCollectorEvidence]) -> K8sPostureStatus:
@@ -925,7 +926,13 @@ def scan_live_cluster_posture_with_evidence(
             config_count = 0
             config_errors: list[K8sTransportError] = []
             node_items = nodes.get("items", []) or []
-            for node in node_items:
+            config_truncated = len(node_items) > MAX_CONFIGZ_NODES
+            config_deadline = monotonic() + MAX_CONFIGZ_BUDGET_SECONDS
+            for node in node_items[:MAX_CONFIGZ_NODES]:
+                remaining_seconds = config_deadline - monotonic()
+                if remaining_seconds <= 0:
+                    config_truncated = True
+                    break
                 if not isinstance(node, dict):
                     continue
                 node_name = (node.get("metadata", {}) or {}).get("name")
@@ -947,7 +954,7 @@ def scan_live_cluster_posture_with_evidence(
                         kubelet_host,
                         kubelet_port,
                         "/configz",
-                        timeout=30,
+                        timeout=max(1, min(MAX_CONFIGZ_REQUEST_SECONDS, ceil(remaining_seconds))),
                     )
                 except K8sTransportError as exc:
                     config_errors.append(exc)
@@ -966,15 +973,19 @@ def scan_live_cluster_posture_with_evidence(
                     else CollectorState.UNEVALUABLE
                 )
                 message = f"{len(config_errors)} node config read(s) were not evaluable"
+            elif config_truncated and config_count == 0:
+                config_state = CollectorState.UNEVALUABLE
+                message = "nodes/configz collection reached its configured bound before any node was evaluated"
             else:
                 config_state = CollectorState.EXECUTED
-                message = ""
+                message = "nodes/configz collection reached its configured bound" if config_truncated else ""
             collectors.append(
                 K8sCollectorEvidence(
                     collector_id="kubelet_configz",
                     state=config_state,
                     object_count=config_count,
                     pages=config_count,
+                    truncated=config_truncated,
                     message=message,
                     transport=transport_name,
                 )

--- a/src/agent_bom/k8s_transport.py
+++ b/src/agent_bom/k8s_transport.py
@@ -212,10 +212,11 @@ class InClusterK8sTransport:
         if not ca_path.is_file():
             raise K8sTransportError("Service-account CA is unavailable", reason="credentials")
 
-        # A custom transport is used only by deterministic tests. Production
-        # clients always verify the mounted cluster CA.
+        # Always construct and retain the mounted cluster CA context. Custom
+        # transports are used by deterministic tests, but must not weaken the
+        # production constructor contract or disable certificate validation.
         try:
-            self._verify: ssl.SSLContext | bool = False if http_transport is not None else ssl.create_default_context(cafile=str(ca_path))
+            self._verify = ssl.create_default_context(cafile=str(ca_path))
             self._headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
             self._http_transport = http_transport
             self._client = httpx.Client(

--- a/src/agent_bom/k8s_transport.py
+++ b/src/agent_bom/k8s_transport.py
@@ -8,11 +8,13 @@ contexts; it is not required by the in-cluster path.
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import os
 import shutil
 import ssl
 import subprocess
+import tempfile
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from pathlib import Path
@@ -27,6 +29,9 @@ DEFAULT_TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
 DEFAULT_CA_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
 MAX_TIMEOUT_SECONDS = 60
 MAX_TOKEN_BYTES = 64 * 1024
+DEFAULT_MAX_RESPONSE_BYTES = 16 * 1024 * 1024
+MAX_RESPONSE_BYTES = 64 * 1024 * 1024
+KUBELET_HTTPS_PORT = 10_250
 
 
 class K8sTransportError(Exception):
@@ -88,9 +93,61 @@ def _clean_host(host: str) -> str:
 
 def _base_url(host: str, port: int) -> str:
     clean_host = _clean_host(host)
-    clean_port = _bounded_positive("port", int(port), 65_535)
+    try:
+        clean_port = _bounded_positive("port", int(port), 65_535)
+    except (TypeError, ValueError) as exc:
+        raise K8sTransportError("Invalid Kubernetes service port", reason="configuration") from exc
     display_host = f"[{clean_host}]" if ":" in clean_host else clean_host
     return f"https://{display_host}:{clean_port}"
+
+
+def validate_kubelet_endpoint(host: str, port: int) -> tuple[str, int]:
+    """Return a private InternalIP kubelet endpoint on its standard HTTPS port."""
+    clean_host = _clean_host(host)
+    try:
+        address = ipaddress.ip_address(clean_host)
+    except ValueError as exc:
+        raise K8sTransportError("Kubelet endpoint must be an internal IP address", reason="invalid_endpoint") from exc
+    if (
+        not address.is_private
+        or address.is_loopback
+        or address.is_link_local
+        or address.is_multicast
+        or address.is_unspecified
+        or address.is_reserved
+    ):
+        raise K8sTransportError("Kubelet endpoint must be an internal IP address", reason="invalid_endpoint")
+    if isinstance(port, bool) or port != KUBELET_HTTPS_PORT:
+        raise K8sTransportError("Kubelet endpoint must use the configured HTTPS port", reason="invalid_endpoint")
+    return clean_host, port
+
+
+def _read_http_response(response: httpx.Response, *, source: str, max_bytes: int) -> bytearray:
+    content_length = response.headers.get("content-length")
+    if content_length:
+        try:
+            declared_length = int(content_length)
+        except ValueError:
+            declared_length = 0
+        if declared_length > max_bytes:
+            raise K8sTransportError(f"{source} exceeded the configured byte bound", reason="response_too_large")
+
+    body = bytearray()
+    for chunk in response.iter_bytes():
+        if len(body) + len(chunk) > max_bytes:
+            raise K8sTransportError(f"{source} exceeded the configured byte bound", reason="response_too_large")
+        body.extend(chunk)
+    return body
+
+
+def _parse_json_object(body: str | bytes | bytearray, *, source: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError) as exc:
+        raise K8sTransportError(f"{source} returned invalid JSON", reason="invalid_json") from exc
+    if not isinstance(payload, dict):
+        raise K8sTransportError(f"{source} returned a non-object response", reason="invalid_json")
+    return payload
 
 
 def _resource_path(resource: str, namespace: str | None, all_namespaces: bool) -> str:
@@ -132,12 +189,14 @@ class InClusterK8sTransport:
         page_size: int = 500,
         max_pages: int = 20,
         max_items: int = 10_000,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
         http_transport: httpx.BaseTransport | None = None,
     ) -> None:
         self._timeout = _bounded_positive("timeout", timeout, MAX_TIMEOUT_SECONDS)
         self._page_size = _bounded_positive("page_size", page_size, 1_000)
         self._max_pages = _bounded_positive("max_pages", max_pages, 100)
         self._max_items = _bounded_positive("max_items", max_items, 50_000)
+        self._max_response_bytes = _bounded_positive("max_response_bytes", max_response_bytes, MAX_RESPONSE_BYTES)
         base_url = _base_url(host, port)
 
         try:
@@ -182,25 +241,26 @@ class InClusterK8sTransport:
     ) -> dict[str, Any]:
         request_timeout = self._timeout if timeout is None else _bounded_positive("timeout", timeout, MAX_TIMEOUT_SECONDS)
         try:
-            response = self._client.get(path, params=params, timeout=request_timeout)
+            with self._client.stream("GET", path, params=params, timeout=request_timeout) as response:
+                if not 200 <= response.status_code < 300:
+                    reason = "forbidden" if response.status_code in {401, 403} else "not_found" if response.status_code == 404 else "http"
+                    raise K8sTransportError(
+                        f"Kubernetes API returned HTTP {response.status_code}",
+                        status_code=response.status_code,
+                        reason=reason,
+                    )
+                body = _read_http_response(
+                    response,
+                    source="Kubernetes API response",
+                    max_bytes=self._max_response_bytes,
+                )
+        except K8sTransportError:
+            raise
         except httpx.TimeoutException as exc:
             raise K8sTransportError(f"Kubernetes API request timed out: {sanitize_error(exc)}", reason="timeout") from exc
         except httpx.HTTPError as exc:
             raise K8sTransportError(f"Kubernetes API request failed: {sanitize_error(exc)}", reason="connection") from exc
-        if not 200 <= response.status_code < 300:
-            reason = "forbidden" if response.status_code in {401, 403} else "not_found" if response.status_code == 404 else "http"
-            raise K8sTransportError(
-                f"Kubernetes API returned HTTP {response.status_code}",
-                status_code=response.status_code,
-                reason=reason,
-            )
-        try:
-            payload = response.json()
-        except (json.JSONDecodeError, ValueError) as exc:
-            raise K8sTransportError("Kubernetes API returned invalid JSON", reason="invalid_json") from exc
-        if not isinstance(payload, dict):
-            raise K8sTransportError("Kubernetes API returned a non-object response", reason="invalid_json")
-        return payload
+        return _parse_json_object(body, source="Kubernetes API")
 
     def get_kubelet_json(
         self,
@@ -213,35 +273,39 @@ class InClusterK8sTransport:
         """Read one explicitly allowed kubelet endpoint without API proxying."""
         if path != "/configz":
             raise K8sTransportError("Kubelet API path is not permitted", reason="invalid_path")
+        kubelet_host, kubelet_port = validate_kubelet_endpoint(host, port)
         request_timeout = self._timeout if timeout is None else _bounded_positive("timeout", timeout, MAX_TIMEOUT_SECONDS)
         try:
-            with httpx.Client(
-                base_url=_base_url(host, port),
-                headers=self._headers,
-                timeout=request_timeout,
-                verify=self._verify,
-                transport=self._http_transport,
-                follow_redirects=False,
-            ) as client:
-                response = client.get(path, timeout=request_timeout)
+            with (
+                httpx.Client(
+                    base_url=_base_url(kubelet_host, kubelet_port),
+                    headers=self._headers,
+                    timeout=request_timeout,
+                    verify=self._verify,
+                    transport=self._http_transport,
+                    follow_redirects=False,
+                ) as client,
+                client.stream("GET", path, timeout=request_timeout) as response,
+            ):
+                if not 200 <= response.status_code < 300:
+                    reason = "forbidden" if response.status_code in {401, 403} else "not_found" if response.status_code == 404 else "http"
+                    raise K8sTransportError(
+                        f"Kubelet API returned HTTP {response.status_code}",
+                        status_code=response.status_code,
+                        reason=reason,
+                    )
+                body = _read_http_response(
+                    response,
+                    source="Kubelet API response",
+                    max_bytes=self._max_response_bytes,
+                )
+        except K8sTransportError:
+            raise
         except httpx.TimeoutException as exc:
             raise K8sTransportError(f"Kubelet API request timed out: {sanitize_error(exc)}", reason="timeout") from exc
         except httpx.HTTPError as exc:
             raise K8sTransportError(f"Kubelet API request failed: {sanitize_error(exc)}", reason="connection") from exc
-        if not 200 <= response.status_code < 300:
-            reason = "forbidden" if response.status_code in {401, 403} else "not_found" if response.status_code == 404 else "http"
-            raise K8sTransportError(
-                f"Kubelet API returned HTTP {response.status_code}",
-                status_code=response.status_code,
-                reason=reason,
-            )
-        try:
-            payload = response.json()
-        except (json.JSONDecodeError, ValueError) as exc:
-            raise K8sTransportError("Kubelet API returned invalid JSON", reason="invalid_json") from exc
-        if not isinstance(payload, dict):
-            raise K8sTransportError("Kubelet API returned a non-object response", reason="invalid_json")
-        return payload
+        return _parse_json_object(body, source="Kubelet API")
 
     def _list_json(self, path: str, *, params: Mapping[str, str | int] | None = None) -> K8sReadResult:
         items: list[Any] = []
@@ -267,7 +331,9 @@ class InClusterK8sTransport:
             pages += 1
             final_payload = payload
             metadata = payload.get("metadata", {})
-            next_token = metadata.get("continue", "") if isinstance(metadata, dict) else ""
+            if not isinstance(metadata, dict):
+                raise K8sTransportError("Kubernetes list response has invalid metadata", reason="invalid_json")
+            next_token = metadata.get("continue", "")
             if not isinstance(next_token, str):
                 raise K8sTransportError("Kubernetes list response has invalid pagination", reason="invalid_json")
             if not next_token:
@@ -315,12 +381,14 @@ class KubectlK8sTransport:
         timeout: int = 60,
         page_size: int = 500,
         max_items: int = 10_000,
+        max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
     ) -> None:
         self.context = context
         self._run_json = run_json or self._default_run_json
         self._timeout = _bounded_positive("timeout", timeout, MAX_TIMEOUT_SECONDS)
         self._page_size = _bounded_positive("page_size", page_size, 1_000)
         self._max_items = _bounded_positive("max_items", max_items, 50_000)
+        self._max_response_bytes = _bounded_positive("max_response_bytes", max_response_bytes, MAX_RESPONSE_BYTES)
 
     def close(self) -> None:
         return None
@@ -332,26 +400,38 @@ class KubectlK8sTransport:
         if self.context:
             command += ["--context", self.context]
         try:
-            result = subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+            with tempfile.TemporaryFile() as stdout_file, tempfile.TemporaryFile() as stderr_file:
+                result = subprocess.run(
+                    command,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    text=False,
+                    timeout=timeout,
+                )
+                stdout_file.seek(0, os.SEEK_END)
+                stdout_size = stdout_file.tell()
+                stdout_file.seek(0)
+                stderr_file.seek(0)
+                result_stdout = getattr(result, "stdout", None)
+                result_stderr = getattr(result, "stderr", None)
+                stdout = result_stdout if isinstance(result_stdout, (str, bytes)) else stdout_file.read(self._max_response_bytes + 1)
+                stderr = result_stderr if isinstance(result_stderr, (str, bytes)) else stderr_file.read(64 * 1024)
         except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
             reason = "timeout" if isinstance(exc, subprocess.TimeoutExpired) else "unavailable"
             raise K8sTransportError(f"kubectl request failed: {sanitize_error(exc)}", reason=reason) from exc
+        if stdout_size > self._max_response_bytes or len(stdout.encode() if isinstance(stdout, str) else stdout) > self._max_response_bytes:
+            raise K8sTransportError("kubectl response exceeded the configured byte bound", reason="response_too_large")
+        stderr_text = stderr.decode("utf-8", errors="replace") if isinstance(stderr, bytes) else stderr
         if result.returncode != 0:
-            safe_stderr = sanitize_text(sanitize_error(result.stderr.strip()), max_len=160)
-            lowered = result.stderr.lower()
+            safe_stderr = sanitize_text(sanitize_error(stderr_text.strip()), max_len=160)
+            lowered = stderr_text.lower()
             status_code = 403 if "forbidden" in lowered else 401 if "unauthorized" in lowered else 404 if "not found" in lowered else None
             raise K8sTransportError(
                 f"kubectl returned exit code {result.returncode}: {safe_stderr}",
                 status_code=status_code,
                 reason="kubectl",
             )
-        try:
-            payload = json.loads(result.stdout)
-        except json.JSONDecodeError as exc:
-            raise K8sTransportError("kubectl returned invalid JSON", reason="invalid_json") from exc
-        if not isinstance(payload, dict):
-            raise K8sTransportError("kubectl returned a non-object response", reason="invalid_json")
-        return payload
+        return _parse_json_object(stdout, source="kubectl")
 
     def list_resource(
         self,
@@ -403,6 +483,7 @@ def select_k8s_transport(
     page_size: int = 500,
     max_pages: int = 20,
     max_items: int = 10_000,
+    max_response_bytes: int = DEFAULT_MAX_RESPONSE_BYTES,
 ) -> K8sReadTransport:
     """Choose native in-cluster HTTPS or the kubectl workstation fallback.
 
@@ -428,22 +509,27 @@ def select_k8s_transport(
             page_size=page_size,
             max_pages=max_pages,
             max_items=max_items,
+            max_response_bytes=max_response_bytes,
         )
     return KubectlK8sTransport(
         context=context,
         run_json=run_json,
         page_size=page_size,
         max_items=max_items,
+        max_response_bytes=max_response_bytes,
     )
 
 
 __all__ = [
     "DEFAULT_CA_PATH",
+    "DEFAULT_MAX_RESPONSE_BYTES",
     "DEFAULT_TOKEN_PATH",
     "InClusterK8sTransport",
     "K8sReadResult",
     "K8sReadTransport",
     "K8sTransportError",
+    "KUBELET_HTTPS_PORT",
     "KubectlK8sTransport",
     "select_k8s_transport",
+    "validate_kubelet_endpoint",
 ]

--- a/src/agent_bom/k8s_transport.py
+++ b/src/agent_bom/k8s_transport.py
@@ -1,0 +1,449 @@
+"""Read-only Kubernetes API transports for live posture collection.
+
+The native transport is intentionally small: it authenticates with the mounted
+service-account token and CA, permits only Kubernetes API GETs, and bounds list
+pagination.  ``kubectl`` remains a workstation fallback for configured local
+contexts; it is not required by the in-cluster path.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import ssl
+import subprocess
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Protocol
+from urllib.parse import quote
+
+import httpx
+
+from agent_bom.security import sanitize_error, sanitize_text
+
+DEFAULT_TOKEN_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/token")
+DEFAULT_CA_PATH = Path("/var/run/secrets/kubernetes.io/serviceaccount/ca.crt")
+MAX_TIMEOUT_SECONDS = 60
+MAX_TOKEN_BYTES = 64 * 1024
+
+
+class K8sTransportError(Exception):
+    """A secret-safe Kubernetes read failure."""
+
+    def __init__(self, message: str, *, status_code: int | None = None, reason: str = "request_failed") -> None:
+        super().__init__(sanitize_text(sanitize_error(message), max_len=200))
+        self.status_code = status_code
+        self.reason = reason
+
+
+@dataclass(frozen=True)
+class K8sReadResult:
+    """One bounded Kubernetes list result."""
+
+    data: dict[str, Any]
+    object_count: int
+    pages: int
+    truncated: bool
+
+
+class K8sReadTransport(Protocol):
+    """Transport boundary used by the posture collector."""
+
+    name: str
+
+    def list_resource(
+        self,
+        resource: str,
+        *,
+        namespace: str | None = None,
+        all_namespaces: bool = False,
+    ) -> K8sReadResult: ...
+
+    def get_kubelet_json(
+        self,
+        host: str,
+        port: int,
+        path: str,
+        *,
+        timeout: int | None = None,
+    ) -> dict[str, Any]: ...
+
+    def close(self) -> None: ...
+
+
+def _bounded_positive(name: str, value: int, maximum: int) -> int:
+    if not 1 <= value <= maximum:
+        raise ValueError(f"{name} must be between 1 and {maximum}")
+    return value
+
+
+def _clean_host(host: str) -> str:
+    clean_host = host.strip()
+    if not clean_host or any(part in clean_host for part in ("/", "://", "@", "?", "#", " ", "\t", "\n")):
+        raise K8sTransportError("Invalid Kubernetes service host", reason="invalid_host")
+    return clean_host
+
+
+def _base_url(host: str, port: int) -> str:
+    clean_host = _clean_host(host)
+    clean_port = _bounded_positive("port", int(port), 65_535)
+    display_host = f"[{clean_host}]" if ":" in clean_host else clean_host
+    return f"https://{display_host}:{clean_port}"
+
+
+def _resource_path(resource: str, namespace: str | None, all_namespaces: bool) -> str:
+    namespaced = {
+        "pods": ("/api/v1", "pods"),
+        "networkpolicies": ("/apis/networking.k8s.io/v1", "networkpolicies"),
+        "roles": ("/apis/rbac.authorization.k8s.io/v1", "roles"),
+    }
+    cluster_scoped = {
+        "clusterrolebindings": "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings",
+        "clusterroles": "/apis/rbac.authorization.k8s.io/v1/clusterroles",
+        "nodes": "/api/v1/nodes",
+    }
+    if resource in cluster_scoped:
+        return cluster_scoped[resource]
+    if resource not in namespaced:
+        raise K8sTransportError("Unsupported Kubernetes resource", reason="invalid_resource")
+    prefix, plural = namespaced[resource]
+    if all_namespaces:
+        return f"{prefix}/{plural}"
+    if not namespace:
+        raise K8sTransportError("Namespace is required for this Kubernetes resource", reason="invalid_namespace")
+    return f"{prefix}/namespaces/{quote(namespace, safe='')}/{plural}"
+
+
+class InClusterK8sTransport:
+    """Native HTTPS transport authenticated by a mounted service account."""
+
+    name = "in-cluster"
+
+    def __init__(
+        self,
+        *,
+        host: str,
+        port: int,
+        token_path: Path = DEFAULT_TOKEN_PATH,
+        ca_path: Path = DEFAULT_CA_PATH,
+        timeout: int = 15,
+        page_size: int = 500,
+        max_pages: int = 20,
+        max_items: int = 10_000,
+        http_transport: httpx.BaseTransport | None = None,
+    ) -> None:
+        self._timeout = _bounded_positive("timeout", timeout, MAX_TIMEOUT_SECONDS)
+        self._page_size = _bounded_positive("page_size", page_size, 1_000)
+        self._max_pages = _bounded_positive("max_pages", max_pages, 100)
+        self._max_items = _bounded_positive("max_items", max_items, 50_000)
+        base_url = _base_url(host, port)
+
+        try:
+            if token_path.stat().st_size > MAX_TOKEN_BYTES:
+                raise K8sTransportError("Service-account token is too large", reason="invalid_credentials")
+            token = token_path.read_text(encoding="utf-8").strip()
+        except K8sTransportError:
+            raise
+        except (OSError, UnicodeError) as exc:
+            raise K8sTransportError(f"Unable to read service-account token: {sanitize_error(exc)}", reason="credentials")
+        if not token:
+            raise K8sTransportError("Service-account token is empty", reason="invalid_credentials")
+        if not ca_path.is_file():
+            raise K8sTransportError("Service-account CA is unavailable", reason="credentials")
+
+        # A custom transport is used only by deterministic tests. Production
+        # clients always verify the mounted cluster CA.
+        try:
+            self._verify: ssl.SSLContext | bool = False if http_transport is not None else ssl.create_default_context(cafile=str(ca_path))
+            self._headers = {"Authorization": f"Bearer {token}", "Accept": "application/json"}
+            self._http_transport = http_transport
+            self._client = httpx.Client(
+                base_url=base_url,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify,
+                transport=http_transport,
+                follow_redirects=False,
+            )
+        except (OSError, ssl.SSLError, ValueError) as exc:
+            raise K8sTransportError(f"Unable to initialize Kubernetes TLS: {sanitize_error(exc)}", reason="tls") from exc
+
+    def close(self) -> None:
+        self._client.close()
+
+    def _request_json(
+        self,
+        path: str,
+        *,
+        params: Mapping[str, str | int] | None = None,
+        timeout: int | None = None,
+    ) -> dict[str, Any]:
+        request_timeout = self._timeout if timeout is None else _bounded_positive("timeout", timeout, MAX_TIMEOUT_SECONDS)
+        try:
+            response = self._client.get(path, params=params, timeout=request_timeout)
+        except httpx.TimeoutException as exc:
+            raise K8sTransportError(f"Kubernetes API request timed out: {sanitize_error(exc)}", reason="timeout") from exc
+        except httpx.HTTPError as exc:
+            raise K8sTransportError(f"Kubernetes API request failed: {sanitize_error(exc)}", reason="connection") from exc
+        if not 200 <= response.status_code < 300:
+            reason = "forbidden" if response.status_code in {401, 403} else "not_found" if response.status_code == 404 else "http"
+            raise K8sTransportError(
+                f"Kubernetes API returned HTTP {response.status_code}",
+                status_code=response.status_code,
+                reason=reason,
+            )
+        try:
+            payload = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise K8sTransportError("Kubernetes API returned invalid JSON", reason="invalid_json") from exc
+        if not isinstance(payload, dict):
+            raise K8sTransportError("Kubernetes API returned a non-object response", reason="invalid_json")
+        return payload
+
+    def get_kubelet_json(
+        self,
+        host: str,
+        port: int,
+        path: str,
+        *,
+        timeout: int | None = None,
+    ) -> dict[str, Any]:
+        """Read one explicitly allowed kubelet endpoint without API proxying."""
+        if path != "/configz":
+            raise K8sTransportError("Kubelet API path is not permitted", reason="invalid_path")
+        request_timeout = self._timeout if timeout is None else _bounded_positive("timeout", timeout, MAX_TIMEOUT_SECONDS)
+        try:
+            with httpx.Client(
+                base_url=_base_url(host, port),
+                headers=self._headers,
+                timeout=request_timeout,
+                verify=self._verify,
+                transport=self._http_transport,
+                follow_redirects=False,
+            ) as client:
+                response = client.get(path, timeout=request_timeout)
+        except httpx.TimeoutException as exc:
+            raise K8sTransportError(f"Kubelet API request timed out: {sanitize_error(exc)}", reason="timeout") from exc
+        except httpx.HTTPError as exc:
+            raise K8sTransportError(f"Kubelet API request failed: {sanitize_error(exc)}", reason="connection") from exc
+        if not 200 <= response.status_code < 300:
+            reason = "forbidden" if response.status_code in {401, 403} else "not_found" if response.status_code == 404 else "http"
+            raise K8sTransportError(
+                f"Kubelet API returned HTTP {response.status_code}",
+                status_code=response.status_code,
+                reason=reason,
+            )
+        try:
+            payload = response.json()
+        except (json.JSONDecodeError, ValueError) as exc:
+            raise K8sTransportError("Kubelet API returned invalid JSON", reason="invalid_json") from exc
+        if not isinstance(payload, dict):
+            raise K8sTransportError("Kubelet API returned a non-object response", reason="invalid_json")
+        return payload
+
+    def _list_json(self, path: str, *, params: Mapping[str, str | int] | None = None) -> K8sReadResult:
+        items: list[Any] = []
+        continue_token = ""
+        seen_tokens: set[str] = set()
+        pages = 0
+        truncated = False
+        final_payload: dict[str, Any] = {}
+
+        while pages < self._max_pages and len(items) < self._max_items:
+            page_params: dict[str, str | int] = dict(params or {})
+            page_params["limit"] = min(self._page_size, self._max_items - len(items))
+            if continue_token:
+                page_params["continue"] = continue_token
+            payload = self._request_json(path, params=page_params)
+            page_items = payload.get("items", [])
+            if not isinstance(page_items, list):
+                raise K8sTransportError("Kubernetes list response has invalid items", reason="invalid_json")
+            remaining = self._max_items - len(items)
+            items.extend(page_items[:remaining])
+            if len(page_items) > remaining:
+                truncated = True
+            pages += 1
+            final_payload = payload
+            metadata = payload.get("metadata", {})
+            next_token = metadata.get("continue", "") if isinstance(metadata, dict) else ""
+            if not isinstance(next_token, str):
+                raise K8sTransportError("Kubernetes list response has invalid pagination", reason="invalid_json")
+            if not next_token:
+                break
+            if next_token in seen_tokens:
+                raise K8sTransportError("Kubernetes pagination token repeated", reason="pagination")
+            seen_tokens.add(next_token)
+            continue_token = next_token
+        else:
+            truncated = bool(continue_token)
+
+        metadata = final_payload.get("metadata", {})
+        if isinstance(metadata, dict) and metadata.get("continue") and (pages >= self._max_pages or len(items) >= self._max_items):
+            truncated = True
+        result_payload = dict(final_payload)
+        result_payload["items"] = items
+        result_metadata = dict(metadata) if isinstance(metadata, dict) else {}
+        result_metadata.pop("continue", None)
+        result_payload["metadata"] = result_metadata
+        return K8sReadResult(data=result_payload, object_count=len(items), pages=pages, truncated=truncated)
+
+    def list_resource(
+        self,
+        resource: str,
+        *,
+        namespace: str | None = None,
+        all_namespaces: bool = False,
+    ) -> K8sReadResult:
+        return self._list_json(_resource_path(resource, namespace, all_namespaces))
+
+
+RunJson = Callable[[list[str], int], dict[str, Any]]
+
+
+class KubectlK8sTransport:
+    """Bounded workstation fallback using a configured kubectl context."""
+
+    name = "kubectl"
+
+    def __init__(
+        self,
+        *,
+        context: str | None = None,
+        run_json: RunJson | None = None,
+        timeout: int = 60,
+        page_size: int = 500,
+        max_items: int = 10_000,
+    ) -> None:
+        self.context = context
+        self._run_json = run_json or self._default_run_json
+        self._timeout = _bounded_positive("timeout", timeout, MAX_TIMEOUT_SECONDS)
+        self._page_size = _bounded_positive("page_size", page_size, 1_000)
+        self._max_items = _bounded_positive("max_items", max_items, 50_000)
+
+    def close(self) -> None:
+        return None
+
+    def _default_run_json(self, args: list[str], timeout: int) -> dict[str, Any]:
+        if shutil.which("kubectl") is None:
+            raise K8sTransportError("kubectl is not available", reason="unavailable")
+        command = ["kubectl", *args]
+        if self.context:
+            command += ["--context", self.context]
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, timeout=timeout)
+        except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+            reason = "timeout" if isinstance(exc, subprocess.TimeoutExpired) else "unavailable"
+            raise K8sTransportError(f"kubectl request failed: {sanitize_error(exc)}", reason=reason) from exc
+        if result.returncode != 0:
+            safe_stderr = sanitize_text(sanitize_error(result.stderr.strip()), max_len=160)
+            lowered = result.stderr.lower()
+            status_code = 403 if "forbidden" in lowered else 401 if "unauthorized" in lowered else 404 if "not found" in lowered else None
+            raise K8sTransportError(
+                f"kubectl returned exit code {result.returncode}: {safe_stderr}",
+                status_code=status_code,
+                reason="kubectl",
+            )
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            raise K8sTransportError("kubectl returned invalid JSON", reason="invalid_json") from exc
+        if not isinstance(payload, dict):
+            raise K8sTransportError("kubectl returned a non-object response", reason="invalid_json")
+        return payload
+
+    def list_resource(
+        self,
+        resource: str,
+        *,
+        namespace: str | None = None,
+        all_namespaces: bool = False,
+    ) -> K8sReadResult:
+        # Validate the resource against the same allowlist as the native path.
+        _resource_path(resource, namespace, all_namespaces)
+        args = ["get", resource, "-o", "json", f"--chunk-size={self._page_size}"]
+        if resource in {"pods", "networkpolicies", "roles"}:
+            if all_namespaces:
+                args.append("-A")
+            elif namespace:
+                args += ["-n", namespace]
+        payload = self._run_json(args, self._timeout)
+        raw_items = payload.get("items", [])
+        if not isinstance(raw_items, list):
+            raise K8sTransportError("kubectl list response has invalid items", reason="invalid_json")
+        truncated = len(raw_items) > self._max_items
+        items = raw_items[: self._max_items]
+        data = dict(payload)
+        data["items"] = items
+        return K8sReadResult(data=data, object_count=len(items), pages=1, truncated=truncated)
+
+    def get_kubelet_json(
+        self,
+        host: str,
+        port: int,
+        path: str,
+        *,
+        timeout: int | None = None,
+    ) -> dict[str, Any]:
+        del host, port, path, timeout
+        raise K8sTransportError(
+            "Direct kubelet config collection is unavailable through the kubectl fallback",
+            status_code=404,
+            reason="unsupported",
+        )
+
+
+def select_k8s_transport(
+    *,
+    context: str | None = None,
+    token_path: Path = DEFAULT_TOKEN_PATH,
+    ca_path: Path = DEFAULT_CA_PATH,
+    run_json: RunJson | None = None,
+    page_size: int = 500,
+    max_pages: int = 20,
+    max_items: int = 10_000,
+) -> K8sReadTransport:
+    """Choose native in-cluster HTTPS or the kubectl workstation fallback.
+
+    An explicit context always selects kubectl.  Otherwise, any in-cluster
+    service environment marker selects the native path and configuration
+    failures are surfaced; they never silently fall back to kubectl.
+    """
+
+    host = os.getenv("KUBERNETES_SERVICE_HOST")
+    port_text = os.getenv("KUBERNETES_SERVICE_PORT")
+    if context is None and (host or port_text):
+        if not host or not port_text:
+            raise K8sTransportError("Incomplete in-cluster Kubernetes service configuration", reason="configuration")
+        try:
+            port = int(port_text)
+        except ValueError as exc:
+            raise K8sTransportError("Invalid Kubernetes service port", reason="configuration") from exc
+        return InClusterK8sTransport(
+            host=host,
+            port=port,
+            token_path=token_path,
+            ca_path=ca_path,
+            page_size=page_size,
+            max_pages=max_pages,
+            max_items=max_items,
+        )
+    return KubectlK8sTransport(
+        context=context,
+        run_json=run_json,
+        page_size=page_size,
+        max_items=max_items,
+    )
+
+
+__all__ = [
+    "DEFAULT_CA_PATH",
+    "DEFAULT_TOKEN_PATH",
+    "InClusterK8sTransport",
+    "K8sReadResult",
+    "K8sReadTransport",
+    "K8sTransportError",
+    "KubectlK8sTransport",
+    "select_k8s_transport",
+]

--- a/tests/test_k8s_live_cluster.py
+++ b/tests/test_k8s_live_cluster.py
@@ -19,12 +19,16 @@ import subprocess
 import pytest
 
 from agent_bom.k8s import (
+    CollectorState,
     K8sDiscoveryError,
+    K8sPostureStatus,
     evaluate_kubelet_config,
     evaluate_pod_security,
     evaluate_rbac,
     scan_live_cluster_posture,
+    scan_live_cluster_posture_with_evidence,
 )
+from agent_bom.k8s_transport import K8sReadResult, K8sTransportError
 
 # ─── PodSecurity (running workloads) ─────────────────────────────────────────
 
@@ -337,10 +341,8 @@ def test_scan_live_cluster_no_kubectl(monkeypatch):
         scan_live_cluster_posture(namespace="prod")
 
 
-def test_scan_live_cluster_kubelet_unreachable_skips_not_fails(monkeypatch):
-    """A managed cluster that blocks the kubelet configz proxy must skip node
-    checks honestly (no finding fabricated, scan still completes) rather than
-    crash or emit a false pass."""
+def test_scan_live_cluster_does_not_request_configz_by_default(monkeypatch):
+    """The compatibility scan does not request opt-in node config evidence."""
     monkeypatch.setattr(shutil, "which", lambda cmd: "/usr/bin/" + cmd)
 
     import json
@@ -361,12 +363,7 @@ def test_scan_live_cluster_kubelet_unreachable_skips_not_fails(monkeypatch):
         r = R()
         r.stderr = ""
         key = tuple(cmd[1:3])
-        if key == ("get", "--raw"):
-            # kubelet configz blocked (managed control plane)
-            r.returncode = 1
-            r.stdout = ""
-            r.stderr = "Error from server (Forbidden): nodes proxy is forbidden"
-            return r
+        assert key != ("get", "--raw")
         r.returncode = 0
         r.stdout = json.dumps(payloads[key])
         return r
@@ -376,3 +373,154 @@ def test_scan_live_cluster_kubelet_unreachable_skips_not_fails(monkeypatch):
     # Must not raise; kubelet checks are simply skipped.
     findings = scan_live_cluster_posture(namespace="prod")
     assert all(not f.rule_id.startswith("K8S-LIVE-02") for f in findings)
+
+
+class _FixtureTransport:
+    name = "fixture"
+
+    def __init__(self, payloads: dict[str, dict], errors: dict[str, K8sTransportError] | None = None) -> None:
+        self.payloads = payloads
+        self.errors = errors or {}
+        self.get_paths: list[tuple[str, int, str]] = []
+
+    def list_resource(self, resource: str, *, namespace: str | None = None, all_namespaces: bool = False):
+        del namespace, all_namespaces
+        if resource in self.errors:
+            raise self.errors[resource]
+        data = self.payloads.get(resource, {"items": []})
+        return K8sReadResult(data=data, object_count=len(data.get("items", [])), pages=1, truncated=False)
+
+    def get_kubelet_json(self, host: str, port: int, path: str, *, timeout: int | None = None):
+        del timeout
+        self.get_paths.append((host, port, path))
+        if "configz" in self.errors:
+            raise self.errors["configz"]
+        return self.payloads.get("configz", {})
+
+    def close(self) -> None:
+        return None
+
+
+def _foundation_payloads() -> dict[str, dict]:
+    return {
+        "pods": {
+            "items": [
+                _pod(
+                    {
+                        "automountServiceAccountToken": False,
+                        "securityContext": {"runAsNonRoot": True},
+                        "containers": [{"name": "c", "securityContext": {"privileged": True}}],
+                    }
+                )
+            ]
+        },
+        "networkpolicies": {"items": []},
+        "clusterrolebindings": {"items": []},
+        "clusterroles": {"items": []},
+        "roles": {"items": []},
+        "nodes": {
+            "items": [
+                {
+                    "metadata": {"name": "node-a"},
+                    "status": {
+                        "addresses": [{"type": "InternalIP", "address": "10.0.0.10"}],
+                        "daemonEndpoints": {"kubeletEndpoint": {"Port": 10250}},
+                    },
+                }
+            ]
+        },
+    }
+
+
+def test_posture_evidence_isolates_forbidden_collector_without_false_network_policy_finding() -> None:
+    transport = _FixtureTransport(
+        _foundation_payloads(),
+        errors={"networkpolicies": K8sTransportError("forbidden", status_code=403)},
+    )
+
+    result = scan_live_cluster_posture_with_evidence(namespace="prod", transport=transport)
+
+    evidence = {item.collector_id: item for item in result.collectors}
+    assert result.status is K8sPostureStatus.PARTIAL
+    assert evidence["pods"].state is CollectorState.EXECUTED
+    assert evidence["networkpolicies"].state is CollectorState.UNEVALUABLE
+    assert "K8S-LIVE-007" in {finding.rule_id for finding in result.findings}
+    assert "K8S-LIVE-005" not in {finding.rule_id for finding in result.findings}
+
+
+def test_kubelet_configz_is_opt_in_and_skipped_without_proxy_access() -> None:
+    transport = _FixtureTransport(_foundation_payloads())
+
+    result = scan_live_cluster_posture_with_evidence(namespace="prod", transport=transport)
+
+    evidence = {item.collector_id: item for item in result.collectors}
+    assert evidence["kubelet_configz"].state is CollectorState.SKIPPED
+    assert result.status is K8sPostureStatus.COMPLETE
+    assert transport.get_paths == []
+
+
+def test_kubelet_configz_forbidden_is_unevaluable_not_clean() -> None:
+    transport = _FixtureTransport(
+        _foundation_payloads(),
+        errors={"configz": K8sTransportError("forbidden", status_code=403)},
+    )
+
+    result = scan_live_cluster_posture_with_evidence(
+        namespace="prod",
+        transport=transport,
+        enable_nodes_configz=True,
+    )
+
+    evidence = {item.collector_id: item for item in result.collectors}
+    assert evidence["kubelet_configz"].state is CollectorState.UNEVALUABLE
+    assert result.status is K8sPostureStatus.PARTIAL
+    assert transport.get_paths == [("10.0.0.10", 10250, "/configz")]
+    assert all(not finding.rule_id.startswith("K8S-LIVE-02") for finding in result.findings)
+
+
+def test_kubelet_configz_success_is_executed_evidence() -> None:
+    payloads = _foundation_payloads()
+    payloads["configz"] = {
+        "kubeletconfig": {
+            "authentication": {"anonymous": {"enabled": False}},
+            "authorization": {"mode": "Webhook"},
+            "readOnlyPort": 0,
+        }
+    }
+    transport = _FixtureTransport(payloads)
+
+    result = scan_live_cluster_posture_with_evidence(
+        namespace="prod",
+        transport=transport,
+        enable_nodes_configz=True,
+    )
+
+    evidence = {item.collector_id: item for item in result.collectors}
+    assert evidence["kubelet_configz"].state is CollectorState.EXECUTED
+    assert evidence["kubelet_configz"].object_count == 1
+    assert result.status is K8sPostureStatus.COMPLETE
+
+
+def test_posture_evidence_records_failed_collectors_without_raising() -> None:
+    errors = {
+        resource: K8sTransportError("connection failed")
+        for resource in ("pods", "networkpolicies", "clusterrolebindings", "clusterroles", "roles", "nodes")
+    }
+
+    result = scan_live_cluster_posture_with_evidence(transport=_FixtureTransport({}, errors=errors))
+
+    assert result.status is K8sPostureStatus.FAILED
+    assert {item.state for item in result.collectors if item.collector_id != "kubelet_configz"} == {CollectorState.FAILED}
+
+
+def test_compatibility_wrapper_fails_closed_on_partial_evidence(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bom.k8s as k8s_module
+
+    transport = _FixtureTransport(
+        _foundation_payloads(),
+        errors={"networkpolicies": K8sTransportError("forbidden", status_code=403)},
+    )
+    monkeypatch.setattr(k8s_module, "select_k8s_transport", lambda **_kwargs: transport)
+
+    with pytest.raises(K8sDiscoveryError, match="forbidden"):
+        scan_live_cluster_posture(namespace="prod")

--- a/tests/test_k8s_live_cluster.py
+++ b/tests/test_k8s_live_cluster.py
@@ -501,6 +501,76 @@ def test_kubelet_configz_success_is_executed_evidence() -> None:
     assert result.status is K8sPostureStatus.COMPLETE
 
 
+def test_kubelet_configz_rejects_external_node_metadata_without_requesting_it() -> None:
+    payloads = _foundation_payloads()
+    payloads["nodes"]["items"][0]["status"]["addresses"] = [
+        {"type": "ExternalIP", "address": "8.8.8.8"},
+    ]
+    transport = _FixtureTransport(payloads)
+
+    result = scan_live_cluster_posture_with_evidence(
+        namespace="prod",
+        transport=transport,
+        enable_nodes_configz=True,
+    )
+
+    evidence = {item.collector_id: item for item in result.collectors}
+    assert evidence["kubelet_configz"].state is CollectorState.UNEVALUABLE
+    assert result.status is K8sPostureStatus.PARTIAL
+    assert transport.get_paths == []
+
+
+def test_kubelet_configz_caps_node_fanout(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bom.k8s as k8s_module
+
+    payloads = _foundation_payloads()
+    second_node = {
+        "metadata": {"name": "node-b"},
+        "status": {
+            "addresses": [{"type": "InternalIP", "address": "10.0.0.11"}],
+            "daemonEndpoints": {"kubeletEndpoint": {"Port": 10250}},
+        },
+    }
+    payloads["nodes"]["items"].append(second_node)
+    payloads["configz"] = {"kubeletconfig": {"readOnlyPort": 0}}
+    transport = _FixtureTransport(payloads)
+    monkeypatch.setattr(k8s_module, "MAX_CONFIGZ_NODES", 1)
+
+    result = scan_live_cluster_posture_with_evidence(
+        namespace="prod",
+        transport=transport,
+        enable_nodes_configz=True,
+    )
+
+    evidence = {item.collector_id: item for item in result.collectors}
+    assert evidence["kubelet_configz"].truncated is True
+    assert evidence["kubelet_configz"].object_count == 1
+    assert result.status is K8sPostureStatus.PARTIAL
+    assert transport.get_paths == [("10.0.0.10", 10250, "/configz")]
+
+
+def test_kubelet_configz_honors_overall_deadline(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bom.k8s as k8s_module
+
+    payloads = _foundation_payloads()
+    transport = _FixtureTransport(payloads)
+    readings = iter((100.0, 161.0))
+    monkeypatch.setattr(k8s_module, "monotonic", lambda: next(readings))
+    monkeypatch.setattr(k8s_module, "MAX_CONFIGZ_BUDGET_SECONDS", 60)
+
+    result = scan_live_cluster_posture_with_evidence(
+        namespace="prod",
+        transport=transport,
+        enable_nodes_configz=True,
+    )
+
+    evidence = {item.collector_id: item for item in result.collectors}
+    assert evidence["kubelet_configz"].truncated is True
+    assert evidence["kubelet_configz"].object_count == 0
+    assert result.status is K8sPostureStatus.PARTIAL
+    assert transport.get_paths == []
+
+
 def test_posture_evidence_records_failed_collectors_without_raising() -> None:
     errors = {
         resource: K8sTransportError("connection failed")
@@ -511,6 +581,18 @@ def test_posture_evidence_records_failed_collectors_without_raising() -> None:
 
     assert result.status is K8sPostureStatus.FAILED
     assert {item.state for item in result.collectors if item.collector_id != "kubelet_configz"} == {CollectorState.FAILED}
+
+
+def test_posture_evidence_normalizes_invalid_in_cluster_port(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "0")
+
+    result = scan_live_cluster_posture_with_evidence()
+
+    assert result.status is K8sPostureStatus.FAILED
+    assert result.transport == "unavailable"
+    assert {item.state for item in result.collectors if item.collector_id != "kubelet_configz"} == {CollectorState.FAILED}
+    assert {item.message for item in result.collectors if item.collector_id != "kubelet_configz"} == {"Invalid Kubernetes service port"}
 
 
 def test_compatibility_wrapper_fails_closed_on_partial_evidence(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_k8s_transport.py
+++ b/tests/test_k8s_transport.py
@@ -1,0 +1,266 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import certifi
+import httpx
+import pytest
+
+from agent_bom.k8s_transport import (
+    InClusterK8sTransport,
+    K8sTransportError,
+    KubectlK8sTransport,
+    select_k8s_transport,
+)
+
+
+def _service_account_files(tmp_path: Path) -> tuple[Path, Path]:
+    token_path = tmp_path / "token"
+    ca_path = tmp_path / "ca.crt"
+    token_path.write_text("service-account-secret\n", encoding="utf-8")
+    ca_path.write_text(Path(certifi.where()).read_text(encoding="utf-8"), encoding="utf-8")
+    return token_path, ca_path
+
+
+def test_native_transport_paginates_with_bearer_auth_and_bounds(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        assert request.method == "GET"
+        assert request.headers["authorization"] == "Bearer service-account-secret"
+        if request.url.params.get("continue"):
+            return httpx.Response(200, json={"items": [{"metadata": {"name": "pod-c"}}], "metadata": {}})
+        return httpx.Response(
+            200,
+            json={
+                "items": [{"metadata": {"name": "pod-a"}}, {"metadata": {"name": "pod-b"}}],
+                "metadata": {"continue": "next-page"},
+            },
+        )
+
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        page_size=2,
+        max_pages=3,
+        max_items=5,
+        http_transport=httpx.MockTransport(handler),
+    )
+    try:
+        result = transport.list_resource("pods", all_namespaces=True)
+    finally:
+        transport.close()
+
+    assert [item["metadata"]["name"] for item in result.data["items"]] == ["pod-a", "pod-b", "pod-c"]
+    assert result.object_count == 3
+    assert result.pages == 2
+    assert result.truncated is False
+    assert requests[0].url.params["limit"] == "2"
+    assert requests[1].url.params["continue"] == "next-page"
+
+
+def test_native_transport_marks_page_limit_truncation(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        page = request.url.params.get("continue") or "0"
+        return httpx.Response(
+            200,
+            json={"items": [{"metadata": {"name": f"pod-{page}"}}], "metadata": {"continue": str(int(page) + 1)}},
+        )
+
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        page_size=1,
+        max_pages=2,
+        max_items=10,
+        http_transport=httpx.MockTransport(handler),
+    )
+    try:
+        result = transport.list_resource("pods", all_namespaces=True)
+    finally:
+        transport.close()
+
+    assert result.pages == 2
+    assert result.object_count == 2
+    assert result.truncated is True
+
+
+def test_native_transport_sanitizes_forbidden_response(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="token=service-account-secret /var/run/secrets/private")
+
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        http_transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(K8sTransportError) as caught:
+            transport.list_resource("pods", all_namespaces=True)
+    finally:
+        transport.close()
+
+    assert caught.value.status_code == 403
+    assert "service-account-secret" not in str(caught.value)
+    assert "/var/run" not in str(caught.value)
+
+
+def test_native_transport_bounds_timeout_and_sanitizes_timeout_detail(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ReadTimeout("token=service-account-secret https://10.0.0.1/private", request=request)
+
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        timeout=5,
+        http_transport=httpx.MockTransport(handler),
+    )
+    try:
+        with pytest.raises(K8sTransportError) as caught:
+            transport.list_resource("pods", all_namespaces=True)
+    finally:
+        transport.close()
+
+    assert caught.value.reason == "timeout"
+    assert "service-account-secret" not in str(caught.value)
+    assert "10.0.0.1" not in str(caught.value)
+
+
+def test_native_transport_rejects_unbounded_timeout(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    with pytest.raises(ValueError, match="timeout"):
+        InClusterK8sTransport(
+            host="10.0.0.1",
+            port=443,
+            token_path=token_path,
+            ca_path=ca_path,
+            timeout=61,
+        )
+
+
+def test_native_transport_rejects_proxy_paths(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        http_transport=httpx.MockTransport(lambda _request: httpx.Response(200, json={})),
+    )
+    try:
+        with pytest.raises(K8sTransportError, match="not permitted"):
+            transport.get_kubelet_json("10.0.0.10", 10250, "/proxy/configz")
+    finally:
+        transport.close()
+
+
+def test_native_transport_reads_only_direct_kubelet_configz(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.host == "10.0.0.10"
+        assert request.url.port == 10250
+        assert request.url.path == "/configz"
+        assert request.headers["authorization"] == "Bearer service-account-secret"
+        return httpx.Response(200, json={"kubeletconfig": {"readOnlyPort": 0}})
+
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        http_transport=httpx.MockTransport(handler),
+    )
+    try:
+        result = transport.get_kubelet_json("10.0.0.10", 10250, "/configz")
+    finally:
+        transport.close()
+
+    assert result == {"kubeletconfig": {"readOnlyPort": 0}}
+
+
+def test_select_transport_prefers_in_cluster_and_never_falls_back_to_kubectl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+
+    selected = select_k8s_transport(token_path=token_path, ca_path=ca_path)
+    try:
+        assert isinstance(selected, InClusterK8sTransport)
+    finally:
+        selected.close()
+
+
+def test_select_transport_uses_kubectl_for_workstation_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+    monkeypatch.delenv("KUBERNETES_SERVICE_PORT", raising=False)
+    selected = select_k8s_transport(context="dev-cluster")
+    assert isinstance(selected, KubectlK8sTransport)
+    assert selected.context == "dev-cluster"
+
+
+def test_in_cluster_configuration_failure_never_falls_back_to_kubectl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "443")
+    missing_token = tmp_path / "missing-token"
+    ca_path = tmp_path / "ca.crt"
+    ca_path.write_text(Path(certifi.where()).read_text(encoding="utf-8"), encoding="utf-8")
+
+    with pytest.raises(K8sTransportError, match="service-account token"):
+        select_k8s_transport(token_path=missing_token, ca_path=ca_path)
+
+
+def test_kubectl_transport_caps_returned_items() -> None:
+    payload = {"items": [{"metadata": {"name": f"pod-{index}"}} for index in range(4)]}
+
+    def run_json(args: list[str], timeout: int) -> dict:
+        assert "--chunk-size=2" in args
+        assert timeout <= 60
+        return json.loads(json.dumps(payload))
+
+    transport = KubectlK8sTransport(run_json=run_json, page_size=2, max_items=3)
+    result = transport.list_resource("pods", namespace="prod")
+
+    assert result.object_count == 3
+    assert result.truncated is True
+
+
+def test_kubectl_transport_classifies_and_sanitizes_forbidden(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bom.k8s_transport as transport_module
+
+    monkeypatch.setattr(transport_module.shutil, "which", lambda _command: "/usr/bin/kubectl")
+    monkeypatch.setattr(
+        transport_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(
+            returncode=1,
+            stdout="",
+            stderr="Error from server (Forbidden): token=cluster-secret /var/run/private",
+        ),
+    )
+    transport = KubectlK8sTransport()
+
+    with pytest.raises(K8sTransportError) as caught:
+        transport.list_resource("networkpolicies", namespace="prod")
+
+    assert caught.value.status_code == 403
+    assert "cluster-secret" not in str(caught.value)
+    assert "/var/run" not in str(caught.value)

--- a/tests/test_k8s_transport.py
+++ b/tests/test_k8s_transport.py
@@ -172,6 +172,27 @@ def test_native_transport_rejects_proxy_paths(tmp_path: Path) -> None:
         transport.close()
 
 
+def test_native_transport_rejects_external_or_nonstandard_kubelet_endpoints(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    requests: list[httpx.Request] = []
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        http_transport=httpx.MockTransport(lambda request: requests.append(request) or httpx.Response(200, json={})),
+    )
+    try:
+        with pytest.raises(K8sTransportError, match="internal"):
+            transport.get_kubelet_json("8.8.8.8", 10250, "/configz")
+        with pytest.raises(K8sTransportError, match="port"):
+            transport.get_kubelet_json("10.0.0.10", 443, "/configz")
+    finally:
+        transport.close()
+
+    assert requests == []
+
+
 def test_native_transport_reads_only_direct_kubelet_configz(tmp_path: Path) -> None:
     token_path, ca_path = _service_account_files(tmp_path)
 
@@ -195,6 +216,45 @@ def test_native_transport_reads_only_direct_kubelet_configz(tmp_path: Path) -> N
         transport.close()
 
     assert result == {"kubeletconfig": {"readOnlyPort": 0}}
+
+
+def test_native_transport_rejects_response_before_json_materialization(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        max_response_bytes=32,
+        http_transport=httpx.MockTransport(lambda _request: httpx.Response(200, content=b'{"items":["' + (b"x" * 64) + b'"]}')),
+    )
+    try:
+        with pytest.raises(K8sTransportError, match="configured byte bound") as caught:
+            transport.list_resource("pods", all_namespaces=True)
+    finally:
+        transport.close()
+
+    assert caught.value.reason == "response_too_large"
+
+
+def test_native_transport_rejects_non_object_list_metadata(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        http_transport=httpx.MockTransport(
+            lambda _request: httpx.Response(200, json={"items": [{"metadata": {"name": "pod-a"}}], "metadata": "bad"})
+        ),
+    )
+    try:
+        with pytest.raises(K8sTransportError, match="metadata") as caught:
+            transport.list_resource("pods", all_namespaces=True)
+    finally:
+        transport.close()
+
+    assert caught.value.reason == "invalid_json"
 
 
 def test_select_transport_prefers_in_cluster_and_never_falls_back_to_kubectl(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -226,6 +286,17 @@ def test_in_cluster_configuration_failure_never_falls_back_to_kubectl(monkeypatc
 
     with pytest.raises(K8sTransportError, match="service-account token"):
         select_k8s_transport(token_path=missing_token, ca_path=ca_path)
+
+
+def test_in_cluster_out_of_range_port_is_a_transport_configuration_error(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.0.0.1")
+    monkeypatch.setenv("KUBERNETES_SERVICE_PORT", "0")
+
+    with pytest.raises(K8sTransportError, match="service port") as caught:
+        select_k8s_transport(token_path=token_path, ca_path=ca_path)
+
+    assert caught.value.reason == "configuration"
 
 
 def test_kubectl_transport_caps_returned_items() -> None:
@@ -264,3 +335,20 @@ def test_kubectl_transport_classifies_and_sanitizes_forbidden(monkeypatch: pytes
     assert caught.value.status_code == 403
     assert "cluster-secret" not in str(caught.value)
     assert "/var/run" not in str(caught.value)
+
+
+def test_kubectl_transport_rejects_stdout_above_byte_bound(monkeypatch: pytest.MonkeyPatch) -> None:
+    import agent_bom.k8s_transport as transport_module
+
+    def oversized_run(*_args, **kwargs):
+        kwargs["stdout"].write(b'{"items":["' + (b"x" * 64) + b'"]}')
+        return SimpleNamespace(returncode=0, stdout=None, stderr=None)
+
+    monkeypatch.setattr(transport_module.shutil, "which", lambda _command: "/usr/bin/kubectl")
+    monkeypatch.setattr(transport_module.subprocess, "run", oversized_run)
+    transport = KubectlK8sTransport(max_response_bytes=32)
+
+    with pytest.raises(K8sTransportError, match="configured byte bound") as caught:
+        transport.list_resource("pods", namespace="prod")
+
+    assert caught.value.reason == "response_too_large"

--- a/tests/test_k8s_transport.py
+++ b/tests/test_k8s_transport.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import ssl
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -216,6 +217,23 @@ def test_native_transport_reads_only_direct_kubelet_configz(tmp_path: Path) -> N
         transport.close()
 
     assert result == {"kubeletconfig": {"readOnlyPort": 0}}
+
+
+def test_custom_http_transport_never_disables_certificate_validation(tmp_path: Path) -> None:
+    token_path, ca_path = _service_account_files(tmp_path)
+    transport = InClusterK8sTransport(
+        host="10.0.0.1",
+        port=443,
+        token_path=token_path,
+        ca_path=ca_path,
+        http_transport=httpx.MockTransport(lambda _request: httpx.Response(200, json={})),
+    )
+    try:
+        assert isinstance(transport._verify, ssl.SSLContext)
+        assert transport._verify.verify_mode is ssl.CERT_REQUIRED
+        assert transport._verify.check_hostname is True
+    finally:
+        transport.close()
 
 
 def test_native_transport_rejects_response_before_json_materialization(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- add a native in-cluster, service-account authenticated HTTPS transport with strict read allowlists, TLS verification, bounded pagination, response sizes, and sanitized failures
- preserve kubectl as an optional workstation fallback while recording each posture collector as executed, skipped, unevaluable, or failed so denied evidence cannot appear clean
- keep kubelet config collection separately opt-in, restricted to private InternalIP port 10250, with no nodes/proxy fallback and explicit node/deadline bounds

## Verification

- `uv run pytest -q tests/test_k8s_transport.py tests/test_k8s_live_cluster.py tests/test_k8s.py tests/test_iac_kubernetes.py` — 127 passed
- `uv run ruff check` on changed source and tests
- `uv run ruff format --check` on changed source and tests
- `uv run mypy src/agent_bom/k8s.py src/agent_bom/k8s_transport.py`
- `uv run python scripts/check_exception_sanitization.py`
- verified-TLS local HTTPS smoke proved CA validation, bearer auth, and two-page pagination
- `git diff --check`

## Notes

- this is foundation phase 1; Helm/RBAC scheduling, versioned CIS rules, persistence/API/CLI/UI evidence surfaces, and kind lock-in remain later phases in #4134
- configz examines at most 100 nodes within a 60-second run budget and reports bounds as partial evidence
- kubectl output is spooled before bounded parsing; its subprocess timeout remains the workstation disk-growth boundary
- no credentialed live cluster was available, so this PR does not claim live deployment proof

Addresses #4134
Addresses #4095