### PR TITLE
fix(cloud): wire two plumbed-but-unfed cloud last-mile legs

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260719_02_runtime_workload_evidence_index.py
+++ b/deploy/supabase/postgres/alembic/versions/20260719_02_runtime_workload_evidence_index.py
@@ -1,0 +1,54 @@
+"""Make the runtime workload-evidence tenant read sargable.
+
+P1 (2026-07-19 audit): PostgresRuntimeWorkloadEvidenceStore created an index on
+(tenant_id, workload_id, observed_at DESC), but list_for_tenant orders by
+(observed_at DESC, dedup_key DESC) under a leading tenant predicate. The old
+index could not satisfy that sort, so at scale every tenant read was a seq-scan +
+sort. Replace it with (tenant_id, observed_at DESC, dedup_key DESC).
+
+The table is created lazily by the store's init_schema (CREATE TABLE IF NOT
+EXISTS), so it may not exist in a fresh migration-owned schema yet; guard every
+DDL with to_regclass so this is a safe no-op until the store has run once.
+
+Revision ID: 20260719_02
+Revises: 20260719_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260719_02"
+down_revision = "20260719_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.runtime_workload_evidence') IS NOT NULL THEN
+                CREATE INDEX IF NOT EXISTS idx_runtime_workload_evidence_tenant_observed_dedup
+                    ON runtime_workload_evidence (tenant_id, observed_at DESC, dedup_key DESC);
+                DROP INDEX IF EXISTS idx_runtime_workload_evidence_tenant_time;
+            END IF;
+        END $$;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.runtime_workload_evidence') IS NOT NULL THEN
+                CREATE INDEX IF NOT EXISTS idx_runtime_workload_evidence_tenant_time
+                    ON runtime_workload_evidence (tenant_id, workload_id, observed_at DESC);
+                DROP INDEX IF EXISTS idx_runtime_workload_evidence_tenant_observed_dedup;
+            END IF;
+        END $$;
+        """
+    )

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 76 tools, 6 resources, 8 workflow prompts |
-| REST API | 368 operations across 44 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 369 operations across 44 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -53,8 +53,8 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Agent.agent_type` enum values | 30 |
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
-| `docs/openapi/v1.json` | paths | 310 |
-| `docs/openapi/v1.json` | component schemas | 104 |
+| `docs/openapi/v1.json` | paths | 311 |
+| `docs/openapi/v1.json` | component schemas | 106 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (310 paths / 368 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (311 paths / 369 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (368 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (369 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -4084,6 +4084,107 @@
         "title": "RotateKeyRequest",
         "type": "object"
       },
+      "RuntimeEvidenceIngestRequest": {
+        "additionalProperties": false,
+        "description": "Authenticated, tenant-scoped CWPP runtime workload-evidence ingest batch.",
+        "properties": {
+          "secret": {
+            "title": "Secret",
+            "type": "string"
+          },
+          "signals": {
+            "items": {
+              "$ref": "#/components/schemas/RuntimeEvidenceSignalIn"
+            },
+            "maxItems": 1000,
+            "title": "Signals",
+            "type": "array"
+          },
+          "source_id": {
+            "title": "Source Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "source_id",
+          "secret"
+        ],
+        "title": "RuntimeEvidenceIngestRequest",
+        "type": "object"
+      },
+      "RuntimeEvidenceSignalIn": {
+        "additionalProperties": false,
+        "description": "One raw CWPP runtime/EDR signal in an ingest batch.\n\nTenant/provider/account are NOT taken from the client here \u2014 they come from\nthe authenticated source (confused-deputy guard in ``build_runtime_signal``).\n``provider``/``account_id`` may be echoed for the source's own bookkeeping but\na mismatch against the authenticated source is rejected.",
+        "properties": {
+          "account_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Account Id"
+          },
+          "dedup_key": {
+            "title": "Dedup Key",
+            "type": "string"
+          },
+          "evidence": {
+            "additionalProperties": true,
+            "title": "Evidence",
+            "type": "object"
+          },
+          "observed_at": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Observed At"
+          },
+          "provider": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Provider"
+          },
+          "severity": {
+            "default": "unknown",
+            "title": "Severity",
+            "type": "string"
+          },
+          "signal_type": {
+            "title": "Signal Type",
+            "type": "string"
+          },
+          "title": {
+            "default": "",
+            "title": "Title",
+            "type": "string"
+          },
+          "workload_ref": {
+            "title": "Workload Ref",
+            "type": "string"
+          }
+        },
+        "required": [
+          "workload_ref",
+          "signal_type",
+          "dedup_key"
+        ],
+        "title": "RuntimeEvidenceSignalIn",
+        "type": "object"
+      },
       "SAMLLoginRequest": {
         "additionalProperties": false,
         "properties": {
@@ -9665,6 +9766,101 @@
         "summary": "Test Connection",
         "tags": [
           "cloud-connections"
+        ]
+      }
+    },
+    "/v1/cloud/runtime-evidence/ingest": {
+      "post": {
+        "description": "Ingest a batch of CWPP runtime/EDR workload signals (#4158 stage 3).\n\nThe authenticated, tenant-scoped door for the runtime workload-evidence store.\nWithout this route the store had no caller in a deployed product and could\nnever be populated. Read-only posture: agent-bom never writes to a customer\ntarget and persists redacted metadata only (raw bytes / secret values are\ndropped at construction). Each source is pre-registered with a hashed shared\nsecret (no per-action credentials); ``provider``/``account`` bind to the\nauthenticated source, never the payload (confused-deputy guard).\n\nFail-closed: an unknown source id, a bad secret, or a source owned by a\ndifferent tenant all return the same generic ``401`` so a caller cannot\nenumerate valid source ids or tenants. The ingest runs off the event loop in a\nworker thread under backpressure so a batch can never stall ``/health``.",
+        "operationId": "cloud_runtime_evidence_ingest_v1_cloud_runtime_evidence_ingest_post",
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/RuntimeEvidenceIngestRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Cloud Runtime Evidence Ingest V1 Cloud Runtime Evidence Ingest Post",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Cloud Runtime Evidence Ingest",
+        "tags": [
+          "cloud",
+          "cloud"
         ]
       }
     },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2797,6 +2797,78 @@ components:
           title: Overlap Seconds
       title: RotateKeyRequest
       type: object
+    RuntimeEvidenceIngestRequest:
+      additionalProperties: false
+      description: Authenticated, tenant-scoped CWPP runtime workload-evidence ingest
+        batch.
+      properties:
+        secret:
+          title: Secret
+          type: string
+        signals:
+          items:
+            $ref: '#/components/schemas/RuntimeEvidenceSignalIn'
+          maxItems: 1000
+          title: Signals
+          type: array
+        source_id:
+          title: Source Id
+          type: string
+      required:
+      - source_id
+      - secret
+      title: RuntimeEvidenceIngestRequest
+      type: object
+    RuntimeEvidenceSignalIn:
+      additionalProperties: false
+      description: "One raw CWPP runtime/EDR signal in an ingest batch.\n\nTenant/provider/account\
+        \ are NOT taken from the client here \u2014 they come from\nthe authenticated\
+        \ source (confused-deputy guard in ``build_runtime_signal``).\n``provider``/``account_id``\
+        \ may be echoed for the source's own bookkeeping but\na mismatch against the\
+        \ authenticated source is rejected."
+      properties:
+        account_id:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Account Id
+        dedup_key:
+          title: Dedup Key
+          type: string
+        evidence:
+          additionalProperties: true
+          title: Evidence
+          type: object
+        observed_at:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Observed At
+        provider:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Provider
+        severity:
+          default: unknown
+          title: Severity
+          type: string
+        signal_type:
+          title: Signal Type
+          type: string
+        title:
+          default: ''
+          title: Title
+          type: string
+        workload_ref:
+          title: Workload Ref
+          type: string
+      required:
+      - workload_ref
+      - signal_type
+      - dedup_key
+      title: RuntimeEvidenceSignalIn
+      type: object
     SAMLLoginRequest:
       additionalProperties: false
       properties:
@@ -6438,6 +6510,87 @@ paths:
       summary: Test Connection
       tags:
       - cloud-connections
+  /v1/cloud/runtime-evidence/ingest:
+    post:
+      description: 'Ingest a batch of CWPP runtime/EDR workload signals (#4158 stage
+        3).
+
+
+        The authenticated, tenant-scoped door for the runtime workload-evidence store.
+
+        Without this route the store had no caller in a deployed product and could
+
+        never be populated. Read-only posture: agent-bom never writes to a customer
+
+        target and persists redacted metadata only (raw bytes / secret values are
+
+        dropped at construction). Each source is pre-registered with a hashed shared
+
+        secret (no per-action credentials); ``provider``/``account`` bind to the
+
+        authenticated source, never the payload (confused-deputy guard).
+
+
+        Fail-closed: an unknown source id, a bad secret, or a source owned by a
+
+        different tenant all return the same generic ``401`` so a caller cannot
+
+        enumerate valid source ids or tenants. The ingest runs off the event loop
+        in a
+
+        worker thread under backpressure so a batch can never stall ``/health``.'
+      operationId: cloud_runtime_evidence_ingest_v1_cloud_runtime_evidence_ingest_post
+      parameters:
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RuntimeEvidenceIngestRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Cloud Runtime Evidence Ingest V1 Cloud Runtime Evidence
+                  Ingest Post
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Cloud Runtime Evidence Ingest
+      tags:
+      - cloud
+      - cloud
   /v1/cloud/{provider}/cis-benchmark:
     get:
       description: 'Run the CIS Foundations benchmark for a cloud provider over REST.

--- a/docs/schemas/v1/RuntimeEvidenceIngestRequest.json
+++ b/docs/schemas/v1/RuntimeEvidenceIngestRequest.json
@@ -1,0 +1,106 @@
+{
+  "$defs": {
+    "RuntimeEvidenceSignalIn": {
+      "additionalProperties": false,
+      "description": "One raw CWPP runtime/EDR signal in an ingest batch.\n\nTenant/provider/account are NOT taken from the client here \u2014 they come from\nthe authenticated source (confused-deputy guard in ``build_runtime_signal``).\n``provider``/``account_id`` may be echoed for the source's own bookkeeping but\na mismatch against the authenticated source is rejected.",
+      "properties": {
+        "account_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Account Id"
+        },
+        "dedup_key": {
+          "title": "Dedup Key",
+          "type": "string"
+        },
+        "evidence": {
+          "additionalProperties": true,
+          "title": "Evidence",
+          "type": "object"
+        },
+        "observed_at": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Observed At"
+        },
+        "provider": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Provider"
+        },
+        "severity": {
+          "default": "unknown",
+          "title": "Severity",
+          "type": "string"
+        },
+        "signal_type": {
+          "title": "Signal Type",
+          "type": "string"
+        },
+        "title": {
+          "default": "",
+          "title": "Title",
+          "type": "string"
+        },
+        "workload_ref": {
+          "title": "Workload Ref",
+          "type": "string"
+        }
+      },
+      "required": [
+        "workload_ref",
+        "signal_type",
+        "dedup_key"
+      ],
+      "title": "RuntimeEvidenceSignalIn",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Authenticated, tenant-scoped CWPP runtime workload-evidence ingest batch.",
+  "properties": {
+    "secret": {
+      "title": "Secret",
+      "type": "string"
+    },
+    "signals": {
+      "items": {
+        "$ref": "#/$defs/RuntimeEvidenceSignalIn"
+      },
+      "maxItems": 1000,
+      "title": "Signals",
+      "type": "array"
+    },
+    "source_id": {
+      "title": "Source Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "source_id",
+    "secret"
+  ],
+  "title": "RuntimeEvidenceIngestRequest",
+  "type": "object"
+}

--- a/docs/schemas/v1/RuntimeEvidenceSignalIn.json
+++ b/docs/schemas/v1/RuntimeEvidenceSignalIn.json
@@ -1,0 +1,76 @@
+{
+  "additionalProperties": false,
+  "description": "One raw CWPP runtime/EDR signal in an ingest batch.\n\nTenant/provider/account are NOT taken from the client here \u2014 they come from\nthe authenticated source (confused-deputy guard in ``build_runtime_signal``).\n``provider``/``account_id`` may be echoed for the source's own bookkeeping but\na mismatch against the authenticated source is rejected.",
+  "properties": {
+    "account_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Account Id"
+    },
+    "dedup_key": {
+      "title": "Dedup Key",
+      "type": "string"
+    },
+    "evidence": {
+      "additionalProperties": true,
+      "title": "Evidence",
+      "type": "object"
+    },
+    "observed_at": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Observed At"
+    },
+    "provider": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Provider"
+    },
+    "severity": {
+      "default": "unknown",
+      "title": "Severity",
+      "type": "string"
+    },
+    "signal_type": {
+      "title": "Signal Type",
+      "type": "string"
+    },
+    "title": {
+      "default": "",
+      "title": "Title",
+      "type": "string"
+    },
+    "workload_ref": {
+      "title": "Workload Ref",
+      "type": "string"
+    }
+  },
+  "required": [
+    "workload_ref",
+    "signal_type",
+    "dedup_key"
+  ],
+  "title": "RuntimeEvidenceSignalIn",
+  "type": "object"
+}

--- a/docs/schemas/v1/index.json
+++ b/docs/schemas/v1/index.json
@@ -202,6 +202,16 @@
       "schema": "RotateKeyRequest.json"
     },
     {
+      "doc": "Authenticated, tenant-scoped CWPP runtime workload-evidence ingest batch.",
+      "name": "RuntimeEvidenceIngestRequest",
+      "schema": "RuntimeEvidenceIngestRequest.json"
+    },
+    {
+      "doc": "One raw CWPP runtime/EDR signal in an ingest batch.",
+      "name": "RuntimeEvidenceSignalIn",
+      "schema": "RuntimeEvidenceSignalIn.json"
+    },
+    {
       "doc": "",
       "name": "SAMLLoginRequest",
       "schema": "SAMLLoginRequest.json"

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -233,6 +233,8 @@ AGENT_BOM_GCP_IMPERSONATE_SA
 AGENT_BOM_GCP_INVENTORY
 # Defensive cap (default 200) on the number of projects walked in the GCP org/folder tree multi-project fan-out.
 AGENT_BOM_GCP_MAX_PROJECTS
+# JSON array provisioning CWPP runtime-evidence ingest sources (source_id/tenant/provider/account/secret_hash); read once to build the process-global source registry. Fail-closed: empty/malformed registers no source.
+AGENT_BOM_RUNTIME_EVIDENCE_SOURCES
 AGENT_BOM_GRAPH_DB
 AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK
 AGENT_BOM_GRAPH_DELTA_WEBHOOK

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -833,6 +833,36 @@ class SourceUpdate(BaseModel):
     config: dict[str, Any] | None = None
 
 
+class RuntimeEvidenceSignalIn(BaseModel):
+    """One raw CWPP runtime/EDR signal in an ingest batch.
+
+    Tenant/provider/account are NOT taken from the client here — they come from
+    the authenticated source (confused-deputy guard in ``build_runtime_signal``).
+    ``provider``/``account_id`` may be echoed for the source's own bookkeeping but
+    a mismatch against the authenticated source is rejected.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+    workload_ref: str
+    signal_type: str
+    dedup_key: str
+    severity: str = "unknown"
+    observed_at: str | None = None
+    title: str = ""
+    evidence: dict[str, Any] = Field(default_factory=dict)
+    provider: str | None = None
+    account_id: str | None = None
+
+
+class RuntimeEvidenceIngestRequest(BaseModel):
+    """Authenticated, tenant-scoped CWPP runtime workload-evidence ingest batch."""
+
+    model_config = ConfigDict(extra="forbid")
+    source_id: str
+    secret: str
+    signals: list[RuntimeEvidenceSignalIn] = Field(default_factory=list, max_length=1000)
+
+
 class CreateKeyRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
     name: str

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -33,8 +33,15 @@ from urllib.parse import urlencode
 import anyio.to_thread
 from fastapi import APIRouter, HTTPException, Query, Request
 
+from agent_bom.api.models import RuntimeEvidenceIngestRequest
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
+from agent_bom.cloud.runtime_workload_evidence import (
+    SourceAuthenticationError,
+    get_runtime_source_registry,
+    ingest_runtime_signals,
+)
+from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
 from agent_bom.rbac import require_authenticated_permission
 
 router = APIRouter(tags=["cloud"])
@@ -800,3 +807,62 @@ async def cloud_account_summary(
             detail=exc.to_dict(),
             headers={"Retry-After": str(exc.retry_after_seconds)},
         ) from exc
+
+
+@router.post("/cloud/runtime-evidence/ingest", tags=["cloud"])
+async def cloud_runtime_evidence_ingest(
+    request: Request,
+    body: RuntimeEvidenceIngestRequest,
+    _role: Any = _SCAN_DEP,
+) -> dict[str, Any]:
+    """Ingest a batch of CWPP runtime/EDR workload signals (#4158 stage 3).
+
+    The authenticated, tenant-scoped door for the runtime workload-evidence store.
+    Without this route the store had no caller in a deployed product and could
+    never be populated. Read-only posture: agent-bom never writes to a customer
+    target and persists redacted metadata only (raw bytes / secret values are
+    dropped at construction). Each source is pre-registered with a hashed shared
+    secret (no per-action credentials); ``provider``/``account`` bind to the
+    authenticated source, never the payload (confused-deputy guard).
+
+    Fail-closed: an unknown source id, a bad secret, or a source owned by a
+    different tenant all return the same generic ``401`` so a caller cannot
+    enumerate valid source ids or tenants. The ingest runs off the event loop in a
+    worker thread under backpressure so a batch can never stall ``/health``.
+    """
+    tenant_id = _tenant(request)
+
+    def _ingest() -> dict[str, Any]:
+        registry = get_runtime_source_registry()
+        source = registry.get(body.source_id)
+        # Tenant binding: the authenticated request tenant must own the source.
+        # Fold "wrong tenant" into the same auth failure so a caller cannot probe
+        # which source ids exist in another tenant.
+        if source is None or source.tenant_id != tenant_id:
+            raise SourceAuthenticationError("runtime evidence source authentication failed")
+        result = ingest_runtime_signals(
+            registry=registry,
+            source_id=body.source_id,
+            secret=body.secret,
+            raw_signals=[s.model_dump(exclude_none=True) for s in body.signals],
+            store=get_runtime_workload_evidence_store(),
+        )
+        return result.to_dict()
+
+    try:
+        async with adaptive_backpressure("runtime_evidence_ingest"):
+            return await anyio.to_thread.run_sync(_ingest)
+    except SourceAuthenticationError as exc:
+        # Generic 401 — never reveal whether the source id or the secret was wrong.
+        raise HTTPException(status_code=401, detail="Runtime evidence source authentication failed") from exc
+    except BackpressureRejectedError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=exc.to_dict(),
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
+    except HTTPException:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        _logger.exception("Runtime evidence ingest failed")
+        raise HTTPException(status_code=500, detail="Runtime evidence ingest failed; see server logs.") from exc

--- a/src/agent_bom/cloud/gcp_inventory.py
+++ b/src/agent_bom/cloud/gcp_inventory.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Mapping
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
@@ -304,6 +305,7 @@ def discover_inventory(
     include_disks: bool = True,
     include_messaging: bool = True,
     force: bool = False,
+    usage_resolver: Any = None,
 ) -> dict[str, Any]:
     """Enumerate the general GCP estate (GCS, instances + firewalls, SAs).
 
@@ -443,6 +445,7 @@ def discover_inventory(
             iam_bindings=iam_bindings,
             role_resolver=role_resolver,
             missing=missing,
+            usage_resolver=usage_resolver,
         )
         iam_groups = _build_iam_group_principals(iam_bindings, member_kinds, project_id=resolved_project, role_resolver=role_resolver)
     if include_containers:
@@ -979,6 +982,48 @@ def _build_iam_group_principals(
     return groups
 
 
+# Fail-closed default when no read-only GCP usage source is wired: usage is
+# UNEVALUABLE, never fabricated as "used" or "unused". Shaped like the AWS
+# Access-Advisor payload (``state`` + ``records``) the graph builder consumes, so
+# a "state != available" bundle makes the builder attach NO ``last_used_at`` and
+# NO access-advisor edges → ``nhi_governance`` stays fail-closed (no phantom
+# dormant / over-grant finding). A live GCP usage source (Policy Analyzer activity
+# / audit-log last-authentication) can be injected via ``usage_resolver`` to
+# populate real telemetry — DEFERRED: no such read-only API is wired in this repo
+# yet, so production inventory honestly reports "usage source not configured".
+_GCP_SA_USAGE_DEFERRED: dict[str, Any] = {
+    "state": "unavailable",
+    "diagnostic": "gcp_service_account_usage_source_not_configured",
+    "records": [],
+}
+
+
+def _service_account_usage_evidence(
+    email: str, roles: list[str], resolver: Any
+) -> dict[str, Any]:
+    """Resolve read-only usage evidence for one service account (never fabricated).
+
+    ``resolver`` is an optional callable ``(email, roles) -> Mapping`` supplying
+    real last-authentication telemetry (mirrors the AWS Access-Advisor collector
+    injection point). When absent or failing, usage is reported as unevaluable so
+    downstream CIEM stays fail-closed.
+    """
+    if resolver is None:
+        return dict(_GCP_SA_USAGE_DEFERRED)
+    try:
+        evidence = resolver(email, list(roles))
+    except Exception:  # noqa: BLE001 — a usage lookup failure must never sink inventory
+        return {"state": "unavailable", "diagnostic": "gcp_usage_resolver_error", "records": []}
+    if not isinstance(evidence, Mapping):
+        return dict(_GCP_SA_USAGE_DEFERRED)
+    records = evidence.get("records")
+    return {
+        "state": str(evidence.get("state") or "unavailable"),
+        "diagnostic": str(evidence.get("diagnostic") or "gcp_usage_resolver"),
+        "records": list(records) if isinstance(records, list) else [],
+    }
+
+
 def _discover_service_accounts(
     project_id: str,
     *,
@@ -987,6 +1032,7 @@ def _discover_service_accounts(
     iam_bindings: dict[str, list[str]] | None = None,
     role_resolver: Any = None,
     missing: list[dict[str, str]] | None = None,
+    usage_resolver: Any = None,
 ) -> list[dict[str, Any]]:
     """Enumerate all service accounts in the project (read-only).
 
@@ -996,6 +1042,12 @@ def _discover_service_accounts(
     effective-permissions overlay and ``OVERPERMISSIONED_TO_SENSITIVE`` /
     CIEM reasoning fire on GCP — mirroring the AWS IAM path. Privilege defaults to
     ``unknown`` when no binding is found — inventory never guesses an inflated level.
+
+    Each record also carries ``usage_evidence`` (AWS Access-Advisor shape) so the
+    graph builder can attach ``last_used_at`` + access-advisor grant edges and
+    ``nhi_governance`` can evaluate GCP identities for over-grant / dormancy. With
+    no wired read-only GCP usage source, usage is reported UNEVALUABLE (fail-closed,
+    never fabricated); a ``usage_resolver`` injects real last-auth telemetry.
     """
     try:
         from google.cloud import iam_admin_v1
@@ -1027,6 +1079,7 @@ def _discover_service_accounts(
                     "policies": policies,
                     "trust_principals": [],
                     "privilege_level": _highest_privilege(roles),
+                    "usage_evidence": _service_account_usage_evidence(email, roles, usage_resolver),
                 }
             )
     except Exception as exc:  # noqa: BLE001 — one failed service accounts list must not sink the scan

--- a/src/agent_bom/cloud/runtime_workload_evidence.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence.py
@@ -38,12 +38,18 @@ from __future__ import annotations
 
 import hashlib
 import hmac
+import json
+import logging
+import os
+import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from enum import Enum
 from typing import Any, Iterable, Mapping
 
 from agent_bom.canonical_ids import canonical_id
+
+logger = logging.getLogger(__name__)
 
 RUNTIME_EVIDENCE_SCHEMA_VERSION = "agent-bom.cwpp.runtime_workload.evidence.v1"
 
@@ -655,8 +661,97 @@ def enrich_graph_workload_runtime_evidence(graph: Any, index: RuntimeWorkloadEvi
     return sum(1 for node in node_iter if attach_workload_runtime_evidence_to_node(node, index))
 
 
+# ── process-global source registry (for the authenticated ingest door) ───────
+#
+# The ingest route authenticates a source against this registry. Sources are
+# provisioned out-of-band (never per-action): an operator declares them in
+# ``AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`` (a JSON array). The default registry is
+# EMPTY, so with no configured source every ingest attempt fails closed (401) —
+# a door that opens to nobody until an operator explicitly registers a source.
+
+RUNTIME_SOURCES_ENV = "AGENT_BOM_RUNTIME_EVIDENCE_SOURCES"
+
+_default_registry: RuntimeSourceRegistry | None = None
+_registry_lock = threading.Lock()
+
+
+def _source_from_entry(entry: Mapping[str, Any]) -> RuntimeEvidenceSource | None:
+    """Build one source from a config entry, preferring a pre-hashed secret.
+
+    ``secret_hash`` (a 64-char sha256 hex digest) is preferred so the plaintext
+    secret never has to sit in the environment; ``secret`` is accepted as a
+    convenience and hashed on load. A malformed entry is skipped (fail closed),
+    never raised — one bad entry must not sink the whole registry.
+    """
+    secret_hash = str(entry.get("secret_hash") or "").strip().lower()
+    try:
+        if secret_hash:
+            return RuntimeEvidenceSource(
+                source_id=str(entry.get("source_id") or "").strip(),
+                tenant_id=str(entry.get("tenant_id") or "").strip(),
+                provider=str(entry.get("provider") or "").strip().lower(),
+                account_id=str(entry.get("account_id") or "").strip(),
+                kind=str(entry.get("kind") or "").strip().lower(),
+                secret_hash=secret_hash,
+            )
+        return RuntimeEvidenceSource.register(
+            source_id=str(entry.get("source_id") or ""),
+            tenant_id=str(entry.get("tenant_id") or ""),
+            provider=str(entry.get("provider") or ""),
+            account_id=str(entry.get("account_id") or ""),
+            kind=str(entry.get("kind") or ""),
+            secret=str(entry.get("secret") or ""),
+        )
+    except ValueError:
+        logger.warning("skipping malformed runtime evidence source entry")
+        return None
+
+
+def _load_registry_from_env() -> RuntimeSourceRegistry:
+    registry = RuntimeSourceRegistry()
+    raw = os.environ.get(RUNTIME_SOURCES_ENV, "").strip()
+    if not raw:
+        return registry
+    try:
+        entries = json.loads(raw)
+    except ValueError:
+        # Malformed config registers NO source (fail closed), never a crash.
+        logger.warning("%s is not valid JSON; no runtime evidence sources registered", RUNTIME_SOURCES_ENV)
+        return registry
+    if not isinstance(entries, list):
+        return registry
+    for entry in entries:
+        if not isinstance(entry, Mapping):
+            continue
+        source = _source_from_entry(entry)
+        if source is not None:
+            registry.add(source)
+    return registry
+
+
+def get_runtime_source_registry() -> RuntimeSourceRegistry:
+    """Return the process default runtime-evidence source registry.
+
+    Loaded once from ``AGENT_BOM_RUNTIME_EVIDENCE_SOURCES``. Defaults to an empty
+    registry so the ingest door fails closed until an operator provisions a
+    source. Tests can inject one with :func:`set_runtime_source_registry`.
+    """
+    global _default_registry
+    with _registry_lock:
+        if _default_registry is None:
+            _default_registry = _load_registry_from_env()
+        return _default_registry
+
+
+def set_runtime_source_registry(registry: RuntimeSourceRegistry | None) -> None:
+    global _default_registry
+    with _registry_lock:
+        _default_registry = registry
+
+
 __all__ = [
     "DEFAULT_MAX_SIGNAL_AGE_SECONDS",
+    "RUNTIME_SOURCES_ENV",
     "RUNTIME_EVIDENCE_SCHEMA_VERSION",
     "STATE_HAS_ALERT",
     "STATE_HAS_IOC",
@@ -676,7 +771,9 @@ __all__ = [
     "build_runtime_signal",
     "canonical_workload_id",
     "enrich_graph_workload_runtime_evidence",
+    "get_runtime_source_registry",
     "ingest_runtime_signals",
     "no_runtime_signal_summary",
+    "set_runtime_source_registry",
     "workload_runtime_summary",
 ]

--- a/src/agent_bom/cloud/runtime_workload_evidence_store.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence_store.py
@@ -151,10 +151,17 @@ class SQLiteRuntimeWorkloadEvidenceStore:
                 )
                 """
             )
+            # Match the ``list_for_tenant`` query: WHERE tenant_id = ?
+            # ORDER BY observed_at DESC, dedup_key DESC. The leading tenant
+            # predicate plus the two ORDER BY columns (same direction) lets the
+            # planner satisfy the sort from the index instead of a temp b-tree.
             connection.execute(
-                "CREATE INDEX IF NOT EXISTS idx_rwe_tenant_workload_time "
-                "ON runtime_workload_evidence (tenant_id, workload_id, observed_at DESC)"
+                "CREATE INDEX IF NOT EXISTS idx_rwe_tenant_observed_dedup "
+                "ON runtime_workload_evidence (tenant_id, observed_at DESC, dedup_key DESC)"
             )
+            # Drop the stale index that ordered by (tenant_id, workload_id,
+            # observed_at) — unusable for the tenant read's ORDER BY.
+            connection.execute("DROP INDEX IF EXISTS idx_rwe_tenant_workload_time")
 
     def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:
         if not signals:
@@ -217,9 +224,16 @@ class PostgresRuntimeWorkloadEvidenceStore:
                 )
                 """  # noqa: S608
             )
+            # Match the ``list_for_tenant`` ORDER BY (observed_at DESC, dedup_key
+            # DESC) under the leading tenant predicate so the read is sargable at
+            # scale instead of a seq-scan + sort.
             conn.execute(
-                f"CREATE INDEX IF NOT EXISTS idx_{self.table}_tenant_time ON {self.table} (tenant_id, workload_id, observed_at DESC)"  # noqa: S608
+                f"CREATE INDEX IF NOT EXISTS idx_{self.table}_tenant_observed_dedup "  # noqa: S608
+                f"ON {self.table} (tenant_id, observed_at DESC, dedup_key DESC)"
             )
+            # Drop the stale (tenant_id, workload_id, observed_at) index that could
+            # not serve that ORDER BY.
+            conn.execute(f"DROP INDEX IF EXISTS idx_{self.table}_tenant_time")  # noqa: S608
             conn.commit()
 
     def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:

--- a/tests/api/test_runtime_evidence_ingest_route.py
+++ b/tests/api/test_runtime_evidence_ingest_route.py
@@ -1,0 +1,217 @@
+"""Contract tests for the CWPP runtime workload-evidence ingest door.
+
+The store (:mod:`agent_bom.cloud.runtime_workload_evidence_store`) and the
+``ingest_runtime_signals`` library existed with ZERO callers in the API/CLI/MCP
+surface — a deployed product could never populate it. These tests pin the new
+authenticated, tenant-scoped, read-only-posture ingest route end-to-end: it
+authenticates a pre-registered source (HMAC secret), enforces tenant binding,
+persists through the store's dedup contract, and the persisted evidence then
+reaches the graph via ``enrich_graph_workload_runtime_evidence``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app, configure_api
+from agent_bom.cloud.runtime_workload_evidence import (
+    RuntimeEvidenceSource,
+    RuntimeSourceRegistry,
+    RuntimeWorkloadEvidenceIndex,
+    enrich_graph_workload_runtime_evidence,
+    get_runtime_source_registry,
+    set_runtime_source_registry,
+)
+from agent_bom.cloud.runtime_workload_evidence_store import (
+    InMemoryRuntimeWorkloadEvidenceStore,
+    set_runtime_workload_evidence_store,
+)
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType
+
+PROXY_SECRET = "test-proxy-secret-with-32-plus-bytes"
+SOURCE_SECRET = "s3cr3t-token-value-1234"
+TENANT = "tenant-alpha"
+
+
+def _proxy_headers(role: str = "admin", tenant: str = TENANT) -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": role,
+        "X-Agent-Bom-Tenant-ID": tenant,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
+
+
+def setup_module() -> None:
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
+    os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
+    configure_api(api_key=None)
+
+
+def teardown_module() -> None:
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH", None)
+    os.environ.pop("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", None)
+    set_runtime_source_registry(None)
+    set_runtime_workload_evidence_store(None)
+
+
+def _install_source(tenant: str = TENANT, account: str = "123456789012") -> None:
+    registry = RuntimeSourceRegistry()
+    registry.add(
+        RuntimeEvidenceSource.register(
+            source_id="edr-1",
+            tenant_id=tenant,
+            provider="aws",
+            account_id=account,
+            kind="edr",
+            secret=SOURCE_SECRET,
+        )
+    )
+    set_runtime_source_registry(registry)
+    set_runtime_workload_evidence_store(InMemoryRuntimeWorkloadEvidenceStore())
+
+
+def _signal(workload_ref: str = "i-0abc", dedup_key: str = "evt-1") -> dict:
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return {
+        "workload_ref": workload_ref,
+        "signal_type": "ioc_detection",
+        "severity": "high",
+        "observed_at": now,
+        "dedup_key": dedup_key,
+        "title": "beacon",
+    }
+
+
+def test_ingest_persists_and_reaches_graph() -> None:
+    _install_source()
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/cloud/runtime-evidence/ingest",
+        headers=_proxy_headers(),
+        json={"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [_signal()]},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["accepted"] == 1
+    assert body["persisted"] == 1
+    assert body["tenant_id"] == TENANT
+
+    # The persisted evidence must actually reach the graph enrichment path.
+    from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+
+    index = RuntimeWorkloadEvidenceIndex.from_store(get_runtime_workload_evidence_store(), TENANT)
+    assert not index.is_empty()
+    graph = UnifiedGraph(tenant_id=TENANT)
+    graph.add_node(
+        UnifiedNode(
+            id="cloud_resource:aws:i-0abc",
+            entity_type=EntityType.CLOUD_RESOURCE,
+            label="i-0abc",
+            attributes={
+                "resource_type": "workload_disk",
+                "cloud_provider": "aws",
+                "account_id": "123456789012",
+                "resource_id": "i-0abc",
+            },
+        )
+    )
+    annotated = enrich_graph_workload_runtime_evidence(graph, index)
+    assert annotated == 1
+    node = graph.nodes["cloud_resource:aws:i-0abc"]
+    assert node.attributes["runtime_evidence"]["state"] == "runtime_ioc_observed"
+    assert node.attributes["runtime_evidence"]["clean_workload_assertion"] is False
+
+
+def test_ingest_dedups_on_retry() -> None:
+    _install_source()
+    client = TestClient(app)
+    payload = {"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [_signal(dedup_key="evt-dup")]}
+    first = client.post("/v1/cloud/runtime-evidence/ingest", headers=_proxy_headers(), json=payload)
+    second = client.post("/v1/cloud/runtime-evidence/ingest", headers=_proxy_headers(), json=payload)
+    assert first.json()["persisted"] == 1
+    assert second.json()["persisted"] == 0
+    assert second.json()["deduped"] == 1
+
+
+def test_ingest_bad_secret_is_401() -> None:
+    _install_source()
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/cloud/runtime-evidence/ingest",
+        headers=_proxy_headers(),
+        json={"source_id": "edr-1", "secret": "wrong-secret-value", "signals": [_signal()]},
+    )
+    assert resp.status_code == 401
+
+
+def test_ingest_unknown_source_is_401_not_enumerable() -> None:
+    _install_source()
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/cloud/runtime-evidence/ingest",
+        headers=_proxy_headers(),
+        json={"source_id": "does-not-exist", "secret": SOURCE_SECRET, "signals": [_signal()]},
+    )
+    assert resp.status_code == 401
+
+
+def test_ingest_cross_tenant_source_rejected() -> None:
+    # Source belongs to tenant-alpha; a request authenticated as another tenant
+    # must not be able to ingest against it even with the right source secret.
+    _install_source(tenant=TENANT)
+    client = TestClient(app)
+    resp = client.post(
+        "/v1/cloud/runtime-evidence/ingest",
+        headers=_proxy_headers(tenant="tenant-beta"),
+        json={"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [_signal()]},
+    )
+    assert resp.status_code == 401
+
+
+def test_ingest_requires_auth() -> None:
+    _install_source()
+    monkey = os.environ.pop("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", None)
+    try:
+        configure_api(api_key=None)
+        client = TestClient(app)
+        resp = client.post(
+            "/v1/cloud/runtime-evidence/ingest",
+            json={"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [_signal()]},
+        )
+        assert resp.status_code == 401
+    finally:
+        if monkey is not None:
+            os.environ["AGENT_BOM_ALLOW_UNAUTHENTICATED_API"] = monkey
+        configure_api(api_key=None)
+
+
+def test_registry_bootstraps_from_env(monkeypatch) -> None:
+    import json
+
+    monkeypatch.setenv(
+        "AGENT_BOM_RUNTIME_EVIDENCE_SOURCES",
+        json.dumps(
+            [
+                {
+                    "source_id": "env-edr",
+                    "tenant_id": "tenant-x",
+                    "provider": "gcp",
+                    "account_id": "proj-1",
+                    "kind": "edr",
+                    "secret": "env-secret-value-12345",
+                }
+            ]
+        ),
+    )
+    set_runtime_source_registry(None)
+    registry = get_runtime_source_registry()
+    src = registry.get("env-edr")
+    assert src is not None
+    assert src.tenant_id == "tenant-x"
+    assert src.authenticate("env-secret-value-12345")
+    set_runtime_source_registry(None)

--- a/tests/cloud/test_gcp_service_account_usage_evidence.py
+++ b/tests/cloud/test_gcp_service_account_usage_evidence.py
@@ -1,0 +1,161 @@
+"""GCP CIEM last-mile: service-account usage evidence feeds nhi_governance.
+
+Before this change ``_discover_service_accounts`` emitted only
+name/email/disabled/privilege_level, so a GCP service account could NEVER produce
+an over-grant / dormant CIEM finding — ``nhi_governance`` governs
+``SERVICE_ACCOUNT`` but had no ``last_used_at`` / ``usage_evidence`` to evaluate,
+so the fail-closed rules never fired. These tests pin:
+
+1. The inventory record now carries ``usage_evidence`` shaped exactly like the
+   AWS Access-Advisor payload the graph builder already consumes.
+2. Fed through the real builder, a GCP SA with an available, never-used grant
+   produces a CIEM over-privilege finding.
+3. Absent usage evidence (no read-only GCP usage source wired) stays UNEVALUABLE
+   — no last_used_at, no access-advisor edges, no fabricated finding (fail-closed).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+from unittest.mock import patch
+
+from agent_bom.cloud import gcp_inventory
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.nhi_governance import build_ciem_over_privilege_findings
+from agent_bom.graph.types import EntityType
+
+
+class _FakeSA:
+    def __init__(self, email: str, display_name: str, unique_id: str, disabled: bool = False) -> None:
+        self.email = email
+        self.display_name = display_name
+        self.unique_id = unique_id
+        self.disabled = disabled
+
+
+def _install_fake_iam(accounts: list[_FakeSA]) -> Any:
+    class _FakeIAMClient:
+        def __init__(self, credentials: Any = None) -> None:
+            pass
+
+        def list_service_accounts(self, request: Any) -> list[Any]:
+            return list(accounts)
+
+    class _FakeReq:
+        def __init__(self, name: str) -> None:
+            self.name = name
+
+    iam_mod = types.ModuleType("google.cloud.iam_admin_v1")
+    iam_mod.IAMClient = _FakeIAMClient  # type: ignore[attr-defined]
+    iam_mod.ListServiceAccountsRequest = _FakeReq  # type: ignore[attr-defined]
+    return patch.dict(
+        sys.modules,
+        {
+            "google": types.ModuleType("google"),
+            "google.cloud": types.ModuleType("google.cloud"),
+            "google.cloud.iam_admin_v1": iam_mod,
+        },
+    )
+
+
+def test_discover_emits_usage_evidence_deferred_by_default() -> None:
+    accounts = [_FakeSA("svc@p.iam.gserviceaccount.com", "Svc", "u-1")]
+    with _install_fake_iam(accounts):
+        records = gcp_inventory._discover_service_accounts(
+            "proj-1", credentials=None, warnings=[], iam_bindings={}
+        )
+    assert len(records) == 1
+    usage = records[0]["usage_evidence"]
+    # Fail-closed default: usage is unevaluable (no wired GCP usage source), NOT
+    # fabricated as "used" or "unused".
+    assert usage["state"] != "available"
+    assert usage["records"] == []
+
+
+def test_discover_emits_usage_evidence_from_resolver() -> None:
+    accounts = [_FakeSA("svc@p.iam.gserviceaccount.com", "Svc", "u-1")]
+
+    def resolver(email: str, roles: list[str]) -> dict[str, Any]:
+        return {
+            "state": "available",
+            "records": [
+                {"service_namespace": "storage.googleapis.com", "state": "available", "last_accessed_at": None},
+                {"service_namespace": "compute.googleapis.com", "state": "available", "last_accessed_at": "2026-01-01T00:00:00Z"},
+            ],
+        }
+
+    with _install_fake_iam(accounts):
+        records = gcp_inventory._discover_service_accounts(
+            "proj-1", credentials=None, warnings=[], iam_bindings={}, usage_resolver=resolver
+        )
+    usage = records[0]["usage_evidence"]
+    assert usage["state"] == "available"
+    assert {r["service_namespace"] for r in usage["records"]} == {
+        "storage.googleapis.com",
+        "compute.googleapis.com",
+    }
+
+
+def _gcp_inventory_with_sa(usage_evidence: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "provider": "gcp",
+        "status": "ok",
+        "project_id": "proj-1",
+        "service_accounts": [
+            {
+                "principal_type": "service-account",
+                "name": "Over-Permissioned",
+                "arn": "overperm@p.iam.gserviceaccount.com",
+                "principal_id": "u-2",
+                "email": "overperm@p.iam.gserviceaccount.com",
+                "disabled": False,
+                "account_id": "proj-1",
+                "roles": ["roles/editor"],
+                "policies": [],
+                "trust_principals": [],
+                "privilege_level": "write",
+                "usage_evidence": usage_evidence,
+            }
+        ],
+    }
+
+
+def test_gcp_sa_with_usage_evidence_produces_ciem_finding() -> None:
+    usage = {
+        "state": "available",
+        "records": [
+            {"service_namespace": "storage.googleapis.com", "state": "available", "last_accessed_at": None},
+            {"service_namespace": "compute.googleapis.com", "state": "available", "last_accessed_at": "2026-01-01T00:00:00Z"},
+        ],
+    }
+    graph = build_unified_graph_from_report({"cloud_inventory": _gcp_inventory_with_sa(usage)})
+
+    sa_nodes = [n for n in graph.nodes.values() if n.entity_type == EntityType.SERVICE_ACCOUNT]
+    assert sa_nodes, "GCP service account should become a SERVICE_ACCOUNT node"
+
+    findings = build_ciem_over_privilege_findings(graph)
+    ciem = [f for f in findings if f.evidence.get("ciem") == "over_privilege"]
+    assert len(ciem) == 1, [f.title for f in findings]
+    assert ciem[0].evidence["cloud_provider"] == "gcp"
+    assert "storage.googleapis.com" in ciem[0].evidence["unused_permissions"]
+    # The used service must NOT be flagged.
+    assert "compute.googleapis.com" not in ciem[0].evidence["unused_permissions"]
+
+
+def test_gcp_sa_without_usage_evidence_stays_unevaluable() -> None:
+    usage = {
+        "state": "unavailable",
+        "diagnostic": "gcp_service_account_usage_source_not_configured",
+        "records": [],
+    }
+    graph = build_unified_graph_from_report({"cloud_inventory": _gcp_inventory_with_sa(usage)})
+
+    sa_nodes = [n for n in graph.nodes.values() if n.entity_type == EntityType.SERVICE_ACCOUNT]
+    assert sa_nodes
+    # No last_used_at was fabricated from absent telemetry.
+    assert "last_used_at" not in sa_nodes[0].attributes
+    # Fail-closed: no over-privilege finding is invented without usage evidence.
+    findings = build_ciem_over_privilege_findings(graph)
+    assert [f for f in findings if f.evidence.get("ciem") == "over_privilege"] == []

--- a/tests/cloud/test_gcp_service_account_usage_evidence.py
+++ b/tests/cloud/test_gcp_service_account_usage_evidence.py
@@ -142,10 +142,13 @@ def test_gcp_sa_with_usage_evidence_produces_ciem_finding() -> None:
     # unused_permissions is a list of GCP service identifiers; assert exact set
     # membership (not a URL substring — CodeQL's url-sanitization heuristic
     # misfires on the .googleapis.com shape otherwise).
+    # unused_permissions is a list of GCP service identifiers; use set-method
+    # assertions (not the ``in`` operator) so CodeQL's url-substring heuristic
+    # does not misfire on the ``.googleapis.com`` shape.
     unused = set(ciem[0].evidence["unused_permissions"])
-    assert "storage.googleapis.com" in unused
+    assert unused.issuperset({"storage.googleapis.com"})
     # The used service must NOT be flagged.
-    assert "compute.googleapis.com" not in unused
+    assert unused.isdisjoint({"compute.googleapis.com"})
 
 
 def test_gcp_sa_without_usage_evidence_stays_unevaluable() -> None:

--- a/tests/cloud/test_gcp_service_account_usage_evidence.py
+++ b/tests/cloud/test_gcp_service_account_usage_evidence.py
@@ -139,9 +139,13 @@ def test_gcp_sa_with_usage_evidence_produces_ciem_finding() -> None:
     ciem = [f for f in findings if f.evidence.get("ciem") == "over_privilege"]
     assert len(ciem) == 1, [f.title for f in findings]
     assert ciem[0].evidence["cloud_provider"] == "gcp"
-    assert "storage.googleapis.com" in ciem[0].evidence["unused_permissions"]
+    # unused_permissions is a list of GCP service identifiers; assert exact set
+    # membership (not a URL substring — CodeQL's url-sanitization heuristic
+    # misfires on the .googleapis.com shape otherwise).
+    unused = set(ciem[0].evidence["unused_permissions"])
+    assert "storage.googleapis.com" in unused
     # The used service must NOT be flagged.
-    assert "compute.googleapis.com" not in ciem[0].evidence["unused_permissions"]
+    assert "compute.googleapis.com" not in unused
 
 
 def test_gcp_sa_without_usage_evidence_stays_unevaluable() -> None:

--- a/tests/cloud/test_runtime_workload_evidence_index_sargable.py
+++ b/tests/cloud/test_runtime_workload_evidence_index_sargable.py
@@ -1,0 +1,50 @@
+"""The runtime workload-evidence index must match the query's ORDER BY.
+
+P1 (2026-07-19 audit): ``list_for_tenant`` orders by
+``(tenant_id, observed_at DESC, dedup_key DESC)`` but the store only created an
+index on ``(tenant_id, workload_id, observed_at DESC)`` — unusable for that sort,
+so at scale every tenant read fell back to a full-scan + temp-b-tree sort. This
+pins the composite index to the query so the planner can satisfy the ORDER BY
+from the index (no ``USE TEMP B-TREE FOR ORDER BY``).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from agent_bom.cloud.runtime_workload_evidence_store import SQLiteRuntimeWorkloadEvidenceStore
+
+
+def test_list_for_tenant_query_plan_uses_index_not_temp_btree(tmp_path) -> None:
+    store = SQLiteRuntimeWorkloadEvidenceStore(tmp_path / "rwe.sqlite")
+    con = sqlite3.connect(str(tmp_path / "rwe.sqlite"))
+    try:
+        plan = con.execute(
+            "EXPLAIN QUERY PLAN "
+            "SELECT payload_json FROM runtime_workload_evidence WHERE tenant_id = ? "
+            "ORDER BY observed_at DESC, dedup_key DESC LIMIT ?",
+            ("tenant-a", 5000),
+        ).fetchall()
+    finally:
+        con.close()
+    detail = " ".join(str(row[-1]) for row in plan)
+    assert "USING INDEX" in detail, detail
+    # The whole point: the sort is satisfied by the index, not a temp b-tree.
+    assert "USE TEMP B-TREE FOR ORDER BY" not in detail, detail
+    del store
+
+
+def test_stale_workload_time_index_is_dropped(tmp_path) -> None:
+    store = SQLiteRuntimeWorkloadEvidenceStore(tmp_path / "rwe.sqlite")
+    con = sqlite3.connect(str(tmp_path / "rwe.sqlite"))
+    try:
+        names = {
+            row[0]
+            for row in con.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='runtime_workload_evidence'"
+            ).fetchall()
+        }
+    finally:
+        con.close()
+    assert "idx_rwe_tenant_workload_time" not in names, names
+    del store


### PR DESCRIPTION
## Summary

Two cloud legs were fully built but had **no caller in a deployed product**, so they delivered nothing end-to-end. This PR adds the smallest honest wiring for each, TDD throughout. Read-only/agentless, least-privilege, fail-closed (§7).

### Leg 1 — CWPP stage-3 runtime evidence had no door
**Root cause:** `ingest_runtime_signals` / `put_batch` (`runtime_workload_evidence_store.py`) and `enrich_graph_workload_runtime_evidence` had **zero callers** in `api`/`cli`/`mcp_tools` (grep-confirmed). Only the findings read-path (`scan.py`) consumed the store, so it could never be populated — the enrichment was dead in a deployed product.

**Fix:** `POST /v1/cloud/runtime-evidence/ingest` — authenticated (RBAC `scan` + tenant), read-only-posture. Authenticates a **pre-registered source** (HMAC shared secret; no per-action credentials), binds tenant/provider/account to the source (confused-deputy guard in `build_runtime_signal`), persists through the store's dedup/staleness contract, and runs off the event loop in a worker thread under backpressure. Sources are provisioned out-of-band via `AGENT_BOM_RUNTIME_EVIDENCE_SOURCES` (JSON, prefers `secret_hash`); the default registry is **empty → 401** until an operator registers one. Unknown source / bad secret / wrong tenant all return the **same generic 401** (non-enumerable).

**P1 index:** the store created `(tenant, workload_id, observed_at)` but `list_for_tenant` orders by `(tenant, observed_at, dedup_key)` — a scan + temp-b-tree sort at scale. Replaced with `(tenant_id, observed_at DESC, dedup_key DESC)` in both SQLite + Postgres backends (stale index dropped), plus a downgrade-able Alembic migration (`20260719_02`, `to_regclass`-guarded) for durable Postgres control planes.

### Leg 2 — GCP CIEM was plumbed but unfed
**Root cause:** `nhi_governance` governs `SERVICE_ACCOUNT`, but `gcp_inventory.py::_discover_service_accounts` emitted only name/email/disabled/privilege_level — no `last_used_at`, no `usage_evidence` — so a GCP SA could **never** produce an over-grant/dormant finding (fail-closed rules never fired).

**Fix:** emit a `usage_evidence` field shaped exactly like the AWS Access-Advisor payload the graph builder already consumes (`_add_inventory_principal` / `_add_access_advisor_grants`) — **zero builder changes**. Populated by an injectable read-only `usage_resolver` (mirrors the AWS collector seam). 

**Deferred (explicit):** no read-only GCP service-account last-authentication API is wired in this repo (verified: no `policy_analyzer`/`recommender`/`list_service_account_keys` usage anywhere; not in the `[gcp]` extra). So the **default is UNEVALUABLE** (`state: unavailable`, `diagnostic: gcp_service_account_usage_source_not_configured`) — fail-closed, never fabricated. Absent evidence stays unevaluable (no `last_used_at`, no edges, no finding); only a real resolver's telemetry produces a finding. Wiring live GCP last-auth telemetry (Policy Analyzer activity / audit-log) is a tracked follow-up.

## Repro (before)
- `grep -rn ingest_runtime_signals src/agent_bom/{api,cli,mcp_tools}` → no hits.
- A GCP SA inventory record carried no `last_used_at`/`usage_evidence` → `build_ciem_over_privilege_findings` / `evaluate_identity_governance` emitted nothing for GCP.

## Verification (all green locally)
- New suites: `tests/api/test_runtime_evidence_ingest_route.py` (persist + reaches graph + auth/tenant fail-closed + dedup + env bootstrap), `tests/cloud/test_runtime_workload_evidence_index_sargable.py` (EXPLAIN QUERY PLAN uses index, no temp b-tree; stale index dropped), `tests/cloud/test_gcp_service_account_usage_evidence.py` (CIEM finding on usage evidence; unevaluable without).
- Regression sweep 119 passed (cloud gcp inventory, nhi parity, cloud surface parity, api surface).
- `ruff` + `mypy` clean on changed src.
- Drift gates regenerated + passing: OpenAPI (`docs/openapi/`), v1 schemas (2 new models), `check-counts` (369 ops / 311 paths), env-var reference, data-model atlas, product-surface + release consistency.
- Alembic: single head (`20260719_02` → `20260719_01`), upgrade + downgrade both `to_regclass`-guarded.

## Blast radius
model → API (route + 2 request models) → OpenAPI/schemas/docs counts → store index (both backends) + Alembic migration → GCP inventory field → graph (no builder change) → tests. Deferred: live GCP usage telemetry source; a CLI mirror of the ingest door.