### PR TITLE
fix(graph): consume admin-equivalent, de-prioritize mitigated exposure, surface skip reason

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -393,18 +393,59 @@ def _fusion_signals_for_path(graph: UnifiedGraph, hops: list[str]) -> list[tuple
             continue
         attrs = node.attributes
         port_detail = _exposed_port_detail(attrs)
+        # A WAF / API-gateway in front of the resource mitigates its exposure
+        # (set by the CNAPP overlay). Honesty (§11): a mitigated node is NOT
+        # counted as a full-weight toxic/exposed foothold, but it is NOT hidden
+        # either — it surfaces as an explicitly *mitigated* signal at lower rank.
+        exposure_mitigated = bool(attrs.get("exposure_mitigated") or attrs.get("protected_by_waf"))
         if attrs.get("toxic_exposed_vulnerable"):
             add("toxic_exposed_vulnerable", "Toxic: exposed + vulnerable", f"{node.label}: exposed{port_detail} + vulnerable.", 20.0)
+        elif attrs.get("toxic_exposed_vulnerable_mitigated"):
+            add(
+                "toxic_exposed_vulnerable_mitigated",
+                "Toxic (mitigated): exposed + vulnerable behind WAF",
+                f"{node.label}: internet-exposed{port_detail} + vulnerable but fronted by a WAF/API gateway (exposure mitigated).",
+                8.0,
+            )
         elif attrs.get("internet_exposed"):
-            add("internet_exposed", "Internet exposed", f"{node.label} is reachable from the public internet{port_detail}.", 15.0)
+            if exposure_mitigated:
+                add(
+                    "internet_exposed_mitigated",
+                    "Internet exposed (mitigated)",
+                    f"{node.label} is internet-exposed{port_detail} but fronted by a WAF/API gateway (exposure mitigated).",
+                    6.0,
+                )
+            else:
+                add("internet_exposed", "Internet exposed", f"{node.label} is reachable from the public internet{port_detail}.", 15.0)
         if attrs.get("escalates_to_admin"):
             add("privilege_escalation_admin", "Admin escalation", f"{node.label} can assume an admin-privileged role.", 20.0)
         elif attrs.get("can_escalate_privilege"):
             add("privilege_escalation", "Privilege escalation", f"{node.label} can assume a role with broader effective access.", 16.0)
+        # Standing admin-equivalent permissions (holds admin directly) — an
+        # independent CIEM signal from the assume-chain escalation above, so it
+        # is added, not chained via elif. Basis provenance stays visible.
+        if attrs.get("admin_equivalent"):
+            basis = attrs.get("admin_equivalence_basis")
+            basis_detail = f" (basis: {basis})" if basis else ""
+            add(
+                "admin_equivalent",
+                "Admin-equivalent identity",
+                f"{node.label} holds admin-equivalent permissions{basis_detail}.",
+                18.0,
+            )
         if attrs.get("toxic_exposed_sensitive"):
-            add("exposed_sensitive_data", "Exposed sensitive data", f"{node.label} holds sensitive data and is internet-exposed.", 22.0)
+            reach = attrs.get("sensitive_data_access_count")
+            reach_detail = f", reachable by {reach} identity/tool path(s)" if isinstance(reach, int) and reach > 0 else ""
+            add(
+                "exposed_sensitive_data",
+                "Exposed sensitive data",
+                f"{node.label} holds sensitive data and is internet-exposed{reach_detail}.",
+                22.0,
+            )
         elif attrs.get("data_sensitivity"):
-            add("sensitive_data", "Sensitive data", f"{node.label} holds sensitive (PII/PHI/secret) data.", 8.0)
+            reach = attrs.get("sensitive_data_access_count")
+            reach_detail = f", reachable by {reach} identity/tool path(s)" if isinstance(reach, int) and reach > 0 else ""
+            add("sensitive_data", "Sensitive data", f"{node.label} holds sensitive (PII/PHI/secret) data{reach_detail}.", 8.0)
         # Runtime-observed reachability: a hop with actual observed runtime
         # activity is confirmed reachable, not just statically connected — so it
         # ranks above an identical static-only chain.
@@ -956,6 +997,27 @@ def _derived_governance_attack_paths(graph: UnifiedGraph) -> list[AttackPath]:
                             45.0,
                             f"{node.label} drifted to using tool {tool.label} outside its declared blueprint.",
                         )
