### PR TITLE
fix(postgres): restore bootstrap, snapshot, and edge parity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(site-docs/|mkdocs\.yml$|\.github/workflows/(docs|ci)\.yml$|\.github/actions/setup-python/)'; then
             docs=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_|deploy/supabase/postgres/)'; then
             postgres=true
           fi
           if printf '%s\n' "$changed" | grep -Eq '^(deploy/endpoints/|scripts/(build-[^/]+|render_homebrew_formula\.py)|src/agent_bom/cli/_runtime\.py|tests/test_cli_runtime\.py|pyproject\.toml|uv\.lock|\.github/actions/setup-python/|site-docs/deployment/aws-company-rollout\.md$)'; then
@@ -836,11 +836,59 @@ jobs:
       - name: Install Postgres test dependencies
         run: uv sync --frozen --extra dev --extra api --extra postgres
 
+      - name: Install Postgres client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client
+
+      - name: Verify Alembic bootstrap and init.sql forward upgrade
+        env:
+          PGPASSWORD: testpass
+        run: |
+          set -euo pipefail
+
+          # Fresh Alembic-only deployment. The dedicated bootstrap owner mirrors
+          # the shipped compose model: it starts privileged enough to provision
+          # roles, then init.sql strips SUPERUSER/BYPASSRLS before the connection
+          # closes. Do not run the baseline as PostgreSQL's protected `postgres`
+          # bootstrap role.
+          psql -h 127.0.0.1 -U postgres -d postgres <<'SQL'
+          CREATE ROLE agentbom_migration_owner LOGIN PASSWORD 'migrationpass' SUPERUSER;
+          CREATE DATABASE agentbom_migration OWNER agentbom_migration_owner;
+          ALTER DATABASE agentbom_migration SET init.app_password = 'apppass';
+          SQL
+          export ALEMBIC_DATABASE_URL='postgresql+psycopg://agentbom_migration_owner:migrationpass@127.0.0.1:5432/agentbom_migration'
+          uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+          # A second invocation is the supported idempotent rerun contract.
+          uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+
+          expected_head="$(uv run alembic -c deploy/supabase/postgres/alembic.ini heads | awk 'NR == 1 {print $1}')"
+          actual_head="$(PGPASSWORD=migrationpass psql -h 127.0.0.1 -U agentbom_migration_owner -d agentbom_migration -Atc 'SELECT version_num FROM alembic_version')"
+          test "$actual_head" = "$expected_head"
+          test -z "$(PGPASSWORD=migrationpass psql -h 127.0.0.1 -U agentbom_migration_owner -d agentbom_migration -Atc "SELECT current_setting('init.app_password', true)")"
+          test "$(PGPASSWORD=migrationpass psql -h 127.0.0.1 -U agentbom_migration_owner -d agentbom_migration -Atc "SELECT rolsuper OR rolbypassrls FROM pg_roles WHERE rolname = current_user")" = "f"
+
+          # Existing Docker/psql bootstrap. init.sql establishes the baseline;
+          # stamping that exact revision and moving forward must reach the same
+          # Alembic head without replaying the baseline.
+          psql -h 127.0.0.1 -U postgres -d postgres <<'SQL'
+          CREATE ROLE agentbom_psql_owner LOGIN PASSWORD 'psqlpass' SUPERUSER;
+          CREATE DATABASE agent_bom OWNER agentbom_psql_owner;
+          ALTER DATABASE agent_bom SET init.app_password = 'apppass';
+          SQL
+          PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom \
+            -v ON_ERROR_STOP=1 -f deploy/supabase/postgres/init.sql
+          export ALEMBIC_DATABASE_URL='postgresql+psycopg://agentbom_psql_owner:psqlpass@127.0.0.1:5432/agent_bom'
+          uv run alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
+          uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+          actual_head="$(PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom -Atc 'SELECT version_num FROM alembic_version')"
+          test "$actual_head" = "$expected_head"
+          test -z "$(PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom -Atc "SELECT current_setting('init.app_password', true)")"
+          test "$(PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom -Atc "SELECT rolsuper OR rolbypassrls FROM pg_roles WHERE rolname = current_user")" = "f"
+
       - name: Provision non-superuser application role
         run: |
           set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends postgresql-client
           # The role is intentionally NOSUPERUSER NOBYPASSRLS so RLS policies
           # actually apply to it. Granting CREATE on the public schema lets the
           # storage layer's _ensure_tenant_rls() create and own its tables, so

