### PR TITLE
chore(ci): PR fast path — single-interpreter matrix on PRs + npm cache

### DIFF
--- a/.github/actions/setup-ui/action.yml
+++ b/.github/actions/setup-ui/action.yml
@@ -19,6 +19,8 @@ runs:
       uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version: ${{ inputs.node-version }}
+        cache: npm
+        cache-dependency-path: ${{ inputs.working-directory }}/package-lock.json
 
     - name: Pin npm
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,7 +706,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.13', '3.14']
+        # PRs run the mainstream interpreter only; pushes to main run the full
+        # matrix (plus coverage on 3.11 below). Interpreter-specific drift is
+        # rare and still caught on main within one merge — this keeps PR
+        # wall-clock near the 4-5 minute mark instead of ~10.
+        python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.13"]') || fromJSON('["3.11", "3.13", "3.14"]') }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/scripts/check_product_surface_contract.py
+++ b/scripts/check_product_surface_contract.py
@@ -253,7 +253,9 @@ def main() -> int:
             "python scripts/check_release_consistency.py",
             "python scripts/check_product_surface_contract.py",
             "Test (Python ${{ matrix.python-version }})",
-            "python-version: ['3.11', '3.13', '3.14']",
+            # PRs run 3.13 only; pushes to main must still exercise the full
+            # advertised interpreter matrix.
+            "fromJSON('[\"3.11\", \"3.13\", \"3.14\"]')",
         ],
         failures,
     )


### PR DESCRIPTION
## What
- **Test matrix**: PRs run Python 3.13 only; pushes to main run the full 3.11/3.13/3.14 matrix (coverage on 3.11 unchanged, already main-only). Interpreter-specific drift is rare and still caught on main within one merge.
- **UI jobs**: `setup-ui` now enables the npm cache keyed on `ui/package-lock.json`, cutting the `npm ci` portion of UI Validate.
- **Branch protection** (already applied): required checks are now Lint, Test (3.13), Build Package, Security Scan, CodeQL — 3.11/3.14 report on main pushes instead.

## Why
PR wall-clock was ~10 min, dominated by the 3-interpreter matrix; the standard production pattern is one mainstream interpreter at PR time with the full matrix on the protected branch. Target: 4–5 min PRs.

## How verified
YAML parses; the matrix expression uses the documented `fromJSON` conditional-array pattern; this PR's own run exercises the PR path (expect exactly one Test job: 3.13). No test, dependency, or product code changes.