### PR TITLE
fix(postgres): restore audit hash-chain fork-guard index in the migration-owned schema

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260719_01_audit_fork_guard_index.py
+++ b/deploy/supabase/postgres/alembic/versions/20260719_01_audit_fork_guard_index.py
@@ -1,0 +1,35 @@
+"""Restore the audit hash-chain fork-guard unique index in the migration-owned schema.
+
+The runtime store's _init_tables() early-returns when Postgres is authoritative
+(#4232), so PostgresAuditLog._ensure_fork_guard_index() no longer runs there and
+UNIQUE(team_id, prev_signature) existed in no authoritative SQL. Without it,
+PostgresAuditLog.append (which has no in-process lock) cannot reject a concurrent
+chain fork across uvicorn --workers N, weakening audit tamper-evidence.
+
+Revision ID: 20260719_01
+Revises: 20260718_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260719_01"
+down_revision = "20260718_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # IF NOT EXISTS so this is a no-op on fresh deployments that already applied
+    # the index from runtime-schema.sql, and idempotent on rerun. Pre-existing
+    # forks in older data would make creation fail; mirror the store's defensive
+    # posture (append still retries) rather than aborting the migration.
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS audit_log_team_prevsig_uniq "
+        "ON audit_log (team_id, prev_signature)"
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP INDEX IF EXISTS audit_log_team_prevsig_uniq")

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -15,6 +15,11 @@ CREATE INDEX IF NOT EXISTS idx_api_keys_scim_subject ON api_keys(team_id,scim_su
 CREATE INDEX IF NOT EXISTS idx_api_keys_owner ON api_keys(team_id,owner);
 CREATE INDEX IF NOT EXISTS idx_audit_log_team_action_ts ON audit_log(team_id,action,timestamp DESC);
 CREATE INDEX IF NOT EXISTS idx_audit_log_team_resource_ts ON audit_log(team_id,resource text_pattern_ops,timestamp DESC);
+-- Hash-chain fork guard (#3665-class): at most one row may link to any predecessor
+-- per tenant, so concurrent appends across uvicorn --workers N cannot fork the chain.
+-- Mirrors PostgresAuditLog._ensure_fork_guard_index; must live in the migration-owned
+-- schema because the runtime store's _init_tables() early-returns when Postgres is authoritative.
+CREATE UNIQUE INDEX IF NOT EXISTS audit_log_team_prevsig_uniq ON audit_log(team_id,prev_signature);
 ALTER TABLE fleet_agents ADD COLUMN IF NOT EXISTS canonical_id TEXT NOT NULL DEFAULT '';
 CREATE INDEX IF NOT EXISTS idx_fleet_canonical_id ON fleet_agents(canonical_id);
 CREATE INDEX IF NOT EXISTS idx_fleet_tenant_state_trust_name ON fleet_agents(tenant_id,lifecycle_state,trust_score DESC,name);


### PR DESCRIPTION
## What
Adds `UNIQUE(team_id, prev_signature)` on `audit_log` to `runtime-schema.sql` (fresh deploys) plus a new Alembic version `20260719_01` (existing deploys).

## Why (security regression from #4232)
#4232 made migrations authoritative and had the runtime store's `_init_tables()` early-return when Postgres is the backend. But the audit-chain fork guard was created *inside* that method (`PostgresAuditLog._ensure_fork_guard_index`), so it now never runs — the unique index existed in **no** authoritative SQL (not init.sql, runtime-schema, or any migration). `PostgresAuditLog.append` has no in-process lock and relies entirely on that index to reject concurrent chain forks across `uvicorn --workers N`; without it, two workers can fork a tenant's tamper-evidence chain undetected. Found in the 2026-07-19 security audit lane.

## How verified (live Postgres 16)
Fresh DB migrated to head (18 upgrades) → `audit_log_team_prevsig_uniq` present; a second INSERT linking to the same predecessor is rejected with `duplicate key value violates unique constraint` (was silently accepted before → `FORKED=2`). `check_release_consistency` green. Idempotent: `IF NOT EXISTS` so the fresh-deploy runtime-schema copy and the migration don't collide.