### PR TITLE
fix(api): scope hosted-scan discovery to the request, not the server host

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -4399,6 +4399,11 @@
             ],
             "title": "Db Sources"
           },
+          "discover_host": {
+            "default": false,
+            "title": "Discover Host",
+            "type": "boolean"
+          },
           "dry_run": {
             "default": false,
             "title": "Dry Run",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2990,6 +2990,10 @@ components:
           - type: string
           - type: 'null'
           title: Db Sources
+        discover_host:
+          default: false
+          title: Discover Host
+          type: boolean
         dry_run:
           default: false
           title: Dry Run

--- a/docs/schemas/v1/ScanJob.json
+++ b/docs/schemas/v1/ScanJob.json
@@ -71,6 +71,11 @@
           "default": null,
           "title": "Db Sources"
         },
+        "discover_host": {
+          "default": false,
+          "title": "Discover Host",
+          "type": "boolean"
+        },
         "dry_run": {
           "default": false,
           "title": "Dry Run",

--- a/docs/schemas/v1/ScanRequest.json
+++ b/docs/schemas/v1/ScanRequest.json
@@ -58,6 +58,11 @@
       "default": null,
       "title": "Db Sources"
     },
+    "discover_host": {
+      "default": false,
+      "title": "Discover Host",
+      "type": "boolean"
+    },
     "dry_run": {
       "default": false,
       "title": "Dry Run",

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -179,6 +179,13 @@ class ScanRequest(BaseModel):
     dynamic_max_depth: int = 4
     """Max directory depth for dynamic discovery."""
 
+    discover_host: bool = False
+    """Also discover the server host's ambient MCP configuration (~/.claude,
+    ~/.cursor, …). Off by default: on the hosted/multi-tenant scan path the
+    server host is not the tenant's estate, so sweeping it would fold the
+    server's own AI clients into a tenant's results. Opt in only for
+    self-hosted single-tenant deployments where the host IS the scan target."""
+
     scope_agents: list[ScanGlobPattern] = Field(default_factory=list)
     """Filter discovered agents by name (glob patterns, e.g. ['claude-*', 'cursor'])."""
 

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -819,11 +819,31 @@ def _run_scan_sync(job: ScanJob) -> None:
                 dynamic_max_depth=req.dynamic_max_depth,
             )
         else:
-            pipeline.start_step("discovery", "Discovering local MCP configurations...")
-            local_agents = discover_all(
-                dynamic=req.dynamic_discovery,
-                dynamic_max_depth=req.dynamic_max_depth,
-            )
+            # Scope discovery to the request's own project paths — the server
+            # host is not the tenant's estate, so ambient host-wide discovery
+            # (discover_all with no project_dir) would fold the server's own AI
+            # clients into a tenant's scan. Host discovery is opt-in via
+            # `discover_host` for self-hosted single-tenant deployments.
+            local_agents = []
+            for proj in effective_agent_projects:
+                pipeline.update_step("discovery", f"Discovering MCP configs in {proj}...")
+                local_agents.extend(
+                    discover_all(
+                        project_dir=str(proj),
+                        dynamic=req.dynamic_discovery,
+                        dynamic_max_depth=req.dynamic_max_depth,
+                    )
+                )
+            if req.discover_host:
+                pipeline.update_step("discovery", "Discovering host ambient MCP configurations...")
+                local_agents.extend(
+                    discover_all(
+                        dynamic=req.dynamic_discovery,
+                        dynamic_max_depth=req.dynamic_max_depth,
+                    )
+                )
+            if not effective_agent_projects and not req.discover_host:
+                pipeline.update_step("discovery", "No local project scope; skipping ambient host discovery")
         agents.extend(local_agents)
 
         if req.inventory:

--- a/tests/api/test_api_pipeline_image_contract.py
+++ b/tests/api/test_api_pipeline_image_contract.py
@@ -95,7 +95,7 @@ def test_api_pipeline_ai_enrichment_inherits_env_and_serializes_typed_provenance
     job = ScanJob(
         job_id="ai-api-123",
         created_at="2026-07-17T12:00:00Z",
-        request=ScanRequest(ai_enrich=True, ai_model="ollama/fake", offline=True),
+        request=ScanRequest(ai_enrich=True, ai_model="ollama/fake", offline=True, discover_host=True),
     )
     agent = _agent_with_package()
     package = agent.mcp_servers[0].packages[0]
