### PR TITLE
feat(deps): agent-bom-collector sidecar image shipping cloud SDKs independently

### DIFF
--- a/.github/workflows/refresh-latest-container.yml
+++ b/.github/workflows/refresh-latest-container.yml
@@ -332,3 +332,109 @@ jobs:
             exit 1
           fi
           rm -f "$RESPONSE_FILE"
+
+  refresh-collector-latest:
+    name: Rebuild and publish collector latest from latest release tag
+    # The cloud-SDK collector's whole reason to exist (#4239): this daily rebuild
+    # of `agent-bom-collector:latest` absorbs newer boto3/azure/google/snowflake
+    # SDK wheels (within the pinned floors) WITHOUT a control-plane version bump,
+    # so the provider SDK layer stays current on its own cadence.
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/setup-python
+        with:
+          python-version: '3.11'
+
+      - name: Install agent-bom scanner (snapshot from default branch)
+        run: |
+          uv venv "${RUNNER_TEMP}/abom-scanner"
+          uv pip install --python "${RUNNER_TEMP}/abom-scanner/bin/python" .
+
+      - name: Resolve latest release tag
+        id: release
+        run: |
+          set -euo pipefail
+          MAIN_SHA=$(git rev-parse HEAD)
+          git fetch --tags --force
+          TAG=$(git tag -l 'v*.*.*' --sort=-version:refname | head -n1)
+          if [ -z "$TAG" ]; then
+            echo "::error::No semver release tag found"
+            exit 1
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "main_sha=$MAIN_SHA" >> "$GITHUB_OUTPUT"
+          git checkout "$TAG"
+
+      - name: Apply current runtime security overlay
+        run: |
+          set -euo pipefail
+          # App code stays pinned to the release tag, but the runtime security
+          # pins (pip hashes, CVE allowlist) float to the default branch so an
+          # old tag never keeps rebuilding a known-vulnerable collector.
+          git checkout "${{ steps.release.outputs.main_sha }}" -- \
+            deploy/docker/pip-requirements.txt \
+            .image-scan-ignore \
+            security/image-exceptions.yaml
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build refresh candidate collector image
+        run: docker build -f deploy/docker/Dockerfile.collector -t agent-bom-collector:latest-refresh-test .
+
+      - name: Smoke test refresh candidate
+        run: |
+          docker run --rm agent-bom-collector:latest-refresh-test --version
+          docker run --rm --entrypoint python agent-bom-collector:latest-refresh-test -c "import boto3, azure.identity, google.cloud.resourcemanager_v3, snowflake.connector"
+
+      - name: Image vulnerability refresh gate
+        run: |
+          "${RUNNER_TEMP}/abom-scanner/bin/agent-bom" image agent-bom-collector:latest-refresh-test \
+            --ignore .image-scan-ignore \
+            --exclude-unfixable \
+            --fail-on-severity medium
+
+      - name: Build and push refreshed collector latest
+        id: build-push
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.collector
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: VERSION=${{ steps.release.outputs.version }}
+          cache-from: type=gha,scope=refresh-collector-latest
+          cache-to: type=gha,mode=max,scope=refresh-collector-latest
+          provenance: true
+          sbom: true
+          tags: |
+            agentbom/agent-bom-collector:latest
+          labels: |
+            org.opencontainers.image.version=${{ steps.release.outputs.version }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.title=agent-bom cloud-SDK collector
+            org.opencontainers.image.description=Read-only cloud collector — ships boto3/azure/google/snowflake SDKs independently of the control-plane release. No external MCP in the scan path.
+            org.opencontainers.image.created=${{ github.run_id }}
+            org.opencontainers.image.revision=${{ steps.release.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -465,6 +465,80 @@ jobs:
               -H "Authorization: Bearer $TOKEN" || true
           done <<< "$ALL_TAGS"
 
+  docker-publish-collector:
+    name: Publish cloud-SDK collector image
+    needs: [build, self-scan-gate, container-gate]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write       # required for SLSA provenance attestation
+      attestations: write   # required for SBOM + provenance attestations
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Extract version from tag
+        id: meta
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Smoke test collector container
+        run: |
+          set -euo pipefail
+          docker build -f deploy/docker/Dockerfile.collector -t agent-bom-collector:release-test .
+          # The collector ships the cloud SDK layer — assert the anchor SDKs are
+          # importable in the built image, not just that the CLI runs.
+          docker run --rm agent-bom-collector:release-test --version
+          docker run --rm --entrypoint python agent-bom-collector:release-test -c "import boto3, azure.identity, google.cloud.resourcemanager_v3, snowflake.connector"
+
+      - name: Set up QEMU (multi-arch)
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4.4.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push collector image
+        id: build-collector-image
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          file: deploy/docker/Dockerfile.collector
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: VERSION=${{ steps.meta.outputs.version }}
+          provenance: true
+          sbom: true
+          tags: |
+            agentbom/agent-bom-collector:${{ steps.meta.outputs.version }}
+            agentbom/agent-bom-collector:latest
+          labels: |
+            org.opencontainers.image.version=${{ steps.meta.outputs.version }}
+            org.opencontainers.image.source=https://github.com/${{ github.repository }}
+            org.opencontainers.image.title=agent-bom cloud-SDK collector
+            org.opencontainers.image.description=Read-only cloud collector — ships boto3/azure/google/snowflake SDKs independently of the control-plane release. No external MCP in the scan path.
+            org.opencontainers.image.created=${{ github.event.head_commit.timestamp }}
+            org.opencontainers.image.revision=${{ github.sha }}
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign collector image
+        run: cosign sign --yes "agentbom/agent-bom-collector@${{ steps.build-collector-image.outputs.digest }}"
+
+      - name: Attest collector image provenance
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-name: index.docker.io/agentbom/agent-bom-collector
+          subject-digest: ${{ steps.build-collector-image.outputs.digest }}
+          push-to-registry: true
+
   docker-publish-ui:
     name: Publish UI image
     needs: [build, self-scan-gate, container-gate]
@@ -1060,7 +1134,7 @@ jobs:
     # Block the GitHub Release until the published-image Trivy gate passes.
     # PyPI/Docker Hub artifacts may already be live; the gate still prevents
     # minting signed release assets when the pushed image crosses the threshold.
-    needs: [pypi-publish, docker-publish, docker-publish-ui, sign, provenance, sbom, helm-publish, published-image-scan-gate]
+    needs: [pypi-publish, docker-publish, docker-publish-collector, docker-publish-ui, sign, provenance, sbom, helm-publish, published-image-scan-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:

--- a/deploy/docker/Dockerfile.collector
+++ b/deploy/docker/Dockerfile.collector
@@ -1,0 +1,107 @@
+# Cloud-SDK collector image (issue #4239, follow-up to #3835).
+#
+# Ships ONLY the cloud-provider SDK layer (boto3 / azure-* / google-cloud-* /
+# snowflake-connector) plus the agent-bom CLI, so the SDK layer can be rebuilt
+# and re-tagged on its own cadence — the daily `refresh-collector-latest` CI job
+# absorbs newer provider-SDK wheels within the pinned floors WITHOUT a
+# control-plane version bump. This is the "middle path" #3835 chose over both a
+# single fat image and an external cloud MCP: the collector keeps the BYOC trust
+# boundary intact (direct, read-only, least-privilege link to the customer's
+# cloud; no external MCP in the credential/data path) while decoupling the
+# fast-moving SDK layer from the control-plane release train.
+#
+# Single source of truth for the SDK versions: the cloud provider extras in
+# pyproject.toml — this image installs `.[${AGENT_BOM_EXTRAS}]`, it never
+# re-declares versions. The same floors are what the cloud-SDK drift gate
+# (scripts/check_cloud_sdk_drift.py) enforces.
+#
+# Build:  docker build -f deploy/docker/Dockerfile.collector -t agent-bom-collector .
+# Run:    docker run --rm agent-bom-collector scan --k8s -f json
+#
+# Deploy: the Helm chart's cloud-scan CronJob runs this image (collectorImage
+# in deploy/helm/agent-bom/values.yaml) instead of the control-plane image, so
+# operators can pin a newer SDK-only build via --set collectorImage.tag=<tag>.
+
+## ── Builder stage ────────────────────────────────────────────────────────────
+FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9 AS builder
+
+WORKDIR /app
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ARG SSL_CERT_FILE
+ARG REQUESTS_CA_BUNDLE
+ARG CURL_CA_BUNDLE
+ARG PIP_CERT
+ENV HTTP_PROXY=${HTTP_PROXY} \
+    HTTPS_PROXY=${HTTPS_PROXY} \
+    NO_PROXY=${NO_PROXY} \
+    SSL_CERT_FILE=${SSL_CERT_FILE} \
+    REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE} \
+    CURL_CA_BUNDLE=${CURL_CA_BUNDLE} \
+    PIP_CERT=${PIP_CERT}
+
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+
+COPY pyproject.toml README.md PYPI_README.md LICENSE ./
+COPY src/ ./src/
+
+# The cloud provider SDK layer — the collector's whole reason to exist. Pinned
+# via the pyproject extras (single source of truth), NOT re-declared here.
+# Override for a narrower collector, e.g. --build-arg AGENT_BOM_EXTRAS=aws,azure.
+ARG AGENT_BOM_EXTRAS=aws,azure,gcp,snowflake
+RUN pip install --no-cache-dir --prefix=/install ".[${AGENT_BOM_EXTRAS}]"
+
+## ── Runtime stage ────────────────────────────────────────────────────────────
+FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
+
+# Baked app-code version (provenance label). The SDK layer moves on its own
+# cadence via the daily refresh job; this records which agent-bom build shipped.
+ARG VERSION=0.96.3
+ARG HTTP_PROXY
+ARG HTTPS_PROXY
+ARG NO_PROXY
+ARG SSL_CERT_FILE
+ARG REQUESTS_CA_BUNDLE
+ARG CURL_CA_BUNDLE
+ARG PIP_CERT
+
+LABEL org.opencontainers.image.title="agent-bom cloud-SDK collector"
+LABEL org.opencontainers.image.description="Read-only cloud collector — ships boto3/azure/google/snowflake SDKs independently of the control-plane release. Runs agent-bom cloud discovery/scan; no external MCP in the scan path."
+LABEL org.opencontainers.image.version="${VERSION}"
+LABEL org.opencontainers.image.source="https://github.com/msaad00/agent-bom"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+# Copy only installed packages from builder (no pip toolchain, no build deps).
+COPY --from=builder /install /usr/local
+COPY --from=builder /app/LICENSE /app/LICENSE
+
+# Apply latest OS security patches (fixes base-image CVEs visible in Docker Scout).
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && apt-get upgrade -y --no-install-recommends && rm -rf /var/lib/apt/lists/*
+COPY deploy/docker/pip-requirements.txt /tmp/pip-req.txt
+RUN pip install --no-cache-dir --require-hashes -r /tmp/pip-req.txt && rm /tmp/pip-req.txt
+
+# Create non-root user for least-privilege execution (read-only collector).
+RUN addgroup --system abom && adduser --system --ingroup abom abom
+
+WORKDIR /workspace
+RUN chown abom:abom /workspace
+RUN mkdir -p /home/abom/.agent-bom && chown -R abom:abom /home/abom
+
+USER abom
+
+ENV PYTHONUNBUFFERED=1
+ENV HOME=/home/abom
+ENV HTTP_PROXY=${HTTP_PROXY}
+ENV HTTPS_PROXY=${HTTPS_PROXY}
+ENV NO_PROXY=${NO_PROXY}
+ENV SSL_CERT_FILE=${SSL_CERT_FILE}
+ENV REQUESTS_CA_BUNDLE=${REQUESTS_CA_BUNDLE}
+ENV CURL_CA_BUNDLE=${CURL_CA_BUNDLE}
+ENV PIP_CERT=${PIP_CERT}
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+    CMD agent-bom --version || exit 1
+
+ENTRYPOINT ["agent-bom"]
+CMD ["--help"]

--- a/deploy/helm/agent-bom/README.md
+++ b/deploy/helm/agent-bom/README.md
@@ -69,6 +69,33 @@ python scripts/install_helm_profile.py focused-pilot
 
 Full profile matrix: [`examples/README.md`](examples/README.md).
 
+## Cloud-SDK collector image
+
+The scheduled cloud scan runs a dedicated **collector image**
+(`agentbom/agent-bom-collector`, built from
+[`deploy/docker/Dockerfile.collector`](../../docker/Dockerfile.collector)) that
+ships the provider SDK layer — boto3, the Azure management SDKs, the Google
+Cloud SDKs, and the Snowflake connector — separately from the control-plane
+image. This lets the fast-moving SDK layer be rebuilt and re-tagged on its own
+cadence: a daily CI job (`refresh-collector-latest`) rebuilds
+`agent-bom-collector:latest` to absorb newer provider-SDK wheels within the
+pinned floors **without** a control-plane version bump. The collector keeps the
+BYOC trust boundary intact — a direct, read-only, least-privilege link to the
+customer's cloud, with no external MCP in the credential/data path.
+
+The SDK versions come from the cloud provider extras in `pyproject.toml` (the
+single source of truth the [cloud-SDK drift gate](../../../scripts/check_cloud_sdk_drift.py)
+enforces); the image never re-declares them. To pin a newer SDK-only build
+between control-plane releases:
+
+```bash
+helm upgrade agent-bom agent-bom/agent-bom \
+  --reuse-values --set collectorImage.tag=<sdk-only-build>
+```
+
+`collectorImage` mirrors the `image`/`uiImage`/`runtimeImage` block convention; a
+blank `collectorImage.tag` falls back to `image.tag`.
+
 ## Key values
 
 | Value | Default | Description |
@@ -76,6 +103,8 @@ Full profile matrix: [`examples/README.md`](examples/README.md).
 | `scanner.enabled` | `true` | Deploy CronJob scanner |
 | `scanner.schedule` | `0 */6 * * *` | Cron schedule |
 | `scanner.allNamespaces` | `true` | Scan all namespaces |
+| `collectorImage.repository` | `agentbom/agent-bom-collector` | Cloud-SDK collector image the scan CronJob runs |
+| `collectorImage.tag` | release version | Collector tag — override to bump the SDK layer independently of the control plane; blank falls back to `image.tag` |
 | `controlPlane.enabled` | `false` | Package API + dashboard Deployments |
 | `controlPlane.ingress.enabled` | `false` | Same-origin ingress for UI + API |
 | `monitor.enabled` | `false` | Optional node-wide runtime monitor |

--- a/deploy/helm/agent-bom/templates/_helpers.tpl
+++ b/deploy/helm/agent-bom/templates/_helpers.tpl
@@ -67,6 +67,28 @@ Scanner service account name.
 {{- end }}
 
 {{/*
+Cloud-SDK collector image reference (issue #4239).
+
+The cloud-scan CronJob runs the collector image, which ships the provider SDK
+layer independently of the control-plane release. `collectorImage.repository` /
+`collectorImage.tag` default to the collector repo pinned at the release
+version; a blank tag falls back to `image.tag` so an operator can never render a
+`repo:` reference with an empty tag. Override `collectorImage.tag` to pin a
+newer SDK-only build between control-plane releases.
+*/}}
+{{- define "agent-bom.collectorImage" -}}
+{{- $c := .Values.collectorImage | default dict -}}
+{{- $repo := $c.repository | default .Values.image.repository -}}
+{{- $tag := $c.tag | default .Values.image.tag -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end }}
+
+{{- define "agent-bom.collectorImagePullPolicy" -}}
+{{- $c := .Values.collectorImage | default dict -}}
+{{- $c.pullPolicy | default .Values.image.pullPolicy -}}
+{{- end }}
+
+{{/*
 Backup service account name.
 */}}
 {{- define "agent-bom.controlPlaneBackupServiceAccountName" -}}

--- a/deploy/helm/agent-bom/templates/cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/cronjob.yaml
@@ -46,8 +46,11 @@ spec:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
           containers:
             - name: scanner
-              image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
-              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              # Cloud-SDK collector image (#4239): ships boto3/azure/google/snowflake
+              # independently of the control-plane release. Falls back to the
+              # control-plane image when collectorImage is unset.
+              image: "{{ include "agent-bom.collectorImage" . }}"
+              imagePullPolicy: {{ include "agent-bom.collectorImagePullPolicy" . }}
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -37,6 +37,20 @@ runtimeImage:
   tag: "0.96.3"
   pullPolicy: IfNotPresent
 
+# Cloud-SDK collector image (issue #4239). Ships the boto3/azure/google/snowflake
+# SDK layer independently of the control-plane release so it can be rebuilt and
+# re-tagged on its own cadence (a daily CI refresh absorbs newer provider-SDK
+# wheels within the pinned floors) WITHOUT a control-plane version bump. The
+# cloud-scan CronJob runs this image instead of the control-plane image. Leave
+# `tag` at the release version to ride the release train, or override
+# `collectorImage.tag` (e.g. --set collectorImage.tag=<sdk-only-build>) to pin a
+# newer SDK-only build between control-plane releases. A blank tag falls back to
+# `image.tag`.
+collectorImage:
+  repository: agentbom/agent-bom-collector
+  tag: "0.96.3"
+  pullPolicy: IfNotPresent
+
 imagePullSecrets: []
 podAnnotations: {}
 nodeSelector: {}

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -26,6 +26,7 @@ VERSION_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ("deploy/docker/Dockerfile.runtime", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
     ("deploy/docker/Dockerfile.sse", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
     ("deploy/docker/Dockerfile.mcp", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
+    ("deploy/docker/Dockerfile.collector", re.compile(r"^(ARG VERSION=)\S+", re.M), r"\g<1>{v}"),
     # MCP Registry server.json (version field + pypi identifier version)
     ("integrations/mcp-registry/server.json", re.compile(r'("version":\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),
     ("integrations/glama/server.json", re.compile(r'("version":\s*")[^"]+(")', re.M), r"\g<1>{v}\g<2>"),

--- a/scripts/check_docker_base_policy.py
+++ b/scripts/check_docker_base_policy.py
@@ -98,6 +98,11 @@ POLICY: dict[str, BasePolicy] = {
         expected_tags=("3.11.12-slim",),
         rationale="Snowpark requires Python 3.11; held back from 3.12 for snowflake-snowpark-python compatibility.",
     ),
+    "deploy/docker/Dockerfile.collector": BasePolicy(
+        image="python",
+        expected_tags=("3.12.13-slim",),
+        rationale="Cloud-SDK collector; Debian slim for boto3/azure/google wheel compatibility (grpcio, cryptography).",
+    ),
     ".clusterfuzzlite/Dockerfile": BasePolicy(
         image="gcr.io/oss-fuzz-base/base-builder-python",
         expected_tags=(),

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -75,6 +75,11 @@ MANAGED_VERSION_REFS: list[tuple[Path, re.Pattern[str], str]] = [
         "Snowpark Dockerfile ARG",
     ),
     (
+        ROOT / "deploy" / "docker" / "Dockerfile.collector",
+        re.compile(r"^ARG VERSION=([0-9]+\.[0-9]+\.[0-9]+)$", re.M),
+        "collector Dockerfile ARG",
+    ),
+    (
         ROOT / "deploy" / "k8s" / "sidecar-example.yaml",
         re.compile(r"agentbom/agent-bom:([0-9]+\.[0-9]+\.[0-9]+)"),
         "K8s sidecar image",

--- a/tests/test_collector_image.py
+++ b/tests/test_collector_image.py
@@ -1,0 +1,165 @@
+"""Structural surface for the cloud-SDK collector image/sidecar (issue #4239).
+
+The collector ships the boto3/azure/google/snowflake SDK layer independently of
+the control-plane release so it can be rebuilt/re-tagged on its own cadence
+(daily CI refresh) WITHOUT a control-plane version bump. These tests assert the
+shipped STRUCTURE — Dockerfile hardening + single-source-of-truth pins, and the
+Helm chart wiring the cloud-scan CronJob to the collector image with a safe
+fallback — not merely that `helm template` exits 0.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tomllib
+from pathlib import Path
+
+import pytest
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = ROOT / "deploy" / "docker" / "Dockerfile.collector"
+CHART = ROOT / "deploy" / "helm" / "agent-bom"
+PYPROJECT = ROOT / "pyproject.toml"
+
+# Anchor SDK distributions the collector image exists to ship. Matches the
+# provider extras in pyproject.toml (the single source of truth).
+ANCHOR_SDKS = ("boto3", "azure-identity", "google-cloud-resource-manager", "snowflake-connector-python")
+
+
+# ── Dockerfile structure ─────────────────────────────────────────────────────
+
+
+def test_collector_dockerfile_exists() -> None:
+    assert DOCKERFILE.is_file(), "deploy/docker/Dockerfile.collector must exist"
+
+
+def test_collector_base_is_digest_pinned() -> None:
+    text = DOCKERFILE.read_text()
+    from_lines = [ln for ln in text.splitlines() if ln.strip().upper().startswith("FROM ")]
+    assert from_lines, "no FROM line in collector Dockerfile"
+    for ln in from_lines:
+        assert "@sha256:" in ln, f"base image must be digest-pinned: {ln!r}"
+        assert ":latest" not in ln, f"base image must not use :latest: {ln!r}"
+
+
+def test_collector_runs_as_non_root_with_healthcheck() -> None:
+    text = DOCKERFILE.read_text()
+    assert re.search(r"^\s*USER\s+abom\s*$", text, re.M), "collector must drop to non-root USER abom"
+    assert "HEALTHCHECK" in text, "collector must define a HEALTHCHECK"
+    assert 'ENTRYPOINT ["agent-bom"]' in text, "collector entrypoint must be agent-bom"
+
+
+def test_collector_installs_cloud_sdk_extras_not_hardcoded_versions() -> None:
+    """The SDK versions come from the pyproject extras, never re-declared here.
+
+    Guards the single-source-of-truth contract with #3835's drift gate: the
+    Dockerfile installs `.[${AGENT_BOM_EXTRAS}]` and must not pin any anchor SDK
+    to a literal version of its own (which would silently fork the floor).
+    """
+    text = DOCKERFILE.read_text()
+    assert 'pip install --no-cache-dir --prefix=/install ".[${AGENT_BOM_EXTRAS}]"' in text, (
+        "collector must install the pyproject cloud extras as the single source of truth"
+    )
+    default = re.search(r"^ARG AGENT_BOM_EXTRAS=(\S+)$", text, re.M)
+    assert default, "collector must declare a default AGENT_BOM_EXTRAS build arg"
+    extras = set(default.group(1).split(","))
+    assert {"aws", "azure", "gcp"} <= extras, f"cloud provider extras missing from default: {extras}"
+    # No literal SDK version pin re-declared in the Dockerfile.
+    for sdk in ANCHOR_SDKS:
+        assert not re.search(rf"{re.escape(sdk)}\s*[><=]=", text), f"{sdk} must not be re-pinned in the collector Dockerfile"
+
+
+def test_collector_extras_resolve_to_real_pinned_sdks_in_pyproject() -> None:
+    """The extras the collector installs actually declare the anchor SDK floors."""
+    data = tomllib.loads(PYPROJECT.read_text())
+    extras = data["project"]["optional-dependencies"]
+    declared = " ".join(spec for group in ("aws", "azure", "gcp", "snowflake") for spec in extras[group])
+    for sdk in ANCHOR_SDKS:
+        assert f"{sdk}>=" in declared, f"{sdk} floor not declared in the provider extras (single source of truth)"
+
+
+def test_collector_version_arg_matches_release_version() -> None:
+    """The baked provenance VERSION stays in lockstep with the release (bump-version)."""
+    version_match = re.search(r'^version\s*=\s*"([^"]+)"', PYPROJECT.read_text(), re.M)
+    assert version_match, "pyproject.toml version not found"
+    version = version_match.group(1)
+    arg = re.search(r"^ARG VERSION=([0-9]+\.[0-9]+\.[0-9]+)$", DOCKERFILE.read_text(), re.M)
+    assert arg, "collector Dockerfile must carry an ARG VERSION"
+    assert arg.group(1) == version, f"collector ARG VERSION {arg.group(1)} != pyproject {version}"
+
+
+def test_collector_registered_in_docker_base_policy() -> None:
+    import importlib.util
+    import sys
+
+    name = "check_docker_base_policy"
+    spec = importlib.util.spec_from_file_location(name, ROOT / "scripts" / "check_docker_base_policy.py")
+    assert spec and spec.loader, "could not load check_docker_base_policy"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod  # dataclass decorator resolves __module__ from sys.modules
+    spec.loader.exec_module(mod)
+    assert "deploy/docker/Dockerfile.collector" in mod.POLICY, "collector Dockerfile not registered in base policy"
+    assert mod.main() == 0, "repo Dockerfiles must satisfy the base policy"
+
+
+# ── Helm chart wiring ────────────────────────────────────────────────────────
+
+
+def _helm_render(*set_values: str) -> list[dict]:
+    if shutil.which("helm") is None:
+        pytest.skip("helm not installed")
+    args = ["helm", "template", "abom", str(CHART)]
+    for value in set_values:
+        args += ["--set", value]
+    proc = subprocess.run(args, capture_output=True, text=True, timeout=120)
+    assert proc.returncode == 0, proc.stderr
+    return [doc for doc in yaml.safe_load_all(proc.stdout) if doc]
+
+
+def _scan_cronjob(docs: list[dict]) -> dict:
+    cronjobs = [d for d in docs if d.get("kind") == "CronJob"]
+    scan = [c for c in cronjobs if c["metadata"]["name"].endswith("-scan")]
+    assert scan, "no cloud-scan CronJob rendered"
+    return scan[0]
+
+
+def _scanner_container(cronjob: dict) -> dict:
+    spec = cronjob["spec"]["jobTemplate"]["spec"]["template"]["spec"]
+    containers = [c for c in spec["containers"] if c["name"] == "scanner"]
+    assert containers, "no scanner container in the scan CronJob"
+    return containers[0]
+
+
+def test_scan_cronjob_uses_collector_image_by_default() -> None:
+    docs = _helm_render()
+    container = _scanner_container(_scan_cronjob(docs))
+    assert container["image"] == "agentbom/agent-bom-collector:0.96.3", container["image"]
+
+
+def test_collector_tag_overrides_independently_of_control_plane() -> None:
+    """The SDK layer bumps without touching the control-plane image.tag (#4239)."""
+    docs = _helm_render("collectorImage.tag=1.2.3-sdk", "image.tag=0.96.3")
+    container = _scanner_container(_scan_cronjob(docs))
+    assert container["image"] == "agentbom/agent-bom-collector:1.2.3-sdk", container["image"]
+    # The control-plane API deployment stays on image.tag — unchanged.
+    apis = [d for d in docs if d.get("kind") == "Deployment" and "api" in d["metadata"]["name"]]
+    for api in apis:
+        for c in api["spec"]["template"]["spec"]["containers"]:
+            assert "agent-bom-collector" not in c["image"], "control-plane must not run the collector image"
+
+
+def test_blank_collector_tag_falls_back_to_control_plane_tag() -> None:
+    """A blank collector tag must never render a `repo:` reference with no tag."""
+    docs = _helm_render("collectorImage.tag=", "image.tag=0.96.3")
+    container = _scanner_container(_scan_cronjob(docs))
+    assert container["image"].endswith(":0.96.3"), container["image"]
+    assert not container["image"].rstrip().endswith(":"), "empty tag rendered"
+
+
+def test_unset_collector_block_falls_back_to_control_plane_image() -> None:
+    docs = _helm_render("collectorImage=null", "image.repository=agentbom/agent-bom", "image.tag=0.96.3")
+    container = _scanner_container(_scan_cronjob(docs))
+    assert container["image"] == "agentbom/agent-bom:0.96.3", container["image"]

--- a/tests/test_watch.py
+++ b/tests/test_watch.py
@@ -290,14 +290,23 @@ def test_webhook_sink_failure_logs_redacted_destination_and_error(caplog):
 
     secret_url = "https://hooks.example.com/services/T000/B111/SUPERSECRET?token=ALSOSECRET"
     alert = Alert(alert_type="config_changed", severity="high", summary="Test")
-    caplog.set_level(logging.WARNING)
+    # Pin capture to the emitting logger and restore its propagation: under
+    # worksteal, an earlier test can leave agent_bom.watch with propagate=False,
+    # which silently empties caplog and makes this redaction check a false pass.
+    watch_logger = logging.getLogger("agent_bom.watch")
+    prev_propagate = watch_logger.propagate
+    watch_logger.propagate = True
+    caplog.set_level(logging.WARNING, logger="agent_bom.watch")
 
-    with (
-        patch("httpx.post", side_effect=httpx.ConnectError(f"failed for {secret_url}")),
-        patch("time.sleep"),
-        patch("agent_bom.security.validate_url", return_value=None),
-    ):
-        WebhookAlertSink(secret_url, retries=0).send(alert)
+    try:
+        with (
+            patch("httpx.post", side_effect=httpx.ConnectError(f"failed for {secret_url}")),
+            patch("time.sleep"),
+            patch("agent_bom.security.validate_url", return_value=None),
+        ):
+            WebhookAlertSink(secret_url, retries=0).send(alert)
+    finally:
+        watch_logger.propagate = prev_propagate
 
     from agent_bom.security import redact_secret_url
 


### PR DESCRIPTION
## What

Ships the cloud-provider SDK layer (boto3 / azure-* / google-cloud-* / snowflake-connector) in a dedicated **`agent-bom-collector`** image so it updates independently of the control-plane release. This is the remaining piece of the cloud-SDK strategy — #3835 already delivered the freshness signal, auto-bump, and CI drift gate; this decouples the fast-moving SDK layer from the control-plane version.

BYOC-safe by design: the collector keeps a direct, read-only, least-privilege link to the customer cloud — **no external MCP in the credential/data path** (the #3835 decision).

## Layers touched (full wire-align)

- **Image** — `deploy/docker/Dockerfile.collector`: lean, hardened (non-root, digest-pinned Debian slim matching `deploy/docker/`, healthcheck). Installs the cloud provider **extras from `pyproject.toml`** — the single source of truth the drift gate (`scripts/check_cloud_sdk_drift.py`) enforces; it never re-declares a version.
- **Helm** — `collectorImage` block + `agent-bom.collectorImage` helper. The cloud-scan CronJob now runs the collector image instead of the control-plane image, with a safe fallback to `image.tag`. Operators bump the SDK layer with `--set collectorImage.tag=<sdk-only-build>` and no control-plane change. Control plane never runs the collector image.
- **CI** — `release.yml` builds/signs/attests `agentbom/agent-bom-collector` (gated into the GitHub Release); `refresh-latest-container.yml` rebuilds `agent-bom-collector:latest` **daily** to absorb newer SDK wheels within the pinned floors with no control-plane bump — the concrete independent cadence.
- **Guards** — registered the new Dockerfile in the base-image policy, release-consistency, and bump-version so it stays version- and base-aligned.
- **Docs** — chart README documents the collector as a first-class artifact; key-values table reconciled.
- **Tests** — `tests/test_collector_image.py`: structural asserts on Dockerfile hardening + single-source pins, and on the rendered Helm wiring (collector image by default, independent tag override, blank-tag fallback, control plane isolation).

## Verification

- `docker build -f deploy/docker/Dockerfile.collector` → succeeds; `agent-bom --version` runs; `import boto3, azure.identity, google.cloud.resourcemanager_v3, snowflake.connector` all import (boto3 1.43.51).
- `pytest tests/test_collector_image.py` → 11 passed; deploy suites (`test_deploy_manifests`, `test_kspm_deploy_surface`, `test_deploy_profiles`, `test_deploy_reference`, `test_iac_helm`) → 141 passed, no regression.
- `ruff` + `ruff format --check` clean; `mypy` clean on changed files.
- Guards: base-image policy OK (9 Dockerfiles), release-consistency OK, cloud-SDK drift gate OK (pins in lockstep), product-surface-contract + package-layout OK.
- Dogfood: agent-bom's own IaC Dockerfile scanner reports no findings on the new Dockerfile.

Closes #4239