### PR TITLE
feat(mitre): typed ATT&CK/ATLAS technique mappings on multi-hop attack paths

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -17959,6 +17959,66 @@
                               "relationships"
                             ],
                             "type": "object"
+                          },
+                          "mitre_technique_ids": {
+                            "description": "Deduped technique IDs mapped across the path's hops (convenience projection).",
+                            "items": {
+                              "type": "string"
+                            },
+                            "type": "array"
+                          },
+                          "technique_mappings": {
+                            "items": {
+                              "additionalProperties": false,
+                              "description": "A typed MITRE ATT&CK / ATLAS technique mapped to one hop of the attack path, derived from the path's observed graph evidence (edge relationship + node type). These are potential/mapped techniques for the kill-chain sequence, NOT a claim of detected attacker activity. Technique and tactic IDs resolve against the bundled catalog.",
+                              "properties": {
+                                "catalog": {
+                                  "enum": [
+                                    "attack",
+                                    "atlas"
+                                  ],
+                                  "type": "string"
+                                },
+                                "confidence": {
+                                  "maximum": 1.0,
+                                  "minimum": 0.0,
+                                  "type": "number"
+                                },
+                                "hop_index": {
+                                  "description": "0-based position in the kill-chain edge sequence.",
+                                  "minimum": 0,
+                                  "type": "integer"
+                                },
+                                "provenance": {
+                                  "description": "The observed edge evidence that produced the mapping.",
+                                  "type": "string"
+                                },
+                                "tactics": {
+                                  "description": "Catalog-resolved tactic phase names / IDs.",
+                                  "items": {
+                                    "type": "string"
+                                  },
+                                  "type": "array"
+                                },
+                                "technique_id": {
+                                  "description": "ATT&CK (e.g. T1078) or ATLAS (e.g. AML.T0053) technique ID.",
+                                  "type": "string"
+                                },
+                                "technique_name": {
+                                  "type": "string"
+                                }
+                              },
+                              "required": [
+                                "hop_index",
+                                "technique_id",
+                                "catalog",
+                                "tactics",
+                                "provenance",
+                                "confidence"
+                              ],
+                              "type": "object"
+                            },
+                            "type": "array"
                           }
                         },
                         "type": "object"

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -11721,6 +11721,62 @@ paths:
                           - hops
                           - relationships
                           type: object
+                        mitre_technique_ids:
+                          description: Deduped technique IDs mapped across the path's
+                            hops (convenience projection).
+                          items:
+                            type: string
+                          type: array
+                        technique_mappings:
+                          items:
+                            additionalProperties: false
+                            description: A typed MITRE ATT&CK / ATLAS technique mapped
+                              to one hop of the attack path, derived from the path's
+                              observed graph evidence (edge relationship + node type).
+                              These are potential/mapped techniques for the kill-chain
+                              sequence, NOT a claim of detected attacker activity.
+                              Technique and tactic IDs resolve against the bundled
+                              catalog.
+                            properties:
+                              catalog:
+                                enum:
+                                - attack
+                                - atlas
+                                type: string
+                              confidence:
+                                maximum: 1.0
+                                minimum: 0.0
+                                type: number
+                              hop_index:
+                                description: 0-based position in the kill-chain edge
+                                  sequence.
+                                minimum: 0
+                                type: integer
+                              provenance:
+                                description: The observed edge evidence that produced
+                                  the mapping.
+                                type: string
+                              tactics:
+                                description: Catalog-resolved tactic phase names /
+                                  IDs.
+                                items:
+                                  type: string
+                                type: array
+                              technique_id:
+                                description: ATT&CK (e.g. T1078) or ATLAS (e.g. AML.T0053)
+                                  technique ID.
+                                type: string
+                              technique_name:
+                                type: string
+                            required:
+                            - hop_index
+                            - technique_id
+                            - catalog
+                            - tactics
+                            - provenance
+                            - confidence
+                            type: object
+                          type: array
                       type: object
                     type: array
                   created_at:

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -23,7 +23,17 @@ if TYPE_CHECKING:
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
 
 from agent_bom.db import graph_store as sqlite_graph_store
-from agent_bom.graph import AttackPath, EntityType, NodeDimensions, NodeStatus, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
+from agent_bom.graph import (
+    AttackPath,
+    EntityType,
+    NodeDimensions,
+    NodeStatus,
+    RelationshipType,
+    UnifiedEdge,
+    UnifiedGraph,
+    UnifiedNode,
+    technique_mappings_from_json,
+)
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 
@@ -897,7 +907,7 @@ class SQLiteGraphStore:
             rows = conn.execute(
                 f"""
                 SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids
+                       summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
                 FROM attack_paths
                 WHERE tenant_id = ? AND scan_id = ? AND source_node IN ({placeholders})
                 """,  # nosec B608 - placeholders are generated internally
@@ -914,6 +924,7 @@ class SQLiteGraphStore:
                     credential_exposure=json.loads(row["credential_exposure"]),
                     tool_exposure=json.loads(row["tool_exposure"]),
                     vuln_ids=json.loads(row["vuln_ids"]),
+                    technique_mappings=technique_mappings_from_json(row["technique_mappings"]),
                 )
                 for row in rows
             ]
