### PR TITLE
fix(compliance): honesty + licensing polish — own-worded CIS titles, no_data score, toxic-combo subsumption, unassessed exploit likelihood

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
-<p align="center">Headless agent primitives and a human cockpit over shared evidence contracts.</p>
+<p align="center">Discover assets, scan and enrich findings, map blast radius and compliance, and enforce runtime policy—from a local CLI or your self-hosted control plane.</p>
 
 <p align="center">
   <a href="https://demo.agent-bom.com"><b>Live demo</b></a> (read-only sandbox) ·
@@ -29,23 +29,25 @@
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
-## Start in two commands
+## Scan your project in two commands
 
 ```bash
 pip install agent-bom
-agent-bom scan -p .
+agent-bom scan .
 ```
 
-The local CLI reads the project directly and prints inventory, findings, blast
-radius, and fix-first actions. No control plane is required. Export an artifact
-when another tool needs it: `agent-bom scan -p . -f sarif -o findings.sarif`.
+`.` means the current project. The local CLI reads it directly and prints
+inventory, findings, reachable context, and fix-first actions; no control plane
+is required. Export evidence when another tool needs it:
+`agent-bom scan . -f sarif -o findings.sarif`. For scripts,
+`--project .` (short form: `-p .`) is equivalent.
 
 ## Three ways to use it
 
 | Product lane | First command | Evidence you get | Natural next step |
 |---|---|---|---|
-| **Scan locally** — repos, images, SBOMs, agent/MCP config, IaC | `agent-bom scan -p .` | console, JSON, SARIF, CycloneDX/SPDX, HTML, graph export | gate CI or open the local report |
-| **Centralize evidence** — fleet, cloud, identity, findings, compliance | `pip install 'agent-bom[ui]' && agent-bom serve` | tenant-scoped API/UI inventory, jobs, graph, audit, posture | self-host with Docker or Helm + Postgres |
+| **Scan and understand risk** — repos, images, SBOMs, agent/MCP config, IaC | `agent-bom scan .` | inventory, findings, fix priority, graph and standard report formats | gate CI or open the local report |
+| **Centralize and visualize evidence** — fleet, cloud, identity, findings, compliance | `pip install 'agent-bom[ui]' && agent-bom serve` | tenant-scoped inventory, attack paths, compliance, jobs and audit | self-host with Docker or Helm + Postgres |
 | **Enforce runtime behavior** — MCP and tool calls | `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` | allow/warn/block decisions and audit events | bind policies to agents and upstream MCPs |
 
 Discovery and static/cloud scanning are read-only. The self-hosted control plane
@@ -65,65 +67,37 @@ credential references, and agents that can reach it. Coverage and boundaries:
 [product boundaries](docs/PRODUCT_BOUNDARIES.md) ·
 [first-run guide](docs/FIRST_RUN.md).
 
-## How the full stack fits together
+## How it works
 
-The surfaces share evidence contracts and lower-level services, but they do not
-all self-call through FastAPI. Local CLI/CI invokes the scanner engine directly;
-the UI and SDK use the authenticated API; MCP server mode exposes shared
-services; gateway/proxy modes enforce runtime traffic at their own boundary.
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom product flow from read-only sources through scanning and graph correlation to reports, the self-hosted control plane, and optional runtime enforcement" width="1100" />
+  </picture>
+</p>
+
+Local CLI and CI call the scanner directly and do not require a server. The
+self-hosted control plane adds an authenticated API and UI, tenant-scoped
+persistence, fleet jobs, attack paths, compliance, and audit. Gateway and proxy
+modes enforce live tool traffic at a separate runtime boundary.
 
 <details>
-<summary><b>Full architecture</b> — execution paths, backend, databases, and optional stores</summary>
+<summary><b>Execution paths and persistence</b></summary>
 
-```mermaid
-flowchart TB
-    subgraph callers ["Entry points"]
-        CLI["CLI · CI · Docker"]
-        UI["Next.js UI · SDK"]
-        MCP["MCP clients"]
-        RT["Runtime MCP/tool traffic"]
-    end
-    subgraph services ["Execution paths"]
-        CORE["Python scanner + correlation engine"]
-        MW["HTTP middleware<br/>auth · tenant · rate limit · audit"]
-        API["FastAPI routes + services"]
-        MCPS["MCP server + shared services"]
-        GW["Gateway / proxy<br/>policy · detectors · audit"]
-    end
-    subgraph stores ["Persistence"]
-        SQL["SQLite<br/>local / single node"]
-        PG["Postgres + RLS<br/>shared / multi-replica"]
-        NEP["Neptune<br/>optional graph backend"]
-        CH["ClickHouse<br/>optional analytics"]
-    end
+| Boundary | Entry point | Service path | Persistence or artifact |
+|---|---|---|---|
+| Local scan | CLI, CI, Docker | Python scanner and correlation engine | console/files; optional SQLite history |
+| Control plane | Next.js UI, REST SDK | auth/tenant/rate-limit/audit middleware → FastAPI services | Postgres + RLS for shared deployments; SQLite for a local pilot |
+| Agent interface | MCP clients | MCP server → shared scanning, finding and graph services | the same normalized evidence contracts |
+| Runtime enforcement | MCP/tool traffic | gateway or proxy → policy, detectors and audit | SQLite or Postgres audit records |
 
-    CLI --> CORE
-    UI --> MW --> API --> CORE
-    MCP --> MCPS --> CORE
-    RT --> GW
-    CORE --> SQL
-    CORE --> PG
-    CORE -. graph option .-> NEP
-    CORE -. analytics .-> CH
-    GW --> SQL
-    GW --> PG
-```
-
-- **Frontend:** Next.js 16 / React 19 in `ui/`; authenticated browser data comes
-  from FastAPI—there is no UI-only privileged store path.
-- **Backend:** Python 3.11+ scanner/services plus FastAPI/uvicorn for the control
-  plane. The product is not single-language: the cockpit is TypeScript/React.
-- **Persistence:** SQLite and Postgres are the primary operational stores.
-  Neptune is optional graph persistence; ClickHouse is optional analytics.
-  Snowflake implements selected warehouse/store paths with documented parity
-  limits—it is not a drop-in implementation of every store.
-- **Evidence:** normalized findings and graph contracts correlate inventory,
-  vulnerabilities, cloud/config posture, identity context, and runtime records.
-  `ContextGraph` and `UnifiedGraph` are still being consolidated, so not every
-  record is physically stored as one object.
-- **Agent interface:** server mode exposes 76 MCP tools, 6 resources, and 8 workflow prompts
-  over strict MCP arguments. Registry metadata includes a committed Smithery manifest;
-  integration docs distinguish committed metadata from current catalog liveness.
+Neptune is an optional graph backend and ClickHouse is optional analytics.
+Snowflake supports selected warehouse/store paths with documented parity
+limits. MCP server mode exposes 76 MCP tools, 6 resources, and 8 workflow prompts
+over strict arguments. Agent distribution includes a committed
+[Smithery manifest](integrations/smithery.yaml); external catalog liveness is
+verified separately. The implementation-level diagram and component
+boundaries live in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
 
 </details>
 
@@ -152,17 +126,42 @@ Matching mechanics and release evidence:
 
 </details>
 
