### PR TITLE
fix(exports): carry KEV/EPSS/CWE, AI-triage, and reachability to the exporters that dropped them

### DIFF
--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -109,8 +109,31 @@ def _merge_dependencies(dependencies: list[dict]) -> list[dict]:
     return [{"ref": ref, "dependsOn": sorted(by_ref[ref])} for ref in sorted(by_ref)]
 
 
+def _cwe_ids_to_integers(cwe_ids: list[str]) -> list[int]:
+    """Map ``["CWE-94", "CWE-502"]`` to the CycloneDX-native integer form.
+
+    CDX 1.7 ``cwes`` is an array of integer CWE IDs (``>= 1``). Non-numeric or
+    malformed entries are dropped rather than invented.
+    """
+    ints: list[int] = []
+    for raw in cwe_ids:
+        match = re.search(r"(\d+)", str(raw))
+        if not match:
+            continue
+        value = int(match.group(1))
+        if value >= 1 and value not in ints:
+            ints.append(value)
+    return ints
+
+
 def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str) -> dict:
-    """Build one package-scoped CycloneDX vulnerability observation."""
+    """Build one package-scoped CycloneDX vulnerability observation.
+
+    Carries the enrichment other exporters already surface: CWE weaknesses via
+    the native ``cwes`` array, EPSS as an ``other``-method rating, and CISA KEV
+    plus EPSS detail as namespaced ``agent-bom:`` properties (KEV/EPSS have no
+    first-class CDX 1.7 vulnerability slot).
+    """
     ratings: list[dict[str, object]] = []
     if vuln.cvss_score:
         ratings.append(
@@ -122,6 +145,16 @@ def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str) -> dict:
         )
     else:
         ratings.append({"severity": vuln.severity.value})
+    if vuln.epss_score is not None:
+        # EPSS is a probability (0.0–1.0), not a CVSS-style severity — surface it
+        # as an `other`-method rating attributed to the EPSS source.
+        ratings.append(
+            {
+                "source": {"name": "EPSS", "url": "https://www.first.org/epss/"},
+                "score": vuln.epss_score,
+                "method": "other",
+            }
+        )
     entry: dict = {
         "id": vuln.id,
         "description": vuln.summary or f"See {vuln.id} for details",
@@ -129,6 +162,24 @@ def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str) -> dict:
         "ratings": ratings,
         "affects": [{"ref": pkg_ref}],
     }
+    cwes = _cwe_ids_to_integers(vuln.cwe_ids)
+    if cwes:
+        entry["cwes"] = cwes
+    vuln_properties: list[dict[str, str]] = []
+    if vuln.is_kev:
+        vuln_properties.append({"name": "agent-bom:kev", "value": "true"})
+        if vuln.kev_date_added:
+            vuln_properties.append({"name": "agent-bom:kev_date_added", "value": vuln.kev_date_added})
+        if vuln.kev_due_date:
+            vuln_properties.append({"name": "agent-bom:kev_due_date", "value": vuln.kev_due_date})
+    if vuln.epss_score is not None:
+        vuln_properties.append({"name": "agent-bom:epss_score", "value": str(vuln.epss_score)})
+    if vuln.epss_percentile is not None:
+        vuln_properties.append({"name": "agent-bom:epss_percentile", "value": str(vuln.epss_percentile)})
+    if vuln.is_kev or vuln.epss_score is not None:
+        vuln_properties.append({"name": "agent-bom:exploit_likelihood", "value": vuln.exploit_likelihood})
+    if vuln_properties:
+        entry["properties"] = vuln_properties
     if vuln.fixed_version:
         entry["recommendation"] = f"Upgrade to {vuln.fixed_version}"
     if vuln.vex_status:
@@ -155,9 +206,7 @@ def _merge_vulnerability_observation(by_id: dict[str, dict], observation: dict) 
         by_id[vuln_id] = observation
         return
     affected_refs = {
-        str(affected.get("ref"))
-        for affected in [*existing.get("affects", []), *observation.get("affects", [])]
-        if affected.get("ref")
+        str(affected.get("ref")) for affected in [*existing.get("affects", []), *observation.get("affects", [])] if affected.get("ref")
     }
     existing["affects"] = [{"ref": ref} for ref in sorted(affected_refs)]
 

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -66,6 +66,36 @@ def evidence(finding: Finding, key: str, default: Any = "") -> Any:
     return default if value is None else value
 
 
