### PR TITLE
chore(typing): bring oidc + fleet store and 3 api modules under strict generics

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,6 +445,26 @@ disallow_incomplete_defs = true
 warn_return_any = true
 warn_unused_ignores = true
 
+# Phase 2 (#1969): api/ modules brought under the STRICTER profile that also
+# forbids implicit ``Any`` generics (``dict``/``list`` without parameters).
+# Kept as a separate override block from the one above because that block does
+# NOT set ``disallow_any_generics``; the strict findings-list/models work in the
+# sibling PR uses the same ``disallow_any_generics`` set, so when both land these
+# two blocks merge cleanly (union the module lists, drop this comment).
+[[tool.mypy.overrides]]
+module = [
+    "agent_bom.api.oidc",
+    "agent_bom.api.postgres_fleet_store",
+    "agent_bom.api.finding_list_envelope",
+    "agent_bom.api.time_window",
+    "agent_bom.api.cost_owner",
+]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_any_generics = true
+warn_return_any = true
+warn_unused_ignores = true
+
 [tool.ruff]
 line-length = 140  # Relaxed from 120 for CLI help strings
 target-version = "py311"

--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -43,7 +43,7 @@ import logging
 import os
 import threading
 import time
-from typing import Optional
+from typing import Any, Optional, cast
 from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -64,10 +64,10 @@ class _JwksCache:
     """Thread-safe cache for OIDC JWKS (JSON Web Key Sets)."""
 
     def __init__(self) -> None:
-        self._cache: dict[str, tuple[dict, float]] = {}  # url → (jwks, fetched_at)
+        self._cache: dict[str, tuple[dict[str, Any], float]] = {}  # url → (jwks, fetched_at)
         self._lock = threading.Lock()
 
-    def get(self, jwks_uri: str) -> dict:
+    def get(self, jwks_uri: str) -> dict[str, Any]:
         """Return cached JWKS or fetch fresh copy if stale/absent."""
         with self._lock:
             entry = self._cache.get(jwks_uri)
@@ -133,7 +133,7 @@ def _validate_tenant_claim_value(value: object) -> str:
 # ── Discovery ──────────────────────────────────────────────────────────────────
 
 
-def _fetch_json(url: str) -> dict:
+def _fetch_json(url: str) -> dict[str, Any]:
     # Defense-in-depth: validate even operator-supplied URLs to block SSRF
     # via misconfigured AGENT_BOM_OIDC_ISSUER pointing at internal services.
     from agent_bom.security import validate_url
@@ -141,12 +141,14 @@ def _fetch_json(url: str) -> dict:
     validate_url(url)
     try:
         with urlopen(url, timeout=_OIDC_TIMEOUT) as resp:  # noqa: S310  # nosec B310 — validated above
-            return json.loads(resp.read())
+            # json.loads is typed to return Any; OIDC discovery/JWKS endpoints
+            # always return a JSON object, so narrow to the documented shape.
+            return cast("dict[str, Any]", json.loads(resp.read()))
     except (URLError, OSError, json.JSONDecodeError) as exc:
         raise OIDCError(f"Failed to fetch {url}: {exc}") from exc
 
 
-def discover_oidc(issuer: str) -> dict:
+def discover_oidc(issuer: str) -> dict[str, Any]:
     """Fetch the OIDC discovery document for ``issuer``.
 
     Args:
@@ -220,7 +222,7 @@ def verify_oidc_token(
     jwks_uri: Optional[str] = None,
     required_nonce: Optional[str] = None,
     allowed_jwks_uris: tuple[str, ...] = (),
-) -> dict:
+) -> dict[str, Any]:
     """Verify an OIDC JWT and return its claims.
 
     Fetches the issuer's JWKS (cached for 1 hour) and verifies the token
