### PR TITLE
security(runtime): publish fail-mode matrix and retire command allowlist theater

### DIFF
--- a/docs/RUNTIME_FAIL_MODES.md
+++ b/docs/RUNTIME_FAIL_MODES.md
@@ -1,0 +1,52 @@
+# Gateway fail-open / fail-closed posture
+
+Every gateway enforcement subsystem decides what happens when its *own*
+machinery fails — a policy file that will not load, a store that errors, an
+evaluator that raises. The canonical inventory is code, not prose:
+
+- **Matrix:** `agent_bom.runtime.fail_mode.GATEWAY_FAIL_MODE_MATRIX`
+- **Live view:** `GET /healthz` on the gateway, under `fail_mode_runtime`
+  (resolved against the running `AGENT_BOM_GATEWAY_FAIL_MODE`)
+- **Regression pin:** `tests/test_runtime_fail_mode.py`
+
+## Summary
+
+| Subsystem | Default posture | Follows `AGENT_BOM_GATEWAY_FAIL_MODE` |
+|---|---|---|
+| Policy engine (unloadable policy file) | fail-closed | yes |
+| Firewall policy (unloadable policy file) | fail-closed | yes |
+| Policy plugins (evaluation error) | fail-closed | yes |
+| Control-plane policy bundle (parse/regex/eval error) | fail-closed | no |
+| Conditional access (evaluation error) | fail-closed | no |
+| Caller identity (invalid/revoked or missing token) | fail-closed | no |
+| Runtime rate limit (store unavailable) | fail-closed (refuses startup) | no |
+| Device posture enrichment (device state unknown) | fail-closed | no |
+| Spend budgets (cost-store error) | fail-open | no |
+| Cost-anomaly enforcement (cost-store error) | fail-open | no |
+| Fleet quarantine (fleet-store error) | fail-open | no |
+| Drift enforcement (drift-store error) | fail-open | no |
+| Graph reachability (evaluation error) | fail-open | no |
+| Audit export (sink/webhook delivery failure) | fail-open | no |
+
+Two rules explain the split:
+
+- **Security decision lanes fail closed** and are never softened by
+  `AGENT_BOM_GATEWAY_FAIL_MODE`. Only the policy engine, firewall policy
+  load, and policy plugins honour that knob, and its default is `closed`.
+- **Advisory and telemetry lanes fail open** by design: a spend-, drift-,
+  fleet-, or audit-store error must never take the data plane down. A
+  successfully evaluated enforce-mode rule in those lanes still blocks.
+
+Per-entry failure behavior (the `on_failure` text) is part of the matrix and
+shows verbatim in the `/healthz` output. For the surface map around the
+gateway see [`RUNTIME_REFERENCE.md`](RUNTIME_REFERENCE.md); for policy-layer
+ordering inside a single tool call see `docs/POLICY_PRECEDENCE.md`.
+
+## What is *not* an isolation boundary
+
+The stdio proxy's launcher check (`agent_bom.security.require_recognized_launcher`)
+and shell-metacharacter argument check are launch-hygiene guards against
+misconfigured server entries. They confer no isolation: a recognized launcher
+(`python`, `node`, `docker`) can still run arbitrary code as the host user.
+The execution control for MCP servers is container isolation —
+`agent_bom.proxy_sandbox` via `--isolate` (see `docs/MCP_SECURITY_MODEL.md`).

--- a/docs/RUNTIME_REFERENCE.md
+++ b/docs/RUNTIME_REFERENCE.md
@@ -18,6 +18,8 @@ This page is the canonical runtime surface map. The detail docs:
 - [`RUNTIME_PROXY_AUDIT_JSONL.md`](RUNTIME_PROXY_AUDIT_JSONL.md) — the proxy
   audit JSONL record format for SIEM forwarding and release evidence
 - `docs/POLICY_PRECEDENCE.md` — policy-layer ordering inside a single tool-call
+- [`RUNTIME_FAIL_MODES.md`](RUNTIME_FAIL_MODES.md) — fail-open vs fail-closed
+  posture per gateway enforcement subsystem, published on gateway `/healthz`
 - [`design/OBSERVE_ENFORCE.md`](design/OBSERVE_ENFORCE.md) — security-eval
   scorecard + the observe→enforce bridge that turns runtime↔scan correlation
   into audit-mode gateway block-rule proposals (enforce only on explicit opt-in)

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -81,6 +81,7 @@ from agent_bom.proxy_policy import (
     summarize_policy_bundle,
 )
 from agent_bom.proxy_scanner import ScanConfig, redact_pii, scan_tool_call, scan_tool_response
