### PR TITLE
fix(discovery): bound remaining repository walks

### DIFF
--- a/src/agent_bom/parsers/dataset_cards.py
+++ b/src/agent_bom/parsers/dataset_cards.py
@@ -21,6 +21,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from agent_bom.parsers.compliance_tags import tag_dataset
+from agent_bom.traversal import iter_discovery_files
 
 logger = logging.getLogger(__name__)
 
@@ -325,17 +326,14 @@ def discover_dataset_files(directory: Path) -> list[Path]:
     """Find dataset card files in a directory tree."""
     results: list[Path] = []
 
-    for p in directory.rglob("*"):
-        if any(skip in p.parts for skip in _SKIP_DIRS):
-            continue
-
+    for p in iter_discovery_files(directory, extra_skip_dirs=frozenset(_SKIP_DIRS)):
         if p.name == "dataset_info.json":
             results.append(p)
         elif p.name == "dataset_infos.json":
             results.append(p)
-        elif p.suffix == ".dvc" and p.is_file():
+        elif p.suffix == ".dvc":
             results.append(p)
-        elif p.name == "README.md" and p.is_file():
+        elif p.name == "README.md":
             # Only include READMEs that look like dataset cards (in data-like dirs)
             parent_name = p.parent.name.lower()
             # Heuristic: if sibling dataset_info.json exists, or parent looks like a dataset dir

--- a/src/agent_bom/parsers/dataset_pii_scanner.py
+++ b/src/agent_bom/parsers/dataset_pii_scanner.py
@@ -45,6 +45,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from agent_bom.runtime.patterns import CREDENTIAL_PATTERNS
+from agent_bom.traversal import iter_discovery_files
 
 logger = logging.getLogger(__name__)
 
