### PR TITLE
fix(gateway,dspm,sast): honest KPIs, drift-cap signal, coverage warnings, aggregated SAST status

### DIFF
--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -16,6 +16,25 @@ from agent_bom.discovery import CONFIG_LOCATIONS
 from agent_bom.discovery import discover_all as _discover_all_default
 from agent_bom.models import AgentType
 
+# Severity ordering for the aggregate SAST summary across multiple --code paths.
+# A failure or skip must outrank a clean/findings result so the summary never
+# hides that a path could not be scanned. Kept module-level so it is unit-testable.
+_SAST_STATUS_RANK = {"failed": 3, "skipped": 2, "findings": 1, "clean": 0}
+
+
+def _aggregate_sast_path_results(path_results: list[dict]) -> dict:
+    """Collapse per-``--code``-path SAST results into one honest summary.
+
+    With multiple code paths, a failure in an *earlier* path must not be lost
+    when a *later* path succeeds. Rank by execution status (failed/skipped
+    outrank findings/clean) and keep the highest-ranked path; ties resolve to
+    the first path at that rank, preserving the first failure's reason/detail.
+    """
+    return max(
+        path_results,
+        key=lambda result: _SAST_STATUS_RANK.get(str(result.get("execution_status")), 0),
+    )
+
 
 def _first_run_hints() -> list[tuple[str, str]]:
     """Return concrete config locations for common MCP clients on this platform."""
