### PR TITLE
fix(api): isolate scan state and restore validation gates

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -721,8 +721,13 @@ def _run_scan_sync(job: ScanJob) -> None:
         from agent_bom.discovery import discover_all
         from agent_bom.output import to_json
         from agent_bom.parsers import extract_packages
-        from agent_bom.scanners import scan_agents_sync
+        from agent_bom.scanners import reset_scan_warnings, scan_agents_sync
         from agent_bom.security import validate_path
+
+        # Scan jobs reuse executor threads, and scanner warnings are thread-local.
+        # Establish a clean request boundary even when this job intentionally
+        # skips scan_agents_sync(), whose normal scan path performs its own reset.
+        reset_scan_warnings()
 
         req = job.request
         agents: list[Any] = []

--- a/src/agent_bom/api/postgres_job_store.py
+++ b/src/agent_bom/api/postgres_job_store.py
@@ -9,7 +9,7 @@ Requires ``pip install 'agent-bom[postgres]'``.
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from agent_bom.api.postgres_common import (
     _ensure_tenant_rls,
@@ -255,7 +255,7 @@ class PostgresJobStore:
                     (job_id, tenant_id),
                 )
             conn.commit()
-            return cast(int, cursor.rowcount) > 0
+            return cursor.rowcount > 0
 
     def list_all(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> list:
         from .server import ScanJob
@@ -474,7 +474,7 @@ class PostgresJobStore:
                 (ttl_seconds,),
             )
             conn.commit()
-            return cast(int, cursor.rowcount)
+            return cursor.rowcount
 
     # ── Distributed dispatch queue ────────────────────────────────────────
     # All lease timing uses the database clock (now()) rather than per-node
@@ -564,7 +564,7 @@ class PostgresJobStore:
                       AND lease_expires_at < {self._NOW_ISO}""",  # nosec B608 - fixed fragment
             )
             conn.commit()
-            return cast(int, cursor.rowcount)
+            return cursor.rowcount
 
     def pending_dispatch_count(self) -> int:
         """Number of jobs waiting to be claimed (operator/metrics visibility)."""

--- a/src/agent_bom/api/postgres_job_store.py
+++ b/src/agent_bom/api/postgres_job_store.py
@@ -255,7 +255,7 @@ class PostgresJobStore:
                     (job_id, tenant_id),
                 )
             conn.commit()
-            return cursor.rowcount > 0
+            return int(cursor.rowcount) > 0
 
     def list_all(self, tenant_id: str | None = None, *, all_tenants: bool = False) -> list:
         from .server import ScanJob
@@ -474,7 +474,7 @@ class PostgresJobStore:
                 (ttl_seconds,),
             )
             conn.commit()
-            return cursor.rowcount
+            return int(cursor.rowcount)
 
     # ── Distributed dispatch queue ────────────────────────────────────────
     # All lease timing uses the database clock (now()) rather than per-node
@@ -564,7 +564,7 @@ class PostgresJobStore:
                       AND lease_expires_at < {self._NOW_ISO}""",  # nosec B608 - fixed fragment
             )
             conn.commit()
-            return cursor.rowcount
+            return int(cursor.rowcount)
 
     def pending_dispatch_count(self) -> int:
         """Number of jobs waiting to be claimed (operator/metrics visibility)."""

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -126,7 +126,7 @@ class PostgresPolicyStore:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(sql, params)
             conn.commit()
-            return cursor.rowcount > 0
+            return int(cursor.rowcount) > 0
 
     def list_policies(self, tenant_id: str | None = None, enabled: bool | None = None, mode: str | None = None) -> list:
         from .policy_store import GatewayPolicy
@@ -307,7 +307,7 @@ class PostgresScheduleStore:
                     (schedule_id, tenant_id),
                 )
             conn.commit()
-            return cursor.rowcount > 0
+            return int(cursor.rowcount) > 0
 
     def list_all(self, tenant_id: str | None = None) -> list:
         from .schedule_store import ScanSchedule
@@ -406,7 +406,7 @@ class PostgresSourceStore:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute("DELETE FROM control_plane_sources WHERE source_id = %s", (source_id,))
             conn.commit()
-            return cursor.rowcount > 0
+            return int(cursor.rowcount) > 0
 
     def list_all(self, tenant_id: str | None = None) -> list:
         from .models import SourceRecord
@@ -507,7 +507,7 @@ class PostgresCredentialRefStore:
                 (credential_ref_id, tenant_id),
             )
             conn.commit()
-            return cursor.rowcount > 0
+            return int(cursor.rowcount) > 0
 
     def list_all(self, tenant_id: str | None = None) -> list:
         from .models import CredentialRefRecord

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
@@ -126,7 +126,7 @@ class PostgresPolicyStore:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute(sql, params)
             conn.commit()
