### PR TITLE
fix(deploy): make Alembic Postgres bootstrap driver-safe

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(site-docs/|mkdocs\.yml$|\.github/workflows/(docs|ci)\.yml$|\.github/actions/setup-python/)'; then
             docs=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_)'; then
+          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_|deploy/supabase/postgres/)'; then
             postgres=true
           fi
           if printf '%s\n' "$changed" | grep -Eq '^(deploy/endpoints/|scripts/(build-[^/]+|render_homebrew_formula\.py)|src/agent_bom/cli/_runtime\.py|tests/test_cli_runtime\.py|pyproject\.toml|uv\.lock|\.github/actions/setup-python/|site-docs/deployment/aws-company-rollout\.md$)'; then
@@ -836,11 +836,59 @@ jobs:
       - name: Install Postgres test dependencies
         run: uv sync --frozen --extra dev --extra api --extra postgres
 
+      - name: Install Postgres client
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends postgresql-client
+
+      - name: Verify Alembic bootstrap and init.sql forward upgrade
+        env:
+          PGPASSWORD: testpass
+        run: |
+          set -euo pipefail
+
+          # Fresh Alembic-only deployment. The dedicated bootstrap owner mirrors
+          # the shipped compose model: it starts privileged enough to provision
+          # roles, then init.sql strips SUPERUSER/BYPASSRLS before the connection
+          # closes. Do not run the baseline as PostgreSQL's protected `postgres`
+          # bootstrap role.
+          psql -h 127.0.0.1 -U postgres -d postgres <<'SQL'
+          CREATE ROLE agentbom_migration_owner LOGIN PASSWORD 'migrationpass' SUPERUSER;
+          CREATE DATABASE agentbom_migration OWNER agentbom_migration_owner;
+          ALTER DATABASE agentbom_migration SET init.app_password = 'apppass';
+          SQL
+          export ALEMBIC_DATABASE_URL='postgresql+psycopg://agentbom_migration_owner:migrationpass@127.0.0.1:5432/agentbom_migration'
+          uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+          # A second invocation is the supported idempotent rerun contract.
+          uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+
+          expected_head="$(uv run alembic -c deploy/supabase/postgres/alembic.ini heads | awk 'NR == 1 {print $1}')"
+          actual_head="$(PGPASSWORD=migrationpass psql -h 127.0.0.1 -U agentbom_migration_owner -d agentbom_migration -Atc 'SELECT version_num FROM alembic_version')"
+          test "$actual_head" = "$expected_head"
+          test -z "$(PGPASSWORD=migrationpass psql -h 127.0.0.1 -U agentbom_migration_owner -d agentbom_migration -Atc "SELECT current_setting('init.app_password', true)")"
+          test "$(PGPASSWORD=migrationpass psql -h 127.0.0.1 -U agentbom_migration_owner -d agentbom_migration -Atc "SELECT rolsuper OR rolbypassrls FROM pg_roles WHERE rolname = current_user")" = "f"
+
+          # Existing Docker/psql bootstrap. init.sql establishes the baseline;
+          # stamping that exact revision and moving forward must reach the same
+          # Alembic head without replaying the baseline.
+          psql -h 127.0.0.1 -U postgres -d postgres <<'SQL'
+          CREATE ROLE agentbom_psql_owner LOGIN PASSWORD 'psqlpass' SUPERUSER;
+          CREATE DATABASE agent_bom OWNER agentbom_psql_owner;
+          ALTER DATABASE agent_bom SET init.app_password = 'apppass';
+          SQL
+          PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom \
+            -v ON_ERROR_STOP=1 -f deploy/supabase/postgres/init.sql
+          export ALEMBIC_DATABASE_URL='postgresql+psycopg://agentbom_psql_owner:psqlpass@127.0.0.1:5432/agent_bom'
+          uv run alembic -c deploy/supabase/postgres/alembic.ini stamp 20260416_01
+          uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+          actual_head="$(PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom -Atc 'SELECT version_num FROM alembic_version')"
+          test "$actual_head" = "$expected_head"
+          test -z "$(PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom -Atc "SELECT current_setting('init.app_password', true)")"
+          test "$(PGPASSWORD=psqlpass psql -h 127.0.0.1 -U agentbom_psql_owner -d agent_bom -Atc "SELECT rolsuper OR rolbypassrls FROM pg_roles WHERE rolname = current_user")" = "f"
+
       - name: Provision non-superuser application role
         run: |
           set -euo pipefail
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends postgresql-client
           # The role is intentionally NOSUPERUSER NOBYPASSRLS so RLS policies
           # actually apply to it. Granting CREATE on the public schema lets the
           # storage layer's _ensure_tenant_rls() create and own its tables, so

