### PR TITLE
fix(graph): render bounded rollup cards eagerly

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -1465,6 +1465,7 @@ function GraphPageInner() {
     sourceNodeCount: flow.nodes.length,
     renderedNodeCount: aggregated.nodes.length,
     clusterCount: aggregated.clusters.size,
+    rollupActive: rollupNavigationActive,
   });
 
   const lineageLayoutNodes = layoutNodes as Node<LineageNodeData>[];

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -114,7 +114,10 @@ import {
   LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES,
   LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
 } from "@/lib/large-graph-overview";
-import { decideGraphRenderer } from "@/lib/graph-renderer-switch";
+import {
+  decideGraphRenderer,
+  shouldVirtualizeReactFlowNodes,
+} from "@/lib/graph-renderer-switch";
 import {
   graphRollupEligible,
   parseGraphRollupUrlPreference,
@@ -3048,7 +3051,9 @@ function GraphPageInner() {
               zoomOnScroll={false}
               panOnScroll={false}
               preventScrolling={false}
-              onlyRenderVisibleElements
+              onlyRenderVisibleElements={shouldVirtualizeReactFlowNodes({
+                rollupActive: rollupNavigationActive,
+              })}
               defaultEdgeOptions={{ type: "smoothstep" }}
               proOptions={{ hideAttribution: true }}
               onNodeClick={onNodeClick}

--- a/ui/lib/graph-renderer-switch.ts
+++ b/ui/lib/graph-renderer-switch.ts
@@ -23,6 +23,18 @@ export interface GraphRendererDecision {
   supportsInvestigation: boolean;
 }
 
+/**
+ * Roll-up navigation already bounds the React Flow node set to the current
+ * hierarchy level. Virtualizing that tiny set before the first fitView
+ * measurement can leave every card outside the initial viewport, so render
+ * roll-up cards eagerly and retain virtualization for ordinary topology.
+ */
+export function shouldVirtualizeReactFlowNodes({
+  rollupActive = false,
+}: Pick<GraphRendererDecisionInput, "rollupActive">): boolean {
+  return !rollupActive;
+}
+
 export function decideGraphRenderer({
   nodeCount,
   edgeCount,

--- a/ui/lib/lod-renderer.ts
+++ b/ui/lib/lod-renderer.ts
@@ -39,6 +39,7 @@ export interface LodGraphShape {
   sourceNodeCount: number;
   renderedNodeCount: number;
   clusterCount: number;
+  rollupActive?: boolean | undefined;
 }
 
 /**
@@ -47,6 +48,12 @@ export interface LodGraphShape {
  * dots, so keep the labeled summary renderer even below the cluster zoom.
  */
 export function effectiveLodBandForGraph(band: LodBand, shape: LodGraphShape): LodBand {
+  // A hierarchy roll-up is already bounded to the current scope. Its cards
+  // carry the label, evidence summary, and drill-down affordance, so replacing
+  // them with generic LOD dots/summary pills makes the decision surface
+  // unreadable and removes the explicit container marker used by automation.
+  if (shape.rollupActive) return "detail";
+
   if (band !== "cluster") return band;
 
   const sourceNodeCount = Math.max(0, shape.sourceNodeCount);

--- a/ui/tests/graph-renderer-switch.test.ts
+++ b/ui/tests/graph-renderer-switch.test.ts
@@ -1,12 +1,20 @@
 import { describe, expect, it } from "vitest";
 
-import { decideGraphRenderer } from "@/lib/graph-renderer-switch";
+import {
+  decideGraphRenderer,
+  shouldVirtualizeReactFlowNodes,
+} from "@/lib/graph-renderer-switch";
 import {
   LARGE_GRAPH_OVERVIEW_EDGE_THRESHOLD,
   LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD,
 } from "@/lib/large-graph-overview";
 
 describe("graph renderer switch", () => {
+  it("renders bounded roll-up cards eagerly before the initial fitView", () => {
+    expect(shouldVirtualizeReactFlowNodes({ rollupActive: true })).toBe(false);
+    expect(shouldVirtualizeReactFlowNodes({ rollupActive: false })).toBe(true);
+  });
+
   it("keeps focused investigation modes on React Flow", () => {
     const broadGraph = {
       nodeCount: LARGE_GRAPH_OVERVIEW_NODE_THRESHOLD + 10,

--- a/ui/tests/lod-renderer.test.ts
+++ b/ui/tests/lod-renderer.test.ts
@@ -37,6 +37,25 @@ describe("lodBandForZoom", () => {
 });
 
 describe("effectiveLodBandForGraph", () => {
+  it("keeps bounded estate roll-ups as readable drill-down cards", () => {
+    expect(
+      effectiveLodBandForGraph("cluster", {
+        sourceNodeCount: 2,
+        renderedNodeCount: 2,
+        clusterCount: 0,
+        rollupActive: true,
+      }),
+    ).toBe("detail");
+    expect(
+      effectiveLodBandForGraph("summary", {
+        sourceNodeCount: 2,
+        renderedNodeCount: 2,
+        clusterCount: 0,
+        rollupActive: true,
+      }),
+    ).toBe("detail");
+  });
+
   it("keeps labeled summary rendering when cluster aggregation did not collapse nodes", () => {
     expect(
       effectiveLodBandForGraph("cluster", {


### PR DESCRIPTION
## Summary

- preserve bounded estate roll-up decision cards across inherited low-zoom LOD state
- render the bounded roll-up node set eagerly while preserving visible-node virtualization for raw topology
- add renderer and LOD regressions for the exact large-estate transition

## Root cause

The 1,241-node raw estate view left React Flow in a low zoom band. After navigation, the roll-up response and its two nodes were present, but adaptive LOD replaced their full container cards with generic summary nodes. Those nodes intentionally omit the roll-up container marker and the complete drill-down content, so the UI showed the correct roll-up summary while rendering zero decision cards. Viewport virtualization was a separate timing risk but was not sufficient to fix the failure.

## Verification

- canonical Node 24.11.0 / npm 10.9.7 toolchain verification
- `npm run typecheck`
- `npm run lint`
- targeted renderer and LOD tests — 14 passed
- full UI unit suite — 138 files, 756 tests passed
- production build — 49 routes
- exact large-estate Playwright regression in dark and light themes with five workers and ten repeats — 20/20 passed
- `git diff --check`

## Notes

- The live E2E smoke used a local unauthenticated development API on an isolated port only to satisfy unrelated background requests; graph and roll-up evidence remained Playwright route fixtures.
- No API, persistence, graph-data, or raw-topology virtualization contract changes.

Closes #4162