### PR TITLE
fix(postgres): shared idempotency store and RLS backstop parity

### DIFF
--- a/src/agent_bom/api/idempotency_store.py
+++ b/src/agent_bom/api/idempotency_store.py
@@ -12,7 +12,8 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
 
-from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.storage_schema import ensure_postgres_schema_version, ensure_sqlite_schema_version
 
 # Fixed namespace for content-derived batch ids so an identical write resent
 # without an ``Idempotency-Key`` header still collapses onto one logical batch
@@ -247,3 +248,105 @@ class SQLiteIdempotencyStore:
         # Prune expired keys on write so the table cannot grow without bound.
         self._prune()
         self._conn.commit()
+
+
+class PostgresIdempotencyStore:
+    """PostgreSQL-backed idempotency store for multi-replica deployments.
+
+    Mirrors :class:`SQLiteIdempotencyStore` semantics — replay the cached
+    response for a repeated ``Idempotency-Key``, raise
+    :class:`IdempotencyConflictError` (surfaced as HTTP 409) when the same key
+    is reused with a different request body, and prune past-TTL rows on write —
+    but shares state across every API replica through Postgres. The per-process
+    :class:`InMemoryIdempotencyStore` fallback silently dropped that guarantee
+    on clustered Postgres deployments: a retried ``POST /v1/findings/bulk`` that
+    landed on a different replica (or after a restart) was not recognized.
+
+    The table is tenant-scoped and registered under ``FORCE ROW LEVEL SECURITY``
+    via the shared :func:`_ensure_tenant_rls` helper, exactly like every other
+    control-plane table, so it never bypasses the tenancy backstop.
+    """
+
+    def __init__(self, pool: ConnectionPool | None = None, ttl_hours: int | None = None) -> None:
+        self._pool = pool or _get_pool()
+        self._ttl_hours = ttl_hours
+        self._init_tables()
+
+    def _init_tables(self) -> None:
+        with self._pool.connection() as conn:
+            ensure_postgres_schema_version(conn, "idempotency")
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS idempotency_keys (
+                    endpoint TEXT NOT NULL,
+                    tenant_id TEXT NOT NULL,
+                    source_id TEXT NOT NULL,
+                    idempotency_key TEXT NOT NULL,
+                    request_hash TEXT NOT NULL DEFAULT '',
+                    response_json TEXT NOT NULL,
+                    created_at TEXT NOT NULL,
+                    PRIMARY KEY (endpoint, tenant_id, source_id, idempotency_key)
+                )
+                """
+            )
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_idempotency_created_at ON idempotency_keys(created_at)")
+            _ensure_tenant_rls(conn, "idempotency_keys", "tenant_id")
+            conn.commit()
+
+    def _prune(self, conn: Any) -> None:
+        """Delete idempotency keys past the TTL (keyed on ``idx_idempotency_created_at``)."""
+        ttl = self._ttl_hours if self._ttl_hours is not None else _idempotency_ttl_hours()
+        cutoff = (datetime.now(timezone.utc) - timedelta(hours=max(1, int(ttl)))).isoformat()
+        conn.execute("DELETE FROM idempotency_keys WHERE created_at < %s", (cutoff,))
+
+    def get(
+        self,
+        endpoint: str,
+        tenant_id: str,
+        source_id: str,
+        idempotency_key: str,
+        *,
+        request_hash: str = "",
+    ) -> dict[str, Any] | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                """SELECT response_json, request_hash FROM idempotency_keys
+                   WHERE endpoint = %s AND tenant_id = %s AND source_id = %s AND idempotency_key = %s""",
+                (endpoint, tenant_id, source_id, idempotency_key),
+            ).fetchone()
+        if row:
+            _ensure_request_hash_matches(str(row[1] or ""), request_hash)
+        return json.loads(row[0]) if row else None
+
+    def put(
+        self,
+        endpoint: str,
+        tenant_id: str,
+        source_id: str,
+        idempotency_key: str,
+        response: dict[str, Any],
+        *,
+        request_hash: str = "",
+    ) -> None:
+        with _tenant_connection(self._pool) as conn:
+            conn.execute(
+                """INSERT INTO idempotency_keys
+                   (endpoint, tenant_id, source_id, idempotency_key, request_hash, response_json, created_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s)
+                   ON CONFLICT (endpoint, tenant_id, source_id, idempotency_key) DO UPDATE SET
+                       request_hash = EXCLUDED.request_hash,
+                       response_json = EXCLUDED.response_json,
+                       created_at = EXCLUDED.created_at""",
+                (
+                    endpoint,
+                    tenant_id,
+                    source_id,
+                    idempotency_key,
+                    request_hash,
+                    json.dumps(response, sort_keys=True),
+                    _utcnow(),
+                ),
+            )
+            # Prune expired keys on write so the table cannot grow without bound.
+            self._prune(conn)
+            conn.commit()

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -62,6 +62,15 @@ class PostgresAuditLog:
                 """
             )
             _ensure_tenant_rls(conn, "audit_log", "team_id")
