### PR TITLE
feat(ciem): surface authorization evidence health

### DIFF
--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -158,6 +158,26 @@ template, one uniform flow around it.
 This is the same code path for the CLI and the API, so both surfaces produce
 identical results.
 
+### Authorization evidence completeness
+
+Azure RBAC and GCP IAM scans report whether every required authorization feed
+was collected as `complete`, `partial`, or `indeterminate`. The authenticated
+cloud-connection API, MCP inventory summary, CLI summary, and connection UI
+expose only aggregate source counts. Raw bindings, conditions, diagnostics,
+provider paths, and provenance stay in the tenant-scoped scan artifact and are
+never copied into operator summaries.
+
+`partial` and `indeterminate` are fail-closed states: they do not prove access
+and they never fall back to name- or privilege-label heuristics on a supported
+authorization-evidence path. The graph API records the same limitation under
+`analysis_status.authorization_evidence:<provider>`.
+
+CI verifies Azure/GCP parity, incomplete-source behavior, heuristic
+containment, and tenant-isolated graph persistence with deterministic fixtures.
+Credentialed Azure/GCP smoke evidence remains environment-owned; a fixture run
+proves the contract but is not a claim that a particular customer tenant was
+successfully scanned.
+
 ---
 
 ## 3. AWS — connect in two steps

--- a/src/agent_bom/api/metrics.py
+++ b/src/agent_bom/api/metrics.py
@@ -72,7 +72,28 @@ _compliance_exports = _LabelledCounter()  # labelled by algorithm (Ed25519, HMAC
 _compliance_export_bytes = _LabelledCounter()  # labelled by framework key
 _scan_completions = _LabelledCounter()  # labelled by status (done, failed, cancelled)
 _gateway_relays = _LabelledCounter()  # labelled by "<upstream>|<outcome>"
+_authorization_evidence = _LabelledCounter()  # labelled by "<provider>|<status>"
+_authorization_evidence_gaps = _LabelledCounter()  # labelled by "<provider>|<reason>"
 _scan_jobs_active = _Gauge()  # in-flight scans (queued + running)
+
+_AUTHORIZATION_PROVIDERS = frozenset({"azure", "gcp"})
+_AUTHORIZATION_STATUSES = frozenset({"complete", "partial", "indeterminate"})
+_AUTHORIZATION_REASON_CODES = frozenset(
+    {
+        "access_denied",
+        "disabled",
+        "duplicate_source",
+        "evidence_missing",
+        "partial",
+        "required_source_missing",
+        "required_sources_missing",
+        "sdk_missing",
+        "stale",
+        "truncated",
+        "unavailable",
+        "unsupported",
+    }
+)
 
 
 def record_auth_failure(reason: str) -> None:
@@ -139,6 +160,16 @@ def record_gateway_relay(upstream: str, outcome: str) -> None:
     _gateway_relays.inc(f"{upstream}|{outcome}")
 
 
+def record_authorization_evidence(*, provider: str, status: str, reason_codes: tuple[str, ...]) -> None:
+    """Record bounded, non-secret authorization collection posture."""
+    safe_provider = provider if provider in _AUTHORIZATION_PROVIDERS else "unknown"
+    safe_status = status if status in _AUTHORIZATION_STATUSES else "indeterminate"
+    _authorization_evidence.inc(f"{safe_provider}|{safe_status}")
+    for reason in set(reason_codes):
+        safe_reason = reason if reason in _AUTHORIZATION_REASON_CODES else "unknown"
+        _authorization_evidence_gaps.inc(f"{safe_provider}|{safe_reason}")
+
+
 def render_prometheus_lines() -> list[str]:
     """Return Prometheus text-format lines for all in-process counters."""
     lines: list[str] = []
@@ -197,6 +228,24 @@ def render_prometheus_lines() -> list[str]:
         upstream, _, outcome = label.partition("|")
         lines.append(f'agent_bom_gateway_relays_total{{upstream="{upstream}",outcome="{outcome}"}} {count}')
 
