### PR TITLE
feat(cwpp): lifecycle foundation + cross-cloud disk adapters + runtime workload evidence (stages 1-3)

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,14 @@
+# GitHub secret-scanning config.
+#
+# These files intentionally contain well-known, NON-FUNCTIONAL example secrets
+# (e.g. AWS's documented AKIAIOSFODNN7EXAMPLE / ASIAIOSFODNN7EXAMPLE placeholders)
+# used as fixtures to test agent-bom's OWN secret detection + redaction. They are
+# documentation placeholders, not real credentials. Scoped to the specific
+# detection-test files only — NOT a blanket tests/ exclusion, so a real accidental
+# secret elsewhere in tests still gets flagged.
+paths-ignore:
+  - "tests/test_ai_enrich_providers.py"
+  - "tests/test_dspm_luhn_secrets.py"
+  - "tests/test_security.py"
+  - "tests/test_trace_attack_path_routes.py"
+  - "tests/test_side_scan.py"

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -41,3 +41,7 @@ e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:360
 0e43ed628801d7c2d4fbdd7e3a01b07fda2b113b:src/agent_bom/api/routes/compliance.py:generic-api-key:534
 # History-only: earlier revision of the note above quoted the flagged pair.
 523c32e9b3c52b355c33cc67bac34e670ff6167f:.gitleaksignore:generic-api-key:39
+
+# One-off prose false positive: a docstring sentence about credential wiring
+# in the side-scan runner matched generic-api-key.
+a9ab4c116af8bc5086aca63933d12a675573bb4b:src/agent_bom/cloud/side_scan_targets.py:generic-api-key:199

--- a/deploy/terraform/connect-azure-sidescan/README.md
+++ b/deploy/terraform/connect-azure-sidescan/README.md
@@ -1,0 +1,29 @@
+# Azure Managed Disk side-scan role
+
+This optional module assigns a dedicated custom role for the Azure snapshot →
+temporary managed disk → collector attach/detach → cleanup lifecycle. It is
+separate from the read-only `connect-azure` role and is inert unless the
+operator explicitly runs with `AGENT_BOM_SIDESCAN=1`.
+
+The adapter receives already-authenticated Azure SDK clients. It applies
+deterministic execution ownership tags and bounds every long-running-operation
+poll. The caller-supplied mount controller mounts the attached temporary disk
+read-only on an in-subscription collector. Only SBOM/CVE and redacted
+type/location evidence is persisted; no disk image or block bytes leave the
+customer subscription.
+
+```hcl
+module "azure_sidescan" {
+  source       = "github.com/<org>/agent-bom//deploy/terraform/connect-azure-sidescan"
+  scope        = "/subscriptions/<subscription>/resourceGroups/<workload-and-collector-rg>"
+  principal_id = "<collector-workload-identity-object-id>"
+}
+```
+
+Azure custom roles cannot condition `write`/`delete` permissions on arbitrary
+resource tags. Keep `scope` narrow; the adapter independently refuses cleanup
+unless all v1 ownership tags match the persisted tenant/account execution.
+
+No live cloud mutation was run for this fixture-tested module. A successful
+`terraform plan` and disposable-resource smoke with customer credentials are
+still required before claiming a live Azure integration proof.

--- a/deploy/terraform/connect-azure-sidescan/main.tf
+++ b/deploy/terraform/connect-azure-sidescan/main.tf
@@ -1,0 +1,31 @@
+# Separate opt-in mutation role for Azure Managed Disk side-scan. This module
+# does not modify the read-only connect-azure identity.
+resource "azurerm_role_definition" "sidescan" {
+  name        = var.role_name
+  scope       = var.scope
+  description = var.description
+
+  permissions {
+    actions = [
+      "Microsoft.Compute/snapshots/read",
+      "Microsoft.Compute/snapshots/write",
+      "Microsoft.Compute/snapshots/delete",
+      "Microsoft.Compute/disks/read",
+      "Microsoft.Compute/disks/write",
+      "Microsoft.Compute/disks/delete",
+      "Microsoft.Compute/virtualMachines/read",
+      "Microsoft.Compute/virtualMachines/write",
+      "Microsoft.Compute/locations/operations/read",
+    ]
+    not_actions  = []
+    data_actions = []
+  }
+
+  assignable_scopes = [var.scope]
+}
+
+resource "azurerm_role_assignment" "sidescan" {
+  scope              = var.scope
+  role_definition_id = azurerm_role_definition.sidescan.role_definition_resource_id
+  principal_id       = var.principal_id
+}

--- a/deploy/terraform/connect-azure-sidescan/outputs.tf
+++ b/deploy/terraform/connect-azure-sidescan/outputs.tf
@@ -1,0 +1,9 @@
+output "role_definition_id" {
+  description = "ID of the custom Azure side-scan lifecycle role."
+  value       = azurerm_role_definition.sidescan.role_definition_resource_id
+}
+
+output "role_assignment_id" {
+  description = "ID of the assignment to the collector workload identity."
+  value       = azurerm_role_assignment.sidescan.id
+}

--- a/deploy/terraform/connect-azure-sidescan/variables.tf
+++ b/deploy/terraform/connect-azure-sidescan/variables.tf
@@ -1,0 +1,21 @@
+variable "scope" {
+  description = "Azure scope for the custom role and assignment. Prefer the narrow resource group containing target disks and the dedicated collector."
+  type        = string
+}
+
+variable "principal_id" {
+  description = "Object ID of the workload identity used by the in-subscription side-scan collector."
+  type        = string
+}
+
+variable "role_name" {
+  description = "Name of the custom Azure side-scan lifecycle role."
+  type        = string
+  default     = "agent-bom-side-scan-lifecycle"
+}
+
+variable "description" {
+  description = "Description for the custom role definition."
+  type        = string
+  default     = "Opt-in snapshot, temporary managed disk, and collector attach/detach lifecycle for agent-bom side-scan."
+}

--- a/deploy/terraform/connect-azure-sidescan/versions.tf
+++ b/deploy/terraform/connect-azure-sidescan/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 3.100, < 5.0"
+    }
+  }
+}

--- a/deploy/terraform/connect-gcp-sidescan/README.md
+++ b/deploy/terraform/connect-gcp-sidescan/README.md
@@ -1,0 +1,29 @@
+# GCP Persistent Disk side-scan role
+
+This optional module binds a project custom role for the GCP snapshot →
+temporary Persistent Disk → collector attach/detach → cleanup lifecycle. It is
+separate from the read-only `connect-gcp` identity and is inert unless the
+operator explicitly runs with `AGENT_BOM_SIDESCAN=1`.
+
+The adapter receives already-authenticated Compute Engine SDK clients. It uses
+deterministic execution labels, bounded operation polling, and a read-only disk
+attachment to an in-project collector. The caller-supplied mount controller
+also mounts the filesystem read-only. Persisted output is package/CVE and
+redacted type/location metadata; no disk image or block bytes leave the project.
+
+```hcl
+module "gcp_sidescan" {
+  source     = "github.com/<org>/agent-bom//deploy/terraform/connect-gcp-sidescan"
+  project_id = "my-project"
+  member     = "serviceAccount:agent-bom-collector@my-project.iam.gserviceaccount.com"
+}
+```
+
+Keep the role in the target project and use a dedicated collector identity. GCP
+Compute IAM does not provide a portable label condition for every lifecycle
+permission, so the adapter also requires the persisted v1 ownership labels
+before it reuses or sweeps a resource.
+
+No live cloud mutation was run for this fixture-tested module. A successful
+`terraform plan` and disposable-resource smoke with customer credentials are
+still required before claiming a live GCP integration proof.

--- a/deploy/terraform/connect-gcp-sidescan/main.tf
+++ b/deploy/terraform/connect-gcp-sidescan/main.tf
@@ -1,0 +1,33 @@
+# Separate opt-in mutation role for GCP Persistent Disk side-scan. This module
+# does not modify the read-only connect-gcp identity.
+resource "google_project_iam_custom_role" "sidescan" {
+  project     = var.project_id
+  role_id     = var.role_id
+  title       = var.role_title
+  description = "Opt-in snapshot, temporary disk, and collector attach/detach lifecycle for agent-bom side-scan."
+
+  permissions = [
+    "compute.disks.create",
+    "compute.disks.createSnapshot",
+    "compute.disks.delete",
+    "compute.disks.get",
+    "compute.disks.list",
+    "compute.disks.use",
+    "compute.instances.attachDisk",
+    "compute.instances.detachDisk",
+    "compute.instances.get",
+    "compute.snapshots.create",
+    "compute.snapshots.delete",
+    "compute.snapshots.get",
+    "compute.snapshots.list",
+    "compute.snapshots.useReadOnly",
+    "compute.globalOperations.get",
+    "compute.zoneOperations.get",
+  ]
+}
+
+resource "google_project_iam_member" "sidescan" {
+  project = var.project_id
+  role    = google_project_iam_custom_role.sidescan.name
+  member  = var.member
+}

--- a/deploy/terraform/connect-gcp-sidescan/outputs.tf
+++ b/deploy/terraform/connect-gcp-sidescan/outputs.tf
@@ -1,0 +1,4 @@
+output "role_name" {
+  description = "Fully qualified name of the project custom side-scan role."
+  value       = google_project_iam_custom_role.sidescan.name
+}

--- a/deploy/terraform/connect-gcp-sidescan/variables.tf
+++ b/deploy/terraform/connect-gcp-sidescan/variables.tf
@@ -1,0 +1,21 @@
+variable "project_id" {
+  description = "GCP project that owns the target disks and in-project collector."
+  type        = string
+}
+
+variable "member" {
+  description = "IAM member for the collector workload identity, for example serviceAccount:collector@project.iam.gserviceaccount.com."
+  type        = string
+}
+
+variable "role_id" {
+  description = "Project custom role ID for the side-scan lifecycle."
+  type        = string
+  default     = "agentBomSideScanLifecycle"
+}
+
+variable "role_title" {
+  description = "Display title for the custom role."
+  type        = string
+  default     = "agent-bom side-scan lifecycle"
+}