@@ -467,6 +486,7 @@ def run_local_discovery(
         from agent_bom.sast import SASTResult, SASTScanError, scan_code
 
         con.print(f"\n[bold blue]Running SAST scan on {len(code_paths)} path(s) via Semgrep...[/bold blue]\n")
+        sast_path_results: list[dict] = []
         for code_path in code_paths:
             try:
                 sast_packages, sast_result = scan_code(code_path, config=sast_config, offline=offline)
@@ -486,19 +506,23 @@ def run_local_discovery(
                         mcp_servers=[server],
                     )
                     ctx.agents.append(sast_agent)
-                ctx.sast_data = sast_result.to_dict()
+                sast_path_results.append(sast_result.to_dict())
             except SASTScanError as exc:
                 detail_by_reason = {
                     "offline_remote_config": "Offline mode disallows registry-backed rules.",
                     "offline_no_local_config": "Offline mode found no local Semgrep rule configuration.",
                     "semgrep_unavailable": "Semgrep is unavailable; install it or import an existing SARIF report.",
                 }
-                ctx.sast_data = SASTResult(
-                    execution_status=exc.execution_status,
-                    status_reason=exc.reason_code,
-                    status_detail=detail_by_reason.get(exc.reason_code, "SAST execution failed."),
-                ).to_dict()
+                sast_path_results.append(
+                    SASTResult(
+                        execution_status=exc.execution_status,
+                        status_reason=exc.reason_code,
+                        status_detail=detail_by_reason.get(exc.reason_code, "SAST execution failed."),
+                    ).to_dict()
+                )
                 con.print(f"  [yellow]![/yellow] {code_path}: [{exc.execution_status.value}] {exc.reason_code}")
+        if sast_path_results:
+            ctx.sast_data = _aggregate_sast_path_results(sast_path_results)
 
     # Step 1d3b: AI component source scan (--ai-inventory)
     ai_inventory_paths = kwargs.get("ai_inventory_paths", ())

--- a/src/agent_bom/cloud/vector_db.py
+++ b/src/agent_bom/cloud/vector_db.py
@@ -442,6 +442,32 @@ def _pinecone_get(path: str, api_key: str, timeout: int = _DEFAULT_TIMEOUT) -> t
         return -1, {}
 
 
+def _record_pinecone_coverage_gap(reason: str, detail: str) -> None:
+    """Emit a structured coverage warning when Pinecone could not be evaluated.
+
+    A 401/403/outage must be distinguishable from a genuinely empty account:
+    both otherwise return an empty result and read as "no vector databases".
+    Mirrors the Snowflake inventory-failure coverage-warning contract so the
+    gap surfaces in the report instead of masquerading as a clean empty.
+    """
+    try:
+        from agent_bom.coverage import CoverageWarning
+        from agent_bom.scanners.state import record_coverage_warning
+
+        record_coverage_warning(
+            CoverageWarning(
+                ecosystem="pinecone",
+                release=f"pinecone:{reason}",
+                reason=reason,
+                detail=detail,
+                package_count=0,
+                advisory_rows=0,
+            ).to_dict()
+        )
+    except Exception:  # noqa: BLE001 — coverage evidence is supplementary; never fail discovery
+        logger.debug("Could not record Pinecone coverage warning", exc_info=True)
+
+
 def check_pinecone(api_key: str, timeout: int = _DEFAULT_TIMEOUT) -> list[PineconeIndexResult]:
     """Assess security posture of all Pinecone indexes for the given API key.
 
@@ -466,12 +492,24 @@ def check_pinecone(api_key: str, timeout: int = _DEFAULT_TIMEOUT) -> list[Pineco
     status, data = _pinecone_get("/indexes", api_key, timeout)
     if status == 401:
         logger.warning("Pinecone: invalid or expired API key")
+        _record_pinecone_coverage_gap(
+            "pinecone_auth_failed",
+            "Pinecone API key invalid or expired (HTTP 401); indexes were not evaluated.",
+        )
         return []
     if status == 403:
         logger.warning("Pinecone: API key lacks list-indexes permission")
+        _record_pinecone_coverage_gap(
+            "pinecone_permission_denied",
+            "Pinecone API key lacks list-indexes permission (HTTP 403); indexes were not evaluated.",
+        )
         return []
     if status < 0 or status >= 300:
         logger.debug("Pinecone: unexpected status %d listing indexes", status)
+        _record_pinecone_coverage_gap(
+            "pinecone_api_unavailable",
+            f"Pinecone API returned status {status} listing indexes; indexes were not evaluated.",
+        )
         return []
 
     indexes = data.get("indexes", [])

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -338,6 +338,13 @@ def _agent_is_quarantined(tenant_id: str, source_agent: str) -> bool:
     return False
 
 
+# Upper bound on open incidents fetched per drift enforcement check. When a
+# tenant has more open incidents than this, we cannot rule out a violation in the
+# untraversed tail, so the lookup returns ``unavailable`` (honest partial signal)
+# rather than silently under-enforcing on the capped result.
+_DRIFT_INCIDENT_LOOKUP_CAP = 200
+
+
 @dataclass(frozen=True)
 class _DriftLookup:
     violates: bool = False
@@ -359,7 +366,7 @@ def _open_drift_violates_tool(tenant_id: str, blueprint_id: str, tool_name: str)
     try:
         from agent_bom.api.drift_incident_store import get_drift_incident_store
 
-        incidents = get_drift_incident_store().list(tenant_id, include_resolved=False, limit=200)
+        incidents = get_drift_incident_store().list(tenant_id, include_resolved=False, limit=_DRIFT_INCIDENT_LOOKUP_CAP)
     except Exception as exc:  # noqa: BLE001
         logger.warning("gateway drift check failed: %s", _sanitize_for_log(exc))
         return _DriftLookup(unavailable=True, reason="drift incident store unavailable")
@@ -376,6 +383,19 @@ def _open_drift_violates_tool(tenant_id: str, blueprint_id: str, tool_name: str)
                 violates=True,
                 reason=f"tool '{tool_name}' is outside role blueprint '{blueprint_id}'",
             )
+    if len(incidents) >= _DRIFT_INCIDENT_LOOKUP_CAP:
+        # The open-incident set was capped, so a violation may exist in the tail
+        # we never inspected. Surface this as unavailable (partial) instead of a
+        # clean pass, so enforce-mode callers fail closed rather than silently
+        # under-enforce for the tenant's tail incidents.
+        logger.warning(
+            "gateway drift check truncated at %d open incidents for tenant; enforcement coverage is partial",
+            _DRIFT_INCIDENT_LOOKUP_CAP,
+        )
+        return _DriftLookup(
+            unavailable=True,
+            reason=f"open drift incidents exceed lookup cap ({_DRIFT_INCIDENT_LOOKUP_CAP}); enforcement coverage partial",
+        )
     return _DriftLookup()
 
 
@@ -2908,21 +2928,29 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
                 upstream_response["result"] = _redact_obj_pii(upstream_response.get("result"))
 
         if settings.audit_sink is not None:
-            await settings.audit_sink(
-                {
-                    "action": "gateway.tool_call" if is_tools_call(message) else "gateway.message",
-                    "upstream": upstream.name,
-                    "tenant_id": tenant_id,
-                    "method": message.get("method"),
-                    "tool": message.get("params", {}).get("name") if is_tools_call(message) else None,
-                    **_typed_runtime_event(
+            _forward_is_tool_call = is_tools_call(message)
+            forward_audit_event: dict[str, Any] = {
+                "action": "gateway.tool_call" if _forward_is_tool_call else "gateway.message",
+                "upstream": upstream.name,
+                "tenant_id": tenant_id,
+                "method": message.get("method"),
+                "tool": message.get("params", {}).get("name") if _forward_is_tool_call else None,
+            }
+            # Only an actual tools/call is an authorized tool invocation. JSON-RPC
+            # handshake / discovery traffic (initialize, tools/list, notifications)
+            # is forwarded too but must not be tagged TOOL_CALL_ALLOWED, or the live
+            # feed would inflate calls_today / tool_calls_authorized with
+            # non-invocation messages.
+            if _forward_is_tool_call:
+                forward_audit_event.update(
+                    _typed_runtime_event(
                         GatewayRuntimeEventType.TOOL_CALL_ALLOWED,
                         decision="allow",
                         policy_source=resolved_policy_source,
-                        tool=str(message.get("params", {}).get("name") or message.get("method") or ""),
-                    ),
-                }
-            )
+                        tool=str(message.get("params", {}).get("name") or ""),
+                    )
+                )
+            await settings.audit_sink(forward_audit_event)
         response_headers = dict(rate_limit_headers)
         response_headers["traceparent"] = str(trace_meta["traceparent"])
         if trace_meta["tracestate"]:

--- a/tests/test_gateway_drift_enforcement.py
+++ b/tests/test_gateway_drift_enforcement.py
@@ -226,3 +226,75 @@ def test_loopback_enforce_allows_legacy_unbound_identity_for_development():
     client = TestClient(create_gateway_app(_settings("enforce")))
     resp = client.post("/mcp/filesystem", json=_call(token="token-a", tool="run_shell"))
     assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+# ── Open-incident lookup cap must not silently under-enforce (honest partial) ──
+
+
+def _seed_many_open_incidents(count: int, *, blueprint_id: str = "unrelated", tenant_id: str = "default") -> None:
+    """Seed more open incidents than the lookup cap, none matching the caller."""
+    store = InMemoryDriftIncidentStore()
+    for i in range(count):
+        store.upsert(
+            DriftIncident(
+                incident_id=f"bulk-{i}",
+                tenant_id=tenant_id,
+                blueprint_id=f"{blueprint_id}-{i}",
+                status="drift_detected",
+                drift_score=0.5,
+                violation_count=1,
+                warning_count=0,
+                top_violations=[{"tool_name": "some_other_tool"}],
+                first_detected_at="2026-06-05T00:00:00Z",
+                last_detected_at=f"2026-06-05T00:{i % 60:02d}:00Z",
+            )
+        )
+    set_drift_incident_store(store)
+
+
+def test_lookup_over_cap_returns_unavailable_not_clean_pass():
+    from agent_bom.gateway_server import _DRIFT_INCIDENT_LOOKUP_CAP, _open_drift_violates_tool
+
+    _seed_many_open_incidents(_DRIFT_INCIDENT_LOOKUP_CAP + 5)
+    result = _open_drift_violates_tool("default", "finance", "run_shell")
+    assert result.unavailable is True
+    assert result.violates is False
+    assert str(_DRIFT_INCIDENT_LOOKUP_CAP) in result.reason
+
+
+def test_lookup_under_cap_returns_clean_pass():
+    from agent_bom.gateway_server import _DRIFT_INCIDENT_LOOKUP_CAP, _open_drift_violates_tool
+
+    _seed_many_open_incidents(_DRIFT_INCIDENT_LOOKUP_CAP - 5)
+    result = _open_drift_violates_tool("default", "finance", "run_shell")
+    assert result.unavailable is False
+    assert result.violates is False
+
+
+def test_secured_enforce_fails_closed_when_open_incidents_exceed_cap():
+    from agent_bom.gateway_server import _DRIFT_INCIDENT_LOOKUP_CAP
+
+    _identity_id, token = _managed_identity(blueprint_id="finance")
+    _seed_many_open_incidents(_DRIFT_INCIDENT_LOOKUP_CAP + 5)
+    client = TestClient(create_gateway_app(_settings("enforce", listener_host="0.0.0.0")))
+    resp = client.post(
+        "/mcp/filesystem",
+        headers={"Authorization": "Bearer gateway-transport-token"},
+        json=_call(token=token, tool="run_shell"),
+    )
+    assert _is_blocked(resp), resp.text
+    assert resp.json()["error"]["data"]["policy_source"] == "drift_enforcement"
+
+
+def test_observable_enforce_audits_partial_coverage_when_over_cap():
+    from agent_bom.gateway_server import _DRIFT_INCIDENT_LOOKUP_CAP
+
+    _identity_id, token = _managed_identity(blueprint_id="finance")
+    _seed_many_open_incidents(_DRIFT_INCIDENT_LOOKUP_CAP + 5)
+    audit: list[dict[str, Any]] = []
+    client = TestClient(create_gateway_app(_settings("enforce", audit=audit)))
+    resp = client.post("/mcp/filesystem", json=_call(token=token, tool="run_shell"))
+    # Loopback/observable enforce does not block, but the partial-coverage gap is
+    # surfaced as an explicit audit signal rather than a silent clean pass.
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+    assert any(e.get("action") == "gateway.drift_binding_unavailable" for e in audit)

--- a/tests/test_gateway_server.py
+++ b/tests/test_gateway_server.py
@@ -301,6 +301,58 @@ def test_metrics_endpoint_returns_prometheus_text_format() -> None:
     assert "agent_bom_gateway_relays_total" in body
 
 
+def test_handshake_messages_are_not_counted_as_authorized_tool_calls() -> None:
+    """JSON-RPC handshake/discovery traffic must not inflate tool-call KPIs.
+
+    Only ``tools/call`` is an authorized tool invocation. ``initialize`` and
+    ``tools/list`` are forwarded (and still audited) but must not be tagged
+    ``TOOL_CALL_ALLOWED``, or the live feed over-counts calls_today /
+    tool_calls_authorized.
+    """
+    from agent_bom.api.routes.gateway_feed import build_gateway_feed_kpis
+    from agent_bom.runtime.gateway_events import GatewayRuntimeEventType
+
+    audit_events: list[dict[str, Any]] = []
+
+    async def fake_caller(upstream, message, extra_headers):
+        return {"jsonrpc": "2.0", "id": message["id"], "result": {"ok": True}}
+
+    async def audit_sink(event):
+        audit_events.append(event)
+
+    settings = GatewaySettings(
+        registry=_simple_registry(),
+        policy={},
+        upstream_caller=fake_caller,
+        audit_sink=audit_sink,
+    )
+    client = TestClient(create_gateway_app(settings))
+
+    for method in ("initialize", "tools/list"):
+        resp = client.post("/mcp/filesystem", json=_json_rpc(method))
+        assert resp.status_code == 200, resp.text
+
+    resp = client.post(
+        "/mcp/filesystem",
+        json=_json_rpc("tools/call", name="read_file", arguments={"path": "/etc/hosts"}),
+    )
+    assert resp.status_code == 200
+
+    allowed = [e for e in audit_events if e.get("event_type") == GatewayRuntimeEventType.TOOL_CALL_ALLOWED.value]
+    assert len(allowed) == 1
+    assert allowed[0]["tool"] == "read_file"
+
+    handshake = [e for e in audit_events if e.get("method") in ("initialize", "tools/list")]
+    assert len(handshake) == 2
+    assert all(e.get("action") == "gateway.message" for e in handshake)
+    assert all("event_type" not in e for e in handshake)
+
+    # End-to-end: the feed rollup counts exactly one authorized tool call.
+    kpis = build_gateway_feed_kpis(tenant_id="default", alerts=audit_events, llm_records=[], uptime_seconds=None)
+    assert kpis["tool_calls_authorized"] == 1
+    assert kpis["calls_today"] == 1
+
+
 def test_relay_forwards_to_upstream_and_returns_response() -> None:
     upstream_calls: list[dict[str, Any]] = []
 

--- a/tests/test_sast_surface_contract.py
+++ b/tests/test_sast_surface_contract.py
@@ -10,9 +10,10 @@ from pathlib import Path
 from click.testing import CliRunner
 
 from agent_bom.cli import main
+from agent_bom.cli.agents._discovery import _aggregate_sast_path_results
 from agent_bom.mcp_server_metadata import build_server_card
 from agent_bom.mcp_tools.scanning import code_scan_impl
-from agent_bom.sast import SASTExecutionStatus, SASTScanError
+from agent_bom.sast import SASTExecutionStatus, SASTResult, SASTScanError
 from agent_bom.scanners.registry import list_registered_scanners
 
 
@@ -108,3 +109,46 @@ def test_mcp_code_scan_returns_typed_sanitized_failure(monkeypatch, tmp_path: Pa
     assert result["status_reason"] == "unexpected_failure"
     assert result["status_detail"] == "SAST execution failed."
     assert secret not in json.dumps(result)
+
+
+# ── Multi-path aggregation: a failure in ANY --code path must survive ──────────
+
+
+def _failed_result() -> dict:
+    return SASTResult(
+        execution_status=SASTExecutionStatus.FAILED,
+        status_reason="semgrep_unavailable",
+        status_detail="Semgrep is unavailable; install it or import an existing SARIF report.",
+    ).to_dict()
+
+
+def _clean_result() -> dict:
+    return SASTResult(execution_status=SASTExecutionStatus.CLEAN).to_dict()
+
+
+def test_earlier_path_failure_not_masked_by_later_path_success() -> None:
+    # First path failed, a later path scanned clean: the summary must still fail.
+    aggregated = _aggregate_sast_path_results([_failed_result(), _clean_result()])
+    assert aggregated["execution_status"] == "failed"
+    assert aggregated["status_reason"] == "semgrep_unavailable"
+
+
+def test_later_path_failure_reflected_in_summary() -> None:
+    aggregated = _aggregate_sast_path_results([_clean_result(), _failed_result()])
+    assert aggregated["execution_status"] == "failed"
+
+
+def test_first_failure_reason_preserved_across_multiple_failures() -> None:
+    first = SASTResult(
+        execution_status=SASTExecutionStatus.FAILED,
+        status_reason="offline_no_local_config",
+        status_detail="Offline mode found no local Semgrep rule configuration.",
+    ).to_dict()
+    second = _failed_result()
+    aggregated = _aggregate_sast_path_results([first, second])
+    assert aggregated["status_reason"] == "offline_no_local_config"
+
+
+def test_all_clean_paths_stay_clean() -> None:
+    aggregated = _aggregate_sast_path_results([_clean_result(), _clean_result()])
+    assert aggregated["execution_status"] == "clean"

--- a/tests/test_vector_db_pinecone.py
+++ b/tests/test_vector_db_pinecone.py
@@ -230,3 +230,50 @@ def test_discover_calls_check_pinecone_with_key():
     mock_check.assert_called_once_with("sk-test-key", timeout=3)
     assert len(result) == 1
     assert result[0].index_name == "env-idx"
+
+
+# ── Coverage-gap signalling (auth / API failures must not read as empty) ───────
+
+
+def _drain_coverage_warnings() -> list[dict]:
+    from agent_bom.scanners.state import consume_coverage_warnings
+
+    return consume_coverage_warnings()
+
+
+def test_403_emits_coverage_warning_not_clean_empty():
+    _drain_coverage_warnings()  # start clean
+    with patch("agent_bom.cloud.vector_db._pinecone_get", return_value=(403, {})):
+        result = check_pinecone("no-permission-key")
+    assert result == []
+    warnings = _drain_coverage_warnings()
+    reasons = {w.get("reason") for w in warnings}
+    assert "pinecone_permission_denied" in reasons
+    gap = next(w for w in warnings if w["reason"] == "pinecone_permission_denied")
+    assert gap["ecosystem"] == "pinecone"
+    assert "403" in gap["detail"]
+
+
+def test_401_emits_coverage_warning():
+    _drain_coverage_warnings()
+    with patch("agent_bom.cloud.vector_db._pinecone_get", return_value=(401, {})):
+        check_pinecone("bad-key")
+    reasons = {w.get("reason") for w in _drain_coverage_warnings()}
+    assert "pinecone_auth_failed" in reasons
+
+
+def test_api_outage_emits_coverage_warning():
+    _drain_coverage_warnings()
+    with patch("agent_bom.cloud.vector_db._pinecone_get", return_value=(503, {})):
+        check_pinecone("key")
+    reasons = {w.get("reason") for w in _drain_coverage_warnings()}
+    assert "pinecone_api_unavailable" in reasons
+
+
+def test_empty_account_records_no_coverage_warning():
+    _drain_coverage_warnings()
+    with patch("agent_bom.cloud.vector_db._pinecone_get", return_value=(200, {"indexes": []})):
+        result = check_pinecone("valid-key")
+    assert result == []
+    # A genuinely empty account must stay distinguishable from an auth/API gap.
+    assert _drain_coverage_warnings() == []


### PR DESCRIPTION
Four confirmed P2 honesty/fidelity defects from the audit. **Part of #4152** (durable profile-aware gateway activity — this closes two of its "event fidelity" / `calls_today` accuracy gaps).

- **Gateway KPI inflation** (`gateway_server.py`) — the forward-path sink emitted `TOOL_CALL_ALLOWED` for *every* message including the JSON-RPC handshake (`initialize`, `tools/list`, notifications), so the feed counted them in `calls_today` / `tool_calls_authorized`. Now it emits the tool-call event only when `is_tools_call(message)`; handshake/discovery are audited as `gateway.message` with no tool-call type.
- **Drift under-enforcement at the lookup cap** (`gateway_server.py`) — the open-incident lookup capped at 200 and, on a full cap with no match, returned a clean pass (silent under-enforcement for the tail). Now returns `unavailable=True` (honest partial): secured enforce fails closed, observable mode emits `gateway.drift_binding_unavailable`.
- **DSPM Pinecone silent auth/API failures** (`cloud/vector_db.py`) — 401/403/5xx returned `[]` with only a log warning, indistinguishable from an empty account. Now emits a `CoverageWarning` (`pinecone_auth_failed`/`pinecone_permission_denied`/`pinecone_api_unavailable`) into `report.coverage_warnings`, mirroring the #4173 Snowflake contract.
- **Multi-path SAST loses an earlier failure** (`cli/agents/_discovery.py`) — the per-path loop overwrote `ctx.sast_data` each iteration, so a first-path `SASTScanError` was hidden when a later path succeeded. New `_aggregate_sast_path_results` collapses per-path results (rank failed>skipped>findings>clean, first failure's reason preserved) so any path's failure shows in the summary.

## How verified
- New TDD tests (red→green): handshake-only feed → `calls_today=0`; drift cap-hit → `unavailable`; Pinecone 403 → coverage warning not clean empty; two `--code` paths where the first fails → aggregate reflects the failure.
- `uv run pytest` touched + sibling suites (gateway_server, gateway_drift_enforcement, vector_db*, sast*, api/test_api_gateway_feed, drift_incidents) — **183 passed**; `ruff`/`mypy` clean.