### PR TITLE
perf(graph): reconcile prior edges in storage

### DIFF
--- a/docs/decisions/006-unified-graph-write-batching.md
+++ b/docs/decisions/006-unified-graph-write-batching.md
@@ -27,6 +27,12 @@ sources are lazy iterators, and the batching helper materializes only one batch
 window at a time. That keeps graph write memory bounded by the batch size rather
 than total graph size.
 
+Temporal edge continuity is part of the same invariant. Both backends preserve
+`first_seen` / `valid_from` for retained edges and close missing prior edges
+with tenant-and-snapshot-scoped database updates. They do not load or sort the
+previous snapshot's edge keys in Python; otherwise a small new snapshot after a
+large prior snapshot would still consume O(previous edges) memory.
+
 Batching helpers are intentionally generic. They operate on row iterables and
 SQL statements, not on graph-specific types. This keeps the pattern reusable for
 future write-heavy paths without creating separate one-off batching code.
@@ -43,7 +49,7 @@ bounded-memory invariant.
 - **Positive:** Backend implementations can differ internally while preserving
   the shared `save_graph(graph)` contract.
 - **Positive:** Lazy row generation keeps write-path memory tied to the batch
-  window, not to graph size.
+  window, not to either the current or previous graph size.
 - **Positive:** The batching primitive is reusable outside graph persistence.
 - **Trade-off:** One shared knob may not be optimal for every backend in every
   deployment. If benchmarks prove a backend-specific need, add optional

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -652,18 +652,6 @@ class PostgresGraphStore:
                     (tenant, previous_row[1]),
                 ).fetchone()
                 previous_scan = str(prior_row[0]) if prior_row else ""
-            previous_edges: dict[tuple[str, str, str], Any] = {}
-            if previous_scan:
-                for row in conn.execute(
-                    """
-                    SELECT source_id, target_id, relationship, first_seen, valid_from, valid_to
-                    FROM graph_edges
-                    WHERE tenant_id = %s AND scan_id = %s
-                    """,
-                    (tenant, previous_scan),
-                ).fetchall():
-                    previous_edges[(row[0], row[1], row[2])] = row
-
             # A scan id represents a complete immutable snapshot. A retry is a
             # replacement, not a merge; remove its old rows inside this same
             # transaction before consuming the new one-shot producers.
@@ -739,25 +727,13 @@ class PostgresGraphStore:
                     _flush_nodes()
             _flush_nodes()
 
-            # Retired-edge detection: start from the prior snapshot's edge keys
-            # and discard each one still present in the incoming stream. This
-            # bounds the tracking set to the PREVIOUS snapshot size instead of
-            # materialising a second O(edges) set of every incoming key (#4055).
-            removed_edge_keys: set[tuple[str, str, str]] = set(previous_edges)
-
             def edge_rows() -> Iterator[tuple[Any, ...]]:
                 nonlocal edge_count
                 for edge in edges:
                     edge_count += 1
                     rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
-                    removed_edge_keys.discard((edge.source, edge.target, rel))
-                    previous = previous_edges.get((edge.source, edge.target, rel))
                     valid_from = edge.valid_from or edge.first_seen or now
-                    first_seen = edge.first_seen
-                    if previous is not None:
-                        valid_from = previous[4] or previous[3] or valid_from
-                        first_seen = previous[3] or first_seen
-                    elif valid_from > now:
+                    if valid_from > now:
                         valid_from = now
                     yield (
                         edge.source,
@@ -766,7 +742,7 @@ class PostgresGraphStore:
                         edge.direction,
                         edge.weight,
                         1 if edge.traversable else 0,
-                        first_seen,
+                        edge.first_seen,
                         edge.last_seen,
                         valid_from,
                         edge.valid_to,
@@ -838,20 +814,48 @@ class PostgresGraphStore:
                 edge_rows(),
                 batch_size=batch_size,
             )