+# Human-facing labels for the code-level reachability signal. Ordered
+# most-specific first. ``state`` drives filtering/styling; ``label`` is the cell.
+_REACHABILITY_LABELS: dict[str, tuple[str, str]] = {
+    "function_reachable": ("Function", "reachable"),
+    "package_reachable": ("Package", "reachable"),
+    "unreachable": ("Unreachable", "unreachable"),
+}
+
+
+def reachability_label(finding: Finding) -> tuple[str, str]:
+    """Human-facing code-reachability signal for a CVE finding.
+
+    Returns ``(label, state)`` where ``state`` is ``"reachable"``,
+    ``"unreachable"``, or ``"unknown"``. This surfaces the symbol/graph
+    reachability moat — *not* the coarse blast-radius ``reachability``
+    classification (which is always populated). §11 honesty: when neither the
+    symbol nor graph engine produced a verdict we report ``"Unknown"`` and
+    never imply the finding is reachable.
+    """
+    symbol = evidence(finding, "symbol_reachability", None)
+    if isinstance(symbol, str) and symbol in _REACHABILITY_LABELS:
+        return _REACHABILITY_LABELS[symbol]
+    graph = finding.evidence.get("graph_reachable", None)
+    if graph is True:
+        return "Reachable", "reachable"
+    if graph is False:
+        return "Unreachable", "unreachable"
+    return "Unknown", "unknown"
+
+
 def package_name(finding: Finding) -> str:
     value = evidence(finding, "package_name", "")
     if value:

--- a/src/agent_bom/output/html/sections.py
+++ b/src/agent_bom/output/html/sections.py
@@ -1,4 +1,5 @@
 """HTML section renderers (summary, tables, graph data, CIS, compliance)."""
+
 from __future__ import annotations
 
 import json
@@ -19,6 +20,7 @@ from agent_bom.output.finding_views import (
     package_name,
     package_version,
     ranked_cve_findings,
+    reachability_label,
     severity_value,
 )
 from agent_bom.output.html._common import (
@@ -33,6 +35,9 @@ from agent_bom.security import sanitize_launch_command, sanitize_path_label
 if TYPE_CHECKING:
     from agent_bom.finding import Finding
     from agent_bom.models import AIBOMReport, BlastRadius
+
+# Reachability cell colors, keyed by the state from ``reachability_label``.
+_REACH_COLOR = {"reachable": "#f87171", "unreachable": "#64748b", "unknown": "#475569"}
 
 
 def _pager_controls(table_id: str, total: int, page_size: int = _PAGE_SIZE) -> str:
@@ -56,7 +61,7 @@ def _pager_controls(table_id: str, total: int, page_size: int = _PAGE_SIZE) -> s
         f'<option value="50"{" selected" if page_size == 50 else ""}>50</option>'
         '<option value="100">100</option>'
         '<option value="250">250</option>'
-        '</select></label>'
+        "</select></label>"
         "</div>"
     )
 
@@ -72,10 +77,7 @@ def _chart_data(findings: list["Finding"]) -> str:
             sev_counts[sev] += 1
 
     top10 = sorted(findings, key=lambda finding: float(finding.risk_score or 0.0), reverse=True)[:10]
-    blast_labels = [
-        f"{(finding.cve_id or finding.title)[:16]}/{package_name(finding)[:14]}"
-        for finding in top10
-    ]
+    blast_labels = [f"{(finding.cve_id or finding.title)[:16]}/{package_name(finding)[:14]}" for finding in top10]
     blast_scores = [round(float(finding.risk_score or 0.0), 2) for finding in top10]
     blast_colors = [_SEV_COLOR.get(severity_value(finding), "#6b7280") for finding in top10]
 
@@ -219,6 +221,8 @@ def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
         key=lambda finding: severity_policy_rank(severity_value(finding)),
         reverse=True,
     )
+    # Advisory AI-triage assessments joined by the finding id they describe.
+    ai_assessments = {assessment.finding_id: assessment for assessment in getattr(report, "ai_finding_assessments", []) or []}
     rows = []
     for idx, finding in enumerate(sorted_findings):
         sev = severity_value(finding)
@@ -249,8 +253,28 @@ def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
             if finding.fixed_version
             else '<span style="color:#475569">No fix</span>'
         )
