### PR TITLE
docs(readme): make public proof concise and architecture-accurate

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -4,10 +4,10 @@ A repo-map for `agent-bom`: where things live, which trees are canonical, and
 how the `src/agent_bom/` package is organized into subsystems. Start here when
 you ask **"where does X live?"**
 
-`agent-bom` is a single pure-Python package (~289K LoC) that exposes one shared
-evidence model through many surfaces: CLI/CI, REST API, MCP server, dashboard,
-and runtime proxy/gateway. The package is intentionally broad — this map groups
-its modules so the breadth reads as a system, not a flat sprawl.
+`agent-bom` combines a Python scanner/control-plane engine with a TypeScript/
+React cockpit. Its surfaces share finding, inventory, graph, and audit contracts:
+CLI/CI, REST API, MCP server, dashboard, and runtime proxy/gateway. The package
+is intentionally broad—this map groups the breadth into owned subsystems.
 
 For the layered architecture and data-flow diagrams, see
 [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md). For role-based entry paths, see
@@ -24,11 +24,11 @@ For the layered architecture and data-flow diagrams, see
 | `docs/` | Operator- and contributor-facing reference docs (this tree). | **Yes** — canonical for engineering/reference docs. |
 | `site-docs/` | MkDocs source for the published docs site. | **Yes** — canonical for the *narrative/getting-started* site; see [Documentation map](#documentation-map). |
 | `ui/` | Next.js 16 + React 19 + Tailwind 4 dashboard (the human cockpit). | Yes — the active UI. |
-| `dashboard/` | Static/build assets and supporting dashboard files. | Build support for the UI. |
+| `dashboard/` | Legacy standalone Streamlit compatibility surface. | Retained for compatibility; `ui/` is the active cockpit. |
 | `sdks/` | Client SDKs: `python`, `go`, `typescript`, `typescript-client`, `shared`. | Yes — typed control-plane clients (not scanner SDKs). |
 | `deploy/` | Helm chart, docker-compose pilot, EKS reference, deployment manifests. | Yes. |
 | `contracts/` | Cross-surface contract fixtures. | Yes. |
-| `docs/openapi/v1.json` | Committed OpenAPI spec — the canonical REST contract (251 paths / 295 operations). | **Yes** — SDK + client contract checks read this. |
+| `docs/openapi/v1.json` | Committed OpenAPI spec — the canonical REST contract. | **Yes** — SDK + client contract checks read this. |
 | `scripts/` | Release, deploy, and consistency tooling (e.g. `check_release_consistency.py`). | Yes. |
 | `integrations/` | External tool integrations and examples. | Yes. |
 | `examples/`, `config/`, `security/`, `fuzz/` | Samples, config, security policy, fuzz harnesses. | Support material. |
@@ -39,8 +39,9 @@ For the layered architecture and data-flow diagrams, see
 
 ## `src/agent_bom/` subsystems
 
-The package has ~223 top-level modules plus 25 subpackages. Grouped by the role
-each plays in the **collect → normalize → serve → enforce** pipeline:
+The top-level Python namespace is frozen; new implementation belongs in the
+owned subpackages below. They are grouped by the role each plays in the
+**collect → normalize → serve → enforce** pipeline:
 
 ### 1. Scan layer — collect evidence
 
@@ -67,10 +68,11 @@ and findings.
 | Cost (FinOps) | `cost_model.py`, `api/cost_*.py` | LLM spend forecasting, budget runway, chargeback, anomaly detection. |
 | Cross-env / correlation | `cross_env_correlation.py`, `correlate.py`, `runtime_correlation.py` | Fuse evidence across environments and runtime logs. |
 
-### 3. Unified Finding + ContextGraph — the convergence point
+### 3. Findings + graph contracts — the convergence point
 
-Every scan path lands on **one** `Finding` model and **one** graph, so blast
-radius, attack-path fusion, and exposure scoring all read the same evidence.
+Scan paths normalize into canonical findings and graph projections so blast
+radius, attack-path fusion, and exposure scoring can correlate evidence. The
+graph layer remains mid-consolidation, as documented below.
 
 | Subsystem | Path | Responsibility |
 |---|---|---|
@@ -84,8 +86,8 @@ The self-hosted operator surface. Same evidence, multi-tenant, audited.
 
 | Subsystem | Path | Responsibility |
 |---|---|---|
-| API | `api/` | FastAPI app. `routes/` (34 route modules; 295 REST operations + 2 WebSocket), `middleware.py` (4 layers), and `*_store.py`/`postgres_*.py` persistence (SQLite default, Postgres for clusters, optional Snowflake/ClickHouse). |
-| MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 70 tools, 6 resources, 8 prompts (mostly read-only; 3 Shield write actions fail closed). |
+| API | `api/` | FastAPI app and route modules; middleware handles HTTP auth/tenant/limits/audit. SQLite and Postgres are the primary stores, Neptune is optional graph persistence, ClickHouse is optional analytics, and Snowflake implements selected store/warehouse paths. |
+| MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 75 tools, 6 resources, and 8 workflow prompts (mostly read-only; Shield write actions fail closed). |
 | Runtime enforcement | `proxy*.py`, `gateway*.py`, `firewall*.py`, `shield.py`, `runtime/`, `enforcement.py` | MCP traffic proxy, secure-by-default gateway, inline firewall, Shield enforcement. **Spread by design** — see [Runtime enforcement spread](#runtime-enforcement-spread). |
 | Auth / tenancy | `rbac.py`, `permissions.py`, `entitlements.py`, `mcp_tenant.py`, `api/auth.py`, `api/oidc.py` | RBAC roles, tenant scoping, API keys, OIDC/SAML/SCIM. |
 | Fleet | `fleet/`, `fleet_scan.py` | Endpoint/collector inventory pushed into one control plane. |
@@ -104,7 +106,7 @@ The self-hosted operator surface. Same evidence, multi-tenant, audited.
 
 | Subsystem | Path | Responsibility |
 |---|---|---|
-| CLI | `cli/` | Click entry point. 60 top-level commands across 7 help categories. See [`docs/CLI_MAP.md`](docs/CLI_MAP.md). |
+| CLI | `cli/` | Click entry point organized into seven help categories. See [`docs/CLI_MAP.md`](docs/CLI_MAP.md). |
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
-<p align="center">Headless agent primitives and human cockpit surfaces over one shared evidence model.</p>
+<p align="center">Headless agent primitives and a human cockpit over shared evidence contracts.</p>
 
 <p align="center">
   <a href="https://demo.agent-bom.com"><b>Live demo</b></a> (read-only sandbox) ·
@@ -29,23 +29,28 @@
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
-## What it is
+## Start in two commands
 
-- **Read-only scanner + self-hosted control plane** over local projects, agent
-  fleets, MCP runtimes, and cloud estates (AWS, Azure, GCP, Snowflake) —
-  agentless, in your own boundary, nothing installed on targets.
-- **One correlated evidence model** — findings, assets, packages, cloud
-  resources, identities, agents, MCP servers, credentials, and runtime decisions
-  normalize into a single `Finding` + `ContextGraph`, so the CLI, API, UI, MCP
-  tools, reports, and gateway all read the same evidence.
-- **Blast radius, not CVE rows** — a vulnerable package links to the MCP server
-  that loads it, the tools it exposes, reachable credential references, and the
-  agents that can call it.
-- **Posture lanes in one place** — vulnerabilities (SCA + AST reachability),
-  cloud misconfigs (CSPM / CIS), identity and authorization evidence (CIEM),
-  Kubernetes (KSPM), data (DSPM), code (SAST), AI / MCP (AISPM), runtime
-  gateway enforcement, and compliance evidence that reconciles from executive
-  read down to each finding.
+```bash
+pip install agent-bom
+agent-bom scan -p .
+```
+
+The local CLI reads the project directly and prints inventory, findings, blast
+radius, and fix-first actions. No control plane is required. Export an artifact
+when another tool needs it: `agent-bom scan -p . -f sarif -o findings.sarif`.
+
+## Three ways to use it
+
+| Product lane | First command | Evidence you get | Natural next step |
+|---|---|---|---|
+| **Scan locally** — repos, images, SBOMs, agent/MCP config, IaC | `agent-bom scan -p .` | console, JSON, SARIF, CycloneDX/SPDX, HTML, graph export | gate CI or open the local report |
+| **Centralize evidence** — fleet, cloud, identity, findings, compliance | `pip install 'agent-bom[ui]' && agent-bom serve` | tenant-scoped API/UI inventory, jobs, graph, audit, posture | self-host with Docker or Helm + Postgres |
+| **Enforce runtime behavior** — MCP and tool calls | `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` | allow/warn/block decisions and audit events | bind policies to agents and upstream MCPs |
+
+Discovery and static/cloud scanning are read-only. The self-hosted control plane
+stores evidence, and runtime modes make explicit policy decisions; those are
+separate operational boundaries, not all one read-only pipeline.
 
 <p align="center">
   <picture>
@@ -54,110 +59,76 @@
   </picture>
 </p>
 
-Coverage depth and honest boundaries:
+Blast radius links package risk to the MCP servers that load it, exposed tools,
+credential references, and agents that can reach it. Coverage and boundaries:
 [AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
-[product boundaries](docs/PRODUCT_BOUNDARIES.md)
+[product boundaries](docs/PRODUCT_BOUNDARIES.md) ·
+[first-run guide](docs/FIRST_RUN.md).
 
-## Who it's for
+## How the full stack fits together
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom personas mapped to value proof: AppSec/GRC to SARIF and compliance, Platform/SRE to fleet sync and CI gates, agent builders to MCP inventory and runtime shield, security engineers to findings queue and attack paths" width="980" />
-  </picture>
-</p>
-
-- **AppSec / GRC** — SARIF, compliance packs, and audit-ready exports from one scan.
-- **Platform / SRE** — fleet sync, Helm deploy, CI gates, SBOM — no separate scanner stack.
-- **Agent builders** — MCP inventory, Shield SDK, optional runtime proxy or gateway enforcement.
-- **Security engineers** — findings queue, attack-path drilldown, blast-radius context in CLI, API, and UI.
-
-Four buyer lanes, two altitudes: an executive single-pane read (posture, top
-risks, compliance evidence) that drills to engineer detail (reachability, path,
-fix) — all from the same scan.
-
-## How it works
-
-One read-only pipeline from source to answer:
-
-```mermaid
-flowchart LR
-    C([connect]) --> D([discover]) --> S([scan]) --> E([enrich]) --> R([correlate]) --> G([graph]) --> X([serve])
-```
-
-**connect** read-only, brokered creds · **discover** estate, agents, MCP ·
-**scan** OSV, advisories, CIS, IaC · **enrich** CVSS, EPSS, KEV, reachability ·
-**correlate** finding → asset → identity → config · **graph** blast radius,
-attack paths · **serve** exec read + engineer drill.
-
-Every stage is read-only and agentless, and the dashboard shows live per-stage
-status rather than a black box. One package carries the full stack: the
-**React / Next.js** cockpit and every headless caller hit the same **FastAPI**
-control plane, behind one middleware seam, over the same pipeline and stores.
-Deeper module and surface detail: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
+The surfaces share evidence contracts and lower-level services, but they do not
+all self-call through FastAPI. Local CLI/CI invokes the scanner engine directly;
+the UI and SDK use the authenticated API; MCP server mode exposes shared
+services; gateway/proxy modes enforce runtime traffic at their own boundary.
 
 <details>
-<summary><b>The stack</b> — callers → control plane → evidence</summary>
+<summary><b>Full architecture</b> — execution paths, backend, databases, and optional stores</summary>
 
 ```mermaid
 flowchart TB
-    subgraph callers ["Callers"]
-        direction LR
-        UI["Next.js UI<br/>human cockpit"] ~~~ HL["Headless<br/>CLI · MCP server · agents / CI"]
+    subgraph callers ["Entry points"]
+        CLI["CLI · CI · Docker"]
+        UI["Next.js UI · SDK"]
+        MCP["MCP clients"]
+        RT["Runtime MCP/tool traffic"]
     end
-    subgraph plane ["Control plane — one seam for every caller"]
-        direction LR
-        MW["Middleware<br/>auth · tenant · RLS · audit"] --> API["FastAPI<br/>REST API · MCP tools"]
+    subgraph services ["Execution paths"]
+        CORE["Python scanner + correlation engine"]
+        MW["HTTP middleware<br/>auth · tenant · rate limit · audit"]
+        API["FastAPI routes + services"]
+        MCPS["MCP server + shared services"]
+        GW["Gateway / proxy<br/>policy · detectors · audit"]
     end
-    subgraph evidence ["Evidence"]
-        direction LR
-        PIPE["Scan pipeline<br/>+ scanners"] --> ENR["Enrichment<br/>CVSS · EPSS · KEV"] --> ST["Stores<br/>SQLite / Postgres · graph"]
+    subgraph stores ["Persistence"]
+        SQL["SQLite<br/>local / single node"]
+        PG["Postgres + RLS<br/>shared / multi-replica"]
+        NEP["Neptune<br/>optional graph backend"]
+        CH["ClickHouse<br/>optional analytics"]
     end
-    callers --> plane --> evidence
+
+    CLI --> CORE
+    UI --> MW --> API --> CORE
+    MCP --> MCPS --> CORE
+    RT --> GW
+    CORE --> SQL
+    CORE --> PG
+    CORE -. graph option .-> NEP
+    CORE -. analytics .-> CH
+    GW --> SQL
+    GW --> PG
 ```
 
-- **Frontend** — Next.js 16 · React 19 · Tailwind 4 (`ui/`). Inventory,
-  findings, graph, compliance, and runtime views all render from the same API —
-  no privileged "UI-only" data path.
-- **Backend** — FastAPI + uvicorn, pure Python 3.11+
-  (`src/agent_bom/api/server.py`). The scan pipeline runs on a bounded
-  `ThreadPoolExecutor` — heavy scan/DB work stays off the event loop.
-- **Stores** scale without a rewrite: SQLite (default / single node) → Postgres
-  (multi-replica), plus a correlated graph store.
-- **Headless parity** — the MCP server and CLI expose the same evidence to
-  agents and CI, not just the UI. Server mode advertises
-  75 MCP tools, 6 resources, and 8 workflow prompts; registry metadata lives
-  in the committed Smithery manifest and Glama listing, with install and
-  liveness checks in the integration docs.
+- **Frontend:** Next.js 16 / React 19 in `ui/`; authenticated browser data comes
+  from FastAPI—there is no UI-only privileged store path.
+- **Backend:** Python 3.11+ scanner/services plus FastAPI/uvicorn for the control
+  plane. The product is not single-language: the cockpit is TypeScript/React.
+- **Persistence:** SQLite and Postgres are the primary operational stores.
+  Neptune is optional graph persistence; ClickHouse is optional analytics.
+  Snowflake implements selected warehouse/store paths with documented parity
+  limits—it is not a drop-in implementation of every store.
+- **Evidence:** normalized findings and graph contracts correlate inventory,
+  vulnerabilities, cloud/config posture, identity context, and runtime records.
+  `ContextGraph` and `UnifiedGraph` are still being consolidated, so not every
+  record is physically stored as one object.
+- **Agent interface:** server mode exposes 75 MCP tools, 6 resources, and 8 workflow prompts
+  over strict MCP arguments. Registry metadata includes a committed Smithery manifest;
+  integration docs distinguish committed metadata from current catalog liveness.
 
 </details>
 
 <details>
-<summary><b>Enrichment</b> — from a CVE row to real-world risk</summary>
-
-- Scanners emit raw findings (`src/agent_bom/scanners/` — OSV batch, GHSA,
-  distro and vendor advisories); `src/agent_bom/enrichment.py` layers
-  **NVD CVSS · EPSS · CISA KEV** and distro advisory data on top.
-- **AST reachability** (`src/agent_bom/reachability_cve.py`) resolves whether a
-  vulnerable symbol is actually reachable — ranking by exploitability, not just
-  CVSS.
-- The result feeds severity, exploitability, and blast-radius scoring.
-
-</details>
-
-<details>
-<summary><b>Correlated graph</b> — the moat</summary>
-
-- `ContextGraph` / `UnifiedGraph` (`src/agent_bom/context_graph.py`) fuses
-  **assets → identities → configs/misconfigs → findings → attack paths** into
-  one connected model.
-- Estate-scale `CONTAINS` roll-up keeps it readable and sargable at scale; the
-  full contract is in [docs/graph/CONTRACT.md](docs/graph/CONTRACT.md).
-
-</details>
-
-<details>
-<summary><b>Accuracy model</b> — match-confidence tiers and NVD key model</summary>
+<summary><b>Evidence and accuracy boundaries</b></summary>
 
 agent-bom normalizes advisory and distro evidence into canonical CVE findings
 with match-confidence tiers:
@@ -175,94 +146,44 @@ database.
 
 Matching mechanics and release evidence:
 [vulnerability matching](docs/VULNERABILITY_MATCHING.md) ·
-[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md)
+[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md) ·
+[graph contract](docs/graph/CONTRACT.md) ·
+[architecture deep dive](docs/ARCHITECTURE.md)
 
 </details>
 
 ## See it
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo" width="820" />
-</p>
+Try the [live demo](https://demo.agent-bom.com) (read-only sandbox). These
+captures come from the shipped Next.js routes using explicitly labeled,
+synthetic demo evidence.
 
-Try the [live demo](https://demo.agent-bom.com) (read-only sandbox), or browse
-the packaged dashboard below.
+| Risk overview | Connect evidence sources |
+|:---:|:---:|
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview command center with posture, findings, scan coverage, and environments" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/cloud-accounts-live.png" alt="Connections hub across cloud, code, AI, and data sources" width="430" /> |
+| **Start a scan** | **Review runtime decisions** |
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/new-scan-live.png" alt="New Scan form with connected account, ad-hoc, and public repo modes" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and tool-call feed" width="430" /> |
 
 <details>
-<summary><b>Product screenshots</b> — packaged dashboard on seeded demo data</summary>
+<summary><b>Full CLI walkthrough</b> — current 0.96.3 console demo</summary>
 
 <p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview command center with posture ring, findings breakdown, scan coverage, and environment tabs" width="900" />
-  <br/><em>Overview command center — posture ring, findings breakdown, scan coverage, environment tabs</em>
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo showing inventory, findings, remediation, and package gate" width="820" />
 </p>
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/cloud-accounts-live.png" alt="Connections hub with connector gallery across cloud, code, AI, and data sources" width="900" />
-  <br/><em>Connections hub — connector gallery across cloud, code, AI, and data sources</em>
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/new-scan-live.png" alt="New Scan form with connected account, ad-hoc, and public repo modes" width="900" />
-  <br/><em>New Scan — connected account, ad-hoc, and public repo modes</em>
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Fix-first attack-path queue with graph evidence export" width="900" />
-  <br/><em>Security graph — fix-first attack-path queue with evidence export</em>
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png" alt="Agent mesh graph across agents, MCP servers, packages, tools, and findings" width="900" />
-  <br/><em>Blast radius — agent → MCP server → package → tool → CVE</em>
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and live tool-call feed" width="900" />
-  <br/><em>Runtime gateway — KPI rollup and live tool-call feed</em>
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with seeded package and CVE evidence" width="900" />
-  <br/><em>Findings — package and CVE evidence from the seeded demo estate</em>
-</p>
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Fix-first remediation table with prioritized packages" width="900" />
-  <br/><em>Remediation — prioritized fix list with framework context</em>
-</p>
-
-<sub>Synthetic seeded evidence for docs proof, captured from the real Next.js
-routes with a visible <strong>Demo data — sample environment</strong> label — not a
-claim these entities came from a buyer environment. Regenerate from the UI package
-with <code>npm run capture:product-proof</code> (see
-<a href="docs/CAPTURE.md">docs/CAPTURE.md</a>). CLI demo GIF:
-<code>bash scripts/render_demo_gif.sh</code>.</sub>
+The demo is intentionally comprehensive, so it is kept collapsed at README
+display width. Its seeded `reqeusts` typosquat produces an expected non-zero
+security-gate exit; that is a demonstrated finding, not a failed recording.
 
 </details>
 
-## First run
-
-```bash
-pip install agent-bom
-agent-bom scan -p .
-```
-
-`agent-bom scan -p .` prints a posture grade, blast radius, and fix-first
-findings inline — nothing to open. Optional next steps:
-
-```bash
-agent-bom db update                     # local vuln DB for --offline package/image scans
-agent-bom quickstart --run --offline    # sample scan, gateway policy seed, dashboard data
-agent-bom scan -p . -f html -o agent-bom-report.html
-```
-
-Then review posture as a team: `pip install 'agent-bom[ui]' && agent-bom serve`.
-Guided path: [docs/FIRST_RUN.md](docs/FIRST_RUN.md)
+Full capture list and reproducible commands: [docs/CAPTURE.md](docs/CAPTURE.md).
 
 ## Run it anywhere
 
-Every surface writes into the same `Finding` and `ContextGraph` model — pick
-the entry point that matches your role:
+The surfaces share normalized finding and graph contracts while keeping their
+execution and authentication boundaries explicit. Pick the entry point that
+matches your role:
 
 | Need | Surface | First action | Main artifact |
 |---|---|---|---|
@@ -270,7 +191,7 @@ the entry point that matches your role:
 | Connect cloud and data-estate evidence | Cloud connectors | `agent-bom connect aws` then `agent-bom cloud scan` | assets, CIS findings, graph edges |
 | Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | findings, graph, audit, compliance |
 | Give agents security tools | MCP server | `agent-bom mcp server` | strict MCP tool responses |
-| Govern runtime tool calls | Proxy / gateway | `agent-bom gateway serve` | allow/warn/block audit trail |
+| Govern runtime tool calls | Proxy / gateway | `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` | allow/warn/block audit trail |
 | Package evidence for audit | Reports / exports | `agent-bom scan -p . -f sarif -o findings.sarif` | SARIF, CycloneDX, SPDX, HTML/PDF, compliance bundle |
 
 Beyond the basics — `agent-bom graph` (multi-hop exposure paths),
@@ -305,11 +226,12 @@ sharing a link. Full guides: [Deploy anywhere](docs/DEPLOY_PLATFORM.md).
 
 </details>
 
-## Connect once
+## Connected control plane
 
-The honest model — **connect once, then every action runs through the stored
-connection.** There is never a per-action credential prompt and no "paste your
-laptop login" to run a scan or push a result.
+For brokered control-plane sources, **connect once, then scheduled and operator
+actions use the stored connection reference**—not a fresh credential prompt.
+Standalone CLI scans remain independent: they read local files or explicitly
+configured provider credentials and do not require a control-plane connection.
 
 - **Humans** sign in via **OAuth / OIDC / SAML SSO** (standard providers plus a
   Snowflake OAuth authorization-code + PKCE flow), with **SCIM** for user and
@@ -321,8 +243,9 @@ laptop login" to run a scan or push a result.
   short-lived, brokered credentials (e.g. AWS `sts:AssumeRole`); connection
   secrets are write-only (encrypted at rest, never read back).
 
-Auth, tenant isolation, and audit are enforced once in middleware for the UI,
-agents, and SDKs alike — there is no privileged backdoor.
+HTTP auth, tenant isolation, and audit are enforced in middleware for the UI and
+API/SDK callers. MCP server and gateway/proxy modes enforce their own documented
+transport-auth and policy boundaries; none receives a privileged UI-only path.
 
 Cloud connectors are opt-in, default-off, and read no secret values.
 `agent-bom connect <provider>` prints the grant template and enable flag

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -2,8 +2,8 @@
 
 One `agent-bom` product, multiple operational surfaces. The package exposes
 CLI entry points, API/UI, MCP server mode, runtime proxy/gateway, cloud posture,
-IaC scanning, fleet, graph, reporting, and compliance workflows over the same
-core evidence model.
+IaC scanning, fleet, graph, reporting, and compliance workflows over shared
+finding, inventory, graph, and audit contracts.
 
 > **Product overview lives in [`HOW_IT_WORKS.md`](HOW_IT_WORKS.md)** — the
 > canonical five-stage flow (intake → scan → evidence → control → artifacts) and
@@ -19,9 +19,9 @@ core evidence model.
 pip install agent-bom    → shared core engine plus focused CLI entry points
 ```
 
-Read the architecture in one direction: collect evidence, normalize it into one
-AI-BOM/security model, then use that same model for local scans, the
-self-hosted control plane, runtime enforcement, and audit/compliance outputs.
+Read the architecture as three cooperating paths: local scanning, a self-hosted
+control plane, and runtime enforcement. They reuse lower-level services and
+evidence contracts, but they do not all traverse the same process or HTTP seam.
 This diagram is intentionally a product map, not a full module graph.
 
 <picture>
@@ -51,61 +51,73 @@ see [`START_HERE.md`](START_HERE.md).
 
 ---
 
-## 1a. Layered Stack
+## 1a. Execution Paths and Persistence
 
-The product reads top to bottom: inputs are normalized into one `Finding` and
-one `ContextGraph`, the control plane serves and enforces over that evidence,
-and outputs flow to both humans and headless agents. Each layer carries a single
-**value** line — what it buys you, not just what it is.
+The CLI invokes scanner libraries directly. Browser and SDK traffic crosses the
+HTTP middleware and FastAPI boundary. MCP server mode exposes shared services
+through MCP transports. Runtime proxy/gateway traffic crosses a separate policy
+and audit boundary. This distinction matters for auth, failure modes, and
+deployment sizing.
 
 ```mermaid
 flowchart TB
-    subgraph L1["Inputs - meet teams where their evidence already lives"]
-        IN["Repos · lockfiles · SBOMs\nContainer images · IaC\nMCP configs · repo URLs\nCloud accounts · runtime events"]
+    subgraph entry["Entry points"]
+        CLI["CLI · CI · Docker"]
+        UI["Next.js UI · SDK clients"]
+        MCP["MCP clients"]
+        TRAFFIC["Runtime MCP/tool traffic"]
     end
-    subgraph L2["Scanners - breadth without standing up agents"]
-        SC["Discovery · parsers (15 ecosystems)\nOSV/advisory scanners · cloud · IaC · SAST · secrets"]
+    subgraph execution["Execution boundaries"]
+        CORE["Python scanner, enrichment,\ncorrelation + graph services"]
+        MW["HTTP middleware\nauth · RBAC · tenant · limits · audit"]
+        API["FastAPI routes + control-plane services"]
+        MCPS["MCP server + shared services"]
+        GATE["Gateway / proxy\npolicy · detectors · audit"]
     end
-    subgraph L3["Unified Finding - one model, so triage never forks per source"]
-        FD["Finding + enrichment\nNVD CVSS · EPSS · KEV · GHSA · compliance tags"]
+    subgraph operational["Primary operational persistence"]
+        SQLITE["SQLite\nlocal / single-node"]
+        POSTGRES["Postgres + RLS\nshared / multi-replica"]
     end
-    subgraph L4["ContextGraph - turn a CVE row into a reachable blast radius"]
-        GR["UnifiedGraph\nattack-path fusion · blast reach · exposure scoring"]
-    end
-    subgraph L5["Control plane - same evidence, multi-tenant + audited"]
-        direction TB
-        MW["Middleware: auth · RBAC · tenant scope · rate-limit · audit"]
-        API["REST API (300 ops)"]
-        GW["Gateway / MCP server / proxy"]
-        MW --> API
-        MW --> GW
-    end
-    subgraph L6["Outputs - decisions in the format each consumer already trusts"]
-        OUT["SARIF · CycloneDX · SPDX · OCSF\nHTML · PDF · JSON · CSV · webhooks"]
-    end
-    subgraph L7["Consumers - one model, two audiences"]
-        HUM["Humans: CLI · UI cockpit"]
-        AG["Headless: MCP tools · REST API"]
+    subgraph optional["Optional specialized persistence"]
+        NEPTUNE["Neptune\ngraph backend"]
+        CLICKHOUSE["ClickHouse\nanalytics"]
+        SNOWFLAKE["Snowflake\nselected warehouse/store paths"]
     end
 
-    L1 --> L2 --> L3 --> L4 --> L5 --> L6 --> L7
+    CLI --> CORE
+    UI --> MW --> API --> CORE
+    MCP --> MCPS --> CORE
+    TRAFFIC --> GATE
+    CORE --> SQLITE
+    CORE --> POSTGRES
+    GATE --> SQLITE
+    GATE --> POSTGRES
+    CORE -. optional graph .-> NEPTUNE
+    CORE -. optional analytics .-> CLICKHOUSE
+    API -. selected protocols .-> SNOWFLAKE
 ```
+
+SQLite and Postgres implement the primary transactional and graph paths.
+Neptune and ClickHouse are specialized options, not interchangeable control-
+plane databases. Snowflake supports selected job/fleet/schedule/exception/policy
+and warehouse-native paths; consult the backend parity matrix before deployment.
 
 ---
 
-## 1b. Implementation stack — hermetic and single-language
+## 1b. Implementation Stack
 
-With the product mental model in place, the implementation detail: agent-bom is
-pure Python (3.11+) end to end — CLI, FastAPI surface, MCP server, parsers,
-OSV/NVD/EPSS/KEV/GHSA enrichment, blast-radius scoring, IaC engine, and CIS
-benchmarks all live in the same interpreter. There is no Rust/Go/CGo extension
-on the scan path. Disk-image scans use native `dpkg` / RPM parsers
+The scanner, CLI, API, MCP server, gateway/proxy, parsers, enrichment, graph,
+IaC, and CIS engines are Python 3.11+. The human cockpit is a separate
+Next.js/React TypeScript application in `ui/`; therefore the full product is not
+single-language. There is no mandatory Rust/Go/CGo extension on the scan path.
+Disk-image scans use native `dpkg` / RPM parsers
 (`src/agent_bom/filesystem.py`); the `syft` Go binary is opt-in only as a
 tar-archive fallback for VM-style images.
 
 Operational consequences:
 
-- One language, one dep tree, one pip-audit/SBOM surface to audit and reproduce.
+- The Python engine has one primary dependency/SBOM surface; the UI has its own
+  pinned Node.js toolchain and lockfile.
 - Wheels build cleanly on `linux/amd64` and `linux/arm64` — no per-arch native toolchain.
 - Slower than Rust/Go scanners on huge fanouts; per-package memory is higher. For VM disk-image scanning at scale, install `syft` alongside agent-bom and let the fallback path take over.
 
@@ -137,50 +149,25 @@ answerable · outputs land in the gate, ticket, or SIEM you already run.
 
 ---
 
-## 1d. Frontend · Backend · Middleware
+## 1d. Surface Boundaries
 
-The dashboard is one door into the product, not the only one. The Next.js UI and
-every headless caller hit the same FastAPI surface, behind the same middleware,
-over the same stores.
+| Surface | Calls | Auth / tenant boundary | Persistence behavior |
+|---|---|---|---|
+| CLI / CI / Docker | Python scan and output libraries directly | local process and provider credentials supplied by the operator | local artifacts; SQLite when persistence is enabled |
+| Next.js UI / SDK | FastAPI over HTTPS | API middleware: auth, RBAC, tenant scope, body/rate limits, audit | configured control-plane stores |
+| MCP server | shared Python services through MCP transports | MCP transport authentication and strict tool arguments | local or configured control-plane stores, depending on mode |
+| Gateway / proxy | upstream runtime traffic | listener auth, policy evaluation, detectors, rate limits, audit | runtime/audit stores and optional control-plane sink |
 
-```mermaid
-flowchart TB
-    subgraph FE["Frontend - human cockpit"]
-        UI["Next.js 16 · React 19 · Tailwind 4\ninventory · findings · graph · compliance · runtime"]
-    end
-    subgraph MW["Middleware - one enforcement seam for every caller"]
-        M1["TrustHeaders"]
-        M2["API key · auth · RBAC · tenant scope"]
-        M3["Rate limit"]
-        M4["Max body size"]
-    end
-    subgraph BE["Backend - FastAPI"]
-        R["366 REST operations across 43 route modules
-plus 2 WebSocket routes"]
-    end
-    subgraph ST["Stores - start on SQLite, scale to a cluster without rewrites"]
-        S1["SQLite (default / single node)"]
-        S2["Postgres (multi-replica)"]
-        S3["Graph store · optional Snowflake / ClickHouse"]
-    end
-
-    EXTAGENT["Headless: MCP server · REST API · SDK clients"]
-
-    UI -->|HTTPS| MW
-    EXTAGENT -->|HTTPS| MW
-    MW --> BE --> ST
-```
-
-**Value:** the middleware seam means auth, tenant isolation, and audit are
-enforced once for the UI, agents, and SDKs alike — there is no privileged
-"UI-only" backdoor.
+The UI has no privileged data path, but that does not make HTTP middleware a
+universal seam for the CLI, MCP server, or runtime gateway.
 
 ---
 
 ## 1e. Auth & Connections
 
-The identity and connection model is **connect once, act through the stored
-connection** — no surface ever prompts for a per-action credential.
+Brokered control-plane sources use **connect once, act through the stored
+connection reference**. Standalone CLI scans remain independent and use local
+files or explicitly configured provider credentials.
 
 - **Humans** sign in via OAuth / OIDC / SAML SSO (standard providers plus a
   Snowflake OAuth authorization-code + PKCE flow), with SCIM provisioning —
@@ -189,12 +176,13 @@ connection** — no surface ever prompts for a per-action credential.
 - **Sources** (AWS, Azure, GCP, Snowflake) are onboarded once via read-only,
   agentless, brokered connectors — one least-privilege managed role per source,
   short-lived brokered credentials (e.g. AWS `sts:AssumeRole`), and write-only
-  secrets (encrypted at rest, never read back). Every scan then runs through that
-  stored connection.
+  secrets (encrypted at rest, never read back). Scheduled or operator-triggered
+  control-plane collection can then reuse that connection.
 
-Auth mode, tenant scope, RBAC, and audit are enforced in the shared middleware
-(`src/agent_bom/api/middleware.py`) for every caller. Provider grants and setup
-are in [`CLOUD_CONNECT.md`](CLOUD_CONNECT.md); the enterprise auth surface and
+API auth mode, tenant scope, RBAC, and audit are enforced in
+`src/agent_bom/api/middleware.py`. MCP and runtime modes have separate transport
+and policy controls. Provider grants and setup are in
+[`CLOUD_CONNECT.md`](CLOUD_CONNECT.md); the enterprise auth surface and
 environment knobs are in [`ENTERPRISE.md`](ENTERPRISE.md).
 
 ---
@@ -215,7 +203,7 @@ flowchart LR
         I6["Cloud account"]
         I7["IaC files"]
     end
-    CORE["Unified Finding\nplus ContextGraph"]
+    CORE["Normalized findings\nplus graph/evidence contracts"]
     subgraph OUTPUTS["Outputs - drop into the tool you already run"]
         O1["SARIF - code scanning"]
         O2["CycloneDX - SBOM"]


### PR DESCRIPTION
## Summary

- lead the README with a two-command first run and three product lanes, then collapse the deeper architecture and CLI walkthrough
- make execution, auth, persistence, and read-only boundaries match the shipped CLI, FastAPI/UI, MCP, gateway, SQLite/Postgres, Neptune, ClickHouse, and selected Snowflake paths
- replace the long screenshot stack with a readable 2x2 product gallery and correct the top-level repository map without reorganizing canonical files

## Verification

- `uv run python scripts/check_release_consistency.py`
- `uv run python scripts/check_product_surface_contract.py`
- `uv run python scripts/check_package_layout.py`
- `uv run pytest -q tests/test_demo_inventory_accuracy.py tests/test_deployment.py tests/test_cli_entry_points.py tests/test_mermaid.py tests/test_public_docs_cli_alignment.py tests/test_backend_parity_docs.py tests/test_cli_exit_contract_docs.py` — 126 passed
- `uv run agent-bom --version` — 0.96.3
- `uv run agent-bom gateway serve --help` — verified required upstream and listener arguments
- `uv run agent-bom agents --demo --offline -f console` — rendered the current demo and exited 1 as documented for the seeded `reqeusts` typosquat
- `git diff --check`

## Notes

- no image or GIF binaries changed: the existing captures are current 0.96.3 artifacts; this PR improves their selection, scale, labeling, and progressive disclosure
- no top-level directories or files moved; `dashboard/` is documented as the retained Streamlit compatibility surface and `ui/` as the active cockpit