+
+    # Admin-equivalent identity: a principal that holds admin-equivalent
+    # permissions is a standing CIEM risk on its own — no assume-chain, finding,
+    # or dangerous-tool anchor required — so surface it as a first-class path so
+    # it appears/ranks in the queue rather than sitting inert on the node. The
+    # admin-equivalence basis (policy_evaluation / scanner_actions / heuristic)
+    # is carried into the summary as provenance.
+    for node in graph.nodes.values():
+        if not node.attributes.get("admin_equivalent"):
+            continue
+        basis = node.attributes.get("admin_equivalence_basis")
+        basis_detail = f" (basis: {basis})" if basis else ""
+        emit(
+            "admin_equivalent",
+            node.id,
+            node.id,
+            [node.id],
+            [],
+            60.0,
+            f"{node.label} holds admin-equivalent permissions{basis_detail} — a standing privilege-escalation risk.",
+        )
     return paths
 
 
@@ -1003,7 +1065,10 @@ def _derived_toxic_combination_paths(graph: UnifiedGraph) -> list[AttackPath]:
             vulnerable.add(edge.source)
         elif rel == RelationshipType.HAS_PERMISSION.value:
             principal = graph.nodes.get(edge.source)
-            if principal is not None and principal.attributes.get("escalates_to_admin"):
+            # A resource is admin-privilege-reachable when a principal that can
+            # escalate to admin OR that already holds admin-equivalent permissions
+            # has effective access to it.
+            if principal is not None and (principal.attributes.get("escalates_to_admin") or principal.attributes.get("admin_equivalent")):
                 admin_reachable.add(edge.target)
         elif rel in (RelationshipType.STORES.value, RelationshipType.EXPOSED_TO.value):
             store = graph.nodes.get(edge.target)
@@ -1015,10 +1080,15 @@ def _derived_toxic_combination_paths(graph: UnifiedGraph) -> list[AttackPath]:
         if _node_type_value(node) not in _TOXIC_RESOURCE_TYPES or len(paths) >= _MAX_TOXIC_PATHS:
             continue
         attrs = node.attributes
+        # WAF / API-gateway in front of the resource mitigates its exposure
+        # (CNAPP overlay). Honesty (§11): the node still surfaces (marked
+        # mitigated), but its exposure factor is not counted at full weight and
+        # the composite band is capped below an unmitigated peer's.
+        exposure_mitigated = bool(attrs.get("exposure_mitigated") or attrs.get("protected_by_waf"))
         factors: list[str] = []
         if attrs.get("internet_exposed"):
-            factors.append("internet-exposed")
-        if node.id in vulnerable or attrs.get("toxic_exposed_vulnerable"):
+            factors.append("internet-exposed (WAF-mitigated)" if exposure_mitigated else "internet-exposed")
+        if node.id in vulnerable or attrs.get("toxic_exposed_vulnerable") or attrs.get("toxic_exposed_vulnerable_mitigated"):
             factors.append("exploitable vulnerability")
         sens_ids = sensitive_neighbors.get(node.id, [])
         if attrs.get("data_sensitivity") or sens_ids:
@@ -1037,7 +1107,13 @@ def _derived_toxic_combination_paths(graph: UnifiedGraph) -> list[AttackPath]:
         hops = [node.id, target] if target != node.id else [node.id]
         edges = ["exposed_to"] if target != node.id else []
         base = _toxic_band(len(factors))
+        if exposure_mitigated:
+            # Below the unmitigated toxic band — the WAF fronts the exposure — but
+            # still surfaced and marked, never dropped.
+            base = min(base, 65.0)
         prefix = "Crown jewel" if len(factors) >= 3 else "Toxic combination"