-## See it
+## See the product
 
 Try the [live demo](https://demo.agent-bom.com) (read-only sandbox). These
 captures come from the shipped Next.js routes using explicitly labeled,
 synthetic demo evidence.
 
-| Risk overview | Connect evidence sources |
+### Prioritize an attack path, not just a CVE
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Prioritized attack path connecting identity, agent, MCP server, package, and critical finding with evidence export and remediation handoff" width="900" />
+</p>
+
+The investigation lens connects identity and agent reachability to the MCP
+server, package, and finding that create the exposure. Operators can export the
+graph evidence or hand the path directly to remediation.
+
+### See every finding and its reach
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with severity, reachable agents, available fixes, and false-positive review actions" width="900" />
+</p>
+
+### Move from risk to owner-ready work
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Prioritized remediation campaign with modeled risk reduction, reach, framework mappings, ownership, and verification state" width="900" />
+</p>
+
+<details>
+<summary><b>More control-plane views</b> — posture and runtime decisions</summary>
+
+| Risk overview | Review runtime decisions |
 |:---:|:---:|
-| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview command center with posture grade, unique findings, scan coverage, and operations" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/cloud-accounts-live.png" alt="Connections hub across cloud, code, AI, and data sources" width="430" /> |
-| **Start a scan** | **Review runtime decisions** |
-| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/new-scan-live.png" alt="New Scan form with connected account, ad-hoc, and public repo modes" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and tool-call feed" width="430" /> |
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview command center with posture grade, unique findings, scan coverage, and operations" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and tool-call feed" width="430" /> |
+
+</details>
 
 <details>
 <summary><b>Full CLI walkthrough</b> — current 0.96.3 console demo</summary>
@@ -187,12 +186,12 @@ matches your role:
 
 | Need | Surface | First action | Main artifact |
 |---|---|---|---|
-| Scan a repo, image, or local agent config | CLI / CI | `agent-bom scan -p .` (or the [GitHub Action](https://github.com/marketplace/actions/agent-bom)) | JSON, SARIF, SBOM, HTML |
+| Scan a repo, image, or local agent config | CLI / CI | `agent-bom scan .` (or the [GitHub Action](https://github.com/marketplace/actions/agent-bom)) | JSON, SARIF, SBOM, HTML |
 | Connect cloud and data-estate evidence | Cloud connectors | `agent-bom connect aws` then `agent-bom cloud scan` | assets, CIS findings, graph edges |
 | Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | findings, graph, audit, compliance |
 | Give agents security tools | MCP server | `agent-bom mcp server` | strict MCP tool responses |
 | Govern runtime tool calls | Proxy / gateway | `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` | allow/warn/block audit trail |
-| Package evidence for audit | Reports / exports | `agent-bom scan -p . -f sarif -o findings.sarif` | SARIF, CycloneDX, SPDX, HTML/PDF, compliance bundle |
+| Package evidence for audit | Reports / exports | `agent-bom scan . -f sarif -o findings.sarif` | SARIF, CycloneDX, SPDX, HTML/PDF, compliance bundle |
 
 Beyond the basics — `agent-bom graph` (multi-hop exposure paths),
 `agent-bom remediate -p .` (advisory fix plan),
@@ -243,9 +242,12 @@ configured provider credentials and do not require a control-plane connection.
   short-lived, brokered credentials (e.g. AWS `sts:AssumeRole`); connection
   secrets are write-only (encrypted at rest, never read back).
 
-HTTP auth, tenant isolation, and audit are enforced in middleware for the UI and
-API/SDK callers. MCP server and gateway/proxy modes enforce their own documented
-transport-auth and policy boundaries; none receives a privileged UI-only path.
+Application-layer authentication, tenant isolation, rate limits, and audit are
+enforced in middleware for UI and API/SDK requests. Non-loopback deployments
+terminate HTTPS/TLS at Caddy, an ingress, an ALB, or an equivalent trusted edge;
+the API and UI remain on loopback or a private network. MCP server and
+gateway/proxy modes enforce their own documented transport authentication and
+policy boundaries; none receives a privileged UI-only path.
 
 Cloud connectors are opt-in, default-off, and read no secret values.
 `agent-bom connect <provider>` prints the grant template and enable flag

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -253,7 +253,7 @@ def _check_1_1(account_client: Any) -> CISCheckResult:
     """CIS 1.1 — Maintain current contact details."""
     result = CISCheckResult(
         check_id="1.1",
-        title="Maintain current contact details",
+        title="Account contact details kept current",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -278,7 +278,7 @@ def _check_1_2(account_client: Any) -> CISCheckResult:
     """CIS 1.2 — Ensure security contact information is registered."""
     result = CISCheckResult(
         check_id="1.2",
-        title="Ensure security contact information is registered",
+        title="Security contact information registered",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -307,7 +307,7 @@ def _check_1_3() -> CISCheckResult:
     """CIS 1.3 — Ensure security questions are not the only way to authenticate to root."""
     return CISCheckResult(
         check_id="1.3",
-        title="Ensure security questions are not the only way to authenticate to root",
+        title="Root not reliant on security questions alone",
         status=CheckStatus.NOT_APPLICABLE,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -320,7 +320,7 @@ def _check_1_4(iam_client: Any) -> CISCheckResult:
     """CIS 1.4 — Ensure no 'root' user account access key exists."""
     result = CISCheckResult(
         check_id="1.4",
-        title="Ensure no root user account access key exists",
+        title="No root account access keys",
         status=CheckStatus.PASS,
         severity="critical",
         cis_section=_IAM_SECTION,
@@ -341,7 +341,7 @@ def _check_1_5(iam_client: Any) -> CISCheckResult:
     """CIS 1.5 — Ensure MFA is enabled for the root user account."""
     result = CISCheckResult(
         check_id="1.5",
-        title="Ensure MFA is enabled for the root user account",
+        title="Root account MFA enabled",
         status=CheckStatus.PASS,
         severity="critical",
         cis_section=_IAM_SECTION,
@@ -362,7 +362,7 @@ def _check_1_6(iam_client: Any) -> CISCheckResult:
     """CIS 1.6 — Ensure hardware MFA is enabled for the root user account."""
     result = CISCheckResult(
         check_id="1.6",
-        title="Ensure hardware MFA is enabled for the root user account",
+        title="Hardware MFA for root account",
         status=CheckStatus.PASS,
         severity="critical",
         cis_section=_IAM_SECTION,
@@ -390,7 +390,7 @@ def _check_1_7(iam_client: Any) -> CISCheckResult:
     """CIS 1.7 — Eliminate use of the root user for administrative and daily tasks."""
     result = CISCheckResult(
         check_id="1.7",
-        title="Eliminate use of the root user for administrative and daily tasks",
+        title="Root user not used for daily tasks",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_IAM_SECTION,
@@ -445,7 +445,7 @@ def _check_1_8(iam_client: Any) -> CISCheckResult:
     """CIS 1.8 — Ensure IAM password policy requires minimum length >= 14."""
     result = CISCheckResult(
         check_id="1.8",
-        title="Ensure IAM password policy requires minimum length >= 14",
+        title="IAM password policy minimum length >= 14",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -473,7 +473,7 @@ def _check_1_10(iam_client: Any) -> CISCheckResult:
     """CIS 1.10 — Ensure MFA is enabled for all IAM users with console access."""
     result = CISCheckResult(
         check_id="1.10",
-        title="Ensure MFA is enabled for all IAM users with console access",
+        title="MFA on all console-access IAM users",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_IAM_SECTION,
@@ -510,7 +510,7 @@ def _check_1_11(iam_client: Any) -> CISCheckResult:
     """CIS 1.11 — Do not setup access keys during initial user setup."""
     result = CISCheckResult(
         check_id="1.11",
-        title="Do not setup access keys during initial user setup",
+        title="No access keys created at user setup",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -580,7 +580,7 @@ def _check_1_12(iam_client: Any) -> CISCheckResult:
     """CIS 1.12 — Ensure credentials unused for 45 days or greater are disabled."""
     result = CISCheckResult(
         check_id="1.12",
-        title="Ensure credentials unused for 45 days or greater are disabled",
+        title="Credentials unused 45+ days disabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -652,7 +652,7 @@ def _check_1_13(iam_client: Any) -> CISCheckResult:
     """CIS 1.13 — Ensure there is only one active access key available for any single IAM user."""
     result = CISCheckResult(
         check_id="1.13",
-        title="Ensure there is only one active access key available for any single IAM user",
+        title="At most one active access key per IAM user",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -684,7 +684,7 @@ def _check_1_15(iam_client: Any) -> CISCheckResult:
     """CIS 1.15 — Ensure IAM users receive permissions only through groups or roles."""
     result = CISCheckResult(
         check_id="1.15",
-        title="Ensure IAM users receive permissions only through groups or roles",
+        title="IAM permissions granted via groups or roles only",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -716,7 +716,7 @@ def _check_1_9(iam_client: Any) -> CISCheckResult:
     """CIS 1.9 — Ensure IAM password policy prevents password reuse."""
     result = CISCheckResult(
         check_id="1.9",
-        title="Ensure IAM password policy prevents password reuse",
+        title="IAM password policy blocks password reuse",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -744,7 +744,7 @@ def _check_1_14(iam_client: Any) -> CISCheckResult:
     """CIS 1.14 — Ensure access keys are rotated every 90 days or less."""
     result = CISCheckResult(
         check_id="1.14",
-        title="Ensure access keys are rotated every 90 days or less",
+        title="Access keys rotated within 90 days",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -780,7 +780,7 @@ def _check_1_16(iam_client: Any) -> CISCheckResult:
     """CIS 1.16 — Ensure IAM policies with full '*:*' admin privileges are not attached."""
     result = CISCheckResult(
         check_id="1.16",
-        title="Ensure IAM policies with full admin privileges are not attached",
+        title="No full-admin IAM policies attached",
         status=CheckStatus.PASS,
         severity="critical",
         cis_section=_IAM_SECTION,
@@ -850,7 +850,7 @@ def _check_1_17(iam_client: Any) -> CISCheckResult:
     """CIS 1.17 — Ensure a support role has been created to manage incidents with AWS Support."""
     result = CISCheckResult(
         check_id="1.17",
-        title="Ensure a support role has been created to manage incidents with AWS Support",
+        title="Support role exists for AWS Support incidents",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -880,7 +880,7 @@ def _check_1_19(ec2_client: Any) -> CISCheckResult:
     """CIS 1.19 — Ensure that IAM instance roles are used for AWS resource access from instances."""
     result = CISCheckResult(
         check_id="1.19",
-        title="Ensure that IAM instance roles are used for AWS resource access from instances",
+        title="Instance roles used for resource access",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -917,7 +917,7 @@ def _check_1_20(accessanalyzer_client: Any) -> CISCheckResult:
     """CIS 1.20 — Ensure that IAM Access Analyzer is enabled for all regions."""
     result = CISCheckResult(
         check_id="1.20",
-        title="Ensure that IAM Access Analyzer is enabled for all regions",
+        title="IAM Access Analyzer enabled in all regions",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -943,7 +943,7 @@ def _check_1_22(iam_client: Any) -> CISCheckResult:
     """CIS 1.22 — Ensure access to AWSCloudShellFullAccess is restricted."""
     result = CISCheckResult(
         check_id="1.22",
-        title="Ensure access to AWSCloudShellFullAccess is restricted",
+        title="AWSCloudShellFullAccess access restricted",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_IAM_SECTION,
@@ -983,7 +983,7 @@ def _check_2_1_1(s3control_client: Any, account_id: str) -> CISCheckResult:
     """CIS 2.1.1 — Ensure S3 account-level public access block is configured."""
     result = CISCheckResult(
         check_id="2.1.1",
-        title="Ensure S3 account-level public access block is configured",
+        title="S3 account-level public access block configured",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_STORAGE_SECTION,
@@ -1012,7 +1012,7 @@ def _check_2_1_2(s3_client: Any) -> CISCheckResult:
     """CIS 2.1.2 — Ensure S3 buckets have server-side encryption enabled."""
     result = CISCheckResult(
         check_id="2.1.2",
-        title="Ensure S3 buckets have server-side encryption enabled",
+        title="S3 bucket server-side encryption enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_STORAGE_SECTION,
@@ -1061,7 +1061,7 @@ def _check_2_1_3(s3_client: Any) -> CISCheckResult:
     """CIS 2.1.3 — Ensure MFA Delete is enabled on S3 buckets."""
     result = CISCheckResult(
         check_id="2.1.3",
-        title="Ensure MFA Delete is enabled on S3 buckets",
+        title="S3 bucket MFA Delete enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_STORAGE_SECTION,
@@ -1105,7 +1105,7 @@ def _check_2_1_4(s3_client: Any) -> CISCheckResult:
     """CIS 2.1.4 — Ensure S3 bucket versioning is enabled."""
     result = CISCheckResult(
         check_id="2.1.4",
-        title="Ensure S3 bucket versioning is enabled",
+        title="S3 bucket versioning enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_STORAGE_SECTION,
@@ -1150,7 +1150,7 @@ def _check_2_2_1(ec2_client: Any) -> CISCheckResult:
     """CIS 2.2.1 — Ensure EBS volume encryption is enabled by default."""
     result = CISCheckResult(
         check_id="2.2.1",
-        title="Ensure EBS volume encryption is enabled by default",
+        title="EBS default volume encryption enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_STORAGE_SECTION,
@@ -1175,7 +1175,7 @@ def _check_2_3_1(rds_client: Any) -> CISCheckResult:
     """CIS 2.3.1 — Ensure RDS instances have encryption at rest enabled."""
     result = CISCheckResult(
         check_id="2.3.1",
-        title="Ensure RDS instances have encryption at rest enabled",
+        title="RDS encryption at rest enabled",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_STORAGE_SECTION,
@@ -1204,7 +1204,7 @@ def _check_2_3_2(rds_client: Any) -> CISCheckResult:
     """CIS 2.3.2 — Ensure auto minor version upgrade is enabled for RDS instances."""
     result = CISCheckResult(
         check_id="2.3.2",
-        title="Ensure auto minor version upgrade is enabled for RDS instances",
+        title="RDS auto minor version upgrade enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_STORAGE_SECTION,
@@ -1233,7 +1233,7 @@ def _check_2_4_1(kms_client: Any) -> CISCheckResult:
     """CIS 2.4.1 — Ensure rotation is enabled for customer-managed KMS keys."""
     result = CISCheckResult(
         check_id="2.4.1",
-        title="Ensure rotation is enabled for customer-managed KMS keys",
+        title="Customer-managed KMS key rotation enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_STORAGE_SECTION,
@@ -1297,7 +1297,7 @@ def _check_3_1(cloudtrail_client: Any) -> CISCheckResult:
     """CIS 3.1 — Ensure CloudTrail is enabled in all regions."""
     result = CISCheckResult(
         check_id="3.1",
-        title="Ensure CloudTrail is enabled in all regions",
+        title="CloudTrail enabled in all regions",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_LOGGING_SECTION,
@@ -1334,7 +1334,7 @@ def _check_3_2(cloudtrail_client: Any) -> CISCheckResult:
     """CIS 3.2 — Ensure CloudTrail log file validation is enabled."""
     result = CISCheckResult(
         check_id="3.2",
-        title="Ensure CloudTrail log file validation is enabled",
+        title="CloudTrail log file validation enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_LOGGING_SECTION,
@@ -1360,7 +1360,7 @@ def _check_3_4(cloudtrail_client: Any) -> CISCheckResult:
     """CIS 3.4 — Ensure CloudTrail trails are integrated with CloudWatch Logs."""
     result = CISCheckResult(
         check_id="3.4",
-        title="Ensure CloudTrail trails are integrated with CloudWatch Logs",
+        title="CloudTrail integrated with CloudWatch Logs",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_LOGGING_SECTION,
@@ -1388,7 +1388,7 @@ def _check_3_5(cloudtrail_client: Any) -> CISCheckResult:
     # Full Config check requires config:DescribeConfigurationRecorders.
     result = CISCheckResult(
         check_id="3.5",
-        title="Ensure CloudTrail records management events in all regions",
+        title="CloudTrail records management events in all regions",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_LOGGING_SECTION,
@@ -1433,7 +1433,7 @@ def _check_3_6(s3_client: Any, cloudtrail_client: Any) -> CISCheckResult:
     """CIS 3.6 — Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket."""
     result = CISCheckResult(
         check_id="3.6",
-        title="Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket",
+        title="Access logging enabled on CloudTrail S3 bucket",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_LOGGING_SECTION,
@@ -1481,7 +1481,7 @@ def _check_3_3(s3_client: Any, cloudtrail_client: Any) -> CISCheckResult:
     """CIS 3.3 — Ensure CloudTrail S3 bucket is not publicly accessible."""
     result = CISCheckResult(
         check_id="3.3",
-        title="Ensure CloudTrail S3 bucket is not publicly accessible",
+        title="CloudTrail S3 bucket not publicly accessible",
         status=CheckStatus.PASS,
         severity="critical",
         cis_section=_LOGGING_SECTION,
@@ -1544,7 +1544,7 @@ def _check_3_7(cloudtrail_client: Any) -> CISCheckResult:
     """CIS 3.7 — Ensure CloudTrail logs are encrypted with KMS CMK."""
     result = CISCheckResult(
         check_id="3.7",
-        title="Ensure CloudTrail logs are encrypted with KMS CMK",
+        title="CloudTrail logs encrypted with KMS CMK",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_LOGGING_SECTION,
@@ -1572,7 +1572,7 @@ def _check_3_9(ec2_client: Any) -> CISCheckResult:
     """CIS 3.9 — Ensure VPC flow logging is enabled in all VPCs."""
     result = CISCheckResult(
         check_id="3.9",
-        title="Ensure VPC flow logging is enabled in all VPCs",
+        title="VPC flow logging enabled in all VPCs",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_LOGGING_SECTION,
@@ -1607,7 +1607,7 @@ def _check_3_10(cloudtrail_client: Any) -> CISCheckResult:
     """CIS 3.10 — Ensure Object-level logging for write events is enabled for S3 buckets."""
     result = CISCheckResult(
         check_id="3.10",
-        title="Ensure Object-level logging for write events is enabled for S3 buckets",
+        title="S3 object-level write-event logging enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_LOGGING_SECTION,
@@ -1667,7 +1667,7 @@ def _check_3_11(cloudtrail_client: Any) -> CISCheckResult:
     """CIS 3.11 — Ensure Object-level logging for read events is enabled for S3 buckets."""
     result = CISCheckResult(
         check_id="3.11",
-        title="Ensure Object-level logging for read events is enabled for S3 buckets",
+        title="S3 object-level read-event logging enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_LOGGING_SECTION,
@@ -1732,7 +1732,7 @@ def _check_4_3(logs_client: Any) -> CISCheckResult:
     """CIS 4.3 — Ensure a metric filter and alarm exist for root account usage."""
     result = CISCheckResult(
         check_id="4.3",
-        title="Ensure a metric filter and alarm exist for root account usage",
+        title="Metric filter and alarm for root account usage",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_MONITORING_SECTION,
@@ -1774,7 +1774,7 @@ def _check_4_4(logs_client: Any) -> CISCheckResult:
     """CIS 4.4 — Ensure a metric filter and alarm exist for IAM policy changes."""
     result = CISCheckResult(
         check_id="4.4",
-        title="Ensure a metric filter and alarm exist for IAM policy changes",
+        title="Metric filter and alarm for IAM policy changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -1828,7 +1828,7 @@ def _check_4_5(logs_client: Any, cloudtrail_client: Any) -> CISCheckResult:
     """CIS 4.5 — Ensure a metric filter and alarm exist for CloudTrail config changes."""
     result = CISCheckResult(
         check_id="4.5",
-        title="Ensure a metric filter and alarm exist for CloudTrail config changes",
+        title="Metric filter and alarm for CloudTrail config changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -1881,7 +1881,7 @@ def _check_4_1(logs_client: Any) -> CISCheckResult:
     """CIS 4.1 — Ensure a metric filter and alarm exist for unauthorized API calls."""
     result = CISCheckResult(
         check_id="4.1",
-        title="Ensure a metric filter and alarm exist for unauthorized API calls",
+        title="Metric filter and alarm for unauthorized API calls",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -1915,7 +1915,7 @@ def _check_4_2(logs_client: Any) -> CISCheckResult:
     """CIS 4.2 — Ensure a metric filter and alarm exist for console sign-in without MFA."""
     result = CISCheckResult(
         check_id="4.2",
-        title="Ensure a metric filter and alarm exist for console sign-in without MFA",
+        title="Metric filter and alarm for console sign-in without MFA",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -1949,7 +1949,7 @@ def _check_4_6(logs_client: Any) -> CISCheckResult:
     """CIS 4.6 — Ensure a metric filter and alarm exist for console authentication failures."""
     result = CISCheckResult(
         check_id="4.6",
-        title="Ensure a metric filter and alarm exist for console authentication failures",
+        title="Metric filter and alarm for console auth failures",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -1983,7 +1983,7 @@ def _check_4_7(logs_client: Any) -> CISCheckResult:
     """CIS 4.7 — Ensure a metric filter and alarm exist for disabling or scheduled deletion of CMKs."""
     result = CISCheckResult(
         check_id="4.7",
-        title="Ensure a metric filter and alarm exist for disabling or scheduled deletion of CMKs",
+        title="Metric filter and alarm for CMK disable or deletion",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2018,7 +2018,7 @@ def _check_4_8(logs_client: Any) -> CISCheckResult:
     """CIS 4.8 — Ensure a metric filter and alarm exist for S3 bucket policy changes."""
     result = CISCheckResult(
         check_id="4.8",
-        title="Ensure a metric filter and alarm exist for S3 bucket policy changes",
+        title="Metric filter and alarm for S3 bucket policy changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2063,7 +2063,7 @@ def _check_4_9(logs_client: Any) -> CISCheckResult:
     """CIS 4.9 — Ensure a metric filter and alarm exist for AWS Config configuration changes."""
     result = CISCheckResult(
         check_id="4.9",
-        title="Ensure a metric filter and alarm exist for AWS Config configuration changes",
+        title="Metric filter and alarm for AWS Config changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2103,7 +2103,7 @@ def _check_4_10(logs_client: Any) -> CISCheckResult:
     """CIS 4.10 — Ensure a metric filter and alarm exist for security group changes."""
     result = CISCheckResult(
         check_id="4.10",
-        title="Ensure a metric filter and alarm exist for security group changes",
+        title="Metric filter and alarm for security group changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2145,7 +2145,7 @@ def _check_4_11(logs_client: Any) -> CISCheckResult:
     """CIS 4.11 — Ensure a metric filter and alarm exist for changes to Network Access Control Lists."""
     result = CISCheckResult(
         check_id="4.11",
-        title="Ensure a metric filter and alarm exist for changes to NACLs",
+        title="Metric filter and alarm for NACL changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2187,7 +2187,7 @@ def _check_4_12(logs_client: Any) -> CISCheckResult:
     """CIS 4.12 — Ensure a metric filter and alarm exist for changes to network gateways."""
     result = CISCheckResult(
         check_id="4.12",
-        title="Ensure a metric filter and alarm exist for changes to network gateways",
+        title="Metric filter and alarm for network gateway changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2229,7 +2229,7 @@ def _check_4_13(logs_client: Any) -> CISCheckResult:
     """CIS 4.13 — Ensure a metric filter and alarm exist for route table changes."""
     result = CISCheckResult(
         check_id="4.13",
-        title="Ensure a metric filter and alarm exist for route table changes",
+        title="Metric filter and alarm for route table changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2272,7 +2272,7 @@ def _check_4_14(logs_client: Any) -> CISCheckResult:
     """CIS 4.14 — Ensure a metric filter and alarm exist for VPC changes."""
     result = CISCheckResult(
         check_id="4.14",
-        title="Ensure a metric filter and alarm exist for VPC changes",
+        title="Metric filter and alarm for VPC changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2319,7 +2319,7 @@ def _check_4_15(logs_client: Any) -> CISCheckResult:
     """CIS 4.15 — Ensure a metric filter and alarm exist for AWS Organizations changes."""
     result = CISCheckResult(
         check_id="4.15",
-        title="Ensure a metric filter and alarm exist for AWS Organizations changes",
+        title="Metric filter and alarm for AWS Organizations changes",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2362,7 +2362,7 @@ def _check_4_16(securityhub_client: Any) -> CISCheckResult:
     """CIS 4.16 — Ensure AWS Security Hub is enabled."""
     result = CISCheckResult(
         check_id="4.16",
-        title="Ensure AWS Security Hub is enabled",
+        title="AWS Security Hub enabled",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -2400,7 +2400,7 @@ def _check_5_2(ec2_client: Any) -> CISCheckResult:
     """CIS 5.2 — Ensure no security groups allow ingress from 0.0.0.0/0 to remote admin ports."""
     result = CISCheckResult(
         check_id="5.2",
-        title="Ensure no security groups allow unrestricted ingress to admin ports (22, 3389)",
+        title="No unrestricted ingress to admin ports (22, 3389)",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_NETWORKING_SECTION,
@@ -2467,7 +2467,7 @@ def _check_5_3(ec2_client: Any) -> CISCheckResult:
     """CIS 5.3 — Ensure the default security group of every VPC restricts all traffic."""
     result = CISCheckResult(
         check_id="5.3",
-        title="Ensure the default security group of every VPC restricts all traffic",
+        title="Default security group restricts all traffic",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_NETWORKING_SECTION,
@@ -2499,7 +2499,7 @@ def _check_5_5(ec2_client: Any) -> CISCheckResult:
     """CIS 5.5 — Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to all ports."""
     result = CISCheckResult(
         check_id="5.5",
-        title="Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to all ports",
+        title="No security group allows all-ports ingress from any IP",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_NETWORKING_SECTION,
@@ -2546,7 +2546,7 @@ def _check_5_6(ec2_client: Any) -> CISCheckResult:
     """CIS 5.6 — Ensure VPC flow logging is enabled in all VPCs."""
     result = CISCheckResult(
         check_id="5.6",
-        title="Ensure VPC flow logging is enabled in all VPCs",
+        title="VPC flow logging enabled in all VPCs",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_NETWORKING_SECTION,
@@ -2581,7 +2581,7 @@ def _check_5_1(ec2_client: Any) -> CISCheckResult:
     """CIS 5.1 — Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote admin ports."""
     result = CISCheckResult(
         check_id="5.1",
-        title="Ensure no Network ACLs allow unrestricted ingress to admin ports",
+        title="No NACL allows unrestricted ingress to admin ports",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_NETWORKING_SECTION,
@@ -2636,7 +2636,7 @@ def _check_5_4(ec2_client: Any) -> CISCheckResult:
     """CIS 5.4 — Ensure routing tables for VPC peering are least-privilege."""
     result = CISCheckResult(
         check_id="5.4",
-        title="Ensure routing tables for VPC peering are least-privilege",
+        title="VPC peering route tables least-privilege",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_NETWORKING_SECTION,

--- a/src/agent_bom/cloud/aws_cis_benchmark.py
+++ b/src/agent_bom/cloud/aws_cis_benchmark.py
@@ -250,7 +250,7 @@ _IAM_SECTION = "1 - Identity and Access Management"
 
 
 def _check_1_1(account_client: Any) -> CISCheckResult:
-    """CIS 1.1 — Maintain current contact details."""
+    """CIS 1.1 — Account contact details kept current."""
     result = CISCheckResult(
         check_id="1.1",
         title="Account contact details kept current",
@@ -275,7 +275,7 @@ def _check_1_1(account_client: Any) -> CISCheckResult:
 
 
 def _check_1_2(account_client: Any) -> CISCheckResult:
-    """CIS 1.2 — Ensure security contact information is registered."""
+    """CIS 1.2 — Security contact information registered."""
     result = CISCheckResult(
         check_id="1.2",
         title="Security contact information registered",
@@ -304,7 +304,7 @@ def _check_1_2(account_client: Any) -> CISCheckResult:
 
 
 def _check_1_3() -> CISCheckResult:
-    """CIS 1.3 — Ensure security questions are not the only way to authenticate to root."""
+    """CIS 1.3 — Root not reliant on security questions alone."""
     return CISCheckResult(
         check_id="1.3",
         title="Root not reliant on security questions alone",
@@ -317,7 +317,7 @@ def _check_1_3() -> CISCheckResult:
 
 
 def _check_1_4(iam_client: Any) -> CISCheckResult:
-    """CIS 1.4 — Ensure no 'root' user account access key exists."""
+    """CIS 1.4 — No root account access keys."""
     result = CISCheckResult(
         check_id="1.4",
         title="No root account access keys",
@@ -338,7 +338,7 @@ def _check_1_4(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_5(iam_client: Any) -> CISCheckResult:
-    """CIS 1.5 — Ensure MFA is enabled for the root user account."""
+    """CIS 1.5 — Root account MFA enabled."""
     result = CISCheckResult(
         check_id="1.5",
         title="Root account MFA enabled",
@@ -359,7 +359,7 @@ def _check_1_5(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_6(iam_client: Any) -> CISCheckResult:
-    """CIS 1.6 — Ensure hardware MFA is enabled for the root user account."""
+    """CIS 1.6 — Hardware MFA for root account."""
     result = CISCheckResult(
         check_id="1.6",
         title="Hardware MFA for root account",
@@ -387,7 +387,7 @@ def _check_1_6(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_7(iam_client: Any) -> CISCheckResult:
-    """CIS 1.7 — Eliminate use of the root user for administrative and daily tasks."""
+    """CIS 1.7 — Root user not used for daily tasks."""
     result = CISCheckResult(
         check_id="1.7",
         title="Root user not used for daily tasks",
@@ -442,7 +442,7 @@ def _check_1_7(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_8(iam_client: Any) -> CISCheckResult:
-    """CIS 1.8 — Ensure IAM password policy requires minimum length >= 14."""
+    """CIS 1.8 — IAM password policy minimum length >= 14."""
     result = CISCheckResult(
         check_id="1.8",
         title="IAM password policy minimum length >= 14",
@@ -470,7 +470,7 @@ def _check_1_8(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_10(iam_client: Any) -> CISCheckResult:
-    """CIS 1.10 — Ensure MFA is enabled for all IAM users with console access."""
+    """CIS 1.10 — MFA on all console-access IAM users."""
     result = CISCheckResult(
         check_id="1.10",
         title="MFA on all console-access IAM users",
@@ -507,7 +507,7 @@ def _check_1_10(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_11(iam_client: Any) -> CISCheckResult:
-    """CIS 1.11 — Do not setup access keys during initial user setup."""
+    """CIS 1.11 — No access keys created at user setup."""
     result = CISCheckResult(
         check_id="1.11",
         title="No access keys created at user setup",
@@ -577,7 +577,7 @@ def _check_1_11(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_12(iam_client: Any) -> CISCheckResult:
-    """CIS 1.12 — Ensure credentials unused for 45 days or greater are disabled."""
+    """CIS 1.12 — Credentials unused 45+ days disabled."""
     result = CISCheckResult(
         check_id="1.12",
         title="Credentials unused 45+ days disabled",
@@ -649,7 +649,7 @@ def _check_1_12(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_13(iam_client: Any) -> CISCheckResult:
-    """CIS 1.13 — Ensure there is only one active access key available for any single IAM user."""
+    """CIS 1.13 — At most one active access key per IAM user."""
     result = CISCheckResult(
         check_id="1.13",
         title="At most one active access key per IAM user",
@@ -681,7 +681,7 @@ def _check_1_13(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_15(iam_client: Any) -> CISCheckResult:
-    """CIS 1.15 — Ensure IAM users receive permissions only through groups or roles."""
+    """CIS 1.15 — IAM permissions granted via groups or roles only."""
     result = CISCheckResult(
         check_id="1.15",
         title="IAM permissions granted via groups or roles only",
@@ -713,7 +713,7 @@ def _check_1_15(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_9(iam_client: Any) -> CISCheckResult:
-    """CIS 1.9 — Ensure IAM password policy prevents password reuse."""
+    """CIS 1.9 — IAM password policy blocks password reuse."""
     result = CISCheckResult(
         check_id="1.9",
         title="IAM password policy blocks password reuse",
@@ -741,7 +741,7 @@ def _check_1_9(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_14(iam_client: Any) -> CISCheckResult:
-    """CIS 1.14 — Ensure access keys are rotated every 90 days or less."""
+    """CIS 1.14 — Access keys rotated within 90 days."""
     result = CISCheckResult(
         check_id="1.14",
         title="Access keys rotated within 90 days",
@@ -777,7 +777,7 @@ def _check_1_14(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_16(iam_client: Any) -> CISCheckResult:
-    """CIS 1.16 — Ensure IAM policies with full '*:*' admin privileges are not attached."""
+    """CIS 1.16 — No full-admin IAM policies attached."""
     result = CISCheckResult(
         check_id="1.16",
         title="No full-admin IAM policies attached",
@@ -847,7 +847,7 @@ def _check_1_16(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_17(iam_client: Any) -> CISCheckResult:
-    """CIS 1.17 — Ensure a support role has been created to manage incidents with AWS Support."""
+    """CIS 1.17 — Support role exists for AWS Support incidents."""
     result = CISCheckResult(
         check_id="1.17",
         title="Support role exists for AWS Support incidents",
@@ -877,7 +877,7 @@ def _check_1_17(iam_client: Any) -> CISCheckResult:
 
 
 def _check_1_19(ec2_client: Any) -> CISCheckResult:
-    """CIS 1.19 — Ensure that IAM instance roles are used for AWS resource access from instances."""
+    """CIS 1.19 — Instance roles used for resource access."""
     result = CISCheckResult(
         check_id="1.19",
         title="Instance roles used for resource access",
@@ -914,7 +914,7 @@ def _check_1_19(ec2_client: Any) -> CISCheckResult:
 
 
 def _check_1_20(accessanalyzer_client: Any) -> CISCheckResult:
-    """CIS 1.20 — Ensure that IAM Access Analyzer is enabled for all regions."""
+    """CIS 1.20 — IAM Access Analyzer enabled in all regions."""
     result = CISCheckResult(
         check_id="1.20",
         title="IAM Access Analyzer enabled in all regions",
@@ -940,7 +940,7 @@ def _check_1_20(accessanalyzer_client: Any) -> CISCheckResult:
 
 
 def _check_1_22(iam_client: Any) -> CISCheckResult:
-    """CIS 1.22 — Ensure access to AWSCloudShellFullAccess is restricted."""
+    """CIS 1.22 — AWSCloudShellFullAccess access restricted."""
     result = CISCheckResult(
         check_id="1.22",
         title="AWSCloudShellFullAccess access restricted",
@@ -980,7 +980,7 @@ _STORAGE_SECTION = "2 - Storage"
 
 
 def _check_2_1_1(s3control_client: Any, account_id: str) -> CISCheckResult:
-    """CIS 2.1.1 — Ensure S3 account-level public access block is configured."""
+    """CIS 2.1.1 — S3 account-level public access block configured."""
     result = CISCheckResult(
         check_id="2.1.1",
         title="S3 account-level public access block configured",
@@ -1009,7 +1009,7 @@ def _check_2_1_1(s3control_client: Any, account_id: str) -> CISCheckResult:
 
 
 def _check_2_1_2(s3_client: Any) -> CISCheckResult:
-    """CIS 2.1.2 — Ensure S3 buckets have server-side encryption enabled."""
+    """CIS 2.1.2 — S3 bucket server-side encryption enabled."""
     result = CISCheckResult(
         check_id="2.1.2",
         title="S3 bucket server-side encryption enabled",
@@ -1058,7 +1058,7 @@ def _check_2_1_2(s3_client: Any) -> CISCheckResult:
 
 
 def _check_2_1_3(s3_client: Any) -> CISCheckResult:
-    """CIS 2.1.3 — Ensure MFA Delete is enabled on S3 buckets."""
+    """CIS 2.1.3 — S3 bucket MFA Delete enabled."""
     result = CISCheckResult(
         check_id="2.1.3",
         title="S3 bucket MFA Delete enabled",
@@ -1102,7 +1102,7 @@ def _check_2_1_3(s3_client: Any) -> CISCheckResult:
 
 
 def _check_2_1_4(s3_client: Any) -> CISCheckResult:
-    """CIS 2.1.4 — Ensure S3 bucket versioning is enabled."""
+    """CIS 2.1.4 — S3 bucket versioning enabled."""
     result = CISCheckResult(
         check_id="2.1.4",
         title="S3 bucket versioning enabled",
@@ -1147,7 +1147,7 @@ def _check_2_1_4(s3_client: Any) -> CISCheckResult:
 
 
 def _check_2_2_1(ec2_client: Any) -> CISCheckResult:
-    """CIS 2.2.1 — Ensure EBS volume encryption is enabled by default."""
+    """CIS 2.2.1 — EBS default volume encryption enabled."""
     result = CISCheckResult(
         check_id="2.2.1",
         title="EBS default volume encryption enabled",
@@ -1172,7 +1172,7 @@ def _check_2_2_1(ec2_client: Any) -> CISCheckResult:
 
 
 def _check_2_3_1(rds_client: Any) -> CISCheckResult:
-    """CIS 2.3.1 — Ensure RDS instances have encryption at rest enabled."""
+    """CIS 2.3.1 — RDS encryption at rest enabled."""
     result = CISCheckResult(
         check_id="2.3.1",
         title="RDS encryption at rest enabled",
@@ -1201,7 +1201,7 @@ def _check_2_3_1(rds_client: Any) -> CISCheckResult:
 
 
 def _check_2_3_2(rds_client: Any) -> CISCheckResult:
-    """CIS 2.3.2 — Ensure auto minor version upgrade is enabled for RDS instances."""
+    """CIS 2.3.2 — RDS auto minor version upgrade enabled."""
     result = CISCheckResult(
         check_id="2.3.2",
         title="RDS auto minor version upgrade enabled",
@@ -1230,7 +1230,7 @@ def _check_2_3_2(rds_client: Any) -> CISCheckResult:
 
 
 def _check_2_4_1(kms_client: Any) -> CISCheckResult:
-    """CIS 2.4.1 — Ensure rotation is enabled for customer-managed KMS keys."""
+    """CIS 2.4.1 — Customer-managed KMS key rotation enabled."""
     result = CISCheckResult(
         check_id="2.4.1",
         title="Customer-managed KMS key rotation enabled",
@@ -1294,7 +1294,7 @@ _LOGGING_SECTION = "3 - Logging"
 
 
 def _check_3_1(cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.1 — Ensure CloudTrail is enabled in all regions."""
+    """CIS 3.1 — CloudTrail enabled in all regions."""
     result = CISCheckResult(
         check_id="3.1",
         title="CloudTrail enabled in all regions",
@@ -1331,7 +1331,7 @@ def _check_3_1(cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_3_2(cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.2 — Ensure CloudTrail log file validation is enabled."""
+    """CIS 3.2 — CloudTrail log file validation enabled."""
     result = CISCheckResult(
         check_id="3.2",
         title="CloudTrail log file validation enabled",
@@ -1357,7 +1357,7 @@ def _check_3_2(cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_3_4(cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.4 — Ensure CloudTrail trails are integrated with CloudWatch Logs."""
+    """CIS 3.4 — CloudTrail integrated with CloudWatch Logs."""
     result = CISCheckResult(
         check_id="3.4",
         title="CloudTrail integrated with CloudWatch Logs",
@@ -1383,7 +1383,7 @@ def _check_3_4(cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_3_5(cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.5 — Ensure AWS Config is enabled in all regions."""
+    """CIS 3.5 — CloudTrail records management events in all regions."""
     # Note: We check via CloudTrail for management event recording as a proxy.
     # Full Config check requires config:DescribeConfigurationRecorders.
     result = CISCheckResult(
@@ -1430,7 +1430,7 @@ def _check_3_5(cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_3_6(s3_client: Any, cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.6 — Ensure S3 bucket access logging is enabled on the CloudTrail S3 bucket."""
+    """CIS 3.6 — Access logging enabled on CloudTrail S3 bucket."""
     result = CISCheckResult(
         check_id="3.6",
         title="Access logging enabled on CloudTrail S3 bucket",
@@ -1478,7 +1478,7 @@ def _check_3_6(s3_client: Any, cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_3_3(s3_client: Any, cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.3 — Ensure CloudTrail S3 bucket is not publicly accessible."""
+    """CIS 3.3 — CloudTrail S3 bucket not publicly accessible."""
     result = CISCheckResult(
         check_id="3.3",
         title="CloudTrail S3 bucket not publicly accessible",
@@ -1541,7 +1541,7 @@ def _check_3_3(s3_client: Any, cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_3_7(cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.7 — Ensure CloudTrail logs are encrypted with KMS CMK."""
+    """CIS 3.7 — CloudTrail logs encrypted with KMS CMK."""
     result = CISCheckResult(
         check_id="3.7",
         title="CloudTrail logs encrypted with KMS CMK",
@@ -1569,7 +1569,7 @@ def _check_3_7(cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_3_9(ec2_client: Any) -> CISCheckResult:
-    """CIS 3.9 — Ensure VPC flow logging is enabled in all VPCs."""
+    """CIS 3.9 — VPC flow logging enabled in all VPCs."""
     result = CISCheckResult(
         check_id="3.9",
         title="VPC flow logging enabled in all VPCs",
@@ -1604,7 +1604,7 @@ def _check_3_9(ec2_client: Any) -> CISCheckResult:
 
 
 def _check_3_10(cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.10 — Ensure Object-level logging for write events is enabled for S3 buckets."""
+    """CIS 3.10 — S3 object-level write-event logging enabled."""
     result = CISCheckResult(
         check_id="3.10",
         title="S3 object-level write-event logging enabled",
@@ -1664,7 +1664,7 @@ def _check_3_10(cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_3_11(cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 3.11 — Ensure Object-level logging for read events is enabled for S3 buckets."""
+    """CIS 3.11 — S3 object-level read-event logging enabled."""
     result = CISCheckResult(
         check_id="3.11",
         title="S3 object-level read-event logging enabled",
@@ -1729,7 +1729,7 @@ _MONITORING_SECTION = "4 - Monitoring"
 
 
 def _check_4_3(logs_client: Any) -> CISCheckResult:
-    """CIS 4.3 — Ensure a metric filter and alarm exist for root account usage."""
+    """CIS 4.3 — Metric filter and alarm for root account usage."""
     result = CISCheckResult(
         check_id="4.3",
         title="Metric filter and alarm for root account usage",
@@ -1771,7 +1771,7 @@ def _check_4_3(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_4(logs_client: Any) -> CISCheckResult:
-    """CIS 4.4 — Ensure a metric filter and alarm exist for IAM policy changes."""
+    """CIS 4.4 — Metric filter and alarm for IAM policy changes."""
     result = CISCheckResult(
         check_id="4.4",
         title="Metric filter and alarm for IAM policy changes",
@@ -1825,7 +1825,7 @@ def _check_4_4(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_5(logs_client: Any, cloudtrail_client: Any) -> CISCheckResult:
-    """CIS 4.5 — Ensure a metric filter and alarm exist for CloudTrail config changes."""
+    """CIS 4.5 — Metric filter and alarm for CloudTrail config changes."""
     result = CISCheckResult(
         check_id="4.5",
         title="Metric filter and alarm for CloudTrail config changes",
@@ -1878,7 +1878,7 @@ def _check_4_5(logs_client: Any, cloudtrail_client: Any) -> CISCheckResult:
 
 
 def _check_4_1(logs_client: Any) -> CISCheckResult:
-    """CIS 4.1 — Ensure a metric filter and alarm exist for unauthorized API calls."""
+    """CIS 4.1 — Metric filter and alarm for unauthorized API calls."""
     result = CISCheckResult(
         check_id="4.1",
         title="Metric filter and alarm for unauthorized API calls",
@@ -1912,7 +1912,7 @@ def _check_4_1(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_2(logs_client: Any) -> CISCheckResult:
-    """CIS 4.2 — Ensure a metric filter and alarm exist for console sign-in without MFA."""
+    """CIS 4.2 — Metric filter and alarm for console sign-in without MFA."""
     result = CISCheckResult(
         check_id="4.2",
         title="Metric filter and alarm for console sign-in without MFA",
@@ -1946,7 +1946,7 @@ def _check_4_2(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_6(logs_client: Any) -> CISCheckResult:
-    """CIS 4.6 — Ensure a metric filter and alarm exist for console authentication failures."""
+    """CIS 4.6 — Metric filter and alarm for console auth failures."""
     result = CISCheckResult(
         check_id="4.6",
         title="Metric filter and alarm for console auth failures",
@@ -1980,7 +1980,7 @@ def _check_4_6(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_7(logs_client: Any) -> CISCheckResult:
-    """CIS 4.7 — Ensure a metric filter and alarm exist for disabling or scheduled deletion of CMKs."""
+    """CIS 4.7 — Metric filter and alarm for CMK disable or deletion."""
     result = CISCheckResult(
         check_id="4.7",
         title="Metric filter and alarm for CMK disable or deletion",
@@ -2015,7 +2015,7 @@ def _check_4_7(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_8(logs_client: Any) -> CISCheckResult:
-    """CIS 4.8 — Ensure a metric filter and alarm exist for S3 bucket policy changes."""
+    """CIS 4.8 — Metric filter and alarm for S3 bucket policy changes."""
     result = CISCheckResult(
         check_id="4.8",
         title="Metric filter and alarm for S3 bucket policy changes",
@@ -2060,7 +2060,7 @@ def _check_4_8(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_9(logs_client: Any) -> CISCheckResult:
-    """CIS 4.9 — Ensure a metric filter and alarm exist for AWS Config configuration changes."""
+    """CIS 4.9 — Metric filter and alarm for AWS Config changes."""
     result = CISCheckResult(
         check_id="4.9",
         title="Metric filter and alarm for AWS Config changes",
@@ -2100,7 +2100,7 @@ def _check_4_9(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_10(logs_client: Any) -> CISCheckResult:
-    """CIS 4.10 — Ensure a metric filter and alarm exist for security group changes."""
+    """CIS 4.10 — Metric filter and alarm for security group changes."""
     result = CISCheckResult(
         check_id="4.10",
         title="Metric filter and alarm for security group changes",
@@ -2142,7 +2142,7 @@ def _check_4_10(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_11(logs_client: Any) -> CISCheckResult:
-    """CIS 4.11 — Ensure a metric filter and alarm exist for changes to Network Access Control Lists."""
+    """CIS 4.11 — Metric filter and alarm for NACL changes."""
     result = CISCheckResult(
         check_id="4.11",
         title="Metric filter and alarm for NACL changes",
@@ -2184,7 +2184,7 @@ def _check_4_11(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_12(logs_client: Any) -> CISCheckResult:
-    """CIS 4.12 — Ensure a metric filter and alarm exist for changes to network gateways."""
+    """CIS 4.12 — Metric filter and alarm for network gateway changes."""
     result = CISCheckResult(
         check_id="4.12",
         title="Metric filter and alarm for network gateway changes",
@@ -2226,7 +2226,7 @@ def _check_4_12(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_13(logs_client: Any) -> CISCheckResult:
-    """CIS 4.13 — Ensure a metric filter and alarm exist for route table changes."""
+    """CIS 4.13 — Metric filter and alarm for route table changes."""
     result = CISCheckResult(
         check_id="4.13",
         title="Metric filter and alarm for route table changes",
@@ -2269,7 +2269,7 @@ def _check_4_13(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_14(logs_client: Any) -> CISCheckResult:
-    """CIS 4.14 — Ensure a metric filter and alarm exist for VPC changes."""
+    """CIS 4.14 — Metric filter and alarm for VPC changes."""
     result = CISCheckResult(
         check_id="4.14",
         title="Metric filter and alarm for VPC changes",
@@ -2316,7 +2316,7 @@ def _check_4_14(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_15(logs_client: Any) -> CISCheckResult:
-    """CIS 4.15 — Ensure a metric filter and alarm exist for AWS Organizations changes."""
+    """CIS 4.15 — Metric filter and alarm for AWS Organizations changes."""
     result = CISCheckResult(
         check_id="4.15",
         title="Metric filter and alarm for AWS Organizations changes",
@@ -2359,7 +2359,7 @@ def _check_4_15(logs_client: Any) -> CISCheckResult:
 
 
 def _check_4_16(securityhub_client: Any) -> CISCheckResult:
-    """CIS 4.16 — Ensure AWS Security Hub is enabled."""
+    """CIS 4.16 — AWS Security Hub enabled."""
     result = CISCheckResult(
         check_id="4.16",
         title="AWS Security Hub enabled",
@@ -2397,7 +2397,7 @@ _NETWORKING_SECTION = "5 - Networking"
 
 
 def _check_5_2(ec2_client: Any) -> CISCheckResult:
-    """CIS 5.2 — Ensure no security groups allow ingress from 0.0.0.0/0 to remote admin ports."""
+    """CIS 5.2 — No unrestricted ingress to admin ports (22, 3389)."""
     result = CISCheckResult(
         check_id="5.2",
         title="No unrestricted ingress to admin ports (22, 3389)",
@@ -2464,7 +2464,7 @@ def _check_5_2(ec2_client: Any) -> CISCheckResult:
 
 
 def _check_5_3(ec2_client: Any) -> CISCheckResult:
-    """CIS 5.3 — Ensure the default security group of every VPC restricts all traffic."""
+    """CIS 5.3 — Default security group restricts all traffic."""
     result = CISCheckResult(
         check_id="5.3",
         title="Default security group restricts all traffic",
@@ -2496,7 +2496,7 @@ def _check_5_3(ec2_client: Any) -> CISCheckResult:
 
 
 def _check_5_5(ec2_client: Any) -> CISCheckResult:
-    """CIS 5.5 — Ensure no security groups allow ingress from 0.0.0.0/0 or ::/0 to all ports."""
+    """CIS 5.5 — No security group allows all-ports ingress from any IP."""
     result = CISCheckResult(
         check_id="5.5",
         title="No security group allows all-ports ingress from any IP",
@@ -2543,7 +2543,7 @@ def _check_5_5(ec2_client: Any) -> CISCheckResult:
 
 
 def _check_5_6(ec2_client: Any) -> CISCheckResult:
-    """CIS 5.6 — Ensure VPC flow logging is enabled in all VPCs."""
+    """CIS 5.6 — VPC flow logging enabled in all VPCs."""
     result = CISCheckResult(
         check_id="5.6",
         title="VPC flow logging enabled in all VPCs",
@@ -2578,7 +2578,7 @@ def _check_5_6(ec2_client: Any) -> CISCheckResult:
 
 
 def _check_5_1(ec2_client: Any) -> CISCheckResult:
-    """CIS 5.1 — Ensure no Network ACLs allow ingress from 0.0.0.0/0 to remote admin ports."""
+    """CIS 5.1 — No NACL allows unrestricted ingress to admin ports."""
     result = CISCheckResult(
         check_id="5.1",
         title="No NACL allows unrestricted ingress to admin ports",
@@ -2633,7 +2633,7 @@ def _check_5_1(ec2_client: Any) -> CISCheckResult:
 
 
 def _check_5_4(ec2_client: Any) -> CISCheckResult:
-    """CIS 5.4 — Ensure routing tables for VPC peering are least-privilege."""
+    """CIS 5.4 — VPC peering route tables least-privilege."""
     result = CISCheckResult(
         check_id="5.4",
         title="VPC peering route tables least-privilege",

--- a/src/agent_bom/cloud/azure_cis_benchmark.py
+++ b/src/agent_bom/cloud/azure_cis_benchmark.py
@@ -250,7 +250,7 @@ def _check_1_1(auth_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 1.1 — Ensure no subscription Owner assignments to guest/external users."""
     result = CISCheckResult(
         check_id="1.1",
-        title="Ensure no subscription Owner role assigned to guest or external users",
+        title="No subscription Owner role for guest/external users",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation=(
@@ -296,7 +296,7 @@ def _check_1_2(auth_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 1.2 — Ensure no subscription-level Contributor assignments to guest users."""
     result = CISCheckResult(
         check_id="1.2",
-        title="Ensure no subscription-level Contributor role assigned to guest users",
+        title="No subscription Contributor role for guest users",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Review all Contributor role assignments and remove guest/external users. Use resource group scope instead.",
@@ -351,7 +351,7 @@ def _check_1_3(graph: Any) -> CISCheckResult:
     """CIS Azure 1.3 — recurring review of guest accounts (Microsoft Graph access reviews)."""
     result = CISCheckResult(
         check_id="1.3",
-        title="Ensure that guest users are reviewed on a regular basis",
+        title="Guest users reviewed regularly",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation=(
@@ -382,7 +382,7 @@ def _check_1_4(graph: Any) -> CISCheckResult:
     """CIS Azure 1.4 — an access review is configured for guest users (Microsoft Graph)."""
     result = CISCheckResult(
         check_id="1.4",
-        title="Ensure Access Review is configured for Guest users",
+        title="Access Review configured for guest users",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Create a Microsoft Entra access review that recertifies guest user access on a recurring schedule.",
@@ -410,7 +410,7 @@ def _check_1_5(auth_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 1.5 — Ensure no custom subscription Administrator roles exist."""
     result = CISCheckResult(
         check_id="1.5",
-        title="Ensure that no custom subscription Administrator roles are created",
+        title="No custom subscription Administrator roles",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove custom roles that replicate subscription-level Owner/Contributor permissions. Use built-in roles.",
@@ -443,7 +443,7 @@ def _check_1_6(graph: Any) -> CISCheckResult:
     """CIS Azure 1.6 — MFA enforced for all users via Conditional Access (Microsoft Graph)."""
     result = CISCheckResult(
         check_id="1.6",
-        title="Ensure that multi-factor authentication is enabled for all users",
+        title="MFA enabled for all users",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation="Enable an enabled Conditional Access policy that requires MFA for all users (or enable Security Defaults).",
@@ -468,7 +468,7 @@ def _check_1_7(auth_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 1.7 — Ensure no subscription-level Custom Roles with Owner permissions."""
     result = CISCheckResult(
         check_id="1.7",
-        title="Ensure that no custom subscription-level Owner roles exist",
+        title="No custom subscription-level Owner roles",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove custom roles that replicate Owner permissions at subscription scope.",
@@ -505,7 +505,7 @@ def _check_1_8(graph: Any) -> CISCheckResult:
     """CIS Azure 1.8 — MFA required for the Azure management app via Conditional Access (Microsoft Graph)."""
     result = CISCheckResult(
         check_id="1.8",
-        title="Ensure that multi-factor authentication is enabled for Azure Portal access",
+        title="MFA enabled for Azure Portal access",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation=(
@@ -536,7 +536,7 @@ def _check_1_9(graph: Any) -> CISCheckResult:
     """CIS Azure 1.9 — Conditional Access requires MFA for administrative roles (Microsoft Graph)."""
     result = CISCheckResult(
         check_id="1.9",
-        title="Ensure Conditional Access policies require MFA for administrative roles",
+        title="Conditional Access requires MFA for admin roles",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation="Create an enabled Conditional Access policy that targets directory roles and requires MFA.",
@@ -561,7 +561,7 @@ def _check_1_10() -> CISCheckResult:
     """CIS 1.10 — Ensure 'Allow users to remember MFA on trusted devices' is disabled."""
     result = CISCheckResult(
         check_id="1.10",
-        title="Ensure 'Allow users to remember multi-factor authentication on trusted devices' is Disabled",
+        title="Remember-MFA on trusted devices disabled",
         status=CheckStatus.NOT_APPLICABLE,
         severity="medium",
         recommendation="Disable 'Remember MFA on trusted devices' to ensure MFA is prompted on every sign-in.",
@@ -578,7 +578,7 @@ def _check_1_11(graph: Any) -> CISCheckResult:
     """CIS Azure 1.11 — Microsoft Entra security defaults enabled (Microsoft Graph)."""
     result = CISCheckResult(
         check_id="1.11",
-        title="Ensure Security Defaults is enabled on Azure Active Directory",
+        title="Security Defaults enabled on Azure AD",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Entra security defaults, or enforce the equivalent controls through Conditional Access.",
@@ -604,7 +604,7 @@ def _check_1_12(graph: Any) -> CISCheckResult:
     """CIS Azure 1.12 — user consent to applications is disabled (Microsoft Graph authorization policy)."""
     result = CISCheckResult(
         check_id="1.12",
-        title="Ensure that 'User consent for applications' is set to 'Do not allow user consent'",
+        title="User consent for applications disallowed",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove app consent grants from the default user role so only admins can consent to application permissions.",
@@ -635,7 +635,7 @@ def _check_1_13(graph: Any) -> CISCheckResult:
     """CIS Azure 1.13 — non-admin users cannot register applications (Microsoft Graph authorization policy)."""
     result = CISCheckResult(
         check_id="1.13",
-        title="Ensure that 'Users can register applications' is set to 'No'",
+        title="User app registration disabled",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation=(
@@ -664,7 +664,7 @@ def _check_1_14(graph: Any) -> CISCheckResult:
     """CIS Azure 1.14 — guest access is set to the most restrictive role (Microsoft Graph authorization policy)."""
     result = CISCheckResult(
         check_id="1.14",
-        title="Ensure that 'Guest users access restrictions' is set to restrict guest access",
+        title="Guest user access restricted",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the guest user role to 'Restricted Guest User' so guests can only read their own directory objects.",
@@ -691,7 +691,7 @@ def _check_1_15(auth_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 1.15 — Ensure custom subscription Administrator roles are not created."""
     result = CISCheckResult(
         check_id="1.15",
-        title="Ensure that custom subscription Administrator roles are not created",
+        title="Custom subscription Administrator roles absent",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Avoid creating custom roles with subscription-level administrative permissions. Use built-in roles instead.",
@@ -724,7 +724,7 @@ def _check_1_16() -> CISCheckResult:
     """CIS 1.16 — Ensure privileged roles are reviewed on a regular basis."""
     result = CISCheckResult(
         check_id="1.16",
-        title="Ensure that privileged roles are reviewed on a regular basis",
+        title="Privileged roles reviewed regularly",
         status=CheckStatus.NOT_APPLICABLE,
         severity="high",
         recommendation="Use Azure AD Privileged Identity Management (PIM) to configure regular access reviews for privileged roles.",
@@ -741,7 +741,7 @@ def _check_1_17() -> CISCheckResult:
     """CIS 1.17 — Ensure that 'Restrict access to Azure AD admin center' is enabled."""
     result = CISCheckResult(
         check_id="1.17",
-        title="Ensure that 'Restrict access to Azure AD administration portal' is set to Yes",
+        title="Access to Azure AD admin portal restricted",
         status=CheckStatus.NOT_APPLICABLE,
         severity="medium",
         recommendation="Set 'Restrict access to Azure AD administration portal' to Yes in Azure AD > User settings.",
@@ -758,7 +758,7 @@ def _check_1_18(graph: Any) -> CISCheckResult:
     """CIS Azure 1.18 — legacy authentication blocked via Conditional Access (Microsoft Graph)."""
     result = CISCheckResult(
         check_id="1.18",
-        title="Ensure that legacy authentication is blocked via Conditional Access Policy",
+        title="Legacy authentication blocked via Conditional Access",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Create an enabled Conditional Access policy that targets legacy client app types and blocks access.",
@@ -786,7 +786,7 @@ def _check_1_19() -> CISCheckResult:
     """CIS 1.19 — Ensure password hash sync is enabled for resiliency."""
     result = CISCheckResult(
         check_id="1.19",
-        title="Ensure that password hash sync is enabled for resiliency and leaked credential detection",
+        title="Password hash sync enabled",
         status=CheckStatus.NOT_APPLICABLE,
         severity="medium",
         recommendation="Enable password hash synchronization in Azure AD Connect to support leaked credential detection.",
@@ -803,7 +803,7 @@ def _check_1_20() -> CISCheckResult:
     """CIS 1.20 — Ensure self-service password reset is enabled."""
     result = CISCheckResult(
         check_id="1.20",
-        title="Ensure that self-service password reset is enabled",
+        title="Self-service password reset enabled",
         status=CheckStatus.NOT_APPLICABLE,
         severity="medium",
         recommendation="Enable self-service password reset for all users in Azure AD > Password reset.",
@@ -820,7 +820,7 @@ def _check_1_21(graph: Any) -> CISCheckResult:
     """CIS Azure 1.21 — MFA required for risky sign-ins via Conditional Access (Microsoft Graph)."""
     result = CISCheckResult(
         check_id="1.21",
-        title="Ensure that multi-factor authentication is required for risky sign-ins",
+        title="MFA required for risky sign-ins",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Create an enabled Conditional Access policy that requires MFA when the sign-in risk level is medium or high.",
@@ -845,7 +845,7 @@ def _check_1_22(graph: Any) -> CISCheckResult:
     """CIS Azure 1.22 — MFA enforced for administrative role holders via Conditional Access (Microsoft Graph)."""
     result = CISCheckResult(
         check_id="1.22",
-        title="Ensure that multi-factor authentication is enabled for all users in administrative roles",
+        title="MFA enabled for all admin-role users",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation="Enforce MFA for administrative directory roles with an enabled Conditional Access policy that targets those roles.",
@@ -875,7 +875,7 @@ def _check_2_1(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.1 — Ensure Microsoft Defender for Servers is enabled."""
     result = CISCheckResult(
         check_id="2.1",
-        title="Ensure Microsoft Defender for Servers is set to On",
+        title="Microsoft Defender for Servers enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for Servers (Standard tier) in Defender for Cloud > Environment settings.",
@@ -900,7 +900,7 @@ def _check_2_2(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.2 — Ensure Microsoft Defender for App Services is enabled."""
     result = CISCheckResult(
         check_id="2.2",
-        title="Ensure Microsoft Defender for App Services is set to On",
+        title="Microsoft Defender for App Services enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for App Services (Standard tier) in Defender for Cloud > Environment settings.",
@@ -925,7 +925,7 @@ def _check_2_3(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.3 — Ensure Microsoft Defender for SQL Servers is enabled."""
     result = CISCheckResult(
         check_id="2.3",
-        title="Ensure Microsoft Defender for Azure SQL Databases is set to On",
+        title="Microsoft Defender for Azure SQL Databases enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for SQL Servers (Standard tier) in Defender for Cloud > Environment settings.",
@@ -950,7 +950,7 @@ def _check_2_4(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.4 — Ensure Microsoft Defender for Storage is enabled."""
     result = CISCheckResult(
         check_id="2.4",
-        title="Ensure Microsoft Defender for Storage is set to On",
+        title="Microsoft Defender for Storage enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for Storage (Standard tier) in Defender for Cloud > Environment settings.",
@@ -975,7 +975,7 @@ def _check_2_5(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.5 — Ensure Microsoft Defender for Key Vault is enabled."""
     result = CISCheckResult(
         check_id="2.5",
-        title="Ensure Microsoft Defender for Key Vault is set to On",
+        title="Microsoft Defender for Key Vault enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for Key Vault (Standard tier) in Defender for Cloud > Environment settings.",
@@ -1000,7 +1000,7 @@ def _check_2_6(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.6 — Ensure Microsoft Defender for DNS is enabled."""
     result = CISCheckResult(
         check_id="2.6",
-        title="Ensure Microsoft Defender for DNS is set to On",
+        title="Microsoft Defender for DNS enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for DNS (Standard tier) in Defender for Cloud > Environment settings.",
@@ -1026,7 +1026,7 @@ def _check_2_7(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.7 — Ensure Microsoft Defender for Resource Manager is enabled."""
     result = CISCheckResult(
         check_id="2.7",
-        title="Ensure Microsoft Defender for Resource Manager is set to On",
+        title="Microsoft Defender for Resource Manager enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for Resource Manager (Standard tier) in Defender for Cloud > Environment settings.",
@@ -1051,7 +1051,7 @@ def _check_2_8(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.8 — Ensure Microsoft Defender for Open-Source Databases is enabled."""
     result = CISCheckResult(
         check_id="2.8",
-        title="Ensure Microsoft Defender for Open-Source Relational Databases is set to On",
+        title="Microsoft Defender for open-source relational DBs enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for Open-Source Relational Databases (Standard tier) in Defender for Cloud > Environment settings.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1076,7 +1076,7 @@ def _check_2_9(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.9 — Ensure Microsoft Defender for Cosmos DB is enabled."""
     result = CISCheckResult(
         check_id="2.9",
-        title="Ensure Microsoft Defender for Cosmos DB is set to On",
+        title="Microsoft Defender for Cosmos DB enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for Cosmos DB (Standard tier) in Defender for Cloud > Environment settings.",
@@ -1101,7 +1101,7 @@ def _check_2_10(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.10 — Ensure Microsoft Defender for Containers is enabled."""
     result = CISCheckResult(
         check_id="2.10",
-        title="Ensure Microsoft Defender for Containers is set to On",
+        title="Microsoft Defender for Containers enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Microsoft Defender for Containers (Standard tier) in Defender for Cloud > Environment settings.",
@@ -1126,7 +1126,7 @@ def _check_2_11(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.11 — Ensure auto-provisioning of Log Analytics agent is set to On."""
     result = CISCheckResult(
         check_id="2.11",
-        title="Ensure that auto-provisioning of the Log Analytics agent is set to On",
+        title="Log Analytics agent auto-provisioning enabled",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable auto-provisioning of the Log Analytics agent in Defender for Cloud > Environment settings > Auto provisioning.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1156,7 +1156,7 @@ def _check_2_12(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.12 — Ensure additional email addresses are configured for security alerts."""
     result = CISCheckResult(
         check_id="2.12",
-        title="Ensure that additional email addresses are configured with a security contact",
+        title="Security contact email addresses configured",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Configure additional email addresses in Defender for Cloud > Environment settings > Email notifications.",
@@ -1186,7 +1186,7 @@ def _check_2_13(security_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 2.13 — Ensure email notification for high severity alerts is enabled."""
     result = CISCheckResult(
         check_id="2.13",
-        title="Ensure that email notification for high severity alerts is enabled",
+        title="Email notification for high-severity alerts enabled",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable email notifications for high severity alerts in Defender for Cloud > Environment settings > Email notifications.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1227,7 +1227,7 @@ def _check_3_1(storage_client: Any) -> CISCheckResult:
     """CIS 3.1 — Ensure 'Secure Transfer Required' is enabled on all Storage Accounts."""
     result = CISCheckResult(
         check_id="3.1",
-        title="Ensure 'Secure Transfer Required' is enabled for all Storage Accounts",
+        title="Secure transfer required on storage accounts",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable 'Secure transfer required' on all storage accounts to enforce HTTPS-only access.",
@@ -1258,7 +1258,7 @@ def _check_3_7(storage_client: Any) -> CISCheckResult:
     """CIS 3.7 — Ensure public access is disabled on all Storage Account blob containers."""
     result = CISCheckResult(
         check_id="3.7",
-        title="Ensure that 'Public access level' is set to Private for all blob containers",
+        title="Blob containers set to private access",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Disable public blob access at the storage account level and audit all containers.",
@@ -1289,7 +1289,7 @@ def _check_3_2(storage_client: Any) -> CISCheckResult:
     """CIS 3.2 — Ensure default network access rule for Storage Accounts is Deny."""
     result = CISCheckResult(
         check_id="3.2",
-        title="Ensure that default network access rule for Storage Accounts is set to Deny",
+        title="Storage account default network rule set to Deny",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation=(
@@ -1324,7 +1324,7 @@ def _check_3_10(storage_client: Any) -> CISCheckResult:
     """CIS 3.10 — Ensure soft delete is enabled for Azure Storage."""
     result = CISCheckResult(
         check_id="3.10",
-        title="Ensure soft delete is enabled for Azure Storage",
+        title="Soft delete enabled for Azure Storage",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable blob soft delete on all storage accounts to protect against accidental deletion.",
@@ -1382,7 +1382,7 @@ def _check_3_3(storage_client: Any) -> CISCheckResult:
     """CIS 3.3 — Ensure storage for critical data is encrypted with Customer Managed Key."""
     result = CISCheckResult(
         check_id="3.3",
-        title="Ensure Storage for critical data are encrypted with Customer Managed Key",
+        title="Critical-data storage encrypted with customer-managed key",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Configure Customer Managed Keys (CMK) for storage accounts containing critical data.",
@@ -1414,7 +1414,7 @@ def _check_3_4(storage_client: Any) -> CISCheckResult:
     """CIS 3.4 — Ensure storage logging is enabled for Queue service."""
     result = CISCheckResult(
         check_id="3.4",
-        title="Ensure that Storage Logging is enabled for Queue Service for read, write, and delete requests",
+        title="Storage logging enabled for Queue service",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable Storage Analytics logging for Queue service read, write, and delete operations.",
@@ -1440,7 +1440,7 @@ def _check_3_5(storage_client: Any) -> CISCheckResult:
     """CIS 3.5 — Ensure storage logging is enabled for Table service."""
     result = CISCheckResult(
         check_id="3.5",
-        title="Ensure that Storage Logging is enabled for Table Service for read, write, and delete requests",
+        title="Storage logging enabled for Table service",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable Storage Analytics logging for Table service read, write, and delete operations.",
@@ -1466,7 +1466,7 @@ def _check_3_6(storage_client: Any) -> CISCheckResult:
     """CIS 3.6 — Ensure storage logging is enabled for Blob service."""
     result = CISCheckResult(
         check_id="3.6",
-        title="Ensure that Storage Logging is enabled for Blob Service for read, write, and delete requests",
+        title="Storage logging enabled for Blob service",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable Storage Analytics logging for Blob service read, write, and delete operations.",
@@ -1492,7 +1492,7 @@ def _check_3_8(storage_client: Any) -> CISCheckResult:
     """CIS 3.8 — Ensure default network access rule for Storage Accounts is set to Deny."""
     result = CISCheckResult(
         check_id="3.8",
-        title="Ensure default network access rule for Storage Accounts is set to Deny",
+        title="Default storage network access rule set to Deny",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Set the default network access rule to 'Deny' on all storage accounts.",
@@ -1524,7 +1524,7 @@ def _check_3_9(storage_client: Any) -> CISCheckResult:
     """CIS 3.9 — Ensure 'Allow Azure services on the trusted services list' is enabled."""
     result = CISCheckResult(
         check_id="3.9",
-        title="Ensure 'Allow Azure services on the trusted services list to access this storage account' is Enabled",
+        title="Trusted Azure services allowed to access storage account",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable 'Allow trusted Microsoft services to access this storage account' in the storage account firewall settings.",
@@ -1557,7 +1557,7 @@ def _check_3_11(storage_client: Any) -> CISCheckResult:
     """CIS 3.11 — Ensure private endpoints are used to access Storage Accounts."""
     result = CISCheckResult(
         check_id="3.11",
-        title="Ensure private endpoints are used to access Storage Accounts",
+        title="Private endpoints used for storage accounts",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Configure private endpoints for all storage accounts to restrict network access to approved virtual networks.",
@@ -1587,7 +1587,7 @@ def _check_3_12(storage_client: Any) -> CISCheckResult:
     """CIS 3.12 — Ensure infrastructure encryption for Storage Accounts is enabled."""
     result = CISCheckResult(
         check_id="3.12",
-        title="Ensure that infrastructure encryption for Azure Storage Accounts is enabled",
+        title="Infrastructure encryption enabled on storage accounts",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable infrastructure encryption (double encryption) for storage accounts containing sensitive data.",
@@ -1623,7 +1623,7 @@ def _check_4_1_1(sql_client: Any) -> CISCheckResult:
     """CIS 4.1.1 — Ensure auditing is set to On for SQL servers."""
     result = CISCheckResult(
         check_id="4.1.1",
-        title="Ensure that 'Auditing' is set to 'On' for SQL servers",
+        title="Auditing enabled on SQL servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable auditing on all Azure SQL servers to track database events and write them to an audit log.",
@@ -1679,7 +1679,7 @@ def _check_4_2_1(sql_client: Any) -> CISCheckResult:
     """CIS 4.2.1 — Ensure TLS version is set to TLSV1.2 for MySQL/PostgreSQL flexible servers."""
     result = CISCheckResult(
         check_id="4.2.1",
-        title="Ensure 'TLS Version' is set to 'TLSV1.2' (or higher) for database servers",
+        title="TLS 1.2 or higher on database servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Set the minimum TLS version to TLS 1.2 on all Azure SQL, MySQL, and PostgreSQL servers.",
@@ -1715,7 +1715,7 @@ def _check_4_1_2(sql_client: Any) -> CISCheckResult:
     """CIS 4.1.2 — Ensure SQL Server Transparent Data Encryption is enabled."""
     result = CISCheckResult(
         check_id="4.1.2",
-        title="Ensure that Transparent Data Encryption (TDE) is enabled for SQL servers",
+        title="Transparent Data Encryption enabled on SQL servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Transparent Data Encryption on all SQL databases.",
@@ -1769,7 +1769,7 @@ def _check_4_1_3(sql_client: Any) -> CISCheckResult:
     """CIS 4.1.3 — Ensure SQL Server Active Directory Admin is configured."""
     result = CISCheckResult(
         check_id="4.1.3",
-        title="Ensure that Azure Active Directory Admin is configured for SQL servers",
+        title="Azure AD admin configured for SQL servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Configure an Azure AD administrator for each SQL server to enable centralized authentication.",
@@ -1821,7 +1821,7 @@ def _check_4_1_4(sql_client: Any) -> CISCheckResult:
     """CIS 4.1.4 — Ensure Advanced Threat Protection is enabled for SQL servers."""
     result = CISCheckResult(
         check_id="4.1.4",
-        title="Ensure that Advanced Threat Protection (ATP) is enabled on SQL servers",
+        title="Advanced Threat Protection enabled on SQL servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Advanced Threat Protection on all SQL servers.",
@@ -1874,7 +1874,7 @@ def _check_4_1_5(sql_client: Any) -> CISCheckResult:
     """CIS 4.1.5 — Ensure SQL Server Vulnerability Assessment is configured."""
     result = CISCheckResult(
         check_id="4.1.5",
-        title="Ensure that Vulnerability Assessment is configured on SQL servers",
+        title="Vulnerability Assessment configured on SQL servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Configure Vulnerability Assessment on all SQL servers with a storage account for scan results.",
@@ -1916,7 +1916,7 @@ def _check_4_1_6(sql_client: Any) -> CISCheckResult:
     """CIS 4.1.6 — Ensure SQL server public network access is disabled."""
     result = CISCheckResult(
         check_id="4.1.6",
-        title="Ensure that public network access is disabled for SQL servers",
+        title="Public network access disabled on SQL servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Disable public network access on SQL servers and use private endpoints for connectivity.",
@@ -1947,7 +1947,7 @@ def _check_4_2_2(mysql_client: Any) -> CISCheckResult:
     """CIS 4.2.2 — Ensure MySQL SSL enforcement is enabled."""
     result = CISCheckResult(
         check_id="4.2.2",
-        title="Ensure 'ssl_enforcement' is set to 'ENABLED' for MySQL Database servers",
+        title="SSL enforcement enabled on MySQL servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable SSL enforcement on all MySQL servers to ensure encrypted connections.",
@@ -1978,7 +1978,7 @@ def _check_4_2_3(mysql_client: Any) -> CISCheckResult:
     """CIS 4.2.3 — Ensure MySQL server parameter 'log_checkpoints' is enabled."""
     result = CISCheckResult(
         check_id="4.2.3",
-        title="Ensure server parameter 'log_checkpoints' is set to 'ON' for MySQL Database servers",
+        title="MySQL log_checkpoints parameter set to ON",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable the 'log_checkpoints' server parameter on all MySQL servers.",
@@ -2031,7 +2031,7 @@ def _check_4_3_1(postgresql_client: Any) -> CISCheckResult:
     """CIS 4.3.1 — Ensure PostgreSQL SSL enforcement is enabled."""
     result = CISCheckResult(
         check_id="4.3.1",
-        title="Ensure 'ssl_enforcement' is set to 'ENABLED' for PostgreSQL Database servers",
+        title="SSL enforcement enabled on PostgreSQL servers",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable SSL enforcement on all PostgreSQL servers to ensure encrypted connections.",
@@ -2062,7 +2062,7 @@ def _check_4_3_2(postgresql_client: Any) -> CISCheckResult:
     """CIS 4.3.2 — Ensure PostgreSQL server parameter 'log_checkpoints' is enabled."""
     result = CISCheckResult(
         check_id="4.3.2",
-        title="Ensure server parameter 'log_checkpoints' is set to 'ON' for PostgreSQL Database servers",
+        title="PostgreSQL log_checkpoints parameter set to ON",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable the 'log_checkpoints' server parameter on all PostgreSQL servers.",
@@ -2115,7 +2115,7 @@ def _check_4_3_3(postgresql_client: Any) -> CISCheckResult:
     """CIS 4.3.3 — Ensure PostgreSQL server parameter 'log_connections' is enabled."""
     result = CISCheckResult(
         check_id="4.3.3",
-        title="Ensure server parameter 'log_connections' is set to 'ON' for PostgreSQL Database servers",
+        title="PostgreSQL log_connections parameter set to ON",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable the 'log_connections' server parameter on all PostgreSQL servers.",
@@ -2168,7 +2168,7 @@ def _check_4_3_4(postgresql_client: Any) -> CISCheckResult:
     """CIS 4.3.4 — Ensure PostgreSQL server parameter 'log_disconnections' is enabled."""
     result = CISCheckResult(
         check_id="4.3.4",
-        title="Ensure server parameter 'log_disconnections' is set to 'ON' for PostgreSQL Database servers",
+        title="PostgreSQL log_disconnections parameter set to ON",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable the 'log_disconnections' server parameter on all PostgreSQL servers.",
@@ -2221,7 +2221,7 @@ def _check_4_3_5(postgresql_client: Any) -> CISCheckResult:
     """CIS 4.3.5 — Ensure PostgreSQL server parameter 'connection_throttling' is enabled."""
     result = CISCheckResult(
         check_id="4.3.5",
-        title="Ensure server parameter 'connection_throttling' is set to 'ON' for PostgreSQL Database servers",
+        title="PostgreSQL connection_throttling parameter set to ON",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable the 'connection_throttling' server parameter on all PostgreSQL servers.",
@@ -2279,7 +2279,7 @@ def _check_5_1_1(monitor_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 5.1.1 — Ensure a Diagnostic Setting exists for the Activity Log."""
     result = CISCheckResult(
         check_id="5.1.1",
-        title="Ensure Diagnostic Setting exists capturing Activity Log",
+        title="Diagnostic setting captures Activity Log",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation=(
@@ -2308,7 +2308,7 @@ def _check_5_1_2(monitor_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 5.1.2 — Ensure Activity Log retention is set to at least 365 days."""
     result = CISCheckResult(
         check_id="5.1.2",
-        title="Ensure Activity Log retention is set to 365 days or greater",
+        title="Activity Log retention 365 days or greater",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation=(
@@ -2390,7 +2390,7 @@ def _check_5_1_3(monitor_client: Any, subscription_id: str) -> CISCheckResult:
     return _check_activity_log_alert(
         monitor_client,
         "5.1.3",
-        "Ensure that Activity Log alert exists for Create or Update Key Vault",
+        "Activity Log alert for Key Vault create/update",
         "Microsoft.KeyVault/vaults/write",
     )
 
@@ -2400,7 +2400,7 @@ def _check_5_1_4(monitor_client: Any, subscription_id: str) -> CISCheckResult:
     return _check_activity_log_alert(
         monitor_client,
         "5.1.4",
-        "Ensure that Activity Log alert exists for Delete Key Vault",
+        "Activity Log alert for Key Vault delete",
         "Microsoft.KeyVault/vaults/delete",
     )
 
@@ -2410,7 +2410,7 @@ def _check_5_1_5(monitor_client: Any, subscription_id: str) -> CISCheckResult:
     return _check_activity_log_alert(
         monitor_client,
         "5.1.5",
-        "Ensure that Activity Log alert exists for Create or Update Network Security Group",
+        "Activity Log alert for NSG create/update",
         "Microsoft.Network/networkSecurityGroups/write",
     )
 
@@ -2420,7 +2420,7 @@ def _check_5_1_6(monitor_client: Any, subscription_id: str) -> CISCheckResult:
     return _check_activity_log_alert(
         monitor_client,
         "5.1.6",
-        "Ensure that Activity Log alert exists for Delete Network Security Group",
+        "Activity Log alert for NSG delete",
         "Microsoft.Network/networkSecurityGroups/delete",
     )
 
@@ -2429,7 +2429,7 @@ def _check_5_2_1(postgresql_client: Any) -> CISCheckResult:
     """CIS 5.2.1 — Ensure server parameter 'log_connections' is set to ON for PostgreSQL."""
     result = CISCheckResult(
         check_id="5.2.1",
-        title="Ensure server parameter 'log_connections' is set to 'ON' for PostgreSQL Database Server",
+        title="PostgreSQL Server log_connections parameter set to ON",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the 'log_connections' server parameter to 'ON' on all PostgreSQL servers.",
@@ -2482,7 +2482,7 @@ def _check_5_2_2(postgresql_client: Any) -> CISCheckResult:
     """CIS 5.2.2 — Ensure server parameter 'log_disconnections' is set to ON."""
     result = CISCheckResult(
         check_id="5.2.2",
-        title="Ensure server parameter 'log_disconnections' is set to 'ON' for PostgreSQL Database Server",
+        title="PostgreSQL Server log_disconnections parameter set to ON",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the 'log_disconnections' server parameter to 'ON' on all PostgreSQL servers.",
@@ -2535,7 +2535,7 @@ def _check_5_2_3(postgresql_client: Any) -> CISCheckResult:
     """CIS 5.2.3 — Ensure server parameter 'connection_throttling' is set to ON."""
     result = CISCheckResult(
         check_id="5.2.3",
-        title="Ensure server parameter 'connection_throttling' is set to 'ON' for PostgreSQL Database Server",
+        title="PostgreSQL Server connection_throttling parameter set to ON",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the 'connection_throttling' server parameter to 'ON' on all PostgreSQL servers.",
@@ -2593,7 +2593,7 @@ def _check_6_1(network_client: Any) -> CISCheckResult:
     """CIS 6.1 — Ensure RDP access from the internet is restricted."""
     result = CISCheckResult(
         check_id="6.1",
-        title="Ensure that RDP access from the internet is evaluated and restricted",
+        title="RDP access from internet restricted",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation=(
@@ -2627,7 +2627,7 @@ def _check_6_2(network_client: Any) -> CISCheckResult:
     """CIS 6.2 — Ensure SSH access from the internet is restricted."""
     result = CISCheckResult(
         check_id="6.2",
-        title="Ensure that SSH access from the internet is evaluated and restricted",
+        title="SSH access from internet restricted",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation=(
@@ -2661,7 +2661,7 @@ def _check_6_3(network_client: Any) -> CISCheckResult:
     """CIS 6.3 — Ensure no SQL Databases allow ingress from 0.0.0.0/0 (Any IP)."""
     result = CISCheckResult(
         check_id="6.3",
-        title="Ensure no SQL Databases allow ingress from 0.0.0.0/0 (ANY IP)",
+        title="No SQL database allows ingress from any IP",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation=(
@@ -2696,7 +2696,7 @@ def _check_6_5(network_client: Any) -> CISCheckResult:
     """CIS 6.5 — Ensure Network Watcher is enabled."""
     result = CISCheckResult(
         check_id="6.5",
-        title="Ensure that Network Watcher is enabled",
+        title="Network Watcher enabled",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable Network Watcher in all regions where you have Azure resources deployed.",
@@ -2721,7 +2721,7 @@ def _check_6_4(network_client: Any) -> CISCheckResult:
     """CIS 6.4 — Ensure that UDP access from the internet is restricted."""
     result = CISCheckResult(
         check_id="6.4",
-        title="Ensure that UDP access from the internet is evaluated and restricted",
+        title="UDP access from internet restricted",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove or restrict NSG inbound rules allowing UDP from 0.0.0.0/0 or ::/0.",
@@ -2755,7 +2755,7 @@ def _check_6_6(network_client: Any) -> CISCheckResult:
     """CIS 6.6 — Ensure Web Application Firewall (WAF) is enabled."""
     result = CISCheckResult(
         check_id="6.6",
-        title="Ensure that Web Application Firewall (WAF) is enabled",
+        title="Web Application Firewall enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable WAF on Application Gateway or Front Door for all public-facing web applications.",
@@ -2813,7 +2813,7 @@ def _check_7_1(compute_client: Any) -> CISCheckResult:
     """CIS 7.1 — Ensure Virtual Machines utilize Managed Disks."""
     result = CISCheckResult(
         check_id="7.1",
-        title="Ensure Virtual Machines utilize Managed Disks",
+        title="Virtual machines use Managed Disks",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Migrate all VM disks to Managed Disks for improved reliability, security, and simplified management.",
@@ -2847,7 +2847,7 @@ def _check_7_2(compute_client: Any) -> CISCheckResult:
     """CIS 7.2 — Ensure VMs use managed disks for OS disks."""
     result = CISCheckResult(
         check_id="7.2",
-        title="Ensure that Virtual Machines use Managed Disks for OS disks",
+        title="VM OS disks use Managed Disks",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Migrate all VM OS disks to Managed Disks.",
@@ -2880,7 +2880,7 @@ def _check_7_3(compute_client: Any) -> CISCheckResult:
     """CIS 7.3 — Ensure OS and data disks are encrypted with CMK."""
     result = CISCheckResult(
         check_id="7.3",
-        title="Ensure that OS and data disks are encrypted with Customer Managed Key (CMK)",
+        title="OS and data disks encrypted with customer-managed key",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable Customer Managed Key encryption for all VM OS and data disks.",
@@ -2915,7 +2915,7 @@ def _check_7_4(compute_client: Any) -> CISCheckResult:
     """CIS 7.4 — Ensure only approved extensions are installed on VMs."""
     result = CISCheckResult(
         check_id="7.4",
-        title="Ensure that only approved extensions are installed on Virtual Machines",
+        title="Only approved VM extensions installed",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Review all VM extensions and remove any unapproved or unnecessary extensions.",
@@ -2950,7 +2950,7 @@ def _check_7_5(compute_client: Any) -> CISCheckResult:
     """CIS 7.5 — Ensure latest OS patches are applied to VMs."""
     result = CISCheckResult(
         check_id="7.5",
-        title="Ensure that the latest OS patches for all Virtual Machines are applied",
+        title="Latest OS patches applied to VMs",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable automatic OS updates or apply latest patches to all VMs. Use Azure Update Management for compliance tracking.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -2974,7 +2974,7 @@ def _check_7_6(compute_client: Any) -> CISCheckResult:
     """CIS 7.6 — Ensure endpoint protection is installed on VMs."""
     result = CISCheckResult(
         check_id="7.6",
-        title="Ensure that endpoint protection is installed on Virtual Machines",
+        title="Endpoint protection installed on VMs",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Install an endpoint protection solution (e.g., Microsoft Defender for Endpoint) on all VMs.",
@@ -3018,7 +3018,7 @@ def _check_8_1(kv_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 8.1 — Ensure expiration date is set on all Key Vault keys."""
     result = CISCheckResult(
         check_id="8.1",
-        title="Ensure that expiration date is set on all keys in Key Vault",
+        title="Expiration date set on Key Vault keys",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set an expiration date on all Key Vault keys to enforce key rotation.",
@@ -3075,7 +3075,7 @@ def _check_8_2(kv_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 8.2 — Ensure expiration date is set on all Key Vault secrets."""
     result = CISCheckResult(
         check_id="8.2",
-        title="Ensure that expiration date is set on all secrets in Key Vault",
+        title="Expiration date set on Key Vault secrets",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set an expiration date on all Key Vault secrets to enforce secret rotation.",
@@ -3129,7 +3129,7 @@ def _check_8_3(kv_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 8.3 — Ensure Key Vault is recoverable (soft delete + purge protection)."""
     result = CISCheckResult(
         check_id="8.3",
-        title="Ensure that the Key Vault is recoverable (soft-delete and purge protection enabled)",
+        title="Key Vault recoverable (soft-delete and purge protection)",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable both soft-delete and purge protection on all Key Vaults.",
@@ -3189,7 +3189,7 @@ def _check_8_4(kv_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 8.4 — Ensure key expiration date is set for all keys in RBAC Key Vaults."""
     result = CISCheckResult(
         check_id="8.4",
-        title="Ensure that the expiration date is set on all keys in RBAC Key Vaults",
+        title="Expiration date set on RBAC Key Vault keys",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set an expiration date on all keys in Key Vaults using RBAC access model.",
@@ -3258,7 +3258,7 @@ def _check_8_5(kv_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 8.5 — Ensure secret expiration date is set for all secrets in RBAC Key Vaults."""
     result = CISCheckResult(
         check_id="8.5",
-        title="Ensure that the expiration date is set on all secrets in RBAC Key Vaults",
+        title="Expiration date set on RBAC Key Vault secrets",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set an expiration date on all secrets in Key Vaults using RBAC access model.",
@@ -3327,7 +3327,7 @@ def _check_8_6(kv_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 8.6 — Ensure Key Vault secrets have content type set."""
     result = CISCheckResult(
         check_id="8.6",
-        title="Ensure that the Key Vault secrets have a content type set",
+        title="Key Vault secrets have a content type set",
         status=CheckStatus.ERROR,
         severity="low",
         recommendation="Set a content type on all Key Vault secrets to describe the secret's usage.",
@@ -3381,7 +3381,7 @@ def _check_8_7(kv_client: Any, subscription_id: str) -> CISCheckResult:
     """CIS 8.7 — Ensure private endpoints are used for Key Vault."""
     result = CISCheckResult(
         check_id="8.7",
-        title="Ensure that private endpoints are used for Azure Key Vault",
+        title="Private endpoints used for Key Vault",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Configure private endpoints for all Key Vaults to restrict network access.",
@@ -3440,7 +3440,7 @@ def _check_9_1(webapp_client: Any) -> CISCheckResult:
     """CIS 9.1 — Ensure App Service Authentication is set on."""
     result = CISCheckResult(
         check_id="9.1",
-        title="Ensure App Service Authentication is set up for apps in Azure App Service",
+        title="App Service Authentication configured",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable App Service Authentication (EasyAuth) on all web apps.",
@@ -3493,7 +3493,7 @@ def _check_9_2(webapp_client: Any) -> CISCheckResult:
     """CIS 9.2 — Ensure web app redirects all HTTP traffic to HTTPS."""
     result = CISCheckResult(
         check_id="9.2",
-        title="Ensure web app redirects all HTTP traffic to HTTPS",
+        title="Web app redirects HTTP to HTTPS",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable 'HTTPS Only' on all web apps to redirect HTTP to HTTPS.",
@@ -3524,7 +3524,7 @@ def _check_9_3(webapp_client: Any) -> CISCheckResult:
     """CIS 9.3 — Ensure web app is using the latest TLS version."""
     result = CISCheckResult(
         check_id="9.3",
-        title="Ensure web app is using the latest version of TLS encryption",
+        title="Web app uses latest TLS version",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Set the minimum TLS version to 1.2 on all web apps.",
@@ -3581,7 +3581,7 @@ def _check_9_4(webapp_client: Any) -> CISCheckResult:
     """CIS 9.4 — Ensure the web app has a Managed Identity."""
     result = CISCheckResult(
         check_id="9.4",
-        title="Ensure the web app has a Managed Service Identity",
+        title="Web app has a Managed Service Identity",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable a System-Assigned or User-Assigned Managed Identity on all web apps.",
@@ -3616,7 +3616,7 @@ def _check_9_5(webapp_client: Any) -> CISCheckResult:
     """CIS 9.5 — Ensure web app has client certificates (Incoming client certificates) enabled."""
     result = CISCheckResult(
         check_id="9.5",
-        title="Ensure the web app has 'Client Certificates (Incoming client certificates)' set to On",
+        title="Web app requires incoming client certificates",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable client certificates on all web apps that require mutual TLS authentication.",
@@ -3647,7 +3647,7 @@ def _check_9_6(webapp_client: Any) -> CISCheckResult:
     """CIS 9.6 — Ensure FTP access is disabled for App Service."""
     result = CISCheckResult(
         check_id="9.6",
-        title="Ensure that FTP access is disabled for Azure App Service",
+        title="FTP access disabled for App Service",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Disable FTP/FTPS access on all web apps. Use FTPS-only or disable FTP state entirely.",

--- a/src/agent_bom/cloud/gcp_cis_benchmark.py
+++ b/src/agent_bom/cloud/gcp_cis_benchmark.py
@@ -296,7 +296,7 @@ def _check_1_1(project_id: str) -> CISCheckResult:
     """CIS 1.1 — Ensure corporate login credentials are used."""
     result = CISCheckResult(
         check_id="1.1",
-        title="Ensure that corporate login credentials are used",
+        title="Corporate login credentials used",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove IAM bindings for members using gmail.com accounts. Use corporate/organisational login credentials instead.",
@@ -333,7 +333,7 @@ def _check_1_2(project_id: str) -> CISCheckResult:
     """CIS 1.2 — Ensure multi-factor authentication is enforced for all users."""
     return CISCheckResult(
         check_id="1.2",
-        title="Ensure multi-factor authentication is enforced for all users",
+        title="MFA enforced for all users",
         status=CheckStatus.NOT_APPLICABLE,
         severity="high",
         evidence="MFA enforcement is configured at the Google Workspace / Cloud Identity level and cannot be verified via project-level API calls. Manual verification required.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -346,7 +346,7 @@ def _check_1_3(project_id: str) -> CISCheckResult:
     """CIS 1.3 — Ensure Security Key enforcement is enabled for all admin accounts."""
     return CISCheckResult(
         check_id="1.3",
-        title="Ensure Security Key enforcement is enabled for all admin accounts",
+        title="Security Key enforcement for admin accounts",
         status=CheckStatus.NOT_APPLICABLE,
         severity="high",
         evidence="Security Key enforcement is configured at the Google Workspace / Cloud Identity level and cannot be verified via project-level API calls. Manual verification required.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -359,7 +359,7 @@ def _check_1_4(project_id: str) -> CISCheckResult:
     """CIS 1.4 — Ensure service account keys are not created for user-managed service accounts."""
     result = CISCheckResult(
         check_id="1.4",
-        title="Ensure service account keys are not created for user-managed service accounts",
+        title="No user-managed service account keys",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation=(
@@ -404,7 +404,7 @@ def _check_1_5(project_id: str) -> CISCheckResult:
     """CIS 1.5 — Ensure primitive roles (Owner/Editor) are not used on the project."""
     result = CISCheckResult(
         check_id="1.5",
-        title="Ensure primitive roles (Owner/Editor) are not assigned at project level",
+        title="No primitive roles (Owner/Editor) at project level",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Replace primitive Owner/Editor bindings with predefined or custom roles following least privilege.",
@@ -446,7 +446,7 @@ def _check_1_6(project_id: str) -> CISCheckResult:
     """CIS 1.6 — Ensure service account has no admin privileges."""
     result = CISCheckResult(
         check_id="1.6",
-        title="Ensure service account has no admin privileges",
+        title="Service accounts lack admin privileges",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation=(
@@ -489,7 +489,7 @@ def _check_1_7(project_id: str) -> CISCheckResult:
     """CIS 1.7 — Ensure user-managed service accounts do not have admin privileges."""
     result = CISCheckResult(
         check_id="1.7",
-        title="Ensure user-managed service accounts do not have admin privileges",
+        title="User-managed service accounts lack admin privileges",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation=(
@@ -537,7 +537,7 @@ def _check_1_8(project_id: str) -> CISCheckResult:
     """CIS 1.8 — Ensure rotation for user-managed service account keys is within 90 days."""
     result = CISCheckResult(
         check_id="1.8",
-        title="Ensure user-managed service account keys are rotated within 90 days",
+        title="User-managed service account keys rotated within 90 days",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Rotate user-managed service account keys every 90 days or less. Prefer short-lived credentials via Workload Identity.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -586,7 +586,7 @@ def _check_1_9(project_id: str) -> CISCheckResult:
     """CIS 1.9 — Ensure Cloud KMS encryption keys are not anonymously or publicly accessible."""
     result = CISCheckResult(
         check_id="1.9",
-        title="Ensure Cloud KMS encryption keys are not anonymously or publicly accessible",
+        title="Cloud KMS keys not publicly accessible",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation="Remove allUsers and allAuthenticatedUsers from Cloud KMS key IAM policies.",
@@ -626,7 +626,7 @@ def _check_1_10(project_id: str) -> CISCheckResult:
     """CIS 1.10 — Ensure KMS encryption keys are rotated within a period of 90 days."""
     result = CISCheckResult(
         check_id="1.10",
-        title="Ensure KMS encryption keys are rotated within 90 days",
+        title="KMS keys rotated within 90 days",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set a rotation period of 90 days or less on all Cloud KMS encryption keys.",
@@ -667,7 +667,7 @@ def _check_1_11(project_id: str) -> CISCheckResult:
     """CIS 1.11 — Ensure separation of duties is enforced while assigning KMS-related roles."""
     result = CISCheckResult(
         check_id="1.11",
-        title="Ensure separation of duties is enforced while assigning KMS-related roles",
+        title="Separation of duties for KMS role assignment",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Ensure no user has both cloudkms.admin and any of cloudkms.cryptoKeyEncrypterDecrypter, cloudkms.cryptoKeyEncrypter, or cloudkms.cryptoKeyDecrypter roles.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -718,7 +718,7 @@ def _check_1_12(project_id: str) -> CISCheckResult:
     """CIS 1.12 — Ensure API keys are restricted to only APIs the application needs."""
     result = CISCheckResult(
         check_id="1.12",
-        title="Ensure API keys are restricted to only APIs the application needs",
+        title="API keys restricted to needed APIs",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Restrict each API key to only the specific APIs required by the application.",
@@ -759,7 +759,7 @@ def _check_1_13(project_id: str) -> CISCheckResult:
     """CIS 1.13 — Ensure API keys are restricted to specific hosts and apps."""
     result = CISCheckResult(
         check_id="1.13",
-        title="Ensure API keys are restricted to specific hosts and apps",
+        title="API keys restricted to specific hosts and apps",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Add application restrictions (HTTP referrers, IP addresses, Android/iOS apps) to each API key.",
@@ -802,7 +802,7 @@ def _check_1_14(project_id: str) -> CISCheckResult:
     """CIS 1.14 — Ensure API keys are rotated within 90 days."""
     result = CISCheckResult(
         check_id="1.14",
-        title="Ensure API keys are rotated within 90 days",
+        title="API keys rotated within 90 days",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Rotate API keys every 90 days or less to reduce the impact of compromised keys.",
@@ -846,7 +846,7 @@ def _check_1_15(project_id: str) -> CISCheckResult:
     """CIS 1.15 — Ensure essential contacts is configured for the organization."""
     result = CISCheckResult(
         check_id="1.15",
-        title="Ensure essential contacts is configured for the organization",
+        title="Essential contacts configured for the org",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Configure Essential Contacts for SECURITY, TECHNICAL, and BILLING notification categories.",
@@ -893,7 +893,7 @@ def _check_2_1(project_id: str) -> CISCheckResult:
     """CIS 2.1 — Ensure Cloud Audit Logs is configured to log Admin Activity and Data Access."""
     result = CISCheckResult(
         check_id="2.1",
-        title="Ensure Cloud Audit Logs is configured for all services",
+        title="Cloud Audit Logs configured for all services",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable DATA_READ and DATA_WRITE audit log types for all services in the project IAM policy.",
@@ -932,7 +932,7 @@ def _check_2_2(project_id: str) -> CISCheckResult:
     """CIS 2.2 — Ensure a log sink is configured for all log entries."""
     result = CISCheckResult(
         check_id="2.2",
-        title="Ensure a log sink is configured to export all log entries",
+        title="Log sink exports all log entries",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation=(
@@ -973,7 +973,7 @@ def _check_2_3(project_id: str) -> CISCheckResult:
     """CIS 2.3 — Ensure log metric filter and alerts exist for Project Ownership changes."""
     result = CISCheckResult(
         check_id="2.3",
-        title="Ensure log metric filter and alerts exist for Project Ownership changes",
+        title="Log metric filter and alerts for Project Ownership changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for (protoPayload.serviceName="cloudresourcemanager.googleapis.com") AND (ProjectOwnership OR projectOwnerInvitee).',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1008,7 +1008,7 @@ def _check_2_4(project_id: str) -> CISCheckResult:
     """CIS 2.4 — Ensure log metric filter and alerts exist for Audit Configuration changes."""
     result = CISCheckResult(
         check_id="2.4",
-        title="Ensure log metric filter and alerts exist for Audit Configuration changes",
+        title="Log metric filter and alerts for Audit Configuration changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for protoPayload.methodName="SetIamPolicy" AND protoPayload.serviceData.policyDelta.auditConfigDeltas:*.',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1043,7 +1043,7 @@ def _check_2_5(project_id: str) -> CISCheckResult:
     """CIS 2.5 — Ensure log metric filter and alerts exist for Custom Role changes."""
     result = CISCheckResult(
         check_id="2.5",
-        title="Ensure log metric filter and alerts exist for Custom Role changes",
+        title="Log metric filter and alerts for Custom Role changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for resource.type="iam_role" AND (methodName="google.iam.admin.v1.CreateRole" OR methodName="google.iam.admin.v1.DeleteRole" OR methodName="google.iam.admin.v1.UpdateRole").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1078,7 +1078,7 @@ def _check_2_6(project_id: str) -> CISCheckResult:
     """CIS 2.6 — Ensure log metric filter and alerts exist for VPC Network Firewall Rule changes."""
     result = CISCheckResult(
         check_id="2.6",
-        title="Ensure log metric filter and alerts exist for VPC Network Firewall Rule changes",
+        title="Log metric filter and alerts for VPC firewall rule changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for resource.type="gce_firewall_rule" AND (methodName:"compute.firewalls.patch" OR methodName:"compute.firewalls.insert" OR methodName:"compute.firewalls.delete").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1113,7 +1113,7 @@ def _check_2_7(project_id: str) -> CISCheckResult:
     """CIS 2.7 — Ensure log metric filter and alerts exist for VPC Network Route changes."""
     result = CISCheckResult(
         check_id="2.7",
-        title="Ensure log metric filter and alerts exist for VPC Network Route changes",
+        title="Log metric filter and alerts for VPC route changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for resource.type="gce_route" AND (methodName:"compute.routes.delete" OR methodName:"compute.routes.insert").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1148,7 +1148,7 @@ def _check_2_8(project_id: str) -> CISCheckResult:
     """CIS 2.8 — Ensure log metric filter and alerts exist for VPC Network changes."""
     result = CISCheckResult(
         check_id="2.8",
-        title="Ensure log metric filter and alerts exist for VPC Network changes",
+        title="Log metric filter and alerts for VPC network changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for resource.type="gce_network" AND (methodName:"compute.networks.insert" OR methodName:"compute.networks.patch" OR methodName:"compute.networks.delete" OR methodName:"compute.networks.removePeering" OR methodName:"compute.networks.addPeering").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1183,7 +1183,7 @@ def _check_2_9(project_id: str) -> CISCheckResult:
     """CIS 2.9 — Ensure log metric filter and alerts exist for Cloud Storage IAM permission changes."""
     result = CISCheckResult(
         check_id="2.9",
-        title="Ensure log metric filter and alerts exist for Cloud Storage IAM permission changes",
+        title="Log metric filter and alerts for Cloud Storage IAM changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for resource.type="gcs_bucket" AND protoPayload.methodName="storage.setIamPermissions".',
@@ -1218,7 +1218,7 @@ def _check_2_10(project_id: str) -> CISCheckResult:
     """CIS 2.10 — Ensure log metric filter and alerts exist for SQL instance configuration changes."""
     result = CISCheckResult(
         check_id="2.10",
-        title="Ensure log metric filter and alerts exist for SQL instance configuration changes",
+        title="Log metric filter and alerts for SQL instance config changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for protoPayload.methodName="cloudsql.instances.update".',
@@ -1253,7 +1253,7 @@ def _check_2_11(project_id: str) -> CISCheckResult:
     """CIS 2.11 — Ensure log metric filter and alerts exist for DNS Zone changes."""
     result = CISCheckResult(
         check_id="2.11",
-        title="Ensure log metric filter and alerts exist for DNS Zone changes",
+        title="Log metric filter and alerts for DNS zone changes",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation='Create a log metric filter for resource.type="dns_managed_zone" AND (methodName:"dns.managedZones.create" OR methodName:"dns.managedZones.patch" OR methodName:"dns.managedZones.update" OR methodName:"dns.managedZones.delete").',  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1288,7 +1288,7 @@ def _check_2_12(project_id: str) -> CISCheckResult:
     """CIS 2.12 — Ensure Cloud DNS logging is enabled for all VPC networks."""
     result = CISCheckResult(
         check_id="2.12",
-        title="Ensure Cloud DNS logging is enabled for all VPC networks",
+        title="Cloud DNS logging enabled for all VPC networks",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable DNS logging on all Cloud DNS managed zones by setting the logging configuration.",
@@ -1332,7 +1332,7 @@ def _check_3_1(project_id: str) -> CISCheckResult:
     """CIS 3.1 — Ensure the default VPC network does not exist in a project."""
     result = CISCheckResult(
         check_id="3.1",
-        title="Ensure the default VPC network does not exist in the project",
+        title="No default VPC network in the project",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Delete the 'default' VPC network and create custom VPC networks with explicit firewall rules.",
@@ -1365,7 +1365,7 @@ def _check_3_2(project_id: str) -> CISCheckResult:
     """CIS 3.2 — Ensure legacy networks do not exist in the project."""
     result = CISCheckResult(
         check_id="3.2",
-        title="Ensure legacy networks do not exist in the project",
+        title="No legacy networks in the project",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Delete legacy networks and create VPC networks with custom subnet mode instead.",
@@ -1403,7 +1403,7 @@ def _check_3_3(project_id: str) -> CISCheckResult:
     """CIS 3.3 — Ensure DNSSEC is enabled for Cloud DNS."""
     result = CISCheckResult(
         check_id="3.3",
-        title="Ensure that DNSSEC is enabled for Cloud DNS",
+        title="DNSSEC enabled for Cloud DNS",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable DNSSEC on all public Cloud DNS managed zones.",
@@ -1442,7 +1442,7 @@ def _check_3_4(project_id: str) -> CISCheckResult:
     """CIS 3.4 — Ensure RSASHA1 is not used for key-signing in DNSSEC."""
     result = CISCheckResult(
         check_id="3.4",
-        title="Ensure that RSASHA1 is not used for the key-signing key in Cloud DNS DNSSEC",
+        title="RSASHA1 not used for DNSSEC key-signing key",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Use RSASHA256, RSASHA512, or ECDSAP256SHA256 for DNSSEC key-signing keys instead of RSASHA1.",
@@ -1480,7 +1480,7 @@ def _check_3_5(project_id: str) -> CISCheckResult:
     """CIS 3.5 — Ensure RSASHA1 is not used for zone-signing in DNSSEC."""
     result = CISCheckResult(
         check_id="3.5",
-        title="Ensure that RSASHA1 is not used for the zone-signing key in Cloud DNS DNSSEC",
+        title="RSASHA1 not used for DNSSEC zone-signing key",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Use RSASHA256, RSASHA512, or ECDSAP256SHA256 for DNSSEC zone-signing keys instead of RSASHA1.",
@@ -1518,7 +1518,7 @@ def _check_3_8(project_id: str) -> CISCheckResult:
     """CIS 3.8 — Ensure Firewall Rules for ICMP are not open to the world."""
     result = CISCheckResult(
         check_id="3.8",
-        title="Ensure that Firewall Rules for ICMP are not open to the world",
+        title="ICMP firewall rules not open to the world",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Remove or restrict firewall rules that allow ICMP from 0.0.0.0/0 or ::/0.",
@@ -1564,7 +1564,7 @@ def _check_3_10(project_id: str) -> CISCheckResult:
     """CIS 3.10 — Ensure private Google access is enabled for all subnets."""
     result = CISCheckResult(
         check_id="3.10",
-        title="Ensure Private Google Access is enabled for all subnets in a VPC",
+        title="Private Google Access enabled on all subnets",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable Private Google Access on all subnets to allow VMs without external IPs to reach Google APIs.",
@@ -1604,7 +1604,7 @@ def _check_3_9(project_id: str) -> CISCheckResult:
     """CIS 3.9 — Ensure VPC Flow Logs are enabled for every subnet."""
     result = CISCheckResult(
         check_id="3.9",
-        title="Ensure VPC Flow Logs are enabled for every subnet",
+        title="VPC Flow Logs enabled on every subnet",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable VPC Flow Logs on all subnets for network monitoring and forensics.",
@@ -1645,7 +1645,7 @@ def _check_3_6(project_id: str) -> CISCheckResult:
     """CIS 3.6 — Ensure SSH access is restricted from the internet."""
     result = CISCheckResult(
         check_id="3.6",
-        title="Ensure that SSH access is restricted from the internet (port 22)",
+        title="SSH (port 22) restricted from the internet",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation="Remove or restrict firewall rules that allow TCP port 22 from 0.0.0.0/0 or ::/0.",
@@ -1692,7 +1692,7 @@ def _check_3_7(project_id: str) -> CISCheckResult:
     """CIS 3.7 — Ensure RDP access is restricted from the internet."""
     result = CISCheckResult(
         check_id="3.7",
-        title="Ensure that RDP access is restricted from the internet (port 3389)",
+        title="RDP (port 3389) restricted from the internet",
         status=CheckStatus.ERROR,
         severity="critical",
         recommendation="Remove or restrict firewall rules that allow TCP port 3389 from 0.0.0.0/0 or ::/0.",
@@ -1744,7 +1744,7 @@ def _check_4_1(project_id: str) -> CISCheckResult:
     """CIS 4.1 — Ensure instances are not configured to use default service account."""
     result = CISCheckResult(
         check_id="4.1",
-        title="Ensure instances are not configured to use default service account",
+        title="Instances not using default service account",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation=(
@@ -1789,7 +1789,7 @@ def _check_4_2(project_id: str) -> CISCheckResult:
     """CIS 4.2 — Ensure instances are not configured to use the default service account with full access."""
     result = CISCheckResult(
         check_id="4.2",
-        title="Ensure instances are not configured to use the default service account with full access to all APIs",
+        title="Instances not using default service account with full API access",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove the default service account or restrict its scopes. Do not use https://www.googleapis.com/auth/cloud-platform scope with the default SA.",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -1836,7 +1836,7 @@ def _check_4_3(project_id: str) -> CISCheckResult:
     """CIS 4.3 — Ensure 'Block Project-wide SSH Keys' is enabled for VM instances."""
     result = CISCheckResult(
         check_id="4.3",
-        title="Ensure 'Block Project-wide SSH Keys' is enabled for VM instances",
+        title="Block Project-wide SSH Keys enabled on VMs",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation=(
@@ -1887,7 +1887,7 @@ def _check_4_4(project_id: str) -> CISCheckResult:
     """CIS 4.4 — Ensure OS login is enabled for a project."""
     result = CISCheckResult(
         check_id="4.4",
-        title="Ensure OS Login is enabled for a project",
+        title="OS Login enabled for the project",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the 'enable-oslogin' metadata key to 'TRUE' at the project level.",
@@ -1928,7 +1928,7 @@ def _check_4_5(project_id: str) -> CISCheckResult:
     """CIS 4.5 — Ensure 'Enable connecting to serial ports' is not enabled for VM instances."""
     result = CISCheckResult(
         check_id="4.5",
-        title="Ensure 'Enable connecting to serial ports' is not enabled for VM instances",
+        title="Serial-port connection disabled on VMs",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set 'serial-port-enable' metadata to 'false' or remove it from all VM instances.",
@@ -1974,7 +1974,7 @@ def _check_4_6(project_id: str) -> CISCheckResult:
     """CIS 4.6 — Ensure IP forwarding is not enabled on instances."""
     result = CISCheckResult(
         check_id="4.6",
-        title="Ensure that IP forwarding is not enabled on Instances",
+        title="IP forwarding disabled on instances",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Disable IP forwarding on instances unless explicitly required for NAT or routing functions.",
@@ -2014,7 +2014,7 @@ def _check_4_7(project_id: str) -> CISCheckResult:
     """CIS 4.7 — Ensure VM disks for critical VMs are encrypted with CSEK."""
     result = CISCheckResult(
         check_id="4.7",
-        title="Ensure VM disks for critical VMs are encrypted with Customer-Supplied Encryption Keys (CSEK)",
+        title="Critical VM disks encrypted with CSEK",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Encrypt VM disks with Customer-Supplied Encryption Keys (CSEK) for critical workloads.",
@@ -2055,7 +2055,7 @@ def _check_4_8(project_id: str) -> CISCheckResult:
     """CIS 4.8 — Ensure Compute instances are launched with Shielded VM enabled."""
     result = CISCheckResult(
         check_id="4.8",
-        title="Ensure Compute instances are launched with Shielded VM enabled",
+        title="Compute instances launched with Shielded VM",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable Shielded VM features (vTPM and Integrity Monitoring) on all Compute instances.",
@@ -2101,7 +2101,7 @@ def _check_4_9(project_id: str) -> CISCheckResult:
     """CIS 4.9 — Ensure that Compute instances do not have public IP addresses."""
     result = CISCheckResult(
         check_id="4.9",
-        title="Ensure that Compute instances do not have public IP addresses",
+        title="Compute instances lack public IP addresses",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove external IP addresses from Compute instances. Use Cloud NAT or IAP for outbound/inbound access.",
@@ -2149,7 +2149,7 @@ def _check_4_11(project_id: str) -> CISCheckResult:
     """CIS 4.11 — Ensure that Compute instances have Confidential Computing enabled."""
     result = CISCheckResult(
         check_id="4.11",
-        title="Ensure that Compute instances have Confidential Computing enabled",
+        title="Confidential Computing enabled on instances",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable Confidential Computing on Compute instances for memory encryption.",
@@ -2195,7 +2195,7 @@ def _check_5_1(project_id: str) -> CISCheckResult:
     """CIS 5.1 — Ensure Cloud Storage buckets are not publicly accessible."""
     result = CISCheckResult(
         check_id="5.1",
-        title="Ensure that Cloud Storage bucket is not anonymously or publicly accessible",
+        title="Cloud Storage buckets not publicly accessible",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove allUsers and allAuthenticatedUsers from bucket IAM policies.",
@@ -2250,7 +2250,7 @@ def _check_5_2(project_id: str) -> CISCheckResult:
     """CIS 5.2 — Ensure that Cloud Storage buckets have uniform bucket-level access enabled."""
     result = CISCheckResult(
         check_id="5.2",
-        title="Ensure that Cloud Storage buckets have uniform bucket-level access enabled",
+        title="Uniform bucket-level access enabled on buckets",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Enable uniform bucket-level access on all Cloud Storage buckets to use IAM exclusively for access control.",
@@ -2294,7 +2294,7 @@ def _check_6_1(project_id: str) -> CISCheckResult:
     """CIS 6.1 — Ensure Cloud SQL database instances require all incoming connections to use SSL."""
     result = CISCheckResult(
         check_id="6.1",
-        title="Ensure Cloud SQL database instances require all incoming connections to use SSL",
+        title="Cloud SQL requires SSL for all connections",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable 'Require SSL' (requireSsl) on all Cloud SQL instances to encrypt connections in transit.",
@@ -2332,7 +2332,7 @@ def _check_6_2(project_id: str) -> CISCheckResult:
     """CIS 6.2 — Ensure Cloud SQL database instances do not have public IPs."""
     result = CISCheckResult(
         check_id="6.2",
-        title="Ensure that Cloud SQL database instances do not have public IPs",
+        title="Cloud SQL instances lack public IPs",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove public IP addresses from Cloud SQL instances and use private IP or Cloud SQL Proxy instead.",
@@ -2370,7 +2370,7 @@ def _check_6_3(project_id: str) -> CISCheckResult:
     """CIS 6.3 — Ensure Cloud SQL database instances have automated backups enabled."""
     result = CISCheckResult(
         check_id="6.3",
-        title="Ensure that Cloud SQL database instances have automated backups enabled",
+        title="Cloud SQL automated backups enabled",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Enable automated backups on all Cloud SQL instances.",
@@ -2407,7 +2407,7 @@ def _check_6_4(project_id: str) -> CISCheckResult:
     """CIS 6.4 — Ensure Cloud SQL PostgreSQL instances have log_error_verbosity set to DEFAULT or stricter."""
     result = CISCheckResult(
         check_id="6.4",
-        title="Ensure Cloud SQL for PostgreSQL instances have log_error_verbosity set to DEFAULT or stricter",
+        title="Cloud SQL PostgreSQL log_error_verbosity DEFAULT or stricter",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the log_error_verbosity database flag to DEFAULT or TERSE on PostgreSQL instances.",
@@ -2453,7 +2453,7 @@ def _check_6_5(project_id: str) -> CISCheckResult:
     """CIS 6.5 — Ensure Cloud SQL PostgreSQL instances have log_connections enabled."""
     result = CISCheckResult(
         check_id="6.5",
-        title="Ensure that Cloud SQL for PostgreSQL instances have log_connections database flag set to on",
+        title="Cloud SQL PostgreSQL log_connections flag on",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the log_connections database flag to 'on' on all PostgreSQL instances.",
@@ -2498,7 +2498,7 @@ def _check_6_6(project_id: str) -> CISCheckResult:
     """CIS 6.6 — Ensure Cloud SQL PostgreSQL instances have log_disconnections enabled."""
     result = CISCheckResult(
         check_id="6.6",
-        title="Ensure that Cloud SQL for PostgreSQL instances have log_disconnections database flag set to on",
+        title="Cloud SQL PostgreSQL log_disconnections flag on",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the log_disconnections database flag to 'on' on all PostgreSQL instances.",
@@ -2543,7 +2543,7 @@ def _check_6_7(project_id: str) -> CISCheckResult:
     """CIS 6.7 — Ensure Cloud SQL PostgreSQL instances have log_min_duration_statement set to -1."""
     result = CISCheckResult(
         check_id="6.7",
-        title="Ensure that Cloud SQL for PostgreSQL instances have log_min_duration_statement set to -1",
+        title="Cloud SQL PostgreSQL log_min_duration_statement set to -1",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set the log_min_duration_statement database flag to '-1' to disable logging of statement durations (prevents sensitive data leakage).",  # noqa: E501 (CIS remediation/log-filter string — kept verbatim for copy-paste)
@@ -2593,7 +2593,7 @@ def _check_7_1(project_id: str) -> CISCheckResult:
     """CIS 7.1 — Ensure BigQuery datasets are not anonymously or publicly accessible."""
     result = CISCheckResult(
         check_id="7.1",
-        title="Ensure that BigQuery datasets are not anonymously or publicly accessible",
+        title="BigQuery datasets not publicly accessible",
         status=CheckStatus.ERROR,
         severity="high",
         recommendation="Remove allUsers and allAuthenticatedUsers from BigQuery dataset IAM policies.",
@@ -2636,7 +2636,7 @@ def _check_7_2(project_id: str) -> CISCheckResult:
     """CIS 7.2 — Ensure BigQuery datasets have default table expiration configured."""
     result = CISCheckResult(
         check_id="7.2",
-        title="Ensure that a default Customer-managed encryption key (CMEK) is specified for all BigQuery Data Sets",
+        title="Default CMEK specified for BigQuery datasets",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set a default table expiration on all BigQuery datasets to automatically clean up unused tables.",
@@ -2677,7 +2677,7 @@ def _check_7_3(project_id: str) -> CISCheckResult:
     """CIS 7.3 — Ensure BigQuery datasets are encrypted with Customer-Managed Keys (CMK)."""
     result = CISCheckResult(
         check_id="7.3",
-        title="Ensure that all BigQuery Tables are encrypted with Customer-managed encryption key (CMEK)",
+        title="BigQuery tables encrypted with CMEK",
         status=CheckStatus.ERROR,
         severity="medium",
         recommendation="Set a default KMS key on all BigQuery datasets so that new tables are automatically encrypted with CMEK.",

--- a/src/agent_bom/cloud/snowflake_cis_benchmark.py
+++ b/src/agent_bom/cloud/snowflake_cis_benchmark.py
@@ -260,19 +260,19 @@ _CHECK_SOURCES = {
 
 _CHECK_ERROR_METADATA = {
     "1.1": (
-        "Ensure MFA is enabled for all users with password authentication",
+        "MFA enabled for password-auth users",
         "critical",
         "1 - Account and Authentication",
     ),
-    "1.4": ("Ensure ACCOUNTADMIN role is granted to no more than 2 users", "critical", "1 - Account and Authentication"),
-    "3.2": ("Ensure data sharing is restricted to authorized accounts only", "medium", "3 - Data Protection"),
-    "4.2": ("Ensure login history shows no excessive failed authentication attempts", "medium", "4 - Monitoring and Logging"),
-    "5.1": ("Ensure the PUBLIC role has no direct privilege grants on objects", "high", "5 - Access Control"),
-    "5.2": ("Ensure no users have ACCOUNTADMIN as their default role", "high", "5 - Access Control"),
-    "1.2": ("Ensure minimum password length is set to 14 or greater", "medium", "1 - Account and Authentication"),
-    "1.5": ("Ensure password reuse is limited by password history of 24 or greater", "medium", "1 - Account and Authentication"),
-    "1.6": ("Ensure password maximum age is set to 90 days or less", "medium", "1 - Account and Authentication"),
-    "4.1": ("Ensure access history is enabled and being collected", "high", "4 - Monitoring and Logging"),
+    "1.4": ("ACCOUNTADMIN granted to at most 2 users", "critical", "1 - Account and Authentication"),
+    "3.2": ("Data sharing restricted to authorized accounts", "medium", "3 - Data Protection"),
+    "4.2": ("Login history free of excessive failed auth attempts", "medium", "4 - Monitoring and Logging"),
+    "5.1": ("PUBLIC role has no direct privilege grants", "high", "5 - Access Control"),
+    "5.2": ("No users default to ACCOUNTADMIN role", "high", "5 - Access Control"),
+    "1.2": ("Minimum password length 14 or greater", "medium", "1 - Account and Authentication"),
+    "1.5": ("Password history of 24 or greater", "medium", "1 - Account and Authentication"),
+    "1.6": ("Password maximum age 90 days or less", "medium", "1 - Account and Authentication"),
+    "4.1": ("Access history enabled and collected", "high", "4 - Monitoring and Logging"),
 }
 
 
@@ -357,7 +357,7 @@ def _check_1_1(cursor: Any) -> CISCheckResult:
     """CIS 1.1 — Ensure MFA is enabled for all users with password authentication."""
     result = CISCheckResult(
         check_id="1.1",
-        title="Ensure MFA is enabled for all users with password authentication",
+        title="MFA enabled for password-auth users",
         status=CheckStatus.PASS,
         severity="critical",
         cis_section=_AUTH_SECTION,
@@ -385,7 +385,7 @@ def _check_1_2(cursor: Any) -> CISCheckResult:
     """CIS 1.2 — Ensure minimum password length is set to 14 or greater."""
     result = CISCheckResult(
         check_id="1.2",
-        title="Ensure minimum password length is set to 14 or greater",
+        title="Minimum password length 14 or greater",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_AUTH_SECTION,
@@ -414,7 +414,7 @@ def _check_1_3(cursor: Any) -> CISCheckResult:
     """CIS 1.3 — Ensure session idle timeout is set to 4 hours or less."""
     result = CISCheckResult(
         check_id="1.3",
-        title="Ensure session idle timeout is set to 4 hours (240 min) or less",
+        title="Session idle timeout 4 hours or less",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_AUTH_SECTION,
@@ -437,7 +437,7 @@ def _check_1_4(cursor: Any) -> CISCheckResult:
     """CIS 1.4 — Ensure ACCOUNTADMIN role is granted to no more than 2 users."""
     result = CISCheckResult(
         check_id="1.4",
-        title="Ensure ACCOUNTADMIN role is granted to no more than 2 users",
+        title="ACCOUNTADMIN granted to at most 2 users",
         status=CheckStatus.PASS,
         severity="critical",
         cis_section=_AUTH_SECTION,
@@ -465,7 +465,7 @@ def _check_1_5(cursor: Any) -> CISCheckResult:
     """CIS 1.5 — Ensure password reuse is limited by password history of 24 or greater."""
     result = CISCheckResult(
         check_id="1.5",
-        title="Ensure password reuse is limited by password history of 24 or greater",
+        title="Password history of 24 or greater",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_AUTH_SECTION,
@@ -494,7 +494,7 @@ def _check_1_6(cursor: Any) -> CISCheckResult:
     """CIS 1.6 — Ensure password maximum age is set to 90 days or less."""
     result = CISCheckResult(
         check_id="1.6",
-        title="Ensure password maximum age is set to 90 days or less",
+        title="Password maximum age 90 days or less",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_AUTH_SECTION,
@@ -530,7 +530,7 @@ def _check_2_1(cursor: Any) -> CISCheckResult:
     """CIS 2.1 — Ensure network policies are configured at the account level."""
     result = CISCheckResult(
         check_id="2.1",
-        title="Ensure network policies are configured at the account level",
+        title="Account-level network policies configured",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_NETWORK_SECTION,
@@ -554,7 +554,7 @@ def _check_2_2(cursor: Any) -> CISCheckResult:
     """CIS 2.2 — Ensure network policies do not allow unrestricted access (0.0.0.0/0)."""
     result = CISCheckResult(
         check_id="2.2",
-        title="Ensure network policies do not allow unrestricted access (0.0.0.0/0)",
+        title="Network policies disallow unrestricted access",
         status=CheckStatus.PASS,
         severity="critical",
         cis_section=_NETWORK_SECTION,
@@ -592,7 +592,7 @@ def _check_3_1(cursor: Any) -> CISCheckResult:
     """CIS 3.1 — Ensure Tri-Secret Secure (customer-managed key) is enabled."""
     result = CISCheckResult(
         check_id="3.1",
-        title="Ensure Tri-Secret Secure (customer-managed key) is enabled",
+        title="Tri-Secret Secure (customer-managed key) enabled",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_DATA_SECTION,
@@ -616,7 +616,7 @@ def _check_3_2(cursor: Any) -> CISCheckResult:
     """CIS 3.2 — Ensure data sharing is restricted to authorized accounts."""
     result = CISCheckResult(
         check_id="3.2",
-        title="Ensure data sharing is restricted to authorized accounts only",
+        title="Data sharing restricted to authorized accounts",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_DATA_SECTION,
@@ -654,7 +654,7 @@ def _check_4_1(cursor: Any) -> CISCheckResult:
     """CIS 4.1 — Ensure access history is enabled and being collected."""
     result = CISCheckResult(
         check_id="4.1",
-        title="Ensure access history is enabled and being collected",
+        title="Access history enabled and collected",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_MONITORING_SECTION,
@@ -688,7 +688,7 @@ def _check_4_2(cursor: Any) -> CISCheckResult:
     """CIS 4.2 — Ensure login history shows no failed authentication patterns."""
     result = CISCheckResult(
         check_id="4.2",
-        title="Ensure login history shows no excessive failed authentication attempts",
+        title="Login history free of excessive failed auth attempts",
         status=CheckStatus.PASS,
         severity="medium",
         cis_section=_MONITORING_SECTION,
@@ -730,7 +730,7 @@ def _check_5_1(cursor: Any) -> CISCheckResult:
     """CIS 5.1 — Ensure the PUBLIC role has no direct privilege grants on objects."""
     result = CISCheckResult(
         check_id="5.1",
-        title="Ensure the PUBLIC role has no direct privilege grants on objects",
+        title="PUBLIC role has no direct privilege grants",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_ACCESS_SECTION,
@@ -757,7 +757,7 @@ def _check_5_2(cursor: Any) -> CISCheckResult:
     """CIS 5.2 — Ensure no users have ACCOUNTADMIN as their default role."""
     result = CISCheckResult(
         check_id="5.2",
-        title="Ensure no users have ACCOUNTADMIN as their default role",
+        title="No users default to ACCOUNTADMIN role",
         status=CheckStatus.PASS,
         severity="high",
         cis_section=_ACCESS_SECTION,

--- a/src/agent_bom/compliance_nist_catalog.py
+++ b/src/agent_bom/compliance_nist_catalog.py
@@ -129,6 +129,7 @@ def build_nist_800_53_catalog_line(
 
     if scan_count == 0 or evaluated == 0:
         status = "no_data"
+        score = 0.0  # never report a passing score off an unscanned/unevaluated estate
     elif failed > 0:
         status = "fail"
     elif warned > 0 or errored > 0:

--- a/src/agent_bom/framework_mapping.py
+++ b/src/agent_bom/framework_mapping.py
@@ -34,8 +34,15 @@ evidencing_checks, ...)}``. It is populated from the vendored data in
 * ``iso-27001`` / ``soc2`` / ``cis`` are **reference-only** stubs
   (``reference_only=True``): the control **ID** is the fact, but the ``title``
   is ``None`` or agent-bom's own short descriptor — never the copyrighted
-  official ISO / AICPA / CIS title, none of which are vendored anywhere in this
-  tree.
+  official ISO / AICPA / CIS title. This own-descriptor rule holds for the
+  control titles in **both** directions of CIS: the compliance-catalog ``cis``
+  (CIS Controls v8) entries here, and the cloud CIS Foundations Benchmark checks
+  in ``agent_bom.cloud.{aws,gcp,azure,snowflake}_cis_benchmark`` — the ``title``
+  agent-bom assigns to each of those checks is its own concise descriptor keyed
+  to the factual CIS check ID, not the verbatim official (copyrighted) CIS
+  Foundations Benchmark title. The control inventory digest
+  (``benchmark_provenance``) is likewise derived from control IDs only, never
+  from title text.
 
 ``control_spec()`` is the read seam. PR3 curates ``evidencing_checks`` for
 ``nist-800-53`` from two VENDOR-ASSERTED, in-repo sources: the CWE -> NIST

--- a/src/agent_bom/graph/toxic_findings.py
+++ b/src/agent_bom/graph/toxic_findings.py
@@ -581,16 +581,36 @@ TOXIC_RULES: tuple[ToxicRule, ...] = (
 
 # ── Public API ───────────────────────────────────────────────────────────────
 
+# The four "public, internet-exposed + vulnerable" rules overlap: a single KEV
+# vuln is also "a known vulnerability" (VULNERABLE), a network-exploitable RCE
+# KEV satisfies all four. Left un-subsumed, one exposure is counted 2-4x in the
+# severity totals and the fail-on-severity gate. They are listed in TOXIC_RULES
+# highest-specificity/severity first (KEV > RCE > NETWORK_EXPLOITABLE >
+# VULNERABLE), so the first family rule to match an exposed entry node subsumes
+# the rest for that node: one exposure yields one finding at its highest
+# applicable severity.
+_EXPOSED_VULN_FAMILY: frozenset[str] = frozenset(
+    {
+        "PUBLIC_EXPOSED_KEV",
+        "PUBLIC_EXPOSED_RCE",
+        "PUBLIC_EXPOSED_NETWORK_EXPLOITABLE",
+        "PUBLIC_EXPOSED_VULNERABLE",
+    }
+)
+
 
 def build_toxic_combination_findings(graph: UnifiedGraph) -> list[Finding]:
     """Run every toxic-combination rule and return enforceable Findings.
 
     Pure, read-only, no network. Severity is escalated one tier above the worst
     participating component (capped at ``critical``). Deduped by
-    ``(rule_id, sorted node-id set)``. Never raises into the builder.
+    ``(rule_id, sorted node-id set)``. Overlapping exposed+vulnerable rules are
+    subsumed by specificity so one exposure yields one finding at its highest
+    applicable severity. Never raises into the builder.
     """
     findings: list[Finding] = []
     seen: set[tuple[str, tuple[str, ...]]] = set()
+    family_claimed: set[str] = set()  # entry nodes already flagged by the exposed+vuln family
     if not graph.nodes:
         return findings
 
@@ -599,7 +619,12 @@ def build_toxic_combination_findings(graph: UnifiedGraph) -> list[Finding]:
             rule_matches = rule.match(graph)
         except Exception:  # noqa: BLE001 — a single bad rule must not kill the rest
             continue
+        in_family = rule.id in _EXPOSED_VULN_FAMILY
         for m in rule_matches:
+            if in_family:
+                if m.entry.id in family_claimed:
+                    continue  # a higher-specificity family rule already claimed this exposure
+                family_claimed.add(m.entry.id)
             dedupe = (rule.id, m.dedupe_key)
             if dedupe in seen:
                 continue

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -213,8 +213,11 @@ class Vulnerability:
           working on (or using) exploits.
         - ``"public_exploit"`` — EPSS percentile ≥ 80. Public exploit
           code exists but widespread exploitation not yet observed.
-        - ``"theoretical"`` — no KEV, low EPSS. Exploitation is
-          theoretically possible but not currently evidenced.
+        - ``"theoretical"`` — no KEV, but EPSS *is* present and low.
+          Exploitation is assessed as possible-but-not-evidenced.
+        - ``"unassessed"`` — no KEV, no EPSS score, and no EPSS
+          percentile. There is no basis for any exploit assessment, so
+          no assessed-sounding label is fabricated from absent signal.
 
         The monotonic ordering means the highest-severity signal wins
         (KEV always beats EPSS-only signals) and never double-counts.
@@ -228,6 +231,8 @@ class Vulnerability:
 
         if self.is_kev:
             return "actively_exploited"
+        if self.epss_score is None and self.epss_percentile is None:
+            return "unassessed"  # no signal → no fabricated assessment
         epss = self.epss_score or 0.0
         pct = self.epss_percentile or 0.0
         if epss >= EPSS_ACTIVE_EXPLOITATION_THRESHOLD or pct >= 95.0:

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -168,13 +168,20 @@ def is_actionable_finding(finding: Finding) -> bool:
 
 
 def exploit_likelihood_value(finding: Finding) -> str:
-    """Graded exploit-likelihood signal derived from unified finding enrichment."""
+    """Graded exploit-likelihood signal derived from unified finding enrichment.
+
+    Returns ``"unassessed"`` (never ``"theoretical"``) when there is no basis —
+    no KEV, no EPSS score, no EPSS percentile — so an assessed-sounding label is
+    never fabricated from absent signal.
+    """
     from agent_bom.config import EPSS_ACTIVE_EXPLOITATION_THRESHOLD
 
     if finding.is_kev:
         return "actively_exploited"
     epss = finding.epss_score
     percentile = evidence(finding, "epss_percentile", None)
+    if epss is None and percentile is None:
+        return "unassessed"  # no signal → no fabricated assessment
     if epss is not None and epss >= EPSS_ACTIVE_EXPLOITATION_THRESHOLD:
         return "likely_exploited"
     if percentile is not None and percentile >= 95:

--- a/tests/test_aws_cis_benchmark.py
+++ b/tests/test_aws_cis_benchmark.py
@@ -2565,3 +2565,52 @@ class TestRunBenchmark:
             report = run_benchmark(checks=["1.4", "1.5"])
             assert report.total == 2
             assert {c.check_id for c in report.checks} == {"1.4", "1.5"}
+
+    def test_error_path_titles_are_own_descriptors_not_verbatim_cis(self):
+        """Copyright guard for the AWS error path.
+
+        On a boto3 failure ``_run_check`` derives the check title from the
+        function docstring via ``_extract_title``. That title is emitted as
+        ``CISCheckResult.title``, so the docstring must carry agent-bom's own
+        descriptor keyed to the CIS check id — never the verbatim (copyrighted)
+        official CIS Foundations Benchmark title. This drives every check onto
+        the error path and asserts no emitted title reproduces the CIS
+        "Ensure ..." house style or a known verbatim title.
+        """
+
+        class _RaisingClient:
+            def __getattr__(self, _name):
+                def _raise(*_a, **_k):
+                    raise RuntimeError("forced failure")
+
+                return _raise
+
+        modules_patch, mock_boto3 = _mock_boto3_modules()
+        with modules_patch:
+            mock_session = MagicMock()
+            mock_boto3.Session.return_value = mock_session
+            mock_session.region_name = "us-east-1"
+
+            mock_sts = MagicMock()
+            mock_sts.get_caller_identity.return_value = {"Account": "123"}
+
+            def client_factory(service, **_kwargs):
+                if service == "sts":
+                    return mock_sts
+                return _RaisingClient()
+
+            mock_session.client.side_effect = client_factory
+
+            report = run_benchmark()
+
+        assert report.total == 60
+        # The forced failures must actually exercise the error path.
+        assert sum(1 for c in report.checks if c.status == CheckStatus.ERROR) >= 50
+        offenders = [c.title for c in report.checks if c.title.lower().startswith("ensure ")]
+        assert not offenders, f"AWS error-path titles leak verbatim CIS text: {offenders}"
+        forbidden = {
+            "Ensure MFA is enabled for the root user account",
+            "Ensure no root user account access key exists",
+            "Maintain current contact details",
+        }
+        assert not (forbidden & {c.title for c in report.checks})

--- a/tests/test_compliance_nist_catalog.py
+++ b/tests/test_compliance_nist_catalog.py
@@ -65,6 +65,20 @@ def test_no_data_when_nothing_mapped():
     assert line["summary"]["evaluated"] == 0
 
 
+def test_no_data_forces_zero_score_even_with_passing_controls():
+    """Contract guard: a no_data line can never carry a non-zero score.
+
+    With ``scan_count=0`` the line is ``no_data`` regardless of any evaluated
+    controls; the raw score must be zeroed so JSON consumers never read a
+    passing score off an unscanned estate (§11 honesty).
+    """
+    cis_statuses = {("aws", "2.1.2"): "pass"}  # a passing evaluated control
+    line = build_nist_800_53_catalog_line([], cis_statuses, scan_count=0)
+    assert line["status"] == "no_data"
+    assert line["summary"]["evaluated"] >= 1
+    assert line["score"] == 0.0
+
+
 def test_drill_reconciles_and_family_rollup_sums_back():
     all_blast, cis_statuses = _scenario()
     line = build_nist_800_53_catalog_line(all_blast, cis_statuses, scan_count=1)

--- a/tests/test_exploit_likelihood.py
+++ b/tests/test_exploit_likelihood.py
@@ -63,13 +63,24 @@ def test_exploit_likelihood_public_exploit_band():
     assert v.exploit_likelihood == "public_exploit"
 
 
-def test_exploit_likelihood_theoretical_fallback():
+def test_exploit_likelihood_theoretical_needs_a_real_low_signal():
+    # EPSS is present but low → "theoretical" is a genuine (low) assessment.
     v = _vuln(is_kev=False, epss_score=0.01, epss_percentile=10.0)
     assert v.exploit_likelihood == "theoretical"
 
 
-def test_exploit_likelihood_no_enrichment():
+def test_exploit_likelihood_no_enrichment_is_unassessed_not_theoretical():
+    # No KEV, no EPSS score, no percentile → there is no basis for any exploit
+    # assessment. Emitting "theoretical" would fabricate an assessed-sounding
+    # label from absent signal; the honest value is "unassessed".
     v = _vuln()
+    assert v.exploit_likelihood == "unassessed"
+
+
+def test_exploit_likelihood_partial_epss_signal_is_assessed():
+    # A single present EPSS signal (percentile only) is a basis → graded, not
+    # "unassessed".
+    v = _vuln(is_kev=False, epss_score=None, epss_percentile=12.0)
     assert v.exploit_likelihood == "theoretical"
 
 
@@ -95,6 +106,26 @@ def test_sarif_embeds_exploit_likelihood_on_rule_and_result():
 
     result = sarif["runs"][0]["results"][0]
     assert result["properties"]["exploit_likelihood"] == "actively_exploited"
+
+
+def test_sarif_does_not_fabricate_theoretical_for_unenriched_vuln():
+    # An enrichment-free vuln must not carry a fabricated "theoretical" exploit
+    # label in SARIF rule/result props — it is unassessed.
+    report = AIBOMReport(blast_radii=[_br(_vuln())], tool_version="0.77.1")
+    sarif = to_sarif(report)
+    rule = sarif["runs"][0]["tool"]["driver"]["rules"][0]
+    result = sarif["runs"][0]["results"][0]
+    assert rule["properties"]["exploit_likelihood"] == "unassessed"
+    assert result["properties"]["exploit_likelihood"] == "unassessed"
+
+
+def test_finding_views_helper_is_unassessed_without_signal():
+    from agent_bom.output.finding_views import exploit_likelihood_value
+
+    # Drive the helper through the report's finding stream (same seam SARIF uses).
+    report = AIBOMReport(blast_radii=[_br(_vuln())])
+    finding = next(f for f in report.to_findings() if f.finding_type.name == "CVE")
+    assert exploit_likelihood_value(finding) == "unassessed"
 
 
 def test_sarif_embeds_run_level_framework_taxonomies():
@@ -157,11 +188,12 @@ def test_html_vuln_table_renders_exploit_badges():
     assert 'class="badge-exploit-public"' in html_poc
     assert 'data-exploit-likelihood="public_exploit"' in html_poc
 
-    # Theoretical → no badge classes
+    # Unassessed (no enrichment) → no badge classes, honest label (not "theoretical")
     br_theo = _br(_vuln())
     report_theo = AIBOMReport(blast_radii=[br_theo])
     html_theo = _vuln_table(report_theo, [br_theo])
     assert 'class="badge-kev"' not in html_theo
     assert 'class="badge-exploit-likely"' not in html_theo
     assert 'class="badge-exploit-public"' not in html_theo
-    assert 'data-exploit-likelihood="theoretical"' in html_theo
+    assert 'data-exploit-likelihood="unassessed"' in html_theo
+    assert 'data-exploit-likelihood="theoretical"' not in html_theo

--- a/tests/test_framework_mapping.py
+++ b/tests/test_framework_mapping.py
@@ -493,6 +493,94 @@ def test_nist_evidenced_controls_set_matches_specs():
     assert "SI-10" in derived
 
 
+# ─── Cloud CIS Foundations Benchmark title provenance (copyright guard) ──────
+
+
+def _cloud_cis_benchmark_title_literals() -> dict[str, list[str]]:
+    """Return every ``title="..."`` string literal passed to a ``CISCheckResult``
+    constructor across the four cloud CIS Foundations Benchmark modules.
+
+    The official CIS Foundations Benchmark titles are copyrighted (not public
+    domain). agent-bom must key its checks to the factual CIS check IDs while
+    carrying its OWN concise descriptor as the ``title`` — never the verbatim
+    official CIS title. This scans the module source (AST) so it stays robust
+    even though the control inventory digest is derived from IDs only.
+    """
+    import ast
+    from pathlib import Path
+
+    import agent_bom.cloud as cloud_pkg
+
+    cloud_dir = Path(cloud_pkg.__file__).parent
+    modules = (
+        "aws_cis_benchmark.py",
+        "gcp_cis_benchmark.py",
+        "azure_cis_benchmark.py",
+        "snowflake_cis_benchmark.py",
+    )
+    out: dict[str, list[str]] = {}
+    for name in modules:
+        source = (cloud_dir / name).read_text()
+        tree = ast.parse(source)
+        titles: list[str] = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            call_name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", "")
+            if call_name != "CISCheckResult":
+                continue
+            for kw in node.keywords:
+                if kw.arg == "title" and isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+                    titles.append(kw.value.value)
+        out[name] = titles
+    return out
+
+
+def test_cloud_cis_benchmark_titles_are_own_descriptors_not_copyrighted():
+    """No emitted cloud CIS Foundations Benchmark check title may reproduce the
+    verbatim official (copyrighted) CIS title. The CIS house style opens every
+    recommendation with "Ensure ..."; the highest-signal guard is that none of
+    agent-bom's own descriptors start with that word, plus a curated block-list
+    of known verbatim titles per provider.
+    """
+    literals = _cloud_cis_benchmark_title_literals()
+
+    # Every one of the four modules must actually contribute titles (guards the
+    # scan itself from silently matching nothing).
+    for name, titles in literals.items():
+        assert titles, f"{name}: no CISCheckResult title literals found — scan is broken"
+
+    all_titles = [t for titles in literals.values() for t in titles]
+
+    # (1) House-style guard: the strongest signal of a verbatim CIS title.
+    offenders = [t for t in all_titles if t.lower().startswith("ensure ")]
+    assert not offenders, f"CIS-house-style 'Ensure ...' titles must be reworded to own descriptors: {offenders}"
+
+    # (2) Curated block-list of known verbatim CIS Foundations Benchmark titles.
+    forbidden = {
+        # AWS
+        "Ensure MFA is enabled for the root user account",
+        "Ensure no root user account access key exists",
+        "Ensure IAM password policy requires minimum length of 14 or greater",
+        "Maintain current contact details",
+        # GCP
+        "Ensure that corporate login credentials are used",
+        "Ensure multi-factor authentication is enforced for all users",
+        "Ensure that the default VPC network does not exist in the project",
+        # Azure
+        "Ensure that multi-factor authentication is enabled for all users",
+        "Ensure that 'Auditing' is set to 'On' for SQL servers",
+        "Ensure Microsoft Defender for Servers is set to On",
+        # Snowflake
+        "Ensure MFA is enabled for all users with password authentication",
+        "Ensure minimum password length is set to 14 or greater",
+        "Ensure ACCOUNTADMIN role is granted to no more than 2 users",
+    }
+    present = forbidden & set(all_titles)
+    assert not present, f"Verbatim copyrighted CIS Foundations Benchmark titles emitted: {sorted(present)}"
+
+
 def test_vendored_catalog_integrity_and_counts_reconcile():
     """Digest + published counts must reconcile with the vendored payloads."""
     from agent_bom import framework_catalog as fc

--- a/tests/test_framework_mapping.py
+++ b/tests/test_framework_mapping.py
@@ -496,6 +496,22 @@ def test_nist_evidenced_controls_set_matches_specs():
 # ─── Cloud CIS Foundations Benchmark title provenance (copyright guard) ──────
 
 
+_CLOUD_CIS_BENCHMARK_MODULES = (
+    "aws_cis_benchmark.py",
+    "gcp_cis_benchmark.py",
+    "azure_cis_benchmark.py",
+    "snowflake_cis_benchmark.py",
+)
+
+
+def _cloud_cis_benchmark_dir():
+    from pathlib import Path
+
+    import agent_bom.cloud as cloud_pkg
+
+    return Path(cloud_pkg.__file__).parent
+
+
 def _cloud_cis_benchmark_title_literals() -> dict[str, list[str]]:
     """Return every ``title="..."`` string literal passed to a ``CISCheckResult``
     constructor across the four cloud CIS Foundations Benchmark modules.
@@ -507,19 +523,10 @@ def _cloud_cis_benchmark_title_literals() -> dict[str, list[str]]:
     even though the control inventory digest is derived from IDs only.
     """
     import ast
-    from pathlib import Path
 
-    import agent_bom.cloud as cloud_pkg
-
-    cloud_dir = Path(cloud_pkg.__file__).parent
-    modules = (
-        "aws_cis_benchmark.py",
-        "gcp_cis_benchmark.py",
-        "azure_cis_benchmark.py",
-        "snowflake_cis_benchmark.py",
-    )
+    cloud_dir = _cloud_cis_benchmark_dir()
     out: dict[str, list[str]] = {}
-    for name in modules:
+    for name in _CLOUD_CIS_BENCHMARK_MODULES:
         source = (cloud_dir / name).read_text()
         tree = ast.parse(source)
         titles: list[str] = []
@@ -558,27 +565,37 @@ def test_cloud_cis_benchmark_titles_are_own_descriptors_not_copyrighted():
     assert not offenders, f"CIS-house-style 'Ensure ...' titles must be reworded to own descriptors: {offenders}"
 
     # (2) Curated block-list of known verbatim CIS Foundations Benchmark titles.
+    #     Scanned against the RAW module source so it also catches titles that
+    #     reach ``CISCheckResult`` indirectly (Azure ``_check_activity_log_alert``
+    #     positional args, Snowflake ``_CHECK_ERROR_METADATA`` tuples), not only
+    #     inline ``title=`` keywords.
     forbidden = {
         # AWS
         "Ensure MFA is enabled for the root user account",
         "Ensure no root user account access key exists",
-        "Ensure IAM password policy requires minimum length of 14 or greater",
+        "Ensure IAM password policy requires minimum length >= 14",
         "Maintain current contact details",
         # GCP
         "Ensure that corporate login credentials are used",
         "Ensure multi-factor authentication is enforced for all users",
         "Ensure that the default VPC network does not exist in the project",
-        # Azure
+        # Azure — inline title= and the indirect Activity-Log-alert positional path
         "Ensure that multi-factor authentication is enabled for all users",
         "Ensure that 'Auditing' is set to 'On' for SQL servers",
         "Ensure Microsoft Defender for Servers is set to On",
-        # Snowflake
+        "Ensure that Activity Log alert exists for Delete Key Vault",
+        # Snowflake — inline title= and the indirect _CHECK_ERROR_METADATA path
         "Ensure MFA is enabled for all users with password authentication",
         "Ensure minimum password length is set to 14 or greater",
         "Ensure ACCOUNTADMIN role is granted to no more than 2 users",
     }
     present = forbidden & set(all_titles)
     assert not present, f"Verbatim copyrighted CIS Foundations Benchmark titles emitted: {sorted(present)}"
+
+    cloud_dir = _cloud_cis_benchmark_dir()
+    joined_source = "\n".join((cloud_dir / name).read_text() for name in _CLOUD_CIS_BENCHMARK_MODULES)
+    in_source = sorted(t for t in forbidden if f'"{t}"' in joined_source)
+    assert not in_source, f"Verbatim copyrighted CIS titles still vendored as string literals: {in_source}"
 
 
 def test_vendored_catalog_integrity_and_counts_reconcile():

--- a/tests/test_toxic_findings.py
+++ b/tests/test_toxic_findings.py
@@ -187,6 +187,66 @@ def test_public_exposed_network_exploitable_rule_uses_cvss_attack_vector():
     assert set(f.evidence["node_ids"]) == {"res:web", "vuln:cve"}
 
 
+def test_exposed_kev_node_yields_single_combination_finding():
+    # One internet-exposed node with one KEV vuln must yield EXACTLY ONE toxic
+    # COMBINATION finding (the highest-specificity rule) — not both
+    # PUBLIC_EXPOSED_KEV and the generic PUBLIC_EXPOSED_VULNERABLE double-counting
+    # the same exposure in severity totals and the fail-on-severity gate.
+    findings = build_toxic_combination_findings(_graph_public_exposed_kev())
+    combos = [f for f in findings if f.finding_type == FindingType.COMBINATION]
+    assert len(combos) == 1
+    assert combos[0].evidence["rule_id"] == "PUBLIC_EXPOSED_KEV"
+    assert combos[0].severity == "critical"
+
+
+def test_worst_case_exposure_fires_once_at_highest_severity():
+    # A network-exploitable, CWE-RCE, CISA-KEV vuln on an exposed node satisfies
+    # all four overlapping exposed+vulnerable rules; subsumption collapses them to
+    # one finding at the highest applicable severity/specificity (KEV).
+    res = _node("res:web", EntityType.CLOUD_RESOURCE, severity="high", toxic_exposed_vulnerable=True, internet_exposed=True)
+    vuln = _node(
+        "vuln:cve",
+        EntityType.VULNERABILITY,
+        severity="critical",
+        is_kev=True,
+        impact_category="code-execution",
+        attack_vector="network",
+        network_exploitable=True,
+    )
+    g = _graph([res, vuln], [_edge("res:web", "vuln:cve", RelationshipType.VULNERABLE_TO)])
+    combos = [f for f in build_toxic_combination_findings(g) if f.finding_type == FindingType.COMBINATION]
+    assert len(combos) == 1
+    assert combos[0].evidence["rule_id"] == "PUBLIC_EXPOSED_KEV"
+    assert combos[0].severity == "critical"
+
+
+def test_exposed_vulnerable_family_does_not_suppress_unrelated_rules():
+    # The exposed+vulnerable family subsumes only within itself: an exposed node
+    # that is also a lateral-movement pivot still gets its independent
+    # PUBLIC_PERMISSION_LATERAL finding.
+    res = _node(
+        "role:public_fn",
+        EntityType.ROLE,
+        severity="high",
+        toxic_exposed_vulnerable=True,
+        internet_exposed=True,
+    )
+    vuln = _node("vuln:cve", EntityType.VULNERABILITY, severity="critical", is_kev=True)
+    other = _node("account:prod", EntityType.ACCOUNT, severity="high")
+    g = _graph(
+        [res, vuln, other],
+        [
+            _edge("role:public_fn", "vuln:cve", RelationshipType.VULNERABLE_TO),
+            _edge("role:public_fn", "account:prod", RelationshipType.ASSUMES),
+        ],
+    )
+    findings = build_toxic_combination_findings(g)
+    rule_ids = {f.evidence["rule_id"] for f in findings}
+    assert "PUBLIC_EXPOSED_KEV" in rule_ids
+    assert "PUBLIC_PERMISSION_LATERAL" in rule_ids
+    assert "PUBLIC_EXPOSED_VULNERABLE" not in rule_ids  # subsumed by KEV
+
+
 def test_public_to_sensitive_data_rule():
     findings = build_toxic_combination_findings(_graph_public_to_sensitive())
     hits = _by_rule(findings, "PUBLIC_TO_SENSITIVE_DATA")


### PR DESCRIPTION
## Summary

Four low-risk correctness/honesty fixes from the 2026-07-19 audit. Each change is small, TDD'd, and independently verified.

### 1. Legal — stop emitting verbatim, copyrighted CIS Benchmark titles (and correct a false "not vendored" claim)
`framework_mapping.py` asserted the official copyrighted CIS titles were "not vendored anywhere in this tree", but the four cloud CIS Foundations Benchmark modules carried ~220 verbatim official CIS titles (`"Ensure MFA is enabled for the root user account"`, …). CIS Benchmark text is **not** public domain.

- **Own-descriptored** every verbatim CIS `title=` across `cloud/{aws,gcp,azure,snowflake}_cis_benchmark.py` — agent-bom's own concise wording keyed to the same factual CIS check ID. `check_id`, `severity`, `cis_section`, `recommendation`, `evidence`, and logic are untouched; the control inventory digest is derived from IDs only, so no benchmark inventory/manifest changed.
- Covered the **indirect** title sources too: Azure `_check_activity_log_alert` positional titles, Snowflake `_CHECK_ERROR_METADATA` error-path titles, and the **AWS error path** — `_run_check` derives the title from each function's docstring via `_extract_title`, so the AWS check docstrings' title segments were reworded to their own-descriptors as well (keeping the `CIS <id> —` prefix intact for `_extract_check_id`). No verbatim CIS title is emitted on any path now.
- **Corrected** the false `framework_mapping.py` claim to state accurately that both the compliance-catalog `cis` (Controls v8) entries and the cloud CIS Foundations Benchmark check titles carry agent-bom's own descriptors keyed to the factual CIS identifiers.
- **Guard tests** (so a verbatim title can't come back): AST scan of all four modules' `title=` literals + a curated verbatim block-list (`test_framework_mapping.py`), and an AWS **error-path** guard that drives every check onto the failure path and asserts no emitted title reproduces the CIS "Ensure …" house style (`test_aws_cis_benchmark.py`).

### 2. no_data lines can no longer carry score=100
`compliance_nist_catalog.build_nist_800_53_catalog_line` computed the score before the `no_data` branch, so the raw JSON contract could return `score=100.0` alongside `status="no_data"`. Zero the score whenever the line resolves to `no_data` (`scan_count==0` or nothing evaluated).

### 3. Toxic-combination multiplicative counting
`graph/toxic_findings.py`: one internet-exposed node with one KEV vuln fired both `PUBLIC_EXPOSED_KEV` and `PUBLIC_EXPOSED_VULNERABLE` (a network-exploitable RCE KEV could fire all four exposed+vuln rules), counting one exposure 2–4× in severity totals and the fail-on-severity gate. The four overlapping rules are now subsumed by specificity (KEV > RCE > NETWORK_EXPLOITABLE > VULNERABLE) per exposed entry node: one exposure yields one COMBINATION finding at its highest applicable severity. Unrelated rules (lateral movement, sensitive-data reach, agent-reaches-privileged) still fire independently on the same node.

### 4. exploit_likelihood='theoretical' fabricated from zero signal
A vuln with no KEV, no EPSS score, and no EPSS percentile was labelled `exploit_likelihood="theoretical"` — an assessed-sounding label from absent signal — in SARIF rule/result props, JSON, CycloneDX, and HTML. Both derivations (`models.Vulnerability.exploit_likelihood` and `output/finding_views.exploit_likelihood_value`, the seam SARIF/HTML use) now return `"unassessed"` when there is no basis. A present-but-low EPSS signal still grades as `"theoretical"` (a genuine low assessment).

## Verification (all green locally)
- pytest: `test_framework_mapping`, `test_aws_cis_benchmark`, `test_gcp_cis_benchmark`, `test_azure_cis(+_benchmark)`, `test_snowflake_cis_benchmark(+_checks)`, `test_cis_benchmark_analytics`, `test_benchmark_catalog_reconciliation`, `test_cloud_benchmark_manifests`, `test_compliance_nist_catalog`, `test_toxic_findings`, `test_toxic_combos`, `test_exploit_likelihood` — **624 passed**. Plus graph/CLI consumers (`test_graph_*`, `test_cli_scan`) and SARIF schema suites (`test_sarif_schema_2_1_0`, `test_sarif_normalization`) green.
- `ruff check` on all changed files — clean.
- `mypy` on the changed source files — clean (the only errors are pre-existing SDK-stub mismatches in untouched `gcp_inventory.py`/`azure_inventory.py`/`destinations.py`).
- Repo gates: `check-counts`, `check_release_consistency`, `check_benchmark_drift` (in sync across 5 providers), `check_framework_catalog` (in sync) — all pass.
- SARIF still schema-valid; `agent-bom agents --demo --offline` smoke: report emits `exploit_likelihood` values `{actively_exploited, unassessed}` — no fabricated `theoretical`.



---

## 5. README product-flow rewrite (folded in from #4269)
Leads with attack-path risk over raw CVEs: positional `agent-bom scan .` form, a How-it-works product-flow diagram, restructured screenshots that open with the investigation lens, and a corrected TLS/edge description. All referenced images already exist in `docs/images`; `check-counts` + `check_product_surface_contract` pass. Closes #4269.
