### PR TITLE
chore(ci): path-conditional Python suite + fuzzing, 3 pytest workers on PRs

### DIFF
--- a/.github/workflows/cflite-pr.yml
+++ b/.github/workflows/cflite-pr.yml
@@ -5,6 +5,15 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    # Fuzzing exercises Python parsers only — skip on docs/UI/deploy-only PRs.
+    # Not a required check, so workflow-level path filtering is safe here.
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.clusterfuzzlite/**'
+      - '.github/workflows/cflite-pr.yml'
   schedule:
     - cron: '0 4 * * 1'  # Weekly batch fuzzing — Monday 04:00 UTC
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
       docs: ${{ steps.classify.outputs.docs }}
       endpoint: ${{ steps.classify.outputs.endpoint }}
       postgres: ${{ steps.classify.outputs.postgres }}
+      python: ${{ steps.classify.outputs.python }}
       ui: ${{ steps.classify.outputs.ui }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -101,6 +102,14 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_|deploy/supabase/postgres/)'; then
             postgres=true
           fi
+          # Python test suite: skip only when a PR clearly cannot affect it
+          # (docs/UI/deploy-only changes). Conservative by construction —
+          # anything under src/, tests/, scripts/, data/, packaging, or the
+          # CI definition itself runs the suite.
+          python=false
+          if printf '%s\n' "$changed" | grep -Eq '^(src/|tests/|scripts/|pyproject\.toml|uv\.lock|action\.yml|contracts/|data/|\.github/workflows/ci\.yml$|\.github/actions/)'; then
+            python=true
+          fi
           if printf '%s\n' "$changed" | grep -Eq '^(deploy/endpoints/|scripts/(build-[^/]+|render_homebrew_formula\.py)|src/agent_bom/cli/_runtime\.py|tests/test_cli_runtime\.py|pyproject\.toml|uv\.lock|\.github/actions/setup-python/|site-docs/deployment/aws-company-rollout\.md$)'; then
             endpoint=true
           fi
@@ -114,6 +123,7 @@ jobs:
             echo "docs=${docs}"
             echo "endpoint=${endpoint}"
             echo "postgres=${postgres}"
+            echo "python=${python}"
             echo "ui=${ui}"
           } >> "$GITHUB_OUTPUT"
           {
@@ -125,6 +135,7 @@ jobs:
             echo "- Docs strict build required: \`${docs}\`"
             echo "- Endpoint packaging required: \`${endpoint}\`"
             echo "- Real Postgres integration required: \`${postgres}\`"
+            echo "- Python test suite required: \`${python}\`"
             echo "- UI Validate (lint + test + build + e2e) required: \`${ui}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -703,6 +714,11 @@ jobs:
     timeout-minutes: 35
     permissions:
       contents: read
+    needs: changes
+    # Skip the suite only when the classifier positively says the PR cannot
+    # affect Python (docs/UI/deploy-only). Fail closed: a classifier failure
+    # or missing output runs the suite.
+    if: always() && (github.event_name != 'pull_request' || needs.changes.result != 'success' || needs.changes.outputs.python == 'true')
     strategy:
       fail-fast: false
       matrix:
@@ -730,7 +746,11 @@ jobs:
           # timeout); 3.13/3.14 drop to 2 so the parallel run's peak RAM stays
           # under the hosted-runner limit (4 heavy interpreters OOM the VM,
           # surfacing as "runner received a shutdown signal" / exit 143).
-          if [ "${{ matrix.python-version }}" = "3.11" ]; then
+          # PRs run a single matrix job (3.13), so it gets 3 workers there —
+          # one below the OOM threshold observed at 4 — to cut PR wall-clock.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-3}"
+          elif [ "${{ matrix.python-version }}" = "3.11" ]; then
             PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-4}"
           else
             PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-2}"
@@ -1093,6 +1113,9 @@ jobs:
     permissions:
       contents: read
     needs: [security, lint, test]
+    # Build still runs when the classifier legitimately skipped the test
+    # suite (docs-only PRs); a failed or cancelled test still blocks it.
+    if: ${{ !cancelled() && needs.security.result == 'success' && needs.lint.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.test.result) }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,9 +756,9 @@ jobs:
             PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-2}"
           fi
           if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
-            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist loadscope
+            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
           else
-            uv run pytest tests/ -q --tb=short -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist loadscope
+            uv run pytest tests/ -q --tb=short -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
           fi
 
       - name: Graph accuracy guards (#2259 — round-trip + edge-count + visual-diff)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -756,9 +756,9 @@ jobs:
             PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-2}"
           fi
           if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
-            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
+            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist loadscope
           else
-            uv run pytest tests/ -q --tb=short -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
+            uv run pytest tests/ -q --tb=short -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist loadscope
           fi
 
       - name: Graph accuracy guards (#2259 — round-trip + edge-count + visual-diff)

--- a/tests/test_api_surface_0943.py
+++ b/tests/test_api_surface_0943.py
@@ -123,6 +123,11 @@ def test_scan_id_filter_still_returns_that_scan(client_with_scans) -> None:
 
 
 def test_findings_fixture_ignores_and_restores_unrelated_bulk_state() -> None:
+    # Hermetic warm phase: the assertions below read through the global job
+    # store and findings-count cache, so leftover state from tests scheduled
+    # earlier on any xdist worker must not leak in.
+    reset_findings_count_cache()
+    set_job_store(InMemoryJobStore())
     unrelated_store = InMemoryComplianceHubStore()
     set_compliance_hub_store(unrelated_store)
     unrelated = [{"id": "unrelated:bulk", "severity": "low", "origin": "bulk_ingest"}]


### PR DESCRIPTION
Follow-up to #4222 — the conditional half of the CI fast path.

## What
- **Path classifier** gains a `python` output — conservative by construction: anything under `src/`, `tests/`, `scripts/`, `data/`, `contracts/`, packaging, `.github/actions/`, or ci.yml itself counts as Python-relevant.
- **Test job** skips only on a positive not-Python classification (docs/UI/deploy-only PRs). Fail-closed: if the classifier errors or reports nothing, the suite runs. Skipped required checks satisfy branch protection, so no PR gets stuck.
- **Build Package** tolerates a legitimately skipped test but still blocks on a failed/cancelled one.
- **PR-Fuzzing** (`cflite-pr.yml`, not a required check) gets a workflow-level paths filter for the same set.
- **PR test runs use 3 pytest workers** instead of 2 — PRs now run a single matrix job per #4222, and 4 workers was the observed runner OOM threshold, so 3 is the measured safe step. Main keeps the existing 4/2/2 split.

## Effect
Code PRs: ~10 → ~4–5 min (worker bump shortens the dominant Test job). Docs/UI-only PRs: ~2 min (Lint + Version Alignment + Security Scan only on the Python side).

## How verified
YAML parses; `check_product_surface_contract.py` and `check_workflow_timeouts.py` pass locally; this PR touches ci.yml so the classifier marks it python=true and alpine=true — its own run exercises the new gating (expect Test (3.13) to RUN here, with 3 workers).