### PR TITLE
feat(compliance): NIST 800-53 check→control mapping + independent per-framework scoring

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -34,3 +34,8 @@ e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:360
 # History-only false positive from a synthetic token-shape redaction fixture.
 # The fixture verifies that prompt sanitization removes the value.
 8b56ca26dfb1f9a575f21678fa8f33be113fc231:tests/test_ai_enrich_providers.py:jwt:47
+
+# False positive: a literal JSON field name/value pair in the compliance
+# scorecard response ("framework_key": "nist_800_53_catalog") — a registry
+# identifier, not a credential. generic-api-key fires on the _key suffix.
+0e43ed628801d7c2d4fbdd7e3a01b07fda2b113b:src/agent_bom/api/routes/compliance.py:generic-api-key:534

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -35,7 +35,7 @@ e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:360
 # The fixture verifies that prompt sanitization removes the value.
 8b56ca26dfb1f9a575f21678fa8f33be113fc231:tests/test_ai_enrich_providers.py:jwt:47
 
-# False positive: a literal JSON field name/value pair in the compliance
-# scorecard response ("framework_key": "nist_800_53_catalog") — a registry
-# identifier, not a credential. generic-api-key fires on the _key suffix.
+# False positive: the compliance scorecard response declares its framework
+# registry identifier in a JSON field whose name ends in _key; the value is
+# the NIST catalog registry id, not a credential.
 0e43ed628801d7c2d4fbdd7e3a01b07fda2b113b:src/agent_bom/api/routes/compliance.py:generic-api-key:534

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -39,3 +39,5 @@ e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:360
 # registry identifier in a JSON field whose name ends in _key; the value is
 # the NIST catalog registry id, not a credential.
 0e43ed628801d7c2d4fbdd7e3a01b07fda2b113b:src/agent_bom/api/routes/compliance.py:generic-api-key:534
+# History-only: earlier revision of the note above quoted the flagged pair.
+523c32e9b3c52b355c33cc67bac34e670ff6167f:.gitleaksignore:generic-api-key:39

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -360,6 +360,10 @@ def _aggregate_cis_foundations_checks(jobs: list[Any]) -> dict[str, Any]:
     seen: set[tuple[str, str]] = set()
     counts = {"pass": 0, "fail": 0, "error": 0, "not_applicable": 0, "other": 0}
     providers: dict[str, dict[str, int]] = {}
+    # Deduped latest status per logical (cloud, check_id) — consumed by the NIST
+    # 800-53 catalog line to map a CIS Foundations check to the NIST controls it
+    # evidences (framework_mapping.nist_controls_for_cis_check).
+    statuses: dict[tuple[str, str], str] = {}
     for row in all_rows:
         key = (str(row.get("cloud") or ""), str(row.get("check_id") or ""))
         if key in seen:
@@ -368,10 +372,11 @@ def _aggregate_cis_foundations_checks(jobs: list[Any]) -> dict[str, Any]:
         status = str(row.get("status") or "").lower()
         bucket = status if status in ("pass", "fail", "error", "not_applicable") else "other"
         counts[bucket] += 1
+        statuses[key] = status
         cloud = str(row.get("cloud") or "unknown")
         prov = providers.setdefault(cloud, {"pass": 0, "fail": 0, "error": 0, "not_applicable": 0, "other": 0})
         prov[bucket] += 1
-    return {"counts": counts, "providers": providers, "total_checks": len(seen)}
+    return {"counts": counts, "providers": providers, "total_checks": len(seen), "statuses": statuses}
 
 
 def _build_cis_foundations_line(agg: dict[str, Any]) -> dict[str, Any]:
@@ -421,6 +426,138 @@ def _build_cis_foundations_line(agg: dict[str, Any]) -> dict[str, Any]:
             "score": score,
         },
         "providers": agg["providers"],