--- a/deploy/supabase/postgres/alembic/versions/20260416_01_control_plane_baseline.py
+++ b/deploy/supabase/postgres/alembic/versions/20260416_01_control_plane_baseline.py
@@ -24,7 +24,12 @@ def upgrade() -> None:
     bind = op.get_bind()
     database_name = bind.exec_driver_sql("SELECT current_database()").scalar_one()
     bootstrap_sql = load_bootstrap_sql(database_name)
-    bind.exec_driver_sql(bootstrap_sql)
+    # The baseline contains server-side PL/pgSQL ``format(... %L ...)`` tokens.
+    # Without ``no_parameters``, SQLAlchemy passes an empty parameter mapping
+    # and psycopg3 parses those tokens as unsupported client placeholders before
+    # PostgreSQL can evaluate them.  No runtime bind values or secrets are
+    # passed through this DBAPI call.
+    bind.exec_driver_sql(bootstrap_sql, execution_options={"no_parameters": True})
 
 
 def downgrade() -> None:  # pragma: no cover - baseline downgrade is intentionally manual

--- a/deploy/supabase/postgres/alembic/versions/20260705_01_hub_observations_partition.py
+++ b/deploy/supabase/postgres/alembic/versions/20260705_01_hub_observations_partition.py
@@ -34,9 +34,14 @@ from agent_bom.api.hub_observations_partition import (  # noqa: E402
 
 def upgrade() -> None:
     bind = op.get_bind()
-    migrated = migrate_observations_to_partitioned(bind)
+    # The shared helper is also used by the runtime psycopg pool and therefore
+    # intentionally uses psycopg's ``execute(sql, tuple)`` contract.  Alembic
+    # exposes a SQLAlchemy Connection, whose parameter contract is different;
+    # unwrap the DBAPI connection while retaining Alembic's transaction.
+    driver_connection = bind.connection.driver_connection
+    migrated = migrate_observations_to_partitioned(driver_connection)
     if migrated:
-        ensure_observation_partitions(bind)
+        ensure_observation_partitions(driver_connection)
 
 
 def downgrade() -> None:

--- a/deploy/supabase/postgres/alembic/versions/20260717_03_graph_snapshot_json_parity.py
+++ b/deploy/supabase/postgres/alembic/versions/20260717_03_graph_snapshot_json_parity.py
@@ -1,0 +1,55 @@
+"""Align graph snapshot JSON columns with the application TEXT contract.
+
+Revision ID: 20260717_03
+Revises: 20260717_02
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260717_03"
+down_revision = "20260717_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Existing installations may have either TEXT (application bootstrap) or
+    # JSONB (init.sql/Alembic bootstrap). ``::text`` preserves both forms as
+    # valid JSON text, and each statement is safe to replay.
+    op.execute("""
+        ALTER TABLE graph_snapshots
+            ALTER COLUMN risk_summary DROP DEFAULT,
+            ALTER COLUMN risk_summary TYPE TEXT USING risk_summary::text,
+            ALTER COLUMN risk_summary SET DEFAULT '{}'
+    """)
+    op.execute("""
+        ALTER TABLE graph_snapshots
+            ALTER COLUMN analysis_status DROP DEFAULT,
+            ALTER COLUMN analysis_status TYPE TEXT USING analysis_status::text,
+            ALTER COLUMN analysis_status SET DEFAULT '{}'
+    """)
+    op.execute("UPDATE graph_snapshots SET analysis_status = '{}' WHERE analysis_status IS NULL")
+    op.execute("ALTER TABLE graph_snapshots ALTER COLUMN analysis_status SET NOT NULL")
+
+
+def downgrade() -> None:
+    op.execute("""
+        ALTER TABLE graph_snapshots
+            ALTER COLUMN risk_summary DROP DEFAULT,
+            ALTER COLUMN risk_summary TYPE JSONB USING
+                CASE WHEN risk_summary IS NULL THEN NULL
+                     WHEN btrim(risk_summary) = '' THEN '{}'::jsonb
+                     ELSE risk_summary::jsonb END,
+            ALTER COLUMN risk_summary SET DEFAULT '{}'::jsonb
+    """)
+    op.execute("""
+        ALTER TABLE graph_snapshots
+            ALTER COLUMN analysis_status DROP DEFAULT,
+            ALTER COLUMN analysis_status TYPE JSONB USING
+                CASE WHEN analysis_status IS NULL OR btrim(analysis_status) = '' THEN '{}'::jsonb
+                     ELSE analysis_status::jsonb END,
+            ALTER COLUMN analysis_status SET DEFAULT '{}'::jsonb,
+            ALTER COLUMN analysis_status SET NOT NULL
+    """)

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -391,8 +391,8 @@ CREATE TABLE IF NOT EXISTS graph_snapshots (
     created_at   TEXT NOT NULL,
     node_count   INTEGER DEFAULT 0,
     edge_count   INTEGER DEFAULT 0,
-    risk_summary JSONB DEFAULT '{}'::jsonb,
-    analysis_status JSONB NOT NULL DEFAULT '{}'::jsonb,
+    risk_summary TEXT DEFAULT '{}',
+    analysis_status TEXT NOT NULL DEFAULT '{}',
     PRIMARY KEY (scan_id, tenant_id)
 );
 

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -178,6 +178,16 @@ def _digest_payload(payload: Any) -> str:
     return "sha256:" + hashlib.sha256(encoded).hexdigest()
 
 
+def _decode_json_object(value: Any) -> dict[str, Any]:
+    """Decode a JSON object from either TEXT or psycopg's native JSONB value."""
+    if value is None or value == "" or value == b"":
+        return {}
+    decoded = value if isinstance(value, Mapping) else json.loads(value)
+    if not isinstance(decoded, Mapping):
+        raise ValueError("Persisted graph snapshot JSON must be an object")
+    return dict(decoded)
+
+
 def _diff_summary_counts(diff: dict[str, Any]) -> dict[str, int]:
     return {
         "nodes_added": len(diff.get("nodes_added") or []),
@@ -305,7 +315,7 @@ class PostgresGraphStore:
                     node_count INTEGER DEFAULT 0,
                     edge_count INTEGER DEFAULT 0,
                     risk_summary TEXT DEFAULT '{}',
-                    analysis_status TEXT DEFAULT '{}',
+                    analysis_status TEXT NOT NULL DEFAULT '{}',
                     PRIMARY KEY (scan_id, tenant_id)
                 )
                 """
@@ -343,7 +353,7 @@ class PostgresGraphStore:
             )
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT ''")
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS tool_exposure TEXT DEFAULT '[]'")
-            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS analysis_status TEXT DEFAULT '{}'")
+            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS analysis_status TEXT NOT NULL DEFAULT '{}'")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_from TEXT DEFAULT ''")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_to TEXT DEFAULT NULL")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION DEFAULT 1.0")
@@ -1012,7 +1022,7 @@ class PostgresGraphStore:
             ).fetchone()
             graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=str(snapshot_row[0]) if snapshot_row else "")
             if snapshot_row:
-                graph.analysis_status = analysis_status_map_from_dict(json.loads(snapshot_row[1] or "{}"))
+                graph.analysis_status = analysis_status_map_from_dict(_decode_json_object(snapshot_row[1]))
 
             query = (
                 "SELECT id, entity_type, label, category_uid, class_uid, type_uid, status, risk_score, severity, severity_id, "
@@ -1586,8 +1596,8 @@ class PostgresGraphStore:
                     "created_at": row[1],
                     "node_count": row[2],
                     "edge_count": row[3],
-                    "risk_summary": json.loads(row[4]),
-                    "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(json.loads(row[5] or "{}"))),
+                    "risk_summary": _decode_json_object(row[4]),
+                    "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(_decode_json_object(row[5]))),
                 }
                 for row in rows
             ]
@@ -1819,7 +1829,7 @@ class PostgresGraphStore:
                 (effective_scan_id, tenant_id),
             ).fetchone()
             analysis_status = analysis_status_map_to_dict(
-                analysis_status_map_from_dict(json.loads((analysis_row[0] if analysis_row else "{}") or "{}"))
+                analysis_status_map_from_dict(_decode_json_object(analysis_row[0] if analysis_row else None))
             )
             # Unfiltered node/edge totals are already materialised on the snapshot
             # row at write time. Re-deriving the edge count here re-scans

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -811,7 +811,8 @@ def save_graph_streaming(
             conn,
             """
             UPDATE graph_edges
-            SET valid_to = COALESCE(valid_to, ?)
+            SET valid_to = COALESCE(valid_to, ?),
+                activity_id = CASE WHEN activity_id = 1 THEN 3 ELSE activity_id END
             WHERE tenant_id = ? AND scan_id = ? AND source_id = ? AND target_id = ? AND relationship = ?
             """,
             ((now, tenant, previous_scan, source, target, relationship) for source, target, relationship in sorted(removed_edge_keys)),

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2992,3 +2992,29 @@ class TestGraphStoreBackendSelection:
 
         assert response.status_code == 404
         assert response.json()["detail"]["missing_roots"] == ["agent:missing"]
+
+
+def test_removed_edge_route_emits_ocsf_close_activity(tmp_path) -> None:
+    """The edge-change API emits the same Close(3) activity as Postgres."""
+    store = SQLiteGraphStore(tmp_path / "edge-close-graph.db")
+    g1 = UnifiedGraph(scan_id="close-s1", created_at="2026-07-16T00:00:00Z")
+    g1.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+    g1.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+    g1.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+    store.save_graph(g1)
+
+    g2 = UnifiedGraph(scan_id="close-s2", created_at="2026-07-17T00:00:00Z")
+    g2.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+    g2.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+    store.save_graph(g2)
+
+    original = api_stores._graph_store
+    try:
+        set_graph_store(store)
+        response = TestClient(app).get("/v1/graph/edges/changes", params={"old": "close-s1", "new": "close-s2"})
+        assert response.status_code == 200
+        removed = response.json()["edges_removed"]
+        assert len(removed) == 1
+        assert removed[0]["activity_id"] == 3
+    finally:
+        set_graph_store(original)

--- a/tests/test_graph_store_streamed_persistence.py
+++ b/tests/test_graph_store_streamed_persistence.py
@@ -134,8 +134,11 @@ def test_streaming_persist_preserves_temporal_reconciliation(tmp_path) -> None:
         assert kept["first_seen"] == t1
         assert kept["valid_from"] == t1
 
-        dropped = conn.execute("SELECT valid_to FROM graph_edges WHERE scan_id='v1' AND source_id='a' AND target_id='c'").fetchone()
+        dropped = conn.execute(
+            "SELECT valid_to, activity_id FROM graph_edges WHERE scan_id='v1' AND source_id='a' AND target_id='c'"
+        ).fetchone()
         assert dropped["valid_to"] == t2
+        assert dropped["activity_id"] == 3
 
 
 def test_streaming_load_iterators_match_load_graph(tmp_path) -> None:

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -11,6 +11,8 @@ connection (no live Postgres required).
 
 from __future__ import annotations
 
+import pytest
+
 from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.types import EntityType, NodeStatus
@@ -265,3 +267,107 @@ def test_postgres_writer_lock_precedes_snapshot_reads_and_deletes(monkeypatch):
     prior_read_at = next(i for i, sql in enumerate(conn.sql_calls) if "from graph_snapshots" in sql and sql.startswith("select"))
     delete_at = next(i for i, sql in enumerate(conn.sql_calls) if sql.startswith("delete from"))
     assert lock_at < prior_read_at < delete_at
+
+
+@pytest.mark.parametrize(
+    ("risk_summary", "analysis_status"),
+    [
+        (
+            {"critical": 2},
+            {
+                "attack_path_fusion": {
+                    "status": "skipped",
+                    "reason_codes": ["node_cap_exceeded"],
+                    "limits": {"max_nodes": 5000},
+                    "observed": {"node_count": 5001},
+                }
+            },
+        ),
+        (
+            '{"critical": 2}',
+            '{"attack_path_fusion":{"status":"skipped","reason_codes":["node_cap_exceeded"],'
+            '"limits":{"max_nodes":5000},"observed":{"node_count":5001}}}',
+        ),
+    ],
+    ids=("native-jsonb", "text-json"),
+)
+def test_snapshot_history_accepts_psycopg_jsonb_objects_and_text(monkeypatch, risk_summary, analysis_status):
+    """Snapshot reads support both canonical TEXT and legacy/native JSONB rows."""
+
+    class _SnapshotConn(_RecordingConn):
+        def execute(self, sql, params=None):
+            low = " ".join(sql.strip().lower().split())
+            if low.startswith("select scan_id, created_at, node_count, edge_count, risk_summary, analysis_status"):
+                return _FakeCursor([("scan-json", "2026-07-17T00:00:00Z", 3, 2, risk_summary, analysis_status)])
+            return super().execute(sql, params)
+
+    store = _make_store(_SnapshotConn(), monkeypatch)
+
+    snapshots = store.list_snapshots(tenant_id="tenant-a")
+
+    assert snapshots[0]["risk_summary"] == {"critical": 2}
+    assert snapshots[0]["analysis_status"]["attack_path_fusion"]["status"] == "skipped"
+
+
+def test_load_graph_accepts_native_jsonb_analysis_status(monkeypatch):
+    """A non-empty psycopg-decoded JSONB status cannot crash the graph read path."""
+    status = {
+        "attack_path_fusion": {
+            "status": "complete",
+            "reason_codes": [],
+            "limits": {"max_nodes": 5000},
+            "observed": {"node_count": 12, "result_count": 1},
+        }
+    }
+
+    class _GraphReadConn(_RecordingConn):
+        def execute(self, sql, params=None):
+            low = " ".join(sql.strip().lower().split())
+            if low.startswith("select created_at, analysis_status from graph_snapshots"):
+                return _FakeCursor([("2026-07-17T00:00:00Z", status)])
+            return super().execute(sql, params)
+
+    store = _make_store(_GraphReadConn(), monkeypatch)
+
+    graph = store.load_graph(tenant_id="tenant-a", scan_id="scan-json")
+
+    assert graph.analysis_status["attack_path_fusion"].status is GraphAnalysisState.COMPLETE
+
+
+def test_retired_edge_update_records_ocsf_close_activity(monkeypatch):
+    """Postgres retirement matches SQLite's canonical OCSF Close activity."""
+
+    class _RetirementConn(_RecordingConn):
+        def __init__(self):
+            super().__init__()
+            self.retirement_sql = ""
+
+        def execute(self, sql, params=None):
+            low = " ".join(sql.strip().lower().split())
+            if low.startswith("select scan_id, created_at from graph_snapshots"):
+                return _FakeCursor([("scan-old", "2026-07-16T00:00:00Z")])
+            if low.startswith("select source_id, target_id, relationship, first_seen, valid_from, valid_to"):
+                return _FakeCursor([("agent:a", "server:b", "uses", "2026-07-16T00:00:00Z", "2026-07-16T00:00:00Z", None)])
+            return super().execute(sql, params)
+
+        def executemany(self, sql, seq):
+            low = " ".join(sql.strip().lower().split())
+            if low.startswith("update graph_edges"):
+                self.retirement_sql = low
+                list(seq)
+                return _FakeCursor()
+            return super().executemany(sql, seq)
+
+    conn = _RetirementConn()
+    store = _make_store(conn, monkeypatch)
+
+    store.save_graph_streaming(
+        scan_id="scan-new",
+        tenant_id="tenant-a",
+        nodes=iter(()),
+        edges=iter(()),
+        created_at="2026-07-17T00:00:00Z",
+    )
+
+    assert "set valid_to = coalesce(valid_to, %s)" in conn.retirement_sql
+    assert "activity_id = case when activity_id = 1 then 3 else activity_id end" in conn.retirement_sql

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -13,6 +13,7 @@ BASELINE = VERSIONS_DIR / "20260416_01_control_plane_baseline.py"
 GRAPH_HOT_PATH_INDEXES = VERSIONS_DIR / "20260513_01_graph_hot_path_indexes.py"
 POSTGRES_STORE_PARITY = VERSIONS_DIR / "20260717_01_postgres_store_parity.py"
 GRAPH_ANALYSIS_STATUS = VERSIONS_DIR / "20260717_02_graph_analysis_status.py"
+GRAPH_SNAPSHOT_JSON_PARITY = VERSIONS_DIR / "20260717_03_graph_snapshot_json_parity.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
 
 
@@ -87,3 +88,14 @@ def test_graph_analysis_status_migration_is_idempotent_and_chained():
     assert re.search(r'revision\s*=\s*"20260717_02"', sql)
     assert re.search(r'down_revision\s*=\s*"20260717_01"', sql)
     assert "ADD COLUMN IF NOT EXISTS analysis_status JSONB NOT NULL" in sql
+
+
+def test_graph_snapshot_json_parity_migration_is_idempotent_and_chained():
+    assert GRAPH_SNAPSHOT_JSON_PARITY.exists()
+    sql = GRAPH_SNAPSHOT_JSON_PARITY.read_text()
+    assert re.search(r'revision\s*=\s*"20260717_03"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260717_02"', sql)
+    for column in ("risk_summary", "analysis_status"):
+        assert f"ALTER COLUMN {column} DROP DEFAULT" in sql
+        assert f"ALTER COLUMN {column} TYPE TEXT" in sql
+        assert f"ALTER COLUMN {column} SET DEFAULT '{{}}'" in sql

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -64,6 +65,7 @@ def test_baseline_migration_executes_bootstrap_without_dbapi_parameters(monkeypa
     baseline contains PL/pgSQL ``format(... %L ...)`` expressions, so its
     driver execution must explicitly suppress DBAPI parameter handling.
     """
+    monkeypatch.setitem(sys.modules, "alembic", SimpleNamespace(op=SimpleNamespace(get_bind=lambda: None)))
     module = _load_module(BASELINE, "abom_control_plane_baseline")
     bootstrap_sql = "DO $$ BEGIN PERFORM format('PASSWORD %L', 'secret'); END $$;"
 
@@ -138,6 +140,7 @@ def test_graph_snapshot_json_parity_migration_is_idempotent_and_chained():
 
 def test_hub_partition_migration_uses_the_psycopg_driver_connection(monkeypatch):
     """The shared partition helper uses psycopg's ``%s`` execute contract."""
+    monkeypatch.setitem(sys.modules, "alembic", SimpleNamespace(op=SimpleNamespace(get_bind=lambda: None)))
     module = _load_module(HUB_OBSERVATIONS_PARTITION, "abom_hub_observations_partition")
     driver_connection = object()
     bind = SimpleNamespace(connection=SimpleNamespace(driver_connection=driver_connection))

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import re
 from pathlib import Path
+from types import SimpleNamespace
 
 POSTGRES_DIR = Path(__file__).parent.parent / "deploy" / "supabase" / "postgres"
 ALEMBIC_DIR = POSTGRES_DIR / "alembic"
@@ -14,6 +15,7 @@ GRAPH_HOT_PATH_INDEXES = VERSIONS_DIR / "20260513_01_graph_hot_path_indexes.py"
 POSTGRES_STORE_PARITY = VERSIONS_DIR / "20260717_01_postgres_store_parity.py"
 GRAPH_ANALYSIS_STATUS = VERSIONS_DIR / "20260717_02_graph_analysis_status.py"
 GRAPH_SNAPSHOT_JSON_PARITY = VERSIONS_DIR / "20260717_03_graph_snapshot_json_parity.py"
+HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
 
 
@@ -52,6 +54,39 @@ GRANT CONNECT ON DATABASE agent_bom TO agent_bom_readonly;
     assert "GRANT CONNECT ON DATABASE pilot_customer TO agent_bom_app;" in rewritten
     assert "GRANT CONNECT ON DATABASE pilot_customer TO agent_bom_readonly;" in rewritten
     assert "GRANT CONNECT ON DATABASE agent_bom TO agent_bom_app;" not in rewritten
+
+
+def test_baseline_migration_executes_bootstrap_without_dbapi_parameters(monkeypatch):
+    """Server-side ``%L`` format tokens must reach Postgres unchanged.
+
+    psycopg3 treats percent tokens as client placeholders whenever SQLAlchemy
+    passes an (even empty) parameter mapping to ``cursor.execute``.  The
+    baseline contains PL/pgSQL ``format(... %L ...)`` expressions, so its
+    driver execution must explicitly suppress DBAPI parameter handling.
+    """
+    module = _load_module(BASELINE, "abom_control_plane_baseline")
+    bootstrap_sql = "DO $$ BEGIN PERFORM format('PASSWORD %L', 'secret'); END $$;"
+
+    class _Result:
+        def scalar_one(self):
+            return "migration_contract"
+
+    calls: list[tuple[str, dict[str, bool] | None]] = []
+
+    class _Bind:
+        def exec_driver_sql(self, sql, *, execution_options=None):
+            calls.append((sql, execution_options))
+            return _Result()
+
+    monkeypatch.setattr(module.op, "get_bind", lambda: _Bind())
+    monkeypatch.setattr(module, "load_bootstrap_sql", lambda database_name: bootstrap_sql)
+
+    module.upgrade()
+
+    assert calls == [
+        ("SELECT current_database()", None),
+        (bootstrap_sql, {"no_parameters": True}),
+    ]
 
 
 def test_graph_hot_path_index_migration_chains_from_baseline():
@@ -99,3 +134,19 @@ def test_graph_snapshot_json_parity_migration_is_idempotent_and_chained():
         assert f"ALTER COLUMN {column} DROP DEFAULT" in sql
         assert f"ALTER COLUMN {column} TYPE TEXT" in sql
         assert f"ALTER COLUMN {column} SET DEFAULT '{{}}'" in sql
+
+
+def test_hub_partition_migration_uses_the_psycopg_driver_connection(monkeypatch):
+    """The shared partition helper uses psycopg's ``%s`` execute contract."""
+    module = _load_module(HUB_OBSERVATIONS_PARTITION, "abom_hub_observations_partition")
+    driver_connection = object()
+    bind = SimpleNamespace(connection=SimpleNamespace(driver_connection=driver_connection))
+    seen: list[object] = []
+
+    monkeypatch.setattr(module.op, "get_bind", lambda: bind)
+    monkeypatch.setattr(module, "migrate_observations_to_partitioned", lambda conn: seen.append(conn) or True)
+    monkeypatch.setattr(module, "ensure_observation_partitions", lambda conn: seen.append(conn))
+
+    module.upgrade()
+
+    assert seen == [driver_connection, driver_connection]

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -141,9 +141,10 @@ def test_graph_tables_have_rls_policies():
         assert f"CREATE POLICY {table}_tenant_isolation ON {table}" in SQL
 
 
-def test_graph_snapshot_analysis_status_is_in_baseline():
+def test_graph_snapshot_json_fields_are_text_in_baseline():
     assert "analysis_status" in _columns_for("graph_snapshots")
-    assert "analysis_status JSONB NOT NULL DEFAULT '{}'::jsonb" in SQL
+    assert "risk_summary TEXT DEFAULT '{}'" in SQL
+    assert "analysis_status TEXT NOT NULL DEFAULT '{}'" in SQL
 
 
 def test_graph_edges_has_versioning_columns():


### PR DESCRIPTION
## Summary

- make the Alembic baseline and partition migration driver-safe so both supported Postgres bootstrap paths reach the current head
- decode graph snapshot JSON from psycopg-native mappings or serialized text, align snapshot storage, and preserve a reversible migration path
- standardize retired-edge evidence on OCSF Close(3) across SQLite and Postgres, with API and backend parity regressions

## Verification

- combined migration, schema, streamed-persistence, SQLite parity, and graph API suite: 152 passed
- owning graph/Postgres/OCSF suite before consolidation: 755 passed
- live PostgreSQL 16 graph migration: native JSONB read, 20260717_02 to 03 conversion, save/load, retired-edge Close(3), downgrade and replay
- shipped postgres:16-alpine bootstrap: empty Alembic database to head plus rerun; init.sql baseline stamp plus forward upgrade
- app-role Postgres storage contract: 5 passed, 1 expected privilege skip
- Ruff check and format, mypy, exception-sanitization guard, git diff check
- make preflight: OpenAPI, v1 schemas, product surface, release consistency, env references, and SDK patterns clean

## Notes

- readers remain tolerant of native JSONB mappings during mixed-version rollout; snapshot writes use the existing serialized graph-store contract
- the snapshot type conversion takes a table lock and should run in a maintenance window on hot installations
- both bootstrap paths clear the transient password GUC and leave bootstrap owners without SUPERUSER or BYPASSRLS
- #4141 and #4142 were closed after their unique coverage and bootstrap commit were consolidated here

Closes #4136
Closes #4138
Addresses #4095