+        if exposure_mitigated:
+            prefix += " (exposure mitigated)"
         paths.append(
             AttackPath(
                 source=node.id,

--- a/src/agent_bom/graph/attack_path_fusion.py
+++ b/src/agent_bom/graph/attack_path_fusion.py
@@ -148,10 +148,19 @@ def _node_boost(node: UnifiedNode) -> float:
     boost = 0.0
     if attrs.get("toxic_exposed_vulnerable"):
         boost += 10.0
+    elif attrs.get("toxic_exposed_vulnerable_mitigated"):
+        # Exposure fronted by a WAF/API gateway: a real but mitigated toxic combo.
+        # Counted at a reduced weight so it ranks below a bare toxic node without
+        # being silently dropped (honesty: de-prioritized, not hidden).
+        boost += 4.0
     if attrs.get("escalates_to_admin"):
         boost += 12.0
     elif attrs.get("can_escalate_privilege"):
         boost += 8.0
+    # Standing admin-equivalent permissions are an independent escalation prize
+    # (holds admin directly, distinct from reaching admin via an assume-chain).
+    if attrs.get("admin_equivalent"):
+        boost += 12.0
     return boost
 
 

--- a/src/agent_bom/graph/effective_permissions.py
+++ b/src/agent_bom/graph/effective_permissions.py
@@ -28,6 +28,7 @@ from agent_bom.cloud.aws_iam_evidence import (
     NormalizedIamPolicy,
     normalize_iam_policy_document,
 )
+from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
 from agent_bom.graph.container import InteractionRisk, UnifiedGraph
 from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
@@ -62,6 +63,8 @@ _ASSUME_RELS = frozenset({RelationshipType.ASSUMES, RelationshipType.INHERITS})
 
 _MAX_PRINCIPALS = 5000
 _MAX_DEPTH = 6
+
+_ANALYZER = "effective_permissions"
 _ADMIN_PRIVILEGE_KEYWORDS = ("administratoraccess", "fullaccess", "poweruseraccess", "iamfullaccess", "*:*", "admin", "owner", "root")
 
 # Admin-equivalence probes for real IAM evaluation. A policy that ALLOWs any of
@@ -134,17 +137,31 @@ def apply_effective_permissions(graph: UnifiedGraph) -> dict[str, object]:
     Returns counts of permission edges added and escalation chains found. Never
     raises into the builder.
     """
+    limits = {"max_principals": _MAX_PRINCIPALS, "max_depth": _MAX_DEPTH}
     principals = [n for n in graph.nodes.values() if n.entity_type in _PRINCIPAL_TYPES]
     if not principals:
+        graph.analysis_status[_ANALYZER] = GraphAnalysisStatus(
+            status=GraphAnalysisState.COMPLETE,
+            limits=limits,
+            observed={"principal_count": 0, "privilege_escalations": 0},
+        )
         return {"has_permission_edges": 0, "privilege_escalations": 0}
     if len(principals) > _MAX_PRINCIPALS:
-        # Capped, NOT "no escalations". Surface a signal (log + returned reason) so
-        # consumers can distinguish "too big to compute" from "genuinely clean".
+        # Capped, NOT "no escalations". Persist the honest SKIPPED status on the
+        # graph (the same analysis_status contract fusion uses, surfaced through
+        # ``stats()``) AND return a reason so consumers can distinguish "too big
+        # to compute" from "genuinely clean".
         _logger.warning(
             "effective-permissions capped: %d principals exceed cap %d; "
             "privilege-escalation NOT computed for this graph (result is 'skipped', not 'none')",
             len(principals),
             _MAX_PRINCIPALS,
+        )
+        graph.analysis_status[_ANALYZER] = GraphAnalysisStatus(
+            status=GraphAnalysisState.SKIPPED,
+            reason_codes=("principal_cap_exceeded",),
+            limits=limits,
+            observed={"principal_count": len(principals), "privilege_escalations": 0},
         )
         return {
             "has_permission_edges": 0,
@@ -326,6 +343,16 @@ def apply_effective_permissions(graph: UnifiedGraph) -> dict[str, object]:
             )
             escalations += 1
 
+    graph.analysis_status[_ANALYZER] = GraphAnalysisStatus(
+        status=GraphAnalysisState.COMPLETE,
+        limits=limits,
+        observed={
+            "principal_count": len(principals),
+            "has_permission_edges": edges_added,
+            "privilege_escalations": escalations,
+            "admin_principals": len(admin_principals),
+        },
+    )
     return {
         "has_permission_edges": edges_added,
         "privilege_escalations": escalations,

--- a/tests/test_attack_path_fusion.py
+++ b/tests/test_attack_path_fusion.py
@@ -6,6 +6,7 @@ from agent_bom.graph.attack_path_fusion import (
     _MAX_DEPTH,
     _MAX_NODES,
     _MAX_PATHS,
+    _node_boost,
     apply_attack_path_fusion,
     compute_fused_attack_paths,
 )
@@ -305,3 +306,21 @@ def test_oversized_graph_surfaces_skipped_signal():
     assert stats["analysis_status"]["status"] == "skipped"
     assert stats["analysis_status"]["reason_codes"] == ["node_cap_exceeded"]
     assert g.analysis_status["attack_path_fusion"].status.value == "skipped"
+
+
+def test_node_boost_recognizes_admin_equivalent():
+    # A standing admin-equivalent node contributes independent escalation risk to
+    # a chain that passes through it (previously read by nothing).
+    plain = UnifiedNode(id="p", entity_type=EntityType.ROLE, label="r")
+    admin = UnifiedNode(id="p2", entity_type=EntityType.ROLE, label="r2", attributes={"admin_equivalent": True})
+    assert _node_boost(admin) > _node_boost(plain)
+
+
+def test_node_boost_deprioritizes_mitigated_toxic_but_keeps_it():
+    # A WAF-fronted (mitigated) toxic node scores below a bare toxic node, yet is
+    # not zeroed out — honesty: de-prioritized, not hidden.
+    bare = UnifiedNode(id="a", entity_type=EntityType.CLOUD_RESOURCE, label="a", attributes={"toxic_exposed_vulnerable": True})
+    mitig = UnifiedNode(
+        id="b", entity_type=EntityType.CLOUD_RESOURCE, label="b", attributes={"toxic_exposed_vulnerable_mitigated": True}
+    )
+    assert 0 < _node_boost(mitig) < _node_boost(bare)

--- a/tests/test_graph_effective_permissions.py
+++ b/tests/test_graph_effective_permissions.py
@@ -370,3 +370,32 @@ def test_capped_graph_surfaces_skipped_signal():
     assert stats["privilege_escalations"] == 0
     assert stats["skipped"] is True
     assert "principal_cap_exceeded" in stats["skipped_reason"]
+
+
+def test_capped_graph_persists_skipped_analysis_status_on_graph():
+    # The capped result must ALSO be persisted on the graph's analysis_status map
+    # (the same honest SKIPPED contract fusion uses) so the read API can report
+    # "escalation NOT computed" rather than letting 0 escalations read as clean.
+    from agent_bom.graph.effective_permissions import _MAX_PRINCIPALS
+
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    for i in range(_MAX_PRINCIPALS + 1):
+        g.add_node(UnifiedNode(id=f"user:{i}", entity_type=EntityType.USER, label=f"u{i}"))
+    apply_effective_permissions(g)
+    status = g.analysis_status.get("effective_permissions")
+    assert status is not None
+    assert status.status.value == "skipped"
+    assert "principal_cap_exceeded" in status.reason_codes
+    # surfaces through stats() the API already serializes
+    assert g.stats()["analysis_status"]["effective_permissions"]["status"] == "skipped"
+
+
+def test_computed_graph_persists_complete_analysis_status_on_graph():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(UnifiedNode(id="user:a", entity_type=EntityType.USER, label="a"))
+    g.add_node(UnifiedNode(id="cloud:r", entity_type=EntityType.CLOUD_RESOURCE, label="r"))
+    g.add_edge(UnifiedEdge(source="user:a", target="cloud:r", relationship=RelationshipType.CAN_ACCESS))
+    apply_effective_permissions(g)
+    status = g.analysis_status.get("effective_permissions")
+    assert status is not None
+    assert status.status.value == "complete"

--- a/tests/test_graph_posture_signal_wiring.py
+++ b/tests/test_graph_posture_signal_wiring.py
@@ -1,0 +1,142 @@
+"""Consumption-side wiring of computed-but-dropped graph posture signals.
+
+Guards three honesty/CIEM fixes on the READ side (graph route + fusion):
+
+1. ``admin_equivalent`` principals now surface + rank in the CIEM/risk surface
+   (previously computed on the node but read by nothing).
+2. CNAPP exposure-mitigation flags (``exposure_mitigated`` / ``protected_by_waf``
+   / ``toxic_exposed_vulnerable_mitigated``) de-prioritize a mitigated node —
+   marked mitigated, never silently dropped — so toxic exposure is not
+   over-reported.
+3. ``sensitive_data_access_count`` (blast-radius reach) is surfaced on the risk
+   signal for a sensitive store.
+"""
+
+from __future__ import annotations
+
+from agent_bom.api.routes.graph import (
+    _derived_attack_paths,
+    _derived_toxic_combination_paths,
+    _fusion_signals_for_path,
+)
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+# ── Defect 1: admin_equivalent surfaces + ranks ──────────────────────────────
+
+
+def test_admin_equivalent_surfaces_as_fusion_signal_with_basis():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(
+        UnifiedNode(
+            id="role:admin",
+            entity_type=EntityType.ROLE,
+            label="admin-role",
+            attributes={"admin_equivalent": True, "admin_equivalence_basis": "policy_evaluation"},
+        )
+    )
+    signals = _fusion_signals_for_path(g, ["role:admin"])
+    kinds = {kind for kind, _label, _detail, _boost in signals}
+    assert "admin_equivalent" in kinds
+    detail = next(detail for kind, _l, detail, _b in signals if kind == "admin_equivalent")
+    # provenance (basis) stays visible where the flag is surfaced
+    assert "policy_evaluation" in detail
+
+
+def test_admin_equivalent_principal_appears_as_ciem_path():
+    # A role that holds admin-equivalent permissions but does NOT reach anything
+    # via an assume-chain must still surface as a first-class CIEM path — before
+    # the fix it was absent from the queue entirely.
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(
+        UnifiedNode(
+            id="role:standing-admin",
+            entity_type=EntityType.ROLE,
+            label="standing-admin",
+            attributes={"admin_equivalent": True, "admin_equivalence_basis": "scanner_actions"},
+        )
+    )
+    paths = _derived_attack_paths(g)
+    assert any("admin-equivalent" in p.summary.lower() for p in paths)
+
+
+# ── Defect 2: exposure mitigation de-prioritizes, marked not hidden ───────────
+
+
+def _exposed_node(node_id: str, *, mitigated: bool) -> UnifiedNode:
+    attrs: dict[str, object] = {"internet_exposed": True}
+    if mitigated:
+        attrs["exposure_mitigated"] = True
+        attrs["protected_by_waf"] = True
+    return UnifiedNode(id=node_id, entity_type=EntityType.CLOUD_RESOURCE, label=node_id, attributes=attrs)
+
+
+def test_mitigated_exposure_is_marked_and_deprioritized_not_dropped():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(_exposed_node("cloud:waf", mitigated=True))
+    signals = _fusion_signals_for_path(g, ["cloud:waf"])
+    kinds = {kind for kind, _l, _d, _b in signals}
+    # honesty: it is NOT scored as a full-weight internet exposure...
+    assert "internet_exposed" not in kinds
+    # ...but it is NOT hidden either — surfaced as an explicitly mitigated signal.
+    assert "internet_exposed_mitigated" in kinds
+    mitig_boost = next(b for kind, _l, _d, b in signals if kind == "internet_exposed_mitigated")
+    full_boost = 15.0  # the unmitigated internet_exposed boost
+    assert 0 < mitig_boost < full_boost
+
+
+def test_mitigated_toxic_combination_scores_below_unmitigated_and_is_marked():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    # Unmitigated: exposed + vulnerable.
+    g.add_node(
+        UnifiedNode(
+            id="cloud:bare",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="bare-api",
+            attributes={"internet_exposed": True, "toxic_exposed_vulnerable": True},
+        )
+    )
+    g.add_node(UnifiedNode(id="vuln:a", entity_type=EntityType.VULNERABILITY, label="CVE-A", severity="critical"))
+    g.add_edge(UnifiedEdge(source="cloud:bare", target="vuln:a", relationship=RelationshipType.VULNERABLE_TO))
+    # Mitigated: same exposure + vuln but WAF-fronted (overlay set the *_mitigated flag).
+    g.add_node(
+        UnifiedNode(
+            id="cloud:waf",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="waf-api",
+            attributes={
+                "internet_exposed": True,
+                "exposure_mitigated": True,
+                "protected_by_waf": True,
+                "toxic_exposed_vulnerable_mitigated": True,
+            },
+        )
+    )
+    g.add_node(UnifiedNode(id="vuln:b", entity_type=EntityType.VULNERABILITY, label="CVE-B", severity="critical"))
+    g.add_edge(UnifiedEdge(source="cloud:waf", target="vuln:b", relationship=RelationshipType.VULNERABLE_TO))
+
+    paths = {p.source: p for p in _derived_toxic_combination_paths(g)}
+    assert "cloud:bare" in paths, "unmitigated toxic combination must surface"
+    assert "cloud:waf" in paths, "mitigated node must still surface (marked), not be dropped"
+    assert paths["cloud:waf"].composite_risk < paths["cloud:bare"].composite_risk
+    assert "mitigat" in paths["cloud:waf"].summary.lower()
+
+
+# ── Defect 2b: sensitive_data_access_count surfaces on the risk signal ────────
+
+
+def test_sensitive_access_count_surfaces_on_sensitive_signal():
+    g = UnifiedGraph(scan_id="s", tenant_id="t")
+    g.add_node(
+        UnifiedNode(
+            id="ds:pii",
+            entity_type=EntityType.DATA_STORE,
+            label="pii-store",
+            attributes={"data_sensitivity": "sensitive", "sensitive_data_access_count": 4},
+        )
+    )
+    signals = _fusion_signals_for_path(g, ["ds:pii"])
+    detail = next(detail for kind, _l, detail, _b in signals if kind == "sensitive_data")
+    assert "4" in detail


### PR DESCRIPTION
Part of the "computed but never surfaced" defect class — graph/posture signals stamped on nodes but read by nothing. Consumption-side only (no `builder.py`/`pipeline.py` changes).

## Fixes
1. **`admin_equivalent` was dropped (HIGH, CIEM)** — stamped by `effective_permissions` but read by nothing, while its sibling `escalates_to_admin` is consumed. Now surfaced as a fusion signal (with `admin_equivalence_basis`), a node boost, an `admin_reachable` toxic factor, and a standalone CIEM path so a principal holding admin directly appears in `/v1/graph/attack-paths`.
2. **CNAPP mitigation flags were dropped → over-report (HIGH, honesty)** — `protected_by_waf`/`exposure_mitigated`/`toxic_exposed_vulnerable_mitigated` were never read, so a WAF-fronted node ranked at full toxic-exposure weight. Now de-prioritized in fusion signals, node boost, and the toxic band — and in every case **visibly marked mitigated** (signal kind, path prefix, factor label), never silently dropped. `sensitive_data_access_count` also surfaced.
3. **"Capped, skipped-not-clean" signal was discarded (MED, honesty)** — `apply_effective_permissions` now persists `GraphAnalysisStatus(SKIPPED, reason_codes=("principal_cap_exceeded",))` on the graph (COMPLETE otherwise), so a large estate reads as "not computed", never "clean".

Not touched (honestly deferred): the `usage=` over-grant map (service-namespace vs resource-node mismatch), redundant `nhi_risk_*` attrs, cost_overlay attrs.

## How verified
9 new tests red→green; touched suites `155 passed`, regression net `147 passed`; `ruff`/`mypy` clean; OpenAPI `--check` OK (new keys ride existing `additionalProperties`). Adversarial reconciliation on a seeded twin-EC2 graph: bare toxic 82.0 vs WAF-mitigated 65.0 "(exposure mitigated)", admin-equivalent role 78.0; overlay counts reconcile, elif ordering can't double-count.