### PR TITLE
fix: post-audit hardening — CIEM double-count, honesty/UI, PCI descriptors + graph edge reconcile (combines #4246 + #4247)

### DIFF
--- a/docs/decisions/006-unified-graph-write-batching.md
+++ b/docs/decisions/006-unified-graph-write-batching.md
@@ -27,6 +27,12 @@ sources are lazy iterators, and the batching helper materializes only one batch
 window at a time. That keeps graph write memory bounded by the batch size rather
 than total graph size.
 
+Temporal edge continuity is part of the same invariant. Both backends preserve
+`first_seen` / `valid_from` for retained edges and close missing prior edges
+with tenant-and-snapshot-scoped database updates. They do not load or sort the
+previous snapshot's edge keys in Python; otherwise a small new snapshot after a
+large prior snapshot would still consume O(previous edges) memory.
+
 Batching helpers are intentionally generic. They operate on row iterables and
 SQL statements, not on graph-specific types. This keeps the pattern reusable for
 future write-heavy paths without creating separate one-off batching code.
@@ -43,7 +49,7 @@ bounded-memory invariant.
 - **Positive:** Backend implementations can differ internally while preserving
   the shared `save_graph(graph)` contract.
 - **Positive:** Lazy row generation keeps write-path memory tied to the batch
-  window, not to graph size.
+  window, not to either the current or previous graph size.
 - **Positive:** The batching primitive is reusable outside graph persistence.
 - **Trade-off:** One shared knob may not be optimal for every backend in every
   deployment. If benchmarks prove a backend-specific need, add optional

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -652,18 +652,6 @@ class PostgresGraphStore:
                     (tenant, previous_row[1]),
                 ).fetchone()
                 previous_scan = str(prior_row[0]) if prior_row else ""
-            previous_edges: dict[tuple[str, str, str], Any] = {}
-            if previous_scan:
-                for row in conn.execute(
-                    """
-                    SELECT source_id, target_id, relationship, first_seen, valid_from, valid_to
-                    FROM graph_edges
-                    WHERE tenant_id = %s AND scan_id = %s
-                    """,
-                    (tenant, previous_scan),
-                ).fetchall():
-                    previous_edges[(row[0], row[1], row[2])] = row
-
             # A scan id represents a complete immutable snapshot. A retry is a
             # replacement, not a merge; remove its old rows inside this same
             # transaction before consuming the new one-shot producers.
@@ -739,25 +727,13 @@ class PostgresGraphStore:
                     _flush_nodes()
             _flush_nodes()
 
-            # Retired-edge detection: start from the prior snapshot's edge keys
-            # and discard each one still present in the incoming stream. This
-            # bounds the tracking set to the PREVIOUS snapshot size instead of
-            # materialising a second O(edges) set of every incoming key (#4055).
-            removed_edge_keys: set[tuple[str, str, str]] = set(previous_edges)
-
             def edge_rows() -> Iterator[tuple[Any, ...]]:
                 nonlocal edge_count
                 for edge in edges:
                     edge_count += 1
                     rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
-                    removed_edge_keys.discard((edge.source, edge.target, rel))
-                    previous = previous_edges.get((edge.source, edge.target, rel))
                     valid_from = edge.valid_from or edge.first_seen or now
-                    first_seen = edge.first_seen
-                    if previous is not None:
-                        valid_from = previous[4] or previous[3] or valid_from
-                        first_seen = previous[3] or first_seen
-                    elif valid_from > now:
+                    if valid_from > now:
                         valid_from = now
                     yield (
                         edge.source,
@@ -766,7 +742,7 @@ class PostgresGraphStore:
                         edge.direction,
                         edge.weight,
                         1 if edge.traversable else 0,
-                        first_seen,
+                        edge.first_seen,
                         edge.last_seen,
                         valid_from,
                         edge.valid_to,
@@ -838,20 +814,48 @@ class PostgresGraphStore:
                 edge_rows(),
                 batch_size=batch_size,
             )
