### PR TITLE
fix(compliance): reconcile executive finding counts

### DIFF
--- a/src/agent_bom/api/findings_current.py
+++ b/src/agent_bom/api/findings_current.py
@@ -1,0 +1,81 @@
+"""Canonical current-state fold for scan-produced findings.
+
+The findings list and executive count surfaces share this module so their
+default time-window, parent-job exclusion, and cross-job replacement semantics
+cannot drift independently.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from datetime import datetime, timezone
+from typing import Any
+
+from agent_bom.api.models import JobStatus
+
+
+def job_in_window(job: Any, since: str | None) -> bool:
+    """Return whether a job's completion timestamp is inside ``since``."""
+    if since is None:
+        return True
+    stamp = getattr(job, "completed_at", None) or getattr(job, "created_at", None)
+    try:
+        observed = datetime.fromisoformat(str(stamp).replace("Z", "+00:00"))
+        cutoff = datetime.fromisoformat(since.replace("Z", "+00:00"))
+        if observed.tzinfo is None:
+            observed = observed.replace(tzinfo=timezone.utc)
+        if cutoff.tzinfo is None:
+            cutoff = cutoff.replace(tzinfo=timezone.utc)
+        return observed >= cutoff
+    except (TypeError, ValueError):
+        return False
+
+
+def finding_identity(finding: dict[str, Any]) -> str:
+    """Stable identity used to collapse a finding across scan jobs."""
+    raw_id = finding.get("id")
+    if raw_id:
+        return str(raw_id)
+    vuln_id = finding.get("vulnerability_id") or finding.get("cve_id") or finding.get("title") or ""
+    raw_asset = finding.get("asset")
+    asset = raw_asset if isinstance(raw_asset, dict) else {}
+    package = finding.get("package") or finding.get("package_name") or asset.get("name", "")
+    return f"{vuln_id}:{package}"
+
+
+def current_scan_findings(
+    jobs: Iterable[Any],
+    *,
+    since: str | None,
+    scan_id: str | None,
+    iter_findings: Callable[[Any], list[dict[str, Any]]],
+) -> list[dict[str, Any]]:
+    """Return the latest current row per identity across eligible scan jobs.
+
+    Parent aggregation jobs are excluded from the unscoped view because their
+    child jobs already own the evidence. A direct ``scan_id`` query retains the
+    selected job's rows verbatim.
+    """
+    deduped: dict[str, dict[str, Any]] = {}
+    eligible = (
+        job for job in jobs if getattr(job, "status", None) == JobStatus.DONE and getattr(job, "result", None) and job_in_window(job, since)
+    )
+    for job in sorted(
+        eligible,
+        key=lambda item: (
+            getattr(item, "completed_at", None) or "",
+            getattr(item, "created_at", None) or "",
+            getattr(item, "job_id", ""),
+        ),
+    ):
+        job_id = str(getattr(job, "job_id", ""))
+        if scan_id and job_id != scan_id:
+            continue
+        if getattr(job, "child_job_ids", None) and job_id != scan_id:
+            continue
+        for row in iter_findings(job):
+            deduped[finding_identity(row)] = row
+    return list(deduped.values())
+
+
+__all__ = ["current_scan_findings", "finding_identity", "job_in_window"]

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -754,6 +754,9 @@ class PostgresComplianceHubStore:
                 )
             conn.commit()
         _invalidate_overview_severity(tenant_id)
+        from agent_bom.api.findings_count_cache import invalidate_tenant
+
+        invalidate_tenant(tenant_id)
         new_total = self._bump_tenant_total(tenant_id, new_rows)
         return new_total, reconciled
 
@@ -1056,9 +1059,7 @@ class PostgresComplianceHubStore:
         # One lookup for every ledger ordinal pointer.
         ordinal_map: dict[str, int] = {}
         if has_ledger_col:
-            ordinal_map = _fetch_ledger_ordinals_postgres(
-                conn, tenant_id, [meta[3] for meta in to_process if meta[3]]
-            )
+            ordinal_map = _fetch_ledger_ordinals_postgres(conn, tenant_id, [meta[3] for meta in to_process if meta[3]])
 
         ledger_upsert_params: list[tuple[Any, ...]] = []
         plain_upsert_params: list[tuple[Any, ...]] = []
