### PR TITLE
feat(sast): add canonical SARIF integrity boundary

### DIFF
--- a/src/agent_bom/compliance_hub_ingest.py
+++ b/src/agent_bom/compliance_hub_ingest.py
@@ -28,6 +28,11 @@ from typing import Any, Iterable
 from agent_bom.compliance_hub import apply_hub_classification
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.graph.severity import normalize_severity
+from agent_bom.parsers.sarif import (
+    NormalizedSarifResult,
+    SarifValidationError,
+    normalize_sarif_document,
+)
 
 # SARIF level → severity. SARIF only defines four levels; we map none/note
 # down to "info" so they don't masquerade as low-severity bugs.
@@ -93,47 +98,6 @@ def _pick_finding_type(
     return FindingType.SAST
 
 
-def _rule_tags(rule: dict) -> list[str]:
-    props = rule.get("properties") or {}
-    tags = props.get("tags") or []
-    return [str(t) for t in tags]
-
-
-def _result_location(result: dict) -> tuple[str, str | None]:
-    """Return (display_name, file_path) for a SARIF result.
-
-    SARIF locations carry a `physicalLocation.artifactLocation.uri`. We use
-    that as both the asset name and location so findings can be deduped by
-    file path across rules.
-    """
-    locations = result.get("locations") or []
-    if not locations:
-        return ("unknown", None)
-    physical = locations[0].get("physicalLocation") or {}
-    artifact = physical.get("artifactLocation") or {}
-    uri = artifact.get("uri")
-    if not uri:
-        return ("unknown", None)
-    region = physical.get("region") or {}
-    line = region.get("startLine")
-    name = f"{uri}:{line}" if line else uri
-    return (str(name), str(uri))
-
-
-def _build_rule_index(run: dict) -> dict[str, dict]:
-    """Index `rules[]` by id so we can fetch metadata for each result."""
-    tool = run.get("tool") or {}
-    driver = tool.get("driver") or {}
-    rules = driver.get("rules") or []
-    return {str(rule.get("id") or ""): rule for rule in rules if rule.get("id")}
-
-
-def _tool_name(run: dict) -> str:
-    tool = run.get("tool") or {}
-    driver = tool.get("driver") or {}
-    return str(driver.get("name") or "external")
-
-
 def ingest_sarif_findings(path: str | Path) -> list[Finding]:
     """Parse a SARIF 2.1.0 file into hub-classified ``Finding`` objects.
 
@@ -156,76 +120,60 @@ def ingest_sarif_findings(path: str | Path) -> list[Finding]:
         return []
     if not isinstance(sarif, dict):
         return []
-    return parse_sarif_document(sarif)
+    try:
+        return parse_sarif_document(sarif)
+    except SarifValidationError:
+        return []
 
 
 def parse_sarif_document(sarif: dict) -> list[Finding]:
     """Parse an in-memory SARIF 2.1.0 document into hub-classified findings."""
-    runs = sarif.get("runs") or []
-    findings: list[Finding] = []
-    for run in runs:
-        if not isinstance(run, dict):
-            continue
-        tool_name = _tool_name(run)
-        rule_index = _build_rule_index(run)
-        for result in run.get("results") or []:
-            if not isinstance(result, dict):
-                continue
-            findings.append(_sarif_result_to_finding(result, rule_index, tool_name))
-    return findings
+    document = normalize_sarif_document(sarif)
+    return [_normalized_sarif_result_to_finding(result) for result in document.results]
 
 
-def _sarif_result_to_finding(result: dict, rule_index: dict[str, dict], tool_name: str) -> Finding:
-    rule_id = str(result.get("ruleId") or "")
-    rule = rule_index.get(rule_id, {})
-    rule_tags = _rule_tags(rule)
-
-    message_text = ((result.get("message") or {}).get("text") or "").strip()
-    rule_short = ((rule.get("shortDescription") or {}).get("text") or "").strip()
-    rule_full = ((rule.get("fullDescription") or {}).get("text") or "").strip()
-    description = message_text or rule_full or rule_short or rule_id
-
-    level = result.get("level")
-    properties = result.get("properties") or {}
-    sec_severity_raw = properties.get("security-severity") or (rule.get("properties") or {}).get("security-severity")
-    sec_severity: float | None
-    try:
-        sec_severity = float(sec_severity_raw) if sec_severity_raw is not None else None
-    except (TypeError, ValueError):
-        sec_severity = None
-
-    severity = _coerce_severity(level, sec_severity)
-
-    asset_name, location = _result_location(result)
+def _normalized_sarif_result_to_finding(result: NormalizedSarifResult) -> Finding:
+    rule_id = result.rule_id
+    rule_tags = list(result.rule_tags)
+    description = result.message or result.rule_full_description or result.rule_short_description or rule_id
+    severity = _coerce_severity(result.level, result.security_severity)
+    location = result.location
+    if location is None:
+        asset_name, file_path = "unknown", None
+    else:
+        file_path = location.uri
+        asset_name = f"{file_path}:{location.start_line}" if location.start_line else file_path
     finding_type = _pick_finding_type(rule_id, rule_tags, description)
-
     cwe_ids = [tag.upper() for tag in rule_tags if tag.lower().startswith("cwe-")]
 
     evidence: dict[str, Any] = {
-        "external_tool": tool_name,
+        "external_tool": result.tool_name,
         "rule_id": rule_id,
         "rule_tags": rule_tags,
-        "sarif_level": level,
+        "sarif_level": result.level,
     }
-    if sec_severity is not None:
-        evidence["sarif_security_severity"] = sec_severity
+    if result.security_severity is not None:
+        evidence["sarif_security_severity"] = result.security_severity
+    if result.fingerprints:
+        evidence["sarif_fingerprints"] = dict(result.fingerprints)
+    if result.partial_fingerprints:
+        evidence["sarif_partial_fingerprints"] = dict(result.partial_fingerprints)
 
-    title = rule_short or rule_id or message_text[:100] or "External finding"
-
+    title = result.rule_short_description or rule_id or result.message[:100] or "External finding"
     finding = Finding(
         finding_type=finding_type,
         source=FindingSource.EXTERNAL,
         asset=Asset(
             name=asset_name,
-            asset_type="file" if location else "external",
+            asset_type="file" if file_path else "external",
             identifier=rule_id or None,
-            location=location,
+            location=file_path,
         ),
         severity=severity,
         title=title,
         description=description,
         cwe_ids=cwe_ids,
-        cvss_score=sec_severity,
+        cvss_score=result.security_severity,
         evidence=evidence,
     )
     return apply_hub_classification(finding)

--- a/src/agent_bom/parsers/sarif.py
+++ b/src/agent_bom/parsers/sarif.py
@@ -1,0 +1,240 @@
+"""Validated, tool-neutral SARIF normalization.
+
+The scanner and external-evidence lanes deliberately share this structural
+boundary.  Adapters may project the normalized records into different product
+models, but they must not reinterpret the source document independently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class SarifValidationError(ValueError):
+    """Raised when a payload cannot be treated as a SARIF document."""
+
+
+@dataclass(frozen=True)
+class SarifLocation:
+    """The first physical source location attached to a SARIF result."""
+
+    uri: str
+    start_line: int = 0
+    end_line: int = 0
+    start_column: int = 0
+    end_column: int = 0
+    snippet: str | None = None
+
+
+@dataclass(frozen=True)
+class NormalizedSarifResult:
+    """A result with its run- and rule-level provenance resolved."""
+
+    tool_name: str
+    rule_id: str
+    message: str
+    level: str | None
+    security_severity: float | None
+    rule_tags: tuple[str, ...] = ()
+    rule_url: str | None = None
+    rule_short_description: str = ""
+    rule_full_description: str = ""
+    location: SarifLocation | None = None
+    fingerprints: dict[str, str] = field(default_factory=dict)
+    partial_fingerprints: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class NormalizedSarifDocument:
+    """Normalized results plus stable document-level accounting."""
+
+    results: tuple[NormalizedSarifResult, ...]
+    rules_loaded: int
+    files_scanned: int
+    tool_names: tuple[str, ...]
+
+
+def _mapping(value: object, field_name: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise SarifValidationError(f"SARIF {field_name} must be an object")
+    return value
+
+
+def _list(value: object, field_name: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise SarifValidationError(f"SARIF {field_name} must be an array")
+    return value
+
+
+def _text(message: object) -> str:
+    if message is None:
+        return ""
+    message_obj = _mapping(message, "message")
+    text = message_obj.get("text")
+    markdown = message_obj.get("markdown")
+    if text is not None and not isinstance(text, str):
+        raise SarifValidationError("SARIF message.text must be a string")
+    if markdown is not None and not isinstance(markdown, str):
+        raise SarifValidationError("SARIF message.markdown must be a string")
+    return str(text or markdown or "")
+
+
+def _properties(value: object, field_name: str) -> dict[str, Any]:
+    if value is None:
+        return {}
+    return _mapping(value, field_name)
+
+
+def _security_severity(result: dict[str, Any], rule: dict[str, Any]) -> float | None:
+    result_properties = _properties(result.get("properties"), "result.properties")
+    rule_properties = _properties(rule.get("properties"), "rule.properties")
+    raw = result_properties.get("security-severity")
+    if raw is None:
+        raw = rule_properties.get("security-severity")
+    if raw is None:
+        return None
+    try:
+        score = float(raw)
+    except (TypeError, ValueError):
+        return None
+    return score if 0.0 <= score <= 10.0 else None
+
+
+def _string_map(value: object, field_name: str) -> dict[str, str]:
+    if value is None:
+        return {}
+    raw = _mapping(value, field_name)
+    return {str(key): item for key, item in raw.items() if isinstance(item, str)}
+
+
+def _location(result: dict[str, Any]) -> SarifLocation | None:
+    raw_locations = result.get("locations")
+    if raw_locations is None:
+        return None
+    locations = _list(raw_locations, "result.locations")
+    if not locations:
+        return None
+    first = _mapping(locations[0], "result.locations[]")
+    physical_raw = first.get("physicalLocation")
+    if physical_raw is None:
+        return None
+    physical = _mapping(physical_raw, "physicalLocation")
+    artifact = _properties(physical.get("artifactLocation"), "artifactLocation")
+    uri_raw = artifact.get("uri")
+    if uri_raw is not None and not isinstance(uri_raw, str):
+        raise SarifValidationError("SARIF artifactLocation.uri must be a string")
+    uri = str(uri_raw or "")
+    if not uri:
+        return None
+
+    region = _properties(physical.get("region"), "region")
+    snippet_obj = _properties(region.get("snippet"), "region.snippet")
+    snippet_raw = snippet_obj.get("text")
+    if snippet_raw is not None and not isinstance(snippet_raw, str):
+        raise SarifValidationError("SARIF region.snippet.text must be a string")
+
+    def integer(name: str, default: int = 0) -> int:
+        value = region.get(name, default)
+        return value if isinstance(value, int) and not isinstance(value, bool) else default
+
+    start_line = integer("startLine")
+    return SarifLocation(
+        uri=uri,
+        start_line=start_line,
+        end_line=integer("endLine", start_line),
+        start_column=integer("startColumn"),
+        end_column=integer("endColumn"),
+        snippet=snippet_raw,
+    )
+
+
+def _description(rule: dict[str, Any], name: str) -> str:
+    value = rule.get(name)
+    return _text(value) if value is not None else ""
+
+
+def normalize_sarif_document(payload: object) -> NormalizedSarifDocument:
+    """Validate and normalize one SARIF 2.x document.
+
+    A structurally invalid payload raises :class:`SarifValidationError`; a
+    valid document with zero results produces an intentionally empty result.
+    """
+
+    sarif = _mapping(payload, "document")
+    version = sarif.get("version")
+    schema = sarif.get("$schema")
+    version_is_sarif = isinstance(version, str) and version.startswith("2.")
+    schema_is_sarif = isinstance(schema, str) and "sarif" in schema.lower()
+    if not version_is_sarif and not schema_is_sarif:
+        raise SarifValidationError("payload is not a SARIF 2.x document")
+
+    runs = _list(sarif.get("runs"), "runs")
+    normalized: list[NormalizedSarifResult] = []
+    files: set[str] = set()
+    tool_names: list[str] = []
+    rules_loaded = 0
+
+    for run_index, raw_run in enumerate(runs):
+        run = _mapping(raw_run, f"runs[{run_index}]")
+        tool = _mapping(run.get("tool"), f"runs[{run_index}].tool")
+        driver = _mapping(tool.get("driver"), f"runs[{run_index}].tool.driver")
+        tool_name = driver.get("name")
+        if not isinstance(tool_name, str) or not tool_name.strip():
+            raise SarifValidationError(f"SARIF runs[{run_index}] tool driver name is required")
+        tool_name = tool_name.strip()
+        if tool_name not in tool_names:
+            tool_names.append(tool_name)
+
+        raw_rules = driver.get("rules", [])
+        rules = _list(raw_rules, f"runs[{run_index}].tool.driver.rules")
+        rule_index: dict[str, dict[str, Any]] = {}
+        for rule_offset, raw_rule in enumerate(rules):
+            rule = _mapping(raw_rule, f"runs[{run_index}].tool.driver.rules[{rule_offset}]")
+            rule_id = rule.get("id")
+            if isinstance(rule_id, str) and rule_id:
+                rule_index[rule_id] = rule
+        rules_loaded += len(rule_index)
+
+        results = _list(run.get("results", []), f"runs[{run_index}].results")
+        for result_offset, raw_result in enumerate(results):
+            result = _mapping(raw_result, f"runs[{run_index}].results[{result_offset}]")
+            raw_rule_id = result.get("ruleId")
+            if raw_rule_id is not None and not isinstance(raw_rule_id, str):
+                raise SarifValidationError("SARIF result.ruleId must be a string")
+            rule_id = str(raw_rule_id or "")
+            rule = rule_index.get(rule_id, {})
+            rule_properties = _properties(rule.get("properties"), "rule.properties")
+            raw_tags = rule_properties.get("tags", [])
+            tags = _list(raw_tags, "rule.properties.tags")
+            rule_tags = tuple(tag for tag in tags if isinstance(tag, str))
+            level = result.get("level")
+            if level is not None and not isinstance(level, str):
+                raise SarifValidationError("SARIF result.level must be a string")
+            location = _location(result)
+            if location is not None:
+                files.add(location.uri)
+
+            normalized.append(
+                NormalizedSarifResult(
+                    tool_name=tool_name,
+                    rule_id=rule_id,
+                    message=_text(result.get("message")),
+                    level=level,
+                    security_severity=_security_severity(result, rule),
+                    rule_tags=rule_tags,
+                    rule_url=str(rule.get("helpUri")) if isinstance(rule.get("helpUri"), str) else None,
+                    rule_short_description=_description(rule, "shortDescription"),
+                    rule_full_description=_description(rule, "fullDescription"),
+                    location=location,
+                    fingerprints=_string_map(result.get("fingerprints"), "result.fingerprints"),
+                    partial_fingerprints=_string_map(result.get("partialFingerprints"), "result.partialFingerprints"),
+                )
+            )
+
+    return NormalizedSarifDocument(
+        results=tuple(normalized),
+        rules_loaded=rules_loaded,
+        files_scanned=len(files),
+        tool_names=tuple(tool_names),
+    )

--- a/src/agent_bom/sast.py
+++ b/src/agent_bom/sast.py
@@ -28,6 +28,7 @@ from pathlib import Path
 from typing import Optional
 
 from agent_bom.models import Package, Severity, Vulnerability
+from agent_bom.parsers.sarif import SarifValidationError, normalize_sarif_document
 
 _logger = logging.getLogger(__name__)
 
@@ -67,6 +68,10 @@ class SASTFinding:
     owasp_ids: list[str] = field(default_factory=list)
     rule_url: Optional[str] = None
     snippet: Optional[str] = None
+    tool_name: str = "external"
+    security_severity: float | None = None
+    fingerprints: dict[str, str] = field(default_factory=dict)
+    partial_fingerprints: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -119,6 +124,10 @@ class SASTResult:
                     "owasp_ids": f.owasp_ids,
                     "rule_url": f.rule_url,
                     "snippet": f.snippet,
+                    "tool_name": f.tool_name,
+                    "security_severity": f.security_severity,
+                    "fingerprints": f.fingerprints,
+                    "partial_fingerprints": f.partial_fingerprints,
                 }
                 for f in self.findings
             ],
@@ -234,69 +243,49 @@ def _resolve_sast_configs(scan_target: Path, config: str) -> list[str]:
 
 
 def _parse_sarif_findings(sarif: dict) -> tuple[list[SASTFinding], int, int]:
-    """Parse Semgrep SARIF output into SASTFinding objects.
+    """Project canonical SARIF records into SASTFinding objects.
 
     Returns (findings, rules_loaded, files_scanned).
     """
+    document = normalize_sarif_document(sarif)
     findings: list[SASTFinding] = []
-    files_seen: set[str] = set()
-    rules_loaded = 0
-
-    for run in sarif.get("runs", []):
-        driver = run.get("tool", {}).get("driver", {})
-        rules = {r["id"]: r for r in driver.get("rules", [])}
-        rules_loaded = max(rules_loaded, len(rules))
-
-        for result in run.get("results", []):
-            rule_id = result.get("ruleId", "unknown")
-            level = result.get("level", "warning")
-            message = result.get("message", {}).get("text", "")
-
-            # Extract location
-            locations = result.get("locations", [])
-            if not locations:
-                continue
-            loc = locations[0].get("physicalLocation", {})
-            artifact = loc.get("artifactLocation", {}).get("uri", "")
-            region = loc.get("region", {})
-            start_line = region.get("startLine", 0)
-            end_line = region.get("endLine", start_line)
-            start_col = region.get("startColumn", 0)
-            end_col = region.get("endColumn", 0)
-            snippet_obj = region.get("snippet", {})
-            snippet = snippet_obj.get("text") if snippet_obj else None
-
-            files_seen.add(artifact)
-
-            severity = _SARIF_LEVEL_MAP.get(level, Severity.UNKNOWN)
-
-            # Extract CWE IDs and OWASP tags from rule metadata
-            rule_meta = rules.get(rule_id, {})
-            rule_props = rule_meta.get("properties", {})
-            tags = rule_props.get("tags", [])
-            cwe_ids = [t for t in tags if t.upper().startswith("CWE-")]
-            owasp_ids = [t for t in tags if ":" in t and t[0] == "A"]
-
-            rule_url = rule_meta.get("helpUri")
-
-            findings.append(
-                SASTFinding(
-                    rule_id=rule_id,
-                    message=message[:500],
-                    severity=severity,
-                    file_path=artifact,
-                    start_line=start_line,
-                    end_line=end_line,
-                    start_col=start_col,
-                    end_col=end_col,
-                    cwe_ids=cwe_ids,
-                    owasp_ids=owasp_ids,
-                    rule_url=rule_url,
-                    snippet=snippet[:200] if snippet else None,
-                )
+    for result in document.results:
+        location = result.location
+        level_severity = _SARIF_LEVEL_MAP.get(result.level or "warning", Severity.UNKNOWN)
+        if result.security_severity is None:
+            severity = level_severity
+        elif result.security_severity >= 9.0:
+            severity = Severity.CRITICAL
+        elif result.security_severity >= 7.0:
+            severity = Severity.HIGH
+        elif result.security_severity >= 4.0:
+            severity = Severity.MEDIUM
+        elif result.security_severity > 0:
+            severity = Severity.LOW
+        else:
+            severity = Severity.NONE
+        findings.append(
+            SASTFinding(
+                rule_id=result.rule_id or "unknown",
+                message=(result.message or result.rule_full_description or result.rule_short_description)[:500],
+                severity=severity,
+                file_path=location.uri if location is not None else "unknown",
+                start_line=location.start_line if location is not None else 0,
+                end_line=location.end_line if location is not None else 0,
+                start_col=location.start_column if location is not None else 0,
+                end_col=location.end_column if location is not None else 0,
+                cwe_ids=[tag for tag in result.rule_tags if tag.upper().startswith("CWE-")],
+                owasp_ids=[tag for tag in result.rule_tags if ":" in tag and tag.startswith("A")],
+                rule_url=result.rule_url,
+                snippet=(location.snippet[:200] if location and location.snippet else None),
+                tool_name=result.tool_name,
+                security_severity=result.security_severity,
+                fingerprints=dict(result.fingerprints),
+                partial_fingerprints=dict(result.partial_fingerprints),
             )
+        )
 
-    return findings, rules_loaded, len(files_seen)
+    return findings, document.rules_loaded, document.files_scanned
 
 
 def _findings_to_packages(findings: list[SASTFinding]) -> list[Package]:
@@ -316,7 +305,7 @@ def _findings_to_packages(findings: list[SASTFinding]) -> list[Package]:
         vulns: list[Vulnerability] = []
         seen_ids: set[str] = set()
         for finding in file_finds:
-            vid = f"{finding.rule_id}:{finding.start_line}"
+            vid = f"{finding.tool_name}:{finding.rule_id}:{finding.start_line}"
             if vid in seen_ids:
                 continue
             seen_ids.add(vid)
@@ -327,6 +316,7 @@ def _findings_to_packages(findings: list[SASTFinding]) -> list[Package]:
                     summary=finding.message,
                     severity=finding.severity,
                     cwe_ids=finding.cwe_ids,
+                    cvss_score=finding.security_severity,
                     references=[finding.rule_url] if finding.rule_url else [],
                 )
             )
@@ -352,9 +342,12 @@ def _import_sarif(path: Path) -> tuple[list[Package], SASTResult]:
     except OSError as exc:
         raise SASTScanError(f"could not read SARIF file {path}: {exc}") from exc
     except json.JSONDecodeError as exc:
-        raise SASTScanError(f"invalid SARIF file {path}: {exc}") from exc
+        raise SASTScanError(f"invalid SARIF file {path}") from exc
 
-    findings, rules_loaded, files_scanned = _parse_sarif_findings(sarif)
+    try:
+        findings, rules_loaded, files_scanned = _parse_sarif_findings(sarif)
+    except SarifValidationError as exc:
+        raise SASTScanError(f"invalid SARIF file {path}") from exc
     packages = _findings_to_packages(findings)
     result = SASTResult(
         findings=findings,
@@ -447,7 +440,10 @@ def scan_code(
 
     elapsed = time.monotonic() - start
 
-    findings, rules_loaded, files_scanned = _parse_sarif_findings(sarif)
+    try:
+        findings, rules_loaded, files_scanned = _parse_sarif_findings(sarif)
+    except SarifValidationError as exc:
+        raise SASTScanError("semgrep produced structurally invalid SARIF output") from exc
     packages = _findings_to_packages(findings)
 
     sast_result = SASTResult(

--- a/tests/test_sarif_normalization.py
+++ b/tests/test_sarif_normalization.py
@@ -1,0 +1,153 @@
+"""Canonical SARIF normalization contracts shared by all ingest lanes."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.compliance_hub_ingest import parse_sarif_document
+from agent_bom.models import Severity
+from agent_bom.parsers.sarif import SarifValidationError, normalize_sarif_document
+from agent_bom.sast import SASTScanError, _parse_sarif_findings, scan_code
+
+
+def _run(tool: str, rule_id: str, *, located: bool) -> dict:
+    result = {
+        "ruleId": rule_id,
+        "level": "warning",
+        "message": {"text": f"{tool} finding"},
+        "properties": {"security-severity": "8.2"},
+        "fingerprints": {"primaryLocationLineHash": f"{tool}-full"},
+        "partialFingerprints": {"primaryLocationStartColumnFingerprint": f"{tool}-partial"},
+    }
+    if located:
+        result["locations"] = [
+            {
+                "physicalLocation": {
+                    "artifactLocation": {"uri": f"src/{tool}.py"},
+                    "region": {"startLine": 7, "snippet": {"text": "danger()"}},
+                }
+            }
+        ]
+    return {
+        "tool": {
+            "driver": {
+                "name": tool,
+                "rules": [
+                    {
+                        "id": rule_id,
+                        "helpUri": f"https://example.invalid/{rule_id}",
+                        "properties": {"tags": ["CWE-79", "security"]},
+                    }
+                ],
+            }
+        },
+        "results": [result],
+    }
+
+
+def test_normalize_preserves_multiple_runs_provenance_and_evidence() -> None:
+    document = normalize_sarif_document(
+        {
+            "version": "2.1.0",
+            "runs": [
+                _run("CodeQL", "js/xss", located=True),
+                _run("Bandit", "B105", located=False),
+            ],
+        }
+    )
+
+    assert document.rules_loaded == 2
+    assert document.files_scanned == 1
+    assert document.tool_names == ("CodeQL", "Bandit")
+    assert len(document.results) == 2
+
+    codeql, bandit = document.results
+    assert codeql.tool_name == "CodeQL"
+    assert codeql.security_severity == 8.2
+    assert codeql.location is not None
+    assert codeql.location.uri == "src/CodeQL.py"
+    assert codeql.location.snippet == "danger()"
+    assert codeql.fingerprints == {"primaryLocationLineHash": "CodeQL-full"}
+    assert codeql.partial_fingerprints == {"primaryLocationStartColumnFingerprint": "CodeQL-partial"}
+
+    assert bandit.tool_name == "Bandit"
+    assert bandit.location is None
+    assert bandit.rule_tags == ("CWE-79", "security")
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        [],
+        {},
+        {"version": "2.1.0", "runs": {}},
+        {"version": "2.1.0", "runs": ["not-a-run"]},
+        {"version": "2.1.0", "runs": [{"tool": {"driver": {}}, "results": []}]},
+        {
+            "version": "2.1.0",
+            "runs": [{"tool": {"driver": {"name": "tool"}}, "results": {}}],
+        },
+    ],
+)
+def test_normalize_rejects_structurally_invalid_documents(payload: object) -> None:
+    with pytest.raises(SarifValidationError):
+        normalize_sarif_document(payload)
+
+
+def test_rule_level_security_severity_is_used_as_fallback() -> None:
+    run = _run("CodeQL", "js/xss", located=True)
+    result = run["results"][0]
+    del result["properties"]
+    run["tool"]["driver"]["rules"][0]["properties"]["security-severity"] = "9.1"
+
+    document = normalize_sarif_document({"version": "2.1.0", "runs": [run]})
+
+    assert document.results[0].security_severity == 9.1
+
+
+def test_external_finding_projection_keeps_tool_score_fingerprints_and_locationless() -> None:
+    findings = parse_sarif_document(
+        {
+            "version": "2.1.0",
+            "runs": [
+                _run("CodeQL", "js/xss", located=True),
+                _run("Bandit", "B105", located=False),
+            ],
+        }
+    )
+
+    assert [finding.evidence["external_tool"] for finding in findings] == ["CodeQL", "Bandit"]
+    assert findings[0].severity == "high"
+    assert findings[0].cvss_score == 8.2
+    assert findings[0].evidence["sarif_fingerprints"] == {"primaryLocationLineHash": "CodeQL-full"}
+    assert findings[0].evidence["sarif_partial_fingerprints"] == {"primaryLocationStartColumnFingerprint": "CodeQL-partial"}
+    assert findings[1].asset.asset_type == "external"
+    assert findings[1].asset.location is None
+
+
+def test_sast_projection_uses_same_evidence_boundary() -> None:
+    findings, rules_loaded, files_scanned = _parse_sarif_findings(
+        {
+            "version": "2.1.0",
+            "runs": [
+                _run("CodeQL", "js/xss", located=True),
+                _run("Bandit", "B105", located=False),
+            ],
+        }
+    )
+
+    assert rules_loaded == 2
+    assert files_scanned == 1
+    assert findings[0].tool_name == "CodeQL"
+    assert findings[0].security_severity == 8.2
+    assert findings[0].severity == Severity.HIGH
+    assert findings[0].fingerprints == {"primaryLocationLineHash": "CodeQL-full"}
+    assert findings[1].file_path == "unknown"
+
+
+def test_sast_file_import_fails_closed_on_json_array(tmp_path) -> None:
+    path = tmp_path / "invalid.sarif"
+    path.write_text("[]", encoding="utf-8")
+
+    with pytest.raises(SASTScanError, match="invalid SARIF file"):
+        scan_code(str(path))

