### PR TITLE
fix(ci): make gitleaks independent of pull request API

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,11 +1,5 @@
 name: Gitleaks Secret Scan
 
-# Runs on every PR + push to main to catch accidentally committed secrets.
-# Reference: https://github.com/gitleaks/gitleaks
-#
-# The gitleaks config in .gitleaks.toml (if present) overrides defaults; we
-# ship the default rules initially and iterate based on false-positive rate.
-
 on:
   pull_request:
     branches: [main]
@@ -28,19 +22,74 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout (full history for PR diff)
+      - name: Checkout full history
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      - name: Run gitleaks
-        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+      - name: Install pinned gitleaks
+        shell: bash
         env:
-          # Required since gitleaks-action v2.x for PR scans.
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # Fail the job on any leak — pilot-grade; no silent advisory mode.
-          GITLEAKS_ENABLE_COMMENTS: "true"
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: "true"
-          # GITLEAKS_LICENSE is only needed for the organisation edition;
-          # individual accounts skip this cleanly.
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_VERSION: "8.24.3"
+          GITLEAKS_ARCHIVE_SHA256: "9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c"
+        run: |
+          set -euo pipefail
+          archive="${RUNNER_TEMP}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          curl --proto '=https' --tlsv1.2 --fail --silent --show-error --location \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            --output "${archive}" \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          printf '%s  %s\n' "${GITLEAKS_ARCHIVE_SHA256}" "${archive}" | sha256sum --check --strict
+          tar -xzf "${archive}" -C "${RUNNER_TEMP}" gitleaks
+          test "$("${RUNNER_TEMP}/gitleaks" version)" = "${GITLEAKS_VERSION}"
+
+      - name: Scan the event's Git range
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PUSH_BEFORE_SHA: ${{ github.event.before }}
+          CURRENT_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          require_commit() {
+            local sha="$1"
+            [[ "${sha}" =~ ^[0-9a-f]{40}$ ]] || {
+              echo "Invalid or missing Git commit for ${EVENT_NAME} scan" >&2
+              exit 2
+            }
+            git cat-file -e "${sha}^{commit}"
+          }
+
+          case "${EVENT_NAME}" in
+            pull_request)
+              require_commit "${PR_BASE_SHA}"
+              require_commit "${PR_HEAD_SHA}"
+              log_opts=(--log-opts "${PR_BASE_SHA}..${PR_HEAD_SHA}")
+              ;;
+            push)
+              require_commit "${PUSH_BEFORE_SHA}"
+              require_commit "${CURRENT_SHA}"
+              log_opts=(--log-opts "${PUSH_BEFORE_SHA}..${CURRENT_SHA}")
+              ;;
+            workflow_dispatch)
+              require_commit "${CURRENT_SHA}"
+              log_opts=(--log-opts "${CURRENT_SHA}^..${CURRENT_SHA}")
+              ;;
+            *)
+              echo "Unsupported event: ${EVENT_NAME}" >&2
+              exit 2
+              ;;
+          esac
+
+          "${RUNNER_TEMP}/gitleaks" git . \
+            --config .gitleaks.toml \
+            --gitleaks-ignore-path .gitleaksignore \
+            --redact=100 \
+            --no-banner \
+            --no-color \
+            --log-level warn \
+            "${log_opts[@]}"

--- a/tests/test_gitleaks_workflow.py
+++ b/tests/test_gitleaks_workflow.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "gitleaks.yml"
+
+
+def test_gitleaks_scans_event_git_ranges_without_github_api_dependency() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "gitleaks/gitleaks-action@" not in workflow
+    assert "GITHUB_TOKEN" not in workflow
+    assert "GITLEAKS_LICENSE" not in workflow
+    assert "GITLEAKS_ENABLE_COMMENTS" not in workflow
+    assert "GITLEAKS_ENABLE_UPLOAD_ARTIFACT" not in workflow
+    assert "github.event.pull_request.base.sha" in workflow
+    assert "github.event.pull_request.head.sha" in workflow
+    assert "github.event.before" in workflow
+    assert "git cat-file -e" in workflow
+    assert "--log-opts" in workflow
+
+
+def test_gitleaks_binary_and_scan_contract_are_fail_closed() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert "timeout-minutes: 15" in workflow
+    assert "fetch-depth: 0" in workflow
+    assert "persist-credentials: false" in workflow
+    assert 'GITLEAKS_VERSION: "8.24.3"' in workflow
+    assert 'GITLEAKS_ARCHIVE_SHA256: "9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c"' in workflow
+    assert "https://github.com/gitleaks/gitleaks/releases/download/" in workflow
+    assert "sha256sum --check --strict" in workflow
+    assert "set -euo pipefail" in workflow
+    assert "--config .gitleaks.toml" in workflow
+    assert "--gitleaks-ignore-path .gitleaksignore" in workflow
+    assert "--redact=100" in workflow


### PR DESCRIPTION
## Summary

- Replace the PR-API-dependent Gitleaks action after repeated HTTP 503 failures occurred before secret scanning began.
- Install the official Gitleaks 8.24.3 binary from its checksum-pinned archive and scan event-provided Git ranges directly.
- Preserve fail-closed scanning, least-privilege checkout, explicit config/ignore/redaction, timeout, and a regression contract without tokens, comments, or artifact uploads.

## Verification

- uv run pytest -q tests/test_gitleaks_workflow.py
- uv run ruff check tests/test_gitleaks_workflow.py
- actionlint .github/workflows/gitleaks.yml
- uv run python scripts/check_workflow_timeouts.py
- Gitleaks 8.24.3: exact origin/main..HEAD scan with .gitleaks.toml and .gitleaksignore
- Gitleaks 8.30.1: exact origin/main..HEAD scan with .gitleaks.toml and .gitleaksignore
- Official Linux x64 archive SHA-256 verified as 9991e0b2903da4c8f6122b5c3186448b927a5da4deef1fe45271c3793f4ee29c
- git diff --check

## Notes

- Pull requests scan base SHA through head SHA; pushes scan before SHA through the current SHA; manual runs scan the current commit.
- Invalid, missing, or unavailable commits exit non-zero before Gitleaks runs.
- The observed failure was GitHub API HTTP 503 at /pulls/4270/commits inside the previous action, not a detected secret.