--- a/deploy/terraform/connect-gcp-sidescan/versions.tf
+++ b/deploy/terraform/connect-gcp-sidescan/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 5.0, < 8.0"
+    }
+  }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -468,7 +468,7 @@ graph TB
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
 | MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (75 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory; CIS posture where published and Databricks security best practices |
-| Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor with in-account snapshot/volume cleanup; Azure Managed Disk and GCP Persistent Disk targets share the same bounded lifecycle contract and graph-visible workload-disk model |
+| Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py`, `src/agent_bom/cloud/side_scan_lifecycle.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor with in-account snapshot/volume cleanup; Azure/GCP target discovery and lifecycle contract only (no shipped provider executors) |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |
 | Audit trail | `src/agent_bom/cloud/audit_trail.py` | Read-only CloudTrail/Activity Log/Cloud Audit ingest → behavioral `ACCESSED`/`INVOKED` graph edges (counts only) |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -468,7 +468,7 @@ graph TB
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
 | MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (75 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory; CIS posture where published and Databricks security best practices |
-| Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py`, `src/agent_bom/cloud/side_scan_lifecycle.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor with in-account snapshot/volume cleanup; Azure/GCP target discovery and lifecycle contract only (no shipped provider executors) |
+| Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py`, `src/agent_bom/cloud/side_scan_lifecycle.py`, `src/agent_bom/cloud/side_scan_provider_adapters.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor; injected-SDK Azure Managed Disk and GCP Persistent Disk lifecycle adapters with durable ownership/cleanup state; Azure/GCP scheduler/CLI wiring and live credentialed proof are not shipped |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |
 | Audit trail | `src/agent_bom/cloud/audit_trail.py` | Read-only CloudTrail/Activity Log/Cloud Audit ingest → behavioral `ACCESSED`/`INVOKED` graph edges (counts only) |
 | Asset Tracker | `src/agent_bom/asset_tracker.py` | Persistent vuln tracking — first_seen, resolved, MTTR |

--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -154,7 +154,7 @@ the source is:
 
 | Source | Command home | Why |
 |---|---|---|
-| AWS / Azure / GCP | `agent-bom cloud ...` | provider APIs expose estate inventory, IAM, network posture, CIS checks, registry sweeps, and side-scan workflows |
+| AWS / Azure / GCP | `agent-bom cloud ...` | provider APIs expose estate inventory, IAM, network posture, CIS checks, and registry sweeps; the side-scan CLI is AWS-only, while Azure/GCP currently expose injected-SDK lifecycle adapters |
 | Snowflake | `agent-bom agents --snowflake` plus `connect snowflake` | Snowflake is a warehouse/governance source: Cortex, grants, query/activity evidence, lineage, and CIS/posture metadata |
 
 Both paths normalize into the same `Finding` and `ContextGraph` model; the

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -516,12 +516,22 @@ snapshot implicitly.
 
 Azure Managed Disk and GCP Persistent Disk inventory also emits
 `side_scan_targets` records with provider, target id, location, size, encryption,
-and execution state. Those records are graph-visible workload-disk targets, and
-the provider-neutral side-scan runner can execute the same snapshot -> temp disk
--> collector mount -> metadata parse -> cleanup lifecycle through scoped Azure
-or GCP lifecycle adapters. The CLI command above remains AWS EBS-specific; Azure
-and GCP execution is wired for connection/scheduler integrations and must still
-use provider-scoped snapshot permissions plus an in-account collector.
+and execution state. Those records are graph-visible workload-disk targets.
+The repository defines a versioned provider-neutral lifecycle/evidence contract
+and a fixture-tested adapter runner, but it **does not ship Azure or GCP lifecycle executors**.
+Provider mutation credentials, scheduler wiring, and CLI commands are also not
+shipped. The command above and the Terraform snapshot role are AWS EBS-only.
+Azure/GCP execution remains roadmap work until provider adapters, least-privilege
+roles, cleanup fault injection, and disposable-resource smokes are shipped.
+
+All provider lifecycle implementations must persist explicit
+`disabled`/`denied`/`partial`/`failed`/`scan_complete` state and separate cleanup
+state. A scan is complete only after owned temporary resources are deleted;
+zero findings are scoped to the scanned disk and never assert that a workload is
+clean. Snapshot operations remain opt-in because they are not read-only.
+`side_scan_lifecycle.py` supplies the versioned records, deterministic ownership
+tags, stale-worker protection, and a tenant-scoped SQLite state store; no
+Azure/GCP executor or production scheduler consumes that foundation yet.
 
 ---
 

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -480,11 +480,15 @@ role you already created:
 Net: turning on audit-trail behavioral edges costs **no new role** and, in
 standard setups, **no new permission**.
 
-> **The one exception is the disk side-scan.** Agentless EBS side-scan
-> (`AGENT_BOM_SIDESCAN=1`) is the single deliberately non-read-only
-> capability, and it is the *only* one that needs a **separate, scoped snapshot
-> role** (`deploy/terraform/connect-aws-sidescan`) distinct from the read-only
-> scanner role, plus an in-account collector instance. Audit-trail does not.
+> **The one exception family is the opt-in disk side-scan.** AWS EBS side-scan
+> is exposed through the CLI with `AGENT_BOM_SIDESCAN=1`. Azure Managed Disk
+> and GCP Persistent Disk lifecycle adapters are available to an embedding
+> scheduler through injected, already-authenticated SDK clients; they are not
+> yet CLI- or scheduler-wired. Each provider requires a **separate, narrowly
+> scoped lifecycle role** distinct from the read-only scanner role:
+> `deploy/terraform/connect-aws-sidescan`,
+> `deploy/terraform/connect-azure-sidescan`, or
+> `deploy/terraform/connect-gcp-sidescan`. Audit-trail does not.
 
 ---
 
@@ -518,11 +522,11 @@ Azure Managed Disk and GCP Persistent Disk inventory also emits
 `side_scan_targets` records with provider, target id, location, size, encryption,
 and execution state. Those records are graph-visible workload-disk targets.
 The repository defines a versioned provider-neutral lifecycle/evidence contract
-and a fixture-tested adapter runner, but it **does not ship Azure or GCP lifecycle executors**.
-Provider mutation credentials, scheduler wiring, and CLI commands are also not
-shipped. The command above and the Terraform snapshot role are AWS EBS-only.
-Azure/GCP execution remains roadmap work until provider adapters, least-privilege
-roles, cleanup fault injection, and disposable-resource smokes are shipped.
+and concrete Azure Managed Disk and GCP Persistent Disk adapters that accept
+already-authenticated SDK clients. Separate least-privilege Terraform modules
+grant the snapshot/temp-disk/collector lifecycle. Azure/GCP credentials,
+scheduler wiring, and CLI commands are not shipped, and no live credentialed
+smoke is claimed. The command above remains AWS EBS-only.
 
 All provider lifecycle implementations must persist explicit
 `disabled`/`denied`/`partial`/`failed`/`scan_complete` state and separate cleanup
@@ -530,8 +534,9 @@ state. A scan is complete only after owned temporary resources are deleted;
 zero findings are scoped to the scanned disk and never assert that a workload is
 clean. Snapshot operations remain opt-in because they are not read-only.
 `side_scan_lifecycle.py` supplies the versioned records, deterministic ownership
-tags, stale-worker protection, and a tenant-scoped SQLite state store; no
-Azure/GCP executor or production scheduler consumes that foundation yet.
+tags, stale-worker protection, and a tenant-scoped SQLite state store. The
+injected-SDK adapters consume that state; no production scheduler or Azure/GCP
+CLI surface invokes them yet.
 
 ---
 

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -538,6 +538,48 @@ tags, stale-worker protection, and a tenant-scoped SQLite state store. The
 injected-SDK adapters consume that state; no production scheduler or Azure/GCP
 CLI surface invokes them yet.
 
+## 7c. Runtime/EDR workload evidence (optional, read-only, additive)
+
+Disk side-scan is agentless and point-in-time. When an operator *already* runs an
+EDR or runtime sensor, agent-bom can ingest that source's signals to **enrich**
+the same canonical workloads — process executions, IOC detections, network
+connections, file-integrity events, behavioural alerts. There is **no mandatory
+host agent**: agent-bom neither installs nor requires a sensor, and runtime
+evidence never replaces disk evidence.
+
+Ingest is hardened and fails closed (`runtime_workload_evidence.py`):
+
+- **Authenticated source.** Each source registers with a hashed shared secret;
+  a batch is accepted only after a constant-time secret check. Tenant, provider,
+  and account are taken from the authenticated source — a payload that claims a
+  different provider/account is rejected (confused-deputy guard).
+- **Freshness + provenance.** Every signal records `observed_at`, `source_id`,
+  and `source_kind`; a signal older than the freshness window is rejected, as is
+  one with no workload reference or an unparseable timestamp.
+- **Deduplicated + isolated.** Signals dedup on
+  `(tenant, provider, account, workload, dedup_key)`; that key leads every store
+  query and is part of the dedup identity, so two tenants can carry the same
+  logical signal without one dropping or leaking. Durable persistence has
+  in-memory, SQLite (restart- and cross-process-safe), and Postgres backends
+  (`runtime_workload_evidence_store.py`).
+- **Metadata only.** Raw block bytes, file contents, and secret values are
+  redacted at construction; only bounded metadata references are retained.
+
+**Honesty — additive, never a cleanliness claim.** Every evidence summary carries
+`clean_workload_assertion: false`. A workload with no matching runtime signal is
+marked `no_runtime_signal`, never "clean". Enrichment annotates workloads,
+findings, and the nodes an attack-path campaign already traverses; it never adds a
+graph edge, so reachability stays edge-derived and is never fabricated.
+
+Wired today: findings surfaced by `GET /v1/findings` (and the overview /
+compliance / observability reads that share the enricher) gain a
+`workload_runtime_evidence` field on workload-scoped rows once a tenant has
+signals; the JSON API export carries it automatically. A graph-join helper
+annotates CWPP workload nodes for a matching tenant. Not yet locked in (stage 4):
+a dedicated ingest REST endpoint, CLI/MCP ingest surface, a scheduler that pulls
+from sources, typed SARIF/report export fields, the live graph/campaign route
+invocation, and any UI panel. No credentialed live source smoke is claimed.
+
 ---
 
 ## 8. Why it scales and stays accurate

--- a/docs/DATA_SOURCES.md
+++ b/docs/DATA_SOURCES.md
@@ -3,8 +3,10 @@
 One-page map from the README intake diagram to the **actual connect path**,
 **permission boundary**, and **first command**. agent-bom is **read-only by
 default** across every lane: no secret values stored, no writes to customer
-environments unless an operator explicitly opts into a documented exception
-(AWS side-scan snapshot lifecycle).
+environments unless an operator explicitly opts into the documented disk
+side-scan lifecycle. AWS EBS is CLI-wired; Azure Managed Disk and GCP
+Persistent Disk adapters require injected, already-authenticated SDK clients
+and are not yet scheduler- or CLI-wired.
 
 ## How intake works (four modes)
 

--- a/docs/SECURITY_ARCHITECTURE.md
+++ b/docs/SECURITY_ARCHITECTURE.md
@@ -55,6 +55,11 @@ Cloud scanning never moves customer data out of the account. The contract:
   snapshot and volume in a guaranteed `try/finally`. An orphan sweep recovers
   any leftover temp resources (tagged by the scanner) after a hard crash, so a
   failed run leaves nothing behind. No volume bytes leave the account.
+  Azure Managed Disk and GCP Persistent Disk adapters use the same durable
+  ownership and cleanup contract through injected, already-authenticated SDK
+  clients. Their provider resources and block bytes remain inside the target
+  subscription/project. These adapters have fake-client contract evidence but
+  no CLI/scheduler integration or credentialed live-cloud proof yet.
 
 ### Control-plane identity
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -872,8 +872,28 @@ def _iter_scan_findings(job: ScanJob) -> list[dict[str, Any]]:
         compliance_tags_from_finding_row,
     )
 
-    runtime_index = build_tenant_runtime_evidence_index(str(getattr(job, "tenant_id", None) or "default"))
+    tenant_id = str(getattr(job, "tenant_id", None) or "default")
+    runtime_index = build_tenant_runtime_evidence_index(tenant_id)
     incidents = result.get("runtime_incident_feedback") if isinstance(result.get("runtime_incident_feedback"), list) else []
+
+    # CWPP runtime/EDR workload evidence (#4158 stage 3): additive, read-only.
+    # Only workload-scoped rows are annotated, and only when this tenant actually
+    # has runtime signals — an empty index leaves every row untouched, so absence
+    # of runtime data is never rendered as a clean workload. Reachability is never
+    # invented here.
+    from agent_bom.cloud.runtime_workload_evidence import (
+        RuntimeWorkloadEvidenceIndex,
+        attach_workload_runtime_evidence_to_finding,
+    )
+    from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+
+    workload_runtime_index: RuntimeWorkloadEvidenceIndex | None = None
+    try:
+        _wl_index = RuntimeWorkloadEvidenceIndex.from_store(get_runtime_workload_evidence_store(), tenant_id)
+        if not _wl_index.is_empty():
+            workload_runtime_index = _wl_index
+    except Exception:  # noqa: BLE001 - runtime evidence is additive; never break the read path
+        workload_runtime_index = None
 
     def _attach_reach(row: dict[str, Any]) -> dict[str, Any]:
         from agent_bom.symbol_reach_triage import adjust_effective_reach_breakdown, symbol_reachability_from_payload
@@ -898,7 +918,10 @@ def _iter_scan_findings(job: ScanJob) -> list[dict[str, Any]]:
             row.setdefault("effective_reach_score", composite)
             row.setdefault("effective_reach_band", band_from_composite(composite))
         row.setdefault("framework_tags", compliance_tags_from_finding_row(row))
-        return attach_runtime_evidence_to_finding(row, runtime_index, incidents=incidents)
+        attach_runtime_evidence_to_finding(row, runtime_index, incidents=incidents)
+        if workload_runtime_index is not None:
+            attach_workload_runtime_evidence_to_finding(row, workload_runtime_index)
+        return row
 
     # Collapse the three per-vulnerability representations (unified ``findings``
     # stream, ``blast_radius`` projection, nested ``package_vulnerability``) onto

--- a/src/agent_bom/cloud/runtime_workload_evidence.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence.py
@@ -1,0 +1,682 @@
+"""Optional, read-only runtime/EDR evidence mapped to canonical workloads.
+
+This is stage 3 of the CWPP cross-cloud programme (#4158). It ingests runtime /
+EDR signals (process executions, IOC detections, network connections, file
+integrity, behavioural alerts) reported by an *external* sensor and joins them to
+the same canonical workload identities the agentless disk side-scan targets.
+
+There is **no mandatory host agent**: agent-bom neither installs nor requires a
+sensor. When an operator already runs an EDR/runtime source, this subsystem lets
+that source push metadata-only signals that *enrich* workloads, findings, and
+attack-path campaigns.
+
+Non-negotiable properties (issue #4158, honesty constraints):
+
+* **Authenticated ingest.** Every source is registered with a hashed shared
+  secret; a signal batch is accepted only after a constant-time secret check.
+* **Identity binding is source-authoritative.** Tenant / provider / account come
+  from the authenticated source, never from the client payload — a spoofed
+  provider/account on a raw signal is rejected (confused-deputy guard). A signal
+  with no workload reference or an unparseable timestamp is rejected.
+* **Fail closed on stale.** A signal older than the freshness window is rejected,
+  not silently accepted.
+* **Deduplicated.** A `(tenant, provider, account, workload, dedup_key)` scope is
+  ingested once; retries and cross-batch duplicates are dropped.
+* **Additive, never a cleanliness claim.** Evidence enriches; the *absence* of a
+  runtime signal is explicitly ``no_runtime_signal`` and every summary carries
+  ``clean_workload_assertion = False``. Enrichment never fabricates reachability.
+* **Metadata only.** Raw block bytes, file contents, and secret values are never
+  persisted; evidence is redacted to bounded metadata at construction.
+* **Tenant isolated.** The enrichment index only ever holds one tenant's signals;
+  graph joins refuse to cross the tenant boundary.
+
+Durable persistence lives in
+:mod:`agent_bom.cloud.runtime_workload_evidence_store`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Iterable, Mapping
+
+from agent_bom.canonical_ids import canonical_id
+
+RUNTIME_EVIDENCE_SCHEMA_VERSION = "agent-bom.cwpp.runtime_workload.evidence.v1"
+
+# Freshness window: a runtime signal observed more than this many seconds before
+# ingestion is stale and rejected (fail closed). One hour by default.
+DEFAULT_MAX_SIGNAL_AGE_SECONDS = 3600
+
+# Enrichment states. None of these ever mean "clean".
+STATE_HAS_IOC = "runtime_ioc_observed"
+STATE_HAS_ALERT = "runtime_alert_observed"
+STATE_OBSERVED = "runtime_activity_observed"
+STATE_NO_SIGNAL = "no_runtime_signal"
+
+_ADDITIVE_NOTE = "Runtime evidence is additive: the absence of a runtime signal is not evidence that the workload is clean."
+
+_VALID_PROVIDERS = frozenset({"aws", "azure", "gcp"})
+_VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low", "info", "unknown"})
+
+# Evidence keys that could carry data-plane bytes / secret values are dropped at
+# construction. Metadata references (``*_ref``, types, counts) are kept, bounded.
+_FORBIDDEN_EVIDENCE_KEYS = frozenset(
+    {
+        "raw_bytes",
+        "bytes",
+        "file_contents",
+        "contents",
+        "content",
+        "secret_value",
+        "secret",
+        "value",
+        "values",
+        "data",
+        "payload",
+        "blob",
+        "raw",
+        "body",
+        "snippet",
+        "sample",
+    }
+)
+_MAX_EVIDENCE_KEYS = 20
+_MAX_EVIDENCE_VALUE_LEN = 256
+
+
+class SourceAuthenticationError(RuntimeError):
+    """Raised when a runtime evidence source cannot be authenticated."""
+
+
+class IncompleteIdentityBindingError(ValueError):
+    """Raised when a raw signal cannot be bound to a workload identity."""
+
+
+class StaleSignalError(ValueError):
+    """Raised when a runtime signal is older than the freshness window."""
+
+
+class RuntimeSignalType(str, Enum):
+    """Bounded set of runtime/EDR signal classes."""
+
+    PROCESS_EXEC = "process_exec"
+    IOC_DETECTION = "ioc_detection"
+    NETWORK_CONNECTION = "network_connection"
+    FILE_INTEGRITY = "file_integrity"
+    BEHAVIORAL_ALERT = "behavioral_alert"
+
+
+def canonical_workload_id(provider: str, account_id: str, workload_ref: str) -> str:
+    """Deterministic canonical identity for a cloud workload.
+
+    Rooted in provider + account/subscription/project + the provider-native
+    resource id, so a runtime signal and the agentless side-scan target resolve to
+    the same workload without fabricating a link.
+    """
+    return canonical_id("workload", provider, account_id, workload_ref)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _parse_ts(value: str) -> datetime | None:
+    text = (value or "").strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _redact_evidence(evidence: Mapping[str, Any] | None) -> dict[str, str]:
+    """Return bounded metadata only; drop any key that could carry data-plane bytes."""
+    if not isinstance(evidence, Mapping):
+        return {}
+    redacted: dict[str, str] = {}
+    for key, value in evidence.items():
+        if len(redacted) >= _MAX_EVIDENCE_KEYS:
+            break
+        key_text = str(key).strip().lower()
+        if not key_text or key_text in _FORBIDDEN_EVIDENCE_KEYS:
+            continue
+        if isinstance(value, (dict, list, tuple, set, bytes, bytearray)):
+            # Nested structures may hide raw content; keep only a type marker.
+            redacted[key_text] = f"<{type(value).__name__}>"
+            continue
+        redacted[key_text] = str(value)[:_MAX_EVIDENCE_VALUE_LEN]
+    return redacted
+
+
+def _normalize_severity(value: str) -> str:
+    sev = (value or "").strip().lower()
+    return sev if sev in _VALID_SEVERITIES else "unknown"
+
+
+@dataclass(frozen=True)
+class RuntimeEvidenceSource:
+    """A registered, authenticated runtime/EDR source scoped to one account."""
+
+    source_id: str
+    tenant_id: str
+    provider: str
+    account_id: str
+    kind: str
+    secret_hash: str
+
+    def __post_init__(self) -> None:
+        required = (self.source_id, self.tenant_id, self.provider, self.account_id, self.kind, self.secret_hash)
+        if not all(str(part).strip() for part in required):
+            raise ValueError("runtime evidence source requires all identity fields")
+        if self.provider not in _VALID_PROVIDERS:
+            raise ValueError(f"unsupported runtime source provider: {self.provider}")
+        if len(self.secret_hash) != 64 or any(ch not in "0123456789abcdef" for ch in self.secret_hash):
+            raise ValueError("secret_hash must be a 64-character lowercase sha256 hex digest")
+
+    @classmethod
+    def register(
+        cls,
+        *,
+        source_id: str,
+        tenant_id: str,
+        provider: str,
+        account_id: str,
+        kind: str,
+        secret: str,
+    ) -> "RuntimeEvidenceSource":
+        """Register a source, storing only the sha256 of the shared secret."""
+        if not secret or len(secret) < 8:
+            raise ValueError("runtime source secret must be at least 8 characters")
+        digest = hashlib.sha256(secret.encode("utf-8")).hexdigest()
+        return cls(
+            source_id=source_id.strip(),
+            tenant_id=tenant_id.strip(),
+            provider=provider.strip().lower(),
+            account_id=account_id.strip(),
+            kind=kind.strip().lower(),
+            secret_hash=digest,
+        )
+
+    def authenticate(self, secret: str) -> bool:
+        """Constant-time comparison of a presented secret against the stored hash."""
+        presented = hashlib.sha256((secret or "").encode("utf-8")).hexdigest()
+        return hmac.compare_digest(presented, self.secret_hash)
+
+
+class RuntimeSourceRegistry:
+    """In-memory registry of authenticated runtime evidence sources."""
+
+    def __init__(self) -> None:
+        self._sources: dict[str, RuntimeEvidenceSource] = {}
+
+    def add(self, source: RuntimeEvidenceSource) -> None:
+        self._sources[source.source_id] = source
+
+    def get(self, source_id: str) -> RuntimeEvidenceSource | None:
+        return self._sources.get(source_id)
+
+    def authenticate(self, source_id: str, secret: str) -> RuntimeEvidenceSource:
+        """Return the source only when it exists and the secret matches; else raise."""
+        source = self._sources.get(source_id)
+        if source is None or not source.authenticate(secret):
+            # One error for both cases so a caller cannot enumerate valid source ids.
+            raise SourceAuthenticationError("runtime evidence source authentication failed")
+        return source
+
+
+@dataclass(frozen=True)
+class RuntimeWorkloadSignal:
+    """One normalized, redacted runtime/EDR signal bound to a canonical workload."""
+
+    tenant_id: str
+    provider: str
+    account_id: str
+    workload_ref: str
+    signal_type: RuntimeSignalType
+    severity: str
+    observed_at: str
+    source_id: str
+    source_kind: str
+    dedup_key: str
+    title: str = ""
+    # Accepts arbitrary metadata on input; redacted to bounded str values in
+    # ``__post_init__`` so no data-plane bytes are ever retained.
+    evidence: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        required = (
+            self.tenant_id,
+            self.provider,
+            self.account_id,
+            self.workload_ref,
+            self.observed_at,
+            self.source_id,
+            self.source_kind,
+            self.dedup_key,
+        )
+        if not all(str(part).strip() for part in required):
+            raise IncompleteIdentityBindingError("runtime signal is missing required identity fields")
+        if self.provider not in _VALID_PROVIDERS:
+            raise IncompleteIdentityBindingError(f"unsupported runtime signal provider: {self.provider}")
+        if not isinstance(self.signal_type, RuntimeSignalType):
+            object.__setattr__(self, "signal_type", RuntimeSignalType(str(self.signal_type)))
+        if _parse_ts(self.observed_at) is None:
+            raise IncompleteIdentityBindingError("runtime signal observed_at is not an ISO-8601 timestamp")
+        object.__setattr__(self, "severity", _normalize_severity(self.severity))
+        object.__setattr__(self, "title", str(self.title)[:_MAX_EVIDENCE_VALUE_LEN])
+        object.__setattr__(self, "evidence", _redact_evidence(self.evidence))
+
+    @property
+    def workload_id(self) -> str:
+        return canonical_workload_id(self.provider, self.account_id, self.workload_ref)
+
+    @property
+    def dedup_scope(self) -> str:
+        """Hashable dedup identity: tenant + workload scope + source dedup key."""
+        return "\x1f".join(
+            (
+                self.tenant_id,
+                self.provider,
+                self.account_id.lower(),
+                self.workload_ref.lower(),
+                self.dedup_key,
+            )
+        )
+
+    def is_stale(self, now: str, max_age_seconds: int) -> bool:
+        """True when the signal is older than the freshness window (fail closed)."""
+        observed = _parse_ts(self.observed_at)
+        reference = _parse_ts(now) or datetime.now(timezone.utc)
+        if observed is None:
+            return True
+        return (reference - observed).total_seconds() > max_age_seconds
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": RUNTIME_EVIDENCE_SCHEMA_VERSION,
+            "tenant_id": self.tenant_id,
+            "provider": self.provider,
+            "account_id": self.account_id,
+            "workload_ref": self.workload_ref,
+            "workload_id": self.workload_id,
+            "signal_type": self.signal_type.value,
+            "severity": self.severity,
+            "observed_at": self.observed_at,
+            "source_id": self.source_id,
+            "source_kind": self.source_kind,
+            "dedup_key": self.dedup_key,
+            "title": self.title,
+            "evidence": dict(self.evidence),
+        }
+
+    def to_evidence_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": RUNTIME_EVIDENCE_SCHEMA_VERSION,
+            "workload_id": self.workload_id,
+            "signal_type": self.signal_type.value,
+            "severity": self.severity,
+            "observed_at": self.observed_at,
+            "source_kind": self.source_kind,
+            "clean_workload_assertion": False,
+            "data_boundary": "customer_account_metadata_only",
+            "redaction": "raw block bytes, file contents, and secret values are not persisted",
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RuntimeWorkloadSignal":
+        raw_evidence = payload.get("evidence")
+        evidence: Mapping[str, Any] = raw_evidence if isinstance(raw_evidence, Mapping) else {}
+        return cls(
+            tenant_id=str(payload.get("tenant_id") or ""),
+            provider=str(payload.get("provider") or ""),
+            account_id=str(payload.get("account_id") or ""),
+            workload_ref=str(payload.get("workload_ref") or ""),
+            signal_type=RuntimeSignalType(str(payload.get("signal_type") or "")),
+            severity=str(payload.get("severity") or "unknown"),
+            observed_at=str(payload.get("observed_at") or ""),
+            source_id=str(payload.get("source_id") or ""),
+            source_kind=str(payload.get("source_kind") or ""),
+            dedup_key=str(payload.get("dedup_key") or ""),
+            title=str(payload.get("title") or ""),
+            evidence=evidence,
+        )
+
+
+def build_runtime_signal(source: RuntimeEvidenceSource, raw: Mapping[str, Any], *, now: str | None = None) -> RuntimeWorkloadSignal:
+    """Bind one raw payload to a workload identity from the AUTHENTICATED source.
+
+    Tenant, provider, and account come from ``source`` — never from the payload.
+    A payload that claims a different provider/account is a confused-deputy attempt
+    and is rejected. Missing workload reference or unparseable timestamp is
+    rejected. Raises :class:`IncompleteIdentityBindingError` on any of these.
+    """
+    workload_ref = str(raw.get("workload_ref") or raw.get("resource_id") or raw.get("target_id") or "").strip()
+    if not workload_ref:
+        raise IncompleteIdentityBindingError("runtime signal is missing a workload reference")
+
+    claimed_provider = str(raw.get("provider") or "").strip().lower()
+    if claimed_provider and claimed_provider != source.provider:
+        raise IncompleteIdentityBindingError("runtime signal provider does not match the authenticated source")
+    claimed_account = str(raw.get("account_id") or "").strip()
+    if claimed_account and claimed_account != source.account_id:
+        raise IncompleteIdentityBindingError("runtime signal account does not match the authenticated source")
+
+    signal_type_raw = str(raw.get("signal_type") or "").strip().lower()
+    try:
+        signal_type = RuntimeSignalType(signal_type_raw)
+    except ValueError as exc:
+        raise IncompleteIdentityBindingError(f"unsupported runtime signal_type: {signal_type_raw or 'missing'}") from exc
+
+    observed_at = str(raw.get("observed_at") or "").strip() or (now or _now_iso())
+    dedup_key = str(raw.get("dedup_key") or raw.get("event_id") or "").strip()
+    if not dedup_key:
+        raise IncompleteIdentityBindingError("runtime signal is missing a dedup_key")
+
+    raw_evidence = raw.get("evidence")
+    evidence: Mapping[str, Any] = raw_evidence if isinstance(raw_evidence, Mapping) else {}
+    return RuntimeWorkloadSignal(
+        tenant_id=source.tenant_id,
+        provider=source.provider,
+        account_id=source.account_id,
+        workload_ref=workload_ref,
+        signal_type=signal_type,
+        severity=str(raw.get("severity") or "unknown"),
+        observed_at=observed_at,
+        source_id=source.source_id,
+        source_kind=source.kind,
+        dedup_key=dedup_key,
+        title=str(raw.get("title") or ""),
+        evidence=evidence,
+    )
+
+
+@dataclass
+class IngestResult:
+    """Non-secret summary of one ingest pass."""
+
+    source_id: str
+    tenant_id: str
+    accepted: list[RuntimeWorkloadSignal] = field(default_factory=list)
+    deduped: int = 0
+    rejected_stale: int = 0
+    rejected_incomplete: int = 0
+    persisted: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": RUNTIME_EVIDENCE_SCHEMA_VERSION,
+            "source_id": self.source_id,
+            "tenant_id": self.tenant_id,
+            "accepted": len(self.accepted),
+            "deduped": self.deduped,
+            "rejected_stale": self.rejected_stale,
+            "rejected_incomplete": self.rejected_incomplete,
+            "persisted": self.persisted,
+        }
+
+
+def ingest_runtime_signals(
+    *,
+    registry: RuntimeSourceRegistry,
+    source_id: str,
+    secret: str,
+    raw_signals: Iterable[Mapping[str, Any]],
+    now: str | None = None,
+    max_age_seconds: int = DEFAULT_MAX_SIGNAL_AGE_SECONDS,
+    store: Any = None,
+    dedup_seen: set[str] | None = None,
+) -> IngestResult:
+    """Authenticate a source and ingest a bounded batch of runtime signals.
+
+    Source authentication failure raises :class:`SourceAuthenticationError` (the
+    whole batch is refused — fail closed). Per-signal problems never sink the
+    batch: an incomplete identity binding or unparseable timestamp is counted in
+    ``rejected_incomplete``, a stale signal in ``rejected_stale``, and duplicates
+    (within the batch, against ``dedup_seen``, or already persisted) in
+    ``deduped``. Accepted signals are persisted through ``store`` when supplied.
+    """
+    source = registry.authenticate(source_id, secret)
+    reference_now = now or _now_iso()
+    result = IngestResult(source_id=source.source_id, tenant_id=source.tenant_id)
+
+    seen: set[str] = set(dedup_seen or set())
+    for raw in raw_signals:
+        try:
+            signal = build_runtime_signal(source, raw, now=reference_now)
+        except IncompleteIdentityBindingError:
+            result.rejected_incomplete += 1
+            continue
+        if signal.is_stale(reference_now, max_age_seconds):
+            result.rejected_stale += 1
+            continue
+        if signal.dedup_scope in seen:
+            result.deduped += 1
+            continue
+        seen.add(signal.dedup_scope)
+        result.accepted.append(signal)
+
+    if store is not None and result.accepted:
+        # The store dedups against already-persisted rows; anything it does not
+        # newly insert is a cross-restart duplicate.
+        persisted = store.put_batch(result.accepted)
+        result.persisted = persisted
+        result.deduped += len(result.accepted) - persisted
+
+    return result
+
+
+# ── Enrichment (additive, honest, tenant-isolated) ───────────────────────────
+
+
+def workload_runtime_summary(signals: list[RuntimeWorkloadSignal]) -> dict[str, Any]:
+    """Summarize present runtime signals for one workload. Never claims clean."""
+    if not signals:
+        return no_runtime_signal_summary()
+
+    types = {sig.signal_type for sig in signals}
+    if RuntimeSignalType.IOC_DETECTION in types:
+        state = STATE_HAS_IOC
+    elif types & {RuntimeSignalType.BEHAVIORAL_ALERT, RuntimeSignalType.FILE_INTEGRITY}:
+        state = STATE_HAS_ALERT
+    else:
+        state = STATE_OBSERVED
+
+    severity_counts: dict[str, int] = {}
+    type_counts: dict[str, int] = {}
+    source_kinds: set[str] = set()
+    latest = ""
+    for sig in signals:
+        severity_counts[sig.severity] = severity_counts.get(sig.severity, 0) + 1
+        type_counts[sig.signal_type.value] = type_counts.get(sig.signal_type.value, 0) + 1
+        source_kinds.add(sig.source_kind)
+        if sig.observed_at > latest:
+            latest = sig.observed_at
+
+    return {
+        "schema_version": RUNTIME_EVIDENCE_SCHEMA_VERSION,
+        "state": state,
+        "signal_count": len(signals),
+        "signal_types": type_counts,
+        "severity_counts": severity_counts,
+        "source_kinds": sorted(source_kinds),
+        "latest_observed_at": latest,
+        "clean_workload_assertion": False,
+        "note": _ADDITIVE_NOTE,
+    }
+
+
+def no_runtime_signal_summary() -> dict[str, Any]:
+    """Explicit no-signal summary. Absence is stated, never rendered as clean."""
+    return {
+        "schema_version": RUNTIME_EVIDENCE_SCHEMA_VERSION,
+        "state": STATE_NO_SIGNAL,
+        "signal_count": 0,
+        "clean_workload_assertion": False,
+        "note": _ADDITIVE_NOTE,
+    }
+
+
+class RuntimeWorkloadEvidenceIndex:
+    """Tenant-scoped index of runtime signals keyed by workload, for enrichment."""
+
+    def __init__(self, tenant_id: str) -> None:
+        self.tenant_id = tenant_id
+        self._by_workload: dict[str, list[RuntimeWorkloadSignal]] = {}
+
+    @staticmethod
+    def _key(provider: str, account_id: str, workload_ref: str) -> str:
+        return "\x1f".join(((provider or "").strip().lower(), (account_id or "").strip().lower(), (workload_ref or "").strip().lower()))
+
+    @classmethod
+    def from_signals(cls, tenant_id: str, signals: Iterable[RuntimeWorkloadSignal]) -> "RuntimeWorkloadEvidenceIndex":
+        index = cls(tenant_id)
+        for sig in signals:
+            # Tenant isolation: a signal from another tenant is never indexed here.
+            if sig.tenant_id != tenant_id:
+                continue
+            index._by_workload.setdefault(cls._key(sig.provider, sig.account_id, sig.workload_ref), []).append(sig)
+        return index
+
+    @classmethod
+    def from_store(cls, store: Any, tenant_id: str, *, limit: int = 5000) -> "RuntimeWorkloadEvidenceIndex":
+        signals = store.list_for_tenant(tenant_id, limit=limit) if store is not None else []
+        return cls.from_signals(tenant_id, signals)
+
+    def is_empty(self) -> bool:
+        return not self._by_workload
+
+    def summary_for(self, provider: str, account_id: str, workload_ref: str) -> dict[str, Any]:
+        signals = self._by_workload.get(self._key(provider, account_id, workload_ref), [])
+        return workload_runtime_summary(signals)
+
+
+def _account_from_ref(value: str) -> str:
+    """Return the bare account id from an ``aws:123`` style account_ref, else the input."""
+    text = (value or "").strip()
+    if ":" in text:
+        return text.split(":", 1)[1].strip()
+    return text
+
+
+def _resolve_finding_workload(row: Mapping[str, Any]) -> tuple[str, str, str] | None:
+    provider = str(row.get("provider") or "").strip().lower()
+    account = _account_from_ref(str(row.get("account_ref") or "")) or str(row.get("account_id") or "").strip()
+    workload_ref = str(row.get("resource_id") or row.get("target_id") or row.get("asset_id") or row.get("workload_ref") or "").strip()
+    if provider and account and workload_ref:
+        return provider, account, workload_ref
+    return None
+
+
+def attach_workload_runtime_evidence_to_finding(row: dict[str, Any], index: RuntimeWorkloadEvidenceIndex | None) -> dict[str, Any]:
+    """Attach ``workload_runtime_evidence`` to a workload-scoped finding row.
+
+    Only rows that resolve to a canonical workload identity are annotated. A
+    workload with no matching signal is marked ``no_runtime_signal`` (never
+    clean). Reachability is never invented. Mutates and returns ``row``.
+    """
+    if index is None:
+        return row
+    resolved = _resolve_finding_workload(row)
+    if resolved is None:
+        return row
+    row["workload_runtime_evidence"] = index.summary_for(*resolved)
+    return row
+
+
+def _node_attributes(node: Any) -> dict[str, Any] | None:
+    if isinstance(node, Mapping):
+        attrs = node.get("attributes")
+        return attrs if isinstance(attrs, dict) else None
+    attrs = getattr(node, "attributes", None)
+    return attrs if isinstance(attrs, dict) else None
+
+
+def _node_entity_type(node: Any) -> str:
+    if isinstance(node, Mapping):
+        return str(node.get("entity_type") or "").strip().lower()
+    et = getattr(node, "entity_type", "")
+    return str(getattr(et, "value", et) or "").strip().lower()
+
+
+def _is_workload_node(node: Any) -> bool:
+    attrs = _node_attributes(node)
+    if attrs is None:
+        return False
+    if _node_entity_type(node) != "cloud_resource":
+        return False
+    return str(attrs.get("resource_type") or "").strip().lower() == "workload_disk"
+
+
+def attach_workload_runtime_evidence_to_node(node: Any, index: RuntimeWorkloadEvidenceIndex | None) -> bool:
+    """Annotate a CWPP workload node's attributes with runtime evidence.
+
+    Adds an additive ``runtime_evidence`` attribute; never adds an edge, so graph
+    reachability stays edge-derived. Returns True when the node was annotated.
+    """
+    if index is None or not _is_workload_node(node):
+        return False
+    attrs = _node_attributes(node)
+    assert attrs is not None  # guaranteed by _is_workload_node
+    provider = str(attrs.get("cloud_provider") or "").strip().lower()
+    account = str(attrs.get("account_id") or "").strip()
+    workload_ref = str(attrs.get("resource_id") or attrs.get("resource_name") or "").strip()
+    if not (provider and account and workload_ref):
+        return False
+    attrs["runtime_evidence"] = index.summary_for(provider, account, workload_ref)
+    return True
+
+
+def enrich_graph_workload_runtime_evidence(graph: Any, index: RuntimeWorkloadEvidenceIndex | None) -> int:
+    """Annotate every workload node in ``graph`` with runtime evidence.
+
+    Tenant isolation in the graph join: the graph's ``tenant_id`` must match the
+    index's, else nothing is enriched. Returns the number of nodes annotated.
+    """
+    if index is None:
+        return 0
+    graph_tenant = str(getattr(graph, "tenant_id", "") or "")
+    if graph_tenant and graph_tenant != index.tenant_id:
+        return 0
+    nodes = getattr(graph, "nodes", None)
+    if isinstance(nodes, Mapping):
+        node_iter: Iterable[Any] = nodes.values()
+    elif nodes is not None:
+        node_iter = nodes
+    else:
+        return 0
+    return sum(1 for node in node_iter if attach_workload_runtime_evidence_to_node(node, index))
+
+
+__all__ = [
+    "DEFAULT_MAX_SIGNAL_AGE_SECONDS",
+    "RUNTIME_EVIDENCE_SCHEMA_VERSION",
+    "STATE_HAS_ALERT",
+    "STATE_HAS_IOC",
+    "STATE_NO_SIGNAL",
+    "STATE_OBSERVED",
+    "IncompleteIdentityBindingError",
+    "IngestResult",
+    "RuntimeEvidenceSource",
+    "RuntimeSignalType",
+    "RuntimeSourceRegistry",
+    "RuntimeWorkloadEvidenceIndex",
+    "RuntimeWorkloadSignal",
+    "SourceAuthenticationError",
+    "StaleSignalError",
+    "attach_workload_runtime_evidence_to_finding",
+    "attach_workload_runtime_evidence_to_node",
+    "build_runtime_signal",
+    "canonical_workload_id",
+    "enrich_graph_workload_runtime_evidence",
+    "ingest_runtime_signals",
+    "no_runtime_signal_summary",
+    "workload_runtime_summary",
+]

--- a/src/agent_bom/cloud/runtime_workload_evidence_store.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence_store.py
@@ -227,7 +227,7 @@ class PostgresRuntimeWorkloadEvidenceStore:
             return 0
         placeholders = ",".join("%s" for _ in _COLUMNS)
         sql = (
-            f"INSERT INTO {self.table} ({','.join(_COLUMNS)}) VALUES ({placeholders}) "  # noqa: S608
+            f"INSERT INTO {self.table} ({','.join(_COLUMNS)}) VALUES ({placeholders}) "  # noqa: S608  # nosec B608 — table validated in __init__, values parameterized
             "ON CONFLICT (tenant_id, provider, account_id, workload_ref, dedup_key) DO NOTHING"
         )
         inserted = 0
@@ -243,7 +243,7 @@ class PostgresRuntimeWorkloadEvidenceStore:
         with self._connect() as conn:
             with conn.cursor() as cur:
                 cur.execute(
-                    f"SELECT payload_json FROM {self.table} WHERE tenant_id = %s "  # noqa: S608
+                    f"SELECT payload_json FROM {self.table} WHERE tenant_id = %s "  # noqa: S608  # nosec B608 — table validated in __init__, values parameterized
                     "ORDER BY observed_at DESC, dedup_key DESC LIMIT %s",
                     (tenant_id, limit),
                 )

--- a/src/agent_bom/cloud/runtime_workload_evidence_store.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence_store.py
@@ -1,0 +1,294 @@
+"""Durable persistence for CWPP runtime/EDR workload evidence (stage 3, #4158).
+
+Three interchangeable backends behind one contract:
+
+* :class:`InMemoryRuntimeWorkloadEvidenceStore` — the default, non-durable tier.
+* :class:`SQLiteRuntimeWorkloadEvidenceStore` — node-local, restart-safe, and
+  safe under cross-process writers (WAL + busy timeout).
+* :class:`PostgresRuntimeWorkloadEvidenceStore` — shared across control-plane
+  replicas.
+
+Tenant isolation is application-level and follows the stage-1 lifecycle store
+(:mod:`agent_bom.cloud.side_scan_lifecycle`): ``tenant_id`` leads every WHERE
+clause and is part of the dedup key, so two tenants can carry the SAME logical
+signal without one dropping or leaking into the other. Dedup is on
+``(tenant_id, provider, account_id, workload_ref, dedup_key)``. Only redacted
+metadata (never data-plane bytes) is stored — the signal already redacts itself
+at construction.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any, Protocol
+
+from agent_bom.cloud.runtime_workload_evidence import RuntimeWorkloadSignal
+
+_COLUMNS = (
+    "tenant_id",
+    "provider",
+    "account_id",
+    "workload_ref",
+    "dedup_key",
+    "workload_id",
+    "signal_type",
+    "severity",
+    "observed_at",
+    "source_id",
+    "source_kind",
+    "payload_json",
+)
+
+
+def _row_values(signal: RuntimeWorkloadSignal) -> tuple[Any, ...]:
+    return (
+        signal.tenant_id,
+        signal.provider,
+        signal.account_id,
+        signal.workload_ref,
+        signal.dedup_key,
+        signal.workload_id,
+        signal.signal_type.value,
+        signal.severity,
+        signal.observed_at,
+        signal.source_id,
+        signal.source_kind,
+        json.dumps(signal.to_dict(), sort_keys=True, separators=(",", ":")),
+    )
+
+
+def _signal_from_json(raw: str) -> RuntimeWorkloadSignal:
+    payload = json.loads(raw)
+    return RuntimeWorkloadSignal.from_dict(payload)
+
+
+class RuntimeWorkloadEvidenceStore(Protocol):
+    """Contract shared by every runtime workload-evidence backend."""
+
+    def init_schema(self) -> None: ...
+
+    def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:
+        """Persist new signals, dedup on the scope key; return newly inserted count."""
+        ...
+
+    def list_for_tenant(self, tenant_id: str, *, limit: int = 5000) -> list[RuntimeWorkloadSignal]:
+        """Return one tenant's signals, most recent first."""
+        ...
+
+
+class InMemoryRuntimeWorkloadEvidenceStore:
+    """Process-local, non-durable store (default tier)."""
+
+    def __init__(self) -> None:
+        self._rows: dict[tuple[str, str, str, str, str], RuntimeWorkloadSignal] = {}
+        self._lock = threading.Lock()
+
+    def init_schema(self) -> None:  # pragma: no cover - nothing to create
+        return None
+
+    @staticmethod
+    def _key(signal: RuntimeWorkloadSignal) -> tuple[str, str, str, str, str]:
+        return (
+            signal.tenant_id,
+            signal.provider,
+            signal.account_id.lower(),
+            signal.workload_ref.lower(),
+            signal.dedup_key,
+        )
+
+    def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:
+        inserted = 0
+        with self._lock:
+            for signal in signals:
+                key = self._key(signal)
+                if key not in self._rows:
+                    self._rows[key] = signal
+                    inserted += 1
+        return inserted
+
+    def list_for_tenant(self, tenant_id: str, *, limit: int = 5000) -> list[RuntimeWorkloadSignal]:
+        with self._lock:
+            rows = [s for s in self._rows.values() if s.tenant_id == tenant_id]
+        rows.sort(key=lambda s: (s.observed_at, s.dedup_key), reverse=True)
+        return rows[:limit]
+
+
+class SQLiteRuntimeWorkloadEvidenceStore:
+    """Node-local, restart-safe, cross-process-safe SQLite backend."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = str(path)
+        self.init_schema()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._path, timeout=30)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA journal_mode=WAL")
+        connection.execute("PRAGMA busy_timeout=30000")
+        return connection
+
+    def init_schema(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS runtime_workload_evidence (
+                    tenant_id TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    account_id TEXT NOT NULL,
+                    workload_ref TEXT NOT NULL,
+                    dedup_key TEXT NOT NULL,
+                    workload_id TEXT NOT NULL,
+                    signal_type TEXT NOT NULL,
+                    severity TEXT NOT NULL,
+                    observed_at TEXT NOT NULL,
+                    source_id TEXT NOT NULL,
+                    source_kind TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, provider, account_id, workload_ref, dedup_key)
+                )
+                """
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_rwe_tenant_workload_time "
+                "ON runtime_workload_evidence (tenant_id, workload_id, observed_at DESC)"
+            )
+
+    def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:
+        if not signals:
+            return 0
+        placeholders = ",".join("?" for _ in _COLUMNS)
+        sql = f"INSERT OR IGNORE INTO runtime_workload_evidence ({','.join(_COLUMNS)}) VALUES ({placeholders})"  # noqa: S608
+        with self._connect() as connection:
+            before = connection.total_changes
+            connection.executemany(sql, [_row_values(signal) for signal in signals])
+            return connection.total_changes - before
+
+    def list_for_tenant(self, tenant_id: str, *, limit: int = 5000) -> list[RuntimeWorkloadSignal]:
+        with self._connect() as connection:
+            rows = connection.execute(
+                "SELECT payload_json FROM runtime_workload_evidence WHERE tenant_id = ? ORDER BY observed_at DESC, dedup_key DESC LIMIT ?",
+                (tenant_id, limit),
+            ).fetchall()
+        return [_signal_from_json(str(row["payload_json"])) for row in rows]
+
+
+class PostgresRuntimeWorkloadEvidenceStore:
+    """Shared Postgres backend with application-level tenant scoping.
+
+    Uses a direct connection (not the RLS pool) so tenant isolation is enforced by
+    the leading ``tenant_id`` predicate and the composite dedup key — the same
+    model the stage-1 lifecycle store uses. ``table`` is parameterizable so tests
+    can isolate into a throwaway relation.
+    """
+
+    def __init__(self, dsn: str, *, table: str = "runtime_workload_evidence") -> None:
+        if not table.replace("_", "").isalnum():
+            raise ValueError("table name must be alphanumeric/underscore")
+        self._dsn = dsn
+        self.table = table
+        self.init_schema()
+
+    def _connect(self) -> Any:
+        import psycopg
+
+        return psycopg.connect(self._dsn)
+
+    def init_schema(self) -> None:
+        with self._connect() as conn:
+            conn.execute(
+                f"""
+                CREATE TABLE IF NOT EXISTS {self.table} (
+                    tenant_id TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    account_id TEXT NOT NULL,
+                    workload_ref TEXT NOT NULL,
+                    dedup_key TEXT NOT NULL,
+                    workload_id TEXT NOT NULL,
+                    signal_type TEXT NOT NULL,
+                    severity TEXT NOT NULL,
+                    observed_at TEXT NOT NULL,
+                    source_id TEXT NOT NULL,
+                    source_kind TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    PRIMARY KEY (tenant_id, provider, account_id, workload_ref, dedup_key)
+                )
+                """  # noqa: S608
+            )
+            conn.execute(
+                f"CREATE INDEX IF NOT EXISTS idx_{self.table}_tenant_time ON {self.table} (tenant_id, workload_id, observed_at DESC)"  # noqa: S608
+            )
+            conn.commit()
+
+    def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:
+        if not signals:
+            return 0
+        placeholders = ",".join("%s" for _ in _COLUMNS)
+        sql = (
+            f"INSERT INTO {self.table} ({','.join(_COLUMNS)}) VALUES ({placeholders}) "  # noqa: S608
+            "ON CONFLICT (tenant_id, provider, account_id, workload_ref, dedup_key) DO NOTHING"
+        )
+        inserted = 0
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                for signal in signals:
+                    cur.execute(sql, _row_values(signal))
+                    inserted += cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+            conn.commit()
+        return inserted
+
+    def list_for_tenant(self, tenant_id: str, *, limit: int = 5000) -> list[RuntimeWorkloadSignal]:
+        with self._connect() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SELECT payload_json FROM {self.table} WHERE tenant_id = %s "  # noqa: S608
+                    "ORDER BY observed_at DESC, dedup_key DESC LIMIT %s",
+                    (tenant_id, limit),
+                )
+                rows = cur.fetchall()
+        return [_signal_from_json(str(row[0])) for row in rows]
+
+    def drop_table(self) -> None:
+        """Drop the backing relation (test cleanup helper)."""
+        with self._connect() as conn:
+            conn.execute(f"DROP TABLE IF EXISTS {self.table}")  # noqa: S608
+            conn.commit()
+
+
+# ── process-global default store (for the live enrichment read path) ─────────
+
+_default_store: RuntimeWorkloadEvidenceStore | None = None
+_default_lock = threading.Lock()
+
+
+def get_runtime_workload_evidence_store() -> RuntimeWorkloadEvidenceStore:
+    """Return the process default runtime workload-evidence store.
+
+    Defaults to the in-memory tier so the finding/graph read path is a no-op until
+    an operator configures a durable backend or seeds signals. Durable SQLite /
+    Postgres backends are wired by stage-4 lock-in (scheduler + config); tests and
+    callers can inject one with :func:`set_runtime_workload_evidence_store`.
+    """
+    global _default_store
+    with _default_lock:
+        if _default_store is None:
+            _default_store = InMemoryRuntimeWorkloadEvidenceStore()
+        return _default_store
+
+
+def set_runtime_workload_evidence_store(store: RuntimeWorkloadEvidenceStore | None) -> None:
+    global _default_store
+    with _default_lock:
+        _default_store = store
+
+
+__all__ = [
+    "InMemoryRuntimeWorkloadEvidenceStore",
+    "PostgresRuntimeWorkloadEvidenceStore",
+    "RuntimeWorkloadEvidenceStore",
+    "SQLiteRuntimeWorkloadEvidenceStore",
+    "get_runtime_workload_evidence_store",
+    "set_runtime_workload_evidence_store",
+]