@@ -1096,9 +1097,7 @@ class PostgresComplianceHubStore:
                 # idx_hub_findings_current_tenant_ordinal instead of a per-row
                 # correlated ledger subquery (#3984).
                 ledger_ordinal_val = ordinal_map.get(ledger_finding_id, _LEDGER_ORDINAL_SENTINEL)
-                ledger_upsert_params.append(
-                    (*base, ledger_finding_id or None, origin_val, scan_id_val, ledger_ordinal_val)
-                )
+                ledger_upsert_params.append((*base, ledger_finding_id or None, origin_val, scan_id_val, ledger_ordinal_val))
             else:
                 plain_upsert_params.append((*base, origin_val, scan_id_val))
 

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -14,14 +14,14 @@ function that another route already exposes:
       counts so findings ingested via ``POST /v1/findings/bulk`` move the
       grade/headline (not scan jobs alone)
 
-The exec headline severity counts, the five coverage lanes, and the risk grade
-are all built from one reconciled rollup over the unified ``findings`` stream
-(``_estate_rollup``) — never the CVE-only ``blast_radius``. That closes the
-divergence where a scan-produced non-CVE critical (malicious/blocklisted
-package, MCP/a2a auth, IaC) was visible in the coverage lanes and
-``/v1/findings`` but invisible in the headline critical/high and the grade
-(#3961). ``blast_radius`` / compact ``summary`` are used only as fallbacks when
-a completed scan carries no findings spine (e.g. post hot-cache compaction).
+The exec headline severity counts and risk grade use the exact default-window,
+parent-job exclusion, and cross-job replacement semantics of ``/v1/findings``.
+The five coverage lanes remain historical scan summaries. This separation is
+intentional: compact summaries can describe prior scan coverage, but cannot
+create executive severity counts whose underlying finding rows no longer exist
+for drill-down. The shared current-state fold includes non-CVE findings and
+canonicalized ``blast_radius`` evidence, so re-scans replace rather than inflate
+the executive count (#3961/#4106).
 
 Domain tiles (cloud / vuln / code / runtime / ...) remain scan-scoped by
 design; only the top-level posture + headline aggregate scan + ingested
@@ -813,11 +813,9 @@ def _reconciled_exec_counts(estate: dict[str, Any], hub_severity: dict[str, int]
     """The single exec-facing severity source of truth (#3961).
 
     Both the ``/v1/overview`` headline and ``/v1/posture/counts`` derive their
-    critical/high/… from THIS reconciliation of the unified findings spine
-    (``_estate_rollup``) with hub-ingested evidence, so the two exec surfaces
-    can never report a different open-severity count for the same estate. The
-    honest ``unrated`` bucket is carried through and the buckets sum to
-    ``total`` (no silent drop).
+    critical/high/… from THIS reconciliation of the canonical, windowed scan
+    current state with hub-ingested current evidence. The honest ``unrated``
+    bucket is carried through and the buckets sum to ``total`` (no silent drop).
     """
     combined = _combined_severity(estate["severity"], hub_severity)
     return {
@@ -832,15 +830,40 @@ def _reconciled_exec_counts(estate: dict[str, Any], hub_severity: dict[str, int]
     }
 
 
+def _current_scan_severity(jobs: list[Any]) -> dict[str, int]:
+    """Severity histogram with the exact scan semantics of ``/v1/findings``."""
+    from agent_bom.api import time_window
+    from agent_bom.api.findings_current import current_scan_findings
+    from agent_bom.api.routes.scan import _iter_scan_findings
+
+    since = time_window.window_since_iso(time_window.normalize_window_days(None))
+    findings = current_scan_findings(
+        jobs,
+        since=since,
+        scan_id=None,
+        iter_findings=_iter_scan_findings,
+    )
+    severity = _empty_severity()
+    for row in findings:
+        severity[_bucket(str(row.get("severity") or ""), severity)] += 1
+    return severity
+
+
+def _exec_estate(estate: dict[str, Any], jobs: list[Any]) -> dict[str, Any]:
+    """Overlay canonical current scan counts without changing domain history."""
+    return {**estate, "severity": _current_scan_severity(jobs)}
+
+
 def exec_severity_counts(request: Request, jobs: list[Any]) -> dict[str, int]:
-    """Reconciled exec severity counts for ``jobs`` (unified spine + hub).
+    """Reconciled current exec severity counts for ``jobs`` + hub evidence.
 
     Public entry point shared with ``/v1/posture/counts`` so nav badges and the
     overview headline read one number. Recomputes the estate rollup and hub
     snapshot; a caller that already holds them should use
     ``_reconciled_exec_counts`` directly to avoid a second pass.
     """
-    return _reconciled_exec_counts(_estate_rollup(jobs), _hub_severity_snapshot(request))
+    estate = _estate_rollup(jobs)
+    return _reconciled_exec_counts(_exec_estate(estate, jobs), _hub_severity_snapshot(request))
 
 
 def _exec_posture(
@@ -961,8 +984,9 @@ def _build_overview(request: Request) -> dict[str, Any]:
 def _compose_overview(request: Request, tenant_id: str, jobs: list[Any], hub_severity: dict[str, int]) -> dict[str, Any]:
     """Fold the estate into the overview payload (the O(estate) hot path)."""
     estate = _estate_rollup(jobs)
+    exec_estate = _exec_estate(estate, jobs)
     coverage = estate["coverage"]
-    posture = _exec_posture(request, _posture_snapshot(jobs), estate, hub_severity)
+    posture = _exec_posture(request, _posture_snapshot(jobs), exec_estate, hub_severity)
     runtime = _runtime_snapshot(request, jobs)
     cost = _cost_snapshot(request)
     identity = _identity_snapshot(request)
@@ -972,7 +996,7 @@ def _compose_overview(request: Request, tenant_id: str, jobs: list[Any], hub_sev
     # /v1/posture/counts reads — the unified spine folded with hub-ingested
     # evidence — never the CVE-only blast_radius (#3961). Both exec surfaces
     # route through ``_reconciled_exec_counts`` so they can never disagree.
-    exec_counts = _reconciled_exec_counts(estate, hub_severity)
+    exec_counts = _reconciled_exec_counts(exec_estate, hub_severity)
     headline_critical = exec_counts["critical"]
     headline_high = exec_counts["high"]
     critical_high = headline_critical + headline_high

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -30,7 +30,6 @@ import logging
 import os
 import time
 import uuid
-from datetime import datetime, timezone
 from functools import partial
 from pathlib import Path
 from typing import Annotated, Any
@@ -308,20 +307,6 @@ def _completed_jobs_for_tenant(tenant_id: str) -> list[ScanJob]:
     return [job for job in _get_store().list_all(tenant_id=tenant_id) if job.status == JobStatus.DONE and job.result]
 
 
-def _job_in_window(job: ScanJob, since: str | None) -> bool:
-    if since is None:
-        return True
-    stamp = job.completed_at or job.created_at
-    try:
-        observed = datetime.fromisoformat(stamp.replace("Z", "+00:00"))
-        cutoff = datetime.fromisoformat(since.replace("Z", "+00:00"))
-        if observed.tzinfo is None:
-            observed = observed.replace(tzinfo=timezone.utc)
-        return observed >= cutoff
-    except (TypeError, ValueError):
-        return False
-
-
 class BulkFindingsRequest(BaseModel):
     """Normalized finding ingest for headless clients and agent runtimes."""
 
@@ -450,10 +435,9 @@ def _finding_identity(finding: dict[str, Any]) -> str:
     Prefers the finding ``id`` (what Postgres' ``hub_findings_current`` keys on)
     and falls back to the vuln:package content key when a scan row omits ``id``.
     """
-    raw_id = finding.get("id")
-    if raw_id:
-        return str(raw_id)
-    return _finding_key(finding)
+    from agent_bom.api.findings_current import finding_identity
+
+    return finding_identity(finding)
 
 
 def _finding_key(finding: dict[str, Any]) -> str:
@@ -1883,18 +1867,14 @@ def _list_findings_impl(
     # ``hub_findings_current`` which already dedupes). Iterate jobs oldest-first
     # so the latest occurrence of each finding id wins; ``?scan_id=`` still
     # returns that scan's rows verbatim.
-    deduped: dict[str, dict[str, Any]] = {}
-    for job in sorted(
-        (job for job in _completed_jobs_for_tenant(tenant_id) if _job_in_window(job, window_since)),
-        key=lambda job: (job.completed_at or "", job.created_at or "", job.job_id),
-    ):
-        if scan_id and job.job_id != scan_id:
-            continue
-        if job.child_job_ids and job.job_id != scan_id:
-            continue
-        for row in _iter_scan_findings(job):
-            deduped[_finding_identity(row)] = row
-    scan_findings: list[dict[str, Any]] = list(deduped.values())
+    from agent_bom.api.findings_current import current_scan_findings
+
+    scan_findings = current_scan_findings(
+        _completed_jobs_for_tenant(tenant_id),
+        since=window_since,
+        scan_id=scan_id,
+        iter_findings=_iter_scan_findings,
+    )
     if severity:
         normalized = severity.lower()
         scan_findings = [item for item in scan_findings if str(item.get("severity", "")).lower() == normalized]

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 
 import json
 import tempfile
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import get_type_hints
 
@@ -1987,10 +1988,7 @@ jobs:
 """)
     agents, warnings = scan_github_actions(str(tmp_path))
     assert agents == []
-    assert warnings == [
-        "CI hardening in ci.yml: missing top-level permissions: policy; "
-        "declare least-privilege GITHUB_TOKEN permissions"
-    ]
+    assert warnings == ["CI hardening in ci.yml: missing top-level permissions: policy; declare least-privilege GITHUB_TOKEN permissions"]
 
 
 def test_gha_detects_ai_sdk_in_run_step(tmp_path):
@@ -4335,11 +4333,12 @@ def test_api_posture_counts_with_data():
 
     tenant_id = "counts-with-data"
     client = TestClient(app)
+    observed_at = datetime.now(timezone.utc).isoformat()
     job = ScanJob(
         job_id="counts-test-001",
         tenant_id=tenant_id,
         status=JobStatus.DONE,
-        created_at="2026-01-01T00:00:00Z",
+        created_at=observed_at,
         request=ScanRequest(),
         result={
             "blast_radius": [

--- a/tests/test_hub_ingest_atomic.py
+++ b/tests/test_hub_ingest_atomic.py
@@ -17,6 +17,7 @@ test runs everywhere against a fake store.
 from __future__ import annotations
 
 import os
+from contextlib import contextmanager
 from typing import Any
 from uuid import uuid4
 
@@ -154,9 +155,7 @@ def test_atomic_ingest_matches_sequential_add_plus_upsert():
     tok = set_current_tenant(tenant_seq)
     try:
         store.add(tenant_seq, payloads)
-        store.upsert_current_batch(
-            tenant_seq, payloads, observed_at="2026-07-16T00:00:00Z", batch_id="b", source="connector"
-        )
+        store.upsert_current_batch(tenant_seq, payloads, observed_at="2026-07-16T00:00:00Z", batch_id="b", source="connector")
         seq_count = store.count(tenant_seq)
         seq_current = store.list_current_page(tenant_seq, limit=50)[1]
     finally:
@@ -248,3 +247,92 @@ def test_shared_body_uses_atomic_seam_when_available():
     assert result["reconciled"] == 0
     assert store.calls and store.calls[0]["batch_id"] == "batch-9"
     assert store.calls[0]["reconcile_absent"] is False
+
+
+def test_postgres_atomic_store_invalidates_cached_finding_totals(monkeypatch):
+    """The atomic write seam invalidates the same tenant cache as split writes."""
+    from agent_bom.api import postgres_compliance_hub as module
+    from agent_bom.api.findings_count_cache import (
+        cache_key,
+        get_cached_total,
+        reset_findings_count_cache,
+        set_cached_total,
+    )
+
+    class _Connection:
+        def commit(self) -> None:
+            return None
+
+    @contextmanager
+    def _connection(_pool):
+        yield _Connection()
+
+    store = module.PostgresComplianceHubStore.__new__(module.PostgresComplianceHubStore)
+    store._pool = object()
+    monkeypatch.setattr(module, "_tenant_connection", _connection)
+    monkeypatch.setattr(store, "_write_ledger_batch", lambda *_a, **_k: 1)
+    monkeypatch.setattr(store, "_write_current_batch", lambda *_a, **_k: None)
+    monkeypatch.setattr(store, "_bump_tenant_total", lambda *_a, **_k: 2)
+
+    key = cache_key(
+        tenant_id="tenant-cache",
+        severity=None,
+        scan_id=None,
+        origin="bulk_ingest",
+        window_days=90,
+    )
+    reset_findings_count_cache()
+    set_cached_total(key, 1)
+
+    total, reconciled = store.ingest_batch_atomic(
+        "tenant-cache",
+        [_payload(2)],
+        observed_at="2026-07-17T00:00:00Z",
+        batch_id="batch-2",
+        source="connector",
+        reconcile_absent=False,
+        present_canonical_ids={"c-2"},
+    )
+
+    assert (total, reconciled) == (2, 0)
+    assert get_cached_total(key) is None
+
+
+@pg_only
+def test_live_postgres_atomic_ingest_invalidates_cached_finding_totals():
+    """A committed live write drops every cached filter/window for its tenant."""
+    from agent_bom.api.findings_count_cache import (
+        cache_key,
+        get_cached_total,
+        reset_findings_count_cache,
+        set_cached_total,
+    )
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_compliance_hub import PostgresComplianceHubStore
+
+    tenant = f"atomic-cache-{uuid4().hex}"
+    token = set_current_tenant(tenant)
+    key = cache_key(
+        tenant_id=tenant,
+        severity="critical",
+        scan_id=None,
+        origin="bulk_ingest",
+        window_days=90,
+    )
+    try:
+        reset_findings_count_cache()
+        set_cached_total(key, 1)
+        store = PostgresComplianceHubStore()
+        store.ingest_batch_atomic(
+            tenant,
+            [_payload(1, severity="critical")],
+            observed_at="2026-07-17T00:00:00Z",
+            batch_id="batch-live-cache",
+            source="connector",
+            reconcile_absent=False,
+            present_canonical_ids={"c-1"},
+        )
+        assert get_cached_total(key) is None
+    finally:
+        reset_findings_count_cache()
+        reset_current_tenant(token)

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import JobStatus, _get_store, app, configure_api
@@ -10,6 +12,10 @@ from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_e
 
 _AUTH_HEADERS = proxy_headers(tenant="default")
 _ADMIN_HEADERS = proxy_headers(role="admin", tenant="default")
+
+
+def _recent_stamp() -> str:
+    return datetime.now(timezone.utc).isoformat()
 
 
 def setup_module() -> None:
@@ -43,11 +49,11 @@ def _add_done_job(
     job = ScanJob(
         job_id=job_id,
         tenant_id=tenant_id,
-        created_at="2026-02-22T10:00:00Z",
+        created_at=_recent_stamp(),
         request=ScanRequest(),
     )
     job.status = JobStatus.DONE
-    job.completed_at = "2026-02-22T10:05:00Z"
+    job.completed_at = _recent_stamp()
     job.result = {
         "agents": [],
         "blast_radius": blast_radius,
@@ -144,11 +150,11 @@ def test_overview_reads_compacted_scan_summary() -> None:
     job = ScanJob(
         job_id="compact-job",
         tenant_id="default",
-        created_at="2026-02-22T10:00:00Z",
+        created_at=_recent_stamp(),
         request=ScanRequest(),
     )
     job.status = JobStatus.DONE
-    job.completed_at = "2026-02-22T10:05:00Z"
+    job.completed_at = _recent_stamp()
     job.result = {
         "summary": {
             "total_vulnerabilities": 87,
@@ -178,16 +184,14 @@ def test_overview_reads_compacted_scan_summary() -> None:
     assert resp.status_code == 200
     data = resp.json()
 
-    # The configurable exec-score engine (#3940) recomputes the grade from the
-    # honest estate counts and takes the *worst* of that and the scan scorecard
-    # floor (42.0). 3 critical + 12 high + 72 unrated is heavy pressure, so the
-    # diminishing-returns score lands well below the floor — still an F, and the
-    # CVE/severity tiles are populated (the compaction-must-not-zero-tiles intent
-    # this test guards).
+    # Historical compact summaries still populate scan/domain reporting and the
+    # scorecard floor. They cannot populate a current finding drill-down because
+    # the rows were compacted, so the executive severity headline remains exact
+    # with /v1/findings instead of presenting non-clickable counts.
     assert data["posture"]["grade"] == "F"
     assert data["posture"]["score"] <= 42.0
-    assert data["headline"]["critical"] == 3
-    assert data["headline"]["high"] == 12
+    assert data["headline"]["critical"] == 0
+    assert data["headline"]["high"] == 0
     assert data["domains"]["vuln"]["metric"] == 87
 
 
@@ -402,11 +406,11 @@ def test_overview_coverage_lanes_map_to_five_domains() -> None:
     job = ScanJob(
         job_id="dom-job",
         tenant_id="default",
-        created_at="2026-02-22T10:00:00Z",
+        created_at=_recent_stamp(),
         request=ScanRequest(),
     )
     job.status = JobStatus.DONE
-    job.completed_at = "2026-02-22T10:05:00Z"
+    job.completed_at = _recent_stamp()
     job.result = {
         "agents": [],
         "scan_sources": ["cloud"],
@@ -453,11 +457,11 @@ def test_overview_coverage_lanes_overlap_for_repo_dependency_cve() -> None:
     job = ScanJob(
         job_id="overlap-job",
         tenant_id="default",
-        created_at="2026-02-22T10:00:00Z",
+        created_at=_recent_stamp(),
         request=ScanRequest(),
     )
     job.status = JobStatus.DONE
-    job.completed_at = "2026-02-22T10:05:00Z"
+    job.completed_at = _recent_stamp()
     job.result = {
         "agents": [],
         "scan_sources": ["project"],
@@ -526,11 +530,11 @@ def test_overview_headline_reflects_noncve_spine_critical() -> None:
     job = ScanJob(
         job_id="spine-job",
         tenant_id="default",
-        created_at="2026-02-22T10:00:00Z",
+        created_at=_recent_stamp(),
         request=ScanRequest(),
     )
     job.status = JobStatus.DONE
-    job.completed_at = "2026-02-22T10:05:00Z"
+    job.completed_at = _recent_stamp()
     job.result = {
         "agents": [],
         "scan_sources": ["agent_discovery"],
@@ -583,11 +587,11 @@ def test_posture_counts_reconcile_with_overview_headline() -> None:
     job = ScanJob(
         job_id="reconcile-job",
         tenant_id="default",
-        created_at="2026-02-22T10:00:00Z",
+        created_at=_recent_stamp(),
         request=ScanRequest(),
     )
     job.status = JobStatus.DONE
-    job.completed_at = "2026-02-22T10:05:00Z"
+    job.completed_at = _recent_stamp()
     job.result = {
         "agents": [],
         "scan_sources": ["agent_discovery"],
@@ -631,11 +635,11 @@ def test_overview_compliance_failing_moves_grade() -> None:
         job = ScanJob(
             job_id="cmp-job",
             tenant_id="default",
-            created_at="2026-02-22T10:00:00Z",
+            created_at=_recent_stamp(),
             request=ScanRequest(),
         )
         job.status = JobStatus.DONE
-        job.completed_at = "2026-02-22T10:05:00Z"
+        job.completed_at = _recent_stamp()
         job.result = {
             "agents": [],
             "scan_sources": ["cloud"],

--- a/tests/test_read_path_compliance_hub.py
+++ b/tests/test_read_path_compliance_hub.py
@@ -86,12 +86,64 @@ def _findings_total(client: TestClient, severity: str) -> int:
     return int(resp.json()["total"])
 
 
+def _put_scan(*, scan_id: str, completed_at: datetime, result: dict) -> None:
+    """Persist a completed scan without going through the asynchronous runner."""
+    from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+    from agent_bom.api.stores import _get_store
+
+    stamp = completed_at.isoformat()
+    _get_store().put(
+        ScanJob(
+            job_id=scan_id,
+            tenant_id="tenant-alpha",
+            status=JobStatus.DONE,
+            created_at=stamp,
+            completed_at=stamp,
+            request=ScanRequest(),
+            result=result,
+        )
+    )
+
+
 # ═══════════════════════════════════════════════════════════════════════════
 # P1b — exec headline reconciles with the /v1/findings drill-down
 # ═══════════════════════════════════════════════════════════════════════════
 
 
 class TestExecHeadlineReconciliation:
+    def test_stale_scan_is_excluded_from_all_exec_severity_surfaces(self) -> None:
+        """The default findings window also bounds scan-derived exec counts."""
+        client = _client()
+        _put_scan(
+            scan_id="stale-scan",
+            completed_at=_now() - timedelta(days=400),
+            result={"findings": [{"id": "stale-critical", "severity": "critical"}]},
+        )
+
+        assert _findings_total(client, "critical") == 0
+        assert client.get("/v1/overview").json()["headline"]["critical"] == 0
+        assert client.get("/v1/posture/counts").json()["critical"] == 0
+
+    def test_blast_radius_rescans_are_deduped_across_exec_surfaces(self) -> None:
+        """Repeated evidence for one CVE/package is one current finding."""
+        client = _client()
+        blast = {
+            "blast_radius": [
+                {
+                    "vulnerability_id": "CVE-2026-4106",
+                    "package": "shared-lib@1.0.0",
+                    "severity": "critical",
+                    "risk_score": 9.8,
+                }
+            ]
+        }
+        _put_scan(scan_id="rescan-1", completed_at=_now() - timedelta(days=2), result=blast)
+        _put_scan(scan_id="rescan-2", completed_at=_now() - timedelta(days=1), result=blast)
+
+        assert _findings_total(client, "critical") == 1
+        assert client.get("/v1/overview").json()["headline"]["critical"] == 1
+        assert client.get("/v1/posture/counts").json()["critical"] == 1
+
     def test_overview_headline_equals_findings_drilldown_for_same_window(self) -> None:
         """overview critical/high == /v1/findings critical/high (reconcile invariant).
 
@@ -302,9 +354,7 @@ class TestCurrentSeverityBreakdown:
         since = time_window.window_since_iso(90, now=now)
         breakdown = store.current_severity_breakdown("t1", origin="bulk_ingest", since=since)
         # Drill-down COUNT for the same window.
-        _rows, crit_total, _c = store.list_current_page(
-            "t1", limit=100, severity="critical", origin="bulk_ingest", since=since
-        )
+        _rows, crit_total, _c = store.list_current_page("t1", limit=100, severity="critical", origin="bulk_ingest", since=since)
         assert breakdown["critical"] == crit_total == 1
         assert breakdown["high"] == 1
 


### PR DESCRIPTION
## Summary

- share one canonical default-window, parent-job exclusion, and latest-wins current-state fold across findings, overview, and posture severity counts
- prevent stale compact summaries and duplicate blast-radius rescans from creating executive counts without matching drill-down rows
- invalidate every tenant findings-total cache after a committed Postgres atomic ingest

## Verification

- focused compliance, overview, and atomic-ingest matrix: 100 passed, 4 optional Postgres skips
- current-main rerun: 45 passed, 4 optional Postgres skips
- stale 400-day scan, duplicate rescan, and atomic-ingest cache regressions pass
- Ruff check and format, mypy, exception-sanitization guard, git diff check
- make preflight: OpenAPI, v1 schemas, product surface, release consistency, env references, and SDK patterns clean

## Notes

- phase 1/P1 only: dashboard count consumption, posture-counts event-loop offload, and hub cursor/keyset continuation remain open in #4106
- historical compact summaries still populate scan/domain coverage and the score floor, but no longer fabricate executive severity without a current drill-down row
- tenant isolation and the documented approximate-total contract are preserved

Addresses #4106
Addresses #4095