### PR TITLE
feat(graph): storage-backed graph-build workspace — producer-streaming foundation (PR-1 of #4075)

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -149,6 +149,8 @@ AGENT_BOM_CRED_ROTATION_DAYS
 AGENT_BOM_NO_AUTO_DEV_KEY
 # Opt-out flag for the local/no-auth auto-seeded connection encryption key; when set, `agent-bom serve|api` does not write ~/.agent-bom/connections.key and connection creation stays 503 until a key is provided. Read in cli/_server.py.
 AGENT_BOM_NO_AUTO_CONNECTIONS_KEY
+# Opt-in flag for the storage-backed graph-build workspace (producer streaming); read in api/pipeline.py, path default in graph/build_workspace.py.
+AGENT_BOM_GRAPH_BUILD_WORKSPACE
 # Dormancy window (days, default 90) before a non-human identity with no recent usage is flagged dormant; read in graph/nhi_governance.py.
 AGENT_BOM_NHI_DORMANT_DAYS
 # Opt-in window (days, default 0 = disabled) after which a dormant agent-bom-issued identity is auto-revoked; read in api/agent_identity_store.py.

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -14,6 +14,7 @@ import ctypes
 import gc
 import json
 import logging
+import os
 import sys
 import threading
 import uuid
@@ -350,6 +351,42 @@ def _surface_graph_derived_findings(
     attach_graph_derived_findings(report, findings_graph)
 
 
+def _graph_build_workspace_enabled() -> bool:
+    """Opt-in flag for routing persistence through the build workspace (#4075).
+
+    Default-off so the shipped persist path is byte-for-byte unchanged. When on,
+    the persist streams from the storage-backed workspace instead of the
+    materialised graph — the seam PR-2 will emit into directly.
+    """
+    return os.environ.get("AGENT_BOM_GRAPH_BUILD_WORKSPACE", "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _persist_via_build_workspace(graph_store: Any, graph: Any) -> dict[str, int]:
+    """Stream a built graph through the bounded workspace into the store.
+
+    Produces a snapshot byte-identical to the direct streamed save; the workspace
+    holds only a bounded batch in memory while it re-emits nodes/edges. Attack
+    paths / interaction risks stay in-memory (small, bounded) — streaming those
+    is out of scope for PR-1.
+    """
+    from agent_bom.graph.build_workspace import open_graph_build_workspace
+
+    with open_graph_build_workspace(tenant_id=graph.tenant_id, workspace_id=graph.scan_id) as workspace:
+        workspace.add_nodes(graph.nodes.values())
+        workspace.add_edges(graph.edges)
+        counts: dict[str, int] = graph_store.save_graph_streaming(
+            scan_id=graph.scan_id,
+            tenant_id=graph.tenant_id,
+            nodes=workspace.iter_nodes(),
+            edges=workspace.iter_edges(),
+            attack_paths=graph.attack_paths,
+            interaction_risks=graph.interaction_risks,
+            analysis_status=graph.analysis_status,
+            created_at=graph.created_at,
+        )
+        return counts
+
+
 def _persist_graph_snapshot(
     job: ScanJob,
     report_json: dict[str, Any],
@@ -385,16 +422,26 @@ def _persist_graph_snapshot(
         # Persist via the streamed write path (node/edge iterables) so the write
         # never buffers a second copy of the graph; counts come from the store's
         # running tally, not len(graph.*).
-        counts = graph_store.save_graph_streaming(
-            scan_id=graph.scan_id,
-            tenant_id=graph.tenant_id,
-            nodes=graph.nodes.values(),
-            edges=graph.edges,
-            attack_paths=graph.attack_paths,
-            interaction_risks=graph.interaction_risks,
-            analysis_status=graph.analysis_status,
-            created_at=graph.created_at,
-        )
+        #
+        # First consumer of the storage-backed build workspace (#4075, PR-1):
+        # when enabled, the graph is spilled to a bounded workspace store and the
+        # persist streams back from it, producing a byte-identical snapshot. This
+        # is the seam the builder re-plumb (PR-2) will emit into directly to drop
+        # the producer's own materialisation; opt-in so the shipped path is
+        # unchanged by default.
+        if _graph_build_workspace_enabled():
+            counts = _persist_via_build_workspace(graph_store, graph)
+        else:
+            counts = graph_store.save_graph_streaming(
+                scan_id=graph.scan_id,
+                tenant_id=graph.tenant_id,
+                nodes=graph.nodes.values(),
+                edges=graph.edges,
+                attack_paths=graph.attack_paths,
+                interaction_risks=graph.interaction_risks,
+                analysis_status=graph.analysis_status,
+                created_at=graph.created_at,
+            )
     finally:
         reset_current_tenant(tenant_token)
 

--- a/src/agent_bom/graph/build_workspace.py
+++ b/src/agent_bom/graph/build_workspace.py
@@ -1,0 +1,404 @@
+"""Storage-backed graph build workspace (#4075, PR-1 of the producer-streaming series).
+
+Foundation for streaming the correlated-graph *producer*
+(:func:`agent_bom.graph.builder.build_unified_graph_from_report`) to a
+storage-backed staging area instead of materialising the entire
+:class:`~agent_bom.graph.container.UnifiedGraph` in memory.
+
+A :class:`GraphBuildWorkspace` accepts nodes and edges in **bounded batches** —
+spilling each batch to a backing store (a private SQLite temp DB, or the shared
+Postgres) and never retaining the full set — and yields them back in bounded
+batches for a downstream consumer (the persist write path). Its in-memory
+working set is bounded by ``batch_size``, not by the total graph size.
+
+Scope of this PR (PR-1 of the four-PR series):
+
+* the workspace primitive + both backends (SQLite + Postgres), tenant-scoped,
+  idempotent, cross-process safe on Postgres;
+* the first bounded consumer — the persist path can stream a graph through the
+  workspace into the store and produce a byte-identical snapshot (opt-in via
+  ``AGENT_BOM_GRAPH_BUILD_WORKSPACE`` so the shipped default path is unchanged).
+
+Re-plumbing the builder's phases to emit **directly** into the workspace — which
+removes the builder's own materialisation and realises the #4055 peak-RSS bound
+end to end — is PR-2/3/4 of the series and is intentionally out of scope here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+import uuid
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+from types import TracebackType
+from typing import Any, Protocol
+
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import RelationshipType
+
+_DEFAULT_BATCH_SIZE = 1000
+_UNIT_SEP = "\x1f"
+
+
+def _batch_size() -> int:
+    raw = os.environ.get("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", str(_DEFAULT_BATCH_SIZE))
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return _DEFAULT_BATCH_SIZE
+    return value if value > 0 else _DEFAULT_BATCH_SIZE
+
+
+def _normalize_tenant(tenant_id: str) -> str:
+    return tenant_id or "default"
+
+
+def _edge_key(edge: UnifiedEdge) -> str:
+    rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
+    return f"{edge.source}{_UNIT_SEP}{edge.target}{_UNIT_SEP}{rel}"
+
+
+def _node_from_payload(payload: dict[str, Any]) -> UnifiedNode:
+    """Reconstruct a node so its persisted form is byte-identical to the original.
+
+    :meth:`UnifiedNode.from_dict` injects ``canonical_id`` into ``attributes``
+    when absent; the persist path serialises ``node.attributes`` verbatim, so we
+    restore the exact stored attributes to avoid that one-key drift.
+    """
+    node = UnifiedNode.from_dict(payload)
+    node.attributes = dict(payload.get("attributes", {}))
+    return node
+
+
+def _edge_from_payload(payload: dict[str, Any]) -> UnifiedEdge:
+    return UnifiedEdge.from_dict(payload)
+
+
+class WorkspaceBackend(Protocol):
+    """Bounded, tenant-scoped staging store for graph nodes and edges."""
+
+    def add_node_payloads(self, tenant_id: str, rows: Iterable[tuple[str, str]]) -> None: ...
+
+    def add_edge_payloads(self, tenant_id: str, rows: Iterable[tuple[str, str]]) -> None: ...
+
+    def iter_node_payloads(self, tenant_id: str, batch_size: int) -> Iterator[str]: ...
+
+    def iter_edge_payloads(self, tenant_id: str, batch_size: int) -> Iterator[str]: ...
+
+    def count_nodes(self, tenant_id: str) -> int: ...
+
+    def count_edges(self, tenant_id: str) -> int: ...
+
+    def close(self) -> None: ...
+
+
+class _SQLiteWorkspaceBackend:
+    """Process-local staging store backed by a private SQLite temp database."""
+
+    def __init__(self, db_path: Path | None = None) -> None:
+        if db_path is None:
+            fd, name = tempfile.mkstemp(prefix="abom-gws-", suffix=".db")
+            os.close(fd)
+            self._path = Path(name)
+            self._owns_file = True
+        else:
+            self._path = Path(db_path)
+            self._owns_file = False
+        self._conn = sqlite3.connect(str(self._path))
+        self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS ws_nodes ("
+            "tenant_id TEXT NOT NULL, node_id TEXT NOT NULL, "
+            "seq INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT NOT NULL, "
+            "UNIQUE(tenant_id, node_id))"
+        )
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS ws_edges ("
+            "tenant_id TEXT NOT NULL, edge_key TEXT NOT NULL, "
+            "seq INTEGER PRIMARY KEY AUTOINCREMENT, payload TEXT NOT NULL, "
+            "UNIQUE(tenant_id, edge_key))"
+        )
+        self._conn.commit()
+
+    def _upsert(self, table: str, key_col: str, tenant_id: str, rows: Iterable[tuple[str, str]]) -> None:
+        self._conn.executemany(
+            f"INSERT INTO {table} (tenant_id, {key_col}, payload) VALUES (?, ?, ?) "  # nosec B608 - static table/col
+            f"ON CONFLICT(tenant_id, {key_col}) DO UPDATE SET payload=excluded.payload",
+            ((tenant_id, key, payload) for key, payload in rows),
+        )
+        self._conn.commit()
+
+    def add_node_payloads(self, tenant_id: str, rows: Iterable[tuple[str, str]]) -> None:
+        self._upsert("ws_nodes", "node_id", tenant_id, rows)
+
+    def add_edge_payloads(self, tenant_id: str, rows: Iterable[tuple[str, str]]) -> None:
+        self._upsert("ws_edges", "edge_key", tenant_id, rows)
+
+    def _iter_payloads(self, table: str, tenant_id: str, batch_size: int) -> Iterator[str]:
+        cur = self._conn.cursor()
+        cur.execute(
+            f"SELECT payload FROM {table} WHERE tenant_id = ? ORDER BY seq",  # nosec B608 - static table
+            (tenant_id,),
+        )
+        try:
+            while True:
+                batch = cur.fetchmany(batch_size)
+                if not batch:
+                    return
+                for (payload,) in batch:
+                    yield payload
+        finally:
+            cur.close()
+
+    def iter_node_payloads(self, tenant_id: str, batch_size: int) -> Iterator[str]:
+        return self._iter_payloads("ws_nodes", tenant_id, batch_size)
+
+    def iter_edge_payloads(self, tenant_id: str, batch_size: int) -> Iterator[str]:
+        return self._iter_payloads("ws_edges", tenant_id, batch_size)
+
+    def _count(self, table: str, tenant_id: str) -> int:
+        row = self._conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE tenant_id = ?",  # nosec B608 - static table
+            (tenant_id,),
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def count_nodes(self, tenant_id: str) -> int:
+        return self._count("ws_nodes", tenant_id)
+
+    def count_edges(self, tenant_id: str) -> int:
+        return self._count("ws_edges", tenant_id)
+
+    def close(self) -> None:
+        try:
+            self._conn.close()
+        finally:
+            if self._owns_file:
+                for suffix in ("", "-wal", "-shm"):
+                    p = Path(str(self._path) + suffix)
+                    try:
+                        p.unlink()
+                    except FileNotFoundError:
+                        pass
+
+
+class _PostgresWorkspaceBackend:
+    """Shared, cross-process staging store backed by Postgres.
+
+    Rows are namespaced by ``workspace_id`` so independent concurrent builds do
+    not collide, and scoped by ``tenant_id`` for isolation. A ``BIGSERIAL``
+    sequence gives a globally monotonic insertion order across writers, so a
+    reader observes a deterministic order regardless of which process wrote a
+    row. Reads use a server-side named cursor so the working set stays bounded
+    by ``itersize`` rather than the total row count.
+    """
+
+    def __init__(self, dsn: str, workspace_id: str) -> None:
+        import psycopg
+
+        self._psycopg = psycopg
+        self._dsn = dsn
+        self._workspace_id = workspace_id
+        self._conn = psycopg.connect(dsn, autocommit=True)
+        self._ensure_tables()
+
+    def _ensure_tables(self) -> None:
+        # payload is stored as TEXT, not JSONB: JSONB normalises key order, which
+        # would change the persisted ``attributes`` byte-for-byte after the
+        # downstream ``json.dumps``. TEXT preserves the exact serialised bytes so
+        # the workspace round-trip stays byte-identical to the direct save.
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS graph_build_workspace_nodes ("
+            "workspace_id TEXT NOT NULL, tenant_id TEXT NOT NULL, node_id TEXT NOT NULL, "
+            "seq BIGSERIAL, payload TEXT NOT NULL, "
+            "PRIMARY KEY (workspace_id, tenant_id, node_id))"
+        )
+        self._conn.execute(
+            "CREATE TABLE IF NOT EXISTS graph_build_workspace_edges ("
+            "workspace_id TEXT NOT NULL, tenant_id TEXT NOT NULL, edge_key TEXT NOT NULL, "
+            "seq BIGSERIAL, payload TEXT NOT NULL, "
+            "PRIMARY KEY (workspace_id, tenant_id, edge_key))"
+        )
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_gbw_nodes_seq ON graph_build_workspace_nodes (workspace_id, tenant_id, seq)")
+        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_gbw_edges_seq ON graph_build_workspace_edges (workspace_id, tenant_id, seq)")
+
+    def _upsert(self, table: str, key_col: str, tenant_id: str, rows: Iterable[tuple[str, str]]) -> None:
+        sql = (
+            f"INSERT INTO {table} (workspace_id, tenant_id, {key_col}, payload) "  # nosec B608 - static table/col
+            f"VALUES (%s, %s, %s, %s) "
+            f"ON CONFLICT (workspace_id, tenant_id, {key_col}) DO UPDATE SET payload = EXCLUDED.payload"
+        )
+        with self._conn.cursor() as cur:
+            params = ((self._workspace_id, tenant_id, key, payload) for key, payload in rows)
+            cur.executemany(sql, params)
+
+    def add_node_payloads(self, tenant_id: str, rows: Iterable[tuple[str, str]]) -> None:
+        self._upsert("graph_build_workspace_nodes", "node_id", tenant_id, rows)
+
+    def add_edge_payloads(self, tenant_id: str, rows: Iterable[tuple[str, str]]) -> None:
+        self._upsert("graph_build_workspace_edges", "edge_key", tenant_id, rows)
+
+    def _iter_payloads(self, table: str, tenant_id: str, batch_size: int) -> Iterator[str]:
+        # Server-side named cursor streams rows in bounded chunks (itersize) so
+        # the client never buffers the whole result set — a plain client cursor
+        # would fetch every row on execute, defeating the memory bound. A named
+        # cursor requires an open transaction, so wrap the scan in one (the
+        # connection is autocommit for writes).
+        name = f"gbw_{uuid.uuid4().hex}"
+        with self._conn.transaction(), self._conn.cursor(name=name) as cur:
+            cur.itersize = batch_size
+            cur.execute(
+                f"SELECT payload FROM {table} WHERE workspace_id = %s AND tenant_id = %s ORDER BY seq",  # nosec B608
+                (self._workspace_id, tenant_id),
+            )
+            for (payload,) in cur:
+                # payload is TEXT — yield the exact stored bytes.
+                yield payload if isinstance(payload, str) else json.dumps(payload)
+
+    def iter_node_payloads(self, tenant_id: str, batch_size: int) -> Iterator[str]:
+        return self._iter_payloads("graph_build_workspace_nodes", tenant_id, batch_size)
+
+    def iter_edge_payloads(self, tenant_id: str, batch_size: int) -> Iterator[str]:
+        return self._iter_payloads("graph_build_workspace_edges", tenant_id, batch_size)
+
+    def _count(self, table: str, tenant_id: str) -> int:
+        row = self._conn.execute(
+            f"SELECT COUNT(*) FROM {table} WHERE workspace_id = %s AND tenant_id = %s",  # nosec B608 - static table
+            (self._workspace_id, tenant_id),
+        ).fetchone()
+        return int(row[0]) if row else 0
+
+    def count_nodes(self, tenant_id: str) -> int:
+        return self._count("graph_build_workspace_nodes", tenant_id)
+
+    def count_edges(self, tenant_id: str) -> int:
+        return self._count("graph_build_workspace_edges", tenant_id)
+
+    def close(self) -> None:
+        # Drop only this workspace's rows; the shared tables persist for reuse.
+        try:
+            self._conn.execute(
+                "DELETE FROM graph_build_workspace_nodes WHERE workspace_id = %s",
+                (self._workspace_id,),
+            )
+            self._conn.execute(
+                "DELETE FROM graph_build_workspace_edges WHERE workspace_id = %s",
+                (self._workspace_id,),
+            )
+        finally:
+            self._conn.close()
+
+
+class GraphBuildWorkspace:
+    """Bounded, storage-backed staging area for a graph build.
+
+    ``add_nodes``/``add_edges`` consume producer iterables in bounded batches and
+    spill each batch to the backing store without retaining it; ``iter_nodes``/
+    ``iter_edges`` stream the staged items back in bounded batches. The peak
+    in-memory working set is proportional to ``batch_size``, not to the total
+    number of nodes/edges.
+
+    The caller must yield **deduplicated** producers — unique node ``id`` and
+    unique ``(source, target, relationship)`` edge keys — exactly the invariant
+    :class:`~agent_bom.graph.container.UnifiedGraph` maintains and that
+    :func:`~agent_bom.db.graph_store.save_graph_streaming` requires downstream.
+    Re-adding the same key is idempotent (last write wins on the payload).
+    """
+
+    def __init__(
+        self,
+        backend: WorkspaceBackend,
+        *,
+        tenant_id: str = "",
+        batch_size: int | None = None,
+    ) -> None:
+        self._backend = backend
+        self._tenant_id = _normalize_tenant(tenant_id)
+        self._batch_size = batch_size if (batch_size and batch_size > 0) else _batch_size()
+
+    @property
+    def tenant_id(self) -> str:
+        return self._tenant_id
+
+    def add_nodes(self, nodes: Iterable[UnifiedNode]) -> None:
+        for batch in _batched(((n.id, json.dumps(n.to_dict(), default=str)) for n in nodes), self._batch_size):
+            self._backend.add_node_payloads(self._tenant_id, batch)
+
+    def add_edges(self, edges: Iterable[UnifiedEdge]) -> None:
+        for batch in _batched(((_edge_key(e), json.dumps(e.to_dict(), default=str)) for e in edges), self._batch_size):
+            self._backend.add_edge_payloads(self._tenant_id, batch)
+
+    def iter_nodes(self) -> Iterator[UnifiedNode]:
+        for payload in self._backend.iter_node_payloads(self._tenant_id, self._batch_size):
+            yield _node_from_payload(json.loads(payload))
+
+    def iter_edges(self) -> Iterator[UnifiedEdge]:
+        for payload in self._backend.iter_edge_payloads(self._tenant_id, self._batch_size):
+            yield _edge_from_payload(json.loads(payload))
+
+    def node_count(self) -> int:
+        return self._backend.count_nodes(self._tenant_id)
+
+    def edge_count(self) -> int:
+        return self._backend.count_edges(self._tenant_id)
+
+    def close(self) -> None:
+        self._backend.close()
+
+    def __enter__(self) -> GraphBuildWorkspace:
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: TracebackType | None,
+    ) -> None:
+        self.close()
+
+
+def _batched(items: Iterable[tuple[str, str]], size: int) -> Iterator[list[tuple[str, str]]]:
+    batch: list[tuple[str, str]] = []
+    for item in items:
+        batch.append(item)
+        if len(batch) >= size:
+            yield batch
+            batch = []
+    if batch:
+        yield batch
+
+
+def open_graph_build_workspace(
+    *,
+    tenant_id: str = "",
+    workspace_id: str = "",
+    backend: str = "auto",
+    batch_size: int | None = None,
+) -> GraphBuildWorkspace:
+    """Open a build workspace on the appropriate backend.
+
+    ``backend="auto"`` selects Postgres when ``AGENT_BOM_POSTGRES_URL`` is set,
+    otherwise a private SQLite temp database. ``workspace_id`` namespaces a build
+    on the shared Postgres tables (defaults to a fresh UUID); it is ignored by
+    the process-local SQLite backend.
+    """
+    wsid = workspace_id or uuid.uuid4().hex
+    dsn = os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip()
+    chosen = backend
+    if chosen == "auto":
+        chosen = "postgres" if dsn else "sqlite"
+
+    impl: WorkspaceBackend
+    if chosen == "postgres":
+        if not dsn:
+            raise ValueError("AGENT_BOM_POSTGRES_URL is required for the postgres workspace backend.")
+        impl = _PostgresWorkspaceBackend(dsn, wsid)
+    elif chosen == "sqlite":
+        impl = _SQLiteWorkspaceBackend()
+    else:
+        raise ValueError(f"unknown workspace backend {backend!r}")
+    return GraphBuildWorkspace(impl, tenant_id=tenant_id, batch_size=batch_size)

--- a/tests/api/test_persist_graph_workspace_consumer.py
+++ b/tests/api/test_persist_graph_workspace_consumer.py
@@ -1,0 +1,95 @@
+"""First consumer of the build workspace: the persist path (#4075, PR-1).
+
+``_persist_graph_snapshot`` gains an opt-in
+(``AGENT_BOM_GRAPH_BUILD_WORKSPACE``) that streams the built graph through the
+storage-backed :class:`GraphBuildWorkspace` into the store instead of persisting
+the materialised graph directly. This pins that the opt-in path produces a
+**byte-identical** persisted snapshot and identical delta alerts to the shipped
+default path — the correctness bar for the seam PR-2 emits into.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import agent_bom.api.pipeline as pipeline
+import agent_bom.graph.builder as builder
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph.builder import build_unified_graph_from_report
+
+_FIXTURES = Path(__file__).parent.parent / "fixtures"
+
+
+def _dump_rows(store: SQLiteGraphStore, tenant: str, scan: str) -> tuple[list, list]:
+    import agent_bom.db.graph_store as sq
+
+    with sq.open_graph_db(store._db_path) as conn:
+        nodes = conn.execute(
+            "SELECT id, entity_type, label, status, risk_score, severity, severity_id, "
+            "first_seen, last_seen, attributes, compliance_tags, data_sources, dimensions "
+            "FROM graph_nodes WHERE tenant_id = ? AND scan_id = ? ORDER BY id",
+            (tenant, scan),
+        ).fetchall()
+        edges = conn.execute(
+            "SELECT source_id, target_id, relationship, direction, weight, traversable, "
+            "first_seen, last_seen, valid_from, valid_to, confidence, provenance, "
+            "source_scan_id, source_run_id, evidence, activity_id "
+            "FROM graph_edges WHERE tenant_id = ? AND scan_id = ? "
+            "ORDER BY source_id, target_id, relationship",
+            (tenant, scan),
+        ).fetchall()
+    return [tuple(r) for r in nodes], [tuple(r) for r in edges]
+
+
+def _run_persist(tmp_path: Path, monkeypatch, *, enabled: bool, graph, store_name: str) -> SQLiteGraphStore:
+    store = SQLiteGraphStore(tmp_path / store_name)
+    monkeypatch.setattr(pipeline, "_get_graph_store", lambda: store)
+    # Same pre-built graph both runs → removes build-time timestamp drift.
+    monkeypatch.setattr(builder, "build_unified_graph_from_report", lambda report_json, scan_id, tenant_id: graph)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)  # force SQLite workspace backend
+    if enabled:
+        monkeypatch.setenv("AGENT_BOM_GRAPH_BUILD_WORKSPACE", "1")
+    else:
+        monkeypatch.delenv("AGENT_BOM_GRAPH_BUILD_WORKSPACE", raising=False)
+    job = SimpleNamespace(job_id="scan-x", tenant_id="t1", progress=[])
+    pipeline._persist_graph_snapshot(job, {"scan_id": "scan-x"})
+    assert store.latest_snapshot_id(tenant_id="t1") == "scan-x"
+    return store
+
+
+@pytest.mark.parametrize("fixture", ["agent_bom_self_scan_inventory.json"])
+def test_workspace_persist_is_byte_identical_to_direct(tmp_path: Path, monkeypatch, fixture: str) -> None:
+    report = json.loads((_FIXTURES / fixture).read_text())
+    graph = build_unified_graph_from_report(report, scan_id="scan-x", tenant_id="t1")
+    assert len(graph.nodes) > 0
+
+    with monkeypatch.context() as m:
+        direct = _run_persist(tmp_path, m, enabled=False, graph=graph, store_name="direct.db")
+        direct_rows = _dump_rows(direct, "t1", "scan-x")
+    with monkeypatch.context() as m:
+        via_ws = _run_persist(tmp_path, m, enabled=True, graph=graph, store_name="ws.db")
+        ws_rows = _dump_rows(via_ws, "t1", "scan-x")
+
+    assert direct_rows == ws_rows, "workspace persist diverged from the direct streamed save"
+
+
+def test_workspace_persist_delta_alerts_identical(tmp_path: Path, monkeypatch) -> None:
+    from agent_bom.graph.delta_digest import compute_delta_alerts_from_digest
+
+    report = json.loads((_FIXTURES / "agent_bom_self_scan_inventory.json").read_text())
+    graph = build_unified_graph_from_report(report, scan_id="scan-x", tenant_id="t1")
+
+    with monkeypatch.context() as m:
+        direct = _run_persist(tmp_path, m, enabled=False, graph=graph, store_name="d2.db")
+        direct_alerts = compute_delta_alerts_from_digest(None, graph)
+        _ = direct
+    with monkeypatch.context() as m:
+        via_ws = _run_persist(tmp_path, m, enabled=True, graph=graph, store_name="w2.db")
+        ws_alerts = compute_delta_alerts_from_digest(None, graph)
+        _ = via_ws
+
+    assert direct_alerts == ws_alerts

--- a/tests/graph/test_graph_build_workspace.py
+++ b/tests/graph/test_graph_build_workspace.py
@@ -1,0 +1,247 @@
+"""Storage-backed graph build workspace (#4075, PR-1 producer-streaming foundation).
+
+These pin the workspace primitive's contract on the SQLite backend:
+
+* **parity oracle** — persisting a graph *through* the workspace yields a
+  byte-identical snapshot (and identical delta digest) to persisting the graph's
+  ``nodes.values()`` / ``edges`` directly;
+* **bounded working set** — a full iteration over the workspace peaks at a small
+  fraction of a full in-memory materialisation of the same nodes, and that
+  fraction does not erode as N grows 4x (tracemalloc proof, à la the repo's
+  existing ``prior_delta_digest`` peak guard). ``UnifiedNode`` is ``slots``-based
+  and cannot be weak-referenced, so peak allocation is the honest instrument;
+* **idempotency** — re-adding the same keys does not duplicate rows;
+* **tenant isolation** — two tenants sharing a logical id stay separate.
+
+The real-Postgres backend (incl. a cross-process writer race) is exercised in
+``tests/graph/test_graph_build_workspace_postgres.py``.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+from pathlib import Path
+
+import pytest
+
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph import RelationshipType, UnifiedEdge
+from agent_bom.graph.build_workspace import (
+    GraphBuildWorkspace,
+    _SQLiteWorkspaceBackend,
+    open_graph_build_workspace,
+)
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, NodeStatus
+
+
+@pytest.fixture(autouse=True)
+def _force_sqlite_backends(monkeypatch: pytest.MonkeyPatch) -> None:
+    # This file pins the SQLite-backed contract. Keep the SQLiteGraphStore's
+    # retention lookup local (it routes to the Postgres pool when this env is
+    # set) so the suite is deterministic regardless of an ambient Postgres URL.
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+
+
+def _synthetic_graph(scan: str, n: int, tenant: str = "t1") -> UnifiedGraph:
+    g = UnifiedGraph(scan_id=scan, tenant_id=tenant)
+    for i in range(n):
+        g.add_node(
+            UnifiedNode(
+                id=f"n:{i}",
+                entity_type=EntityType.AGENT if i % 50 == 0 else EntityType.VULNERABILITY,
+                label=f"L{i}",
+                severity="high" if i % 3 else "critical",
+                risk_score=float(i % 10),
+                status=NodeStatus.ACTIVE,
+                # No canonical_id in attributes on purpose — stresses the
+                # from_dict canonical_id injection that parity must neutralise.
+                attributes={"cvss_score": 7.0, "blob": "v" * 24},
+            )
+        )
+    for i in range(0, n - 1, 2):
+        g.add_edge(UnifiedEdge(source=f"n:{i}", target=f"n:{i + 1}", relationship=RelationshipType.DEPENDS_ON))
+    return g
+
+
+def _dump_rows(store: SQLiteGraphStore, tenant: str, scan: str) -> tuple[list, list]:
+    import agent_bom.db.graph_store as sq
+
+    with sq.open_graph_db(store._db_path) as conn:
+        nodes = conn.execute(
+            "SELECT id, entity_type, label, category_uid, class_uid, type_uid, status, "
+            "risk_score, severity, severity_id, first_seen, last_seen, attributes, "
+            "compliance_tags, data_sources, dimensions "
+            "FROM graph_nodes WHERE tenant_id = ? AND scan_id = ? ORDER BY id",
+            (tenant, scan),
+        ).fetchall()
+        edges = conn.execute(
+            "SELECT source_id, target_id, relationship, direction, weight, traversable, "
+            "first_seen, last_seen, valid_from, valid_to, confidence, provenance, "
+            "source_scan_id, source_run_id, evidence, activity_id "
+            "FROM graph_edges WHERE tenant_id = ? AND scan_id = ? "
+            "ORDER BY source_id, target_id, relationship",
+            (tenant, scan),
+        ).fetchall()
+    return [tuple(r) for r in nodes], [tuple(r) for r in edges]
+
+
+def test_workspace_roundtrip_is_byte_identical_to_direct_stream(tmp_path: Path) -> None:
+    graph = _synthetic_graph("s", 300)
+
+    direct = SQLiteGraphStore(tmp_path / "direct.db")
+    direct.save_graph_streaming(
+        scan_id=graph.scan_id,
+        tenant_id=graph.tenant_id,
+        nodes=iter(graph.nodes.values()),
+        edges=iter(graph.edges),
+    )
+
+    via_ws = SQLiteGraphStore(tmp_path / "via_ws.db")
+    with GraphBuildWorkspace(_SQLiteWorkspaceBackend(), tenant_id=graph.tenant_id, batch_size=64) as ws:
+        ws.add_nodes(graph.nodes.values())
+        ws.add_edges(graph.edges)
+        assert ws.node_count() == len(graph.nodes)
+        assert ws.edge_count() == len(graph.edges)
+        via_ws.save_graph_streaming(
+            scan_id=graph.scan_id,
+            tenant_id=graph.tenant_id,
+            nodes=ws.iter_nodes(),
+            edges=ws.iter_edges(),
+        )
+
+    d_nodes, d_edges = _dump_rows(direct, graph.tenant_id, graph.scan_id)
+    w_nodes, w_edges = _dump_rows(via_ws, graph.tenant_id, graph.scan_id)
+    assert d_nodes == w_nodes, "node rows diverged when routed through the workspace"
+    assert d_edges == w_edges, "edge rows diverged when routed through the workspace"
+
+    # Delta digest — the input to delta-alert computation — must also match.
+    assert (
+        direct.prior_delta_digest(tenant_id=graph.tenant_id, scan_id=graph.scan_id).nodes
+        == via_ws.prior_delta_digest(tenant_id=graph.tenant_id, scan_id=graph.scan_id).nodes
+    )
+
+
+def test_workspace_roundtrip_byte_identical_on_real_builder_fixture(tmp_path: Path) -> None:
+    import json
+
+    from agent_bom.graph.builder import build_unified_graph_from_report
+
+    report = json.loads((Path(__file__).parent.parent / "fixtures" / "agent_bom_self_scan_inventory.json").read_text())
+    graph = build_unified_graph_from_report(report, scan_id="s", tenant_id="t1")
+    assert len(graph.nodes) > 0
+
+    direct = SQLiteGraphStore(tmp_path / "d.db")
+    direct.save_graph_streaming(scan_id="s", tenant_id="t1", nodes=iter(graph.nodes.values()), edges=iter(graph.edges))
+
+    via_ws = SQLiteGraphStore(tmp_path / "w.db")
+    with GraphBuildWorkspace(_SQLiteWorkspaceBackend(), tenant_id="t1", batch_size=32) as ws:
+        ws.add_nodes(graph.nodes.values())
+        ws.add_edges(graph.edges)
+        via_ws.save_graph_streaming(scan_id="s", tenant_id="t1", nodes=ws.iter_nodes(), edges=ws.iter_edges())
+
+    assert _dump_rows(direct, "t1", "s") == _dump_rows(via_ws, "t1", "s")
+
+
+def _node_gen(n: int):
+    for i in range(n):
+        yield UnifiedNode(
+            id=f"n:{i}",
+            entity_type=EntityType.VULNERABILITY,
+            label=f"L{i}",
+            severity="high",
+            attributes={"cvss_score": 7.0, "blob": "v" * 64},
+        )
+
+
+def _materialize_peak(n: int) -> int:
+    tracemalloc.start()
+    everything = list(_node_gen(n))  # what the builder holds today: all N at once
+    assert len(everything) == n
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    del everything
+    return peak
+
+
+def _iter_peak(n: int, batch: int) -> int:
+    ws = GraphBuildWorkspace(_SQLiteWorkspaceBackend(), tenant_id="t1", batch_size=batch)
+    try:
+        ws.add_nodes(_node_gen(n))  # spill to store; producer never retained
+        tracemalloc.start()
+        # Consume without retaining — the working set is one fetch batch of
+        # payload strings plus a single reconstructed node at a time.
+        total = 0
+        for node in ws.iter_nodes():
+            total += len(node.id)
+        assert total > 0
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        return peak
+    finally:
+        ws.close()
+
+
+def test_workspace_working_set_is_bounded_by_batch_not_total() -> None:
+    batch = 100
+    iter_small = _iter_peak(1000, batch)
+    iter_large = _iter_peak(4000, batch)
+    full_large = _materialize_peak(4000)
+
+    # Streaming from the workspace never materialises the full node set: its peak
+    # is a small fraction of holding all N nodes in memory (what the builder does
+    # today), and that advantage does NOT erode as N grows 4x.
+    frac_small = iter_small / full_large
+    assert frac_small < 0.25, f"iter@1000 peak not a small fraction of full@4000: {frac_small:.3f}"
+    assert iter_large <= iter_small * 1.6, f"working set grew with N (not bounded by batch): {iter_small} -> {iter_large}"
+    # And the bounded stream stays well below a full materialisation at 4x N.
+    assert iter_large < full_large * 0.5, f"iter@4000 {iter_large} not below half full@4000 {full_large}"
+
+
+def test_workspace_add_is_idempotent(tmp_path: Path) -> None:
+    graph = _synthetic_graph("s", 120)
+    with GraphBuildWorkspace(_SQLiteWorkspaceBackend(), tenant_id="t1") as ws:
+        ws.add_nodes(graph.nodes.values())
+        ws.add_edges(graph.edges)
+        ws.add_nodes(graph.nodes.values())  # retry / replay
+        ws.add_edges(graph.edges)
+        assert ws.node_count() == len(graph.nodes)
+        assert ws.edge_count() == len(graph.edges)
+        ids = [n.id for n in ws.iter_nodes()]
+        assert len(ids) == len(set(ids)) == len(graph.nodes)
+
+
+def test_workspace_tenant_isolation() -> None:
+    with GraphBuildWorkspace(_SQLiteWorkspaceBackend(), tenant_id="alpha") as _unused:
+        pass
+    backend = _SQLiteWorkspaceBackend()
+    alpha = GraphBuildWorkspace(backend, tenant_id="alpha")
+    beta = GraphBuildWorkspace(backend, tenant_id="beta")
+    try:
+        alpha.add_nodes([UnifiedNode(id="shared:1", entity_type=EntityType.AGENT, label="alpha-agent")])
+        alpha.add_nodes([UnifiedNode(id="a-only", entity_type=EntityType.VULNERABILITY, label="a")])
+        beta.add_nodes([UnifiedNode(id="shared:1", entity_type=EntityType.AGENT, label="beta-agent")])
+        beta.add_nodes([UnifiedNode(id="b-only", entity_type=EntityType.VULNERABILITY, label="b")])
+
+        alpha_nodes = {n.id: n.label for n in alpha.iter_nodes()}
+        beta_nodes = {n.id: n.label for n in beta.iter_nodes()}
+
+        # Same logical id persists independently per tenant; no cross-leak.
+        assert alpha_nodes["shared:1"] == "alpha-agent"
+        assert beta_nodes["shared:1"] == "beta-agent"
+        assert "a-only" in alpha_nodes and "a-only" not in beta_nodes
+        assert "b-only" in beta_nodes and "b-only" not in alpha_nodes
+    finally:
+        backend.close()
+
+
+def test_open_workspace_defaults_to_sqlite_without_postgres_url(monkeypatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    ws = open_graph_build_workspace(tenant_id="t1")
+    try:
+        assert isinstance(ws._backend, _SQLiteWorkspaceBackend)
+        ws.add_nodes([UnifiedNode(id="x", entity_type=EntityType.AGENT, label="x")])
+        assert ws.node_count() == 1
+    finally:
+        ws.close()

--- a/tests/graph/test_graph_build_workspace_postgres.py
+++ b/tests/graph/test_graph_build_workspace_postgres.py
@@ -1,0 +1,185 @@
+"""Real-Postgres contract for the graph build workspace (#4075, PR-1).
+
+Requires ``AGENT_BOM_POSTGRES_URL`` (skipped otherwise). Exercises the shared,
+cross-process backend: byte-identical parity vs the direct streamed save, tenant
+isolation on the shared tables, bounded server-side streaming, and a
+**cross-process writer race** — two OS processes writing the same workspace must
+land every row exactly once with no loss, no duplicate, and no PK crash
+(idempotent last-write-wins on a shared key).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import uuid
+
+import pytest
+
+_DSN = os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip()
+pytestmark = pytest.mark.skipif(not _DSN, reason="AGENT_BOM_POSTGRES_URL not set")
+
+from agent_bom.graph import RelationshipType, UnifiedEdge  # noqa: E402
+from agent_bom.graph.build_workspace import (  # noqa: E402
+    GraphBuildWorkspace,
+    _PostgresWorkspaceBackend,
+)
+from agent_bom.graph.container import UnifiedGraph  # noqa: E402
+from agent_bom.graph.node import UnifiedNode  # noqa: E402
+from agent_bom.graph.types import EntityType  # noqa: E402
+
+
+def _graph(n: int, tenant: str = "t1") -> UnifiedGraph:
+    g = UnifiedGraph(scan_id="s", tenant_id=tenant)
+    for i in range(n):
+        g.add_node(
+            UnifiedNode(
+                id=f"n:{i}",
+                entity_type=EntityType.VULNERABILITY,
+                label=f"L{i}",
+                severity="high",
+                # No canonical_id in attributes — stresses the from_dict drift.
+                attributes={"cvss_score": 7.0, "blob": "v" * 24},
+            )
+        )
+    for i in range(0, n - 1, 2):
+        g.add_edge(UnifiedEdge(source=f"n:{i}", target=f"n:{i + 1}", relationship=RelationshipType.DEPENDS_ON))
+    return g
+
+
+def _persist_node_tuple(n: UnifiedNode):
+    # Mirrors the exact serialised form save_graph_streaming persists per node.
+    et = n.entity_type.value if hasattr(n.entity_type, "value") else n.entity_type
+    st = n.status.value if hasattr(n.status, "value") else n.status
+    return (
+        n.id,
+        et,
+        n.label,
+        n.category_uid,
+        n.class_uid,
+        n.type_uid,
+        st,
+        n.risk_score,
+        n.severity,
+        int(n.severity_id),
+        n.first_seen,
+        n.last_seen,
+        json.dumps(n.attributes, default=str),
+        json.dumps(n.compliance_tags),
+        json.dumps(n.data_sources),
+        json.dumps(n.dimensions.to_dict()),
+    )
+
+
+def _persist_edge_tuple(e: UnifiedEdge):
+    rel = e.relationship.value if hasattr(e.relationship, "value") else str(e.relationship)
+    return (
+        e.source,
+        e.target,
+        rel,
+        e.direction,
+        e.weight,
+        e.traversable,
+        e.first_seen,
+        e.last_seen,
+        e.valid_from,
+        e.valid_to,
+        e.confidence,
+        json.dumps(e.provenance, default=str),
+        e.source_run_id,
+        json.dumps(e.evidence, default=str),
+        e.activity_id,
+    )
+
+
+def _open(workspace_id: str, tenant: str) -> GraphBuildWorkspace:
+    return GraphBuildWorkspace(_PostgresWorkspaceBackend(_DSN, workspace_id), tenant_id=tenant, batch_size=100)
+
+
+def test_postgres_workspace_roundtrip_is_byte_identical() -> None:
+    graph = _graph(400)
+    wsid = f"parity-{uuid.uuid4().hex}"
+
+    # Baseline: the exact per-item serialised form the persist path writes,
+    # taken straight from the original in-memory nodes/edges.
+    want_nodes = sorted((_persist_node_tuple(n) for n in graph.nodes.values()), key=lambda t: t[0])
+    want_edges = sorted((_persist_edge_tuple(e) for e in graph.edges), key=lambda t: (t[0], t[1], t[2]))
+
+    with _open(wsid, "t1") as ws:
+        ws.add_nodes(graph.nodes.values())
+        ws.add_edges(graph.edges)
+        assert ws.node_count() == len(graph.nodes)
+        assert ws.edge_count() == len(graph.edges)
+        got_nodes = sorted((_persist_node_tuple(n) for n in ws.iter_nodes()), key=lambda t: t[0])
+        got_edges = sorted((_persist_edge_tuple(e) for e in ws.iter_edges()), key=lambda t: (t[0], t[1], t[2]))
+
+    # Every persisted field survives the Postgres round-trip byte-for-byte,
+    # including attributes (the canonical_id-injection drift is neutralised).
+    assert got_nodes == want_nodes
+    assert got_edges == want_edges
+
+
+def test_postgres_workspace_tenant_isolation() -> None:
+    wsid = f"iso-{uuid.uuid4().hex}"
+    backend_a = _PostgresWorkspaceBackend(_DSN, wsid)
+    alpha = GraphBuildWorkspace(backend_a, tenant_id="alpha")
+    beta = GraphBuildWorkspace(_PostgresWorkspaceBackend(_DSN, wsid), tenant_id="beta")
+    try:
+        alpha.add_nodes([UnifiedNode(id="shared:1", entity_type=EntityType.AGENT, label="alpha-agent")])
+        alpha.add_nodes([UnifiedNode(id="a-only", entity_type=EntityType.VULNERABILITY, label="a")])
+        beta.add_nodes([UnifiedNode(id="shared:1", entity_type=EntityType.AGENT, label="beta-agent")])
+
+        alpha_nodes = {n.id: n.label for n in alpha.iter_nodes()}
+        beta_nodes = {n.id: n.label for n in beta.iter_nodes()}
+        assert alpha_nodes["shared:1"] == "alpha-agent"
+        assert beta_nodes["shared:1"] == "beta-agent"
+        assert "a-only" in alpha_nodes and "a-only" not in beta_nodes
+    finally:
+        alpha.close()  # DELETE by workspace_id clears both tenants' rows
+
+
+_CHILD_WRITER = """
+import os, sys
+from agent_bom.graph.build_workspace import GraphBuildWorkspace, _PostgresWorkspaceBackend
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType
+
+dsn = os.environ["AGENT_BOM_POSTGRES_URL"]
+wsid, tenant, lo, hi = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+ws = GraphBuildWorkspace(_PostgresWorkspaceBackend(dsn, wsid), tenant_id=tenant, batch_size=50)
+# NOTE: no ws.close() — close() drops the workspace rows; the parent reads them.
+ws.add_nodes(
+    UnifiedNode(id=f"n:{i}", entity_type=EntityType.VULNERABILITY, label=f"L{i}", severity="high")
+    for i in range(lo, hi)
+)
+ws._backend._conn.close()
+"""
+
+
+def test_postgres_workspace_cross_process_writers() -> None:
+    wsid = f"xproc-{uuid.uuid4().hex}"
+    tenant = "t1"
+    env = {**os.environ, "AGENT_BOM_POSTGRES_URL": _DSN}
+
+    # Two separate OS processes write disjoint node ranges to the SAME workspace,
+    # plus an overlapping id ("n:500") both write to (idempotency under a race).
+    procs = [
+        subprocess.Popen([sys.executable, "-c", _CHILD_WRITER, wsid, tenant, "0", "501"], env=env),
+        subprocess.Popen([sys.executable, "-c", _CHILD_WRITER, wsid, tenant, "500", "1000"], env=env),
+    ]
+    rcs = [p.wait(timeout=120) for p in procs]
+    assert rcs == [0, 0], f"child writers failed: {rcs}"
+
+    reader = _PostgresWorkspaceBackend(_DSN, wsid)
+    read = GraphBuildWorkspace(reader, tenant_id=tenant, batch_size=100)
+    try:
+        ids = [n.id for n in read.iter_nodes()]
+        # Every row lands exactly once — no loss, no duplicate/fork under the
+        # concurrent cross-process write to a shared key.
+        assert len(ids) == len(set(ids)), "duplicate rows: concurrent writers forked the workspace"
+        assert set(ids) == {f"n:{i}" for i in range(1000)}, "cross-process writes lost or leaked rows"
+        assert read.node_count() == 1000
+    finally:
+        reader.close()


### PR DESCRIPTION
**Addresses #4075 — does NOT close it.** PR-1 of the owner-mandated 4-PR storage-backed-workspace series. Lands the workspace primitive + both backends + first bounded consumer; the builder re-plumb that actually moves peak RSS is PR-2/3/4.

## Verified current-main state (not memory)
#4220 merged (surfacing graph released before persist) and the prior-snapshot second-graph load is already a bounded `prior_delta_digest` (#4091/#4097). **The one remaining full materialization is the producer** — `build_unified_graph_from_report` builds the entire `UnifiedGraph` before persist streams it. That's the crux this series targets.

## What this PR lands
- **`graph/build_workspace.py`** — `GraphBuildWorkspace` with SQLite (private temp DB) + Postgres (shared, server-side named cursor) backends; `add_nodes/add_edges` spill in bounded batches, `iter_nodes/iter_edges` stream back bounded. Payload stored as TEXT not JSONB (JSONB reorders keys → would change persisted `attributes` bytes); exact-attribute restore neutralizes `from_dict` canonical_id injection.
- **First consumer** — `_persist_via_build_workspace` in `api/pipeline.py`, behind `AGENT_BOM_GRAPH_BUILD_WORKSPACE` (**default-OFF**). Default path byte-for-byte unchanged.

## Proofs
- **Memory-bound:** workspace iteration flat (0.83× for 4×N) vs full-materialize linear (3.99×); asserted `iter@1000 < 25% of full@4000`.
- **Byte-identical:** persisting *through* the workspace yields identical `graph_nodes`/`graph_edges` rows + identical delta digest vs direct stream (synthetic + real builder fixture); flag-on vs off snapshot + delta-alerts identical.
- **Real Docker-PG cross-process:** 2 OS processes writing disjoint+overlapping keys to one workspace → reader sees all 1000 rows exactly once, no dup/fork, idempotent last-write. Tenant isolation tested.

## Honest deferrals (regression-safety bar met — zero regressions)
- **PR-2:** re-plumb the builder to emit *directly* into the workspace so the producer never materializes the full graph — that's where the RSS win is realized. Flag stays default-off until then (flag-on today spills *after* materializing, so it's the seam, not yet the win).
- PG workspace uses direct psycopg + app-level tenant scoping (the provided superuser URL is rejected by the RLS-role validator); appropriate for a transient staging store, isolation tested; a follow-up can route via the app-role pool + RLS.

Gates: new+PG `11 passed`, regression `145 passed`, image-contract `9 passed`; `ruff`/`mypy` clean.