@@ -263,7 +265,7 @@ def verify_oidc_token(
     except Exception as exc:
         raise OIDCError(f"Failed to resolve signing key: {exc}") from exc
 
-    decode_kwargs: dict = {
+    decode_kwargs: dict[str, Any] = {
         "algorithms": list(OIDC_ALLOWED_ALGORITHMS),
         "issuer": issuer,
         "options": {"require": ["exp", "iat", "iss"]},
@@ -304,7 +306,7 @@ def verify_oidc_token(
 # ── Role mapping ───────────────────────────────────────────────────────────────
 
 
-def claims_to_role(claims: dict, role_claim: str = "agent_bom_role") -> str:
+def claims_to_role(claims: dict[str, Any], role_claim: str = "agent_bom_role") -> str:
     """Map OIDC JWT claims to an agent-bom role string.
 
     Checks ``role_claim`` in the JWT, then falls back to ``roles`` and
@@ -342,7 +344,7 @@ def claims_to_role(claims: dict, role_claim: str = "agent_bom_role") -> str:
     return "viewer"
 
 
-def claims_have_role_signal(claims: dict, role_claim: str = "agent_bom_role") -> bool:
+def claims_have_role_signal(claims: dict[str, Any], role_claim: str = "agent_bom_role") -> bool:
     """Return True when claims include an explicit recognizable role signal."""
     admin_values = {"admin", "administrator", "superuser"}
     analyst_values = {"analyst", "security-analyst", "engineer", "developer"}
@@ -361,7 +363,7 @@ def claims_have_role_signal(claims: dict, role_claim: str = "agent_bom_role") ->
     return False
 
 
-def claims_to_tenant(claims: dict, tenant_claim: str = "tenant_id") -> str | None:
+def claims_to_tenant(claims: dict[str, Any], tenant_claim: str = "tenant_id") -> str | None:
     """Map OIDC JWT claims to a tenant identifier."""
     tenant_val = claims.get(tenant_claim)
     if tenant_val not in (None, ""):
@@ -375,7 +377,7 @@ def claims_to_tenant(claims: dict, tenant_claim: str = "tenant_id") -> str | Non
     return None
 
 
-def _decode_unverified_claims(token: str) -> dict:
+def _decode_unverified_claims(token: str) -> dict[str, Any]:
     """Read JWT claims without verifying the signature so issuer routing can occur."""
     parts = token.split(".")
     if len(parts) != 3:
@@ -497,7 +499,7 @@ class OIDCConfig:
             raise OIDCError("JWT missing issuer claim required for tenant-bound OIDC")
         return self._provider_for_issuer(issuer)
 
-    def _provider_for_claims(self, claims: dict) -> OIDCConfig:
+    def _provider_for_claims(self, claims: dict[str, Any]) -> OIDCConfig:
         if not self.tenant_providers:
             return self
         issuer = str(claims.get("iss") or "").strip()
@@ -505,7 +507,7 @@ class OIDCConfig:
             raise OIDCError("JWT missing issuer claim required for tenant-bound OIDC")
         return self._provider_for_issuer(issuer)
 
-    def _validate_bound_tenant(self, claims: dict) -> None:
+    def _validate_bound_tenant(self, claims: dict[str, Any]) -> None:
         if self.tenant_id is None:
             return
         tenant_id = claims_to_tenant(claims, self.tenant_claim)
@@ -518,7 +520,7 @@ class OIDCConfig:
         if self.require_tenant_claim:
             raise OIDCError(f"JWT missing required tenant claim '{self.tenant_claim}'")
 
-    def verify(self, token: str) -> tuple[dict, str]:
+    def verify(self, token: str) -> tuple[dict[str, Any], str]:
         """Verify a JWT and return ``(claims, role)``.
 
         Raises:
@@ -543,7 +545,7 @@ class OIDCConfig:
         role = claims_to_role(claims, provider.role_claim)
         return claims, role
 
-    def resolve_tenant(self, claims: dict) -> str:
+    def resolve_tenant(self, claims: dict[str, Any]) -> str:
         """Resolve tenant context from claims or fail closed when required."""
         provider = self._provider_for_claims(claims)
         tenant_id = claims_to_tenant(claims, provider.tenant_claim)

--- a/src/agent_bom/api/postgres_fleet_store.py
+++ b/src/agent_bom/api/postgres_fleet_store.py
@@ -9,18 +9,25 @@ Requires ``pip install 'agent-bom[postgres]'``.
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING, Any
 
 from agent_bom.api.postgres_common import (
+    ConnectionPool,
     _ensure_tenant_rls,
     _get_pool,
     _tenant_connection,
 )
 
+if TYPE_CHECKING:
+    # Imported lazily at runtime (inside methods) to avoid a circular import
+    # with fleet_store; TYPE_CHECKING keeps the annotations resolvable.
+    from .fleet_store import FleetAgent, FleetLifecycleState
+
 
 class PostgresFleetStore:
     """PostgreSQL-backed fleet agent persistence."""
 
-    def __init__(self, pool=None) -> None:
+    def __init__(self, pool: ConnectionPool | None = None) -> None:
         self._pool = pool or _get_pool()
         self._init_tables()
 
@@ -58,7 +65,7 @@ class PostgresFleetStore:
             _ensure_tenant_rls(conn, "fleet_agents", "tenant_id")
             conn.commit()
 
-    def put(self, agent) -> None:
+    def put(self, agent: FleetAgent) -> None:
         data = agent.model_dump_json()
         with _tenant_connection(self._pool) as conn:
             conn.execute(
@@ -85,7 +92,7 @@ class PostgresFleetStore:
             )
             conn.commit()
 
-    def get(self, agent_id: str, *, tenant_id: str):
+    def get(self, agent_id: str, *, tenant_id: str) -> FleetAgent | None:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
@@ -98,7 +105,7 @@ class PostgresFleetStore:
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return FleetAgent.model_validate_json(raw)
 
-    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None):
+    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None) -> FleetAgent | None:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
@@ -114,7 +121,7 @@ class PostgresFleetStore:
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return FleetAgent.model_validate_json(raw)
 
-    def get_by_name(self, name: str):
+    def get_by_name(self, name: str) -> FleetAgent | None:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
@@ -131,23 +138,23 @@ class PostgresFleetStore:
                 (agent_id, tenant_id),
             )
             conn.commit()
-            return cursor.rowcount > 0
+            return bool(cursor.rowcount > 0)
 
-    def list_all(self) -> list:
+    def list_all(self) -> list[FleetAgent]:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT data FROM fleet_agents ORDER BY name").fetchall()
             return [FleetAgent.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
-    def list_summary(self) -> list[dict]:
+    def list_summary(self) -> list[dict[str, Any]]:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT agent_id, canonical_id, name, lifecycle_state, trust_score FROM fleet_agents ORDER BY name"
             ).fetchall()
             return [{"agent_id": r[0], "canonical_id": r[1], "name": r[2], "lifecycle_state": r[3], "trust_score": r[4]} for r in rows]
 
-    def list_by_tenant(self, tenant_id: str) -> list:
+    def list_by_tenant(self, tenant_id: str) -> list[FleetAgent]:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
@@ -165,7 +172,7 @@ class PostgresFleetStore:
         include_quarantined: bool = False,
         limit: int = 50,
         offset: int = 0,
-    ) -> tuple[list, int]:
+    ) -> tuple[list[FleetAgent], int]:
         from .fleet_store import FleetAgent
 
         clauses = ["tenant_id = %s"]
