### PR TITLE
fix(audit): serialize the tamper-evident hash chain to prevent forks under concurrent writes

### DIFF
--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -40,6 +40,10 @@ _MAX_AUDIT_DETAIL_STRING_LENGTH = 2048
 _MAX_AUDIT_DETAIL_COLLECTION_ITEMS = 32
 _MAX_AUDIT_DETAIL_DEPTH = 4
 _MAX_AUDIT_DETAILS_JSON_BYTES = 16 * 1024
+# Bound on chain-head re-read retries when a concurrent writer wins the race to
+# link the current head; each retry re-reads a strictly newer head, so this only
+# caps pathological contention rather than normal operation.
+_MAX_APPEND_RETRIES = 50
 
 
 def _env_enabled(name: str) -> bool:
@@ -401,10 +405,14 @@ class InMemoryAuditLog:
 
     def append(self, entry: AuditEntry) -> None:
         tenant_id = _entry_tenant(entry)
-        entry.prev_signature = self._last_sig_by_tenant[tenant_id]
-        entry.sign()
-        self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
+        # The chain-head read, signature, and head write must be atomic with the
+        # list append: doing the read-modify-write outside the lock lets two
+        # threads read the same head and fork the chain (both sign against one
+        # predecessor). Hold the lock across the whole sequence.
         with self._lock:
+            entry.prev_signature = self._last_sig_by_tenant[tenant_id]
+            entry.sign()
+            self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
             self._entries.append(entry)
             self._update_checkpoint(tenant_id, entry.hmac_signature)
             if len(self._entries) > self._MAX_ENTRIES:
@@ -460,6 +468,7 @@ class SQLiteAuditLog:
         self._db_path = db_path
         self._local = threading.local()
         self._last_sig_by_tenant: dict[str, str] = defaultdict(str)
+        self._append_lock = threading.Lock()
         self._init_db()
         self._hydrate_last_signatures()
         if os.path.exists(self._db_path):
@@ -471,6 +480,9 @@ class SQLiteAuditLog:
         if conn is None:
             conn = sqlite3.connect(self._db_path, check_same_thread=False)
             conn.execute("PRAGMA journal_mode=WAL")
+            # Let a concurrent writer wait for the write lock instead of failing
+            # fast with "database is locked" under multi-thread contention.
+            conn.execute("PRAGMA busy_timeout=5000")
             self._local.conn = conn
         return conn
 
@@ -508,7 +520,33 @@ class SQLiteAuditLog:
             head_signature TEXT NOT NULL
         )""")
         self._conn.commit()
+        self._ensure_fork_guard_index()
         self._hydrate_checkpoints()
+
+    def _ensure_fork_guard_index(self) -> None:
+        """Serialize the hash chain at the DB with a per-tenant head uniqueness.
+
+        ``UNIQUE(tenant_id, prev_signature)`` lets at most one row link to any
+        given predecessor (and exactly one genesis, ``prev_signature = ''``, per
+        tenant), so a concurrent fork is rejected instead of persisted. Built
+        defensively: pre-existing forks in older data would make the unique index
+        creation fail, and we log rather than refuse to start — appends still
+        retry, but cross-writer forks cannot be rejected until the data is
+        reconciled.
+        """
+        try:
+            self._conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_tenant_prevsig "
+                "ON audit_log(tenant_id, prev_signature)"
+            )
+            self._conn.commit()
+        except sqlite3.IntegrityError:
+            self._conn.rollback()
+            logger.warning(
+                "Could not create audit_log fork-guard unique index "
+                "(pre-existing chain forks?); appends will retry but forks cannot "
+                "be rejected at the DB until the existing rows are reconciled"
+            )
 
     def _hydrate_checkpoints(self) -> None:
         existing = self._conn.execute("SELECT COUNT(*) FROM audit_chain_checkpoint").fetchone()
@@ -559,12 +597,16 @@ class SQLiteAuditLog:
         )
 
     def _latest_signature_for_tenant(self, tenant_id: str) -> str:
+        # The chain head is the LAST-APPENDED row (max rowid), not the row with
+        # the latest timestamp. Under concurrent appends a later-inserted entry
+        # can carry an earlier wall-clock timestamp, so ordering by rowid (true
+        # insertion/append order) keeps head selection aligned with the chain.
         row = self._conn.execute(
             """
             SELECT hmac_signature
             FROM audit_log
             WHERE COALESCE(NULLIF(json_extract(details, '$.tenant_id'), ''), 'default') = ?
