### PR TITLE
chore(typing): combine strict-generics work — models, findings_current, oidc, fleet store + 3 api modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,6 +445,26 @@ disallow_incomplete_defs = true
 warn_return_any = true
 warn_unused_ignores = true
 
+# Phase 2 (#1969): api/ modules brought under the STRICTER profile that also
+# forbids implicit ``Any`` generics (``dict``/``list`` without parameters).
+# Kept as a separate override block from the one above because that block does
+# NOT set ``disallow_any_generics``; the strict findings-list/models work in the
+# sibling PR uses the same ``disallow_any_generics`` set, so when both land these
+# two blocks merge cleanly (union the module lists, drop this comment).
+[[tool.mypy.overrides]]
+module = [
+    "agent_bom.api.oidc",
+    "agent_bom.api.postgres_fleet_store",
+    "agent_bom.api.finding_list_envelope",
+    "agent_bom.api.time_window",
+    "agent_bom.api.cost_owner",
+]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_any_generics = true
+warn_return_any = true
+warn_unused_ignores = true
+
 [tool.ruff]
 line-length = 140  # Relaxed from 120 for CLI help strings
 target-version = "py311"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -445,6 +445,22 @@ disallow_incomplete_defs = true
 warn_return_any = true
 warn_unused_ignores = true
 
+# Phase 5 (#1969): tighten one strictness notch further — ban bare/implicit
+# generics (`dict`/`list` -> `dict[str, Any]`/`list[Any]`) so serialized-payload
+# fields declare their shape instead of degrading to `Any`. Applied
+# module-by-module; expand this list as each module is de-genericized. Not a
+# global flip — the base [tool.mypy] settings stay unchanged.
+[[tool.mypy.overrides]]
+module = [
+    "agent_bom.models",
+    "agent_bom.api.findings_current",
+]
+disallow_untyped_defs = true
+disallow_incomplete_defs = true
+disallow_any_generics = true
+warn_return_any = true
+warn_unused_ignores = true
+
 [tool.ruff]
 line-length = 140  # Relaxed from 120 for CLI help strings
 target-version = "py311"

--- a/src/agent_bom/api/findings_current.py
+++ b/src/agent_bom/api/findings_current.py
@@ -9,12 +9,28 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Protocol
 
 from agent_bom.api.models import JobStatus
 
 
-def job_in_window(job: Any, since: str | None) -> bool:
+class _ScanJobLike(Protocol):
+    """Structural contract for the scan-job rows this fold reads.
+
+    Kept as a Protocol (rather than importing ``ScanJob``) so the fold stays
+    decoupled from the concrete store row and accepts any object exposing the
+    same surface. ``ScanJob`` satisfies it structurally.
+    """
+
+    job_id: str
+    status: JobStatus
+    result: dict[str, Any] | None
+    created_at: str
+    completed_at: str | None
+    child_job_ids: list[str]
+
+
+def job_in_window(job: _ScanJobLike, since: str | None) -> bool:
     """Return whether a job's completion timestamp is inside ``since``."""
     if since is None:
         return True
