### PR TITLE
fix(graph): keep distinct credential nodes instead of collapsing to one phantom node

### DIFF
--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -491,6 +491,22 @@ def _key_looks_sensitive(key: object) -> bool:
     return any(re.search(pattern, str(key).lower()) for pattern in SENSITIVE_PATTERNS)
 
 
+# Fields whose string members are credential *env-var names* — identifiers such
+# as ``OPENAI_API_KEY`` — not secret values.  The key text ("credential…")
+# matches SENSITIVE_PATTERNS, so without this exception every name would redact
+# to ``***REDACTED***``; downstream the graph exporter mints node IDs from these
+# labels and set-dedups them, collapsing distinct credentials into one phantom
+# node and inventing cross-agent ``reaches_tool``/``exposes_cred`` edges.  Only
+# the VALUE of a credential is sensitive, and values are never carried here.
+_CREDENTIAL_IDENTIFIER_KEYS = frozenset(
+    {"credential_env_vars", "credential_env_var", "credential_names", "credential_refs"}
+)
+
+
+def _key_is_credential_identifier(key: object) -> bool:
+    return str(key or "").strip().lower().replace("-", "_") in _CREDENTIAL_IDENTIFIER_KEYS
+
+
 def _key_looks_like_url(key: object) -> bool:
     key_text = str(key).lower()
     return key_text in {"url", "uri", "endpoint", "webhook"} or key_text.endswith(("_url", "_uri", "_endpoint", "_webhook"))
@@ -550,6 +566,11 @@ def sanitize_sensitive_payload(value: object, *, key: object | None = None, max_
     if value is None or isinstance(value, bool | int | float):
         return value
     if isinstance(value, str):
+        # A credential env-var NAME is an identifier, not a secret value.  Keep
+        # it intact so distinct credentials stay distinct graph nodes; still
+        # redact defensively if the string itself looks like a leaked secret.
+        if _key_is_credential_identifier(key) and not _looks_sensitive_value(value):
+            return sanitize_text(value, max_len=max_str_len)
         if key is not None and _key_looks_sensitive(key):
             return "***REDACTED***"
         if key is not None and _key_looks_like_email(key):

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -203,6 +203,85 @@ def test_credential_to_tool_reaches_edges_export_with_evidence():
         os.unlink(path)
 
 
+def test_redacted_report_keeps_distinct_credential_nodes_and_no_phantom_edges():
+    """Regression: credential env-var NAMES are identifiers, not secret values.
+
+    The report-write path (``to_redacted_json`` → ``sanitize_sensitive_payload``)
+    must not collapse distinct credential names into one ``***REDACTED***`` label.
+    A collapse mints a single ``cred:***REDACTED***`` node that set-dedups across
+    unrelated agents and invents phantom cross-agent ``reaches_tool`` edges.
+    """
+    from agent_bom.security import sanitize_sensitive_payload
+
+    agent_a = _agent(
+        "agent-a",
+        [
+            _server(
+                "openai-srv",
+                has_creds=True,
+                tools=[{"name": "chat"}],
+                credential_env_vars=["OPENAI_API_KEY"],
+            ),
+            _server(
+                "vector-srv",
+                has_creds=True,
+                tools=[{"name": "vector_search"}],
+                credential_env_vars=["VECTOR_DB_TOKEN"],
+            ),
+        ],
+    )
+    agent_b = _agent(
+        "agent-b",
+        [
+            _server(
+                "browser-srv",
+                has_creds=True,
+                tools=[{"name": "browse"}],
+                credential_env_vars=["BROWSER_SESSION_TOKEN"],
+            ),
+            _server(
+                "anthropic-srv",
+                has_creds=True,
+                tools=[{"name": "complete"}],
+                credential_env_vars=["ANTHROPIC_API_KEY"],
+            ),
+        ],
+    )
+    raw = _make_scan_json([agent_a, agent_b])
+
+    # Run through the exact redaction the report writer applies before persistence.
+    redacted = sanitize_sensitive_payload(raw)
+    assert isinstance(redacted, dict)
+
+    path = _write_scan(redacted)
+    try:
+        graph = load_graph_from_scan(path)
+    finally:
+        os.unlink(path)
+
+    cred_nodes = {node.id for node in graph.nodes if node.kind == "credential"}
+    # (a) each distinct credential stays its own node — no collapse to one label.
+    assert cred_nodes == {
+        "cred:OPENAI_API_KEY",
+        "cred:VECTOR_DB_TOKEN",
+        "cred:BROWSER_SESSION_TOKEN",
+        "cred:ANTHROPIC_API_KEY",
+    }
+    assert "cred:***REDACTED***" not in cred_nodes
+
+    # (b) no phantom cross-agent credential→tool edge: every reaches_tool edge
+    # must connect a credential and a tool that belong to the SAME server.
+    for edge in graph.edges:
+        if edge.kind != "reaches_tool":
+            continue
+        target_node = next(node for node in graph.nodes if node.id == edge.target)
+        server_id = target_node.attributes.get("server")
+        cred_node = next(node for node in graph.nodes if node.id == edge.source)
+        assert cred_node.attributes.get("server") == server_id, (
+            f"phantom cross-server edge {edge.source} -> {edge.target}"
+        )
+
+
 def test_vulnerable_package_gets_pkg_vuln_kind():
     pkg = _pkg("lodash", "4.17.20", "npm", vulns=[_vuln("CVE-2021-23337")])
     data = _make_scan_json([_agent("a", [_server("s", [pkg])])])


### PR DESCRIPTION
## What

On a seeded estate with distinct credentials (OPENAI_API_KEY, VECTOR_DB_TOKEN, BROWSER_SESSION_TOKEN, ANTHROPIC_API_KEY), `agent-bom graph <report>.json -f json` exported a **single** `cred:***REDACTED***` node carrying `reaches_tool`/`exposes_cred` edges across unrelated agents — 3 real credential nodes dropped, phantom cross-agent lateral-movement edges invented.

## Root cause

The redaction fires on the **field key**, not the value: `_key_looks_sensitive("credential_env_vars")` is `True` (matches the `credential` pattern), so `sanitize_sensitive_payload` redacted every credential env-var **name** to `***REDACTED***`. A credential env-var name (`OPENAI_API_KEY`) is an identifier, not a secret — and the field never carries values. The graph exporter then minted node IDs from those identical redacted labels and set-deduped them, collapsing the credentials and cross-wiring edges. At discovery the names are correct; corruption happens at report write.

## Fix

Narrow exception in `sanitize_sensitive_payload` for the credential-identifier fields (`credential_env_vars`/`credential_env_var`/`credential_names`/`credential_refs`): keep the string via `sanitize_text` **unless the string itself looks like a leaked secret value** (`_looks_sensitive_value`), in which case it still redacts. No new stable-id machinery in the exporter.

**No secret value leaks:** scoped to those four identifier keys only; values under `api_key`/`password`/`auth_token` still redact, and a real-looking secret placed inside the credential field still redacts via the defensive guard.

## How verified

- New `test_graph_export.py::test_redacted_report_keeps_distinct_credential_nodes_and_no_phantom_edges` runs export through the redacted-report path (the prior CI blind spot — fixtures used raw names) and asserts 4 distinct cred nodes + no cross-server `reaches_tool` edge. Red before (`{'cred:***REDACTED***'}`), green after.
- `pytest`: graph_export (107) + security (106) + redaction/credential/hardening (91) + context_graph (46) — all pass. `ruff`/`mypy` clean on changed files.
- Live: `quickstart --run --offline` then `graph <report>.json -f json` → 4 distinct `cred:` nodes, zero phantom cross-server edges.