+    evidence = _authorization_evidence.snapshot()
+    lines.append("# HELP agent_bom_authorization_evidence_total Cloud authorization evidence collections by posture")
+    lines.append("# TYPE agent_bom_authorization_evidence_total counter")
+    if not evidence:
+        lines.append('agent_bom_authorization_evidence_total{provider="none",status="indeterminate"} 0')
+    for label, count in sorted(evidence.items()):
+        provider, _, status = label.partition("|")
+        lines.append(f'agent_bom_authorization_evidence_total{{provider="{provider}",status="{status}"}} {count}')
+
+    gaps = _authorization_evidence_gaps.snapshot()
+    lines.append("# HELP agent_bom_authorization_evidence_gaps_total Cloud authorization evidence gaps by reason code")
+    lines.append("# TYPE agent_bom_authorization_evidence_gaps_total counter")
+    if not gaps:
+        lines.append('agent_bom_authorization_evidence_gaps_total{provider="none",reason="none"} 0')
+    for label, count in sorted(gaps.items()):
+        provider, _, reason = label.partition("|")
+        lines.append(f'agent_bom_authorization_evidence_gaps_total{{provider="{provider}",reason="{reason}"}} {count}')
+
     return lines
 
 
@@ -209,6 +258,8 @@ def reset_for_tests() -> None:
         _compliance_export_bytes,
         _scan_completions,
         _gateway_relays,