--- a/deploy/supabase/postgres/alembic/versions/20260416_01_control_plane_baseline.py
+++ b/deploy/supabase/postgres/alembic/versions/20260416_01_control_plane_baseline.py
@@ -24,7 +24,12 @@ def upgrade() -> None:
     bind = op.get_bind()
     database_name = bind.exec_driver_sql("SELECT current_database()").scalar_one()
     bootstrap_sql = load_bootstrap_sql(database_name)
-    bind.exec_driver_sql(bootstrap_sql)
+    # The baseline contains server-side PL/pgSQL ``format(... %L ...)`` tokens.
+    # Without ``no_parameters``, SQLAlchemy passes an empty parameter mapping
+    # and psycopg3 parses those tokens as unsupported client placeholders before
+    # PostgreSQL can evaluate them.  No runtime bind values or secrets are
+    # passed through this DBAPI call.
+    bind.exec_driver_sql(bootstrap_sql, execution_options={"no_parameters": True})
 
 
 def downgrade() -> None:  # pragma: no cover - baseline downgrade is intentionally manual

--- a/deploy/supabase/postgres/alembic/versions/20260705_01_hub_observations_partition.py
+++ b/deploy/supabase/postgres/alembic/versions/20260705_01_hub_observations_partition.py
@@ -34,9 +34,14 @@ from agent_bom.api.hub_observations_partition import (  # noqa: E402
 
 def upgrade() -> None:
     bind = op.get_bind()
-    migrated = migrate_observations_to_partitioned(bind)
+    # The shared helper is also used by the runtime psycopg pool and therefore
+    # intentionally uses psycopg's ``execute(sql, tuple)`` contract.  Alembic
+    # exposes a SQLAlchemy Connection, whose parameter contract is different;
+    # unwrap the DBAPI connection while retaining Alembic's transaction.
+    driver_connection = bind.connection.driver_connection
+    migrated = migrate_observations_to_partitioned(driver_connection)
     if migrated:
-        ensure_observation_partitions(bind)
+        ensure_observation_partitions(driver_connection)
 
 
 def downgrade() -> None:

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import re
 from pathlib import Path
+from types import SimpleNamespace
 
 POSTGRES_DIR = Path(__file__).parent.parent / "deploy" / "supabase" / "postgres"
 ALEMBIC_DIR = POSTGRES_DIR / "alembic"
@@ -13,6 +14,7 @@ BASELINE = VERSIONS_DIR / "20260416_01_control_plane_baseline.py"
 GRAPH_HOT_PATH_INDEXES = VERSIONS_DIR / "20260513_01_graph_hot_path_indexes.py"
 POSTGRES_STORE_PARITY = VERSIONS_DIR / "20260717_01_postgres_store_parity.py"
 GRAPH_ANALYSIS_STATUS = VERSIONS_DIR / "20260717_02_graph_analysis_status.py"
+HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
 
 
@@ -53,6 +55,39 @@ GRANT CONNECT ON DATABASE agent_bom TO agent_bom_readonly;
     assert "GRANT CONNECT ON DATABASE agent_bom TO agent_bom_app;" not in rewritten
 
 
+def test_baseline_migration_executes_bootstrap_without_dbapi_parameters(monkeypatch):
+    """Server-side ``%L`` format tokens must reach Postgres unchanged.
+
+    psycopg3 treats percent tokens as client placeholders whenever SQLAlchemy
+    passes an (even empty) parameter mapping to ``cursor.execute``.  The
+    baseline contains PL/pgSQL ``format(... %L ...)`` expressions, so its
+    driver execution must explicitly suppress DBAPI parameter handling.
+    """
+    module = _load_module(BASELINE, "abom_control_plane_baseline")
+    bootstrap_sql = "DO $$ BEGIN PERFORM format('PASSWORD %L', 'secret'); END $$;"
+
+    class _Result:
+        def scalar_one(self):
+            return "migration_contract"
+
+    calls: list[tuple[str, dict[str, bool] | None]] = []
+
+    class _Bind:
+        def exec_driver_sql(self, sql, *, execution_options=None):
+            calls.append((sql, execution_options))
+            return _Result()
+
+    monkeypatch.setattr(module.op, "get_bind", lambda: _Bind())
+    monkeypatch.setattr(module, "load_bootstrap_sql", lambda database_name: bootstrap_sql)
+
+    module.upgrade()
+
+    assert calls == [
+        ("SELECT current_database()", None),
+        (bootstrap_sql, {"no_parameters": True}),
+    ]
+
+
 def test_graph_hot_path_index_migration_chains_from_baseline():
     sql = GRAPH_HOT_PATH_INDEXES.read_text()
     assert re.search(r'revision\s*=\s*"20260513_01"', sql)
@@ -87,3 +122,19 @@ def test_graph_analysis_status_migration_is_idempotent_and_chained():
     assert re.search(r'revision\s*=\s*"20260717_02"', sql)
     assert re.search(r'down_revision\s*=\s*"20260717_01"', sql)
     assert "ADD COLUMN IF NOT EXISTS analysis_status JSONB NOT NULL" in sql
+
+
+def test_hub_partition_migration_uses_the_psycopg_driver_connection(monkeypatch):
+    """The shared partition helper uses psycopg's ``%s`` execute contract."""
+    module = _load_module(HUB_OBSERVATIONS_PARTITION, "abom_hub_observations_partition")
+    driver_connection = object()
+    bind = SimpleNamespace(connection=SimpleNamespace(driver_connection=driver_connection))
+    seen: list[object] = []
+
+    monkeypatch.setattr(module.op, "get_bind", lambda: bind)
+    monkeypatch.setattr(module, "migrate_observations_to_partitioned", lambda conn: seen.append(conn) or True)
+    monkeypatch.setattr(module, "ensure_observation_partitions", lambda conn: seen.append(conn))
+
+    module.upgrade()
+
+    assert seen == [driver_connection, driver_connection]


### PR DESCRIPTION
## Summary

- preserve server-side PL/pgSQL percent-format tokens through the psycopg3 baseline migration without client parameter parsing
- unwrap the SQLAlchemy connection for the shared psycopg partition helper while retaining the Alembic transaction
- exercise both supported Postgres bootstrap paths in CI: empty Alembic-to-head and init.sql baseline-to-head, including rerun, credential cleanup, and bootstrap-privilege assertions

## Verification

- shipped postgres:16-alpine: empty Alembic database to head plus idempotent rerun
- shipped postgres:16-alpine: init.sql, baseline stamp, and forward upgrade to head
- app-role Postgres storage contract: 5 passed, 1 expected privilege skip
- 120 owning and security tests passed
- Ruff check and format, mypy, actionlint, workflow timeout/release lint, exception-sanitization guard, and git diff check

## Notes

- root cause 1: SQLAlchemy supplied an empty parameter mapping, so psycopg3 interpreted PL/pgSQL percent-L tokens as client placeholders
- root cause 2: a later migration passed a SQLAlchemy Connection to a helper that intentionally implements the psycopg execute contract
- both migration paths clear the transient password GUC and leave bootstrap owners without SUPERUSER or BYPASSRLS

Closes #4138
Addresses #4095