@@ -596,14 +597,14 @@ def scan_directory_for_pii(
         agg.warnings.append(f"Not a directory: {root}")
         return agg
 
+    candidates = sorted(
+        path
+        for path in iter_discovery_files(root, extra_skip_dirs=_SKIP_DIRS)
+        if not any(part in _SKIP_DIRS or part.startswith(".") for part in path.parts)
+        and path.suffix.lower() in _DATASET_EXTENSIONS
+    )
     files_checked = 0
-    for path in sorted(root.rglob("*")):
-        if not path.is_file():
-            continue
-        if any(part in _SKIP_DIRS or part.startswith(".") for part in path.parts):
-            continue
-        if path.suffix.lower() not in _DATASET_EXTENSIONS:
-            continue
+    for path in candidates:
         if files_checked >= max_files:
             agg.warnings.append(f"Reached max_files={max_files} limit; some files not scanned")
             break

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -12,12 +12,14 @@ import os
 import re
 from datetime import datetime, timezone
 from functools import lru_cache
+from itertools import islice
 from pathlib import Path
 from urllib.parse import quote
 
 from agent_bom.checksums import parse_sri
 from agent_bom.models import MCPServer, Package
 from agent_bom.parsers.file_limits import read_json_limited, read_text_limited
+from agent_bom.traversal import iter_discovery_files
 
 logger = logging.getLogger(__name__)
 
@@ -126,9 +128,10 @@ def _workspace_package_versions(root: str) -> dict[str, str]:
                 base = workspace_root / pattern[: -len(recursive_suffix)].rstrip("/")
                 if base.is_dir():
                     package_jsons.extend(
-                        pkg_json
-                        for pkg_json in base.rglob("package.json")
-                        if "node_modules" not in pkg_json.parts and ".git" not in pkg_json.parts
+                        islice(
+                            (pkg_json for pkg_json in iter_discovery_files(base) if pkg_json.name == "package.json"),
+                            _MAX_WORKSPACE_PACKAGE_JSONS,
+                        )
                     )
             else:
                 logger.debug("Skipping unsupported recursive workspace pattern %s in %s", pattern, workspace_root)

--- a/src/agent_bom/parsers/prompt_scanner.py
+++ b/src/agent_bom/parsers/prompt_scanner.py
@@ -25,6 +25,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from agent_bom.traversal import iter_discovery_files
+
 logger = logging.getLogger(__name__)
 
 # ── Obfuscation normalization ──────────────────────────────────────────────
@@ -406,48 +408,36 @@ def discover_prompt_files(
     if not root.is_dir():
         return found
 
-    def _walk(directory: Path, depth: int) -> None:
-        if depth > max_depth:
-            return
-        try:
-            entries = sorted(directory.iterdir())
-        except PermissionError:
-            return
+    prompt_dir_extensions = {
+        ".txt",
+        ".md",
+        ".yaml",
+        ".yml",
+        ".json",
+        ".j2",
+        ".jinja2",
+        ".hbs",
+        ".mustache",
+        ".prompt",
+        ".promptfile",
+    }
+    for path in iter_discovery_files(root, extra_skip_dirs=frozenset(_SKIP_DIRS)):
+        relative_parts = path.relative_to(root).parts
+        parent_parts = relative_parts[:-1]
+        prompt_dir_depths = [
+            index for index, part in enumerate(parent_parts) if part.lower() in PROMPT_DIR_NAMES
+        ]
+        in_reachable_prompt_dir = bool(prompt_dir_depths) and min(prompt_dir_depths) <= max_depth
+        within_normal_depth = len(parent_parts) <= max_depth
 
-        for entry in entries:
-            if entry.is_dir():
-                if entry.name in _SKIP_DIRS:
-                    continue
-                # Check if it's a prompt directory
-                if entry.name.lower() in PROMPT_DIR_NAMES:
-                    # Scan all files inside prompt directories
-                    for f in sorted(entry.rglob("*")):
-                        if f.is_file() and f.suffix in {
-                            ".txt",
-                            ".md",
-                            ".yaml",
-                            ".yml",
-                            ".json",
-                            ".j2",
-                            ".jinja2",
-                            ".hbs",
-                            ".mustache",
-                            ".prompt",
-                            ".promptfile",
-                        }:
-                            found.append(f)
-                else:
-                    _walk(entry, depth + 1)
-            elif entry.is_file():
-                # Match by extension
-                if entry.suffix.lower() in PROMPT_FILE_EXTENSIONS:
-                    found.append(entry)
-                # Match by exact name
-                elif entry.name.lower() in PROMPT_FILE_NAMES:
-                    found.append(entry)
+        if in_reachable_prompt_dir and path.suffix.lower() in prompt_dir_extensions:
+            found.append(path)
+        elif within_normal_depth and (
+            path.suffix.lower() in PROMPT_FILE_EXTENSIONS or path.name.lower() in PROMPT_FILE_NAMES
+        ):
+            found.append(path)
 
-    _walk(root, 0)
-    return found
+    return sorted(found)
 
 
 # ── Analysis ─────────────────────────────────────────────────────────────────

--- a/src/agent_bom/parsers/training_pipeline.py
+++ b/src/agent_bom/parsers/training_pipeline.py
@@ -23,6 +23,7 @@ from pathlib import Path
 
 from agent_bom.parsers.compliance_tags import tag_training_run
 from agent_bom.runtime.patterns import PII_PATTERNS, RESPONSE_INJECTION_PATTERNS
+from agent_bom.traversal import iter_discovery_files
 
 logger = logging.getLogger(__name__)
 
@@ -555,12 +556,7 @@ def discover_training_files(directory: Path) -> list[Path]:
     """Find ML training pipeline metadata files in a directory tree."""
     results: list[Path] = []
 
-    for p in directory.rglob("*"):
-        if any(skip in p.parts for skip in _SKIP_DIRS):
-            continue
-        if not p.is_file():
-            continue
-
+    for p in iter_discovery_files(directory, extra_skip_dirs=frozenset(_SKIP_DIRS)):
         name = p.name
 
         # MLflow

--- a/src/agent_bom/repo_auto_detect.py
+++ b/src/agent_bom/repo_auto_detect.py
@@ -120,11 +120,10 @@ def _walk_limited(root: Path, *, max_files: int = 4000) -> list[Path]:
 def project_has_notebooks(root: Path) -> bool:
     if not root.is_dir():
         return False
-    for path in root.rglob("*.ipynb"):
-        if ".ipynb_checkpoints" in path.parts:
-            continue
-        return True
-    return False
+    return any(
+        path.suffix.lower() == ".ipynb"
+        for path in iter_discovery_files(root, extra_skip_dirs=_SKIP_DIRS, max_files=4000)
+    )
 
 
 def project_has_sast_targets(root: Path) -> bool:
@@ -143,10 +142,10 @@ def project_has_prompt_templates(root: Path) -> bool:
 def project_has_terraform(root: Path) -> bool:
     if not root.is_dir():
         return False
-    for pattern in ("*.tf", "*.tfvars"):
-        if any(root.rglob(pattern)):
-            return True
-    return False
+    return any(
+        path.suffix.lower() in {".tf", ".tfvars"}
+        for path in iter_discovery_files(root, extra_skip_dirs=_SKIP_DIRS, max_files=4000)
+    )
 
 
 def project_has_github_actions(root: Path) -> bool:

--- a/tests/test_discovery_traversal.py
+++ b/tests/test_discovery_traversal.py
@@ -9,8 +9,14 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from agent_bom.parsers.dataset_cards import discover_dataset_files
+from agent_bom.parsers.dataset_pii_scanner import scan_directory_for_pii
+from agent_bom.parsers.node_parsers import _workspace_package_versions
+from agent_bom.parsers.prompt_scanner import discover_prompt_files
 from agent_bom.parsers.skills import discover_skill_files
+from agent_bom.parsers.training_pipeline import discover_training_files
 from agent_bom.python_agents import _collect_requirements
+from agent_bom.repo_auto_detect import project_has_notebooks, project_has_terraform
 from agent_bom.traversal import (
     VENDOR_SKIP_DIRS,
     is_nested_worktree_root,
@@ -62,6 +68,75 @@ def test_iter_discovery_files_respects_max_files(tmp_path):
         (tmp_path / f"f{i}.txt").write_text("x")
     got = list(iter_discovery_files(tmp_path, max_files=5))
     assert len(got) == 5
+
+
+def test_iter_discovery_files_does_not_follow_directory_symlinks(tmp_path):
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "sentinel.txt").write_text("outside")
+    root = tmp_path / "root"
+    root.mkdir()
+    (root / "link").symlink_to(outside, target_is_directory=True)
+
+    assert not list(iter_discovery_files(root))
+
+
+def test_repo_auto_detection_skips_nested_worktree_targets(tmp_path):
+    nested = tmp_path / ".cursor" / "worktrees" / "copy"
+    _make_worktree(nested)
+    (nested / "copy.ipynb").write_text("{}")
+    (nested / "copy.tf").write_text('resource "null_resource" "copy" {}')
+
+    assert project_has_notebooks(tmp_path) is False
+    assert project_has_terraform(tmp_path) is False
+
+    (tmp_path / "real.ipynb").write_text("{}")
+    (tmp_path / "real.tfvars").write_text('region = "us-east-1"')
+    assert project_has_notebooks(tmp_path) is True
+    assert project_has_terraform(tmp_path) is True
+
+
+def test_dataset_and_training_discovery_skip_nested_worktrees(tmp_path):
+    (tmp_path / "dataset_info.json").write_text("{}")
+    (tmp_path / "MLmodel").write_text("name: real")
+    nested = tmp_path / ".claude" / "worktrees" / "copy"
+    _make_worktree(nested)
+    (nested / "dataset_info.json").write_text("{}")
+    (nested / "MLmodel").write_text("name: duplicate")
+
+    assert discover_dataset_files(tmp_path) == [tmp_path / "dataset_info.json"]
+    assert discover_training_files(tmp_path) == [tmp_path / "MLmodel"]
+
+
+def test_prompt_and_pii_discovery_skip_nested_worktrees(tmp_path):
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    (prompts / "real.prompt").write_text("Be helpful")
+    (tmp_path / "real.csv").write_text("email\nreal@example.com\n")
+    nested = tmp_path / ".cursor" / "worktrees" / "copy"
+    _make_worktree(nested)
+    (nested / "duplicate.prompt").write_text("duplicate")
+    (nested / "duplicate.csv").write_text("email\nduplicate@example.com\n")
+
+    assert discover_prompt_files(tmp_path) == [prompts / "real.prompt"]
+    result = scan_directory_for_pii(tmp_path)
+    assert result.files_scanned == 1
+    assert [Path(item.file_path).name for item in result.file_results] == ["real.csv"]
+
+
+def test_recursive_node_workspace_discovery_skips_nested_worktrees(tmp_path):
+    (tmp_path / "pnpm-workspace.yaml").write_text("packages:\n  - packages/**\n")
+    real = tmp_path / "packages" / "real"
+    real.mkdir(parents=True)
+    (real / "package.json").write_text('{"name":"real-package","version":"1.2.3"}')
+    nested = tmp_path / "packages" / "copy"
+    _make_worktree(nested)
+    (nested / "package.json").write_text('{"name":"duplicate-package","version":"9.9.9"}')
+
+    _workspace_package_versions.cache_clear()
+    versions = _workspace_package_versions(str(tmp_path))
+
+    assert versions == {"real-package": "1.2.3"}
 
 
 def test_collect_requirements_not_inflated_by_worktrees(tmp_path):


### PR DESCRIPTION
## Summary

- Route the remaining recursive repository discovery paths through the shared bounded, nested-worktree-aware traversal.
- Preserve prompt depth behavior, PII supported-file limits and ordering, npm workspace manifest limits, and specialized shallow/cache globs.
- Add regression coverage for nested worktrees, directory symlinks, repository target detection, dataset/training/prompt/PII discovery, and recursive npm workspaces.

## Verification

- `uv run pytest -q tests/test_discovery_traversal.py tests/test_repo_auto_detect.py tests/test_dataset_cards.py tests/test_prompt_scanner.py tests/test_dataset_pii_scanner.py tests/test_training_pipeline.py tests/test_parser_interop.py tests/test_core.py -x` (422 passed)
- `uv run pytest -q tests/test_discovery_traversal.py tests/test_repo_auto_detect.py tests/test_dataset_cards.py tests/test_prompt_scanner.py tests/test_dataset_pii_scanner.py tests/test_training_pipeline.py tests/test_parser_interop.py` (164 passed)
- `uv run ruff check src tests`
- `uv run mypy src/agent_bom/repo_auto_detect.py src/agent_bom/parsers/node_parsers.py src/agent_bom/parsers/dataset_cards.py src/agent_bom/parsers/prompt_scanner.py src/agent_bom/parsers/dataset_pii_scanner.py src/agent_bom/parsers/training_pipeline.py`
- `uv run python scripts/check_package_layout.py`
- `uv run agent-bom agents --demo --offline --quiet --format json` (valid JSON artifact)
- `git diff --check`

## Notes

- Shallow GitHub workflow discovery, caller-declared npm workspace globs, and the bounded npx cache lookup remain specialized because routing them through the shared repository traversal would change their contract.
- The pre-fix regression run failed in four clusters because nested worktree copies were detected as real repository inputs.

Closes #4051