--- a/tests/test_sast.py
+++ b/tests/test_sast.py
@@ -138,11 +138,12 @@ def test_parse_sarif_empty():
 
 
 def test_parse_sarif_no_location():
-    """Results without locations are skipped."""
+    """Results without locations remain available as external evidence."""
     sarif = {
+        "version": "2.1.0",
         "runs": [
             {
-                "tool": {"driver": {"rules": []}},
+                "tool": {"driver": {"name": "semgrep", "rules": []}},
                 "results": [
                     {
                         "ruleId": "test-rule",
@@ -152,10 +153,12 @@ def test_parse_sarif_no_location():
                     }
                 ],
             }
-        ]
+        ],
     }
     findings, _, _ = _parse_sarif_findings(sarif)
-    assert findings == []
+    assert len(findings) == 1
+    assert findings[0].file_path == "unknown"
+    assert findings[0].tool_name == "semgrep"
 
 
 # ── Severity mapping ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- add one tool-neutral SARIF structural normalization boundary shared by native SAST import and Compliance Hub external evidence ingest
- preserve per-run tool provenance, security severity, fingerprints, CWE/OWASP metadata, rule help, multiple runs, and locationless results
- fail closed on malformed SARIF in the SAST path while retaining the documented legacy file-ingest compatibility boundary

## Verification

- full owning normalization/SAST/external-ingest/MCP matrix: 192 passed
- current-main focused rerun: 99 passed
- Ruff check and format, mypy, exception-sanitization guard, git diff check
- signed commit verified after rebasing onto current main

## Notes

- foundation phase only: Semgrep offline/config enforcement, typed API execution status, registry metadata, CLI/MCP/UI copy, and documentation alignment remain in #4137
- additive tool-neutral provenance retains the legacy semgrep_version and config_used fields
- normalization records the first physical location to preserve existing projection semantics; it does not multiply one SARIF result into multiple findings

Addresses #4137
Addresses #4095