--- a/src/agent_bom/cloud/side_scan.py
+++ b/src/agent_bom/cloud/side_scan.py
@@ -1,10 +1,10 @@
 """Agentless AWS EBS disk side-scan (CWPP) with guaranteed cleanup.
 
-This is the **one deliberate, opt-in, non-read-only** capability in agent-bom.
-Everything else in the product calls only ``List*/Describe*/Get*``. The side-scan
-needs a separately-scoped *snapshot role* (distinct from the read-only scanner
-role) so it can take an EBS snapshot, attach a temp volume to an in-account
-collector, read the filesystem, and tear everything back down.
+This is the AWS executor for agent-bom's **one deliberate, opt-in mutation
+family**: disk side-scan. Normal cloud inventory remains read-only. The AWS
+executor needs a separately scoped *snapshot role* (distinct from the read-only
+scanner role) so it can take an EBS snapshot, attach a temp volume to an
+in-account collector, read the filesystem, and tear everything back down.
 
 Trust model (non-negotiable):
 
@@ -62,8 +62,8 @@ SIDESCAN_ENV_VAR = "AGENT_BOM_SIDESCAN"
 def is_sidescan_enabled() -> bool:
     """Return True only when the operator has explicitly opted in.
 
-    The side-scan is the single non-read-only capability in agent-bom, so it is
-    gated behind ``AGENT_BOM_SIDESCAN`` and is OFF by default.
+    The side-scan mutation family is gated behind ``AGENT_BOM_SIDESCAN`` and is
+    OFF by default.
     """
     raw = os.environ.get(SIDESCAN_ENV_VAR)
     if raw is None:
@@ -272,8 +272,8 @@ class AwsEbsSideScanner:
     ) -> None:
         if not is_sidescan_enabled():
             raise SideScanDisabledError(
-                "Disk side-scan is opt-in and currently OFF. It is the only non-read-only "
-                f"capability in agent-bom. To enable it, set {SIDESCAN_ENV_VAR}=1, apply the "
+                "Disk side-scan is an opt-in mutation and currently OFF. "
+                f"To enable the AWS executor, set {SIDESCAN_ENV_VAR}=1, apply the "
                 "scoped snapshot role (deploy/terraform/connect-aws-sidescan), and provide an "
                 "in-account collector instance."
             )

--- a/src/agent_bom/cloud/side_scan_lifecycle.py
+++ b/src/agent_bom/cloud/side_scan_lifecycle.py
@@ -1,0 +1,731 @@
+"""Durable provider-neutral contracts for opt-in workload disk side-scans.
+
+This module contains state and evidence contracts only.  It does not create,
+attach, mount, or delete cloud resources and it does not load provider
+credentials.  AWS execution remains in :mod:`agent_bom.cloud.side_scan`;
+Azure and GCP expose target discovery and an adapter boundary, not shipped
+executors.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sqlite3
+import uuid
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Literal, Mapping, cast
+
+SideScanProvider = Literal["aws", "azure", "gcp"]
+
+LIFECYCLE_SCHEMA_VERSION = "agent-bom.cwpp.side_scan.lifecycle.v1"
+EVIDENCE_SCHEMA_VERSION = "agent-bom.cwpp.side_scan.evidence.v1"
+
+_EXECUTION_NAMESPACE = uuid.UUID("91c9da65-16da-4e4c-9a4c-82f07918db88")
+_PHASES = frozenset({"requested", "snapshot", "temp_disk", "attached", "mounted", "scanning", "cleanup", "finished"})
+
+
+class ExecutionStatus(str, Enum):
+    """Explicit side-scan execution outcomes; none imply a clean workload."""
+
+    QUEUED = "queued"
+    RUNNING = "running"
+    SCAN_COMPLETE = "scan_complete"
+    PARTIAL = "partial"
+    DISABLED = "disabled"
+    DENIED = "denied"
+    FAILED = "failed"
+
+
+class CleanupStatus(str, Enum):
+    """Retryable teardown state for resources owned by one execution."""
+
+    NOT_STARTED = "not_started"
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETE = "complete"
+    PARTIAL = "partial"
+
+
+class TemporaryResourceStatus(str, Enum):
+    """Lifecycle state for a scanner-created cloud or collector resource."""
+
+    CREATED = "created"
+    CLEANUP_PENDING = "cleanup_pending"
+    DELETED = "deleted"
+    CLEANUP_FAILED = "cleanup_failed"
+
+
+_EXECUTION_TRANSITIONS: dict[ExecutionStatus, frozenset[ExecutionStatus]] = {
+    ExecutionStatus.QUEUED: frozenset(
+        {
+            ExecutionStatus.QUEUED,
+            ExecutionStatus.RUNNING,
+            ExecutionStatus.DISABLED,
+            ExecutionStatus.DENIED,
+            ExecutionStatus.FAILED,
+        }
+    ),
+    ExecutionStatus.RUNNING: frozenset(
+        {
+            ExecutionStatus.RUNNING,
+            ExecutionStatus.SCAN_COMPLETE,
+            ExecutionStatus.PARTIAL,
+            ExecutionStatus.DENIED,
+            ExecutionStatus.FAILED,
+        }
+    ),
+    ExecutionStatus.SCAN_COMPLETE: frozenset({ExecutionStatus.SCAN_COMPLETE, ExecutionStatus.PARTIAL}),
+    ExecutionStatus.PARTIAL: frozenset({ExecutionStatus.PARTIAL}),
+    ExecutionStatus.DISABLED: frozenset({ExecutionStatus.DISABLED}),
+    ExecutionStatus.DENIED: frozenset({ExecutionStatus.DENIED}),
+    ExecutionStatus.FAILED: frozenset({ExecutionStatus.FAILED}),
+}
+
+_CLEANUP_TRANSITIONS: dict[CleanupStatus, frozenset[CleanupStatus]] = {
+    CleanupStatus.NOT_STARTED: frozenset(
+        {CleanupStatus.NOT_STARTED, CleanupStatus.PENDING, CleanupStatus.IN_PROGRESS, CleanupStatus.COMPLETE}
+    ),
+    CleanupStatus.PENDING: frozenset(
+        {CleanupStatus.PENDING, CleanupStatus.IN_PROGRESS, CleanupStatus.COMPLETE, CleanupStatus.PARTIAL}
+    ),
+    CleanupStatus.IN_PROGRESS: frozenset(
+        {CleanupStatus.IN_PROGRESS, CleanupStatus.COMPLETE, CleanupStatus.PARTIAL}
+    ),
+    CleanupStatus.PARTIAL: frozenset({CleanupStatus.PARTIAL, CleanupStatus.IN_PROGRESS, CleanupStatus.COMPLETE}),
+    CleanupStatus.COMPLETE: frozenset({CleanupStatus.COMPLETE}),
+}
+
+_RESOURCE_TRANSITIONS: dict[TemporaryResourceStatus, frozenset[TemporaryResourceStatus]] = {
+    TemporaryResourceStatus.CREATED: frozenset(
+        {
+            TemporaryResourceStatus.CREATED,
+            TemporaryResourceStatus.CLEANUP_PENDING,
+            TemporaryResourceStatus.DELETED,
+            TemporaryResourceStatus.CLEANUP_FAILED,
+        }
+    ),
+    TemporaryResourceStatus.CLEANUP_PENDING: frozenset(
+        {
+            TemporaryResourceStatus.CLEANUP_PENDING,
+            TemporaryResourceStatus.DELETED,
+            TemporaryResourceStatus.CLEANUP_FAILED,
+        }
+    ),
+    TemporaryResourceStatus.CLEANUP_FAILED: frozenset(
+        {
+            TemporaryResourceStatus.CLEANUP_FAILED,
+            TemporaryResourceStatus.CLEANUP_PENDING,
+            TemporaryResourceStatus.DELETED,
+        }
+    ),
+    TemporaryResourceStatus.DELETED: frozenset({TemporaryResourceStatus.DELETED}),
+}
+
+
+@dataclass(frozen=True)
+class SideScanProviderCapability:
+    """Code-backed capability statement for one provider."""
+
+    provider: SideScanProvider
+    target_discovery: bool
+    lifecycle_contract: bool
+    executor: Literal["shipped", "contract_only"]
+    cli_available: bool
+    credentialed_smoke: bool
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "provider": self.provider,
+            "target_discovery": self.target_discovery,
+            "lifecycle_contract": self.lifecycle_contract,
+            "executor": self.executor,
+            "cli_available": self.cli_available,
+            "credentialed_smoke": self.credentialed_smoke,
+        }
+
+
+def side_scan_provider_capabilities() -> dict[SideScanProvider, SideScanProviderCapability]:
+    """Return the shipped side-scan surface without inferring adapter availability."""
+    return {
+        "aws": SideScanProviderCapability("aws", True, True, "shipped", True, False),
+        "azure": SideScanProviderCapability("azure", True, True, "contract_only", False, False),
+        "gcp": SideScanProviderCapability("gcp", True, True, "contract_only", False, False),
+    }
+
+
+@dataclass(frozen=True)
+class SideScanCleanupOwnership:
+    """Deterministic ownership proof required before cleanup is attempted."""
+
+    execution_id: str
+    owner_id: str
+    scope_hash: str
+
+    def __post_init__(self) -> None:
+        try:
+            uuid.UUID(self.execution_id)
+        except ValueError as exc:
+            raise ValueError("cleanup ownership execution id must be a UUID") from exc
+        hex_chars = frozenset("0123456789abcdef")
+        if (
+            len(self.owner_id) != 24
+            or len(self.scope_hash) != 24
+            or not set(self.owner_id) <= hex_chars
+            or not set(self.scope_hash) <= hex_chars
+        ):
+            raise ValueError("cleanup owner and scope ids must be 24-character lowercase hex")
+
+    def required_tags(self) -> dict[str, str]:
+        return {
+            "agent-bom-sidescan": "true",
+            "agent-bom-sidescan-owner": self.owner_id,
+            "agent-bom-sidescan-scope": self.scope_hash,
+            "agent-bom-sidescan-execution": self.execution_id,
+        }
+
+    def owns(self, resource_tags: Mapping[str, str]) -> bool:
+        """Return true only when every ownership tag matches exactly."""
+        return all(resource_tags.get(key) == value for key, value in self.required_tags().items())
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "execution_id": self.execution_id,
+            "owner_id": self.owner_id,
+            "scope_hash": self.scope_hash,
+            "required_tags": self.required_tags(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "SideScanCleanupOwnership":
+        return cls(
+            execution_id=str(payload.get("execution_id") or ""),
+            owner_id=str(payload.get("owner_id") or ""),
+            scope_hash=str(payload.get("scope_hash") or ""),
+        )
+
+
+@dataclass(frozen=True)
+class SideScanTemporaryResource:
+    """Metadata for one temporary resource; never contains data-plane bytes."""
+
+    kind: str
+    resource_id: str
+    status: TemporaryResourceStatus
+    ownership_tags: Mapping[str, str]
+
+    def __post_init__(self) -> None:
+        if not self.kind.strip() or not self.resource_id.strip():
+            raise ValueError("temporary resource kind and id are required")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "kind": self.kind,
+            "resource_id": self.resource_id,
+            "status": self.status.value,
+            "ownership_tags": dict(self.ownership_tags),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "SideScanTemporaryResource":
+        raw_tags = payload.get("ownership_tags")
+        tags = {str(key): str(value) for key, value in raw_tags.items()} if isinstance(raw_tags, dict) else {}
+        return cls(
+            kind=str(payload.get("kind") or ""),
+            resource_id=str(payload.get("resource_id") or ""),
+            status=TemporaryResourceStatus(str(payload.get("status") or "")),
+            ownership_tags=tags,
+        )
+
+
+@dataclass(frozen=True)
+class SideScanExecutionRecord:
+    """Versioned, restart-safe execution state and metadata-only evidence."""
+
+    execution_id: str
+    idempotency_key: str
+    tenant_id: str
+    provider: SideScanProvider
+    account_id: str
+    target_id: str
+    collector_id: str
+    cleanup_ownership: SideScanCleanupOwnership
+    status: ExecutionStatus = ExecutionStatus.QUEUED
+    phase: str = "requested"
+    cleanup_status: CleanupStatus = CleanupStatus.NOT_STARTED
+    resources: tuple[SideScanTemporaryResource, ...] = ()
+    package_count: int = 0
+    vulnerability_count: int = 0
+    secret_count: int = 0
+    config_finding_count: int = 0
+    ioc_finding_count: int = 0
+    failure_code: str = ""
+    warning_codes: tuple[str, ...] = ()
+    state_version: int = 1
+    created_at: str = ""
+    updated_at: str = ""
+    schema_version: str = field(default=LIFECYCLE_SCHEMA_VERSION, init=False)
+
+    def __post_init__(self) -> None:
+        required = (
+            self.execution_id,
+            self.idempotency_key,
+            self.tenant_id,
+            self.provider,
+            self.account_id,
+            self.target_id,
+            self.collector_id,
+            self.created_at,
+            self.updated_at,
+        )
+        if not all(str(value).strip() for value in required):
+            raise ValueError("side-scan execution scope and timestamps are required")
+        if self.phase not in _PHASES:
+            raise ValueError(f"unsupported side-scan phase: {self.phase}")
+        counts = (
+            self.package_count,
+            self.vulnerability_count,
+            self.secret_count,
+            self.config_finding_count,
+            self.ioc_finding_count,
+            self.state_version,
+        )
+        if any(not isinstance(value, int) or isinstance(value, bool) or value < 0 for value in counts):
+            raise ValueError("side-scan counts and state version must be non-negative integers")
+        if self.state_version < 1:
+            raise ValueError("state_version must be at least 1")
+        if self.cleanup_ownership.execution_id != self.execution_id:
+            raise ValueError("cleanup ownership must match the execution id")
+        if self.provider not in {"aws", "azure", "gcp"}:
+            raise ValueError("unsupported side-scan provider")
+        if self.failure_code and (len(self.failure_code) > 128 or any(char.isspace() for char in self.failure_code)):
+            raise ValueError("failure_code must be a bounded machine-readable code")
+        if any(len(code) > 128 or not code or any(char.isspace() for char in code) for code in self.warning_codes):
+            raise ValueError("warning_codes must be bounded machine-readable codes")
+
+    @property
+    def disposition(self) -> str:
+        """Return evidence completeness without ever claiming workload cleanliness."""
+        if self.status is ExecutionStatus.SCAN_COMPLETE and self.cleanup_status is CleanupStatus.COMPLETE:
+            return "complete"
+        if self.status in {ExecutionStatus.SCAN_COMPLETE, ExecutionStatus.PARTIAL}:
+            return "partial"
+        return "unevaluable"
+
+    def transition(
+        self,
+        *,
+        status: ExecutionStatus | None = None,
+        phase: str | None = None,
+        cleanup_status: CleanupStatus | None = None,
+        package_count: int | None = None,
+        vulnerability_count: int | None = None,
+        secret_count: int | None = None,
+        config_finding_count: int | None = None,
+        ioc_finding_count: int | None = None,
+        failure_code: str | None = None,
+        warning_codes: tuple[str, ...] | None = None,
+        now: str | None = None,
+    ) -> "SideScanExecutionRecord":
+        """Advance state with optimistic-version semantics; repeated writes are no-ops."""
+        next_status = status or self.status
+        next_cleanup = cleanup_status or self.cleanup_status
+        if next_status not in _EXECUTION_TRANSITIONS[self.status]:
+            raise ValueError(f"invalid execution transition: {self.status.value} -> {next_status.value}")
+        if next_cleanup not in _CLEANUP_TRANSITIONS[self.cleanup_status]:
+            raise ValueError(f"invalid cleanup transition: {self.cleanup_status.value} -> {next_cleanup.value}")
+        if next_cleanup is CleanupStatus.COMPLETE and self.cleanup_candidates():
+            raise ValueError("cleanup cannot complete while owned temporary resources remain")
+        next_phase = phase or self.phase
+        next_package_count = self.package_count if package_count is None else package_count
+        next_vulnerability_count = self.vulnerability_count if vulnerability_count is None else vulnerability_count
+        next_secret_count = self.secret_count if secret_count is None else secret_count
+        next_config_finding_count = self.config_finding_count if config_finding_count is None else config_finding_count
+        next_ioc_finding_count = self.ioc_finding_count if ioc_finding_count is None else ioc_finding_count
+        next_failure_code = self.failure_code if failure_code is None else failure_code
+        next_warning_codes = self.warning_codes if warning_codes is None else warning_codes
+        if (
+            next_status is self.status
+            and next_phase == self.phase
+            and next_cleanup is self.cleanup_status
+            and next_package_count == self.package_count
+            and next_vulnerability_count == self.vulnerability_count
+            and next_secret_count == self.secret_count
+            and next_config_finding_count == self.config_finding_count
+            and next_ioc_finding_count == self.ioc_finding_count
+            and next_failure_code == self.failure_code
+            and next_warning_codes == self.warning_codes
+        ):
+            return self
+        return replace(
+            self,
+            status=next_status,
+            phase=next_phase,
+            cleanup_status=next_cleanup,
+            package_count=next_package_count,
+            vulnerability_count=next_vulnerability_count,
+            secret_count=next_secret_count,
+            config_finding_count=next_config_finding_count,
+            ioc_finding_count=next_ioc_finding_count,
+            failure_code=next_failure_code,
+            warning_codes=next_warning_codes,
+            state_version=self.state_version + 1,
+            updated_at=now or _now(),
+        )
+
+    def register_resource(self, resource: SideScanTemporaryResource, *, now: str | None = None) -> "SideScanExecutionRecord":
+        """Register an owned resource once; exact retries return the same record."""
+        if not self.cleanup_ownership.owns(resource.ownership_tags):
+            raise ValueError("temporary resource does not match cleanup ownership")
+        if dict(resource.ownership_tags) != self.cleanup_ownership.required_tags():
+            raise ValueError("only cleanup ownership tags may be persisted")
+        for existing in self.resources:
+            if existing.kind == resource.kind and existing.resource_id == resource.resource_id:
+                if existing == resource:
+                    return self
+                raise ValueError("temporary resource identity already has different state")
+        return replace(
+            self,
+            resources=(*self.resources, resource),
+            state_version=self.state_version + 1,
+            updated_at=now or _now(),
+        )
+
+    def mark_resource_cleanup(
+        self,
+        resource_id: str,
+        *,
+        status: TemporaryResourceStatus,
+        now: str | None = None,
+    ) -> "SideScanExecutionRecord":
+        """Update cleanup state idempotently for one owned resource."""
+        updated: list[SideScanTemporaryResource] = []
+        found = False
+        changed = False
+        for resource in self.resources:
+            if resource.resource_id != resource_id:
+                updated.append(resource)
+                continue
+            found = True
+            if not self.cleanup_ownership.owns(resource.ownership_tags):
+                raise ValueError("temporary resource does not match cleanup ownership")
+            if status not in _RESOURCE_TRANSITIONS[resource.status]:
+                raise ValueError(f"invalid resource cleanup transition: {resource.status.value} -> {status.value}")
+            if resource.status is status:
+                updated.append(resource)
+            else:
+                updated.append(replace(resource, status=status))
+                changed = True
+        if not found:
+            raise KeyError(resource_id)
+        if not changed:
+            return self
+        return replace(
+            self,
+            resources=tuple(updated),
+            state_version=self.state_version + 1,
+            updated_at=now or _now(),
+        )
+
+    def cleanup_candidates(self) -> tuple[SideScanTemporaryResource, ...]:
+        """Return only owned resources still requiring deletion."""
+        return tuple(
+            resource
+            for resource in self.resources
+            if resource.status is not TemporaryResourceStatus.DELETED
+            and self.cleanup_ownership.owns(resource.ownership_tags)
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": self.schema_version,
+            "execution_id": self.execution_id,
+            "idempotency_key": self.idempotency_key,
+            "tenant_id": self.tenant_id,
+            "provider": self.provider,
+            "account_id": self.account_id,
+            "target_id": self.target_id,
+            "collector_id": self.collector_id,
+            "status": self.status.value,
+            "phase": self.phase,
+            "cleanup_status": self.cleanup_status.value,
+            "cleanup_ownership": self.cleanup_ownership.to_dict(),
+            "resources": [resource.to_dict() for resource in self.resources],
+            "counts": self._counts(),
+            "failure_code": self.failure_code,
+            "warning_codes": list(self.warning_codes),
+            "state_version": self.state_version,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+    def to_evidence_dict(self) -> dict[str, object]:
+        return {
+            "schema_version": EVIDENCE_SCHEMA_VERSION,
+            "execution_id": self.execution_id,
+            "provider": self.provider,
+            "account_id": self.account_id,
+            "target_id": self.target_id,
+            "execution_status": self.status.value,
+            "cleanup_status": self.cleanup_status.value,
+            "disposition": self.disposition,
+            "negative_result_scope": "scanned_disk_only" if self.disposition == "complete" else "unavailable",
+            "clean_workload_assertion": False,
+            **self._counts(),
+            "failure_code": self.failure_code,
+            "warning_codes": list(self.warning_codes),
+            "data_boundary": "customer_account_metadata_only",
+            "redaction": "raw block bytes, file contents, and secret values are not persisted",
+            "updated_at": self.updated_at,
+        }
+
+    def _counts(self) -> dict[str, int]:
+        return {
+            "package_count": self.package_count,
+            "vulnerability_count": self.vulnerability_count,
+            "secret_count": self.secret_count,
+            "config_finding_count": self.config_finding_count,
+            "ioc_finding_count": self.ioc_finding_count,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, object]) -> "SideScanExecutionRecord":
+        if payload.get("schema_version") != LIFECYCLE_SCHEMA_VERSION:
+            raise ValueError("unsupported side-scan lifecycle schema")
+        raw_counts = payload.get("counts")
+        counts = raw_counts if isinstance(raw_counts, dict) else {}
+        raw_resources = payload.get("resources")
+        resources = (
+            tuple(SideScanTemporaryResource.from_dict(item) for item in raw_resources if isinstance(item, dict))
+            if isinstance(raw_resources, list)
+            else ()
+        )
+        raw_owner = payload.get("cleanup_ownership")
+        if not isinstance(raw_owner, dict):
+            raise ValueError("side-scan cleanup ownership is required")
+        provider = str(payload.get("provider") or "")
+        if provider not in {"aws", "azure", "gcp"}:
+            raise ValueError("unsupported side-scan provider")
+        raw_warnings = payload.get("warning_codes")
+        return cls(
+            execution_id=str(payload.get("execution_id") or ""),
+            idempotency_key=str(payload.get("idempotency_key") or ""),
+            tenant_id=str(payload.get("tenant_id") or ""),
+            provider=cast(SideScanProvider, provider),
+            account_id=str(payload.get("account_id") or ""),
+            target_id=str(payload.get("target_id") or ""),
+            collector_id=str(payload.get("collector_id") or ""),
+            cleanup_ownership=SideScanCleanupOwnership.from_dict(raw_owner),
+            status=ExecutionStatus(str(payload.get("status") or "")),
+            phase=str(payload.get("phase") or ""),
+            cleanup_status=CleanupStatus(str(payload.get("cleanup_status") or "")),
+            resources=resources,
+            package_count=int(counts.get("package_count", 0)),
+            vulnerability_count=int(counts.get("vulnerability_count", 0)),
+            secret_count=int(counts.get("secret_count", 0)),
+            config_finding_count=int(counts.get("config_finding_count", 0)),
+            ioc_finding_count=int(counts.get("ioc_finding_count", 0)),
+            failure_code=str(payload.get("failure_code") or ""),
+            warning_codes=tuple(str(item) for item in raw_warnings) if isinstance(raw_warnings, list) else (),
+            state_version=_coerce_int(payload.get("state_version")),
+            created_at=str(payload.get("created_at") or ""),
+            updated_at=str(payload.get("updated_at") or ""),
+        )
+
+
+class SideScanStateConflictError(RuntimeError):
+    """Raised when a stale worker attempts to overwrite newer lifecycle state."""
+
+
+class SQLiteSideScanStateStore:
+    """Tenant-scoped SQLite persistence for restart-safe execution state."""
+
+    def __init__(self, path: str | Path) -> None:
+        self._path = str(path)
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        connection = sqlite3.connect(self._path, timeout=30)
+        connection.row_factory = sqlite3.Row
+        return connection
+
+    def _initialize(self) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                """
+                CREATE TABLE IF NOT EXISTS side_scan_execution_state (
+                    execution_id TEXT PRIMARY KEY,
+                    tenant_id TEXT NOT NULL,
+                    provider TEXT NOT NULL,
+                    account_id TEXT NOT NULL,
+                    target_id TEXT NOT NULL,
+                    idempotency_key TEXT NOT NULL,
+                    state_version INTEGER NOT NULL,
+                    cleanup_status TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    payload_json TEXT NOT NULL,
+                    UNIQUE (tenant_id, provider, account_id, target_id, idempotency_key)
+                )
+                """
+            )
+            connection.execute(
+                "CREATE INDEX IF NOT EXISTS idx_side_scan_cleanup ON side_scan_execution_state "
+                "(tenant_id, cleanup_status, updated_at)"
+            )
+
+    def create_or_get(self, record: SideScanExecutionRecord) -> SideScanExecutionRecord:
+        """Create once per tenant/target/idempotency key; duplicate requests reuse state."""
+        with self._connect() as connection:
+            connection.execute("BEGIN IMMEDIATE")
+            row = connection.execute(
+                """
+                SELECT payload_json FROM side_scan_execution_state
+                WHERE tenant_id = ? AND provider = ? AND account_id = ?
+                  AND target_id = ? AND idempotency_key = ?
+                """,
+                (record.tenant_id, record.provider, record.account_id, record.target_id, record.idempotency_key),
+            ).fetchone()
+            if row is not None:
+                return _record_from_json(str(row["payload_json"]))
+            connection.execute(
+                """
+                INSERT INTO side_scan_execution_state
+                    (execution_id, tenant_id, provider, account_id, target_id, idempotency_key,
+                     state_version, cleanup_status, updated_at, payload_json)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                self._row_values(record),
+            )
+        return record
+
+    def get(self, *, tenant_id: str, execution_id: str) -> SideScanExecutionRecord | None:
+        """Load one execution without crossing the tenant boundary."""
+        with self._connect() as connection:
+            row = connection.execute(
+                "SELECT payload_json FROM side_scan_execution_state WHERE tenant_id = ? AND execution_id = ?",
+                (tenant_id, execution_id),
+            ).fetchone()
+        return _record_from_json(str(row["payload_json"])) if row is not None else None
+
+    def save(self, record: SideScanExecutionRecord, *, expected_version: int) -> None:
+        """Persist one state advance and reject stale-worker overwrites."""
+        if record.state_version != expected_version + 1:
+            raise SideScanStateConflictError("side-scan state version must advance by exactly one")
+        with self._connect() as connection:
+            cursor = connection.execute(
+                """
+                UPDATE side_scan_execution_state
+                SET state_version = ?, cleanup_status = ?, updated_at = ?, payload_json = ?
+                WHERE tenant_id = ? AND execution_id = ? AND state_version = ?
+                """,
+                (
+                    record.state_version,
+                    record.cleanup_status.value,
+                    record.updated_at,
+                    _record_json(record),
+                    record.tenant_id,
+                    record.execution_id,
+                    expected_version,
+                ),
+            )
+            if cursor.rowcount != 1:
+                raise SideScanStateConflictError("side-scan execution was updated by another worker")
+
+    def list_cleanup_due(self, *, tenant_id: str, limit: int = 100) -> list[SideScanExecutionRecord]:
+        """Return bounded retry work for incomplete cleanup in one tenant."""
+        if limit < 1:
+            raise ValueError("limit must be at least 1")
+        with self._connect() as connection:
+            rows = connection.execute(
+                """
+                SELECT payload_json FROM side_scan_execution_state
+                WHERE tenant_id = ? AND cleanup_status IN (?, ?, ?)
+                ORDER BY updated_at, execution_id
+                LIMIT ?
+                """,
+                (
+                    tenant_id,
+                    CleanupStatus.PENDING.value,
+                    CleanupStatus.IN_PROGRESS.value,
+                    CleanupStatus.PARTIAL.value,
+                    limit,
+                ),
+            ).fetchall()
+        return [_record_from_json(str(row["payload_json"])) for row in rows]
+
+    @staticmethod
+    def _row_values(record: SideScanExecutionRecord) -> tuple[object, ...]:
+        return (
+            record.execution_id,
+            record.tenant_id,
+            record.provider,
+            record.account_id,
+            record.target_id,
+            record.idempotency_key,
+            record.state_version,
+            record.cleanup_status.value,
+            record.updated_at,
+            _record_json(record),
+        )
+
+
+def new_side_scan_execution(
+    *,
+    tenant_id: str,
+    provider: SideScanProvider,
+    account_id: str,
+    target_id: str,
+    collector_id: str,
+    idempotency_key: str,
+    now: str | None = None,
+) -> SideScanExecutionRecord:
+    """Build a deterministic execution identity for retry-safe scheduling."""
+    scope = "\x1f".join((tenant_id, provider, account_id, target_id, idempotency_key))
+    execution_id = str(uuid.uuid5(_EXECUTION_NAMESPACE, scope))
+    owner_id = hashlib.sha256(f"owner\x1f{execution_id}".encode()).hexdigest()[:24]
+    scope_hash = hashlib.sha256(f"scope\x1f{tenant_id}\x1f{provider}\x1f{account_id}".encode()).hexdigest()[:24]
+    timestamp = now or _now()
+    ownership = SideScanCleanupOwnership(execution_id=execution_id, owner_id=owner_id, scope_hash=scope_hash)
+    return SideScanExecutionRecord(
+        execution_id=execution_id,
+        idempotency_key=idempotency_key,
+        tenant_id=tenant_id,
+        provider=provider,
+        account_id=account_id,
+        target_id=target_id,
+        collector_id=collector_id,
+        cleanup_ownership=ownership,
+        created_at=timestamp,
+        updated_at=timestamp,
+    )
+
+
+def _record_json(record: SideScanExecutionRecord) -> str:
+    return json.dumps(record.to_dict(), sort_keys=True, separators=(",", ":"))
+
+
+def _record_from_json(raw: str) -> SideScanExecutionRecord:
+    payload = json.loads(raw)
+    if not isinstance(payload, dict):
+        raise ValueError("invalid persisted side-scan state")
+    return SideScanExecutionRecord.from_dict(payload)
+
+
+def _coerce_int(value: object) -> int:
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    return 0
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/src/agent_bom/cloud/side_scan_lifecycle.py
+++ b/src/agent_bom/cloud/side_scan_lifecycle.py
@@ -152,8 +152,8 @@ def side_scan_provider_capabilities() -> dict[SideScanProvider, SideScanProvider
     """Return the shipped side-scan surface without inferring adapter availability."""
     return {
         "aws": SideScanProviderCapability("aws", True, True, "shipped", True, False),
-        "azure": SideScanProviderCapability("azure", True, True, "contract_only", False, False),
-        "gcp": SideScanProviderCapability("gcp", True, True, "contract_only", False, False),
+        "azure": SideScanProviderCapability("azure", True, True, "shipped", False, False),
+        "gcp": SideScanProviderCapability("gcp", True, True, "shipped", False, False),
     }
 
 

--- a/src/agent_bom/cloud/side_scan_provider_adapters.py
+++ b/src/agent_bom/cloud/side_scan_provider_adapters.py
@@ -1,0 +1,775 @@
+"""Opt-in Azure Managed Disk and GCP Persistent Disk lifecycle adapters.
+
+The adapters accept already-authenticated provider SDK clients.  They never
+load credentials, transfer block bytes, or mount filesystems themselves.  All
+temporary resources use deterministic names and the ownership tags from the v1
+side-scan execution contract; durable state is updated after each mutation so
+cleanup can resume after a worker restart.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from agent_bom.security import sanitize_text
+
+from .side_scan_lifecycle import (
+    CleanupStatus,
+    ExecutionStatus,
+    SideScanExecutionRecord,
+    SideScanTemporaryResource,
+    SQLiteSideScanStateStore,
+    TemporaryResourceStatus,
+)
+from .side_scan_targets import CloudSideScanTarget
+
+
+class SideScanPermissionDeniedError(RuntimeError):
+    """Provider denied a scoped lifecycle operation."""
+
+
+class SideScanLifecycleTimeoutError(RuntimeError):
+    """A provider operation did not finish inside the configured poll bound."""
+
+
+class SideScanOwnershipError(RuntimeError):
+    """A deterministic provider resource exists but is not owned by this run."""
+
+
+@dataclass(frozen=True)
+class _WaitPolicy:
+    max_attempts: int
+    interval_seconds: float
+    sleep: Callable[[float], None]
+
+    def __post_init__(self) -> None:
+        if self.max_attempts < 1:
+            raise ValueError("max_wait_attempts must be at least 1")
+        if self.interval_seconds < 0:
+            raise ValueError("wait_interval_seconds cannot be negative")
+
+
+class _PersistedLifecycleAdapter:
+    provider: str
+
+    def __init__(
+        self,
+        *,
+        execution: SideScanExecutionRecord | None,
+        state_store: SQLiteSideScanStateStore,
+        max_wait_attempts: int,
+        wait_interval_seconds: float,
+        sleep: Callable[[float], None],
+    ) -> None:
+        if execution is None:
+            raise ValueError("persisted side-scan execution is required")
+        if execution.provider != self.provider:
+            raise ValueError("side-scan execution provider does not match adapter")
+        self.execution = execution
+        self._store = state_store
+        self._wait_policy = _WaitPolicy(max_wait_attempts, wait_interval_seconds, sleep)
+        self.last_operation: Any | None = None
+
+    def _validate_target(self, target: CloudSideScanTarget) -> None:
+        if (
+            target.provider != self.execution.provider
+            or target.account_id != self.execution.account_id
+            or target.target_id != self.execution.target_id
+        ):
+            raise ValueError("side-scan target is outside the persisted execution scope")
+
+    def _save(self, record: SideScanExecutionRecord) -> None:
+        if record == self.execution:
+            return
+        self._store.save(record, expected_version=self.execution.state_version)
+        self.execution = record
+
+    def _ensure_running(self, phase: str) -> None:
+        if self.execution.status is ExecutionStatus.QUEUED:
+            self._save(self.execution.transition(status=ExecutionStatus.RUNNING, phase=phase))
+        elif self.execution.status is ExecutionStatus.RUNNING:
+            self._save(self.execution.transition(phase=phase))
+        else:
+            raise ValueError(f"side-scan execution is not runnable: {self.execution.status.value}")
+
+    def _register(self, kind: str, resource_id: str) -> None:
+        resource = SideScanTemporaryResource(
+            kind=kind,
+            resource_id=resource_id,
+            status=TemporaryResourceStatus.CREATED,
+            ownership_tags=self.execution.cleanup_ownership.required_tags(),
+        )
+        self._save(self.execution.register_resource(resource))
+
+    def _wait(self, operation: Any) -> Any:
+        self.last_operation = operation
+        done = getattr(operation, "done", None)
+        result = getattr(operation, "result", None)
+        if not callable(done) or not callable(result):
+            raise TypeError("provider operation must expose done() and result()")
+        for attempt in range(self._wait_policy.max_attempts):
+            if done():
+                return result()
+            if attempt + 1 < self._wait_policy.max_attempts:
+                self._wait_policy.sleep(self._wait_policy.interval_seconds)
+        raise SideScanLifecycleTimeoutError("provider operation exceeded bounded wait")
+
+    def _persist_failure(self, exc: Exception) -> None:
+        denied = _is_denied(exc)
+        cleanup = (
+            CleanupStatus.PENDING
+            if isinstance(exc, SideScanLifecycleTimeoutError) or self.execution.resources
+            else CleanupStatus.COMPLETE
+        )
+        status = ExecutionStatus.DENIED if denied else ExecutionStatus.FAILED
+        if denied:
+            code = "permission_denied"
+        elif isinstance(exc, SideScanLifecycleTimeoutError):
+            code = "operation_timeout"
+        else:
+            code = "provider_operation_failed"
+        self._save(
+            self.execution.transition(
+                status=status,
+                phase="cleanup" if cleanup is CleanupStatus.PENDING else "finished",
+                cleanup_status=cleanup,
+                failure_code=code,
+            )
+        )
+
+    def _raise_provider_error(self, exc: Exception) -> None:
+        self._persist_failure(exc)
+        if _is_denied(exc):
+            raise SideScanPermissionDeniedError("provider denied the scoped side-scan lifecycle operation") from exc
+        if isinstance(exc, SideScanLifecycleTimeoutError):
+            raise exc
+        raise RuntimeError("provider side-scan lifecycle operation failed") from exc
+
+    def mark_scan_complete(
+        self,
+        *,
+        package_count: int = 0,
+        vulnerability_count: int = 0,
+        secret_count: int = 0,
+        config_finding_count: int = 0,
+        ioc_finding_count: int = 0,
+    ) -> SideScanExecutionRecord:
+        """Persist metadata-only scan counts and queue mandatory cleanup."""
+        self._save(
+            self.execution.transition(
+                status=ExecutionStatus.SCAN_COMPLETE,
+                phase="cleanup",
+                cleanup_status=CleanupStatus.PENDING,
+                package_count=package_count,
+                vulnerability_count=vulnerability_count,
+                secret_count=secret_count,
+                config_finding_count=config_finding_count,
+                ioc_finding_count=ioc_finding_count,
+            )
+        )
+        return self.execution
+
+    def mark_scan_failed(self, *, failure_code: str = "scan_failed") -> SideScanExecutionRecord:
+        """Persist a fail-closed scan outcome before mandatory cleanup."""
+        if self.execution.status in {ExecutionStatus.QUEUED, ExecutionStatus.RUNNING}:
+            self._save(
+                self.execution.transition(
+                    status=ExecutionStatus.FAILED,
+                    phase="cleanup",
+                    cleanup_status=CleanupStatus.PENDING,
+                    failure_code=failure_code,
+                )
+            )
+        return self.execution
+
+    def cleanup(self, target: CloudSideScanTarget, collector_id: str) -> SideScanExecutionRecord:
+        """Retry teardown from persisted resources; every step is idempotent."""
+        self._validate_target(target)
+        if self.execution.cleanup_status is CleanupStatus.COMPLETE:
+            return self.execution
+        self._save(self.execution.transition(phase="cleanup", cleanup_status=CleanupStatus.IN_PROGRESS))
+        warning_codes = list(self.execution.warning_codes)
+        order = {"attachment": 0, "scan_disk": 1, "snapshot": 2}
+        resources = sorted(self.execution.cleanup_candidates(), key=lambda resource: order.get(resource.kind, 99))
+        for resource in resources:
+            try:
+                if resource.kind == "attachment":
+                    scan_disk_id = resource.resource_id.split("|", 1)[-1]
+                    self.detach_scan_disk(target, scan_disk_id, collector_id)
+                elif resource.kind == "scan_disk":
+                    self.delete_scan_disk(target, resource.resource_id)
+                elif resource.kind == "snapshot":
+                    self.delete_snapshot(target, resource.resource_id)
+                else:
+                    raise ValueError(f"unknown temporary resource kind: {resource.kind}")
+            except Exception as exc:  # noqa: BLE001 - cleanup continues and persists a safe code
+                if _is_not_found(exc):
+                    self._save(
+                        self.execution.mark_resource_cleanup(
+                            resource.resource_id,
+                            status=TemporaryResourceStatus.DELETED,
+                        )
+                    )
+                    continue
+                code = f"cleanup_{resource.kind}_failed"
+                if code not in warning_codes:
+                    warning_codes.append(code)
+                self._save(
+                    self.execution.mark_resource_cleanup(
+                        resource.resource_id,
+                        status=TemporaryResourceStatus.CLEANUP_FAILED,
+                    )
+                )
+                continue
+            self._save(
+                self.execution.mark_resource_cleanup(
+                    resource.resource_id,
+                    status=TemporaryResourceStatus.DELETED,
+                )
+            )
+        if self.execution.cleanup_candidates():
+            self._save(
+                self.execution.transition(
+                    cleanup_status=CleanupStatus.PARTIAL,
+                    warning_codes=tuple(warning_codes),
+                )
+            )
+        else:
+            self._save(
+                self.execution.transition(
+                    phase="finished",
+                    cleanup_status=CleanupStatus.COMPLETE,
+                    warning_codes=tuple(warning_codes),
+                )
+            )
+        return self.execution
+
+    def detach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> None:
+        raise NotImplementedError
+
+    def delete_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str) -> None:
+        raise NotImplementedError
+
+    def delete_snapshot(self, target: CloudSideScanTarget, snapshot_id: str) -> None:
+        raise NotImplementedError
+
+
+class AzureManagedDiskLifecycleAdapter(_PersistedLifecycleAdapter):
+    """Azure Compute SDK adapter for snapshot/temp-disk/collector lifecycle."""
+
+    provider = "azure"
+
+    def __init__(
+        self,
+        *,
+        snapshots_client: Any,
+        disks_client: Any,
+        virtual_machines_client: Any,
+        execution: SideScanExecutionRecord | None,
+        state_store: SQLiteSideScanStateStore,
+        collector_resource_group: str,
+        collector_vm_name: str,
+        collector_lun: int = 63,
+        max_wait_attempts: int = 60,
+        wait_interval_seconds: float = 5.0,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        super().__init__(
+            execution=execution,
+            state_store=state_store,
+            max_wait_attempts=max_wait_attempts,
+            wait_interval_seconds=wait_interval_seconds,
+            sleep=sleep,
+        )
+        if not collector_resource_group.strip() or not collector_vm_name.strip():
+            raise ValueError("Azure collector resource group and VM name are required")
+        if collector_lun < 0 or collector_lun > 63:
+            raise ValueError("Azure collector LUN must be between 0 and 63")
+        self._snapshots = snapshots_client
+        self._disks = disks_client
+        self._vms = virtual_machines_client
+        self._collector_resource_group = collector_resource_group
+        self._collector_vm_name = collector_vm_name
+        self._collector_lun = collector_lun
+
+    def create_snapshot(self, target: CloudSideScanTarget) -> str:
+        self._validate_target(target)
+        self._ensure_running("snapshot")
+        resource_group = _azure_resource_group(target.target_id)
+        name = _resource_name(self.execution.cleanup_ownership.owner_id, "snapshot")
+        try:
+            existing = self._azure_get(self._snapshots, resource_group, name)
+            if existing is not None:
+                self._assert_owned(_tags(existing))
+                resource_id = _resource_id(existing)
+            else:
+                operation = self._snapshots.begin_create_or_update(
+                    resource_group,
+                    name,
+                    {
+                        "location": target.location,
+                        "tags": self.execution.cleanup_ownership.required_tags(),
+                        "creation_data": {"create_option": "Copy", "source_resource_id": target.target_id},
+                    },
+                )
+                resource_id = _resource_id(self._wait(operation))
+            self._register("snapshot", resource_id)
+            return resource_id
+        except Exception as exc:  # noqa: BLE001
+            self._raise_provider_error(exc)
+            raise AssertionError("unreachable")
+
+    def create_scan_disk(self, target: CloudSideScanTarget, snapshot_id: str) -> str:
+        self._validate_target(target)
+        self._ensure_running("temp_disk")
+        resource_group = _azure_resource_group(target.target_id)
+        name = _resource_name(self.execution.cleanup_ownership.owner_id, "disk")
+        try:
+            existing = self._azure_get(self._disks, resource_group, name)
+            if existing is not None:
+                self._assert_owned(_tags(existing))
+                resource_id = _resource_id(existing)
+            else:
+                operation = self._disks.begin_create_or_update(
+                    resource_group,
+                    name,
+                    {
+                        "location": target.location,
+                        "tags": self.execution.cleanup_ownership.required_tags(),
+                        "creation_data": {"create_option": "Copy", "source_resource_id": snapshot_id},
+                    },
+                )
+                resource_id = _resource_id(self._wait(operation))
+            self._register("scan_disk", resource_id)
+            return resource_id
+        except Exception as exc:  # noqa: BLE001
+            self._raise_provider_error(exc)
+            raise AssertionError("unreachable")
+
+    def attach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> str:
+        self._validate_target(target)
+        self._ensure_running("attached")
+        if collector_id != self.execution.collector_id or collector_id != self._collector_vm_name:
+            raise ValueError("collector is outside the persisted execution scope")
+        try:
+            vm = self._vms.get(self._collector_resource_group, self._collector_vm_name)
+            current = [_azure_disk_dict(item) for item in getattr(getattr(vm, "storage_profile", None), "data_disks", []) or []]
+            attached_ids = {str((item.get("managed_disk") or {}).get("id") or "") for item in current}
+            if scan_disk_id not in attached_ids:
+                if any(int(item.get("lun", -1)) == self._collector_lun for item in current):
+                    raise ValueError("configured Azure collector LUN is already occupied")
+                current.append(
+                    {
+                        "lun": self._collector_lun,
+                        "name": _resource_name(self.execution.cleanup_ownership.owner_id, "disk"),
+                        "create_option": "Attach",
+                        "managed_disk": {"id": scan_disk_id},
+                    }
+                )
+                self._wait(
+                    self._vms.begin_update(
+                        self._collector_resource_group,
+                        self._collector_vm_name,
+                        {"storage_profile": {"data_disks": current}},
+                    )
+                )
+            self._register("attachment", f"{collector_id}|{scan_disk_id}")
+            return f"/dev/disk/azure/scsi1/lun{self._collector_lun}"
+        except Exception as exc:  # noqa: BLE001
+            self._raise_provider_error(exc)
+            raise AssertionError("unreachable")
+
+    def detach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> None:
+        self._validate_target(target)
+        if collector_id != self.execution.collector_id:
+            raise ValueError("collector is outside the persisted execution scope")
+        vm = self._vms.get(self._collector_resource_group, self._collector_vm_name)
+        current = [_azure_disk_dict(item) for item in getattr(getattr(vm, "storage_profile", None), "data_disks", []) or []]
+        retained = [item for item in current if str((item.get("managed_disk") or {}).get("id") or "") != scan_disk_id]
+        if len(retained) == len(current):
+            return
+        self._wait(
+            self._vms.begin_update(
+                self._collector_resource_group,
+                self._collector_vm_name,
+                {"storage_profile": {"data_disks": retained}},
+            )
+        )
+
+    def delete_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str) -> None:
+        resource_group, name = _azure_group_and_name(scan_disk_id)
+        try:
+            self._wait(self._disks.begin_delete(resource_group, name))
+        except Exception as exc:
+            if not _is_not_found(exc):
+                raise
+
+    def delete_snapshot(self, target: CloudSideScanTarget, snapshot_id: str) -> None:
+        resource_group, name = _azure_group_and_name(snapshot_id)
+        try:
+            self._wait(self._snapshots.begin_delete(resource_group, name))
+        except Exception as exc:
+            if not _is_not_found(exc):
+                raise
+
+    def sweep_orphans(self, *, active_execution_ids: set[str]) -> list[str]:
+        """Delete only resources in this tenant/account scope not marked active."""
+        swept: list[str] = []
+        scope = self.execution.cleanup_ownership.scope_hash
+        for client, kind in ((self._disks, "disk"), (self._snapshots, "snapshot")):
+            for resource in list(client.list()):
+                tags = _tags(resource)
+                if not _orphan_candidate(tags, scope=scope, active_execution_ids=active_execution_ids):
+                    continue
+                resource_id = _resource_id(resource)
+                resource_group, name = _azure_group_and_name(resource_id)
+                try:
+                    if kind == "disk":
+                        self.detach_scan_disk(_target_for_execution(self.execution), resource_id, self.execution.collector_id)
+                    self._wait(client.begin_delete(resource_group, name))
+                    swept.append(name)
+                except Exception as exc:  # noqa: BLE001
+                    if not _is_not_found(exc):
+                        continue
+        return swept
+
+    @staticmethod
+    def _azure_get(client: Any, resource_group: str, name: str) -> Any | None:
+        try:
+            return client.get(resource_group, name)
+        except Exception as exc:
+            if _is_not_found(exc):
+                return None
+            raise
+
+    def _assert_owned(self, tags: Mapping[str, str]) -> None:
+        if not self.execution.cleanup_ownership.owns(tags):
+            raise SideScanOwnershipError("deterministic Azure resource name is not owned by this execution")
+
+
+class GcpPersistentDiskLifecycleAdapter(_PersistedLifecycleAdapter):
+    """Google Compute Engine SDK adapter for snapshot/temp-disk lifecycle."""
+
+    provider = "gcp"
+
+    def __init__(
+        self,
+        *,
+        snapshots_client: Any,
+        disks_client: Any,
+        instances_client: Any,
+        execution: SideScanExecutionRecord | None,
+        state_store: SQLiteSideScanStateStore,
+        project_id: str,
+        collector_zone: str,
+        collector_instance: str,
+        max_wait_attempts: int = 60,
+        wait_interval_seconds: float = 5.0,
+        sleep: Callable[[float], None] = time.sleep,
+    ) -> None:
+        super().__init__(
+            execution=execution,
+            state_store=state_store,
+            max_wait_attempts=max_wait_attempts,
+            wait_interval_seconds=wait_interval_seconds,
+            sleep=sleep,
+        )
+        if execution is not None and execution.account_id != project_id:
+            raise ValueError("GCP project does not match persisted execution scope")
+        if not project_id.strip() or not collector_zone.strip() or not collector_instance.strip():
+            raise ValueError("GCP project, collector zone, and collector instance are required")
+        self._snapshots = snapshots_client
+        self._disks = disks_client
+        self._instances = instances_client
+        self._project = project_id
+        self._collector_zone = collector_zone
+        self._collector_instance = collector_instance
+        self._device_name = _resource_name(self.execution.cleanup_ownership.owner_id, "disk")
+
+    def create_snapshot(self, target: CloudSideScanTarget) -> str:
+        self._validate_target(target)
+        self._ensure_running("snapshot")
+        name = _resource_name(self.execution.cleanup_ownership.owner_id, "snapshot")
+        try:
+            existing = self._gcp_get(self._snapshots, {"project": self._project, "snapshot": name})
+            if existing is not None:
+                self._assert_owned(_labels(existing))
+                resource_id = _resource_id(existing)
+            else:
+                operation = self._snapshots.insert(
+                    request={
+                        "project": self._project,
+                        "snapshot_resource": {
+                            "name": name,
+                            "source_disk": target.target_id,
+                            "labels": self.execution.cleanup_ownership.required_tags(),
+                        },
+                    }
+                )
+                self._wait(operation)
+                created = self._gcp_get(self._snapshots, {"project": self._project, "snapshot": name})
+                if created is None:
+                    raise RuntimeError("created GCP snapshot could not be read back")
+                resource_id = _resource_id(created)
+            self._register("snapshot", resource_id)
+            return resource_id
+        except Exception as exc:  # noqa: BLE001
+            self._raise_provider_error(exc)
+            raise AssertionError("unreachable")
+
+    def create_scan_disk(self, target: CloudSideScanTarget, snapshot_id: str) -> str:
+        self._validate_target(target)
+        self._ensure_running("temp_disk")
+        name = _resource_name(self.execution.cleanup_ownership.owner_id, "disk")
+        try:
+            existing = self._gcp_get(
+                self._disks,
+                {"project": self._project, "zone": target.location, "disk": name},
+            )
+            if existing is not None:
+                self._assert_owned(_labels(existing))
+                resource_id = _resource_id(existing)
+            else:
+                operation = self._disks.insert(
+                    request={
+                        "project": self._project,
+                        "zone": target.location,
+                        "disk_resource": {
+                            "name": name,
+                            "source_snapshot": snapshot_id,
+                            "labels": self.execution.cleanup_ownership.required_tags(),
+                        },
+                    }
+                )
+                self._wait(operation)
+                created = self._gcp_get(
+                    self._disks,
+                    {"project": self._project, "zone": target.location, "disk": name},
+                )
+                if created is None:
+                    raise RuntimeError("created GCP disk could not be read back")
+                resource_id = _resource_id(created)
+            self._register("scan_disk", resource_id)
+            return resource_id
+        except Exception as exc:  # noqa: BLE001
+            self._raise_provider_error(exc)
+            raise AssertionError("unreachable")
+
+    def attach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> str:
+        self._validate_target(target)
+        self._ensure_running("attached")
+        if collector_id != self.execution.collector_id or collector_id != self._collector_instance:
+            raise ValueError("collector is outside the persisted execution scope")
+        try:
+            self._wait(
+                self._instances.attach_disk(
+                    request={
+                        "project": self._project,
+                        "zone": self._collector_zone,
+                        "instance": self._collector_instance,
+                        "attached_disk_resource": {
+                            "source": scan_disk_id,
+                            "device_name": self._device_name,
+                            "mode": "READ_ONLY",
+                            "auto_delete": False,
+                        },
+                    }
+                )
+            )
+            self._register("attachment", f"{collector_id}|{scan_disk_id}")
+            return f"/dev/disk/by-id/google-{self._device_name}"
+        except Exception as exc:  # noqa: BLE001
+            if _is_conflict(exc):
+                self._register("attachment", f"{collector_id}|{scan_disk_id}")
+                return f"/dev/disk/by-id/google-{self._device_name}"
+            self._raise_provider_error(exc)
+            raise AssertionError("unreachable")
+
+    def detach_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str, collector_id: str) -> None:
+        self._validate_target(target)
+        if collector_id != self.execution.collector_id:
+            raise ValueError("collector is outside the persisted execution scope")
+        try:
+            self._wait(
+                self._instances.detach_disk(
+                    request={
+                        "project": self._project,
+                        "zone": self._collector_zone,
+                        "instance": self._collector_instance,
+                        "device_name": self._device_name,
+                    }
+                )
+            )
+        except Exception as exc:
+            if not _is_not_found(exc):
+                raise
+
+    def delete_scan_disk(self, target: CloudSideScanTarget, scan_disk_id: str) -> None:
+        name = scan_disk_id.rsplit("/", 1)[-1]
+        zone = _gcp_zone(scan_disk_id) or target.location
+        try:
+            self._wait(self._disks.delete(request={"project": self._project, "zone": zone, "disk": name}))
+        except Exception as exc:
+            if not _is_not_found(exc):
+                raise
+
+    def delete_snapshot(self, target: CloudSideScanTarget, snapshot_id: str) -> None:
+        name = snapshot_id.rsplit("/", 1)[-1]
+        try:
+            self._wait(self._snapshots.delete(request={"project": self._project, "snapshot": name}))
+        except Exception as exc:
+            if not _is_not_found(exc):
+                raise
+
+    def sweep_orphans(self, *, active_execution_ids: set[str]) -> list[str]:
+        """Delete only labels matching this tenant/project scope."""
+        swept: list[str] = []
+        scope = self.execution.cleanup_ownership.scope_hash
+        resources: tuple[tuple[Any, str, dict[str, str]], ...] = (
+            (self._disks, "disk", {"project": self._project, "zone": _gcp_zone(self.execution.target_id) or self._collector_zone}),
+            (self._snapshots, "snapshot", {"project": self._project}),
+        )
+        target = _target_for_execution(self.execution)
+        for client, kind, request in resources:
+            for resource in list(client.list(request=request)):
+                labels = _labels(resource)
+                if not _orphan_candidate(labels, scope=scope, active_execution_ids=active_execution_ids):
+                    continue
+                resource_id = _resource_id(resource)
+                name = resource_id.rsplit("/", 1)[-1]
+                try:
+                    if kind == "disk":
+                        self.detach_scan_disk(target, resource_id, self.execution.collector_id)
+                        self._wait(client.delete(request={**request, "disk": name}))
+                    else:
+                        self._wait(client.delete(request={**request, "snapshot": name}))
+                    swept.append(name)
+                except Exception as exc:  # noqa: BLE001
+                    if not _is_not_found(exc):
+                        continue
+        return swept
+
+    @staticmethod
+    def _gcp_get(client: Any, request: dict[str, str]) -> Any | None:
+        try:
+            return client.get(request=request)
+        except Exception as exc:
+            if _is_not_found(exc):
+                return None
+            raise
+
+    def _assert_owned(self, labels: Mapping[str, str]) -> None:
+        if not self.execution.cleanup_ownership.owns(labels):
+            raise SideScanOwnershipError("deterministic GCP resource name is not owned by this execution")
+
+
+def _resource_name(owner_id: str, suffix: str) -> str:
+    return f"abom-{owner_id}-{suffix}"[:63]
+
+
+def _resource_id(resource: Any) -> str:
+    if isinstance(resource, Mapping):
+        value = resource.get("self_link") or resource.get("selfLink") or resource.get("id") or resource.get("name")
+    else:
+        value = getattr(resource, "id", None) or getattr(resource, "self_link", None) or getattr(resource, "name", None)
+    result = str(value or "").strip()
+    if not result:
+        raise RuntimeError("provider operation returned no resource id")
+    return result
+
+
+def _tags(resource: Any) -> dict[str, str]:
+    raw = resource.get("tags") if isinstance(resource, Mapping) else getattr(resource, "tags", None)
+    return {str(key): str(value) for key, value in raw.items()} if isinstance(raw, Mapping) else {}
+
+
+def _labels(resource: Any) -> dict[str, str]:
+    raw = resource.get("labels") if isinstance(resource, Mapping) else getattr(resource, "labels", None)
+    return {str(key): str(value) for key, value in raw.items()} if isinstance(raw, Mapping) else {}
+
+
+def _azure_resource_group(resource_id: str) -> str:
+    parts = [part for part in resource_id.split("/") if part]
+    try:
+        return parts[parts.index("resourceGroups") + 1]
+    except (ValueError, IndexError) as exc:
+        raise ValueError("Azure target id is missing a resource group") from exc
+
+
+def _azure_group_and_name(resource_id: str) -> tuple[str, str]:
+    return _azure_resource_group(resource_id), resource_id.rstrip("/").rsplit("/", 1)[-1]
+
+
+def _azure_disk_dict(item: Any) -> dict[str, Any]:
+    if isinstance(item, Mapping):
+        return dict(item)
+    managed = getattr(item, "managed_disk", None)
+    managed_id = managed.get("id") if isinstance(managed, Mapping) else getattr(managed, "id", None)
+    return {
+        "lun": getattr(item, "lun", None),
+        "name": getattr(item, "name", ""),
+        "create_option": getattr(item, "create_option", "Attach"),
+        "managed_disk": {"id": str(managed_id or "")},
+    }
+
+
+def _gcp_zone(resource_id: str) -> str:
+    parts = [part for part in resource_id.split("/") if part]
+    try:
+        return parts[parts.index("zones") + 1]
+    except (ValueError, IndexError):
+        return ""
+
+
+def _target_for_execution(execution: SideScanExecutionRecord) -> CloudSideScanTarget:
+    return CloudSideScanTarget(
+        provider=execution.provider,
+        target_type="managed_disk" if execution.provider == "azure" else "persistent_disk",
+        target_id=execution.target_id,
+        name=execution.target_id.rstrip("/").rsplit("/", 1)[-1],
+        account_id=execution.account_id,
+        location=_gcp_zone(execution.target_id),
+        size_gb=None,
+        encryption="unknown",
+    )
+
+
+def _orphan_candidate(tags: Mapping[str, str], *, scope: str, active_execution_ids: set[str]) -> bool:
+    return (
+        tags.get("agent-bom-sidescan") == "true"
+        and tags.get("agent-bom-sidescan-scope") == scope
+        and bool(tags.get("agent-bom-sidescan-owner"))
+        and tags.get("agent-bom-sidescan-execution") not in active_execution_ids
+    )
+
+
+def _status_code(exc: Exception) -> int | None:
+    raw = getattr(exc, "status_code", None)
+    if isinstance(raw, int):
+        return raw
+    code = getattr(exc, "code", None)
+    if callable(code):
+        code = code()
+    if isinstance(code, int):
+        return code
+    value = getattr(code, "value", None)
+    return int(value) if isinstance(value, int) else None
+
+
+def _is_denied(exc: Exception) -> bool:
+    return _status_code(exc) in {401, 403}
+
+
+def _is_not_found(exc: Exception) -> bool:
+    return _status_code(exc) == 404
+
+
+def _is_conflict(exc: Exception) -> bool:
+    return _status_code(exc) in {409, 412}
+
+
+def sanitized_provider_error(exc: Exception) -> str:
+    """Expose a sanitized diagnostic for logs without changing state codes."""
+    return sanitize_text(exc)