@@ -943,7 +954,7 @@ class SQLiteGraphStore:
             rows = conn.execute(
                 """
                 SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids
+                       summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
                 FROM attack_paths
                 WHERE tenant_id = ? AND scan_id = ?
                 ORDER BY composite_risk DESC, source_node ASC, target_node ASC
@@ -965,6 +976,7 @@ class SQLiteGraphStore:
                         credential_exposure=json.loads(row["credential_exposure"]),
                         tool_exposure=json.loads(row["tool_exposure"]),
                         vuln_ids=json.loads(row["vuln_ids"]),
+                        technique_mappings=technique_mappings_from_json(row["technique_mappings"]),
                     )
                     for row in rows
                 ],

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -23,7 +23,7 @@ from agent_bom.api.graph_store import (
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMENT_TIMEOUT_MS
 from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, graph_retention_policy, normalize_graph_tenant_id
-from agent_bom.graph import EntityType
+from agent_bom.graph import EntityType, technique_mappings_from_json
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
 from agent_bom.security import sanitize_text
 
@@ -334,6 +334,7 @@ class PostgresGraphStore:
                     credential_exposure TEXT DEFAULT '[]',
                     tool_exposure TEXT DEFAULT '[]',
                     vuln_ids TEXT DEFAULT '[]',
+                    technique_mappings TEXT DEFAULT '[]',
                     scan_id TEXT NOT NULL,
                     tenant_id TEXT NOT NULL DEFAULT 'default',
                     computed_at TEXT NOT NULL,
@@ -353,6 +354,7 @@ class PostgresGraphStore:
             )
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS summary TEXT DEFAULT ''")
             conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS tool_exposure TEXT DEFAULT '[]'")
+            conn.execute("ALTER TABLE attack_paths ADD COLUMN IF NOT EXISTS technique_mappings TEXT DEFAULT '[]'")
             conn.execute("ALTER TABLE graph_snapshots ADD COLUMN IF NOT EXISTS analysis_status TEXT NOT NULL DEFAULT '{}'")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_from TEXT DEFAULT ''")
             conn.execute("ALTER TABLE graph_edges ADD COLUMN IF NOT EXISTS valid_to TEXT DEFAULT NULL")
@@ -790,6 +792,7 @@ class PostgresGraphStore:
                         json.dumps(ap.credential_exposure),
                         json.dumps(ap.tool_exposure),
                         json.dumps(ap.vuln_ids),
+                        json.dumps([m.to_dict() for m in ap.technique_mappings]),
                         scan,
                         tenant,
                         now,
@@ -855,8 +858,9 @@ class PostgresGraphStore:
                 INSERT INTO attack_paths (
                     source_node, target_node, hop_count, composite_risk,
                     summary, path_nodes, path_edges, credential_exposure,
-                    tool_exposure, vuln_ids, scan_id, tenant_id, computed_at
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    tool_exposure, vuln_ids, technique_mappings, scan_id,
+                    tenant_id, computed_at
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (source_node, target_node, scan_id, tenant_id) DO UPDATE SET
                     hop_count = EXCLUDED.hop_count,
                     composite_risk = EXCLUDED.composite_risk,
@@ -866,6 +870,7 @@ class PostgresGraphStore:
                     credential_exposure = EXCLUDED.credential_exposure,
                     tool_exposure = EXCLUDED.tool_exposure,
                     vuln_ids = EXCLUDED.vuln_ids,
+                    technique_mappings = EXCLUDED.technique_mappings,
                     computed_at = EXCLUDED.computed_at
                 """,
                 attack_path_rows(),
@@ -1084,7 +1089,7 @@ class PostgresGraphStore:
                 for row in conn.execute(
                     """
                     SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                           summary, credential_exposure, tool_exposure, vuln_ids
+                           summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
                     FROM attack_paths
                     WHERE tenant_id = %s AND scan_id = %s
                     """,
@@ -1101,6 +1106,7 @@ class PostgresGraphStore:
                             credential_exposure=json.loads(row[6]),
                             tool_exposure=json.loads(row[7]),
                             vuln_ids=json.loads(row[8]),
+                            technique_mappings=technique_mappings_from_json(row[9]),
                         )
                     )
 
@@ -1239,7 +1245,7 @@ class PostgresGraphStore:
             rows = conn.execute(
                 f"""
                 SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids
+                       summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
                 FROM attack_paths
                 WHERE tenant_id = %s AND scan_id = %s AND source_node IN ({placeholders})
                 ORDER BY composite_risk DESC, source_node ASC, target_node ASC
@@ -1260,6 +1266,7 @@ class PostgresGraphStore:
                 credential_exposure=json.loads(row[6]),
                 tool_exposure=json.loads(row[7]),
                 vuln_ids=json.loads(row[8]),
+                technique_mappings=technique_mappings_from_json(row[9]),
             )
             for row in rows
         ]
@@ -1289,7 +1296,7 @@ class PostgresGraphStore:
             rows = conn.execute(
                 """
                 SELECT source_node, target_node, path_nodes, path_edges, composite_risk,
-                       summary, credential_exposure, tool_exposure, vuln_ids
+                       summary, credential_exposure, tool_exposure, vuln_ids, technique_mappings
                 FROM attack_paths
                 WHERE tenant_id = %s AND scan_id = %s
                 ORDER BY composite_risk DESC, source_node ASC, target_node ASC
@@ -1314,6 +1321,7 @@ class PostgresGraphStore:
                     credential_exposure=json.loads(row[6]),
                     tool_exposure=json.loads(row[7]),
                     vuln_ids=json.loads(row[8]),
+                    technique_mappings=technique_mappings_from_json(row[9]),
                 )
                 for row in rows
             ],

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -84,6 +84,41 @@ _SEMANTIC_LAYER_LABELS = {
     GraphSemanticLayer.CI.value: "CI/CD",
 }
 
+_TECHNIQUE_MAPPING_OPENAPI_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "description": (
+        "A typed MITRE ATT&CK / ATLAS technique mapped to one hop of the attack path, "
+        "derived from the path's observed graph evidence (edge relationship + node type). "
+        "These are potential/mapped techniques for the kill-chain sequence, NOT a claim of "
+        "detected attacker activity. Technique and tactic IDs resolve against the bundled catalog."
+    ),
+    "required": ["hop_index", "technique_id", "catalog", "tactics", "provenance", "confidence"],
+    "properties": {
+        "hop_index": {"type": "integer", "minimum": 0, "description": "0-based position in the kill-chain edge sequence."},
+        "technique_id": {"type": "string", "description": "ATT&CK (e.g. T1078) or ATLAS (e.g. AML.T0053) technique ID."},
+        "technique_name": {"type": "string"},
+        "catalog": {"type": "string", "enum": ["attack", "atlas"]},
+        "tactics": {"type": "array", "items": {"type": "string"}, "description": "Catalog-resolved tactic phase names / IDs."},
+        "provenance": {"type": "string", "description": "The observed edge evidence that produced the mapping."},
+        "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+    },
+    "additionalProperties": False,
+}
+
+_ATTACK_PATH_ITEM_OPENAPI_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "exposure_path": None,  # filled after _EXPOSURE_PATH_OPENAPI_SCHEMA is defined
+        "technique_mappings": {"type": "array", "items": _TECHNIQUE_MAPPING_OPENAPI_SCHEMA},
+        "mitre_technique_ids": {
+            "type": "array",
+            "items": {"type": "string"},
+            "description": "Deduped technique IDs mapped across the path's hops (convenience projection).",
+        },
+    },
+    "additionalProperties": True,
+}
+
 _EXPOSURE_PATH_OPENAPI_SCHEMA: dict[str, Any] = {
     "type": "object",
     "description": "Investigation-first exposure path shared by graph views and report exports.",
@@ -111,6 +146,8 @@ _EXPOSURE_PATH_OPENAPI_SCHEMA: dict[str, Any] = {
         "provenance": {"type": "object", "additionalProperties": True},
     },
 }
