### PR TITLE
feat(compliance): framework library surface lock-in — CLI/API/exports/UI/MCP (closes #4214)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,19 @@
+# agent-bom gitleaks configuration.
+#
+# Extends the default ruleset (nothing is disabled). When a false-positive
+# PATTERN recurs, add a narrowly-scoped allowlist here; .gitleaksignore stays
+# for genuine one-off fingerprints. Keep every regex anchored to the specific
+# field or shape that misfires — never allowlist by entropy, file glob alone,
+# or a broad keyword that could mask a real credential.
+
+title = "agent-bom"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "Compliance framework registry-identifier fields: framework_key holds a registry slug (e.g. the NIST catalog id), not a credential. The generic-api-key rule fires on the _key suffix."
+regexTarget = "line"
+regexes = [
+  '''["']?framework_key["']?\s*[:=]''',
+]

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -41,10 +41,3 @@ e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:360
 0e43ed628801d7c2d4fbdd7e3a01b07fda2b113b:src/agent_bom/api/routes/compliance.py:generic-api-key:534
 # History-only: earlier revision of the note above quoted the flagged pair.
 523c32e9b3c52b355c33cc67bac34e670ff6167f:.gitleaksignore:generic-api-key:39
-
-# False positives: the framework-library surface declares its NIST catalog
-# registry identifier in fields whose names end in _key across the API types,
-# UI test fixture, and catalog module — registry ids, not credentials.
-1909a366b5e9a5f2c7827393602f448a63f6f612:ui/lib/api-types.ts:generic-api-key:1971
-1909a366b5e9a5f2c7827393602f448a63f6f612:ui/tests/compliance-nist-catalog.test.tsx:generic-api-key:14
-eb61a063cce566930a6b0da61733c79dc3a71af4:src/agent_bom/compliance_nist_catalog.py:generic-api-key:146

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -41,3 +41,10 @@ e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:360
 0e43ed628801d7c2d4fbdd7e3a01b07fda2b113b:src/agent_bom/api/routes/compliance.py:generic-api-key:534
 # History-only: earlier revision of the note above quoted the flagged pair.
 523c32e9b3c52b355c33cc67bac34e670ff6167f:.gitleaksignore:generic-api-key:39
+
+# False positives: the framework-library surface declares its NIST catalog
+# registry identifier in fields whose names end in _key across the API types,
+# UI test fixture, and catalog module — registry ids, not credentials.
+1909a366b5e9a5f2c7827393602f448a63f6f612:ui/lib/api-types.ts:generic-api-key:1971
+1909a366b5e9a5f2c7827393602f448a63f6f612:ui/tests/compliance-nist-catalog.test.tsx:generic-api-key:14
+eb61a063cce566930a6b0da61733c79dc3a71af4:src/agent_bom/compliance_nist_catalog.py:generic-api-key:146

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 75 tools, 6 resources, 8 workflow prompts |
-| REST API | 365 operations across 43 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 366 operations across 43 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -155,7 +155,7 @@ flowchart TB
         M4["Max body size"]
     end
     subgraph BE["Backend - FastAPI"]
-        R["365 REST operations across 43 route modules
+        R["366 REST operations across 43 route modules
 plus 2 WebSocket routes"]
     end
     subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,7 +53,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 308 |
+| `docs/openapi/v1.json` | paths | 309 |
 | `docs/openapi/v1.json` | component schemas | 101 |
 
 <!-- DATA_MODEL_ATLAS:END -->

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (308 paths / 365 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (309 paths / 366 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (365 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (366 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -10467,6 +10467,116 @@
         ]
       }
     },
+    "/v1/compliance/nist-800-53": {
+      "get": {
+        "description": "Drill the catalog-backed NIST SP 800-53 Rev 5 line.\n\nReturns per-control status (pass / fail / error / not_evaluated), the\nvendor-asserted evidencing checks behind each evaluated control, a family\nrollup for scale-aware navigation, and the ISO/IEC 27001 attribution derived\nBY ID from NIST's official SP 800-53 \u2192 ISO crosswalk (identifiers only; no\ncopyrighted ISO title text).\n\nThe headline ``summary``/``score``/``status`` are the SAME values the\n``/v1/compliance`` ``nist_800_53_catalog`` line reports (one source of\ntruth). By default only EVALUATED controls are listed \u2014 the ~1000-control\n``not_evaluated`` remainder is a count, not a mile-long tower. Pass\n``include_not_evaluated=true`` to enumerate the full catalog; ``status=``\n(comma-separated) filters the displayed control list WITHOUT changing the\ncounts. Declared before ``/compliance/{framework}`` so FastAPI does not treat\n``nist-800-53`` as a tag-mapped framework slug.",
+        "operationId": "get_compliance_nist_800_53_v1_compliance_nist_800_53_get",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Status"
+            }
+          },
+          {
+            "in": "query",
+            "name": "include_not_evaluated",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Not Evaluated",
+              "type": "boolean"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Get Compliance Nist 800 53 V1 Compliance Nist 800 53 Get",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Get Compliance Nist 800 53",
+        "tags": [
+          "compliance"
+        ]
+      }
+    },
     "/v1/compliance/report/pack": {
       "get": {
         "description": "Export one signed evidence pack covering every tag-mapped framework.\n\nThis is the auditor \"grab everything\" download: instead of pulling a\nper-framework bundle from ``/v1/compliance/{framework}/report`` one at a\ntime, operators get a single tamper-evident JSON with each framework's\ncontrols, mapped findings, and the shared audit-window integrity totals.\n\nThe pack shares the single-bundle security envelope: a fresh 128-bit\n``nonce`` and explicit ``expires_at`` are inside the signed body, the\nsignature (``X-Agent-Bom-Compliance-Report-Signature``) covers the\ncanonical UTF-8 body, and every framework's evidence + the audit events\nare tenant-filtered so cross-tenant data never leaks into the pack.",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -6991,6 +6991,81 @@ paths:
       summary: Get Compliance Narrative By Framework
       tags:
       - compliance
+  /v1/compliance/nist-800-53:
+    get:
+      description: "Drill the catalog-backed NIST SP 800-53 Rev 5 line.\n\nReturns\
+        \ per-control status (pass / fail / error / not_evaluated), the\nvendor-asserted\
+        \ evidencing checks behind each evaluated control, a family\nrollup for scale-aware\
+        \ navigation, and the ISO/IEC 27001 attribution derived\nBY ID from NIST's\
+        \ official SP 800-53 \u2192 ISO crosswalk (identifiers only; no\ncopyrighted\
+        \ ISO title text).\n\nThe headline ``summary``/``score``/``status`` are the\
+        \ SAME values the\n``/v1/compliance`` ``nist_800_53_catalog`` line reports\
+        \ (one source of\ntruth). By default only EVALUATED controls are listed \u2014\
+        \ the ~1000-control\n``not_evaluated`` remainder is a count, not a mile-long\
+        \ tower. Pass\n``include_not_evaluated=true`` to enumerate the full catalog;\
+        \ ``status=``\n(comma-separated) filters the displayed control list WITHOUT\
+        \ changing the\ncounts. Declared before ``/compliance/{framework}`` so FastAPI\
+        \ does not treat\n``nist-800-53`` as a tag-mapped framework slug."
+      operationId: get_compliance_nist_800_53_v1_compliance_nist_800_53_get
+      parameters:
+      - in: query
+        name: status
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Status
+      - in: query
+        name: include_not_evaluated
+        required: false
+        schema:
+          default: false
+          title: Include Not Evaluated
+          type: boolean
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Get Compliance Nist 800 53 V1 Compliance Nist 800
+                  53 Get
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Get Compliance Nist 800 53
+      tags:
+      - compliance
   /v1/compliance/report/pack:
     get:
       description: 'Export one signed evidence pack covering every tag-mapped framework.

--- a/scripts/check_package_layout.py
+++ b/scripts/check_package_layout.py
@@ -67,6 +67,7 @@ ALLOWED_TOP_LEVEL_MODULES: frozenset[str] = frozenset(
     'compliance_coverage.py',
     'compliance_hub.py',
     'compliance_hub_ingest.py',
+    'compliance_nist_catalog.py',
     'compliance_utils.py',
     'config.py',
     'constants.py',

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -6,6 +6,7 @@ Endpoints:
     GET  /v1/compliance/aisvs                OWASP AISVS benchmark posture
     GET  /v1/compliance/narrative            full compliance narrative (all frameworks)
     GET  /v1/compliance/narrative/{framework} single-framework narrative
+    GET  /v1/compliance/nist-800-53          NIST 800-53 catalog drill (per-control + ISO-by-id)
     GET  /v1/compliance/{framework}          single framework (must be after /narrative)
     GET  /v1/compliance/{framework}/report   signed evidence bundle for auditors
     GET  /v1/posture                         enterprise posture scorecard
@@ -41,6 +42,13 @@ from agent_bom.api.stores import (
 )
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
+from agent_bom.compliance_nist_catalog import (
+    build_nist_800_53_catalog_line,
+    build_nist_800_53_drill,
+)
+from agent_bom.compliance_nist_catalog import (
+    evaluated_control_status as _evaluated_control_status,
+)
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.security import sanitize_error, sanitize_text
@@ -312,23 +320,6 @@ def _derive_deployment_context(request: Request, jobs: list[Any]) -> dict[str, A
     }
 
 
-def _evaluated_control_status(sev_breakdown: dict[str, int]) -> str:
-    """Status of a control that HAS mapped findings, by worst severity.
-
-    Mirror of ``compliance_narrative._control_status`` so ``/v1/compliance``, the
-    narrative, and the CLI export agree: critical/high → fail, medium/low →
-    warning. The caller only reaches this with findings > 0, so an all-zero
-    breakdown means the mapped findings are all unrated-severity — evidence
-    exists but severity is ungraded, which is ``not_evaluated``, never a silent
-    pass (a false pass inflated overall_score). Keep in sync with that function.
-    """
-    if sev_breakdown.get("critical", 0) > 0 or sev_breakdown.get("high", 0) > 0:
-        return "fail"
-    if sev_breakdown.get("medium", 0) > 0 or sev_breakdown.get("low", 0) > 0:
-        return "warning"
-    return "not_evaluated"
-
-
 def _aggregate_cis_foundations_checks(jobs: list[Any]) -> dict[str, Any]:
     """Deduped CIS Foundations Benchmark status rollup across a tenant's scans.
 
@@ -426,138 +417,6 @@ def _build_cis_foundations_line(agg: dict[str, Any]) -> dict[str, Any]:
             "score": score,
         },
         "providers": agg["providers"],
-    }
-
-
-# Order used to collapse multiple evidence signals on one NIST control into a
-# single status. Higher wins: a real weakness (fail/warning) beats an
-# unevaluable check (error) which beats a clean pass; a control with no run
-# check stays not_evaluated (never a silent pass).
-_NIST_STATUS_RANK = {"not_evaluated": 0, "pass": 1, "error": 2, "warning": 3, "fail": 4}
-
-
-def _build_nist_800_53_catalog_line(
-    all_blast: list[dict],
-    cis_statuses: dict[tuple[str, str], str],
-    scan_count: int,
-) -> dict[str, Any]:
-    """Score the full vendored NIST SP 800-53 Rev 5 catalog over EVALUATED
-    controls only, using PR3's curated (vendor-asserted) check -> control map.
-
-    A control is *evaluated* when at least one mapped check ran: a CVE/CWE
-    finding whose ``nist_800_53_tags`` include a curated (evidencing_checks)
-    control, or a CIS Foundations check the vendor-asserted table maps to it.
-    Findings can only fail/warn (absence of a CVE is never a pass); a CIS check
-    contributes pass/fail/error. ERROR is an explicit bucket — counted toward the
-    evaluated denominator but never the numerator. Controls with no run check are
-    ``not_evaluated`` against the full catalog. Scored INDEPENDENTLY: this line is
-    never folded into ``overall_score`` (the same evidence already drives the
-    existing per-framework lines — folding it would double-count).
-    """
-    from agent_bom import framework_mapping as fm
-
-    catalog = fm.FRAMEWORK_CONTROL_CATALOG.get(fm.FRAMEWORK_NIST_800_53, {})
-    evidenced = fm.NIST_800_53_EVIDENCED_CONTROLS
-
-    # Finding-driven severity per curated control (worst-severity -> status via
-    # the shared _evaluated_control_status helper the rest of the scorecard uses).
-    finding_sev: dict[str, dict[str, int]] = {}
-    finding_count: dict[str, int] = {}
-    for br in all_blast:
-        for control_id in br.get("nist_800_53_tags", []) or []:
-            if control_id not in evidenced:
-                continue  # vuln-intrinsic tag with no curated check -> reconcile out
-            sev = str(br.get("severity") or "").lower()
-            bucket = finding_sev.setdefault(control_id, {"critical": 0, "high": 0, "medium": 0, "low": 0})
-            if sev in bucket:
-                bucket[sev] += 1
-            finding_count[control_id] = finding_count.get(control_id, 0) + 1
-
-    # CIS-driven statuses per control via the vendor-asserted CIS -> NIST table.
-    cis_by_control: dict[str, set[str]] = {}
-    for (cloud, check_id), status in cis_statuses.items():
-        if status not in ("pass", "fail", "error"):
-            continue  # not_applicable / unknown never evaluate a control
-        for control_id in fm.nist_controls_for_cis_check(cloud, check_id):
-            cis_by_control.setdefault(control_id, set()).add(status)
-
-    controls: list[dict[str, Any]] = []
-    tally = {"pass": 0, "fail": 0, "warning": 0, "error": 0}
-    for control_id in sorted(evidenced):
-        signals: set[str] = set()
-        if control_id in finding_sev:
-            fstatus = _evaluated_control_status(finding_sev[control_id])
-            if fstatus != "not_evaluated":  # all-unrated findings are not evidence
-                signals.add(fstatus)
-        for cis_status in cis_by_control.get(control_id, set()):
-            signals.add("warning" if cis_status == "warn" else cis_status)
-        if not signals:
-            continue  # curated control, but nothing ran -> not_evaluated
-        status = max(signals, key=lambda s: _NIST_STATUS_RANK[s])
-        tally[status] += 1
-        spec = catalog.get(control_id)
-        iso_ids = fm.nist_to_iso(control_id) if status == "fail" else []
-        controls.append(
-            {
-                "control_id": control_id,
-                "title": spec.title if spec else None,
-                "status": status,
-                "findings": finding_count.get(control_id, 0),
-                "evidencing_checks": list(spec.evidencing_checks) if spec else [],
-                "iso_27001_derived": iso_ids,
-            }
-        )
-
-    passed, failed, warned, errored = tally["pass"], tally["fail"], tally["warning"], tally["error"]
-    evaluated = passed + failed + warned + errored
-    catalog_size = len(catalog)
-    not_evaluated = catalog_size - evaluated
-    score = round((passed / evaluated) * 100, 1) if evaluated > 0 else 0.0
-    coverage_pct = round((evaluated / catalog_size) * 100, 2) if catalog_size > 0 else 0.0
-
-    if scan_count == 0 or evaluated == 0:
-        status = "no_data"
-    elif failed > 0:
-        status = "fail"
-    elif warned > 0 or errored > 0:
-        status = "warning"
-    else:
-        status = "pass"
-
-    # Emergent cross-framework: failing NIST controls implicate ISO Annex A
-    # controls via NIST's own official SP 800-53 -> ISO 27001 crosswalk. Surface
-    # BY ID ONLY (ISO titles are copyrighted), clearly labeled as derived.
-    iso_derived_ids = sorted({iso for c in controls if c["status"] == "fail" for iso in c["iso_27001_derived"]})
-
-    return {
-        "framework": "nist-800-53",
-        "framework_key": "nist_800_53_catalog",
-        "framework_label": "NIST SP 800-53 Rev 5",
-        "representation": "catalog",
-        "source": "framework_control_catalog",
-        "vendor_asserted": True,
-        "status": status,
-        "score": score,
-        "summary": {
-            "pass": passed,
-            "fail": failed,
-            "warning": warned,
-            "error": errored,
-            "evaluated": evaluated,
-            "not_evaluated": not_evaluated,
-            "catalog_size": catalog_size,
-            "coverage_pct": coverage_pct,
-            "score": score,
-        },
-        "controls": controls,
-        "iso_27001_derived": {
-            "source": "nist_800_53_to_iso_27001_crosswalk",
-            "note": (
-                "ISO/IEC 27001:2022 Annex A control IDs implicated by the failing NIST controls, "
-                "derived from NIST's official SP 800-53 Rev 5 -> ISO 27001 crosswalk (identifiers only)."
-            ),
-            "controls": iso_derived_ids,
-        },
     }
 
 
@@ -733,7 +592,7 @@ async def get_compliance(request: Request) -> dict:
     # controls only (curated check -> control map). Deliberately NOT folded into
     # overall_score/overall_status — the same CVE/CIS evidence already drives the
     # existing per-framework lines, so folding would double-count.
-    nist_800_53_catalog_line = _build_nist_800_53_catalog_line(
+    nist_800_53_catalog_line = build_nist_800_53_catalog_line(
         all_blast,
         cis_foundations_agg.get("statuses", {}),
         scan_count,
@@ -1341,6 +1200,37 @@ async def get_compliance_summary(request: Request) -> dict:
     # needed here.
 
     return response
+
+
+@router.get("/compliance/nist-800-53", tags=["compliance"])
+async def get_compliance_nist_800_53(
+    request: Request,
+    status: str | None = None,
+    include_not_evaluated: bool = False,
+) -> dict:
+    """Drill the catalog-backed NIST SP 800-53 Rev 5 line.
+
+    Returns per-control status (pass / fail / error / not_evaluated), the
+    vendor-asserted evidencing checks behind each evaluated control, a family
+    rollup for scale-aware navigation, and the ISO/IEC 27001 attribution derived
+    BY ID from NIST's official SP 800-53 → ISO crosswalk (identifiers only; no
+    copyrighted ISO title text).
+
+    The headline ``summary``/``score``/``status`` are the SAME values the
+    ``/v1/compliance`` ``nist_800_53_catalog`` line reports (one source of
+    truth). By default only EVALUATED controls are listed — the ~1000-control
+    ``not_evaluated`` remainder is a count, not a mile-long tower. Pass
+    ``include_not_evaluated=true`` to enumerate the full catalog; ``status=``
+    (comma-separated) filters the displayed control list WITHOUT changing the
+    counts. Declared before ``/compliance/{framework}`` so FastAPI does not treat
+    ``nist-800-53`` as a tag-mapped framework slug.
+    """
+    full = await get_compliance(request)
+    return build_nist_800_53_drill(
+        full["nist_800_53_catalog"],
+        status=status,
+        include_not_evaluated=include_not_evaluated,
+    )
 
 
 @router.get("/compliance/{framework}", tags=["compliance"])

--- a/src/agent_bom/cli/_history.py
+++ b/src/agent_bom/cli/_history.py
@@ -583,6 +583,64 @@ def rescan_command(baseline: str, output: Optional[str], md: Optional[str], enri
     sys.exit(1 if remaining else 0)
 
 
+def _render_nist_catalog_markdown(lines: list, catalog: dict) -> None:
+    """Render the catalog-backed NIST 800-53 line + per-control drill.
+
+    Surfaces the same evaluated-only score, honest not_evaluated/ERROR buckets,
+    vendor-asserted provenance, and ISO-by-id attribution the API reports — the
+    human equivalent of the ``nist_800_53_catalog`` JSON (agent) output.
+    """
+    if not catalog:
+        return
+    summary = catalog.get("summary", {})
+    label = catalog.get("framework_label", "NIST SP 800-53")
+    lines.extend([f"## {label} (vendor-asserted)", ""])
+    if catalog.get("status") == "no_data":
+        lines.extend(
+            [
+                "No NIST 800-53 control was evaluated by this scan (no mapped evidence). "
+                "Reported as not evaluated, not compliant.",
+                "",
+            ]
+        )
+        return
+    lines.append(
+        f"Status: `{catalog.get('status')}` · Score: `{catalog.get('score')}/100` "
+        f"(over {summary.get('evaluated', 0)} evaluated controls)"
+    )
+    lines.append(
+        f"- Pass: {summary.get('pass', 0)} · Fail: {summary.get('fail', 0)} · "
+        f"Warning: {summary.get('warning', 0)} · ERROR: {summary.get('error', 0)}"
+    )
+    lines.append(
+        f"- Evaluated: {summary.get('evaluated', 0)} · Not evaluated: {summary.get('not_evaluated', 0)} "
+        f"of {summary.get('catalog_size', 0)} · Coverage: {summary.get('coverage_pct', 0)}%"
+    )
+    lines.append("")
+
+    graded = [c for c in catalog.get("controls", []) if c.get("status") in ("fail", "error", "warning")]
+    if graded:
+        lines.append("Controls needing attention:")
+        lines.append("")
+        lines.append("| Control | Status | Findings | ISO 27001 (derived, by id) |")
+        lines.append("| --- | --- | --- | --- |")
+        for control in sorted(graded, key=lambda c: c["control_id"]):
+            iso_ids = ", ".join(control.get("iso_27001_derived", [])) or "—"
+            lines.append(
+                f"| {control['control_id']} | {control['status']} | {control.get('findings', 0)} | {iso_ids} |"
+            )
+        lines.append("")
+
+    iso_block = catalog.get("iso_27001_derived", {})
+    iso_controls = iso_block.get("controls", []) if isinstance(iso_block, dict) else []
+    if iso_controls:
+        lines.append(
+            "ISO/IEC 27001:2022 Annex A control ids implicated via NIST's official crosswalk "
+            f"(identifiers only): {', '.join(iso_controls)}"
+        )
+        lines.append("")
+
+
 @click.command("compliance-narrative")
 @click.argument("scan_file", type=click.Path(exists=True))
 @click.option(
@@ -614,6 +672,7 @@ def compliance_narrative_cmd(scan_file: str, framework: Optional[str], output_fo
                 for recommendation in fw.recommendations:
                     lines.append(f"- {recommendation}")
                 lines.append("")
+        _render_nist_catalog_markdown(lines, narrative.nist_800_53_catalog)
         if narrative.remediation_impact:
             lines.extend(["## Remediation Impact", ""])
             for impact in narrative.remediation_impact:

--- a/src/agent_bom/compliance_nist_catalog.py
+++ b/src/agent_bom/compliance_nist_catalog.py
@@ -1,0 +1,267 @@
+"""Catalog-backed NIST SP 800-53 Rev 5 scoring — the single source of truth.
+
+The ``/v1/compliance`` route, its ``/compliance/nist-800-53`` drill, the MCP
+``compliance`` tool, the auditor compliance narrative, and the CLI all score the
+vendored NIST 800-53 catalog through the functions here, so every surface reports
+the SAME numbers by construction (§11 one-source-of-truth). No FastAPI / CLI /
+MCP dependency lives in this module — it takes plain blast-radius dicts + a CIS
+status map and returns plain dicts.
+
+Scoring is over EVALUATED controls only (a control is evaluated when at least one
+vendor-asserted evidencing check ran): findings can only fail/warn, a CIS
+Foundations check contributes pass/fail/error, ERROR is an explicit bucket
+counted toward the evaluated denominator but never the numerator, and a control
+with no run check stays ``not_evaluated`` against the full catalog. The line is
+scored INDEPENDENTLY and is never folded into ``overall_score`` (the same
+CVE/CIS evidence already drives the existing per-framework lines — folding it
+would double-count). All framework mappings here are VENDOR-ASSERTED, never an
+authority-published crosswalk; ISO/IEC 27001 attribution is surfaced BY ID ONLY
+(ISO titles are copyrighted) via NIST's official SP 800-53 → ISO crosswalk.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Order used to collapse multiple evidence signals on one NIST control into a
+# single status. Higher wins: a real weakness (fail/warning) beats an
+# unevaluable check (error) which beats a clean pass; a control with no run
+# check stays not_evaluated (never a silent pass).
+NIST_STATUS_RANK = {"not_evaluated": 0, "pass": 1, "error": 2, "warning": 3, "fail": 4}
+
+NIST_800_53_FRAMEWORK_LABEL = "NIST SP 800-53 Rev 5"
+
+
+def evaluated_control_status(sev_breakdown: dict[str, int]) -> str:
+    """Status of a control that HAS mapped findings, by worst severity.
+
+    Mirror of ``compliance_narrative._control_status`` so ``/v1/compliance``, the
+    narrative, and the CLI export agree: critical/high → fail, medium/low →
+    warning. The caller only reaches this with findings > 0, so an all-zero
+    breakdown means the mapped findings are all unrated-severity — evidence
+    exists but severity is ungraded, which is ``not_evaluated``, never a silent
+    pass (a false pass inflated overall_score). Keep in sync with that function.
+    """
+    if sev_breakdown.get("critical", 0) > 0 or sev_breakdown.get("high", 0) > 0:
+        return "fail"
+    if sev_breakdown.get("medium", 0) > 0 or sev_breakdown.get("low", 0) > 0:
+        return "warning"
+    return "not_evaluated"
+
+
+def build_nist_800_53_catalog_line(
+    all_blast: list[dict],
+    cis_statuses: dict[tuple[str, str], str],
+    scan_count: int,
+) -> dict[str, Any]:
+    """Score the full vendored NIST SP 800-53 Rev 5 catalog over EVALUATED
+    controls only, using the curated (vendor-asserted) check → control map.
+
+    A control is *evaluated* when at least one mapped check ran: a CVE/CWE
+    finding whose ``nist_800_53_tags`` include a curated (evidencing_checks)
+    control, or a CIS Foundations check the vendor-asserted table maps to it.
+    Findings can only fail/warn (absence of a CVE is never a pass); a CIS check
+    contributes pass/fail/error. ERROR is an explicit bucket — counted toward the
+    evaluated denominator but never the numerator. Controls with no run check are
+    ``not_evaluated`` against the full catalog. Scored INDEPENDENTLY: this line is
+    never folded into ``overall_score``.
+    """
+    from agent_bom import framework_mapping as fm
+
+    catalog = fm.FRAMEWORK_CONTROL_CATALOG.get(fm.FRAMEWORK_NIST_800_53, {})
+    evidenced = fm.NIST_800_53_EVIDENCED_CONTROLS
+
+    # Finding-driven severity per curated control (worst-severity → status via
+    # the shared evaluated_control_status helper the rest of the scorecard uses).
+    finding_sev: dict[str, dict[str, int]] = {}
+    finding_count: dict[str, int] = {}
+    for br in all_blast:
+        for control_id in br.get("nist_800_53_tags", []) or []:
+            if control_id not in evidenced:
+                continue  # vuln-intrinsic tag with no curated check → reconcile out
+            sev = str(br.get("severity") or "").lower()
+            bucket = finding_sev.setdefault(control_id, {"critical": 0, "high": 0, "medium": 0, "low": 0})
+            if sev in bucket:
+                bucket[sev] += 1
+            finding_count[control_id] = finding_count.get(control_id, 0) + 1
+
+    # CIS-driven statuses per control via the vendor-asserted CIS → NIST table.
+    cis_by_control: dict[str, set[str]] = {}
+    for (cloud, check_id), status in cis_statuses.items():
+        if status not in ("pass", "fail", "error"):
+            continue  # not_applicable / unknown never evaluate a control
+        for control_id in fm.nist_controls_for_cis_check(cloud, check_id):
+            cis_by_control.setdefault(control_id, set()).add(status)
+
+    controls: list[dict[str, Any]] = []
+    tally = {"pass": 0, "fail": 0, "warning": 0, "error": 0}
+    for control_id in sorted(evidenced):
+        signals: set[str] = set()
+        if control_id in finding_sev:
+            fstatus = evaluated_control_status(finding_sev[control_id])
+            if fstatus != "not_evaluated":  # all-unrated findings are not evidence
+                signals.add(fstatus)
+        for cis_status in cis_by_control.get(control_id, set()):
+            signals.add("warning" if cis_status == "warn" else cis_status)
+        if not signals:
+            continue  # curated control, but nothing ran → not_evaluated
+        status = max(signals, key=lambda s: NIST_STATUS_RANK[s])
+        tally[status] += 1
+        spec = catalog.get(control_id)
+        iso_ids = fm.nist_to_iso(control_id) if status == "fail" else []
+        controls.append(
+            {
+                "control_id": control_id,
+                "title": spec.title if spec else None,
+                "status": status,
+                "findings": finding_count.get(control_id, 0),
+                "evidencing_checks": list(spec.evidencing_checks) if spec else [],
+                "iso_27001_derived": iso_ids,
+            }
+        )
+
+    passed, failed, warned, errored = tally["pass"], tally["fail"], tally["warning"], tally["error"]
+    evaluated = passed + failed + warned + errored
+    catalog_size = len(catalog)
+    not_evaluated = catalog_size - evaluated
+    score = round((passed / evaluated) * 100, 1) if evaluated > 0 else 0.0
+    coverage_pct = round((evaluated / catalog_size) * 100, 2) if catalog_size > 0 else 0.0
+
+    if scan_count == 0 or evaluated == 0:
+        status = "no_data"
+    elif failed > 0:
+        status = "fail"
+    elif warned > 0 or errored > 0:
+        status = "warning"
+    else:
+        status = "pass"
+
+    # Emergent cross-framework: failing NIST controls implicate ISO Annex A
+    # controls via NIST's own official SP 800-53 → ISO 27001 crosswalk. Surface
+    # BY ID ONLY (ISO titles are copyrighted), clearly labeled as derived.
+    iso_derived_ids = sorted({iso for c in controls if c["status"] == "fail" for iso in c["iso_27001_derived"]})
+
+    return {
+        "framework": "nist-800-53",
+        "framework_key": "nist_800_53_catalog",
+        "framework_label": NIST_800_53_FRAMEWORK_LABEL,
+        "representation": "catalog",
+        "source": "framework_control_catalog",
+        "vendor_asserted": True,
+        "status": status,
+        "score": score,
+        "summary": {
+            "pass": passed,
+            "fail": failed,
+            "warning": warned,
+            "error": errored,
+            "evaluated": evaluated,
+            "not_evaluated": not_evaluated,
+            "catalog_size": catalog_size,
+            "coverage_pct": coverage_pct,
+            "score": score,
+        },
+        "controls": controls,
+        "iso_27001_derived": {
+            "source": "nist_800_53_to_iso_27001_crosswalk",
+            "note": (
+                "ISO/IEC 27001:2022 Annex A control IDs implicated by the failing NIST controls, "
+                "derived from NIST's official SP 800-53 Rev 5 -> ISO 27001 crosswalk (identifiers only)."
+            ),
+            "controls": iso_derived_ids,
+        },
+    }
+
+
+def nist_family(control_id: str) -> str:
+    """Return the NIST 800-53 family prefix (AC, AU, SC, …) for a control id."""
+    return control_id.split("-", 1)[0]
+
+
+def build_family_rollup(evaluated_controls: list[dict], catalog: dict[str, Any]) -> list[dict]:
+    """Partition the FULL vendored catalog into families and fold the evaluated
+    per-control statuses into each. ``total`` counts every catalog control in the
+    family; ``evaluated`` / ``pass`` / ``fail`` / … come from the scored controls;
+    ``not_evaluated`` is the remainder. Sums reconcile with the catalog line by
+    construction, giving the UI a scale-aware grouping over 1000+ controls.
+    """
+    fam: dict[str, dict[str, int]] = {}
+    for control_id in catalog:
+        rec = fam.setdefault(
+            nist_family(control_id),
+            {"total": 0, "evaluated": 0, "pass": 0, "fail": 0, "warning": 0, "error": 0, "not_evaluated": 0},
+        )
+        rec["total"] += 1
+    for control in evaluated_controls:
+        rec = fam.get(nist_family(control["control_id"]))
+        if rec is None:
+            continue
+        st = control["status"]
+        if st in ("pass", "fail", "warning", "error"):
+            rec["evaluated"] += 1
+            rec[st] += 1
+    out: list[dict] = []
+    for name in sorted(fam):
+        rec = fam[name]
+        rec["not_evaluated"] = rec["total"] - rec["evaluated"]
+        out.append({"family": name, **rec})
+    return out
+
+
+def build_nist_800_53_drill(
+    line: dict[str, Any],
+    *,
+    status: str | None = None,
+    include_not_evaluated: bool = False,
+) -> dict[str, Any]:
+    """Expand a catalog line into a per-control drill: family rollup, optional
+    full-catalog listing, and a display-only status filter.
+
+    The headline ``summary`` / ``score`` / ``status`` are carried through
+    unchanged from ``line`` (one source of truth). By default only EVALUATED
+    controls are listed; ``include_not_evaluated`` enumerates the full catalog
+    (each unrun control as ``not_evaluated`` — never a silent pass); ``status``
+    (comma-separated) filters the displayed list WITHOUT changing the counts.
+    """
+    from agent_bom import framework_mapping as fm
+
+    catalog = fm.FRAMEWORK_CONTROL_CATALOG.get(fm.FRAMEWORK_NIST_800_53, {})
+    evaluated_controls = list(line.get("controls", []))
+    families = build_family_rollup(evaluated_controls, catalog)
+
+    controls = list(evaluated_controls)
+    if include_not_evaluated:
+        evaluated_ids = {c["control_id"] for c in evaluated_controls}
+        for control_id in sorted(catalog):
+            if control_id in evaluated_ids:
+                continue
+            spec = catalog[control_id]
+            controls.append(
+                {
+                    "control_id": control_id,
+                    "title": spec.title,
+                    "status": "not_evaluated",
+                    "findings": 0,
+                    "evidencing_checks": list(spec.evidencing_checks),
+                    "iso_27001_derived": [],
+                }
+            )
+
+    if status:
+        wanted = {s.strip() for s in status.split(",") if s.strip()}
+        controls = [c for c in controls if c["status"] in wanted]
+
+    return {
+        "framework": line["framework"],
+        "framework_key": line["framework_key"],
+        "framework_label": line["framework_label"],
+        "representation": line["representation"],
+        "source": line["source"],
+        "vendor_asserted": line["vendor_asserted"],
+        "status": line["status"],
+        "score": line["score"],
+        "summary": line["summary"],
+        "families": families,
+        "controls": controls,
+        "iso_27001_derived": line["iso_27001_derived"],
+    }

--- a/src/agent_bom/compliance_nist_catalog.py
+++ b/src/agent_bom/compliance_nist_catalog.py
@@ -193,13 +193,13 @@ def build_family_rollup(evaluated_controls: list[dict], catalog: dict[str, Any])
         )
         rec["total"] += 1
     for control in evaluated_controls:
-        rec = fam.get(nist_family(control["control_id"]))
-        if rec is None:
+        frec = fam.get(nist_family(control["control_id"]))
+        if frec is None:
             continue
         st = control["status"]
         if st in ("pass", "fail", "warning", "error"):
-            rec["evaluated"] += 1
-            rec[st] += 1
+            frec["evaluated"] += 1
+            frec[st] += 1
     out: list[dict] = []
     for name in sorted(fam):
         rec = fam[name]

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1020,7 +1020,10 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             JSON with overall_score (0-100), overall_status (pass/warning/fail),
             and per-control details for OWASP LLM Top 10 (10 controls),
             OWASP MCP Top 10 (10 controls), MITRE ATLAS (13 techniques),
-            and NIST AI RMF (14 subcategories).
+            and NIST AI RMF (14 subcategories). Plus a nist_800_53_catalog line:
+            the vendor-asserted, catalog-backed NIST SP 800-53 Rev 5 score over
+            evaluated controls only (with ISO-27001-by-id attribution), scored
+            independently and NOT folded into overall_score.
         """
         return await _execute_tool_async(
             "compliance",

--- a/src/agent_bom/mcp_tools/compliance.py
+++ b/src/agent_bom/mcp_tools/compliance.py
@@ -64,6 +64,7 @@ async def compliance_impl(
                     "atlas_tags": list(br.atlas_tags),
                     "nist_ai_rmf_tags": list(br.nist_ai_rmf_tags),
                     "owasp_mcp_tags": list(br.owasp_mcp_tags),
+                    "nist_800_53_tags": list(getattr(br, "nist_800_53_tags", [])),
                 }
             )
 
@@ -108,6 +109,18 @@ async def compliance_impl(
         has_fail = any(c["status"] == "fail" for c in all_controls)
         has_warn = any(c["status"] == "warning" for c in all_controls)
 
+        # Catalog-backed NIST SP 800-53 Rev 5 line (vendor-asserted), scored
+        # INDEPENDENTLY over evaluated controls only via the shared scorer — the
+        # SAME representation the /v1/compliance API and CLI narrative report.
+        # Deliberately NOT folded into overall_score (the AI-framework score
+        # above): the curated CVE evidence would otherwise be double-counted. No
+        # CIS Foundations checks exist on the local-scan path, so CIS statuses
+        # are empty; scan_count is 1 when agents were discovered so an unmapped
+        # estate reads no_data, never a false pass.
+        from agent_bom.compliance_nist_catalog import build_nist_800_53_catalog_line
+
+        nist_800_53_catalog = build_nist_800_53_catalog_line(br_dicts, {}, 1 if agents else 0)
+
         return _truncate_response(
             json.dumps(
                 {
@@ -118,6 +131,7 @@ async def compliance_impl(
                     "mitre_atlas": atlas,
                     "nist_ai_rmf": nist,
                     "owasp_mcp_top10": owasp_mcp,
+                    "nist_800_53_catalog": nist_800_53_catalog,
                 },
                 indent=2,
                 default=str,

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -132,6 +132,11 @@ class ComplianceNarrative:
     remediation_impact: list[RemediationImpact]
     risk_narrative: str
     generated_at: str  # ISO 8601
+    # Catalog-backed NIST SP 800-53 Rev 5 line (vendor-asserted), scored over
+    # EVALUATED controls only, with ISO-by-id attribution — the same
+    # representation the /v1/compliance API line reports (one source of truth).
+    # Empty dict when a single-framework narrative is scoped to a non-NIST slug.
+    nist_800_53_catalog: dict = field(default_factory=dict)
 
 
 # ─── Internal helpers ─────────────────────────────────────────────────────────
@@ -736,10 +741,22 @@ def generate_compliance_narrative(
         generated_at=generated_at,
     )
 
+    # Catalog-backed NIST 800-53 line (vendor-asserted, scored over evaluated
+    # controls only). The narrative path has no CIS Foundations checks, so CIS
+    # statuses are empty; scan_count is 1 when the report carries findings (a
+    # scan ran) so an unmapped estate reads no_data, never a false pass. Included
+    # for the full narrative and the nist-800-53 single-framework narrative only.
+    nist_800_53_catalog: dict = {}
+    if framework is None or framework == "nist-800-53":
+        from agent_bom.compliance_nist_catalog import build_nist_800_53_catalog_line
+
+        nist_800_53_catalog = build_nist_800_53_catalog_line(blast_dicts, {}, 1 if blast_dicts else 0)
+
     return ComplianceNarrative(
         executive_summary=executive_summary,
         framework_narratives=framework_narratives,
         remediation_impact=remediation_impact,
         risk_narrative=risk_narrative,
         generated_at=generated_at,
+        nist_800_53_catalog=nist_800_53_catalog,
     )

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -178,6 +178,21 @@ def _cyclonedx_vulnerability(vuln: Vulnerability, pkg_ref: str) -> dict:
         vuln_properties.append({"name": "agent-bom:epss_percentile", "value": str(vuln.epss_percentile)})
     if vuln.is_kev or vuln.epss_score is not None:
         vuln_properties.append({"name": "agent-bom:exploit_likelihood", "value": vuln.exploit_likelihood})
+    # Framework control attribution (CDX 1.7 has no first-class vulnerability
+    # slot for compliance mappings) as namespaced properties: framework:control
+    # IDs only — no copyrighted control-title text — labeled vendor-asserted so
+    # consumers never read agent-bom's own mapping judgment as an official
+    # crosswalk.
+    compliance_tags = getattr(vuln, "compliance_tags", None) or {}
+    emitted_compliance = False
+    if isinstance(compliance_tags, dict):
+        for framework, controls in sorted(compliance_tags.items()):
+            control_list = [controls] if isinstance(controls, str) else list(controls or [])
+            for control in control_list:
+                vuln_properties.append({"name": "agent-bom:compliance-tag", "value": f"{framework}:{control}"})
+                emitted_compliance = True
+    if emitted_compliance:
+        vuln_properties.append({"name": "agent-bom:compliance-tag-provenance", "value": "vendor-asserted"})
     if vuln_properties:
         entry["properties"] = vuln_properties
     if vuln.fixed_version:

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -237,6 +237,18 @@ def _build_run_taxonomies(results: list[dict]) -> list[dict]:
                 "name": name,
                 "fullName": full_name,
                 "informationUri": uri,
+                # Honesty: agent-bom's finding→control mappings are its own
+                # asserted judgment of which control a finding evidences, not an
+                # authority-published crosswalk. Label the provenance so SARIF
+                # consumers never read these as official. taxa carry control IDs
+                # only (name == id) — no copyrighted control-title text.
+                "properties": {
+                    "agent-bom:mappingProvenance": "vendor-asserted",
+                    "agent-bom:mappingProvenanceNote": (
+                        "Finding-to-control mappings are agent-bom's own asserted judgment of which "
+                        "control a finding evidences, not an authority-published crosswalk."
+                    ),
+                },
                 "taxa": [{"id": tag, "name": tag} for tag in sorted(tags)],
             }
         )

--- a/src/agent_bom/output/spdx_fmt.py
+++ b/src/agent_bom/output/spdx_fmt.py
@@ -321,8 +321,14 @@ def _vulnerability_annotations(vuln: Any, subject: str, *, compliance_tags: list
         statements.append(f"agent-bom:kev-due-date={vuln.kev_due_date}")
     for cwe_id in vuln.cwe_ids:
         statements.append(f"agent-bom:cwe={cwe_id}")
-    for tag in [*list(compliance_tags or []), *_vulnerability_compliance_tags(vuln)]:
+    compliance_statements = [*list(compliance_tags or []), *_vulnerability_compliance_tags(vuln)]
+    for tag in compliance_statements:
         statements.append(f"agent-bom:compliance-tag={tag}")
+    if compliance_statements:
+        # Honesty: these finding→control tags are agent-bom's own asserted
+        # mapping judgment, not an authority-published crosswalk. Label the
+        # provenance so SPDX consumers never read them as official.
+        statements.append("agent-bom:compliance-tag-provenance=vendor-asserted")
 
     return [
         {

--- a/tests/test_cli_history.py
+++ b/tests/test_cli_history.py
@@ -475,6 +475,57 @@ def test_compliance_narrative_command_json(tmp_path):
     assert payload["framework_narratives"]
 
 
+def _nist_report(tmp_path):
+    report = tmp_path / "report.json"
+    report.write_text(
+        json.dumps(
+            {
+                "summary": {"total_agents": 1, "total_packages": 1, "total_vulnerabilities": 1},
+                "blast_radius": [
+                    {
+                        "vulnerability_id": "CVE-2025-9000",
+                        "severity": "high",
+                        "package": "flask@1.0.0",
+                        "ecosystem": "pypi",
+                        "affected_agents": ["claude"],
+                        "affected_servers": ["filesystem"],
+                        "owasp_tags": [],
+                        "nist_800_53_tags": ["SI-10"],
+                    }
+                ],
+            }
+        )
+    )
+    return report
+
+
+def test_compliance_narrative_json_carries_nist_catalog(tmp_path):
+    runner = CliRunner()
+    report = _nist_report(tmp_path)
+    result = runner.invoke(compliance_narrative_cmd, [str(report), "--format", "json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    catalog = payload["nist_800_53_catalog"]
+    assert catalog["framework_key"] == "nist_800_53_catalog"
+    assert catalog["vendor_asserted"] is True
+    assert catalog["status"] == "fail"
+    assert any(c["control_id"] == "SI-10" and c["status"] == "fail" for c in catalog["controls"])
+
+
+def test_compliance_narrative_markdown_renders_nist_catalog_drill(tmp_path):
+    runner = CliRunner()
+    report = _nist_report(tmp_path)
+    result = runner.invoke(compliance_narrative_cmd, [str(report), "--format", "markdown"])
+    assert result.exit_code == 0, result.output
+    out = result.output
+    # Exec line: label + vendor-asserted provenance + honest buckets.
+    assert "NIST SP 800-53 Rev 5" in out
+    assert "vendor-asserted" in out.lower()
+    assert "Evaluated" in out and "Not evaluated" in out
+    # Engineer drill: the failing control id surfaces.
+    assert "SI-10" in out
+
+
 def test_compliance_narrative_uses_saved_summary_totals(tmp_path):
     runner = CliRunner()
     report = tmp_path / "report.json"

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -762,6 +762,94 @@ def test_nist_catalog_line_no_data_when_nothing_mapped():
     _clear_jobs()
 
 
+# ─── PR4: NIST 800-53 catalog drill endpoint (surface lock-in) ───────────────
+
+
+def test_nist_800_53_drill_reconciles_with_compliance_line():
+    """GET /v1/compliance/nist-800-53 returns the SAME summary as the
+    /v1/compliance nist_800_53_catalog line (one source of truth) and lists the
+    evaluated controls with vendor-asserted provenance + ISO-by-id attribution."""
+    _clear_jobs()
+    _nist_catalog_scenario()
+    client = TestClient(app)
+    line = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()["nist_800_53_catalog"]
+    drill = client.get("/v1/compliance/nist-800-53", headers=_AUTH_HEADERS).json()
+
+    # Reconciliation: the drill's headline numbers equal the aggregate line's.
+    assert drill["framework"] == "nist-800-53"
+    assert drill["framework_key"] == "nist_800_53_catalog"
+    assert drill["vendor_asserted"] is True
+    assert drill["summary"] == line["summary"]
+    assert drill["score"] == line["score"]
+    assert drill["status"] == line["status"]
+
+    by_id = {c["control_id"]: c for c in drill["controls"]}
+    assert by_id["SI-10"]["status"] == "fail"
+    assert by_id["SC-28"]["status"] == "pass"
+    assert by_id["AC-6"]["status"] == "error"
+    # Vendor-asserted evidencing checks ride the drill.
+    assert by_id["SI-10"]["evidencing_checks"]
+    # ISO by ID only, derived, no title text.
+    assert by_id["AC-2"]["iso_27001_derived"] == ["A.5.16", "A.5.18", "A.8.2"]
+    assert all(i.startswith("A.") for i in drill["iso_27001_derived"]["controls"])
+
+    # Default drill does NOT dump the ~1000-row not_evaluated tower (scale).
+    assert all(c["status"] in ("pass", "fail", "warning", "error") for c in drill["controls"])
+
+
+def test_nist_800_53_drill_family_rollup_reconciles():
+    """The family rollup partitions the full catalog and its evaluated counts sum
+    back to the line's evaluated total (scale-aware navigation, honest counts)."""
+    _clear_jobs()
+    _nist_catalog_scenario()
+    client = TestClient(app)
+    drill = client.get("/v1/compliance/nist-800-53", headers=_AUTH_HEADERS).json()
+
+    families = drill["families"]
+    assert families, "family rollup must be present for scale-aware UI grouping"
+    # Every evaluated control belongs to exactly one family; totals reconcile.
+    assert sum(f["evaluated"] for f in families) == drill["summary"]["evaluated"]
+    assert sum(f["total"] for f in families) == drill["summary"]["catalog_size"]
+    assert sum(f["fail"] for f in families) == drill["summary"]["fail"]
+    # AC family carries the AC-2 / AC-3 / AC-6 evaluated controls.
+    ac = next(f for f in families if f["family"] == "AC")
+    assert ac["evaluated"] >= 3
+
+
+def test_nist_800_53_drill_status_filter_and_not_evaluated_opt_in():
+    """?status= filters the control list; ?include_not_evaluated=true opts into
+    the full catalog listing (still one honest set of counts)."""
+    _clear_jobs()
+    _nist_catalog_scenario()
+    client = TestClient(app)
+
+    only_fail = client.get("/v1/compliance/nist-800-53?status=fail", headers=_AUTH_HEADERS).json()
+    assert only_fail["controls"]
+    assert all(c["status"] == "fail" for c in only_fail["controls"])
+    # Summary is unchanged by the display filter (counts are the source of truth).
+    assert only_fail["summary"]["pass"] == 1
+
+    full = client.get("/v1/compliance/nist-800-53?include_not_evaluated=true", headers=_AUTH_HEADERS).json()
+    statuses = {c["control_id"]: c["status"] for c in full["controls"]}
+    assert len(full["controls"]) == full["summary"]["catalog_size"]
+    # A curated-but-unrun control appears as not_evaluated (never a silent pass).
+    not_eval = [cid for cid, s in statuses.items() if s == "not_evaluated"]
+    assert len(not_eval) == full["summary"]["not_evaluated"]
+
+
+def test_nist_800_53_drill_no_data_is_honest():
+    """A completed scan with no NIST-mapped evidence drills to no_data, never a
+    fabricated 100% pass."""
+    _clear_jobs()
+    _add_done_job([{"vulnerability_id": "CVE-x", "severity": "high", "owasp_tags": ["LLM05"]}])
+    client = TestClient(app)
+    drill = client.get("/v1/compliance/nist-800-53", headers=_AUTH_HEADERS).json()
+    assert drill["status"] == "no_data"
+    assert drill["score"] == 0.0
+    assert drill["summary"]["evaluated"] == 0
+    _clear_jobs()
+
+
 def test_posture_has_proxy_flips_on_proxy_alert_ingest():
     """audit P1-B: ingesting proxy alerts via /v1/proxy/audit must flip
     the ``has_proxy`` posture flag on /v1/posture/counts.

--- a/tests/test_compliance_narrative.py
+++ b/tests/test_compliance_narrative.py
@@ -488,3 +488,50 @@ def test_same_control_id_does_not_bleed_between_frameworks():
     assert status_by_slug["fedramp"] == "not_evaluated"
     assert result.remediation_impact
     assert result.remediation_impact[0].frameworks_impacted == ["NIST 800-53"]
+
+
+# ─── PR4: catalog-backed NIST 800-53 line rides the narrative ─────────────────
+
+
+def test_narrative_carries_nist_800_53_catalog_line():
+    """The auditor narrative surfaces the catalog-backed NIST 800-53 line
+    (vendor-asserted), scored over evaluated controls only, with ISO-by-id
+    attribution — the SAME representation the /v1/compliance API line reports."""
+    br = _make_blast_radius(vuln=_make_vuln(severity=Severity.HIGH), owasp_tags=[])
+    br.nist_800_53_tags = ["SI-10"]  # curated CWE-backed evidencing check
+    report = _make_report(blast_radii=[br])
+
+    result = generate_compliance_narrative(report)
+    catalog = result.nist_800_53_catalog
+    assert catalog["framework_key"] == "nist_800_53_catalog"
+    assert catalog["vendor_asserted"] is True
+    assert catalog["status"] == "fail"
+    by_id = {c["control_id"]: c for c in catalog["controls"]}
+    assert by_id["SI-10"]["status"] == "fail"
+    assert by_id["SI-10"]["evidencing_checks"]
+    # ISO attribution surfaces BY ID only.
+    assert all(i.startswith("A.") for i in catalog["iso_27001_derived"]["controls"])
+
+
+def test_narrative_nist_catalog_no_data_when_unmapped():
+    """Findings that map to no NIST control yield an honest no_data catalog line,
+    never a fabricated pass."""
+    br = _make_blast_radius(vuln=_make_vuln(severity=Severity.HIGH), owasp_tags=["LLM05"])
+    br.nist_800_53_tags = []
+    report = _make_report(blast_radii=[br])
+    result = generate_compliance_narrative(report)
+    assert result.nist_800_53_catalog["status"] == "no_data"
+    assert result.nist_800_53_catalog["summary"]["evaluated"] == 0
+
+
+def test_narrative_single_framework_filter_scopes_catalog_line():
+    """A single-framework narrative for a non-NIST slug does not carry the NIST
+    catalog line; the nist-800-53 slug does."""
+    br = _make_blast_radius(vuln=_make_vuln(severity=Severity.HIGH), owasp_tags=["LLM05"])
+    br.nist_800_53_tags = ["SI-10"]
+    report = _make_report(blast_radii=[br])
+
+    owasp = generate_compliance_narrative(report, framework="owasp-llm")
+    assert owasp.nist_800_53_catalog == {}
+    nist = generate_compliance_narrative(report, framework="nist-800-53")
+    assert nist.nist_800_53_catalog["framework_key"] == "nist_800_53_catalog"

--- a/tests/test_compliance_nist_catalog.py
+++ b/tests/test_compliance_nist_catalog.py
@@ -1,0 +1,88 @@
+"""Direct unit tests for the shared catalog-backed NIST 800-53 scorer.
+
+The route, MCP tool, narrative, and CLI all call these functions, so pinning
+their behavior here guards the one-source-of-truth reconciliation across every
+surface (§11).
+"""
+
+from __future__ import annotations
+
+from agent_bom.compliance_nist_catalog import (
+    build_family_rollup,
+    build_nist_800_53_catalog_line,
+    build_nist_800_53_drill,
+    evaluated_control_status,
+)
+from agent_bom.framework_mapping import FRAMEWORK_CONTROL_CATALOG, FRAMEWORK_NIST_800_53
+
+
+def _scenario() -> tuple[list[dict], dict[tuple[str, str], str]]:
+    """CVE-driven SI-10 fail + a CIS estate exercising pass/fail/error/N-A."""
+    all_blast = [
+        {"vulnerability_id": "CVE-1", "severity": "high", "nist_800_53_tags": ["SI-10"]},
+        {"vulnerability_id": "CVE-2", "severity": "critical", "nist_800_53_tags": ["RA-5"]},
+    ]
+    cis_statuses = {
+        ("aws", "2.1.2"): "pass",  # SC-28 pass
+        ("aws", "2.1.1"): "fail",  # AC-3, SC-7 fail
+        ("aws", "1.12"): "fail",  # AC-2, IA-5 fail
+        ("aws", "1.4"): "error",  # AC-6, IA-5 error
+        ("aws", "1.5"): "not_applicable",  # IA-2 ignored
+    }
+    return all_blast, cis_statuses
+
+
+def test_evaluated_control_status_severity_bands():
+    assert evaluated_control_status({"critical": 1}) == "fail"
+    assert evaluated_control_status({"high": 1}) == "fail"
+    assert evaluated_control_status({"medium": 1}) == "warning"
+    assert evaluated_control_status({"low": 1}) == "warning"
+    # Evidence exists but severity ungraded -> not a silent pass.
+    assert evaluated_control_status({"critical": 0, "high": 0, "medium": 0, "low": 0}) == "not_evaluated"
+
+
+def test_catalog_line_scores_over_evaluated_only():
+    all_blast, cis_statuses = _scenario()
+    line = build_nist_800_53_catalog_line(all_blast, cis_statuses, scan_count=1)
+    s = line["summary"]
+    assert line["vendor_asserted"] is True
+    assert line["framework_key"] == "nist_800_53_catalog"
+    # fail: SI-10, AC-3, SC-7, AC-2, IA-5 = 5 ; pass: SC-28 = 1 ; error: AC-6 = 1
+    assert (s["fail"], s["pass"], s["error"], s["warning"]) == (5, 1, 1, 0)
+    assert s["evaluated"] == 7
+    assert s["catalog_size"] == len(FRAMEWORK_CONTROL_CATALOG[FRAMEWORK_NIST_800_53])
+    assert s["not_evaluated"] == s["catalog_size"] - 7
+    assert line["score"] == 14.3
+    by_id = {c["control_id"]: c["status"] for c in line["controls"]}
+    assert by_id["IA-5"] == "fail"  # fail (1.12) beats error (1.4)
+    assert "RA-5" not in by_id  # vuln-intrinsic tag, no curated check
+
+
+def test_no_data_when_nothing_mapped():
+    line = build_nist_800_53_catalog_line([], {}, scan_count=1)
+    assert line["status"] == "no_data"
+    assert line["score"] == 0.0
+    assert line["summary"]["evaluated"] == 0
+
+
+def test_drill_reconciles_and_family_rollup_sums_back():
+    all_blast, cis_statuses = _scenario()
+    line = build_nist_800_53_catalog_line(all_blast, cis_statuses, scan_count=1)
+    drill = build_nist_800_53_drill(line)
+    assert drill["summary"] == line["summary"]
+    assert sum(f["evaluated"] for f in drill["families"]) == line["summary"]["evaluated"]
+    assert sum(f["total"] for f in drill["families"]) == line["summary"]["catalog_size"]
+
+    full = build_nist_800_53_drill(line, include_not_evaluated=True)
+    assert len(full["controls"]) == full["summary"]["catalog_size"]
+    only_fail = build_nist_800_53_drill(line, status="fail")
+    assert only_fail["controls"] and all(c["status"] == "fail" for c in only_fail["controls"])
+    # A display filter never changes the counts.
+    assert only_fail["summary"]["pass"] == 1
+
+
+def test_family_rollup_not_evaluated_is_remainder():
+    catalog = FRAMEWORK_CONTROL_CATALOG[FRAMEWORK_NIST_800_53]
+    rollup = build_family_rollup([], catalog)
+    assert sum(f["total"] for f in rollup) == len(catalog)
+    assert all(f["not_evaluated"] == f["total"] and f["evaluated"] == 0 for f in rollup)

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -513,6 +513,72 @@ async def test_compliance_impl_no_agents():
     assert "overall_status" in data or "error" in data
 
 
+def _nist_blast_radius():
+    from agent_bom.models import (
+        Agent,
+        AgentType,
+        BlastRadius,
+        Package,
+        Severity,
+        Vulnerability,
+    )
+
+    vuln = Vulnerability(id="CVE-2025-9000", summary="x", severity=Severity.HIGH, fixed_version=None)
+    pkg = Package(name="flask", version="1.0.0", ecosystem="pypi", vulnerabilities=[vuln])
+    agent = Agent(name="claude", agent_type=AgentType.CUSTOM, config_path="/tmp")
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[],
+        affected_agents=[agent],
+        exposed_credentials=[],
+        exposed_tools=[],
+        risk_score=7.0,
+    )
+    br.nist_800_53_tags = ["SI-10"]
+    return agent, br
+
+
+@pytest.mark.asyncio
+async def test_compliance_impl_surfaces_nist_catalog_line():
+    """The MCP compliance tool surfaces the catalog-backed NIST 800-53 line
+    (vendor-asserted), consistent with the /v1/compliance API, and scored
+    INDEPENDENTLY — it must not move overall_score."""
+    from agent_bom.mcp_tools.compliance import compliance_impl
+
+    agent, br = _nist_blast_radius()
+
+    async def _pipeline(_config=None, _image=None):
+        return [agent], [br], [], []
+
+    result = await compliance_impl(
+        config_path=None, image=None, _run_scan_pipeline=_pipeline, _truncate_response=_trunc
+    )
+    data = json.loads(result)
+    catalog = data["nist_800_53_catalog"]
+    assert catalog["framework_key"] == "nist_800_53_catalog"
+    assert catalog["vendor_asserted"] is True
+    assert catalog["status"] == "fail"
+    assert any(c["control_id"] == "SI-10" and c["status"] == "fail" for c in catalog["controls"])
+    # Independent: the AI-framework overall_score is not dragged by the catalog line.
+    assert "nist_800_53_catalog" not in data.get("owasp_llm_top10", [])
+
+
+@pytest.mark.asyncio
+async def test_compliance_impl_nist_catalog_no_data_without_agents():
+    from agent_bom.mcp_tools.compliance import compliance_impl
+
+    async def _pipeline(_config=None, _image=None):
+        return [], [], [], []
+
+    result = await compliance_impl(
+        config_path=None, image=None, _run_scan_pipeline=_pipeline, _truncate_response=_trunc
+    )
+    catalog = json.loads(result)["nist_800_53_catalog"]
+    assert catalog["status"] == "no_data"
+    assert catalog["summary"]["evaluated"] == 0
+
+
 @pytest.mark.asyncio
 async def test_compliance_impl_exception():
     from agent_bom.mcp_tools.compliance import compliance_impl

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -850,6 +850,9 @@ def test_spdx_vulnerability_annotations_preserve_enrichment_and_compliance_metad
     assert "agent-bom:cwe=CWE-352" in statements
     assert "agent-bom:compliance-tag=owasp_llm:LLM05" in statements
     assert "agent-bom:compliance-tag=soc2:CC7.1" in statements
+    # Honesty: the emitted compliance tags are agent-bom's own asserted
+    # finding→control mappings, labeled vendor-asserted, never "official".
+    assert "agent-bom:compliance-tag-provenance=vendor-asserted" in statements
 
 
 def test_spdx_vulnerability_annotations_use_unified_findings_without_blast_radii():

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -855,6 +855,26 @@ def test_spdx_vulnerability_annotations_preserve_enrichment_and_compliance_metad
     assert "agent-bom:compliance-tag-provenance=vendor-asserted" in statements
 
 
+def test_cyclonedx_vulnerability_carries_vendor_asserted_compliance_tags():
+    """CycloneDX vulnerability properties carry the vendor-asserted framework
+    control tags (NIST/ISO ids) with an explicit provenance label — ids only,
+    never copyrighted control-title text."""
+    from agent_bom.output.cyclonedx_fmt import to_cyclonedx
+
+    vuln = _make_enriched_vuln()
+    vuln.compliance_tags = {"nist_800_53": ["SI-10"], "iso_27001": ["A.8.8"]}
+    pkg = _make_pkg("web-lib", "1.0.0")
+    pkg.vulnerabilities = [vuln]
+    report = _make_report(agents=[_make_agent(servers=[_make_server(packages=[pkg])])], blast_radii=[_make_blast_radius(pkg=pkg, vuln=vuln)])
+
+    cdx = to_cyclonedx(report)
+    vuln_entry = next(v for v in cdx.get("vulnerabilities", []) if v["id"] == vuln.id)
+    props = {(p["name"], p["value"]) for p in vuln_entry.get("properties", [])}
+    assert ("agent-bom:compliance-tag", "nist_800_53:SI-10") in props
+    assert ("agent-bom:compliance-tag", "iso_27001:A.8.8") in props
+    assert ("agent-bom:compliance-tag-provenance", "vendor-asserted") in props
+
+
 def test_spdx_vulnerability_annotations_use_unified_findings_without_blast_radii():
     vuln = _make_enriched_vuln()
     vuln.id = "CVE-2026-4242"

--- a/tests/test_sarif_schema_2_1_0.py
+++ b/tests/test_sarif_schema_2_1_0.py
@@ -223,6 +223,29 @@ def test_sarif_spans_multiple_finding_families(sarif_doc: dict) -> None:
     assert any(rid.startswith("ai-inventory/") for rid in rule_ids)  # AI inventory
 
 
+def test_sarif_framework_taxonomy_labels_mappings_vendor_asserted() -> None:
+    """The finding→control framework taxonomy must be labeled vendor-asserted
+    (agent-bom's own mapping judgment, not an authority crosswalk), with taxa as
+    control IDs only (no copyrighted control-title text)."""
+    from agent_bom.output.sarif import to_sarif
+
+    report = _multi_finding_report()
+    report.blast_radii[0].nist_800_53_tags = ["SI-10"]
+    report.blast_radii[0].iso_27001_tags = ["A.8.8"]
+    doc = to_sarif(report)
+    taxonomies = doc["runs"][0]["tool"]["driver"].get("supportedTaxonomies") or doc["runs"][0].get("taxonomies") or []
+    # taxonomies live under run.taxonomies in this exporter
+    taxonomies = doc["runs"][0].get("taxonomies", [])
+    by_name = {t["name"]: t for t in taxonomies}
+    nist = by_name["nist-800-53"]
+    assert nist["properties"]["agent-bom:mappingProvenance"] == "vendor-asserted"
+    # taxa are IDs only — the control id appears, never a title/description.
+    taxa_ids = {t["id"] for t in nist["taxa"]}
+    assert "SI-10" in taxa_ids
+    assert all(set(t.keys()) <= {"id", "name"} for t in nist["taxa"])
+    assert all(t["name"] == t["id"] for t in nist["taxa"])  # name == id, no title text
+
+
 def _full_chain_report() -> AIBOMReport:
     """A report whose blast radius spans agent → server → package → CVE → tool."""
     vuln = Vulnerability(

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -40,6 +40,7 @@ import {
 import { ComplianceHeatmap } from "@/components/compliance-heatmap";
 import { ComplianceMatrix } from "@/components/compliance-matrix";
 import { CISBenchmarkDetail } from "@/components/cis-benchmark-detail";
+import { ComplianceNistCatalog } from "@/components/compliance-nist-catalog";
 import { FrameworkIcon } from "@/components/framework-icon";
 import {
   complianceFrameworkSummaries,
@@ -642,6 +643,8 @@ function CompliancePageContent() {
             placeholder="Select a framework to review its controls and evidence."
             data-testid="compliance-split"
           />
+
+          <ComplianceNistCatalog />
 
           <Collapsible
             title="Cloud CIS benchmark drill-down"

--- a/ui/components/compliance-nist-catalog.tsx
+++ b/ui/components/compliance-nist-catalog.tsx
@@ -1,0 +1,399 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { Layers, Loader2, ShieldAlert } from "lucide-react";
+
+import { api } from "@/lib/api";
+import type { NistCatalogControl, NistCatalogDrill } from "@/lib/api";
+import { userFacingApiErrorMessage } from "@/lib/api-errors";
+import { Collapsible } from "@/components/collapsible";
+import { isNotEvaluated, postureLabel, StatusIcon, statusColor } from "@/components/compliance-status";
+
+type StatusFilter = "all" | "fail" | "warning" | "error" | "pass";
+
+const STATUS_LABEL: Record<string, string> = {
+  pass: "Pass",
+  fail: "Fail",
+  warning: "Warn",
+  error: "Error",
+  not_evaluated: "Not evaluated",
+};
+
+const FILTER_TABS: { key: StatusFilter; label: string }[] = [
+  { key: "all", label: "All" },
+  { key: "fail", label: "Fail" },
+  { key: "warning", label: "Warn" },
+  { key: "error", label: "Error" },
+  { key: "pass", label: "Pass" },
+];
+
+/** One compact honest bucket tile — value renders as its own node so the count
+ *  is always legible and reconciles 1:1 with the API summary. */
+function BucketTile({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: "success" | "warn" | "danger" | "error" | "neutral";
+}) {
+  const color =
+    accent === "success"
+      ? "text-[color:var(--status-success)]"
+      : accent === "warn"
+        ? "text-[color:var(--status-warn)]"
+        : accent === "danger"
+          ? "text-[color:var(--status-danger)]"
+          : accent === "error"
+            ? "text-[color:var(--status-warn)]"
+            : "text-[color:var(--foreground)]";
+  return (
+    <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2">
+      <div className={`text-lg font-semibold tabular-nums ${color}`}>{value}</div>
+      <div className="text-[11px] uppercase tracking-wide text-[color:var(--text-tertiary)]">{label}</div>
+    </div>
+  );
+}
+
+function ControlStatusBadge({ status }: { status: string }) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <StatusIcon status={status} className="h-3.5 w-3.5" />
+      <span className={`text-xs font-medium ${statusColor(status)}`}>{STATUS_LABEL[status] ?? status}</span>
+    </span>
+  );
+}
+
+/**
+ * Catalog-backed NIST SP 800-53 Rev 5 posture — exec line (score over evaluated,
+ * coverage, honest evaluated/not_evaluated/ERROR buckets) drilling to the
+ * engineer view (family rollup, per-control evidencing checks, ISO-27001-by-id
+ * derived). Consumes `/v1/compliance/nist-800-53`, so every number reconciles
+ * 1:1 with the `/v1/compliance` line, the CLI narrative, and the MCP tool (one
+ * shared scorer). Scale-aware over the full ~1000-control catalog: the drill
+ * leads with a family rollup and lists evaluated controls only until the reader
+ * opts into the full catalog — never a mile-long not_evaluated tower.
+ */
+export function ComplianceNistCatalog() {
+  const [drill, setDrill] = useState<NistCatalogDrill | null>(null);
+  const [fullControls, setFullControls] = useState<NistCatalogControl[] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
+  const [familyFilter, setFamilyFilter] = useState<string | null>(null);
+  const [showFullCatalog, setShowFullCatalog] = useState(false);
+  const [loadingFull, setLoadingFull] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    void api
+      .getComplianceNist80053()
+      .then((d) => {
+        if (!cancelled) setDrill(d);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(userFacingApiErrorMessage(err, "NIST 800-53 catalog posture is unavailable."));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleToggleFullCatalog = () => {
+    const next = !showFullCatalog;
+    setShowFullCatalog(next);
+    if (next && !fullControls) {
+      setLoadingFull(true);
+      void api
+        .getComplianceNist80053({ includeNotEvaluated: true })
+        .then((d) => setFullControls(d.controls))
+        .catch(() => setShowFullCatalog(false))
+        .finally(() => setLoadingFull(false));
+    }
+  };
+
+  const baseControls = useMemo<NistCatalogControl[]>(
+    () => (showFullCatalog && fullControls ? fullControls : (drill?.controls ?? [])),
+    [showFullCatalog, fullControls, drill],
+  );
+
+  const visibleControls = useMemo(() => {
+    return baseControls.filter((c) => {
+      const matchesStatus = statusFilter === "all" || c.status === statusFilter;
+      const matchesFamily = !familyFilter || c.control_id.split("-", 1)[0] === familyFilter;
+      return matchesStatus && matchesFamily;
+    });
+  }, [baseControls, statusFilter, familyFilter]);
+
+  if (loading) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 text-sm text-[color:var(--text-tertiary)]"
+        data-testid="nist-catalog-loading"
+      >
+        <Loader2 className="h-4 w-4 animate-spin" /> Loading NIST 800-53 catalog posture…
+      </div>
+    );
+  }
+
+  if (error || !drill) {
+    return (
+      <div
+        className="flex items-center gap-2 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 text-sm text-[color:var(--text-tertiary)]"
+        data-testid="nist-catalog-error"
+      >
+        <ShieldAlert className="h-4 w-4 text-[color:var(--status-warn)]" />
+        {error ?? "NIST 800-53 catalog posture is unavailable."}
+      </div>
+    );
+  }
+
+  const s = drill.summary;
+  const noData = isNotEvaluated(drill.status) || s.evaluated === 0;
+  const isoControls = drill.iso_27001_derived.controls;
+
+  return (
+    <div
+      className="space-y-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 elev-1"
+      data-testid="nist-catalog-panel"
+    >
+      {/* Exec line */}
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <Layers className="h-4 w-4 text-[color:var(--accent)]" />
+            <h3 className="text-sm font-semibold text-[color:var(--foreground)]">{drill.framework_label}</h3>
+            <span className="rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-[color:var(--text-tertiary)]">
+              Vendor-asserted
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+            Full catalog scored independently over evidenced checks —{" "}
+            {noData ? (
+              "no NIST-mapped evidence yet; connect a cloud account or run a scan to evaluate controls."
+            ) : (
+              <>
+                {s.pass.toLocaleString()} of {s.evaluated.toLocaleString()} evaluated controls passing across{" "}
+                {s.catalog_size.toLocaleString()} controls.
+              </>
+            )}
+          </p>
+        </div>
+        <div className="flex items-center gap-1.5 self-start whitespace-nowrap">
+          <StatusIcon status={drill.status} className="h-4 w-4" />
+          <span className={`text-sm font-semibold ${statusColor(drill.status)}`}>{postureLabel(drill.status)}</span>
+        </div>
+      </div>
+
+      {/* Honest bucket strip — reconciles 1:1 with the API summary. */}
+      <div
+        className="grid grid-cols-2 gap-2 sm:grid-cols-4 lg:grid-cols-8"
+        data-testid="nist-catalog-buckets"
+      >
+        <BucketTile label="Score" value={noData ? "—" : `${s.score}%`} />
+        <BucketTile label="Coverage" value={`${s.coverage_pct}%`} />
+        <BucketTile label="Evaluated" value={s.evaluated.toLocaleString()} />
+        <BucketTile label="Pass" value={s.pass.toLocaleString()} accent="success" />
+        <BucketTile label="Fail" value={s.fail.toLocaleString()} accent="danger" />
+        <BucketTile label="Warn" value={s.warning.toLocaleString()} accent="warn" />
+        <BucketTile label="Error" value={s.error.toLocaleString()} accent="error" />
+        <BucketTile label="Not eval." value={s.not_evaluated.toLocaleString()} accent="neutral" />
+      </div>
+
+      {/* Engineer drill */}
+      <Collapsible
+        title="Control drill (engineer view)"
+        subtitle="Family rollup · evidencing checks · ISO 27001 by id"
+        defaultOpen={false}
+      >
+        <div className="space-y-4">
+          {/* Family rollup — scale-aware entry over the full catalog. */}
+          <div className="overflow-x-auto" data-testid="nist-catalog-families">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="text-left text-[color:var(--text-tertiary)]">
+                  <th className="px-2 py-1 font-medium">Family</th>
+                  <th className="px-2 py-1 text-right font-medium">Evaluated</th>
+                  <th className="px-2 py-1 text-right font-medium">Pass</th>
+                  <th className="px-2 py-1 text-right font-medium">Fail</th>
+                  <th className="px-2 py-1 text-right font-medium">Error</th>
+                  <th className="px-2 py-1 text-right font-medium">Not eval.</th>
+                </tr>
+              </thead>
+              <tbody>
+                {drill.families
+                  .filter((f) => f.evaluated > 0 || familyFilter === f.family)
+                  .map((f) => {
+                    const active = familyFilter === f.family;
+                    return (
+                      <tr
+                        key={f.family}
+                        onClick={() => setFamilyFilter(active ? null : f.family)}
+                        className={`cursor-pointer border-t border-[color:var(--border-subtle)] transition-colors hover:bg-[color:var(--surface-muted)] ${
+                          active ? "bg-[color:var(--accent-soft)]" : ""
+                        }`}
+                      >
+                        <td className="px-2 py-1 font-mono font-medium text-[color:var(--foreground)]">{f.family}</td>
+                        <td className="px-2 py-1 text-right tabular-nums text-[color:var(--text-secondary)]">
+                          {f.evaluated}/{f.total}
+                        </td>
+                        <td className="px-2 py-1 text-right tabular-nums text-[color:var(--status-success)]">{f.pass}</td>
+                        <td className="px-2 py-1 text-right tabular-nums text-[color:var(--status-danger)]">{f.fail}</td>
+                        <td className="px-2 py-1 text-right tabular-nums text-[color:var(--status-warn)]">{f.error}</td>
+                        <td className="px-2 py-1 text-right tabular-nums text-[color:var(--text-tertiary)]">
+                          {f.not_evaluated}
+                        </td>
+                      </tr>
+                    );
+                  })}
+              </tbody>
+            </table>
+            {familyFilter ? (
+              <button
+                type="button"
+                onClick={() => setFamilyFilter(null)}
+                className="mt-1 text-[11px] font-medium text-[color:var(--accent)] hover:underline"
+              >
+                Clear {familyFilter} filter
+              </button>
+            ) : null}
+          </div>
+
+          {/* Controls toolbar */}
+          <div className="flex flex-wrap items-center gap-2">
+            <div className="flex items-center gap-1 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-0.5">
+              {FILTER_TABS.map((tab) => (
+                <button
+                  key={tab.key}
+                  type="button"
+                  onClick={() => setStatusFilter(tab.key)}
+                  className={`rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+                    statusFilter === tab.key
+                      ? "bg-[color:var(--surface-elevated)] text-[color:var(--foreground)]"
+                      : "text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+                  }`}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={handleToggleFullCatalog}
+              className={`rounded-lg border px-2.5 py-1 text-xs font-medium transition-colors ${
+                showFullCatalog
+                  ? "border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] text-[color:var(--accent)]"
+                  : "border-[color:var(--border-subtle)] text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]"
+              }`}
+            >
+              {loadingFull ? "Loading full catalog…" : showFullCatalog ? "Evaluated only" : "Show full catalog"}
+            </button>
+            <span className="text-[11px] text-[color:var(--text-tertiary)]">
+              {visibleControls.length} shown
+              {showFullCatalog ? ` of ${s.catalog_size.toLocaleString()}` : ` of ${s.evaluated.toLocaleString()} evaluated`}
+            </span>
+          </div>
+
+          {/* Controls list */}
+          <div className="max-h-[24rem] overflow-y-auto rounded-lg border border-[color:var(--border-subtle)]" data-testid="nist-catalog-controls">
+            <table className="w-full text-xs">
+              <thead className="sticky top-0 bg-[color:var(--surface-elevated)]">
+                <tr className="text-left text-[color:var(--text-tertiary)]">
+                  <th className="px-2 py-1.5 font-medium">Control</th>
+                  <th className="px-2 py-1.5 font-medium">Status</th>
+                  <th className="px-2 py-1.5 font-medium">Evidencing checks</th>
+                  <th className="px-2 py-1.5 font-medium">ISO 27001 (derived)</th>
+                </tr>
+              </thead>
+              <tbody>
+                {visibleControls.map((c) => (
+                  <tr key={c.control_id} className="border-t border-[color:var(--border-subtle)] align-top">
+                    <td className="px-2 py-1.5">
+                      <div className="font-mono font-medium text-[color:var(--foreground)]">{c.control_id}</div>
+                      {c.title ? (
+                        <div className="text-[11px] text-[color:var(--text-tertiary)]">{c.title}</div>
+                      ) : null}
+                    </td>
+                    <td className="px-2 py-1.5 whitespace-nowrap">
+                      <ControlStatusBadge status={c.status} />
+                    </td>
+                    <td className="px-2 py-1.5">
+                      {c.evidencing_checks.length ? (
+                        <div className="flex flex-wrap gap-1">
+                          {c.evidencing_checks.map((ck) => (
+                            <span
+                              key={ck}
+                              className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--text-secondary)]"
+                            >
+                              {ck}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-[color:var(--text-tertiary)]">—</span>
+                      )}
+                    </td>
+                    <td className="px-2 py-1.5">
+                      {c.iso_27001_derived.length ? (
+                        <div className="flex flex-wrap gap-1">
+                          {c.iso_27001_derived.map((iso) => (
+                            <span
+                              key={iso}
+                              className="rounded border border-[color:var(--border-subtle)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--text-tertiary)]"
+                            >
+                              {iso}
+                            </span>
+                          ))}
+                        </div>
+                      ) : (
+                        <span className="text-[color:var(--text-tertiary)]">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+                {visibleControls.length === 0 ? (
+                  <tr>
+                    <td colSpan={4} className="px-2 py-6 text-center text-[color:var(--text-tertiary)]">
+                      No controls match the current filters.
+                    </td>
+                  </tr>
+                ) : null}
+              </tbody>
+            </table>
+          </div>
+
+          {/* ISO attribution — by identifier only, labeled derived from crosswalk. */}
+          <div
+            className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3"
+            data-testid="nist-catalog-iso"
+          >
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-[color:var(--text-tertiary)]">
+              ISO/IEC 27001 (derived by id from crosswalk)
+            </div>
+            {isoControls.length ? (
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {isoControls.map((iso) => (
+                  <span
+                    key={iso}
+                    className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--text-secondary)]"
+                  >
+                    {iso}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <p className="mt-1 text-[11px] text-[color:var(--text-tertiary)]">
+                No ISO Annex A controls implicated (no failing NIST controls).
+              </p>
+            )}
+            <p className="mt-2 text-[10px] leading-relaxed text-[color:var(--text-tertiary)]">{drill.iso_27001_derived.note}</p>
+          </div>
+        </div>
+      </Collapsible>
+    </div>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1920,6 +1920,71 @@ export interface CISBenchmarkChecksResponse {
   source: string;
 }
 
+/** One scored control on the catalog-backed NIST SP 800-53 line. */
+export interface NistCatalogControl {
+  control_id: string;
+  title: string | null;
+  status: "pass" | "fail" | "warning" | "error" | "not_evaluated";
+  findings: number;
+  evidencing_checks: string[];
+  iso_27001_derived: string[];
+}
+
+/** Family rollup partitioning the full vendored catalog for scale-aware nav. */
+export interface NistCatalogFamily {
+  family: string;
+  total: number;
+  evaluated: number;
+  pass: number;
+  fail: number;
+  warning: number;
+  error: number;
+  not_evaluated: number;
+}
+
+export interface NistCatalogSummary {
+  pass: number;
+  fail: number;
+  warning: number;
+  error: number;
+  evaluated: number;
+  not_evaluated: number;
+  catalog_size: number;
+  coverage_pct: number;
+  score: number;
+}
+
+export interface NistCatalogIsoDerived {
+  source: string;
+  note: string;
+  controls: string[];
+}
+
+/**
+ * Catalog-backed NIST SP 800-53 Rev 5 line — the same shape the `/v1/compliance`
+ * `nist_800_53_catalog` field carries and the `/v1/compliance/nist-800-53` drill
+ * returns (one source of truth). Scored over EVALUATED controls only; ERROR and
+ * not_evaluated are explicit buckets; ISO attribution is by identifier only.
+ */
+export interface NistCatalogLine {
+  framework: "nist-800-53";
+  framework_key: "nist_800_53_catalog";
+  framework_label: string;
+  representation: "catalog";
+  source: string;
+  vendor_asserted: boolean;
+  status: "pass" | "fail" | "warning" | "no_data";
+  score: number;
+  summary: NistCatalogSummary;
+  controls: NistCatalogControl[];
+  iso_27001_derived: NistCatalogIsoDerived;
+}
+
+/** The `/v1/compliance/nist-800-53` drill: catalog line + family rollup. */
+export interface NistCatalogDrill extends NistCatalogLine {
+  families: NistCatalogFamily[];
+}
+
 export interface ComplianceResponse {
   overall_score: number;
   overall_status: "pass" | "warning" | "fail";
@@ -1942,6 +2007,12 @@ export interface ComplianceResponse {
   nist_800_53: ComplianceControl[];
   fedramp: ComplianceControl[];
   pci_dss: ComplianceControl[];
+  /**
+   * Catalog-backed NIST SP 800-53 Rev 5 line, scored INDEPENDENTLY over the full
+   * vendored catalog. Optional so a response predating the catalog scorer still
+   * types; the UI falls back to the drill endpoint as the source of truth.
+   */
+  nist_800_53_catalog?: NistCatalogLine | undefined;
   aisvs_benchmark: AISVSComplianceResponse;
   summary: {
     owasp_pass: number;
@@ -1980,6 +2051,12 @@ export interface ComplianceResponse {
     nist_800_53_pass: number;
     nist_800_53_warn: number;
     nist_800_53_fail: number;
+    nist_800_53_catalog_pass?: number | undefined;
+    nist_800_53_catalog_fail?: number | undefined;
+    nist_800_53_catalog_warning?: number | undefined;
+    nist_800_53_catalog_error?: number | undefined;
+    nist_800_53_catalog_evaluated?: number | undefined;
+    nist_800_53_catalog_not_evaluated?: number | undefined;
     fedramp_pass: number;
     fedramp_warn: number;
     fedramp_fail: number;

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -69,6 +69,7 @@ import type {
   ComplianceNarrativeResponse,
   AISVSComplianceResponse,
   ComplianceResponse,
+  NistCatalogDrill,
   CISBenchmarkChecksResponse,
   FrameworkCatalogsResponse,
   AgentDetailResponse,
@@ -279,6 +280,12 @@ export type {
   AISVSBenchmark,
   AISVSComplianceResponse,
   ComplianceResponse,
+  NistCatalogDrill,
+  NistCatalogLine,
+  NistCatalogControl,
+  NistCatalogFamily,
+  NistCatalogSummary,
+  NistCatalogIsoDerived,
   CISBenchmarkCheck,
   CISBenchmarkRemediation,
   CISBenchmarkChecksResponse,
@@ -1077,6 +1084,20 @@ export const api = {
 
   /** Compliance posture across all completed scans */
   getCompliance: () => get<ComplianceResponse>("/v1/compliance"),
+
+  /**
+   * Catalog-backed NIST SP 800-53 Rev 5 drill: per-control status, evidencing
+   * checks, family rollup, and ISO-27001-by-id attribution. `status` filters the
+   * displayed list without changing the counts; `include_not_evaluated`
+   * enumerates the full ~1000-control catalog.
+   */
+  getComplianceNist80053: (opts?: { status?: string; includeNotEvaluated?: boolean }) => {
+    const params = new URLSearchParams();
+    if (opts?.status) params.set("status", opts.status);
+    if (opts?.includeNotEvaluated) params.set("include_not_evaluated", "true");
+    const qs = params.toString();
+    return get<NistCatalogDrill>(`/v1/compliance/nist-800-53${qs ? `?${qs}` : ""}`);
+  },
 
   /** Latest tenant-scoped OWASP AISVS benchmark posture */
   getAISVSCompliance: () => get<AISVSComplianceResponse>("/v1/compliance/aisvs"),

--- a/ui/tests/compliance-nist-catalog.test.tsx
+++ b/ui/tests/compliance-nist-catalog.test.tsx
@@ -1,0 +1,154 @@
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ComplianceNistCatalog } from "@/components/compliance-nist-catalog";
+import type { NistCatalogDrill } from "@/lib/api";
+
+// The seeded reconciliation estate (tests/test_compliance.py::_nist_catalog_scenario):
+// fail 5 (SI-10, AC-3, SC-7, AC-2, IA-5), pass 1 (SC-28), error 1 (AC-6),
+// evaluated 7, not_evaluated 1007, catalog 1014, score 14.3, coverage 0.69%.
+// These MUST be the identical numbers the API drill / CLI / MCP report.
+function scenarioDrill(): NistCatalogDrill {
+  return {
+    framework: "nist-800-53",
+    framework_key: "nist_800_53_catalog",
+    framework_label: "NIST SP 800-53 Rev 5",
+    representation: "catalog",
+    source: "framework_control_catalog",
+    vendor_asserted: true,
+    status: "fail",
+    score: 14.3,
+    summary: {
+      pass: 1,
+      fail: 5,
+      warning: 0,
+      error: 1,
+      evaluated: 7,
+      not_evaluated: 1007,
+      catalog_size: 1014,
+      coverage_pct: 0.69,
+      score: 14.3,
+    },
+    families: [
+      { family: "AC", total: 120, evaluated: 3, pass: 0, fail: 2, warning: 0, error: 1, not_evaluated: 117 },
+      { family: "IA", total: 90, evaluated: 1, pass: 0, fail: 1, warning: 0, error: 0, not_evaluated: 89 },
+      { family: "SC", total: 110, evaluated: 2, pass: 1, fail: 1, warning: 0, error: 0, not_evaluated: 108 },
+      { family: "SI", total: 80, evaluated: 1, pass: 0, fail: 1, warning: 0, error: 0, not_evaluated: 79 },
+      { family: "AU", total: 60, evaluated: 0, pass: 0, fail: 0, warning: 0, error: 0, not_evaluated: 60 },
+    ],
+    controls: [
+      { control_id: "AC-2", title: "Account Management", status: "fail", findings: 0, evidencing_checks: ["cis:aws:1.12"], iso_27001_derived: ["A.5.16", "A.5.18"] },
+      { control_id: "AC-3", title: "Access Enforcement", status: "fail", findings: 0, evidencing_checks: ["cis:aws:2.1.1"], iso_27001_derived: ["A.5.15"] },
+      { control_id: "AC-6", title: "Least Privilege", status: "error", findings: 0, evidencing_checks: ["cis:aws:1.4"], iso_27001_derived: [] },
+      { control_id: "IA-5", title: "Authenticator Management", status: "fail", findings: 0, evidencing_checks: ["cis:aws:1.12", "cis:aws:1.4"], iso_27001_derived: ["A.5.17"] },
+      { control_id: "SC-7", title: "Boundary Protection", status: "fail", findings: 0, evidencing_checks: ["cis:aws:2.1.1"], iso_27001_derived: ["A.8.20", "A.8.22"] },
+      { control_id: "SC-28", title: "Protection of Information at Rest", status: "pass", findings: 0, evidencing_checks: ["cis:aws:2.1.2"], iso_27001_derived: [] },
+      { control_id: "SI-10", title: "Information Input Validation", status: "fail", findings: 1, evidencing_checks: ["cwe:CWE-20"], iso_27001_derived: ["A.8.26"] },
+    ],
+    iso_27001_derived: {
+      source: "nist_800_53_to_iso_27001_crosswalk",
+      note: "ISO/IEC 27001:2022 Annex A control IDs implicated by the failing NIST controls, derived from NIST's official SP 800-53 Rev 5 -> ISO 27001 crosswalk (identifiers only).",
+      controls: ["A.5.15", "A.5.16", "A.5.17", "A.5.18", "A.8.20", "A.8.22", "A.8.26"],
+    },
+  };
+}
+
+function noDataDrill(): NistCatalogDrill {
+  const d = scenarioDrill();
+  return {
+    ...d,
+    status: "no_data",
+    score: 0,
+    summary: { pass: 0, fail: 0, warning: 0, error: 0, evaluated: 0, not_evaluated: 1014, catalog_size: 1014, coverage_pct: 0, score: 0 },
+    families: d.families.map((f) => ({ ...f, evaluated: 0, pass: 0, fail: 0, warning: 0, error: 0, not_evaluated: f.total })),
+    controls: [],
+    iso_27001_derived: { ...d.iso_27001_derived, controls: [] },
+  };
+}
+
+const getNist = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return { ...actual, api: { getComplianceNist80053: (...a: unknown[]) => getNist(...a) } };
+});
+
+afterEach(() => {
+  getNist.mockReset();
+});
+
+describe("ComplianceNistCatalog", () => {
+  it("renders the exec line with score-over-evaluated, coverage, and honest buckets", async () => {
+    getNist.mockResolvedValue(scenarioDrill());
+    render(<ComplianceNistCatalog />);
+
+    const panel = await screen.findByTestId("nist-catalog-panel");
+    expect(within(panel).getByText("NIST SP 800-53 Rev 5")).toBeInTheDocument();
+    // Vendor-asserted must be labeled — never implied "official".
+    expect(within(panel).getByText(/vendor-asserted/i)).toBeInTheDocument();
+    // Failing estate -> Non-compliant, never a green/100%.
+    expect(within(panel).getByText("Non-compliant")).toBeInTheDocument();
+    expect(within(panel).queryByText(/100%/)).not.toBeInTheDocument();
+
+    const strip = within(panel).getByTestId("nist-catalog-buckets");
+    expect(within(strip).getByText("14.3%")).toBeInTheDocument(); // score over evaluated
+    expect(within(strip).getByText("0.69%")).toBeInTheDocument(); // coverage
+    // Evaluated / not_evaluated / error explicit.
+    expect(within(strip).getByText("7")).toBeInTheDocument();
+    expect(within(strip).getByText("1,007")).toBeInTheDocument();
+    // score is over EVALUATED only — copy must say so.
+    expect(within(panel).getByText(/1 of 7 evaluated controls passing/i)).toBeInTheDocument();
+  });
+
+  it("drills to the engineer view: family rollup + evidencing checks + ISO-by-id", async () => {
+    getNist.mockResolvedValue(scenarioDrill());
+    render(<ComplianceNistCatalog />);
+    await screen.findByTestId("nist-catalog-panel");
+
+    // Open the engineer drill.
+    fireEvent.click(screen.getByRole("button", { name: /control drill/i }));
+
+    // Family rollup is the scale-aware entry (not a 1014-row tower).
+    const families = await screen.findByTestId("nist-catalog-families");
+    expect(within(families).getByText("AC")).toBeInTheDocument();
+    expect(within(families).getByText("SC")).toBeInTheDocument();
+
+    // Evaluated controls listed with evidencing checks; not_evaluated NOT listed by default.
+    const controls = screen.getByTestId("nist-catalog-controls");
+    expect(within(controls).getByText("SI-10")).toBeInTheDocument();
+    expect(within(controls).getByText(/CWE-20/)).toBeInTheDocument();
+    // 7 evaluated rows, never the 1007 not_evaluated remainder.
+    expect(within(controls).queryByText("not_evaluated")).not.toBeInTheDocument();
+
+    // ISO attribution is by identifier only, labeled derived-from-crosswalk.
+    const iso = screen.getByTestId("nist-catalog-iso");
+    expect(within(iso).getByText("A.8.26")).toBeInTheDocument();
+    expect(within(iso).getByText(/NIST's official SP 800-53 Rev 5 -> ISO 27001 crosswalk/i)).toBeInTheDocument();
+  });
+
+  it("status filter narrows the list without changing headline counts", async () => {
+    getNist.mockResolvedValue(scenarioDrill());
+    render(<ComplianceNistCatalog />);
+    await screen.findByTestId("nist-catalog-panel");
+    fireEvent.click(screen.getByRole("button", { name: /control drill/i }));
+    await screen.findByTestId("nist-catalog-controls");
+
+    fireEvent.click(screen.getByRole("button", { name: /^Fail$/ }));
+    const controls = screen.getByTestId("nist-catalog-controls");
+    await waitFor(() => expect(within(controls).queryByText("SC-28")).not.toBeInTheDocument());
+    expect(within(controls).getByText("SI-10")).toBeInTheDocument();
+    // Headline buckets unchanged (display filter only).
+    const strip = screen.getByTestId("nist-catalog-buckets");
+    expect(within(strip).getByText("14.3%")).toBeInTheDocument();
+    expect(within(strip).getByText("7")).toBeInTheDocument();
+  });
+
+  it("shows an honest not-evaluated state with no fabricated compliance", async () => {
+    getNist.mockResolvedValue(noDataDrill());
+    render(<ComplianceNistCatalog />);
+    const panel = await screen.findByTestId("nist-catalog-panel");
+    expect(within(panel).getByText("Not evaluated")).toBeInTheDocument();
+    expect(within(panel).queryByText("Compliant")).not.toBeInTheDocument();
+    expect(within(panel).queryByText(/100%/)).not.toBeInTheDocument();
+  });
+});

--- a/ui/tests/compliance-page.test.tsx
+++ b/ui/tests/compliance-page.test.tsx
@@ -13,6 +13,12 @@ vi.mock("@/components/cis-benchmark-detail", () => ({
   CISBenchmarkDetail: () => <div>cis benchmark</div>,
 }));
 
+// The catalog panel fetches its own /v1/compliance/nist-800-53 drill on mount —
+// stub it so this test stays focused on the tag-mapped framework surface.
+vi.mock("@/components/compliance-nist-catalog", () => ({
+  ComplianceNistCatalog: () => <div>nist catalog</div>,
+}));
+
 const { compliance } = vi.hoisted(() => {
   const control = (
     code: string,


### PR DESCRIPTION
Framework-library PR4 (the closer). Builds on PR1 (unify mapping) + PR2 (NIST catalog + NIST↔ISO Annex-A crosswalk) + PR3 (check→control + independent scoring), all on main. Full wire-align — every surface, one source of truth, no partial.

## One shared scorer → identical numbers everywhere
`compliance_nist_catalog.py` (`build_nist_800_53_catalog_line` / `build_nist_800_53_drill`) is the single source; API drill, CLI, exports, MCP, and UI all score through it, so they cannot disagree.

## 5 surfaces
1. **API drill** — `GET /v1/compliance/nist-800-53` (per-control status, vendor-asserted evidencing checks, family rollup, ISO-by-id); OpenAPI regenerated (paths 308→309).
2. **CLI** — `report compliance-narrative` NIST exec line + per-control drill (human + JSON).
3. **Exports** — SARIF taxonomy `agent-bom:mappingProvenance: vendor-asserted`, SPDX-3.0 + CycloneDX framework control tags with vendor-asserted provenance (IDs only). *(SPDX-2 left as-is — it carries no compliance tags today; net-new, tracked as optional follow-up.)*
4. **UI** (both themes) — compliance page NIST 800-53 exec line (evaluated/not_evaluated/ERROR buckets + coverage%, Vendor-asserted label, honest no_data) drilling to a 20-family rollup (scale over 1014 controls) with evidencing-check chips + ISO-by-id; tokens only, no `zinc-*`.
5. **MCP** — `nist_800_53_catalog` tool, scored independently (not folded into `overall_score`).

## Honesty / reconciliation
Adversarial cross-surface check on one seeded failing estate: identical `fail · 14.3% · pass 1 · fail 5 · error 1 · evaluated 7 · not_evaluated 1007 · catalog 1014 · coverage 0.69%` across API/CLI/MCP/UI; families sum back; status filter never changes counts; ISO derived by ID only; unmapped estate is honest `no_data`, never a fabricated 100%. Vendor-asserted labeled, no copyrighted ISO/SOC2/CIS text.

## Verified
`265 passed` pytest; `ruff`/`mypy` clean; `export_openapi`/`check-counts`/product-surface/framework-catalog/release-consistency all pass. UI: `tsc` + `NEXT_EXPORT` build (49/49) + vitest `764 passed`; both-theme screenshots at 1280/1440 confirm the reconciled figures.

Closes #4214.