+        _authorization_evidence,
+        _authorization_evidence_gaps,
     ):
         with counter._lock:  # noqa: SLF001
             counter._values.clear()  # noqa: SLF001

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -650,6 +650,8 @@ def inventory_cmd(
     if provider in ("gcp", "all"):
         reports.append(gcp_inventory.discover_inventory(project_id=project))
 
+    reports = [_project_authorization_posture(report) for report in reports]
+
     if output_format == "json":
         click.echo(_json.dumps({"providers": reports}, indent=2, sort_keys=True, default=str))
         return
@@ -665,6 +667,7 @@ def inventory_cmd(
     table.add_column("Status")
     table.add_column("Assets")
     table.add_column("Warnings", justify="right")
+    table.add_column("Authorization")
     any_disabled = False
     for rep in reports:
         status = str(rep.get("status", "unknown"))
@@ -676,6 +679,7 @@ def inventory_cmd(
             f"[{style}]{status}[/{style}]",
             _asset_summary(rep),
             str(len(rep.get("warnings") or [])),
+            str((rep.get("authorization_evidence") or {}).get("status", "not_applicable")),
         )
     con.print(table)
     if any_disabled:
@@ -686,6 +690,28 @@ def inventory_cmd(
         )
     con.print()
 
+
+def _project_authorization_posture(report: dict) -> dict:
+    """Expose bounded authorization posture without policy or diagnostic data."""
+    projected = dict(report)
+    provider = str(projected.get("provider", "unknown"))
+    evidence = projected.pop("authorization_evidence", None)
+    if provider not in {"azure", "gcp"}:
+        if evidence is not None:
+            projected["authorization_evidence"] = evidence
+        return projected
+
+    from agent_bom.cloud.authorization_evidence import authorization_evidence_gap_reason_codes, summarize_authorization_evidence
+
+    evidence_payload = evidence if isinstance(evidence, dict) else {}
+    summary = summarize_authorization_evidence(evidence_payload)
+    projected["authorization_evidence"] = summary.to_dict()
+    reason_codes = authorization_evidence_gap_reason_codes(evidence_payload)
+
+    from agent_bom.api.metrics import record_authorization_evidence
+
+    record_authorization_evidence(provider=provider, status=summary.status.value, reason_codes=reason_codes)
+    return projected
 
 # Report keys that are lists but NOT asset collections — excluded from the count
 # so the summary auto-includes every resource type a provider adds without drift.

--- a/src/agent_bom/cloud/authorization_evidence.py
+++ b/src/agent_bom/cloud/authorization_evidence.py
@@ -7,6 +7,8 @@ distinguish a proven empty policy set from evidence that was never collected.
 
 from __future__ import annotations
 
+from collections import Counter
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
@@ -28,6 +30,118 @@ class EvidenceSourceState(StrEnum):
     STALE = "stale"
     TRUNCATED = "truncated"
     UNAVAILABLE = "unavailable"
+
+
+class AuthorizationEvidenceStatus(StrEnum):
+    """Public completeness verdict for authorization evidence collection."""
+
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+    INDETERMINATE = "indeterminate"
+
+
+@dataclass(frozen=True)
+class AuthorizationEvidenceSummary:
+    """Count-only, non-secret projection safe for REST and MCP responses."""
+
+    status: AuthorizationEvidenceStatus
+    required_source_count: int
+    complete_source_count: int
+    partial_source_count: int
+    indeterminate_source_count: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "required_source_count": self.required_source_count,
+            "complete_source_count": self.complete_source_count,
+            "partial_source_count": self.partial_source_count,
+            "indeterminate_source_count": self.indeterminate_source_count,
+        }
+
+
+_PARTIAL_SOURCE_STATES = {
+    EvidenceSourceState.PARTIAL.value,
+    EvidenceSourceState.STALE.value,
+    EvidenceSourceState.TRUNCATED.value,
+}
+
+
+def summarize_authorization_evidence(payload: Mapping[str, Any]) -> AuthorizationEvidenceSummary:
+    """Summarize required-source coverage without projecting raw evidence.
+
+    Diagnostics, provenance, binding identifiers, conditions, and permissions
+    are intentionally ignored. Unknown, missing, denied, disabled, and
+    unsupported sources remain indeterminate (fail closed).
+    """
+    raw_required = payload.get("required_sources")
+    required = (
+        tuple(dict.fromkeys(str(name) for name in raw_required if isinstance(name, str) and name))
+        if isinstance(raw_required, (list, tuple))
+        else ()
+    )
+    raw_sources = payload.get("sources")
+    sources = tuple(source for source in raw_sources if isinstance(source, Mapping)) if isinstance(raw_sources, list) else ()
+    names = [str(source.get("name") or "") for source in sources]
+    name_counts = Counter(names)
+
+    complete = partial = indeterminate = 0
+    for name in required:
+        matches = [source for source in sources if source.get("name") == name]
+        if not matches:
+            indeterminate += 1
+            continue
+        states = {str(source.get("state") or "").strip().lower() for source in matches}
+        if name_counts[name] > 1 or states & _PARTIAL_SOURCE_STATES:
+            partial += 1
+        elif states == {EvidenceSourceState.COMPLETE.value}:
+            complete += 1
+        else:
+            indeterminate += 1
+
+    if not required or indeterminate:
+        status = AuthorizationEvidenceStatus.INDETERMINATE
+    elif partial:
+        status = AuthorizationEvidenceStatus.PARTIAL
+    else:
+        status = AuthorizationEvidenceStatus.COMPLETE
+    return AuthorizationEvidenceSummary(
+        status=status,
+        required_source_count=len(required),
+        complete_source_count=complete,
+        partial_source_count=partial,
+        indeterminate_source_count=indeterminate,
+    )
+
+
+def authorization_evidence_gap_reason_codes(payload: Mapping[str, Any]) -> tuple[str, ...]:
+    """Return bounded metric reasons without exposing source names or diagnostics."""
+    raw_required = payload.get("required_sources")
+    required = tuple(str(item) for item in raw_required if isinstance(item, str)) if isinstance(raw_required, list) else ()
+    raw_sources = payload.get("sources")
+    sources = tuple(source for source in raw_sources if isinstance(source, Mapping)) if isinstance(raw_sources, list) else ()
+    if not sources:
+        return ("evidence_missing",)
+
+    reasons: set[str] = set()
+    name_counts = Counter(str(source.get("name") or "") for source in sources)
+    for source in sources:
+        state = str(source.get("state") or "unavailable").strip().lower()
+        if state != EvidenceSourceState.COMPLETE.value:
+            reasons.add(state if state in _PUBLIC_GAP_REASON_CODES else "unavailable")
+    if not required:
+        reasons.add("required_sources_missing")
+    for name in required:
+        if name_counts[name] == 0:
+            reasons.add("required_source_missing")
+        elif name_counts[name] > 1:
+            reasons.add("duplicate_source")
+    return tuple(sorted(reasons))
+
+
+_PUBLIC_GAP_REASON_CODES = frozenset(
+    {"partial", "access_denied", "disabled", "sdk_missing", "unsupported", "stale", "truncated", "unavailable"}
+)
 
 
 _SOURCE_STATE_SEVERITY: dict[EvidenceSourceState, int] = {
@@ -296,6 +410,8 @@ __all__ = [
     "AuthorizationEffect",
     "AuthorizationEvaluation",
     "AuthorizationEvidenceBundle",
+    "AuthorizationEvidenceStatus",
+    "AuthorizationEvidenceSummary",
     "AuthorizationPlane",
     "AuthorizationProvider",
     "AuthorizationRequest",
@@ -305,4 +421,6 @@ __all__ = [
     "PrincipalMembership",
     "ResourceAncestry",
     "RoleDefinitionEvidence",
+    "authorization_evidence_gap_reason_codes",
+    "summarize_authorization_evidence",
 ]

--- a/src/agent_bom/mcp_tools/posture.py
+++ b/src/agent_bom/mcp_tools/posture.py
@@ -155,7 +155,7 @@ def _summarize_inventory_payload(provider: str, payload: dict[str, Any]) -> dict
     public_warnings = [f"{warning_count} provider discovery warning(s) — see server logs for detail."] if warning_count else []
     raw_status = str(payload.get("status", "unknown") or "unknown").strip().lower()
     public_status = raw_status if raw_status in _PUBLIC_INVENTORY_STATUSES else "unknown"
-    return {
+    summary = {
         "provider": provider,
         "status": public_status,
         "account": payload.get("account_id") or payload.get("subscription_id") or payload.get("project_id") or None,
@@ -171,6 +171,22 @@ def _summarize_inventory_payload(provider: str, payload: dict[str, Any]) -> dict
         },
         "warnings": public_warnings,
     }
+    authorization_evidence = payload.get("authorization_evidence")
+    if isinstance(authorization_evidence, dict):
+        from agent_bom.api.metrics import record_authorization_evidence
+        from agent_bom.cloud.authorization_evidence import (
+            authorization_evidence_gap_reason_codes,
+            summarize_authorization_evidence,
+        )
+
+        evidence_summary = summarize_authorization_evidence(authorization_evidence)
+        summary["authorization_evidence"] = evidence_summary.to_dict()
+        record_authorization_evidence(
+            provider=str(provider).strip().lower(),
+            status=evidence_summary.status.value,
+            reason_codes=authorization_evidence_gap_reason_codes(authorization_evidence),
+        )
+    return summary
 
 
 async def cloud_inventory_impl(

--- a/tests/cloud/test_cloud_connections.py
+++ b/tests/cloud/test_cloud_connections.py
@@ -11,6 +11,7 @@ key-pair connection) plus the per-provider read-only scan-launch route.
 from __future__ import annotations
 
 import base64
+import json
 import os
 import sqlite3
 import sys
@@ -1694,6 +1695,35 @@ def test_summarize_inventory_payload_redacts_raw_warnings() -> None:
     assert warnings == ["2 provider discovery warning(s) — see server logs for detail."]
     blob = " ".join(warnings)
     assert "Traceback" not in blob and "AccessDenied" not in blob and "arn:aws:iam" not in blob
+
+
+def test_summarize_inventory_payload_projects_authorization_coverage_without_secret_fields() -> None:
+    from agent_bom.mcp_tools.posture import _summarize_inventory_payload
+
+    payload = {
+        "status": "partial",
+        "subscription_id": "subscription-1",
+        "authorization_evidence": {
+            "required_sources": ["assignments", "roles"],
+            "sources": [
+                {"name": "assignments", "state": "complete", "diagnostics": ["safe-looking but private"]},
+                {"name": "roles", "state": "partial", "provenance": ["/private/provider/path"]},
+            ],
+            "bindings": [{"binding_id": "do-not-project"}],
+        },
+    }
+
+    summary = _summarize_inventory_payload("azure", payload)
+
+    assert summary["authorization_evidence"] == {
+        "status": "partial",
+        "required_source_count": 2,
+        "complete_source_count": 1,
+        "partial_source_count": 1,
+        "indeterminate_source_count": 0,
+    }
+    assert "private" not in json.dumps(summary)
+    assert "do-not-project" not in json.dumps(summary)
 
 
 # Sensitive raw exception text (KMS broker / encryption path) must never reach the

--- a/tests/test_authorization_evidence.py
+++ b/tests/test_authorization_evidence.py
@@ -13,6 +13,7 @@ from agent_bom.cloud.authorization_evidence import (
     EvidenceSourceState,
     ResourceAncestry,
     RoleDefinitionEvidence,
+    summarize_authorization_evidence,
 )
 
 
@@ -73,6 +74,47 @@ def test_bundle_serializes_source_completeness_and_provenance() -> None:
         }
     ]
     assert json.loads(json.dumps(payload)) == payload
+
+
+def test_authorization_summary_counts_complete_partial_and_indeterminate_without_diagnostics() -> None:
+    payload = {
+        "provider": "gcp",
+        "required_sources": ["allow_policies", "deny_policies", "role_definitions", "ancestry"],
+        "sources": [
+            {"name": "allow_policies", "state": "complete", "diagnostics": ["token=secret"]},
+            {"name": "deny_policies", "state": "partial", "provenance": ["private/path"]},
+            {"name": "role_definitions", "state": "access_denied", "diagnostics": ["arn:secret"]},
+        ],
+        "bindings": [{"binding_id": "sensitive-binding"}],
+    }
+
+    summary = summarize_authorization_evidence(payload)
+
+    assert summary.to_dict() == {
+        "status": "indeterminate",
+        "required_source_count": 4,
+        "complete_source_count": 1,
+        "partial_source_count": 1,
+        "indeterminate_source_count": 2,
+    }
+    assert "secret" not in json.dumps(summary.to_dict())
+
+
+def test_authorization_summary_is_complete_only_when_every_required_source_is_complete() -> None:
+    summary = summarize_authorization_evidence(
+        {
+            "required_sources": ["bindings", "roles"],
+            "sources": [
+                {"name": "bindings", "state": "complete"},
+                {"name": "roles", "state": "complete"},
+            ],
+        }
+    )
+
+    assert summary.status == "complete"
+    assert summary.complete_source_count == 2
+    assert summary.partial_source_count == 0
+    assert summary.indeterminate_source_count == 0
 
 
 def test_missing_required_source_is_not_complete() -> None:

--- a/tests/test_authorization_evidence_metrics.py
+++ b/tests/test_authorization_evidence_metrics.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.api import metrics
+
+
+@pytest.fixture(autouse=True)
+def _reset_metrics() -> None:
+    metrics.reset_for_tests()
+
+
+def test_authorization_evidence_metrics_are_bounded_and_secret_safe() -> None:
+    metrics.record_authorization_evidence(
+        provider="azure",
+        status="partial",
+        reason_codes=("access_denied", "Bearer secret"),
+    )
+
+    text = "\n".join(metrics.render_prometheus_lines())
+    assert 'agent_bom_authorization_evidence_total{provider="azure",status="partial"} 1' in text
+    assert 'agent_bom_authorization_evidence_gaps_total{provider="azure",reason="access_denied"} 1' in text
+    assert "Bearer secret" not in text
+
+
+def test_authorization_evidence_metrics_normalize_unknown_labels() -> None:
+    metrics.record_authorization_evidence(provider="future-cloud", status="broken", reason_codes=("new-gap",))
+
+    text = "\n".join(metrics.render_prometheus_lines())
+    assert 'agent_bom_authorization_evidence_total{provider="unknown",status="indeterminate"} 1' in text
+    assert 'agent_bom_authorization_evidence_gaps_total{provider="unknown",reason="unknown"} 1' in text
+
+
+def test_cloud_connection_summary_records_partial_authorization_health() -> None:
+    from agent_bom.mcp_tools.posture import _summarize_inventory_payload
+
+    _summarize_inventory_payload(
+        "gcp",
+        {
+            "authorization_evidence": {
+                "required_sources": ["allow", "deny"],
+                "sources": [
+                    {"name": "allow", "state": "complete"},
+                    {"name": "deny", "state": "truncated"},
+                ],
+            }
+        },
+    )
+
+    text = "\n".join(metrics.render_prometheus_lines())
+    assert 'agent_bom_authorization_evidence_total{provider="gcp",status="partial"} 1' in text
+    assert 'agent_bom_authorization_evidence_gaps_total{provider="gcp",reason="truncated"} 1' in text

--- a/tests/test_cli_governance_commands.py
+++ b/tests/test_cli_governance_commands.py
@@ -224,3 +224,44 @@ def test_cloud_inventory_single_provider():
     payload = json.loads(result.output)
     assert len(payload["providers"]) == 1
     assert payload["providers"][0]["provider"] == "aws"
+
+
+def test_cloud_inventory_projects_indeterminate_authorization_evidence(monkeypatch):
+    report = {
+        "provider": "azure",
+        "status": "ok",
+        "authorization_evidence": {
+            "required_sources": ["role_assignments", "role_definitions"],
+            "sources": [
+                {"name": "role_assignments", "state": "complete", "diagnostics": ["secret-value"]},
+                {"name": "role_definitions", "state": "access_denied", "diagnostics": ["Bearer secret"]},
+            ],
+        },
+    }
+    monkeypatch.setattr("agent_bom.cloud.azure_inventory.discover_inventory", lambda **_kwargs: report)
+
+    result = CliRunner().invoke(main, ["cloud", "inventory", "--provider", "azure", "--format", "json"])
+
+    assert result.exit_code == 0
+    summary = json.loads(result.output)["providers"][0]["authorization_evidence"]
+    assert summary == {
+        "complete_source_count": 1,
+        "indeterminate_source_count": 1,
+        "partial_source_count": 0,
+        "required_source_count": 2,
+        "status": "indeterminate",
+    }
+    assert "secret-value" not in result.output
+    assert "Bearer secret" not in result.output
+
+
+def test_cloud_inventory_projects_missing_authorization_evidence_as_indeterminate(monkeypatch):
+    report = {"provider": "gcp", "status": "ok", "authorization_evidence": None}
+    monkeypatch.setattr("agent_bom.cloud.gcp_inventory.discover_inventory", lambda **_kwargs: report)
+
+    result = CliRunner().invoke(main, ["cloud", "inventory", "--provider", "gcp", "--format", "json"])
+
+    assert result.exit_code == 0
+    summary = json.loads(result.output)["providers"][0]["authorization_evidence"]
+    assert summary["status"] == "indeterminate"
+    assert summary["required_source_count"] == 0

--- a/tests/test_graph_authorization_evidence_integration.py
+++ b/tests/test_graph_authorization_evidence_integration.py
@@ -319,6 +319,28 @@ def test_authorization_decision_and_status_survive_persistence_and_graph_api(tmp
     )
 
 
+def test_authorization_evidence_graph_state_is_tenant_isolated(tmp_path) -> None:
+    store = SQLiteGraphStore(tmp_path / "authorization-tenant-graph.db")
+    alpha = build_unified_graph_from_report(
+        {"scan_id": "shared-scan", "cloud_inventory": _azure_inventory()},
+        tenant_id="tenant-alpha",
+    )
+    beta = build_unified_graph_from_report(
+        {"scan_id": "shared-scan", "cloud_inventory": _gcp_inventory(conditional=True)},
+        tenant_id="tenant-beta",
+    )
+    store.save_graph(alpha)
+    store.save_graph(beta)
+
+    loaded_alpha = store.load_graph(scan_id="shared-scan", tenant_id="tenant-alpha")
+    loaded_beta = store.load_graph(scan_id="shared-scan", tenant_id="tenant-beta")
+
+    assert "authorization_evidence:azure" in loaded_alpha.analysis_status
+    assert "authorization_evidence:gcp" not in loaded_alpha.analysis_status
+    assert "authorization_evidence:gcp" in loaded_beta.analysis_status
+    assert "authorization_evidence:azure" not in loaded_beta.analysis_status
+
+
 def test_authoritative_gcp_evidence_suppresses_legacy_org_role_reachability() -> None:
     inventory = _gcp_inventory(conditional=True)
     inventory["gcp_organization"] = {

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -97,6 +97,7 @@ import {
   type ConnectDepth,
 } from "@/lib/cloud-connect-wizard";
 import { serviceEntry } from "@/lib/service-registry";
+import { authorizationEvidenceCopy } from "@/lib/authorization-evidence";
 import { vendorLogo } from "@/lib/vendor-logos";
 import { FirstRunJourney } from "@/components/first-run-journey";
 import {
@@ -2814,6 +2815,9 @@ function ScanResultPanel({ result }: { result: CloudConnectionScanResponse }) {
   const { inventory, cis_benchmark: cis } = result;
   const isSnowflake = inventory.agent_count != null;
   const warnings = inventory.warnings ?? [];
+  const authorizationCopy = inventory.authorization_evidence
+    ? authorizationEvidenceCopy(inventory.authorization_evidence)
+    : null;
   return (
     <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -2839,6 +2843,21 @@ function ScanResultPanel({ result }: { result: CloudConnectionScanResponse }) {
         />
         <StatTile icon={KeyRound} label="CIS pass rate" value={formatPassRate(cis.pass_rate)} />
       </div>
+      {authorizationCopy ? (
+        <div className="mt-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="inline-flex items-center gap-1.5 text-xs font-medium text-[color:var(--foreground)]">
+              <Shield className="h-3.5 w-3.5 text-sky-500" /> Authorization evidence
+            </p>
+            <span className="rounded-full border border-[color:var(--border-subtle)] px-2 py-0.5 text-[10px] font-semibold text-[color:var(--text-secondary)]">
+              {authorizationCopy.label}
+            </span>
+          </div>
+          <p className="mt-1.5 text-[11px] leading-5 text-[color:var(--text-secondary)]">
+            {authorizationCopy.detail}
+          </p>
+        </div>
+      ) : null}
       {warnings.length > 0 ? (
         <p className="mt-3 text-[11px] leading-5 text-amber-300">{warnings.join(" · ")}</p>
       ) : null}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -3225,6 +3225,14 @@ export interface CloudConnectionUpdateRequest {
   scan_interval_minutes: number | null;
 }
 
+export interface AuthorizationEvidenceSummary {
+  status: "complete" | "partial" | "indeterminate";
+  required_source_count: number;
+  complete_source_count: number;
+  partial_source_count: number;
+  indeterminate_source_count: number;
+}
+
 export interface CloudConnectionScanInventory {
   provider: string;
   /** Present for AWS/Azure/GCP; "ok" for Snowflake. */
@@ -3244,6 +3252,8 @@ export interface CloudConnectionScanInventory {
   /** Snowflake discovery count (Cortex/MCP agents). */
   agent_count?: number;
   warnings?: string[];
+  /** Count-only authorization evidence state. Raw bindings and diagnostics are never returned here. */
+  authorization_evidence?: AuthorizationEvidenceSummary | null;
 }
 
 export interface CloudConnectionScanCis {

--- a/ui/lib/authorization-evidence.ts
+++ b/ui/lib/authorization-evidence.ts
@@ -1,0 +1,23 @@
+import type { AuthorizationEvidenceSummary } from "@/lib/api-types";
+
+export function authorizationEvidenceCopy(summary: AuthorizationEvidenceSummary): {
+  label: "Complete" | "Partial" | "Indeterminate";
+  detail: string;
+} {
+  if (summary.status === "complete") {
+    return {
+      label: "Complete",
+      detail: `${summary.complete_source_count} of ${summary.required_source_count} required evidence sources are complete for this scan.`,
+    };
+  }
+  if (summary.status === "partial") {
+    return {
+      label: "Partial",
+      detail: `${summary.complete_source_count} of ${summary.required_source_count} required evidence sources are complete. Authorization decisions may remain indeterminate.`,
+    };
+  }
+  return {
+    label: "Indeterminate",
+    detail: "Authorization evidence is not conclusive for this scan. No allow or deny should be inferred.",
+  };
+}

--- a/ui/tests/authorization-evidence.test.ts
+++ b/ui/tests/authorization-evidence.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { authorizationEvidenceCopy } from "@/lib/authorization-evidence";
+
+describe("authorizationEvidenceCopy", () => {
+  it("describes complete evidence without overstating its scope", () => {
+    expect(authorizationEvidenceCopy({ status: "complete", required_source_count: 2, complete_source_count: 2,
+      partial_source_count: 0, indeterminate_source_count: 0 })).toEqual({
+      label: "Complete",
+      detail: "2 of 2 required evidence sources are complete for this scan.",
+    });
+  });
+
+  it("describes partial evidence as unsuitable for conclusive authorization decisions", () => {
+    expect(authorizationEvidenceCopy({ status: "partial", required_source_count: 3, complete_source_count: 2,
+      partial_source_count: 1, indeterminate_source_count: 0 })).toEqual({
+      label: "Partial",
+      detail: "2 of 3 required evidence sources are complete. Authorization decisions may remain indeterminate.",
+    });
+  });
+
+  it("does not imply an authorization result when evidence is indeterminate", () => {
+    expect(authorizationEvidenceCopy({ status: "indeterminate", required_source_count: 3, complete_source_count: 1,
+      partial_source_count: 0, indeterminate_source_count: 2 })).toEqual({
+      label: "Indeterminate",
+      detail: "Authorization evidence is not conclusive for this scan. No allow or deny should be inferred.",
+    });
+  });
+});

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -576,6 +576,56 @@ describe("ConnectionsPage — Sources segment (unified table)", () => {
     );
   });
 
+  it("shows authorization evidence completeness without exposing raw evidence records", async () => {
+    apiMock.listCloudConnections.mockResolvedValue({
+      schema_version: "cloud.connections.v1",
+      tenant_id: "tenant-acme",
+      connections: [{ ...CREATED_RECORD, provider: "azure" }],
+      count: 1,
+    });
+    apiMock.scanCloudConnection.mockResolvedValue({
+      schema_version: "cloud.connections.scan.v1",
+      connection_id: "conn-1",
+      tenant_id: "tenant-acme",
+      provider: "azure",
+      scan_id: "azure-scan-1",
+      inventory: {
+        provider: "azure",
+        resource_count: 4,
+        identity_count: 2,
+        authorization_evidence: {
+          status: "partial",
+          required_source_count: 3,
+          complete_source_count: 2,
+          partial_source_count: 1,
+          indeterminate_source_count: 0,
+        },
+      },
+      cis_benchmark: {
+        benchmark: "CIS Azure",
+        benchmark_version: "2.0",
+        passed: 1,
+        failed: 0,
+        total: 1,
+        pass_rate: 1,
+      },
+      audit_metadata: { read_only: true, writes_performed: false, note: "Read-only scan." },
+      connection: { ...CREATED_RECORD, provider: "azure", status: "active" },
+    });
+
+    render(<ConnectionsPage />);
+    await waitFor(() => expect(screen.getByText("Production account")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "Run scan" }));
+    await waitFor(() => expect(apiMock.scanCloudConnection).toHaveBeenCalledWith("conn-1"));
+    fireEvent.click(screen.getByRole("button", { name: "Production account" }));
+
+    const drawer = await screen.findByRole("dialog", { name: "Production account" });
+    expect(within(drawer).getByText("Authorization evidence")).toBeInTheDocument();
+    expect(within(drawer).getByText("Partial")).toBeInTheDocument();
+    expect(within(drawer).getByText(/2 of 3 required evidence sources are complete/i)).toBeInTheDocument();
+    expect(within(drawer).queryByText(/binding|diagnostic/i)).not.toBeInTheDocument();
+  });
+
   it("keeps one direct scan action in the connection drawer", async () => {
     apiMock.listCloudConnections.mockResolvedValue({
       schema_version: "cloud.connections.v1",


### PR DESCRIPTION
## Summary

- project one canonical, count-only Azure/GCP authorization-evidence health contract through authenticated cloud scan responses, MCP summaries, CLI JSON/console, and the Connections UI
- expose bounded Prometheus posture/gap metrics while keeping bindings, conditions, diagnostics, provenance, and provider paths out of operator summaries
- lock in fail-closed partial/indeterminate behavior, heuristic containment, Azure/GCP parity, and tenant-isolated graph state

## Verification

- `uv run pytest -q tests/test_authorization_evidence.py tests/test_authorization_evidence_metrics.py tests/cloud/test_cloud_connections.py tests/test_cli_governance_commands.py tests/test_graph_authorization_evidence_integration.py tests/test_graph_effective_permissions.py tests/test_mcp_posture_tools.py` — 147 passed
- `uv run ruff check src tests`
- `uv run mypy src/agent_bom/cloud/authorization_evidence.py src/agent_bom/mcp_tools/posture.py src/agent_bom/cli/_cloud_group.py src/agent_bom/api/metrics.py`
- `make preflight`
- `uv run python scripts/check_exception_sanitization.py`
- `uv run python scripts/check_package_layout.py`
- Node 24 toolchain verification, TypeScript typecheck, 760 UI tests, and production Next.js build
- disabled-provider `agent-bom cloud inventory --provider all --format json` smoke

## Notes

- Credentialed Azure/GCP smoke remains environment-owned. The checked-in deterministic fixtures prove contract/parity/failure behavior without claiming a customer tenant was scanned.
- `partial` and `indeterminate` remain fail-closed and never authorize through legacy heuristic fallback when authoritative evidence is present.

Closes #4131