+
+_ATTACK_PATH_ITEM_OPENAPI_SCHEMA["properties"]["exposure_path"] = _EXPOSURE_PATH_OPENAPI_SCHEMA
 
 _FIX_FIRST_VIEW_OPENAPI_RESPONSE: dict[str, Any] = {
     "description": "Fix-first graph view with ranked cards and embedded ExposurePath payloads.",
@@ -154,13 +191,7 @@ _ATTACK_PATHS_OPENAPI_RESPONSE: dict[str, Any] = {
                     "edges": {"type": "array", "items": {"type": "object", "additionalProperties": True}},
                     "attack_paths": {
                         "type": "array",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "exposure_path": _EXPOSURE_PATH_OPENAPI_SCHEMA,
-                            },
-                            "additionalProperties": True,
-                        },
+                        "items": _ATTACK_PATH_ITEM_OPENAPI_SCHEMA,
                     },
                     "stats": {
                         "type": "object",
@@ -1052,6 +1083,25 @@ def _derived_toxic_combination_paths(graph: UnifiedGraph) -> list[AttackPath]:
     return paths
 
 
+def _with_technique_mappings(paths: list[AttackPath], graph: UnifiedGraph) -> list[AttackPath]:
+    """Ensure every path carries typed MITRE mappings derived from its evidence.
+
+    Persisted paths already carry mappings from build time; route-derived paths
+    (governance / toxic-combination / fallback vuln chains) are enriched here so
+    the API surfaces the same typed kill-chain sequence for a pure-render UI.
+    Never raises into the route.
+    """
+    try:
+        from agent_bom.graph.attack_path_mitre import derive_attack_path_techniques
+
+        for path in paths:
+            if not path.technique_mappings:
+                path.technique_mappings = derive_attack_path_techniques(path, graph)
+    except Exception:  # noqa: BLE001
+        pass
+    return paths
+
+
 def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     """Derive fix-first paths when a snapshot lacks materialised path rows.
 
@@ -1067,10 +1117,13 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
     """
     governance_paths = _derived_governance_attack_paths(graph) + _derived_toxic_combination_paths(graph)
     if graph.attack_paths:
-        return sorted(
-            list(graph.attack_paths) + governance_paths,
-            key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
-            reverse=True,
+        return _with_technique_mappings(
+            sorted(
+                list(graph.attack_paths) + governance_paths,
+                key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
+                reverse=True,
+            ),
+            graph,
         )
 
     incoming: dict[str, list] = {}
@@ -1161,10 +1214,13 @@ def _derived_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                     )
 
     paths.extend(governance_paths)
-    return sorted(
-        paths,
-        key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
-        reverse=True,
+    return _with_technique_mappings(
+        sorted(
+            paths,
+            key=lambda path: (path.composite_risk, len(path.hops), len(path.credential_exposure), len(path.tool_exposure)),
+            reverse=True,
+        ),
+        graph,
     )
 
 

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -34,6 +34,7 @@ from agent_bom.graph import (
     UnifiedGraph,
     UnifiedNode,
     _now_iso,
+    technique_mappings_from_json,
 )
 from agent_bom.graph.analysis import (
     GraphAnalysisStatus,
@@ -167,6 +168,7 @@ CREATE TABLE IF NOT EXISTS attack_paths (
     credential_exposure TEXT DEFAULT '[]',
     tool_exposure   TEXT DEFAULT '[]',
     vuln_ids        TEXT DEFAULT '[]',
+    technique_mappings TEXT DEFAULT '[]',
     scan_id         TEXT NOT NULL,
     tenant_id       TEXT NOT NULL DEFAULT 'default',
     computed_at     TEXT NOT NULL,
@@ -302,6 +304,8 @@ def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) 
         conn.execute("ALTER TABLE attack_paths ADD COLUMN summary TEXT DEFAULT ''")
     if "tool_exposure" not in existing_columns:
         conn.execute("ALTER TABLE attack_paths ADD COLUMN tool_exposure TEXT DEFAULT '[]'")
+    if "technique_mappings" not in existing_columns:
+        conn.execute("ALTER TABLE attack_paths ADD COLUMN technique_mappings TEXT DEFAULT '[]'")
     edge_columns = {row["name"] for row in conn.execute("PRAGMA table_info(graph_edges)").fetchall()}
     # v3 adds replay metadata. Empty valid_from is interpreted as first_seen for
     # stores created before this migration, so old snapshots remain queryable.
@@ -828,8 +832,9 @@ def save_graph_streaming(
             INSERT OR REPLACE INTO attack_paths (
                 source_node, target_node, hop_count, composite_risk,
                 summary, path_nodes, path_edges, credential_exposure,
-                tool_exposure, vuln_ids, scan_id, tenant_id, computed_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                tool_exposure, vuln_ids, technique_mappings, scan_id,
+                tenant_id, computed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
             (
                 ap.source,
@@ -842,6 +847,7 @@ def save_graph_streaming(
                 json.dumps(ap.credential_exposure),
                 json.dumps(ap.tool_exposure),
                 json.dumps(ap.vuln_ids),
+                json.dumps([m.to_dict() for m in ap.technique_mappings]),
                 scan,
                 tenant,
                 now,
@@ -1015,6 +1021,7 @@ def load_graph(
                     credential_exposure=json.loads(row["credential_exposure"]),
                     tool_exposure=json.loads(row["tool_exposure"]),
                     vuln_ids=json.loads(row["vuln_ids"]),
+                    technique_mappings=technique_mappings_from_json(row["technique_mappings"]),
                 )
             )
 

--- a/src/agent_bom/graph/__init__.py
+++ b/src/agent_bom/graph/__init__.py
@@ -15,7 +15,9 @@ from agent_bom.graph.container import (
     GraphFilterOptions,
     InteractionRisk,
     LegendEntry,
+    TechniqueMapping,
     UnifiedGraph,
+    technique_mappings_from_json,
 )
 from agent_bom.graph.dependency_reach import (
     PackageReachability,
@@ -84,6 +86,8 @@ __all__ = [
     "UnifiedGraph",
     "AttackPath",
     "InteractionRisk",
+    "TechniqueMapping",
+    "technique_mappings_from_json",
     "GraphFilterOptions",
     "LegendEntry",
     "SemanticCluster",

--- a/src/agent_bom/graph/attack_path_mitre.py
+++ b/src/agent_bom/graph/attack_path_mitre.py
@@ -1,0 +1,198 @@
+"""Typed MITRE ATT&CK / ATLAS technique enrichment for attack paths (#4108).
+
+Derives *potential* technique/tactic mappings for each hop of an
+:class:`~agent_bom.graph.container.AttackPath` from the OBSERVED GRAPH EVIDENCE —
+the hop's edge relationship type, the target node's entity type, and the edge's
+evidence dict — never by parsing the human-readable ``summary`` / edge-label
+text. A hop whose evidence maps to no known technique is left UNMAPPED
+(fail-closed / honest): the kill-chain surfaces only the techniques the evidence
+supports.
+
+Every emitted ``technique_id`` and its ``tactics`` resolve against the bundled
+catalogs (``mitre_fetch`` for ATT&CK, ``atlas_fetch`` for ATLAS) exactly like the
+catalog-freshness tests validate — no dangling identifiers. Tactics are read from
+the catalog, never hardcoded here.
+
+Honesty: these are mapped/potential techniques for the kill-chain *sequence*, not
+detections. Nothing in this module asserts observed attacker activity.
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph.container import AttackPath, TechniqueMapping, UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+# ── Evidence → technique rules ───────────────────────────────────────────────
+#
+# Each rule keys off the OBSERVED edge relationship (and, where the signal needs
+# it, the target node's entity type or the edge evidence). ``catalog`` selects
+# which bundled catalog validates the id and supplies its tactics.
+
+_ATTACK = "attack"
+_ATLAS = "atlas"
+
+# Data-store targets — reaching a crown-jewel store is a "collection" signal.
+_DATA_ACCESS_RELS = frozenset(
+    {
+        RelationshipType.STORES,
+        RelationshipType.HAS_PERMISSION,
+        RelationshipType.CAN_ACCESS,
+        RelationshipType.ACCESSED,
+    }
+)
+_VULN_RELS = frozenset({RelationshipType.VULNERABLE_TO, RelationshipType.EXPLOITABLE_VIA})
+_CRED_RELS = frozenset({RelationshipType.EXPOSES_CRED})
+_TOOL_RELS = frozenset({RelationshipType.REACHES_TOOL, RelationshipType.PROVIDES_TOOL})
+_ASSUME_RELS = frozenset({RelationshipType.ASSUMES, RelationshipType.INHERITS})
+_CRED_TYPES = frozenset({EntityType.CREDENTIAL, EntityType.CREDENTIAL_REF})
+
+
+def _resolve_hop(
+    graph: UnifiedGraph,
+    source_id: str,
+    target_id: str,
+    rel: RelationshipType,
+) -> UnifiedEdge | None:
+    """Return the observed edge object for this hop (carries edge evidence)."""
+    for edge in graph.adjacency.get(source_id, []):
+        if edge.target == target_id and edge.relationship == rel:
+            return edge
+    return None
+
+
+def _candidate(
+    rel: RelationshipType,
+    source: UnifiedNode | None,
+    target: UnifiedNode | None,
+    edge: UnifiedEdge | None,
+) -> tuple[str, str, float, str] | None:
+    """Map one hop's observed evidence to ``(technique_id, catalog, confidence, provenance)``.
+
+    Returns ``None`` when no evidence maps to a technique (the hop stays unmapped).
+    Provenance is composed only from the relationship enum + node entity type +
+    edge evidence — never from the path summary or human edge-label text.
+    """
+    target_type = target.entity_type if target is not None else None
+    target_ref = target.id if target is not None else "?"
+    prov_target = target_type.value if target_type is not None else "node"
+
+    # Reaching a crown-jewel data store — Data from Cloud Storage (collection).
+    if target_type == EntityType.DATA_STORE and rel in _DATA_ACCESS_RELS:
+        return "T1530", _ATTACK, 0.7, f"observed {rel.value} edge into {prov_target} '{target_ref}'"
+
+    # Exploiting a vulnerability. From an internet-exposed entry it maps to
+    # Exploit Public-Facing Application; elsewhere to Exploitation for Priv Esc.
+    if rel in _VULN_RELS or target_type == EntityType.VULNERABILITY:
+        if source is not None and source.attributes.get("internet_exposed"):
+            return "T1190", _ATTACK, 0.85, f"observed {rel.value} edge from internet-exposed entry into {prov_target} '{target_ref}'"
+        return "T1068", _ATTACK, 0.8, f"observed {rel.value} edge into {prov_target} '{target_ref}'"
+
+    # Harvesting exposed credentials — Unsecured Credentials (credential-access).
+    if rel in _CRED_RELS or target_type in _CRED_TYPES:
+        return "T1552", _ATTACK, 0.8, f"observed {rel.value} edge into {prov_target} '{target_ref}'"
+
+    # Reaching an agent tool — ATLAS AI Agent Tool Invocation.
+    if rel in _TOOL_RELS or target_type == EntityType.TOOL:
+        return "AML.T0053", _ATLAS, 0.65, f"observed {rel.value} edge into {prov_target} '{target_ref}'"
+
+    # Privilege escalation via an assume-chain effective permission.
+    if rel == RelationshipType.HAS_PERMISSION and (edge is not None and (edge.evidence or {}).get("access") == "assume_chain"):
+        return "T1548", _ATTACK, 0.75, f"observed {rel.value} edge (assume_chain) into {prov_target} '{target_ref}'"
+
+    # Assuming a role / inheriting a principal — Valid Accounts.
+    if rel in _ASSUME_RELS:
+        return "T1078", _ATTACK, 0.7, f"observed {rel.value} edge into {prov_target} '{target_ref}'"
+
+    # Internet exposure edge — Exploit Public-Facing Application (initial-access).
+    if rel == RelationshipType.EXPOSED_TO:
+        return "T1190", _ATTACK, 0.7, f"observed {rel.value} edge into {prov_target} '{target_ref}'"
+
+    return None
+
+
+def _attack_tactics(technique_id: str) -> list[str] | None:
+    """Tactic phase names for an ATT&CK id, or ``None`` if not in the catalog."""
+    from agent_bom.mitre_fetch import get_techniques
+
+    meta = get_techniques().get(technique_id)
+    if meta is None:
+        return None
+    return list(meta.get("tactics", []))
+
+
+def _atlas_meta(technique_id: str) -> tuple[str, list[str]] | None:
+    """``(name, tactic_ids)`` for a curated ATLAS id, or ``None`` if unknown."""
+    from agent_bom.atlas import ATLAS_TECHNIQUES
+    from agent_bom.atlas_fetch import get_techniques as atlas_techniques
+
+    if technique_id not in ATLAS_TECHNIQUES:
+        return None
+    meta = atlas_techniques().get(technique_id, {})
+    name = meta.get("name") or ATLAS_TECHNIQUES.get(technique_id, "")
+    return name, list(meta.get("tactics", []))
+
+
+def derive_attack_path_techniques(path: AttackPath, graph: UnifiedGraph) -> list[TechniqueMapping]:
+    """Derive ordered, catalog-resolved technique mappings for ``path``.
+
+    One mapping per hop that carries mappable evidence, in kill-chain order.
+    Hops with no mappable evidence — or whose candidate technique does not
+    resolve in the bundled catalog — are skipped (fail-closed). Never raises.
+    """
+    mappings: list[TechniqueMapping] = []
+    edges = path.edges or []
+    hops = path.hops or []
+    for i, rel_value in enumerate(edges):
+        if i + 1 >= len(hops):
+            break
+        try:
+            rel = RelationshipType(rel_value)
+        except ValueError:
+            continue
+        source = graph.nodes.get(hops[i])
+        target = graph.nodes.get(hops[i + 1])
+        edge = _resolve_hop(graph, hops[i], hops[i + 1], rel)
+        candidate = _candidate(rel, source, target, edge)
+        if candidate is None:
+            continue
+        technique_id, catalog, confidence, provenance = candidate
+        if catalog == _ATLAS:
+            resolved = _atlas_meta(technique_id)
+            if resolved is None:
+                continue  # dangling id — fail closed
+            name, tactics = resolved
+        else:
+            tactics_or_none = _attack_tactics(technique_id)
+            if tactics_or_none is None:
+                continue  # dangling id — fail closed
+            from agent_bom.mitre_attack import ATTACK_TECHNIQUES
+
+            name = ATTACK_TECHNIQUES.get(technique_id, "")
+            tactics = tactics_or_none
+        mappings.append(
+            TechniqueMapping(
+                hop_index=i,
+                technique_id=technique_id,
+                technique_name=name,
+                catalog=catalog,
+                tactics=tactics,
+                provenance=provenance,
+                confidence=confidence,
+            )
+        )
+    return mappings
+
+
+def apply_attack_path_technique_mappings(graph: UnifiedGraph) -> int:
+    """Populate ``technique_mappings`` on every attack path in ``graph``.
+
+    Idempotent: recomputes from the current evidence each call. Returns the
+    number of mappings materialised. Never raises into the builder.
+    """
+    total = 0
+    for path in graph.attack_paths:
+        path.technique_mappings = derive_attack_path_techniques(path, graph)
+        total += len(path.technique_mappings)
+    return total

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1089,6 +1089,17 @@ def build_unified_graph_from_report(
         )
         _logger.warning("attack-path fusion failed: analysis_error")
 
+    # Enrich every materialised attack path with typed MITRE ATT&CK / ATLAS
+    # technique mappings derived from the path's observed evidence (edge
+    # relationship + node type), so persistence/API/exports carry the typed
+    # kill-chain sequence. Potential techniques, never detected activity.
+    try:
+        from agent_bom.graph.attack_path_mitre import apply_attack_path_technique_mappings
+
+        apply_attack_path_technique_mappings(graph)
+    except Exception:  # noqa: BLE001
+        _logger.warning("attack-path technique mapping failed: analysis_error")
+
     # Cost (FinOps) fusion: attach LLM spend to agent/resource nodes, roll it up
     # the CONTAINS hierarchy, and flag nodes that are BOTH high-cost AND
     # high-risk. Runs LAST so it sees every exposure/toxic/critical flag the

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -17,6 +17,71 @@ from agent_bom.graph.util import _now_iso
 
 
 @dataclass(slots=True)
+class TechniqueMapping:
+    """A typed MITRE ATT&CK / ATLAS technique mapped to one hop of an attack path.
+
+    These are *potential* techniques derived from the graph's observed evidence
+    (the hop's edge relationship type + the target node's entity type + the
+    edge's evidence), NOT a claim that the technique was detected being used.
+    ``technique_id`` / ``tactics`` always resolve against the bundled catalog
+    (see :mod:`agent_bom.graph.attack_path_mitre`); a hop whose evidence maps to
+    no known technique is simply left without a mapping (fail-closed).
+    """
+
+    hop_index: int  # 0-based position in the kill-chain edge sequence
+    technique_id: str  # e.g. "T1078" (ATT&CK) or "AML.T0053" (ATLAS)
+    technique_name: str = ""
+    catalog: str = "attack"  # "attack" | "atlas"
+    tactics: list[str] = field(default_factory=list)
+    provenance: str = ""  # observed evidence that produced the mapping
+    confidence: float = 0.0  # 0..1 signal, never an assertion of activity
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "hop_index": self.hop_index,
+            "technique_id": self.technique_id,
+            "technique_name": self.technique_name,
+            "catalog": self.catalog,
+            "tactics": self.tactics,
+            "provenance": self.provenance,
+            "confidence": self.confidence,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TechniqueMapping:
+        return cls(
+            hop_index=int(data.get("hop_index", 0)),
+            technique_id=data["technique_id"],
+            technique_name=data.get("technique_name", ""),
+            catalog=data.get("catalog", "attack"),
+            tactics=list(data.get("tactics", [])),
+            provenance=data.get("provenance", ""),
+            confidence=float(data.get("confidence", 0.0)),
+        )
+
+
+def technique_mappings_from_json(raw: object) -> list["TechniqueMapping"]:
+    """Decode persisted ``technique_mappings`` JSON into typed objects.
+
+    Tolerant of legacy rows: ``None`` / empty / malformed values yield ``[]``.
+    """
+    import json
+
+    if not raw:
+        return []
+    if isinstance(raw, (str, bytes, bytearray)):
+        try:
+            data = json.loads(raw)
+        except (ValueError, TypeError):
+            return []
+    else:
+        data = raw
+    if not isinstance(data, list):
+        return []
+    return [TechniqueMapping.from_dict(m) for m in data if isinstance(m, dict)]
+
+
+@dataclass(slots=True)
 class AttackPath:
     """Precomputed attack path between two nodes."""
 
@@ -29,6 +94,14 @@ class AttackPath:
     credential_exposure: list[str] = field(default_factory=list)
     tool_exposure: list[str] = field(default_factory=list)
     vuln_ids: list[str] = field(default_factory=list)
+    # Typed MITRE ATT&CK / ATLAS techniques mapped from this path's observed
+    # evidence, ordered by hop. Potential/mapped techniques for the kill-chain
+    # sequence — never a claim of observed attacker activity.
+    technique_mappings: list[TechniqueMapping] = field(default_factory=list)
+
+    def mitre_technique_ids(self) -> list[str]:
+        """Deduped, sorted technique IDs mapped across all hops (convenience)."""
+        return sorted({m.technique_id for m in self.technique_mappings})
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -41,6 +114,8 @@ class AttackPath:
             "credential_exposure": self.credential_exposure,
             "tool_exposure": self.tool_exposure,
             "vuln_ids": self.vuln_ids,
+            "technique_mappings": [m.to_dict() for m in self.technique_mappings],
+            "mitre_technique_ids": self.mitre_technique_ids(),
         }
 
     @classmethod
@@ -55,6 +130,7 @@ class AttackPath:
             credential_exposure=data.get("credential_exposure", []),
             tool_exposure=data.get("tool_exposure", []),
             vuln_ids=data.get("vuln_ids", []),
+            technique_mappings=[TechniqueMapping.from_dict(m) for m in data.get("technique_mappings", [])],
         )
 
 

--- a/tests/test_attack_path_mitre.py
+++ b/tests/test_attack_path_mitre.py
@@ -1,0 +1,226 @@
+"""Typed MITRE ATT&CK / ATLAS technique enrichment for attack paths (#4108).
+
+Mappings are derived from OBSERVED GRAPH EVIDENCE (edge relationship type +
+target node entity type + edge evidence) — never by parsing the human-readable
+summary/edge-label text — and every technique/tactic ID resolves against the
+bundled catalog. Hops without mappable evidence stay unmapped (fail-closed).
+These are *potential/mapped* techniques for the kill-chain sequence, never a
+claim of detected attacker activity.
+"""
+
+from __future__ import annotations
+
+from agent_bom.atlas import ATLAS_TECHNIQUES
+from agent_bom.db import graph_store as gs
+from agent_bom.graph.attack_path_fusion import apply_attack_path_fusion, compute_fused_attack_paths
+from agent_bom.graph.attack_path_mitre import (
+    apply_attack_path_technique_mappings,
+    derive_attack_path_techniques,
+)
+from agent_bom.graph.container import AttackPath, TechniqueMapping, UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+from agent_bom.mitre_attack import get_attack_techniques
+
+
+def _kill_chain_graph(tenant_id: str = "t", scan_id: str = "s") -> UnifiedGraph:
+    """internet→vuln workload→ASSUMES role→HAS_PERMISSION(assume_chain)→data store."""
+    g = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
+    g.add_node(
+        UnifiedNode(
+            id="res:web",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="public-ec2",
+            attributes={"internet_exposed": True, "toxic_exposed_vulnerable": True},
+            risk_score=9.0,
+        )
+    )
+    g.add_node(UnifiedNode(id="vuln:CVE-1", entity_type=EntityType.VULNERABILITY, label="CVE-1", severity="critical", risk_score=9.8))
+    g.add_edge(UnifiedEdge(source="res:web", target="vuln:CVE-1", relationship=RelationshipType.VULNERABLE_TO, weight=8.0))
+    g.add_node(
+        UnifiedNode(
+            id="role:admin",
+            entity_type=EntityType.ROLE,
+            label="AdminRole",
+            attributes={"can_escalate_privilege": True, "escalates_to_admin": True},
+        )
+    )
+    g.add_edge(UnifiedEdge(source="res:web", target="role:admin", relationship=RelationshipType.ASSUMES))
+    g.add_node(
+        UnifiedNode(
+            id="data_store:vault",
+            entity_type=EntityType.DATA_STORE,
+            label="data: cardholder-db",
+            attributes={
+                "data_sensitivity": "sensitive",
+                "data_regulatory_frameworks": ["PCI-DSS"],
+                "data_classification_tier": "restricted",
+            },
+        )
+    )
+    g.add_edge(
+        UnifiedEdge(
+            source="role:admin",
+            target="data_store:vault",
+            relationship=RelationshipType.HAS_PERMISSION,
+            evidence={"access": "assume_chain"},
+        )
+    )
+    return g
+
+
+def _catalog_ids() -> set[str]:
+    return set(get_attack_techniques()) | set(ATLAS_TECHNIQUES)
+
+
+# ── Derivation from observed evidence ────────────────────────────────────────
+
+
+def test_multihop_evidence_maps_to_catalog_techniques_ordered():
+    g = _kill_chain_graph()
+    path = compute_fused_attack_paths(g)[0]
+    assert path.hops == ["res:web", "role:admin", "data_store:vault"]
+
+    mappings = derive_attack_path_techniques(path, g)
+
+    # One mapping per hop that carried mappable evidence, ordered by kill-chain.
+    assert [m.hop_index for m in mappings] == [0, 1]
+    # hop 0: ASSUMES into a role → Valid Accounts (privilege escalation).
+    assert mappings[0].technique_id == "T1078"
+    assert mappings[0].catalog == "attack"
+    assert "privilege-escalation" in mappings[0].tactics
+    # hop 1: effective permission reaching a crown-jewel data store → collection.
+    assert mappings[1].technique_id == "T1530"
+    assert "collection" in mappings[1].tactics
+
+    catalog = _catalog_ids()
+    for m in mappings:
+        assert m.technique_id in catalog, f"dangling technique {m.technique_id}"
+        assert 0.0 < m.confidence <= 1.0
+        assert m.tactics  # resolved from catalog, never empty
+        # Provenance is derived from the observed graph edge, not the summary text.
+        assert path.summary not in m.provenance
+        assert m.provenance  # non-empty evidence description
+
+
+def test_vulnerable_edge_from_internet_entry_maps_to_exploit_public_facing():
+    g = _kill_chain_graph()
+    # Direct exploit hop off the internet-exposed entry.
+    path = AttackPath(source="res:web", target="vuln:CVE-1", hops=["res:web", "vuln:CVE-1"], edges=["vulnerable_to"])
+    mappings = derive_attack_path_techniques(path, g)
+    assert len(mappings) == 1
+    assert mappings[0].technique_id == "T1190"  # Exploit Public-Facing Application
+    assert "initial-access" in mappings[0].tactics
+
+
+def test_tool_reach_maps_to_atlas_and_resolves():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.CLOUD_RESOURCE, label="agent", attributes={"internet_exposed": True}))
+    g.add_node(UnifiedNode(id="tool:shell", entity_type=EntityType.TOOL, label="shell-tool"))
+    g.add_edge(UnifiedEdge(source="agent:a", target="tool:shell", relationship=RelationshipType.REACHES_TOOL))
+    path = AttackPath(source="agent:a", target="tool:shell", hops=["agent:a", "tool:shell"], edges=["reaches_tool"])
+
+    mappings = derive_attack_path_techniques(path, g)
+
+    assert len(mappings) == 1
+    assert mappings[0].catalog == "atlas"
+    assert mappings[0].technique_id in ATLAS_TECHNIQUES
+    assert mappings[0].tactics  # ATLAS tactic IDs resolved from the upstream catalog
+
+
+def test_hop_without_mappable_evidence_left_unmapped():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="app:x", entity_type=EntityType.CLOUD_RESOURCE, label="app"))
+    g.add_node(UnifiedNode(id="lib:y", entity_type=EntityType.PACKAGE, label="libc"))
+    g.add_edge(UnifiedEdge(source="app:x", target="lib:y", relationship=RelationshipType.USES))
+    path = AttackPath(source="app:x", target="lib:y", hops=["app:x", "lib:y"], edges=["uses"])
+
+    mappings = derive_attack_path_techniques(path, g)
+
+    # No evidence maps to a technique → fail closed, no fabricated mapping.
+    assert mappings == []
+
+
+def test_mappings_never_claim_detected_activity():
+    g = _kill_chain_graph()
+    path = compute_fused_attack_paths(g)[0]
+    mappings = derive_attack_path_techniques(path, g)
+    joined = " ".join(m.provenance.lower() for m in mappings)
+    assert "detected" not in joined
+    assert "observed activity" not in joined
+
+
+# ── Serialization round-trips ────────────────────────────────────────────────
+
+
+def test_to_dict_from_dict_roundtrip_preserves_typed_fields():
+    g = _kill_chain_graph()
+    apply_attack_path_fusion(g)
+    apply_attack_path_technique_mappings(g)
+    path = g.attack_paths[0]
+    assert path.technique_mappings
+
+    d = path.to_dict()
+    assert "technique_mappings" in d
+    # Convenience deduped id list for exports/UI.
+    assert d["mitre_technique_ids"] == sorted({m.technique_id for m in path.technique_mappings})
+
+    restored = AttackPath.from_dict(d)
+    assert restored.technique_mappings == path.technique_mappings
+
+
+def test_sqlite_roundtrip_preserves_technique_mappings(tmp_path):
+    g = _kill_chain_graph(tenant_id="acme", scan_id="s1")
+    apply_attack_path_fusion(g)
+    apply_attack_path_technique_mappings(g)
+    expected = g.attack_paths[0].technique_mappings
+    assert expected
+
+    db = tmp_path / "graph.db"
+    with gs.open_graph_db(db) as conn:
+        gs.save_graph(conn, g)
+    with gs.open_graph_db(db) as conn:
+        loaded = gs.load_graph(conn, tenant_id="acme", scan_id="s1")
+
+    assert len(loaded.attack_paths) == 1
+    assert loaded.attack_paths[0].technique_mappings == expected
+
+
+def test_tenant_isolation_technique_mappings_do_not_leak(tmp_path):
+    g_a = _kill_chain_graph(tenant_id="tenant-a", scan_id="shared-scan")
+    apply_attack_path_fusion(g_a)
+    apply_attack_path_technique_mappings(g_a)
+    a_ids = {m.technique_id for p in g_a.attack_paths for m in p.technique_mappings}
+    assert a_ids
+
+    # Tenant B: same scan id, a benign path with no mappable evidence.
+    g_b = UnifiedGraph(scan_id="shared-scan", tenant_id="tenant-b")
+    g_b.add_node(UnifiedNode(id="app:x", entity_type=EntityType.CLOUD_RESOURCE, label="app"))
+    g_b.add_node(UnifiedNode(id="lib:y", entity_type=EntityType.PACKAGE, label="libc"))
+    g_b.add_edge(UnifiedEdge(source="app:x", target="lib:y", relationship=RelationshipType.USES))
+    g_b.attack_paths.append(AttackPath(source="app:x", target="lib:y", hops=["app:x", "lib:y"], edges=["uses"]))
+    apply_attack_path_technique_mappings(g_b)
+
+    db = tmp_path / "graph.db"
+    with gs.open_graph_db(db) as conn:
+        gs.save_graph(conn, g_a)
+        gs.save_graph(conn, g_b)
+    with gs.open_graph_db(db) as conn:
+        loaded_b = gs.load_graph(conn, tenant_id="tenant-b", scan_id="shared-scan")
+
+    b_ids = {m.technique_id for p in loaded_b.attack_paths for m in p.technique_mappings}
+    assert b_ids.isdisjoint(a_ids)
+
+
+def test_technique_mapping_to_dict_from_dict_symmetry():
+    m = TechniqueMapping(
+        hop_index=2,
+        technique_id="T1078",
+        technique_name="Valid Accounts",
+        catalog="attack",
+        tactics=["privilege-escalation"],
+        provenance="assumes edge into ROLE 'role:admin'",
+        confidence=0.7,
+    )
+    assert TechniqueMapping.from_dict(m.to_dict()) == m

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -260,10 +260,10 @@ class MockConnection:
                     scan_id = params[1] if len(params) > 1 else ""
                     requested_sources = set(params[2:])
                     rows = [
-                        r for r in rows if r[11] == tenant_id and r[10] == scan_id and (not requested_sources or r[0] in requested_sources)
+                        r for r in rows if r[12] == tenant_id and r[11] == scan_id and (not requested_sources or r[0] in requested_sources)
                     ]
                 rows.sort(key=lambda r: (-float(r[3]), str(r[0]), str(r[1])))
-                cursor.rows = [(r[0], r[1], r[5], r[6], r[3], r[4], r[7], r[8], r[9]) for r in rows]
+                cursor.rows = [(r[0], r[1], r[5], r[6], r[3], r[4], r[7], r[8], r[9], r[10]) for r in rows]
             elif params:
                 for table_data in self._store.values():
                     for pk, row in table_data.items():
@@ -1651,6 +1651,52 @@ def test_graph_store_attack_paths_for_sources_uses_materialized_table(mock_pool,
     assert paths[0].tool_exposure == ["run_shell"]
     select_sql = "\n".join(sql for sql, _params in mock_pool._conn.executed if "FROM attack_paths" in sql)
     assert "source_node IN" in select_sql
+
+
+def test_graph_store_attack_paths_preserve_technique_mappings(mock_pool):
+    """Typed MITRE mappings survive the Postgres persist→load path (fake conn)."""
+    from agent_bom.api.postgres_store import PostgresGraphStore
+    from agent_bom.graph import AttackPath, EntityType, TechniqueMapping, UnifiedGraph, UnifiedNode
+
+    store = PostgresGraphStore(pool=mock_pool)
+    graph = UnifiedGraph(scan_id="scan-graph", tenant_id="tenant-alpha")
+    graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="Agent A"))
+    graph.add_node(UnifiedNode(id="vuln:cve", entity_type=EntityType.VULNERABILITY, label="CVE-2026-0001"))
+    graph.attack_paths.append(
+        AttackPath(
+            source="agent:a",
+            target="vuln:cve",
+            hops=["agent:a", "vuln:cve"],
+            edges=["vulnerable_to"],
+            composite_risk=9.4,
+            summary="agent-a reaches CVE-2026-0001",
+            technique_mappings=[
+                TechniqueMapping(
+                    hop_index=0,
+                    technique_id="T1190",
+                    technique_name="Exploit Public-Facing Application",
+                    catalog="attack",
+                    tactics=["initial-access"],
+                    provenance="observed vulnerable_to edge into vulnerability 'vuln:cve'",
+                    confidence=0.85,
+                )
+            ],
+        )
+    )
+    store.save_graph(graph)
+
+    paths = store.attack_paths_for_sources(tenant_id="tenant-alpha", scan_id="scan-graph", source_ids={"agent:a"})
+    assert len(paths) == 1
+    mappings = paths[0].technique_mappings
+    assert len(mappings) == 1
+    assert mappings[0].technique_id == "T1190"
+    assert mappings[0].hop_index == 0
+    assert mappings[0].tactics == ["initial-access"]
+    assert mappings[0].catalog == "attack"
+
+    # The INSERT must include the technique_mappings column (generated SQL check).
+    insert_sql = "\n".join(sql for sql, _p in mock_pool._conn.executed if "INSERT INTO attack_paths" in sql)
+    assert "technique_mappings" in insert_sql
 
 
 def test_scan_cache_put_get(mock_pool):


### PR DESCRIPTION
Part of #4108 — the "typed attack-path MITRE enrichment" workstream (core). The freshness workstream is #4197; the investigation-UI is a deferred follow-up. After this + the UI PR, #4108 closes.

## What
- **Model** (`graph/container.py`): `TechniqueMapping` (`hop_index`, `technique_id`, `technique_name`, `catalog`, `tactics`, `provenance`, `confidence`) + `AttackPath.technique_mappings`, dict round-trip, `mitre_technique_ids()`, tolerant JSON decoder.
- **Derivation from evidence, not label text** (`graph/attack_path_mitre.py`): each hop maps from the observed edge relationship + target entity type + edge evidence dict — never from `summary`/edge-label strings. Unmappable hops stay unmapped (fail-closed). Every ID validates against the bundled ATT&CK + ATLAS catalogs; tactics read from the catalog (no dangling IDs). Provenance is evidence-derived and never claims detected activity (it describes observed graph structure).
- **Wiring**: builder populates mappings after fusion; route-derived governance/toxic paths enriched on read so the API is fully populated.
- **Persistence** (symmetric SQLite + Postgres): new `technique_mappings` column + migration + read projections in all three store layers.
- **Contract**: OpenAPI schema extended + regenerated; graph JSON export carries the fields via `to_dict()`. (No SDK model to regen; SARIF/CDX/SPDX serialize paths at the finding level only, left unchanged.)

## Deferred
Investigation UI — a pure render of `technique_mappings[]` + `mitre_technique_ids` from `/v1/graph/attack-paths` (both already populated).

## How verified
9 new tests red→green (evidence-ordered mappings, exploit-public-facing from internet entry, ATLAS tool-reach, unmapped-when-no-evidence, never-claims-activity, dict/SQLite round-trip, tenant isolation) + fake-conn Postgres persist→load; broad graph sweep `453 passed, 10 skipped`; `ruff`/`mypy` clean; OpenAPI `--check`, `check-counts`, product-surface + freshness gates pass.

Note: best merged after #4197 (v18.1 catalog) so tactic labels resolve against the refreshed catalog; functions independently since tactics always resolve from whatever catalog is bundled.

Closes #4203.