+        reach_label, reach_state = reachability_label(finding)
+        reach_color = _REACH_COLOR.get(reach_state, "#475569")
+        reach_title = {
+            "reachable": "Vulnerable code is reached from an entrypoint",
+            "unreachable": "Package present but not reached from any entrypoint",
+            "unknown": "Reachability engine did not produce a verdict",
+        }.get(reach_state, "")
+        reach_cell = (
+            f'<span class="reach-badge" data-reach="{reach_state}" title="{reach_title}" '
+            f'style="font-size:.68rem;color:{reach_color}">{reach_label}</span>'
+        )
         summary_text = (finding.description or "")[:90]
         summary = _esc(summary_text) if summary_text else '<span style="color:#475569;font-style:italic">Run --enrich</span>'
+        assessment = ai_assessments.get(finding.id)
+        if assessment is not None:
+            summary += (
+                f'<div class="ai-triage" style="margin-top:4px;font-size:.66rem;color:#a5b4fc">'
+                f'<span class="badge-ai" title="AI triage (advisory)">AI</span> '
+                f"{_esc(assessment.classification)} "
+                f'<span style="color:#94a3b8">&middot; FP&nbsp;likelihood: {_esc(assessment.false_positive_likelihood)}</span>'
+                f"</div>"
+            )
         agents_s = ", ".join(_esc(name) for name in finding.affected_agents) or "<span style='color:#334155'>&mdash;</span>"
         creds_s = (
             " ".join(f'<code style="color:#fbbf24">{_esc(c)}</code>' for c in finding.exposed_credentials)
@@ -276,6 +300,7 @@ def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
         rows.append(
             f'<tr class="pg-row{pg_cls}" data-severity="{sev}" data-kev="{"1" if finding.is_kev else "0"}" '
             f'data-exploit-likelihood="{exploit_level}" '
+            f'data-reachability="{reach_state}" '
             f'data-match-tier="{_esc(tier or "")}" '
             f'data-cvss="{finding.cvss_score if finding.cvss_score else 0}">'
             f'<td><code class="vuln-id">{_esc(vuln_id)}</code>{tier_hint}</td>'
@@ -285,6 +310,7 @@ def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
             f"<td>{cvss_bar}</td>"
             f'<td style="text-align:center;font-size:.82rem;color:#94a3b8">{epss}</td>'
             f'<td style="text-align:center">{kev}</td>'
+            f'<td style="text-align:center">{reach_cell}</td>'
             f"<td>{fix}</td>"
             f'<td style="font-size:.78rem;color:#94a3b8">{agents_s}</td>'
             f'<td style="font-size:.78rem">{creds_s}</td>'
@@ -292,7 +318,7 @@ def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
             f"</tr>"
         )
 
-    headers = ["Vuln ID", "Severity", "Package", "CVSS", "EPSS", "KEV", "Fix", "Affected Agents", "Exposed Creds", "Summary"]
+    headers = ["Vuln ID", "Severity", "Package", "CVSS", "EPSS", "KEV", "Reach", "Fix", "Affected Agents", "Exposed Creds", "Summary"]
 
     filter_bar = (
         '<div class="vuln-filter-bar" style="display:flex;flex-wrap:wrap;gap:12px;align-items:center;'
@@ -558,7 +584,7 @@ def _policy_findings_section(findings: list["Finding"]) -> str:
         f'<div class="table-wrap"><table class="data-table sortable paginated" id="policyFindingsTable">'
         f"<thead><tr>{header_html}</tr></thead>"
         f"<tbody>{''.join(rows)}</tbody></table></div>"
-        f'{_pager_controls("policyFindingsTable", len(rows))}'
+        f"{_pager_controls('policyFindingsTable', len(rows))}"
         f"</div></section>"
     )
 
@@ -724,6 +750,7 @@ _CIS_CLOUD_LABELS = {
     "databricks": ("Databricks", "databricks_cis_benchmark_data"),
 }
 
+
 def _cis_evidence_html(check: dict) -> str:
     """Affected-resource evidence cell: resource IDs when present, else text."""
     resources = check.get("resource_ids") or []
@@ -776,9 +803,7 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
         band_color = "#16a34a" if pass_rate >= 90 else "#eab308" if pass_rate >= 70 else "#ef4444"
 
         # Verdict + per-severity failed counts for the summary header.
-        sev_counts = {
-            s: sum(1 for c in failed if (c.get("severity") or "").lower() == s) for s in SEVERITY_THRESHOLD_LABELS
-        }
+        sev_counts = {s: sum(1 for c in failed if (c.get("severity") or "").lower() == s) for s in SEVERITY_THRESHOLD_LABELS}
         if errored and not evaluated:
             verdict_text, verdict_color = "ERROR", "#dc2626"
         elif errored:

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -17,6 +17,7 @@ from agent_bom.output.finding_views import (
     package_name,
     package_version,
     ranked_cve_findings,
+    reachability_label,
     severity_counts,
     severity_value,
 )
@@ -103,8 +104,8 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
     if cve_rows:
         lines.append("## Findings")
         lines.append("")
-        lines.append("| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | CWE | Tags | Source | Agents |")
-        lines.append("|----------|-----|---------|---------|-----|------|------|-----|-----|------|--------|--------|")
+        lines.append("| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | Reach | CWE | Tags | Source | Agents |")
+        lines.append("|----------|-----|---------|---------|-----|------|------|-----|-------|-----|------|--------|--------|")
 
         for finding in sorted(cve_rows, key=lambda f: _finding_sev_order(severity_value(f))):
             vuln_id = finding.cve_id or finding.id
@@ -112,6 +113,7 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
             cvss = f"{finding.cvss_score}" if finding.cvss_score is not None else "-"
             epss = f"{finding.epss_score:.4f}" if finding.epss_score is not None else "-"
             kev = "Yes" if finding.is_kev else "-"
+            reach = reachability_label(finding)[0]
             cwe = _md_cell(", ".join(finding.cwe_ids) if finding.cwe_ids else "-")
             tags = _md_cell(", ".join(framework_qualified_finding_tags(finding)) or "-")
             source = _md_cell(evidence(finding, "severity_source", "-") or "-")
@@ -119,7 +121,7 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
             agents = str(len(finding.affected_agents))
             lines.append(
                 f"| {sev_badge} | {vuln_id} | {package_name(finding)} | {package_version(finding) or '-'} | {fix} | {cvss} | "
-                f"{epss} | {kev} | {cwe} | {tags} | {source} | {agents} |"
+                f"{epss} | {kev} | {reach} | {cwe} | {tags} | {source} | {agents} |"
             )
 
         lines.append("")
@@ -161,6 +163,9 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
                 lines.append(f"- **Fix**: Upgrade to {finding.fixed_version}")
             if finding.cwe_ids:
                 lines.append(f"- **CWE**: {', '.join(finding.cwe_ids)}")
+            reach_label, reach_state = reachability_label(finding)
+            reach_suffix = " (code reachability not evaluated)" if reach_state == "unknown" else ""
+            lines.append(f"- **Reachability**: {reach_label}{reach_suffix}")
             compliance_tags = ", ".join(framework_qualified_finding_tags(finding))
             if compliance_tags:
                 lines.append(f"- **Compliance tags**: {compliance_tags}")

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -54,11 +54,10 @@ def _sarif_fingerprint_fields(
             "agent-bom/v1": hashlib.sha256(stable_input.encode()).hexdigest(),
         },
         "partialFingerprints": {
-            "primaryLocationLineHash": hashlib.sha256(
-                f"{artifact_uri}:{start_line}".encode()
-            ).hexdigest(),
+            "primaryLocationLineHash": hashlib.sha256(f"{artifact_uri}:{start_line}".encode()).hexdigest(),
         },
     }
