### PR TITLE
feat(ciem): project proved authorization evidence into graph

### DIFF
--- a/src/agent_bom/cloud/authorization_evaluator.py
+++ b/src/agent_bom/cloud/authorization_evaluator.py
@@ -219,8 +219,8 @@ def evaluate_authorization(bundle: AuthorizationEvidenceBundle, request: Authori
     """Evaluate one request without converting absent evidence into a decision.
 
     Matching explicit denies are useful even in a partial bundle.  An allow or
-    implicit deny, however, requires every source named by ``required_sources``
-    and every referenced role definition to be complete.
+    implicit deny, however, requires a non-empty ``required_sources`` contract,
+    every named source, and every referenced role definition to be complete.
     """
     if (
         request.provider is not bundle.provider

--- a/src/agent_bom/cloud/authorization_evidence.py
+++ b/src/agent_bom/cloud/authorization_evidence.py
@@ -229,6 +229,11 @@ class AuthorizationEvidenceBundle:
         return tuple(sorted(name for name, count in counts.items() if count > 1))
 
     def incomplete_required_sources(self) -> tuple[str, ...]:
+        # An empty requirement set is not proof that no provider evidence is
+        # needed. Treat it as an incomplete contract so hand-built, restored,
+        # or future provider bundles cannot authorize from a thin allow record.
+        if not self.required_sources:
+            return ("required_sources:missing",)
         duplicate_names = set(self.duplicate_source_names())
         incomplete: list[str] = []
         for name in self.required_sources:

--- a/src/agent_bom/cloud/aws_iam_collector.py
+++ b/src/agent_bom/cloud/aws_iam_collector.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import time
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from typing import Any, Mapping
 
@@ -20,6 +22,8 @@ _UNSUPPORTED_CODES = {"NotSupported", "NotSupportedException", "UnsupportedOpera
 _ACCESS_ADVISOR_PAGE_SIZE = 100
 _ACCESS_ADVISOR_HARD_MAX_POLLS = 10
 _ACCESS_ADVISOR_HARD_MAX_PAGES = 10
+_ACCESS_ADVISOR_INITIAL_BACKOFF_SECONDS = 1.0
+_ACCESS_ADVISOR_MAX_BACKOFF_SECONDS = 5.0
 
 
 def _error_code(exc: Exception) -> str:
@@ -132,7 +136,7 @@ def _collect_access_advisor(
             return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
         response: Mapping[str, Any] = {}
         poll_budget = min(_ACCESS_ADVISOR_HARD_MAX_POLLS, max(1, max_polls))
-        for _ in range(poll_budget):
+        for poll_index in range(poll_budget):
             candidate = client.get_service_last_accessed_details(JobId=job_id, MaxItems=_ACCESS_ADVISOR_PAGE_SIZE)
             if not isinstance(candidate, Mapping):
                 return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
@@ -141,52 +145,226 @@ def _collect_access_advisor(
                 break
             if response.get("JobStatus") == "FAILED":
                 return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
+            if poll_index + 1 < poll_budget:
+                delay = min(
+                    _ACCESS_ADVISOR_INITIAL_BACKOFF_SECONDS * (2**poll_index),
+                    _ACCESS_ADVISOR_MAX_BACKOFF_SECONDS,
+                )
+                time.sleep(delay)
         else:
             return (), UsageEvidenceState.PENDING, "access_advisor_pending"
 
-        pages: list[Mapping[str, Any]] = [response]
-        page_budget = min(_ACCESS_ADVISOR_HARD_MAX_PAGES, max(1, max_pages))
-        while bool(pages[-1].get("IsTruncated")):
-            if len(pages) >= page_budget:
-                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_page_budget_exhausted"
-            marker = pages[-1].get("Marker")
-            if not isinstance(marker, str) or not marker:
-                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
-            candidate = client.get_service_last_accessed_details(
-                JobId=job_id,
-                MaxItems=_ACCESS_ADVISOR_PAGE_SIZE,
-                Marker=marker,
-            )
-            if not isinstance(candidate, Mapping) or candidate.get("JobStatus") not in {None, "COMPLETED"}:
-                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
-            pages.append(candidate)
-
-        evidence: list[IamServiceUsageEvidence] = []
-        for page in pages:
-            services = page.get("ServicesLastAccessed", [])
-            if not isinstance(services, list):
-                return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
-            for service in services:
-                if not isinstance(service, Mapping):
-                    continue
-                namespace = service.get("ServiceNamespace")
-                if not isinstance(namespace, str) or not namespace:
-                    continue
-                accessed = service.get("LastAuthenticated")
-                region = service.get("LastAuthenticatedRegion")
-                evidence.append(
-                    IamServiceUsageEvidence(
-                        service_namespace=namespace,
-                        state=UsageEvidenceState.AVAILABLE,
-                        last_accessed_at=accessed if isinstance(accessed, datetime) else None,
-                        last_accessed_region=region if isinstance(region, str) else None,
-                        collected_at=collected_at,
-                    )
-                )
-        return tuple(evidence), UsageEvidenceState.AVAILABLE, "access_advisor_available"
+        return _completed_access_advisor_evidence(
+            client,
+            job_id,
+            response,
+            max_pages=max_pages,
+            collected_at=collected_at,
+        )
     except Exception as exc:
         state, diagnostic = _usage_failure(exc)
         return (), state, diagnostic
+
+
+def _completed_access_advisor_evidence(
+    client: Any,
+    job_id: str,
+    response: Mapping[str, Any],
+    *,
+    max_pages: int,
+    collected_at: datetime,
+) -> tuple[tuple[IamServiceUsageEvidence, ...], UsageEvidenceState, str]:
+    """Read every page of one completed job without retaining partial output."""
+    pages: list[Mapping[str, Any]] = [response]
+    page_budget = min(_ACCESS_ADVISOR_HARD_MAX_PAGES, max(1, max_pages))
+    while bool(pages[-1].get("IsTruncated")):
+        if len(pages) >= page_budget:
+            return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_page_budget_exhausted"
+        marker = pages[-1].get("Marker")
+        if not isinstance(marker, str) or not marker:
+            return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
+        candidate = client.get_service_last_accessed_details(
+            JobId=job_id,
+            MaxItems=_ACCESS_ADVISOR_PAGE_SIZE,
+            Marker=marker,
+        )
+        if not isinstance(candidate, Mapping) or candidate.get("JobStatus") not in {None, "COMPLETED"}:
+            return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
+        pages.append(candidate)
+
+    evidence: list[IamServiceUsageEvidence] = []
+    for page in pages:
+        services = page.get("ServicesLastAccessed", [])
+        if not isinstance(services, list):
+            return (), UsageEvidenceState.UNAVAILABLE, "access_advisor_unavailable"
+        for service in services:
+            if not isinstance(service, Mapping):
+                continue
+            namespace = service.get("ServiceNamespace")
+            if not isinstance(namespace, str) or not namespace:
+                continue
+            accessed = service.get("LastAuthenticated")
+            region = service.get("LastAuthenticatedRegion")
+            evidence.append(
+                IamServiceUsageEvidence(
+                    service_namespace=namespace,
+                    state=UsageEvidenceState.AVAILABLE,
+                    last_accessed_at=accessed if isinstance(accessed, datetime) else None,
+                    last_accessed_region=region if isinstance(region, str) else None,
+                    collected_at=collected_at,
+                )
+            )
+    return tuple(evidence), UsageEvidenceState.AVAILABLE, "access_advisor_available"
+
+
+def _usage_result(
+    client: Any,
+    *,
+    principal_arn: str,
+    role_name: str,
+    role_snapshot: Mapping[str, Any] | None,
+    usage: tuple[IamServiceUsageEvidence, ...],
+    usage_state: UsageEvidenceState,
+    diagnostic: str,
+    collected_at: datetime,
+) -> IamRoleUsageEvidence:
+    role_usage = _role_last_used(
+        client,
+        role_name,
+        role_snapshot=role_snapshot,
+        collected_at=collected_at,
+    )
+    if role_usage is not None:
+        usage = (*usage, role_usage)
+    return IamRoleUsageEvidence(
+        principal_arn=principal_arn,
+        usage_state=usage_state,
+        records=usage,
+        diagnostic=diagnostic,
+        collected_at=collected_at,
+    )
+
+
+def collect_iam_roles_usage_evidence(
+    client: Any,
+    roles: Sequence[tuple[str, str, Mapping[str, Any] | None]],
+    *,
+    max_access_advisor_polls: int = 3,
+    max_access_advisor_pages: int = 5,
+    collected_at: datetime | None = None,
+) -> dict[str, IamRoleUsageEvidence]:
+    """Collect several roles using shared, bounded Access Advisor poll rounds.
+
+    Access Advisor jobs are asynchronous. Starting and immediately polling one
+    role at a time makes the default three polls collapse into one instant and
+    usually returns ``pending`` for every role. This method starts the bounded
+    estate batch first, then polls all jobs in shared exponential-backoff rounds,
+    so waiting is once per estate rather than once per role.
+    """
+    observed_at = collected_at or datetime.now(timezone.utc)
+    results: dict[str, IamRoleUsageEvidence] = {}
+    jobs: dict[str, tuple[str, str, Mapping[str, Any] | None]] = {}
+    for principal_arn, role_name, role_snapshot in roles:
+        try:
+            started = client.generate_service_last_accessed_details(
+                Arn=principal_arn,
+                Granularity="SERVICE_LEVEL",
+            )
+            job_id = started.get("JobId")
+            if not isinstance(job_id, str) or not job_id:
+                raise ValueError("missing Access Advisor job id")
+            jobs[principal_arn] = (job_id, role_name, role_snapshot)
+        except Exception as exc:
+            state, diagnostic = _usage_failure(exc)
+            results[principal_arn] = _usage_result(
+                client,
+                principal_arn=principal_arn,
+                role_name=role_name,
+                role_snapshot=role_snapshot,
+                usage=(),
+                usage_state=state,
+                diagnostic=diagnostic,
+                collected_at=observed_at,
+            )
+
+    poll_budget = min(_ACCESS_ADVISOR_HARD_MAX_POLLS, max(1, max_access_advisor_polls))
+    for poll_index in range(poll_budget):
+        for principal_arn, (job_id, role_name, role_snapshot) in tuple(jobs.items()):
+            try:
+                response = client.get_service_last_accessed_details(
+                    JobId=job_id,
+                    MaxItems=_ACCESS_ADVISOR_PAGE_SIZE,
+                )
+                if not isinstance(response, Mapping):
+                    raise TypeError("invalid Access Advisor response")
+                status = str(response.get("JobStatus") or "").upper()
+                if status == "COMPLETED":
+                    usage, state, diagnostic = _completed_access_advisor_evidence(
+                        client,
+                        job_id,
+                        response,
+                        max_pages=max_access_advisor_pages,
+                        collected_at=observed_at,
+                    )
+                    results[principal_arn] = _usage_result(
+                        client,
+                        principal_arn=principal_arn,
+                        role_name=role_name,
+                        role_snapshot=role_snapshot,
+                        usage=usage,
+                        usage_state=state,
+                        diagnostic=diagnostic,
+                        collected_at=observed_at,
+                    )
+                    del jobs[principal_arn]
+                elif status == "FAILED":
+                    results[principal_arn] = _usage_result(
+                        client,
+                        principal_arn=principal_arn,
+                        role_name=role_name,
+                        role_snapshot=role_snapshot,
+                        usage=(),
+                        usage_state=UsageEvidenceState.UNAVAILABLE,
+                        diagnostic="access_advisor_unavailable",
+                        collected_at=observed_at,
+                    )
+                    del jobs[principal_arn]
+                elif status not in {"IN_PROGRESS", "RUNNING", "PENDING"}:
+                    raise ValueError("unknown Access Advisor job status")
+            except Exception as exc:
+                state, diagnostic = _usage_failure(exc)
+                results[principal_arn] = _usage_result(
+                    client,
+                    principal_arn=principal_arn,
+                    role_name=role_name,
+                    role_snapshot=role_snapshot,
+                    usage=(),
+                    usage_state=state,
+                    diagnostic=diagnostic,
+                    collected_at=observed_at,
+                )
+                del jobs[principal_arn]
+
+        if not jobs or poll_index + 1 >= poll_budget:
+            break
+        delay = min(
+            _ACCESS_ADVISOR_INITIAL_BACKOFF_SECONDS * (2**poll_index),
+            _ACCESS_ADVISOR_MAX_BACKOFF_SECONDS,
+        )
+        time.sleep(delay)
+
+    for principal_arn, (_job_id, role_name, role_snapshot) in jobs.items():
+        results[principal_arn] = _usage_result(
+            client,
+            principal_arn=principal_arn,
+            role_name=role_name,
+            role_snapshot=role_snapshot,
+            usage=(),
+            usage_state=UsageEvidenceState.PENDING,
+            diagnostic="access_advisor_pending",
+            collected_at=observed_at,
+        )
+    return results
 
 
 def _role_last_used(

--- a/src/agent_bom/cloud/aws_inventory.py
+++ b/src/agent_bom/cloud/aws_inventory.py
@@ -50,7 +50,7 @@ from .aws import (
     _policy_actions_from_document,
     _resolve_account_id,
 )
-from .aws_iam_collector import collect_iam_role_usage_evidence
+from .aws_iam_collector import collect_iam_role_usage_evidence, collect_iam_roles_usage_evidence
 from .aws_iam_evidence import IamRoleUsageEvidence, UsageEvidenceState
 from .normalization import sanitize_discovery_warning
 
@@ -1276,23 +1276,52 @@ def _discover_iam(
     users: list[dict[str, Any]] = []
     groups: list[dict[str, Any]] = []
 
+    raw_roles: list[dict[str, Any]] = []
     try:
         role_paginator = iam.get_paginator("list_roles")
         for page in role_paginator.paginate():
             for role in page.get("Roles", []):
-                roles.append(
-                    _normalize_role(
-                        iam,
-                        role,
-                        account_id=account_id,
-                        warnings=warnings,
-                        collect_usage=len(roles) < _MAX_IAM_USAGE_ROLES,
-                    )
-                )
+                if isinstance(role, dict):
+                    raw_roles.append(role)
     except Exception as exc:  # noqa: BLE001 — one failed IAM list must not sink the scan
         record_discovery_failure(
             exc=exc, resource_type="IAM roles", permission="iam:ListRoles", cloud="aws", warnings=warnings, missing=missing
         )
+
+    # Normalize policy/trust evidence without serially polling asynchronous
+    # Access Advisor jobs. The bounded usage subset is started together and then
+    # polled in shared backoff rounds, so one estate waits once rather than once
+    # per role.
+    for role in raw_roles:
+        roles.append(
+            _normalize_role(
+                iam,
+                role,
+                account_id=account_id,
+                warnings=warnings,
+                collect_usage=False,
+            )
+        )
+    usage_inputs = [
+        (
+            str(role.get("Arn") or ""),
+            str(role.get("RoleName") or ""),
+            role,
+        )
+        for role in raw_roles[:_MAX_IAM_USAGE_ROLES]
+        if str(role.get("Arn") or "") and str(role.get("RoleName") or "")
+    ]
+    usage_by_arn = collect_iam_roles_usage_evidence(
+        iam,
+        usage_inputs,
+        max_access_advisor_polls=_MAX_ACCESS_ADVISOR_POLLS,
+        max_access_advisor_pages=_MAX_ACCESS_ADVISOR_PAGES,
+    )
+    for role in roles[:_MAX_IAM_USAGE_ROLES]:
+        principal_arn = str(role.get("arn") or "")
+        evidence = usage_by_arn.get(principal_arn)
+        if evidence is not None:
+            role["usage_evidence"] = evidence.to_dict()
 
     try:
         group_paginator = iam.get_paginator("list_groups")

--- a/src/agent_bom/graph/authorization_evidence.py
+++ b/src/agent_bom/graph/authorization_evidence.py
@@ -1,0 +1,463 @@
+"""Project proven Azure/GCP authorization decisions into the unified graph.
+
+The provider collectors and normalizers own evidence completeness.  This module
+only emits traversable graph edges when the fail-closed evaluator returns an
+explicit ``ALLOW`` for a concrete action and resource.  Partial, conditional,
+stale, truncated, or otherwise unresolved evidence is retained as a typed graph
+analysis status and never converted into reachability.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from agent_bom.cloud.authorization_evaluator import evaluate_authorization
+from agent_bom.cloud.authorization_evidence import (
+    AuthorizationBinding,
+    AuthorizationDecision,
+    AuthorizationEvidenceBundle,
+    AuthorizationPlane,
+    AuthorizationProvider,
+    AuthorizationRequest,
+)
+from agent_bom.cloud.azure_rbac_evidence import normalize_azure_rbac_inventory
+from agent_bom.cloud.gcp_iam_evidence import normalize_gcp_iam_inventory
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+_SOURCE = "authorization-evidence"
+_MAX_EVALUATIONS = 100_000
+
+_PRINCIPAL_TYPES: dict[str, EntityType] = {
+    "group": EntityType.GROUP,
+    "managedidentity": EntityType.MANAGED_IDENTITY,
+    "managed-identity": EntityType.MANAGED_IDENTITY,
+    "public": EntityType.FEDERATED_IDENTITY,
+    "serviceaccount": EntityType.SERVICE_ACCOUNT,
+    "service-account": EntityType.SERVICE_ACCOUNT,
+    "serviceprincipal": EntityType.SERVICE_PRINCIPAL,
+    "service-principal": EntityType.SERVICE_PRINCIPAL,
+    "user": EntityType.USER,
+}
+
+_PRINCIPAL_PREFIX: dict[EntityType, str] = {
+    EntityType.GROUP: "group",
+    EntityType.MANAGED_IDENTITY: "managed_identity",
+    EntityType.FEDERATED_IDENTITY: "federated_identity",
+    EntityType.SERVICE_ACCOUNT: "service_account",
+    EntityType.SERVICE_PRINCIPAL: "service_principal",
+    EntityType.USER: "user",
+}
+
+
+def has_authoritative_authorization_evidence(inventory: Any) -> bool:
+    """Return whether *inventory* carries the authoritative collector contract."""
+    if not isinstance(inventory, Mapping):
+        return False
+    provider = str(inventory.get("provider") or "").strip().lower()
+    marker = inventory.get("authorization_evidence")
+    if not isinstance(marker, Mapping):
+        return False
+    if provider == AuthorizationProvider.AZURE.value:
+        return isinstance(inventory.get("authorization_sources"), list)
+    if provider == AuthorizationProvider.GCP.value:
+        return isinstance(inventory.get("iam_sources"), list)
+    return False
+
+
+def _bundle(inventory: Mapping[str, Any]) -> AuthorizationEvidenceBundle | None:
+    provider = str(inventory.get("provider") or "").strip().lower()
+    if provider == AuthorizationProvider.AZURE.value:
+        return normalize_azure_rbac_inventory(inventory)
+    if provider == AuthorizationProvider.GCP.value:
+        return normalize_gcp_iam_inventory(inventory)
+    return None
+
+
+def _principal_type(binding: AuthorizationBinding) -> EntityType:
+    key = binding.principal_type.strip().lower().replace("_", "")
+    return _PRINCIPAL_TYPES.get(key, EntityType.SERVICE_ACCOUNT)
+
+
+def _principal_node(graph: UnifiedGraph, binding: AuthorizationBinding, provider: str) -> str:
+    principal_id = binding.principal_id.strip()
+    normalized = _principal_aliases(principal_id)
+    for node in graph.nodes.values():
+        if str(node.attributes.get("cloud_provider") or "").casefold() != provider:
+            continue
+        candidates: set[str] = set()
+        for key in ("principal_id", "principal_name", "directory_principal_id", "principal_email"):
+            candidates.update(_principal_aliases(str(node.attributes.get(key) or "")))
+        if normalized & candidates:
+            return node.id
+
+    entity_type = _principal_type(binding)
+    prefix = _PRINCIPAL_PREFIX.get(entity_type, "identity")
+    node_id = f"{prefix}:{provider}:{principal_id}"
+    graph.add_node(
+        UnifiedNode(
+            id=node_id,
+            entity_type=entity_type,
+            label=principal_id,
+            attributes={
+                "principal_id": principal_id,
+                "principal_type": binding.principal_type,
+                "cloud_provider": provider,
+                "authorization_evidence_state": "observed",
+            },
+            data_sources=[_SOURCE],
+            dimensions=NodeDimensions(cloud_provider=provider, surface="identity"),
+        )
+    )
+    return node_id
+
+
+def _principal_aliases(value: str) -> set[str]:
+    normalized = value.strip().casefold()
+    if not normalized:
+        return set()
+    aliases = {normalized}
+    prefix, separator, suffix = normalized.partition(":")
+    if separator and prefix in {"group", "serviceaccount", "user"} and suffix:
+        aliases.add(suffix)
+    return aliases
+
+
+def _canonical_resource(node: UnifiedNode, bundle: AuthorizationEvidenceBundle) -> str:
+    resource_id = str(node.attributes.get("resource_id") or "").strip().rstrip("/")
+    if node.entity_type is EntityType.ACCOUNT:
+        account_id = str(node.attributes.get("account_id") or "").strip()
+        if bundle.provider is AuthorizationProvider.AZURE and account_id:
+            return f"/subscriptions/{account_id}"
+        if bundle.provider is AuthorizationProvider.GCP and account_id:
+            return f"projects/{account_id}"
+    if bundle.provider is AuthorizationProvider.AZURE:
+        return resource_id if resource_id.casefold().startswith("/subscriptions/") else ""
+    return resource_id if resource_id.startswith(("projects/", "folders/", "organizations/", "//")) else ""
+
+
+def _resource_nodes(graph: UnifiedGraph, bundle: AuthorizationEvidenceBundle) -> list[tuple[UnifiedNode, str]]:
+    provider = bundle.provider.value
+    candidates: list[tuple[UnifiedNode, str]] = []
+    for node in graph.nodes.values():
+        if node.entity_type not in {EntityType.ACCOUNT, EntityType.CLOUD_RESOURCE, EntityType.DATA_STORE, EntityType.RESOURCE}:
+            continue
+        if str(node.attributes.get("cloud_provider") or "").strip().lower() != provider:
+            continue
+        resource = _canonical_resource(node, bundle)
+        if resource:
+            candidates.append((node, resource))
+    return sorted(candidates, key=lambda item: item[0].id)
+
+
+def _permission_values(bundle: AuthorizationEvidenceBundle, binding: AuthorizationBinding) -> tuple[str, ...]:
+    role = bundle.role_definition(binding.role_id) if binding.role_id else None
+    values = binding.permissions + binding.data_permissions + (role.permissions if role else ()) + (role.data_permissions if role else ())
+    return tuple(sorted({value.strip() for value in values if value.strip()}))
+
+
+def _service_tokens(node: UnifiedNode) -> set[str]:
+    attrs = node.attributes
+    return {
+        str(attrs.get("cloud_service") or "").strip().lower(),
+        str(attrs.get("resource_type") or "").strip().lower(),
+        str(attrs.get("resource_kind") or "").strip().lower(),
+        node.label.lower(),
+    }
+
+
+def _action_relevant(provider: AuthorizationProvider, action: str, node: UnifiedNode) -> bool:
+    """Conservatively associate a provider action with its resource family."""
+    tokens = " ".join(_service_tokens(node))
+    if node.entity_type is EntityType.ACCOUNT:
+        if provider is AuthorizationProvider.AZURE:
+            return action.casefold().startswith(("microsoft.resources/", "microsoft.authorization/"))
+        return action.startswith("resourcemanager.")
+    if provider is AuthorizationProvider.AZURE:
+        namespace = action.partition("/")[0].casefold().removeprefix("microsoft.")
+        aliases = {
+            "storage": ("storage", "bucket", "disk"),
+            "compute": ("compute", "vm", "instance", "disk"),
+            "keyvault": ("key vault", "secret"),
+            "containerregistry": ("registry",),
+            "containerservice": ("kubernetes", "container"),
+            "sql": ("database", "sql"),
+            "network": ("network", "firewall", "load balancer", "public ip"),
+            "managedidentity": ("identity",),
+        }
+        return any(alias in tokens for alias in aliases.get(namespace, (namespace,)))
+    service = action.partition(".")[0].lower()
+    aliases = {
+        "storage": ("gcs", "storage", "bucket", "disk"),
+        "compute": ("compute", "instance", "disk", "network", "firewall"),
+        "container": ("gke", "container", "kubernetes"),
+        "run": ("cloud run", "function"),
+        "cloudfunctions": ("cloud function", "function"),
+        "cloudsql": ("cloud sql", "database"),
+        "pubsub": ("pubsub", "messaging"),
+    }
+    return any(alias in tokens for alias in aliases.get(service, (service,)))
+
+
+def _concrete_actions(bundle: AuthorizationEvidenceBundle, binding: AuthorizationBinding, node: UnifiedNode) -> tuple[str, ...]:
+    permissions = _permission_values(bundle, binding)
+    # Exact permissions are directly provable. Wildcards are not requests, so
+    # probe a small provider/resource-specific catalog only when the evaluator
+    # can verify that concrete probe against the wildcard and all deny/boundary
+    # evidence. This keeps the edge concrete and reviewable.
+    exact = {action for action in permissions if "*" not in action and _action_relevant(bundle.provider, action, node)}
+    probes = _RESOURCE_PROBES.get(bundle.provider, ())
+    for action in probes:
+        if not _action_relevant(bundle.provider, action, node):
+            continue
+        if any(_pattern_allows(bundle.provider, action, pattern) for pattern in permissions if "*" in pattern):
+            exact.add(action)
+    return tuple(sorted(exact))
+
+
+def _pattern_allows(provider: AuthorizationProvider, action: str, pattern: str) -> bool:
+    from fnmatch import fnmatchcase
+
+    if provider is AuthorizationProvider.AZURE:
+        return fnmatchcase(action.casefold(), pattern.casefold())
+    return fnmatchcase(action, pattern)
+
+
+_RESOURCE_PROBES: dict[AuthorizationProvider, tuple[str, ...]] = {
+    AuthorizationProvider.AZURE: (
+        "Microsoft.Authorization/roleAssignments/write",
+        "Microsoft.Compute/virtualMachines/read",
+        "Microsoft.Compute/virtualMachines/write",
+        "Microsoft.KeyVault/vaults/read",
+        "Microsoft.Storage/storageAccounts/listKeys/action",
+        "Microsoft.Storage/storageAccounts/read",
+        "Microsoft.Storage/storageAccounts/write",
+    ),
+    AuthorizationProvider.GCP: (
+        "cloudsql.instances.get",
+        "compute.instances.get",
+        "compute.instances.setIamPolicy",
+        "container.clusters.get",
+        "pubsub.topics.get",
+        "resourcemanager.projects.get",
+        "resourcemanager.projects.setIamPolicy",
+        "storage.buckets.get",
+        "storage.objects.create",
+        "storage.objects.get",
+    ),
+}
+
+_ASSUME_PROBES: dict[AuthorizationProvider, tuple[str, ...]] = {
+    AuthorizationProvider.AZURE: ("Microsoft.ManagedIdentity/userAssignedIdentities/assign/action",),
+    AuthorizationProvider.GCP: ("iam.serviceAccounts.actAs",),
+}
+
+
+def _assumable_principals(
+    graph: UnifiedGraph,
+    bundle: AuthorizationEvidenceBundle,
+) -> list[tuple[UnifiedNode, str]]:
+    candidates: list[tuple[UnifiedNode, str]] = []
+    for node in graph.nodes.values():
+        if str(node.attributes.get("cloud_provider") or "").strip().lower() != bundle.provider.value:
+            continue
+        principal_id = str(node.attributes.get("principal_id") or "").strip()
+        if bundle.provider is AuthorizationProvider.GCP and node.entity_type is EntityType.SERVICE_ACCOUNT:
+            email = str(node.attributes.get("principal_email") or "").strip()
+            if not email and "@" in principal_id:
+                email = principal_id.removeprefix("serviceAccount:")
+            if email:
+                candidates.append((node, f"{bundle.scope.rstrip('/')}/serviceAccounts/{email}"))
+        elif bundle.provider is AuthorizationProvider.AZURE and node.entity_type is EntityType.MANAGED_IDENTITY:
+            resource_id = str(node.attributes.get("principal_resource_id") or "").strip()
+            if resource_id.casefold().startswith("/subscriptions/"):
+                candidates.append((node, resource_id.rstrip("/")))
+    return sorted(candidates, key=lambda item: item[0].id)
+
+
+def _assume_actions(bundle: AuthorizationEvidenceBundle, binding: AuthorizationBinding) -> tuple[str, ...]:
+    permissions = _permission_values(bundle, binding)
+    actions: set[str] = set()
+    for probe in _ASSUME_PROBES[bundle.provider]:
+        if probe in permissions or any(_pattern_allows(bundle.provider, probe, pattern) for pattern in permissions if "*" in pattern):
+            actions.add(probe)
+    return tuple(sorted(actions))
+
+
+def apply_authorization_evidence(graph: UnifiedGraph, inventory: Any) -> dict[str, int]:
+    """Emit evaluator-proven access edges and a secret-safe execution status."""
+    if not has_authoritative_authorization_evidence(inventory):
+        return {}
+    assert isinstance(inventory, Mapping)
+    bundle = _bundle(inventory)
+    if bundle is None:
+        return {}
+
+    evaluated = 0
+    allow_edges = 0
+    denied = 0
+    indeterminate = 0
+    unmapped = 0
+    capped = False
+    seen_requests: set[tuple[str, str, str]] = set()
+    resources = _resource_nodes(graph, bundle)
+    assumable_principals = _assumable_principals(graph, bundle)
+    provider = bundle.provider.value
+
+    for binding in bundle.bindings:
+        if binding.effect.value != "allow":
+            continue
+        principal_node_id = _principal_node(graph, binding, provider)
+        matched_resource = False
+        assume_actions = _assume_actions(bundle, binding)
+        for resource_node, resource in resources:
+            actions = _concrete_actions(bundle, binding, resource_node)
+            if not actions:
+                continue
+            matched_resource = True
+            for action in actions:
+                key = (binding.principal_id.casefold(), action.casefold(), resource.casefold())
+                if key in seen_requests:
+                    continue
+                if evaluated >= _MAX_EVALUATIONS:
+                    capped = True
+                    break
+                seen_requests.add(key)
+                evaluated += 1
+                result = evaluate_authorization(
+                    bundle,
+                    AuthorizationRequest(
+                        provider=bundle.provider,
+                        principal_id=binding.principal_id,
+                        action=action,
+                        resource=resource,
+                        # ANY evaluates both control- and data-plane grants. The
+                        # provider normalizers already preserve those planes;
+                        # classifying a GCP permission name by string would lose
+                        # valid storage data access because GCP roles expose one
+                        # unified permission list.
+                        plane=AuthorizationPlane.ANY,
+                    ),
+                )
+                if result.decision is AuthorizationDecision.ALLOW:
+                    before = len(graph.edges)
+                    graph.add_edge(
+                        UnifiedEdge(
+                            source=principal_node_id,
+                            target=resource_node.id,
+                            relationship=RelationshipType.CAN_ACCESS,
+                            weight=4.0,
+                            confidence=1.0,
+                            provenance={"source": _SOURCE},
+                            evidence={
+                                "source": _SOURCE,
+                                "provider": provider,
+                                "decision": result.decision.value,
+                                "action": action,
+                                "resource": resource,
+                                "binding_ids": list(result.matched_allow_bindings),
+                                "observed_at": bundle.observed_at.isoformat() if bundle.observed_at else None,
+                            },
+                        )
+                    )
+                    if len(graph.edges) > before:
+                        allow_edges += 1
+                elif result.decision in {AuthorizationDecision.EXPLICIT_DENY, AuthorizationDecision.IMPLICIT_DENY}:
+                    denied += 1
+                else:
+                    indeterminate += 1
+            if capped:
+                break
+        if not matched_resource and not assume_actions:
+            unmapped += 1
+        if capped:
+            break
+
+        # A provider-native impersonation primitive is the only authorization
+        # evidence that becomes ASSUMES. Role names, owner labels, and broad
+        # admin classifications never create this escalation hop.
+        for action in assume_actions:
+            for target_node, resource in assumable_principals:
+                if target_node.id == principal_node_id:
+                    continue
+                key = (binding.principal_id.casefold(), action.casefold(), resource.casefold())
+                if key in seen_requests:
+                    continue
+                if evaluated >= _MAX_EVALUATIONS:
+                    capped = True
+                    break
+                seen_requests.add(key)
+                evaluated += 1
+                result = evaluate_authorization(
+                    bundle,
+                    AuthorizationRequest(
+                        provider=bundle.provider,
+                        principal_id=binding.principal_id,
+                        action=action,
+                        resource=resource,
+                        plane=AuthorizationPlane.ANY,
+                    ),
+                )
+                if result.decision is AuthorizationDecision.ALLOW:
+                    before = len(graph.edges)
+                    graph.add_edge(
+                        UnifiedEdge(
+                            source=principal_node_id,
+                            target=target_node.id,
+                            relationship=RelationshipType.ASSUMES,
+                            weight=6.0,
+                            confidence=1.0,
+                            provenance={"source": _SOURCE},
+                            evidence={
+                                "source": _SOURCE,
+                                "provider": provider,
+                                "decision": result.decision.value,
+                                "action": action,
+                                "resource": resource,
+                                "binding_ids": list(result.matched_allow_bindings),
+                                "observed_at": bundle.observed_at.isoformat() if bundle.observed_at else None,
+                            },
+                        )
+                    )
+                    if len(graph.edges) > before:
+                        allow_edges += 1
+                elif result.decision in {AuthorizationDecision.EXPLICIT_DENY, AuthorizationDecision.IMPLICIT_DENY}:
+                    denied += 1
+                else:
+                    indeterminate += 1
+            if capped:
+                break
+        if capped:
+            break
+
+    reason_codes: list[str] = []
+    if bundle.incomplete_required_sources():
+        reason_codes.append("incomplete_required_sources")
+    if indeterminate:
+        reason_codes.append("indeterminate_evaluations")
+    if unmapped:
+        reason_codes.append("unmapped_resources")
+    if capped:
+        reason_codes.append("evaluation_cap_exceeded")
+    state = GraphAnalysisState.LIMITED if reason_codes else GraphAnalysisState.COMPLETE
+    observed = {
+        "allow_edges": allow_edges,
+        "denied_evaluations": denied,
+        "evaluated_requests": evaluated,
+        "indeterminate_evaluations": indeterminate,
+        "unmapped_resources": unmapped,
+    }
+    graph.analysis_status[f"authorization_evidence:{provider}"] = GraphAnalysisStatus(
+        status=state,
+        reason_codes=tuple(sorted(reason_codes)),
+        limits={"max_evaluations": _MAX_EVALUATIONS},
+        observed=observed,
+    )
+    return observed
+
+
+__all__ = ["apply_authorization_evidence", "has_authoritative_authorization_evidence"]

--- a/src/agent_bom/graph/authorization_evidence.py
+++ b/src/agent_bom/graph/authorization_evidence.py
@@ -292,7 +292,8 @@ def apply_authorization_evidence(graph: UnifiedGraph, inventory: Any) -> dict[st
     """Emit evaluator-proven access edges and a secret-safe execution status."""
     if not has_authoritative_authorization_evidence(inventory):
         return {}
-    assert isinstance(inventory, Mapping)
+    if not isinstance(inventory, Mapping):
+        return {}
     bundle = _bundle(inventory)
     if bundle is None:
         return {}

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -17,6 +17,7 @@ from agent_bom.api.tracing import get_tracer
 from agent_bom.asset_provenance import package_version_provenance, sanitize_discovery_provenance
 from agent_bom.canonical_ids import canonical_agent_id, canonical_graph_node_id, source_ids
 from agent_bom.cloud.aws_iam_evidence import EvidenceCompleteness, normalize_iam_policy_document
+from agent_bom.graph.authorization_evidence import apply_authorization_evidence, has_authoritative_authorization_evidence
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import NodeDimensions, UnifiedNode, stable_node_id
@@ -955,6 +956,7 @@ def build_unified_graph_from_report(
     for inventory_payload in _iter_cloud_inventories(report_json.get("cloud_inventory")):
         _add_cloud_inventory(graph, inventory_payload, data_source_tag)
         _add_cloud_role_assignments(graph, inventory_payload, data_source_tag)
+        apply_authorization_evidence(graph, inventory_payload)
         # GCP estate roll-up backbone (org → folders → projects), carried on the
         # GCP inventory payload. Promoted after the inventory so project nodes the
         # CONTAINS tree references already exist to stitch onto.
@@ -4132,6 +4134,11 @@ def _add_cloud_role_assignments(graph: UnifiedGraph, inventory: Any, data_source
     """
     if not isinstance(inventory, dict):
         return
+    if has_authoritative_authorization_evidence(inventory):
+        # The normalized evaluator path below emits only proved access. Retaining
+        # these legacy role-name edges as well would re-introduce reachability
+        # when the authoritative sources are partial or conditional.
+        return
     assignments = inventory.get("role_assignments") or []
     if not assignments:
         return
@@ -4364,6 +4371,7 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
     # data/secret/registry/network collections; keep the original to ingest them
     # through the normalized resource model.
     original_inventory = inventory
+    allow_heuristic_authorization = not has_authoritative_authorization_evidence(original_inventory)
     inventory = _normalize_cloud_inventory(inventory)
     provider = _clean_graph_part(inventory.get("provider")) or "aws"
     account_id = _clean_graph_part(inventory.get("account_id"))
@@ -4785,7 +4793,13 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
     for principal in [*(inventory.get("roles", []) or []), *(inventory.get("users", []) or [])]:
         if isinstance(principal, dict):
             _add_inventory_principal(
-                graph, principal, provider=provider, account_node_id=account_node_id, resource_ids=resource_ids, data_sources=data_sources
+                graph,
+                principal,
+                provider=provider,
+                account_node_id=account_node_id,
+                resource_ids=resource_ids,
+                data_sources=data_sources,
+                allow_heuristic_authorization=allow_heuristic_authorization,
             )
 
     _wire_instance_profile_roles(
@@ -4804,7 +4818,13 @@ def _add_cloud_inventory(graph: UnifiedGraph, inventory: Any, data_source: str) 
     for group in inventory.get("groups", []) or []:
         if isinstance(group, dict):
             _add_inventory_group(
-                graph, group, provider=provider, account_node_id=account_node_id, resource_ids=resource_ids, data_sources=data_sources
+                graph,
+                group,
+                provider=provider,
+                account_node_id=account_node_id,
+                resource_ids=resource_ids,
+                data_sources=data_sources,
+                allow_heuristic_authorization=allow_heuristic_authorization,
             )
 
 
@@ -5562,6 +5582,7 @@ def _add_inventory_principal(
     account_node_id: str,
     resource_ids: list[str],
     data_sources: list[str],
+    allow_heuristic_authorization: bool = True,
 ) -> None:
     """Emit one IAM role/user as an identity principal with policy + access edges."""
     principal_type = _clean_graph_part(principal.get("principal_type")) or "user"
@@ -5580,6 +5601,9 @@ def _add_inventory_principal(
                 "principal_id": principal_id,
                 "principal_name": principal_name,
                 "principal_type": principal_type,
+                "directory_principal_id": _clean_graph_part(principal.get("principal_id")),
+                "principal_email": _clean_graph_part(principal.get("email")),
+                "principal_resource_id": _clean_graph_part(principal.get("arn")),
                 "cloud_provider": provider,
                 "privilege_level": _clean_graph_part(principal.get("privilege_level")) or "unknown",
                 "iam_path": _clean_graph_part(principal.get("path")),
@@ -5670,7 +5694,7 @@ def _add_inventory_principal(
     # HAS_PERMISSION transitive closure; admin-privileged principals reach
     # every resource, others get a baseline same-account access edge.
     privilege = _clean_graph_part(principal.get("privilege_level")) or "unknown"
-    if privilege in ("admin", "write"):
+    if allow_heuristic_authorization and privilege in ("admin", "write"):
         for resource_id in resource_ids:
             graph.add_edge(
                 UnifiedEdge(
@@ -5690,6 +5714,7 @@ def _add_inventory_group(
     account_node_id: str,
     resource_ids: list[str],
     data_sources: list[str],
+    allow_heuristic_authorization: bool = True,
 ) -> None:
     """Emit one IAM/Entra group as a ``GROUP`` node with policies + membership.
 
@@ -5750,7 +5775,7 @@ def _add_inventory_group(
 
     # Admin/write group → baseline same-account CAN_ACCESS, so the overlay can
     # inherit it to members via MEMBER_OF (mirrors the user/role baseline).
-    if privilege in ("admin", "write"):
+    if allow_heuristic_authorization and privilege in ("admin", "write"):
         for resource_id in resource_ids:
             _add_rel_edge(
                 graph,

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -960,7 +960,12 @@ def build_unified_graph_from_report(
         # GCP estate roll-up backbone (org → folders → projects), carried on the
         # GCP inventory payload. Promoted after the inventory so project nodes the
         # CONTAINS tree references already exist to stitch onto.
-        _add_gcp_organization(graph, inventory_payload.get("gcp_organization"), data_source_tag)
+        _add_gcp_organization(
+            graph,
+            inventory_payload.get("gcp_organization"),
+            data_source_tag,
+            allow_heuristic_authorization=not has_authoritative_authorization_evidence(inventory_payload),
+        )
 
     _add_aws_organization(graph, report_json.get("aws_organization"), data_source_tag)
     _add_snowflake_object_graph(graph, report_json.get("snowflake_object_graph"), data_source_tag)
@@ -3954,7 +3959,13 @@ def _add_aws_organization(graph: UnifiedGraph, payload: Any, data_source: str) -
                 _add_rel_edge(graph, scp_node, tgt_node, RelationshipType.GOVERNS, {"source": "aws-organizations"})
 
 
-def _add_gcp_organization(graph: UnifiedGraph, payload: Any, data_source: str) -> None:
+def _add_gcp_organization(
+    graph: UnifiedGraph,
+    payload: Any,
+    data_source: str,
+    *,
+    allow_heuristic_authorization: bool = True,
+) -> None:
     """Promote the GCP Organization (org → folders → projects) into the graph.
 
     The GCP analogue of :func:`_add_aws_organization` and the Azure
@@ -4047,7 +4058,7 @@ def _add_gcp_organization(graph: UnifiedGraph, payload: Any, data_source: str) -
         "user": EntityType.USER,
         "group": EntityType.USER,
     }
-    for binding in payload.get("iam_bindings", []) or []:
+    for binding in (payload.get("iam_bindings", []) or []) if allow_heuristic_authorization else ():
         if not isinstance(binding, dict):
             continue
         role = _clean_graph_part(binding.get("role"))

--- a/tests/test_authorization_evaluator.py
+++ b/tests/test_authorization_evaluator.py
@@ -78,6 +78,46 @@ def test_complete_matching_evidence_allows() -> None:
     assert result.matched_allow_bindings == ("allow-storage-read",)
 
 
+def _thin_bundle(effect: AuthorizationEffect = AuthorizationEffect.ALLOW) -> AuthorizationEvidenceBundle:
+    return AuthorizationEvidenceBundle(
+        provider=AuthorizationProvider.GCP,
+        scope="projects/proj-1",
+        bindings=(
+            AuthorizationBinding(
+                binding_id=f"thin-{effect.value}",
+                effect=effect,
+                principal_id=_PRINCIPAL,
+                principal_type="serviceaccount",
+                scope="projects/proj-1",
+                data_permissions=("storage.objects.get",),
+                plane=AuthorizationPlane.DATA,
+            ),
+        ),
+    )
+
+
+def test_empty_required_sources_can_never_allow() -> None:
+    result = evaluate_authorization(_thin_bundle(), _request())
+
+    assert result.decision is AuthorizationDecision.INDETERMINATE
+    assert result.diagnostics == ("required_sources:missing",)
+    assert result.matched_allow_bindings == ()
+
+
+def test_empty_required_sources_can_never_imply_deny() -> None:
+    result = evaluate_authorization(_thin_bundle(), _request("storage.objects.delete"))
+
+    assert result.decision is AuthorizationDecision.INDETERMINATE
+    assert result.diagnostics == ("required_sources:missing",)
+
+
+def test_explicit_deny_remains_authoritative_without_required_source_contract() -> None:
+    result = evaluate_authorization(_thin_bundle(AuthorizationEffect.DENY), _request())
+
+    assert result.decision is AuthorizationDecision.EXPLICIT_DENY
+    assert result.matched_deny_bindings == ("thin-deny",)
+
+
 @pytest.mark.parametrize("state", [EvidenceSourceState.PARTIAL, EvidenceSourceState.UNAVAILABLE])
 def test_incomplete_role_evidence_can_never_allow(state: EvidenceSourceState) -> None:
     result = evaluate_authorization(_bundle(role_state=state), _request())

--- a/tests/test_authorization_evidence.py
+++ b/tests/test_authorization_evidence.py
@@ -86,6 +86,16 @@ def test_missing_required_source_is_not_complete() -> None:
     assert bundle.incomplete_required_sources() == ("deny_assignments:missing",)
 
 
+def test_empty_required_source_contract_is_not_complete() -> None:
+    bundle = AuthorizationEvidenceBundle(
+        provider=AuthorizationProvider.GCP,
+        scope="projects/proj-1",
+        sources=(EvidenceSource("allow_policies", EvidenceSourceState.COMPLETE),),
+    )
+
+    assert bundle.incomplete_required_sources() == ("required_sources:missing",)
+
+
 def test_duplicate_source_state_is_deterministic_and_incomplete() -> None:
     bundle = AuthorizationEvidenceBundle(
         provider=AuthorizationProvider.GCP,

--- a/tests/test_aws_iam_collector.py
+++ b/tests/test_aws_iam_collector.py
@@ -3,8 +3,16 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+import pytest
+
+from agent_bom.cloud import aws_iam_collector
 from agent_bom.cloud.aws_iam_collector import collect_iam_role_evidence, collect_iam_role_usage_evidence
 from agent_bom.cloud.aws_iam_evidence import EvidenceCompleteness, UsageEvidenceState
+
+
+@pytest.fixture(autouse=True)
+def _avoid_real_access_advisor_waits(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(aws_iam_collector.time, "sleep", lambda _delay: None)
 
 
 class ProviderError(Exception):
@@ -105,6 +113,35 @@ def test_access_advisor_pending_is_bounded_and_explicit() -> None:
     )
 
     assert evidence.usage_state is UsageEvidenceState.PENDING
+
+
+def test_access_advisor_nonterminal_states_use_backoff_before_completion(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = IamClient()
+    statuses = iter(("RUNNING", "PENDING", "COMPLETED"))
+    delays: list[float] = []
+    monkeypatch.setattr(aws_iam_collector.time, "sleep", delays.append)
+
+    def delayed(**kwargs: str) -> dict[str, Any]:
+        status = next(statuses)
+        if status != "COMPLETED":
+            return {"JobStatus": status}
+        return {
+            "JobStatus": status,
+            "ServicesLastAccessed": [{"ServiceNamespace": "s3"}],
+            "IsTruncated": False,
+        }
+
+    client.get_service_last_accessed_details = delayed  # type: ignore[method-assign]
+    evidence = collect_iam_role_usage_evidence(
+        client,
+        principal_arn="arn:aws:iam::123456789012:role/scanner",
+        role_name="scanner",
+        max_access_advisor_polls=3,
+    )
+
+    assert evidence.usage_state is UsageEvidenceState.AVAILABLE
+    assert evidence.diagnostic == "access_advisor_available"
+    assert delays == [1.0, 2.0]
 
 
 def test_policy_read_failure_makes_collection_partial_without_exception_text() -> None:

--- a/tests/test_aws_inventory_iam_usage.py
+++ b/tests/test_aws_inventory_iam_usage.py
@@ -5,7 +5,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from agent_bom.cloud import aws_inventory
+from agent_bom.cloud import aws_iam_collector, aws_inventory
 
 
 class _Paginator:
@@ -108,6 +108,25 @@ class _Session:
         return self.iam
 
 
+class _DelayedInventoryIam(_InventoryIam):
+    def __init__(self, *, role_count: int = 2) -> None:
+        super().__init__(role_count=role_count)
+        self.polls_by_job: dict[str, int] = {}
+
+    def get_service_last_accessed_details(self, **kwargs: Any) -> dict[str, Any]:
+        job_id = str(kwargs["JobId"])
+        poll = self.polls_by_job.get(job_id, 0)
+        self.polls_by_job[job_id] = poll + 1
+        status = ("RUNNING", "PENDING", "COMPLETED")[min(poll, 2)]
+        if status != "COMPLETED":
+            return {"JobStatus": status}
+        return {
+            "JobStatus": "COMPLETED",
+            "ServicesLastAccessed": [{"ServiceNamespace": f"service-{job_id}"}],
+            "IsTruncated": False,
+        }
+
+
 def test_role_inventory_threads_usage_evidence_without_repeating_policy_reads() -> None:
     iam = _InventoryIam()
     role = {
@@ -139,6 +158,24 @@ def test_role_usage_collection_has_an_estate_budget_and_marks_skips_unavailable(
     assert [role["usage_evidence"]["state"] for role in roles] == ["available", "unavailable"]
     assert roles[1]["usage_evidence"]["diagnostic"] == "role_collection_budget_exhausted"
     assert iam.generate_calls == 1
+
+
+def test_role_usage_jobs_are_polled_in_shared_backoff_rounds(monkeypatch: Any) -> None:
+    """Slow Access Advisor jobs remain useful without sleeping once per role."""
+    iam = _DelayedInventoryIam(role_count=2)
+    delays: list[float] = []
+    monkeypatch.setattr(aws_iam_collector.time, "sleep", delays.append)
+
+    roles, users, groups = aws_inventory._discover_iam(
+        _Session(iam),
+        account_id="123456789012",
+        warnings=[],
+    )
+
+    assert users == [] and groups == []
+    assert [role["usage_evidence"]["state"] for role in roles] == ["available", "available"]
+    assert delays == [1.0, 2.0]
+    assert iam.polls_by_job == {"job-1": 3, "job-2": 3}
 
 
 def test_inventory_permission_envelope_declares_only_usage_reads_added_for_ciem() -> None:

--- a/tests/test_graph_authorization_evidence_integration.py
+++ b/tests/test_graph_authorization_evidence_integration.py
@@ -1,0 +1,319 @@
+"""Production graph integration for Azure/GCP authorization evidence."""
+
+from __future__ import annotations
+
+from starlette.testclient import TestClient
+
+from agent_bom.api import stores as api_stores
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.api.server import app
+from agent_bom.api.stores import set_graph_store
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.types import RelationshipType
+
+
+def _complete_sources(*names: str) -> list[dict[str, object]]:
+    return [{"name": name, "state": "complete", "diagnostics": [], "provenance": [f"test:{name}"]} for name in names]
+
+
+def _azure_inventory(*, role_state: str = "complete") -> dict[str, object]:
+    subscription = "/subscriptions/sub-1"
+    storage_id = f"{subscription}/resourceGroups/rg/providers/Microsoft.Storage/storageAccounts/prod"
+    sources = _complete_sources("role_assignments", "role_definitions", "deny_assignments")
+    if role_state != "complete":
+        sources[1]["state"] = role_state
+    return {
+        "provider": "azure",
+        "status": "ok",
+        "subscription_id": "sub-1",
+        "account_id": "sub-1",
+        "storage_accounts": [{"name": "prod", "id": storage_id}],
+        "managed_identities": [
+            {
+                "name": "scanner-mi",
+                "arn": "sp-1",
+                "principal_type": "serviceprincipal",
+                # This legacy classifier must not create broad access when the
+                # authoritative authorization evidence is incomplete.
+                "privilege_level": "admin",
+            }
+        ],
+        "role_assignments": [
+            {
+                "id": f"{subscription}/providers/Microsoft.Authorization/roleAssignments/a-1",
+                "principal_id": "sp-1",
+                "principal_type": "serviceprincipal",
+                "role_definition_id": f"{subscription}/providers/Microsoft.Authorization/roleDefinitions/storage-reader",
+                "scope": storage_id,
+            }
+        ],
+        "role_definitions": [
+            {
+                "id": f"{subscription}/providers/Microsoft.Authorization/roleDefinitions/storage-reader",
+                "completeness": role_state,
+                "permissions": [
+                    {
+                        "actions": ["Microsoft.Storage/storageAccounts/read"],
+                        "not_actions": [],
+                        "data_actions": [],
+                        "not_data_actions": [],
+                    }
+                ],
+            }
+        ],
+        "deny_assignments": [],
+        "authorization_sources": sources,
+        "authorization_observed_at": "2026-07-17T12:00:00+00:00",
+        "authorization_evidence": {"provider": "azure"},
+    }
+
+
+def _gcp_inventory(*, conditional: bool = False) -> dict[str, object]:
+    resource = "//storage.googleapis.com/projects/_/buckets/prod-data"
+    condition = {"expression": "request.time < timestamp('2026-01-01T00:00:00Z')"} if conditional else None
+    return {
+        "provider": "gcp",
+        "status": "ok",
+        "project_id": "proj-1",
+        "account_id": "proj-1",
+        "buckets": [{"name": "prod-data", "id": resource}],
+        "service_accounts": [
+            {
+                "name": "Reader",
+                "arn": "reader@proj-1.iam.gserviceaccount.com",
+                "principal_id": "10001",
+                "email": "reader@proj-1.iam.gserviceaccount.com",
+                "principal_type": "service-account",
+                "privilege_level": "admin",
+            }
+        ],
+        "allow_policies": [
+            {
+                "resource": resource,
+                "ancestors": ["projects/proj-1"],
+                "bindings": [
+                    {
+                        "id": "binding-1",
+                        "role": "roles/storage.objectViewer",
+                        "members": ["serviceAccount:reader@proj-1.iam.gserviceaccount.com"],
+                        "condition": condition,
+                    }
+                ],
+            }
+        ],
+        "role_definitions": [
+            {
+                "id": "roles/storage.objectViewer",
+                "permissions": ["storage.objects.get"],
+                "completeness": "complete",
+            }
+        ],
+        "deny_policies": [],
+        "pab_policies": [],
+        "pab_bindings": [],
+        "iam_hierarchy": ["projects/proj-1"],
+        "iam_scope": "projects/proj-1",
+        "iam_sources": _complete_sources(
+            "allow_policies",
+            "role_definitions",
+            "resource_hierarchy",
+            "deny_policies",
+            "principal_access_boundaries",
+        ),
+        "iam_observed_at": "2026-07-17T12:00:00+00:00",
+        "authorization_evidence": {"provider": "gcp"},
+    }
+
+
+def _edges(graph, relationship: RelationshipType):
+    return [edge for edge in graph.edges if edge.relationship is relationship]
+
+
+def test_complete_azure_evidence_drives_effective_permission_and_json_status() -> None:
+    graph = build_unified_graph_from_report({"scan_id": "scan-azure", "cloud_inventory": _azure_inventory()})
+
+    proved = [edge for edge in _edges(graph, RelationshipType.CAN_ACCESS) if edge.evidence.get("source") == "authorization-evidence"]
+    assert len(proved) == 1
+    assert proved[0].evidence["decision"] == "allow"
+    assert proved[0].evidence["action"] == "Microsoft.Storage/storageAccounts/read"
+    assert any(
+        edge.source == proved[0].source and edge.target == proved[0].target and edge.relationship is RelationshipType.HAS_PERMISSION
+        for edge in graph.edges
+    )
+    assert graph.to_dict()["analysis_status"]["authorization_evidence:azure"] == {
+        "status": "complete",
+        "reason_codes": [],
+        "limits": {"max_evaluations": 100000},
+        "observed": {
+            "allow_edges": 1,
+            "denied_evaluations": 0,
+            "evaluated_requests": 1,
+            "indeterminate_evaluations": 0,
+            "unmapped_resources": 0,
+        },
+    }
+
+
+def test_incomplete_azure_evidence_never_falls_back_to_broad_classifier_edges() -> None:
+    graph = build_unified_graph_from_report({"scan_id": "scan-azure-partial", "cloud_inventory": _azure_inventory(role_state="partial")})
+
+    principal = "service_principal:azure:sp-1"
+    assert not any(
+        edge.source == principal and edge.relationship in {RelationshipType.CAN_ACCESS, RelationshipType.HAS_PERMISSION}
+        for edge in graph.edges
+    )
+    status = graph.to_dict()["analysis_status"]["authorization_evidence:azure"]
+    assert status["status"] == "limited"
+    assert "incomplete_required_sources" in status["reason_codes"]
+    assert status["observed"]["indeterminate_evaluations"] == 1
+
+
+def test_complete_gcp_evidence_survives_provider_to_graph_to_json() -> None:
+    graph = build_unified_graph_from_report({"scan_id": "scan-gcp", "cloud_inventory": _gcp_inventory()})
+    payload = graph.to_dict()
+
+    proved = [
+        edge
+        for edge in payload["edges"]
+        if edge["relationship"] == "can_access" and edge["evidence"].get("source") == "authorization-evidence"
+    ]
+    assert len(proved) == 1
+    assert proved[0]["evidence"]["provider"] == "gcp"
+    assert proved[0]["evidence"]["action"] == "storage.objects.get"
+    assert payload["analysis_status"]["authorization_evidence:gcp"]["status"] == "complete"
+
+
+def test_conditional_gcp_allow_is_indeterminate_and_never_reachable() -> None:
+    graph = build_unified_graph_from_report({"scan_id": "scan-gcp-conditional", "cloud_inventory": _gcp_inventory(conditional=True)})
+
+    assert not any(
+        edge.evidence.get("source") == "authorization-evidence"
+        and edge.relationship in {RelationshipType.CAN_ACCESS, RelationshipType.HAS_PERMISSION}
+        for edge in graph.edges
+    )
+    status = graph.to_dict()["analysis_status"]["authorization_evidence:gcp"]
+    assert status["status"] == "limited"
+    assert "indeterminate_evaluations" in status["reason_codes"]
+    assert status["observed"]["allow_edges"] == 0
+
+
+def test_gcp_act_as_is_the_only_evidence_that_creates_an_assume_escalation() -> None:
+    inventory = _gcp_inventory()
+    assert isinstance(inventory["service_accounts"], list)
+    inventory["service_accounts"] = [
+        {
+            "name": "Source",
+            "arn": "source@proj-1.iam.gserviceaccount.com",
+            "principal_id": "10002",
+            "email": "source@proj-1.iam.gserviceaccount.com",
+            "principal_type": "service-account",
+            "privilege_level": "unknown",
+        },
+        {
+            "name": "Target",
+            "arn": "target@proj-1.iam.gserviceaccount.com",
+            "principal_id": "10003",
+            "email": "target@proj-1.iam.gserviceaccount.com",
+            "principal_type": "service-account",
+            "privilege_level": "unknown",
+        },
+    ]
+    bucket_policy = inventory["allow_policies"][0]
+    bucket_policy["bindings"][0]["members"] = ["serviceAccount:target@proj-1.iam.gserviceaccount.com"]
+    inventory["allow_policies"].append(
+        {
+            "resource": "projects/proj-1",
+            "bindings": [
+                {
+                    "id": "binding-act-as",
+                    "role": "roles/iam.serviceAccountUser",
+                    "members": ["serviceAccount:source@proj-1.iam.gserviceaccount.com"],
+                    "condition": None,
+                }
+            ],
+        }
+    )
+    inventory["role_definitions"].append(
+        {
+            "id": "roles/iam.serviceAccountUser",
+            "permissions": ["iam.serviceAccounts.actAs"],
+            "completeness": "complete",
+        }
+    )
+
+    graph = build_unified_graph_from_report({"scan_id": "scan-gcp-act-as", "cloud_inventory": inventory})
+    source = "service_account:gcp:source@proj-1.iam.gserviceaccount.com"
+    target = "service_account:gcp:target@proj-1.iam.gserviceaccount.com"
+    bucket = "cloud_resource:gcp:gcs:bucket:prod-data"
+
+    assume = next(
+        edge for edge in graph.edges if edge.source == source and edge.target == target and edge.relationship is RelationshipType.ASSUMES
+    )
+    assert assume.evidence["action"] == "iam.serviceAccounts.actAs"
+    inherited = next(
+        edge
+        for edge in graph.edges
+        if edge.source == source and edge.target == bucket and edge.relationship is RelationshipType.HAS_PERMISSION
+    )
+    assert inherited.evidence["access"] == "assume_chain"
+    assert graph.nodes[source].attributes["can_escalate_privilege"] is True
+
+
+def test_gcp_explicit_deny_never_becomes_access() -> None:
+    inventory = _gcp_inventory()
+    inventory["deny_policies"] = [
+        {
+            "name": "policies/project/denypolicies/protect",
+            "attachment_point": "cloudresourcemanager.googleapis.com/projects/proj-1",
+            "rules": [
+                {
+                    "denied_principals": [
+                        "principal://iam.googleapis.com/projects/-/serviceAccounts/reader@proj-1.iam.gserviceaccount.com"
+                    ],
+                    "denied_permissions": ["storage.googleapis.com/objects.get"],
+                    "exception_permissions": [],
+                    "exception_principals": [],
+                    "condition": None,
+                }
+            ],
+        }
+    ]
+
+    graph = build_unified_graph_from_report({"scan_id": "scan-gcp-deny", "cloud_inventory": inventory})
+
+    assert not any(
+        edge.evidence.get("source") == "authorization-evidence"
+        and edge.relationship in {RelationshipType.CAN_ACCESS, RelationshipType.HAS_PERMISSION}
+        for edge in graph.edges
+    )
+    status = graph.to_dict()["analysis_status"]["authorization_evidence:gcp"]
+    assert status["status"] == "complete"
+    assert status["observed"]["denied_evaluations"] == 1
+
+
+def test_authorization_decision_and_status_survive_persistence_and_graph_api(tmp_path) -> None:
+    graph = build_unified_graph_from_report(
+        {"scan_id": "scan-authorization-api", "cloud_inventory": _gcp_inventory()},
+        tenant_id="default",
+    )
+    store = SQLiteGraphStore(tmp_path / "authorization-graph.db")
+    store.save_graph(graph)
+    original = api_stores._graph_store
+    try:
+        set_graph_store(store)
+        response = TestClient(app).get(
+            "/v1/graph",
+            params={"scan": "scan-authorization-api", "limit": 200},
+        )
+    finally:
+        set_graph_store(original)
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["stats"]["analysis_status"]["authorization_evidence:gcp"]["status"] == "complete"
+    assert any(
+        edge["relationship"] == "can_access"
+        and edge["evidence"].get("source") == "authorization-evidence"
+        and edge["evidence"].get("decision") == "allow"
+        for edge in body["edges"]
+    )

--- a/tests/test_graph_authorization_evidence_integration.py
+++ b/tests/test_graph_authorization_evidence_integration.py
@@ -317,3 +317,30 @@ def test_authorization_decision_and_status_survive_persistence_and_graph_api(tmp
         and edge["evidence"].get("decision") == "allow"
         for edge in body["edges"]
     )
+
+
+def test_authoritative_gcp_evidence_suppresses_legacy_org_role_reachability() -> None:
+    inventory = _gcp_inventory(conditional=True)
+    inventory["gcp_organization"] = {
+        "status": "ok",
+        "org_id": "organizations/20",
+        "org_name": "example",
+        "folders": [],
+        "projects": [{"id": "proj-1", "name": "prod", "number": "123", "parent_id": "organizations/20"}],
+        "iam_bindings": [
+            {
+                "role": "roles/owner",
+                "scope_id": "organizations/20",
+                "scope_level": "organization",
+                "privilege_level": "admin",
+                "members": ["serviceAccount:reader@proj-1.iam.gserviceaccount.com"],
+            }
+        ],
+        "org_policies": [],
+    }
+
+    graph = build_unified_graph_from_report({"scan_id": "scan-gcp-org", "cloud_inventory": inventory})
+
+    assert not any(
+        edge.relationship is RelationshipType.HAS_PERMISSION and edge.evidence.get("source") == "gcp-organizations" for edge in graph.edges
+    )


### PR DESCRIPTION
## Summary

- Project only evaluator-proven Azure/GCP authorization into graph access, permission, and assumption edges; incomplete or conditional evidence stays limited instead of becoming a fabricated allow.
- Suppress legacy organization/name/role reachability when normalized authorization evidence is available and persist typed analysis status for supported consumers.
- Poll AWS Access Advisor jobs in shared bounded rounds, preserve pending evidence, and reject empty required-source contracts fail closed.

## Verification

- Focused CIEM/AWS/Azure/GCP/graph matrix — 185 passed
- Post-guard graph integration rerun — 8 passed
- In-process Azure/GCP smoke — one evaluator-proven `ALLOW` edge and `complete` status per provider
- `uv run ruff check` and changed-file formatting checks
- `uv run mypy src/agent_bom` — 765 source files
- Bandit on changed Python files — no findings
- `make preflight`
- exception-sanitization and package-layout guards
- `git diff --check`

## Notes

- Collection remains read-only and only proved authorization becomes graph reachability.
- Deferred #4131 scope: dedicated CLI evidence, operator UI, health/operability surfaces, credentialed provider smokes, parity/failure/scale lock-in, deployment permission proof, and complete supported-path fallback removal.

Closes #4170
Addresses #4131