+    }
+
+
+# Order used to collapse multiple evidence signals on one NIST control into a
+# single status. Higher wins: a real weakness (fail/warning) beats an
+# unevaluable check (error) which beats a clean pass; a control with no run
+# check stays not_evaluated (never a silent pass).
+_NIST_STATUS_RANK = {"not_evaluated": 0, "pass": 1, "error": 2, "warning": 3, "fail": 4}
+
+
+def _build_nist_800_53_catalog_line(
+    all_blast: list[dict],
+    cis_statuses: dict[tuple[str, str], str],
+    scan_count: int,
+) -> dict[str, Any]:
+    """Score the full vendored NIST SP 800-53 Rev 5 catalog over EVALUATED
+    controls only, using PR3's curated (vendor-asserted) check -> control map.
+
+    A control is *evaluated* when at least one mapped check ran: a CVE/CWE
+    finding whose ``nist_800_53_tags`` include a curated (evidencing_checks)
+    control, or a CIS Foundations check the vendor-asserted table maps to it.
+    Findings can only fail/warn (absence of a CVE is never a pass); a CIS check
+    contributes pass/fail/error. ERROR is an explicit bucket — counted toward the
+    evaluated denominator but never the numerator. Controls with no run check are
+    ``not_evaluated`` against the full catalog. Scored INDEPENDENTLY: this line is
+    never folded into ``overall_score`` (the same evidence already drives the
+    existing per-framework lines — folding it would double-count).
+    """
+    from agent_bom import framework_mapping as fm
+
+    catalog = fm.FRAMEWORK_CONTROL_CATALOG.get(fm.FRAMEWORK_NIST_800_53, {})
+    evidenced = fm.NIST_800_53_EVIDENCED_CONTROLS
+
+    # Finding-driven severity per curated control (worst-severity -> status via
+    # the shared _evaluated_control_status helper the rest of the scorecard uses).
+    finding_sev: dict[str, dict[str, int]] = {}
+    finding_count: dict[str, int] = {}
+    for br in all_blast:
+        for control_id in br.get("nist_800_53_tags", []) or []:
+            if control_id not in evidenced:
+                continue  # vuln-intrinsic tag with no curated check -> reconcile out
+            sev = str(br.get("severity") or "").lower()
+            bucket = finding_sev.setdefault(control_id, {"critical": 0, "high": 0, "medium": 0, "low": 0})
+            if sev in bucket:
+                bucket[sev] += 1
+            finding_count[control_id] = finding_count.get(control_id, 0) + 1
+
+    # CIS-driven statuses per control via the vendor-asserted CIS -> NIST table.
+    cis_by_control: dict[str, set[str]] = {}
+    for (cloud, check_id), status in cis_statuses.items():
+        if status not in ("pass", "fail", "error"):
+            continue  # not_applicable / unknown never evaluate a control
+        for control_id in fm.nist_controls_for_cis_check(cloud, check_id):
+            cis_by_control.setdefault(control_id, set()).add(status)
+
+    controls: list[dict[str, Any]] = []
+    tally = {"pass": 0, "fail": 0, "warning": 0, "error": 0}
+    for control_id in sorted(evidenced):
+        signals: set[str] = set()
+        if control_id in finding_sev:
+            fstatus = _evaluated_control_status(finding_sev[control_id])
+            if fstatus != "not_evaluated":  # all-unrated findings are not evidence
+                signals.add(fstatus)
+        for cis_status in cis_by_control.get(control_id, set()):
+            signals.add("warning" if cis_status == "warn" else cis_status)
+        if not signals:
+            continue  # curated control, but nothing ran -> not_evaluated
+        status = max(signals, key=lambda s: _NIST_STATUS_RANK[s])
+        tally[status] += 1
+        spec = catalog.get(control_id)
+        iso_ids = fm.nist_to_iso(control_id) if status == "fail" else []
+        controls.append(
+            {
+                "control_id": control_id,
+                "title": spec.title if spec else None,
+                "status": status,
+                "findings": finding_count.get(control_id, 0),
+                "evidencing_checks": list(spec.evidencing_checks) if spec else [],
+                "iso_27001_derived": iso_ids,
+            }
+        )
+
+    passed, failed, warned, errored = tally["pass"], tally["fail"], tally["warning"], tally["error"]
+    evaluated = passed + failed + warned + errored
+    catalog_size = len(catalog)
+    not_evaluated = catalog_size - evaluated
+    score = round((passed / evaluated) * 100, 1) if evaluated > 0 else 0.0
+    coverage_pct = round((evaluated / catalog_size) * 100, 2) if catalog_size > 0 else 0.0
+
+    if scan_count == 0 or evaluated == 0:
+        status = "no_data"
+    elif failed > 0:
+        status = "fail"
+    elif warned > 0 or errored > 0:
+        status = "warning"
+    else:
+        status = "pass"
+
+    # Emergent cross-framework: failing NIST controls implicate ISO Annex A
+    # controls via NIST's own official SP 800-53 -> ISO 27001 crosswalk. Surface
+    # BY ID ONLY (ISO titles are copyrighted), clearly labeled as derived.
+    iso_derived_ids = sorted({iso for c in controls if c["status"] == "fail" for iso in c["iso_27001_derived"]})
+
+    return {
+        "framework": "nist-800-53",
+        "framework_key": "nist_800_53_catalog",
+        "framework_label": "NIST SP 800-53 Rev 5",
+        "representation": "catalog",
+        "source": "framework_control_catalog",
+        "vendor_asserted": True,
+        "status": status,
+        "score": score,
+        "summary": {
+            "pass": passed,
+            "fail": failed,
+            "warning": warned,
+            "error": errored,
+            "evaluated": evaluated,
+            "not_evaluated": not_evaluated,
+            "catalog_size": catalog_size,
+            "coverage_pct": coverage_pct,
+            "score": score,
+        },
+        "controls": controls,
+        "iso_27001_derived": {
+            "source": "nist_800_53_to_iso_27001_crosswalk",
+            "note": (
+                "ISO/IEC 27001:2022 Annex A control IDs implicated by the failing NIST controls, "
+                "derived from NIST's official SP 800-53 Rev 5 -> ISO 27001 crosswalk (identifiers only)."
+            ),
+            "controls": iso_derived_ids,
+        },
     }
 
 
