### PR TITLE
fix(hub): atomic local ingest, bulk field validation, honest evidence truncation

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1299,6 +1299,11 @@
             "title": "Tampered",
             "type": "integer"
           },
+          "truncated": {
+            "default": false,
+            "title": "Truncated",
+            "type": "boolean"
+          },
           "verified": {
             "default": 0,
             "title": "Verified",
@@ -1590,6 +1595,16 @@
             "default": 0,
             "title": "Audit Event Count",
             "type": "integer"
+          },
+          "audit_event_limit": {
+            "default": 0,
+            "title": "Audit Event Limit",
+            "type": "integer"
+          },
+          "audit_events_truncated": {
+            "default": false,
+            "title": "Audit Events Truncated",
+            "type": "boolean"
           },
           "completed_scan_count": {
             "default": 0,

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -939,6 +939,10 @@ components:
           default: 0
           title: Tampered
           type: integer
+        truncated:
+          default: false
+          title: Truncated
+          type: boolean
         verified:
           default: 0
           title: Verified
@@ -1123,6 +1127,14 @@ components:
           default: 0
           title: Audit Event Count
           type: integer
+        audit_event_limit:
+          default: 0
+          title: Audit Event Limit
+          type: integer
+        audit_events_truncated:
+          default: false
+          title: Audit Events Truncated
+          type: boolean
         completed_scan_count:
           default: 0
           title: Completed Scan Count

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -785,35 +785,94 @@ class InMemoryComplianceHubStore:
         self._current_observations: dict[str, set[tuple[str, str]]] = {}
         self._lock = threading.Lock()
 
+    def _invalidate_ingest_caches(self, tenant_id: str) -> None:
+        from agent_bom.api import hub_overview_cache
+        from agent_bom.api.findings_count_cache import invalidate_tenant
+
+        invalidate_tenant(tenant_id)
+        hub_overview_cache.invalidate_tenant(tenant_id)
+
+    def _add_locked(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+        """Append the batch to the ledger. Caller MUST hold ``self._lock``."""
+        bucket = self._by_tenant.setdefault(tenant_id, [])
+        slots = self._slots.setdefault(tenant_id, {})
+        for payload in findings:
+            if not isinstance(payload, dict):
+                continue
+            slim = normalize_finding_payload_for_store(tenant_id, payload)
+            stored = _redact_finding(slim)
+            # Materialise the effective-reach composite once at ingest so the
+            # read-path sort never re-derives it per row (#4049). Mirrors the
+            # SQL backends materialising the ``effective_reach_score`` column.
+            stored[_REACH_SORT_KEY] = compute_effective_reach_score(stored)
+            finding_id = str(stored.get("id") or "")
+            if finding_id and finding_id in slots:
+                # Refresh payload, keep original ingest position.
+                bucket[slots[finding_id]] = stored
+                continue
+            if finding_id:
+                slots[finding_id] = len(bucket)
+            bucket.append(stored)
+        return len(bucket)
+
     def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
         with self._lock:
-            bucket = self._by_tenant.setdefault(tenant_id, [])
-            slots = self._slots.setdefault(tenant_id, {})
-            for payload in findings:
-                if not isinstance(payload, dict):
-                    continue
-                slim = normalize_finding_payload_for_store(tenant_id, payload)
-                stored = _redact_finding(slim)
-                # Materialise the effective-reach composite once at ingest so the
-                # read-path sort never re-derives it per row (#4049). Mirrors the
-                # SQL backends materialising the ``effective_reach_score`` column.
-                stored[_REACH_SORT_KEY] = compute_effective_reach_score(stored)
-                finding_id = str(stored.get("id") or "")
-                if finding_id and finding_id in slots:
-                    # Refresh payload, keep original ingest position.
-                    bucket[slots[finding_id]] = stored
-                    continue
-                if finding_id:
-                    slots[finding_id] = len(bucket)
-                bucket.append(stored)
-            total = len(bucket)
+            total = self._add_locked(tenant_id, findings)
         if findings:
-            from agent_bom.api import hub_overview_cache
-            from agent_bom.api.findings_count_cache import invalidate_tenant
-
-            invalidate_tenant(tenant_id)
-            hub_overview_cache.invalidate_tenant(tenant_id)
+            self._invalidate_ingest_caches(tenant_id)
         return total
+
+    def ingest_batch_atomic(
+        self,
+        tenant_id: str,
+        findings: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str,
+        reconcile_absent: bool,
+        present_canonical_ids: set[str],
+    ) -> tuple[int, int]:
+        """Ledger append + current upsert (+ reconcile) as one atomic unit.
+
+        The three writes ran as separate lock acquisitions, so a failure between
+        them left the ledger appended while current-state stayed behind. Here all
+        three run under a single lock; on failure the pre-batch snapshot is
+        restored so nothing is partially applied. Mirrors the SQL backends'
+        single-transaction seam. Returns ``(new_total, reconciled)``.
+        """
+        clean = _redact_findings(findings)
+        with self._lock:
+            snap_bucket = list(self._by_tenant.get(tenant_id, []))
+            snap_slots = dict(self._slots.get(tenant_id, {}))
+            snap_current = {k: dict(v) for k, v in self._current.get(tenant_id, {}).items()}
+            snap_obs = set(self._current_observations.get(tenant_id, set()))
+            try:
+                total = self._add_locked(tenant_id, findings)
+                self._upsert_current_locked(
+                    tenant_id,
+                    clean,
+                    observed_at=observed_at,
+                    batch_id=batch_id,
+                    source=source,
+                )
+                reconciled = 0
+                if reconcile_absent:
+                    reconciled = self._reconcile_locked(
+                        tenant_id,
+                        present_canonical_ids=present_canonical_ids,
+                        observed_at=observed_at,
+                        scope_source=source,
+                    )
+            except Exception:
+                self._by_tenant[tenant_id] = snap_bucket
+                self._slots[tenant_id] = snap_slots
+                self._current[tenant_id] = snap_current
+                self._current_observations[tenant_id] = snap_obs
+                raise
+        if findings or reconcile_absent:
+            self._invalidate_ingest_caches(tenant_id)
+        return total, reconciled
 
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
         with self._lock:
@@ -906,6 +965,48 @@ class InMemoryComplianceHubStore:
             hub_overview_cache.invalidate_tenant(tenant_id)
         return removed
 
+    def _upsert_current_locked(
+        self,
+        tenant_id: str,
+        clean: Sequence[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str = "",
+    ) -> None:
+        """Upsert current-state for a redacted batch. Caller MUST hold the lock."""
+        from agent_bom.api.finding_lifecycle import (
+            apply_observation_to_current,
+            lifecycle_metrics,
+            resolve_canonical_id,
+        )
+
+        now = _now_utc_iso()
+        current = self._current.setdefault(tenant_id, {})
+        observations = self._current_observations.setdefault(tenant_id, set())
+        for payload in clean:
+            canonical = resolve_canonical_id(payload, source=source)
+            obs_key = (canonical, batch_id)
+            if obs_key in observations:
+                continue
+            observations.add(obs_key)
+            merged = apply_observation_to_current(
+                current.get(canonical),
+                canonical_id=canonical,
+                observed_at=observed_at,
+                metrics=lifecycle_metrics(payload),
+                payload=payload,
+                updated_at=now,
+            )
+            finding_id = resolve_ledger_finding_id(payload, canonical_id=canonical)
+            if finding_id:
+                merged["ledger_finding_id"] = finding_id
+                merged["payload"] = current_state_overlay(payload)
+                merged["ledger_ordinal"] = self._slots.get(tenant_id, {}).get(finding_id, _LEDGER_ORDINAL_SENTINEL)
+            else:
+                merged["ledger_ordinal"] = _LEDGER_ORDINAL_SENTINEL
+            current[canonical] = merged
+
     def upsert_current_batch(
         self,
         tenant_id: str,
@@ -915,39 +1016,15 @@ class InMemoryComplianceHubStore:
         batch_id: str,
         source: str = "",
     ) -> None:
-        from agent_bom.api.finding_lifecycle import (
-            apply_observation_to_current,
-            lifecycle_metrics,
-            resolve_canonical_id,
-        )
-
         clean = _redact_findings(findings)
-        now = _now_utc_iso()
         with self._lock:
-            current = self._current.setdefault(tenant_id, {})
-            observations = self._current_observations.setdefault(tenant_id, set())
-            for payload in clean:
-                canonical = resolve_canonical_id(payload, source=source)
-                obs_key = (canonical, batch_id)
-                if obs_key in observations:
-                    continue
-                observations.add(obs_key)
-                merged = apply_observation_to_current(
-                    current.get(canonical),
-                    canonical_id=canonical,
-                    observed_at=observed_at,
-                    metrics=lifecycle_metrics(payload),
-                    payload=payload,
-                    updated_at=now,
-                )
-                finding_id = resolve_ledger_finding_id(payload, canonical_id=canonical)
-                if finding_id:
-                    merged["ledger_finding_id"] = finding_id
-                    merged["payload"] = current_state_overlay(payload)
-                    merged["ledger_ordinal"] = self._slots.get(tenant_id, {}).get(finding_id, _LEDGER_ORDINAL_SENTINEL)
-                else:
-                    merged["ledger_ordinal"] = _LEDGER_ORDINAL_SENTINEL
-                current[canonical] = merged
+            self._upsert_current_locked(
+                tenant_id,
+                clean,
+                observed_at=observed_at,
+                batch_id=batch_id,
+                source=source,
+            )
 
     def _ledger_payload_map(self, tenant_id: str, finding_ids: Sequence[str]) -> dict[str, dict[str, Any]]:
         slots = self._slots.get(tenant_id, {})
@@ -1031,6 +1108,34 @@ class InMemoryComplianceHubStore:
             next_cursor = cursor_from_current_row(rows[-1], sort=normalized_sort)
         return enriched, total, next_cursor
 
+    def _reconcile_locked(
+        self,
+        tenant_id: str,
+        *,
+        present_canonical_ids: set[str],
+        observed_at: str,
+        scope_source: str | None = None,
+    ) -> int:
+        """Resolve absent open findings. Caller MUST hold ``self._lock``."""
+        now = _now_utc_iso()
+        updated = 0
+        current = self._current.setdefault(tenant_id, {})
+        for canonical_id, row in list(current.items()):
+            if str(row.get("status") or "") not in ("open", "reopened"):
+                continue
+            if canonical_id in present_canonical_ids:
+                continue
+            payload = row.get("payload") or {}
+            if scope_source is not None and str(payload.get("source") or "") != scope_source:
+                continue
+            merged = dict(row)
+            merged["status"] = "resolved"
+            merged["resolved_at"] = observed_at
+            merged["updated_at"] = now
+            current[canonical_id] = merged
+            updated += 1
+        return updated
+
     def reconcile_current_absent(
         self,
         tenant_id: str,
@@ -1039,25 +1144,13 @@ class InMemoryComplianceHubStore:
         observed_at: str,
         scope_source: str | None = None,
     ) -> int:
-        now = _now_utc_iso()
-        updated = 0
         with self._lock:
-            current = self._current.setdefault(tenant_id, {})
-            for canonical_id, row in list(current.items()):
-                if str(row.get("status") or "") not in ("open", "reopened"):
-                    continue
-                if canonical_id in present_canonical_ids:
-                    continue
-                payload = row.get("payload") or {}
-                if scope_source is not None and str(payload.get("source") or "") != scope_source:
-                    continue
-                merged = dict(row)
-                merged["status"] = "resolved"
-                merged["resolved_at"] = observed_at
-                merged["updated_at"] = now
-                current[canonical_id] = merged
-                updated += 1
-        return updated
+            return self._reconcile_locked(
+                tenant_id,
+                present_canonical_ids=present_canonical_ids,
+                observed_at=observed_at,
+                scope_source=scope_source,
+            )
 
 
 # ─── SQLite backend ─────────────────────────────────────────────────────────
@@ -1497,13 +1590,21 @@ class SQLiteComplianceHubStore:
         with self._ingest_stats_lock:
             return self._next_ordinal_by_tenant[tenant_id]
 
-    def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
-        if not findings:
-            self._bootstrap_ingest_stats(tenant_id)
-            with self._ingest_stats_lock:
-                if tenant_id in self._finding_count_by_tenant:
-                    return self._finding_count_by_tenant[tenant_id]
-            return self.count(tenant_id)
+    def _invalidate_ingest_caches(self, tenant_id: str) -> None:
+        from agent_bom.api import hub_overview_cache
+        from agent_bom.api.findings_count_cache import invalidate_tenant
+
+        invalidate_tenant(tenant_id)
+        hub_overview_cache.invalidate_tenant(tenant_id)
+
+    def _ledger_insert_no_commit(self, tenant_id: str, findings: list[dict[str, Any]]) -> tuple[int, int, int]:
+        """Append the batch to the ledger WITHOUT committing.
+
+        Returns ``(new_rows, next_ord, num_rows)`` so the caller can commit (or
+        roll back) as part of a larger transaction and only then advance the
+        cached ordinal/total. The commit and the post-commit stat/cache updates
+        are the caller's responsibility (see ``add`` / ``ingest_batch_atomic``).
+        """
         now = _now_utc_iso()
         next_ord = self._next_ordinal(tenant_id)
         rows: list[tuple[Any, ...]] = []
@@ -1558,17 +1659,74 @@ class SQLiteComplianceHubStore:
             """,
             rows,
         )
-        self._conn.commit()
-        if rows:
-            from agent_bom.api import hub_overview_cache
-            from agent_bom.api.findings_count_cache import invalidate_tenant
+        return new_rows, next_ord, len(rows)
 
-            invalidate_tenant(tenant_id)
-            hub_overview_cache.invalidate_tenant(tenant_id)
+    def _commit_ledger_stats(self, tenant_id: str, next_ord: int, num_rows: int, new_rows: int) -> int:
+        """Advance the cached ordinal/total AFTER the ledger write committed."""
         with self._ingest_stats_lock:
-            self._next_ordinal_by_tenant[tenant_id] = next_ord + len(rows)
+            self._next_ordinal_by_tenant[tenant_id] = next_ord + num_rows
             self._finding_count_by_tenant[tenant_id] += new_rows
             return self._finding_count_by_tenant[tenant_id]
+
+    def add(self, tenant_id: str, findings: list[dict[str, Any]]) -> int:
+        if not findings:
+            self._bootstrap_ingest_stats(tenant_id)
+            with self._ingest_stats_lock:
+                if tenant_id in self._finding_count_by_tenant:
+                    return self._finding_count_by_tenant[tenant_id]
+            return self.count(tenant_id)
+        new_rows, next_ord, num_rows = self._ledger_insert_no_commit(tenant_id, findings)
+        self._conn.commit()
+        if num_rows:
+            self._invalidate_ingest_caches(tenant_id)
+        return self._commit_ledger_stats(tenant_id, next_ord, num_rows, new_rows)
+
+    def ingest_batch_atomic(
+        self,
+        tenant_id: str,
+        findings: list[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str,
+        reconcile_absent: bool,
+        present_canonical_ids: set[str],
+    ) -> tuple[int, int]:
+        """Ledger append + current upsert (+ reconcile) in ONE transaction.
+
+        ``add`` / ``upsert_current_batch`` / ``reconcile_current_absent`` each
+        committed independently, so a crash between the ledger commit and the
+        current-state upsert left ``tenant_total`` inflated while the findings
+        never appeared in any list. Threading all three writes through a single
+        ``with conn`` block (commit on success, rollback on failure) makes a
+        mid-batch failure roll BOTH back, mirroring the Postgres seam. The cached
+        ordinal/total is advanced only after the commit succeeds. Returns
+        ``(new_total, reconciled)``.
+        """
+        conn = self._conn
+        with conn:  # sqlite3 connection: commit on success, rollback on exception
+            if findings:
+                new_rows, next_ord, num_rows = self._ledger_insert_no_commit(tenant_id, findings)
+            else:
+                new_rows, next_ord, num_rows = 0, self._next_ordinal(tenant_id), 0
+            self._upsert_current_no_commit(
+                tenant_id,
+                findings,
+                observed_at=observed_at,
+                batch_id=batch_id,
+                source=source,
+            )
+            reconciled = 0
+            if reconcile_absent:
+                reconciled = self._reconcile_current_absent_no_commit(
+                    tenant_id,
+                    present_canonical_ids=present_canonical_ids,
+                    observed_at=observed_at,
+                    scope_source=source,
+                )
+        self._invalidate_ingest_caches(tenant_id)
+        new_total = self._commit_ledger_stats(tenant_id, next_ord, num_rows, new_rows)
+        return new_total, reconciled
 
     def list(self, tenant_id: str) -> list[dict[str, Any]]:
         rows = self._conn.execute(
@@ -1744,7 +1902,7 @@ class SQLiteComplianceHubStore:
             hub_overview_cache.invalidate_tenant(tenant_id)
         return removed
 
-    def upsert_current_batch(
+    def _upsert_current_no_commit(
         self,
         tenant_id: str,
         findings: Sequence[dict[str, Any]],
@@ -1767,6 +1925,23 @@ class SQLiteComplianceHubStore:
                 source=source,
                 has_ledger_col=has_ledger_col,
             )
+
+    def upsert_current_batch(
+        self,
+        tenant_id: str,
+        findings: Sequence[dict[str, Any]],
+        *,
+        observed_at: str,
+        batch_id: str,
+        source: str = "",
+    ) -> None:
+        self._upsert_current_no_commit(
+            tenant_id,
+            findings,
+            observed_at=observed_at,
+            batch_id=batch_id,
+            source=source,
+        )
         self._conn.commit()
 
     def get_current(self, tenant_id: str, canonical_id: str) -> dict[str, Any] | None:
@@ -1883,7 +2058,7 @@ class SQLiteComplianceHubStore:
             next_cursor = cursor_from_current_row(hydrated_rows[-1], sort=normalized_sort)
         return out, total, next_cursor
 
-    def reconcile_current_absent(
+    def _reconcile_current_absent_no_commit(
         self,
         tenant_id: str,
         *,
@@ -1919,6 +2094,22 @@ class SQLiteComplianceHubStore:
                 [observed_at, now, *params, *chunk],
             )
             total += int(cur.rowcount or 0)
+        return total
+
+    def reconcile_current_absent(
+        self,
+        tenant_id: str,
+        *,
+        present_canonical_ids: set[str],
+        observed_at: str,
+        scope_source: str | None = None,
+    ) -> int:
+        total = self._reconcile_current_absent_no_commit(
+            tenant_id,
+            present_canonical_ids=present_canonical_ids,
+            observed_at=observed_at,
+            scope_source=scope_source,
+        )
         self._conn.commit()
         return total
 

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -449,6 +449,10 @@ class ComplianceReportScope(BaseModel):
     control_count: int = 0
     finding_count: int = 0
     audit_event_count: int = 0
+    # True when the audit window held more entries than the export cap; the
+    # bundle then carries a partial (most-recent) set, not the full window.
+    audit_events_truncated: bool = False
+    audit_event_limit: int = 0
     completed_scan_count: int = 0
 
 
@@ -467,6 +471,8 @@ class ComplianceAuditIntegrity(BaseModel):
     verified: int = 0
     tampered: int = 0
     checked: int = 0
+    # True when the checked set is a truncated (partial) view of the window.
+    truncated: bool = False
 
 
 class ComplianceThreatModel(BaseModel):

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -56,6 +56,12 @@ def _dep(permission: str) -> Any:
 router = APIRouter(dependencies=[_dep("read")])
 _logger = logging.getLogger(__name__)
 
+# Cap on audit entries pulled into a single signed evidence bundle. When the
+# window holds more than this the bundle marks itself truncated (honest partial
+# evidence) rather than silently presenting the capped set as the complete
+# window; consumers paginate the full trail via /v1/audit.
+_AUDIT_EVIDENCE_FETCH_LIMIT = 10_000
+
 _CLUSTER_SCAN_SOURCES = {"gpu_infra", "k8s"}
 _CI_CD_SCAN_SOURCES = {"github_actions"}
 _REGISTRY_SCAN_SOURCES = {"external_scan", "image", "sbom"}
@@ -1364,8 +1370,13 @@ async def export_compliance_report(
 
     store = get_audit_log()
     audit_since_iso = since_dt.isoformat()
-    # Cap audit fetch at 10k for export sanity; consumers paginate further via /v1/audit
-    audit_entries = store.list_entries(since=audit_since_iso, limit=10_000, tenant_id=tenant_id)
+    # Cap audit fetch for export sanity; consumers paginate further via /v1/audit.
+    # ``list_entries`` returns most-recent-first, so hitting the cap drops the
+    # OLDEST in-window entries — the bundle must say so rather than present a
+    # partial window as complete.
+    audit_fetch_limit = _AUDIT_EVIDENCE_FETCH_LIMIT
+    audit_entries = store.list_entries(since=audit_since_iso, limit=audit_fetch_limit, tenant_id=tenant_id)
+    audit_truncated = len(audit_entries) >= audit_fetch_limit
     until_iso = until_dt.isoformat()
     audit_in_window = [e for e in audit_entries if audit_since_iso <= (e.timestamp or "") <= until_iso]
     verified, tampered = _verify_audit_entries(audit_in_window)
@@ -1416,6 +1427,8 @@ async def export_compliance_report(
             "control_count": len(controls),
             "finding_count": total_findings,
             "audit_event_count": len(audit_in_window),
+            "audit_events_truncated": audit_truncated,
+            "audit_event_limit": audit_fetch_limit,
             "completed_scan_count": completed_scan_count,
         },
         "summary": {
@@ -1432,6 +1445,7 @@ async def export_compliance_report(
             "verified": verified,
             "tampered": tampered,
             "checked": len(audit_in_window),
+            "truncated": audit_truncated,
         },
         "signature_algorithm": signing_algorithm,
         "threat_model": {
@@ -1575,7 +1589,11 @@ async def export_compliance_pack(
 
     store = get_audit_log()
     audit_since_iso = since_dt.isoformat()
-    audit_entries = store.list_entries(since=audit_since_iso, limit=10_000, tenant_id=tenant_id)
+    # Same honest-truncation contract as the single-framework report: a window
+    # deeper than the cap is marked truncated, never presented as complete.
+    audit_fetch_limit = _AUDIT_EVIDENCE_FETCH_LIMIT
+    audit_entries = store.list_entries(since=audit_since_iso, limit=audit_fetch_limit, tenant_id=tenant_id)
+    audit_truncated = len(audit_entries) >= audit_fetch_limit
     until_iso = until_dt.isoformat()
     audit_in_window = [e for e in audit_entries if audit_since_iso <= (e.timestamp or "") <= until_iso]
     verified, tampered = _verify_audit_entries(audit_in_window)
@@ -1636,6 +1654,8 @@ async def export_compliance_pack(
             "control_count": total_controls,
             "finding_count": total_findings,
             "audit_event_count": len(audit_in_window),
+            "audit_events_truncated": audit_truncated,
+            "audit_event_limit": audit_fetch_limit,
             "completed_scan_count": completed_scan_count,
         },
         "summary": {
@@ -1648,6 +1668,7 @@ async def export_compliance_pack(
             "verified": verified,
             "tampered": tampered,
             "checked": len(audit_in_window),
+            "truncated": audit_truncated,
         },
         "signature_algorithm": signing_algorithm,
     }

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import os
 import time
 import uuid
@@ -366,6 +367,66 @@ def _derive_bulk_finding_id(row: dict[str, Any], *, source: str) -> str:
     return canonical_finding_id(source, str(rule), str(location), str(package))
 
 
+def _coerce_bulk_severity(value: Any, *, ordinal: int) -> str:
+    """Validate/normalise a bulk finding's severity, failing closed on bad types.
+
+    A non-string severity (nested object, number, list) cannot be honestly
+    mapped to a severity bucket — accepting it materialised a row that leaked the
+    value verbatim and never matched the severity filter. Reject it with a 422.
+    A string severity is normalised to the canonical enum; an unrecognised label
+    maps to ``unknown`` explicitly (never leaked as-is).
+    """
+    if value is None:
+        return "unknown"
+    if not isinstance(value, str):
+        raise HTTPException(
+            status_code=422,
+            detail=f"finding {ordinal}: severity must be a string severity label, not {type(value).__name__}",
+        )
+    from agent_bom.graph.severity import normalize_severity
+
+    return normalize_severity(value)
+
+
+def _coerce_bulk_cvss(value: Any, *, ordinal: int) -> float | None:
+    """Validate/coerce a bulk finding's cvss_score to a 0.0-10.0 float or null.
+
+    A non-numeric string (``"NaNstring"``), a nested object, NaN/inf, or an
+    out-of-range number cannot be an honest CVSS base score — accepting it left a
+    value that never matched a cvss filter. Reject it with a 422. ``None`` /
+    absent is allowed (no score); a numeric string that parses cleanly in range
+    is coerced to float.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise HTTPException(
+            status_code=422,
+            detail=f"finding {ordinal}: cvss_score must be a number in 0.0-10.0 or null, not bool",
+        )
+    if isinstance(value, (int, float)):
+        score = float(value)
+    elif isinstance(value, str):
+        try:
+            score = float(value)
+        except ValueError:
+            raise HTTPException(
+                status_code=422,
+                detail=f"finding {ordinal}: cvss_score {value!r} is not a number in 0.0-10.0",
+            ) from None
+    else:
+        raise HTTPException(
+            status_code=422,
+            detail=f"finding {ordinal}: cvss_score must be a number in 0.0-10.0 or null, not {type(value).__name__}",
+        )
+    if not math.isfinite(score) or not (0.0 <= score <= 10.0):
+        raise HTTPException(
+            status_code=422,
+            detail=f"finding {ordinal}: cvss_score must be a finite number within 0.0-10.0",
+        )
+    return score
+
+
 def _normalized_bulk_finding(row: dict[str, Any], *, source: str, batch_id: str, ordinal: int) -> dict[str, Any]:
     payload = dict(row)
     client_id = row.get("id")
@@ -373,7 +434,14 @@ def _normalized_bulk_finding(row: dict[str, Any], *, source: str, batch_id: str,
     # resends collapse (idempotent) rather than mint a fresh batch_id:ordinal.
     payload["id"] = str(client_id) if client_id else _derive_bulk_finding_id(row, source=source)
     payload.setdefault("source", source)
-    payload.setdefault("severity", "unknown")
+    # Fail closed on garbage severity/cvss types instead of materialising a row
+    # that leaks the value verbatim and never matches the severity/cvss filter.
+    payload["severity"] = _coerce_bulk_severity(row.get("severity"), ordinal=ordinal)
+    cvss = _coerce_bulk_cvss(row.get("cvss_score"), ordinal=ordinal)
+    if cvss is None:
+        payload.pop("cvss_score", None)
+    else:
+        payload["cvss_score"] = cvss
     payload["origin"] = "bulk_ingest"
     payload["batch_id"] = batch_id
     payload["bulk_ordinal"] = ordinal

--- a/tests/test_bulk_finding_validation.py
+++ b/tests/test_bulk_finding_validation.py
@@ -1,0 +1,121 @@
+"""Type validation for /v1/findings/bulk (wave-2 #2).
+
+Bulk ingest used to accept garbage ``severity`` / ``cvss_score`` types with a
+201 and materialise rows that leak the value verbatim and can never match the
+severity/cvss filters. These tests pin the fail-closed contract: a non-string
+severity or a non-numeric / out-of-range cvss_score is rejected with 422, an
+unknown severity STRING is mapped to ``unknown`` explicitly, and the valid path
+still 201s and stores canonical values.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import reset_compliance_hub_store
+from agent_bom.api.server import app
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+
+
+def setup_function() -> None:
+    reset_compliance_hub_store()
+
+
+def teardown_function() -> None:
+    reset_compliance_hub_store()
+
+
+def _client(tenant: str) -> TestClient:
+    client = TestClient(app)
+    client.headers.update(proxy_headers(role="analyst", tenant=tenant))
+    return client
+
+
+def _post(client: TestClient, finding: dict) -> object:
+    return client.post(
+        "/v1/findings/bulk",
+        json={"source": "connector", "findings": [finding]},
+    )
+
+
+def test_nested_severity_rejected_422():
+    client = _client(f"bulk-val-{uuid4().hex}")
+    resp = _post(client, {"id": "f-1", "severity": {"nested": True}})
+    assert resp.status_code == 422, resp.text
+    assert "severity" in resp.text.lower()
+
+
+def test_numeric_severity_rejected_422():
+    client = _client(f"bulk-val-{uuid4().hex}")
+    resp = _post(client, {"id": "f-1", "severity": 5})
+    assert resp.status_code == 422, resp.text
+
+
+def test_non_numeric_cvss_string_rejected_422():
+    client = _client(f"bulk-val-{uuid4().hex}")
+    resp = _post(client, {"id": "f-1", "severity": "high", "cvss_score": "NaNstring"})
+    assert resp.status_code == 422, resp.text
+    assert "cvss" in resp.text.lower()
+
+
+def test_out_of_range_cvss_rejected_422():
+    client = _client(f"bulk-val-{uuid4().hex}")
+    resp = _post(client, {"id": "f-1", "severity": "high", "cvss_score": 42})
+    assert resp.status_code == 422, resp.text
+
+
+def test_nan_cvss_rejected_422():
+    client = _client(f"bulk-val-{uuid4().hex}")
+    resp = _post(client, {"id": "f-1", "severity": "high", "cvss_score": "NaN"})
+    assert resp.status_code == 422, resp.text
+
+
+def test_dict_cvss_rejected_422():
+    client = _client(f"bulk-val-{uuid4().hex}")
+    resp = _post(client, {"id": "f-1", "severity": "high", "cvss_score": {"score": 7.0}})
+    assert resp.status_code == 422, resp.text
+
+
+def test_unknown_severity_string_mapped_to_unknown():
+    tenant = f"bulk-val-{uuid4().hex}"
+    client = _client(tenant)
+    resp = _post(client, {"id": "f-1", "severity": "totally-bogus"})
+    assert resp.status_code == 201, resp.text
+    # The stored row must be filterable as unknown, never leaking the raw label.
+    listed = client.get("/v1/findings?severity=unknown&window_days=0")
+    assert listed.status_code == 200, listed.text
+    ids = {f.get("id") for f in listed.json().get("findings", [])}
+    assert "f-1" in ids
+
+
+def test_valid_severity_and_cvss_still_201_and_stored():
+    tenant = f"bulk-val-{uuid4().hex}"
+    client = _client(tenant)
+    resp = client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "connector",
+            "findings": [
+                {"id": "f-crit", "severity": "critical", "cvss_score": 9.8},
+                {"id": "f-num-str", "severity": "high", "cvss_score": "7.5"},
+                {"id": "f-null", "severity": "low", "cvss_score": None},
+            ],
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["ingested"] == 3
+
+    listed = client.get("/v1/findings?severity=critical&window_days=0")
+    assert listed.status_code == 200, listed.text
+    ids = {f.get("id") for f in listed.json().get("findings", [])}
+    assert "f-crit" in ids

--- a/tests/test_compliance_report_truncation.py
+++ b/tests/test_compliance_report_truncation.py
@@ -1,0 +1,104 @@
+"""Honest truncation marking for the signed compliance evidence bundle (#3).
+
+The bundle fetches audit evidence with a hard cap (``list_entries(limit=...)``)
+and reported ``audit_event_count`` / integrity ``checked`` over the capped set
+with NO ``truncated`` marker — a window with more events than the cap presented
+partial evidence as the complete window inside a *signed* artifact.
+
+These tests pin the fix: when the audit fetch hits the cap the signed bundle
+carries ``audit_events_truncated: true`` + the cap; under the cap it is false.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from fastapi.responses import JSONResponse
+
+from agent_bom.api.audit_log import AuditEntry, InMemoryAuditLog, set_audit_log
+from agent_bom.api.routes import compliance as compliance_routes
+
+
+def setup_module() -> None:
+    from tests.auth_helpers import enable_trusted_proxy_env
+
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    from tests.auth_helpers import disable_trusted_proxy_env
+
+    disable_trusted_proxy_env()
+
+
+def _request(tenant_id: str, actor: str = "ci-bot") -> SimpleNamespace:
+    return SimpleNamespace(state=SimpleNamespace(tenant_id=tenant_id, api_key_name=actor))
+
+
+def _seed_audit(tenant_id: str, count: int) -> InMemoryAuditLog:
+    audit = InMemoryAuditLog()
+    now = datetime.now(timezone.utc)
+    for idx in range(count):
+        audit.append(
+            AuditEntry(
+                entry_id=f"e{idx}",
+                timestamp=(now - timedelta(minutes=count - idx)).isoformat(),
+                action="scan.started",
+                actor="ci-bot",
+                resource=f"scan/{idx}",
+                details={"tenant_id": tenant_id},
+            )
+        )
+    set_audit_log(audit)
+    return audit
+
+
+_FULL = {
+    "owasp_llm_top10": [
+        {"control_id": "LLM01", "name": "Prompt Injection", "status": "pass", "tags": ["LLM01"]},
+    ]
+}
+
+
+def _run_export(tenant: str) -> dict:
+    req = _request(tenant)
+    with patch.object(compliance_routes, "_tenant_jobs", return_value=[]):
+        with patch.object(compliance_routes, "get_compliance", return_value=_FULL):
+            resp = asyncio.run(compliance_routes.export_compliance_report(req, "owasp-llm"))
+    assert isinstance(resp, JSONResponse)
+    return json.loads(resp.body)
+
+
+def test_bundle_marks_truncated_when_audit_fetch_hits_cap(monkeypatch):
+    tenant = "tenant-trunc"
+    _seed_audit(tenant, count=5)
+    monkeypatch.setattr(compliance_routes, "_AUDIT_EVIDENCE_FETCH_LIMIT", 3)
+
+    body = _run_export(tenant)
+
+    scope = body["scope"]
+    assert scope["audit_events_truncated"] is True
+    assert scope["audit_event_limit"] == 3
+    # Honest: the reported count never claims to be the complete window.
+    assert scope["audit_event_count"] == 3
+    assert body["audit_log_integrity"]["truncated"] is True
+
+    # The truncation flag is inside the SIGNED canonical body.
+    assert '"audit_events_truncated": true' in json.dumps(body, sort_keys=True)
+
+
+def test_bundle_not_truncated_under_cap(monkeypatch):
+    tenant = "tenant-untrunc"
+    _seed_audit(tenant, count=2)
+    monkeypatch.setattr(compliance_routes, "_AUDIT_EVIDENCE_FETCH_LIMIT", 10)
+
+    body = _run_export(tenant)
+
+    scope = body["scope"]
+    assert scope["audit_events_truncated"] is False
+    assert scope["audit_event_count"] == 2
+    assert body["audit_log_integrity"]["truncated"] is False

--- a/tests/test_hub_ingest_atomic_local.py
+++ b/tests/test_hub_ingest_atomic_local.py
@@ -1,0 +1,220 @@
+"""Batch-ingest atomicity for the SQLite + in-memory hub stores (wave-2 #1).
+
+The Postgres backend already commits ledger append + current upsert (+ reconcile)
+in ONE transaction (``ingest_batch_atomic``). The SQLite and in-memory backends
+previously exposed only ``add`` / ``upsert_current_batch`` /
+``reconcile_current_absent`` — three separately-committed writes. A failure
+between the ledger commit and the current-state upsert left ``tenant_total``
+inflated while the findings never appeared in any list.
+
+These tests pin the fix on the non-Postgres backends: a mid-batch failure rolls
+back the ledger too (no inflated count, no partial current-state); the happy
+path commits both; an idempotent resend stays exact; and reconcile runs inside
+the same transaction.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agent_bom.api.compliance_hub_store import (
+    InMemoryComplianceHubStore,
+    SQLiteComplianceHubStore,
+)
+
+
+def _payload(idx: int, *, severity: str = "high", source: str = "connector") -> dict[str, Any]:
+    return {
+        "id": f"f-{idx}",
+        "canonical_id": f"c-{idx}",
+        "severity": severity,
+        "source": source,
+        "cvss_score": 7.5,
+    }
+
+
+def _sqlite_store(tmp_path) -> SQLiteComplianceHubStore:
+    return SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+
+
+# ── SQLite: single-transaction atomicity ─────────────────────────────────────
+
+
+def test_sqlite_atomic_rolls_back_ledger_when_upsert_fails(tmp_path):
+    store = _sqlite_store(tmp_path)
+    tenant = "atomic-sqlite"
+
+    def _explode(*_a: Any, **_k: Any) -> None:
+        raise RuntimeError("injected upsert failure")
+
+    store._upsert_current_no_commit = _explode  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        store.ingest_batch_atomic(
+            tenant,
+            [_payload(1), _payload(2)],
+            observed_at="2026-07-18T00:00:00Z",
+            batch_id="batch-1",
+            source="connector",
+            reconcile_absent=False,
+            present_canonical_ids=set(),
+        )
+
+    # Ledger append rolled back with the failed upsert: no inflated count.
+    assert store.count(tenant) == 0
+    assert store.list_current_page(tenant, limit=50)[0] == []
+
+
+def test_sqlite_atomic_rolls_back_when_reconcile_fails(tmp_path):
+    store = _sqlite_store(tmp_path)
+    tenant = "atomic-sqlite-recon"
+
+    def _explode(*_a: Any, **_k: Any) -> int:
+        raise RuntimeError("injected reconcile failure")
+
+    store._reconcile_current_absent_no_commit = _explode  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        store.ingest_batch_atomic(
+            tenant,
+            [_payload(1), _payload(2)],
+            observed_at="2026-07-18T00:00:00Z",
+            batch_id="batch-1",
+            source="connector",
+            reconcile_absent=True,
+            present_canonical_ids={"c-1", "c-2"},
+        )
+
+    assert store.count(tenant) == 0
+    assert store.list_current_page(tenant, limit=50)[0] == []
+
+
+def test_sqlite_atomic_happy_path_commits_both_and_is_idempotent(tmp_path):
+    store = _sqlite_store(tmp_path)
+    tenant = "atomic-sqlite-ok"
+    payloads = [_payload(1), _payload(2), _payload(3)]
+
+    total, reconciled = store.ingest_batch_atomic(
+        tenant,
+        payloads,
+        observed_at="2026-07-18T00:00:00Z",
+        batch_id="batch-1",
+        source="connector",
+        reconcile_absent=False,
+        present_canonical_ids=set(),
+    )
+    assert total == 3
+    assert reconciled == 0
+    assert store.count(tenant) == 3
+    current, current_total, _ = store.list_current_page(tenant, limit=50)
+    assert len(current) == 3
+    assert current_total == 3
+
+    # Idempotent resend: no new ledger or current rows.
+    total2, _ = store.ingest_batch_atomic(
+        tenant,
+        payloads,
+        observed_at="2026-07-18T00:00:00Z",
+        batch_id="batch-1",
+        source="connector",
+        reconcile_absent=False,
+        present_canonical_ids=set(),
+    )
+    assert total2 == 3
+    assert store.count(tenant) == 3
+    assert store.list_current_page(tenant, limit=50)[1] == 3
+
+
+def test_sqlite_atomic_reconcile_resolves_absent_in_same_txn(tmp_path):
+    store = _sqlite_store(tmp_path)
+    tenant = "atomic-sqlite-reconcile"
+
+    store.ingest_batch_atomic(
+        tenant,
+        [_payload(1), _payload(2), _payload(3)],
+        observed_at="2026-07-18T00:00:00Z",
+        batch_id="batch-1",
+        source="connector",
+        reconcile_absent=False,
+        present_canonical_ids=set(),
+    )
+
+    # The store keys current-state on the resolved canonical id (the finding id
+    # here). Second batch is present only for the first two; reconcile_absent
+    # must resolve the third — in the SAME transaction as the ledger/current
+    # writes.
+    _total, reconciled = store.ingest_batch_atomic(
+        tenant,
+        [_payload(1), _payload(2)],
+        observed_at="2026-07-18T01:00:00Z",
+        batch_id="batch-2",
+        source="connector",
+        reconcile_absent=True,
+        present_canonical_ids={"f-1", "f-2"},
+    )
+    assert reconciled == 1
+    open_rows, _total2, _ = store.list_current_page(tenant, limit=50)
+    statuses = {str(r.get("canonical_id") or r.get("id")): r.get("status") for r in open_rows}
+    assert statuses.get("f-3") == "resolved"
+
+
+# ── In-memory: rollback under a single lock acquisition ──────────────────────
+
+
+def test_inmemory_atomic_rolls_back_when_reconcile_fails():
+    store = InMemoryComplianceHubStore()
+    tenant = "atomic-mem"
+
+    def _explode(*_a: Any, **_k: Any) -> int:
+        raise RuntimeError("injected reconcile failure")
+
+    store._reconcile_locked = _explode  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError):
+        store.ingest_batch_atomic(
+            tenant,
+            [_payload(1), _payload(2)],
+            observed_at="2026-07-18T00:00:00Z",
+            batch_id="batch-1",
+            source="connector",
+            reconcile_absent=True,
+            present_canonical_ids={"c-1", "c-2"},
+        )
+
+    # Ledger + current-state restored: nothing partially applied.
+    assert store.count(tenant) == 0
+    assert store.list_current_page(tenant, limit=50)[0] == []
+
+
+def test_inmemory_atomic_happy_path_commits_both_and_is_idempotent():
+    store = InMemoryComplianceHubStore()
+    tenant = "atomic-mem-ok"
+    payloads = [_payload(1), _payload(2), _payload(3)]
+
+    total, reconciled = store.ingest_batch_atomic(
+        tenant,
+        payloads,
+        observed_at="2026-07-18T00:00:00Z",
+        batch_id="batch-1",
+        source="connector",
+        reconcile_absent=False,
+        present_canonical_ids=set(),
+    )
+    assert total == 3
+    assert reconciled == 0
+    assert store.count(tenant) == 3
+    assert store.list_current_page(tenant, limit=50)[1] == 3
+
+    total2, _ = store.ingest_batch_atomic(
+        tenant,
+        payloads,
+        observed_at="2026-07-18T00:00:00Z",
+        batch_id="batch-1",
+        source="connector",
+        reconcile_absent=False,
+        present_canonical_ids=set(),
+    )
+    assert total2 == 3
+    assert store.count(tenant) == 3


### PR DESCRIPTION
Three write-path/ingest honesty defects.

## 1. SQLite/in-memory bulk ingest was non-atomic (P2)
Ledger append, current-state upsert, and reconcile committed as three separate transactions on the local backends (the atomic seam existed only on Postgres). A crash between the ledger commit and the current-state upsert left `tenant_total` inflated while the findings never appeared in any list.

**Fix:** implemented `ingest_batch_atomic` for `SQLiteComplianceHubStore` (single transaction, rollback on failure, cached ordinal/total advance only post-commit) and `InMemoryComplianceHubStore` (single lock, snapshot-restore on failure), matching the Postgres seam's `(new_total, reconciled)` contract. `hub_ingest.py` already prefers the atomic path, so all backends now use it.

## 2. Bulk ingest accepted garbage field types with 201 (P3)
`_normalized_bulk_finding` did no type validation, so `{"cvss_score": "NaNstring"}` or `{"severity": {"nested": true}}` returned 201 and materialised rows that leaked the value verbatim and could never match the severity/cvss filter.

**Fix:** severity must be a string (normalised to the canonical enum; unknown labels → `unknown` explicitly), cvss_score must be a finite number in 0.0–10.0 or null — otherwise a clear 422. Fails closed instead of storing a misleading row.

## 3. Signed compliance evidence bundle silently truncated at 10k (P3)
The audit-evidence fetch capped at 10,000 entries, then reported counts over the capped set with no marker — presenting partial evidence as the window's complete record.

**Fix:** when the fetch hits the cap, the signed body now carries `scope.audit_events_truncated` + `scope.audit_event_limit` and `audit_log_integrity.truncated`. Fixed the sibling `/compliance/report/pack` route too; the signature covers the flag.

## How verified
TDD red→green per defect (16 new tests incl. rollback-on-failure for both local backends, 422s for each bad type, truncation-marked vs not). Consolidated regression `75 passed, 7 skipped` (Postgres-only skips); broader bulk-route `181 passed`. OpenAPI regenerated; artifact + client-parity guards pass. `ruff`/`mypy` clean.