--- a/src/agent_bom/cloud/side_scan_targets.py
+++ b/src/agent_bom/cloud/side_scan_targets.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Literal, Protocol, cast
+from typing import Any, Protocol, cast
 
 from agent_bom.filesystem import scan_disk_path_native
 from agent_bom.models import Package
@@ -26,8 +26,9 @@ from .side_scan import (
     is_sidescan_enabled,
     scan_workload_disk_findings,
 )
+from .side_scan_lifecycle import SideScanProvider
 
-CloudSideScanProvider = Literal["aws", "azure", "gcp"]
+CloudSideScanProvider = SideScanProvider
 
 
 @dataclass(frozen=True)
@@ -64,7 +65,11 @@ class CloudSideScanTarget:
 
 @dataclass
 class CloudSideScanExecutionResult:
-    """Metadata-only side-scan result for Azure/GCP disk targets."""
+    """Metadata-only result returned by the fixture-tested adapter runner.
+
+    No production Azure or GCP lifecycle adapter currently ships. Durable
+    execution/evidence state belongs to :mod:`side_scan_lifecycle`.
+    """
 
     provider: CloudSideScanProvider
     target_type: str
@@ -187,12 +192,12 @@ async def run_cloud_side_scan_targets(
     scan_secrets_enabled: bool = True,
     max_targets: int = 10,
 ) -> list[CloudSideScanExecutionResult]:
