### PR TITLE
fix(graph): guard JSONB analysis_status reads and reconcile retired-edge activity_id across backends

### DIFF
--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -32,6 +32,23 @@ from .postgres_common import _apply_tenant_session, _ensure_tenant_rls, _get_poo
 logger = logging.getLogger(__name__)
 
 
+def _json_column_to_dict(value: Any) -> dict[str, Any]:
+    """Normalize a JSON/JSONB column value to a ``dict``.
+
+    ``init.sql`` and the enterprise migration declare ``risk_summary`` /
+    ``analysis_status`` as ``JSONB`` while the app's own ``_init_tables`` created
+    legacy tables as ``TEXT``. Under psycopg3 a ``JSONB`` column returns an
+    already-parsed ``dict`` and a ``TEXT`` column returns a ``str``, so the read
+    must handle both to stay correct across the two schema variants. Mirrors the
+    guard already used in ``postgres_audit`` (``isinstance(x, dict)``).
+    """
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        return json.loads(value or "{}")
+    return {}
+
+
 def select_expired_snapshot_ids(
     rows: Iterable[Sequence[Any]],
     *,
@@ -304,8 +321,8 @@ class PostgresGraphStore:
                     created_at TEXT NOT NULL,
                     node_count INTEGER DEFAULT 0,
                     edge_count INTEGER DEFAULT 0,
-                    risk_summary TEXT DEFAULT '{}',
-                    analysis_status TEXT DEFAULT '{}',
+                    risk_summary JSONB DEFAULT '{}'::jsonb,
+                    analysis_status JSONB NOT NULL DEFAULT '{}'::jsonb,
                     PRIMARY KEY (scan_id, tenant_id)
                 )
                 """
@@ -343,7 +360,7 @@ class PostgresGraphStore:
             )
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT ''")
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS tool_exposure TEXT DEFAULT '[]'")
-            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS analysis_status TEXT DEFAULT '{}'")
+            conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS analysis_status JSONB NOT NULL DEFAULT '{}'::jsonb")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_from TEXT DEFAULT ''")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_to TEXT DEFAULT NULL")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS confidence DOUBLE PRECISION DEFAULT 1.0")
@@ -1012,7 +1029,7 @@ class PostgresGraphStore:
             ).fetchone()
             graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=str(snapshot_row[0]) if snapshot_row else "")
             if snapshot_row:
-                graph.analysis_status = analysis_status_map_from_dict(json.loads(snapshot_row[1] or "{}"))
+                graph.analysis_status = analysis_status_map_from_dict(_json_column_to_dict(snapshot_row[1]))
 
             query = (
                 "SELECT id, entity_type, label, category_uid, class_uid, type_uid, status, risk_score, severity, severity_id, "
@@ -1586,8 +1603,8 @@ class PostgresGraphStore:
                     "created_at": row[1],
                     "node_count": row[2],
                     "edge_count": row[3],
-                    "risk_summary": json.loads(row[4]),
-                    "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(json.loads(row[5] or "{}"))),
+                    "risk_summary": _json_column_to_dict(row[4]),
+                    "analysis_status": analysis_status_map_to_dict(analysis_status_map_from_dict(_json_column_to_dict(row[5]))),
                 }
                 for row in rows
             ]
@@ -1819,7 +1836,7 @@ class PostgresGraphStore:
                 (effective_scan_id, tenant_id),
             ).fetchone()
             analysis_status = analysis_status_map_to_dict(
-                analysis_status_map_from_dict(json.loads((analysis_row[0] if analysis_row else "{}") or "{}"))
+                analysis_status_map_from_dict(_json_column_to_dict(analysis_row[0] if analysis_row else None))
             )
             # Unfiltered node/edge totals are already materialised on the snapshot
             # row at write time. Re-deriving the edge count here re-scans

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -811,7 +811,8 @@ def save_graph_streaming(
             conn,
             """
             UPDATE graph_edges
