### PR TITLE
fix(findings): complete the scan-finding read path (keyset + export)

### DIFF
--- a/src/agent_bom/api/finding_cursor.py
+++ b/src/agent_bom/api/finding_cursor.py
@@ -64,6 +64,57 @@ def decode_finding_cursor(cursor: str, *, expected_sort: str) -> tuple[float, st
         raise ValueError("Invalid findings cursor") from exc
 
 
+_MERGED_SCAN_CURSOR_MARKER = "merge1"
+
+
+def encode_merged_scan_cursor(*, sort: str, scan_index: int, bulk_cursor: str) -> str:
+    """Encode a compound cursor over the merged in-memory-scan + hub stream.
+
+    ``/v1/findings`` interleaves two sources: the fully-materialized in-memory
+    scan findings (walked by integer index) and the keyset-paged hub findings
+    (walked by ``bulk_cursor``). One opaque token carries both frontiers so a
+    keyset caller resumes the merge with 0 dups / 0 drops instead of losing the
+    scan half after page 1.
+    """
+    payload = {
+        "t": _MERGED_SCAN_CURSOR_MARKER,
+        "sort": sort if sort in _ALLOWED_SORTS else "effective_reach",
+        "si": int(scan_index),
+        "bc": bulk_cursor or "",
+    }
+    raw = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def decode_merged_scan_cursor(cursor: str, *, expected_sort: str) -> tuple[int, str] | None:
+    """Decode a compound merged cursor.
+
+    Returns ``(scan_index, bulk_cursor)`` when ``cursor`` is a merged token,
+    ``None`` when it is a plain hub keyset cursor (so the caller can fall back).
+    Raises ``ValueError`` when it IS a merged token but is corrupt or its sort
+    disagrees with ``expected_sort`` (mirrors :func:`decode_finding_cursor`).
+    """
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        raw = base64.urlsafe_b64decode(padded.encode()).decode()
+        payload = json.loads(raw)
+    except Exception:
+        return None
+    if not isinstance(payload, dict) or payload.get("t") != _MERGED_SCAN_CURSOR_MARKER:
+        return None
+    sort = str(payload.get("sort") or "")
+    if sort != expected_sort:
+        raise ValueError("Cursor sort mismatch")
+    try:
+        scan_index = int(payload.get("si") or 0)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid merged findings cursor") from exc
+    if scan_index < 0:
+        raise ValueError("Invalid merged findings cursor")
+    bulk_cursor = str(payload.get("bc") or "")
+    return scan_index, bulk_cursor
+
+
 def cursor_from_current_row(row: dict[str, Any], *, sort: str) -> str:
     normalized = sort if sort in _ALLOWED_SORTS else "effective_reach"
     primary: float | int

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -34,7 +34,7 @@ import uuid
 from collections.abc import AsyncIterator, Callable, Mapping
 from functools import partial
 from pathlib import Path
-from typing import Annotated, Any, cast
+from typing import Annotated, Any, NamedTuple, cast
 
 import anyio.to_thread
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -308,6 +308,33 @@ def _visible_to_tenant(job: ScanJob, tenant_id: str) -> bool:
 
 def _completed_jobs_for_tenant(tenant_id: str) -> list[ScanJob]:
     return [job for job in _get_store().list_all(tenant_id=tenant_id) if job.status == JobStatus.DONE and job.result]
+
+
+def iter_tenant_scan_spine_findings(
+    tenant_id: str,
+    *,
+    since: str | None = None,
+    severity: str | None = None,
+) -> list[dict[str, Any]]:
+    """Current scan-spine findings for a tenant — the same source ``/v1/findings`` shows.
+
+    The scan pipeline never writes the compliance hub, so these live only in the
+    in-memory job store. The scheduled findings export unions this with the hub
+    stream so a scan-based estate is not silently exported as empty. Bounded by
+    the scan-job results already resident in memory (no per-tenant DB scan).
+    """
+    from agent_bom.api.findings_current import current_scan_findings
+
+    rows = current_scan_findings(
+        _completed_jobs_for_tenant(tenant_id),
+        since=since,
+        scan_id=None,
+        iter_findings=_iter_scan_findings,
+    )
+    if severity:
+        normalized = severity.lower()
+        rows = [item for item in rows if str(item.get("severity", "")).lower() == normalized]
+    return rows
 
 
 class BulkFindingsRequest(BaseModel):
@@ -1719,6 +1746,23 @@ def _finding_sort_key(row: dict[str, Any], sort: str) -> tuple[float, float, flo
 _BULK_MERGE_CHUNK = 256
 
 
+class MergedScanBulkPage(NamedTuple):
+    """A merged page plus the frontier needed to resume the keyset walk.
+
+    ``next_scan_index`` is how many pre-sorted scan findings have been consumed
+    (skipped + emitted); ``next_bulk_cursor`` is the hub keyset cursor of the
+    last consumed bulk row (``""`` when no bulk row was consumed). Together they
+    let ``/v1/findings`` emit ONE compound cursor so a keyset caller walks the
+    full merged set with 0 dups / 0 drops instead of losing the scan half after
+    page 1.
+    """
+
+    rows: list[dict[str, Any]]
+    next_scan_index: int
+    next_bulk_cursor: str
+    has_more: bool
+
+
 def _merged_scan_bulk_page(
     scan_findings: list[dict[str, Any]],
     *,
@@ -1729,74 +1773,67 @@ def _merged_scan_bulk_page(
     scan_id: str | None,
     offset: int,
     limit: int,
+    scan_start: int = 0,
+    bulk_cursor: str | None = None,
     since: str | None = None,
     scope: Mapping[str, str] | None = None,
     status: str | None = None,
-) -> list[dict[str, Any]]:
+) -> MergedScanBulkPage:
     """Merge pre-sorted scan findings with bulk hub pages without O(table) work.
 
     Streams two sorted sources with a two-pointer walk so deep ``offset`` does
     not require loading ``offset + limit`` bulk rows up front or re-sorting the
-    full combined window in memory. When ``scope`` is set the bulk source is
-    refilled by keyset cursor (the scope-filtered store path is cursor-only, not
-    offset-addressable) so the merge still streams a bounded window per chunk.
-    ``status`` filters the bulk source's lifecycle status to match the merged
-    scan findings' basis (default open) so both halves reconcile.
+    full combined window in memory. The bulk source is refilled by keyset cursor
+    (``list_current_page``) so the merge stays sargable and — critically — the
+    frontier it stops at is expressible as one resumable cursor. ``scan_start``
+    (index into ``scan_findings``) and ``bulk_cursor`` (hub keyset position)
+    resume a prior page; ``status`` filters the bulk source's lifecycle status
+    to match the merged scan findings' basis (default open) so both halves
+    reconcile.
+
+    Each source is consumed strictly in order (scan by ascending index, bulk in
+    the store's keyset order), so a page consumes a contiguous prefix of each
+    source after its resume point — that is what makes the walk drop-free and
+    dup-free regardless of the merge comparator's tiebreakers.
     """
-    scan_i = 0
-    bulk_remote_offset = 0
+    from agent_bom.api.finding_cursor import cursor_from_current_row
+
+    scan_i = scan_start
     bulk_buf: list[dict[str, Any]] = []
     bulk_i = 0
-    bulk_cursor: str | None = None
+    fetch_cursor: str | None = bulk_cursor or None
     bulk_exhausted = False
+    last_bulk_consumed: dict[str, Any] | None = None
 
-    # Only the current-state store path carries the ``since`` / ``status``
-    # predicates; when active pass them through, otherwise stay byte-compatible
-    # with the legacy ``list_page`` bulk path that has neither kwarg.
     extra_kwargs: dict[str, Any] = {}
     if since:
         extra_kwargs["since"] = since
     if status is not None:
         extra_kwargs["status"] = status
+    if scope:
+        extra_kwargs["scope"] = dict(scope)
 
     def _refill_bulk() -> bool:
-        nonlocal bulk_buf, bulk_i, bulk_remote_offset, bulk_cursor, bulk_exhausted
-        if scope:
-            if bulk_exhausted:
-                bulk_buf = []
-                bulk_i = 0
-                return False
-            bulk_result = bulk_list(
-                tenant_id,
-                limit=_BULK_MERGE_CHUNK,
-                sort=sort_key,
-                severity=severity,
-                scan_id=scan_id,
-                origin="bulk_ingest",
-                include_total=False,
-                cursor=bulk_cursor,
-                scope=dict(scope),
-                **extra_kwargs,
-            )
-            bulk_buf = bulk_result[0]
-            bulk_cursor = bulk_result[2] if len(bulk_result) > 2 else None
-            if not bulk_cursor:
-                bulk_exhausted = True
+        nonlocal bulk_buf, bulk_i, fetch_cursor, bulk_exhausted
+        if bulk_exhausted:
+            bulk_buf = []
             bulk_i = 0
-            return bool(bulk_buf)
+            return False
         bulk_result = bulk_list(
             tenant_id,
             limit=_BULK_MERGE_CHUNK,
-            offset=bulk_remote_offset,
             sort=sort_key,
             severity=severity,
             scan_id=scan_id,
             origin="bulk_ingest",
             include_total=False,
+            cursor=fetch_cursor,
             **extra_kwargs,
         )
         bulk_buf = bulk_result[0]
-        bulk_remote_offset += len(bulk_buf)
+        fetch_cursor = bulk_result[2] if len(bulk_result) > 2 else None
+        if not fetch_cursor:
+            bulk_exhausted = True
         bulk_i = 0
         return bool(bulk_buf)
 
@@ -1817,9 +1854,10 @@ def _merged_scan_bulk_page(
         return row
 
     def take_bulk() -> dict[str, Any]:
-        nonlocal bulk_i
+        nonlocal bulk_i, last_bulk_consumed
         row = bulk_buf[bulk_i]
         bulk_i += 1
+        last_bulk_consumed = row
         return row
 
     def pick_next() -> dict[str, Any] | None:
@@ -1838,7 +1876,7 @@ def _merged_scan_bulk_page(
     skipped = 0
     while skipped < offset:
         if pick_next() is None:
-            return []
+            break
         skipped += 1
 
     page: list[dict[str, Any]] = []
@@ -1847,7 +1885,13 @@ def _merged_scan_bulk_page(
         if row is None:
             break
         page.append(row)
-    return page
+
+    has_more = scan_head() is not None or bulk_head() is not None
+    if last_bulk_consumed is not None:
+        next_bulk_cursor = cursor_from_current_row(last_bulk_consumed, sort=sort_key)
+    else:
+        next_bulk_cursor = bulk_cursor or ""
+    return MergedScanBulkPage(page, scan_i, next_bulk_cursor, has_more)
 
 
 @router.get("/findings", tags=["scan"])
@@ -1953,7 +1997,7 @@ def _list_findings_impl(
     """
     from agent_bom.api import time_window
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store, status_matches
-    from agent_bom.api.finding_cursor import decode_finding_cursor
+    from agent_bom.api.finding_cursor import decode_finding_cursor, decode_merged_scan_cursor
 
     tenant_id = _tenant_id(request)
     # Default read-window (≈90d): bound counts to a recent, honestly-labelled
@@ -1993,11 +2037,21 @@ def _list_findings_impl(
             status_code=400,
             detail=f"offset exceeds ceiling {_HUB_LIST_OFFSET_CEILING}; use cursor pagination for deeper walks",
         )
+    # A ``/v1/findings`` cursor is either a compound merged token (scan + hub
+    # frontier) or a plain hub keyset cursor. Decode the compound form first so a
+    # keyset caller resuming the scan half is routed to the merged walk rather
+    # than 400-ing against the plain decoder.
+    merged_cursor: tuple[int, str] | None = None
     if cursor:
         try:
-            decode_finding_cursor(cursor, expected_sort=sort_key)
+            merged_cursor = decode_merged_scan_cursor(cursor, expected_sort=sort_key)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
+        if merged_cursor is None:
+            try:
+                decode_finding_cursor(cursor, expected_sort=sort_key)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
 
     from agent_bom.api.findings_count_cache import (
         cache_key,
@@ -2053,12 +2107,18 @@ def _list_findings_impl(
     next_cursor: str | None = None
     warnings: list[str] = []
 
-    if cursor:
-        # Cursor pages page bulk-ingested findings ONLY; the in-memory scan
-        # findings only ever appear on page 1, so their full current-state fold is
-        # discarded here. Skip that O(all-completed-jobs) fold entirely and derive
-        # the "page-1-only" warning from a cheap completed-jobs presence check
-        # instead of computing findings we throw away.
+    # Resume frontiers. A compound merged cursor carries both a scan-findings
+    # index and the hub keyset position; a plain cursor carries only the hub
+    # position (scan half was already fully delivered on earlier pages). The
+    # merged walk (with ``list_current_page``) is what keeps the scan half from
+    # being dropped after page 1.
+    scan_start = merged_cursor[0] if merged_cursor is not None else 0
+    bulk_cursor_in: str | None = (merged_cursor[1] or None) if merged_cursor is not None else cursor
+
+    if cursor and merged_cursor is None:
+        # Plain hub keyset cursor: the in-memory scan findings were delivered on
+        # earlier (merged) pages, so their full current-state fold is discarded
+        # here. Skip that O(all-completed-jobs) fold entirely.
         scan_findings: list[dict[str, Any]] = []
         if _completed_jobs_for_tenant(tenant_id):
             warnings.append("cursor pagination applies to bulk-ingested findings only; in-memory scan findings appear on the first page")
@@ -2081,6 +2141,20 @@ def _list_findings_impl(
             scan_findings = [item for item in scan_findings if _row_matches_scope(item, scope_filters)]
         scan_findings.sort(key=lambda row: _finding_sort_key(row, sort_key))
 
+    from agent_bom.api.finding_cursor import encode_merged_scan_cursor
+
+    # Take the merged (scan + hub) keyset walk whenever the scan half is in play:
+    # a page-1 request that has scan findings, or any resume of a compound merged
+    # cursor. Pure-bulk reads (no scan findings, plain cursor) keep the simpler
+    # hub-only keyset path and its plain cursors — unchanged. ``_merged_scan_bulk_page``
+    # requires the cursor-capable ``list_current_page``, hence ``has_current_page``.
+    use_merged = has_current_page and (merged_cursor is not None or (not cursor and bool(scan_findings)))
+
+    def _encode_merged_next(page: MergedScanBulkPage) -> str | None:
+        if not page.has_more:
+            return None
+        return encode_merged_scan_cursor(sort=sort_key, scan_index=page.next_scan_index, bulk_cursor=page.next_bulk_cursor)
+
     # Scope/domain filters run INSIDE the store on pre-enrichment current rows,
     # batched + keyset-paged (provider/account/environment live in the JSON
     # payload and ``domain`` is a computed overlapping-lens SET, so neither can be
@@ -2089,10 +2163,10 @@ def _list_findings_impl(
     # ``total`` is honestly approximate (no O(table) COUNT under a scope filter).
     if scope_filters and has_current_page and callable(bulk_list):
         scope_arg = dict(scope_filters)
-        if scan_findings and not cursor:
-            # scan findings (already scope-filtered) merge onto page 1 exactly
-            # like the unfiltered branch; the bulk source is scope-filtered too.
-            page_rows = _merged_scan_bulk_page(
+        if use_merged:
+            # scan findings (already scope-filtered) merge with the scope-filtered
+            # bulk source under one keyset frontier so later pages keep both halves.
+            merged = _merged_scan_bulk_page(
                 scan_findings,
                 bulk_list=bulk_list,
                 tenant_id=tenant_id,
@@ -2101,10 +2175,14 @@ def _list_findings_impl(
                 scan_id=scan_id,
                 offset=offset,
                 limit=limit,
+                scan_start=scan_start,
+                bulk_cursor=bulk_cursor_in,
                 since=window_since,
                 scope=scope_arg,
                 status=status_key,
             )
+            page_rows = merged.rows
+            next_cursor = _encode_merged_next(merged)
         else:
             bulk_result = bulk_list(
                 tenant_id,
@@ -2115,7 +2193,7 @@ def _list_findings_impl(
                 scan_id=scan_id,
                 origin="bulk_ingest",
                 include_total=False,
-                cursor=cursor,
+                cursor=bulk_cursor_in,
                 since=window_since,
                 scope=scope_arg,
                 status=status_key,
@@ -2125,21 +2203,26 @@ def _list_findings_impl(
         total = None
         total_approximate = True
     elif callable(bulk_list) and not scope_filters:
-        if scan_findings and not cursor:
-            bulk_result = bulk_list(
-                tenant_id,
-                limit=1,
-                offset=0,
-                sort=sort_key,
-                severity=severity,
-                scan_id=scan_id,
-                origin="bulk_ingest",
-                include_total=include_bulk_total,
-                since=window_since,
-                status=status_key,
-            )
-            bulk_total = bulk_result[1]
-            page_rows = _merged_scan_bulk_page(
+        if use_merged:
+            # A COUNT probe is only worth paying on page 1 (no incoming cursor);
+            # resume pages stay approximate to avoid an O(table) count per page.
+            if merged_cursor is None:
+                bulk_result = bulk_list(
+                    tenant_id,
+                    limit=1,
+                    offset=0,
+                    sort=sort_key,
+                    severity=severity,
+                    scan_id=scan_id,
+                    origin="bulk_ingest",
+                    include_total=include_bulk_total,
+                    since=window_since,
+                    status=status_key,
+                )
+                bulk_total = bulk_result[1]
+            else:
+                bulk_total = None
+            merged = _merged_scan_bulk_page(
                 scan_findings,
                 bulk_list=bulk_list,
                 tenant_id=tenant_id,
@@ -2148,22 +2231,30 @@ def _list_findings_impl(
                 scan_id=scan_id,
                 offset=offset,
                 limit=limit,
+                scan_start=scan_start,
+                bulk_cursor=bulk_cursor_in,
                 since=window_since,
                 status=status_key,
             )
-            resolved_bulk, total_approximate = _resolve_bulk_findings_total(
-                tenant_id=tenant_id,
-                severity=severity,
-                scan_id=scan_id,
-                approximate_total=approximate_total or effective_approximate_total,
-                offset=offset,
-                bulk_total=bulk_total,
-                page_len=len(page_rows),
-                limit=limit,
-                window_days=resolved_window,
-                status=status_key,
-            )
-            total = None if resolved_bulk is None else len(scan_findings) + resolved_bulk
+            page_rows = merged.rows
+            next_cursor = _encode_merged_next(merged)
+            if merged_cursor is None:
+                resolved_bulk, total_approximate = _resolve_bulk_findings_total(
+                    tenant_id=tenant_id,
+                    severity=severity,
+                    scan_id=scan_id,
+                    approximate_total=approximate_total or effective_approximate_total,
+                    offset=offset,
+                    bulk_total=bulk_total,
+                    page_len=len(page_rows),
+                    limit=limit,
+                    window_days=resolved_window,
+                    status=status_key,
+                )
+                total = None if resolved_bulk is None else len(scan_findings) + resolved_bulk
+            else:
+                total = None
+                total_approximate = True
         else:
             bulk_result = bulk_list(
                 tenant_id,
@@ -2174,7 +2265,7 @@ def _list_findings_impl(
                 scan_id=scan_id,
                 origin="bulk_ingest",
                 include_total=include_bulk_total,
-                cursor=cursor,
+                cursor=bulk_cursor_in,
                 since=window_since,
                 status=status_key,
             )
@@ -2206,7 +2297,15 @@ def _list_findings_impl(
         combined = scan_findings + bulk_findings
         combined.sort(key=lambda row: _finding_sort_key(row, sort_key))
         total = len(combined)
-        page_rows = combined[offset : offset + limit]
+        # No keyset store here (store exposes neither list_page nor
+        # list_current_page): ``combined`` is fully materialized in memory, so walk
+        # it by index. The merged cursor's ``scan_index`` slot doubles as that
+        # index so ``has_more`` stays honest and the rest is retrievable (0 drops).
+        start = scan_start if merged_cursor is not None else offset
+        page_rows = combined[start : start + limit]
+        end = start + len(page_rows)
+        if end < len(combined):
+            next_cursor = encode_merged_scan_cursor(sort=sort_key, scan_index=end, bulk_cursor="")
 
     page = _redact_finding_page(page_rows)
     envelope = finding_list_envelope(

--- a/src/agent_bom/export/runner.py
+++ b/src/agent_bom/export/runner.py
@@ -1,9 +1,17 @@
 """Streaming findings export runner (#4040).
 
-Streams a tenant's current findings from the compliance hub via the same keyset
-cursor the async report export uses (``list_current_page``) — bounded, never
-materializing the whole result set — and hands the row stream to a destination
-adapter. Read-only on the source; audit-logged; tenant-scoped.
+Streams a tenant's current findings and hands the row stream to a destination
+adapter. Two sources are unioned so the export matches what ``/v1/findings``
+shows the user:
+
+* the in-memory **scan spine** (completed scan jobs) — the scan pipeline never
+  writes the compliance hub, so exporting only the hub silently shipped ZERO
+  rows on a scan-based estate;
+* the **compliance hub** current-state findings, streamed via the same keyset
+  cursor the async report export uses (``list_current_page``) — bounded, never
+  materializing the whole result set.
+
+Read-only on both sources; audit-logged; tenant-scoped.
 """
 
 from __future__ import annotations
@@ -22,6 +30,26 @@ logger = logging.getLogger(__name__)
 _PAGE_SIZE = 500
 
 
+def iter_scan_spine_findings(
+    tenant_id: str,
+    *,
+    severity: str | None = None,
+    since: str | None = None,
+) -> Iterator[dict[str, Any]]:
+    """Yield the in-memory scan-spine findings ``/v1/findings`` shows.
+
+    Bounded by the scan-job results already resident in memory. Best-effort: if
+    the scan route/store is unavailable the export continues with the hub only
+    rather than failing the run.
+    """
+    try:
+        from agent_bom.api.routes.scan import iter_tenant_scan_spine_findings
+    except Exception:  # noqa: BLE001 - scan spine is additive; hub export must still run
+        logger.debug("scan-spine finding source unavailable; exporting hub only", exc_info=True)
+        return
+    yield from iter_tenant_scan_spine_findings(tenant_id, since=since, severity=severity)
+
+
 def iter_current_findings(
     tenant_id: str,
     *,
@@ -30,20 +58,30 @@ def iter_current_findings(
     since: str | None = None,
     page_size: int = _PAGE_SIZE,
     hub: Any | None = None,
+    include_scan_spine: bool = True,
 ) -> Iterator[dict[str, Any]]:
     """Yield current findings for ``tenant_id`` one row at a time (bounded).
 
-    Pages ``hub.list_current_page`` with a keyset cursor so memory stays flat
-    regardless of finding count. Tenant scope is enforced by passing
-    ``tenant_id`` into the store query (never a client-supplied filter).
+    Unions the in-memory scan spine (the read path's scan-derived findings) with
+    the compliance hub current-state stream so a scan-based estate is never
+    exported as empty. The hub half pages ``list_current_page`` with a keyset
+    cursor so memory stays flat regardless of finding count; the scan half is
+    bounded by the resident scan-job results. Tenant scope is enforced by passing
+    ``tenant_id`` into every query (never a client-supplied filter).
     """
+    if include_scan_spine:
+        yield from iter_scan_spine_findings(tenant_id, severity=severity, since=since)
+
     if hub is None:
         from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
         hub = get_compliance_hub_store()
     list_page = getattr(hub, "list_current_page", None)
     if not callable(list_page):
-        raise RuntimeError("Compliance hub store does not support current-state finding exports")
+        # Scan-spine rows (if any) were already yielded above; only the hub half
+        # is unsupported here, so degrade to hub-empty rather than losing them.
+        logger.debug("compliance hub store lacks current-state paging; exporting scan spine only")
+        return
 
     cursor: str | None = None
     first = True

--- a/tests/test_findings_mixed_merge.py
+++ b/tests/test_findings_mixed_merge.py
@@ -72,11 +72,14 @@ def test_merged_scan_bulk_page_matches_full_sort_reference() -> None:
     _seed_bulk(store, tenant, 30)
     scan_sorted = sorted(scan_rows, key=lambda row: _finding_sort_key(row, "effective_reach"))
 
+    # The bulk source is the cursor-capable current-state page (the same source
+    # the route merges), so the reference merges scan with those rows too.
+    bulk_rows = store.list_current_page(tenant, limit=1000)[0]
     for offset in (0, 2, 5, 10):
         for limit in (1, 3, 7):
             merged = _merged_scan_bulk_page(
                 scan_sorted,
-                bulk_list=store.list_page,
+                bulk_list=store.list_current_page,
                 tenant_id=tenant,
                 sort_key="effective_reach",
                 severity=None,
@@ -84,9 +87,8 @@ def test_merged_scan_bulk_page_matches_full_sort_reference() -> None:
                 offset=offset,
                 limit=limit,
             )
-            bulk_rows = store.list(tenant)
             reference = sorted(scan_sorted + bulk_rows, key=lambda row: _finding_sort_key(row, "effective_reach"))
-            assert [row["id"] for row in merged] == [row["id"] for row in reference[offset : offset + limit]]
+            assert [row["id"] for row in merged.rows] == [row["id"] for row in reference[offset : offset + limit]]
 
 
 def test_findings_api_merges_scan_and_bulk_at_deep_offset() -> None:
@@ -132,7 +134,7 @@ def test_findings_api_merges_scan_and_bulk_at_deep_offset() -> None:
             "origin": "native_scan",
         }
     ]
-    bulk_rows, _ = store.list_page(tenant, limit=1000, offset=0)
+    bulk_rows = store.list_current_page(tenant, limit=1000)[0]
     reference = sorted(
         scan_rows + bulk_rows,
         key=lambda row: _finding_sort_key(row, "effective_reach"),

--- a/tests/test_findings_readpath_completeness.py
+++ b/tests/test_findings_readpath_completeness.py
@@ -1,0 +1,217 @@
+"""Findings read-path completeness (pre-release audit 2026-07-19).
+
+Two regressions where scan-derived findings failed to reach the consumer:
+
+* Fix 1 — ``/v1/findings`` keyset pagination silently dropped in-memory scan
+  findings: the merged scan+bulk branch never emitted a ``next_cursor`` so a
+  client following the documented keyset contract (advance while ``has_more``)
+  stopped after page 1 and lost the rest.
+* Fix 2 — the scheduled findings export streamed ONLY the compliance hub, which
+  the scan pipeline never writes, so a scan-based estate exported zero rows with
+  no partiality warning even though ``/v1/findings`` shows them.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.models import JobStatus
+from agent_bom.api.server import ScanJob, ScanRequest, app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store
+from agent_bom.export.runner import iter_current_findings, run_findings_export
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+
+def setup_module() -> None:
+    enable_trusted_proxy_env()
+
+
+def teardown_module() -> None:
+    disable_trusted_proxy_env()
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+
+
+def _scan_finding(idx: int) -> dict[str, Any]:
+    # Distinct effective_reach_score + id so the keyset order is total and the
+    # 0-dup / 0-drop assertion is unambiguous.
+    return {
+        "id": f"scan-{idx:03d}",
+        "vulnerability_id": f"CVE-2026-{idx:04d}",
+        "severity": "high",
+        "cvss_score": 5.0 + (idx % 5),
+        "effective_reach_score": float(1000 - idx),
+        "package": f"pkg-{idx}",
+    }
+
+
+def _seed_scan_job(tenant: str, count: int) -> None:
+    set_job_store(InMemoryJobStore())
+    job = ScanJob(
+        job_id=f"scan-job-{uuid4().hex}",
+        tenant_id=tenant,
+        created_at="2026-07-19T10:00:00Z",
+        request=ScanRequest(),
+    )
+    job.status = JobStatus.DONE
+    job.completed_at = "2026-07-19T10:01:00Z"
+    job.result = {"findings": [_scan_finding(i) for i in range(count)]}
+    _get_store().put(job)
+
+
+def _walk_keyset(client: TestClient, headers: dict[str, str], *, limit: int) -> list[str]:
+    """Follow the documented keyset contract: advance while ``has_more``."""
+    seen: list[str] = []
+    cursor = ""
+    guard = 0
+    while True:
+        guard += 1
+        assert guard < 1000, "keyset walk did not terminate"
+        url = f"/v1/findings?limit={limit}&sort=effective_reach"
+        if cursor:
+            url += f"&cursor={cursor}"
+        body = client.get(url, headers=headers).json()
+        seen.extend(str(row.get("id")) for row in body["findings"])
+        if not body["has_more"]:
+            break
+        cursor = body["next_cursor"]
+        assert cursor, "has_more was true but next_cursor was empty"
+    return seen
+
+
+# --------------------------------------------------------------------------
+# Fix 1 — keyset pagination over in-memory scan findings
+# --------------------------------------------------------------------------
+def test_keyset_walks_all_scan_findings_zero_dup_zero_drop() -> None:
+    tenant = f"scan-keyset-{uuid4().hex}"
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    _seed_scan_job(tenant, 19)
+
+    client = TestClient(app)
+    headers = proxy_headers(tenant=tenant)
+
+    first = client.get("/v1/findings?limit=5&sort=effective_reach", headers=headers).json()
+    assert first["count"] == 5
+    assert first["total"] == 19
+    # The bug: has_more was False here, stranding 14 findings.
+    assert first["has_more"] is True
+    assert first["next_cursor"]
+
+    seen = _walk_keyset(client, headers, limit=5)
+    assert len(seen) == 19, f"expected all 19 findings, got {len(seen)}"
+    assert len(set(seen)) == 19, "keyset walk produced duplicates"
+    assert set(seen) == {f"scan-{i:03d}" for i in range(19)}
+
+
+def test_keyset_walk_cvss_sort_zero_dup_zero_drop() -> None:
+    tenant = f"scan-cvss-{uuid4().hex}"
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    _seed_scan_job(tenant, 13)
+
+    client = TestClient(app)
+    headers = proxy_headers(tenant=tenant)
+
+    seen: list[str] = []
+    cursor = ""
+    while True:
+        url = "/v1/findings?limit=4&sort=cvss"
+        if cursor:
+            url += f"&cursor={cursor}"
+        body = client.get(url, headers=headers).json()
+        seen.extend(str(r.get("id")) for r in body["findings"])
+        if not body["has_more"]:
+            break
+        cursor = body["next_cursor"]
+    assert set(seen) == {f"scan-{i:03d}" for i in range(13)}
+    assert len(seen) == 13
+
+
+def test_merged_cursor_rejects_sort_mismatch_and_garbage() -> None:
+    tenant = f"scan-badcur-{uuid4().hex}"
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    _seed_scan_job(tenant, 8)
+    client = TestClient(app)
+    headers = proxy_headers(tenant=tenant)
+
+    first = client.get("/v1/findings?limit=3&sort=effective_reach", headers=headers).json()
+    cursor = first["next_cursor"]
+    assert cursor
+    # Reusing an effective_reach cursor under a different sort must 400, not
+    # silently mis-page.
+    assert client.get(f"/v1/findings?limit=3&sort=cvss&cursor={cursor}", headers=headers).status_code == 400
+    # Garbage cursor is rejected.
+    assert client.get("/v1/findings?limit=3&cursor=not-a-cursor", headers=headers).status_code == 400
+    # cursor + offset are mutually exclusive.
+    assert client.get(f"/v1/findings?limit=3&offset=3&cursor={cursor}", headers=headers).status_code == 400
+
+
+def test_keyset_walks_mixed_scan_and_bulk_zero_dup_zero_drop() -> None:
+    tenant = f"mixed-keyset-{uuid4().hex}"
+    store = InMemoryComplianceHubStore()
+    set_compliance_hub_store(store)
+    bulk = [
+        {
+            "id": f"bulk-{idx:03d}",
+            "severity": "medium",
+            "cvss_score": float(idx % 10),
+            "effective_reach_score": float(500 - idx),
+            "origin": "bulk_ingest",
+            "source": "test",
+            "batch_id": "mix-batch",
+        }
+        for idx in range(23)
+    ]
+    store.add(tenant, bulk)
+    store.upsert_current_batch(tenant, bulk, observed_at="2026-07-19T00:00:00Z", batch_id="mix-batch", source="test")
+    _seed_scan_job(tenant, 11)
+
+    client = TestClient(app)
+    headers = proxy_headers(tenant=tenant)
+
+    seen = _walk_keyset(client, headers, limit=4)
+    expected = {f"scan-{i:03d}" for i in range(11)} | {f"bulk-{i:03d}" for i in range(23)}
+    assert len(seen) == len(expected), f"expected {len(expected)} rows, got {len(seen)}"
+    assert len(set(seen)) == len(seen), "keyset walk produced duplicates"
+    assert set(seen) == expected
+
+
+# --------------------------------------------------------------------------
+# Fix 2 — scheduled export must include scan-spine findings
+# --------------------------------------------------------------------------
+class _FakeDestination:
+    kind = "s3"
+
+    def __init__(self) -> None:
+        self.rows: list[dict[str, Any]] = []
+
+    def write_findings(self, rows: Any, *, tenant_id: str, run_id: str) -> Any:
+        from agent_bom.export.destinations import ExportResult
+
+        self.rows = [dict(r) for r in rows]
+        return ExportResult(kind=self.kind, destination_uri="s3://x/y", row_count=len(self.rows), byte_count=0)
+
+
+def test_iter_current_findings_includes_scan_spine() -> None:
+    tenant = f"export-scan-{uuid4().hex}"
+    set_compliance_hub_store(InMemoryComplianceHubStore())  # hub is empty
+    _seed_scan_job(tenant, 7)
+
+    rows = list(iter_current_findings(tenant))
+    ids = {str(r.get("id")) for r in rows}
+    assert ids == {f"scan-{i:03d}" for i in range(7)}, f"scan-spine findings missing from export: {ids}"
+
+
+def test_run_findings_export_ships_scan_findings_end_to_end() -> None:
+    tenant = f"export-e2e-{uuid4().hex}"
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    _seed_scan_job(tenant, 5)
+
+    dest = _FakeDestination()
+    result = run_findings_export(tenant_id=tenant, kind="s3", config={}, destination=dest)
+    assert result.row_count == 5, "scheduled export shipped zero scan-derived findings"
+    assert {str(r.get("id")) for r in dest.rows} == {f"scan-{i:03d}" for i in range(5)}


### PR DESCRIPTION
## Summary

Two P1 defects from the 2026-07-19 pre-release audit where scan-derived findings failed to fully reach the consumer. Both are on the **scan spine** (in-memory completed-scan findings) — the hub-backed path was already correct.

### Fix 1 — keyset pagination silently dropped in-memory scan findings
- **Root cause:** the envelope derives `has_more = bool(next_cursor)`, but the merged scan+bulk branch of `_list_findings_impl` (and the no-keyset fallback) never emitted a `next_cursor` for scan findings. `total` still counted them, so a client following the documented keyset contract (advance while `has_more`) got `count=5, total=19, has_more=false` and **stopped after page 1, dropping 14 rows**. Scan findings only ever appeared on page 1; a plain cursor discarded them entirely.
- **Repro (before):** `GET /v1/findings?limit=5` on a 19-finding scan estate → `has_more=false`, keyset walk yields 5/19.
- **Fix:** emit ONE opaque **compound cursor** over the merged stream — an integer index into the pre-sorted scan findings + the hub keyset position (`encode_merged_scan_cursor`). `_merged_scan_bulk_page` now refills the bulk half by keyset cursor (`list_current_page`) and returns its stop frontier, so the walk resumes both halves with **0 dups / 0 drops** and stays sargable (no deep OFFSET). Each source is consumed strictly in order, so a page takes a contiguous prefix of each after its resume point — drop-free/dup-free independent of the merge comparator's tiebreakers. The no-keyset fallback walks its fully-materialized `combined` list by index cursor for the same honesty.

### Fix 2 — scheduled export shipped zero scan-derived findings
- **Root cause:** `export/runner.py::iter_current_findings` streamed only the compliance hub (`list_current_page`), which the scan pipeline never writes — so a scan-based estate exported **nothing, with no partiality warning**, inconsistent with `/v1/findings` (which reads the scan spine).
- **Fix:** union the read path's in-memory scan spine (`iter_tenant_scan_spine_findings`) with the hub keyset stream, **keeping the runner's bounded-memory guarantee** — the scan spine is bounded by the scan-job results already resident in memory (the same footprint the read path uses), and the hub half stays keyset-streamed. Best-effort: if the scan source is unavailable the hub export still runs.

## Verification
- `tests/test_findings_readpath_completeness.py` (new): keyset walk over scan-only, mixed scan+bulk, and `sort=cvss` — each asserts **0 dup / 0 drop / all rows retrieved**; cursor sort-mismatch / garbage / `offset+cursor` all rejected `400`; export ships scan findings end-to-end (`iter_current_findings` + `run_findings_export`).
- `tests/test_findings_mixed_merge.py`: updated for the cursor-capable bulk source and the richer `MergedScanBulkPage` return type.
- Green locally: finding/export/scan/cursor/compliance sweep (**3214 passed, 12 skipped**), `ruff check`, `mypy` on changed src, and the OpenAPI / v1-schema / `check-counts` drift gates (**no contract change** — the cursor stays an opaque string; envelope shape unchanged).

## Notes / deferred legs
- **No contract/schema change:** the compound cursor is backward-compatible — plain hub keyset cursors still decode and page as before; pure-bulk reads keep their existing plain cursors.
- **Scan-spine process locality (deferred):** scan findings live in the in-memory job store, so the union reflects them only where that store is populated — same locality constraint the read path already has. Persisting the scan spine so an out-of-process export worker sees it is out of scope here; the union closes the silent-zero gap for the co-located case and never fabricates rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012LcADV7MF1mS7kmhGPxHx6