### PR TITLE
fix(sast): mask comments and string literals in Go source analysis

### DIFF
--- a/src/agent_bom/ast_go.py
+++ b/src/agent_bom/ast_go.py
@@ -24,6 +24,7 @@ from agent_bom.ast_signal_utils import (
     check_prompt_risks,
     classify_prompt_type,
 )
+from agent_bom.ast_source_mask import mask_line_comments_and_strings
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -298,8 +299,13 @@ def _canonicalize_go_call_name(raw_name: str, alias_map: dict[str, str]) -> str:
 
 
 def _go_call_sites(body: str, *, line_offset: int, alias_map: dict[str, str]) -> list[_GoCallSite]:
+    # Mask comments and string/backtick-raw-string literals so sink tokens such
+    # as ``exec.Command`` mentioned inside them are never treated as call sites.
+    # Masking preserves character positions and newlines, so line numbers stay
+    # accurate. Mirrors the php/ruby/java/rust/swift/csharp call-site passes.
+    masked = mask_line_comments_and_strings(body, backtick_strings=True)
     call_sites: list[_GoCallSite] = []
-    for match in _GO_CALL_RE.finditer(body):
+    for match in _GO_CALL_RE.finditer(masked):
         raw_name = match.group("name")
         if raw_name in _GO_CALL_SKIP:
             continue
@@ -307,7 +313,7 @@ def _go_call_sites(body: str, *, line_offset: int, alias_map: dict[str, str]) ->
         if canonical in _GO_CALL_SKIP:
             continue
         open_index = match.end() - 1
-        args_segment = _balanced_segment(body, open_index, open_char="(", close_char=")")
+        args_segment = _balanced_segment(masked, open_index, open_char="(", close_char=")")
         argument_names: list[list[str]] = []
         if args_segment is not None:
             args_text, _ = args_segment
@@ -315,7 +321,7 @@ def _go_call_sites(body: str, *, line_offset: int, alias_map: dict[str, str]) ->
         call_sites.append(
             _GoCallSite(
                 name=canonical,
-                line_number=line_offset + body[: match.start()].count("\n"),
+                line_number=line_offset + masked[: match.start()].count("\n"),
                 argument_names=argument_names,
             )
         )
@@ -1017,8 +1023,12 @@ def scan_go_file(
         )
 
     entrypoint = tools[0].name if tools else "module"
+    # Mask comments and string/backtick-raw-string literals so sink/LLM tokens
+    # mentioned inside them are not reported as real dangerous or LLM calls.
+    # Masking preserves positions and newlines, so line numbers stay accurate.
+    masked_source = mask_line_comments_and_strings(source, backtick_strings=True)
     for sink_name, pattern in [*_GO_DANGEROUS_PATTERNS, *_GO_LLM_PATTERNS]:
-        for match in pattern.finditer(source):
+        for match in pattern.finditer(masked_source):
             category = "go_llm_call" if sink_name.startswith(("openai", "anthropic")) else "go_dangerous_call"
             title = "Go source invokes an LLM client" if category == "go_llm_call" else "Go source invokes a dangerous capability"
             flow_findings.append(

--- a/src/agent_bom/ast_source_mask.py
+++ b/src/agent_bom/ast_source_mask.py
@@ -45,7 +45,7 @@ def _consume_heredoc(source: str, start: int) -> tuple[str, int] | None:
 
 
 def mask_line_comments_and_strings(
-    source: str, *, hash_comments: bool = False, heredoc: bool = False
+    source: str, *, hash_comments: bool = False, heredoc: bool = False, backtick_strings: bool = False
 ) -> str:
     """Return ``source`` with comments and quoted literals replaced by spaces.
 
@@ -53,6 +53,11 @@ def mask_line_comments_and_strings(
     ``heredoc`` masks PHP heredoc/nowdoc (``<<<EOT`` / ``<<<'EOT'``) bodies,
     where an identifier such as ``$client->request`` inside a SQL/HTML template
     must not be mistaken for a call site.
+    ``backtick_strings`` masks Go backtick-delimited raw string literals
+    (``` `...` ```), where backslashes are literal and a sink token such as
+    ``exec.Command`` inside the raw string must not be mistaken for a call site.
+    It is opt-in because a backtick means something else in other languages
+    (e.g. a Swift keyword-escaped identifier), so only Go enables it.
     """
     result: list[str] = []
     i = 0
@@ -87,6 +92,11 @@ def mask_line_comments_and_strings(
                 result.append(" ")
                 i += 1
                 continue
+            if backtick_strings and char == "`":
+                state = "raw_string"
+                result.append(" ")
+                i += 1
+                continue
             if char in {"'", '"'}:
                 state = "string"
                 quote = char
@@ -113,6 +123,16 @@ def mask_line_comments_and_strings(
                 i += 2
                 continue
             result.append("\n" if char == "\n" else " ")
+            i += 1
+            continue
+
+        if state == "raw_string":
+            # Go backtick raw strings have no escapes; a literal backtick ends them.
+            if char == "`":
+                state = "code"
+                result.append(" ")
+            else:
+                result.append("\n" if char == "\n" else " ")
             i += 1
             continue
 

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from agent_bom.ast_analyzer import analyze_project
+from agent_bom.ast_go import scan_go_file
 from agent_bom.cli import main
 
 
@@ -639,7 +640,7 @@ def test_analyze_project_surfaces_swift_dependency_symbol_reach(tmp_path: Path) 
         encoding="utf-8",
     )
     (tmp_path / "Server.swift").write_text(
-        'import Alamofire\n\n'
+        "import Alamofire\n\n"
         "func register(server: MCPServer) {\n"
         '    server.tool("fetch_url", fetchUrl)\n'
         "}\n\n"
@@ -663,7 +664,7 @@ def test_analyze_project_swift_bare_helper_call_chain(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     (tmp_path / "Server.swift").write_text(
-        'import Alamofire\n\n'
+        "import Alamofire\n\n"
         "func register(server: MCPServer) {\n"
         '    server.tool("fetch_url", handler)\n'
         "}\n\n"
@@ -954,6 +955,87 @@ def test_analyze_project_scans_go_source_for_tools_prompts_and_exec(tmp_path: Pa
     assert any(prompt.file_path == "server.go" for prompt in result.prompts)
     assert any(tool.name == "run_cmd" and tool.file_path == "server.go" for tool in result.tools)
     assert any(finding.category == "go_dangerous_call" and finding.sink == "exec.Command" for finding in result.flow_findings)
+
+
+def test_scan_go_file_ignores_sink_tokens_in_comments_and_strings(tmp_path: Path):
+    go_file = tmp_path / "commented.go"
+    go_file.write_text(
+        "package main\n\n"
+        "func main() {\n"
+        '    // exec.Command("sh", "-c", "ls") lives only in a line comment\n'
+        "    /* os.WriteFile(path, data, 0644) lives only in a block comment\n"
+        "       and template.JS(payload) too */\n"
+        '    msg := "template.HTML(userInput) is only a string literal"\n'
+        '    other := "ioutil.WriteFile(path, data, 0644) also just a string"\n'
+        '    raw := `exec.Command("rm", "-rf", "/") inside a backtick raw string\n'
+        "       and CreateChatCompletion spanning lines`\n"
+        '    note := "the model calls Messages.Create somewhere"\n'
+        "    _ = msg\n"
+        "    _ = other\n"
+        "    _ = raw\n"
+        "    _ = note\n"
+        "}\n"
+    )
+
+    _, _, _, flow_findings, _, _, _ = scan_go_file(go_file, "commented.go")
+
+    assert not [f for f in flow_findings if f.category == "go_dangerous_call"]
+    assert not [f for f in flow_findings if f.category == "go_llm_call"]
+
+
+def test_scan_go_file_flags_real_dangerous_and_llm_calls(tmp_path: Path):
+    go_file = tmp_path / "real.go"
+    go_file.write_text(
+        "package main\n\n"
+        'import "os/exec"\n\n'
+        "func main() {\n"
+        '    exec.Command("sh", "-c", "ls")\n'
+        "    template.HTML(userInput)\n"
+        "    client.CreateChatCompletion(ctx, req)\n"
+        "}\n"
+    )
+
+    _, _, _, flow_findings, _, _, _ = scan_go_file(go_file, "real.go")
+
+    dangerous = {f.sink for f in flow_findings if f.category == "go_dangerous_call"}
+    assert "exec.Command" in dangerous
+    assert "template.HTML" in dangerous
+    assert any(f.category == "go_llm_call" and f.sink == "openai.ChatCompletion" for f in flow_findings)
+
+
+def test_scan_go_file_ignores_call_sites_in_comments_and_strings(tmp_path: Path):
+    go_file = tmp_path / "handler.go"
+    go_file.write_text(
+        "package main\n\n"
+        "func handler() error {\n"
+        '    // exec.Command("sh", "-c", "ls") in a comment must not be a call site\n'
+        '    log := "exec.Command was requested"\n'
+        "    raw := `os.WriteFile(path, data, 0644)`\n"
+        "    _ = log\n"
+        "    _ = raw\n"
+        "    return nil\n"
+        "}\n"
+    )
+
+    _, _, _, _, _, _, go_analysis = scan_go_file(go_file, "handler.go")
+    assert go_analysis is not None
+    handler = go_analysis.functions["handler"]
+
+    assert handler.dangerous_call_sites == []
+    assert not [site for site in handler.call_sites if site.name in {"exec.Command", "os.WriteFile"}]
+
+
+def test_scan_go_file_records_real_dangerous_call_sites(tmp_path: Path):
+    go_file = tmp_path / "handler_real.go"
+    go_file.write_text(
+        'package main\n\nimport "os/exec"\n\nfunc handler(cmd string) error {\n    return exec.Command("sh", "-c", cmd).Run()\n}\n'
+    )
+
+    _, _, _, _, _, _, go_analysis = scan_go_file(go_file, "handler_real.go")
+    assert go_analysis is not None
+    handler = go_analysis.functions["handler"]
+
+    assert any(site.name == "exec.Command" for site in handler.dangerous_call_sites)
 
 
 def test_analyze_project_reports_js_ts_dom_xss_pattern(tmp_path: Path):


### PR DESCRIPTION
## What
`scan_go_file` was the only one of seven regex source parsers running its dangerous/LLM pattern passes and its call-site extraction against raw Go source. Sink tokens (`exec.Command`, `os.WriteFile`, `template.HTML`) and LLM-client tokens appearing inside `//` and `/* */` comments, `"..."` strings, or backtick raw strings were reported as real dangerous/LLM capability calls — even with no matching import — inflating Go findings and reachability.

## Fix
- `_go_call_sites` and the dangerous/LLM pattern pass in `scan_go_file` now run against `mask_line_comments_and_strings(..., backtick_strings=True)`, mirroring the php/ruby/java/rust/swift/csharp call-site passes. Prompt/import extraction still reads raw source (it needs literal contents).
- Added an **opt-in** `backtick_strings` flag to the shared masker for Go raw strings. It defaults off, so the other six parsers call the helper unchanged (a backtick means something different in Swift/Ruby/PHP). Masking preserves character positions and newlines, so line numbers stay accurate.

## How verified
- New tests (red → green): sink/LLM tokens in comments, `"..."` strings, and backtick raw strings produce zero findings; positive controls confirm real calls are still flagged.
- Parser regression suite: `205 passed`. New Go tests: `4 passed`. `ruff check`/`format`: clean. `mypy` on both changed source files: clean. Ran the other six parsers' suites — no regression from the masker change.