@@ -592,6 +729,15 @@ async def get_compliance(request: Request) -> dict:
         if not_evaluated:
             summary[f"{metadata.summary_prefix}_not_evaluated"] = not_evaluated
     cis_foundations_line = _build_cis_foundations_line(cis_foundations_agg)
+    # PR3: catalog-backed NIST 800-53 line, scored INDEPENDENTLY over evaluated
+    # controls only (curated check -> control map). Deliberately NOT folded into
+    # overall_score/overall_status — the same CVE/CIS evidence already drives the
+    # existing per-framework lines, so folding would double-count.
+    nist_800_53_catalog_line = _build_nist_800_53_catalog_line(
+        all_blast,
+        cis_foundations_agg.get("statuses", {}),
+        scan_count,
+    )
     summary.update(
         {
             "aisvs_pass": aisvs_summary["pass"],
@@ -603,6 +749,12 @@ async def get_compliance(request: Request) -> dict:
             "cis_foundations_error": cis_foundations_line["summary"]["error"],
             "cis_foundations_not_applicable": cis_foundations_line["summary"]["not_applicable"],
             "cis_foundations_evaluated": cis_foundations_line["summary"]["evaluated"],
+            "nist_800_53_catalog_pass": nist_800_53_catalog_line["summary"]["pass"],
+            "nist_800_53_catalog_fail": nist_800_53_catalog_line["summary"]["fail"],
+            "nist_800_53_catalog_warning": nist_800_53_catalog_line["summary"]["warning"],
+            "nist_800_53_catalog_error": nist_800_53_catalog_line["summary"]["error"],
+            "nist_800_53_catalog_evaluated": nist_800_53_catalog_line["summary"]["evaluated"],
+            "nist_800_53_catalog_not_evaluated": nist_800_53_catalog_line["summary"]["not_evaluated"],
         }
     )
 
@@ -616,6 +768,7 @@ async def get_compliance(request: Request) -> dict:
         "scan_sources": sorted(all_scan_sources),
         "aisvs_benchmark": aisvs,
         "cis_foundations_benchmark": cis_foundations_line,
+        "nist_800_53_catalog": nist_800_53_catalog_line,
         "summary": summary,
     }
     for metadata in TAG_MAPPED_FRAMEWORKS:

--- a/src/agent_bom/framework_mapping.py
+++ b/src/agent_bom/framework_mapping.py
@@ -37,9 +37,15 @@ evidencing_checks, ...)}``. It is populated from the vendored data in
   official ISO / AICPA / CIS title, none of which are vendored anywhere in this
   tree.
 