-            SET valid_to = COALESCE(valid_to, ?)
+            SET valid_to = COALESCE(valid_to, ?),
+                activity_id = CASE WHEN activity_id = 1 THEN 3 ELSE activity_id END
             WHERE tenant_id = ? AND scan_id = ? AND source_id = ? AND target_id = ? AND relationship = ?
             """,
             ((now, tenant, previous_scan, source, target, relationship) for source, target, relationship in sorted(removed_edge_keys)),

--- a/tests/test_graph_backend_correctness.py
+++ b/tests/test_graph_backend_correctness.py
@@ -1,0 +1,177 @@
+"""Graph-backend correctness: JSONB-column reads and cross-backend retire parity.
+
+Two regressions covered here:
+
+1. ``analysis_status``/``risk_summary`` are declared ``JSONB`` by ``init.sql`` and
+   the enterprise migration but ``TEXT`` by the app's own ``_init_tables``. Under
+   psycopg3 a ``JSONB`` column returns an already-parsed ``dict``, so the bare
+   ``json.loads(...)`` in the graph reads raised ``TypeError`` whenever the status
+   was non-empty. The reads must be robust to BOTH a ``str`` (TEXT) and a ``dict``
+   (JSONB) return.
+
+2. On retiring an edge dropped from a new snapshot, Postgres stamps the OCSF
+   ``activity_id`` Create(1) -> Close(3) but SQLite left it at Create(1) — the same
+   scan sequence produced a different change feed per backend. SQLite must match
+   Postgres.
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+
+from agent_bom.graph.analysis import GraphAnalysisState
+
+# ── Fix 1: JSONB dict-return reads ──────────────────────────────────────────
+
+
+class _FakeCursor:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+
+    def fetchone(self):
+        return self.rows[0] if self.rows else None
+
+    def fetchall(self):
+        return self.rows
+
+    def __iter__(self):
+        return iter(self.rows)
+
+
+_NON_EMPTY_STATUS = {
+    "attack_path_fusion": {
+        "status": "complete",
+        "reason_codes": [],
+        "limits": {},
+        "observed": {"paths": 3},
+    }
+}
+_RISK_SUMMARY = {"critical": 2, "high": 1}
+
+
+class _JsonbConn:
+    """Fake Postgres connection that returns dicts for JSONB columns (psycopg3)."""
+
+    def __init__(self):
+        self.committed = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def execute(self, sql, params=None):
+        low = " ".join(sql.strip().lower().split())
+        if "select created_at, analysis_status from graph_snapshots" in low:
+            # load_graph snapshot row: JSONB analysis_status arrives as a dict.
+            return _FakeCursor([("2026-07-17T00:00:00Z", dict(_NON_EMPTY_STATUS))])
+        if "select scan_id, created_at, node_count, edge_count, risk_summary, analysis_status" in low:
+            # list_snapshots: risk_summary AND analysis_status arrive as dicts.
+            return _FakeCursor([("scan-1", "2026-07-17T00:00:00Z", 4, 3, dict(_RISK_SUMMARY), dict(_NON_EMPTY_STATUS))])
+        if "select analysis_status from graph_snapshots" in low:
+            return _FakeCursor([(dict(_NON_EMPTY_STATUS),)])
+        return _FakeCursor()
+
+    def commit(self):
+        self.committed += 1
+
+    def rollback(self):
+        pass
+
+
+class _FakePool:
+    def __init__(self, conn):
+        self._conn = conn
+
+    def connection(self):
+        return self._conn
+
+
+def _make_pg_store(conn, monkeypatch):
+    from agent_bom.api import postgres_graph
+
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_tables", lambda self: None)
+    monkeypatch.setattr(postgres_graph.PostgresGraphStore, "_init_optional_search_indexes", lambda self: None)
+    return postgres_graph.PostgresGraphStore(pool=_FakePool(conn))
+
+
+def test_load_graph_reads_jsonb_analysis_status_dict(monkeypatch):
+    store = _make_pg_store(_JsonbConn(), monkeypatch)
+
+    graph = store.load_graph(tenant_id="default", scan_id="scan-1")
+
+    status = graph.analysis_status["attack_path_fusion"]
+    assert status.status is GraphAnalysisState.COMPLETE
+    assert status.observed == {"paths": 3}
+
+
+def test_list_snapshots_reads_jsonb_columns_dict(monkeypatch):
+    store = _make_pg_store(_JsonbConn(), monkeypatch)
+
+    rows = store.list_snapshots(tenant_id="default")
+
+    assert rows[0]["risk_summary"] == _RISK_SUMMARY
+    assert rows[0]["analysis_status"]["attack_path_fusion"]["status"] == "complete"
+
+
+# ── Fix 2: retire-edge activity_id parity (SQLite must match Postgres) ───────
+
+
+def _init_sqlite_graph_db() -> sqlite3.Connection:
+    from agent_bom.db.graph_store import _init_db
+
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    _init_db(conn)
+    return conn
+
+
+def _build_two_snapshots():
+    from agent_bom.graph import RelationshipType, UnifiedEdge, UnifiedGraph
+    from agent_bom.graph.node import UnifiedNode
+    from agent_bom.graph.types import EntityType
+
+    def node(node_id: str) -> UnifiedNode:
+        return UnifiedNode(id=node_id, entity_type=EntityType.SERVER, label=node_id)
+
+    g1 = UnifiedGraph(scan_id="s1", tenant_id="default", created_at="2026-07-16T00:00:00Z")
+    for nid in ("a", "b", "c"):
+        g1.add_node(node(nid))
+    g1.add_edge(UnifiedEdge(source="a", target="b", relationship=RelationshipType.USES))
+    g1.add_edge(UnifiedEdge(source="b", target="c", relationship=RelationshipType.USES))
+
+    # s2 drops the b->c edge (retire).
+    g2 = UnifiedGraph(scan_id="s2", tenant_id="default", created_at="2026-07-17T00:00:00Z")
+    for nid in ("a", "b", "c"):
+        g2.add_node(node(nid))
+    g2.add_edge(UnifiedEdge(source="a", target="b", relationship=RelationshipType.USES))
+    return g1, g2
+
+
+def test_sqlite_retire_stamps_activity_id_close_like_postgres():
+    from agent_bom.db.graph_store import changed_edges_between_scans, save_graph
+
+    conn = _init_sqlite_graph_db()
+    g1, g2 = _build_two_snapshots()
+    save_graph(conn, g1)
+    save_graph(conn, g2)
+
+    changes = changed_edges_between_scans(conn, "s1", "s2", tenant_id="default")
+    removed = changes["edges_removed"]
+    assert [(e["source_id"], e["target_id"]) for e in removed] == [("b", "c")]
+    # OCSF Close(3): a retired edge is Closed, matching the Postgres backend.
+    assert removed[0]["activity_id"] == 3
+
+
+def test_retire_activity_id_sql_parity_across_backends():
+    """Both stores must issue the identical Create(1)->Close(3) stamp on retire."""
+    src = Path(__file__).parent.parent / "src" / "agent_bom"
+    sqlite_src = (src / "db" / "graph_store.py").read_text()
+    pg_src = (src / "api" / "postgres_graph.py").read_text()
+
+    case_expr = r"activity_id\s*=\s*CASE\s+WHEN\s+activity_id\s*=\s*1\s+THEN\s+3\s+ELSE\s+activity_id\s+END"
+    assert re.search(case_expr, sqlite_src), "SQLite retire must stamp activity_id 1->3"
+    assert re.search(case_expr, pg_src), "Postgres retire must stamp activity_id 1->3"


