### PR TITLE
feat(compliance): align executive and findings scopes

### DIFF
--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -361,8 +361,11 @@ function FindingsPage() {
     const parsed = Number(paramPage ?? "1");
     return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 1;
   });
-  const [findingsTotal, setFindingsTotal] = useState(0);
+  const [findingsTotal, setFindingsTotal] = useState<number | null>(0);
   const [findingsTotalApproximate, setFindingsTotalApproximate] = useState(false);
+  const [hasMoreFindings, setHasMoreFindings] = useState(false);
+  const [nextFindingsCursor, setNextFindingsCursor] = useState("");
+  const [pageCursors, setPageCursors] = useState<string[]>([""]);
   const PAGE_SIZE = 25;
   const useServerPaging = groupBy === "none" && !search.trim();
   const showLifecycleColumns = useMemo(() => hasLifecycleMetadata(vulns), [vulns]);
@@ -719,6 +722,8 @@ function FindingsPage() {
 
   useEffect(() => {
     async function loadLegacyFindings() {
+      setHasMoreFindings(false);
+      setNextFindingsCursor("");
       if (paramScan) {
         try {
           const findings = await api.listFindings({ scanId: paramScan, limit: 1000 });
@@ -774,6 +779,7 @@ function FindingsPage() {
         if (useServerPaging) {
           const scanId =
             paramScan ?? (scope === "latest" && jobs[0] ? jobs[0].job_id : undefined);
+          const currentCursor = pageCursors[page - 1] || undefined;
           const response = await api.listFindings({
             ...(scanId ? { scanId } : {}),
             ...(filter !== "all" ? { severity: filter } : {}),
@@ -783,15 +789,18 @@ function FindingsPage() {
             ...(environmentFilter.trim() ? { environment: environmentFilter.trim() } : {}),
             sort: serverFindingsSort(sortKey),
             limit: PAGE_SIZE,
-            offset: (page - 1) * PAGE_SIZE,
+            ...(!currentCursor ? { offset: (page - 1) * PAGE_SIZE } : {}),
+            ...(currentCursor ? { cursor: currentCursor } : {}),
             approximateTotal: true,
             windowDays,
           });
           setAppliedWindow(response.window ?? null);
-          if (response.total > 0 || response.findings.length > 0) {
+          if ((response.total ?? 0) > 0 || response.findings.length > 0) {
             setVulns(collectUnifiedFindings(response.findings));
-            setFindingsTotal(response.total);
+            setFindingsTotal(typeof response.total === "number" ? response.total : null);
             setFindingsTotalApproximate(Boolean(response.total_approximate));
+            setHasMoreFindings(Boolean(response.has_more || response.next_cursor));
+            setNextFindingsCursor(response.next_cursor ?? "");
             return;
           }
         }
@@ -821,6 +830,7 @@ function FindingsPage() {
     environmentFilter,
     windowDays,
     sortKey,
+    pageCursors,
   ]);
 
   function handleSort(field: SortKey) {
@@ -870,10 +880,18 @@ function FindingsPage() {
   }, [vulns, filter, issueTypeFilter, search, sortKey, sortDir, useServerPaging]);
 
   // Reset page when filters change
-  useEffect(() => { setPage(1); }, [filter, issueTypeFilter, search, sortKey, sortDir, groupBy, scope, paramScan, domainFilter, providerFilter, accountFilter, environmentFilter]);
+  useEffect(() => {
+    setPage(1);
+    setPageCursors((existing) =>
+      existing.length === 1 && existing[0] === "" ? existing : [""],
+    );
+    setNextFindingsCursor("");
+  }, [filter, issueTypeFilter, search, sortKey, sortDir, groupBy, scope, paramScan, domainFilter, providerFilter, accountFilter, environmentFilter, windowDays]);
 
   const totalPages = useServerPaging
-    ? Math.max(1, Math.ceil(findingsTotal / PAGE_SIZE))
+    ? findingsTotal == null
+      ? null
+      : Math.max(1, Math.ceil(findingsTotal / PAGE_SIZE))
     : Math.max(1, Math.ceil(displayed.length / PAGE_SIZE));
   const paged = useServerPaging
     ? displayed
@@ -929,10 +947,13 @@ function FindingsPage() {
     return c;
   }, [vulns]);
 
-  const findingsTotalLabel = formatFindingsTotal(
-    findingsTotal,
-    useServerPaging && findingsTotalApproximate,
-  );
+  const findingsTotalLabel = findingsTotal == null
+    ? "Total unavailable"
+    : formatFindingsTotal(findingsTotal, useServerPaging && findingsTotalApproximate);
+  const findingsFilterTotalLabel = findingsTotal == null ? "unknown total" : findingsTotalLabel;
+  const findingsWindowLabel = appliedWindow?.label ??
+    WINDOW_OPTIONS.find((option) => option.value === windowDays)?.label ??
+    "Last 90 days";
 
   // Advanced filters live behind the "Filters (n)" popover. ``n`` counts the
   // non-default ones; each active filter is also surfaced as a removable chip so
@@ -968,7 +989,7 @@ function FindingsPage() {
   const FILTERS: { key: SeverityFilter; label: string; color: string }[] = [
     {
       key: "all",
-      label: `All (${useServerPaging ? findingsTotalLabel : vulns.length})`,
+      label: `All (${useServerPaging ? findingsFilterTotalLabel : vulns.length})`,
       color: "text-[var(--text-secondary)]",
     },
     { key: "critical", label: `Critical${useServerPaging ? "" : ` (${counts.critical})`}`, color: "text-red-400" },
@@ -991,16 +1012,16 @@ function FindingsPage() {
         title="Findings"
         subtitle={findingsPageSubtitle(
           lens,
-          `${useServerPaging ? findingsTotalLabel : vulns.length} findings`,
+          `${useServerPaging ? findingsTotalLabel : vulns.length}${findingsTotal == null ? "" : " findings"}`,
           scope === "latest"
             ? paramScan
               ? `from scan ${paramScan.slice(0, 8)}.`
               : "from the latest completed scan."
-            : "aggregated across completed scans.",
+            : `current state across completed scans · ${findingsWindowLabel}.`,
         )}
         scopeChip={
           <span className="inline-flex items-center rounded-full border border-cyan-500/30 bg-cyan-500/10 px-2.5 py-0.5 text-[11px] font-medium text-cyan-700 dark:text-cyan-200">
-            Shared · Engineering &amp; Compliance
+            {scope === "all" ? `Current state · ${findingsWindowLabel}` : "Latest scan"}
           </span>
         }
         actions={
@@ -1455,9 +1476,19 @@ function FindingsPage() {
               page={page}
               totalPages={totalPages}
               totalItems={useServerPaging ? findingsTotal : displayed.length}
+              hasMore={hasMoreFindings}
               itemLabel={useServerPaging && findingsTotalApproximate ? "findings (approx.)" : "findings"}
               onPrevious={() => setPage((p) => Math.max(1, p - 1))}
-              onNext={() => setPage((p) => Math.min(totalPages, p + 1))}
+              onNext={() => {
+                if (nextFindingsCursor) {
+                  setPageCursors((existing) => {
+                    const next = [...existing];
+                    next[page] = nextFindingsCursor;
+                    return next;
+                  });
+                }
+                setPage((current) => totalPages == null ? current + 1 : Math.min(totalPages, current + 1));
+              }}
             />
           )}
 
@@ -1482,4 +1513,3 @@ function FindingsPage() {
     </div>
   );
 }
-

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -34,7 +34,6 @@ import {
   buildExposurePathView,
   buildExecExposurePaths,
 } from "@/lib/dashboard-data";
-import { buildIssueSeverityMatrix } from "@/lib/finding-issue-type";
 import {
   ShieldAlert, ArrowRight, Clock,
   AlertTriangle, GitBranch, Network,
@@ -212,20 +211,32 @@ export default function Dashboard() {
     [doneJobs]
   );
 
-  const severity = useMemo(() => aggregateSeverity(allBlast), [allBlast]);
-  const issueMatrix = useMemo(
-    () =>
-      buildIssueSeverityMatrix(
-        allBlast.map((blast) => ({
-          id: blast.vulnerability_id,
-          severity: blast.severity,
-          impact_category: blast.impact_category,
-          framework_tags: blast.framework_tags,
-          exposed_credentials: blast.exposed_credentials,
-        })),
-      ),
-    [allBlast],
-  );
+  // Blast rows remain useful for exposure-path detail, but they are not an
+  // estate count source: this client hydrates at most ten completed jobs and
+  // would otherwise display a partial/repeated severity histogram. The API's
+  // posture-count spine is current-state, deduplicated, and uses the same
+  // default window as /v1/findings. Imported offline reports are the one local
+  // exception because no server-side canonical view exists for them.
+  const importedSeverity = useMemo(() => aggregateSeverity(allBlast), [allBlast]);
+  const canonicalSeverity = useMemo(() => {
+    if (importedReport) return importedSeverity;
+    if (counts) {
+      return {
+        critical: counts.critical,
+        high: counts.high,
+        medium: counts.medium,
+        low: counts.low,
+        total: counts.total,
+      };
+    }
+    return {
+      critical: overview?.headline.critical ?? 0,
+      high: overview?.headline.high ?? 0,
+      medium: 0,
+      low: 0,
+      total: overview?.headline.critical_high ?? 0,
+    };
+  }, [counts, importedReport, importedSeverity, overview]);
   const kevCount = useMemo(() => allBlast.filter((b) => (b.is_kev ?? b.cisa_kev) === true).length, [allBlast]);
   const credentialExposureCount = useMemo(() => allBlast.filter((b) => blastCredentials(b).length > 0).length, [allBlast]);
   const reachableToolCount = useMemo(() => new Set(allBlast.flatMap(blastTools)).size, [allBlast]);
@@ -281,21 +292,16 @@ export default function Dashboard() {
   const summaryReady = !jobsLoading || Boolean(importedReport);
   const detailsReady = !detailLoading || Boolean(importedReport);
 
-  const criticalCount = detailsReady
-    ? (severity.critical || (seededEvidence ? (overview?.headline.critical ?? counts?.critical ?? summaryStats?.critical_findings ?? 0) : severity.critical))
-    : (overview?.headline.critical ?? summaryStats?.critical_findings ?? counts?.critical ?? 0);
-  const highCount = detailsReady
-    ? (severity.high || (seededEvidence ? (overview?.headline.high ?? counts?.high ?? summaryStats?.high_findings ?? 0) : severity.high))
-    : (overview?.headline.high ?? summaryStats?.high_findings ?? counts?.high ?? 0);
-  const fallbackVulnTotal = overview?.headline.critical_high ?? counts?.total ?? summaryStats?.total_vulnerabilities ?? 0;
-  const displayedUniqueCVEs = detailsReady
-    ? (uniqueCVEs > 0 ? uniqueCVEs : (seededEvidence ? fallbackVulnTotal : uniqueCVEs))
-    : (summaryStats?.total_vulnerabilities ?? fallbackVulnTotal);
-  const displayedKevCount = detailsReady
-    ? (kevCount > 0 ? kevCount : (seededEvidence ? (overview?.headline.kev ?? counts?.kev ?? 0) : kevCount))
-    : (overview?.headline.kev ?? counts?.kev ?? 0);
-  const displayedCredentialExposure = detailsReady
-    ? (credentialExposureCount > 0 ? credentialExposureCount : (seededEvidence ? (overview?.headline.credential_exposed ?? 0) : credentialExposureCount))
+  const criticalCount = canonicalSeverity.critical;
+  const highCount = canonicalSeverity.high;
+  const displayedUniqueCVEs = importedReport
+    ? uniqueCVEs
+    : (overview?.domains.vuln.metric ?? 0);
+  const displayedKevCount = importedReport
+    ? kevCount
+    : (counts?.kev ?? overview?.headline.kev ?? 0);
+  const displayedCredentialExposure = importedReport
+    ? credentialExposureCount
     : (overview?.headline.credential_exposed ?? 0);
   const displayedReachableTools = detailsReady ? reachableToolCount : null;
   const displayedPackages = detailsReady
@@ -390,9 +396,9 @@ export default function Dashboard() {
         scans={summaryReady ? (counts?.scan_count ?? effectiveRecentJobs.length) : null}
         latestScan={jobsLoading ? null : latestScanShort}
         mode={deploymentModeLabel(counts?.deployment_mode)}
-        summaryReady={summaryReady}
-        severity={severity}
-        issueMatrix={issueMatrix}
+        summaryReady={Boolean(importedReport || counts || overview)}
+        findingsScopeLabel="Current findings · Last 90 days"
+        severity={canonicalSeverity}
         domains={overview?.domains ?? null}
         coverage={overview?.coverage ?? null}
         topPath={topExposurePath}

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -397,7 +397,7 @@ export default function Dashboard() {
         latestScan={jobsLoading ? null : latestScanShort}
         mode={deploymentModeLabel(counts?.deployment_mode)}
         summaryReady={Boolean(importedReport || counts || overview)}
-        findingsScopeLabel="Current findings · Last 90 days"
+        findingsScopeLabel="Current findings · configured window"
         severity={canonicalSeverity}
         domains={overview?.domains ?? null}
         coverage={overview?.coverage ?? null}

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -164,6 +164,8 @@ export interface OverviewCockpitProps {
   latestScan: string | null;
   mode: string;
   summaryReady: boolean;
+  /** Honest scope shared by the headline and its finding drill-downs. */
+  findingsScopeLabel?: string | undefined;
   severity: SeverityCounts;
   /** Severity × issue-type matrix (CVEs, misconfigs, secrets, identity). */
   issueMatrix?: IssueSeverityMatrix | null | undefined;
@@ -199,6 +201,7 @@ export function OverviewCockpit({
   scans,
   latestScan,
   summaryReady,
+  findingsScopeLabel,
   severity,
   issueMatrix = null,
   domains,
@@ -249,6 +252,7 @@ export function OverviewCockpit({
               complianceScore={complianceScore}
               severity={severity}
               matrix={issueMatrix}
+              scopeLabel={findingsScopeLabel}
             />
           </div>
 
@@ -716,7 +720,7 @@ function TopRisksPanel({
           </Link>
         ) : null}
         <Link
-          href="/findings?severity=critical"
+          href="/findings?scope=all&severity=critical"
           className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-1.5 text-xs font-medium text-[color:var(--foreground)]"
         >
           Critical findings
@@ -1055,6 +1059,7 @@ function SeverityIssueStrip({
   complianceScore,
   severity,
   matrix,
+  scopeLabel,
 }: {
   summaryReady: boolean;
   critical: number;
@@ -1064,6 +1069,7 @@ function SeverityIssueStrip({
   complianceScore?: string | undefined;
   severity: SeverityCounts;
   matrix: IssueSeverityMatrix | null | undefined;
+  scopeLabel?: string | undefined;
 }) {
   const resolved = matrix ?? emptyIssueSeverityMatrix();
   const hasTyped = resolved.openTotal > 0;
@@ -1109,7 +1115,7 @@ function SeverityIssueStrip({
         bare
         title="Open issues"
         titleClassName={SECTION_TITLE_CLASS}
-        subtitle="By severity · CVE, misconfig, secret, identity"
+        subtitle={scopeLabel ?? "By severity · CVE, misconfig, secret, identity"}
         defaultOpen
         actions={
           <div className="flex flex-wrap items-center gap-1.5">
@@ -1119,7 +1125,7 @@ function SeverityIssueStrip({
                 green pass). The glyph carries the distinction. */}
             {summaryReady && kev != null ? (
               <CategoryChip
-                href={findingsHref({ kev: true })}
+                href={findingsHref({ scope: "all", kev: true })}
                 icon={Flame}
                 label="KEV"
                 value={kev}
@@ -1128,7 +1134,7 @@ function SeverityIssueStrip({
             ) : null}
             {summaryReady && credentials != null ? (
               <CategoryChip
-                href={findingsHref({ issue: "secret" })}
+                href={findingsHref({ scope: "all", issue: "secret" })}
                 icon={KeyRound}
                 label="Secrets"
                 value={credentials}
@@ -1176,7 +1182,7 @@ function SeverityIssueStrip({
         {bands.map((band) => (
           <Link
             key={band.key}
-            href={findingsHref({ severity: band.key })}
+            href={findingsHref({ scope: "all", severity: band.key })}
             className={`rounded-lg border px-2.5 py-2 transition ${band.tint}`}
           >
             <p className="text-[10px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-secondary)]">
@@ -1231,7 +1237,7 @@ function SeverityIssueStrip({
             return (
               <Link
                 key={issue}
-                href={findingsHref({ issue })}
+                href={findingsHref({ scope: "all", issue })}
                 className="inline-flex items-center gap-1.5 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-2 py-0.5 text-[10px] text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
               >
                 <Glyph className="h-3 w-3 text-[color:var(--text-tertiary)]" aria-hidden="true" />

--- a/ui/components/pagination-bar.tsx
+++ b/ui/components/pagination-bar.tsx
@@ -4,8 +4,10 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 
 interface PaginationBarProps {
   page: number;
-  totalPages: number;
-  totalItems?: number;
+  totalPages: number | null;
+  totalItems?: number | null;
+  /** Server-provided continuation when an exact total is intentionally absent. */
+  hasMore?: boolean;
   itemLabel?: string;
   onPrevious: () => void;
   onNext: () => void;
@@ -18,17 +20,20 @@ export function PaginationBar({
   page,
   totalPages,
   totalItems,
+  hasMore,
   itemLabel = "total",
   onPrevious,
   onNext,
   previousDisabled = page <= 1,
-  nextDisabled = page >= totalPages,
+  nextDisabled = totalPages == null ? !hasMore : page >= totalPages,
   className = "",
 }: PaginationBarProps) {
   const summary =
-    typeof totalItems === "number"
+    typeof totalItems === "number" && totalPages != null
       ? `Page ${page} of ${totalPages} (${totalItems.toLocaleString()} ${itemLabel})`
-      : `Page ${page} of ${totalPages}`;
+      : totalPages != null
+        ? `Page ${page} of ${totalPages}`
+        : `Page ${page} · total unavailable`;
 
   return (
     <div className={`flex flex-wrap items-center justify-between gap-3 ${className}`}>

--- a/ui/e2e/overview-findings-reconciliation.spec.ts
+++ b/ui/e2e/overview-findings-reconciliation.spec.ts
@@ -1,0 +1,226 @@
+import { mkdir } from "node:fs/promises";
+
+import { expect, test, type Page, type TestInfo } from "@playwright/test";
+
+const COUNTS = {
+  critical: 7,
+  high: 26,
+  medium: 13,
+  low: 17,
+  unrated: 19,
+  total: 82,
+  kev: 5,
+  compound_issues: 3,
+  deployment_mode: "fleet",
+  scan_count: 14,
+  scan_sources: ["aws-organizations", "github-actions", "local-agents"],
+  services: {
+    cloud_accounts: { state: "connected", count: 4 },
+    local_agents: { state: "live", count: 18 },
+    compliance: { state: "live", count: 82 },
+  },
+};
+
+function domain(label: string, metric: number, metricLabel: string, href: string) {
+  return { label, metric, metric_label: metricLabel, href, status: "ok", detail: {} };
+}
+
+const OVERVIEW = {
+  schema_version: "overview.v1",
+  tenant_id: "tenant-production",
+  posture: {
+    grade: "D",
+    score: 48,
+    display_format: "percent",
+    summary: "Current estate needs prioritized remediation.",
+    breakdown: [
+      { driver: "critical", label: "Critical findings", count: 7, weight: 12, contribution: 84 },
+      { driver: "high", label: "High findings", count: 26, weight: 6, contribution: 156 },
+    ],
+  },
+  headline: {
+    critical: 7,
+    high: 26,
+    critical_high: 33,
+    kev: 5,
+    credential_exposed: 4,
+    scans: 14,
+    latest_scan_at: "2026-07-17T16:30:00Z",
+    hub_findings: 82,
+  },
+  coverage: [
+    { domain: "cspm", label: "CSPM", href: "/findings?scope=all&domain=cspm", count: 22, severity: { critical: 2, high: 9, medium: 7, low: 3, unrated: 1 } },
+    { domain: "vuln", label: "Vuln mgmt", href: "/findings?scope=all&domain=vuln", count: 33, severity: { critical: 5, high: 15, medium: 7, low: 4, unrated: 2 } },
+    { domain: "aspm", label: "ASPM", href: "/findings?scope=all&domain=aspm", count: 12, severity: { critical: 0, high: 2, medium: 5, low: 3, unrated: 2 } },
+    { domain: "dspm", label: "DSPM", href: "/findings?scope=all&domain=dspm", count: 9, severity: { critical: 1, high: 2, medium: 2, low: 1, unrated: 3 } },
+    { domain: "aispm", label: "AISPM", href: "/findings?scope=all&domain=aispm", count: 6, severity: { critical: 0, high: 1, medium: 2, low: 1, unrated: 2 } },
+  ],
+  domains: {
+    cloud: domain("Cloud posture", 4, "accounts connected", "/connections"),
+    vuln: domain("Vuln / SCA", 33, "open CVEs", "/findings?scope=all&issue=vulnerability"),
+    code: domain("Code / repo", 12, "repo scans", "/scan"),
+    runtime: domain("Runtime", 3, "active surfaces", "/runtime"),
+    cost: domain("LLM Cost", 1824, "USD tracked", "/cost"),
+    identity: domain("NHI / Identity", 41, "identities + agents", "/identity"),
+    ops: domain("Ops", 14, "completed scans", "/jobs"),
+  },
+  top_risks: [
+    { vulnerability_id: "CVE-2026-7001", package: "gateway-runtime", severity: "critical", risk_score: 9.8, is_kev: true, affected_agents: ["payments-agent"] },
+    { vulnerability_id: "CVE-2026-7002", package: "identity-broker", severity: "high", risk_score: 8.4, is_kev: false, affected_agents: ["release-agent"] },
+  ],
+};
+
+function staleScan(index: number) {
+  return {
+    job_id: `scan-${index}`,
+    status: "done",
+    created_at: `2026-07-17T${String(23 - index).padStart(2, "0")}:00:00Z`,
+    request: { inventory: true },
+    progress: [],
+    result: {
+      agents: [],
+      blast_radius: [{
+        vulnerability_id: `CVE-STALE-${index}`,
+        package: "old-scan-only",
+        severity: "critical",
+        risk_score: 7.1,
+        affected_agents: [],
+        exposed_credentials: [],
+        reachable_tools: [],
+      }],
+      remediation_plan: [],
+    },
+  };
+}
+
+function finding(index: number) {
+  return {
+    id: `finding-${index}`,
+    cve_id: `CVE-2026-${String(8000 + index)}`,
+    title: `Production exposure ${index}`,
+    severity: "high",
+    status: "open",
+    asset: { name: `prod-workload-${index}`, type: "workload" },
+    package: { name: `runtime-lib-${index}`, version: "1.0.0" },
+    effective_reach_score: 8.2,
+    last_seen: "2026-07-17T16:00:00Z",
+  };
+}
+
+async function routeProductFixture(page: Page) {
+  await page.route("**/health", (route) => route.fulfill({ json: { status: "ok", version: "0.96.3" } }));
+  await page.route("**/version", (route) => route.fulfill({ json: { version: "0.96.3" } }));
+  await page.route("**/v1/auth/me", (route) => route.fulfill({
+    json: {
+      authenticated: true,
+      auth_required: false,
+      configured_modes: [],
+      recommended_ui_mode: "no_auth",
+      auth_method: null,
+      subject: "operator@example.com",
+      role: "admin",
+      tenant_id: "tenant-production",
+      memberships: [],
+    },
+  }));
+  await page.route("**/v1/posture/counts", (route) => route.fulfill({ json: COUNTS }));
+  await page.route("**/v1/posture", (route) => route.fulfill({ json: { grade: "D", score: 48, summary: OVERVIEW.posture.summary } }));
+  await page.route("**/v1/overview", (route) => route.fulfill({ json: OVERVIEW }));
+  await page.route("**/v1/compliance", (route) => route.fulfill({ status: 503, json: { detail: "not configured" } }));
+  await page.route("**/v1/agents", (route) => route.fulfill({ json: { count: 18, agents: [] } }));
+  await page.route("**/v1/jobs", (route) => route.fulfill({
+    json: {
+      jobs: Array.from({ length: 14 }, (_, index) => ({
+        job_id: `scan-${index}`,
+        status: "done",
+        created_at: `2026-07-17T${String(23 - index).padStart(2, "0")}:00:00Z`,
+        request: { inventory: true },
+        summary: { total_vulnerabilities: 1, critical_findings: 1 },
+      })),
+    },
+  }));
+  await page.route(/\/v1\/scan\/scan-(\d+)$/, (route) => {
+    const match = route.request().url().match(/scan-(\d+)$/);
+    return route.fulfill({ json: staleScan(Number(match?.[1] ?? 0)) });
+  });
+  await page.route("**/v1/findings**", (route) => {
+    const url = new URL(route.request().url());
+    if (url.pathname === "/v1/findings/triage") {
+      return route.fulfill({ json: { triage: [], count: 0 } });
+    }
+    if (url.searchParams.get("severity") !== "high") {
+      return route.fulfill({
+        json: { schema_version: "v1", findings: [], count: 0, total: 0, limit: 25, offset: 0, sort: "severity", cursor: "", next_cursor: "", has_more: false, warnings: [], window: { days: 90, since: "2026-04-18T00:00:00Z", applied: true, label: "Last 90 days" } },
+      });
+    }
+    const cursor = url.searchParams.get("cursor");
+    const rows = cursor ? [finding(25)] : Array.from({ length: 25 }, (_, index) => finding(index));
+    return route.fulfill({
+      json: {
+        schema_version: "v1",
+        findings: rows,
+        count: rows.length,
+        total: cursor ? null : 26,
+        limit: 25,
+        offset: 0,
+        sort: "severity",
+        cursor: cursor ?? "",
+        next_cursor: cursor ? "" : "opaque-high-page-2",
+        has_more: !cursor,
+        warnings: [],
+        window: { days: 90, since: "2026-04-18T00:00:00Z", applied: true, label: "Last 90 days" },
+      },
+    });
+  });
+}
+
+async function capture(page: Page, testInfo: TestInfo, name: string) {
+  await mkdir(".screenshots", { recursive: true });
+  await page.screenshot({ path: testInfo.outputPath(name), fullPage: true });
+  await page.screenshot({ path: `.screenshots/${name}`, fullPage: true });
+}
+
+for (const theme of ["light", "dark"] as const) {
+  test(`overview and findings reconcile in ${theme} theme`, async ({ page }, testInfo) => {
+    await page.addInitScript((selectedTheme) => localStorage.setItem("agent-bom-theme", selectedTheme), theme);
+    await page.setViewportSize({ width: 1440, height: 1000 });
+    await routeProductFixture(page);
+
+    await page.goto("/");
+    await expect(page.getByText("Current findings · Last 90 days")).toBeVisible();
+    const critical = page.getByRole("link", { name: /^Critical 7/i });
+    const high = page.getByRole("link", { name: /^High 26/i });
+    await expect(critical).toHaveAttribute("href", "/findings?scope=all&severity=critical");
+    await expect(high).toHaveAttribute("href", "/findings?scope=all&severity=high");
+    await expect(page.getByRole("link", { name: /^Critical 10/i })).toHaveCount(0);
+    await capture(page, testInfo, `overview-reconciled-${theme}.png`);
+
+    await high.click();
+    await expect.poll(() => new URL(page.url()).pathname).toBe("/findings");
+    await expect.poll(() => new URL(page.url()).searchParams.get("scope")).toBe("all");
+    await expect.poll(() => new URL(page.url()).searchParams.get("severity")).toBe("high");
+    await expect(page.getByText("Current state · Last 90 days")).toBeVisible();
+    await expect(page.getByText(/26 findings/).first()).toBeVisible();
+    await expect(page.getByText("Page 1 of 2 (26 findings)")).toBeVisible();
+    await page.getByRole("button", { name: /Next/i }).click();
+    await expect(page.getByText("Page 2 · total unavailable")).toBeVisible();
+    await expect(page.getByRole("button", { name: /Next/i })).toBeDisabled();
+    await capture(page, testInfo, `findings-continuation-${theme}.png`);
+  });
+}
+
+test("overview and current-state findings remain readable without mobile overflow", async ({ page }, testInfo) => {
+  await page.addInitScript(() => localStorage.setItem("agent-bom-theme", "dark"));
+  await page.setViewportSize({ width: 390, height: 844 });
+  await routeProductFixture(page);
+
+  await page.goto("/");
+  await expect(page.getByRole("link", { name: /^Critical 7/i })).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+  await capture(page, testInfo, "overview-reconciled-mobile.png");
+
+  await page.getByRole("link", { name: /^High 26/i }).click();
+  await expect(page.getByText("Current state · Last 90 days")).toBeVisible();
+  expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth)).toBe(true);
+  await capture(page, testInfo, "findings-current-state-mobile.png");
+});

--- a/ui/e2e/overview-findings-reconciliation.spec.ts
+++ b/ui/e2e/overview-findings-reconciliation.spec.ts
@@ -187,7 +187,7 @@ for (const theme of ["light", "dark"] as const) {
     await routeProductFixture(page);
 
     await page.goto("/");
-    await expect(page.getByText("Current findings · Last 90 days")).toBeVisible();
+    await expect(page.getByText("Current findings · configured window")).toBeVisible();
     const critical = page.getByRole("link", { name: /^Critical 7/i });
     const high = page.getByRole("link", { name: /^High 26/i });
     await expect(critical).toHaveAttribute("href", "/findings?scope=all&severity=critical");

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -582,6 +582,8 @@ export interface PostureCountsResponse {
   high: number;
   medium: number;
   low: number;
+  /** Findings whose source severity is unknown or unscored. */
+  unrated?: number | undefined;
   total: number;
   kev: number;
   compound_issues: number;
@@ -928,7 +930,8 @@ export interface FindingListEnvelope<T> {
   schema_version: string;
   findings: T[];
   count: number;
-  total: number;
+  /** Null on continuation pages whose first-page count may no longer be current. */
+  total: number | null;
   total_approximate?: boolean | undefined;
   limit: number;
   offset: number;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -1263,6 +1263,7 @@ export const api = {
     sort?: string;
     limit?: number;
     offset?: number;
+    cursor?: string;
     approximateTotal?: boolean;
     // First-class scope + taxonomy filters (issue #3946). All optional +
     // backward compatible; the server canonicalizes and never rejects them.
@@ -1280,6 +1281,7 @@ export const api = {
     if (filters?.sort) params.set("sort", filters.sort);
     if (filters?.limit != null) params.set("limit", String(filters.limit));
     if (filters?.offset != null) params.set("offset", String(filters.offset));
+    if (filters?.cursor) params.set("cursor", filters.cursor);
     if (filters?.approximateTotal) params.set("approximate_total", "true");
     if (filters?.provider) params.set("provider", filters.provider);
     if (filters?.account) params.set("account", filters.account);

--- a/ui/lib/finding-issue-type.ts
+++ b/ui/lib/finding-issue-type.ts
@@ -147,11 +147,13 @@ export function buildIssueSeverityMatrix(
 }
 
 export function findingsHref(opts: {
+  scope?: "latest" | "all";
   severity?: SeverityBand | "all";
   issue?: IssueTypeFilter;
   kev?: boolean;
 }): string {
   const params = new URLSearchParams();
+  if (opts.scope === "all") params.set("scope", "all");
   if (opts.severity && opts.severity !== "all") params.set("severity", opts.severity);
   if (opts.issue && opts.issue !== "all") params.set("issue", opts.issue);
   if (opts.kev) params.set("kev", "1");

--- a/ui/lib/findings-lens.ts
+++ b/ui/lib/findings-lens.ts
@@ -52,7 +52,7 @@ export function findingsPageSubtitle(lens: FindingsLens, countLabel: string, sco
     lens === "trust"
       ? "Shared with engineering — filter by issue type for misconfigs and secrets, then record disposition for audit packs."
       : "Shared with compliance and audit — triage decisions and OpenVEX export feed trust reviews.";
-  return `${countLabel} ${scopeLine} ${audience}`;
+  return `${countLabel} · ${scopeLine} ${audience}`;
 }
 
 export function findingsQueueTitle(lens: FindingsLens): string {

--- a/ui/tests/finding-issue-type.test.ts
+++ b/ui/tests/finding-issue-type.test.ts
@@ -86,5 +86,8 @@ describe("finding-issue-type", () => {
       "/findings?severity=critical&issue=misconfiguration",
     );
     expect(findingsHref({ kev: true })).toBe("/findings?kev=1");
+    expect(findingsHref({ scope: "all", severity: "critical" })).toBe(
+      "/findings?scope=all&severity=critical",
+    );
   });
 });

--- a/ui/tests/findings-lens.test.ts
+++ b/ui/tests/findings-lens.test.ts
@@ -22,6 +22,7 @@ describe("findings-lens", () => {
     expect(findingsQueueTitle("ops")).toBe("Findings queue");
     expect(findingsLensHint("trust")).toMatch(/GRC|audit/i);
     expect(findingsLensHint("ops")).toMatch(/Engineering/i);
+    expect(findingsPageSubtitle("trust", "12 findings", "from latest.")).toMatch(/12 findings · from latest/i);
     expect(findingsPageSubtitle("trust", "12 findings", "from latest.")).toMatch(/Shared with engineering/i);
     expect(findingsPageSubtitle("ops", "12 findings", "from latest.")).toMatch(/Shared with compliance/i);
   });

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import FindingsPage from "@/app/findings/page";
 
-const { apiMock } = vi.hoisted(() => ({
+const { apiMock, navigationState } = vi.hoisted(() => ({
   apiMock: {
     listJobs: vi.fn(),
     getScan: vi.fn(),
@@ -14,10 +14,11 @@ const { apiMock } = vi.hoisted(() => ({
     exportFindingTriageVex: vi.fn(),
     getPostureCounts: vi.fn(),
   },
+  navigationState: { query: "" },
 }));
 
 vi.mock("next/navigation", () => ({
-  useSearchParams: () => new URLSearchParams(),
+  useSearchParams: () => new URLSearchParams(navigationState.query),
   useRouter: () => ({ replace: vi.fn() }),
   usePathname: () => "/findings",
 }));
@@ -91,6 +92,7 @@ function scanJob() {
 
 describe("FindingsPage", () => {
   beforeEach(() => {
+    navigationState.query = "";
     apiMock.listJobs.mockReset();
     apiMock.getScan.mockReset();
     apiMock.listFindings.mockReset();
@@ -228,5 +230,61 @@ describe("FindingsPage", () => {
     await waitFor(() =>
       expect(apiMock.listFindings).toHaveBeenCalledWith(expect.objectContaining({ windowDays: 0 })),
     );
+  });
+
+  it("follows opaque continuation while labeling an intentionally unknown total", async () => {
+    navigationState.query = "scope=all";
+    const finding = (index: number) => ({
+      id: `uuid-${index}`,
+      severity: "high",
+      cve_id: `CVE-2026-${String(index).padStart(4, "0")}`,
+      title: `Finding ${index}`,
+      asset: { name: `asset-${index}` },
+    });
+    apiMock.listFindings
+      .mockResolvedValueOnce({
+        schema_version: "v1",
+        findings: Array.from({ length: 25 }, (_, index) => finding(index)),
+        count: 25,
+        total: null,
+        total_approximate: false,
+        limit: 25,
+        offset: 0,
+        sort: "severity",
+        cursor: "",
+        next_cursor: "opaque-page-2",
+        has_more: true,
+        warnings: [],
+        window: { days: 90, since: "2026-04-18T00:00:00Z", applied: true, label: "Last 90 days" },
+      })
+      .mockResolvedValueOnce({
+        schema_version: "v1",
+        findings: [finding(25)],
+        count: 1,
+        total: null,
+        total_approximate: false,
+        limit: 25,
+        offset: 0,
+        sort: "severity",
+        cursor: "opaque-page-2",
+        next_cursor: "",
+        has_more: false,
+        warnings: [],
+        window: { days: 90, since: "2026-04-18T00:00:00Z", applied: true, label: "Last 90 days" },
+      });
+
+    render(<FindingsPage />);
+
+    expect(await screen.findByText("Page 1 · total unavailable")).toBeInTheDocument();
+    expect(screen.getByText("Current state · Last 90 days")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /Next/i }));
+
+    await waitFor(() =>
+      expect(apiMock.listFindings).toHaveBeenLastCalledWith(
+        expect.objectContaining({ cursor: "opaque-page-2", windowDays: 90 }),
+      ),
+    );
+    expect(await screen.findByText("Page 2 · total unavailable")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
   });
 });

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -168,7 +168,7 @@ describe("OverviewCockpit", () => {
   });
 
   it("surfaces risk themes and links into findings / compliance", () => {
-    render(<OverviewCockpit {...baseProps} findingsScopeLabel="Current findings · Last 90 days" />);
+    render(<OverviewCockpit {...baseProps} findingsScopeLabel="Current findings · configured window" />);
 
     expect(screen.getByText(/2 critical findings need attention/i)).toBeInTheDocument();
     expect(screen.getByText("CVE-2020-14343")).toBeInTheDocument();
@@ -177,7 +177,7 @@ describe("OverviewCockpit", () => {
       "href",
       "/findings?scope=all&severity=critical",
     );
-    expect(screen.getByText("Current findings · Last 90 days")).toBeInTheDocument();
+    expect(screen.getByText("Current findings · configured window")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Compliance evidence" })).toHaveAttribute(
       "href",
       "/compliance",

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -168,15 +168,16 @@ describe("OverviewCockpit", () => {
   });
 
   it("surfaces risk themes and links into findings / compliance", () => {
-    render(<OverviewCockpit {...baseProps} />);
+    render(<OverviewCockpit {...baseProps} findingsScopeLabel="Current findings · Last 90 days" />);
 
     expect(screen.getByText(/2 critical findings need attention/i)).toBeInTheDocument();
     expect(screen.getByText("CVE-2020-14343")).toBeInTheDocument();
     expect(screen.getByText("cursor")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Critical findings" })).toHaveAttribute(
       "href",
-      "/findings?severity=critical",
+      "/findings?scope=all&severity=critical",
     );
+    expect(screen.getByText("Current findings · Last 90 days")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "Compliance evidence" })).toHaveAttribute(
       "href",
       "/compliance",

--- a/ui/tests/overview-page-reconciliation.test.tsx
+++ b/ui/tests/overview-page-reconciliation.test.tsx
@@ -126,7 +126,7 @@ describe("Overview canonical finding counts", () => {
     const high = screen.getByRole("link", { name: /^High 11/i });
     expect(critical).toHaveTextContent("7");
     expect(high).toHaveTextContent("11");
-    expect(screen.getByText("Current findings · Last 90 days")).toBeInTheDocument();
+    expect(screen.getByText("Current findings · configured window")).toBeInTheDocument();
     expect(critical).toHaveAttribute("href", "/findings?scope=all&severity=critical");
   });
 });

--- a/ui/tests/overview-page-reconciliation.test.tsx
+++ b/ui/tests/overview-page-reconciliation.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Dashboard from "@/app/page";
+
+const { apiMock, deploymentCounts } = vi.hoisted(() => ({
+  apiMock: {
+    getPosture: vi.fn(),
+    getOverview: vi.fn(),
+    getCompliance: vi.fn(),
+    listJobs: vi.fn(),
+    listAgents: vi.fn(),
+    getScan: vi.fn(),
+    updateScoreConfig: vi.fn(),
+  },
+  deploymentCounts: {
+    critical: 7,
+    high: 11,
+    medium: 13,
+    low: 17,
+    unrated: 19,
+    total: 67,
+    kev: 5,
+    compound_issues: 2,
+    scan_count: 12,
+    services: {},
+  },
+}));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, api: apiMock };
+});
+
+vi.mock("@/hooks/use-deployment-context", () => ({
+  useDeploymentContext: () => ({ counts: deploymentCounts, loading: false, error: null }),
+}));
+
+vi.mock("@/lib/use-capture-mode", () => ({ useCaptureMode: () => false }));
+vi.mock("@/components/activity-feed", () => ({ ActivityFeed: () => <div>Activity fixture</div> }));
+
+function overviewFixture() {
+  const domain = (label: string, metric: number, metricLabel: string, href: string) => ({
+    label,
+    href,
+    metric,
+    metric_label: metricLabel,
+    status: "ok" as const,
+    detail: {},
+  });
+  return {
+    schema_version: "overview.v1",
+    tenant_id: "tenant-ui",
+    posture: { grade: "D", score: 49, summary: "Canonical posture", breakdown: [], display_format: "percent" as const },
+    headline: {
+      critical: 7,
+      high: 11,
+      critical_high: 18,
+      kev: 5,
+      credential_exposed: 3,
+      scans: 12,
+      latest_scan_at: "2026-07-17T12:00:00Z",
+      hub_findings: 67,
+    },
+    domains: {
+      cloud: domain("Cloud posture", 2, "accounts", "/connections"),
+      vuln: domain("Vuln / SCA", 23, "open CVEs", "/findings?scope=all&issue=vulnerability"),
+      code: domain("Code / repo", 1, "repo scans", "/scan"),
+      runtime: domain("Runtime", 1, "surface", "/runtime"),
+      cost: domain("LLM Cost", 0, "USD", "/cost"),
+      identity: domain("NHI / Identity", 4, "identities", "/identity"),
+      ops: domain("Ops", 12, "completed scans", "/jobs"),
+    },
+    coverage: [],
+    top_risks: [],
+  };
+}
+
+function staleScan(jobId: string) {
+  return {
+    job_id: jobId,
+    status: "done",
+    created_at: "2026-07-17T10:00:00Z",
+    request: {},
+    progress: [],
+    result: {
+      agents: [],
+      blast_radius: [
+        {
+          vulnerability_id: `${jobId}-stale`,
+          severity: "critical",
+          affected_agents: [],
+          exposed_credentials: [],
+          reachable_tools: [],
+          risk_score: 9,
+        },
+      ],
+    },
+  };
+}
+
+describe("Overview canonical finding counts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    apiMock.getPosture.mockResolvedValue({ grade: "D", score: 49 });
+    apiMock.getOverview.mockResolvedValue(overviewFixture());
+    apiMock.getCompliance.mockRejectedValue(new Error("not configured"));
+    apiMock.listAgents.mockResolvedValue({ count: 4, agents: [] });
+    apiMock.updateScoreConfig.mockResolvedValue({});
+    apiMock.listJobs.mockResolvedValue({
+      jobs: Array.from({ length: 12 }, (_, index) => ({
+        job_id: `scan-${index}`,
+        status: "done",
+        created_at: `2026-07-17T${String(23 - index).padStart(2, "0")}:00:00Z`,
+        request: {},
+      })),
+    });
+    apiMock.getScan.mockImplementation(async (jobId: string) => staleScan(jobId));
+  });
+
+  it("uses canonical posture/overview counts instead of recomputing the latest ten scans", async () => {
+    render(<Dashboard />);
+
+    await waitFor(() => expect(apiMock.getScan).toHaveBeenCalledTimes(10));
+    const critical = await screen.findByRole("link", { name: /^Critical 7/i });
+    const high = screen.getByRole("link", { name: /^High 11/i });
+    expect(critical).toHaveTextContent("7");
+    expect(high).toHaveTextContent("11");
+    expect(screen.getByText("Current findings · Last 90 days")).toBeInTheDocument();
+    expect(critical).toHaveAttribute("href", "/findings?scope=all&severity=critical");
+  });
+});

--- a/ui/tests/pagination-bar.test.tsx
+++ b/ui/tests/pagination-bar.test.tsx
@@ -1,0 +1,27 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { PaginationBar } from "@/components/pagination-bar";
+
+describe("PaginationBar continuation state", () => {
+  it("surfaces an unknown total without disabling an available continuation", () => {
+    const onNext = vi.fn();
+    render(
+      <PaginationBar
+        page={2}
+        totalPages={null}
+        totalItems={null}
+        hasMore
+        itemLabel="findings"
+        onPrevious={() => {}}
+        onNext={onNext}
+      />,
+    );
+
+    expect(screen.getByText("Page 2 · total unavailable")).toBeInTheDocument();
+    const next = screen.getByRole("button", { name: /Next/i });
+    expect(next).toBeEnabled();
+    fireEvent.click(next);
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
## Summary

- make overview severity and KEV authority consume the canonical current-state posture counts instead of recomputing from the latest ten hydrated jobs
- follow opaque findings cursors, represent unknown continuation totals honestly, and preserve legacy first-page compatibility
- scope drill-down links to the complete current finding set and label configured evidence windows without inventing precision

## Verification

- Node 22.22.2 / npm 10.9.7 toolchain contract
- TypeScript typecheck and ESLint
- 35 focused Vitest tests across findings, overview, pagination, and scope helpers
- Next.js production build — 49 pages
- Playwright reconciliation proof — light, dark, and 390px mobile; 3 passed with no horizontal overflow
- `git diff --check`

## Notes

- the backend current-state fold, Postgres cache invalidation, posture-count offload, and ordinal keyset landed in #4143 and #4146
- continuation pages intentionally expose an unknown total instead of repeating a stale or expensive count

Closes #4106
Addresses #4095