-            if removed_edge_keys:
-                _execute_many_batched(
-                    conn,
+            if previous_scan:
+                # Preserve temporal continuity and retire missing prior edges
+                # inside Postgres. Loading the prior snapshot into a Python dict
+                # + set made this streamed writer O(previous-edge-count) memory.
+                conn.execute(
                     """
-                    UPDATE graph_edges
-                    SET valid_to = COALESCE(valid_to, %s),
-                        activity_id = CASE WHEN activity_id = 1 THEN 3 ELSE activity_id END
-                    WHERE tenant_id = %s AND scan_id = %s AND source_id = %s AND target_id = %s AND relationship = %s
+                    UPDATE graph_edges AS current
+                    SET first_seen = COALESCE(NULLIF(previous.first_seen, ''), current.first_seen),
+                        valid_from = COALESCE(
+                            NULLIF(previous.valid_from, ''),
+                            NULLIF(previous.first_seen, ''),
+                            current.valid_from
+                        )
+                    FROM graph_edges AS previous
+                    WHERE current.source_id = previous.source_id
+                      AND current.target_id = previous.target_id
+                      AND current.relationship = previous.relationship
+                      AND current.scan_id = %s
+                      AND current.tenant_id = %s
+                      AND previous.scan_id = %s
+                      AND previous.tenant_id = %s
                     """,
-                    (
-                        (now, tenant, previous_scan, source, target, relationship)
-                        for source, target, relationship in sorted(removed_edge_keys)
-                    ),
-                    batch_size=batch_size,
+                    (scan, tenant, previous_scan, tenant),
+                )
+                conn.execute(
+                    """
+                    UPDATE graph_edges AS previous
+                    SET valid_to = COALESCE(previous.valid_to, %s),
+                        activity_id = CASE WHEN previous.activity_id = 1 THEN 3 ELSE previous.activity_id END
+                    WHERE previous.tenant_id = %s
+                      AND previous.scan_id = %s
+                      AND NOT EXISTS (
+                            SELECT 1
+                            FROM graph_edges AS current
+                            WHERE current.source_id = previous.source_id
+                              AND current.target_id = previous.target_id
+                              AND current.relationship = previous.relationship
+                              AND current.scan_id = %s
+                              AND current.tenant_id = %s
+                      )
+                    """,
+                    (now, tenant, previous_scan, scan, tenant),
                 )
             _execute_many_batched(
                 conn,

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -620,8 +620,9 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
     """Persist a UnifiedGraph as an immutable per-scan snapshot.
 
     Thin wrapper over :func:`save_graph_streaming` — the streamed path never
-    holds more than one write batch plus the prior snapshot's edge index in
-    memory, so peak RSS is decoupled from graph size (see #4055). Callers that
+    holds more than one write batch in memory; prior-edge lifecycle
+    reconciliation is database-side, so peak RSS is decoupled from both the
+    incoming and previous graph sizes (see #4055/#4075). Callers that
     already hold a fully built ``UnifiedGraph`` keep the same behaviour; callers
     that can produce nodes/edges lazily should call ``save_graph_streaming``
     directly with generators to avoid materialising the whole graph.
@@ -680,18 +681,6 @@ def save_graph_streaming(
     previous_scan = latest_snapshot_id(conn, tenant_id=tenant)
     if previous_scan == scan:
         previous_scan = previous_snapshot_id(conn, tenant_id=tenant, before_scan_id=scan)
-    previous_edges: dict[tuple[str, str, str], sqlite3.Row] = {}
-    if previous_scan:
-        for row in conn.execute(
-            """
-            SELECT source_id, target_id, relationship, first_seen, valid_from, valid_to
-            FROM graph_edges
-            WHERE tenant_id = ? AND scan_id = ?
-            """,
-            (tenant, previous_scan),
-        ):
-            previous_edges[(row["source_id"], row["target_id"], row["relationship"])] = row
-
     # A scan id is one complete snapshot. Retries/replays must replace that
     # snapshot atomically; upserts alone would retain rows absent from the
     # retried producer and make graph_snapshots counts contradict graph rows.
@@ -710,12 +699,6 @@ def save_graph_streaming(
     edge_count = 0
     severity_counts: dict[str, int] = defaultdict(int)
     type_counts: dict[str, int] = defaultdict(int)
-    # Retired-edge detection: start with the prior snapshot's edge keys and
-    # discard each one still present in the incoming stream. This bounds the
-    # extra set to the PREVIOUS snapshot size (empty on a first save) rather
-    # than tracking every incoming edge key — so peak RSS stays flat.
-    removed_edge_keys: set[tuple[str, str, str]] = set(previous_edges)
-
     # ── Nodes ──
     def node_rows() -> Iterator[tuple[Any, ...]]:
         nonlocal node_count
@@ -766,14 +749,8 @@ def save_graph_streaming(
         for edge in edges:
             edge_count += 1
             rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
-            removed_edge_keys.discard((edge.source, edge.target, rel))
-            previous = previous_edges.get((edge.source, edge.target, rel))
             valid_from = edge.valid_from or edge.first_seen or now
-            first_seen = edge.first_seen
-            if previous is not None:
-                valid_from = previous["valid_from"] or previous["first_seen"] or valid_from
-                first_seen = previous["first_seen"] or first_seen
-            elif valid_from > now:
+            if valid_from > now:
                 valid_from = now
             yield (
                 edge.source,
@@ -782,7 +759,7 @@ def save_graph_streaming(
                 edge.direction,
                 edge.weight,
                 1 if edge.traversable else 0,
-                first_seen,
+                edge.first_seen,
                 edge.last_seen,
                 valid_from,
                 edge.valid_to,
@@ -810,17 +787,90 @@ def save_graph_streaming(
         batch_size=batch_size,
     )
 
-    if removed_edge_keys:
-        _executemany_batched(
-            conn,
+    if previous_scan:
+        # Reconcile temporal continuity in SQL. The prior implementation loaded
+        # every previous edge into a Python dict + set, making the supposedly
+        # streamed path retain O(previous-edge-count) heap. Exact-key correlated
+        # lookups use graph_edges' primary key and keep Python memory batch-sized.
+        conn.execute(
             """
-            UPDATE graph_edges
-            SET valid_to = COALESCE(valid_to, ?),
-                activity_id = CASE WHEN activity_id = 1 THEN 3 ELSE activity_id END
-            WHERE tenant_id = ? AND scan_id = ? AND source_id = ? AND target_id = ? AND relationship = ?
+            UPDATE graph_edges AS current
+            SET first_seen = COALESCE(
+                    (
+                        SELECT NULLIF(previous.first_seen, '')
+                        FROM graph_edges AS previous
+                        WHERE previous.source_id = current.source_id
+                          AND previous.target_id = current.target_id
+                          AND previous.relationship = current.relationship
+                          AND previous.scan_id = ?
+                          AND previous.tenant_id = ?
+                    ),
+                    current.first_seen
+                ),
+                valid_from = COALESCE(
+                    (
+                        SELECT NULLIF(previous.valid_from, '')
+                        FROM graph_edges AS previous
+                        WHERE previous.source_id = current.source_id
+                          AND previous.target_id = current.target_id
+                          AND previous.relationship = current.relationship
+                          AND previous.scan_id = ?
+                          AND previous.tenant_id = ?
+                    ),
+                    (
+                        SELECT NULLIF(previous.first_seen, '')
+                        FROM graph_edges AS previous
+                        WHERE previous.source_id = current.source_id
+                          AND previous.target_id = current.target_id
+                          AND previous.relationship = current.relationship
+                          AND previous.scan_id = ?
+                          AND previous.tenant_id = ?
+                    ),
+                    current.valid_from
+                )
+            WHERE current.scan_id = ?
+              AND current.tenant_id = ?
+              AND EXISTS (
+                    SELECT 1
+                    FROM graph_edges AS previous
+                    WHERE previous.source_id = current.source_id
+                      AND previous.target_id = current.target_id
+                      AND previous.relationship = current.relationship
+                      AND previous.scan_id = ?
+                      AND previous.tenant_id = ?
+              )
             """,
-            ((now, tenant, previous_scan, source, target, relationship) for source, target, relationship in sorted(removed_edge_keys)),
-            batch_size=batch_size,
+            (
+                previous_scan,
+                tenant,
+                previous_scan,
+                tenant,
+                previous_scan,
+                tenant,
+                scan,
+                tenant,
+                previous_scan,
+                tenant,
+            ),
+        )
+        conn.execute(
+            """
+            UPDATE graph_edges AS previous
+            SET valid_to = COALESCE(previous.valid_to, ?),
+                activity_id = CASE WHEN previous.activity_id = 1 THEN 3 ELSE previous.activity_id END
+            WHERE previous.tenant_id = ?
+              AND previous.scan_id = ?
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM graph_edges AS current
+                    WHERE current.source_id = previous.source_id
+                      AND current.target_id = previous.target_id
+                      AND current.relationship = previous.relationship
+                      AND current.scan_id = ?
+                      AND current.tenant_id = ?
+              )
+            """,
+            (now, tenant, previous_scan, scan, tenant),
         )
 
     # ── Attack paths ──

--- a/tests/test_graph_store_streamed_persistence.py
+++ b/tests/test_graph_store_streamed_persistence.py
@@ -601,3 +601,57 @@ def test_streaming_persist_peak_python_heap_is_bounded() -> None:
     # the full path retains every node/edge, so its heap is orders of magnitude larger.
     full_large = _peak_pymem_mb(_MEM_N_LARGE, "full")
     assert stream_large < full_large * 0.5, f"streaming ({stream_large:.1f}MB) not < half of full ({full_large:.1f}MB)"
+
+
+_PRIOR_EDGE_MEM_SCRIPT = textwrap.dedent(
+    """
+    import os, sys, tempfile, tracemalloc
+    from agent_bom.db import graph_store as gs
+    from agent_bom.graph.edge import UnifiedEdge
+    from agent_bom.graph.node import UnifiedNode
+    from agent_bom.graph.types import EntityType, RelationshipType
+
+    n = int(sys.argv[1])
+    db = os.path.join(tempfile.mkdtemp(), "prior.db")
+
+    def node(i):
+        return UnifiedNode(id=f"n:{i}", entity_type=EntityType.PACKAGE, label=f"pkg-{i}")
+
+    def edge(i):
+        return UnifiedEdge(source=f"n:{i}", target=f"n:{i + 1}", relationship=RelationshipType.DEPENDS_ON)
+
+    with gs.open_graph_db(db) as conn:
+        gs.save_graph_streaming(
+            conn,
+            scan_id="prior",
+            tenant_id="t",
+            nodes=(node(i) for i in range(n + 1)),
+            edges=(edge(i) for i in range(n)),
+        )
+        tracemalloc.start()
+        gs.save_graph_streaming(
+            conn,
+            scan_id="current",
+            tenant_id="t",
+            nodes=(node(i) for i in range(2)),
+            edges=(edge(i) for i in range(1)),
+        )
+        _, peak = tracemalloc.get_traced_memory()
+    print(peak / 1024 / 1024)
+    """
+)
+
+
+def _prior_edge_peak_mb(n: int) -> float:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p) + os.pathsep + env.get("PYTHONPATH", "")
+    out = subprocess.check_output([sys.executable, "-c", _PRIOR_EDGE_MEM_SCRIPT, str(n)], text=True, env=env)
+    return float(out.strip().splitlines()[-1])
+
+
+def test_streaming_persist_does_not_materialize_prior_edge_index() -> None:
+    """A large prior snapshot must not make the next streamed save grow O(prior edges)."""
+    small = _prior_edge_peak_mb(2_000)
+    large = _prior_edge_peak_mb(12_000)
+
+    assert large < small * 2.0, f"prior-edge heap grew with snapshot size: {small:.1f} -> {large:.1f} MB"

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 import pytest
 
 from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
+from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
-from agent_bom.graph.types import EntityType, NodeStatus
+from agent_bom.graph.types import EntityType, NodeStatus, RelationshipType
 
 
 class _FakeCursor:
@@ -45,6 +46,7 @@ class _RecordingConn:
         self.deleted_tables: list[str] = []
         self.advisory_locks: list[tuple] = []
         self.sql_calls: list[str] = []
+        self.sql_params: list[tuple | None] = []
         self.rolled_back = 0
 
     def __enter__(self):
@@ -58,6 +60,7 @@ class _RecordingConn:
     def execute(self, sql, params=None):
         low = " ".join(sql.strip().lower().split())
         self.sql_calls.append(low)
+        self.sql_params.append(tuple(params) if params is not None else None)
         if low.startswith("select pg_advisory_xact_lock"):
             self.advisory_locks.append(tuple(params))
         elif low.startswith("delete from"):
@@ -269,6 +272,39 @@ def test_postgres_writer_lock_precedes_snapshot_reads_and_deletes(monkeypatch):
     assert lock_at < prior_read_at < delete_at
 
 
+def test_prior_edges_reconcile_in_postgres_without_python_materialization(monkeypatch):
+    class _PreviousSnapshotConn(_RecordingConn):
+        def execute(self, sql, params=None):
+            low = " ".join(sql.strip().lower().split())
+            if low.startswith("select scan_id, created_at") and "from graph_snapshots" in low:
+                self.sql_calls.append(low)
+                self.sql_params.append(tuple(params) if params is not None else None)
+                return _FakeCursor([("prior-scan", "2026-07-18T00:00:00Z")])
+            if low.startswith("select source_id, target_id, relationship"):
+                raise AssertionError("prior graph edges must not be fetched into Python")
+            return super().execute(sql, params)
+
+    conn = _PreviousSnapshotConn()
+    store = _make_store(conn, monkeypatch)
+    edge = UnifiedEdge(source="agent:1", target="pkg:1", relationship=RelationshipType.DEPENDS_ON)
+
+    store.save_graph_streaming(
+        scan_id="current-scan",
+        tenant_id="tenant-a",
+        nodes=_nodes(1),
+        edges=iter([edge]),
+    )
+
+    continuity_at = next(
+        i for i, sql in enumerate(conn.sql_calls) if sql.startswith("update graph_edges as current")
+    )
+    retirement_at = next(
+        i for i, sql in enumerate(conn.sql_calls) if sql.startswith("update graph_edges as previous")
+    )
+    assert conn.sql_params[continuity_at] == ("current-scan", "tenant-a", "prior-scan", "tenant-a")
+    assert conn.sql_params[retirement_at][1:] == ("tenant-a", "prior-scan", "current-scan", "tenant-a")
+
+
 @pytest.mark.parametrize(
     ("risk_summary", "analysis_status"),
     [
@@ -346,17 +382,9 @@ def test_retired_edge_update_records_ocsf_close_activity(monkeypatch):
             low = " ".join(sql.strip().lower().split())
             if low.startswith("select scan_id, created_at from graph_snapshots"):
                 return _FakeCursor([("scan-old", "2026-07-16T00:00:00Z")])
-            if low.startswith("select source_id, target_id, relationship, first_seen, valid_from, valid_to"):
-                return _FakeCursor([("agent:a", "server:b", "uses", "2026-07-16T00:00:00Z", "2026-07-16T00:00:00Z", None)])
-            return super().execute(sql, params)
-
-        def executemany(self, sql, seq):
-            low = " ".join(sql.strip().lower().split())
-            if low.startswith("update graph_edges"):
+            if low.startswith("update graph_edges as previous"):
                 self.retirement_sql = low
-                list(seq)
-                return _FakeCursor()
-            return super().executemany(sql, seq)
+            return super().execute(sql, params)
 
     conn = _RetirementConn()
     store = _make_store(conn, monkeypatch)
@@ -369,5 +397,5 @@ def test_retired_edge_update_records_ocsf_close_activity(monkeypatch):
         created_at="2026-07-17T00:00:00Z",
     )
 
-    assert "set valid_to = coalesce(valid_to, %s)" in conn.retirement_sql
-    assert "activity_id = case when activity_id = 1 then 3 else activity_id end" in conn.retirement_sql
+    assert "set valid_to = coalesce(previous.valid_to, %s)" in conn.retirement_sql
+    assert "activity_id = case when previous.activity_id = 1 then 3 else previous.activity_id end" in conn.retirement_sql


### PR DESCRIPTION
## Summary

- reconcile retained and retired graph edges inside SQLite and Postgres instead of loading every prior edge into Python
- preserve temporal continuity for retained edges and retire missing edges with tenant/snapshot-scoped anti-joins
- lock prior-edge heap growth to the configured write batch with SQLite and Postgres regressions

## Verification

- red regression before the fix: 2,000 prior edges used ~1.244 MB; 12,000 used ~6.805 MB
- green regression after the fix: both 2,000 and 12,000 prior-edge cases used ~0.005 MB
- `uv run pytest -q tests/test_graph_api.py tests/test_postgres_graph_streaming.py tests/test_graph_store_streamed_persistence.py tests/test_graph_persist_memory_bound.py tests/test_graph_delta_digest.py` — 95 passed
- `uv run ruff check src/agent_bom/db/graph_store.py src/agent_bom/api/postgres_graph.py tests/test_graph_store_streamed_persistence.py tests/test_postgres_graph_streaming.py`
- `uv run mypy src/agent_bom/db/graph_store.py src/agent_bom/api/postgres_graph.py`
- `.venv/bin/python scripts/check_exception_sanitization.py`
- live Docker Postgres smoke in an isolated temporary database: retained-edge timestamps preserved, missing edges retired, new edges inserted, and another tenant remained unchanged; temporary database dropped

## Notes

- this bounds prior-snapshot reconciliation memory; graph producer materialization remains separate follow-up work under #4075