-``control_spec()`` is the read seam; ``evidencing_checks`` stays empty here
-(PR3 curates check -> control). ``nist_to_iso()`` exposes NIST's own official
-SP 800-53 Rev 5 -> ISO/IEC 27001:2022 crosswalk (ISO referenced by ID only).
+``control_spec()`` is the read seam. PR3 curates ``evidencing_checks`` for
+``nist-800-53`` from two VENDOR-ASSERTED, in-repo sources: the CWE -> NIST
+controls already in ``CWE_COMPLIANCE_MAP`` (inverted into ``cwe:<CWE-ID>``
+checks) and the conservative ``CIS_FOUNDATIONS_TO_NIST_800_53`` table
+(``cis:<cloud>:<check_id>`` checks). Neither is an authority-published
+crosswalk; both are check -> control judgments (which agent-bom check evidences
+which NIST control), not control-to-control mappings. ``nist_to_iso()`` exposes
+NIST's own official SP 800-53 Rev 5 -> ISO/IEC 27001:2022 crosswalk (ISO
+referenced by ID only).
 """
 
 from __future__ import annotations
@@ -69,6 +75,9 @@ __all__ = [
     "select_frameworks",
     "is_framework_relevant",
     "ALL_FRAMEWORKS",
+    "CIS_FOUNDATIONS_TO_NIST_800_53",
+    "nist_controls_for_cis_check",
+    "NIST_800_53_EVIDENCED_CONTROLS",
 ]
 
 
@@ -390,6 +399,103 @@ def is_framework_relevant(
     )
 
 
+# ─── PR3: check -> NIST 800-53 control curation (VENDOR-ASSERTED) ─────────────
+# Two curated, in-repo sources decide which agent-bom check evidences which NIST
+# SP 800-53 Rev 5 control. Neither is an authority-published crosswalk; both are
+# agent-bom's own asserted "our check evidences this control" judgment (see the
+# module docstring — this is check -> control, NOT control-to-control).
+#
+#   1. CWE -> NIST controls: reused verbatim from ``CWE_COMPLIANCE_MAP`` (already
+#      curated in-repo). Every CVE/CWE finding evidences the controls its CWE
+#      maps to. Inverted into ``cwe:<CWE-ID>`` evidencing checks below — zero new
+#      assertion, so it inherits that table's provenance.
+#
+#   2. CIS Foundations Benchmark check -> NIST controls: the small, conservative
+#      table below. Only unambiguous control-objective matches are mapped (a CIS
+#      check and a NIST control addressing the same objective); anything unclear
+#      is deliberately left unmapped (honest — unmapped is fine). Scoped to the
+#      AWS CIS Foundations Benchmark, whose check numbering is the most stable and
+#      widely-referenced. Keyed by ``(cloud, check_id)`` because CIS check numbers
+#      are provider-specific. Every referenced NIST control id is validated
+#      against the vendored catalog by the test-suite.
+CIS_FOUNDATIONS_TO_NIST_800_53: dict[tuple[str, str], tuple[str, ...]] = {
+    # ── Identity & access (CIS section 1) ───────────────────────────────────
+    ("aws", "1.4"): ("AC-6", "IA-5"),  # no root access key
+    ("aws", "1.5"): ("IA-2",),  # MFA for root
+    ("aws", "1.6"): ("IA-2",),  # hardware MFA for root
+    ("aws", "1.7"): ("AC-6",),  # eliminate day-to-day root use
+    ("aws", "1.8"): ("IA-5",),  # password policy: min length
+    ("aws", "1.9"): ("IA-5",),  # password policy: reuse prevention
+    ("aws", "1.10"): ("IA-2",),  # MFA for all console IAM users
+    ("aws", "1.12"): ("AC-2", "IA-5"),  # disable credentials unused >= 45 days
+    ("aws", "1.14"): ("IA-5",),  # rotate access keys every 90 days
+    ("aws", "1.15"): ("AC-6",),  # permissions only via groups/roles
+    ("aws", "1.16"): ("AC-6",),  # no full-admin ("*:*") policies attached
+    # ── Data protection at rest / boundary (CIS section 2) ───────────────────
+    ("aws", "2.1.1"): ("AC-3", "SC-7"),  # S3 account-level public access block
+    ("aws", "2.1.2"): ("SC-28",),  # S3 server-side encryption
+    ("aws", "2.2.1"): ("SC-28",),  # EBS default encryption
+    ("aws", "2.3.1"): ("SC-28",),  # RDS encryption at rest
+    ("aws", "2.4.1"): ("SC-12",),  # KMS customer-managed key rotation
+    # ── Logging & audit (CIS section 3) ──────────────────────────────────────
+    ("aws", "3.1"): ("AU-2", "AU-12"),  # CloudTrail enabled in all regions
+    ("aws", "3.2"): ("AU-9",),  # CloudTrail log file validation
+    ("aws", "3.3"): ("AC-3", "SC-7"),  # CloudTrail S3 bucket not public
+    ("aws", "3.4"): ("AU-6",),  # CloudTrail -> CloudWatch Logs
+    ("aws", "3.5"): ("AU-2",),  # management events in all regions
+    ("aws", "3.7"): ("SC-28",),  # CloudTrail logs encrypted with KMS
+    ("aws", "3.9"): ("AU-2",),  # VPC flow logging
+    ("aws", "3.10"): ("AU-2",),  # S3 object-level write logging
+    ("aws", "3.11"): ("AU-2",),  # S3 object-level read logging
+    # ── Monitoring / alerting (CIS section 4) ────────────────────────────────
+    ("aws", "4.1"): ("SI-4",),  # alarm: unauthorized API calls
+    ("aws", "4.2"): ("SI-4",),  # alarm: console sign-in without MFA
+    ("aws", "4.3"): ("SI-4",),  # alarm: root account usage
+    ("aws", "4.4"): ("SI-4",),  # alarm: IAM policy changes
+    ("aws", "4.5"): ("SI-4",),  # alarm: CloudTrail config changes
+    ("aws", "4.16"): ("SI-4",),  # Security Hub enabled
+    # ── Network boundary (CIS section 5) ─────────────────────────────────────
+    ("aws", "5.1"): ("SC-7",),  # NACLs restrict admin-port ingress
+    ("aws", "5.2"): ("SC-7",),  # security groups restrict admin-port ingress
+    ("aws", "5.3"): ("SC-7",),  # default security group restricts all traffic
+    ("aws", "5.5"): ("SC-7",),  # no unrestricted 0.0.0.0/0 ingress to all ports
+    ("aws", "5.6"): ("AU-2",),  # VPC flow logging
+}
+
+
+def nist_controls_for_cis_check(cloud: str, check_id: str) -> list[str]:
+    """Return the NIST 800-53 controls a CIS Foundations check evidences.
+
+    Vendor-asserted objective match (see ``CIS_FOUNDATIONS_TO_NIST_800_53``);
+    empty list when the check has no defensible NIST mapping. The result is
+    sorted so callers get a stable order.
+    """
+    return sorted(CIS_FOUNDATIONS_TO_NIST_800_53.get((cloud, check_id), ()))
+
+
+# Set of NIST controls with at least one curated evidencing check. Populated by
+# ``_build_framework_control_catalog``; the ``/v1/compliance`` NIST catalog line
+# scores against exactly this set so its evaluated denominator reconciles with
+# the curated check -> control mapping (never the looser vuln-intrinsic tags).
+NIST_800_53_EVIDENCED_CONTROLS: frozenset[str] = frozenset()
+
+
+def _nist_evidencing_checks() -> dict[str, list[str]]:
+    """Invert the two curated sources into ``{nist_control_id: [check, ...]}``.
+
+    CWE checks are namespaced ``cwe:<CWE-ID>``; CIS Foundations checks are
+    ``cis:<cloud>:<check_id>``. Deterministic (sorted) so the catalog is stable.
+    """
+    checks: dict[str, set[str]] = {}
+    for cwe, frameworks in CWE_COMPLIANCE_MAP.items():
+        for control_id in frameworks.get("nist_800_53", []):
+            checks.setdefault(control_id, set()).add(f"cwe:{cwe.upper()}")
+    for (cloud, check_id), controls in CIS_FOUNDATIONS_TO_NIST_800_53.items():
+        for control_id in controls:
+            checks.setdefault(control_id, set()).add(f"cis:{cloud}:{check_id}")
+    return {control_id: sorted(values) for control_id, values in checks.items()}
+
+
 # ─── Populate the provenanced control catalog (import-time, once) ─────────────
 
 
@@ -407,10 +513,21 @@ def _build_framework_control_catalog() -> None:
     from agent_bom.iso_27001 import ISO_27001
     from agent_bom.soc2 import SOC2_TSC
 
+    global NIST_800_53_EVIDENCED_CONTROLS
+
+    # PR3: curated check -> control mapping (vendor-asserted), keyed by control.
+    evidencing = _nist_evidencing_checks()
     FRAMEWORK_CONTROL_CATALOG[FRAMEWORK_NIST_800_53] = {
-        control_id: ControlSpec(control_id=control_id, title=spec["title"])
+        control_id: ControlSpec(
+            control_id=control_id,
+            title=spec["title"],
+            evidencing_checks=tuple(evidencing.get(control_id, ())),
+        )
         for control_id, spec in framework_catalog.nist_controls().items()
     }
+    NIST_800_53_EVIDENCED_CONTROLS = frozenset(
+        cid for cid, checks in evidencing.items() if cid in FRAMEWORK_CONTROL_CATALOG[FRAMEWORK_NIST_800_53] and checks
+    )
 
     # ISO 27001 (reference-only): every Annex A control NIST's crosswalk cites,
     # plus the IDs our own taggers use. Title = our own descriptor if we have

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -596,6 +596,172 @@ def test_cis_foundations_reconciles_with_cis_checks():
     _clear_jobs()
 
 
+# ─── PR3: NIST 800-53 catalog-backed scoring line ────────────────────────────
+
+
+def _nist_catalog_scenario() -> None:
+    """Seed one estate exercising every NIST-catalog status transition.
+
+    CVE finding tagged SI-10 (curated CWE evidence) -> fail; a second finding
+    tagged only RA-5 (a vuln-intrinsic tag with NO curated check -> control
+    mapping) -> must stay not_evaluated so the line reconciles with the curated
+    evidencing_checks. AWS CIS Foundations checks drive pass/fail/error/N-A.
+    """
+    _add_done_job(
+        [
+            {
+                "vulnerability_id": "CVE-2025-1000",
+                "severity": "high",
+                "package": "flask",
+                "nist_800_53_tags": ["SI-10"],
+            },
+            {
+                "vulnerability_id": "CVE-2025-2000",
+                "severity": "critical",
+                "package": "requests",
+                "nist_800_53_tags": ["RA-5"],  # not a curated check -> control
+            },
+        ],
+        result_extra=_cis_benchmark_result(
+            [
+                {"check_id": "2.1.2", "title": "S3 SSE", "status": "PASS", "severity": "high"},  # SC-28 pass
+                {"check_id": "2.1.1", "title": "S3 public", "status": "FAIL", "severity": "high"},  # AC-3, SC-7 fail
+                {"check_id": "1.12", "title": "Unused creds", "status": "FAIL", "severity": "medium"},  # AC-2, IA-5 fail
+                {"check_id": "1.4", "title": "Root key", "status": "ERROR", "severity": "critical"},  # AC-6, IA-5 err
+                {"check_id": "1.5", "title": "Manual", "status": "NOT_APPLICABLE", "severity": "low"},  # IA-2 ignored
+            ]
+        ),
+    )
+
+
+def test_compliance_surfaces_nist_800_53_catalog_line():
+    """A NIST-mapped estate surfaces a catalog-backed 800-53 line scored over
+    EVALUATED controls only, with an explicit ERROR bucket and a not_evaluated
+    remainder against the full vendored catalog."""
+    from agent_bom.framework_mapping import FRAMEWORK_CONTROL_CATALOG
+
+    _clear_jobs()
+    _nist_catalog_scenario()
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+
+    line = data["nist_800_53_catalog"]
+    assert line["framework_key"] == "nist_800_53_catalog"
+    assert line["representation"] == "catalog"
+    assert line["vendor_asserted"] is True
+
+    catalog_size = len(FRAMEWORK_CONTROL_CATALOG["nist-800-53"])
+    summary = line["summary"]
+    # fail: SI-10, AC-3, SC-7, AC-2, IA-5 (fail beats the 1.4 error) = 5
+    # pass: SC-28 = 1 ; error: AC-6 = 1 ; warning: 0
+    assert summary["fail"] == 5
+    assert summary["pass"] == 1
+    assert summary["error"] == 1
+    assert summary["warning"] == 0
+    assert summary["evaluated"] == 7  # pass + fail + warning + error
+    assert summary["catalog_size"] == catalog_size
+    assert summary["not_evaluated"] == catalog_size - 7
+    # Score is over evaluated controls only: 1 pass / 7 evaluated.
+    assert summary["score"] == 14.3
+    assert line["score"] == 14.3
+    assert line["status"] == "fail"
+
+    by_id = {c["control_id"]: c for c in line["controls"]}
+    assert by_id["SI-10"]["status"] == "fail"
+    assert by_id["AC-2"]["status"] == "fail"
+    assert by_id["SC-28"]["status"] == "pass"
+    assert by_id["AC-6"]["status"] == "error"  # unevaluable, not pass/fail
+    assert by_id["IA-5"]["status"] == "fail"  # fail (1.12) wins over error (1.4)
+    # Reconciliation: controls with no curated check are never on this line.
+    assert "RA-5" not in by_id  # vuln-intrinsic tag, not a curated check
+    assert "IA-2" not in by_id  # only a NOT_APPLICABLE check touched it
+    # Only evaluated controls are listed (no 1000-row not_evaluated tower).
+    assert all(c["status"] in ("pass", "fail", "warning", "error") for c in line["controls"])
+    _clear_jobs()
+
+
+def test_nist_catalog_line_iso_attribution_is_derived_by_id_only():
+    """A failing NIST control surfaces its ISO 27001 attribution BY ID ONLY,
+    labeled as derived from NIST's official SP 800-53 -> ISO crosswalk — never an
+    ISO control title (copyrighted)."""
+    from agent_bom.framework_mapping import nist_to_iso
+
+    _clear_jobs()
+    _nist_catalog_scenario()
+    client = TestClient(app)
+    line = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()["nist_800_53_catalog"]
+
+    # AC-2 is the canonical example: NIST maps it to A.5.16 / A.5.18 / A.8.2.
+    ac2 = next(c for c in line["controls"] if c["control_id"] == "AC-2")
+    assert ac2["iso_27001_derived"] == nist_to_iso("AC-2") == ["A.5.16", "A.5.18", "A.8.2"]
+
+    derived = line["iso_27001_derived"]
+    assert "crosswalk" in derived["note"].lower()
+    assert derived["source"] == "nist_800_53_to_iso_27001_crosswalk"
+    # Identifiers only — every entry is an ISO Annex A id, no title text leaks.
+    assert all(i.startswith("A.") for i in derived["controls"])
+    assert "A.5.16" in derived["controls"]
+    # Only failing controls contribute (SC-28 passed -> its ISO ids not implicated
+    # unless another failing control shares them).
+    assert derived["controls"] == sorted(set(derived["controls"]))
+    _clear_jobs()
+
+
+def test_nist_catalog_line_is_independent_and_does_not_move_overall():
+    """The catalog line is scored INDEPENDENTLY: its pass/fail must not be folded
+    into overall_score (that would double-count the same CVE/CIS evidence already
+    driving the existing lines). The existing CIS Foundations line is unchanged."""
+    _clear_jobs()
+    # CIS-only estate: no CVE tags. overall is driven by the CIS Foundations fold
+    # exactly as before PR3.
+    _add_done_job(
+        [],
+        result_extra=_cis_benchmark_result(
+            [
+                {"check_id": "2.1.2", "title": "S3 SSE", "status": "PASS", "severity": "high"},
+                {"check_id": "2.1.1", "title": "S3 public", "status": "FAIL", "severity": "high"},
+                {"check_id": "1.12", "title": "Unused creds", "status": "FAIL", "severity": "medium"},
+                {"check_id": "1.4", "title": "Root key", "status": "ERROR", "severity": "critical"},
+                {"check_id": "1.5", "title": "Manual", "status": "NOT_APPLICABLE", "severity": "low"},
+            ]
+        ),
+    )
+    client = TestClient(app)
+    data = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+
+    # cis_foundations fold: pass=1, fail=2, error=1 -> evaluated 4, score 25.0.
+    assert data["cis_foundations_benchmark"]["summary"] == {
+        "pass": 1,
+        "fail": 2,
+        "error": 1,
+        "not_applicable": 1,
+        "evaluated": 4,
+        "score": 25.0,
+    }
+    assert data["overall_status"] == "fail"
+    assert data["overall_score"] == 25.0  # NOT dragged further by the NIST line
+
+    # The NIST catalog line still reports its own (independent) failing controls.
+    nist_line = data["nist_800_53_catalog"]
+    assert nist_line["summary"]["fail"] >= 3  # AC-3, SC-7, AC-2, IA-5
+    # Its counts are NOT added into the overall aggregate summary.
+    assert "nist_800_53_catalog_fail" in data["summary"]
+    _clear_jobs()
+
+
+def test_nist_catalog_line_no_data_when_nothing_mapped():
+    """An estate with a completed scan but no NIST-mapped evidence yields an
+    honest no_data line, not a false 100% pass."""
+    _clear_jobs()
+    _add_done_job([{"vulnerability_id": "CVE-x", "severity": "high", "owasp_tags": ["LLM05"]}])
+    client = TestClient(app)
+    line = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()["nist_800_53_catalog"]
+    assert line["summary"]["evaluated"] == 0
+    assert line["status"] == "no_data"
+    assert line["score"] == 0.0
+    _clear_jobs()
+
+
 def test_posture_has_proxy_flips_on_proxy_alert_ingest():
     """audit P1-B: ingesting proxy alerts via /v1/proxy/audit must flip
     the ``has_proxy`` posture flag on /v1/posture/counts.

