### PR TITLE
fix(attestation): require external DSSE signer trust

### DIFF
--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -76,7 +76,7 @@ Graph, mesh, dashboard, and narrative reporting workflows.
 | `mesh` | Agent-mesh view. |
 | `report` | Reporting group (history, narrative, exports). |
 | `findings` | Findings workbench for CLI users: `list` normalized findings (lifecycle columns when bulk-ingest metadata exists), `push` external scanner or normalized JSON to `POST /v1/findings/bulk`, triage queue items, decisions, and signed OpenVEX export. |
-| `attest` | Sign SBOMs with Ed25519 DSSE PAE and verify only against explicit `--public-key` trust files; legacy embedded-key envelopes are reported as untrusted. |
+| `attest` | Sign tenant/freshness/replay-bound SBOM DSSE PAE and verify explicit Ed25519 keys; the library exposes a pinned local Sigstore adapter policy, and legacy embedded-key envelopes remain untrusted. |
 
 ## Governance
 

--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -76,6 +76,7 @@ Graph, mesh, dashboard, and narrative reporting workflows.
 | `mesh` | Agent-mesh view. |
 | `report` | Reporting group (history, narrative, exports). |
 | `findings` | Findings workbench for CLI users: `list` normalized findings (lifecycle columns when bulk-ingest metadata exists), `push` external scanner or normalized JSON to `POST /v1/findings/bulk`, triage queue items, decisions, and signed OpenVEX export. |
+| `attest` | Sign SBOMs with Ed25519 DSSE PAE and verify only against explicit `--public-key` trust files; legacy embedded-key envelopes are reported as untrusted. |
 
 ## Governance
 

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -72,7 +72,20 @@ verbs are additive entry points that delegate to the underlying implementations.
 | `findings` | List normalized findings, manage the triage queue, record decisions, and export signed OpenVEX evidence |
 | `findings push` | Push normalized findings or Trivy / Grype / Syft JSON to `POST /v1/findings/bulk` on the control plane |
 | `findings list` | List findings from the control plane; prints lifecycle columns when bulk-ingest metadata is present |
-| `attest` | Sign and verify generated SBOM output (SHA-256 digest + in-toto attestation) |
+| `attest` | Sign generated SBOMs as Ed25519 DSSE-PAE attestations and verify them against explicit trusted public-key files |
+
+SBOM signing is fail-closed and does not reuse the compliance/audit HMAC
+fallback. Configure a persistent Ed25519 private key, preferably through the
+file-first secret boundary, then distribute only its public key to verifiers:
+
+```bash
+export AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE=/run/secrets/sbom-signing.pem
+agent-bom attest sign report.cdx.json
+agent-bom attest verify report.cdx.json --public-key trusted-sbom-signing.pub.pem
+```
+
+Verification never trusts a key embedded in an envelope. Older envelopes remain
+readable as `legacy_attestation_untrusted`, but cannot produce a verified result.
 
 ### Governance And Operations
 

--- a/site-docs/reference/cli.md
+++ b/site-docs/reference/cli.md
@@ -72,7 +72,7 @@ verbs are additive entry points that delegate to the underlying implementations.
 | `findings` | List normalized findings, manage the triage queue, record decisions, and export signed OpenVEX evidence |
 | `findings push` | Push normalized findings or Trivy / Grype / Syft JSON to `POST /v1/findings/bulk` on the control plane |
 | `findings list` | List findings from the control plane; prints lifecycle columns when bulk-ingest metadata is present |
-| `attest` | Sign generated SBOMs as Ed25519 DSSE-PAE attestations and verify them against explicit trusted public-key files |
+| `attest` | Sign tenant-bound SBOM DSSE-PAE attestations and verify explicit Ed25519 trust policies |
 
 SBOM signing is fail-closed and does not reuse the compliance/audit HMAC
 fallback. Configure a persistent Ed25519 private key, preferably through the
@@ -80,12 +80,23 @@ file-first secret boundary, then distribute only its public key to verifiers:
 
 ```bash
 export AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE=/run/secrets/sbom-signing.pem
-agent-bom attest sign report.cdx.json
-agent-bom attest verify report.cdx.json --public-key trusted-sbom-signing.pub.pem
+agent-bom attest sign report.cdx.json --tenant-id tenant-a
+agent-bom attest verify report.cdx.json \
+  --tenant-id tenant-a \
+  --public-key trusted-sbom-signing.pub.pem \
+  --replay-cache /var/lib/agent-bom/attestation-replay.sqlite3
 ```
 
 Verification never trusts a key embedded in an envelope. Older envelopes remain
 readable as `legacy_attestation_untrusted`, but cannot produce a verified result.
+The verifier also pins the statement builder, predicate type, tenant, issue and
+expiry times, maximum age, nonce, and evidence ID. Use `--replay-cache` when
+replay detection must survive separate CLI processes.
+
+Library integrations can supply a bounded Sigstore verifier adapter. That
+policy requires a local bundle, local TrustedRoot JSON, certificate identity
+regexp, and exact OIDC issuer; no Sigstore signer policy is read from envelope
+metadata or environment defaults.
 
 ### Governance And Operations
 

--- a/src/agent_bom/cli/_attest_group.py
+++ b/src/agent_bom/cli/_attest_group.py
@@ -15,6 +15,8 @@ from agent_bom.sbom_attestation import (
     AttestationSigningError,
     AttestationTrustError,
     AttestationTrustPolicy,
+    MemoryAttestationReplayStore,
+    SQLiteAttestationReplayStore,
     sign_sbom_file,
     verify_sbom_attestation,
 )
@@ -36,10 +38,25 @@ def attest_group() -> None:
     help="Attestation path (default: <sbom>.intoto.json).",
 )
 @click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
-def sign_cmd(sbom_path: str, sig_out: str | None, att_out: str | None, as_json: bool) -> None:
+@click.option("--tenant-id", required=True, help="Tenant bound into the signed attestation.")
+@click.option("--ttl-seconds", type=click.IntRange(1, 2_592_000), default=900, show_default=True)
+def sign_cmd(
+    sbom_path: str,
+    sig_out: str | None,
+    att_out: str | None,
+    as_json: bool,
+    tenant_id: str,
+    ttl_seconds: int,
+) -> None:
     """Sign a generated SBOM file: SHA-256 digest + signed in-toto attestation."""
     try:
-        result = sign_sbom_file(sbom_path, signature_path=sig_out, attestation_path=att_out)
+        result = sign_sbom_file(
+            sbom_path,
+            signature_path=sig_out,
+            attestation_path=att_out,
+            tenant_id=tenant_id,
+            ttl_seconds=ttl_seconds,
+        )
     except AttestationSigningError as exc:
         reason = str(exc)
         if as_json:
@@ -95,16 +112,30 @@ def sign_cmd(sbom_path: str, sig_out: str | None, att_out: str | None, as_json: 
     multiple=True,
     help="Trusted Ed25519 public-key PEM file. Repeat for key rotation; embedded envelope keys are never trusted.",
 )
