### PR TITLE
fix(security): close IAM condition-drop and gateway conditional-access/identity-scope fail-opens

### DIFF
--- a/src/agent_bom/cloud/aws_iam_evidence.py
+++ b/src/agent_bom/cloud/aws_iam_evidence.py
@@ -33,6 +33,25 @@ def _strings(value: Any) -> tuple[str, ...]:
     return tuple(sorted({item.strip() for item in values if isinstance(item, str) and item.strip()}))
 
 
+def _canonical_condition_scalar(item: Any) -> str | None:
+    # bool is a subclass of int, so it must be checked first; a JSON bool/number
+    # condition value must reach the evaluator, not be dropped as a non-string.
+    if isinstance(item, bool):
+        return "true" if item else "false"
+    if isinstance(item, str):
+        stripped = item.strip()
+        return stripped or None
+    if isinstance(item, (int, float)):
+        return str(item)
+    return None
+
+
+def _condition_values(value: Any) -> tuple[str, ...]:
+    values = value if isinstance(value, list) else [value]
+    canonical = {resolved for item in values if (resolved := _canonical_condition_scalar(item)) is not None}
+    return tuple(sorted(canonical))
+
+
 def _conditions(value: Any) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
     if not isinstance(value, Mapping):
         return ()
@@ -43,7 +62,7 @@ def _conditions(value: Any) -> tuple[tuple[str, str, tuple[str, ...]], ...]:
         for key, raw_values in entries.items():
             if not isinstance(key, str):
                 continue
-            values = _strings(raw_values)
+            values = _condition_values(raw_values)
             if values:
                 normalized.append((operator.strip(), key.strip(), values))
     return tuple(sorted(normalized))

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -2199,7 +2199,23 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             quarantine = False
             quarantine_reason = ""
             policy_source = "file"
-            if allowed and scoped_identity is not None and not scoped_identity.tool_allowed(tool_name):
+            # A managed (``abi_``) token carries a per-identity tool scope; if the
+            # identity store was unavailable we could not load that scope, so the
+            # call must fail closed rather than forward unscoped even when the
+            # token still resolves to an agent via a policy mapping. A non-managed
+            # token legitimately has no identity scope and is unaffected.
+            if (
+                allowed
+                and scoped_identity is None
+                and managed_identity_lookup_unavailable
+                and (identity_token or "").startswith("abi_")
+            ):
+                allowed, reason, policy_source = (
+                    False,
+                    "managed identity store unavailable; tool scope cannot be verified",
+                    "identity_scope",
+                )
+            elif allowed and scoped_identity is not None and not scoped_identity.tool_allowed(tool_name):
                 try:
                     from agent_bom.api.agent_identity_store import active_jit_grant_for_tool, get_agent_identity_store
 
@@ -2443,28 +2459,37 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                     client_id=_request_client_id(request),
                     attributes=_request_context_attributes(request),
                 )
+                # Conditional-access rules are a fixed fail-closed lane: an
+                # evaluate_conditional_rules error ALWAYS denies and is never
+                # softened by AGENT_BOM_GATEWAY_FAIL_MODE (matches the store-backed
+                # conditional-access lane and docs/RUNTIME_FAIL_MODES.md).
                 try:
                     cond_decision, cond_reason, _cond_rule = evaluate_conditional_rules(current_policy, decision_ctx)
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("gateway conditional-rules evaluation error: %s", _sanitize_for_log(exc))
+                    cond_decision, cond_reason = GatewayDecision.DENY, "conditional rules evaluation error"
+                # Policy plugins follow the gateway fail-mode knob (fail-open
+                # forwards on a plugin engine error, fail-closed denies).
+                try:
                     plugin_decision, plugin_reason, _plugin_name = evaluate_policy_plugins(
                         decision_ctx,
                         current_policy,
                         fail_closed=fail_closed,
                     )
-                    eval_error = False
+                    plugin_eval_error = False
                 except Exception as exc:  # noqa: BLE001
