### PR TITLE
chore(security): stop secret-scanning flagging our detection-test fixtures

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,14 @@
+# GitHub secret-scanning config.
+#
+# These files intentionally contain well-known, NON-FUNCTIONAL example secrets
+# (e.g. AWS's documented AKIAIOSFODNN7EXAMPLE / ASIAIOSFODNN7EXAMPLE placeholders)
+# used as fixtures to test agent-bom's OWN secret detection + redaction. They are
+# documentation placeholders, not real credentials. Scoped to the specific
+# detection-test files only — NOT a blanket tests/ exclusion, so a real accidental
+# secret elsewhere in tests still gets flagged.
+paths-ignore:
+  - "tests/test_ai_enrich_providers.py"
+  - "tests/test_dspm_luhn_secrets.py"
+  - "tests/test_security.py"
+  - "tests/test_trace_attack_path_routes.py"
+  - "tests/test_side_scan.py"


### PR DESCRIPTION
Resolves the `Public leak` alert on `ASIAIOSFODNN7EXAMPLE` (Security alert #1, `tests/test_ai_enrich_providers.py:43`).

**It's a false positive.** `AKIAIOSFODNN7EXAMPLE` / `ASIAIOSFODNN7EXAMPLE` are AWS's own non-functional documentation placeholder keys, used across 6 test files as fixtures that verify agent-bom's **own** secret detection + redaction (`test_redact_secrets_scrubs_known_shapes` etc.). GitHub auto-allowlists the `AKIA` form but not the `ASIA` (STS) variant — hence the alert.

**Fix:** a `.github/secret_scanning.yml` `paths-ignore` scoped to the specific detection-test files (NOT a blanket `tests/` exclusion) — so a real accidental secret elsewhere in tests still gets flagged. No test coverage removed (the fixtures must stay to test ASIA/temporary-key detection).