-    """Run Azure/GCP snapshot side-scans through provider lifecycle adapters.
+    """Run Azure/GCP snapshot side-scans through caller-supplied adapters.
 
     The runner is opt-in, bounded, and metadata-only. Provider SDK calls stay
-    behind ``CloudSideScanLifecycle`` so production integrations can wrap Azure
-    Managed Disk or GCP Persistent Disk APIs while unit tests prove lifecycle and
-    cleanup behavior without real cloud credentials.
+    behind ``CloudSideScanLifecycle``. The repository uses fake adapters to
+    prove lifecycle shape and cleanup behavior; it does not ship production
+    Azure Managed Disk or GCP Persistent Disk executors or credentials.
     """
 
     if not is_sidescan_enabled():

--- a/src/agent_bom/cloud/side_scan_targets.py
+++ b/src/agent_bom/cloud/side_scan_targets.py
@@ -1,9 +1,9 @@
-"""Provider-neutral agentless workload side-scan target metadata.
+"""Provider-neutral agentless workload side-scan targets and runner.
 
-This module does not execute snapshot lifecycle actions. It projects already
-discovered disk inventory into a shared contract that the side-scan executor can
-consume later. The output is metadata-only and safe to include in normal
-read-only inventory scans.
+Inventory projection is metadata-only and safe in normal read-only scans. The
+separate runner executes snapshot lifecycle actions only after the operator
+opts in and supplies provider adapters, collector configuration, and scoped
+mutation credentials.
 """
 
 from __future__ import annotations