--- a/tests/test_framework_mapping.py
+++ b/tests/test_framework_mapping.py
@@ -334,7 +334,9 @@ def test_nist_control_spec_carries_authoritative_public_domain_title():
     assert spec.control_id == "AC-2"
     assert spec.title == "Account Management"  # authoritative NIST SP 800-53 title
     assert spec.reference_only is False
-    assert spec.evidencing_checks == ()  # PR3 curates check -> control
+    # PR3 curates check -> control: AC-2 (Account Management) is evidenced by the
+    # AWS CIS Foundations "credentials unused >= 45 days are disabled" check only.
+    assert spec.evidencing_checks == ("cis:aws:1.12",)
     # Every control our CWE table maps to must resolve to a real NIST title.
     for cid in ("AC-3", "AC-6", "AU-2", "CM-7", "IA-5", "SC-8", "SI-3", "SR-3"):
         assert fm.control_spec("nist-800-53", cid).title
@@ -403,6 +405,63 @@ def test_reference_only_frameworks_carry_no_copyrighted_title():
     # A CIS/SOC2 spec resolves and carries our own (non-official) descriptor.
     assert fm.control_spec("cis", "CIS-07.1").title == "Vulnerability-management program"
     assert fm.control_spec("soc2", "CC7.1").title == "Anomaly and event detection"