-            ORDER BY timestamp DESC, rowid DESC
+            ORDER BY rowid DESC
             LIMIT 1
             """,
             (tenant_id,),
@@ -581,7 +623,7 @@ class SQLiteAuditLog:
                     hmac_signature,
                     ROW_NUMBER() OVER (
                         PARTITION BY tenant_id
-                        ORDER BY timestamp DESC, rowid DESC
+                        ORDER BY rowid DESC
                     ) AS rn
                 FROM audit_log
             )
@@ -593,31 +635,50 @@ class SQLiteAuditLog:
 
     def append(self, entry: AuditEntry) -> None:
         tenant_id = _entry_tenant(entry)
-        prev_sig = self._last_sig_by_tenant.get(tenant_id)
-        if prev_sig is None or prev_sig == "":
-            prev_sig = self._latest_signature_for_tenant(tenant_id)
-        entry.prev_signature = prev_sig
-        entry.sign()
-        self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
-        self._conn.execute(
-            "INSERT INTO audit_log"
-            " (entry_id, timestamp, action, actor, resource,"
-            " details, prev_signature, hmac_signature, tenant_id)"
-            " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            (
-                entry.entry_id,
-                entry.timestamp,
-                entry.action,
-                entry.actor,
-                entry.resource,
-                json.dumps(entry.details),
-                entry.prev_signature,
-                entry.hmac_signature,
-                tenant_id,
-            ),
-        )
-        self._upsert_checkpoint(tenant_id, entry.hmac_signature)
-        self._conn.commit()
+        # An in-process lock serializes seal+insert so threads sharing this store
+        # can't read the same head and fork the chain. The DB-level
+        # UNIQUE(tenant_id, prev_signature) plus this retry handle the
+        # cross-process case (separate connections/replicas): a writer that loses
+        # the race is rejected, then re-reads the advanced head and re-links.
+        with self._append_lock:
+            attempts = 0
+            while True:
+                attempts += 1
+                prev_sig = self._last_sig_by_tenant.get(tenant_id)
+                if prev_sig is None or prev_sig == "":
+                    prev_sig = self._latest_signature_for_tenant(tenant_id)
+                entry.prev_signature = prev_sig
+                entry.sign()
+                try:
+                    self._conn.execute(
+                        "INSERT INTO audit_log"
+                        " (entry_id, timestamp, action, actor, resource,"
+                        " details, prev_signature, hmac_signature, tenant_id)"
+                        " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                        (
+                            entry.entry_id,
+                            entry.timestamp,
+                            entry.action,
+                            entry.actor,
+                            entry.resource,
+                            json.dumps(entry.details),
+                            entry.prev_signature,
+                            entry.hmac_signature,
+                            tenant_id,
+                        ),
+                    )
+                    self._upsert_checkpoint(tenant_id, entry.hmac_signature)
+                    self._conn.commit()
+                except sqlite3.IntegrityError as exc:
+                    self._conn.rollback()
+                    if "prev_signature" not in str(exc) or attempts > _MAX_APPEND_RETRIES:
+                        raise
+                    # Another writer linked this head first — drop the stale cache
+                    # and re-read the advanced head before retrying.
+                    self._last_sig_by_tenant[tenant_id] = self._latest_signature_for_tenant(tenant_id)
+                    continue
+                self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
+                return
 
     def list_entries(
         self,
@@ -689,9 +750,13 @@ class SQLiteAuditLog:
             clauses.append("tenant_id = ?")
             params.append(tenant_id)
         where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        # Walk the chain in true append order (rowid), which is how entries were
+        # linked. Ordering by timestamp would reorder concurrently-appended rows
+        # whose wall-clock times don't match insertion order and report a healthy
+        # chain as tampered.
         sql = (
             f"SELECT entry_id, timestamp, action, actor, resource, details, prev_signature, hmac_signature"  # nosec B608
-            f" FROM audit_log {where} ORDER BY timestamp ASC, rowid ASC LIMIT ?"
+            f" FROM audit_log {where} ORDER BY rowid ASC LIMIT ?"
         )
         params.append(limit)
         rows = self._conn.execute(sql, params).fetchall()

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -3,9 +3,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any
 
-from agent_bom.api.audit_log import AuditEntry, _AuditChainCheckpoint, _verify_audit_chain_with_checkpoint
+from agent_bom.api.audit_log import (
+    _MAX_APPEND_RETRIES,
+    AuditEntry,
+    _AuditChainCheckpoint,
+    _verify_audit_chain_with_checkpoint,
+)
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.baseline import TrendPoint
 
@@ -17,6 +23,23 @@ from .postgres_common import (
     _tenant_connection,
     bypass_tenant_rls,
 )
+
+logger = logging.getLogger(__name__)
+
+# Name of the per-tenant chain-head uniqueness guard. A concurrent fork violates
+# it (SQLSTATE 23505), which `append` catches to re-read the head and re-link.
+_AUDIT_FORK_GUARD_INDEX = "audit_log_team_prevsig_uniq"
+
+
+def _is_chain_fork_conflict(exc: Exception) -> bool:
+    """True when ``exc`` is a unique violation on the chain fork-guard index."""
+    if getattr(exc, "sqlstate", None) != "23505":
+        return False
+    diag = getattr(exc, "diag", None)
+    constraint = getattr(diag, "constraint_name", None) if diag else None
+    # entry_id is a fresh uuid4 per entry, so an unlabeled unique violation on
+    # this INSERT path is a fork race on (team_id, prev_signature).
+    return constraint in (None, "", _AUDIT_FORK_GUARD_INDEX)
 
 
 class PostgresAuditLog:
@@ -63,7 +86,36 @@ class PostgresAuditLog:
             )
             _ensure_tenant_rls(conn, "audit_log", "team_id")
             conn.commit()
+        self._ensure_fork_guard_index()
         self._hydrate_checkpoints()
+
+    def _ensure_fork_guard_index(self) -> None:
+        """Serialize the hash chain at the DB via per-tenant head uniqueness.
+
+        ``UNIQUE (team_id, prev_signature)`` lets at most one row link to any
+        given predecessor (and exactly one genesis, ``prev_signature = ''``, per
+        tenant — the column is ``NOT NULL DEFAULT ''`` so no NULL defeats it), so
+        two writers across threadpool workers or ``uvicorn --workers N`` processes
+        cannot fork the chain: the loser's INSERT is rejected and retried against
+        the advanced head. Built defensively — pre-existing forks in older data
+        would fail index creation, so we log rather than refuse to start; appends
+        still retry, but forks cannot be rejected until the data is reconciled.
+        """
+        try:
+            with self._pool.connection() as conn:
+                conn.execute(
+                    f"CREATE UNIQUE INDEX IF NOT EXISTS {_AUDIT_FORK_GUARD_INDEX} "
+                    "ON audit_log (team_id, prev_signature)"
+                )
+                conn.commit()
+        except Exception:
+            logger.warning(
+                "Could not create audit_log fork-guard unique index %s "
+                "(pre-existing chain forks?); appends will retry but forks cannot "
+                "be rejected at the DB until the existing rows are reconciled",
+                _AUDIT_FORK_GUARD_INDEX,
+                exc_info=True,
+            )
 
     def _hydrate_checkpoints(self) -> None:
         # Enumerating DISTINCT team_id spans every tenant, which FORCE ROW LEVEL
@@ -155,28 +207,42 @@ class PostgresAuditLog:
 
     def append(self, entry: AuditEntry) -> None:
         tenant_id = str((entry.details or {}).get("tenant_id") or _current_tenant.get())
-        prev_sig = self._latest_signature_for_tenant(tenant_id)
-        entry.prev_signature = prev_sig
-        entry.sign()
-        with _tenant_connection(self._pool) as conn:
-            conn.execute(
-                """INSERT INTO audit_log
-                   (entry_id, timestamp, action, actor, resource, team_id, details, prev_signature, hmac_signature)
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
-                (
-                    entry.entry_id,
-                    entry.timestamp,
-                    entry.action,
-                    entry.actor,
-                    entry.resource,
-                    tenant_id,
-                    json.dumps(entry.details),
-                    entry.prev_signature,
-                    entry.hmac_signature,
-                ),
-            )
-            self._upsert_checkpoint(conn, tenant_id, entry.hmac_signature)
-            conn.commit()
+        # The head read and the INSERT run on separate connections, so nothing
+        # serializes them in-process — and across `uvicorn --workers N` processes
+        # nothing could. The DB-level UNIQUE (team_id, prev_signature) rejects a
+        # fork: a writer that lost the race re-reads the advanced head, re-signs,
+        # and re-inserts. Both statements share one transaction so a rejected
+        # INSERT rolls back its checkpoint bump too.
+        attempts = 0
+        while True:
+            attempts += 1
+            entry.prev_signature = self._latest_signature_for_tenant(tenant_id)
+            entry.sign()
+            try:
+                with _tenant_connection(self._pool) as conn:
+                    conn.execute(
+                        """INSERT INTO audit_log
+                           (entry_id, timestamp, action, actor, resource, team_id, details, prev_signature, hmac_signature)
+                           VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                        (
+                            entry.entry_id,
+                            entry.timestamp,
+                            entry.action,
+                            entry.actor,
+                            entry.resource,
+                            tenant_id,
+                            json.dumps(entry.details),
+                            entry.prev_signature,
+                            entry.hmac_signature,
+                        ),
+                    )
+                    self._upsert_checkpoint(conn, tenant_id, entry.hmac_signature)
+                    conn.commit()
+            except Exception as exc:
+                if _is_chain_fork_conflict(exc) and attempts <= _MAX_APPEND_RETRIES:
+                    continue
+                raise
+            break
         self._last_sig_by_tenant[tenant_id] = entry.hmac_signature
 
     def list_entries(

--- a/tests/test_audit_chain_concurrency.py
+++ b/tests/test_audit_chain_concurrency.py
@@ -1,0 +1,248 @@
+"""Concurrency regression tests for the tamper-evident audit hash chain.
+
+A hash chain forks when two concurrent appends read the same chain head
+(``prev_signature``), sign against it, and both insert — producing two rows that
+share one predecessor. ``_verify_audit_chain`` walks the chain chronologically
+requiring ``entry.prev_signature == previous.hmac_signature``, so every forked
+sibling is scored ``tampered`` and a forged entry can hide among the benign
+forks.
+
+These tests drive many threads appending to the SAME tenant and assert the chain
+never forks: no two rows share a ``prev_signature`` and ``verify_integrity``
+reports the chain intact.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+import threading
+
+import pytest
+
+from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog, SQLiteAuditLog
+
+
+def _append_concurrently(log: object, tenant: str, n: int) -> list[Exception]:
+    """Fire ``n`` threads that each append one entry to ``tenant`` at once.
+
+    A barrier aligns every thread on the read of the chain head, and the GIL
+    switch interval is shortened so an unserialized read-modify-write forks
+    reliably rather than by luck.
+    """
+    barrier = threading.Barrier(n)
+    errors: list[Exception] = []
+
+    def worker(i: int) -> None:
+        try:
+            barrier.wait()
+            log.append(  # type: ignore[attr-defined]
+                AuditEntry(
+                    action="scan",
+                    actor="worker",
+                    resource=f"pkg-{i}",
+                    details={"tenant_id": tenant},
+                )
+            )
+        except Exception as exc:  # noqa: BLE001 - surfaced to the assertion
+            errors.append(exc)
+
+    original_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.setswitchinterval(original_interval)
+    return errors
+
+
+def test_inmemory_concurrent_append_does_not_fork_chain() -> None:
+    log = InMemoryAuditLog()
+    tenant = "tenant-alpha"
+    n = 24
+
+    errors = _append_concurrently(log, tenant, n)
+    assert not errors, f"append raised under concurrency: {errors!r}"
+
+    entries = log.list_entries(limit=1000, tenant_id=tenant)
+    assert len(entries) == n
+
+    prevs = [e.prev_signature for e in entries]
+    duplicates = len(prevs) - len(set(prevs))
+    assert duplicates == 0, f"chain forked: {duplicates} rows share a prev_signature"
+
+    verified, tampered = log.verify_integrity(tenant_id=tenant)
+    assert tampered == 0, f"verify_integrity reported {tampered} tampered rows"
+    assert verified == n
+
+
+def test_sqlite_concurrent_append_does_not_fork_chain(tmp_path) -> None:
+    db = str(tmp_path / "audit.db")
+    log = SQLiteAuditLog(db)
+    tenant = "tenant-alpha"
+    n = 16
+
+    errors = _append_concurrently(log, tenant, n)
+    assert not errors, f"append raised under concurrency: {errors!r}"
+
+    entries = log.list_entries(limit=1000, tenant_id=tenant)
+    assert len(entries) == n
+
+    prevs = [e.prev_signature for e in entries]
+    duplicates = len(prevs) - len(set(prevs))
+    assert duplicates == 0, f"chain forked: {duplicates} rows share a prev_signature"
+
+    verified, tampered = log.verify_integrity(tenant_id=tenant)
+    assert tampered == 0, f"verify_integrity reported {tampered} tampered rows"
+    assert verified == n
+
+
+def test_sqlite_fork_guard_rejects_second_row_on_same_head(tmp_path) -> None:
+    """A cross-connection writer that links to an already-used head is rejected.
+
+    Emulates two uvicorn workers (separate connections) that both link to the
+    same predecessor: once one row links to a head, the DB unique guard on
+    ``(tenant_id, prev_signature)`` must reject a second row sharing that
+    predecessor rather than persist a fork.
+    """
+    db = str(tmp_path / "audit.db")
+    log = SQLiteAuditLog(db)
+    tenant = "tenant-alpha"
+    log.append(AuditEntry(action="scan", actor="w", resource="genesis", details={"tenant_id": tenant}))
+    genesis_head = log._latest_signature_for_tenant(tenant)
+    # A legitimate second append links to the genesis head.
+    log.append(AuditEntry(action="scan", actor="w", resource="pkg-b", details={"tenant_id": tenant}))
+
+    # A second, independent connection forges a row that links to the SAME
+    # predecessor the legitimate entry already used — a fork of genesis_head.
+    raw = sqlite3.connect(db)
+    try:
+        forged = AuditEntry(action="scan", actor="attacker", resource="forged", details={"tenant_id": tenant})
+        forged.prev_signature = genesis_head
+        forged.sign()
+        try:
+            raw.execute(
+                "INSERT INTO audit_log"
+                " (entry_id, timestamp, action, actor, resource,"
+                " details, prev_signature, hmac_signature, tenant_id)"
+                " VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    forged.entry_id,
+                    forged.timestamp,
+                    forged.action,
+                    forged.actor,
+                    forged.resource,
+                    "{}",
+                    forged.prev_signature,
+                    forged.hmac_signature,
+                    tenant,
+                ),
+            )
+            raw.commit()
+            forged_inserted = True
+        except sqlite3.IntegrityError:
+            forged_inserted = False
+    finally:
+        raw.close()
+
+    assert not forged_inserted, "fork guard missing: a second row linked to the same head was accepted"
+
+    # The legitimate next append still succeeds, linking to the real head.
+    log.append(AuditEntry(action="scan", actor="w", resource="pkg-c", details={"tenant_id": tenant}))
+    verified, tampered = log.verify_integrity(tenant_id=tenant)
+    assert tampered == 0
+    assert verified == 3
+
+
+def test_chain_fork_conflict_detector_matches_only_fork_violations() -> None:
+    """The Postgres retry only fires on a fork-guard unique violation."""
+    from agent_bom.api.postgres_audit import _AUDIT_FORK_GUARD_INDEX, _is_chain_fork_conflict
+
+    class _Diag:
+        def __init__(self, name):
+            self.constraint_name = name
+
+    class _FakeDbError(Exception):
+        def __init__(self, sqlstate, constraint):
+            super().__init__("boom")
+            self.sqlstate = sqlstate
+            self.diag = _Diag(constraint)
+
+    # Unique violation on the fork-guard index → retry.
+    assert _is_chain_fork_conflict(_FakeDbError("23505", _AUDIT_FORK_GUARD_INDEX)) is True
+    # Unique violation with no surfaced constraint name → treat as a fork race.
+    assert _is_chain_fork_conflict(_FakeDbError("23505", None)) is True
+    # Unique violation on some unrelated constraint → do not retry.
+    assert _is_chain_fork_conflict(_FakeDbError("23505", "some_other_constraint")) is False
+    # Non-unique-violation SQLSTATE (e.g. serialization failure) → do not retry.
+    assert _is_chain_fork_conflict(_FakeDbError("40001", _AUDIT_FORK_GUARD_INDEX)) is False
+    # A plain exception with no sqlstate → do not retry.
+    assert _is_chain_fork_conflict(ValueError("nope")) is False
+
+
+@pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="requires a live PostgreSQL (AGENT_BOM_POSTGRES_URL) — mock pool cannot enforce the unique fork guard",
+)
+def test_postgres_concurrent_append_does_not_fork_chain() -> None:
+    """Cross-thread appends against a live Postgres store must not fork the chain.
+
+    Runs only with a real database (the fork guard is a DB-enforced UNIQUE
+    constraint). Each thread opens its own pooled connection, so this also
+    exercises the multi-connection path that a multi-worker deployment hits.
+    """
+    from agent_bom.api.postgres_common import set_current_tenant
+    from agent_bom.api.postgres_store import PostgresAuditLog
+
+    store = PostgresAuditLog()
+    tenant = "tenant-concurrency-probe"
+    n = 16
+
+    barrier = threading.Barrier(n)
+    errors: list[Exception] = []
+
+    def worker(i: int) -> None:
+        token = set_current_tenant(tenant)
+        try:
+            barrier.wait()
+            store.append(
+                AuditEntry(
+                    action="scan",
+                    actor="worker",
+                    resource=f"pkg-{i}",
+                    details={"tenant_id": tenant},
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+        finally:
+            from agent_bom.api.postgres_common import _current_tenant
+
+            _current_tenant.reset(token)
+
+    original_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        threads = [threading.Thread(target=worker, args=(i,)) for i in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+    finally:
+        sys.setswitchinterval(original_interval)
+
+    assert not errors, f"append raised under concurrency: {errors!r}"
+
+    entries = store.list_entries(limit=1000, tenant_id=tenant)
+    fresh = [e for e in entries if e.resource.startswith("pkg-")]
+    prevs = [e.prev_signature for e in fresh]
+    duplicates = len(prevs) - len(set(prevs))
+    assert duplicates == 0, f"chain forked: {duplicates} rows share a prev_signature"
+
+    verified, tampered = store.verify_integrity(tenant_id=tenant)
+    assert tampered == 0, f"verify_integrity reported {tampered} tampered rows"


### PR DESCRIPTION
## What

`PostgresAuditLog.append()` did an unserialized read-modify-write of the tenant's chain head (read head → sign → insert on a separate connection). Concurrent appends to one tenant — across threadpool workers **and** `uvicorn --workers N` processes — all read the same `prev_signature`, signed against it, and inserted, **forking the chain**. `_verify_audit_chain` then scored every forked sibling `tampered`, so legitimate concurrent traffic reads as tampered — and a forged entry can hide among the benign forks. The sibling `governance_audit_log` store already had the `UNIQUE + retry` fix; the primary `audit_log` did not.

## Fix (mirrors the governance store pattern)

- `postgres_audit.py` — added a `UNIQUE (team_id, prev_signature)` fork-guard index (`audit_log_team_prevsig_uniq`); `append()` retries on that violation (SQLSTATE 23505 via a precise `_is_chain_fork_conflict` detector), re-reading the advanced head and re-signing until it commits. INSERT + checkpoint bump share one transaction so a rejected fork rolls back cleanly. Index creation is defensive (logs rather than refuses to start if pre-existing data has forks).
- `audit_log.py` — `InMemoryAuditLog.append` now holds the lock across the head read/sign/write (was outside); `SQLiteAuditLog` gains the same `UNIQUE(tenant_id, prev_signature)` guard, in-process append lock, `busy_timeout`, and retry. **Also fixed a latent verify bug**: verify/hydration now order by `rowid` (true append order) instead of `timestamp`, which reorders concurrently-appended rows and would false-flag a healthy chain.
- Genesis handled: `prev_signature` is `NOT NULL DEFAULT ''`, so the unique index permits exactly one genesis per tenant and no NULL defeats it.

## How verified

- `tests/test_audit_chain_concurrency.py` reproduces the fork BEFORE the fix: cross-thread InMemory + SQLite (real DDL) tests were failing pre-fix (9–12 rows shared a `prev_signature`), passing post-fix over repeated runs; plus a SQLite fork-guard rejection test, the conflict-detector unit test, and a skip-guarded live-Postgres cross-thread test.
- `uv run pytest` touched suites (audit chain/concurrency + postgres store + governance audit) — **324 passed, 1 skipped** (live-PG), stable over 5 reruns; `ruff`/`mypy` clean.

## Coverage caveat (honest)

Cross-**thread** is covered and CI-runnable. Cross-**process** is guaranteed structurally by the DB-enforced `UNIQUE(...prev_signature)` + retry (same mechanism the governance PG tier relies on) and exercised by the multi-connection SQLite fork-guard test; the live-Postgres concurrency test skips in CI without `AGENT_BOM_POSTGRES_URL` (a real DB is required to exercise the PG fork guard end-to-end).