+@click.option("--tenant-id", required=True, help="Expected signed tenant boundary.")
+@click.option("--max-age-seconds", type=click.IntRange(1, 2_592_000), default=3600, show_default=True)
+@click.option("--clock-skew-seconds", type=click.IntRange(0, 300), default=60, show_default=True)
+@click.option(
+    "--replay-cache",
+    type=click.Path(dir_okay=False),
+    default=None,
+    help="SQLite replay cache shared across verifier processes. Without it, replay state is process-local.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
 def verify_cmd(
     sbom_path: str,
     att_path: str | None,
     sig_path: str | None,
     public_key_paths: tuple[str, ...],
+    tenant_id: str,
+    max_age_seconds: int,
+    clock_skew_seconds: int,
+    replay_cache: str | None,
     as_json: bool,
 ) -> None:
     """Verify a generated SBOM against its in-toto attestation and detached signature."""
     trust_policy = None
+    replay_store = SQLiteAttestationReplayStore(replay_cache) if replay_cache else MemoryAttestationReplayStore()
     if public_key_paths:
         try:
             pems: list[str] = []
@@ -113,7 +144,13 @@ def verify_cmd(
                 if path.stat().st_size > 64 * 1024:
                     raise AttestationTrustError("trusted_public_key_file_too_large")
                 pems.append(path.read_text(encoding="utf-8"))
-            trust_policy = AttestationTrustPolicy.from_public_key_pems(pems)
+            trust_policy = AttestationTrustPolicy.from_public_key_pems(
+                pems,
+                expected_tenant_id=tenant_id,
+                max_age_seconds=max_age_seconds,
+                clock_skew_seconds=clock_skew_seconds,
+                replay_store=replay_store,
+            )
         except (OSError, UnicodeError, AttestationTrustError) as exc:
             reason = str(exc) if isinstance(exc, AttestationTrustError) else "trusted_public_key_unreadable"
             if as_json:
@@ -144,6 +181,10 @@ def verify_cmd(
                     "format_version": result.format_version,
                     "legacy": result.legacy,
                     "trust_status": result.trust_status,
+                    "tenant_id": result.tenant_id,
+                    "evidence_id": result.evidence_id,
+                    "issued_at": result.issued_at,
+                    "expires_at": result.expires_at,
                 },
                 indent=2,
             )

--- a/src/agent_bom/cli/_attest_group.py
+++ b/src/agent_bom/cli/_attest_group.py
@@ -7,10 +7,17 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import click
 
-from agent_bom.sbom_attestation import sign_sbom_file, verify_sbom_attestation
+from agent_bom.sbom_attestation import (
+    AttestationSigningError,
+    AttestationTrustError,
+    AttestationTrustPolicy,
+    sign_sbom_file,
+    verify_sbom_attestation,
+)
 
 
 @click.group("attest")
@@ -31,7 +38,15 @@ def attest_group() -> None:
 @click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
 def sign_cmd(sbom_path: str, sig_out: str | None, att_out: str | None, as_json: bool) -> None:
     """Sign a generated SBOM file: SHA-256 digest + signed in-toto attestation."""
-    result = sign_sbom_file(sbom_path, signature_path=sig_out, attestation_path=att_out)
+    try:
+        result = sign_sbom_file(sbom_path, signature_path=sig_out, attestation_path=att_out)
+    except AttestationSigningError as exc:
+        reason = str(exc)
+        if as_json:
+            click.echo(json.dumps({"sbom": sbom_path, "signed": False, "reason": reason}, indent=2))
+        else:
+            click.echo(f"FAILED: {sbom_path}\n  reason: {reason}")
+        raise SystemExit(1) from None
     if as_json:
         click.echo(
             json.dumps(
@@ -50,16 +65,11 @@ def sign_cmd(sbom_path: str, sig_out: str | None, att_out: str | None, as_json: 
         return
     click.echo(f"Signed SBOM:   {result.sbom_path}")
     click.echo(f"  sha256:      {result.sha256}")
-    click.echo(f"  algorithm:   {result.algorithm}" + ("" if result.cryptographic else "  (tamper-evident, not asymmetric)"))
+    click.echo(f"  algorithm:   {result.algorithm}")
     if result.key_id:
         click.echo(f"  key_id:      {result.key_id}")
     click.echo(f"  signature:   {result.signature_path}")
     click.echo(f"  attestation: {result.attestation_path}")
-    if not result.cryptographic:
-        click.echo(
-            "  note: HMAC-SHA256 mode — verifiers need the shared secret. "
-            "Set AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM for asymmetric, third-party-verifiable signatures."
-        )
 
 
 @attest_group.command("verify")
@@ -78,10 +88,45 @@ def sign_cmd(sbom_path: str, sig_out: str | None, att_out: str | None, as_json: 
     default=None,
     help="Detached signature path (default: <sbom>.sig).",
 )
+@click.option(
+    "--public-key",
+    "public_key_paths",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+    multiple=True,
+    help="Trusted Ed25519 public-key PEM file. Repeat for key rotation; embedded envelope keys are never trusted.",
+)
 @click.option("--json", "as_json", is_flag=True, help="Emit machine-readable JSON.")
-def verify_cmd(sbom_path: str, att_path: str | None, sig_path: str | None, as_json: bool) -> None:
+def verify_cmd(
+    sbom_path: str,
+    att_path: str | None,
+    sig_path: str | None,
+    public_key_paths: tuple[str, ...],
+    as_json: bool,
+) -> None:
     """Verify a generated SBOM against its in-toto attestation and detached signature."""
-    result = verify_sbom_attestation(sbom_path, attestation_path=att_path, signature_path=sig_path)
+    trust_policy = None
+    if public_key_paths:
+        try:
+            pems: list[str] = []
+            for raw_path in public_key_paths:
+                path = Path(raw_path)
+                if path.stat().st_size > 64 * 1024:
+                    raise AttestationTrustError("trusted_public_key_file_too_large")
+                pems.append(path.read_text(encoding="utf-8"))
+            trust_policy = AttestationTrustPolicy.from_public_key_pems(pems)
+        except (OSError, UnicodeError, AttestationTrustError) as exc:
+            reason = str(exc) if isinstance(exc, AttestationTrustError) else "trusted_public_key_unreadable"
+            if as_json:
+                click.echo(json.dumps({"sbom": sbom_path, "verified": False, "reason": reason}, indent=2))
+            else:
+                click.echo(f"FAILED: {sbom_path}\n  reason: {reason}")
+            raise SystemExit(1) from None
+    result = verify_sbom_attestation(
+        sbom_path,
+        attestation_path=att_path,
+        signature_path=sig_path,
+        trust_policy=trust_policy,
+    )
     if as_json:
         click.echo(
             json.dumps(
@@ -96,6 +141,9 @@ def verify_cmd(sbom_path: str, att_path: str | None, sig_path: str | None, as_js
                     "checks": result.checks,
                     "expected_sha256": result.expected_sha256,
                     "actual_sha256": result.actual_sha256,
+                    "format_version": result.format_version,
+                    "legacy": result.legacy,
+                    "trust_status": result.trust_status,
                 },
                 indent=2,
             )

--- a/src/agent_bom/sbom_attestation.py
+++ b/src/agent_bom/sbom_attestation.py
@@ -1,57 +1,103 @@
-"""Sign and attest generated SBOM output.
+"""Sign and verify generated SBOMs at an explicit DSSE trust boundary.
 
-This closes the supply-chain-integrity loop for SBOMs that *agent-bom itself
-emits* (CycloneDX / SPDX / JSON). Release artifacts are already signed via the
-Sigstore/cosign release workflow; this module signs the **content** of a
-generated SBOM file so a downstream consumer can prove the document was not
-altered after generation.
-
-What it produces for an SBOM file ``foo.cdx.json``:
-
-- ``foo.cdx.json.sig`` — a self-describing *detached signature* over the raw
-  SBOM bytes.
-- ``foo.cdx.json.intoto.json`` — a DSSE-style envelope wrapping an
-  `in-toto Statement v1 <https://in-toto.io/Statement/v1>`_ with a SLSA-style
-  provenance predicate. The statement binds the SBOM's SHA-256 digest to the
-  builder identity and signs that binding.
-
-Honesty about cryptography
---------------------------
-The signing primitive is reused from :mod:`agent_bom.api.compliance_signing`:
-
-- When ``AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM`` is set, signatures are
-  **real asymmetric Ed25519** signatures. The public key is embedded in the
-  artifacts, so a third party can verify them offline with only the public key
-  — this is genuine cryptographic provenance.
-- Otherwise it falls back to **HMAC-SHA256** using the audit shared secret.
-  HMAC is *tamper-evident*, not non-repudiable: a verifier needs the same
-  shared secret, and anyone holding that secret could forge a signature. The
-  emitted artifacts label themselves ``"cryptographic": false`` in that mode so
-  no one mistakes them for asymmetric signatures.
-
-Either way the SHA-256 digest binding is real: the attestation always lets a
-consumer detect that the SBOM bytes changed.
+New attestations use DSSE pre-authentication encoding (PAE) and Ed25519 only.
+Verification trusts only caller-supplied public keys; envelope metadata and
+embedded legacy keys are evidence, never trust anchors. Older self-consistent
+envelopes remain readable but are always reported as legacy and untrusted.
 """
 
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import json
+import os
+import re
+import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey, Ed25519PublicKey
 
 from agent_bom import __version__
 
-# in-toto / SLSA constants
 _STATEMENT_TYPE = "https://in-toto.io/Statement/v1"
 _PREDICATE_TYPE = "https://slsa.dev/provenance/v1"
 _DSSE_PAYLOAD_TYPE = "application/vnd.in-toto+json"
+_DSSE_SCHEMA_VERSION = "agent-bom-sbom-dsse-v2"
 _BUILDER_ID = "https://github.com/msaad00/agent-bom"
+_DETACHED_TYPE = "https://agent-bom.dev/sbom-detached-signature/v2"
+_PRIVATE_KEY_ENV = "AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM"
 
 _SIG_SUFFIX = ".sig"
 _ATTESTATION_SUFFIX = ".intoto.json"
+_MAX_ENVELOPE_BYTES = 16 * 1024 * 1024
+_MAX_PAYLOAD_BYTES = 12 * 1024 * 1024
+_MAX_SIGNATURE_FILE_BYTES = 64 * 1024
+_MAX_TRUSTED_KEYS = 32
+_SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+
+
+class AttestationSigningError(RuntimeError):
+    """Controlled signing configuration failure with no secret-bearing detail."""
+
+
+class AttestationTrustError(ValueError):
+    """Controlled caller trust-policy configuration failure."""
+
+
+class _DuplicateJsonKeyError(ValueError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class _TrustedEd25519Key:
+    key_id: str
+    public_key: Ed25519PublicKey
+
+
+@dataclass(frozen=True, slots=True)
+class AttestationTrustPolicy:
+    """Bounded immutable set of verifier-configured Ed25519 trust anchors."""
+
+    keys: tuple[_TrustedEd25519Key, ...]
+
+    def __post_init__(self) -> None:
+        if not self.keys:
+            raise AttestationTrustError("trusted_public_key_required")
+        if len(self.keys) > _MAX_TRUSTED_KEYS:
+            raise AttestationTrustError("too_many_trusted_public_keys")
+        key_ids = [key.key_id for key in self.keys]
+        if len(key_ids) != len(set(key_ids)):
+            raise AttestationTrustError("ambiguous_trusted_key_id")
+
+    @classmethod
+    def from_public_key_pems(cls, public_key_pems: Iterable[str]) -> AttestationTrustPolicy:
+        by_id: dict[str, _TrustedEd25519Key] = {}
+        for pem in public_key_pems:
+            try:
+                loaded = serialization.load_pem_public_key(str(pem).encode("utf-8"))
+            except (TypeError, ValueError):
+                raise AttestationTrustError("trusted_public_key_invalid") from None
+            if not isinstance(loaded, Ed25519PublicKey):
+                raise AttestationTrustError("trusted_public_key_not_ed25519")
+            key_id = _public_key_id(loaded)
+            existing = by_id.get(key_id)
+            if existing is not None and _public_der(existing.public_key) != _public_der(loaded):
+                raise AttestationTrustError("ambiguous_trusted_key_id")
+            by_id[key_id] = _TrustedEd25519Key(key_id=key_id, public_key=loaded)
+            if len(by_id) > _MAX_TRUSTED_KEYS:
+                raise AttestationTrustError("too_many_trusted_public_keys")
+        return cls(keys=tuple(by_id[key_id] for key_id in sorted(by_id)))
+
+    def resolve(self, key_id: str) -> Ed25519PublicKey | None:
+        matches = [key.public_key for key in self.keys if key.key_id == key_id]
+        return matches[0] if len(matches) == 1 else None
 
 
 @dataclass(frozen=True)
@@ -70,7 +116,7 @@ class AttestationResult:
 
 @dataclass
 class VerificationResult:
-    """Outcome of verifying an SBOM attestation/signature."""
+    """Outcome of verifying one SBOM attestation against caller trust."""
 
     sbom_path: str
     verified: bool = False
@@ -83,16 +129,24 @@ class VerificationResult:
     expected_sha256: str = ""
     actual_sha256: str = ""
     checks: list[str] = field(default_factory=list)
+    format_version: str = ""
+    legacy: bool = False
+    trust_status: str = "untrusted"
 
 
-def _canonical_bytes(obj: dict) -> bytes:
-    """Deterministic JSON encoding used as the signed payload."""
+def _canonical_bytes(obj: Mapping[str, Any]) -> bytes:
     return json.dumps(obj, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
 
 
 def compute_sbom_digest(data: bytes) -> str:
-    """Return the hex SHA-256 digest of raw SBOM bytes."""
     return hashlib.sha256(data).hexdigest()
+
+
+def dsse_pae(payload_type: str, payload: bytes) -> bytes:
+    """Return DSSE v1 pre-authentication encoding for type and payload."""
+
+    type_bytes = payload_type.encode("utf-8")
+    return b"DSSEv1 " + str(len(type_bytes)).encode("ascii") + b" " + type_bytes + b" " + str(len(payload)).encode("ascii") + b" " + payload
 
 
 def _infer_format(name: str) -> str:
@@ -109,8 +163,7 @@ def build_intoto_statement(
     sbom_bytes: bytes,
     *,
     sbom_format: str | None = None,
-) -> dict:
-    """Build an in-toto Statement v1 binding the SBOM digest to a SLSA predicate."""
+) -> dict[str, Any]:
     name = Path(sbom_path).name
     digest = compute_sbom_digest(sbom_bytes)
     now = datetime.now(timezone.utc).isoformat()
@@ -121,9 +174,7 @@ def build_intoto_statement(
         "predicate": {
             "buildDefinition": {
                 "buildType": "https://agent-bom.dev/sbom-generation/v1",
-                "externalParameters": {
-                    "sbomFormat": sbom_format or _infer_format(name),
-                },
+                "externalParameters": {"sbomFormat": sbom_format or _infer_format(name)},
             },
             "runDetails": {
                 "builder": {"id": _BUILDER_ID, "version": {"agent-bom": __version__}},
@@ -133,12 +184,51 @@ def build_intoto_statement(
     }
 
 
-def _sign(payload: bytes):
-    """Return (SignatureResult, cryptographic_bool) using the shared signer."""
-    from agent_bom.api.compliance_signing import sign_compliance_bundle
+def _public_der(public_key: Ed25519PublicKey) -> bytes:
+    return public_key.public_bytes(
+        encoding=serialization.Encoding.DER,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
 
-    result = sign_compliance_bundle(payload)
-    return result, result.algorithm == "Ed25519"
+
+def _public_key_id(public_key: Ed25519PublicKey) -> str:
+    return hashlib.sha256(_public_der(public_key)).hexdigest()
+
+
+def _load_private_signer() -> Ed25519PrivateKey:
+    from agent_bom.api.secret_source import resolve_secret
+
+    try:
+        pem = resolve_secret(_PRIVATE_KEY_ENV)
+    except (OSError, ValueError):
+        raise AttestationSigningError("ed25519_signing_key_invalid") from None
+    if not pem:
+        raise AttestationSigningError("ed25519_signing_key_required")
+    try:
+        loaded = serialization.load_pem_private_key(pem.encode("utf-8"), password=None)
+    except (TypeError, ValueError):
+        raise AttestationSigningError("ed25519_signing_key_invalid") from None
+    if not isinstance(loaded, Ed25519PrivateKey):
+        raise AttestationSigningError("ed25519_signing_key_not_ed25519")
+    return loaded
+
+
+def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, temporary = tempfile.mkstemp(prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except Exception:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
 
 
 def sign_sbom_file(
@@ -148,86 +238,171 @@ def sign_sbom_file(
     attestation_path: str | Path | None = None,
     sbom_format: str | None = None,
 ) -> AttestationResult:
-    """Sign a generated SBOM file: write a detached signature + in-toto attestation.
+    """Write an Ed25519 detached signature and DSSE-PAE attestation."""
 
-    Reuses the Ed25519 (preferred) / HMAC-SHA256 signer from
-    :mod:`agent_bom.api.compliance_signing`. See the module docstring for the
-    honest distinction between the two modes.
-    """
     src = Path(sbom_path)
-    sbom_bytes = src.read_bytes()
+    try:
+        sbom_bytes = src.read_bytes()
+    except OSError:
+        raise AttestationSigningError("sbom_file_unreadable") from None
+    signer = _load_private_signer()
+    public_key = signer.public_key()
+    key_id = _public_key_id(public_key)
+    public_pem = public_key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
     digest = compute_sbom_digest(sbom_bytes)
-
-    # 1. Detached signature over the raw SBOM bytes.
-    blob_sig, cryptographic = _sign(sbom_bytes)
-    sig_obj = {
-        "_type": "https://agent-bom.dev/sbom-detached-signature/v1",
-        "subject": src.name,
-        "sha256": digest,
-        "algorithm": blob_sig.algorithm,
-        "cryptographic": cryptographic,
-        "keyId": blob_sig.key_id,
-        "publicKeyPem": blob_sig.public_key_pem,
-        "signature": blob_sig.signature_hex,
-    }
     sig_out = Path(signature_path) if signature_path else Path(str(src) + _SIG_SUFFIX)
-    sig_out.write_text(json.dumps(sig_obj, indent=2), encoding="utf-8")
+    att_out = Path(attestation_path) if attestation_path else Path(str(src) + _ATTESTATION_SUFFIX)
+    if sig_out.resolve() == att_out.resolve():
+        raise AttestationSigningError("signature_and_attestation_paths_must_differ")
 
-    # 2. in-toto Statement + DSSE-style envelope (the attestation).
     statement = build_intoto_statement(src, sbom_bytes, sbom_format=sbom_format)
     payload = _canonical_bytes(statement)
-    stmt_sig, _ = _sign(payload)
+    if len(payload) > _MAX_PAYLOAD_BYTES:
+        raise AttestationSigningError("attestation_payload_too_large")
     envelope = {
         "payloadType": _DSSE_PAYLOAD_TYPE,
         "payload": base64.b64encode(payload).decode("ascii"),
-        "signatures": [{"keyid": stmt_sig.key_id or "", "sig": stmt_sig.signature_hex}],
-        "_agentBom": {
-            "algorithm": stmt_sig.algorithm,
-            "cryptographic": cryptographic,
-            "publicKeyPem": stmt_sig.public_key_pem,
-            "note": (
-                "Ed25519: asymmetric, third-party verifiable with the public key. "
-                "HMAC-SHA256: tamper-evident only; verification requires the shared secret."
-            ),
-        },
+        "signatures": [
+            {
+                "keyid": key_id,
+                "sig": base64.b64encode(signer.sign(dsse_pae(_DSSE_PAYLOAD_TYPE, payload))).decode("ascii"),
+            }
+        ],
+        "_agentBom": {"schemaVersion": _DSSE_SCHEMA_VERSION},
     }
-    att_out = Path(attestation_path) if attestation_path else Path(str(src) + _ATTESTATION_SUFFIX)
-    att_out.write_text(json.dumps(envelope, indent=2), encoding="utf-8")
+    detached = {
+        "_type": _DETACHED_TYPE,
+        "subject": src.name,
+        "sha256": digest,
+        "algorithm": "Ed25519",
+        "keyId": key_id,
+        "signature": base64.b64encode(signer.sign(sbom_bytes)).decode("ascii"),
+    }
+    try:
+        _atomic_write_json(sig_out, detached)
+        _atomic_write_json(att_out, envelope)
+    except OSError:
+        try:
+            sig_out.unlink()
+        except OSError:
+            pass
+        raise AttestationSigningError("attestation_artifact_write_failed") from None
 
     return AttestationResult(
         sbom_path=str(src),
         sha256=digest,
-        algorithm=blob_sig.algorithm,
-        cryptographic=cryptographic,
-        key_id=blob_sig.key_id,
+        algorithm="Ed25519",
+        cryptographic=True,
+        key_id=key_id,
         signature_path=str(sig_out),
         attestation_path=str(att_out),
-        public_key_pem=blob_sig.public_key_pem,
+        public_key_pem=public_pem,
     )
 
 
-def _verify_signature(payload: bytes, signature_hex: str, algorithm: str, public_key_pem: str | None) -> bool:
-    """Verify a signature against the signed payload for the given algorithm."""
-    if algorithm == "Ed25519":
-        if not public_key_pem:
-            return False
-        try:
-            from cryptography.exceptions import InvalidSignature
-            from cryptography.hazmat.primitives import serialization
-            from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+def _reject_duplicate_keys(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise _DuplicateJsonKeyError
+        result[key] = value
+    return result
 
-            loaded = serialization.load_pem_public_key(public_key_pem.encode())
-            if not isinstance(loaded, Ed25519PublicKey):
-                return False
-            loaded.verify(bytes.fromhex(signature_hex), payload)
-            return True
-        except (InvalidSignature, ValueError, TypeError):
-            return False
-    if algorithm == "HMAC-SHA256":
-        from agent_bom.api.audit_log import verify_export_payload
 
-        return verify_export_payload(payload, signature_hex)
-    return False
+def _load_json_object(raw: bytes) -> dict[str, Any]:
+    decoded = json.loads(raw, object_pairs_hook=_reject_duplicate_keys)
+    if not isinstance(decoded, dict):
+        raise ValueError
+    return decoded
+
+
+def _decode_payload(envelope: Mapping[str, Any]) -> tuple[bytes, dict[str, Any]]:
+    encoded = envelope.get("payload")
+    if not isinstance(encoded, str):
+        raise ValueError
+    payload = base64.b64decode(encoded, validate=True)
+    if len(payload) > _MAX_PAYLOAD_BYTES:
+        raise OverflowError
+    return payload, _load_json_object(payload)
+
+
+def _statement_digest(statement: Mapping[str, Any], expected_name: str) -> str:
+    if statement.get("_type") != _STATEMENT_TYPE or statement.get("predicateType") != _PREDICATE_TYPE:
+        return ""
+    subjects = statement.get("subject")
+    if not isinstance(subjects, list) or len(subjects) != 1 or not isinstance(subjects[0], Mapping):
+        return ""
+    subject = subjects[0]
+    if subject.get("name") != expected_name or not isinstance(subject.get("digest"), Mapping):
+        return ""
+    digest = subject["digest"].get("sha256")
+    return str(digest) if isinstance(digest, str) and _SHA256_RE.fullmatch(digest) else ""
+
+
+def _verify_ed25519(public_key: Ed25519PublicKey, signature_b64: Any, signed: bytes) -> bool:
+    if not isinstance(signature_b64, str):
+        return False
+    try:
+        signature = base64.b64decode(signature_b64, validate=True)
+        if len(signature) != 64:
+            return False
+        public_key.verify(signature, signed)
+        return True
+    except (binascii.Error, InvalidSignature, ValueError):
+        return False
+
+
+def _legacy_result(
+    result: VerificationResult,
+    envelope: Mapping[str, Any],
+    *,
+    actual_digest: str,
+    sbom_name: str,
+) -> VerificationResult:
+    """Read only the legacy digest binding; never trust embedded signer data."""
+
+    result.legacy = True
+    result.format_version = "legacy"
+    result.algorithm = "legacy-untrusted"
+    result.trust_status = "legacy_untrusted"
+    try:
+        _payload, statement = _decode_payload(envelope)
+        result.expected_sha256 = _statement_digest(statement, sbom_name)
+        result.digest_matches = bool(result.expected_sha256) and result.expected_sha256 == actual_digest
+        result.checks.append("legacy_digest_match=" + ("ok" if result.digest_matches else "FAIL"))
+        result.checks.append("legacy_signature_trust=untrusted")
+        result.reason = "legacy_attestation_untrusted"
+    except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError, ValueError, OverflowError, _DuplicateJsonKeyError):
+        result.reason = "malformed_attestation"
+    return result
+
+
+def _verify_detached(
+    path: Path,
+    *,
+    sbom_bytes: bytes,
+    actual_digest: str,
+    key_id: str,
+    public_key: Ed25519PublicKey,
+) -> tuple[bool, str]:
+    try:
+        if path.stat().st_size > _MAX_SIGNATURE_FILE_BYTES:
+            return False, "detached_signature_too_large"
+        detached = _load_json_object(path.read_bytes())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError, _DuplicateJsonKeyError):
+        return False, "detached_signature_invalid"
+    if detached.get("_type") != _DETACHED_TYPE or detached.get("algorithm") != "Ed25519":
+        return False, "detached_signature_invalid"
+    if detached.get("keyId") != key_id:
+        return False, "detached_key_id_mismatch"
+    if detached.get("sha256") != actual_digest:
+        return False, "detached_digest_mismatch"
+    if not _verify_ed25519(public_key, detached.get("signature"), sbom_bytes):
+        return False, "detached_signature_invalid"
+    return True, ""
 
 
 def verify_sbom_attestation(
@@ -235,90 +410,114 @@ def verify_sbom_attestation(
     *,
     attestation_path: str | Path | None = None,
     signature_path: str | Path | None = None,
+    trust_policy: AttestationTrustPolicy | None = None,
 ) -> VerificationResult:
-    """Verify a generated SBOM against its in-toto attestation (and detached sig).
+    """Verify a versioned DSSE envelope only against external caller trust."""
 
-    Recomputes the SBOM SHA-256, confirms it matches the digest bound in the
-    signed in-toto subject, and validates the signature. For Ed25519 this is a
-    full asymmetric check using the embedded public key; for HMAC-SHA256 it
-    recomputes the MAC with the shared secret.
-    """
     src = Path(sbom_path)
     result = VerificationResult(sbom_path=str(src))
-
     if not src.is_file():
         result.reason = "sbom_file_not_found"
         return result
-
-    sbom_bytes = src.read_bytes()
+    try:
+        sbom_bytes = src.read_bytes()
+    except OSError:
+        result.reason = "sbom_file_unreadable"
+        return result
     actual_digest = compute_sbom_digest(sbom_bytes)
     result.actual_sha256 = actual_digest
-
     att_path = Path(attestation_path) if attestation_path else Path(str(src) + _ATTESTATION_SUFFIX)
     if not att_path.is_file():
         result.reason = "attestation_not_found"
         return result
-
     try:
-        envelope = json.loads(att_path.read_text(encoding="utf-8"))
-        payload = base64.b64decode(envelope["payload"])
-        statement = json.loads(payload)
-        meta = envelope.get("_agentBom", {})
-        sig_entry = envelope["signatures"][0]
-    except (OSError, ValueError, KeyError, IndexError) as exc:
-        result.reason = f"malformed_attestation: {type(exc).__name__}"
+        if att_path.stat().st_size > _MAX_ENVELOPE_BYTES:
+            result.reason = "attestation_too_large"
+            return result
+        envelope = _load_json_object(att_path.read_bytes())
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError, _DuplicateJsonKeyError):
+        result.reason = "malformed_attestation"
         return result
 
-    result.algorithm = str(meta.get("algorithm", ""))
-    result.cryptographic = bool(meta.get("cryptographic", False))
-    result.key_id = sig_entry.get("keyid") or None
-
-    # Digest binding: recomputed SBOM hash must equal the signed subject digest.
-    expected_digest = ""
-    for subject in statement.get("subject", []):
-        expected_digest = subject.get("digest", {}).get("sha256", "")
-        if expected_digest:
-            break
+    metadata = envelope.get("_agentBom")
+    metadata_map: Mapping[str, Any] = metadata if isinstance(metadata, Mapping) else {}
+    version = metadata_map.get("schemaVersion")
+    if version is None:
+        return _legacy_result(result, envelope, actual_digest=actual_digest, sbom_name=src.name)
+    if version != _DSSE_SCHEMA_VERSION:
+        result.reason = "unsupported_attestation_version"
+        return result
+    if "algorithm" in metadata_map:
+        result.reason = "algorithm_metadata_invalid"
+        return result
+    result.format_version = _DSSE_SCHEMA_VERSION
+    result.algorithm = "Ed25519"
+    result.cryptographic = True
+    if envelope.get("payloadType") != _DSSE_PAYLOAD_TYPE:
+        result.reason = "payload_type_invalid"
+        return result
+    signatures = envelope.get("signatures")
+    if not isinstance(signatures, list) or len(signatures) != 1 or not isinstance(signatures[0], Mapping):
+        result.reason = "ambiguous_signatures"
+        return result
+    signature = signatures[0]
+    if set(signature) != {"keyid", "sig"}:
+        result.reason = "signature_metadata_invalid"
+        return result
+    key_id = signature.get("keyid")
+    if not isinstance(key_id, str) or not _SHA256_RE.fullmatch(key_id):
+        result.reason = "key_id_missing" if not key_id else "key_id_invalid"
+        return result
+    try:
+        payload, statement = _decode_payload(envelope)
+    except OverflowError:
+        result.reason = "attestation_payload_too_large"
+        return result
+    except (binascii.Error, json.JSONDecodeError, UnicodeDecodeError, ValueError, _DuplicateJsonKeyError):
+        result.reason = "malformed_attestation"
+        return result
+    expected_digest = _statement_digest(statement, src.name)
+    if not expected_digest:
+        result.reason = "statement_subject_invalid"
+        return result
     result.expected_sha256 = expected_digest
-    result.digest_matches = bool(expected_digest) and expected_digest == actual_digest
+    result.digest_matches = expected_digest == actual_digest
     result.checks.append("digest_match=" + ("ok" if result.digest_matches else "FAIL"))
 
-    # Signature over the in-toto statement payload.
-    result.signature_valid = _verify_signature(
-        payload,
-        sig_entry.get("sig", ""),
-        result.algorithm,
-        meta.get("publicKeyPem"),
-    )
-    result.checks.append("statement_signature=" + ("ok" if result.signature_valid else "FAIL"))
+    if trust_policy is None:
+        result.reason = "trusted_public_key_required"
+        result.checks.append("signer_trust=missing")
+        return result
+    public_key = trust_policy.resolve(key_id)
+    if public_key is None:
+        result.reason = "untrusted_signer"
+        result.checks.append("signer_trust=untrusted")
+        return result
+    result.key_id = key_id
+    result.trust_status = "trusted"
+    result.signature_valid = _verify_ed25519(public_key, signature.get("sig"), dsse_pae(_DSSE_PAYLOAD_TYPE, payload))
+    result.checks.append("dsse_signature=" + ("ok" if result.signature_valid else "FAIL"))
 
-    # Optional: detached signature over the raw SBOM bytes.
+    detached_ok = True
+    detached_reason = ""
     sig_path = Path(signature_path) if signature_path else Path(str(src) + _SIG_SUFFIX)
     if sig_path.is_file():
-        try:
-            sig_obj = json.loads(sig_path.read_text(encoding="utf-8"))
-            blob_ok = (
-                sig_obj.get("sha256") == actual_digest
-                and _verify_signature(
-                    sbom_bytes,
-                    sig_obj.get("signature", ""),
-                    str(sig_obj.get("algorithm", "")),
-                    sig_obj.get("publicKeyPem"),
-                )
-            )
-        except (OSError, ValueError):
-            blob_ok = False
-        result.checks.append("detached_signature=" + ("ok" if blob_ok else "FAIL"))
-        signature_ok = result.signature_valid and blob_ok
-    else:
-        signature_ok = result.signature_valid
+        detached_ok, detached_reason = _verify_detached(
+            sig_path,
+            sbom_bytes=sbom_bytes,
+            actual_digest=actual_digest,
+            key_id=key_id,
+            public_key=public_key,
+        )
+        result.checks.append("detached_signature=" + ("ok" if detached_ok else "FAIL"))
 
     if not result.digest_matches:
         result.reason = "digest_mismatch"
-    elif not signature_ok:
+    elif not result.signature_valid:
         result.reason = "signature_invalid"
+    elif not detached_ok:
+        result.reason = detached_reason
     else:
         result.verified = True
         result.reason = "verified"
-
     return result

--- a/src/agent_bom/sbom_attestation.py
+++ b/src/agent_bom/sbom_attestation.py
@@ -1,9 +1,10 @@
 """Sign and verify generated SBOMs at an explicit DSSE trust boundary.
 
-New attestations use DSSE pre-authentication encoding (PAE) and Ed25519 only.
-Verification trusts only caller-supplied public keys; envelope metadata and
-embedded legacy keys are evidence, never trust anchors. Older self-consistent
-envelopes remain readable but are always reported as legacy and untrusted.
+New attestations use DSSE pre-authentication encoding (PAE) and Ed25519 signing.
+Verification trusts only caller-supplied Ed25519 keys or an explicitly pinned,
+offline Sigstore identity/issuer policy; envelope metadata and embedded legacy
+keys are evidence, never trust anchors. Older self-consistent envelopes remain
+readable but are always reported as legacy and untrusted.
 """
 
 from __future__ import annotations
@@ -14,11 +15,16 @@ import hashlib
 import json
 import os
 import re
+import secrets
+import sqlite3
 import tempfile
+import threading
+import uuid
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Any, Iterable, Mapping, Protocol
+from urllib.parse import urlparse
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import serialization
@@ -39,8 +45,17 @@ _ATTESTATION_SUFFIX = ".intoto.json"
 _MAX_ENVELOPE_BYTES = 16 * 1024 * 1024
 _MAX_PAYLOAD_BYTES = 12 * 1024 * 1024
 _MAX_SIGNATURE_FILE_BYTES = 64 * 1024
+_MAX_SIGNATURE_BYTES = 16 * 1024
 _MAX_TRUSTED_KEYS = 32
+_MAX_SIGSTORE_BUNDLE_BYTES = 16 * 1024 * 1024
+_MAX_POLICY_TEXT_BYTES = 2048
+_MAX_TENANT_ID_BYTES = 256
+_MAX_MAX_AGE_SECONDS = 30 * 24 * 60 * 60
+_MAX_CLOCK_SKEW_SECONDS = 300
+_DEFAULT_ATTESTATION_TTL_SECONDS = 15 * 60
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+_NONCE_RE = re.compile(r"^[0-9a-f]{32}$")
+_EVIDENCE_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]{15,127}$")
 
 
 class AttestationSigningError(RuntimeError):
@@ -61,23 +76,195 @@ class _TrustedEd25519Key:
     public_key: Ed25519PublicKey
 
 
+class AttestationReplayStore(Protocol):
+    """Consume a signed evidence identity once until its expiry."""
+
+    def consume(
+        self,
+        *,
+        tenant_id: str,
+        evidence_id: str,
+        nonce: str,
+        expires_at: datetime,
+        now: datetime,
+    ) -> str: ...
+
+
+class SigstoreVerificationAdapter(Protocol):
+    """Verify exact bytes against an externally supplied Sigstore bundle."""
+
+    def verify(
+        self,
+        *,
+        signed_bytes: bytes,
+        signature_b64: str,
+        bundle_bytes: bytes,
+        trusted_root_bytes: bytes,
+        identity_regexp: str,
+        issuer: str,
+    ) -> bool: ...
+
+
+class MemoryAttestationReplayStore:
+    """Bounded process-local replay guard for library callers and tests."""
+
+    def __init__(self, *, max_entries: int = 10_000) -> None:
+        if max_entries < 1 or max_entries > 1_000_000:
+            raise AttestationTrustError("replay_store_size_invalid")
+        self._max_entries = max_entries
+        self._entries: dict[tuple[str, str, str], float] = {}
+        self._lock = threading.Lock()
+
+    def consume(
+        self,
+        *,
+        tenant_id: str,
+        evidence_id: str,
+        nonce: str,
+        expires_at: datetime,
+        now: datetime,
+    ) -> str:
+        key = (tenant_id, evidence_id, nonce)
+        now_epoch = now.timestamp()
+        with self._lock:
+            self._entries = {entry: expiry for entry, expiry in self._entries.items() if expiry > now_epoch}
+            if key in self._entries:
+                return "replay"
+            if len(self._entries) >= self._max_entries:
+                return "full"
+            self._entries[key] = expires_at.timestamp()
+        return "accepted"
+
+
+class SQLiteAttestationReplayStore:
+    """SQLite-backed replay guard shared safely across CLI processes."""
+
+    def __init__(self, path: str | Path, *, max_entries: int = 100_000) -> None:
+        if max_entries < 1 or max_entries > 1_000_000:
+            raise AttestationTrustError("replay_store_size_invalid")
+        self._path = Path(path)
+        self._max_entries = max_entries
+
+    def consume(
+        self,
+        *,
+        tenant_id: str,
+        evidence_id: str,
+        nonce: str,
+        expires_at: datetime,
+        now: datetime,
+    ) -> str:
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            with sqlite3.connect(self._path, timeout=5) as connection:
+                connection.execute(
+                    "CREATE TABLE IF NOT EXISTS attestation_replay ("
+                    "tenant_id TEXT NOT NULL, evidence_id TEXT NOT NULL, nonce TEXT NOT NULL, "
+                    "expires_at REAL NOT NULL, PRIMARY KEY (tenant_id, evidence_id, nonce))"
+                )
+                connection.execute("BEGIN IMMEDIATE")
+                connection.execute("DELETE FROM attestation_replay WHERE expires_at <= ?", (now.timestamp(),))
+                existing = connection.execute(
+                    "SELECT 1 FROM attestation_replay WHERE tenant_id = ? AND evidence_id = ? AND nonce = ?",
+                    (tenant_id, evidence_id, nonce),
+                ).fetchone()
+                if existing is not None:
+                    connection.rollback()
+                    return "replay"
+                count = int(connection.execute("SELECT COUNT(*) FROM attestation_replay").fetchone()[0])
+                if count >= self._max_entries:
+                    connection.rollback()
+                    return "full"
+                connection.execute(
+                    "INSERT INTO attestation_replay (tenant_id, evidence_id, nonce, expires_at) VALUES (?, ?, ?, ?)",
+                    (tenant_id, evidence_id, nonce, expires_at.timestamp()),
+                )
+                connection.commit()
+            return "accepted"
+        except sqlite3.Error:
+            return "unavailable"
+
+
+def _validate_policy_text(value: str, field_name: str, max_bytes: int) -> None:
+    if (
+        not isinstance(value, str)
+        or not value
+        or value.strip() != value
+        or len(value.encode("utf-8")) > max_bytes
+        or not all(char.isprintable() for char in value)
+    ):
+        raise AttestationTrustError(f"{field_name}_required" if not value else f"{field_name}_invalid")
+
+
 @dataclass(frozen=True, slots=True)
 class AttestationTrustPolicy:
-    """Bounded immutable set of verifier-configured Ed25519 trust anchors."""
+    """Bounded verifier policy for signer, semantic, freshness, and replay trust."""
 
     keys: tuple[_TrustedEd25519Key, ...]
+    expected_tenant_id: str
+    expected_builder_id: str = _BUILDER_ID
+    expected_predicate_type: str = _PREDICATE_TYPE
+    max_age_seconds: int = 60 * 60
+    clock_skew_seconds: int = 60
+    replay_store: AttestationReplayStore = field(default_factory=MemoryAttestationReplayStore)
+    sigstore_identity_regexp: str | None = None
+    sigstore_issuer: str | None = None
+    sigstore_trusted_root: bytes | None = None
+    sigstore_trusted_root_sha256: str | None = None
 
     def __post_init__(self) -> None:
-        if not self.keys:
-            raise AttestationTrustError("trusted_public_key_required")
+        _validate_policy_text(self.expected_tenant_id, "expected_tenant_id", _MAX_TENANT_ID_BYTES)
+        _validate_policy_text(self.expected_builder_id, "expected_builder_id", _MAX_POLICY_TEXT_BYTES)
+        _validate_policy_text(self.expected_predicate_type, "expected_predicate_type", _MAX_POLICY_TEXT_BYTES)
+        if not 1 <= self.max_age_seconds <= _MAX_MAX_AGE_SECONDS:
+            raise AttestationTrustError("max_age_seconds_invalid")
+        if not 0 <= self.clock_skew_seconds <= _MAX_CLOCK_SKEW_SECONDS:
+            raise AttestationTrustError("clock_skew_seconds_invalid")
         if len(self.keys) > _MAX_TRUSTED_KEYS:
             raise AttestationTrustError("too_many_trusted_public_keys")
         key_ids = [key.key_id for key in self.keys]
         if len(key_ids) != len(set(key_ids)):
             raise AttestationTrustError("ambiguous_trusted_key_id")
+        sigstore_configured = any(
+            value is not None
+            for value in (
+                self.sigstore_identity_regexp,
+                self.sigstore_issuer,
+                self.sigstore_trusted_root,
+                self.sigstore_trusted_root_sha256,
+            )
+        )
+        if self.keys and sigstore_configured:
+            raise AttestationTrustError("ambiguous_signer_policy")
+        if not self.keys and not sigstore_configured:
+            raise AttestationTrustError("trusted_public_key_required")
+        if sigstore_configured:
+            identity = self.sigstore_identity_regexp or ""
+            issuer = self.sigstore_issuer or ""
+            _validate_policy_text(identity, "sigstore_identity", _MAX_POLICY_TEXT_BYTES)
+            _validate_policy_text(issuer, "sigstore_issuer", _MAX_POLICY_TEXT_BYTES)
+            try:
+                re.compile(identity)
+            except re.error:
+                raise AttestationTrustError("sigstore_identity_invalid") from None
+            parsed = urlparse(issuer)
+            if parsed.scheme != "https" or not parsed.netloc or parsed.username or parsed.password or parsed.query or parsed.fragment:
+                raise AttestationTrustError("sigstore_issuer_invalid")
+            if self.sigstore_trusted_root is None or not _SHA256_RE.fullmatch(self.sigstore_trusted_root_sha256 or ""):
+                raise AttestationTrustError("sigstore_trusted_root_required")
 
     @classmethod
-    def from_public_key_pems(cls, public_key_pems: Iterable[str]) -> AttestationTrustPolicy:
+    def from_public_key_pems(
+        cls,
+        public_key_pems: Iterable[str],
+        *,
+        expected_tenant_id: str,
+        expected_builder_id: str = _BUILDER_ID,
+        expected_predicate_type: str = _PREDICATE_TYPE,
+        max_age_seconds: int = 60 * 60,
+        clock_skew_seconds: int = 60,
+        replay_store: AttestationReplayStore | None = None,
+    ) -> AttestationTrustPolicy:
         by_id: dict[str, _TrustedEd25519Key] = {}
         for pem in public_key_pems:
             try:
@@ -93,11 +280,70 @@ class AttestationTrustPolicy:
             by_id[key_id] = _TrustedEd25519Key(key_id=key_id, public_key=loaded)
             if len(by_id) > _MAX_TRUSTED_KEYS:
                 raise AttestationTrustError("too_many_trusted_public_keys")
-        return cls(keys=tuple(by_id[key_id] for key_id in sorted(by_id)))
+        return cls(
+            keys=tuple(by_id[key_id] for key_id in sorted(by_id)),
+            expected_tenant_id=expected_tenant_id,
+            expected_builder_id=expected_builder_id,
+            expected_predicate_type=expected_predicate_type,
+            max_age_seconds=max_age_seconds,
+            clock_skew_seconds=clock_skew_seconds,
+            replay_store=replay_store or MemoryAttestationReplayStore(),
+        )
+
+    @classmethod
+    def from_sigstore(
+        cls,
+        *,
+        expected_identity_regexp: str,
+        expected_issuer: str,
+        trusted_root_path: str | Path,
+        expected_tenant_id: str,
+        expected_builder_id: str = _BUILDER_ID,
+        expected_predicate_type: str = _PREDICATE_TYPE,
+        max_age_seconds: int = 60 * 60,
+        clock_skew_seconds: int = 60,
+        replay_store: AttestationReplayStore | None = None,
+    ) -> AttestationTrustPolicy:
+        trusted_root = Path(trusted_root_path)
+        try:
+            if not trusted_root.is_file() or trusted_root.stat().st_size > _MAX_SIGSTORE_BUNDLE_BYTES:
+                raise AttestationTrustError("sigstore_trusted_root_invalid")
+            trusted_root_bytes = trusted_root.read_bytes()
+            _load_json_object(trusted_root_bytes)
+        except AttestationTrustError:
+            raise
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError, _DuplicateJsonKeyError):
+            raise AttestationTrustError("sigstore_trusted_root_invalid") from None
+        return cls(
+            keys=(),
+            expected_tenant_id=expected_tenant_id,
+            expected_builder_id=expected_builder_id,
+            expected_predicate_type=expected_predicate_type,
+            max_age_seconds=max_age_seconds,
+            clock_skew_seconds=clock_skew_seconds,
+            replay_store=replay_store or MemoryAttestationReplayStore(),
+            sigstore_identity_regexp=expected_identity_regexp,
+            sigstore_issuer=expected_issuer,
+            sigstore_trusted_root=trusted_root_bytes,
+            sigstore_trusted_root_sha256=hashlib.sha256(trusted_root_bytes).hexdigest(),
+        )
 
     def resolve(self, key_id: str) -> Ed25519PublicKey | None:
         matches = [key.public_key for key in self.keys if key.key_id == key_id]
         return matches[0] if len(matches) == 1 else None
+
+    @property
+    def signer_mode(self) -> str:
+        return "sigstore" if self.sigstore_identity_regexp is not None else "ed25519"
+
+    @property
+    def sigstore_key_id(self) -> str | None:
+        if self.signer_mode != "sigstore":
+            return None
+        identity = self.sigstore_identity_regexp or ""
+        issuer = self.sigstore_issuer or ""
+        root_digest = self.sigstore_trusted_root_sha256 or ""
+        return hashlib.sha256(f"sigstore\0{identity}\0{issuer}\0{root_digest}".encode()).hexdigest()
 
 
 @dataclass(frozen=True)
@@ -132,6 +378,10 @@ class VerificationResult:
     format_version: str = ""
     legacy: bool = False
     trust_status: str = "untrusted"
+    tenant_id: str = ""
+    evidence_id: str = ""
+    issued_at: str = ""
+    expires_at: str = ""
 
 
 def _canonical_bytes(obj: Mapping[str, Any]) -> bytes:
@@ -163,10 +413,26 @@ def build_intoto_statement(
     sbom_bytes: bytes,
     *,
     sbom_format: str | None = None,
+    tenant_id: str = "local",
+    issued_at: datetime | None = None,
+    ttl_seconds: int = _DEFAULT_ATTESTATION_TTL_SECONDS,
+    nonce: str | None = None,
+    evidence_id: str | None = None,
 ) -> dict[str, Any]:
+    _validate_signed_metadata(
+        tenant_id=tenant_id,
+        ttl_seconds=ttl_seconds,
+        nonce=nonce,
+        evidence_id=evidence_id,
+        issued_at=issued_at,
+    )
     name = Path(sbom_path).name
     digest = compute_sbom_digest(sbom_bytes)
-    now = datetime.now(timezone.utc).isoformat()
+    issued = _normalize_datetime(issued_at or datetime.now(timezone.utc))
+    expires = issued + timedelta(seconds=ttl_seconds)
+    nonce_value = nonce or secrets.token_hex(16)
+    evidence_value = evidence_id or str(uuid.uuid4())
+    now = issued.isoformat()
     return {
         "_type": _STATEMENT_TYPE,
         "subject": [{"name": name, "digest": {"sha256": digest}}],
@@ -180,8 +446,43 @@ def build_intoto_statement(
                 "builder": {"id": _BUILDER_ID, "version": {"agent-bom": __version__}},
                 "metadata": {"startedOn": now, "finishedOn": now},
             },
+            "agentBom": {
+                "tenantId": tenant_id,
+                "issuedAt": now,
+                "expiresAt": expires.isoformat(),
+                "nonce": nonce_value,
+                "evidenceId": evidence_value,
+            },
         },
     }
+
+
+def _normalize_datetime(value: datetime) -> datetime:
+    if value.tzinfo is None or value.utcoffset() is None:
+        raise AttestationSigningError("issued_at_timezone_required")
+    return value.astimezone(timezone.utc)
+
+
+def _validate_signed_metadata(
+    *,
+    tenant_id: str,
+    ttl_seconds: int,
+    nonce: str | None,
+    evidence_id: str | None,
+    issued_at: datetime | None,
+) -> None:
+    try:
+        _validate_policy_text(tenant_id, "tenant_id", _MAX_TENANT_ID_BYTES)
+    except AttestationTrustError as exc:
+        raise AttestationSigningError(str(exc)) from None
+    if not 1 <= ttl_seconds <= _MAX_MAX_AGE_SECONDS:
+        raise AttestationSigningError("attestation_ttl_invalid")
+    if nonce is not None and not _NONCE_RE.fullmatch(nonce):
+        raise AttestationSigningError("attestation_nonce_invalid")
+    if evidence_id is not None and not _EVIDENCE_ID_RE.fullmatch(evidence_id):
+        raise AttestationSigningError("attestation_evidence_id_invalid")
+    if issued_at is not None:
+        _normalize_datetime(issued_at)
 
 
 def _public_der(public_key: Ed25519PublicKey) -> bytes:
@@ -237,6 +538,11 @@ def sign_sbom_file(
     signature_path: str | Path | None = None,
     attestation_path: str | Path | None = None,
     sbom_format: str | None = None,
+    tenant_id: str = "local",
+    issued_at: datetime | None = None,
+    ttl_seconds: int = _DEFAULT_ATTESTATION_TTL_SECONDS,
+    nonce: str | None = None,
+    evidence_id: str | None = None,
 ) -> AttestationResult:
     """Write an Ed25519 detached signature and DSSE-PAE attestation."""
 
@@ -258,7 +564,16 @@ def sign_sbom_file(
     if sig_out.resolve() == att_out.resolve():
         raise AttestationSigningError("signature_and_attestation_paths_must_differ")
 
-    statement = build_intoto_statement(src, sbom_bytes, sbom_format=sbom_format)
+    statement = build_intoto_statement(
+        src,
+        sbom_bytes,
+        sbom_format=sbom_format,
+        tenant_id=tenant_id,
+        issued_at=issued_at,
+        ttl_seconds=ttl_seconds,
+        nonce=nonce,
+        evidence_id=evidence_id,
+    )
     payload = _canonical_bytes(statement)
     if len(payload) > _MAX_PAYLOAD_BYTES:
         raise AttestationSigningError("attestation_payload_too_large")
@@ -330,7 +645,7 @@ def _decode_payload(envelope: Mapping[str, Any]) -> tuple[bytes, dict[str, Any]]
 
 
 def _statement_digest(statement: Mapping[str, Any], expected_name: str) -> str:
-    if statement.get("_type") != _STATEMENT_TYPE or statement.get("predicateType") != _PREDICATE_TYPE:
+    if statement.get("_type") != _STATEMENT_TYPE:
         return ""
     subjects = statement.get("subject")
     if not isinstance(subjects, list) or len(subjects) != 1 or not isinstance(subjects[0], Mapping):
@@ -340,6 +655,70 @@ def _statement_digest(statement: Mapping[str, Any], expected_name: str) -> str:
         return ""
     digest = subject["digest"].get("sha256")
     return str(digest) if isinstance(digest, str) and _SHA256_RE.fullmatch(digest) else ""
+
+
+def _parse_signed_datetime(value: Any) -> datetime | None:
+    if not isinstance(value, str) or len(value) > 64:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return None
+    return parsed.astimezone(timezone.utc)
+
+
+def _semantic_policy_result(
+    statement: Mapping[str, Any],
+    policy: AttestationTrustPolicy,
+    *,
+    now: datetime,
+) -> tuple[str, dict[str, str], datetime | None]:
+    if statement.get("predicateType") != policy.expected_predicate_type:
+        return "predicate_type_mismatch", {}, None
+    predicate = statement.get("predicate")
+    if not isinstance(predicate, Mapping):
+        return "attestation_policy_metadata_invalid", {}, None
+    run_details = predicate.get("runDetails")
+    builder = run_details.get("builder") if isinstance(run_details, Mapping) else None
+    if not isinstance(builder, Mapping) or builder.get("id") != policy.expected_builder_id:
+        return "builder_mismatch", {}, None
+    agent_bom = predicate.get("agentBom")
+    if not isinstance(agent_bom, Mapping):
+        return "attestation_policy_metadata_invalid", {}, None
+    tenant_id = agent_bom.get("tenantId")
+    nonce = agent_bom.get("nonce")
+    evidence_id = agent_bom.get("evidenceId")
+    if tenant_id != policy.expected_tenant_id:
+        return "tenant_mismatch", {}, None
+    if not isinstance(nonce, str) or not _NONCE_RE.fullmatch(nonce):
+        return "attestation_nonce_invalid", {}, None
+    if not isinstance(evidence_id, str) or not _EVIDENCE_ID_RE.fullmatch(evidence_id):
+        return "attestation_evidence_id_invalid", {}, None
+    issued_at = _parse_signed_datetime(agent_bom.get("issuedAt"))
+    expires_at = _parse_signed_datetime(agent_bom.get("expiresAt"))
+    if issued_at is None or expires_at is None or expires_at <= issued_at:
+        return "attestation_time_invalid", {}, None
+    current = now.astimezone(timezone.utc)
+    skew = timedelta(seconds=policy.clock_skew_seconds)
+    if issued_at > current + skew:
+        return "issued_in_future", {}, None
+    if current > expires_at + skew:
+        return "attestation_expired", {}, None
+    if (current - issued_at).total_seconds() > policy.max_age_seconds:
+        return "attestation_max_age_exceeded", {}, None
+    return (
+        "",
+        {
+            "tenant_id": tenant_id,
+            "nonce": nonce,
+            "evidence_id": evidence_id,
+            "issued_at": issued_at.isoformat(),
+            "expires_at": expires_at.isoformat(),
+        },
+        expires_at,
+    )
 
 
 def _verify_ed25519(public_key: Ed25519PublicKey, signature_b64: Any, signed: bytes) -> bool:
@@ -411,6 +790,9 @@ def verify_sbom_attestation(
     attestation_path: str | Path | None = None,
     signature_path: str | Path | None = None,
     trust_policy: AttestationTrustPolicy | None = None,
+    sigstore_bundle_path: str | Path | None = None,
+    sigstore_verifier: SigstoreVerificationAdapter | None = None,
+    now: datetime | None = None,
 ) -> VerificationResult:
     """Verify a versioned DSSE envelope only against external caller trust."""
 
@@ -451,7 +833,6 @@ def verify_sbom_attestation(
         result.reason = "algorithm_metadata_invalid"
         return result
     result.format_version = _DSSE_SCHEMA_VERSION
-    result.algorithm = "Ed25519"
     result.cryptographic = True
     if envelope.get("payloadType") != _DSSE_PAYLOAD_TYPE:
         result.reason = "payload_type_invalid"
@@ -488,20 +869,93 @@ def verify_sbom_attestation(
         result.reason = "trusted_public_key_required"
         result.checks.append("signer_trust=missing")
         return result
-    public_key = trust_policy.resolve(key_id)
-    if public_key is None:
-        result.reason = "untrusted_signer"
-        result.checks.append("signer_trust=untrusted")
-        return result
+    signed_pae = dsse_pae(_DSSE_PAYLOAD_TYPE, payload)
+    public_key: Ed25519PublicKey | None = None
+    if trust_policy.signer_mode == "ed25519":
+        result.algorithm = "Ed25519"
+        public_key = trust_policy.resolve(key_id)
+        if public_key is None:
+            result.reason = "untrusted_signer"
+            result.checks.append("signer_trust=untrusted")
+            return result
+        result.signature_valid = _verify_ed25519(public_key, signature.get("sig"), signed_pae)
+    else:
+        result.algorithm = "Sigstore"
+        if sigstore_bundle_path is None:
+            result.reason = "sigstore_bundle_required"
+            return result
+        if sigstore_verifier is None:
+            result.reason = "sigstore_verifier_required"
+            return result
+        if key_id != trust_policy.sigstore_key_id:
+            result.reason = "untrusted_signer"
+            result.checks.append("signer_trust=untrusted")
+            return result
+        signature_b64 = signature.get("sig")
+        try:
+            signature_bytes = base64.b64decode(signature_b64, validate=True) if isinstance(signature_b64, str) else b""
+        except (binascii.Error, ValueError):
+            signature_bytes = b""
+        if not signature_bytes or len(signature_bytes) > _MAX_SIGNATURE_BYTES:
+            result.reason = "signature_invalid"
+            return result
+        assert isinstance(signature_b64, str)
+        identity = trust_policy.sigstore_identity_regexp or ""
+        issuer = trust_policy.sigstore_issuer or ""
+        trusted_root_bytes = trust_policy.sigstore_trusted_root
+        if trusted_root_bytes is None:
+            result.reason = "sigstore_trusted_root_required"
+            return result
+        bundle_path = Path(sigstore_bundle_path)
+        try:
+            if not bundle_path.is_file() or bundle_path.stat().st_size > _MAX_SIGSTORE_BUNDLE_BYTES:
+                result.reason = "sigstore_bundle_invalid"
+                return result
+            bundle_bytes = bundle_path.read_bytes()
+            bundle = _load_json_object(bundle_bytes)
+            message_signature = bundle.get("messageSignature")
+            if not isinstance(message_signature, Mapping) or message_signature.get("signature") != signature_b64:
+                result.reason = "sigstore_bundle_signature_mismatch"
+                return result
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError, ValueError, _DuplicateJsonKeyError):
+            result.reason = "sigstore_bundle_invalid"
+            return result
+        result.signature_valid = sigstore_verifier.verify(
+            signed_bytes=signed_pae,
+            signature_b64=signature_b64,
+            bundle_bytes=bundle_bytes,
+            trusted_root_bytes=trusted_root_bytes,
+            identity_regexp=identity,
+            issuer=issuer,
+        )
     result.key_id = key_id
     result.trust_status = "trusted"
-    result.signature_valid = _verify_ed25519(public_key, signature.get("sig"), dsse_pae(_DSSE_PAYLOAD_TYPE, payload))
     result.checks.append("dsse_signature=" + ("ok" if result.signature_valid else "FAIL"))
+
+    if not result.signature_valid:
+        result.reason = "signature_invalid"
+        return result
+
+    try:
+        current = _normalize_datetime(now or datetime.now(timezone.utc))
+    except AttestationSigningError:
+        result.reason = "verification_time_invalid"
+        return result
+    policy_reason, signed_metadata, expires_at = _semantic_policy_result(statement, trust_policy, now=current)
+    if policy_reason:
+        result.reason = policy_reason
+        result.checks.append("semantic_policy=FAIL")
+        return result
+    result.tenant_id = signed_metadata["tenant_id"]
+    result.evidence_id = signed_metadata["evidence_id"]
+    result.issued_at = signed_metadata["issued_at"]
+    result.expires_at = signed_metadata["expires_at"]
+    result.checks.append("semantic_policy=ok")
 
     detached_ok = True
     detached_reason = ""
     sig_path = Path(signature_path) if signature_path else Path(str(src) + _SIG_SUFFIX)
-    if sig_path.is_file():
+    if trust_policy.signer_mode == "ed25519" and sig_path.is_file() and public_key is not None:
         detached_ok, detached_reason = _verify_detached(
             sig_path,
             sbom_bytes=sbom_bytes,
@@ -513,11 +967,26 @@ def verify_sbom_attestation(
 
     if not result.digest_matches:
         result.reason = "digest_mismatch"
-    elif not result.signature_valid:
-        result.reason = "signature_invalid"
     elif not detached_ok:
         result.reason = detached_reason
     else:
-        result.verified = True
-        result.reason = "verified"
+        assert expires_at is not None
+        replay_status = trust_policy.replay_store.consume(
+            tenant_id=result.tenant_id,
+            evidence_id=result.evidence_id,
+            nonce=signed_metadata["nonce"],
+            expires_at=expires_at + timedelta(seconds=trust_policy.clock_skew_seconds),
+            now=current,
+        )
+        if replay_status == "accepted":
+            result.verified = True
+            result.reason = "verified"
+            result.checks.append("replay_guard=accepted")
+        else:
+            result.reason = {
+                "replay": "attestation_replay_detected",
+                "full": "replay_store_full",
+                "unavailable": "replay_store_unavailable",
+            }.get(replay_status, "replay_store_unavailable")
+            result.checks.append("replay_guard=rejected")
     return result

--- a/tests/test_sbom_attestation.py
+++ b/tests/test_sbom_attestation.py
@@ -1,19 +1,15 @@
-"""Tests for signing + attesting generated SBOM output.
-
-Verifies the supply-chain-integrity loop for emitted SBOMs:
-- ``sign_sbom_file`` writes a detached signature and an in-toto attestation
-- a clean SBOM verifies
-- a tampered SBOM fails verification (digest binding is real)
-- Ed25519 mode is genuinely asymmetric: a third party verifies with only the
-  embedded public key
-- the ``attest`` CLI group round-trips
-"""
+"""Trusted DSSE verification boundary for generated SBOM attestations."""
 
 from __future__ import annotations
 
 import base64
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
+import pytest
 from click.testing import CliRunner
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -21,137 +17,353 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from agent_bom.cli._attest_group import attest_group
 from agent_bom.sbom_attestation import (
     _ATTESTATION_SUFFIX,
+    _DSSE_PAYLOAD_TYPE,
+    _DSSE_SCHEMA_VERSION,
     _SIG_SUFFIX,
+    AttestationSigningError,
+    AttestationTrustPolicy,
+    dsse_pae,
     sign_sbom_file,
     verify_sbom_attestation,
 )
 
 
-def _write_sbom(tmp_path) -> str:
+def _write_sbom(tmp_path: Path) -> Path:
     sbom = tmp_path / "report.cdx.json"
     sbom.write_text(json.dumps({"bomFormat": "CycloneDX", "specVersion": "1.6", "components": []}), encoding="utf-8")
-    return str(sbom)
+    return sbom
 
 
-def test_sign_emits_signature_and_attestation(tmp_path):
-    path = _write_sbom(tmp_path)
-    result = sign_sbom_file(path)
-
-    assert result.signature_path.endswith(_SIG_SUFFIX)
-    assert result.attestation_path.endswith(_ATTESTATION_SUFFIX)
-
-    # in-toto Statement v1 with the SBOM digest bound in the subject.
-    envelope = json.loads((tmp_path / ("report.cdx.json" + _ATTESTATION_SUFFIX)).read_text())
-    statement = json.loads(base64.b64decode(envelope["payload"]))
-    assert statement["_type"] == "https://in-toto.io/Statement/v1"
-    assert statement["subject"][0]["digest"]["sha256"] == result.sha256
-    assert statement["predicateType"] == "https://slsa.dev/provenance/v1"
-    assert envelope["signatures"][0]["sig"]
-
-
-def test_clean_sbom_verifies(tmp_path):
-    path = _write_sbom(tmp_path)
-    sign_sbom_file(path)
-
-    result = verify_sbom_attestation(path)
-    assert result.verified is True
-    assert result.digest_matches is True
-    assert result.signature_valid is True
-    assert result.reason == "verified"
-
-
-def test_tampered_sbom_fails_verification(tmp_path):
-    path = _write_sbom(tmp_path)
-    sign_sbom_file(path)
-
-    # Mutate the SBOM after signing.
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write("\n")
-
-    result = verify_sbom_attestation(path)
-    assert result.verified is False
-    assert result.digest_matches is False
-    assert result.reason == "digest_mismatch"
-
-
-def test_tampered_attestation_signature_fails(tmp_path):
-    path = _write_sbom(tmp_path)
-    sign_sbom_file(path)
-
-    att_path = tmp_path / ("report.cdx.json" + _ATTESTATION_SUFFIX)
-    envelope = json.loads(att_path.read_text())
-    # Flip the signature so the digest still matches but the sig does not.
-    envelope["signatures"][0]["sig"] = "00" * 32
-    att_path.write_text(json.dumps(envelope))
-
-    result = verify_sbom_attestation(path)
-    assert result.verified is False
-    assert result.signature_valid is False
-    assert result.reason == "signature_invalid"
-
-
-def test_ed25519_is_asymmetric_third_party_verifiable(tmp_path, monkeypatch):
-    from agent_bom.api import compliance_signing
-
+def _key_material() -> tuple[Ed25519PrivateKey, str, str]:
     key = Ed25519PrivateKey.generate()
-    pem = key.private_bytes(
+    private_pem = key.private_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode()
-    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", pem)
+    public_pem = key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+    return key, private_pem, public_pem
+
+
+@pytest.fixture
+def signing_key(monkeypatch) -> tuple[Ed25519PrivateKey, str, str]:
+    from agent_bom.api import compliance_signing
+
+    material = _key_material()
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", material[1])
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE", raising=False)
     compliance_signing.reset_signer_cache_for_tests()
-    try:
-        path = _write_sbom(tmp_path)
-        signed = sign_sbom_file(path)
-        assert signed.algorithm == "Ed25519"
-        assert signed.cryptographic is True
-        assert signed.public_key_pem
-
-        # Verification succeeds using only the embedded public key.
-        result = verify_sbom_attestation(path)
-        assert result.verified is True
-        assert result.cryptographic is True
-
-        # Independently verify the in-toto payload with the public key alone.
-        envelope = json.loads((tmp_path / ("report.cdx.json" + _ATTESTATION_SUFFIX)).read_text())
-        payload = base64.b64decode(envelope["payload"])
-        sig = bytes.fromhex(envelope["signatures"][0]["sig"])
-        pub = serialization.load_pem_public_key(signed.public_key_pem.encode())
-        pub.verify(sig, payload)  # raises on failure
-    finally:
-        compliance_signing.reset_signer_cache_for_tests()
+    yield material
+    compliance_signing.reset_signer_cache_for_tests()
 
 
-def test_missing_attestation_reports_reason(tmp_path):
+def _policy(public_pem: str) -> AttestationTrustPolicy:
+    return AttestationTrustPolicy.from_public_key_pems([public_pem])
+
+
+def test_dsse_pae_matches_the_specification_encoding() -> None:
+    assert dsse_pae("text/plain", b"hello") == b"DSSEv1 10 text/plain 5 hello"
+
+
+def test_sign_emits_versioned_dsse_without_embedded_trust_material(tmp_path: Path, signing_key) -> None:
+    path = _write_sbom(tmp_path)
+
+    result = sign_sbom_file(path)
+
+    assert result.algorithm == "Ed25519"
+    assert result.cryptographic is True
+    assert result.signature_path.endswith(_SIG_SUFFIX)
+    assert result.attestation_path.endswith(_ATTESTATION_SUFFIX)
+    envelope = json.loads(Path(result.attestation_path).read_text())
+    assert envelope["payloadType"] == _DSSE_PAYLOAD_TYPE
+    assert envelope["_agentBom"] == {"schemaVersion": _DSSE_SCHEMA_VERSION}
+    assert "publicKeyPem" not in json.dumps(envelope)
+    assert len(envelope["signatures"]) == 1
+    assert len(base64.b64decode(envelope["signatures"][0]["sig"], validate=True)) == 64
+    statement = json.loads(base64.b64decode(envelope["payload"], validate=True))
+    assert statement["_type"] == "https://in-toto.io/Statement/v1"
+    assert statement["subject"] == [{"name": path.name, "digest": {"sha256": result.sha256}}]
+    signing_key[0].public_key().verify(
+        base64.b64decode(envelope["signatures"][0]["sig"], validate=True),
+        dsse_pae(envelope["payloadType"], base64.b64decode(envelope["payload"], validate=True)),
+    )
+
+
+def test_missing_or_malformed_signer_never_falls_back_to_hmac(tmp_path: Path, monkeypatch) -> None:
+    from agent_bom.api import compliance_signing
+
+    path = _write_sbom(tmp_path)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", raising=False)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE", raising=False)
+    compliance_signing.reset_signer_cache_for_tests()
+
+    with pytest.raises(AttestationSigningError, match="ed25519_signing_key_required"):
+        sign_sbom_file(path)
+    assert not Path(str(path) + _SIG_SUFFIX).exists()
+    assert not Path(str(path) + _ATTESTATION_SUFFIX).exists()
+
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", "not a private key")
+    compliance_signing.reset_signer_cache_for_tests()
+    with pytest.raises(AttestationSigningError, match="ed25519_signing_key_invalid"):
+        sign_sbom_file(path)
+    assert not Path(str(path) + _SIG_SUFFIX).exists()
+    assert not Path(str(path) + _ATTESTATION_SUFFIX).exists()
+
+
+def test_clean_dsse_requires_external_trust_and_then_verifies(tmp_path: Path, signing_key) -> None:
+    path = _write_sbom(tmp_path)
+    signed = sign_sbom_file(path)
+
+    untrusted = verify_sbom_attestation(path)
+    assert untrusted.verified is False
+    assert untrusted.digest_matches is True
+    assert untrusted.signature_valid is False
+    assert untrusted.reason == "trusted_public_key_required"
+    assert untrusted.trust_status == "untrusted"
+
+    trusted = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+    assert trusted.verified is True
+    assert trusted.digest_matches is True
+    assert trusted.signature_valid is True
+    assert trusted.reason == "verified"
+    assert trusted.trust_status == "trusted"
+    assert trusted.key_id == signed.key_id
+
+
+def test_embedded_attacker_key_is_never_a_trust_anchor(tmp_path: Path, signing_key) -> None:
+    path = _write_sbom(tmp_path)
+    sign_sbom_file(path)
+    envelope_path = Path(str(path) + _ATTESTATION_SUFFIX)
+    envelope = json.loads(envelope_path.read_text())
+    envelope["_agentBom"]["publicKeyPem"] = signing_key[2]
+    envelope_path.write_text(json.dumps(envelope))
+    _other_key, _other_private, other_public = _key_material()
+
+    result = verify_sbom_attestation(path, trust_policy=_policy(other_public))
+
+    assert result.verified is False
+    assert result.signature_valid is False
+    assert result.reason == "untrusted_signer"
+    assert result.key_id is None
+
+
+def test_payload_type_tamper_is_rejected_before_signature_verification(tmp_path: Path, signing_key) -> None:
+    path = _write_sbom(tmp_path)
+    sign_sbom_file(path)
+    envelope_path = Path(str(path) + _ATTESTATION_SUFFIX)
+    envelope = json.loads(envelope_path.read_text())
+    envelope["payloadType"] = "application/attacker-controlled"
+    envelope_path.write_text(json.dumps(envelope))
+
+    result = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+
+    assert result.verified is False
+    assert result.signature_valid is False
+    assert result.reason == "payload_type_invalid"
+
+
+@pytest.mark.parametrize(
+    ("target", "reason"),
+    [
+        ("envelope", "algorithm_metadata_invalid"),
+        ("signature", "signature_metadata_invalid"),
+    ],
+)
+def test_algorithm_metadata_cannot_select_a_different_verifier(tmp_path: Path, signing_key, target: str, reason: str) -> None:
+    path = _write_sbom(tmp_path)
+    sign_sbom_file(path)
+    envelope_path = Path(str(path) + _ATTESTATION_SUFFIX)
+    envelope = json.loads(envelope_path.read_text())
+    if target == "envelope":
+        envelope["_agentBom"]["algorithm"] = "HMAC-SHA256"
+    else:
+        envelope["signatures"][0]["algorithm"] = "HMAC-SHA256"
+    envelope_path.write_text(json.dumps(envelope))
+
+    result = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+
+    assert result.verified is False
+    assert result.signature_valid is False
+    assert result.reason == reason
+
+
+@pytest.mark.parametrize(
+    ("mutate", "reason"),
+    [
+        (lambda envelope: envelope["signatures"].append(dict(envelope["signatures"][0])), "ambiguous_signatures"),
+        (lambda envelope: envelope["signatures"][0].update({"keyid": ""}), "key_id_missing"),
+        (lambda envelope: envelope["signatures"][0].update({"keyid": "f" * 64}), "untrusted_signer"),
+    ],
+)
+def test_signature_and_key_id_ambiguity_fail_closed(tmp_path: Path, signing_key, mutate, reason: str) -> None:
+    path = _write_sbom(tmp_path)
+    sign_sbom_file(path)
+    envelope_path = Path(str(path) + _ATTESTATION_SUFFIX)
+    envelope = json.loads(envelope_path.read_text())
+    mutate(envelope)
+    envelope_path.write_text(json.dumps(envelope))
+
+    result = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+
+    assert result.verified is False
+    assert result.signature_valid is False
+    assert result.reason == reason
+
+
+def test_detached_key_id_must_match_the_dsse_signer(tmp_path: Path, signing_key) -> None:
+    path = _write_sbom(tmp_path)
+    sign_sbom_file(path)
+    signature_path = Path(str(path) + _SIG_SUFFIX)
+    detached = json.loads(signature_path.read_text())
+    detached["keyId"] = "f" * 64
+    signature_path.write_text(json.dumps(detached))
+
+    result = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+
+    assert result.verified is False
+    assert result.signature_valid is True
+    assert result.reason == "detached_key_id_mismatch"
+
+
+def test_tampered_sbom_and_dsse_signature_fail_independently(tmp_path: Path, signing_key) -> None:
+    path = _write_sbom(tmp_path)
+    sign_sbom_file(path)
+    path.write_text(path.read_text() + "\n")
+
+    digest_failure = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+    assert digest_failure.digest_matches is False
+    assert digest_failure.signature_valid is True
+    assert digest_failure.reason == "digest_mismatch"
+
+    path = _write_sbom(tmp_path)
+    sign_sbom_file(path)
+    envelope_path = Path(str(path) + _ATTESTATION_SUFFIX)
+    envelope = json.loads(envelope_path.read_text())
+    envelope["signatures"][0]["sig"] = base64.b64encode(b"\0" * 64).decode()
+    envelope_path.write_text(json.dumps(envelope))
+    signature_failure = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+    assert signature_failure.digest_matches is True
+    assert signature_failure.signature_valid is False
+    assert signature_failure.reason == "signature_invalid"
+
+
+def test_legacy_self_consistent_envelope_is_reported_but_never_verified(tmp_path: Path, signing_key) -> None:
+    from agent_bom.sbom_attestation import _canonical_bytes, build_intoto_statement
+
+    key, _private_pem, public_pem = signing_key
+    path = _write_sbom(tmp_path)
+    payload = _canonical_bytes(build_intoto_statement(path, path.read_bytes()))
+    legacy = {
+        "payloadType": _DSSE_PAYLOAD_TYPE,
+        "payload": base64.b64encode(payload).decode(),
+        "signatures": [{"keyid": "legacy", "sig": key.sign(payload).hex()}],
+        "_agentBom": {"algorithm": "Ed25519", "cryptographic": True, "publicKeyPem": public_pem},
+    }
+    Path(str(path) + _ATTESTATION_SUFFIX).write_text(json.dumps(legacy))
+
+    result = verify_sbom_attestation(path, trust_policy=_policy(public_pem))
+
+    assert result.verified is False
+    assert result.legacy is True
+    assert result.format_version == "legacy"
+    assert result.digest_matches is True
+    assert result.signature_valid is False
+    assert result.trust_status == "legacy_untrusted"
+    assert result.reason == "legacy_attestation_untrusted"
+    assert result.key_id is None
+
+
+def test_malformed_and_oversized_envelopes_are_bounded(tmp_path: Path, signing_key, monkeypatch) -> None:
+    import agent_bom.sbom_attestation as module
+
+    path = _write_sbom(tmp_path)
+    attestation_path = Path(str(path) + _ATTESTATION_SUFFIX)
+    attestation_path.write_text("not-json")
+    malformed = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+    assert malformed.reason == "malformed_attestation"
+    assert "JSON" not in malformed.reason
+
+    attestation_path.write_text("{}" * 32)
+    monkeypatch.setattr(module, "_MAX_ENVELOPE_BYTES", 16)
+    oversized = verify_sbom_attestation(path, trust_policy=_policy(signing_key[2]))
+    assert oversized.reason == "attestation_too_large"
+
+
+def test_cli_verify_requires_explicit_public_key(tmp_path: Path, signing_key) -> None:
+    path = _write_sbom(tmp_path)
+    runner = CliRunner()
+    signed = runner.invoke(attest_group, ["sign", str(path), "--json"])
+    assert signed.exit_code == 0, signed.output
+
+    without_key = runner.invoke(attest_group, ["verify", str(path), "--json"])
+    assert without_key.exit_code == 1
+    assert json.loads(without_key.output)["reason"] == "trusted_public_key_required"
+
+    public_key_file = tmp_path / "trusted.pub.pem"
+    public_key_file.write_text(signing_key[2])
+    with_key = runner.invoke(attest_group, ["verify", str(path), "--public-key", str(public_key_file), "--json"])
+    assert with_key.exit_code == 0, with_key.output
+    assert json.loads(with_key.output)["verified"] is True
+
+
+def test_cli_cross_process_sign_then_verify_uses_only_explicit_public_key(tmp_path: Path) -> None:
+    _key, private_pem, public_pem = _key_material()
+    path = _write_sbom(tmp_path)
+    private_file = tmp_path / "signing.pem"
+    public_file = tmp_path / "trusted.pub.pem"
+    private_file.write_text(private_pem)
+    public_file.write_text(public_pem)
+    command = [sys.executable, "-c", "from agent_bom.cli import cli_main; cli_main()"]
+    source_path = str(Path(__file__).resolve().parents[1] / "src")
+    sign_env = {
+        **os.environ,
+        "AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE": str(private_file),
+        "PYTHONPATH": source_path + os.pathsep + os.environ.get("PYTHONPATH", ""),
+    }
+    sign_env.pop("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", None)
+
+    signed = subprocess.run(
+        [*command, "attest", "sign", str(path), "--json"],
+        cwd=tmp_path,
+        env=sign_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert signed.returncode == 0, signed.stderr
+
+    verify_env = dict(os.environ)
+    verify_env["PYTHONPATH"] = source_path + os.pathsep + verify_env.get("PYTHONPATH", "")
+    verify_env.pop("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", None)
+    verify_env.pop("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE", None)
+    verified = subprocess.run(
+        [*command, "attest", "verify", str(path), "--public-key", str(public_file), "--json"],
+        cwd=tmp_path,
+        env=verify_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert verified.returncode == 0, verified.stderr
+    assert json.loads(verified.stdout)["verified"] is True
+
+    no_trust = subprocess.run(
+        [*command, "attest", "verify", str(path), "--json"],
+        cwd=tmp_path,
+        env=verify_env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert no_trust.returncode == 1
+    assert json.loads(no_trust.stdout)["reason"] == "trusted_public_key_required"
+
+
+def test_missing_attestation_reports_reason(tmp_path: Path) -> None:
     path = _write_sbom(tmp_path)
     result = verify_sbom_attestation(path)
     assert result.verified is False
     assert result.reason == "attestation_not_found"
-
-
-def test_cli_sign_and_verify_roundtrip(tmp_path):
-    path = _write_sbom(tmp_path)
-    runner = CliRunner()
-
-    signed = runner.invoke(attest_group, ["sign", path, "--json"])
-    assert signed.exit_code == 0, signed.output
-    payload = json.loads(signed.output)
-    assert payload["sha256"]
-    assert payload["attestation"].endswith(_ATTESTATION_SUFFIX)
-
-    verified = runner.invoke(attest_group, ["verify", path, "--json"])
-    assert verified.exit_code == 0, verified.output
-    assert json.loads(verified.output)["verified"] is True
-
-
-def test_cli_verify_tampered_exits_nonzero(tmp_path):
-    path = _write_sbom(tmp_path)
-    runner = CliRunner()
-    runner.invoke(attest_group, ["sign", path])
-
-    with open(path, "a", encoding="utf-8") as fh:
-        fh.write("tampered")
-
-    verified = runner.invoke(attest_group, ["verify", path])
-    assert verified.exit_code == 1

--- a/tests/test_sbom_attestation.py
+++ b/tests/test_sbom_attestation.py
@@ -41,10 +41,14 @@ def _key_material() -> tuple[Ed25519PrivateKey, str, str]:
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
     ).decode()
-    public_pem = key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode()
+    public_pem = (
+        key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
     return key, private_pem, public_pem
 
 
@@ -61,7 +65,7 @@ def signing_key(monkeypatch) -> tuple[Ed25519PrivateKey, str, str]:
 
 
 def _policy(public_pem: str) -> AttestationTrustPolicy:
-    return AttestationTrustPolicy.from_public_key_pems([public_pem])
+    return AttestationTrustPolicy.from_public_key_pems([public_pem], expected_tenant_id="local")
 
 
 def test_dsse_pae_matches_the_specification_encoding() -> None:
@@ -295,16 +299,19 @@ def test_malformed_and_oversized_envelopes_are_bounded(tmp_path: Path, signing_k
 def test_cli_verify_requires_explicit_public_key(tmp_path: Path, signing_key) -> None:
     path = _write_sbom(tmp_path)
     runner = CliRunner()
-    signed = runner.invoke(attest_group, ["sign", str(path), "--json"])
+    signed = runner.invoke(attest_group, ["sign", str(path), "--tenant-id", "local", "--json"])
     assert signed.exit_code == 0, signed.output
 
-    without_key = runner.invoke(attest_group, ["verify", str(path), "--json"])
+    without_key = runner.invoke(attest_group, ["verify", str(path), "--tenant-id", "local", "--json"])
     assert without_key.exit_code == 1
     assert json.loads(without_key.output)["reason"] == "trusted_public_key_required"
 
     public_key_file = tmp_path / "trusted.pub.pem"
     public_key_file.write_text(signing_key[2])
-    with_key = runner.invoke(attest_group, ["verify", str(path), "--public-key", str(public_key_file), "--json"])
+    with_key = runner.invoke(
+        attest_group,
+        ["verify", str(path), "--tenant-id", "local", "--public-key", str(public_key_file), "--json"],
+    )
     assert with_key.exit_code == 0, with_key.output
     assert json.loads(with_key.output)["verified"] is True
 
@@ -326,7 +333,7 @@ def test_cli_cross_process_sign_then_verify_uses_only_explicit_public_key(tmp_pa
     sign_env.pop("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", None)
 
     signed = subprocess.run(
-        [*command, "attest", "sign", str(path), "--json"],
+        [*command, "attest", "sign", str(path), "--tenant-id", "local", "--json"],
         cwd=tmp_path,
         env=sign_env,
         capture_output=True,
@@ -340,7 +347,17 @@ def test_cli_cross_process_sign_then_verify_uses_only_explicit_public_key(tmp_pa
     verify_env.pop("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", None)
     verify_env.pop("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE", None)
     verified = subprocess.run(
-        [*command, "attest", "verify", str(path), "--public-key", str(public_file), "--json"],
+        [
+            *command,
+            "attest",
+            "verify",
+            str(path),
+            "--tenant-id",
+            "local",
+            "--public-key",
+            str(public_file),
+            "--json",
+        ],
         cwd=tmp_path,
         env=verify_env,
         capture_output=True,
@@ -351,7 +368,7 @@ def test_cli_cross_process_sign_then_verify_uses_only_explicit_public_key(tmp_pa
     assert json.loads(verified.stdout)["verified"] is True
 
     no_trust = subprocess.run(
-        [*command, "attest", "verify", str(path), "--json"],
+        [*command, "attest", "verify", str(path), "--tenant-id", "local", "--json"],
         cwd=tmp_path,
         env=verify_env,
         capture_output=True,

--- a/tests/test_sbom_attestation_policy.py
+++ b/tests/test_sbom_attestation_policy.py
@@ -1,0 +1,347 @@
+"""Semantic and offline signer policy for SBOM attestations."""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from agent_bom.cli._attest_group import attest_group
+from agent_bom.sbom_attestation import (
+    _ATTESTATION_SUFFIX,
+    _DSSE_PAYLOAD_TYPE,
+    _SIG_SUFFIX,
+    AttestationTrustError,
+    AttestationTrustPolicy,
+    MemoryAttestationReplayStore,
+    SQLiteAttestationReplayStore,
+    dsse_pae,
+    sign_sbom_file,
+    verify_sbom_attestation,
+)
+
+_TENANT = "tenant-a"
+_ISSUED_AT = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+_NONCE = "ab" * 16
+_EVIDENCE_ID = "018f1f5e-7b44-7a86-b5af-010203040506"
+
+
+def _write_sbom(tmp_path: Path) -> Path:
+    path = tmp_path / "report.cdx.json"
+    path.write_text(json.dumps({"bomFormat": "CycloneDX", "components": []}), encoding="utf-8")
+    return path
+
+
+def _keys(monkeypatch: pytest.MonkeyPatch) -> tuple[str, str]:
+    private = Ed25519PrivateKey.generate()
+    private_pem = private.private_bytes(
+        serialization.Encoding.PEM,
+        serialization.PrivateFormat.PKCS8,
+        serialization.NoEncryption(),
+    ).decode()
+    public_pem = (
+        private.public_key()
+        .public_bytes(
+            serialization.Encoding.PEM,
+            serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode()
+    )
+    monkeypatch.setenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM", private_pem)
+    monkeypatch.delenv("AGENT_BOM_COMPLIANCE_ED25519_PRIVATE_KEY_PEM_FILE", raising=False)
+    return private_pem, public_pem
+
+
+def _sign(path: Path) -> None:
+    sign_sbom_file(
+        path,
+        tenant_id=_TENANT,
+        issued_at=_ISSUED_AT,
+        ttl_seconds=300,
+        nonce=_NONCE,
+        evidence_id=_EVIDENCE_ID,
+    )
+
+
+def _policy(public_pem: str, **overrides: object) -> AttestationTrustPolicy:
+    values: dict[str, object] = {
+        "expected_tenant_id": _TENANT,
+        "max_age_seconds": 600,
+        "clock_skew_seconds": 30,
+        "replay_store": MemoryAttestationReplayStore(max_entries=8),
+    }
+    values.update(overrides)
+    return AttestationTrustPolicy.from_public_key_pems([public_pem], **values)
+
+
+def _trusted_root(tmp_path: Path) -> Path:
+    path = tmp_path / "trusted-root.json"
+    path.write_text(json.dumps({"mediaType": "application/vnd.dev.sigstore.trustedroot+json;version=0.1"}))
+    return path
+
+
+def test_statement_policy_accepts_expected_builder_predicate_tenant_and_time(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_sbom(tmp_path)
+    _private_pem, public_pem = _keys(monkeypatch)
+    _sign(path)
+
+    result = verify_sbom_attestation(path, trust_policy=_policy(public_pem), now=_ISSUED_AT + timedelta(seconds=60))
+
+    assert result.verified is True
+    assert result.reason == "verified"
+    assert result.tenant_id == _TENANT
+    assert result.evidence_id == _EVIDENCE_ID
+    assert result.issued_at == _ISSUED_AT.isoformat()
+    assert result.expires_at == (_ISSUED_AT + timedelta(seconds=300)).isoformat()
+    assert "semantic_policy=ok" in result.checks
+    assert "replay_guard=accepted" in result.checks
+
+
+@pytest.mark.parametrize(
+    ("overrides", "reason"),
+    [
+        ({"expected_builder_id": "https://builder.example/wrong"}, "builder_mismatch"),
+        ({"expected_predicate_type": "https://predicate.example/wrong"}, "predicate_type_mismatch"),
+        ({"expected_tenant_id": "tenant-b"}, "tenant_mismatch"),
+    ],
+)
+def test_signed_statement_must_match_semantic_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    overrides: dict[str, object],
+    reason: str,
+) -> None:
+    path = _write_sbom(tmp_path)
+    _private_pem, public_pem = _keys(monkeypatch)
+    _sign(path)
+
+    result = verify_sbom_attestation(
+        path,
+        trust_policy=_policy(public_pem, **overrides),
+        now=_ISSUED_AT + timedelta(seconds=60),
+    )
+
+    assert result.verified is False
+    assert result.signature_valid is True
+    assert result.reason == reason
+
+
+@pytest.mark.parametrize(
+    ("now", "policy_overrides", "reason"),
+    [
+        (_ISSUED_AT - timedelta(seconds=31), {}, "issued_in_future"),
+        (_ISSUED_AT + timedelta(seconds=331), {}, "attestation_expired"),
+        (_ISSUED_AT + timedelta(seconds=121), {"max_age_seconds": 120}, "attestation_max_age_exceeded"),
+    ],
+)
+def test_freshness_policy_rejects_future_expired_and_over_age_attestations(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    now: datetime,
+    policy_overrides: dict[str, object],
+    reason: str,
+) -> None:
+    path = _write_sbom(tmp_path)
+    _private_pem, public_pem = _keys(monkeypatch)
+    _sign(path)
+
+    result = verify_sbom_attestation(path, trust_policy=_policy(public_pem, **policy_overrides), now=now)
+
+    assert result.verified is False
+    assert result.signature_valid is True
+    assert result.reason == reason
+
+
+def test_replay_nonce_and_evidence_id_are_consumed_only_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_sbom(tmp_path)
+    _private_pem, public_pem = _keys(monkeypatch)
+    _sign(path)
+    policy = _policy(public_pem)
+
+    first = verify_sbom_attestation(path, trust_policy=policy, now=_ISSUED_AT + timedelta(seconds=60))
+    replay = verify_sbom_attestation(path, trust_policy=policy, now=_ISSUED_AT + timedelta(seconds=61))
+
+    assert first.verified is True
+    assert replay.verified is False
+    assert replay.signature_valid is True
+    assert replay.reason == "attestation_replay_detected"
+    assert "replay_guard=rejected" in replay.checks
+
+
+def test_sqlite_replay_store_rejects_across_verifier_instances(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_sbom(tmp_path)
+    _private_pem, public_pem = _keys(monkeypatch)
+    _sign(path)
+    replay_db = tmp_path / "replay.sqlite3"
+
+    first_policy = _policy(public_pem, replay_store=SQLiteAttestationReplayStore(replay_db, max_entries=8))
+    second_policy = _policy(public_pem, replay_store=SQLiteAttestationReplayStore(replay_db, max_entries=8))
+
+    assert verify_sbom_attestation(path, trust_policy=first_policy, now=_ISSUED_AT + timedelta(seconds=60)).verified is True
+    replay = verify_sbom_attestation(path, trust_policy=second_policy, now=_ISSUED_AT + timedelta(seconds=61))
+    assert replay.reason == "attestation_replay_detected"
+
+
+def test_cli_sqlite_replay_cache_rejects_a_second_process_style_verification(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_sbom(tmp_path)
+    _private_pem, public_pem = _keys(monkeypatch)
+    public_key_path = tmp_path / "trusted.pub.pem"
+    public_key_path.write_text(public_pem)
+    replay_cache = tmp_path / "replay.sqlite3"
+    runner = CliRunner()
+    assert runner.invoke(attest_group, ["sign", str(path), "--tenant-id", _TENANT]).exit_code == 0
+    command = [
+        "verify",
+        str(path),
+        "--tenant-id",
+        _TENANT,
+        "--public-key",
+        str(public_key_path),
+        "--replay-cache",
+        str(replay_cache),
+        "--json",
+    ]
+
+    first = runner.invoke(attest_group, command)
+    replay = runner.invoke(attest_group, command)
+
+    assert first.exit_code == 0, first.output
+    assert replay.exit_code == 1
+    assert json.loads(replay.output)["reason"] == "attestation_replay_detected"
+
+
+def test_cli_requires_an_explicit_tenant_for_sign_and_verify(tmp_path: Path) -> None:
+    path = _write_sbom(tmp_path)
+    runner = CliRunner()
+
+    assert runner.invoke(attest_group, ["sign", str(path)]).exit_code == 2
+    assert runner.invoke(attest_group, ["verify", str(path)]).exit_code == 2
+
+
+def test_policy_rejects_unbounded_or_ambiguous_configuration() -> None:
+    with pytest.raises(AttestationTrustError, match="expected_tenant_id_required"):
+        AttestationTrustPolicy.from_public_key_pems([], expected_tenant_id="")
+    with pytest.raises(AttestationTrustError, match="max_age_seconds_invalid"):
+        AttestationTrustPolicy.from_public_key_pems([], expected_tenant_id=_TENANT, max_age_seconds=0)
+    with pytest.raises(AttestationTrustError, match="clock_skew_seconds_invalid"):
+        AttestationTrustPolicy.from_public_key_pems([], expected_tenant_id=_TENANT, clock_skew_seconds=301)
+
+
+class _SyntheticSigstoreVerifier:
+    def __init__(self, expected_pae: bytes, expected_signature: str) -> None:
+        self.expected_pae = expected_pae
+        self.expected_signature = expected_signature
+        self.calls = 0
+
+    def verify(
+        self,
+        *,
+        signed_bytes: bytes,
+        signature_b64: str,
+        bundle_bytes: bytes,
+        trusted_root_bytes: bytes,
+        identity_regexp: str,
+        issuer: str,
+    ) -> bool:
+        self.calls += 1
+        return (
+            signed_bytes == self.expected_pae
+            and signature_b64 == self.expected_signature
+            and json.loads(bundle_bytes)["messageSignature"]["signature"] == signature_b64
+            and "trustedroot" in json.loads(trusted_root_bytes)["mediaType"]
+            and identity_regexp == r"https://github\.com/acme/repo/.+"
+            and issuer == "https://token.actions.githubusercontent.com"
+        )
+
+
+def test_sigstore_policy_verifies_exact_pae_with_explicit_identity_and_issuer(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path = _write_sbom(tmp_path)
+    _private_pem, _public_pem = _keys(monkeypatch)
+    _sign(path)
+    Path(str(path) + _SIG_SUFFIX).unlink()
+    envelope_path = Path(str(path) + _ATTESTATION_SUFFIX)
+    envelope = json.loads(envelope_path.read_text())
+    payload = base64.b64decode(envelope["payload"], validate=True)
+    signature_b64 = base64.b64encode(b"s" * 64).decode()
+    policy = AttestationTrustPolicy.from_sigstore(
+        expected_identity_regexp=r"https://github\.com/acme/repo/.+",
+        expected_issuer="https://token.actions.githubusercontent.com",
+        trusted_root_path=_trusted_root(tmp_path),
+        expected_tenant_id=_TENANT,
+        replay_store=MemoryAttestationReplayStore(max_entries=8),
+    )
+    envelope["signatures"] = [{"keyid": policy.sigstore_key_id, "sig": signature_b64}]
+    envelope_path.write_text(json.dumps(envelope))
+    bundle_path = tmp_path / "attestation.sigstore.json"
+    bundle_path.write_text(json.dumps({"messageSignature": {"signature": signature_b64}}))
+    adapter = _SyntheticSigstoreVerifier(dsse_pae(_DSSE_PAYLOAD_TYPE, payload), signature_b64)
+
+    result = verify_sbom_attestation(
+        path,
+        trust_policy=policy,
+        sigstore_bundle_path=bundle_path,
+        sigstore_verifier=adapter,
+        now=_ISSUED_AT + timedelta(seconds=60),
+    )
+
+    assert result.verified is True
+    assert result.algorithm == "Sigstore"
+    assert result.trust_status == "trusted"
+    assert adapter.calls == 1
+
+
+def test_sigstore_policy_requires_bundle_and_exact_policy_key_id(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = _write_sbom(tmp_path)
+    _private_pem, _public_pem = _keys(monkeypatch)
+    _sign(path)
+    policy = AttestationTrustPolicy.from_sigstore(
+        expected_identity_regexp=r"https://github\.com/acme/repo/.+",
+        expected_issuer="https://token.actions.githubusercontent.com",
+        trusted_root_path=_trusted_root(tmp_path),
+        expected_tenant_id=_TENANT,
+    )
+
+    missing_bundle = verify_sbom_attestation(path, trust_policy=policy, now=_ISSUED_AT + timedelta(seconds=60))
+    assert missing_bundle.reason == "sigstore_bundle_required"
+
+    envelope_path = Path(str(path) + _ATTESTATION_SUFFIX)
+    envelope = json.loads(envelope_path.read_text())
+    signature_b64 = base64.b64encode(b"s" * 64).decode()
+    envelope["signatures"] = [{"keyid": policy.sigstore_key_id, "sig": signature_b64}]
+    envelope_path.write_text(json.dumps(envelope))
+    bundle_path = tmp_path / "attestation.sigstore.json"
+    bundle_path.write_text(json.dumps({"messageSignature": {"signature": signature_b64}}))
+
+    missing_adapter = verify_sbom_attestation(
+        path,
+        trust_policy=policy,
+        sigstore_bundle_path=bundle_path,
+        now=_ISSUED_AT + timedelta(seconds=60),
+    )
+    assert missing_adapter.reason == "sigstore_verifier_required"
+
+    envelope["signatures"] = [{"keyid": "f" * 64, "sig": signature_b64}]
+    envelope_path.write_text(json.dumps(envelope))
+    adapter = _SyntheticSigstoreVerifier(b"unused", signature_b64)
+
+    mismatch = verify_sbom_attestation(
+        path,
+        trust_policy=policy,
+        sigstore_bundle_path=bundle_path,
+        sigstore_verifier=adapter,
+        now=_ISSUED_AT + timedelta(seconds=60),
+    )
+    assert mismatch.reason == "untrusted_signer"
+    assert adapter.calls == 0


### PR DESCRIPTION
## Summary

- replace artifact-controlled attestation trust with a versioned DSSE v1 envelope using true pre-authentication encoding and explicit external Ed25519 verifier policy
- fail closed on missing trust, payload-type/key/algorithm ambiguity, signer or tenant mismatch, expiry, replay, malformed input, and detached-signature disagreement
- preserve legacy envelope readability as `legacy_attestation_untrusted`, add cross-process CLI verification, and document freshness and replay-cache boundaries
- expose a bounded network-free Sigstore verifier policy interface that pins certificate identity, issuer, and local trust-root digest without claiming a built-in cosign adapter

## Verification

- `uv run pytest -q tests/test_sbom_attestation.py tests/test_sbom_attestation_policy.py tests/test_compliance_signing.py tests/test_cli_canonical_verbs.py tests/test_cli_entry_points.py tests/test_public_docs_cli_alignment.py tests/test_security.py tests/test_security_hardening.py tests/test_hardening.py tests/test_focused_security_gates.py` — 258 passed
- `uv run ruff format --check ...` and `uv run ruff check ...`
- `uv run mypy src/agent_bom/sbom_attestation.py src/agent_bom/cli/_attest_group.py`
- `uv run python scripts/check_exception_sanitization.py`
- `make preflight`
- `uv run mkdocs build --strict`
- `git diff --check origin/main...HEAD`

## Notes

- Verification requires caller-controlled trust; embedded public-key material is never sufficient.
- The verifier does not require signing secret material and the cross-process regression removes signing secrets before verification.
- Cosign 3.0.4 exposes no offline verification flag, so the Sigstore path is a bounded local policy/adapter interface rather than a subprocess or network-backed product claim.

Closes #4155
Addresses #4151