+            # Parity with the ~47 other tenant tables: the checkpoint cache is a
+            # per-tenant summary of the audit_log chain head, so it lives under
+            # the same FORCE ROW LEVEL SECURITY backstop keyed on tenant_id. The
+            # append path writes it under the request tenant context (the same
+            # value it inserts into audit_log.team_id on the same connection, so
+            # it passes WITH CHECK whenever the audit_log insert does); the
+            # cross-tenant startup rebuild below runs under an explicit
+            # bypass_tenant_rls maintenance context.
+            _ensure_tenant_rls(conn, "audit_chain_checkpoint", "tenant_id")
             conn.commit()
         self._hydrate_checkpoints()
 
@@ -70,7 +79,9 @@ class PostgresAuditLog:
         # SECURITY on audit_log hides from a normally-scoped connection (a
         # NOSUPERUSER role would only ever see the 'default' tenant here). This
         # is a trusted startup rebuild, so bind the RLS bypass session for the
-        # cross-tenant read; audit_chain_checkpoint itself carries no RLS policy.
+        # cross-tenant read and the per-tenant checkpoint upsert. Both audit_log
+        # and audit_chain_checkpoint now enforce tenant RLS, so the bypass is
+        # required for this maintenance write to every tenant's checkpoint row.
         with bypass_tenant_rls(audit=False), _tenant_connection(self._pool) as conn:
             row = conn.execute("SELECT COUNT(*) FROM audit_chain_checkpoint").fetchone()
             if row and int(row[0]) > 0:
@@ -100,11 +111,20 @@ class PostgresAuditLog:
             conn.commit()
 
     def _get_checkpoint(self, tenant_id: str) -> _AuditChainCheckpoint | None:
-        with _tenant_connection(self._pool) as conn:
-            row = conn.execute(
-                "SELECT entry_count, head_signature FROM audit_chain_checkpoint WHERE tenant_id = %s",
-                (tenant_id,),
-            ).fetchone()
+        # audit_chain_checkpoint is under FORCE ROW LEVEL SECURITY keyed on
+        # tenant_id, so bind the requested tenant on the connection rather than
+        # relying on the ambient request context — otherwise a verify call for a
+        # tenant other than the ambient one would resolve zero rows and silently
+        # fall back to a full re-scan.
+        token = _current_tenant.set(tenant_id)
+        try:
+            with _tenant_connection(self._pool) as conn:
+                row = conn.execute(
+                    "SELECT entry_count, head_signature FROM audit_chain_checkpoint WHERE tenant_id = %s",
+                    (tenant_id,),
+                ).fetchone()
+        finally:
+            _current_tenant.reset(token)
         if not row:
             return None
         if len(row) >= 3:

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -57,7 +57,7 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     StorageSchemaComponent("sources", "sqlite/postgres", ("sources", "control_plane_sources")),
     StorageSchemaComponent("schedules", "sqlite/postgres", ("scan_schedules",)),
     StorageSchemaComponent("exceptions", "sqlite/postgres", ("vuln_exceptions",)),