+
 
 # GitHub Security tab uses security-severity (0.0–10.0) for granular sorting.
 # Ranges per docs.github.com: >9.0=critical, 7.0–8.9=high, 4.0–6.9=medium, 0.1–3.9=low
@@ -486,6 +485,27 @@ def _ensure_cve_sarif_rule(
     )
 
 
+def _ai_assessment_result_properties(assessment: Any) -> dict[str, Any]:
+    """Advisory AI-triage fields for a SARIF result, namespaced under agent-bom.
+
+    The triage assessment is advisory only (it never changes severity or
+    suppression); it is joined onto the finding it describes by ``finding_id``
+    so a SARIF consumer sees the classification inline instead of only in the
+    JSON side-block.
+    """
+    props: dict[str, Any] = {
+        "agent-bom:ai_classification": assessment.classification,
+        "agent-bom:ai_confidence": assessment.confidence,
+        "agent-bom:ai_false_positive_likelihood": assessment.false_positive_likelihood,
+    }
+    rationale = (assessment.rationale or "").strip()
+    if rationale:
+        props["agent-bom:ai_rationale"] = _sanitize_sarif_text("description", rationale, fallback="")
+    if assessment.suggested_controls:
+        props["agent-bom:ai_suggested_controls"] = list(assessment.suggested_controls)
+    return props
+
+
 def _cve_sarif_result(
     report: AIBOMReport,
     finding: Finding,
@@ -495,6 +515,7 @@ def _cve_sarif_result(
     level: str,
     pkg_name: str,
     pkg_version: str,
+    ai_assessment: Any = None,
 ) -> dict:
     exposure_path = exposure_path_for_report_finding(finding, rank=rank)
     affected = ", ".join(str(name) for name in finding.affected_agents)
@@ -580,6 +601,8 @@ def _cve_sarif_result(
     framework_props = _framework_tag_properties(finding)
     if framework_props:
         result_properties.update(framework_props)
+    if ai_assessment is not None:
+        result_properties.update(_ai_assessment_result_properties(ai_assessment))
     result["properties"] = result_properties
     suppressions = _suppression_entries(finding)
     if suppressions:
@@ -606,6 +629,11 @@ def to_sarif(
     rules: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
     seen_rule_ids: set[str] = set()
+    # Advisory AI-triage assessments keyed by the finding_id they describe, so
+    # each is joined onto its finding's result instead of only the JSON block.
+    ai_assessments_by_finding: dict[str, Any] = {
+        assessment.finding_id: assessment for assessment in getattr(report, "ai_finding_assessments", []) or []
+    }
 
     # Stable-sort the CVE stream so exposure_path.rank never flips on score ties:
     # primary key is descending unified risk, tie-broken by finding id. This keeps
@@ -645,6 +673,7 @@ def to_sarif(
                 level=level,
                 pkg_name=pkg_name,
                 pkg_version=pkg_version,
+                ai_assessment=ai_assessments_by_finding.get(finding.id),
             )
         )
 

--- a/tests/fixtures/output/demo-markdown-golden.md
+++ b/tests/fixtures/output/demo-markdown-golden.md
@@ -19,12 +19,12 @@
 
 ## Findings
 
-| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | CWE | Tags | Source | Agents |
-|----------|-----|---------|---------|-----|------|------|-----|-----|------|--------|--------|
-| **CRITICAL** | CVE-2024-0001 | lodash | 4.17.20 | 4.17.21 | 9.8 | - | - | CWE-1321 | - | - | 1 |
-| **HIGH** | CVE-2024-0002 | requests | 2.28.0 | 2.31.0 | 7.5 | - | - | - | - | - | 1 |
-| **MEDIUM** | CVE-2024-0003 | express | 4.18.0 | - | 5.3 | - | - | - | - | - | 1 |
-| **LOW** | CVE-2024-0004 | debug | 4.3.0 | 4.17.21 | 2.1 | - | - | - | - | - | 1 |
+| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | Reach | CWE | Tags | Source | Agents |
+|----------|-----|---------|---------|-----|------|------|-----|-------|-----|------|--------|--------|
+| **CRITICAL** | CVE-2024-0001 | lodash | 4.17.20 | 4.17.21 | 9.8 | - | - | Unknown | CWE-1321 | - | - | 1 |
+| **HIGH** | CVE-2024-0002 | requests | 2.28.0 | 2.31.0 | 7.5 | - | - | Unknown | - | - | - | 1 |
+| **MEDIUM** | CVE-2024-0003 | express | 4.18.0 | - | 5.3 | - | - | Unknown | - | - | - | 1 |
+| **LOW** | CVE-2024-0004 | debug | 4.3.0 | 4.17.21 | 2.1 | - | - | Unknown | - | - | - | 1 |
 
 ## Exposure Paths
 
@@ -45,6 +45,7 @@
 - **CVSS**: 9.8
 - **Fix**: Upgrade to 4.17.21
 - **CWE**: CWE-1321
+- **Reachability**: Unknown (code reachability not evaluated)
 - **Affected agents**: claude
 
 ### CVE-2024-0002 — requests@2.28.0
@@ -54,6 +55,7 @@
 - **Severity**: HIGH
 - **CVSS**: 7.5
 - **Fix**: Upgrade to 2.31.0
+- **Reachability**: Unknown (code reachability not evaluated)
 - **Affected agents**: claude
 
 ---

--- a/tests/test_export_enrichment_parity.py
+++ b/tests/test_export_enrichment_parity.py
@@ -1,0 +1,294 @@
+"""Enrichment-parity gate: fields computed and carried by most exporters must
+not be silently dropped by specific ones.
+
+Covers three "computed but not surfaced" omissions:
+
+1. CycloneDX drops KEV / EPSS / CWE — every other exporter serializes them.
+2. AI triage assessments reach only the JSON side-block — join them onto the
+   findings they describe in SARIF and the HTML CVE table.
+3. Reachability is missing from the HTML findings tables and Markdown — the
+   human-facing moat signal, present in JSON/SARIF/CSV.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from agent_bom.ai_schemas import AIFindingAssessment, AIProvenance
+from agent_bom.models import (
+    Agent,
+    AgentType,
+    AIBOMReport,
+    BlastRadius,
+    MCPServer,
+    MCPTool,
+    Package,
+    Severity,
+    Vulnerability,
+)
+from agent_bom.output.cyclonedx_fmt import to_cyclonedx
+from agent_bom.output.finding_views import cve_findings
+from agent_bom.output.html.sections import _vuln_table
+from agent_bom.output.markdown import to_markdown
+from agent_bom.output.sarif import to_sarif
+
+_FIXTURES = Path(__file__).parent / "fixtures"
+
+
+# ── shared fixtures ──────────────────────────────────────────────────────────
+
+
+def _kev_epss_cwe_vuln() -> Vulnerability:
+    return Vulnerability(
+        id="CVE-2026-0001",
+        summary="Remote code execution in flask",
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        fixed_version="2.3.0",
+        epss_score=0.94567,
+        epss_percentile=99.1,
+        is_kev=True,
+        kev_date_added="2026-01-02",
+        kev_due_date="2026-01-23",
+        cwe_ids=["CWE-94", "CWE-502"],
+    )
+
+
+def _report_with_vuln(vuln: Vulnerability) -> AIBOMReport:
+    pkg = Package(
+        name="flask",
+        version="0.12.2",
+        ecosystem="pypi",
+        purl="pkg:pypi/flask@0.12.2",
+        vulnerabilities=[vuln],
+        is_direct=True,
+    )
+    server = MCPServer(
+        name="db-server",
+        packages=[pkg],
+        tools=[MCPTool(name="query", description="run sql")],
+    )
+    agent = Agent(
+        name="claude-desktop",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/claude-desktop.json",
+        mcp_servers=[server],
+        version="1.0",
+    )
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[server],
+        affected_agents=[agent],
+        exposed_credentials=["AWS_SECRET_ACCESS_KEY"],
+        exposed_tools=[],
+    )
+    br.calculate_risk_score()
+    return AIBOMReport(
+        agents=[agent],
+        blast_radii=[br],
+        scan_sources=["agent_discovery"],
+        scan_id="3c249b23-4088-4c46-911d-1d4daf950e47",
+        tool_version="0.0.0-test",
+        generated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+    )
+
+
+def _report_with_reachability(reach: str | None) -> AIBOMReport:
+    vuln = Vulnerability(
+        id="CVE-2026-0002",
+        summary="Reachable RCE",
+        severity=Severity.HIGH,
+        cvss_score=8.1,
+        fixed_version="3.0.0",
+    )
+    report = _report_with_vuln(vuln)
+    br = report.blast_radii[0]
+    # Code-level reachability (the moat signal) is genuinely absent unless the
+    # AST/symbol engine ran; set only that field so "Unknown" stays honest.
+    if reach is not None:
+        br.symbol_reachability = reach
+        if reach == "function_reachable":
+            br.reachable_affected_symbols = ["flask.Flask.run"]
+    return report
+
+
+# ── CycloneDX schema helpers (mirror test_interop_schema_conformance) ─────────
+
+
+def _cyclonedx_registry():
+    from referencing import Registry, Resource
+
+    resources = []
+    for name in (
+        "cyclonedx-1.7.schema.json",
+        "spdx.schema.json",
+        "jsf-0.82.schema.json",
+        "cryptography-defs.schema.json",
+    ):
+        path = _FIXTURES / name
+        if not path.exists():
+            continue
+        schema = json.loads(path.read_text())
+        uri = schema.get("$id") or schema.get("id")
+        if uri:
+            resources.append((uri, Resource.from_contents(schema)))
+    return Registry().with_resources(resources)
+
+
+def _cdx_vuln(report: AIBOMReport) -> dict:
+    cdx = to_cyclonedx(report)
+    vulns = cdx.get("vulnerabilities", [])
+    return next(v for v in vulns if v["id"] == "CVE-2026-0001")
+
+
+# ── Instance 1: CycloneDX carries KEV / EPSS / CWE ───────────────────────────
+
+
+def test_cyclonedx_vulnerability_carries_cwes_native() -> None:
+    entry = _cdx_vuln(_report_with_vuln(_kev_epss_cwe_vuln()))
+    # CDX 1.7 `cwes` is a native array of integer CWE IDs.
+    assert entry.get("cwes") == [94, 502]
+
+
+def test_cyclonedx_vulnerability_carries_epss_rating() -> None:
+    entry = _cdx_vuln(_report_with_vuln(_kev_epss_cwe_vuln()))
+    epss_ratings = [r for r in entry.get("ratings", []) if (r.get("source") or {}).get("name") == "EPSS"]
+    assert epss_ratings, "EPSS must be surfaced as a CDX rating"
+    assert epss_ratings[0]["method"] == "other"
+    assert epss_ratings[0]["score"] == pytest.approx(0.94567)
+
+
+def test_cyclonedx_vulnerability_carries_kev_epss_properties() -> None:
+    entry = _cdx_vuln(_report_with_vuln(_kev_epss_cwe_vuln()))
+    props = {p["name"]: p["value"] for p in entry.get("properties", [])}
+    assert props.get("agent-bom:kev") == "true"
+    assert props.get("agent-bom:kev_date_added") == "2026-01-02"
+    assert props.get("agent-bom:kev_due_date") == "2026-01-23"
+    assert props.get("agent-bom:epss_score") == "0.94567"
+    assert props.get("agent-bom:epss_percentile") == "99.1"
+    assert props.get("agent-bom:exploit_likelihood") == "actively_exploited"
+
+
+def test_cyclonedx_no_enrichment_omits_kev_epss_properties() -> None:
+    plain = Vulnerability(
+        id="CVE-2026-0001",
+        summary="plain",
+        severity=Severity.MEDIUM,
+    )
+    entry = _cdx_vuln(_report_with_vuln(plain))
+    props = {p["name"] for p in entry.get("properties", [])}
+    assert "agent-bom:kev" not in props
+    assert "agent-bom:epss_score" not in props
+    assert "cwes" not in entry
+
+
+def test_cyclonedx_kev_epss_cwe_stays_schema_valid() -> None:
+    pytest.importorskip("jsonschema")
+    from jsonschema import Draft7Validator
+
+    schema_path = _FIXTURES / "cyclonedx-1.7.schema.json"
+    if not schema_path.exists():
+        pytest.skip("vendored CycloneDX 1.7 schema unavailable")
+    cdx = to_cyclonedx(_report_with_vuln(_kev_epss_cwe_vuln()))
+    schema = json.loads(schema_path.read_text())
+    validator = Draft7Validator(schema, registry=_cyclonedx_registry())
+    errors = sorted(validator.iter_errors(cdx), key=lambda e: list(e.path))
+    assert not errors, "\n".join(f"  - {'/'.join(str(p) for p in e.path)}: {e.message}" for e in errors[:20])
+
+
+# ── Instance 2: AI triage assessment joins onto SARIF + HTML ─────────────────
+
+
+def _report_with_assessment() -> tuple[AIBOMReport, str]:
+    report = _report_with_vuln(_kev_epss_cwe_vuln())
+    finding = cve_findings(report)[0]
+    provenance = AIProvenance(
+        run_id="run-1",
+        provider="ollama",
+        model="qwen2.5",
+        prompt_sha256="a" * 64,
+        response_sha256="b" * 64,
+        generated_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        deterministic=True,
+        redaction_applied=False,
+    )
+    report.ai_finding_assessments = [
+        AIFindingAssessment(
+            finding_id=finding.id,
+            classification="true_positive",
+            confidence="high",
+            false_positive_likelihood="low",
+            rationale="Reachable RCE in a running server.",
+            suggested_controls=["upgrade flask"],
+            provenance=provenance,
+        )
+    ]
+    return report, finding.id
+
+
+def test_sarif_result_carries_ai_assessment() -> None:
+    report, finding_id = _report_with_assessment()
+    sarif = to_sarif(report)
+    results = sarif["runs"][0]["results"]
+    target = next(r for r in results if r["ruleId"] == "CVE-2026-0001")
+    props = target["properties"]
+    assert props.get("agent-bom:ai_classification") == "true_positive"
+    assert props.get("agent-bom:ai_false_positive_likelihood") == "low"
+    assert props.get("agent-bom:ai_confidence") == "high"
+
+
+def test_sarif_result_without_assessment_has_no_ai_props() -> None:
+    report = _report_with_vuln(_kev_epss_cwe_vuln())  # no assessments
+    sarif = to_sarif(report)
+    target = next(r for r in sarif["runs"][0]["results"] if r["ruleId"] == "CVE-2026-0001")
+    assert "agent-bom:ai_classification" not in target["properties"]
+
+
+def test_html_vuln_table_shows_ai_assessment() -> None:
+    report, _ = _report_with_assessment()
+    html = _vuln_table(report, report.blast_radii)
+    assert "true_positive" in html
+    # false-positive likelihood must be surfaced on the annotated row.
+    assert "FP" in html or "false" in html.lower()
+
+
+def test_html_vuln_table_without_assessment_has_no_ai_annotation() -> None:
+    report = _report_with_vuln(_kev_epss_cwe_vuln())
+    html = _vuln_table(report, report.blast_radii)
+    assert "ai-triage" not in html
+
+
+# ── Instance 3: reachability in HTML findings table + Markdown ───────────────
+
+
+def test_html_vuln_table_shows_reachability_when_reachable() -> None:
+    report = _report_with_reachability("function_reachable")
+    html = _vuln_table(report, report.blast_radii)
+    assert "data-reachability=" in html
+    assert "Function" in html
+
+
+def test_html_vuln_table_shows_reachability_unknown_when_absent() -> None:
+    report = _report_with_reachability(None)
+    html = _vuln_table(report, report.blast_radii)
+    assert 'data-reachability="unknown"' in html
+    assert "Unknown" in html
+
+
+def test_markdown_findings_table_shows_reachability() -> None:
+    report = _report_with_reachability("function_reachable")
+    md = to_markdown(report, report.blast_radii)
+    assert "Reach" in md
+    assert "Function" in md
+
+
+def test_markdown_findings_table_reachability_unknown_when_absent() -> None:
+    report = _report_with_reachability(None)
+    md = to_markdown(report, report.blast_radii)
+    assert "Reach" in md
+    assert "Unknown" in md

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -633,7 +633,7 @@ class TestMarkdown:
 
         md = to_markdown(report, [br])
 
-        assert "| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | CWE | Tags | Source | Agents |" in md
+        assert "| Severity | CVE | Package | Version | Fix | CVSS | EPSS | KEV | Reach | CWE | Tags | Source | Agents |" in md
         assert "0.8123" in md
         assert "Yes" in md
         assert "CWE-79, CWE-352" in md


### PR DESCRIPTION
Part of the "computed but never surfaced" defect class — enrichment computed once but silently dropped by specific exporters.

## Fixes
1. **CycloneDX dropped KEV / EPSS / CWE** — the one SBOM/VEX artifact downstream tools ingest for prioritization hid "actively exploited" + exploit-probability. Added `cwes` (native CDX 1.7 integer array), EPSS as an `other`-method rating, and KEV/EPSS detail as namespaced `agent-bom:` vulnerability properties. Emitted only when present (no fabrication).
2. **AI triage assessments reached only JSON** — `AIFindingAssessment` (classification, false-positive likelihood, provenance) is now joined by `finding_id` into SARIF result properties and the HTML findings table. Advisory-only; only findings with an assessment are annotated.
3. **Reachability missing from HTML + Markdown** — added a shared honest `reachability_label()` keyed off the code-level `symbol_reachability`/`graph_reachable` moat signal (explicit **Unknown** when the AST/graph engine didn't run, per §11), surfaced as a "Reach" column in the HTML and Markdown findings tables + a Markdown detail line. SPDX left untouched (no native slot).

## How verified
CDX BOM validated against the vendored CDX 1.7 schema (0 errors) with pinned `cyclonedx-python-lib` 11.11.0; SARIF validated against sarif-2.1.0. 13 new tests red→green; exporter suites `262 passed, 1 skipped`; `ruff`/`mypy` clean. Snapshots updated only for the new "Reach" column (demo rows honestly "Unknown"). No KEV/EPSS/reachability fabricated when absent.