### PR TITLE
fix(cloud): surface Snowflake inventory evaluation gaps

### DIFF
--- a/src/agent_bom/cloud/snowflake.py
+++ b/src/agent_bom/cloud/snowflake.py
@@ -58,6 +58,7 @@ from agent_bom.governance import (
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 from agent_bom.security import sanitize_error
 
+from .aws_inventory import record_discovery_failure
 from .base import CloudDiscoveryError
 from .normalization import (
     build_cloud_origin,
@@ -65,9 +66,56 @@ from .normalization import (
     coerce_int_or_none,
     coerce_truthy,
     resolve_env_or_value,
+    sanitize_discovery_warning,
 )
 
 logger = logging.getLogger(__name__)
+
+# Security-relevant Snowflake inventory surfaces that must never fail silently.
+_SNOWFLAKE_INVENTORY_FAILURES: dict[str, str] = {
+    "cortex_agents": "SHOW AGENTS IN ACCOUNT",
+    "mcp_servers": "SHOW MCP SERVERS IN ACCOUNT",
+    "grants_to_roles": "SELECT on SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_ROLES",
+    "grants_to_users": "SELECT on SNOWFLAKE.ACCOUNT_USAGE.GRANTS_TO_USERS",
+    "live_role_grants": "SHOW GRANTS TO/OF ROLE",
+}
+
+
+def _record_snowflake_inventory_failure(
+    *,
+    exc: BaseException,
+    resource_type: str,
+    inventory_key: str,
+    warnings: list[str],
+    missing: list[dict[str, str]] | None = None,
+) -> None:
+    """Translate a failed Snowflake inventory read into warnings + coverage evidence."""
+    permission = _SNOWFLAKE_INVENTORY_FAILURES.get(inventory_key, inventory_key)
+    record_discovery_failure(
+        exc=exc,
+        resource_type=resource_type,
+        permission=permission,
+        cloud="snowflake",
+        warnings=warnings,
+        missing=missing,
+    )
+    try:
+        from agent_bom.coverage import CoverageWarning
+        from agent_bom.scanners.state import record_coverage_warning
+
+        record_coverage_warning(
+            CoverageWarning(
+                ecosystem="snowflake",
+                release=f"snowflake:{inventory_key}",
+                reason="inventory_evaluation_failed",
+                detail=sanitize_discovery_warning(exc),
+                package_count=0,
+                advisory_rows=0,
+            ).to_dict()
+        )
+    except Exception:  # noqa: BLE001 — coverage evidence is supplementary; never fail discovery
+        logger.debug("Could not record Snowflake inventory coverage warning", exc_info=True)
+
 
 # Backwards-compatible aliases for the shared cloud helpers. Call sites and
 # tests may reference either the shared public names or these private aliases.
@@ -787,9 +835,10 @@ def _discover_snowflake_notebooks(
 
             except ValueError as exc:
                 warnings.append(f"Skipping Snowflake notebook with unsafe identifier: {sanitize_error(exc)}")
-            except Exception:
-                # DESCRIBE NOTEBOOK may not be available on all editions
-                pass
+            except Exception as exc:
+                warnings.append(
+                    f"Could not describe Snowflake notebook {nb_name!r}: {sanitize_error(exc)}"
+                )
 
             server = MCPServer(
                 name=f"sf-notebook:{nb_name}",
@@ -904,7 +953,12 @@ def _discover_cortex_agents(
             agents.append(agent)
 
     except Exception as exc:
-        warnings.append(f"Could not list Cortex Agents: {sanitize_error(exc)}")
+        _record_snowflake_inventory_failure(
+            exc=exc,
+            resource_type="Cortex Agents",
+            inventory_key="cortex_agents",
+            warnings=warnings,
+        )
 
     finally:
         cursor.close()
@@ -969,7 +1023,12 @@ def _discover_mcp_servers(
             agents.append(agent)
 
     except Exception as exc:
-        warnings.append(f"Could not list Snowflake MCP Servers: {sanitize_error(exc)}")
+        _record_snowflake_inventory_failure(
+            exc=exc,
+            resource_type="Snowflake MCP Servers",
+            inventory_key="mcp_servers",
+            warnings=warnings,
+        )
 
     finally:
         cursor.close()
@@ -1449,7 +1508,12 @@ def _mine_grants_to_roles(
             )
 
     except Exception as exc:
-        warnings.append(f"Could not query GRANTS_TO_ROLES: {sanitize_error(exc)}")
+        _record_snowflake_inventory_failure(
+            exc=exc,
+            resource_type="GRANTS_TO_ROLES",
+            inventory_key="grants_to_roles",
+            warnings=warnings,
+        )
 
     finally:
         cursor.close()
@@ -2048,7 +2112,12 @@ def _discover_sf_grants(conn: Any, warnings: list[str]) -> tuple[list[dict[str, 
                 }
             )
     except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not query GRANTS_TO_ROLES: {sanitize_error(exc)}")
+        _record_snowflake_inventory_failure(
+            exc=exc,
+            resource_type="GRANTS_TO_ROLES",
+            inventory_key="grants_to_roles",
+            warnings=warnings,
+        )
     finally:
         cursor.close()
 
@@ -2066,7 +2135,12 @@ def _discover_sf_grants(conn: Any, warnings: list[str]) -> tuple[list[dict[str, 
             if user_name and role:
                 memberships.append({"user": user_name, "role": role})
     except Exception as exc:  # noqa: BLE001
-        warnings.append(f"Could not query GRANTS_TO_USERS: {sanitize_error(exc)}")
+        _record_snowflake_inventory_failure(
+            exc=exc,
+            resource_type="GRANTS_TO_USERS",
+            inventory_key="grants_to_users",
+            warnings=warnings,
+        )
     finally:
         cursor.close()
 
@@ -2350,7 +2424,12 @@ def _live_role_grants(conn: Any, role_names: list[str], warnings_list: list[str]
                         }
                     )
         except Exception as exc:  # noqa: BLE001
-            warnings_list.append(f"Could not read grants TO role {role_name!r}: {sanitize_error(exc)}")
+            _record_snowflake_inventory_failure(
+                exc=exc,
+                resource_type=f"grants TO role {role_name!r}",
+                inventory_key="live_role_grants",
+                warnings=warnings_list,
+            )
         finally:
             cursor.close()
 
@@ -2371,7 +2450,12 @@ def _live_role_grants(conn: Any, role_names: list[str], warnings_list: list[str]
                     # The grantee role is a member of this role (grantee → role_name).
                     _add_role_membership(grantee, role_name)
         except Exception as exc:  # noqa: BLE001
-            warnings_list.append(f"Could not read grants OF role {role_name!r}: {sanitize_error(exc)}")
+            _record_snowflake_inventory_failure(
+                exc=exc,
+                resource_type=f"grants OF role {role_name!r}",
+                inventory_key="live_role_grants",
+                warnings=warnings_list,
+            )
         finally:
             cursor.close()
 

--- a/tests/cloud/test_snowflake_inventory_evaluation_failed.py
+++ b/tests/cloud/test_snowflake_inventory_evaluation_failed.py
@@ -1,0 +1,165 @@
+"""Snowflake inventory evaluation gaps must surface as warnings and coverage evidence."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_bom.finding import FindingType, cloud_cis_check_to_finding
+from agent_bom.models import AIBOMReport
+from agent_bom.scanners.state import consume_coverage_warnings, reset_scan_warnings
+
+
+def _install_mock_snowflake() -> types.ModuleType:
+    snowflake = types.ModuleType("snowflake")
+    snowflake_connector = types.ModuleType("snowflake.connector")
+    snowflake_connector_errors = types.ModuleType("snowflake.connector.errors")
+
+    class _DatabaseError(Exception):
+        pass
+
+    snowflake_connector_errors.DatabaseError = _DatabaseError
+    snowflake_connector.connect = MagicMock
+    snowflake_connector.errors = snowflake_connector_errors
+    snowflake.connector = snowflake_connector
+
+    sys.modules.setdefault("snowflake", snowflake)
+    sys.modules.setdefault("snowflake.connector", snowflake_connector)
+    sys.modules.setdefault("snowflake.connector.errors", snowflake_connector_errors)
+    return snowflake_connector
+
+
+@pytest.fixture(autouse=True)
+def _clean_scan_state() -> None:
+    reset_scan_warnings()
+    yield
+    reset_scan_warnings()
+
+
+def test_cortex_agents_list_failure_is_not_silent() -> None:
+    _install_mock_snowflake()
+    importlib.reload(importlib.import_module("agent_bom.cloud.snowflake"))
+    from agent_bom.cloud.snowflake import _discover_cortex_agents
+
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_cursor.execute.side_effect = RuntimeError("SHOW AGENTS denied")
+
+    agents, warnings = _discover_cortex_agents(mock_conn, "myorg")
+
+    assert agents == []
+    assert len(warnings) == 1
+    assert "Cortex Agents" in warnings[0]
+    coverage = consume_coverage_warnings()
+    assert len(coverage) == 1
+    assert coverage[0]["reason"] == "inventory_evaluation_failed"
+    assert coverage[0]["ecosystem"] == "snowflake"
+    assert "cortex" in coverage[0]["release"].lower()
+
+
+def test_mcp_servers_list_failure_is_not_silent() -> None:
+    _install_mock_snowflake()
+    importlib.reload(importlib.import_module("agent_bom.cloud.snowflake"))
+    from agent_bom.cloud.snowflake import _discover_mcp_servers
+
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_cursor.execute.side_effect = RuntimeError("SHOW MCP SERVERS denied")
+
+    agents, warnings = _discover_mcp_servers(mock_conn, "myorg")
+
+    assert agents == []
+    assert len(warnings) == 1
+    assert "MCP Servers" in warnings[0]
+    coverage = consume_coverage_warnings()
+    assert len(coverage) == 1
+    assert coverage[0]["reason"] == "inventory_evaluation_failed"
+    assert "mcp" in coverage[0]["release"].lower()
+
+
+def test_grants_to_roles_failure_is_not_silent() -> None:
+    _install_mock_snowflake()
+    importlib.reload(importlib.import_module("agent_bom.cloud.snowflake"))
+    from agent_bom.cloud.snowflake import _mine_grants_to_roles
+
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_cursor.execute.side_effect = RuntimeError("GRANTS_TO_ROLES unavailable")
+
+    grants, warnings = _mine_grants_to_roles(mock_conn)
+
+    assert grants == []
+    assert len(warnings) == 1
+    assert "GRANTS_TO_ROLES" in warnings[0]
+    coverage = consume_coverage_warnings()
+    assert len(coverage) == 1
+    assert coverage[0]["reason"] == "inventory_evaluation_failed"
+    assert "grants" in coverage[0]["release"].lower()
+
+
+def test_notebook_describe_failure_emits_warning_not_silent_pass() -> None:
+    _install_mock_snowflake()
+    importlib.reload(importlib.import_module("agent_bom.cloud.snowflake"))
+    from agent_bom.cloud.snowflake import _discover_snowflake_notebooks
+
+    class _Cursor:
+        def __init__(self) -> None:
+            self.description: list[tuple[str]] = []
+            self._rows: list[tuple[str, ...]] = []
+            self.executed: list[str] = []
+
+        def execute(self, sql: str) -> None:
+            self.executed.append(sql)
+            if sql == "SHOW NOTEBOOKS IN ACCOUNT":
+                self.description = [
+                    ("name",),
+                    ("database_name",),
+                    ("schema_name",),
+                    ("owner",),
+                    ("comment",),
+                ]
+                self._rows = [("nb1", "DB", "SCHEMA", "owner", "comment")]
+            elif sql.startswith("DESCRIBE NOTEBOOK "):
+                raise RuntimeError("DESCRIBE NOTEBOOK unavailable")
+
+        def fetchall(self) -> list[tuple[str, ...]]:
+            return self._rows
+
+        def close(self) -> None:
+            return None
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = _Cursor()
+
+    agents, warnings = _discover_snowflake_notebooks(mock_conn, "myorg")
+
+    assert len(agents) == 1
+    assert any("notebook" in w.lower() and "nb1" in w.lower() for w in warnings)
+
+
+def test_cloud_cis_error_converter_and_report_lift() -> None:
+    check = {
+        "check_id": "1.1",
+        "title": "MFA coverage",
+        "status": "ERROR",
+        "severity": "high",
+        "evidence": "ACCOUNT_USAGE stale",
+        "recommendation": "Restore read-only evidence access and rerun.",
+    }
+    finding = cloud_cis_check_to_finding(check, "snowflake")
+    assert finding.finding_type == FindingType.CIS_ERROR
+    assert finding.evidence["status"] == "ERROR"
+
+    report = AIBOMReport(scan_id="contract")
+    report.snowflake_cis_benchmark_data = {"checks": [check]}
+    lifted = report._cloud_cis_findings()
+    assert len(lifted) == 1
+    assert lifted[0].finding_type == FindingType.CIS_ERROR
+    assert lifted[0].id == finding.id


### PR DESCRIPTION
## Summary
- Add `_record_snowflake_inventory_failure` to route Cortex Agents, MCP Servers, and grants discovery failures through `record_discovery_failure` plus structured `CoverageWarning` evidence (`inventory_evaluation_failed`).
- Replace the silent `except Exception: pass` on notebook `DESCRIBE NOTEBOOK` with a sanitized warning so partial notebook inventory is visible.
- Lock the fail-closed CIS path with regression tests for MCP/agent/grants listing exceptions and a contract test that `cloud_cis_check_to_finding` + `_cloud_cis_findings` lift `ERROR` to `CIS_ERROR`.

## Verification
- `uv run pytest tests/cloud/test_snowflake_inventory_evaluation_failed.py -q` (5 passed)
- `uv run pytest tests/test_snowflake_governance.py::TestGrantsToRoles::test_mine_grants_error tests/cloud/test_cloud.py::test_snowflake_cortex_agents_discovered tests/cloud/test_cloud.py::test_snowflake_mcp_servers_discovered tests/cloud/test_cloud_cis_convergence.py -q` (16 passed)
- `uv run ruff check src/agent_bom/cloud/snowflake.py tests/cloud/test_snowflake_inventory_evaluation_failed.py`
- `uv run mypy src/agent_bom/cloud/snowflake.py`


Made with [Cursor](https://cursor.com)