-            return cast(int, cursor.rowcount) > 0
+            return cursor.rowcount > 0
 
     def list_policies(self, tenant_id: str | None = None, enabled: bool | None = None, mode: str | None = None) -> list:
         from .policy_store import GatewayPolicy
@@ -307,7 +307,7 @@ class PostgresScheduleStore:
                     (schedule_id, tenant_id),
                 )
             conn.commit()
-            return cast(int, cursor.rowcount) > 0
+            return cursor.rowcount > 0
 
     def list_all(self, tenant_id: str | None = None) -> list:
         from .schedule_store import ScanSchedule
@@ -406,7 +406,7 @@ class PostgresSourceStore:
         with _tenant_connection(self._pool) as conn:
             cursor = conn.execute("DELETE FROM control_plane_sources WHERE source_id = %s", (source_id,))
             conn.commit()
-            return cast(int, cursor.rowcount) > 0
+            return cursor.rowcount > 0
 
     def list_all(self, tenant_id: str | None = None) -> list:
         from .models import SourceRecord
@@ -507,7 +507,7 @@ class PostgresCredentialRefStore:
                 (credential_ref_id, tenant_id),
             )
             conn.commit()
-            return cast(int, cursor.rowcount) > 0
+            return cursor.rowcount > 0
 
     def list_all(self, tenant_id: str | None = None) -> list:
         from .models import CredentialRefRecord

--- a/tests/api/test_api_pipeline_image_contract.py
+++ b/tests/api/test_api_pipeline_image_contract.py
@@ -221,6 +221,8 @@ def test_api_pipeline_persistence_failure_is_surfaced_not_silent_success(monkeyp
 
 
 def test_api_pipeline_no_scan_skips_vulnerability_scan_and_result_side_effects(monkeypatch):
+    from agent_bom.scanners import record_coverage_warning
+
     store = _DummyStore()
     job = ScanJob(
         job_id="no-scan-123",
@@ -238,6 +240,18 @@ def test_api_pipeline_no_scan_skips_vulnerability_scan_and_result_side_effects(m
     monkeypatch.setattr("agent_bom.api.pipeline._persist_graph_snapshot", _unexpected)
     monkeypatch.setattr("agent_bom.api.pipeline._sync_scan_agents_to_fleet", _unexpected)
     monkeypatch.setattr("agent_bom.api.pipeline._get_analytics_store", _unexpected)
+
+    # API scan workers are reused. A coverage warning left by an earlier job on
+    # the same thread must not downgrade this intentionally unscanned request.
+    record_coverage_warning(
+        {
+            "kind": "offline_release_gap",
+            "release": "debian:10",
+            "ecosystems": ["deb"],
+            "package_count": 1,
+            "detail": "stale warning from an earlier API job",
+        }
+    )
 
     _run_scan_sync(job)
 

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -865,7 +865,10 @@ def test_cyclonedx_vulnerability_carries_vendor_asserted_compliance_tags():
     vuln.compliance_tags = {"nist_800_53": ["SI-10"], "iso_27001": ["A.8.8"]}
     pkg = _make_pkg("web-lib", "1.0.0")
     pkg.vulnerabilities = [vuln]
-    report = _make_report(agents=[_make_agent(servers=[_make_server(packages=[pkg])])], blast_radii=[_make_blast_radius(pkg=pkg, vuln=vuln)])
+    report = _make_report(
+        agents=[_make_agent(servers=[_make_server(packages=[pkg])])],
+        blast_radii=[_make_blast_radius(pkg=pkg, vuln=vuln)],
+    )
 
     cdx = to_cyclonedx(report)
     vuln_entry = next(v for v in cdx.get("vulnerabilities", []) if v["id"] == vuln.id)


### PR DESCRIPTION
## Summary

- Reset thread-local scanner warnings at each API scan-job boundary so reused executor threads cannot downgrade later jobs with stale coverage state.
- Add a regression that reproduces the prior `complete` → `partial` contamination for an intentional `no_scan` request.
- Restore current-main validation by removing seven redundant Postgres row-count casts and wrapping one pre-existing Ruff overflow.

## Verification

- `uv run pytest -q tests/api/test_api_pipeline_image_contract.py::test_api_pipeline_no_scan_skips_vulnerability_scan_and_result_side_effects -vv --tb=short` (failed before the runtime reset: `partial != complete`)
- `uv run pytest -q tests/api/test_api_pipeline_image_contract.py tests/test_scanner_thread_safety.py tests/test_coverage_warning.py tests/test_postgres_store.py tests/test_output_formats.py --tb=short` (162 passed)
- `make lint` (Ruff passed; mypy passed across 787 source files)
- `make preflight`
- `git diff --check`

## Notes

- The eight planned remediation PRs were already merged when the randomized full-suite failure exposed this reusable-worker state leak.
- The Postgres cast and line-wrap edits are behavior-neutral corrections required to make the documented repository validation commands pass on the merged `main` baseline.
