### PR TITLE
feat(ciem): extend identity governance to AWS and GCP with real usage telemetry

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -5585,6 +5585,33 @@ def _wire_network_entry_exposure_paths(
                     )
 
 
+def _role_last_used_at(usage_evidence: Any) -> str | None:
+    """Newest real last-accessed timestamp across role usage-evidence records.
+
+    Threads bounded AWS Access Advisor / RoleLastUsed telemetry
+    (:mod:`agent_bom.cloud.aws_iam_evidence`) onto the identity node so NHI
+    governance dormancy uses a real last-used signal. Returns ``None`` when no
+    record carries a timestamp — absent telemetry must never be turned into a
+    false "never used" (fail-closed); the role then stays not-evaluated for
+    dormancy rather than being fabricated as dormant.
+    """
+    if not isinstance(usage_evidence, Mapping):
+        return None
+    records = usage_evidence.get("records")
+    if not isinstance(records, list):
+        return None
+    newest: str | None = None
+    for record in records:
+        if not isinstance(record, Mapping):
+            continue
+        raw = record.get("last_accessed_at")
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        if newest is None or raw > newest:
+            newest = raw
+    return newest
+
+
 def _add_inventory_principal(
     graph: UnifiedGraph,
     principal: dict[str, Any],
@@ -5603,23 +5630,35 @@ def _add_inventory_principal(
         return
     entity_type = _identity_entity_type(principal_type)
     principal_node_id = _identity_node_id(entity_type, provider, principal_id)
+    node_attributes: dict[str, Any] = {
+        "principal_id": principal_id,
+        "principal_name": principal_name,
+        "principal_type": principal_type,
+        "directory_principal_id": _clean_graph_part(principal.get("principal_id")),
+        "principal_email": _clean_graph_part(principal.get("email")),
+        "principal_resource_id": _clean_graph_part(principal.get("arn")),
+        "cloud_provider": provider,
+        "privilege_level": _clean_graph_part(principal.get("privilege_level")) or "unknown",
+        "iam_path": _clean_graph_part(principal.get("path")),
+        "source": "cloud-inventory",
+    }
+    # Thread collected role usage evidence so NHI governance dormancy uses a real
+    # last-used signal. Only a real timestamp sets ``last_used_at`` — absent
+    # telemetry leaves the field unset so dormancy stays fail-closed.
+    usage_evidence = principal.get("usage_evidence")
+    if isinstance(usage_evidence, Mapping):
+        state = usage_evidence.get("state")
+        if isinstance(state, str) and state.strip():
+            node_attributes["usage_evidence_state"] = state
+        last_used = _role_last_used_at(usage_evidence)
+        if last_used:
+            node_attributes["last_used_at"] = last_used
     graph.add_node(
         UnifiedNode(
             id=principal_node_id,
             entity_type=entity_type,
             label=principal_name,
-            attributes={
-                "principal_id": principal_id,
-                "principal_name": principal_name,
-                "principal_type": principal_type,
-                "directory_principal_id": _clean_graph_part(principal.get("principal_id")),
-                "principal_email": _clean_graph_part(principal.get("email")),
-                "principal_resource_id": _clean_graph_part(principal.get("arn")),
-                "cloud_provider": provider,
-                "privilege_level": _clean_graph_part(principal.get("privilege_level")) or "unknown",
-                "iam_path": _clean_graph_part(principal.get("path")),
-                "source": "cloud-inventory",
-            },
+            attributes=node_attributes,
             data_sources=data_sources,
             dimensions=NodeDimensions(cloud_provider=provider, surface="identity"),
         )

--- a/src/agent_bom/graph/nhi_governance.py
+++ b/src/agent_bom/graph/nhi_governance.py
@@ -25,6 +25,13 @@ the three core NHI governance analytics that close the 2026-06-19 audit gap:
    dormancy. The score is written back onto the ``managed_identity`` node so the
    graph, API, and findings all rank the same way.
 
+The verdict covers every non-human identity type in the graph — Azure/
+discovered ``managed_identity`` nodes plus AWS IAM ``role`` and GCP
+``service_account`` nodes — so CIEM over-grant / dormant / orphan findings span
+all three clouds. For the cloud-inventory role/service-account types, which do
+not carry owner or last-used as a first-class contract, absent evidence is
+fail-closed: it is never turned into a dormant / over-grant / orphan verdict.
+
 Reference-only: consumes labels, timestamps, and edge metadata already in the
 graph; never touches secret material and never raises into the builder.
 """
@@ -46,6 +53,19 @@ from agent_bom.graph.types import EntityType, RelationshipType
 _OVERLAY_SOURCE = "nhi-governance"
 
 DEFAULT_DORMANT_DAYS = 90
+
+# Identity node types that carry a governance verdict. MANAGED_IDENTITY (Azure /
+# discovered NHIs) is the original; ROLE (AWS IAM roles, Snowflake roles) and
+# SERVICE_ACCOUNT (GCP service accounts) are governed too so CIEM over-grant /
+# dormant findings cover AWS and GCP, not just Azure.
+_GOVERNED_ENTITY_TYPES = frozenset({EntityType.MANAGED_IDENTITY, EntityType.ROLE, EntityType.SERVICE_ACCOUNT})
+
+# For these types the base cloud inventory does NOT carry owner / last-used as a
+# first-class contract, so ABSENT evidence must never be turned into a dormant /
+# over-grant / orphan verdict (fail-closed). MANAGED_IDENTITY keeps its legacy
+# "no timestamp == dormant" / "no owner == orphaned" semantics because the NHI
+# discovery overlay always supplies those fields.
+_STRICT_EVIDENCE_TYPES = frozenset({EntityType.ROLE, EntityType.SERVICE_ACCOUNT})
 
 # Permission/scope edges that count as a *granted* capability for right-sizing.
 _GRANT_RELS = frozenset({RelationshipType.HAS_PERMISSION, RelationshipType.SCOPED_TO})
@@ -184,6 +204,20 @@ def _granted_targets(graph: UnifiedGraph, node_id: str) -> dict[str, str | None]
     return granted
 
 
+def _node_provider(attrs: Mapping[str, Any]) -> str | None:
+    """Provider attribution for an identity node.
+
+    MANAGED_IDENTITY nodes carry ``provider``; cloud-inventory ROLE /
+    SERVICE_ACCOUNT nodes carry ``cloud_provider``. Read either so AWS/GCP
+    findings are attributed correctly.
+    """
+    for key in ("provider", "cloud_provider"):
+        value = attrs.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
 def _exposed_targets(graph: UnifiedGraph, targets: set[str]) -> bool:
     return any(graph.nodes.get(tid) is not None and bool(graph.nodes[tid].attributes.get("internet_exposed")) for tid in targets)
 
@@ -209,19 +243,29 @@ def evaluate_identity_governance(
         for key, vals in usage.items():
             usage_map[str(key)] = {str(v) for v in vals}
 
-    identities = [n for n in graph.nodes.values() if n.entity_type == EntityType.MANAGED_IDENTITY]
+    identities = [n for n in graph.nodes.values() if n.entity_type in _GOVERNED_ENTITY_TYPES]
     results: list[IdentityGovernance] = []
     for node in identities[:_MAX_IDENTITIES]:
         attrs = node.attributes
+        strict = node.entity_type in _STRICT_EVIDENCE_TYPES
         identity_id = str(attrs.get("identity_id") or node.id)
         owner = attrs.get("owner")
         owner_str = str(owner).strip() if isinstance(owner, str) and str(owner).strip() else None
 
         granted = _granted_targets(graph, node.id)
-        observed = set(usage_map.get(identity_id, set())) | set(usage_map.get(node.id, set()))
-        # Edge-level last_used markers count as observed usage for that target.
-        observed |= {tid for tid, last_used in granted.items() if last_used}
-        unused = sorted(tid for tid in granted if tid not in observed)
+        # Observed usage: a caller-supplied usage map keyed by identity_id or node
+        # id, plus any per-target ``last_used_at`` marker on the grant edges.
+        mapped_usage = set(usage_map.get(identity_id, set())) | set(usage_map.get(node.id, set()))
+        edge_usage = {tid for tid, last_used in granted.items() if last_used}
+        observed = mapped_usage | edge_usage
+        has_observed_signal = bool(mapped_usage or edge_usage)
+        if strict and not has_observed_signal:
+            # Fail-closed: without a per-target usage signal for an AWS/GCP
+            # identity we cannot claim any grant is unused — never fabricate an
+            # over-grant from absent evidence.
+            unused: list[str] = []
+        else:
+            unused = sorted(tid for tid in granted if tid not in observed)
 
         # ── Dormancy ──
         last_used_at = attrs.get("last_used_at")
@@ -230,10 +274,18 @@ def evaluate_identity_governance(
         if last_used_dt is not None:
             dormancy_days = max(0, _days_since(last_used_dt, now))
             is_dormant = dormancy_days >= window
+        elif strict:
+            # No real last-used telemetry for an AWS/GCP identity → not
+            # assessable. Fail-closed: absence of evidence is never dormancy.
+            is_dormant = False
         else:
             # No usage timestamp at all → treat as dormant (never-observed).
             is_dormant = True
-        is_orphaned = owner_str is None
+        # Orphan detection needs an owner *contract*: MANAGED_IDENTITY always
+        # carries an ``owner`` attribute (empty when unowned), so a missing owner
+        # is a real orphan. Cloud-inventory ROLE/SERVICE_ACCOUNT nodes carry no
+        # owner key, so their absence is "not tracked", not "orphaned".
+        is_orphaned = ("owner" in attrs) and owner_str is None if strict else owner_str is None
 
         # ── Privilege / exposure ──
         is_privileged = bool(attrs.get("escalates_to_admin") or attrs.get("is_admin") or attrs.get("privilege_level") == "admin")
@@ -245,7 +297,7 @@ def evaluate_identity_governance(
             {
                 "id": identity_id,
                 "name": node.label,
-                "provider": attrs.get("provider"),
+                "provider": _node_provider(attrs),
                 "credential_expires_at": attrs.get("credential_expires_at"),
                 "last_rotated": attrs.get("last_rotated") or attrs.get("created_at"),
             },
@@ -294,7 +346,7 @@ def evaluate_identity_governance(
                 node_id=node.id,
                 identity_id=identity_id,
                 name=node.label,
-                provider=attrs.get("provider") if isinstance(attrs.get("provider"), str) else None,
+                provider=_node_provider(attrs),
                 owner=owner_str,
                 risk_score=risk_score,
                 risk_band=_risk_band(risk_score),

--- a/tests/test_nhi_governance_aws_gcp_parity.py
+++ b/tests/test_nhi_governance_aws_gcp_parity.py
@@ -1,0 +1,236 @@
+"""CIEM parity: AWS IAM roles + GCP service accounts get governance verdicts.
+
+Before this change ``evaluate_identity_governance`` iterated only
+``MANAGED_IDENTITY`` (Azure), so AWS ``ROLE`` and GCP ``SERVICE_ACCOUNT``
+identities produced no over-grant / dormant / orphan finding at all. These
+tests pin two things:
+
+1. GAP 1 — the evaluator now scores ROLE + SERVICE_ACCOUNT with correct
+   provider attribution, driven by the same node attributes/edges the Azure
+   path uses, and FAIL-CLOSED: an identity with no usage evidence never
+   fabricates a dormant / over-grant / orphan verdict.
+2. GAP 2 — real AWS Access Advisor / RoleLastUsed ``usage_evidence`` collected
+   during inventory is threaded onto the ROLE node's ``last_used_at`` so
+   dormancy uses real last-used telemetry (and absent telemetry stays
+   not-evaluated).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from agent_bom.graph.builder import _role_last_used_at, build_unified_graph_from_report
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.nhi_governance import (
+    build_nhi_governance_findings,
+    evaluate_identity_governance,
+)
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+NOW = datetime(2026, 6, 20, tzinfo=timezone.utc)
+
+
+def _iso(days_ago: int) -> str:
+    return (NOW - timedelta(days=days_ago)).isoformat()
+
+
+def _role(nid: str, label: str, **attrs: Any) -> UnifiedNode:
+    return UnifiedNode(id=nid, entity_type=EntityType.ROLE, label=label, attributes=attrs)
+
+
+def _sa(nid: str, label: str, **attrs: Any) -> UnifiedNode:
+    return UnifiedNode(id=nid, entity_type=EntityType.SERVICE_ACCOUNT, label=label, attributes=attrs)
+
+
+def _resource(nid: str, label: str, **attrs: Any) -> UnifiedNode:
+    return UnifiedNode(id=nid, entity_type=EntityType.CLOUD_RESOURCE, label=label, attributes=attrs)
+
+
+def _grant(src: str, tgt: str) -> UnifiedEdge:
+    return UnifiedEdge(source=src, target=tgt, relationship=RelationshipType.HAS_PERMISSION)
+
+
+def _verdict(verdicts: list[Any], node_id: str) -> Any:
+    return next(v for v in verdicts if v.node_id == node_id)
+
+
+# ── GAP 1: AWS ROLE parity ───────────────────────────────────────────────────
+def test_aws_role_over_grant_and_dormant_emitted_with_provider() -> None:
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    rid = "role:aws:arn:aws:iam::111122223333:role/app"
+    g.add_node(_role(rid, "app-role", cloud_provider="aws", last_used_at=_iso(200)))
+    g.add_node(_resource("res:used", "used-bucket"))
+    g.add_node(_resource("res:unused", "unused-bucket"))
+    g.add_edge(_grant(rid, "res:used"))
+    g.add_edge(_grant(rid, "res:unused"))
+
+    verdicts = evaluate_identity_governance(g, usage={rid: {"res:used"}}, now=NOW)
+    v = _verdict(verdicts, rid)
+    assert v.provider == "aws"
+    assert v.is_dormant is True
+    assert v.dormant_days == 200
+    assert v.unused_targets == ["res:unused"]
+
+    findings = build_nhi_governance_findings(g, verdicts)
+    over = [f for f in findings if f.evidence.get("nhi_governance") == "over_grant"]
+    unattended = [f for f in findings if f.evidence.get("nhi_governance") == "unattended_identity"]
+    assert len(over) == 1
+    assert len(unattended) == 1
+    assert over[0].asset.location == "aws"
+    assert unattended[0].asset.location == "aws"
+    assert "unused-bucket" in over[0].evidence["unused_targets"]
+
+
+# ── GAP 1: GCP SERVICE_ACCOUNT parity ────────────────────────────────────────
+def test_gcp_service_account_dormant_emitted_with_provider() -> None:
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    sid = "service_account:gcp:svc@proj.iam.gserviceaccount.com"
+    g.add_node(_sa(sid, "svc@proj", cloud_provider="gcp", last_used_at=_iso(200), escalates_to_admin=True))
+
+    verdicts = evaluate_identity_governance(g, now=NOW)
+    v = _verdict(verdicts, sid)
+    assert v.provider == "gcp"
+    assert v.is_dormant is True
+    assert v.is_privileged is True
+
+    findings = build_nhi_governance_findings(g, verdicts)
+    unattended = [f for f in findings if f.evidence.get("nhi_governance") == "unattended_identity"]
+    assert len(unattended) == 1
+    assert unattended[0].asset.location == "gcp"
+    # Privileged + dormant → high severity.
+    assert unattended[0].severity == "high"
+
+
+# ── GAP 1: fail-closed on absent evidence ────────────────────────────────────
+def test_aws_role_without_evidence_is_not_fabricated() -> None:
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    rid = "role:aws:arn:aws:iam::111122223333:role/bare"
+    # No last_used_at, no owner key, granted to two resources, NO usage signal.
+    g.add_node(_role(rid, "bare-role", cloud_provider="aws"))
+    g.add_node(_resource("res:a", "a"))
+    g.add_node(_resource("res:b", "b"))
+    g.add_edge(_grant(rid, "res:a"))
+    g.add_edge(_grant(rid, "res:b"))
+
+    verdicts = evaluate_identity_governance(g, now=NOW)
+    v = _verdict(verdicts, rid)
+    # Absent evidence must never become a dormant / over-grant / orphan verdict.
+    assert v.is_dormant is False
+    assert v.dormant_days is None
+    assert v.is_orphaned is False
+    assert v.unused_targets == []
+
+    findings = build_nhi_governance_findings(g, verdicts)
+    node_findings = [f for f in findings if f.asset.identifier == v.identity_id]
+    assert node_findings == []
+
+
+# ── Regression: MANAGED_IDENTITY behavior unchanged ──────────────────────────
+def test_managed_identity_over_grant_without_signal_unchanged() -> None:
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(
+        UnifiedNode(
+            id="managed_identity:m",
+            entity_type=EntityType.MANAGED_IDENTITY,
+            label="m",
+            attributes={"identity_id": "m", "owner": "alice", "last_used_at": _iso(1)},
+        )
+    )
+    g.add_node(_resource("res:x", "x"))
+    g.add_edge(_grant("managed_identity:m", "res:x"))
+
+    v = _verdict(evaluate_identity_governance(g, now=NOW), "managed_identity:m")
+    # Legacy: a grant with no observed usage is still an over-grant for a
+    # MANAGED_IDENTITY (the NHI overlay supplies the usage contract). The
+    # fail-closed gate applies ONLY to the newly-governed ROLE/SERVICE_ACCOUNT.
+    assert v.unused_targets == ["res:x"]
+
+
+# ── GAP 2: usage_evidence → last_used_at helper ──────────────────────────────
+def test_role_last_used_at_picks_newest_real_timestamp() -> None:
+    evidence = {
+        "state": "available",
+        "records": [
+            {"service_namespace": "s3", "last_accessed_at": "2020-01-01T00:00:00+00:00"},
+            {"service_namespace": "*", "last_accessed_at": "2021-05-01T00:00:00+00:00"},
+        ],
+    }
+    assert _role_last_used_at(evidence) == "2021-05-01T00:00:00+00:00"
+
+
+def test_role_last_used_at_absent_stays_none() -> None:
+    # Access Advisor available but never used → no timestamp, never a false date.
+    assert _role_last_used_at({"state": "available", "records": [{"last_accessed_at": None}]}) is None
+    assert _role_last_used_at({"state": "unavailable", "records": []}) is None
+    assert _role_last_used_at(None) is None
+
+
+# ── GAP 2: end-to-end inventory → ROLE node last_used_at → dormancy ───────────
+def _role_report(usage_evidence: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "scan_sources": ["aws-inventory"],
+        "cloud_inventory": {
+            "status": "ok",
+            "provider": "aws",
+            "account_id": "111122223333",
+            "roles": [
+                {
+                    "name": "old-role",
+                    "arn": "arn:aws:iam::111122223333:role/old-role",
+                    "principal_type": "role",
+                    "privilege_level": "unknown",
+                    "policies": [],
+                    "usage_evidence": usage_evidence,
+                }
+            ],
+        },
+    }
+
+
+def test_role_usage_evidence_threads_last_used_and_marks_dormant() -> None:
+    evidence = {
+        "principal_arn": "arn:aws:iam::111122223333:role/old-role",
+        "state": "available",
+        "diagnostic": "access_advisor_available",
+        "collected_at": "2026-06-20T00:00:00+00:00",
+        "records": [
+            {
+                "service_namespace": "s3",
+                "state": "available",
+                "observed": True,
+                "last_accessed_at": "2020-01-02T00:00:00+00:00",
+                "source": "access_advisor",
+            },
+            {
+                "service_namespace": "*",
+                "state": "available",
+                "observed": True,
+                "last_accessed_at": "2020-03-15T00:00:00+00:00",
+                "source": "role_last_used",
+            },
+        ],
+    }
+    graph = build_unified_graph_from_report(_role_report(evidence))
+    role = next(n for n in graph.nodes.values() if n.entity_type == EntityType.ROLE)
+    # Newest real Access-Advisor / RoleLastUsed timestamp lands on the node.
+    assert role.attributes.get("last_used_at") == "2020-03-15T00:00:00+00:00"
+    # ...and dormancy (real "now" is years later) reflects real telemetry.
+    assert role.attributes.get("nhi_is_dormant") is True
+
+
+def test_role_without_usage_timestamp_stays_not_evaluated() -> None:
+    evidence = {
+        "principal_arn": "arn:aws:iam::111122223333:role/old-role",
+        "state": "unavailable",
+        "diagnostic": "access_advisor_unavailable",
+        "collected_at": "2026-06-20T00:00:00+00:00",
+        "records": [],
+    }
+    graph = build_unified_graph_from_report(_role_report(evidence))
+    role = next(n for n in graph.nodes.values() if n.entity_type == EntityType.ROLE)
+    # Fail-closed: no real last-used telemetry → no fabricated timestamp/dormancy.
+    assert "last_used_at" not in role.attributes
+    assert role.attributes.get("nhi_is_dormant") is False


### PR DESCRIPTION
## What
CIEM over-grant / dormant / orphan findings previously covered only Azure/discovered `managed_identity` nodes — AWS IAM roles (`ROLE`) and GCP service accounts (`SERVICE_ACCOUNT`) got no governance verdict at all. Separately, AWS Access Advisor usage evidence was collected but never consumed, so dormancy could not use real last-used telemetry.

## Changes
- `evaluate_identity_governance` now iterates `ROLE` and `SERVICE_ACCOUNT` in addition to `MANAGED_IDENTITY`, so over-grant/dormant findings span all three clouds. Provider attribution reads `provider` or `cloud_provider`.
- Builder threads collected AWS `usage_evidence` onto the identity node's `last_used_at` (newest real Access Advisor / RoleLastUsed timestamp), so dormancy uses real telemetry.

## Fail-closed (honesty)
For the cloud-inventory role/service-account types — which do not carry owner or last-used as a first-class contract — absent evidence is never turned into a verdict: no per-target usage signal ⇒ over-grant not evaluated; no last-used timestamp ⇒ not dormant; no `owner` key ⇒ not orphaned. `MANAGED_IDENTITY` behavior is unchanged.

Note: an AWS over-grant right-sizing `usage` map is intentionally **not** synthesized from Access Advisor — Access Advisor is service-namespace-level while grant targets are resource nodes, so a 1:1 mapping would risk false negatives. Over-grant for AWS roles stays fail-closed/not-evaluated until a resource-level usage source exists (wire point noted in `builder.py`). Dormancy, the primary telemetry goal, is fully wired.

## How verified
- New suite (8 tests, red→green): AWS role over-grant+dormant with `provider=aws`; GCP service-account dormant with `provider=gcp`; no-evidence role fabricates nothing; Azure behavior unchanged; `last_used_at` derivation unit + end-to-end.
- Governance regression suites `106 passed`; wider graph/builder/fusion `128 passed`; full-graph bootstrap `44 passed`. `ruff` + `mypy` clean.