### PR TITLE
fix(scan): surface graph-derived finding categories on every scan surface

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -36,7 +36,6 @@ from agent_bom.api.stores import (
     _jobs_put,
 )
 from agent_bom.config import API_SCAN_WORKER_RECYCLE_JOBS, API_SCAN_WORKERS
-from agent_bom.graph.scan_findings import attach_graph_derived_findings
 from agent_bom.security import sanitize_error
 
 _logger = logging.getLogger(__name__)
@@ -333,22 +332,18 @@ def _surface_graph_derived_findings(
     """Attach graph-derived findings (NHI-governance, toxic-combination) to the report.
 
     The unified graph built here — with its node dict, edge list, and adjacency /
-    reverse-adjacency indexes — plus the interim JSON are locals of this helper, so
-    they are released when it returns. Scoping them keeps the surfacing graph from
-    outliving the call and overlapping the persist phase's own graph rebuild, which
-    would otherwise leave the full-scan path holding two full current graphs at the
-    persist peak (#4055/#4075).
-    """
-    from agent_bom.graph.builder import build_unified_graph_from_report
-    from agent_bom.output import to_json
+    reverse-adjacency indexes — plus the interim JSON are locals of the shared
+    helper, so they are released when it returns. Scoping them keeps the surfacing
+    graph from outliving the call and overlapping the persist phase's own graph
+    rebuild, which would otherwise leave the full-scan path holding two full current
+    graphs at the persist peak (#4055/#4075).
 
-    interim_json = to_json(report)
-    findings_graph = build_unified_graph_from_report(
-        interim_json,
-        scan_id=scan_id,
-        tenant_id=tenant_id,
-    )
-    attach_graph_derived_findings(report, findings_graph)
+    Delegates to the single build+attach helper the CLI and MCP scan surfaces also
+    use, so all three emit the same graph-derived finding categories.
+    """
+    from agent_bom.graph.scan_findings import surface_graph_derived_findings
+
+    surface_graph_derived_findings(report, scan_id=scan_id, tenant_id=tenant_id)
 
 
 def _graph_build_workspace_enabled() -> bool:

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2058,6 +2058,29 @@ def scan(
             ],
         }
 
+    # ── Graph-derived findings on EVERY scan (surface parity) ───────
+    # COMBINATION / CIEM_OVER_PRIVILEGE / NHI derive from the unified graph, not
+    # the raw inventory. Surface them on the default path too — not only under
+    # --context-graph — so the CLI emits the same finding categories as the API
+    # and MCP surfaces (all three call one shared build+attach helper). The
+    # unified stream (report.to_findings()) is the single source of truth for the
+    # toxic COMBINATION count, so the printed count can never contradict it.
+    if agents:
+        from agent_bom.cli._tenant import resolve_cli_tenant_id as _resolve_cli_tenant_id
+        from agent_bom.graph.scan_findings import surface_graph_derived_findings
+
+        surface_graph_derived_findings(report, scan_id=_scan_id, tenant_id=_resolve_cli_tenant_id())
+        if not quiet:
+            _n_toxic = len(report.toxic_combination_findings_data or [])
+            _n_nhi = len(report.nhi_governance_findings or [])
+            _n_ciem = len(report.ciem_over_privilege_findings_data or [])
+            if _n_toxic:
+                con.print(f"  [green]✓[/green] Toxic combinations: {_n_toxic} finding(s)")
+            if _n_nhi:
+                con.print(f"  [green]✓[/green] NHI governance: {_n_nhi} finding(s)")
+            if _n_ciem:
+                con.print(f"  [green]✓[/green] CIEM over-privilege: {_n_ciem} finding(s)")
+
     # ── Context graph: lateral movement analysis ────────────────────
     # Build whenever requested — credential pivots / SHARES_CREDENTIAL lateral
     # edges exist independent of any CVE, so gating on blast_radii hid the
@@ -2104,30 +2127,11 @@ def scan(
             from agent_bom.db.graph_store import default_graph_db_path, open_graph_db, save_graph
             from agent_bom.graph.builder import build_unified_graph_from_report
 
+            # Graph-derived findings (COMBINATION / NHI / CIEM) are surfaced
+            # un-gated above, so every scan surface stays at parity. Here the
+            # unified graph is (re)built only to persist the full snapshot to the
+            # local graph DB — a --context-graph-only side effect.
             _ug = build_unified_graph_from_report(_graph_json, scan_id=_scan_id, tenant_id=_resolve_cli_tenant_id())
-
-            # Graph-derived findings: now that every overlay has enriched the
-            # unified graph, surface NHI-governance + toxic-combination findings
-            # into the unified stream so they reach the --fail-on-severity gate and
-            # machine outputs (mirrors cloud CIS). Shared with the API scan
-            # pipeline so both paths emit the same finding categories.
-            try:
-                from agent_bom.graph.scan_findings import attach_graph_derived_findings
-
-                attach_graph_derived_findings(report, _ug)
-                if report.toxic_combination_findings_data:
-                    _n_toxic = len(report.toxic_combination_findings_data)
-                    con.print(f"  [green]✓[/green] Toxic combinations: {_n_toxic} finding(s)")
-                if report.nhi_governance_findings:
-                    _n_nhi = len(report.nhi_governance_findings)
-                    con.print(f"  [green]✓[/green] NHI governance: {_n_nhi} finding(s)")
-                if report.ciem_over_privilege_findings_data:
-                    _n_ciem = len(report.ciem_over_privilege_findings_data)
-                    con.print(f"  [green]✓[/green] CIEM over-privilege: {_n_ciem} finding(s)")
-            except Exception as _gderiv_err:  # noqa: BLE001
-                import logging as _tlog
-
-                _tlog.getLogger(__name__).debug("Graph-derived findings evaluation skipped: %s", _gderiv_err)
 
             _graph_db_path = default_graph_db_path()
             _graph_db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -2198,13 +2202,15 @@ def scan(
         from agent_bom.toxic_combos import prioritize_findings as _prioritize
         from agent_bom.toxic_combos import to_serializable as _toxic_ser
 
+        # The legacy detector still feeds graph TRIGGERS edges (builder reads
+        # report.toxic_combinations) and prioritized_findings, but it is NOT a
+        # user-facing count: the single honest toxic number is the COMBINATION
+        # category in the unified stream, printed once above from the graph
+        # evaluator. Printing len(_toxic) here would resurrect the contradictory
+        # "11 vs 5 vs 0" console output the 2026-07-19 audit flagged.
         _toxic = _detect_toxic(report, context_graph_data=report.context_graph_data)
         report.toxic_combinations = _toxic_ser(_toxic)
         report.prioritized_findings = _prioritize(report.blast_radii, _toxic)
-        if not quiet and _toxic:
-            _n_crit = sum(1 for t in _toxic if t.severity == "critical")
-            _n_high = sum(1 for t in _toxic if t.severity == "high")
-            con.print(f"  [red]![/red] Toxic combinations: {len(_toxic)} detected ({_n_crit} critical, {_n_high} high)")
 
     # ── Step 1i: Model binary file scan ─────────────────────────────
     # Auto-detect: if no --model-dirs given, check project dir for model files

--- a/src/agent_bom/graph/scan_findings.py
+++ b/src/agent_bom/graph/scan_findings.py
@@ -73,4 +73,26 @@ def attach_graph_derived_findings(report: "AIBOMReport", graph: "UnifiedGraph") 
         _logger.debug("CIEM over-privilege findings surfacing skipped: %s", exc)
 
 
-__all__ = ["attach_graph_derived_findings"]
+def surface_graph_derived_findings(report: "AIBOMReport", *, scan_id: str, tenant_id: str) -> None:
+    """Build the unified graph from ``report`` and attach graph-derived findings.
+
+    The single build+attach entry point shared by the CLI (default path), the API
+    scan pipeline, and the MCP scan tool, so every scan surface emits the same
+    graph-derived categories (``COMBINATION`` / ``CIEM_OVER_PRIVILEGE`` / ``NHI``).
+
+    The interim JSON and the throwaway graph are locals released when this returns,
+    so the surfacing graph never outlives the call. Best-effort: a graph-build or
+    surfacing failure is logged and swallowed — it must never fail the scan.
+    """
+    try:
+        from agent_bom.graph.builder import build_unified_graph_from_report
+        from agent_bom.output import to_json
+
+        interim_json = to_json(report)
+        graph = build_unified_graph_from_report(interim_json, scan_id=scan_id, tenant_id=tenant_id)
+        attach_graph_derived_findings(report, graph)
+    except Exception as exc:  # noqa: BLE001 — never fail the scan on findings surfacing
+        _logger.debug("graph-derived findings surfacing skipped: %s", exc)
+
+
+__all__ = ["attach_graph_derived_findings", "surface_graph_derived_findings"]

--- a/src/agent_bom/mcp_tools/scanning.py
+++ b/src/agent_bom/mcp_tools/scanning.py
@@ -251,6 +251,22 @@ async def _scan_impl_inner(
 
         report = AIBOMReport(agents=agents, blast_radii=blast_radii, scan_sources=scan_sources)
 
+        # Surface graph-derived finding categories (COMBINATION / CIEM_OVER_PRIVILEGE
+        # / NHI) so the MCP scan reaches CLI/API parity — the same shared build+attach
+        # helper both other surfaces use. Offloaded to a worker thread so the unified
+        # graph build never blocks the event loop; best-effort (never fails the scan).
+        if agents:
+            import asyncio
+
+            from agent_bom.graph.scan_findings import surface_graph_derived_findings
+
+            await asyncio.to_thread(
+                surface_graph_derived_findings,
+                report,
+                scan_id=report.scan_id or "mcp-scan",
+                tenant_id="default",
+            )
+
         # Format selection
         if output_format == "sarif":
             from agent_bom.output.sarif import to_sarif

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1166,7 +1166,11 @@ class AIBOMReport:
     aisvs_benchmark_data: Optional[dict[str, Any]] = None  # Serialized AISVS compliance results
     vector_db_scan_data: Optional[list[Any]] = None  # Serialized vector DB security assessments
     gpu_infra_data: Optional[dict[str, Any]] = None  # Serialized GPU/AI compute infra scan results
-    iac_findings_data: Optional[dict[str, Any]] = None  # Serialized IaC misconfiguration findings (set by CLI)
+    # Serialized IaC misconfiguration findings. Set by the CLI scan path and by the
+    # API repo_url tree scan (api/repo_tree_scan.py). NOT yet populated for API
+    # local-estate/inventory scans or the MCP scan tool — those surfaces do not run
+    # the IaC scanner, so /v1/findings shows the IaC category only for repo scans.
+    iac_findings_data: Optional[dict[str, Any]] = None
     # Graph toxic-combination findings (serialized Finding dicts; set at the graph-build call site).
     # Rehydrated into the unified Finding stream by to_findings() so they reach --fail-on-severity.
     toxic_combination_findings_data: Optional[list[Any]] = None

--- a/tests/api/test_api_pipeline_findings_surface.py
+++ b/tests/api/test_api_pipeline_findings_surface.py
@@ -11,9 +11,9 @@ from __future__ import annotations
 
 import json
 
-from agent_bom.api import pipeline as pipeline_mod
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _run_scan_sync
+from agent_bom.graph import scan_findings as sf_mod
 
 
 def _scan_job(inventory_path: str) -> ScanJob:
@@ -56,13 +56,13 @@ def test_pipeline_output_phase_invokes_graph_derived_findings(tmp_path, monkeypa
     every hosted scan gets the same finding categories the CLI emits."""
     _patch_scan(monkeypatch)
     calls: list[tuple] = []
-    real = pipeline_mod.attach_graph_derived_findings
+    real = sf_mod.attach_graph_derived_findings
 
     def _spy(report, graph):
         calls.append((report, graph))
         return real(report, graph)
 
-    monkeypatch.setattr(pipeline_mod, "attach_graph_derived_findings", _spy)
+    monkeypatch.setattr(sf_mod, "attach_graph_derived_findings", _spy)
 
     job = _scan_job(_empty_inventory(tmp_path))
     _run_scan_sync(job)
@@ -78,7 +78,7 @@ def test_pipeline_surfaces_mcp_tool_rule_finding_end_to_end(tmp_path, monkeypatc
     """A discovered MCP tool with a stored schema-rule finding surfaces as a
     unified finding in job.result after the hosted scan completes."""
     _patch_scan(monkeypatch)
-    real = pipeline_mod.attach_graph_derived_findings
+    real = sf_mod.attach_graph_derived_findings
 
     def _wrapped(report, graph):
         from agent_bom.models import Agent, AgentType, MCPServer, MCPTool
@@ -105,7 +105,7 @@ def test_pipeline_surfaces_mcp_tool_rule_finding_end_to_end(tmp_path, monkeypatc
         report.agents = list(report.agents) + [agent]
         return real(report, graph)
 
-    monkeypatch.setattr(pipeline_mod, "attach_graph_derived_findings", _wrapped)
+    monkeypatch.setattr(sf_mod, "attach_graph_derived_findings", _wrapped)
 
     job = _scan_job(_empty_inventory(tmp_path))
     _run_scan_sync(job)

--- a/tests/test_scan_surface_parity.py
+++ b/tests/test_scan_surface_parity.py
@@ -1,0 +1,218 @@
+"""Scan-surface parity: the same graph-derived finding CATEGORIES surface on
+every scan surface (CLI default, MCP, API) for one seeded estate.
+
+Regression for the 2026-07-19 audit: graph-derived categories
+(``COMBINATION`` / ``CIEM_OVER_PRIVILEGE`` / ``NHI``) were only surfaced on the
+CLI ``--context-graph`` path and the API. The MCP scan path and the default CLI
+path dropped them, so ``scan_impl(config_path=<estate>)`` and a default demo run
+emitted ``{CVE}`` while ``/v1/findings`` carried ``COMBINATION``.
+
+The estate below (an agent whose credentialed MCP server carries a vulnerable
+package) yields a COMBINATION toxic-combination finding when built into the
+unified graph — the same category the API surfaces.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent_bom.models import (
+    Agent,
+    AgentType,
+    AIBOMReport,
+    BlastRadius,
+    MCPServer,
+    Package,
+    Severity,
+    TransportType,
+    Vulnerability,
+)
+
+
+def _trunc(s: str) -> str:
+    return s
+
+
+def _seeded_estate() -> tuple[list[Agent], list[BlastRadius]]:
+    """An agent + credentialed MCP server + a critical CVE that the unified graph
+    turns into a COMBINATION (agentic credential-harvest) toxic chain."""
+    pkg = Package(name="requests", version="2.0.0", ecosystem="pypi")
+    vuln = Vulnerability(
+        id="CVE-2024-9999",
+        summary="RCE",
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        fixed_version="2.32.0",
+    )
+    pkg.vulnerabilities = [vuln]
+    server = MCPServer(
+        name="gh",
+        command="npx",
+        transport=TransportType.STDIO,
+        env={"GITHUB_TOKEN": "x", "AWS_SECRET_ACCESS_KEY": "y"},
+        packages=[pkg],
+    )
+    agent = Agent(
+        name="assistant",
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/cfg.json",
+        mcp_servers=[server],
+    )
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[server],
+        affected_agents=[agent],
+        exposed_credentials=["GITHUB_TOKEN"],
+        exposed_tools=[],
+        risk_score=9.0,
+    )
+    return [agent], [br]
+
+
+def _categories_from_report(report: AIBOMReport) -> set[str]:
+    return {f.finding_type.value for f in report.to_findings()}
+
+
+def _categories_from_json(payload: dict) -> set[str]:
+    return {str(f.get("finding_type")) for f in payload.get("findings", [])}
+
+
+# ── The shared build+attach helper produces the graph-derived category ────────
+
+
+def test_shared_helper_surfaces_combination_from_estate():
+    from agent_bom.graph.scan_findings import surface_graph_derived_findings
+
+    agents, brs = _seeded_estate()
+    report = AIBOMReport(agents=agents, blast_radii=brs)
+    # Before surfacing: only the raw CVE.
+    assert _categories_from_report(report) == {"CVE"}
+
+    surface_graph_derived_findings(report, scan_id="s1", tenant_id="default")
+
+    cats = _categories_from_report(report)
+    assert "COMBINATION" in cats
+    assert "CVE" in cats
+
+
+# ── MCP scan path emits the same categories (leg 1) ───────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mcp_scan_emits_graph_derived_categories():
+    from agent_bom.mcp_tools.scanning import scan_impl
+
+    agents, brs = _seeded_estate()
+
+    async def _pipeline(*_args, **_kwargs):
+        return agents, brs, [], []
+
+    result = await scan_impl(
+        config_path="/tmp/estate",
+        offline=True,
+        _run_scan_pipeline=_pipeline,
+        _truncate_response=_trunc,
+    )
+    payload = json.loads(result)
+    cats = _categories_from_json(payload)
+    assert "COMBINATION" in cats, f"MCP dropped graph-derived category; got {cats}"
+    assert "CVE" in cats
+
+
+# ── MCP == API category parity on the same estate ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_mcp_matches_api_categories():
+    from agent_bom.graph.scan_findings import surface_graph_derived_findings
+    from agent_bom.mcp_tools.scanning import scan_impl
+
+    agents, brs = _seeded_estate()
+
+    async def _pipeline(*_args, **_kwargs):
+        return agents, brs, [], []
+
+    mcp_payload = json.loads(
+        await scan_impl(
+            config_path="/tmp/estate",
+            offline=True,
+            _run_scan_pipeline=_pipeline,
+            _truncate_response=_trunc,
+        )
+    )
+    mcp_cats = _categories_from_json(mcp_payload)
+
+    # API path: same shared build+attach helper.
+    api_report = AIBOMReport(agents=agents, blast_radii=brs)
+    surface_graph_derived_findings(api_report, scan_id="s1", tenant_id="default")
+    api_cats = _categories_from_report(api_report)
+
+    assert mcp_cats == api_cats
+
+
+# ── Default CLI path (no --context-graph) surfaces the same categories (leg 2) ─
+
+
+def test_default_cli_scan_surfaces_combination():
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    agents, brs = _seeded_estate()
+    pkg = agents[0].mcp_servers[0].packages[0]
+
+    runner = CliRunner()
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=agents),
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=brs),
+        patch("agent_bom.cli.agents.extract_packages", return_value=[pkg]),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=None),
+        patch("agent_bom.vex.is_vex_suppressed", return_value=False),
+    ):
+        # No --context-graph flag — the default surface.
+        result = runner.invoke(
+            main,
+            ["scan", "--no-auto-update-db", "--format", "json"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0, result.output
+    # The console prints a status banner before the JSON document.
+    payload = json.loads(result.output[result.output.index("{") :])
+    cats = _categories_from_json(payload)
+    assert "COMBINATION" in cats, f"default CLI dropped graph-derived category; got {cats}"
+
+
+def test_default_cli_toxic_count_is_single_honest_number():
+    """The console must not print a legacy toxic count that contradicts the
+    unified stream (never 11 vs 5 vs 0). Only the unified graph count shows."""
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    agents, brs = _seeded_estate()
+    pkg = agents[0].mcp_servers[0].packages[0]
+
+    runner = CliRunner()
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=agents),
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=brs),
+        patch("agent_bom.cli.agents.extract_packages", return_value=[pkg]),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=None),
+        patch("agent_bom.vex.is_vex_suppressed", return_value=False),
+    ):
+        result = runner.invoke(
+            main,
+            ["scan", "--no-auto-update-db", "--enrich", "--offline"],
+            catch_exceptions=False,
+        )
+    assert result.exit_code == 0, result.output
+    # The legacy "N detected (…critical, …high)" wording must not appear; the
+    # single reconciled toxic line uses "finding(s)".
+    assert "detected (" not in result.output


### PR DESCRIPTION
## Summary

Extends the #4215 surface-parity fix, which only reached **CLI-with-`--context-graph` ↔ API**. MCP scans and default-CLI scans still dropped the graph-derived finding categories, and the default CLI printed a toxic-combination count that contradicted the unified stream.

- **Shared helper.** New `surface_graph_derived_findings(report, *, scan_id, tenant_id)` in `graph/scan_findings.py` builds the unified graph from the report and attaches the graph-derived findings. **CLI, API, and MCP now all route through this one helper**, so every surface emits the same categories (`COMBINATION` / `CIEM_OVER_PRIVILEGE` / `NHI`).
- **MCP (leg 1).** `_scan_impl_inner` now runs the shared helper before output formatting — offloaded via `asyncio.to_thread` so the unified-graph build never blocks the event loop. `scan_impl` now emits the same categories the API does.
- **Default CLI (leg 2).** Graph-derived surfacing runs **un-gated** (not only under `--context-graph`). Chosen option: *run graph-derived findings on the default path so the categories + printed toxic count are consistent with the unified stream.* The single honest toxic number is the `COMBINATION` category in the unified stream; the legacy detector's contradictory `"N detected"` console line is removed. The legacy `report.toxic_combinations` is still computed because it feeds graph `TRIGGERS` edges and `prioritized_findings`, but it is no longer surfaced as a user-facing count. The `--context-graph` block keeps rebuilding the graph **only** to persist the local snapshot.
- **API.** `_surface_graph_derived_findings` now delegates to the shared helper (DRY; no route/model change).
- **IaC (leg 3 — deferred, documented).** IaC already reaches the API via the `repo_url` tree scan (`api/repo_tree_scan.py` → pipeline → `to_findings`). It does **not** reach API local-estate/inventory scans or MCP. Wiring an estate-scan IaC path needs a new `ScanRequest` field + OpenAPI/schema regen + estate-vs-repo IaC semantics — larger than this PR. Corrected the stale `iac_findings_data` "set by CLI" comment to state the real surface reality so it is not a silent gap.

## Root cause

`mcp_tools/scanning.py` assembled `to_json(report)` without ever building the unified graph or calling `attach_graph_derived_findings` (grep: 0 calls). `cli/agents/scan_cmd.py` gated the graph build + attach behind `context_graph_flag`, and printed the legacy `report.toxic_combinations` count alongside the (0 or graph) unified count.

## Repro (before)

- In-process `scan_impl(config_path=<estate>)` finding types = `{CVE}` only, while `/v1/findings` carried `COMBINATION`.
- Default CLI demo run printed `Toxic combinations: 11` (legacy) while the unified stream carried 0 (or 5 with `--context-graph`).

## How verified

- New `tests/test_scan_surface_parity.py`: seeds one estate (agent + credentialed MCP server + critical CVE → `COMBINATION` in the unified graph) and asserts **CLI(default) == MCP == API** finding categories. RED before the fix (MCP/CLI emitted `{CVE}` only), GREEN after.
- Updated `tests/api/test_api_pipeline_findings_surface.py` to patch the attach seam at its new home in the shared helper module.
- Green locally: touched `pytest` suites (parity, toxic-findings, mcp tool impls, two-tier severity, cli scan, api surface), `ruff`, `mypy` on changed src. OpenAPI export `--check` reports no drift (no routes/models changed).

## Honesty / non-negotiables

Totals come from deduped `to_findings()`; graph attack-paths stay a separate metric. Finding ids are deterministic (graph evaluator ids derive from node ids, not `scan_id`), so surfacing is idempotent. Surfacing is best-effort and fail-closed — it never raises into the scan and fabricates nothing when evidence is absent. MCP surfacing is tenant-scoped `default` and thread-offloaded (no event-loop block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LcADV7MF1mS7kmhGPxHx6