### PR TITLE
perf(graph): stream the SQLite search-index refresh + map the producer-streaming wall (PR-2 of #4075)

### DIFF
--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -433,7 +433,17 @@ class SQLiteGraphStore:
     def _refresh_snapshot_search_index(self, conn: sqlite3.Connection, *, tenant_id: str, scan_id: str) -> None:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn.execute("DELETE FROM graph_node_search WHERE tenant_id = ? AND scan_id = ?", (tenant_id, scan_id))
-        rows = conn.execute(
+        # Stream the snapshot's node rows in bounded batches rather than
+        # ``.fetchall()`` of every row + a full ``UnifiedNode`` per row: this
+        # refresh runs at the persist peak while the builder's in-memory graph is
+        # still resident, so a fetchall added a second O(N) materialisation of the
+        # whole node set on top of it. A separate read cursor iterates a different
+        # table (graph_nodes) than the one being written (graph_node_search), so
+        # interleaving the reads and the batched inserts is safe on one
+        # connection; peak stays proportional to the batch size, not the snapshot
+        # size (#4075). Rows written are byte-identical to the fetchall path.
+        batch_size = sqlite_graph_store._graph_write_batch_size()
+        select_cur = conn.execute(
             """
             SELECT
                 id, entity_type, label, category_uid, class_uid, type_uid,
@@ -443,26 +453,34 @@ class SQLiteGraphStore:
             WHERE tenant_id = ? AND scan_id = ?
             """,
             (tenant_id, scan_id),
-        ).fetchall()
-        for row in rows:
+        )
+        insert_sql = """
+            INSERT INTO graph_node_search (
+                tenant_id, scan_id, node_id, entity_type, severity, compliance_tags, data_sources, search_text
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        """
+
+        def _search_row(row: sqlite3.Row) -> tuple[Any, ...]:
             node = self._node_from_row(row)
-            conn.execute(
-                """
-                INSERT INTO graph_node_search (
-                    tenant_id, scan_id, node_id, entity_type, severity, compliance_tags, data_sources, search_text
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-                """,
-                (
-                    tenant_id,
-                    scan_id,
-                    node.id,
-                    node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type),
-                    node.severity.lower(),
-                    " ".join(node.compliance_tags).lower(),
-                    " ".join(node.data_sources).lower(),
-                    _node_search_text(node),
-                ),
+            return (
+                tenant_id,
+                scan_id,
+                node.id,
+                node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type),
+                node.severity.lower(),
+                " ".join(node.compliance_tags).lower(),
+                " ".join(node.data_sources).lower(),
+                _node_search_text(node),
             )
+
+        try:
+            while True:
+                batch = select_cur.fetchmany(batch_size)
+                if not batch:
+                    break
+                conn.executemany(insert_sql, [_search_row(row) for row in batch])
+        finally:
+            select_cur.close()
 
     def delete_tenant(self, *, tenant_id: str = "") -> int:
         """Delete graph rows for one tenant and return the number of rows removed."""