@@ -225,7 +225,7 @@ def test_api_pipeline_no_scan_skips_vulnerability_scan_and_result_side_effects(m
     job = ScanJob(
         job_id="no-scan-123",
         created_at="2026-03-25T12:00:00Z",
-        request=ScanRequest(no_scan=True, auto_update_db=True),
+        request=ScanRequest(no_scan=True, auto_update_db=True, discover_host=True),
     )
 
     def _unexpected(*_args, **_kwargs):
@@ -254,7 +254,7 @@ def test_api_pipeline_offline_scan_never_retries_online(monkeypatch):
     job = ScanJob(
         job_id="offline-123",
         created_at="2026-03-25T12:00:00Z",
-        request=ScanRequest(offline=True, enrich=True),
+        request=ScanRequest(offline=True, enrich=True, discover_host=True),
     )
     seen_offline: list[bool | None] = []
 

--- a/tests/api/test_api_scan_discovery_scope.py
+++ b/tests/api/test_api_scan_discovery_scope.py
@@ -1,0 +1,78 @@
+"""The hosted scan path must not sweep the server host's ambient MCP configs
+into a tenant's scan. Discovery is scoped to the request's own project paths;
+ambient host-wide discovery is opt-in via `discover_host`.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.pipeline import _run_scan_sync
+from agent_bom.api.store import InMemoryJobStore
+
+
+def _record_discovery(monkeypatch, store):
+    """Patch the pipeline's heavy deps and record every discover_all project_dir."""
+    calls: list[str | None] = []
+
+    def fake_discover_all(*args, project_dir=None, **kwargs):
+        calls.append(project_dir)
+        return []
+
+    monkeypatch.setattr("agent_bom.discovery.discover_all", fake_discover_all)
+    monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)
+    monkeypatch.setattr(
+        "agent_bom.api.pipeline._sync_scan_agents_to_fleet",
+        lambda _agents, tenant_id="default": None,
+    )
+    monkeypatch.setattr(
+        "agent_bom.scanners.scan_agents_sync",
+        lambda agents, enable_enrichment=False, **kwargs: [],
+    )
+    return calls
+
+
+def _run(store, request):
+    job = ScanJob(
+        job_id=str(uuid.uuid4()),
+        tenant_id="tenant-a",
+        status=JobStatus.RUNNING,
+        created_at="2026-07-19T00:00:00Z",
+        request=request,
+    )
+    store.put(job)
+    _run_scan_sync(job)
+    return store.get(job.job_id, tenant_id="tenant-a")
+
+
+def test_scan_with_projects_scopes_discovery_and_never_touches_host(monkeypatch, tmp_path):
+    store = InMemoryJobStore()
+    calls = _record_discovery(monkeypatch, store)
+    proj = tmp_path / "tenant-project"
+    proj.mkdir()
+
+    _run(store, ScanRequest(agent_projects=[str(proj)], offline=True, enrich=False))
+
+    # Discovery is scoped to the submitted project; the host (project_dir=None)
+    # is never swept.
+    assert str(proj) in calls
+    assert None not in calls, "hosted scan must not run ambient host-wide discovery"
+
+
+def test_scan_without_scope_does_not_sweep_host_by_default(monkeypatch):
+    store = InMemoryJobStore()
+    calls = _record_discovery(monkeypatch, store)
+
+    _run(store, ScanRequest(offline=True, enrich=False))
+
+    assert None not in calls, "ambient host discovery must be opt-in, not the default"
+
+
+def test_scan_opts_into_host_discovery_explicitly(monkeypatch):
+    store = InMemoryJobStore()
+    calls = _record_discovery(monkeypatch, store)
+
+    _run(store, ScanRequest(offline=True, enrich=False, discover_host=True))
+
+    assert None in calls, "discover_host=True must run ambient host-wide discovery"

--- a/tests/api/test_api_scan_vex_parity.py
+++ b/tests/api/test_api_scan_vex_parity.py
@@ -271,7 +271,7 @@ def test_api_pipeline_applies_vex_and_rebuilds_findings(monkeypatch, tmp_path):
     job = ScanJob(
         job_id="vex-parity",
         created_at="2026-07-06T00:00:00Z",
-        request=ScanRequest(vex=str(vex_path), enrich=False),
+        request=ScanRequest(vex=str(vex_path), enrich=False, discover_host=True),
     )
 
     monkeypatch.setattr("agent_bom.api.pipeline._get_store", lambda: store)


### PR DESCRIPTION
## The bug (audit 2026-07-19, P1 → leans P0)
A hosted `POST /v1/scan` with no cloned repo ran `discover_all()` **unscoped** (`api/pipeline.py:822`), which reads the **server host's** ambient MCP configuration (`~/.claude`, `~/.cursor`, …) and folded the server's own AI clients into the **tenant's** scan.

- **Cross-tenant leak** in multi-tenant hosting: host posture bleeds into tenant data.
- **Count inflation**: 32 API findings vs 21 CLI on identical inventory (`affected_agents` showed host clients) — and the root cause of the CLI↔API count mismatches the audit kept hitting.
- **Also**: when `agent_projects` were supplied, the pipeline still discovered the *host* instead of those projects.

## The fix
Scope discovery to the request's own project paths. Ambient host-wide discovery is now **opt-in** via a new `ScanRequest.discover_host` (default `false`) — for self-hosted single-tenant deployments where the host genuinely is the scan target. The CLI's existing `--no-discover` is unaffected (this only changes the hosted API path).

Blast radius wired: model → pipeline → OpenAPI + v1 schemas regenerated (55 models) → tests. No API-contract drift beyond the new field.

## How verified
- New `tests/api/test_api_scan_discovery_scope.py` red→green: projects scope discovery, host is never swept by default, `discover_host=true` opts in.
- **140 passed** across pipeline / discovery / dynamic-discovery / demo-estate / cross-tenant-matrix / tenant-isolation suites — no regressions.
- `ruff` clean; `export_openapi --check`, `generate_v1_schemas --check`, `check-counts`, `check_release_consistency`, `check_product_surface_contract` all green.

Part of the audit remediation backlog (top-ranked P1).