+from agent_bom.runtime.fail_mode import gateway_fail_mode_matrix
 from agent_bom.runtime.gateway_events import GatewayRuntimeEventType, build_gateway_runtime_event
 from agent_bom.runtime.graph_reachability import ReachabilityMap, load_reachability_map
 from agent_bom.security import sanitize_error, sanitize_text
@@ -1332,6 +1333,14 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 "tool_scope_mapped_tools": len(settings.tool_scope_map),
                 "dlp_enabled": settings.dlp_enabled,
                 "dlp_mode": settings.dlp_mode if settings.dlp_enabled else "disabled",
+            },
+            # Honest fail-open/fail-closed posture per enforcement subsystem
+            # (docs/RUNTIME_FAIL_MODES.md). Resolved once at app build; the
+            # matrix itself is static documentation-as-data from
+            # agent_bom.runtime.fail_mode.
+            "fail_mode_runtime": {
+                "policy_fail_mode": resolved_fail_mode,
+                "subsystems": gateway_fail_mode_matrix(resolved_fail_mode),
             },
         }
         if settings.enable_visual_leak_detection:

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -2510,12 +2510,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             if allowed and dlp_config.enabled:
                 arg_findings = scan_tool_call(tool_name, arguments, dlp_config)
                 arg_blocked = dlp_config.mode == "enforce" and any(f.blocked for f in arg_findings)