@@ -67,8 +67,8 @@ class CloudSideScanTarget:
 class CloudSideScanExecutionResult:
     """Metadata-only result returned by the fixture-tested adapter runner.
 
-    No production Azure or GCP lifecycle adapter currently ships. Durable
-    execution/evidence state belongs to :mod:`side_scan_lifecycle`.
+    Azure/GCP injected-SDK adapters live in :mod:`side_scan_provider_adapters`;
+    durable execution/evidence state belongs to :mod:`side_scan_lifecycle`.
     """
 
     provider: CloudSideScanProvider
@@ -195,9 +195,9 @@ async def run_cloud_side_scan_targets(
     """Run Azure/GCP snapshot side-scans through caller-supplied adapters.
 
     The runner is opt-in, bounded, and metadata-only. Provider SDK calls stay
-    behind ``CloudSideScanLifecycle``. The repository uses fake adapters to
-    prove lifecycle shape and cleanup behavior; it does not ship production
-    Azure Managed Disk or GCP Persistent Disk executors or credentials.
+    behind ``CloudSideScanLifecycle``. Concrete Azure Managed Disk and GCP
+    Persistent Disk adapters accept injected SDK clients; credentials,
+    scheduler/CLI wiring, and live cloud proof are deliberately separate.
     """
 
     if not is_sidescan_enabled():
@@ -235,27 +235,52 @@ async def run_cloud_side_scan_targets(
             result.config_findings, result.ioc_findings = scan_workload_disk_findings(mount_point)
             if scan_secrets_enabled:
                 result.secrets = _redacted_secret_findings(mount_point)
+            mark_complete = getattr(lifecycle, "mark_scan_complete", None)
+            if callable(mark_complete):
+                mark_complete(
+                    package_count=len(result.packages),
+                    vulnerability_count=result.vulnerability_count,
+                    secret_count=len(result.secrets),
+                    config_finding_count=len(result.config_findings),
+                    ioc_finding_count=len(result.ioc_findings),
+                )
+        except Exception:
+            mark_failed = getattr(lifecycle, "mark_scan_failed", None)
+            if callable(mark_failed):
+                mark_failed(failure_code="scan_failed")
+            raise
         finally:
             if mount_point is not None:
                 try:
                     mount_controller.unmount(mount_point)
                 except Exception as exc:  # noqa: BLE001
                     result.warnings.append(f"unmount failed: {sanitize_text(exc)}")
-            if scan_disk_id:
+            persisted_cleanup = getattr(lifecycle, "cleanup", None)
+            if callable(persisted_cleanup):
                 try:
-                    lifecycle.detach_scan_disk(target, scan_disk_id, collector_id)
+                    execution = persisted_cleanup(target, collector_id)
+                    result.warnings.extend(str(code) for code in getattr(execution, "warning_codes", ()) if code)
+                    result.cleaned_up = getattr(getattr(execution, "cleanup_status", None), "value", "") == "complete"
                 except Exception as exc:  # noqa: BLE001
-                    result.warnings.append(f"detach disk failed: {sanitize_text(exc)}")
-                try:
-                    lifecycle.delete_scan_disk(target, scan_disk_id)
-                except Exception as exc:  # noqa: BLE001
-                    result.warnings.append(f"delete disk failed: {sanitize_text(exc)}")
-            if result.snapshot_id:
-                try:
-                    lifecycle.delete_snapshot(target, result.snapshot_id)
-                except Exception as exc:  # noqa: BLE001
-                    result.warnings.append(f"delete snapshot failed: {sanitize_text(exc)}")
-            result.cleaned_up = not result.warnings
+                    result.warnings.append(f"persisted cleanup failed: {sanitize_text(exc)}")
+            else:
+                if scan_disk_id:
+                    try:
+                        lifecycle.detach_scan_disk(target, scan_disk_id, collector_id)
+                    except Exception as exc:  # noqa: BLE001
+                        result.warnings.append(f"detach disk failed: {sanitize_text(exc)}")
+                    try:
+                        lifecycle.delete_scan_disk(target, scan_disk_id)
+                    except Exception as exc:  # noqa: BLE001
+                        result.warnings.append(f"delete disk failed: {sanitize_text(exc)}")
+                if result.snapshot_id:
+                    try:
+                        lifecycle.delete_snapshot(target, result.snapshot_id)
+                    except Exception as exc:  # noqa: BLE001
+                        result.warnings.append(f"delete snapshot failed: {sanitize_text(exc)}")
+                result.cleaned_up = not result.warnings
+            if result.warnings:
+                result.cleaned_up = False
         results.append(result)
     return results
 

--- a/tests/cloud/test_runtime_workload_evidence.py
+++ b/tests/cloud/test_runtime_workload_evidence.py
@@ -1,0 +1,324 @@
+"""Contract tests for the CWPP runtime/EDR workload-evidence subsystem (stage 3).
+
+Runtime evidence is optional, read-only, and ADDITIVE. These tests pin the
+non-negotiable honesty + security properties from issue #4158 stage 3:
+
+* ingest authenticates sources, records freshness/provenance, deduplicates, and
+  fails closed on a stale signal or an incomplete identity binding;
+* evidence enriches workloads/findings without fabricating reachability;
+* absence of a runtime signal is NEVER rendered as a clean workload;
+* tenant/account/subscription/project isolation holds in ingest, persistence,
+  and graph joins.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.cloud.runtime_workload_evidence import (
+    DEFAULT_MAX_SIGNAL_AGE_SECONDS,
+    RUNTIME_EVIDENCE_SCHEMA_VERSION,
+    STATE_HAS_IOC,
+    STATE_NO_SIGNAL,
+    STATE_OBSERVED,
+    IngestResult,
+    RuntimeEvidenceSource,
+    RuntimeSignalType,
+    RuntimeSourceRegistry,
+    RuntimeWorkloadEvidenceIndex,
+    RuntimeWorkloadSignal,
+    SourceAuthenticationError,
+    attach_workload_runtime_evidence_to_finding,
+    attach_workload_runtime_evidence_to_node,
+    canonical_workload_id,
+    ingest_runtime_signals,
+    no_runtime_signal_summary,
+)
+
+_T0 = "2026-07-18T12:00:00Z"
+
+
+def _source(secret: str = "s3cr3t-token-value") -> tuple[RuntimeSourceRegistry, RuntimeEvidenceSource, str]:
+    registry = RuntimeSourceRegistry()
+    src = RuntimeEvidenceSource.register(
+        source_id="edr-1",
+        tenant_id="tenant-a",
+        provider="aws",
+        account_id="123456789012",
+        kind="edr",
+        secret=secret,
+    )
+    registry.add(src)
+    return registry, src, secret
+
+
+def _raw(**over: object) -> dict[str, object]:
+    base: dict[str, object] = {
+        "workload_ref": "i-0abc",
+        "signal_type": "ioc_detection",
+        "severity": "high",
+        "observed_at": _T0,
+        "dedup_key": "evt-1",
+        "title": "known C2 domain contacted",
+        "evidence": {"ioc_type": "domain", "indicator_ref": "redacted:domain#7f3a"},
+    }
+    base.update(over)
+    return base
+
+
+# ── canonical identity ───────────────────────────────────────────────────────
+
+
+def test_canonical_workload_id_is_deterministic_and_scope_bound():
+    a = canonical_workload_id("aws", "123456789012", "i-0abc")
+    assert a == canonical_workload_id("aws", "123456789012", "i-0abc")
+    assert a != canonical_workload_id("aws", "999999999999", "i-0abc")
+    assert a != canonical_workload_id("azure", "123456789012", "i-0abc")
+
+
+# ── source authentication ────────────────────────────────────────────────────
+
+
+def test_ingest_rejects_unknown_source():
+    registry, _src, secret = _source()
+    with pytest.raises(SourceAuthenticationError):
+        ingest_runtime_signals(registry=registry, source_id="ghost", secret=secret, raw_signals=[_raw()])
+
+
+def test_ingest_rejects_wrong_secret():
+    registry, _src, _secret = _source()
+    with pytest.raises(SourceAuthenticationError):
+        ingest_runtime_signals(registry=registry, source_id="edr-1", secret="wrong", raw_signals=[_raw()])
+
+
+def test_source_authenticate_is_constant_time_hash_not_plaintext():
+    _registry, src, secret = _source()
+    assert src.authenticate(secret) is True
+    assert src.authenticate("nope") is False
+    # the shared secret is never stored in the clear
+    assert secret not in src.secret_hash
+    assert len(src.secret_hash) == 64
+
+
+# ── identity binding: fail closed ────────────────────────────────────────────
+
+
+def test_ingest_binds_identity_from_source_not_from_client_claim():
+    registry, _src, secret = _source()
+    # a spoofed account/provider on the raw signal must not steer persistence
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(provider="gcp", account_id="000000000000")],
+        now=_T0,
+    )
+    assert result.rejected_incomplete == 1
+    assert not result.accepted
+
+
+def test_ingest_fails_closed_on_missing_workload_ref():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(workload_ref="")],
+        now=_T0,
+    )
+    assert result.rejected_incomplete == 1
+    assert not result.accepted
+
+
+# ── freshness: fail closed on stale ──────────────────────────────────────────
+
+
+def test_ingest_rejects_stale_signal():
+    registry, _src, secret = _source()
+    now = "2026-07-18T13:30:00Z"  # 90 min after observed_at, window is 60 min
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw()],
+        now=now,
+        max_age_seconds=DEFAULT_MAX_SIGNAL_AGE_SECONDS,
+    )
+    assert result.rejected_stale == 1
+    assert not result.accepted
+
+
+def test_ingest_rejects_unparseable_timestamp_as_incomplete():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(observed_at="not-a-time")],
+        now=_T0,
+    )
+    assert result.accepted == []
+    assert result.rejected_incomplete == 1
+
+
+# ── dedup + provenance/freshness recorded ────────────────────────────────────
+
+
+def test_ingest_deduplicates_within_and_across_batches():
+    registry, _src, secret = _source()
+    r1 = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw(), _raw()], now=_T0)
+    assert len(r1.accepted) == 1
+    assert r1.deduped == 1
+    seen = {sig.dedup_scope for sig in r1.accepted}
+    r2 = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw()], now=_T0, dedup_seen=seen)
+    assert r2.accepted == []
+    assert r2.deduped == 1
+
+
+def test_signal_records_provenance_and_freshness():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw()], now=_T0)
+    sig = result.accepted[0]
+    assert sig.source_id == "edr-1"
+    assert sig.source_kind == "edr"
+    assert sig.observed_at == _T0
+    assert sig.tenant_id == "tenant-a"
+    assert sig.provider == "aws"
+    assert sig.account_id == "123456789012"
+    ev = sig.to_evidence_dict()
+    assert ev["schema_version"] == RUNTIME_EVIDENCE_SCHEMA_VERSION
+    assert ev["clean_workload_assertion"] is False
+
+
+# ── redaction: no data-plane bytes persisted ─────────────────────────────────
+
+
+def test_signal_redacts_oversized_and_forbidden_evidence():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[
+            _raw(
+                evidence={
+                    "ioc_type": "hash",
+                    "raw_bytes": "A" * 100000,
+                    "file_contents": "SECRET DATA",
+                    "indicator_ref": "redacted:sha256#abcd",
+                }
+            )
+        ],
+        now=_T0,
+    )
+    sig = result.accepted[0]
+    dumped = str(sig.to_dict())
+    assert "SECRET DATA" not in dumped
+    assert "A" * 1000 not in dumped
+    assert "raw_bytes" not in sig.evidence
+    assert "file_contents" not in sig.evidence
+    assert sig.evidence.get("ioc_type") == "hash"
+
+
+# ── honesty: absence of signal is NOT clean ──────────────────────────────────
+
+
+def test_no_runtime_signal_summary_never_asserts_clean():
+    summary = no_runtime_signal_summary()
+    assert summary["state"] == STATE_NO_SIGNAL
+    assert summary["clean_workload_assertion"] is False
+    assert summary["signal_count"] == 0
+    # the note must communicate additivity, never cleanliness
+    assert "clean" in summary["note"].lower()
+
+
+def test_finding_with_no_matching_runtime_evidence_is_marked_no_signal_not_clean():
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [])
+    row = {"provider": "aws", "account_ref": "aws:123456789012", "resource_id": "i-0abc", "cve_id": "CVE-2026-1"}
+    attach_workload_runtime_evidence_to_finding(row, index)
+    ev = row["workload_runtime_evidence"]
+    assert ev["state"] == STATE_NO_SIGNAL
+    assert ev["clean_workload_assertion"] is False
+
+
+def test_finding_without_workload_identity_is_left_untouched():
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [])
+    row = {"cve_id": "CVE-2026-2"}  # no workload scope resolvable
+    attach_workload_runtime_evidence_to_finding(row, index)
+    assert "workload_runtime_evidence" not in row
+
+
+# ── enrichment: additive, no fabricated reachability ─────────────────────────
+
+
+def _signal(**over: object) -> RuntimeWorkloadSignal:
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw(**over)], now=_T0)
+    return result.accepted[0]
+
+
+def test_finding_enrichment_attaches_ioc_state_and_counts():
+    sig = _signal()
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [sig])
+    row = {"provider": "aws", "account_ref": "aws:123456789012", "resource_id": "i-0abc"}
+    attach_workload_runtime_evidence_to_finding(row, index)
+    ev = row["workload_runtime_evidence"]
+    assert ev["state"] == STATE_HAS_IOC
+    assert ev["signal_count"] == 1
+    assert ev["clean_workload_assertion"] is False
+    # enrichment never invents a reachability verdict
+    assert "reachable" not in ev
+    assert "effective_reach" not in row
+
+
+def test_process_exec_signal_yields_observed_state_not_ioc():
+    sig = _signal(signal_type="process_exec", severity="info", dedup_key="p-1", title="sshd started")
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [sig])
+    row = {"provider": "aws", "account_ref": "aws:123456789012", "resource_id": "i-0abc"}
+    attach_workload_runtime_evidence_to_finding(row, index)
+    assert row["workload_runtime_evidence"]["state"] == STATE_OBSERVED
+
+
+def test_node_enrichment_matches_workload_and_never_adds_reachability():
+    sig = _signal()
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [sig])
+    node = {
+        "entity_type": "cloud_resource",
+        "attributes": {
+            "resource_type": "workload_disk",
+            "cloud_provider": "aws",
+            "account_id": "123456789012",
+            "resource_id": "i-0abc",
+        },
+    }
+    changed = attach_workload_runtime_evidence_to_node(node, index)
+    assert changed is True
+    assert node["attributes"]["runtime_evidence"]["state"] == STATE_HAS_IOC
+    assert node["attributes"]["runtime_evidence"]["clean_workload_assertion"] is False
+
+
+# ── tenant isolation in the enrichment index ─────────────────────────────────
+
+
+def test_index_never_leaks_signals_across_tenants():
+    sig = _signal()  # tenant-a
+    # An index built for tenant-b must not include tenant-a's signal.
+    index_b = RuntimeWorkloadEvidenceIndex.from_signals("tenant-b", [sig])
+    row = {"provider": "aws", "account_ref": "aws:123456789012", "resource_id": "i-0abc"}
+    attach_workload_runtime_evidence_to_finding(row, index_b)
+    assert row["workload_runtime_evidence"]["state"] == STATE_NO_SIGNAL
+
+
+def test_signal_type_enum_is_bounded():
+    assert RuntimeSignalType("ioc_detection") is RuntimeSignalType.IOC_DETECTION
+    with pytest.raises(ValueError):
+        RuntimeSignalType("made_up")
+
+
+def test_ingest_result_summary_is_serializable_and_non_secret():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(registry=registry, source_id="edr-1", secret=secret, raw_signals=[_raw()], now=_T0)
+    assert isinstance(result, IngestResult)
+    summary = result.to_dict()
+    assert summary["accepted"] == 1
+    assert secret not in str(summary)

--- a/tests/cloud/test_runtime_workload_evidence_graph.py
+++ b/tests/cloud/test_runtime_workload_evidence_graph.py
@@ -1,0 +1,90 @@
+"""Graph-join enrichment for CWPP runtime workload evidence (#4158 stage 3).
+
+The enrichment annotates a workload node's attributes with additive runtime
+evidence. It must NEVER add an edge (reachability stays edge-derived) and must
+refuse to cross the tenant boundary in the graph join.
+"""
+
+from __future__ import annotations
+
+from agent_bom.cloud.runtime_workload_evidence import (
+    STATE_HAS_IOC,
+    RuntimeWorkloadEvidenceIndex,
+    RuntimeWorkloadSignal,
+    enrich_graph_workload_runtime_evidence,
+)
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.types import EntityType
+
+
+def _signal(tenant: str = "tenant-a") -> RuntimeWorkloadSignal:
+    return RuntimeWorkloadSignal(
+        tenant_id=tenant,
+        provider="aws",
+        account_id="123456789012",
+        workload_ref="i-0abc",
+        signal_type="ioc_detection",  # type: ignore[arg-type]
+        severity="high",
+        observed_at="2026-07-18T12:00:00Z",
+        source_id="edr-1",
+        source_kind="edr",
+        dedup_key="evt-1",
+        title="known C2",
+        evidence={"ioc_type": "domain"},
+    )
+
+
+def _workload_graph(tenant: str = "tenant-a") -> UnifiedGraph:
+    graph = UnifiedGraph(tenant_id=tenant)
+    # Mirrors the builder's CWPP side-scan target node (builder.py ~4445).
+    graph.add_node(
+        UnifiedNode(
+            id="cloud_resource:aws:cwpp:managed_disk:i-0abc",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="managed_disk: i-0abc",
+            attributes={
+                "resource_id": "i-0abc",
+                "resource_type": "workload_disk",
+                "resource_kind": "managed_disk",
+                "cloud_provider": "aws",
+                "cloud_service": "cwpp-side-scan",
+                "account_id": "123456789012",
+            },
+            dimensions=NodeDimensions(cloud_provider="aws", surface="cwpp"),
+        )
+    )
+    return graph
+
+
+def test_graph_enrichment_annotates_workload_node_without_new_edges():
+    graph = _workload_graph()
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [_signal()])
+    edges_before = len(graph.edges)
+    count = enrich_graph_workload_runtime_evidence(graph, index)
+    assert count == 1
+    node = graph.nodes["cloud_resource:aws:cwpp:managed_disk:i-0abc"]
+    ev = node.attributes["runtime_evidence"]
+    assert ev["state"] == STATE_HAS_IOC
+    assert ev["clean_workload_assertion"] is False
+    # reachability is never fabricated: no edges added
+    assert len(graph.edges) == edges_before
+
+
+def test_graph_enrichment_refuses_cross_tenant_join():
+    graph = _workload_graph(tenant="tenant-b")
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [_signal(tenant="tenant-a")])
+    count = enrich_graph_workload_runtime_evidence(graph, index)
+    assert count == 0
+    node = graph.nodes["cloud_resource:aws:cwpp:managed_disk:i-0abc"]
+    assert "runtime_evidence" not in node.attributes
+
+
+def test_graph_enrichment_marks_unmatched_workload_no_signal_not_clean():
+    graph = _workload_graph()
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [])  # no signals
+    count = enrich_graph_workload_runtime_evidence(graph, index)
+    assert count == 1
+    node = graph.nodes["cloud_resource:aws:cwpp:managed_disk:i-0abc"]
+    assert node.attributes["runtime_evidence"]["state"] == "no_runtime_signal"
+    assert node.attributes["runtime_evidence"]["clean_workload_assertion"] is False

--- a/tests/cloud/test_runtime_workload_evidence_store.py
+++ b/tests/cloud/test_runtime_workload_evidence_store.py
@@ -1,0 +1,178 @@
+"""Persistence + isolation tests for the runtime workload-evidence store.
+
+Covers both backends: SQLite (restart-safe, cross-process concurrency) and — when
+``AGENT_BOM_POSTGRES_URL`` is set — real Postgres (roundtrip, dedup, cross-tenant
+isolation, cross-process concurrency). Tenant isolation and dedup are the
+security-critical properties (issue #4158).
+"""
+
+from __future__ import annotations
+
+import multiprocessing as mp
+import os
+import uuid
+
+import pytest
+
+from agent_bom.cloud.runtime_workload_evidence import RuntimeWorkloadSignal
+from agent_bom.cloud.runtime_workload_evidence_store import (
+    InMemoryRuntimeWorkloadEvidenceStore,
+    PostgresRuntimeWorkloadEvidenceStore,
+    SQLiteRuntimeWorkloadEvidenceStore,
+)
+
+_PG_URL = os.environ.get("AGENT_BOM_POSTGRES_URL")
+_requires_pg = pytest.mark.skipif(not _PG_URL, reason="AGENT_BOM_POSTGRES_URL required for real Postgres tests")
+
+
+def _signal(
+    *,
+    tenant: str = "tenant-a",
+    provider: str = "aws",
+    account: str = "123456789012",
+    workload: str = "i-0abc",
+    dedup: str = "evt-1",
+    stype: str = "ioc_detection",
+    observed: str = "2026-07-18T12:00:00Z",
+) -> RuntimeWorkloadSignal:
+    return RuntimeWorkloadSignal(
+        tenant_id=tenant,
+        provider=provider,
+        account_id=account,
+        workload_ref=workload,
+        signal_type=stype,  # type: ignore[arg-type]
+        severity="high",
+        observed_at=observed,
+        source_id="edr-1",
+        source_kind="edr",
+        dedup_key=dedup,
+        title="known C2 domain contacted",
+        evidence={"ioc_type": "domain"},
+    )
+
+
+# ── in-memory (default backend) ──────────────────────────────────────────────
+
+
+def test_in_memory_put_batch_dedups_and_lists_by_tenant():
+    store = InMemoryRuntimeWorkloadEvidenceStore()
+    assert store.put_batch([_signal(), _signal()]) == 1
+    assert store.put_batch([_signal()]) == 0  # already persisted
+    rows = store.list_for_tenant("tenant-a")
+    assert len(rows) == 1
+    assert store.list_for_tenant("tenant-b") == []
+
+
+# ── SQLite: restart persistence + isolation + dedup ──────────────────────────
+
+
+def test_sqlite_persists_across_reopen(tmp_path):
+    path = str(tmp_path / "rwe.sqlite")
+    store = SQLiteRuntimeWorkloadEvidenceStore(path)
+    assert store.put_batch([_signal()]) == 1
+    reopened = SQLiteRuntimeWorkloadEvidenceStore(path)
+    rows = reopened.list_for_tenant("tenant-a")
+    assert len(rows) == 1
+    assert rows[0].workload_ref == "i-0abc"
+    assert rows[0].source_kind == "edr"
+
+
+def test_sqlite_cross_tenant_same_dedup_key_both_persist_no_leak(tmp_path):
+    path = str(tmp_path / "rwe.sqlite")
+    store = SQLiteRuntimeWorkloadEvidenceStore(path)
+    # Two tenants, IDENTICAL logical key (same account/workload/dedup_key).
+    store.put_batch([_signal(tenant="tenant-a")])
+    store.put_batch([_signal(tenant="tenant-b")])
+    a = store.list_for_tenant("tenant-a")
+    b = store.list_for_tenant("tenant-b")
+    assert len(a) == 1 and len(b) == 1  # neither dropped
+    assert a[0].tenant_id == "tenant-a"
+    assert b[0].tenant_id == "tenant-b"  # no cross-tenant leak
+
+
+def test_sqlite_dedup_within_tenant(tmp_path):
+    path = str(tmp_path / "rwe.sqlite")
+    store = SQLiteRuntimeWorkloadEvidenceStore(path)
+    assert store.put_batch([_signal(dedup="a"), _signal(dedup="a"), _signal(dedup="b")]) == 2
+
+
+def _writer(path: str, tenant: str, dedup_keys: list[str]) -> None:
+    store = SQLiteRuntimeWorkloadEvidenceStore(path)
+    for key in dedup_keys:
+        store.put_batch([_signal(tenant=tenant, dedup=key)])
+
+
+def test_sqlite_cross_process_writers_do_not_duplicate_or_corrupt(tmp_path):
+    path = str(tmp_path / "rwe.sqlite")
+    SQLiteRuntimeWorkloadEvidenceStore(path)  # create schema first
+    keys = [f"evt-{i}" for i in range(25)]
+    ctx = mp.get_context("spawn")
+    procs = [ctx.Process(target=_writer, args=(path, "tenant-a", keys)) for _ in range(3)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(30)
+        assert p.exitcode == 0
+    rows = SQLiteRuntimeWorkloadEvidenceStore(path).list_for_tenant("tenant-a", limit=1000)
+    # 3 processes each wrote the SAME 25 dedup keys -> exactly 25 unique rows.
+    assert len(rows) == 25
+    assert len({r.dedup_key for r in rows}) == 25
+
+
+# ── Postgres: real backend ───────────────────────────────────────────────────
+
+
+@pytest.fixture
+def pg_store():
+    assert _PG_URL
+    table = f"runtime_workload_evidence_test_{uuid.uuid4().hex[:8]}"
+    store = PostgresRuntimeWorkloadEvidenceStore(_PG_URL, table=table)
+    try:
+        yield store
+    finally:
+        store.drop_table()
+
+
+@_requires_pg
+def test_postgres_roundtrip_and_dedup(pg_store):
+    assert pg_store.put_batch([_signal(), _signal()]) == 1
+    assert pg_store.put_batch([_signal()]) == 0
+    rows = pg_store.list_for_tenant("tenant-a")
+    assert len(rows) == 1
+    assert rows[0].signal_type.value == "ioc_detection"
+    assert rows[0].evidence.get("ioc_type") == "domain"
+
+
+@_requires_pg
+def test_postgres_cross_tenant_same_key_both_persist_no_leak(pg_store):
+    pg_store.put_batch([_signal(tenant="tenant-a")])
+    pg_store.put_batch([_signal(tenant="tenant-b")])
+    a = pg_store.list_for_tenant("tenant-a")
+    b = pg_store.list_for_tenant("tenant-b")
+    assert len(a) == 1 and len(b) == 1
+    assert a[0].tenant_id == "tenant-a"
+    assert b[0].tenant_id == "tenant-b"
+    # a tenant-a query must never surface tenant-b rows
+    assert all(r.tenant_id == "tenant-a" for r in a)
+
+
+def _pg_writer(dsn: str, table: str, tenant: str, dedup_keys: list[str]) -> None:
+    store = PostgresRuntimeWorkloadEvidenceStore(dsn, table=table)
+    for key in dedup_keys:
+        store.put_batch([_signal(tenant=tenant, dedup=key)])
+
+
+@_requires_pg
+def test_postgres_cross_process_writers_do_not_duplicate(pg_store):
+    assert _PG_URL
+    keys = [f"evt-{i}" for i in range(20)]
+    ctx = mp.get_context("spawn")
+    procs = [ctx.Process(target=_pg_writer, args=(_PG_URL, pg_store.table, "tenant-a", keys)) for _ in range(3)]
+    for p in procs:
+        p.start()
+    for p in procs:
+        p.join(30)
+        assert p.exitcode == 0
+    rows = pg_store.list_for_tenant("tenant-a", limit=1000)
+    assert len(rows) == 20
+    assert len({r.dedup_key for r in rows}) == 20

--- a/tests/cloud/test_runtime_workload_evidence_wiring.py
+++ b/tests/cloud/test_runtime_workload_evidence_wiring.py
@@ -1,0 +1,137 @@
+"""Wiring test: CWPP workload runtime evidence surfaces in the findings read path.
+
+Proves the stage-3 enrichment is actually wired into ``_iter_scan_findings`` (the
+shared enricher behind ``GET /v1/findings``, overview, compliance, observability),
+that it is gated on real signals, and that absence never renders as clean.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.api.models import ScanJob, ScanRequest
+from agent_bom.api.routes.scan import _iter_scan_findings
+from agent_bom.cloud.runtime_workload_evidence import (
+    STATE_HAS_IOC,
+    STATE_NO_SIGNAL,
+    RuntimeEvidenceSource,
+    RuntimeSourceRegistry,
+    ingest_runtime_signals,
+)
+from agent_bom.cloud.runtime_workload_evidence_store import (
+    InMemoryRuntimeWorkloadEvidenceStore,
+    set_runtime_workload_evidence_store,
+)
+
+
+@pytest.fixture
+def clean_default_store():
+    set_runtime_workload_evidence_store(None)
+    try:
+        yield
+    finally:
+        set_runtime_workload_evidence_store(None)
+
+
+def _seed_store(tenant: str = "tenant-a") -> InMemoryRuntimeWorkloadEvidenceStore:
+    store = InMemoryRuntimeWorkloadEvidenceStore()
+    registry = RuntimeSourceRegistry()
+    src = RuntimeEvidenceSource.register(
+        source_id="edr-1",
+        tenant_id=tenant,
+        provider="aws",
+        account_id="123456789012",
+        kind="edr",
+        secret="s3cr3t-token-value",
+    )
+    registry.add(src)
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret="s3cr3t-token-value",
+        raw_signals=[
+            {
+                "workload_ref": "i-0abc",
+                "signal_type": "ioc_detection",
+                "severity": "high",
+                "observed_at": now,
+                "dedup_key": "evt-1",
+                "title": "known C2 contacted",
+                "evidence": {"ioc_type": "domain"},
+            }
+        ],
+        now=now,
+        store=store,
+    )
+    set_runtime_workload_evidence_store(store)
+    return store
+
+
+def _job_with_workload_finding(tenant: str = "tenant-a") -> ScanJob:
+    return ScanJob.model_construct(
+        job_id="job-1",
+        tenant_id=tenant,
+        request=ScanRequest(),
+        result={
+            "findings": [
+                {
+                    "id": "f1",
+                    "cve_id": "CVE-2026-1",
+                    "provider": "aws",
+                    "account_ref": "aws:123456789012",
+                    "resource_id": "i-0abc",
+                    "severity": "high",
+                }
+            ]
+        },
+    )
+
+
+def test_workload_finding_is_enriched_when_tenant_has_signals(clean_default_store):
+    _seed_store()
+    rows = _iter_scan_findings(_job_with_workload_finding())
+    assert len(rows) == 1
+    ev = rows[0]["workload_runtime_evidence"]
+    assert ev["state"] == STATE_HAS_IOC
+    assert ev["clean_workload_assertion"] is False
+
+
+def test_no_field_when_tenant_has_no_signals(clean_default_store):
+    # default store empty -> read path is a no-op, no field attached (silence, not clean)
+    rows = _iter_scan_findings(_job_with_workload_finding())
+    assert "workload_runtime_evidence" not in rows[0]
+
+
+def test_other_workload_marked_no_signal_not_clean(clean_default_store):
+    _seed_store()
+    job = ScanJob.model_construct(
+        job_id="job-2",
+        tenant_id="tenant-a",
+        request=ScanRequest(),
+        result={
+            "findings": [
+                {
+                    "id": "f2",
+                    "cve_id": "CVE-2026-2",
+                    "provider": "aws",
+                    "account_ref": "aws:123456789012",
+                    "resource_id": "i-DIFFERENT",  # no signal for this workload
+                    "severity": "high",
+                }
+            ]
+        },
+    )
+    rows = _iter_scan_findings(job)
+    ev = rows[0]["workload_runtime_evidence"]
+    assert ev["state"] == STATE_NO_SIGNAL
+    assert ev["clean_workload_assertion"] is False
+
+
+def test_cross_tenant_signals_do_not_enrich_other_tenant(clean_default_store):
+    _seed_store(tenant="tenant-a")
+    # a job for tenant-b must not see tenant-a's signals
+    rows = _iter_scan_findings(_job_with_workload_finding(tenant="tenant-b"))
+    assert "workload_runtime_evidence" not in rows[0]

--- a/tests/cloud/test_side_scan_lifecycle_contract.py
+++ b/tests/cloud/test_side_scan_lifecycle_contract.py
@@ -35,8 +35,8 @@ def test_provider_capabilities_do_not_claim_unshipped_executors() -> None:
 
     assert capabilities["aws"].executor == "shipped"
     assert capabilities["aws"].cli_available is True
-    assert capabilities["azure"].executor == "contract_only"
-    assert capabilities["gcp"].executor == "contract_only"
+    assert capabilities["azure"].executor == "shipped"
+    assert capabilities["gcp"].executor == "shipped"
     assert capabilities["azure"].cli_available is False
     assert capabilities["gcp"].cli_available is False
 

--- a/tests/cloud/test_side_scan_lifecycle_contract.py
+++ b/tests/cloud/test_side_scan_lifecycle_contract.py
@@ -1,0 +1,224 @@
+"""Contract tests for durable, provider-neutral side-scan lifecycle state."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.cloud.side_scan_lifecycle import (
+    CleanupStatus,
+    ExecutionStatus,
+    SideScanStateConflictError,
+    SideScanTemporaryResource,
+    SQLiteSideScanStateStore,
+    TemporaryResourceStatus,
+    new_side_scan_execution,
+    side_scan_provider_capabilities,
+)
+
+
+def _execution(*, tenant_id: str = "tenant-a", idempotency_key: str = "scan-request-1"):
+    return new_side_scan_execution(
+        tenant_id=tenant_id,
+        provider="azure",
+        account_id="subscription-1",
+        target_id="/subscriptions/subscription-1/disks/os-disk",
+        collector_id="collector-1",
+        idempotency_key=idempotency_key,
+        now="2026-07-17T20:00:00Z",
+    )
+
+
+def test_provider_capabilities_do_not_claim_unshipped_executors() -> None:
+    capabilities = side_scan_provider_capabilities()
+
+    assert capabilities["aws"].executor == "shipped"
+    assert capabilities["aws"].cli_available is True
+    assert capabilities["azure"].executor == "contract_only"
+    assert capabilities["gcp"].executor == "contract_only"
+    assert capabilities["azure"].cli_available is False
+    assert capabilities["gcp"].cli_available is False
+
+
+@pytest.mark.parametrize("status", [ExecutionStatus.DISABLED, ExecutionStatus.DENIED, ExecutionStatus.FAILED])
+def test_non_execution_states_are_unevaluable_not_clean(status: ExecutionStatus) -> None:
+    record = _execution().transition(status=status, phase="finished", now="2026-07-17T20:01:00Z")
+    evidence = record.to_evidence_dict()
+
+    assert evidence["schema_version"] == "agent-bom.cwpp.side_scan.evidence.v1"
+    assert evidence["execution_status"] == status.value
+    assert evidence["disposition"] == "unevaluable"
+    assert evidence["negative_result_scope"] == "unavailable"
+    assert evidence["clean_workload_assertion"] is False
+
+
+def test_scan_is_complete_only_after_cleanup_completes() -> None:
+    running = _execution().transition(
+        status=ExecutionStatus.RUNNING,
+        phase="scanning",
+        now="2026-07-17T20:00:30Z",
+    )
+    record = running.transition(
+        status=ExecutionStatus.SCAN_COMPLETE,
+        phase="cleanup",
+        cleanup_status=CleanupStatus.PENDING,
+        now="2026-07-17T20:01:00Z",
+    )
+
+    assert record.to_evidence_dict()["disposition"] == "partial"
+
+    cleaned = record.transition(
+        phase="finished",
+        cleanup_status=CleanupStatus.COMPLETE,
+        package_count=12,
+        vulnerability_count=2,
+        now="2026-07-17T20:02:00Z",
+    )
+    evidence = cleaned.to_evidence_dict()
+
+    assert evidence["disposition"] == "complete"
+    assert evidence["negative_result_scope"] == "scanned_disk_only"
+    assert evidence["package_count"] == 12
+    assert evidence["vulnerability_count"] == 2
+    assert evidence["clean_workload_assertion"] is False
+
+
+def test_cleanup_ownership_is_deterministic_and_scope_bound() -> None:
+    first = _execution()
+    duplicate = _execution()
+
+    assert first.execution_id == duplicate.execution_id
+    assert first.cleanup_ownership == duplicate.cleanup_ownership
+    tags = first.cleanup_ownership.required_tags()
+    assert first.cleanup_ownership.owns(tags)
+    assert not first.cleanup_ownership.owns({**tags, "agent-bom-sidescan-owner": "other"})
+    assert not first.cleanup_ownership.owns({"agent-bom-sidescan": "true"})
+
+
+def test_resource_registration_and_cleanup_are_retry_safe() -> None:
+    record = _execution()
+    snapshot = SideScanTemporaryResource(
+        kind="snapshot",
+        resource_id="snap-1",
+        status=TemporaryResourceStatus.CREATED,
+        ownership_tags=record.cleanup_ownership.required_tags(),
+    )
+
+    registered = record.register_resource(snapshot, now="2026-07-17T20:01:00Z")
+    assert registered.register_resource(snapshot, now="2026-07-17T20:02:00Z") == registered
+    assert registered.cleanup_candidates() == (snapshot,)
+
+    wrong_owner = SideScanTemporaryResource(
+        kind="disk",
+        resource_id="disk-foreign",
+        status=TemporaryResourceStatus.CREATED,
+        ownership_tags={"agent-bom-sidescan": "true", "agent-bom-sidescan-owner": "foreign"},
+    )
+    with pytest.raises(ValueError, match="cleanup ownership"):
+        registered.register_resource(wrong_owner, now="2026-07-17T20:02:00Z")
+
+    deleted = registered.mark_resource_cleanup(
+        "snap-1",
+        status=TemporaryResourceStatus.DELETED,
+        now="2026-07-17T20:03:00Z",
+    )
+    assert deleted.cleanup_candidates() == ()
+    assert deleted.mark_resource_cleanup(
+        "snap-1",
+        status=TemporaryResourceStatus.DELETED,
+        now="2026-07-17T20:04:00Z",
+    ) == deleted
+    with pytest.raises(ValueError, match="invalid resource cleanup transition"):
+        deleted.mark_resource_cleanup(
+            "snap-1",
+            status=TemporaryResourceStatus.CLEANUP_FAILED,
+            now="2026-07-17T20:05:00Z",
+        )
+
+
+def test_cleanup_cannot_complete_while_owned_resource_remains() -> None:
+    record = _execution()
+    snapshot = SideScanTemporaryResource(
+        kind="snapshot",
+        resource_id="snap-1",
+        status=TemporaryResourceStatus.CREATED,
+        ownership_tags=record.cleanup_ownership.required_tags(),
+    )
+    registered = record.register_resource(snapshot, now="2026-07-17T20:01:00Z")
+
+    with pytest.raises(ValueError, match="temporary resources remain"):
+        registered.transition(
+            cleanup_status=CleanupStatus.COMPLETE,
+            now="2026-07-17T20:02:00Z",
+        )
+
+
+def test_sqlite_store_survives_restart_and_deduplicates_jobs(tmp_path: Path) -> None:
+    db_path = tmp_path / "side-scan-state.db"
+    record = _execution()
+    store = SQLiteSideScanStateStore(db_path)
+
+    assert store.create_or_get(record) == record
+    assert store.create_or_get(_execution()) == record
+
+    restarted = SQLiteSideScanStateStore(db_path)
+    assert restarted.get(tenant_id="tenant-a", execution_id=record.execution_id) == record
+    assert restarted.get(tenant_id="tenant-b", execution_id=record.execution_id) is None
+
+    other_tenant = _execution(tenant_id="tenant-b")
+    assert restarted.create_or_get(other_tenant).execution_id != record.execution_id
+
+
+def test_sqlite_store_rejects_stale_worker_update(tmp_path: Path) -> None:
+    store = SQLiteSideScanStateStore(tmp_path / "side-scan-state.db")
+    original = store.create_or_get(_execution())
+    running = original.transition(status=ExecutionStatus.RUNNING, phase="snapshot", now="2026-07-17T20:01:00Z")
+    store.save(running, expected_version=original.state_version)
+
+    stale = original.transition(status=ExecutionStatus.DENIED, phase="finished", now="2026-07-17T20:02:00Z")
+    with pytest.raises(SideScanStateConflictError):
+        store.save(stale, expected_version=original.state_version)
+
+
+def test_sqlite_store_returns_only_tenant_scoped_cleanup_retries(tmp_path: Path) -> None:
+    store = SQLiteSideScanStateStore(tmp_path / "side-scan-state.db")
+    original = store.create_or_get(_execution())
+    pending = original.transition(
+        status=ExecutionStatus.FAILED,
+        phase="cleanup",
+        cleanup_status=CleanupStatus.PENDING,
+        failure_code="mount_failed",
+        now="2026-07-17T20:01:00Z",
+    )
+    store.save(pending, expected_version=original.state_version)
+
+    assert store.list_cleanup_due(tenant_id="tenant-a") == [pending]
+    assert store.list_cleanup_due(tenant_id="tenant-b") == []
+
+    retrying = pending.transition(
+        phase="cleanup",
+        cleanup_status=CleanupStatus.IN_PROGRESS,
+        now="2026-07-17T20:02:00Z",
+    )
+    store.save(retrying, expected_version=pending.state_version)
+    cleaned = retrying.transition(
+        phase="finished",
+        cleanup_status=CleanupStatus.COMPLETE,
+        now="2026-07-17T20:03:00Z",
+    )
+    store.save(cleaned, expected_version=retrying.state_version)
+
+    restarted = SQLiteSideScanStateStore(tmp_path / "side-scan-state.db")
+    assert restarted.get(tenant_id="tenant-a", execution_id=cleaned.execution_id) == cleaned
+    assert restarted.list_cleanup_due(tenant_id="tenant-a") == []
+
+
+def test_serialized_state_contains_metadata_only() -> None:
+    payload = _execution().to_dict()
+
+    assert payload["schema_version"] == "agent-bom.cwpp.side_scan.lifecycle.v1"
+    assert payload["cleanup_ownership"]["required_tags"]["agent-bom-sidescan"] == "true"
+    assert "credential" not in payload
+    assert "content" not in payload
+    assert "secret_value" not in payload

--- a/tests/cloud/test_side_scan_provider_adapters.py
+++ b/tests/cloud/test_side_scan_provider_adapters.py
@@ -1,0 +1,450 @@
+"""Fake-SDK tests for Azure/GCP side-scan lifecycle adapters."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent_bom.cloud.side_scan_lifecycle import (
+    CleanupStatus,
+    ExecutionStatus,
+    SQLiteSideScanStateStore,
+    TemporaryResourceStatus,
+    new_side_scan_execution,
+)
+from agent_bom.cloud.side_scan_provider_adapters import (
+    AzureManagedDiskLifecycleAdapter,
+    GcpPersistentDiskLifecycleAdapter,
+    SideScanLifecycleTimeoutError,
+    SideScanPermissionDeniedError,
+)
+from agent_bom.cloud.side_scan_targets import CloudSideScanTarget, run_cloud_side_scan_targets
+
+
+class FakeSdkError(Exception):
+    def __init__(self, message: str, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class FakeOperation:
+    def __init__(self, result: Any, *, done_after: int = 1, error: Exception | None = None) -> None:
+        self._result = result
+        self._done_after = done_after
+        self._error = error
+        self.done_calls = 0
+
+    def done(self) -> bool:
+        self.done_calls += 1
+        return self.done_calls >= self._done_after
+
+    def result(self) -> Any:
+        if self._error is not None:
+            raise self._error
+        return self._result
+
+
+class FakeAzureCollection:
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        self.resources: dict[str, Any] = {}
+        self.create_calls: list[tuple[str, str, dict[str, Any]]] = []
+        self.delete_calls: list[tuple[str, str]] = []
+        self.create_error: Exception | None = None
+        self.delete_failures: set[str] = set()
+        self.done_after = 1
+
+    def get(self, resource_group: str, name: str) -> Any:
+        key = f"{resource_group}/{name}"
+        if key not in self.resources:
+            raise FakeSdkError("not found", 404)
+        return self.resources[key]
+
+    def begin_create_or_update(self, resource_group: str, name: str, parameters: dict[str, Any]) -> FakeOperation:
+        if self.create_error is not None:
+            raise self.create_error
+        self.create_calls.append((resource_group, name, parameters))
+        resource_id = f"/subscriptions/sub-1/resourceGroups/{resource_group}/providers/Microsoft.Compute/{self.kind}/{name}"
+        resource = SimpleNamespace(id=resource_id, name=name, tags=parameters["tags"])
+        self.resources[f"{resource_group}/{name}"] = resource
+        return FakeOperation(resource, done_after=self.done_after)
+
+    def begin_delete(self, resource_group: str, name: str) -> FakeOperation:
+        self.delete_calls.append((resource_group, name))
+        if name in self.delete_failures:
+            return FakeOperation(None, error=FakeSdkError("delete failed token=secret", 500))
+        self.resources.pop(f"{resource_group}/{name}", None)
+        return FakeOperation(None)
+
+    def list(self) -> list[Any]:
+        return list(self.resources.values())
+
+
+class FakeAzureVms:
+    def __init__(self) -> None:
+        self.data_disks: list[dict[str, Any]] = []
+        self.update_calls: list[dict[str, Any]] = []
+
+    def get(self, resource_group: str, name: str) -> Any:
+        return SimpleNamespace(storage_profile=SimpleNamespace(data_disks=list(self.data_disks)))
+
+    def begin_update(self, resource_group: str, name: str, parameters: dict[str, Any]) -> FakeOperation:
+        self.update_calls.append(parameters)
+        self.data_disks = list(parameters["storage_profile"]["data_disks"])
+        return FakeOperation(SimpleNamespace(id=f"/subscriptions/sub-1/vms/{name}"))
+
+
+class FakeGcpCollection:
+    def __init__(self, kind: str) -> None:
+        self.kind = kind
+        self.resources: dict[str, dict[str, Any]] = {}
+        self.insert_calls: list[dict[str, Any]] = []
+        self.delete_calls: list[dict[str, Any]] = []
+        self.insert_error: Exception | None = None
+        self.delete_failures: set[str] = set()
+        self.done_after = 1
+
+    def get(self, *, request: dict[str, Any]) -> dict[str, Any]:
+        name = str(request.get("snapshot") or request.get("disk") or "")
+        if name not in self.resources:
+            raise FakeSdkError("not found", 404)
+        return self.resources[name]
+
+    def insert(self, *, request: dict[str, Any]) -> FakeOperation:
+        if self.insert_error is not None:
+            raise self.insert_error
+        self.insert_calls.append(request)
+        body_key = "snapshot_resource" if self.kind == "snapshots" else "disk_resource"
+        body = request[body_key]
+        name = body["name"]
+        location = "global" if self.kind == "snapshots" else request["zone"]
+        resource = {
+            "name": name,
+            "id": name,
+            "self_link": f"https://compute.googleapis.com/compute/v1/projects/proj-1/{location}/{self.kind}/{name}",
+            "labels": dict(body["labels"]),
+        }
+        self.resources[name] = resource
+        return FakeOperation(resource, done_after=self.done_after)
+
+    def delete(self, *, request: dict[str, Any]) -> FakeOperation:
+        self.delete_calls.append(request)
+        name = str(request.get("snapshot") or request.get("disk") or "")
+        if name in self.delete_failures:
+            return FakeOperation(None, error=FakeSdkError("delete failed token=secret", 500))
+        self.resources.pop(name, None)
+        return FakeOperation(None)
+
+    def list(self, *, request: dict[str, Any]) -> list[dict[str, Any]]:
+        return list(self.resources.values())
+
+
+class FakeGcpInstances:
+    def __init__(self) -> None:
+        self.disks: list[dict[str, Any]] = []
+        self.attach_calls: list[dict[str, Any]] = []
+        self.detach_calls: list[dict[str, Any]] = []
+
+    def attach_disk(self, *, request: dict[str, Any]) -> FakeOperation:
+        self.attach_calls.append(request)
+        disk = dict(request["attached_disk_resource"])
+        self.disks.append(disk)
+        return FakeOperation(None)
+
+    def detach_disk(self, *, request: dict[str, Any]) -> FakeOperation:
+        self.detach_calls.append(request)
+        device_name = request["device_name"]
+        self.disks = [disk for disk in self.disks if disk.get("device_name") != device_name]
+        return FakeOperation(None)
+
+
+class FakeMount:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.unmounted: list[Path] = []
+
+    def attach_and_mount(self, volume_id: str, device: str) -> Path:
+        return self.path
+
+    def unmount(self, mount_point: Path) -> None:
+        self.unmounted.append(mount_point)
+
+
+def _target(provider: str) -> CloudSideScanTarget:
+    if provider == "azure":
+        return CloudSideScanTarget(
+            provider="azure",
+            target_type="managed_disk",
+            target_id="/subscriptions/sub-1/resourceGroups/workloads/providers/Microsoft.Compute/disks/os-disk",
+            name="os-disk",
+            account_id="sub-1",
+            location="eastus",
+            size_gb=128,
+            encryption="provider-managed",
+        )
+    return CloudSideScanTarget(
+        provider="gcp",
+        target_type="persistent_disk",
+        target_id="https://compute.googleapis.com/compute/v1/projects/proj-1/zones/us-central1-a/disks/os-disk",
+        name="os-disk",
+        account_id="proj-1",
+        location="us-central1-a",
+        size_gb=128,
+        encryption="provider-managed",
+    )
+
+
+def _record(provider: str, store: SQLiteSideScanStateStore):
+    target = _target(provider)
+    record = new_side_scan_execution(
+        tenant_id="tenant-a",
+        provider=target.provider,
+        account_id=target.account_id,
+        target_id=target.target_id,
+        collector_id="collector-1",
+        idempotency_key="request-1",
+        now="2026-07-17T20:00:00Z",
+    )
+    return store.create_or_get(record)
+
+
+def _azure_adapter(tmp_path: Path):
+    store = SQLiteSideScanStateStore(tmp_path / "state.db")
+    snapshots = FakeAzureCollection("snapshots")
+    disks = FakeAzureCollection("disks")
+    vms = FakeAzureVms()
+    adapter = AzureManagedDiskLifecycleAdapter(
+        snapshots_client=snapshots,
+        disks_client=disks,
+        virtual_machines_client=vms,
+        execution=_record("azure", store),
+        state_store=store,
+        collector_resource_group="collectors",
+        collector_vm_name="collector-1",
+        max_wait_attempts=3,
+        wait_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+    return adapter, store, snapshots, disks, vms
+
+
+def _gcp_adapter(tmp_path: Path):
+    store = SQLiteSideScanStateStore(tmp_path / "state.db")
+    snapshots = FakeGcpCollection("snapshots")
+    disks = FakeGcpCollection("disks")
+    instances = FakeGcpInstances()
+    adapter = GcpPersistentDiskLifecycleAdapter(
+        snapshots_client=snapshots,
+        disks_client=disks,
+        instances_client=instances,
+        execution=_record("gcp", store),
+        state_store=store,
+        project_id="proj-1",
+        collector_zone="us-central1-a",
+        collector_instance="collector-1",
+        max_wait_attempts=3,
+        wait_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+    return adapter, store, snapshots, disks, instances
+
+
+def test_azure_create_is_owned_bounded_and_idempotent(tmp_path: Path) -> None:
+    adapter, _store, snapshots, _disks, _vms = _azure_adapter(tmp_path)
+    target = _target("azure")
+
+    first = adapter.create_snapshot(target)
+    second = adapter.create_snapshot(target)
+
+    assert first == second
+    assert len(snapshots.create_calls) == 1
+    tags = snapshots.create_calls[0][2]["tags"]
+    assert tags == adapter.execution.cleanup_ownership.required_tags()
+    assert len(adapter.execution.resources) == 1
+
+
+def test_azure_permission_denial_persists_denied_not_clean(tmp_path: Path) -> None:
+    adapter, store, snapshots, _disks, _vms = _azure_adapter(tmp_path)
+    snapshots.create_error = FakeSdkError("authorization token=secret", 403)
+
+    with pytest.raises(SideScanPermissionDeniedError):
+        adapter.create_snapshot(_target("azure"))
+
+    persisted = store.get(tenant_id="tenant-a", execution_id=adapter.execution.execution_id)
+    assert persisted is not None
+    assert persisted.status is ExecutionStatus.DENIED
+    assert persisted.to_evidence_dict()["disposition"] == "unevaluable"
+    assert "token=secret" not in repr(persisted.to_dict())
+
+
+def test_azure_full_lifecycle_detaches_and_deletes_owned_resources(tmp_path: Path) -> None:
+    adapter, _store, snapshots, disks, vms = _azure_adapter(tmp_path)
+    target = _target("azure")
+    snapshot_id = adapter.create_snapshot(target)
+    disk_id = adapter.create_scan_disk(target, snapshot_id)
+    device = adapter.attach_scan_disk(target, disk_id, "collector-1")
+    adapter.mark_scan_complete()
+
+    complete = adapter.cleanup(target, "collector-1")
+
+    assert device == "/dev/disk/azure/scsi1/lun63"
+    assert vms.data_disks == []
+    assert snapshots.resources == {}
+    assert disks.resources == {}
+    assert complete.cleanup_status is CleanupStatus.COMPLETE
+    assert complete.cleanup_candidates() == ()
+
+
+def test_gcp_wait_timeout_is_bounded_and_persisted_failed(tmp_path: Path) -> None:
+    adapter, store, snapshots, _disks, _instances = _gcp_adapter(tmp_path)
+    snapshots.done_after = 99
+
+    with pytest.raises(SideScanLifecycleTimeoutError):
+        adapter.create_snapshot(_target("gcp"))
+
+    operation = adapter.last_operation
+    assert operation is not None and operation.done_calls == 3
+    persisted = store.get(tenant_id="tenant-a", execution_id=adapter.execution.execution_id)
+    assert persisted is not None
+    assert persisted.status is ExecutionStatus.FAILED
+    assert persisted.cleanup_status is CleanupStatus.PENDING
+    assert persisted.failure_code == "operation_timeout"
+    assert snapshots.resources, "the provider operation may complete after the worker times out"
+    swept = adapter.sweep_orphans(active_execution_ids=set())
+    assert len(swept) == 1
+    assert snapshots.resources == {}
+
+
+def test_cleanup_restarts_after_delete_failure_without_leaking_other_scope(tmp_path: Path) -> None:
+    adapter, store, snapshots, disks, instances = _gcp_adapter(tmp_path)
+    target = _target("gcp")
+    snapshot_id = adapter.create_snapshot(target)
+    disk_id = adapter.create_scan_disk(target, snapshot_id)
+    adapter.attach_scan_disk(target, disk_id, "collector-1")
+    adapter.mark_scan_complete(package_count=4, vulnerability_count=1)
+    disk_name = disk_id.rsplit("/", 1)[-1]
+    disks.delete_failures.add(disk_name)
+
+    partial = adapter.cleanup(target, "collector-1")
+    assert partial.cleanup_status is CleanupStatus.PARTIAL
+    assert partial.to_evidence_dict()["disposition"] == "partial"
+    assert not instances.disks
+    assert not snapshots.resources
+    assert any(resource.status is TemporaryResourceStatus.CLEANUP_FAILED for resource in partial.resources)
+
+    disks.delete_failures.clear()
+    restarted = GcpPersistentDiskLifecycleAdapter(
+        snapshots_client=snapshots,
+        disks_client=disks,
+        instances_client=instances,
+        execution=store.get(tenant_id="tenant-a", execution_id=partial.execution_id),
+        state_store=store,
+        project_id="proj-1",
+        collector_zone="us-central1-a",
+        collector_instance="collector-1",
+        max_wait_attempts=3,
+        wait_interval_seconds=0,
+        sleep=lambda _seconds: None,
+    )
+    complete = restarted.cleanup(target, "collector-1")
+
+    assert complete.cleanup_status is CleanupStatus.COMPLETE
+    assert complete.to_evidence_dict()["disposition"] == "complete"
+    assert not complete.cleanup_candidates()
+
+
+def test_adapter_rejects_cross_account_target_before_sdk_call(tmp_path: Path) -> None:
+    adapter, _store, snapshots, _disks, _vms = _azure_adapter(tmp_path)
+    target = _target("azure")
+    wrong = CloudSideScanTarget(**{**target.__dict__, "account_id": "sub-other"})
+
+    with pytest.raises(ValueError, match="execution scope"):
+        adapter.create_snapshot(wrong)
+
+    assert snapshots.create_calls == []
+
+
+def test_orphan_sweep_deletes_only_matching_tenant_scope(tmp_path: Path) -> None:
+    adapter, _store, snapshots, disks, _vms = _azure_adapter(tmp_path)
+    owned = adapter.execution.cleanup_ownership.required_tags()
+    foreign = {**owned, "agent-bom-sidescan-scope": "0" * 24}
+    snapshots.resources["workloads/owned-snap"] = SimpleNamespace(
+        id="/subscriptions/sub-1/resourceGroups/workloads/providers/Microsoft.Compute/snapshots/owned-snap",
+        name="owned-snap",
+        tags=owned,
+    )
+    snapshots.resources["workloads/foreign-snap"] = SimpleNamespace(
+        id="/subscriptions/sub-1/resourceGroups/workloads/providers/Microsoft.Compute/snapshots/foreign-snap",
+        name="foreign-snap",
+        tags=foreign,
+    )
+    disks.resources["workloads/owned-disk"] = SimpleNamespace(
+        id="/subscriptions/sub-1/resourceGroups/workloads/providers/Microsoft.Compute/disks/owned-disk",
+        name="owned-disk",
+        tags=owned,
+    )
+
+    swept = adapter.sweep_orphans(active_execution_ids=set())
+
+    assert set(swept) == {"owned-snap", "owned-disk"}
+    assert "workloads/foreign-snap" in snapshots.resources
+
+
+def test_gcp_orphan_sweep_deletes_only_matching_project_scope(tmp_path: Path) -> None:
+    adapter, _store, snapshots, disks, _instances = _gcp_adapter(tmp_path)
+    owned = adapter.execution.cleanup_ownership.required_tags()
+    foreign = {**owned, "agent-bom-sidescan-scope": "0" * 24}
+    snapshots.resources["owned-snap"] = {
+        "name": "owned-snap",
+        "self_link": "https://compute.googleapis.com/compute/v1/projects/proj-1/global/snapshots/owned-snap",
+        "labels": owned,
+    }
+    snapshots.resources["foreign-snap"] = {
+        "name": "foreign-snap",
+        "self_link": "https://compute.googleapis.com/compute/v1/projects/proj-1/global/snapshots/foreign-snap",
+        "labels": foreign,
+    }
+    disks.resources["owned-disk"] = {
+        "name": "owned-disk",
+        "self_link": "https://compute.googleapis.com/compute/v1/projects/proj-1/zones/us-central1-a/disks/owned-disk",
+        "labels": owned,
+    }
+
+    swept = adapter.sweep_orphans(active_execution_ids=set())
+
+    assert set(swept) == {"owned-snap", "owned-disk"}
+    assert "foreign-snap" in snapshots.resources
+
+
+@pytest.mark.asyncio
+async def test_runner_persists_scan_evidence_and_guaranteed_cleanup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    adapter, store, _snapshots, _disks, _instances = _gcp_adapter(tmp_path)
+    mount_path = tmp_path / "mount"
+    mount_path.mkdir()
+    mount = FakeMount(mount_path)
+    monkeypatch.setenv("AGENT_BOM_SIDESCAN", "1")
+
+    async def _no_cves(_packages: object) -> int:
+        return 0
+
+    monkeypatch.setattr("agent_bom.cloud.side_scan_targets._scan_packages", _no_cves)
+    results = await run_cloud_side_scan_targets(
+        [_target("gcp")],
+        lifecycles={"gcp": adapter},
+        collector_ids={"gcp": "collector-1"},
+        mount_controller=mount,
+        scan_secrets_enabled=False,
+    )
+
+    persisted = store.get(tenant_id="tenant-a", execution_id=adapter.execution.execution_id)
+    assert results[0].cleaned_up is True
+    assert mount.unmounted == [mount_path]
+    assert persisted is not None
+    assert persisted.status is ExecutionStatus.SCAN_COMPLETE
+    assert persisted.cleanup_status is CleanupStatus.COMPLETE
+    assert persisted.to_evidence_dict()["disposition"] == "complete"

--- a/tests/test_side_scan_capability_docs.py
+++ b/tests/test_side_scan_capability_docs.py
@@ -1,0 +1,18 @@
+"""Keep public side-scan claims aligned with shipped provider executors."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cloud_connect_does_not_claim_azure_or_gcp_execution() -> None:
+    cloud_connect = (ROOT / "docs" / "CLOUD_CONNECT.md").read_text()
+
+    assert "does not ship Azure or GCP lifecycle executors" in cloud_connect
+    assert "execution is wired for connection/scheduler integrations" not in cloud_connect
+
+
+def test_architecture_labels_cross_cloud_surface_as_contract_only() -> None:
+    architecture = (ROOT / "docs" / "ARCHITECTURE.md").read_text()
+
+    assert "Azure/GCP target discovery and lifecycle contract only" in architecture

--- a/tests/test_side_scan_capability_docs.py
+++ b/tests/test_side_scan_capability_docs.py
@@ -5,14 +5,15 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 
 
-def test_cloud_connect_does_not_claim_azure_or_gcp_execution() -> None:
+def test_cloud_connect_scopes_azure_and_gcp_execution_claims() -> None:
     cloud_connect = (ROOT / "docs" / "CLOUD_CONNECT.md").read_text()
 
-    assert "does not ship Azure or GCP lifecycle executors" in cloud_connect
+    assert "concrete Azure Managed Disk and GCP Persistent Disk adapters" in cloud_connect
+    assert "no live credentialed" in cloud_connect
     assert "execution is wired for connection/scheduler integrations" not in cloud_connect
 
 
-def test_architecture_labels_cross_cloud_surface_as_contract_only() -> None:
+def test_architecture_labels_cross_cloud_surface_as_injected_sdk_only() -> None:
     architecture = (ROOT / "docs" / "ARCHITECTURE.md").read_text()
 
-    assert "Azure/GCP target discovery and lifecycle contract only" in architecture
+    assert "injected-SDK Azure Managed Disk and GCP Persistent Disk lifecycle adapters" in architecture

--- a/tests/test_side_scan_cross_cloud_terraform.py
+++ b/tests/test_side_scan_cross_cloud_terraform.py
@@ -1,0 +1,50 @@
+"""Least-privilege guards for Azure/GCP side-scan mutation roles."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_azure_sidescan_role_is_custom_and_lifecycle_scoped() -> None:
+    main = (ROOT / "deploy" / "terraform" / "connect-azure-sidescan" / "main.tf").read_text()
+
+    for action in (
+        "Microsoft.Compute/snapshots/read",
+        "Microsoft.Compute/snapshots/write",
+        "Microsoft.Compute/snapshots/delete",
+        "Microsoft.Compute/disks/read",
+        "Microsoft.Compute/disks/write",
+        "Microsoft.Compute/disks/delete",
+        "Microsoft.Compute/virtualMachines/read",
+        "Microsoft.Compute/virtualMachines/write",
+    ):
+        assert action in main
+    assert 'role_definition_name = "Owner"' not in main
+    assert 'role_definition_name = "Contributor"' not in main
+    assert "Microsoft.Storage/storageAccounts/blobServices/containers/blobs/read" not in main
+
+
+def test_gcp_sidescan_role_has_no_data_plane_or_project_wide_admin() -> None:
+    main = (ROOT / "deploy" / "terraform" / "connect-gcp-sidescan" / "main.tf").read_text()
+
+    for permission in (
+        "compute.snapshots.create",
+        "compute.snapshots.delete",
+        "compute.disks.create",
+        "compute.disks.delete",
+        "compute.instances.attachDisk",
+        "compute.instances.detachDisk",
+    ):
+        assert permission in main
+    assert "roles/owner" not in main
+    assert "roles/editor" not in main
+    assert "storage.objects.get" not in main
+    assert "compute.instances.setMetadata" not in main
+
+
+def test_cross_cloud_sidescan_docs_keep_mutations_opt_in_and_smokes_fixture_scoped() -> None:
+    for provider in ("azure", "gcp"):
+        readme = (ROOT / "deploy" / "terraform" / f"connect-{provider}-sidescan" / "README.md").read_text()
+        assert "AGENT_BOM_SIDESCAN=1" in readme
+        assert "No live cloud mutation was run" in readme
+        assert "block bytes" in readme


### PR DESCRIPTION
**Addresses #4158 (stages 1-3) — does NOT close it.** Stage 4 (surface lock-in) + credentialed Azure/GCP live smokes remain (creds-gated). Combines the previously-frozen stages 1-2 (rebased onto current main, re-verified) with net-new stage 3, plus a small folded-in secret-scan config (below) to save a standalone CI run.

## Stage 1 — lifecycle/evidence foundation
Versioned provider-neutral lifecycle/evidence contracts, execution-state persistence, deterministic tenant/account/execution ownership, retry-safe transitions, explicit cleanup state, metadata-only/non-clean evidence semantics, idempotency ids, tenant-scoped SQLite restart persistence, stale-worker protection, code-backed capability map. (Corrected the stale CLOUD_CONNECT.md "Azure/GCP wired" overclaim.)

## Stage 2 — cross-cloud executors (injected-client, fixture-scoped)
Azure Managed Disk + GCP Persistent Disk lifecycle adapters: deterministic names/tags, per-mutation durable state, bounded polling, idempotent creation, deny/timeout-safe failure, restart-safe detach/delete cleanup, scope-bound orphan sweep, least-privilege Terraform. **Honesty:** these are injected-client adapters, NOT described as shipped/proven executors — that needs a credentialed live smoke (stage 4).

## Stage 3 — runtime/EDR workload evidence (net-new)
Read-only runtime signal ingest → canonical workload identities + findings + graph, **no mandatory host agent**: authenticated source registry (constant-time hashed secret), source-authoritative identity binding, freshness/provenance, dedup, **fail-closed on stale/incomplete binding**. Additive only — `no_runtime_signal` for absence, `clean_workload_assertion=false` everywhere (absence ≠ clean); annotates workload nodes without adding edges (reachability stays edge-derived); tenant-boundary-checked. Wired: store (SQLite+Postgres), `/v1/findings` read path, graph join, docs.

## Verified (real Docker-Postgres, not fake-conn)
Stage-1+2 re-verified on advanced main: `131 passed`. Stage-3: 35 new tests red→green; **real-PG cross-process test — 3 spawned processes × 20 shared keys → exactly 20 unique rows** (+ SQLite cross-process); cross-tenant no-leak. `ruff`/`mypy`/OpenAPI/check-counts clean; `tests/cloud/` `667 passed, 3 skipped`.

## Folded in: secret-scan config
`.github/secret_scanning.yml` (scoped `paths-ignore` for the 6 detection-test files that intentionally hold AWS's `AKIA/ASIA IOSFODNN7EXAMPLE` documentation-placeholder fixtures used to test our own redaction). Resolves Security alert #1 (already dismissed `used_in_tests`); prevents recurrence. Not a blanket `tests/` exclusion.