### PR DESCRIPTION
Two contained graph-backend correctness bugs, one PR. TDD: both regressions have a test that fails RED before the fix and passes after.

## Fix 1 — P1: `analysis_status`/`risk_summary` crash graph reads on the JSONB schema

**Root cause.** `deploy/supabase/postgres/init.sql` and the enterprise migration `20260717_02_graph_analysis_status.py` declare `graph_snapshots.analysis_status` (and `risk_summary`) as **JSONB**, but the app's own `_init_tables` created legacy tables as **TEXT** — a schema-type divergence. The Postgres reads did bare `json.loads(...)`:
- `postgres_graph.py` `load_graph` (`analysis_status`)
- `list_snapshots` (`risk_summary` + `analysis_status`)
- snapshot-detail (`analysis_status`)

Under psycopg3 a JSONB column returns an **already-parsed `dict`**, so `json.loads(dict)` raises `TypeError` and the graph read crashes — and only when the status is non-empty (an empty `{}` is falsy so it fell back to `"{}"`), i.e. exactly when attack-path fusion recorded a status.

**Fix.** Added a `_json_column_to_dict` guard that is robust to BOTH a `str` (TEXT column) and a `dict` (JSONB column) — mirroring the existing `isinstance(x, dict)` guard in `postgres_audit.py`. Applied at all three `analysis_status` read sites and the sibling `risk_summary` read.