-                arg_redacted = (
-                    dlp_config.mode == "enforce"
-                    and dlp_config.pii_action == "redact"
-                    and bool(arg_findings)
-                    and not arg_blocked
-                )
+                arg_redacted = dlp_config.mode == "enforce" and dlp_config.pii_action == "redact" and bool(arg_findings) and not arg_blocked
                 if arg_findings and settings.audit_sink is not None:
                     typed_arg_event = (
                         _typed_runtime_event(
@@ -2832,10 +2827,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             resp_findings = scan_tool_response(result_text, dlp_config)
             result_blocked = dlp_config.mode == "enforce" and any(f.blocked for f in resp_findings)
             result_redacted = (
-                dlp_config.mode == "enforce"
-                and dlp_config.pii_action == "redact"
-                and bool(resp_findings)
-                and not result_blocked
+                dlp_config.mode == "enforce" and dlp_config.pii_action == "redact" and bool(resp_findings) and not result_blocked
             )
             if resp_findings and settings.audit_sink is not None:
                 typed_result_event: dict[str, Any] = {}

--- a/src/agent_bom/proxy.py
+++ b/src/agent_bom/proxy.py
@@ -44,7 +44,7 @@ from agent_bom.async_stdin import create_async_stdin_reader, read_async_stdin_li
 from agent_bom.langfuse_otel import set_langfuse_runtime_attributes
 from agent_bom.proxy_sandbox import SandboxConfig, build_sandboxed_command
 from agent_bom.proxy_scanner import ScanConfig, load_scan_config, scan_tool_call, scan_tool_response
-from agent_bom.security import sanitize_text, validate_arguments, validate_command
+from agent_bom.security import require_recognized_launcher, sanitize_text, validate_arguments
 
 logger = logging.getLogger(__name__)
 
@@ -1523,8 +1523,11 @@ async def run_proxy(
         # carries the same posture detail in machine-readable form.
         logger.warning(warning)
 
-    # Validate the effective server command before spawning
-    validate_command(_command_name_for_validation(server_cmd[0], sandbox_evidence))
+    # Launch-hygiene checks on the effective server command before spawning.
+    # These catch typos and shell-interpolation configs; they are NOT the
+    # isolation boundary — that is the container sandbox wired above
+    # (agent_bom.proxy_sandbox, --isolate).
+    require_recognized_launcher(_command_name_for_validation(server_cmd[0], sandbox_evidence))
     if len(server_cmd) > 1:
         validate_arguments(list(server_cmd[1:]))
 

--- a/src/agent_bom/runtime/fail_mode.py
+++ b/src/agent_bom/runtime/fail_mode.py
@@ -1,0 +1,222 @@
+"""Fail-open / fail-closed posture matrix for the runtime gateway.
+
+Every enforcement subsystem in ``agent_bom.gateway_server`` makes a decision
+about what happens when its *own* machinery fails (a policy file that will not
+load, a store that errors, an evaluator that raises). Those decisions were
+previously scattered across inline comments; this module is the single
+publishable inventory so operators can audit the posture without reading the
+relay source.
+
+Two invariants keep the matrix honest:
+
+- Advisory/enrichment lanes (spend telemetry, drift, fleet state, reachability,
+  audit export) fail OPEN by design: their store errors must never take the
+  data plane down.
+- Security decision lanes (identity, conditional access, control-plane
+  bundles, device-posture-gated policies) fail CLOSED and are NOT softened by
+  ``AGENT_BOM_GATEWAY_FAIL_MODE`` — only the policy engine, firewall policy
+  load, and policy plugins honour that knob (default ``closed``).
+
+The matrix is exposed read-only on the gateway ``/healthz`` endpoint under
+``fail_mode_runtime`` and documented in ``docs/RUNTIME_FAIL_MODES.md``. Tests
+in ``tests/test_runtime_fail_mode.py`` pin each entry to the implemented
+behavior; changing a posture in ``gateway_server.py`` requires updating both.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+__all__ = [
+    "FailPosture",
+    "SubsystemFailMode",
+    "GATEWAY_FAIL_MODE_MATRIX",
+    "gateway_fail_mode_matrix",
+]
+
+
+class FailPosture(str, Enum):
+    """What a subsystem does when its own machinery fails."""
+
+    OPEN = "fail_open"  # failure never blocks the relay
+    CLOSED = "fail_closed"  # failure denies the request (or refuses startup)
+
+
+@dataclass(frozen=True)
+class SubsystemFailMode:
+    """Documented failure posture for one gateway enforcement subsystem."""
+
+    subsystem: str
+    # Posture under the default gateway fail mode ("closed").
+    default_posture: FailPosture
+    # True only for subsystems whose posture flips with AGENT_BOM_GATEWAY_FAIL_MODE.
+    follows_gateway_fail_mode: bool
+    # The operator control governing this posture, or "none (fixed)".
+    control: str
+    # What actually happens when this subsystem's machinery fails.
+    on_failure: str
+
+
+GATEWAY_FAIL_MODE_MATRIX: tuple[SubsystemFailMode, ...] = (
+    SubsystemFailMode(
+        subsystem="policy_engine",
+        default_posture=FailPosture.CLOSED,
+        follows_gateway_fail_mode=True,
+        control="AGENT_BOM_GATEWAY_FAIL_MODE (default: closed)",
+        on_failure=(
+            "A configured policy file that never loaded denies every relay "
+            "request in fail-closed mode; fail-open forwards against the "
+            "empty default-allow policy."
+        ),
+    ),
+    SubsystemFailMode(
+        subsystem="firewall_policy",
+        default_posture=FailPosture.CLOSED,
+        follows_gateway_fail_mode=True,
+        control="AGENT_BOM_GATEWAY_FAIL_MODE (default: closed)",
+        on_failure=(
+            "A configured inter-agent firewall policy file that never loaded "
+            "denies requests in fail-closed mode instead of falling back to "
+            "default-allow."
+        ),
+    ),
+    SubsystemFailMode(
+        subsystem="control_plane_policy_bundle",
+        default_posture=FailPosture.CLOSED,
+        follows_gateway_fail_mode=False,
+        control="none (fixed)",
+        on_failure=(
+            "A control-plane bundle whose policies all fail to parse, carry "
+            "an invalid regex, or raise during evaluation denies the request; "
+            "an operator typo never silently disables enforcement."
+        ),
+    ),
+    SubsystemFailMode(
+        subsystem="policy_plugins",
+        default_posture=FailPosture.CLOSED,
+        follows_gateway_fail_mode=True,
+        control="AGENT_BOM_GATEWAY_FAIL_MODE (default: closed)",
+        on_failure=("A policy-plugin evaluation error denies the request in fail-closed mode and allows it in fail-open mode."),
+    ),
+    SubsystemFailMode(
+        subsystem="conditional_access",
+        default_posture=FailPosture.CLOSED,
+        follows_gateway_fail_mode=False,
+        control="none (fixed)",
+        on_failure=(
+            "A conditional-access evaluation error denies the request "
+            "whenever any conditional-access policy exists for the tenant, "
+            "or when the policy store cannot be read to prove none exist."
+        ),
+    ),
+    SubsystemFailMode(
+        subsystem="caller_identity",
+        default_posture=FailPosture.CLOSED,
+        follows_gateway_fail_mode=False,
+        control="AGENT_BOM_GATEWAY_ALLOW_ANONYMOUS_AGENTS (missing identity only)",
+        on_failure=(
+            "An invalid or revoked agent-identity token always denies. A "
+            "fully-missing identity denies on non-loopback listeners unless "
+            "the explicit anonymous-agents opt-out is set."
+        ),
+    ),
+    SubsystemFailMode(
+        subsystem="runtime_rate_limit",
+        default_posture=FailPosture.CLOSED,
+        follows_gateway_fail_mode=False,
+        control="AGENT_BOM_POSTGRES_URL / AGENT_BOM_GATEWAY_REPLICAS",
+        on_failure=(
+            "A configured Postgres limiter that cannot initialize, or a "
+            "multi-replica deployment without a shared store, refuses to "
+            "start the gateway rather than degrading to process-local state."
+        ),
+    ),
+    SubsystemFailMode(
+        subsystem="spend_budgets",
+        default_posture=FailPosture.OPEN,
+        follows_gateway_fail_mode=False,
+        control="none (fixed)",
+        on_failure=(
+            "Cost-store errors during agent/tenant, cost-center, and owner "
+            "budget checks are logged and never block the relay; only a "
+            "successfully evaluated enforce-mode budget can deny."
+        ),
+    ),
+    SubsystemFailMode(
+        subsystem="cost_anomaly_enforcement",
+        default_posture=FailPosture.OPEN,
+        follows_gateway_fail_mode=False,
+        control="anomaly_enforcement_mode (default: off)",
+        on_failure="Cost-store errors during the spend-anomaly check never block the relay.",
+    ),
+    SubsystemFailMode(
+        subsystem="fleet_quarantine_enforcement",
+        default_posture=FailPosture.OPEN,
+        follows_gateway_fail_mode=False,
+        control="fleet_enforcement_mode (default: off)",
+        on_failure="Fleet-store errors during the quarantine lookup are logged and never block the relay.",
+    ),
+    SubsystemFailMode(
+        subsystem="drift_enforcement",
+        default_posture=FailPosture.OPEN,
+        follows_gateway_fail_mode=False,
+        control="drift_enforcement_mode (default: off)",
+        on_failure="Drift-store errors during the behavioral-drift lookup never block the relay.",
+    ),
+    SubsystemFailMode(
+        subsystem="graph_reachability_enforcement",
+        default_posture=FailPosture.OPEN,
+        follows_gateway_fail_mode=False,
+        control="graph_reachability_enforcement_mode (default: off)",
+        on_failure="A reachability-map evaluation error is logged and never blocks the relay.",
+    ),
+    SubsystemFailMode(
+        subsystem="device_posture_enrichment",
+        default_posture=FailPosture.CLOSED,
+        follows_gateway_fail_mode=False,
+        control="none (fixed)",
+        on_failure=(
+            "A device-posture enrichment error leaves the device state "
+            "unknown, so any conditional policy that requires a managed, "
+            "compliant, or disk-encrypted device denies the request."
+        ),
+    ),
+    SubsystemFailMode(
+        subsystem="audit_export",
+        default_posture=FailPosture.OPEN,
+        follows_gateway_fail_mode=False,
+        control="none (fixed)",
+        on_failure=(
+            "Audit-sink, SIEM webhook, and OCSF interop delivery failures never block the relay; decisions are made before export."
+        ),
+    ),
+)
+
+
+def gateway_fail_mode_matrix(fail_mode: str) -> list[dict[str, object]]:
+    """Return the effective per-subsystem posture for a resolved gateway fail mode.
+
+    ``fail_mode`` must already be resolved to ``"open"`` or ``"closed"``
+    (see ``agent_bom.proxy_policy.resolve_fail_mode``). Entries with
+    ``follows_gateway_fail_mode`` report the flipped posture in open mode;
+    fixed entries always report their default.
+    """
+    if fail_mode not in ("open", "closed"):
+        raise ValueError(f"fail_mode must be 'open' or 'closed', got {fail_mode!r}")
+    rows: list[dict[str, object]] = []
+    for entry in GATEWAY_FAIL_MODE_MATRIX:
+        if entry.follows_gateway_fail_mode:
+            posture = FailPosture.CLOSED if fail_mode == "closed" else FailPosture.OPEN
+        else:
+            posture = entry.default_posture
+        rows.append(
+            {
+                "subsystem": entry.subsystem,
+                "posture": posture.value,
+                "follows_gateway_fail_mode": entry.follows_gateway_fail_mode,
+                "control": entry.control,
+                "on_failure": entry.on_failure,
+            }
+        )
+    return rows

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -17,11 +17,16 @@ from urllib.parse import urlsplit, urlunsplit
 logger = logging.getLogger(__name__)
 ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 
-# Allowed executables for MCP servers (security allowlist).
-# Includes package managers, runtimes, and container tools commonly used
-# to launch MCP servers. Adding a binary here means discovery won't block
-# the server — it does NOT mean the binary is safe to run untrusted.
-ALLOWED_COMMANDS = {
+# Recognized MCP server launcher binaries (package managers, runtimes, and
+# container tools commonly used to launch MCP servers).
+#
+# This list is a misconfiguration/typo guard for the stdio proxy spawn path —
+# it is NOT a sandbox and NOT an isolation boundary. Every binary here can
+# execute arbitrary code with the proxy's full host privileges; membership
+# only means the command *shape* looks like a plausible MCP launcher. The
+# actual execution control is container isolation via
+# ``agent_bom.proxy_sandbox`` (``--isolate`` / AGENT_BOM_MCP_SANDBOX).
+KNOWN_MCP_LAUNCHERS = {
     # JavaScript/TypeScript runtimes & package managers
     "npx",
     "npm",
@@ -64,7 +69,10 @@ DANGEROUS_ENV_VARS = {
     "NODE_OPTIONS",  # Can inject malicious code
 }
 
-# Shell metacharacters that indicate potential injection
+# Shell metacharacters rejected by validate_arguments. agent-bom itself spawns
+# MCP servers via an exec array (never a shell), so these characters are not
+# interpreted on our spawn path; the check flags configs that appear to expect
+# shell interpolation. Config hygiene, not an execution control.
 SHELL_METACHARACTERS = {";", "|", "&", "$", "`", "<", ">", "\n", "\r"}
 
 # Patterns for sensitive data (for redaction)
@@ -94,30 +102,49 @@ class SecurityError(Exception):
     pass
 
 
-def validate_command(command: str) -> None:
+def require_recognized_launcher(command: str) -> None:
     """
-    Validate that a command is in the allowed list.
+    Require that *command* is a recognized MCP launcher binary.
+
+    This is a launch-hygiene check that catches typos and obviously
+    misconfigured server commands before the proxy spawns them. It provides
+    NO isolation: every recognized launcher (``python``, ``node``,
+    ``docker``, …) can still execute arbitrary code as the host user.
+    Passing this check must never be read as "the server is sandboxed" —
+    the real execution control is container isolation via
+    ``agent_bom.proxy_sandbox`` (``--isolate``).
 
     Args:
-        command: The command to validate
+        command: The launcher command to check
 
     Raises:
-        SecurityError: If command is not allowed
+        SecurityError: If command is not a recognized MCP launcher
     """
-    if command not in ALLOWED_COMMANDS:
-        raise SecurityError(f"Command '{command}' is not in the allowed list. Allowed commands: {', '.join(sorted(ALLOWED_COMMANDS))}")
-    logger.debug(f"Command '{command}' validated successfully")
+    if command not in KNOWN_MCP_LAUNCHERS:
+        raise SecurityError(
+            f"Command '{command}' is not a recognized MCP launcher. Recognized launchers: "
+            f"{', '.join(sorted(KNOWN_MCP_LAUNCHERS))}. This check guards against misconfigured "
+            "server commands only — it is not a sandbox. Use container isolation (--isolate) "
+            "to restrict what a server can do."
+        )
+    logger.debug(f"Command '{command}' is a recognized MCP launcher")
 
 
 def validate_arguments(args: list[str]) -> None:
     """
-    Validate command arguments for shell metacharacters.
+    Reject command arguments containing shell metacharacters.
+
+    Config-hygiene check: agent-bom spawns MCP servers via an exec array
+    (never through a shell), so these characters are not interpreted on our
+    spawn path. An argument that contains them was almost certainly written
+    for shell interpolation and indicates a misconfigured server entry.
+    This is not an execution control and confers no isolation.
 
     Args:
         args: List of command arguments
 
     Raises:
-        SecurityError: If dangerous characters found
+        SecurityError: If shell metacharacters found
     """
     for arg in args:
         for char in SHELL_METACHARACTERS:
@@ -772,19 +799,24 @@ def create_safe_subprocess_env() -> dict[str, str]:
 
 def validate_mcp_server_config(server_config: dict) -> None:
     """
-    Validate an MCP server configuration for security issues.
+    Validate an MCP server configuration for hygiene issues before launch.
+
+    Checks launcher recognition, argument shape, and dangerous environment
+    variables. These are misconfiguration guards, not isolation — a config
+    that passes still runs with full host privileges unless container
+    isolation (``agent_bom.proxy_sandbox``, ``--isolate``) is enabled.
 
     Args:
         server_config: MCP server configuration dictionary
 
     Raises:
-        SecurityError: If configuration has security issues
+        SecurityError: If configuration fails a hygiene check
     """
-    # Validate command (remote/URL-based servers don't require a local command)
+    # Check the launcher (remote/URL-based servers don't require a local command)
     command = server_config.get("command", "")
     has_url = bool(server_config.get("url") or server_config.get("uri"))
     if not has_url:
-        validate_command(command)
+        require_recognized_launcher(command)
 
     # Validate arguments
     args = server_config.get("args", [])
@@ -849,7 +881,7 @@ def sanitize_error(exc: Exception | str, generic: bool = False) -> str:
 # Export all validation functions
 __all__ = [
     "SecurityError",
-    "validate_command",
+    "require_recognized_launcher",
     "validate_arguments",
     "validate_environment",
     "validate_path",

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -28,6 +28,7 @@ from agent_bom.api.auth import Role
 from agent_bom.api.tracing import parse_traceparent
 from agent_bom.gateway_server import GatewaySettings, GatewayUpstreamRelay, create_gateway_app
 from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
+from agent_bom.runtime.fail_mode import gateway_fail_mode_matrix
 
 
 def _simple_registry() -> UpstreamRegistry:
@@ -134,7 +135,37 @@ def test_healthz_lists_configured_upstreams() -> None:
             "dlp_enabled": False,
             "dlp_mode": "disabled",
         },
+        "fail_mode_runtime": {
+            "policy_fail_mode": "closed",
+            "subsystems": gateway_fail_mode_matrix("closed"),
+        },
     }
+
+
+def test_healthz_publishes_fail_mode_matrix_default_closed() -> None:
+    settings = GatewaySettings(registry=_simple_registry(), policy={})
+    client = TestClient(create_gateway_app(settings))
+    payload = client.get("/healthz").json()["fail_mode_runtime"]
+    assert payload["policy_fail_mode"] == "closed"
+    subsystems = {row["subsystem"]: row for row in payload["subsystems"]}
+    assert subsystems["policy_engine"]["posture"] == "fail_closed"
+    assert subsystems["caller_identity"]["posture"] == "fail_closed"
+    assert subsystems["drift_enforcement"]["posture"] == "fail_open"
+    assert subsystems["audit_export"]["posture"] == "fail_open"
+
+
+def test_healthz_fail_mode_matrix_reflects_explicit_open_mode() -> None:
+    settings = GatewaySettings(registry=_simple_registry(), policy={}, fail_mode="open")
+    client = TestClient(create_gateway_app(settings))
+    payload = client.get("/healthz").json()["fail_mode_runtime"]
+    assert payload["policy_fail_mode"] == "open"
+    subsystems = {row["subsystem"]: row for row in payload["subsystems"]}
+    # Configurable lanes flip with the fail mode …
+    assert subsystems["policy_engine"]["posture"] == "fail_open"
+    assert subsystems["firewall_policy"]["posture"] == "fail_open"
+    # … security decision lanes never soften.
+    assert subsystems["caller_identity"]["posture"] == "fail_closed"
+    assert subsystems["conditional_access"]["posture"] == "fail_closed"
 
 
 def test_healthz_reports_policy_reload_runtime(tmp_path: Path) -> None:

--- a/tests/test_runtime_fail_mode.py
+++ b/tests/test_runtime_fail_mode.py
@@ -1,0 +1,111 @@
+"""Tests for the published gateway fail-open/fail-closed posture matrix.
+
+The matrix in ``agent_bom.runtime.fail_mode`` is the single honest inventory
+of what each gateway subsystem does when its own machinery fails. These tests
+pin the documented posture to the behavior actually implemented in
+``gateway_server.py`` — if enforcement code changes posture, the matrix (and
+these tests) must change with it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.runtime.fail_mode import (
+    GATEWAY_FAIL_MODE_MATRIX,
+    FailPosture,
+    SubsystemFailMode,
+    gateway_fail_mode_matrix,
+)
+
+_BY_NAME = {entry.subsystem: entry for entry in GATEWAY_FAIL_MODE_MATRIX}
+
+
+def test_matrix_covers_every_gateway_enforcement_subsystem() -> None:
+    assert set(_BY_NAME) == {
+        "policy_engine",
+        "firewall_policy",
+        "control_plane_policy_bundle",
+        "policy_plugins",
+        "conditional_access",
+        "caller_identity",
+        "runtime_rate_limit",
+        "spend_budgets",
+        "cost_anomaly_enforcement",
+        "fleet_quarantine_enforcement",
+        "drift_enforcement",
+        "graph_reachability_enforcement",
+        "device_posture_enrichment",
+        "audit_export",
+    }
+
+
+def test_every_entry_is_fully_documented() -> None:
+    for entry in GATEWAY_FAIL_MODE_MATRIX:
+        assert isinstance(entry, SubsystemFailMode)
+        assert entry.subsystem
+        assert entry.on_failure, f"{entry.subsystem} must describe its failure behavior"
+        assert entry.control, f"{entry.subsystem} must name the operator control (or state there is none)"
+        assert entry.default_posture in (FailPosture.OPEN, FailPosture.CLOSED)
+
+
+def test_advisory_enrichment_paths_are_documented_fail_open() -> None:
+    for subsystem in (
+        "spend_budgets",
+        "cost_anomaly_enforcement",
+        "fleet_quarantine_enforcement",
+        "drift_enforcement",
+        "graph_reachability_enforcement",
+        "audit_export",
+    ):
+        assert _BY_NAME[subsystem].default_posture is FailPosture.OPEN, subsystem
+        assert not _BY_NAME[subsystem].follows_gateway_fail_mode, subsystem
+
+
+def test_security_decision_paths_are_documented_fail_closed() -> None:
+    for subsystem in (
+        "control_plane_policy_bundle",
+        "conditional_access",
+        "caller_identity",
+        "runtime_rate_limit",
+        "device_posture_enrichment",
+    ):
+        assert _BY_NAME[subsystem].default_posture is FailPosture.CLOSED, subsystem
+        assert not _BY_NAME[subsystem].follows_gateway_fail_mode, subsystem
+
+
+def test_fail_mode_governed_subsystems_default_closed() -> None:
+    for subsystem in ("policy_engine", "firewall_policy", "policy_plugins"):
+        entry = _BY_NAME[subsystem]
+        assert entry.follows_gateway_fail_mode, subsystem
+        assert entry.default_posture is FailPosture.CLOSED, subsystem
+        assert "AGENT_BOM_GATEWAY_FAIL_MODE" in entry.control, subsystem
+
+
+def test_matrix_summary_resolves_configurable_entries() -> None:
+    closed = {row["subsystem"]: row for row in gateway_fail_mode_matrix("closed")}
+    opened = {row["subsystem"]: row for row in gateway_fail_mode_matrix("open")}
+
+    assert closed["policy_engine"]["posture"] == "fail_closed"
+    assert opened["policy_engine"]["posture"] == "fail_open"
+    assert opened["policy_engine"]["follows_gateway_fail_mode"] is True
+
+    # Fixed postures never flip with the gateway fail mode.
+    assert closed["caller_identity"]["posture"] == "fail_closed"
+    assert opened["caller_identity"]["posture"] == "fail_closed"
+    assert closed["drift_enforcement"]["posture"] == "fail_open"
+    assert opened["drift_enforcement"]["posture"] == "fail_open"
+
+
+def test_matrix_summary_rows_are_json_shaped() -> None:
+    rows = gateway_fail_mode_matrix("closed")
+    assert len(rows) == len(GATEWAY_FAIL_MODE_MATRIX)
+    for row in rows:
+        assert set(row) == {"subsystem", "posture", "follows_gateway_fail_mode", "control", "on_failure"}
+        assert row["posture"] in ("fail_open", "fail_closed")
+        assert isinstance(row["follows_gateway_fail_mode"], bool)
+
+
+def test_matrix_summary_rejects_unresolved_fail_mode() -> None:
+    with pytest.raises(ValueError):
+        gateway_fail_mode_matrix("maybe")

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -12,6 +12,7 @@ from agent_bom.security import (
     _is_obfuscated_credential,
     _shannon_entropy,
     create_safe_subprocess_env,
+    require_recognized_launcher,
     sanitize_command_args,
     sanitize_env_vars,
     sanitize_error,
@@ -19,7 +20,6 @@ from agent_bom.security import (
     sanitize_path_label,
     sanitize_url,
     validate_arguments,
-    validate_command,
     validate_environment,
     validate_file_size,
     validate_image_ref,
@@ -45,22 +45,37 @@ def test_sanitize_log_label_bounds_length():
 
 
 # ---------------------------------------------------------------------------
-# validate_command
+# require_recognized_launcher — launch-hygiene check, NOT a sandbox
 # ---------------------------------------------------------------------------
 
 
-def test_validate_command_allowed():
-    validate_command("npx")
-    validate_command("python3")
+def test_require_recognized_launcher_accepts_known_launchers():
+    require_recognized_launcher("npx")
+    require_recognized_launcher("python3")
 
 
-def test_validate_command_rejected():
+def test_require_recognized_launcher_rejects_unknown_binary():
     with pytest.raises(SecurityError):
-        validate_command("rm")
+        require_recognized_launcher("rm")
+
+
+def test_require_recognized_launcher_error_points_at_real_isolation():
+    """The rejection message must not present the launcher list as a sandbox.
+
+    The list is a misconfiguration guard; actual isolation is the container
+    sandbox (``agent_bom.proxy_sandbox``, ``--isolate``). The error text must
+    say so, so operators are never led to believe passing this check confers
+    isolation.
+    """
+    with pytest.raises(SecurityError) as excinfo:
+        require_recognized_launcher("bash")
+    message = str(excinfo.value)
+    assert "not a sandbox" in message
+    assert "--isolate" in message
 
 
 # ---------------------------------------------------------------------------
-# validate_arguments
+# validate_arguments — config-hygiene metacharacter check, not an exec control
 # ---------------------------------------------------------------------------
 
 

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -8,8 +8,8 @@ import pytest
 
 from agent_bom.security import (
     SecurityError,
+    require_recognized_launcher,
     sanitize_error,
-    validate_command,
     validate_image_ref,
 )
 
@@ -163,22 +163,27 @@ class TestErrorSanitization:
 # ─── Proxy Command Validation ────────────────────────────────────────────────
 
 
-class TestProxyCommandValidation:
-    """Proxy should validate commands before spawning."""
+class TestProxyLaunchHygiene:
+    """Proxy rejects unrecognized launcher binaries before spawning.
 
-    def test_allowed_commands_accepted(self):
-        """npx, uvx, python, etc. should be allowed."""
+    This is a misconfiguration/typo guard, NOT isolation: a recognized
+    launcher (python, node, docker) can still run arbitrary code. Actual
+    isolation is the container sandbox (agent_bom.proxy_sandbox, --isolate).
+    """
+
+    def test_known_launchers_accepted(self):
+        """npx, uvx, python, etc. are recognized MCP launchers."""
         for cmd in ["npx", "uvx", "python", "python3", "node", "deno", "bun"]:
-            validate_command(cmd)  # Should not raise
+            require_recognized_launcher(cmd)  # Should not raise
 
-    def test_arbitrary_commands_rejected(self):
-        """Random executables should be rejected."""
+    def test_unrecognized_binaries_rejected(self):
+        """Binaries outside the recognized launcher set are refused."""
         with pytest.raises(SecurityError):
-            validate_command("bash")
+            require_recognized_launcher("bash")
         with pytest.raises(SecurityError):
-            validate_command("/usr/bin/evil")
+            require_recognized_launcher("/usr/bin/evil")
         with pytest.raises(SecurityError):
-            validate_command("curl")
+            require_recognized_launcher("curl")
 
 
 # ─── Safe Path Validation ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Publish a single fail-open/fail-closed posture matrix for every gateway enforcement subsystem (`agent_bom/runtime/fail_mode.py`), replacing the previously scattered inline-comment decisions. The matrix is exposed read-only on the existing gateway `/healthz` under `fail_mode_runtime`, resolved against the running `AGENT_BOM_GATEWAY_FAIL_MODE`, and documented for operators in `docs/RUNTIME_FAIL_MODES.md` (linked from `docs/RUNTIME_REFERENCE.md`).
- Retire the command-allowlist framing in `security.py`: `ALLOWED_COMMANDS` → `KNOWN_MCP_LAUNCHERS` and `validate_command` → `require_recognized_launcher`, with docstrings, error text, and the proxy spawn-path comment stating explicitly that launcher recognition and shell-metacharacter checks are launch-hygiene guards, not isolation — the execution control is container isolation via `proxy_sandbox` (`--isolate`). Behavior is unchanged (same launcher set, same `SecurityError`); no sandbox behavior weakened.
- Tests pin the matrix to implemented relay behavior (advisory lanes fail open, security decision lanes fail closed and never soften with the fail-mode knob) and encode the honest launcher framing, including asserting the rejection message points at `--isolate` rather than presenting the list as a sandbox.

## Verification
- `uv run pytest tests/test_runtime_fail_mode.py tests/test_gateway_server.py tests/test_security.py tests/test_security_hardening.py tests/test_proxy.py tests/test_proxy_helpers.py tests/test_proxy_sandbox.py tests/test_proxy_cov.py -q` — 368 passed
- `uv run ruff check` + `ruff format` on changed files — clean
- `uv run mypy src/agent_bom/runtime/fail_mode.py src/agent_bom/security.py src/agent_bom/gateway_server.py src/agent_bom/proxy.py` — no issues
- Guards: `generate_env_var_reference.py --check`, `check_exception_sanitization.py`, `check_comment_hygiene.py`, `check-counts.py` — all pass

## Notes
- Fail-mode postures in the matrix were each verified against the current `gateway_server.py` code paths (policy/firewall load failure, control-plane bundle parse/eval, conditional access, caller identity, rate-limit store startup, budget/anomaly/fleet/drift/reachability store errors, device-posture enrichment, audit/webhook delivery).
- `docs/archive/AUDIT.md` still names `validate_command`; left untouched as a historical record.

Made with [Cursor](https://cursor.com)