-    StorageSchemaComponent("idempotency", "sqlite", ("idempotency_keys",)),
+    StorageSchemaComponent("idempotency", "sqlite/postgres", ("idempotency_keys",)),
     StorageSchemaComponent("mcp_observations", "sqlite", ("mcp_observations",)),
     StorageSchemaComponent("proxy_replay_log", "sqlite/postgres", ("proxy_replay_log",)),
     StorageSchemaComponent(

--- a/src/agent_bom/api/stores.py
+++ b/src/agent_bom/api/stores.py
@@ -83,9 +83,7 @@ def _compact_terminal_job(job: ScanJob) -> ScanJob:
             compact_result["scan_timestamp"] = compact_result["generated_at"]
         scorecard = job.result.get("posture_scorecard")
         if isinstance(scorecard, dict):
-            compact_result["posture_scorecard"] = {
-                key: scorecard[key] for key in ("grade", "score", "summary") if key in scorecard
-            }
+            compact_result["posture_scorecard"] = {key: scorecard[key] for key in ("grade", "score", "summary") if key in scorecard}
         scan_sources = job.result.get("scan_sources")
         if isinstance(scan_sources, list):
             compact_result["scan_sources"] = scan_sources
@@ -164,7 +162,15 @@ def _get_idempotency_store() -> Any:
     if _idempotency_store is None:
         with _store_lock:
             if _idempotency_store is None:
-                if os.environ.get("AGENT_BOM_DB"):
+                if os.environ.get("AGENT_BOM_POSTGRES_URL"):
+                    # Multi-replica deployments must share idempotency state so a
+                    # retried write is recognized on any replica; a per-process
+                    # in-memory map would silently drop the same-key-different-body
+                    # 409 guarantee across replicas / restarts.
+                    from agent_bom.api.idempotency_store import PostgresIdempotencyStore
+
+                    _idempotency_store = PostgresIdempotencyStore()
+                elif os.environ.get("AGENT_BOM_DB"):
                     from agent_bom.api.idempotency_store import SQLiteIdempotencyStore
 
                     _idempotency_store = SQLiteIdempotencyStore(os.environ["AGENT_BOM_DB"])

--- a/tests/test_idempotency_store_selection.py
+++ b/tests/test_idempotency_store_selection.py
@@ -1,0 +1,66 @@
+"""Backend selection for the idempotency store (stores._get_idempotency_store).
+
+Multi-replica prod runs Postgres (AGENT_BOM_POSTGRES_URL set, no local
+AGENT_BOM_DB). Before this wiring the selector fell through to a per-process
+InMemoryIdempotencyStore, so a retried write with the same Idempotency-Key on
+another replica was not recognized and the same-key-different-body 409 guarantee
+was lost. These tests pin the selection precedence without needing a live DB.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.api import idempotency_store as idem_mod
+from agent_bom.api import stores
+from agent_bom.api.idempotency_store import InMemoryIdempotencyStore, SQLiteIdempotencyStore
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    stores.set_idempotency_store(None)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    yield
+    stores.set_idempotency_store(None)
+
+
+def test_default_selects_in_memory():
+    assert isinstance(stores._get_idempotency_store(), InMemoryIdempotencyStore)
+
+
+def test_sqlite_selected_when_only_db_set(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "jobs.db"))
+    assert isinstance(stores._get_idempotency_store(), SQLiteIdempotencyStore)
+
+
+def test_postgres_url_selects_postgres_backend(monkeypatch):
+    """AGENT_BOM_POSTGRES_URL must select the shared Postgres backend, not memory."""
+    constructed: list[bool] = []
+
+    class _StubPostgresIdempotencyStore:
+        def __init__(self, *args, **kwargs):  # noqa: D401 - no real pool touched
+            constructed.append(True)
+
+    # Stub the class so no live pool/connection is required for the selection check.
+    monkeypatch.setattr(idem_mod, "PostgresIdempotencyStore", _StubPostgresIdempotencyStore)
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://stub")
+
+    store = stores._get_idempotency_store()
+
+    assert constructed == [True]
+    assert isinstance(store, _StubPostgresIdempotencyStore)
+    assert not isinstance(store, InMemoryIdempotencyStore)
+
+
+def test_postgres_url_takes_precedence_over_sqlite(monkeypatch, tmp_path):
+    class _StubPostgresIdempotencyStore:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    monkeypatch.setattr(idem_mod, "PostgresIdempotencyStore", _StubPostgresIdempotencyStore)
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://stub")
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "jobs.db"))
+
+    store = stores._get_idempotency_store()
+    assert isinstance(store, _StubPostgresIdempotencyStore)

--- a/tests/test_postgres_idempotency_store.py
+++ b/tests/test_postgres_idempotency_store.py
@@ -1,0 +1,183 @@
+"""Postgres-backed idempotency store: contract + tenant-RLS wiring.
+
+A live Postgres is not required. These tests use a mock connection/pool that
+records the store's DDL and implements just enough of the ``idempotency_keys``
+SQL surface (INSERT ... ON CONFLICT / SELECT / prune DELETE) to exercise the
+same replay / 409-mismatch / TTL-prune contract the SQLite backend guarantees,
+plus assertions that the table is created tenant-scoped and registered under
+``_ensure_tenant_rls`` like every other control-plane table.
+
+The real-Postgres integration counterpart lives in test_postgres_integration.py
+and is skipped when no live database is configured.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent_bom.api import idempotency_store as idem_mod
+from agent_bom.api.idempotency_store import (
+    IdempotencyConflictError,
+    PostgresIdempotencyStore,
+    idempotency_request_fingerprint,
+)
+
+
+class _FakeCursor:
+    def __init__(self, rows: list[tuple] | None = None) -> None:
+        self._rows = rows or []
+        self.rowcount = len(self._rows)
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeConn:
+    """Minimal in-memory stand-in for a psycopg connection.
+
+    Stores ``idempotency_keys`` rows keyed by the four-part primary key and
+    honours the exact statements the Postgres idempotency store issues.
+    """
+
+    def __init__(self, table: dict[tuple, dict]) -> None:
+        self._table = table
+        self.executed: list[tuple[str, object]] = []
+
+    def __enter__(self) -> _FakeConn:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        return None
+
+    def commit(self) -> None:
+        return None
+
+    def execute(self, sql: str, params: tuple | None = None) -> _FakeCursor:
+        self.executed.append((sql, params))
+        low = " ".join(sql.split()).lower()
+        params = params or ()
+
+        # Tenant-session setup (from _apply_tenant_session) and all DDL are no-ops.
+        if low.startswith("select set_config"):
+            return _FakeCursor()
+        if (
+            low.startswith("create table")
+            or low.startswith("create index")
+            or low.startswith("create or replace function")
+            or low.startswith("alter table")
+            or low.startswith("do $$")
+        ):
+            return _FakeCursor()
+        if low.startswith("insert into control_plane_schema_versions"):
+            return _FakeCursor()
+
+        if low.startswith("insert into idempotency_keys"):
+            endpoint, tenant_id, source_id, key, request_hash, response_json, created_at = params
+            self._table[(endpoint, tenant_id, source_id, key)] = {
+                "request_hash": request_hash,
+                "response_json": response_json,
+                "created_at": created_at,
+            }
+            return _FakeCursor()
+
+        if low.startswith("select response_json, request_hash from idempotency_keys"):
+            endpoint, tenant_id, source_id, key = params
+            rec = self._table.get((endpoint, tenant_id, source_id, key))
+            if rec is None:
+                return _FakeCursor()
+            return _FakeCursor([(rec["response_json"], rec["request_hash"])])
+
+        if low.startswith("delete from idempotency_keys where created_at"):
+            (cutoff,) = params
+            stale = [pk for pk, rec in self._table.items() if rec["created_at"] < cutoff]
+            for pk in stale:
+                self._table.pop(pk, None)
+            cur = _FakeCursor()
+            cur.rowcount = len(stale)
+            return cur
+
+        raise AssertionError(f"unexpected SQL in fake conn: {sql!r}")
+
+
+class _FakePool:
+    """Pool that hands out one shared connection so DDL is inspectable."""
+
+    def __init__(self) -> None:
+        self.table: dict[tuple, dict] = {}
+        self.conn = _FakeConn(self.table)
+
+    def connection(self) -> _FakeConn:
+        return self.conn
+
+
+# ── RLS / DDL wiring ─────────────────────────────────────────────────────────
+
+
+def test_postgres_idempotency_table_is_tenant_scoped_and_rls_registered(monkeypatch):
+    """The table must carry tenant_id + be registered with _ensure_tenant_rls."""
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(idem_mod, "_ensure_tenant_rls", lambda conn, table, column: calls.append((table, column)))
+
+    pool = _FakePool()
+    PostgresIdempotencyStore(pool=pool)
+
+    # Registered under the shared FORCE ROW LEVEL SECURITY backstop, keyed on tenant_id.
+    assert ("idempotency_keys", "tenant_id") in calls
+
+    # The CREATE TABLE carries tenant_id and the four-part primary key.
+    ddl = "\n".join(sql for sql, _ in pool.conn.executed).lower()
+    assert "create table if not exists idempotency_keys" in ddl
+    assert "tenant_id text not null" in ddl
+    assert "primary key (endpoint, tenant_id, source_id, idempotency_key)" in ddl
+
+
+# ── Replay / conflict / TTL contract (mirrors the SQLite backend) ────────────
+
+
+def test_postgres_idempotency_replays_same_payload_and_rejects_mismatch():
+    store = PostgresIdempotencyStore(pool=_FakePool())
+    request_hash = idempotency_request_fingerprint({"idempotency_key": "k-1", "value": 1})
+    mismatch_hash = idempotency_request_fingerprint({"idempotency_key": "k-1", "value": 2})
+
+    store.put("/v1/findings/bulk", "tenant-a", "source-a", "k-1", {"ok": True}, request_hash=request_hash)
+
+    assert store.get("/v1/findings/bulk", "tenant-a", "source-a", "k-1", request_hash=request_hash) == {"ok": True}
+    with pytest.raises(IdempotencyConflictError):
+        store.get("/v1/findings/bulk", "tenant-a", "source-a", "k-1", request_hash=mismatch_hash)
+
+
+def test_postgres_idempotency_miss_returns_none():
+    store = PostgresIdempotencyStore(pool=_FakePool())
+    assert store.get("/v1/findings/bulk", "tenant-a", "source-a", "absent") is None
+
+
+def test_postgres_idempotency_isolates_by_tenant_key():
+    """A key under tenant-a must not resolve for tenant-b (composite PK)."""
+    store = PostgresIdempotencyStore(pool=_FakePool())
+    store.put("/v1/findings/bulk", "tenant-a", "s", "k", {"who": "a"})
+    assert store.get("/v1/findings/bulk", "tenant-b", "s", "k") is None
+    assert store.get("/v1/findings/bulk", "tenant-a", "s", "k") == {"who": "a"}
+
+
+def test_postgres_idempotency_put_prunes_expired_keys():
+    pool = _FakePool()
+    store = PostgresIdempotencyStore(pool=pool, ttl_hours=24)
+
+    stale_ts = (datetime.now(timezone.utc) - timedelta(hours=48)).isoformat()
+    pool.table[("/v1/findings/bulk", "t", "s", "old")] = {
+        "request_hash": "",
+        "response_json": json.dumps({}),
+        "created_at": stale_ts,
+    }
+
+    store.put("/v1/findings/bulk", "t", "s", "new", {"ok": True})
+
+    assert store.get("/v1/findings/bulk", "t", "s", "old") is None
+    assert store.get("/v1/findings/bulk", "t", "s", "new") == {"ok": True}
+    assert len(pool.table) == 1

--- a/tests/test_postgres_rls_backstop_parity.py
+++ b/tests/test_postgres_rls_backstop_parity.py
@@ -1,0 +1,162 @@
+"""Tenant-RLS backstop parity for two tenant-adjacent Postgres tables.
+
+Defect: ``audit_chain_checkpoint`` (has tenant_id PK) and ``scan_dispatch_queue``
+(has tenant_id) sat outside the FORCE-ROW-LEVEL-SECURITY backstop that ~47 other
+tables use. No live leak today (queries filter by tenant manually) but they lost
+the systematic backstop.
+
+Resolution:
+  * ``audit_chain_checkpoint`` is now registered with ``_ensure_tenant_rls`` for
+    parity — its append path already runs under the request tenant context and
+    its cross-tenant startup rebuild runs under an explicit ``bypass_tenant_rls``.
+  * ``scan_dispatch_queue`` is global-by-design routing metadata (job_id +
+    tenant_id + timing; the confidential payload lives in the RLS-protected
+    ``scan_jobs.data``). It is intentionally NOT RLS'd because the background
+    claim-loop must see pending jobs across all tenants. This test locks that
+    intent: it stays out of RLS AND must never grow a confidential column.
+
+A live Postgres is not required — a mock connection captures the emitted DDL and
+records every ``_ensure_tenant_rls`` registration.
+"""
+
+from __future__ import annotations
+
+import re
+
+from agent_bom.api import postgres_audit as audit_mod
+from agent_bom.api import postgres_job_store as job_mod
+
+
+class _FakeCursor:
+    def __init__(self, rows=None):
+        self._rows = rows or []
+        self.rowcount = len(self._rows)
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+
+class _FakeConn:
+    def __init__(self):
+        self.executed: list[tuple[str, object]] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return None
+
+    def commit(self):
+        return None
+
+    def execute(self, sql, params=None):
+        self.executed.append((sql, params))
+        low = " ".join(sql.split()).lower()
+        if low.startswith("select count(*)"):
+            return _FakeCursor([(0,)])
+        if low.startswith("select"):
+            return _FakeCursor([])
+        return _FakeCursor()
+
+
+class _FakePool:
+    def __init__(self):
+        self.conn = _FakeConn()
+
+    def connection(self):
+        return self.conn
+
+
+def _rls_registrations(monkeypatch, module) -> list[tuple[str, str]]:
+    calls: list[tuple[str, str]] = []
+    monkeypatch.setattr(module, "_ensure_tenant_rls", lambda conn, table, column: calls.append((table, column)))
+    return calls
+
+
+def _create_table_columns(ddl: str, table: str) -> set[str]:
+    """Extract column names from a ``CREATE TABLE ... table ( ... )`` block."""
+    marker = ddl.lower().find(f"create table if not exists {table}")
+    assert marker != -1, f"{table} CREATE TABLE not found"
+    open_paren = ddl.index("(", marker)
+    depth = 0
+    end = open_paren
+    for i in range(open_paren, len(ddl)):
+        if ddl[i] == "(":
+            depth += 1
+        elif ddl[i] == ")":
+            depth -= 1
+            if depth == 0:
+                end = i
+                break
+    body = ddl[open_paren + 1 : end]
+    cols: set[str] = set()
+    depth = 0
+    for raw in body.split("\n"):
+        line = raw.strip()
+        # Only split on commas at paren-depth 0 by scanning char state per line.
+        segment = line.strip().rstrip(",").strip()
+        if not segment or segment.startswith("--"):
+            continue
+        first = segment.split()[0]
+        if first.upper() in ("PRIMARY", "CONSTRAINT", "UNIQUE", "FOREIGN", "CHECK"):
+            continue
+        if re.match(r"^[a-z_][a-z0-9_]*$", first):
+            cols.add(first.lower())
+    return cols
+
+
+# ── audit_chain_checkpoint: now under the RLS backstop ───────────────────────
+
+
+def test_audit_chain_checkpoint_registered_for_rls(monkeypatch):
+    calls = _rls_registrations(monkeypatch, audit_mod)
+    pool = _FakePool()
+
+    audit_mod.PostgresAuditLog(pool=pool)
+
+    assert ("audit_chain_checkpoint", "tenant_id") in calls
+    # audit_log parity (already present) must remain.
+    assert ("audit_log", "team_id") in calls
+
+    ddl = "\n".join(sql for sql, _ in pool.conn.executed).lower()
+    assert "create table if not exists audit_chain_checkpoint" in ddl
+    cols = _create_table_columns(ddl, "audit_chain_checkpoint")
+    assert "tenant_id" in cols
+
+
+# ── scan_dispatch_queue: global-by-design routing metadata, no RLS ───────────
+
+# The full, intentional column set. If a future change adds a column it must
+# fail here first, forcing an explicit decision: is the new column confidential
+# (then RLS the table) or still pure routing metadata (then widen this set)?
+_DISPATCH_QUEUE_ALLOWED_COLUMNS = {
+    "job_id",
+    "tenant_id",
+    "created_at",
+    "status",
+    "claimed_by",
+    "lease_expires_at",
+}
+
+
+def test_scan_dispatch_queue_is_global_routing_metadata_only(monkeypatch):
+    calls = _rls_registrations(monkeypatch, job_mod)
+    pool = _FakePool()
+
+    job_mod.PostgresJobStore(pool=pool)
+
+    registered = {table for table, _ in calls}
+    # scan_jobs / cis_benchmark_checks stay RLS-registered; the dispatch queue does not.
+    assert "scan_jobs" in registered
+    assert "scan_dispatch_queue" not in registered
+
+    ddl = "\n".join(sql for sql, _ in pool.conn.executed).lower()
+    cols = _create_table_columns(ddl, "scan_dispatch_queue")
+    assert cols == _DISPATCH_QUEUE_ALLOWED_COLUMNS, (
+        "scan_dispatch_queue grew/lost a column; confirm it is still pure routing "
+        "metadata (widen the allow-set) or RLS-protect it if it now holds "
+        f"tenant-confidential data. Got: {sorted(cols)}"
+    )


### PR DESCRIPTION
Two Postgres/multi-replica backend-parity gaps.

## 1. Idempotency-Key store fell back to per-process memory on Postgres deployments
`_get_idempotency_store()` selected the store by `AGENT_BOM_DB` only, never consulting `AGENT_BOM_POSTGRES_URL`, and there was no Postgres backend. In the multi-replica prod config each replica got its own in-memory idempotency map, so a retried `POST /v1/findings/bulk` with the same `Idempotency-Key` landing on another replica (or after restart) was not recognized, and the same-key-different-body 409 guarantee disappeared.

**Fix:** added `PostgresIdempotencyStore` mirroring the SQLite backend's semantics (cached-response replay, 409 on body mismatch, TTL prune on write) with shared state across replicas. `stores.py` selects it when `AGENT_BOM_POSTGRES_URL` is set. The `idempotency_keys` table is tenant-scoped and registered under `FORCE ROW LEVEL SECURITY` via the shared `_ensure_tenant_rls` helper — never bypassing the tenancy backstop.

## 2. Two tenant tables sat outside the FORCE-RLS backstop
`audit_chain_checkpoint` (tenant_id PK) was never registered with `_ensure_tenant_rls`, unlike the ~47 other tenant tables — no live leak (queries filter manually) but no systematic backstop.

**Fix:** registered `audit_chain_checkpoint` for RLS. The append path writes under the request tenant context; the cross-tenant startup rebuild runs under an explicit `bypass_tenant_rls`; `_get_checkpoint` now binds the requested tenant so a verify for a non-ambient tenant resolves its real row under RLS instead of silently full-rescanning. `scan_dispatch_queue` was confirmed global-by-design (routing metadata only — confidential payload lives in RLS-protected `scan_jobs`) and that intent is locked with a test asserting its column set can't drift.

## How verified
No live Postgres in the dev env, so wiring is proven by generated-DDL/RLS-registration assertions, store-selection unit tests, and a mock-connection contract exercising replay/409/TTL; live-DB counterparts run in the CI Postgres job. New tests red→green. `ruff`/`mypy`/`pre-commit` clean; new + regression suites `78 passed`, broader postgres/schema sweep `258 passed`.

Part of #4205.