@@ -210,12 +217,12 @@ class PostgresFleetStore:
             agents = [FleetAgent.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
             return agents, int(total_row[0] if total_row else 0)
 
-    def list_tenants(self) -> list[dict]:
+    def list_tenants(self) -> list[dict[str, Any]]:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT tenant_id, COUNT(*) as cnt FROM fleet_agents GROUP BY tenant_id ORDER BY tenant_id").fetchall()
             return [{"tenant_id": r[0], "agent_count": r[1]} for r in rows]
 
-    def update_state(self, agent_id: str, state) -> bool:
+    def update_state(self, agent_id: str, state: FleetLifecycleState) -> bool:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(
                 "UPDATE fleet_agents SET lifecycle_state = %s WHERE agent_id = %s",
@@ -233,9 +240,9 @@ class PostgresFleetStore:
                         (json.dumps(data), agent_id),
                     )
             conn.commit()
-            return cursor.rowcount > 0
+            return bool(cursor.rowcount > 0)
 
-    def batch_put(self, agents: list) -> int:
+    def batch_put(self, agents: list[FleetAgent]) -> int:
         count = 0
         for agent in agents:
             self.put(agent)


### PR DESCRIPTION
Part of #1969 — second slice of the "phase in stricter mypy for api/ and models.py" tracker.

## What
Five `api/` modules brought under a per-module `disallow_any_generics` (+ strict-defs) override:
- `api/oidc.py` — 15 fixes: bare `dict` JWT-claims/discovery annotations → `dict[str, Any]`; `json.loads` result narrowed with a documented `cast`.
- `api/postgres_fleet_store.py` — 14 fixes: untyped store methods annotated with real `FleetAgent`/`FleetLifecycleState`/`ConnectionPool` types (via `TYPE_CHECKING` to avoid the circular import), bare `list`/`dict` returns parameterized, `rowcount > 0` wrapped in `bool()`.
- `api/finding_list_envelope.py`, `api/time_window.py`, `api/cost_owner.py` — already clean under the stricter profile; locked in against regression.

~29 bare generics parameterized. No `type: ignore` added/removed (none present); the remaining `Any` are legitimate JSON/claims payloads, now inside parameterized generics. A separate override block (not a global flip); it unions cleanly with the sibling models/findings block (#4195) when both land.

## Scope honesty
This does **not** close #1969. 104 of 173 api modules are now in the strict block; ~65 remain (the `routes/*` handler tail, `server.py`, `middleware.py`, several stores) — the api/ phase stays open for further module-by-module slices.

## How verified
Strict mypy on the 5 modules: clean. Repo-wide CI mypy: `Success: no issues found in 768 source files`. `ruff` clean; `test_api_oidc.py` 59 passed, touched suites 191 passed. Behavior-preserving.

Closes #4207.