-                    logger.warning("gateway conditional/plugin evaluation error: %s", _sanitize_for_log(exc))
-                    cond_decision = plugin_decision = GatewayDecision.ALLOW
-                    cond_reason = plugin_reason = ""
-                    eval_error = True
+                    logger.warning("gateway plugin evaluation error: %s", _sanitize_for_log(exc))
+                    plugin_decision, plugin_reason = GatewayDecision.ALLOW, ""
+                    plugin_eval_error = True
                 # Compose: DENY outranks QUARANTINE outranks ALLOW. Conditional
                 # rules win ties over plugins (an explicit policy deny is stronger
-                # than a third-party quarantine). A fail-closed eval error denies.
+                # than a third-party quarantine). A fail-closed plugin eval error denies.
                 _rank = {GatewayDecision.ALLOW: 0, GatewayDecision.QUARANTINE: 1, GatewayDecision.DENY: 2}
                 if _rank[plugin_decision] > _rank[cond_decision]:
                     composed, composed_reason, composed_source = plugin_decision, plugin_reason, "policy_plugin"
                 else:
                     composed, composed_reason, composed_source = cond_decision, cond_reason, "conditional_access"
-                if eval_error and fail_closed:
+                if plugin_eval_error and fail_closed:
                     allowed, reason, policy_source = False, "policy evaluation error", "conditional_access"
                 elif composed == GatewayDecision.DENY:
                     allowed, reason, policy_source = False, composed_reason, composed_source

--- a/tests/test_aws_iam_evaluator.py
+++ b/tests/test_aws_iam_evaluator.py
@@ -63,6 +63,32 @@ def test_not_action_not_resource_and_implicit_deny() -> None:
     )
 
 
