### PR TITLE
fix: collapse CIEM over-privilege double-count, reword PCI descriptors, idle vuln tile on empty estate

### DIFF
--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -1088,7 +1088,11 @@ def _compose_overview(request: Request, tenant_id: str, jobs: list[Any], hub_sev
             "graph_href": _cloud_graph_href(vuln_severity),
             "metric": vuln_metric,
             "metric_label": "open CVEs",
-            "status": _status_for(vuln_severity["critical"], vuln_severity["high"]),
+            # No vuln data at all → "idle" (mirrors the sibling scan-scoped tiles),
+            # never a green "ok" on a brand-new zero-finding estate while the
+            # posture headline reads N/A. Only rate the tile once real CVE evidence
+            # exists (metric > 0); the critical/high gate then decides ok/warn/critical.
+            "status": (_status_for(vuln_severity["critical"], vuln_severity["high"]) if vuln_metric > 0 else "idle"),
             "detail": {
                 "critical": vuln_severity["critical"],
                 "high": vuln_severity["high"],

--- a/src/agent_bom/graph/nhi_governance.py
+++ b/src/agent_bom/graph/nhi_governance.py
@@ -398,20 +398,30 @@ def build_nhi_governance_findings(
     for v in verdicts:
         asset = Asset(name=v.name, asset_type="agent", identifier=v.identity_id, location=v.provider)
 
-        # 1. Right-sizing — granted but never used.
-        if v.unused_targets:
-            labels = [_target_label(graph, tid) for tid in v.unused_targets[:20]]
+        # 1. Right-sizing — granted but never used. Never-used targets already
+        #    covered by the Access-Advisor CIEM emitter
+        #    (:func:`build_ciem_over_privilege_findings`) are excluded here so the
+        #    SAME over-privilege risk is not emitted twice under two different ids
+        #    (the 2026-07-18 double-count regression): a role/service-account with
+        #    a MIX of used + never-used Access-Advisor grants was flagged on BOTH
+        #    paths. The CIEM finding is richer (stable id, provider, actionable),
+        #    so it is the single source for Access-Advisor-observed over-grants;
+        #    the NHI path only right-sizes grants CIEM does not cover.
+        aa_unused = {tid for tid, last_used in _access_advisor_grants(graph, v.node_id).items() if not last_used}
+        over_grant_targets = [tid for tid in v.unused_targets if tid not in aa_unused]
+        if over_grant_targets:
+            labels = [_target_label(graph, tid) for tid in over_grant_targets[:20]]
             findings.append(
                 Finding(
                     finding_type=FindingType.CIEM_OVER_PRIVILEGE,
                     source=FindingSource.MCP_SCAN,
                     asset=asset,
                     severity="medium" if v.is_privileged else "low",
-                    title=f"Over-granted identity: {v.name} has {len(v.unused_targets)} unused permission(s)",
+                    title=f"Over-granted identity: {v.name} has {len(over_grant_targets)} unused permission(s)",
                     description=(
                         f"Identity '{v.name}' is granted {v.granted_count} permission(s) but is observed using "
                         f"{v.used_count}. Right-size by removing the unused grants: {', '.join(labels)}"
-                        + ("…" if len(v.unused_targets) > 20 else ".")
+                        + ("…" if len(over_grant_targets) > 20 else ".")
                     ),
                     remediation_guidance=("Remove the unused permissions / tool scopes from this identity to enforce least privilege."),
                     evidence={
@@ -419,7 +429,7 @@ def build_nhi_governance_findings(
                         "identity_id": v.identity_id,
                         "granted_count": v.granted_count,
                         "used_count": v.used_count,
-                        "unused_permission_count": len(v.unused_targets),
+                        "unused_permission_count": len(over_grant_targets),
                         "unused_targets": labels,
                         "risk_score": v.risk_score,
                     },

--- a/src/agent_bom/pci_dss.py
+++ b/src/agent_bom/pci_dss.py
@@ -30,24 +30,30 @@ _HIGH_RISK = high_risk_severities()
 
 # ─── Catalog ──────────────────────────────────────────────────────────────────
 
+# NOTE — the descriptors below are agent-bom's OWN short wording for each PCI DSS
+# requirement area, not the official PCI DSS 4.0 requirement text. PCI DSS is
+# copyrighted by the PCI Security Standards Council, so its requirement wording is
+# NOT reproduced or redistributed here; only the requirement **identifier** (the
+# fact) is used. Consult the standard for the official text:
+# https://www.pcisecuritystandards.org/document_library/
 PCI_DSS_REQUIREMENTS: dict[str, str] = {
     # Requirement 6 — Develop and maintain secure systems and software
-    "6.2.4": "Software engineering practices prevent and mitigate common software attacks and vulnerabilities",
-    "6.3.1": "Security vulnerabilities identified and managed using reputable external sources",
-    "6.3.2": "Inventory of bespoke and custom software, and third-party software components maintained",
-    "6.3.3": "Security patches/updates installed to protect against known vulnerabilities",
+    "6.2.4": "Secure software-engineering practices",
+    "6.3.1": "Vulnerability identification from reputable sources",
+    "6.3.2": "Third-party / custom software component inventory",
+    "6.3.3": "Timely security patching",
     # Requirement 11 — Regularly test security systems and networks
-    "11.3.1": "Internal vulnerability scans performed at least quarterly",
-    "11.3.2": "External vulnerability scans performed at least quarterly by PCI SSC ASV",
+    "11.3.1": "Internal vulnerability scanning",
+    "11.3.2": "External / ASV vulnerability scanning",
     # Requirement 12 — Maintain policy that addresses information security
-    "12.3.1": "Risk assessment performed for each entity's critical assets, threats, and vulnerabilities",
-    "12.3.4": "Cryptographic cipher suites and protocols in use reviewed annually",
+    "12.3.1": "Critical-asset risk assessment",
+    "12.3.4": "Periodic cryptographic-suite review",
     # Requirement 2 — Apply secure configurations
-    "2.2.1": "System configuration standards address all known security vulnerabilities",
-    "2.2.7": "All non-console administrative access encrypted with strong cryptography",
+    "2.2.1": "Secure configuration standards",
+    "2.2.7": "Encrypted administrative access",
     # Requirement 8 — Identify users and authenticate access
-    "8.3.6": "Passwords/passphrases meet minimum complexity requirements",
-    "8.6.1": "System or application accounts managed based on least privilege",
+    "8.3.6": "Authentication-factor strength",
+    "8.6.1": "Least-privilege system accounts",
 }
 
 

--- a/tests/test_api_findings_surface_parity.py
+++ b/tests/test_api_findings_surface_parity.py
@@ -216,6 +216,103 @@ def test_all_three_categories_present_once():
     assert [f for f in findings if f.evidence.get("mcp_tool_rule")]
 
 
+# ── Access-Advisor over-privilege: no double-count ───────────────────────────
+
+
+def _access_advisor_grant(src: str, tgt: str, service: str, last_used: str | None) -> UnifiedEdge:
+    return UnifiedEdge(
+        source=src,
+        target=tgt,
+        relationship=RelationshipType.HAS_PERMISSION,
+        evidence={
+            "source": "access-advisor",
+            "access_advisor": True,
+            "service_namespace": service,
+            "last_used_at": last_used,
+        },
+    )
+
+
+def _mixed_access_advisor_graph() -> UnifiedGraph:
+    """An AWS ROLE and a GCP SERVICE_ACCOUNT, each with Access-Advisor grants
+    that MIX used + never-used services.
+
+    This is the case the plain-HAS_PERMISSION ``_dormant_over_granted_graph``
+    fixture never exercised: because there is an observed-usage signal (the used
+    service's ``last_used_at``), the NHI over-grant path ALSO flags the never-used
+    services — so the same over-privilege risk was emitted twice (once by the NHI
+    right-sizing emitter, once by the Access-Advisor CIEM emitter) under two
+    different ids, double-counting in every total.
+    """
+    g = UnifiedGraph(scan_id="scan-1", tenant_id="tenant-a")
+
+    # AWS IAM role: s3 used, dynamodb + kms never used.
+    g.add_node(
+        UnifiedNode(
+            id="role:aws:app",
+            entity_type=EntityType.ROLE,
+            label="app-role",
+            attributes={"cloud_provider": "aws", "principal_id": "AROA-app", "is_admin": True},
+        )
+    )
+    for svc, last in (("s3", "2026-06-01T00:00:00Z"), ("dynamodb", None), ("kms", None)):
+        g.add_node(UnifiedNode(id=f"res:aws:{svc}", entity_type=EntityType.CLOUD_RESOURCE, label=svc))
+        g.add_edge(_access_advisor_grant("role:aws:app", f"res:aws:{svc}", svc, last))
+
+    # GCP service account: bigquery used, storage never used.
+    g.add_node(
+        UnifiedNode(
+            id="sa:gcp:etl",
+            entity_type=EntityType.SERVICE_ACCOUNT,
+            label="etl-sa",
+            attributes={"cloud_provider": "gcp", "principal_id": "etl@proj.iam"},
+        )
+    )
+    for svc, last in (("bigquery", "2026-06-02T00:00:00Z"), ("storage", None)):
+        g.add_node(UnifiedNode(id=f"res:gcp:{svc}", entity_type=EntityType.CLOUD_RESOURCE, label=svc))
+        g.add_edge(_access_advisor_grant("sa:gcp:etl", f"res:gcp:{svc}", svc, last))
+
+    return g
+
+
+def test_access_advisor_over_privilege_not_double_counted():
+    """Mixed used+never-used Access-Advisor grants yield exactly ONE
+    CIEM_OVER_PRIVILEGE finding per identity — not one from the NHI over-grant
+    emitter AND one from the CIEM emitter (the 2026-07-18 double-count regression).
+    """
+    from agent_bom.graph.nhi_governance import apply_nhi_governance_with_findings
+
+    graph = _mixed_access_advisor_graph()
+    _, nhi = apply_nhi_governance_with_findings(graph, now=NOW)
+    graph.nhi_governance_findings = nhi
+
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id="scan-1")
+    attach_graph_derived_findings(report, graph)
+    findings = report.to_findings()
+
+    over_priv = [f for f in findings if f.finding_type == FindingType.CIEM_OVER_PRIVILEGE]
+    # One per over-privileged identity — never two for the same identity.
+    by_identity: dict[str, int] = {}
+    for f in over_priv:
+        by_identity[f.asset.identifier] = by_identity.get(f.asset.identifier, 0) + 1
+    assert by_identity == {"AROA-app": 1, "etl@proj.iam": 1}, by_identity
+    assert len(over_priv) == 2, [f.title for f in over_priv]
+
+    # The surviving finding is the richer Access-Advisor CIEM one and still covers
+    # the full never-used set (merge, not silent drop).
+    aws = next(f for f in over_priv if f.asset.identifier == "AROA-app")
+    assert set(aws.evidence["unused_permissions"]) == {"dynamodb", "kms"}
+    assert aws.evidence.get("analysis") == "access_advisor_rightsizing"
+
+    # No id appears twice, and CSPM-domain routing counts each identity once.
+    ids = [f.id for f in findings]
+    assert len(ids) == len(set(ids)), "over-privilege risk must not double-count within one stream"
+    from agent_bom.finding_scope import security_domain_for
+
+    cspm = [f for f in over_priv if security_domain_for(f.source, f.finding_type) == "cspm"]
+    assert len(cspm) == 2
+
+
 # ── Exporter surface ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_framework_mapping.py
+++ b/tests/test_framework_mapping.py
@@ -190,6 +190,35 @@ def test_pci_dss_tags_unchanged():
     ]
 
 
+def test_pci_dss_descriptors_are_own_wording_not_copyrighted_text():
+    """PCI DSS 4.0 requirement text is copyrighted; the catalog must carry
+    agent-bom's OWN short descriptors and the same provenance/copyright note the
+    sibling framework modules (iso_27001, soc2, cis_controls) already carry —
+    only the factual requirement IDs are reused.
+    """
+    import inspect
+
+    # Near-verbatim PCI DSS 4.0 requirement phrasings must not be reproduced.
+    banned_phrases = [
+        "at least quarterly by pci ssc asv",
+        "performed at least quarterly",
+        "cryptographic cipher suites and protocols in use",
+        "minimum complexity requirements",
+    ]
+    for code, descriptor in pci_dss.PCI_DSS_REQUIREMENTS.items():
+        low = descriptor.lower()
+        for phrase in banned_phrases:
+            assert phrase not in low, f"{code} reproduces copyrighted PCI DSS wording: {descriptor!r}"
+
+    # The IDs (the facts) are preserved so tagging is unaffected.
+    assert {"6.3.1", "6.3.2", "11.3.1", "11.3.2", "12.3.1"} <= set(pci_dss.PCI_DSS_REQUIREMENTS)
+
+    # Provenance/copyright note present in the module source, like the siblings.
+    src = inspect.getsource(pci_dss)
+    assert "copyright" in src.lower()
+    assert "own" in src.lower()
+
+
 def test_vuln_compliance_tags_unchanged():
     br = _representative_br()
     assert vuln_compliance.tag_vulnerability(br.vulnerability, br.package) == {

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -430,6 +430,42 @@ def test_overview_hub_kev_finding_moves_exec_kev_count() -> None:
     get_compliance_hub_store().clear("default")
 
 
+def test_overview_vuln_tile_idle_on_empty_estate() -> None:
+    """A brand-new tenant with zero scans/findings must show the Vuln/SCA tile as
+    "idle" (no data), mirroring the sibling tiles — never a green "ok" while the
+    posture headline reads N/A (#4-audit 2026-07-18).
+    """
+    _clear_jobs()
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    get_compliance_hub_store().clear("default")
+    data = client_get_overview()
+    assert data["posture"]["grade"] == "N/A"
+    vuln = data["domains"]["vuln"]
+    assert vuln["metric"] == 0
+    assert vuln["status"] == "idle", vuln
+    # Sibling scan-scoped tiles agree — no tile claims "ok" on an empty estate.
+    assert data["domains"]["code"]["status"] == "idle"
+
+
+def test_overview_vuln_tile_ok_when_only_low_severity() -> None:
+    """With vuln data present but nothing critical/high, the tile stays "ok"
+    (there IS data) — the idle gate must not swallow a real low-severity estate.
+    """
+    _clear_jobs()
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    get_compliance_hub_store().clear("default")
+    _ingest_hub_findings(
+        [{"finding_id": "L-1", "severity": "low", "title": "cve", "vulnerability_id": "CVE-2025-low"}]
+    )
+    data = client_get_overview()
+    vuln = data["domains"]["vuln"]
+    assert vuln["metric"] > 0
+    assert vuln["status"] == "ok", vuln
+    get_compliance_hub_store().clear("default")
+
+
 def test_overview_vuln_tile_reflects_pushed_findings_without_scan() -> None:
     """`findings push` (no scan job) must not leave the Vuln/SCA tile at
     "0 open CVEs · ok" while /findings?domain=vuln returns real highs (#3962).


### PR DESCRIPTION
Post-merge audit remediation for the three findings from the 2026-07-18 framework-library audit. One coherent PR (disjoint file sets); TDD, all gates green.

## Findings fixed

### P1 — CIEM over-privilege double-count → collapsed to one
`build_nhi_governance_findings` and `build_ciem_over_privilege_findings` both emitted `CIEM_OVER_PRIVILEGE` for the same Access-Advisor-unused permissions with different ids, so `to_findings()` id-dedup never merged them (identity counted twice in exec/severity/CSPM/SARIF/JSON).

Fix (`graph/nhi_governance.py`): the NHI over-grant emitter now computes the never-used Access-Advisor targets for the node and **excludes** them; if all unused grants are AA-covered the NHI finding is skipped, leaving the richer CIEM finding (stable id, provider, `is_actionable`, `impact_category`) as the single source. Non-Access-Advisor unused grants still surface via the NHI path (MANAGED_IDENTITY dormant case unaffected).

Red→green: `test_access_advisor_over_privilege_not_double_counted` (AWS ROLE + GCP SERVICE_ACCOUNT, mixed used/never-used AA grants) — exactly one `CIEM_OVER_PRIVILEGE` per identity, full unused set retained, no duplicate ids, CSPM routing counts each once.

### P1 — PCI DSS copyrighted text → own descriptors
`pci_dss.py` reproduced near-verbatim PCI DSS 4.0 requirement wording. Reworded every `PCI_DSS_REQUIREMENTS` value to agent-bom's own short descriptor (IDs preserved) + added the sibling-style provenance/copyright note (matches iso_27001/soc2/cis_controls).

Red→green: `test_pci_dss_descriptors_are_own_wording_not_copyrighted_text` — banned near-verbatim phrases absent, IDs intact, copyright note present.

### P2 — Vuln tile green on zero-data → idle
`overview.py` `_status_for(...)` returned "ok" on an empty estate. Now gates on the vuln metric (`... if vuln_metric > 0 else "idle"`), matching sibling tiles.

Red→green: `test_overview_vuln_tile_idle_on_empty_estate` + `test_overview_vuln_tile_ok_when_only_low_severity` (guards against over-gating).

## Gates
New tests 4 passed; touched suites 113 passed; wider compliance/overview 82 passed 1 skipped; graph regression 51 passed + `test_graph_builder` 60 passed; `ruff check` clean; `mypy` (3 changed src) clean. No finding-count regression — the change only alters behavior for identities carrying `access_advisor` edges (subset skip); finding shape/evidence keys unchanged (no OpenAPI/check-counts regen needed).