@@ -44,7 +60,7 @@ def finding_identity(finding: dict[str, Any]) -> str:
 
 
 def current_scan_findings(
-    jobs: Iterable[Any],
+    jobs: Iterable[_ScanJobLike],
     *,
     since: str | None,
     scan_id: str | None,

--- a/src/agent_bom/api/oidc.py
+++ b/src/agent_bom/api/oidc.py
@@ -43,7 +43,7 @@ import logging
 import os
 import threading
 import time
-from typing import Optional
+from typing import Any, Optional, cast
 from urllib.error import URLError
 from urllib.parse import urlparse
 from urllib.request import urlopen
@@ -64,10 +64,10 @@ class _JwksCache:
     """Thread-safe cache for OIDC JWKS (JSON Web Key Sets)."""
 
     def __init__(self) -> None:
-        self._cache: dict[str, tuple[dict, float]] = {}  # url → (jwks, fetched_at)
+        self._cache: dict[str, tuple[dict[str, Any], float]] = {}  # url → (jwks, fetched_at)
         self._lock = threading.Lock()
 
-    def get(self, jwks_uri: str) -> dict:
+    def get(self, jwks_uri: str) -> dict[str, Any]:
         """Return cached JWKS or fetch fresh copy if stale/absent."""
         with self._lock:
             entry = self._cache.get(jwks_uri)
@@ -133,7 +133,7 @@ def _validate_tenant_claim_value(value: object) -> str:
 # ── Discovery ──────────────────────────────────────────────────────────────────
 
 
-def _fetch_json(url: str) -> dict:
+def _fetch_json(url: str) -> dict[str, Any]:
     # Defense-in-depth: validate even operator-supplied URLs to block SSRF
     # via misconfigured AGENT_BOM_OIDC_ISSUER pointing at internal services.
     from agent_bom.security import validate_url
@@ -141,12 +141,14 @@ def _fetch_json(url: str) -> dict:
     validate_url(url)
     try:
         with urlopen(url, timeout=_OIDC_TIMEOUT) as resp:  # noqa: S310  # nosec B310 — validated above
-            return json.loads(resp.read())
+            # json.loads is typed to return Any; OIDC discovery/JWKS endpoints
+            # always return a JSON object, so narrow to the documented shape.
+            return cast("dict[str, Any]", json.loads(resp.read()))
     except (URLError, OSError, json.JSONDecodeError) as exc:
         raise OIDCError(f"Failed to fetch {url}: {exc}") from exc
 
 
-def discover_oidc(issuer: str) -> dict:
+def discover_oidc(issuer: str) -> dict[str, Any]:
     """Fetch the OIDC discovery document for ``issuer``.
 
     Args:
@@ -220,7 +222,7 @@ def verify_oidc_token(
     jwks_uri: Optional[str] = None,
     required_nonce: Optional[str] = None,
     allowed_jwks_uris: tuple[str, ...] = (),
-) -> dict:
+) -> dict[str, Any]:
     """Verify an OIDC JWT and return its claims.
 
     Fetches the issuer's JWKS (cached for 1 hour) and verifies the token
@@ -263,7 +265,7 @@ def verify_oidc_token(
     except Exception as exc:
         raise OIDCError(f"Failed to resolve signing key: {exc}") from exc
 
-    decode_kwargs: dict = {
+    decode_kwargs: dict[str, Any] = {
         "algorithms": list(OIDC_ALLOWED_ALGORITHMS),
         "issuer": issuer,
         "options": {"require": ["exp", "iat", "iss"]},
@@ -304,7 +306,7 @@ def verify_oidc_token(
 # ── Role mapping ───────────────────────────────────────────────────────────────
 
 
-def claims_to_role(claims: dict, role_claim: str = "agent_bom_role") -> str:
+def claims_to_role(claims: dict[str, Any], role_claim: str = "agent_bom_role") -> str:
     """Map OIDC JWT claims to an agent-bom role string.
 
     Checks ``role_claim`` in the JWT, then falls back to ``roles`` and
@@ -342,7 +344,7 @@ def claims_to_role(claims: dict, role_claim: str = "agent_bom_role") -> str:
     return "viewer"
 
 
-def claims_have_role_signal(claims: dict, role_claim: str = "agent_bom_role") -> bool:
+def claims_have_role_signal(claims: dict[str, Any], role_claim: str = "agent_bom_role") -> bool:
     """Return True when claims include an explicit recognizable role signal."""
     admin_values = {"admin", "administrator", "superuser"}
     analyst_values = {"analyst", "security-analyst", "engineer", "developer"}
@@ -361,7 +363,7 @@ def claims_have_role_signal(claims: dict, role_claim: str = "agent_bom_role") ->
     return False
 
 
-def claims_to_tenant(claims: dict, tenant_claim: str = "tenant_id") -> str | None:
+def claims_to_tenant(claims: dict[str, Any], tenant_claim: str = "tenant_id") -> str | None:
     """Map OIDC JWT claims to a tenant identifier."""
     tenant_val = claims.get(tenant_claim)
     if tenant_val not in (None, ""):
@@ -375,7 +377,7 @@ def claims_to_tenant(claims: dict, tenant_claim: str = "tenant_id") -> str | Non
     return None
 
 
-def _decode_unverified_claims(token: str) -> dict:
+def _decode_unverified_claims(token: str) -> dict[str, Any]:
     """Read JWT claims without verifying the signature so issuer routing can occur."""
     parts = token.split(".")
     if len(parts) != 3:
@@ -497,7 +499,7 @@ class OIDCConfig:
             raise OIDCError("JWT missing issuer claim required for tenant-bound OIDC")
         return self._provider_for_issuer(issuer)
 
-    def _provider_for_claims(self, claims: dict) -> OIDCConfig:
+    def _provider_for_claims(self, claims: dict[str, Any]) -> OIDCConfig:
         if not self.tenant_providers:
             return self
         issuer = str(claims.get("iss") or "").strip()
@@ -505,7 +507,7 @@ class OIDCConfig:
             raise OIDCError("JWT missing issuer claim required for tenant-bound OIDC")
         return self._provider_for_issuer(issuer)
 
-    def _validate_bound_tenant(self, claims: dict) -> None:
+    def _validate_bound_tenant(self, claims: dict[str, Any]) -> None:
         if self.tenant_id is None:
             return
         tenant_id = claims_to_tenant(claims, self.tenant_claim)
@@ -518,7 +520,7 @@ class OIDCConfig:
         if self.require_tenant_claim:
             raise OIDCError(f"JWT missing required tenant claim '{self.tenant_claim}'")
 
-    def verify(self, token: str) -> tuple[dict, str]:
+    def verify(self, token: str) -> tuple[dict[str, Any], str]:
         """Verify a JWT and return ``(claims, role)``.
 
         Raises:
@@ -543,7 +545,7 @@ class OIDCConfig:
         role = claims_to_role(claims, provider.role_claim)
         return claims, role
 
-    def resolve_tenant(self, claims: dict) -> str:
+    def resolve_tenant(self, claims: dict[str, Any]) -> str:
         """Resolve tenant context from claims or fail closed when required."""
         provider = self._provider_for_claims(claims)
         tenant_id = claims_to_tenant(claims, provider.tenant_claim)

--- a/src/agent_bom/api/postgres_fleet_store.py
+++ b/src/agent_bom/api/postgres_fleet_store.py
@@ -9,18 +9,25 @@ Requires ``pip install 'agent-bom[postgres]'``.
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING, Any
 
 from agent_bom.api.postgres_common import (
+    ConnectionPool,
     _ensure_tenant_rls,
     _get_pool,
     _tenant_connection,
 )
 
+if TYPE_CHECKING:
+    # Imported lazily at runtime (inside methods) to avoid a circular import
+    # with fleet_store; TYPE_CHECKING keeps the annotations resolvable.
+    from .fleet_store import FleetAgent, FleetLifecycleState
+
 
 class PostgresFleetStore:
     """PostgreSQL-backed fleet agent persistence."""
 
-    def __init__(self, pool=None) -> None:
+    def __init__(self, pool: ConnectionPool | None = None) -> None:
         self._pool = pool or _get_pool()
         self._init_tables()
 
@@ -58,7 +65,7 @@ class PostgresFleetStore:
             _ensure_tenant_rls(conn, "fleet_agents", "tenant_id")
             conn.commit()
 
-    def put(self, agent) -> None:
+    def put(self, agent: FleetAgent) -> None:
         data = agent.model_dump_json()
         with _tenant_connection(self._pool) as conn:
             conn.execute(
@@ -85,7 +92,7 @@ class PostgresFleetStore:
             )
             conn.commit()
 
-    def get(self, agent_id: str, *, tenant_id: str):
+    def get(self, agent_id: str, *, tenant_id: str) -> FleetAgent | None:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
@@ -98,7 +105,7 @@ class PostgresFleetStore:
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return FleetAgent.model_validate_json(raw)
 
-    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None):
+    def get_by_canonical_id(self, canonical_id: str, tenant_id: str | None = None) -> FleetAgent | None:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
@@ -114,7 +121,7 @@ class PostgresFleetStore:
             raw = row[0] if isinstance(row[0], str) else json.dumps(row[0])
             return FleetAgent.model_validate_json(raw)
 
-    def get_by_name(self, name: str):
+    def get_by_name(self, name: str) -> FleetAgent | None:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
@@ -131,23 +138,23 @@ class PostgresFleetStore:
                 (agent_id, tenant_id),
             )
             conn.commit()
-            return cursor.rowcount > 0
+            return bool(cursor.rowcount > 0)
 
-    def list_all(self) -> list:
+    def list_all(self) -> list[FleetAgent]:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT data FROM fleet_agents ORDER BY name").fetchall()
             return [FleetAgent.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
 
-    def list_summary(self) -> list[dict]:
+    def list_summary(self) -> list[dict[str, Any]]:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(
                 "SELECT agent_id, canonical_id, name, lifecycle_state, trust_score FROM fleet_agents ORDER BY name"
             ).fetchall()
             return [{"agent_id": r[0], "canonical_id": r[1], "name": r[2], "lifecycle_state": r[3], "trust_score": r[4]} for r in rows]
 
-    def list_by_tenant(self, tenant_id: str) -> list:
+    def list_by_tenant(self, tenant_id: str) -> list[FleetAgent]:
         from .fleet_store import FleetAgent
 
         with _tenant_connection(self._pool) as conn:
@@ -165,7 +172,7 @@ class PostgresFleetStore:
         include_quarantined: bool = False,
         limit: int = 50,
         offset: int = 0,
-    ) -> tuple[list, int]:
+    ) -> tuple[list[FleetAgent], int]:
         from .fleet_store import FleetAgent
 
         clauses = ["tenant_id = %s"]
@@ -210,12 +217,12 @@ class PostgresFleetStore:
             agents = [FleetAgent.model_validate_json(r[0] if isinstance(r[0], str) else json.dumps(r[0])) for r in rows]
             return agents, int(total_row[0] if total_row else 0)
 
-    def list_tenants(self) -> list[dict]:
+    def list_tenants(self) -> list[dict[str, Any]]:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute("SELECT tenant_id, COUNT(*) as cnt FROM fleet_agents GROUP BY tenant_id ORDER BY tenant_id").fetchall()
             return [{"tenant_id": r[0], "agent_count": r[1]} for r in rows]
 
-    def update_state(self, agent_id: str, state) -> bool:
+    def update_state(self, agent_id: str, state: FleetLifecycleState) -> bool:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(
                 "UPDATE fleet_agents SET lifecycle_state = %s WHERE agent_id = %s",
@@ -233,9 +240,9 @@ class PostgresFleetStore:
                         (json.dumps(data), agent_id),
                     )
             conn.commit()
-            return cursor.rowcount > 0
+            return bool(cursor.rowcount > 0)
 
-    def batch_put(self, agents: list) -> int:
+    def batch_put(self, agents: list[FleetAgent]) -> int:
         count = 0
         for agent in agents:
             self.put(agent)

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -6,7 +6,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 if TYPE_CHECKING:
     from agent_bom.ai_schemas import AIFindingAssessment
@@ -363,8 +363,8 @@ class Package:
     resolved_version: Optional[str] = None  # Exact version selected after resolution, when known
     version_confidence: Optional[str] = None  # ADR-007 confidence enum for the resolved version
     version_resolved_at: Optional[str] = None  # Timestamp when version was resolved
-    version_evidence: list[dict] = field(default_factory=list)  # Structured evidence for version source
-    version_conflicts: list[dict] = field(default_factory=list)  # Conflicting source/version observations
+    version_evidence: list[dict[str, Any]] = field(default_factory=list)  # Structured evidence for version source
+    version_conflicts: list[dict[str, Any]] = field(default_factory=list)  # Conflicting source/version observations
     floating_reference: bool = False  # True when the package/source ref is mutable (latest/main/no digest)
     floating_reference_reason: Optional[str] = None  # Why the ref is mutable
     is_malicious: bool = False  # True if flagged as known malicious (MAL- prefix in OSV)
@@ -405,7 +405,7 @@ class Package:
     maintainer_count: Optional[int] = None
     source_repo: Optional[str] = None
     occurrences: list[PackageOccurrence] = field(default_factory=list)  # Layer/file provenance for concrete package observations
-    discovery_provenance: Optional[dict] = None  # Sanitized discovery provenance contract for this package asset
+    discovery_provenance: Optional[dict[str, Any]] = None  # Sanitized discovery provenance contract for this package asset
 
     @property
     def stable_id(self) -> str:
@@ -485,10 +485,10 @@ class MCPTool:
     description: str
     discovery_source: Optional[str] = None
     discovery_confidence: Optional[str] = None
-    input_schema: Optional[dict] = None
+    input_schema: Optional[dict[str, Any]] = None
     declared_capabilities: list[str] = field(default_factory=list)
     schema_findings: list[str] = field(default_factory=list)
-    schema_rule_findings: list[dict] = field(default_factory=list)
+    schema_rule_findings: list[dict[str, Any]] = field(default_factory=list)
     server_canonical_id: Optional[str] = None  # Owning server scope (stamped by MCPServer)
 
     @property
@@ -653,7 +653,7 @@ class MCPServer:
     security_intelligence: list[dict[str, object]] = field(default_factory=list)
     surface: ServerSurface = ServerSurface.MCP
     discovery_sources: list[str] = field(default_factory=list)
-    discovery_provenance: Optional[dict] = None  # Sanitized discovery provenance contract for this server asset
+    discovery_provenance: Optional[dict[str, Any]] = None  # Sanitized discovery provenance contract for this server asset
 
     def __post_init__(self) -> None:
         """Scope child tool/resource/prompt identities to this server."""
@@ -784,15 +784,15 @@ class Agent:
     last_seen: Optional[str] = None
     parent_agent: Optional[str] = None  # Parent agent name (for spawn tree / delegation)
     metadata: dict[str, object] = field(default_factory=dict)  # Extra config data (permissions, hooks, etc.)
-    automation_settings: list = field(default_factory=list)  # Risky automation settings (scheduled tasks, etc.)
-    discovery_provenance: Optional[dict] = None  # Sanitized discovery provenance contract for this agent asset
+    automation_settings: list[Any] = field(default_factory=list)  # Risky automation settings (scheduled tasks, etc.)
+    discovery_provenance: Optional[dict[str, Any]] = None  # Sanitized discovery provenance contract for this agent asset
     # Per-run discovery envelope (#2083): trust contract for THIS scan run
     # -- scan_mode, discovery_scope, permissions_used, redaction_status.
     # Stored as a dict so the model stays JSON-friendly without dragging
     # `discovery_envelope.DiscoveryEnvelope` into the import path; producers
     # populate via `DiscoveryEnvelope.to_dict()` and consumers can re-hydrate
     # via `DiscoveryEnvelope.from_dict()`.
-    discovery_envelope: Optional[dict] = None
+    discovery_envelope: Optional[dict[str, Any]] = None
 
     def __post_init__(self) -> None:
         """Backfill lifecycle fields for legacy Agent construction paths."""
@@ -878,7 +878,7 @@ class BlastRadius:
     # Multi-hop delegation fields
     hop_depth: int = 1  # How many hops from the vulnerable package (1 = direct)
     delegation_chain: list[str] = field(default_factory=list)  # e.g. ["server1→agent1→server2→agent2"]
-    transitive_agents: list[dict] = field(default_factory=list)  # Agents reached via delegation
+    transitive_agents: list[dict[str, Any]] = field(default_factory=list)  # Agents reached via delegation
     transitive_credentials: list[str] = field(default_factory=list)  # Credentials exposed transitively
     transitive_risk_score: float = 0.0  # Risk score weighted by hop distance
 
@@ -1097,70 +1097,74 @@ class AIBOMReport:
     tool_version: str = ""
     executive_summary: Optional[str] = None  # LLM-generated executive summary
     ai_threat_chains: list[str] = field(default_factory=list)  # LLM-generated threat chain analyses
-    mcp_config_analysis: Optional[dict] = None  # LLM-powered MCP config security analysis
-    ai_enrichment_metadata: Optional[dict] = None  # Non-secret provider/model provenance for AI-generated fields
+    mcp_config_analysis: Optional[dict[str, Any]] = None  # LLM-powered MCP config security analysis
+    ai_enrichment_metadata: Optional[dict[str, Any]] = None  # Non-secret provider/model provenance for AI-generated fields
     ai_finding_assessments: list[AIFindingAssessment] = field(default_factory=list)
-    skill_audit_data: Optional[dict] = None  # Serialized SkillAuditResult (set by CLI)
-    trust_assessment_data: Optional[dict] = None  # Serialized TrustAssessmentResult (set by CLI)
-    prompt_scan_data: Optional[dict] = None  # Serialized PromptScanResult (set by CLI)
-    model_files: list[dict] = field(default_factory=list)
-    model_manifests: list[dict] = field(default_factory=list)
-    model_provenance: list[dict] = field(default_factory=list)  # HuggingFace provenance results
-    model_hash_verification_data: Optional[dict] = None  # Serialized model hash verification report
-    model_supply_chain_data: Optional[dict] = None  # Consolidated model file/provenance/hash summary
-    enforcement_data: Optional[dict] = None  # Serialized EnforcementReport (set by CLI)
-    context_graph_data: Optional[dict] = None  # Serialized context graph (set by CLI)
-    license_report: Optional[dict] = None  # Serialized license compliance report
-    vex_data: Optional[dict] = None  # Serialized VEX document
-    toxic_combinations: Optional[list] = None  # Serialized ToxicCombination list
-    prioritized_findings: Optional[list] = None  # Priority-ordered findings
-    sast_data: Optional[dict] = None  # Serialized SAST scan results (Semgrep)
-    aws_organization_data: Optional[dict] = None  # AWS Organizations: org/OUs/accounts/SCPs hierarchy
-    cis_benchmark_data: Optional[dict] = None  # Serialized CIS AWS Benchmark results
-    snowflake_cis_benchmark_data: Optional[dict] = None  # Serialized CIS Snowflake Benchmark results
-    snowflake_object_graph_data: Optional[dict] = None  # Snowflake tables/views + OBJECT_DEPENDENCIES lineage
-    snowflake_login_anomalies_data: Optional[dict] = None  # Snowflake impossible-travel / login-anomaly detection
-    snowflake_exfil_graph_data: Optional[dict] = None  # Snowflake egress: outbound shares, external stages, sensitive objects
-    snowflake_auth_posture_data: Optional[dict] = None  # Snowflake per-user auth matrix + network policies (MFA/key-pair/password)
-    snowflake_services_data: Optional[dict] = None  # Snowflake compute (warehouses) + database/schema containment hierarchy
-    snowflake_pipeline_data: Optional[dict] = None  # Snowflake data-pipeline objects: tasks, streams, pipes
-    snowflake_integrations_data: Optional[dict] = None  # Snowflake account integrations: storage/API/external-access/security/catalog
-    snowflake_external_data_data: Optional[dict] = None  # Snowflake open-table-format + external data: iceberg + external tables
-    snowflake_governance_data: Optional[dict] = (
+    skill_audit_data: Optional[dict[str, Any]] = None  # Serialized SkillAuditResult (set by CLI)
+    trust_assessment_data: Optional[dict[str, Any]] = None  # Serialized TrustAssessmentResult (set by CLI)
+    prompt_scan_data: Optional[dict[str, Any]] = None  # Serialized PromptScanResult (set by CLI)
+    model_files: list[dict[str, Any]] = field(default_factory=list)
+    model_manifests: list[dict[str, Any]] = field(default_factory=list)
+    model_provenance: list[dict[str, Any]] = field(default_factory=list)  # HuggingFace provenance results
+    model_hash_verification_data: Optional[dict[str, Any]] = None  # Serialized model hash verification report
+    model_supply_chain_data: Optional[dict[str, Any]] = None  # Consolidated model file/provenance/hash summary
+    enforcement_data: Optional[dict[str, Any]] = None  # Serialized EnforcementReport (set by CLI)
+    context_graph_data: Optional[dict[str, Any]] = None  # Serialized context graph (set by CLI)
+    license_report: Optional[dict[str, Any]] = None  # Serialized license compliance report
+    vex_data: Optional[dict[str, Any]] = None  # Serialized VEX document
+    toxic_combinations: Optional[list[Any]] = None  # Serialized ToxicCombination list
+    prioritized_findings: Optional[list[Any]] = None  # Priority-ordered findings
+    sast_data: Optional[dict[str, Any]] = None  # Serialized SAST scan results (Semgrep)
+    aws_organization_data: Optional[dict[str, Any]] = None  # AWS Organizations: org/OUs/accounts/SCPs hierarchy
+    cis_benchmark_data: Optional[dict[str, Any]] = None  # Serialized CIS AWS Benchmark results
+    snowflake_cis_benchmark_data: Optional[dict[str, Any]] = None  # Serialized CIS Snowflake Benchmark results
+    snowflake_object_graph_data: Optional[dict[str, Any]] = None  # Snowflake tables/views + OBJECT_DEPENDENCIES lineage
+    snowflake_login_anomalies_data: Optional[dict[str, Any]] = None  # Snowflake impossible-travel / login-anomaly detection
+    snowflake_exfil_graph_data: Optional[dict[str, Any]] = None  # Snowflake egress: outbound shares, external stages, sensitive objects
+    snowflake_auth_posture_data: Optional[dict[str, Any]] = (
+        None  # Snowflake per-user auth matrix + network policies (MFA/key-pair/password)
+    )
+    snowflake_services_data: Optional[dict[str, Any]] = None  # Snowflake compute (warehouses) + database/schema containment hierarchy
+    snowflake_pipeline_data: Optional[dict[str, Any]] = None  # Snowflake data-pipeline objects: tasks, streams, pipes
+    snowflake_integrations_data: Optional[dict[str, Any]] = (
+        None  # Snowflake account integrations: storage/API/external-access/security/catalog
+    )
+    snowflake_external_data_data: Optional[dict[str, Any]] = None  # Snowflake open-table-format + external data: iceberg + external tables
+    snowflake_governance_data: Optional[dict[str, Any]] = (
         None  # Snowflake governance: ACCESS_HISTORY reads + Cortex agent telemetry + derived findings
     )
-    snowflake_activity_data: Optional[dict] = (
+    snowflake_activity_data: Optional[dict[str, Any]] = (
         None  # Snowflake activity timeline: QUERY_HISTORY (365d) + AI observability events (summarized)
     )
-    azure_cis_benchmark_data: Optional[dict] = None  # Serialized CIS Azure Benchmark results
-    gcp_cis_benchmark_data: Optional[dict] = None  # Serialized CIS GCP Benchmark results
-    databricks_cis_benchmark_data: Optional[dict] = None  # Serialized Databricks Security Best Practices results
-    aisvs_benchmark_data: Optional[dict] = None  # Serialized AISVS compliance results
-    vector_db_scan_data: Optional[list] = None  # Serialized vector DB security assessments
-    gpu_infra_data: Optional[dict] = None  # Serialized GPU/AI compute infra scan results
-    iac_findings_data: Optional[dict] = None  # Serialized IaC misconfiguration findings (set by CLI)
+    azure_cis_benchmark_data: Optional[dict[str, Any]] = None  # Serialized CIS Azure Benchmark results
+    gcp_cis_benchmark_data: Optional[dict[str, Any]] = None  # Serialized CIS GCP Benchmark results
+    databricks_cis_benchmark_data: Optional[dict[str, Any]] = None  # Serialized Databricks Security Best Practices results
+    aisvs_benchmark_data: Optional[dict[str, Any]] = None  # Serialized AISVS compliance results
+    vector_db_scan_data: Optional[list[Any]] = None  # Serialized vector DB security assessments
+    gpu_infra_data: Optional[dict[str, Any]] = None  # Serialized GPU/AI compute infra scan results
+    iac_findings_data: Optional[dict[str, Any]] = None  # Serialized IaC misconfiguration findings (set by CLI)
     # Graph toxic-combination findings (serialized Finding dicts; set at the graph-build call site).
     # Rehydrated into the unified Finding stream by to_findings() so they reach --fail-on-severity.
-    toxic_combination_findings_data: Optional[list] = None
+    toxic_combination_findings_data: Optional[list[Any]] = None
     # Estate-wide cloud asset inventory; one provider payload or a per-provider list (opt-in AGENT_BOM_CLOUD_INVENTORY)
-    cloud_inventory_data: Optional[Union[dict, list]] = None
-    identity_discovery_data: Optional[dict] = None  # Discovered non-human identities (opt-in AGENT_BOM_OKTA/ENTRA_DISCOVERY)
+    cloud_inventory_data: Optional[Union[dict[str, Any], list[Any]]] = None
+    identity_discovery_data: Optional[dict[str, Any]] = None  # Discovered non-human identities (opt-in AGENT_BOM_OKTA/ENTRA_DISCOVERY)
     # Cloud audit-trail behavioral payload(s); per-provider list of aggregated
     # (principal, resource, action) edges + findings (opt-in AGENT_BOM_AUDIT_TRAIL, read-only)
-    cloud_audit_trail_data: Optional[Union[dict, list]] = None
-    runtime_correlation: Optional[dict] = None  # Runtime ↔ scan correlation (proxy audit vs CVE findings)
-    delta_data: Optional[dict] = None  # Baseline/delta comparison metadata for CI gate outputs
-    scan_performance_data: Optional[dict] = None  # Cache coverage / scan latency metadata
-    vuln_data_freshness: Optional[dict] = None  # Vuln-data source/age/staleness snapshot (set by CLI; surfaced to API/MCP)
-    training_pipelines: Optional[dict] = None  # Serialized TrainingPipelineScanResult
-    dataset_cards: Optional[dict] = None  # Serialized DatasetScanResult
-    serving_configs: Optional[list] = None  # Serialized ServingConfig list
-    browser_extensions: Optional[dict] = None  # Serialized browser extension scan results
-    ai_inventory_data: Optional[dict] = None  # AI component source scan results (SDK imports, models, keys)
-    project_inventory_data: Optional[dict] = None  # Project manifest / lockfile inventory summary
-    introspection_data: Optional[dict] = None  # Runtime MCP introspection results (tools, resources, drift)
-    health_check_data: Optional[dict] = None  # MCP server reachability/health results
-    runtime_session_graph: Optional[dict] = None  # Structured runtime session graph/timeline evidence
+    cloud_audit_trail_data: Optional[Union[dict[str, Any], list[Any]]] = None
+    runtime_correlation: Optional[dict[str, Any]] = None  # Runtime ↔ scan correlation (proxy audit vs CVE findings)
+    delta_data: Optional[dict[str, Any]] = None  # Baseline/delta comparison metadata for CI gate outputs
+    scan_performance_data: Optional[dict[str, Any]] = None  # Cache coverage / scan latency metadata
+    vuln_data_freshness: Optional[dict[str, Any]] = None  # Vuln-data source/age/staleness snapshot (set by CLI; surfaced to API/MCP)
+    training_pipelines: Optional[dict[str, Any]] = None  # Serialized TrainingPipelineScanResult
+    dataset_cards: Optional[dict[str, Any]] = None  # Serialized DatasetScanResult
+    serving_configs: Optional[list[Any]] = None  # Serialized ServingConfig list
+    browser_extensions: Optional[dict[str, Any]] = None  # Serialized browser extension scan results
+    ai_inventory_data: Optional[dict[str, Any]] = None  # AI component source scan results (SDK imports, models, keys)
+    project_inventory_data: Optional[dict[str, Any]] = None  # Project manifest / lockfile inventory summary
+    introspection_data: Optional[dict[str, Any]] = None  # Runtime MCP introspection results (tools, resources, drift)
+    health_check_data: Optional[dict[str, Any]] = None  # MCP server reachability/health results
+    runtime_session_graph: Optional[dict[str, Any]] = None  # Structured runtime session graph/timeline evidence
 
     # Unified Finding stream (issue #566 — Phase 1).
     # Populated alongside blast_radii for backward compatibility.
@@ -1178,7 +1182,7 @@ class AIBOMReport:
     # data source does not carry advisories for an OS release present in the scan
     # target (typically end-of-life) — a low/zero count there must NOT be read as
     # a clean bill of health.
-    coverage_warnings: list[dict] = field(default_factory=list)
+    coverage_warnings: list[dict[str, Any]] = field(default_factory=list)
 
     @property
     def has_mcp_context(self) -> bool:


### PR DESCRIPTION
Combines **#4195** and **#4200** — both bring modules under the mypy `disallow_any_generics` strict override, and they **conflicted on `pyproject.toml`** (each added the same strict override block), so they can't merge independently. #4200's own comment anticipated this: "when both land these two blocks merge cleanly (union the module lists)."

## Resolution
Unioned the two `[[tool.mypy.overrides]]` module lists into one block (identical settings on both sides — `disallow_any_generics` / `disallow_untyped_defs` / etc.), covering all 7 modules:
- from #4195: `agent_bom.models`, `agent_bom.api.findings_current`
- from #4200: `agent_bom.api.oidc`, `agent_bom.api.postgres_fleet_store`, `agent_bom.api.finding_list_envelope`, `agent_bom.api.time_window`, `agent_bom.api.cost_owner`

Plus each PR's source de-genericization (`models.py`, `findings_current.py`, `oidc.py`, `postgres_fleet_store.py`).

## Verified on the merged result
- `mypy` on all 7 strict modules under the combined config — **Success, no issues**.
- `ruff check src` clean; `pyproject.toml` is valid TOML.

Part of #1969 (phased stricter mypy). Supersedes #4195 and #4200.