--- a/tests/api/test_search_index_refresh_streaming.py
+++ b/tests/api/test_search_index_refresh_streaming.py
@@ -1,0 +1,102 @@
+"""Bounded (streamed) SQLite snapshot search-index refresh (#4075, PR-2).
+
+``_refresh_snapshot_search_index`` used to ``.fetchall()`` every node row of the
+snapshot and reconstruct a full ``UnifiedNode`` for each before inserting the
+search mirror — an O(N) second materialisation of the whole node set, executed
+at the persist peak while the builder's in-memory graph is still resident. This
+pins that the refresh now streams in bounded batches (peak flat as the snapshot
+grows) while producing a byte-identical ``graph_node_search`` table, on both the
+``save_graph`` and ``save_graph_streaming`` write paths.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+from pathlib import Path
+
+import agent_bom.db.graph_store as sg
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph import RelationshipType, UnifiedEdge
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, NodeStatus
+
+
+def _synthetic_graph(scan: str, n: int) -> UnifiedGraph:
+    g = UnifiedGraph(scan_id=scan, tenant_id="t1")
+    for i in range(n):
+        g.add_node(
+            UnifiedNode(
+                id=f"n:{i}",
+                entity_type=EntityType.AGENT if i % 50 == 0 else EntityType.VULNERABILITY,
+                label=f"label-{i}",
+                severity="high" if i % 3 else "critical",
+                risk_score=float(i % 10),
+                status=NodeStatus.ACTIVE,
+                compliance_tags=["cis-1.1", "soc2"],
+                data_sources=["mcp-scan"],
+                attributes={"cvss_score": 7.0, "blob": "v" * 64, "purl": f"pkg:pypi/x-{i}@1.0"},
+            )
+        )
+    for i in range(0, n - 1, 2):
+        g.add_edge(UnifiedEdge(source=f"n:{i}", target=f"n:{i + 1}", relationship=RelationshipType.DEPENDS_ON))
+    return g
+
+
+def _refresh_peak(tmp_path: Path, n: int, monkeypatch) -> int:
+    # Small batch so a streamed refresh is unambiguously flat; a fetchall refresh
+    # ignores it and stays O(N).
+    monkeypatch.setenv("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", "500")
+    store = SQLiteGraphStore(tmp_path / f"r{n}.db")
+    store.save_graph(_synthetic_graph("s", n))
+    with sg.open_graph_db(store._db_path) as conn:
+        tracemalloc.start()
+        store._refresh_snapshot_search_index(conn, tenant_id="t1", scan_id="s")
+        _, peak = tracemalloc.get_traced_memory()
+        tracemalloc.stop()
+        conn.commit()
+    return peak
+
+
+def test_refresh_peak_is_bounded_as_snapshot_grows(tmp_path: Path, monkeypatch) -> None:
+    small = _refresh_peak(tmp_path, 2000, monkeypatch)
+    large = _refresh_peak(tmp_path, 8000, monkeypatch)
+
+    # 4x the nodes must NOT cost ~4x the transient allocation; a fetchall refresh
+    # is linear (~4x), a bounded streamed refresh stays roughly flat. Guard at 2x.
+    assert large <= small * 2.0, f"refresh peak scales with snapshot size: {small} -> {large} (4x nodes)"
+
+
+def _search_rows(store: SQLiteGraphStore, scan: str) -> list[tuple]:
+    with sg.open_graph_db(store._db_path) as conn:
+        return sorted(
+            tuple(r)
+            for r in conn.execute(
+                "SELECT node_id, entity_type, severity, compliance_tags, data_sources, search_text "
+                "FROM graph_node_search WHERE tenant_id = 't1' AND scan_id = ? ",
+                (scan,),
+            ).fetchall()
+        )
+
+
+def test_search_index_content_identical_across_write_paths(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", "500")
+    graph = _synthetic_graph("s", 1500)
+
+    full = SQLiteGraphStore(tmp_path / "full.db")
+    full.save_graph(graph)
+
+    stream = SQLiteGraphStore(tmp_path / "stream.db")
+    stream.save_graph_streaming(
+        scan_id="s",
+        tenant_id="t1",
+        nodes=iter(graph.nodes.values()),
+        edges=iter(graph.edges),
+    )
+
+    full_rows = _search_rows(full, "s")
+    stream_rows = _search_rows(stream, "s")
+    assert full_rows == stream_rows, "streamed vs full save produced different search rows"
+    assert len(full_rows) == 1500, "every node must have a search row"
+    # search_text is non-empty and lowercased (mirror content preserved).
+    assert all(r[5] and r[5] == r[5].lower() for r in full_rows)


### PR DESCRIPTION
**Addresses #4075 — does NOT close it.** PR-2 set out to re-plumb the producer to stream; instead it **measured that full producer-streaming is architecturally blocked**, landed the one safe byte-identical win, and documented the wall for PR-3/4. No forced/risky re-plumb (regression-safety was the hard bar).

## The measured finding (68k-node profile)
| N | producer graph | persist (flag OFF) | persist (flag ON/workspace) |
|---|---|---|---|
| 17k | 47.6 MB | 62.6 | 62.8 |
| 68k | **191.9 MB** | 253.8 | 254.0 |

- The correlated `UnifiedGraph` is the **irreducible floor** (191.9 MB @68k, linear): every overlay/fusion phase (CNAPP, effective-permissions, NHI-gov, attack-path fusion, MITRE, cost, ASPM) traverses + mutates the whole graph in place, and `compute_delta_alerts_from_digest` walks it after save. Can't drain/stream without rearchitecting those phases (would break byte-identical fusion output).
- The `AGENT_BOM_GRAPH_BUILD_WORKSPACE` flag is a **measured wash** (254.0 vs 253.8) — flag-on spills *after* materializing. **Stays default-OFF** (can't prove it's lower — honest PR-3/4 blocker).

## The safe win landed
`SQLiteGraphStore._refresh_snapshot_search_index` did a full `.fetchall()` + `UnifiedNode` reconstruction of every node (a second O(N) materialization while the builder graph is resident). Now a bounded `fetchmany` cursor → insert in batches. Byte-identical; helps both `save_graph` and `save_graph_streaming`, no flag. (Postgres already built this mirror inline — untouched.)
- Isolated refresh: `2.0→8.0 MB @2k→8k (linear)` → **`2.1→2.1 MB (flat)`**. Production persist @68k: 253.8 → **247.9 MB**.

## Verified / regression-safe
1 source file (`api/graph_store.py`, +37/−19) + 1 test. Search-index/persist `38 passed`; broad graph/builder/fusion/overlay/delta `149 + 195 + 154 passed`; real-PG workspace cross-process `3 passed`. `ruff`/`mypy` clean. Zero Postgres/builder/fusion code touched, no flag flipped. (The 65 `test_postgres_store` failures are pre-existing env — proven identical on baseline main; a local-DB migration-provisioning gap, i.e. the #4232 domain.)

## To close #4075 (PR-3/4)
Make the overlay/fusion phases **streaming/two-pass** (bounded "core" pass vs streamable remainder, or back the graph container with the workspace during correlation) so the producer never holds the whole correlated graph. That's the risky rearchitecture this PR deliberately did not force.