+
+
+# ─── PR3: check -> NIST 800-53 control curation (vendor-asserted) ─────────────
+
+
+def test_nist_evidencing_checks_reuse_cwe_compliance_map():
+    """Every CWE the in-repo CWE_COMPLIANCE_MAP maps to a NIST control appears as
+    a ``cwe:<CWE-ID>`` evidencing check on that control's spec — 100% reuse of
+    already-curated data, no new assertion."""
+    from agent_bom import framework_mapping as fm
+    from agent_bom.constants import CWE_COMPLIANCE_MAP
+
+    for cwe, frameworks in CWE_COMPLIANCE_MAP.items():
+        for control_id in frameworks.get("nist_800_53", []):
+            spec = fm.control_spec("nist-800-53", control_id)
+            assert spec is not None, f"{control_id} missing from NIST catalog"
+            assert f"cwe:{cwe}" in spec.evidencing_checks
+
+    # SI-10 (Information Input Validation) is evidenced by the injection CWEs.
+    si10 = fm.control_spec("nist-800-53", "SI-10")
+    assert "cwe:CWE-89" in si10.evidencing_checks
+    # Every evidencing check carries a recognised, namespaced provenance prefix.
+    assert all(c.startswith(("cwe:", "cis:")) for c in si10.evidencing_checks)
+
+
+def test_nist_evidencing_checks_include_vendor_asserted_cis_mapping():
+    """A defensible CIS-Foundations-check -> NIST-control objective match is
+    surfaced as a ``cis:<cloud>:<check_id>`` evidencing check (vendor-asserted)."""
+    from agent_bom import framework_mapping as fm
+
+    # Public-S3 account block evidences boundary protection + access enforcement.
+    assert fm.nist_controls_for_cis_check("aws", "2.1.1") == ["AC-3", "SC-7"]
+    # S3 server-side encryption evidences protection of data at rest.
+    assert "SC-28" in fm.nist_controls_for_cis_check("aws", "2.1.2")
+    # Unknown check / cloud -> empty, never KeyError.
+    assert fm.nist_controls_for_cis_check("aws", "99.99") == []
+    assert fm.nist_controls_for_cis_check("no-such-cloud", "2.1.1") == []
+
+    # The mapping is reflected on the control specs (both directions reconcile).
+    ac3 = fm.control_spec("nist-800-53", "AC-3")
+    assert "cis:aws:2.1.1" in ac3.evidencing_checks
+    # Every NIST control the CIS table references resolves to a real NIST title.
+    for (_cloud, _check), controls in fm.CIS_FOUNDATIONS_TO_NIST_800_53.items():
+        for control_id in controls:
+            assert fm.control_spec("nist-800-53", control_id).title
+
+
+def test_nist_evidenced_controls_set_matches_specs():
+    """The exported evidenced-controls set equals the controls whose spec carries
+    at least one evidencing check — the route's reconciliation seam."""
+    from agent_bom import framework_mapping as fm
+
+    derived = {cid for cid, spec in fm.FRAMEWORK_CONTROL_CATALOG["nist-800-53"].items() if spec.evidencing_checks}
+    assert derived == set(fm.NIST_800_53_EVIDENCED_CONTROLS)
+    # AC-2 is evidenced only via the CIS table; SI-10 only via CWE; both present.
+    assert "AC-2" in derived
+    assert "SI-10" in derived
 
 
 def test_vendored_catalog_integrity_and_counts_reconcile():