-            if removed_edge_keys:
-                _execute_many_batched(
-                    conn,
+            if previous_scan:
+                # Preserve temporal continuity and retire missing prior edges
+                # inside Postgres. Loading the prior snapshot into a Python dict
+                # + set made this streamed writer O(previous-edge-count) memory.
+                conn.execute(
                     """
-                    UPDATE graph_edges
-                    SET valid_to = COALESCE(valid_to, %s),
-                        activity_id = CASE WHEN activity_id = 1 THEN 3 ELSE activity_id END
-                    WHERE tenant_id = %s AND scan_id = %s AND source_id = %s AND target_id = %s AND relationship = %s
+                    UPDATE graph_edges AS current
+                    SET first_seen = COALESCE(NULLIF(previous.first_seen, ''), current.first_seen),
+                        valid_from = COALESCE(
+                            NULLIF(previous.valid_from, ''),
+                            NULLIF(previous.first_seen, ''),
+                            current.valid_from
+                        )
+                    FROM graph_edges AS previous
+                    WHERE current.source_id = previous.source_id
+                      AND current.target_id = previous.target_id
+                      AND current.relationship = previous.relationship
+                      AND current.scan_id = %s
+                      AND current.tenant_id = %s
+                      AND previous.scan_id = %s
+                      AND previous.tenant_id = %s
                     """,
-                    (
-                        (now, tenant, previous_scan, source, target, relationship)
-                        for source, target, relationship in sorted(removed_edge_keys)
-                    ),
-                    batch_size=batch_size,
+                    (scan, tenant, previous_scan, tenant),
+                )
+                conn.execute(
+                    """
+                    UPDATE graph_edges AS previous
+                    SET valid_to = COALESCE(previous.valid_to, %s),
+                        activity_id = CASE WHEN previous.activity_id = 1 THEN 3 ELSE previous.activity_id END
+                    WHERE previous.tenant_id = %s
+                      AND previous.scan_id = %s
+                      AND NOT EXISTS (
+                            SELECT 1
+                            FROM graph_edges AS current
+                            WHERE current.source_id = previous.source_id
+                              AND current.target_id = previous.target_id
+                              AND current.relationship = previous.relationship
+                              AND current.scan_id = %s
+                              AND current.tenant_id = %s
+                      )
+                    """,
+                    (now, tenant, previous_scan, scan, tenant),
                 )
             _execute_many_batched(
                 conn,

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -1088,7 +1088,11 @@ def _compose_overview(request: Request, tenant_id: str, jobs: list[Any], hub_sev
             "graph_href": _cloud_graph_href(vuln_severity),
             "metric": vuln_metric,
             "metric_label": "open CVEs",
-            "status": _status_for(vuln_severity["critical"], vuln_severity["high"]),
+            # No vuln data at all → "idle" (mirrors the sibling scan-scoped tiles),
+            # never a green "ok" on a brand-new zero-finding estate while the
+            # posture headline reads N/A. Only rate the tile once real CVE evidence
+            # exists (metric > 0); the critical/high gate then decides ok/warn/critical.
+            "status": (_status_for(vuln_severity["critical"], vuln_severity["high"]) if vuln_metric > 0 else "idle"),
             "detail": {
                 "critical": vuln_severity["critical"],
                 "high": vuln_severity["high"],

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -620,8 +620,9 @@ def save_graph(conn: sqlite3.Connection, graph: UnifiedGraph) -> None:
     """Persist a UnifiedGraph as an immutable per-scan snapshot.
 
     Thin wrapper over :func:`save_graph_streaming` — the streamed path never
-    holds more than one write batch plus the prior snapshot's edge index in
-    memory, so peak RSS is decoupled from graph size (see #4055). Callers that
+    holds more than one write batch in memory; prior-edge lifecycle
+    reconciliation is database-side, so peak RSS is decoupled from both the
+    incoming and previous graph sizes (see #4055/#4075). Callers that
     already hold a fully built ``UnifiedGraph`` keep the same behaviour; callers
     that can produce nodes/edges lazily should call ``save_graph_streaming``
     directly with generators to avoid materialising the whole graph.
@@ -680,18 +681,6 @@ def save_graph_streaming(
     previous_scan = latest_snapshot_id(conn, tenant_id=tenant)
     if previous_scan == scan:
         previous_scan = previous_snapshot_id(conn, tenant_id=tenant, before_scan_id=scan)
-    previous_edges: dict[tuple[str, str, str], sqlite3.Row] = {}
-    if previous_scan:
-        for row in conn.execute(
-            """
-            SELECT source_id, target_id, relationship, first_seen, valid_from, valid_to
-            FROM graph_edges
-            WHERE tenant_id = ? AND scan_id = ?
-            """,
-            (tenant, previous_scan),
-        ):
-            previous_edges[(row["source_id"], row["target_id"], row["relationship"])] = row
-
     # A scan id is one complete snapshot. Retries/replays must replace that
     # snapshot atomically; upserts alone would retain rows absent from the
     # retried producer and make graph_snapshots counts contradict graph rows.
@@ -710,12 +699,6 @@ def save_graph_streaming(
     edge_count = 0
     severity_counts: dict[str, int] = defaultdict(int)
     type_counts: dict[str, int] = defaultdict(int)
-    # Retired-edge detection: start with the prior snapshot's edge keys and
-    # discard each one still present in the incoming stream. This bounds the
-    # extra set to the PREVIOUS snapshot size (empty on a first save) rather
-    # than tracking every incoming edge key — so peak RSS stays flat.
-    removed_edge_keys: set[tuple[str, str, str]] = set(previous_edges)
-
     # ── Nodes ──
     def node_rows() -> Iterator[tuple[Any, ...]]:
         nonlocal node_count
@@ -766,14 +749,8 @@ def save_graph_streaming(
         for edge in edges:
             edge_count += 1
             rel = edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship)
-            removed_edge_keys.discard((edge.source, edge.target, rel))
-            previous = previous_edges.get((edge.source, edge.target, rel))
             valid_from = edge.valid_from or edge.first_seen or now
-            first_seen = edge.first_seen
-            if previous is not None:
-                valid_from = previous["valid_from"] or previous["first_seen"] or valid_from
-                first_seen = previous["first_seen"] or first_seen
-            elif valid_from > now:
+            if valid_from > now:
                 valid_from = now
             yield (
                 edge.source,
@@ -782,7 +759,7 @@ def save_graph_streaming(
                 edge.direction,
                 edge.weight,
                 1 if edge.traversable else 0,
-                first_seen,
+                edge.first_seen,
                 edge.last_seen,
                 valid_from,
                 edge.valid_to,
@@ -810,17 +787,90 @@ def save_graph_streaming(
         batch_size=batch_size,
     )
 
-    if removed_edge_keys:
-        _executemany_batched(
-            conn,
+    if previous_scan:
+        # Reconcile temporal continuity in SQL. The prior implementation loaded
+        # every previous edge into a Python dict + set, making the supposedly
+        # streamed path retain O(previous-edge-count) heap. Exact-key correlated
+        # lookups use graph_edges' primary key and keep Python memory batch-sized.
+        conn.execute(
             """
-            UPDATE graph_edges
-            SET valid_to = COALESCE(valid_to, ?),
-                activity_id = CASE WHEN activity_id = 1 THEN 3 ELSE activity_id END
-            WHERE tenant_id = ? AND scan_id = ? AND source_id = ? AND target_id = ? AND relationship = ?
+            UPDATE graph_edges AS current
+            SET first_seen = COALESCE(
+                    (
+                        SELECT NULLIF(previous.first_seen, '')
+                        FROM graph_edges AS previous
+                        WHERE previous.source_id = current.source_id
+                          AND previous.target_id = current.target_id
+                          AND previous.relationship = current.relationship
+                          AND previous.scan_id = ?
+                          AND previous.tenant_id = ?
+                    ),
+                    current.first_seen
+                ),
+                valid_from = COALESCE(
+                    (
+                        SELECT NULLIF(previous.valid_from, '')
+                        FROM graph_edges AS previous
+                        WHERE previous.source_id = current.source_id
+                          AND previous.target_id = current.target_id
+                          AND previous.relationship = current.relationship
+                          AND previous.scan_id = ?
+                          AND previous.tenant_id = ?
+                    ),
+                    (
+                        SELECT NULLIF(previous.first_seen, '')
+                        FROM graph_edges AS previous
+                        WHERE previous.source_id = current.source_id
+                          AND previous.target_id = current.target_id
+                          AND previous.relationship = current.relationship
+                          AND previous.scan_id = ?
+                          AND previous.tenant_id = ?
+                    ),
+                    current.valid_from
+                )
+            WHERE current.scan_id = ?
+              AND current.tenant_id = ?
+              AND EXISTS (
+                    SELECT 1
+                    FROM graph_edges AS previous
+                    WHERE previous.source_id = current.source_id
+                      AND previous.target_id = current.target_id
+                      AND previous.relationship = current.relationship
+                      AND previous.scan_id = ?
+                      AND previous.tenant_id = ?
+              )
             """,
-            ((now, tenant, previous_scan, source, target, relationship) for source, target, relationship in sorted(removed_edge_keys)),
-            batch_size=batch_size,
+            (
+                previous_scan,
+                tenant,
+                previous_scan,
+                tenant,
+                previous_scan,
+                tenant,
+                scan,
+                tenant,
+                previous_scan,
+                tenant,
+            ),
+        )
+        conn.execute(
+            """
+            UPDATE graph_edges AS previous
+            SET valid_to = COALESCE(previous.valid_to, ?),
+                activity_id = CASE WHEN previous.activity_id = 1 THEN 3 ELSE previous.activity_id END
+            WHERE previous.tenant_id = ?
+              AND previous.scan_id = ?
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM graph_edges AS current
+                    WHERE current.source_id = previous.source_id
+                      AND current.target_id = previous.target_id
+                      AND current.relationship = previous.relationship
+                      AND current.scan_id = ?
+                      AND current.tenant_id = ?
+              )
+            """,
+            (now, tenant, previous_scan, scan, tenant),
         )
 
     # ── Attack paths ──

--- a/src/agent_bom/graph/nhi_governance.py
+++ b/src/agent_bom/graph/nhi_governance.py
@@ -398,20 +398,30 @@ def build_nhi_governance_findings(
     for v in verdicts:
         asset = Asset(name=v.name, asset_type="agent", identifier=v.identity_id, location=v.provider)
 
-        # 1. Right-sizing — granted but never used.
-        if v.unused_targets:
-            labels = [_target_label(graph, tid) for tid in v.unused_targets[:20]]
+        # 1. Right-sizing — granted but never used. Never-used targets already
+        #    covered by the Access-Advisor CIEM emitter
+        #    (:func:`build_ciem_over_privilege_findings`) are excluded here so the
+        #    SAME over-privilege risk is not emitted twice under two different ids
+        #    (the 2026-07-18 double-count regression): a role/service-account with
+        #    a MIX of used + never-used Access-Advisor grants was flagged on BOTH
+        #    paths. The CIEM finding is richer (stable id, provider, actionable),
+        #    so it is the single source for Access-Advisor-observed over-grants;
+        #    the NHI path only right-sizes grants CIEM does not cover.
+        aa_unused = {tid for tid, last_used in _access_advisor_grants(graph, v.node_id).items() if not last_used}
+        over_grant_targets = [tid for tid in v.unused_targets if tid not in aa_unused]
+        if over_grant_targets:
+            labels = [_target_label(graph, tid) for tid in over_grant_targets[:20]]
             findings.append(
                 Finding(
                     finding_type=FindingType.CIEM_OVER_PRIVILEGE,
                     source=FindingSource.MCP_SCAN,
                     asset=asset,
                     severity="medium" if v.is_privileged else "low",
-                    title=f"Over-granted identity: {v.name} has {len(v.unused_targets)} unused permission(s)",
+                    title=f"Over-granted identity: {v.name} has {len(over_grant_targets)} unused permission(s)",
                     description=(
                         f"Identity '{v.name}' is granted {v.granted_count} permission(s) but is observed using "
                         f"{v.used_count}. Right-size by removing the unused grants: {', '.join(labels)}"
-                        + ("…" if len(v.unused_targets) > 20 else ".")
+                        + ("…" if len(over_grant_targets) > 20 else ".")
                     ),
                     remediation_guidance=("Remove the unused permissions / tool scopes from this identity to enforce least privilege."),
                     evidence={
@@ -419,7 +429,7 @@ def build_nhi_governance_findings(
                         "identity_id": v.identity_id,
                         "granted_count": v.granted_count,
                         "used_count": v.used_count,
-                        "unused_permission_count": len(v.unused_targets),
+                        "unused_permission_count": len(over_grant_targets),
                         "unused_targets": labels,
                         "risk_score": v.risk_score,
                     },

--- a/src/agent_bom/pci_dss.py
+++ b/src/agent_bom/pci_dss.py
@@ -30,24 +30,30 @@ _HIGH_RISK = high_risk_severities()
 
 # ─── Catalog ──────────────────────────────────────────────────────────────────
 
+# NOTE — the descriptors below are agent-bom's OWN short wording for each PCI DSS
+# requirement area, not the official PCI DSS 4.0 requirement text. PCI DSS is
+# copyrighted by the PCI Security Standards Council, so its requirement wording is
+# NOT reproduced or redistributed here; only the requirement **identifier** (the
+# fact) is used. Consult the standard for the official text:
+# https://www.pcisecuritystandards.org/document_library/
 PCI_DSS_REQUIREMENTS: dict[str, str] = {
     # Requirement 6 — Develop and maintain secure systems and software
-    "6.2.4": "Software engineering practices prevent and mitigate common software attacks and vulnerabilities",
-    "6.3.1": "Security vulnerabilities identified and managed using reputable external sources",
-    "6.3.2": "Inventory of bespoke and custom software, and third-party software components maintained",
-    "6.3.3": "Security patches/updates installed to protect against known vulnerabilities",
+    "6.2.4": "Secure software-engineering practices",
+    "6.3.1": "Vulnerability identification from reputable sources",
+    "6.3.2": "Third-party / custom software component inventory",
+    "6.3.3": "Timely security patching",
     # Requirement 11 — Regularly test security systems and networks
-    "11.3.1": "Internal vulnerability scans performed at least quarterly",
-    "11.3.2": "External vulnerability scans performed at least quarterly by PCI SSC ASV",
+    "11.3.1": "Internal vulnerability scanning",
+    "11.3.2": "External / ASV vulnerability scanning",
     # Requirement 12 — Maintain policy that addresses information security
-    "12.3.1": "Risk assessment performed for each entity's critical assets, threats, and vulnerabilities",
-    "12.3.4": "Cryptographic cipher suites and protocols in use reviewed annually",
+    "12.3.1": "Critical-asset risk assessment",
+    "12.3.4": "Periodic cryptographic-suite review",
     # Requirement 2 — Apply secure configurations
-    "2.2.1": "System configuration standards address all known security vulnerabilities",
-    "2.2.7": "All non-console administrative access encrypted with strong cryptography",
+    "2.2.1": "Secure configuration standards",
+    "2.2.7": "Encrypted administrative access",
     # Requirement 8 — Identify users and authenticate access
-    "8.3.6": "Passwords/passphrases meet minimum complexity requirements",
-    "8.6.1": "System or application accounts managed based on least privilege",
+    "8.3.6": "Authentication-factor strength",
+    "8.6.1": "Least-privilege system accounts",
 }
 
 

--- a/tests/test_api_findings_surface_parity.py
+++ b/tests/test_api_findings_surface_parity.py
@@ -216,6 +216,103 @@ def test_all_three_categories_present_once():
     assert [f for f in findings if f.evidence.get("mcp_tool_rule")]
 
 
+# ── Access-Advisor over-privilege: no double-count ───────────────────────────
+
+
+def _access_advisor_grant(src: str, tgt: str, service: str, last_used: str | None) -> UnifiedEdge:
+    return UnifiedEdge(
+        source=src,
+        target=tgt,
+        relationship=RelationshipType.HAS_PERMISSION,
+        evidence={
+            "source": "access-advisor",
+            "access_advisor": True,
+            "service_namespace": service,
+            "last_used_at": last_used,
+        },
+    )
+
+
+def _mixed_access_advisor_graph() -> UnifiedGraph:
+    """An AWS ROLE and a GCP SERVICE_ACCOUNT, each with Access-Advisor grants
+    that MIX used + never-used services.
+
+    This is the case the plain-HAS_PERMISSION ``_dormant_over_granted_graph``
+    fixture never exercised: because there is an observed-usage signal (the used
+    service's ``last_used_at``), the NHI over-grant path ALSO flags the never-used
+    services — so the same over-privilege risk was emitted twice (once by the NHI
+    right-sizing emitter, once by the Access-Advisor CIEM emitter) under two
+    different ids, double-counting in every total.
+    """
+    g = UnifiedGraph(scan_id="scan-1", tenant_id="tenant-a")
+
+    # AWS IAM role: s3 used, dynamodb + kms never used.
+    g.add_node(
+        UnifiedNode(
+            id="role:aws:app",
+            entity_type=EntityType.ROLE,
+            label="app-role",
+            attributes={"cloud_provider": "aws", "principal_id": "AROA-app", "is_admin": True},
+        )
+    )
+    for svc, last in (("s3", "2026-06-01T00:00:00Z"), ("dynamodb", None), ("kms", None)):
+        g.add_node(UnifiedNode(id=f"res:aws:{svc}", entity_type=EntityType.CLOUD_RESOURCE, label=svc))
+        g.add_edge(_access_advisor_grant("role:aws:app", f"res:aws:{svc}", svc, last))
+
+    # GCP service account: bigquery used, storage never used.
+    g.add_node(
+        UnifiedNode(
+            id="sa:gcp:etl",
+            entity_type=EntityType.SERVICE_ACCOUNT,
+            label="etl-sa",
+            attributes={"cloud_provider": "gcp", "principal_id": "etl@proj.iam"},
+        )
+    )
+    for svc, last in (("bigquery", "2026-06-02T00:00:00Z"), ("storage", None)):
+        g.add_node(UnifiedNode(id=f"res:gcp:{svc}", entity_type=EntityType.CLOUD_RESOURCE, label=svc))
+        g.add_edge(_access_advisor_grant("sa:gcp:etl", f"res:gcp:{svc}", svc, last))
+
+    return g
+
+
+def test_access_advisor_over_privilege_not_double_counted():
+    """Mixed used+never-used Access-Advisor grants yield exactly ONE
+    CIEM_OVER_PRIVILEGE finding per identity — not one from the NHI over-grant
+    emitter AND one from the CIEM emitter (the 2026-07-18 double-count regression).
+    """
+    from agent_bom.graph.nhi_governance import apply_nhi_governance_with_findings
+
+    graph = _mixed_access_advisor_graph()
+    _, nhi = apply_nhi_governance_with_findings(graph, now=NOW)
+    graph.nhi_governance_findings = nhi
+
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id="scan-1")
+    attach_graph_derived_findings(report, graph)
+    findings = report.to_findings()
+
+    over_priv = [f for f in findings if f.finding_type == FindingType.CIEM_OVER_PRIVILEGE]
+    # One per over-privileged identity — never two for the same identity.
+    by_identity: dict[str, int] = {}
+    for f in over_priv:
+        by_identity[f.asset.identifier] = by_identity.get(f.asset.identifier, 0) + 1
+    assert by_identity == {"AROA-app": 1, "etl@proj.iam": 1}, by_identity
+    assert len(over_priv) == 2, [f.title for f in over_priv]
+
+    # The surviving finding is the richer Access-Advisor CIEM one and still covers
+    # the full never-used set (merge, not silent drop).
+    aws = next(f for f in over_priv if f.asset.identifier == "AROA-app")
+    assert set(aws.evidence["unused_permissions"]) == {"dynamodb", "kms"}
+    assert aws.evidence.get("analysis") == "access_advisor_rightsizing"
+
+    # No id appears twice, and CSPM-domain routing counts each identity once.
+    ids = [f.id for f in findings]
+    assert len(ids) == len(set(ids)), "over-privilege risk must not double-count within one stream"
+    from agent_bom.finding_scope import security_domain_for
+
+    cspm = [f for f in over_priv if security_domain_for(f.source, f.finding_type) == "cspm"]
+    assert len(cspm) == 2
+
+
 # ── Exporter surface ─────────────────────────────────────────────────────────
 
 

--- a/tests/test_framework_mapping.py
+++ b/tests/test_framework_mapping.py
@@ -190,6 +190,35 @@ def test_pci_dss_tags_unchanged():
     ]
 
 
+def test_pci_dss_descriptors_are_own_wording_not_copyrighted_text():
+    """PCI DSS 4.0 requirement text is copyrighted; the catalog must carry
+    agent-bom's OWN short descriptors and the same provenance/copyright note the
+    sibling framework modules (iso_27001, soc2, cis_controls) already carry —
+    only the factual requirement IDs are reused.
+    """
+    import inspect
+
+    # Near-verbatim PCI DSS 4.0 requirement phrasings must not be reproduced.
+    banned_phrases = [
+        "at least quarterly by pci ssc asv",
+        "performed at least quarterly",
+        "cryptographic cipher suites and protocols in use",
+        "minimum complexity requirements",
+    ]
+    for code, descriptor in pci_dss.PCI_DSS_REQUIREMENTS.items():
+        low = descriptor.lower()
+        for phrase in banned_phrases:
+            assert phrase not in low, f"{code} reproduces copyrighted PCI DSS wording: {descriptor!r}"
+
+    # The IDs (the facts) are preserved so tagging is unaffected.
+    assert {"6.3.1", "6.3.2", "11.3.1", "11.3.2", "12.3.1"} <= set(pci_dss.PCI_DSS_REQUIREMENTS)
+
+    # Provenance/copyright note present in the module source, like the siblings.
+    src = inspect.getsource(pci_dss)
+    assert "copyright" in src.lower()
+    assert "own" in src.lower()
+
+
 def test_vuln_compliance_tags_unchanged():
     br = _representative_br()
     assert vuln_compliance.tag_vulnerability(br.vulnerability, br.package) == {

--- a/tests/test_graph_store_streamed_persistence.py
+++ b/tests/test_graph_store_streamed_persistence.py
@@ -601,3 +601,57 @@ def test_streaming_persist_peak_python_heap_is_bounded() -> None:
     # the full path retains every node/edge, so its heap is orders of magnitude larger.
     full_large = _peak_pymem_mb(_MEM_N_LARGE, "full")
     assert stream_large < full_large * 0.5, f"streaming ({stream_large:.1f}MB) not < half of full ({full_large:.1f}MB)"
+
+
+_PRIOR_EDGE_MEM_SCRIPT = textwrap.dedent(
+    """
+    import os, sys, tempfile, tracemalloc
+    from agent_bom.db import graph_store as gs
+    from agent_bom.graph.edge import UnifiedEdge
+    from agent_bom.graph.node import UnifiedNode
+    from agent_bom.graph.types import EntityType, RelationshipType
+
+    n = int(sys.argv[1])
+    db = os.path.join(tempfile.mkdtemp(), "prior.db")
+
+    def node(i):
+        return UnifiedNode(id=f"n:{i}", entity_type=EntityType.PACKAGE, label=f"pkg-{i}")
+
+    def edge(i):
+        return UnifiedEdge(source=f"n:{i}", target=f"n:{i + 1}", relationship=RelationshipType.DEPENDS_ON)
+
+    with gs.open_graph_db(db) as conn:
+        gs.save_graph_streaming(
+            conn,
+            scan_id="prior",
+            tenant_id="t",
+            nodes=(node(i) for i in range(n + 1)),
+            edges=(edge(i) for i in range(n)),
+        )
+        tracemalloc.start()
+        gs.save_graph_streaming(
+            conn,
+            scan_id="current",
+            tenant_id="t",
+            nodes=(node(i) for i in range(2)),
+            edges=(edge(i) for i in range(1)),
+        )
+        _, peak = tracemalloc.get_traced_memory()
+    print(peak / 1024 / 1024)
+    """
+)
+
+
+def _prior_edge_peak_mb(n: int) -> float:
+    env = dict(os.environ)
+    env["PYTHONPATH"] = os.pathsep.join(p for p in sys.path if p) + os.pathsep + env.get("PYTHONPATH", "")
+    out = subprocess.check_output([sys.executable, "-c", _PRIOR_EDGE_MEM_SCRIPT, str(n)], text=True, env=env)
+    return float(out.strip().splitlines()[-1])
+
+
+def test_streaming_persist_does_not_materialize_prior_edge_index() -> None:
+    """A large prior snapshot must not make the next streamed save grow O(prior edges)."""
+    small = _prior_edge_peak_mb(2_000)
+    large = _prior_edge_peak_mb(12_000)
+
+    assert large < small * 2.0, f"prior-edge heap grew with snapshot size: {small:.1f} -> {large:.1f} MB"

--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -430,6 +430,42 @@ def test_overview_hub_kev_finding_moves_exec_kev_count() -> None:
     get_compliance_hub_store().clear("default")
 
 
+def test_overview_vuln_tile_idle_on_empty_estate() -> None:
+    """A brand-new tenant with zero scans/findings must show the Vuln/SCA tile as
+    "idle" (no data), mirroring the sibling tiles — never a green "ok" while the
+    posture headline reads N/A (#4-audit 2026-07-18).
+    """
+    _clear_jobs()
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    get_compliance_hub_store().clear("default")
+    data = client_get_overview()
+    assert data["posture"]["grade"] == "N/A"
+    vuln = data["domains"]["vuln"]
+    assert vuln["metric"] == 0
+    assert vuln["status"] == "idle", vuln
+    # Sibling scan-scoped tiles agree — no tile claims "ok" on an empty estate.
+    assert data["domains"]["code"]["status"] == "idle"
+
+
+def test_overview_vuln_tile_ok_when_only_low_severity() -> None:
+    """With vuln data present but nothing critical/high, the tile stays "ok"
+    (there IS data) — the idle gate must not swallow a real low-severity estate.
+    """
+    _clear_jobs()
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    get_compliance_hub_store().clear("default")
+    _ingest_hub_findings(
+        [{"finding_id": "L-1", "severity": "low", "title": "cve", "vulnerability_id": "CVE-2025-low"}]
+    )
+    data = client_get_overview()
+    vuln = data["domains"]["vuln"]
+    assert vuln["metric"] > 0
+    assert vuln["status"] == "ok", vuln
+    get_compliance_hub_store().clear("default")
+
+
 def test_overview_vuln_tile_reflects_pushed_findings_without_scan() -> None:
     """`findings push` (no scan job) must not leave the Vuln/SCA tile at
     "0 open CVEs · ok" while /findings?domain=vuln returns real highs (#3962).

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -14,8 +14,9 @@ from __future__ import annotations
 import pytest
 
 from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
+from agent_bom.graph.edge import UnifiedEdge
 from agent_bom.graph.node import UnifiedNode
-from agent_bom.graph.types import EntityType, NodeStatus
+from agent_bom.graph.types import EntityType, NodeStatus, RelationshipType
 
 
 class _FakeCursor:
@@ -45,6 +46,7 @@ class _RecordingConn:
         self.deleted_tables: list[str] = []
         self.advisory_locks: list[tuple] = []
         self.sql_calls: list[str] = []
+        self.sql_params: list[tuple | None] = []
         self.rolled_back = 0
 
     def __enter__(self):
@@ -58,6 +60,7 @@ class _RecordingConn:
     def execute(self, sql, params=None):
         low = " ".join(sql.strip().lower().split())
         self.sql_calls.append(low)
+        self.sql_params.append(tuple(params) if params is not None else None)
         if low.startswith("select pg_advisory_xact_lock"):
             self.advisory_locks.append(tuple(params))
         elif low.startswith("delete from"):
@@ -269,6 +272,39 @@ def test_postgres_writer_lock_precedes_snapshot_reads_and_deletes(monkeypatch):
     assert lock_at < prior_read_at < delete_at
 
 
+def test_prior_edges_reconcile_in_postgres_without_python_materialization(monkeypatch):
+    class _PreviousSnapshotConn(_RecordingConn):
+        def execute(self, sql, params=None):
+            low = " ".join(sql.strip().lower().split())
+            if low.startswith("select scan_id, created_at") and "from graph_snapshots" in low:
+                self.sql_calls.append(low)
+                self.sql_params.append(tuple(params) if params is not None else None)
+                return _FakeCursor([("prior-scan", "2026-07-18T00:00:00Z")])
+            if low.startswith("select source_id, target_id, relationship"):
+                raise AssertionError("prior graph edges must not be fetched into Python")
+            return super().execute(sql, params)
+
+    conn = _PreviousSnapshotConn()
+    store = _make_store(conn, monkeypatch)
+    edge = UnifiedEdge(source="agent:1", target="pkg:1", relationship=RelationshipType.DEPENDS_ON)
+
+    store.save_graph_streaming(
+        scan_id="current-scan",
+        tenant_id="tenant-a",
+        nodes=_nodes(1),
+        edges=iter([edge]),
+    )
+
+    continuity_at = next(
+        i for i, sql in enumerate(conn.sql_calls) if sql.startswith("update graph_edges as current")
+    )
+    retirement_at = next(
+        i for i, sql in enumerate(conn.sql_calls) if sql.startswith("update graph_edges as previous")
+    )
+    assert conn.sql_params[continuity_at] == ("current-scan", "tenant-a", "prior-scan", "tenant-a")
+    assert conn.sql_params[retirement_at][1:] == ("tenant-a", "prior-scan", "current-scan", "tenant-a")
+
+
 @pytest.mark.parametrize(
     ("risk_summary", "analysis_status"),
     [
@@ -346,17 +382,9 @@ def test_retired_edge_update_records_ocsf_close_activity(monkeypatch):
             low = " ".join(sql.strip().lower().split())
             if low.startswith("select scan_id, created_at from graph_snapshots"):
                 return _FakeCursor([("scan-old", "2026-07-16T00:00:00Z")])
-            if low.startswith("select source_id, target_id, relationship, first_seen, valid_from, valid_to"):
-                return _FakeCursor([("agent:a", "server:b", "uses", "2026-07-16T00:00:00Z", "2026-07-16T00:00:00Z", None)])
-            return super().execute(sql, params)
-
-        def executemany(self, sql, seq):
-            low = " ".join(sql.strip().lower().split())
-            if low.startswith("update graph_edges"):
+            if low.startswith("update graph_edges as previous"):
                 self.retirement_sql = low
-                list(seq)
-                return _FakeCursor()
-            return super().executemany(sql, seq)
+            return super().execute(sql, params)
 
     conn = _RetirementConn()
     store = _make_store(conn, monkeypatch)
@@ -369,5 +397,5 @@ def test_retired_edge_update_records_ocsf_close_activity(monkeypatch):
         created_at="2026-07-17T00:00:00Z",
     )
 
-    assert "set valid_to = coalesce(valid_to, %s)" in conn.retirement_sql
-    assert "activity_id = case when activity_id = 1 then 3 else activity_id end" in conn.retirement_sql
+    assert "set valid_to = coalesce(previous.valid_to, %s)" in conn.retirement_sql
+    assert "activity_id = case when previous.activity_id = 1 then 3 else previous.activity_id end" in conn.retirement_sql


### PR DESCRIPTION
Combines #4246 and #4247 — disjoint file sets, both post-2026-07-19-audit hardening; verified together. Supersedes and closes those two PRs.

## From #4246 — audit remediation (correctness/honesty)
- **CIEM over-privilege double-count (audit P1, confirmed by 2 lanes)** — the NHI over-grant path now excludes grants already covered by the Access-Advisor CIEM emitter (`graph/nhi_governance.py`), so one over-privileged principal no longer emits two findings under different ids into `to_findings()`, the severity gate, and exports. The CIEM finding (richer: stable id, provider, actionable) wins; the NHI path only right-sizes grants CIEM doesn't cover.
- **PCI descriptors reworded** (`pci_dss.py`) — replaces near-verbatim PCI DSS v4 requirement phrasing with own descriptors keyed to the factual requirement id (same treatment applied to CIS v8 / ISO earlier), narrowing the licensing exposure the audit flagged.
- **Idle vuln tile on empty estate** (`api/routes/overview.py`) — the vuln tile reads honestly idle instead of implying a scanned-and-clean state when no estate data exists.

## From #4247 — graph edge reconciliation (perf)
- Reconciles prior edges in storage on streamed graph persistence (`api/postgres_graph.py`, `db/graph_store.py`) so a re-persist doesn't leave stale/duplicate edges; decision recorded in `docs/decisions/006-unified-graph-write-batching.md`.

## How verified (combined branch)
Both suites on the merged result: **89 passed** (`test_api_findings_surface_parity`, `test_framework_mapping`, `test_overview`, `test_graph_store_streamed_persistence`, `test_postgres_graph_streaming`); `ruff` clean; OpenAPI `--check`, `check-counts`, `check_release_consistency` all green. The CIEM dedup is asserted by the parity suite (one principal → one CIEM finding).

Closes #4246, closes #4247.