+def test_bool_gated_statement_is_not_scored_as_unconditional_allow() -> None:
+    gated = policy(
+        {
+            "Sid": "mfa-only",
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "*",
+            "Condition": {"Bool": {"aws:MultiFactorAuthPresent": True}},
+        }
+    )
+    # No MFA context is supplied: the Bool condition cannot be positively
+    # satisfied, so the statement must NOT flatten into an unconditional allow.
+    result = evaluate_identity_policies([gated], action="s3:GetObject", resource="arn:aws:s3:::bucket/key")
+    assert result.decision is not IamDecision.ALLOW
+    assert result.decision is IamDecision.INDETERMINATE
+
+    # With MFA present in context the Bool condition is satisfied → allow.
+    with_mfa = evaluate_identity_policies(
+        [gated],
+        action="s3:GetObject",
+        resource="arn:aws:s3:::bucket/key",
+        context={"aws:MultiFactorAuthPresent": "true"},
+    )
+    assert with_mfa.decision is IamDecision.ALLOW
+
+
 def test_partial_policy_can_never_produce_allow() -> None:
     partial = normalize_iam_policy_document(
         {"Statement": [{"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}, {"Effect": "Maybe", "Action": "*"}]}

--- a/tests/test_aws_iam_evidence.py
+++ b/tests/test_aws_iam_evidence.py
@@ -43,6 +43,33 @@ def test_normalizes_allow_deny_resource_and_conditions_deterministically() -> No
     assert policy.statements[1].not_actions == ("iam:Get*",)
 
 
+def test_bool_and_numeric_condition_values_are_retained_not_dropped() -> None:
+    policy = normalize_iam_policy_document(
+        {
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Action": "s3:GetObject",
+                    "Resource": "*",
+                    "Condition": {
+                        "Bool": {"aws:MultiFactorAuthPresent": True},
+                        "NumericLessThan": {"s3:max-keys": 10},
+                        "DateGreaterThan": {"aws:CurrentTime": "2026-01-01T00:00:00Z"},
+                    },
+                }
+            ]
+        }
+    )
+
+    # A JSON bool/number condition value must survive normalization so the
+    # evaluator still sees the guardrail instead of an empty (unconditional) tuple.
+    assert policy.statements[0].conditions == (
+        ("Bool", "aws:MultiFactorAuthPresent", ("true",)),
+        ("DateGreaterThan", "aws:CurrentTime", ("2026-01-01T00:00:00Z",)),
+        ("NumericLessThan", "s3:max-keys", ("10",)),
+    )
+
+
 def test_invalid_provider_statements_are_partial_not_exceptions() -> None:
     policy = normalize_iam_policy_document(
         {

--- a/tests/test_runtime_fail_mode.py
+++ b/tests/test_runtime_fail_mode.py
@@ -9,8 +9,15 @@ these tests) must change with it.
 
 from __future__ import annotations
 
-import pytest
+from typing import Any
 
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom import agent_identity, gateway_server
+from agent_bom.api import agent_identity_store
+from agent_bom.gateway_server import GatewaySettings, create_gateway_app
+from agent_bom.gateway_upstreams import UpstreamConfig, UpstreamRegistry
 from agent_bom.runtime.fail_mode import (
     GATEWAY_FAIL_MODE_MATRIX,
     FailPosture,
@@ -109,3 +116,95 @@ def test_matrix_summary_rows_are_json_shaped() -> None:
 def test_matrix_summary_rejects_unresolved_fail_mode() -> None:
     with pytest.raises(ValueError):
         gateway_fail_mode_matrix("maybe")
+
+
+# ── Behavior tests: the relay must implement the documented postures ────────
+#
+# The tests above pin the published matrix DATA. These drive the actual relay
+# and assert the runtime honors it: conditional-access eval errors fail closed
+# regardless of the knob, plugin eval errors follow the knob, and a managed
+# identity whose store is unavailable is not forwarded unscoped.
+
+
+async def _ok_caller(upstream: Any, message: dict[str, Any], extra_headers: Any) -> dict[str, Any]:
+    return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+
+def _settings(*, fail_mode: str, policy: dict[str, Any] | None = None) -> GatewaySettings:
+    return GatewaySettings(
+        registry=UpstreamRegistry([UpstreamConfig(name="filesystem", url="http://fs.local:8100")]),
+        policy=policy if policy is not None else {"agent_tokens": {"token-a": "agent-a"}},
+        upstream_caller=_ok_caller,
+        fail_mode=fail_mode,
+    )
+
+
+def _call(*, token: str = "token-a", tool: str = "read_file") -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/call",
+        "params": {"name": tool, "arguments": {}, "_meta": {"agent_identity": token}},
+    }
+
+
+def _blocked_source(resp: Any) -> str | None:
+    body = resp.json()
+    error = body.get("error")
+    if not isinstance(error, dict) or error.get("code") != -32001:
+        return None
+    return error.get("data", {}).get("policy_source")
+
+
+def _boom(*_args: Any, **_kwargs: Any) -> Any:
+    raise RuntimeError("evaluator exploded")
+
+
+def test_conditional_rules_eval_error_denies_even_under_fail_open(monkeypatch: pytest.MonkeyPatch) -> None:
+    # docs/RUNTIME_FAIL_MODES.md: a conditional-access eval error ALWAYS denies
+    # and is never softened by AGENT_BOM_GATEWAY_FAIL_MODE=open.
+    monkeypatch.setattr(gateway_server, "evaluate_conditional_rules", _boom)
+    client = TestClient(create_gateway_app(_settings(fail_mode="open")))
+    resp = client.post("/mcp/filesystem", json=_call())
+    assert _blocked_source(resp) == "conditional_access", resp.text
+
+
+def test_plugin_eval_error_follows_fail_mode_knob(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Policy plugins DO follow the knob: fail-open forwards on a plugin engine
+    # error, fail-closed denies. (Guards against over-tightening the split.)
+    monkeypatch.setattr(gateway_server, "evaluate_policy_plugins", _boom)
+
+    open_client = TestClient(create_gateway_app(_settings(fail_mode="open")))
+    open_resp = open_client.post("/mcp/filesystem", json=_call())
+    assert _blocked_source(open_resp) is None, open_resp.text
+    assert open_resp.json().get("result") == {"ok": True}, open_resp.text
+
+    closed_client = TestClient(create_gateway_app(_settings(fail_mode="closed")))
+    closed_resp = closed_client.post("/mcp/filesystem", json=_call())
+    assert _blocked_source(closed_resp) == "conditional_access", closed_resp.text
+
+
+def test_managed_identity_lookup_outage_denies_scoped_tool(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A managed (abi_) token resolves to an agent via the policy mapping, but the
+    # identity store is down so its per-identity tool scope cannot be loaded. The
+    # call must fail closed instead of forwarding unscoped.
+    monkeypatch.setattr(agent_identity, "_LOCAL_IDENTITY_VERIFIER", None)
+    monkeypatch.setattr(agent_identity_store, "identity_for_token", _boom)
+    token = "abi_deadbeef_topsecret"
+    settings = _settings(fail_mode="open", policy={"agent_tokens": {token: "agent-a"}})
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call(token=token))
+    assert _blocked_source(resp) == "identity_scope", resp.text
+
+
+def test_non_managed_token_unaffected_by_identity_store_outage(monkeypatch: pytest.MonkeyPatch) -> None:
+    # A non-managed (opaque) token legitimately has no identity scope; an
+    # identity-store error must not turn its call into a denial (distinguish
+    # "lookup errored" from "no scope configured").
+    monkeypatch.setattr(agent_identity, "_LOCAL_IDENTITY_VERIFIER", None)
+    monkeypatch.setattr(agent_identity_store, "identity_for_token", _boom)
+    settings = _settings(fail_mode="open", policy={"agent_tokens": {"token-a": "agent-a"}})
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call(token="token-a"))
+    assert _blocked_source(resp) is None, resp.text
+    assert resp.json().get("result") == {"ok": True}, resp.text


### PR DESCRIPTION
## What changed

Three confirmed fail-open defects where a security lane permitted on dropped evidence or an eval error. All found by a hands-on audit of `origin/main` and reproduced by a test that fails on pre-fix source.

**1. AWS IAM condition-drop → unconditional ALLOW (P1)** — `cloud/aws_iam_evidence.py`
`_conditions()` built condition tuples only from string values, silently discarding any condition whose value is a JSON bool or number. A statement AWS gates on `Bool aws:MultiFactorAuthPresent:true` (or a numeric/date operator) lost its condition, so `aws_iam_evaluator._conditions_match` saw an empty tuple, returned `True`, and `evaluate_identity_policies` scored it as an unconditional `ALLOW` — the exact fail-open the CIEM "fail-closed, conditions honored" contract forbids. Fix: retain condition values of every JSON scalar type (bool→`"true"`/`"false"`, int/float→`str`, string), so the condition reaches the evaluator; a retained operator it can't positively satisfy now yields INDETERMINATE (fail-closed), not ALLOW.

**2. Gateway conditional-access allowed on eval error under fail-open (P2)** — `gateway_server.py`
The inline conditional-rules lane allowed on an `evaluate_conditional_rules` exception when `AGENT_BOM_GATEWAY_FAIL_MODE=open`, contradicting `docs/RUNTIME_FAIL_MODES.md` and `runtime/fail_mode.py` (which state conditional-access errors always deny and are never softened by the knob). Fix: split the combined try — conditional-rules errors now always `DENY`; policy-plugin errors keep following the fail-mode knob.

**3. Identity tool-scope skipped on managed-store outage (P2)** — `gateway_server.py`
When a managed (`abi_`) token resolved via a policy mapping but `identity_for_token` raised, `scoped_identity` stayed `None`, so the `allowed_tools` scope check never ran and the call forwarded unscoped. Fix: when a managed token's identity lookup errored, fail closed (`policy_source="identity_scope"`) instead of forwarding; opaque tokens that legitimately carry no identity scope are unaffected, distinguishing "lookup errored" from "no scope configured".

## How verified

- New tests reproduce each fail-open before the fix, then pass after: `test_aws_iam_evidence`, `test_aws_iam_evaluator`, and four cases in `test_runtime_fail_mode` (conditional-error-denies-under-fail-open, plugin-error-follows-knob, managed-identity-outage-denies-scoped-tool, non-managed-token-unaffected). Confirmed all four core repros FAIL on stashed pre-fix source.
- `uv run pytest -q` across 11 touched suites (aws_iam evidence/evaluator/collector/privilege, authorization_evaluator, runtime_fail_mode, gateway server/drift/hardening/oauth) — 192 passed.
- `uv run ruff check` (5 files) clean; `uv run mypy` on both changed source files clean.