### PR DESCRIPTION
Part of #4214 — framework-library PR3 (check→control curation + per-framework scoring). Builds on PR1 (unify mapping) + PR2 (NIST catalog + crosswalk), both on main. Offline, no creds. **PR4 (surface) closes the epic.**

## Check→NIST-control mappings (vendor-asserted, sourced)
- **CWE reuse — zero new assertion:** inverted `CWE_COMPLIANCE_MAP` → 53 CWEs become `cwe:<id>` evidencing checks across the 16 NIST controls that table already maps (AC-3/6, AU-2, CM-7, IA-5, SC-8/12/13/17/28, SI-3/4/7/10/16, SR-3). Inherits its provenance.
- **New vendor-asserted CIS→NIST:** a conservative 36-row AWS CIS Foundations table (`CIS_FOUNDATIONS_TO_NIST_800_53`), only unambiguous objective matches (public-S3 2.1.1→AC-3/SC-7; SSE 2.1.2→SC-28; unused-creds 1.12→AC-2/IA-5; monitoring 4.x→SI-4). AWS-only (stablest numbering); unclear left unmapped (honest). Every referenced control validated against the vendored catalog by test. Labeled **vendor-asserted**, not official.

## Independent NIST scoring line
New `nist_800_53_catalog` line in `/v1/compliance`: evaluated = controls with ≥1 curated check that ran; score = pass/evaluated; ERROR its own bucket (denominator, never numerator); `not_evaluated = 1014 − evaluated`; `coverage_pct` shown (machine-verifiable). Scored **independently — not folded into `overall_score`** (no double-counting the same evidence). Failing NIST controls surface ISO Annex A **by ID only**, labeled derived-from-the-NIST-crosswalk.

## Honesty / verified
Existing CIS lines unchanged (characterization). 7 red→green tests + `169 passed` touched / `1376 passed` broad; `ruff`/`mypy`/catalog-integrity/check-counts/OpenAPI clean. Live: seeded estate → NIST line `fail` score 14.3, `evaluated == pass+fail+warning+error`, `catalog_size == evaluated+not_evaluated`, AC-2 ISO derived `["A.5.16","A.5.18","A.8.2"]` (matches crosswalk, IDs only).

## PR4 to close #4214
Surface this across CLI `compliance`, `/v1/compliance/nist-800-53` drill + narrative/report exports, UI (exec read + engineer drill, both themes), MCP parity; optionally extend CIS→NIST beyond AWS.