### PR TITLE
fix(compliance): wire CIS benchmark posture into the scorecard and narrow the framework over-claim

### DIFF
--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -322,6 +322,101 @@ def _evaluated_control_status(sev_breakdown: dict[str, int]) -> str:
     return "not_evaluated"
 
 
+def _aggregate_cis_foundations_checks(jobs: list[Any]) -> dict[str, Any]:
+    """Deduped CIS Foundations Benchmark status rollup across a tenant's scans.
+
+    Reuses ``build_cis_benchmark_check_rows`` + the same latest-per-(cloud,
+    check_id) dedup as ``/v1/cis/checks`` so the scorecard's benchmark line
+    reconciles with that endpoint by construction.
+
+    This is the CIS *Foundations Benchmark* taxonomy (``CIS-2.1.1`` …), a
+    different standard from the CVE-driven CIS Controls v8 line (safeguard
+    ``CIS-02.1`` …) built elsewhere in :func:`get_compliance`. The two never
+    share identifiers, so no control is counted in both lines.
+    """
+    from agent_bom.analytics_contract import build_cis_benchmark_check_rows
+
+    all_rows: list[dict[str, Any]] = []
+    for job in jobs:
+        if job.status != JobStatus.DONE or not isinstance(getattr(job, "result", None), dict):
+            continue
+        all_rows.extend(
+            build_cis_benchmark_check_rows(
+                job.result,
+                str(job.result.get("scan_id") or job.job_id),
+                measured_at=getattr(job, "completed_at", None) or getattr(job, "created_at", None),
+            )
+        )
+    # Newest measurement per logical (cloud, check_id) wins — identical dedup to
+    # the /v1/cis/checks scan_jobs fallback so the two surfaces agree.
+    all_rows.sort(key=lambda row: (str(row.get("measured_at") or ""), -int(row.get("priority") or 0)), reverse=True)
+    seen: set[tuple[str, str]] = set()
+    counts = {"pass": 0, "fail": 0, "error": 0, "not_applicable": 0, "other": 0}
+    providers: dict[str, dict[str, int]] = {}
+    for row in all_rows:
+        key = (str(row.get("cloud") or ""), str(row.get("check_id") or ""))
+        if key in seen:
+            continue
+        seen.add(key)
+        status = str(row.get("status") or "").lower()
+        bucket = status if status in ("pass", "fail", "error", "not_applicable") else "other"
+        counts[bucket] += 1
+        cloud = str(row.get("cloud") or "unknown")
+        prov = providers.setdefault(cloud, {"pass": 0, "fail": 0, "error": 0, "not_applicable": 0, "other": 0})
+        prov[bucket] += 1
+    return {"counts": counts, "providers": providers, "total_checks": len(seen)}
+
+
+def _build_cis_foundations_line(agg: dict[str, Any]) -> dict[str, Any]:
+    """Shape the benchmark-backed CIS Foundations scorecard line.
+
+    Denominator is honest: ``evaluated = pass + fail + error`` (NOT_APPLICABLE
+    checks are excluded from the score). ERROR is an explicit bucket — an
+    unevaluable control (permission-denied / unreadable, which the eval layer
+    correctly refuses to PASS) is neither pass nor fail, and never inflates the
+    numerator.
+    """
+    counts = agg["counts"]
+    passed = int(counts["pass"])
+    failed = int(counts["fail"])
+    errored = int(counts["error"])
+    not_applicable = int(counts["not_applicable"])
+    evaluated = passed + failed + errored
+    score = round((passed / evaluated) * 100, 1) if evaluated > 0 else 0.0
+
+    if not agg["total_checks"]:
+        status = "no_data"
+    elif failed > 0:
+        status = "fail"
+    elif errored > 0:
+        # Everything evaluable passed, but some controls were unevaluable — not a
+        # clean pass. Surface as warning so the reader knows coverage is partial.
+        status = "warning"
+    elif evaluated > 0:
+        status = "pass"
+    else:
+        status = "no_data"  # only NOT_APPLICABLE checks — nothing was evaluated
+
+    return {
+        "framework": "cis-foundations",
+        "framework_key": "cis_foundations_benchmark",
+        "framework_label": "CIS Foundations Benchmark",
+        "representation": "benchmark",
+        "source": "cis_benchmark_data",
+        "status": status,
+        "score": score,
+        "summary": {
+            "pass": passed,
+            "fail": failed,
+            "error": errored,
+            "not_applicable": not_applicable,
+            "evaluated": evaluated,
+            "score": score,
+        },
+        "providers": agg["providers"],
+    }
+
+
 @router.get("/compliance", tags=["compliance"])
 async def get_compliance(request: Request) -> dict:
     """Aggregate OWASP LLM Top 10, OWASP MCP Top 10, MITRE ATLAS, NIST AI RMF,
@@ -429,16 +524,35 @@ async def get_compliance(request: Request) -> dict:
     total_pass = sum(s[0] for s in status_totals)
     total_warn = sum(s[1] for s in status_totals)
     total_fail = sum(s[2] for s in status_totals)
-    # Score over EVALUATED controls only (those with mapped findings). A control
-    # with no findings is not_evaluated, never a silent pass — otherwise every
-    # never-triggered bundled control inflates the score toward 100. Matches the
-    # narrative so a benign/empty estate can't read as "fully compliant".
-    evaluated_controls = total_pass + total_warn + total_fail
-    overall_score = round((total_pass / evaluated_controls) * 100, 1) if evaluated_controls > 0 else 0.0
 
-    if total_fail > 0:
+    # Wire the CIS Foundations Benchmark posture (report.cis_benchmark_data + the
+    # azure/gcp/snowflake/databricks siblings) into the aggregate. Previously the
+    # scorecard derived every status ONLY from CVE-tag data, so a cloud account
+    # failing CIS controls read green/no_data. The benchmark is a DIFFERENT
+    # taxonomy than the CVE-driven CIS Controls v8 line, kept as its own labeled
+    # line below; here we only fold its pass/fail/error into the top-line so a
+    # failing CIS account can't read as compliant. ERROR is unevaluable — counted
+    # toward the evaluated denominator (drags the score down) but never the
+    # numerator.
+    cis_foundations_agg = _aggregate_cis_foundations_checks(tenant_jobs)
+    bench_pass = int(cis_foundations_agg["counts"]["pass"])
+    bench_fail = int(cis_foundations_agg["counts"]["fail"])
+    bench_error = int(cis_foundations_agg["counts"]["error"])
+
+    # Score over EVALUATED controls/checks only (CVE controls with mapped
+    # findings + benchmark pass/fail/error). A CVE control with no findings is
+    # not_evaluated, never a silent pass — otherwise every never-triggered bundled
+    # control inflates the score toward 100. Matches the narrative so a
+    # benign/empty estate can't read as "fully compliant".
+    aggregate_pass = total_pass + bench_pass
+    aggregate_fail = total_fail + bench_fail
+    evaluated_controls = aggregate_pass + total_warn + aggregate_fail + bench_error
+    overall_score = round((aggregate_pass / evaluated_controls) * 100, 1) if evaluated_controls > 0 else 0.0
+
+    if aggregate_fail > 0:
         overall_status = "fail"
-    elif total_warn > 0:
+    elif total_warn > 0 or bench_error > 0:
+        # A benchmark ERROR (unevaluable control) is not a clean pass either.
         overall_status = "warning"
     elif evaluated_controls > 0:
         overall_status = "pass"
@@ -470,12 +584,18 @@ async def get_compliance(request: Request) -> dict:
         not_evaluated = len(controls_list) - passed - warned - failed
         if not_evaluated:
             summary[f"{metadata.summary_prefix}_not_evaluated"] = not_evaluated
+    cis_foundations_line = _build_cis_foundations_line(cis_foundations_agg)
     summary.update(
         {
             "aisvs_pass": aisvs_summary["pass"],
             "aisvs_fail": aisvs_summary["fail"],
             "aisvs_error": aisvs_summary["error"],
             "aisvs_not_applicable": aisvs_summary["not_applicable"],
+            "cis_foundations_pass": cis_foundations_line["summary"]["pass"],
+            "cis_foundations_fail": cis_foundations_line["summary"]["fail"],
+            "cis_foundations_error": cis_foundations_line["summary"]["error"],
+            "cis_foundations_not_applicable": cis_foundations_line["summary"]["not_applicable"],
+            "cis_foundations_evaluated": cis_foundations_line["summary"]["evaluated"],
         }
     )
 
@@ -488,6 +608,7 @@ async def get_compliance(request: Request) -> dict:
         "has_agent_context": has_agent_context,
         "scan_sources": sorted(all_scan_sources),
         "aisvs_benchmark": aisvs,
+        "cis_foundations_benchmark": cis_foundations_line,
         "summary": summary,
     }
     for metadata in TAG_MAPPED_FRAMEWORKS:

--- a/src/agent_bom/compliance_hub.py
+++ b/src/agent_bom/compliance_hub.py
@@ -131,7 +131,13 @@ _SOURCE_BASELINE: dict[FindingSource, tuple[str, ...]] = {
         FRAMEWORK_ATLAS,
     ),
     FindingSource.CONTAINER: _CONTAINER_FRAMEWORKS,
-    FindingSource.CLOUD_CIS: _CLOUD_POSTURE_FRAMEWORKS,
+    # A CIS Foundations Benchmark check (CIS-2.1.1 …) authoritatively asserts the
+    # CIS control it failed and nothing more. There is no authoritative
+    # CIS-Foundations → SOC2/ISO-27001/NIST-800-53 crosswalk in the repo, so the
+    # prior wholesale fan-out (_CLOUD_POSTURE_FRAMEWORKS) over-claimed
+    # cross-framework coverage. Assert only CIS; a specific SOC2/ISO/NIST claim
+    # must wait on an authoritative crosswalk (tracked follow-up).
+    FindingSource.CLOUD_CIS: (FRAMEWORK_CIS,),
     FindingSource.CLOUD_SECURITY: tuple(framework for framework in _CLOUD_POSTURE_FRAMEWORKS if framework != FRAMEWORK_CIS),
     FindingSource.SBOM: (
         FRAMEWORK_NIST_CSF,
@@ -207,7 +213,12 @@ def select_frameworks(
 
     selected.update(_SOURCE_BASELINE.get(source, ()))
 
-    if asset_type and not (source == FindingSource.CLOUD_SECURITY and asset_type == "cloud_resource"):
+    # Cloud-posture sources already carry an authoritative source baseline; the
+    # broad cloud_resource asset addition (_CLOUD_POSTURE_FRAMEWORKS) would
+    # re-introduce the SOC2/ISO/NIST-800-53 over-claim they were narrowed away
+    # from, so skip it for those sources.
+    _cloud_posture_sources = {FindingSource.CLOUD_SECURITY, FindingSource.CLOUD_CIS}
+    if asset_type and not (source in _cloud_posture_sources and asset_type == "cloud_resource"):
         selected.update(_ASSET_TYPE_ADDITIONS.get(asset_type, ()))
 
     if finding_type:

--- a/src/agent_bom/compliance_hub.py
+++ b/src/agent_bom/compliance_hub.py
@@ -138,7 +138,16 @@ _SOURCE_BASELINE: dict[FindingSource, tuple[str, ...]] = {
     # cross-framework coverage. Assert only CIS; a specific SOC2/ISO/NIST claim
     # must wait on an authoritative crosswalk (tracked follow-up).
     FindingSource.CLOUD_CIS: (FRAMEWORK_CIS,),
-    FindingSource.CLOUD_SECURITY: tuple(framework for framework in _CLOUD_POSTURE_FRAMEWORKS if framework != FRAMEWORK_CIS),
+    # Vendor security best practices (e.g. Databricks) are explicitly NOT official
+    # CIS/SOC2/ISO/NIST controls, and there is no authoritative crosswalk from
+    # them to those frameworks in the repo. Claiming SOC2/ISO-27001/NIST-800-53
+    # coverage (the prior wholesale fan-out) over-claims, so assert no official
+    # framework — the vendor-best-practice designation lives in the finding type
+    # (CLOUD_BEST_PRACTICE_*), source, title, and evidence, not in
+    # applicable_frameworks (which holds only official framework slugs). A
+    # finding-shape refinement (e.g. CREDENTIAL_EXPOSURE) can still add frameworks
+    # on its own authority; the source baseline just asserts nothing.
+    FindingSource.CLOUD_SECURITY: (),
     FindingSource.SBOM: (
         FRAMEWORK_NIST_CSF,
         FRAMEWORK_SOC2,

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -842,6 +842,16 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
             "benchmark": "Databricks Security Best Practices" if is_vendor_best_practice else "CIS",
         },
     )
+    # Populate applicable_frameworks via the hub selection table, consistent with
+    # every other finding generator (blast_radius/malicious/auth). Previously this
+    # converter set only compliance_tags, leaving applicable_frameworks empty so
+    # the finding was invisible in the hub posture aggregation. CIS providers
+    # resolve to the CIS framework only (no fabricated SOC2/ISO/NIST crosswalk);
+    # vendor best-practice providers keep their source baseline.
+    from agent_bom.compliance_hub import apply_hub_classification
+
+    apply_hub_classification(finding)
+
     # Reference pattern for the advisory-remediation foundation: attach the
     # structured fix + least-privilege-to-apply + runbook artifact. Advisory
     # only — agent-bom recommends, the user applies.

--- a/tests/cloud/test_cloud_cis_convergence.py
+++ b/tests/cloud/test_cloud_cis_convergence.py
@@ -147,6 +147,14 @@ def test_databricks_findings_are_vendor_best_practices_and_still_gate(status: st
     assert finding.evidence["benchmark"] == "Databricks Security Best Practices"
     assert not any(tag.startswith("CIS-") for tag in finding.compliance_tags)
     assert "cis" not in finding.applicable_frameworks
+    # A vendor best-practice finding must not claim official SOC2/ISO/NIST
+    # framework coverage — there is no authoritative crosswalk, so the honest
+    # floor is no official framework (the best-practice designation lives in the
+    # finding type / source / title, not applicable_frameworks).
+    assert "soc2" not in finding.applicable_frameworks
+    assert "iso-27001" not in finding.applicable_frameworks
+    assert "nist-800-53" not in finding.applicable_frameworks
+    assert finding.applicable_frameworks == []
     assert _gate(r) == 1
 
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -431,6 +431,171 @@ def test_compliance_summary_with_scan_counts_evaluated_controls():
     _clear_jobs()
 
 
+def _cis_benchmark_result(checks: list[dict], *, cloud_key: str = "cis_benchmark") -> dict:
+    """Build a result_extra dict carrying a serialized CIS benchmark blob.
+
+    ``cloud_key`` selects the provider slot used by the JSON output layer
+    (``cis_benchmark`` for AWS, ``azure_cis_benchmark`` for Azure, etc.) —
+    the exact keys /v1/cis/checks reads via build_cis_benchmark_check_rows.
+    """
+    return {"scan_id": "cis-scan", cloud_key: {"checks": checks}}
+
+
+def test_compliance_surfaces_cis_foundations_benchmark_line():
+    """A cloud account with CIS Foundations Benchmark PASS/FAIL/ERROR checks must
+    surface a dedicated benchmark-backed CIS-Foundations line with an honest
+    pass/(pass+fail+error) denominator — the scorecard previously ignored
+    ``cis_benchmark_data`` entirely, so a failing CIS account read green."""
+    _clear_jobs()
+    _add_done_job(
+        [],
+        result_extra=_cis_benchmark_result(
+            [
+                {"check_id": "2.1.1", "title": "S3 SSE", "status": "PASS", "severity": "high"},
+                {"check_id": "2.1.2", "title": "S3 public", "status": "FAIL", "severity": "high"},
+                {"check_id": "1.4", "title": "Root MFA", "status": "ERROR", "severity": "critical"},
+                {"check_id": "1.5", "title": "Manual", "status": "NOT_APPLICABLE", "severity": "low"},
+            ]
+        ),
+    )
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+
+    line = data["cis_foundations_benchmark"]
+    assert line["framework_key"] == "cis_foundations_benchmark"
+    assert line["representation"] == "benchmark"
+    # evaluated = pass + fail + error (NOT not_applicable); score = pass/evaluated.
+    assert line["summary"] == {
+        "pass": 1,
+        "fail": 1,
+        "error": 1,
+        "not_applicable": 1,
+        "evaluated": 3,
+        "score": 33.3,
+    }
+    assert line["status"] == "fail"
+    # ERROR is a distinct bucket — not folded into pass, not folded into fail.
+    assert line["summary"]["error"] == 1
+    assert line["summary"]["pass"] == 1
+    assert line["summary"]["fail"] == 1
+    # Summary counters mirror the benchmark line.
+    assert data["summary"]["cis_foundations_pass"] == 1
+    assert data["summary"]["cis_foundations_fail"] == 1
+    assert data["summary"]["cis_foundations_error"] == 1
+    assert data["summary"]["cis_foundations_evaluated"] == 3
+    _clear_jobs()
+
+
+def test_failing_cis_account_is_not_green():
+    """The core defect: a cloud account failing CIS controls (and with NO
+    CVE-derived findings) previously read overall_status=no_data / score 0 as if
+    nothing were wrong. It must now read fail."""
+    _clear_jobs()
+    _add_done_job(
+        [],
+        result_extra=_cis_benchmark_result(
+            [
+                {"check_id": "2.1.2", "title": "S3 public", "status": "FAIL", "severity": "high"},
+                {"check_id": "2.1.1", "title": "S3 SSE", "status": "PASS", "severity": "high"},
+            ]
+        ),
+    )
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+
+    assert data["overall_status"] == "fail"
+    assert data["overall_score"] < 100.0
+    assert data["cis_foundations_benchmark"]["status"] == "fail"
+    _clear_jobs()
+
+
+def test_cis_foundations_error_only_is_not_a_clean_pass():
+    """ERROR (permission-denied / unevaluable) must never read as a clean pass:
+    an account whose evaluable checks pass but has an unevaluable control is
+    warning, not pass, and error is excluded from the numerator."""
+    _clear_jobs()
+    _add_done_job(
+        [],
+        result_extra=_cis_benchmark_result(
+            [
+                {"check_id": "2.1.1", "title": "S3 SSE", "status": "PASS", "severity": "high"},
+                {"check_id": "1.4", "title": "Root MFA", "status": "ERROR", "severity": "critical"},
+            ]
+        ),
+    )
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+
+    line = data["cis_foundations_benchmark"]
+    assert line["summary"]["error"] == 1
+    assert line["summary"]["fail"] == 0
+    # score = pass / (pass + fail + error) = 1/2 = 50.0 — unevaluable ≠ pass.
+    assert line["summary"]["score"] == 50.0
+    assert line["status"] == "warning"
+    assert data["overall_status"] == "warning"
+    _clear_jobs()
+
+
+def test_cis_foundations_does_not_double_count_cis_controls_v8():
+    """The CIS Foundations Benchmark line (CIS-2.1.1 taxonomy) and the CVE-driven
+    CIS Controls v8 line (safeguard CIS-02.1 taxonomy) are distinct surfaces —
+    neither counts the other's data, so nothing is conflated."""
+    _clear_jobs()
+    _add_done_job(
+        [
+            {
+                "vulnerability_id": "CVE-2025-7777",
+                "severity": "high",
+                "package": "openssl",
+                "cis_tags": ["CIS-07.1"],  # Controls v8 safeguard
+            }
+        ],
+        result_extra=_cis_benchmark_result([{"check_id": "2.1.2", "title": "S3 public", "status": "FAIL", "severity": "high"}]),
+    )
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+
+    # Foundations line reflects the benchmark FAIL only (1 evaluated check).
+    assert data["cis_foundations_benchmark"]["summary"]["fail"] == 1
+    assert data["cis_foundations_benchmark"]["summary"]["evaluated"] == 1
+
+    # Controls v8 line (cis_controls, cis_tags) reflects the CVE safeguard only —
+    # the benchmark FAIL never appears there (different taxonomy / no shared id).
+    cis_controls = data["cis_controls"]
+    failed_v8 = [c for c in cis_controls if c["status"] == "fail"]
+    assert all(c["control_id"] == "CIS-07.1" for c in failed_v8)
+    assert all(not c["control_id"].startswith("CIS-2.1") for c in cis_controls)
+    _clear_jobs()
+
+
+def test_cis_foundations_reconciles_with_cis_checks():
+    """The benchmark-backed scorecard line's counts must reconcile with
+    /v1/cis/checks — both derive from the same build_cis_benchmark_check_rows
+    data with the same latest-per-(cloud,check_id) dedup."""
+    _clear_jobs()
+    checks = [
+        {"check_id": "2.1.1", "title": "a", "status": "PASS", "severity": "high"},
+        {"check_id": "2.1.2", "title": "b", "status": "FAIL", "severity": "high"},
+        {"check_id": "2.1.3", "title": "c", "status": "FAIL", "severity": "medium"},
+        {"check_id": "1.4", "title": "d", "status": "ERROR", "severity": "critical"},
+    ]
+    _add_done_job([], result_extra=_cis_benchmark_result(checks))
+    client = TestClient(app)
+
+    scorecard = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()["cis_foundations_benchmark"]["summary"]
+    rows = client.get("/v1/cis/checks?limit=500", headers=_AUTH_HEADERS).json()["checks"]
+
+    tally = {"pass": 0, "fail": 0, "error": 0}
+    for row in rows:
+        st = str(row["status"]).lower()
+        if st in tally:
+            tally[st] += 1
+    assert scorecard["pass"] == tally["pass"]
+    assert scorecard["fail"] == tally["fail"]
+    assert scorecard["error"] == tally["error"]
+    _clear_jobs()
+
+
 def test_posture_has_proxy_flips_on_proxy_alert_ingest():
     """audit P1-B: ingesting proxy alerts via /v1/proxy/audit must flip
     the ``has_proxy`` posture flag on /v1/posture/counts.

--- a/tests/test_compliance_hub.py
+++ b/tests/test_compliance_hub.py
@@ -170,6 +170,22 @@ def test_cloud_cis_posture_is_narrowed_to_cis_only() -> None:
     assert FRAMEWORK_NIST_800_53 not in selected
 
 
+def test_cloud_security_best_practice_asserts_no_official_framework() -> None:
+    """A vendor security best-practice finding (FindingSource.CLOUD_SECURITY, e.g.
+    Databricks) must NOT claim SOC2 / ISO 27001 / NIST 800-53 specific-framework
+    coverage. These checks are vendor best practices, explicitly NOT official
+    CIS/SOC2/ISO/NIST controls, and there is no authoritative crosswalk in the
+    repo — so the honest floor is to assert no official framework at all. The
+    vendor-best-practice designation lives in the finding type / source / title,
+    not in applicable_frameworks (which holds only official framework slugs)."""
+    selected = set(select_frameworks(FindingSource.CLOUD_SECURITY, asset_type="cloud_resource"))
+    assert selected == set(), f"CLOUD_SECURITY best practices must assert no official framework; got {sorted(selected)}"
+    assert FRAMEWORK_SOC2 not in selected
+    assert FRAMEWORK_ISO_27001 not in selected
+    assert FRAMEWORK_NIST_800_53 not in selected
+    assert FRAMEWORK_CIS not in selected
+
+
 # ─── External imports — auto-detect / catch-all ─────────────────────────────
 
 

--- a/tests/test_compliance_hub.py
+++ b/tests/test_compliance_hub.py
@@ -75,11 +75,14 @@ _AI_FRAMEWORK_SET = {
             "container",
             {FRAMEWORK_CIS, FRAMEWORK_NIST_CSF, FRAMEWORK_PCI_DSS, FRAMEWORK_SOC2},
         ),
-        # Cloud CIS posture → CIS + SOC2 + ISO + NIST 800-53
+        # Cloud CIS posture → CIS only. A CIS Foundations Benchmark failure
+        # authoritatively asserts the CIS control it failed; there is no
+        # authoritative CIS-Foundations → SOC2/ISO/NIST crosswalk in the repo, so
+        # fanning out to those frameworks over-claims (narrowed).
         (
             FindingSource.CLOUD_CIS,
             "cloud_resource",
-            {FRAMEWORK_CIS, FRAMEWORK_SOC2, FRAMEWORK_ISO_27001, FRAMEWORK_NIST_800_53},
+            {FRAMEWORK_CIS},
         ),
         # SBOM / supply chain → NIST CSF + SOC2 + PCI
         (FindingSource.SBOM, "package", {FRAMEWORK_NIST_CSF, FRAMEWORK_SOC2, FRAMEWORK_PCI_DSS}),
@@ -153,6 +156,18 @@ def test_injection_finding_pulls_in_ai_frameworks_even_from_neutral_source() -> 
 def test_cis_fail_pulls_in_cis_even_when_source_does_not() -> None:
     selected = set(select_frameworks(FindingSource.SAST, finding_type=FindingType.CIS_FAIL))
     assert FRAMEWORK_CIS in selected
+
+
+def test_cloud_cis_posture_is_narrowed_to_cis_only() -> None:
+    """A CIS Foundations Benchmark finding must NOT claim SOC2 / ISO 27001 /
+    NIST 800-53 — there is no authoritative CIS-Foundations → those crosswalk in
+    the repo, so the prior wholesale fan-out over-claimed cross-framework
+    coverage. The honest floor is the CIS framework the check actually failed."""
+    selected = set(select_frameworks(FindingSource.CLOUD_CIS, asset_type="cloud_resource"))
+    assert selected == {FRAMEWORK_CIS}, f"CLOUD_CIS should assert only CIS; got {sorted(selected)}"
+    assert FRAMEWORK_SOC2 not in selected
+    assert FRAMEWORK_ISO_27001 not in selected
+    assert FRAMEWORK_NIST_800_53 not in selected
 
 
 # ─── External imports — auto-detect / catch-all ─────────────────────────────

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -416,6 +416,26 @@ def test_blast_radius_to_finding_compliance_tags_carried():
     assert finding.soc2_tags == ["CC7.1"]
 
 
+def test_cloud_cis_check_to_finding_sets_applicable_frameworks():
+    """cloud_cis_check_to_finding must populate applicable_frameworks (via
+    apply_hub_classification) like every other generator — previously it set only
+    compliance_tags, leaving applicable_frameworks empty so the finding was
+    invisible in the hub posture aggregation."""
+    from agent_bom.finding import cloud_cis_check_to_finding
+
+    check = {"check_id": "2.1.2", "title": "S3 public", "status": "FAIL", "severity": "high"}
+    finding = cloud_cis_check_to_finding(check, "aws")
+
+    assert finding.applicable_frameworks, "applicable_frameworks must be populated"
+    # A CIS Foundations benchmark failure authoritatively asserts the CIS control.
+    assert "cis" in finding.applicable_frameworks
+    # But it must NOT fabricate a specific SOC2/ISO/NIST crosswalk — there is no
+    # authoritative CIS-Foundations → SOC2/ISO/NIST-800-53 mapping in the repo.
+    assert "soc2" not in finding.applicable_frameworks
+    assert "iso-27001" not in finding.applicable_frameworks
+    assert "nist-800-53" not in finding.applicable_frameworks
+
+
 def test_blast_radius_to_finding_risk_score():
     br = _make_blast_radius()
     finding = blast_radius_to_finding(br)


### PR DESCRIPTION
Part of the "computed but never surfaced" defect class. **⚠️ Changes the compliance scorecard — please review the numbers closely.**

## Root cause
`/v1/compliance` built every control status only from `blast_radius` CVE tags and never read `report.cis_benchmark_data` — so a cloud account **failing CIS Foundations Benchmark controls showed a green/`no_data` scorecard** even though `/cis/checks` reported the failures.

## Fixes
1. **CIS benchmark → scorecard**: new `cis_foundations_benchmark` line built from the **same** `build_cis_benchmark_check_rows` + same latest-per-`(cloud,check_id)` dedup as `/v1/cis/checks`, so the two reconcile by construction. Its FAIL/pass/error fold into `overall_status`/`overall_score` — a failing-CIS account now reads `fail`.
2. **No double-count**: kept **distinct** from the CVE-driven CIS Controls v8 line (Foundations `CIS-2.1.1` vs safeguard `CIS-02.1` never share IDs).
3. **ERROR honesty**: explicit `error` bucket; denominator `evaluated = pass+fail+error`, `score = pass/evaluated` — ERROR never folds into pass/fail; an error-only account reads `warning`, not a clean pass (consistent with `finalize_read_coverage` refusing to PASS permission-denied controls).
4. **Narrowed the over-claim WITHOUT fabricating a crosswalk**: `CLOUD_CIS` previously fanned out to CIS+SOC2+ISO+NIST wholesale; now asserts **only CIS** (the framework it actually failed). `applicable_frameworks` consistency added to `cloud_cis_check_to_finding`.

## How verified
7 tests red→green incl. failing-CIS-not-green, error-not-a-pass, no-double-count, reconciles-with-/cis/checks. Suites `426 passed` / final CIS batch `119 passed, 5 skipped`; `ruff`/`mypy` clean; OpenAPI/schema/check-counts pass. Adversarial TestClient render: seeded failing-CIS account → `overall_status: fail`, `score 25.0`, counts match `/cis/checks` exactly.

## Deferred (blocked on data)
An authoritative CIS-Foundations → SOC2/ISO/NIST **specific-control crosswalk** needs licensed CIS mapping data not in the repo — cross-framework attribution is intentionally **withheld rather than invented** until it lands. Same-class follow-up flagged: the Databricks `CLOUD_SECURITY` source still carries a source-level SOC2/ISO/NIST baseline (next to narrow).