**Schema-alignment choice.** The canonical schema (`init.sql` + the existing `20260717_02` migration) is already **JSONB**; the app's `_init_tables` was the lone TEXT outlier. I aligned `_init_tables` (both the `CREATE TABLE` and the `ADD COLUMN` ALTER) to JSONB to match, so new app-path tables are consistent with the canonical schema. No new migration is needed (the JSONB migration already exists). Existing legacy TEXT tables are untouched (`CREATE/ADD COLUMN IF NOT EXISTS` no-op on an existing column) and remain correct because the `isinstance` guard handles both types. The write path already stores `json.dumps(...)` strings, which PostgreSQL assignment-casts into JSONB (unchanged, already how JSONB production DBs worked).

**How verified.** New tests simulate psycopg3's dict return for JSONB and drive the real `load_graph`/`list_snapshots` — RED before (`TypeError: the JSON object must be str, bytes or bytearray, not dict`), green after.

## Fix 2 — P1-class: retired-edge `activity_id` parity (SQLite ≠ Postgres)

**Root cause.** On retiring an edge dropped from a new snapshot, Postgres stamps `activity_id = CASE WHEN activity_id = 1 THEN 3 ELSE activity_id END` (OCSF Create→Close), but SQLite only set `valid_to` and left Create(1). `activity_id` is in the edge-change fingerprint on both backends and flows into `edges_removed` → the change feed / OCSF `type_uid`, so the same scan sequence yielded a different diff by backend.

**Fix.** Aligned the SQLite retire UPDATE to also stamp Create(1)→Close(3), matching Postgres (the more correct OCSF change-feed semantics — a retired edge is Closed).

**How verified.** New cross-backend parity test: retire the same edge on SQLite end-to-end and assert `edges_removed[0]["activity_id"] == 3` (RED: was `1`), plus a structural assertion that both stores issue the identical `CASE` stamp (RED before on the SQLite side).

## Scope / safety
Backend-only (graph stores). No API/UI contract shape change: reads return the same `analysis_status` dict; `activity_id` values only reconcile. `tenant_id`/RLS scoping preserved on every touched query; no new UNIQUE keys.

## VERIFY (all reproduced, green)
- New tests: 4 RED before → 4 passed after.
- Touched suites (both backends): `test_graph_api test_graph_delta_digest test_graph_backend test_postgres_graph_streaming test_postgres_graph_retention test_attack_path_fusion test_graph_attack_path_fusion test_postgres_migrations test_ocsf test_graph_cloud_edge_lifecycle test_graph_roundtrip` → 182 passed.
- `ruff check` + `ruff format --check` clean; `mypy` changed files clean; `bandit -r src/ --severity-level medium` exit 0.
- `scripts/check-counts.py`, `export_openapi.py --check`, `generate_v1_schemas.py --check` all pass.