### PR TITLE
refactor(api): consolidate auth resolution into one resolve_principal pipeline (#4274)

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -13,7 +13,8 @@ import sys
 import threading
 import time
 import uuid
-from collections.abc import Sequence
+from collections.abc import Awaitable, Callable, Iterable, Sequence
+from dataclasses import dataclass
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any, cast
 
@@ -701,6 +702,54 @@ class TrustHeadersMiddleware(BaseHTTPMiddleware):
         return response
 
 
+@dataclass(frozen=True)
+class Resolved:
+    """A resolver authenticated a principal; ``response`` is the downstream result.
+
+    The resolver has already applied the per-route authorization/tenant policy
+    and dispatched (or produced the terminal authz rejection for) the request.
+    """
+
+    response: Response
+
+
+@dataclass(frozen=True)
+class Invalid:
+    """A resolver saw a credential it could not accept.
+
+    Terminal: a presented-but-invalid credential is returned as-is and never
+    falls through to a later resolver or the anonymous fallback.
+    """
+
+    response: Response
+
+
+@dataclass(frozen=True)
+class Absent:
+    """No credential this resolver can act on — the pipeline tries the next one."""
+
+
+Resolution = Resolved | Invalid | Absent
+
+
+async def run_resolver_chain(resolvers: Iterable[Callable[[], Awaitable[Resolution]]]) -> Response | None:
+    """Run an ordered authentication resolver chain: first non-Absent result wins.
+
+    This is the single place that expresses the pipeline's control-flow
+    invariant — ``Absent`` continues to the next resolver, while both
+    ``Resolved`` and ``Invalid`` are terminal and return their response
+    immediately. Returns ``None`` only when every resolver is ``Absent`` (the
+    production chain ends in a terminal resolver, so that never happens there;
+    it is meaningful for unit tests exercising the loop directly).
+    """
+    for resolver in resolvers:
+        result = await resolver()
+        if isinstance(result, Absent):
+            continue
+        return result.response
+    return None
+
+
 class APIKeyMiddleware(BaseHTTPMiddleware):
     """Optional API key authentication via Bearer token or X-API-Key header.
 
@@ -1178,49 +1227,96 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
                 _logger.critical("Rejecting request while Postgres tenant RLS bypass context is active")
                 return JSONResponse(status_code=500, content={"detail": "Tenant isolation guard is not clean"})
 
-        if self._is_scim_path(request.url.path):
-            return await self._try_scim_bearer_auth(request, call_next)
+        return await self.resolve_principal(request, call_next)
 
+    async def resolve_principal(self, request: StarletteRequest, call_next: RequestResponseEndpoint) -> Response:
+        """Decide authentication for a request through one ordered resolver chain.
+
+        This is the single authentication decision point. Each credential source
+        (SCIM bearer, browser session, trusted proxy, static key, OIDC bearer,
+        API key, anonymous fallback) is a resolver returning ``Resolved`` (a
+        principal was authenticated), ``Invalid`` (a credential was presented and
+        rejected — terminal, never falls through), or ``Absent`` (nothing to act
+        on — try the next resolver). The order and per-resolver semantics are
+        exactly those of the previous inline dispatch chain; see the individual
+        ``_resolve_*`` methods. The final resolver is always terminal.
+        """
         session_token = request.cookies.get(SESSION_COOKIE_NAME, "")
-        if session_token:
-            session_response = await self._try_browser_session_auth(request, call_next, session_token)
-            if session_response is not None:
-                return session_response
-
         # Extract raw key from headers for CLI and service clients.
-        raw_key = ""
         auth = request.headers.get("authorization", "")
-        if auth.startswith("Bearer "):
-            raw_key = auth[7:]
+        raw_key = auth[7:] if auth.startswith("Bearer ") else ""
         if not raw_key:
             raw_key = request.headers.get("x-api-key", "")
 
-        if not raw_key:
-            proxy_response = await self._try_proxy_header_auth(request, call_next)
-            if proxy_response is not None:
-                return proxy_response
-            # No API key, no session cookie, no trusted-proxy attestation. If the
-            # operator opted into anonymous read-only access AND no credential
-            # was presented in any form, serve the request as NO_AUTH_ROLE
-            # instead of 401. A present-but-malformed credential (e.g. an
-            # unsupported Authorization scheme) must NOT silently downgrade to
-            # anonymous — it is treated as a presented credential and rejected.
-            if self._allow_unauthenticated and not self._credential_presented(request, auth):
-                return await self._serve_anonymous(request, call_next)
-            return JSONResponse(
-                status_code=401,
-                content={"detail": "Unauthorized — provide API key via Authorization: Bearer <key> or X-API-Key header"},
-            )
+        resolvers: tuple[Callable[[], Awaitable[Resolution]], ...] = (
+            lambda: self._resolve_scim_bearer(request, call_next),
+            lambda: self._resolve_browser_session(request, call_next, session_token),
+            lambda: self._resolve_trusted_proxy(request, call_next, raw_key),
+            lambda: self._resolve_static_key(request, call_next, raw_key),
+            lambda: self._resolve_oidc_bearer(request, call_next, raw_key, auth),
+            lambda: self._resolve_api_key(request, call_next, raw_key),
+            lambda: self._resolve_terminal(request, call_next, raw_key, auth),
+        )
+        response = await run_resolver_chain(resolvers)
+        if response is not None:
+            return response
+        # Unreachable: the terminal resolver never returns Absent. Fail closed.
+        return JSONResponse(status_code=401, content={"detail": "Unauthorized"})
 
+    @staticmethod
+    def _classify_terminal(request: StarletteRequest, response: Response) -> Resolution:
+        """Tag a terminal helper Response as Resolved or Invalid.
+
+        The SCIM / browser-session / trusted-proxy helpers set
+        ``request.state.auth_method`` only once a principal is established; an
+        auth rejection returns a JSONResponse without it. Both outcomes are
+        terminal, so the distinction is purely semantic (and sets up the
+        post-resolution policy point), never a control-flow change.
+        """
+        if getattr(request.state, "auth_method", None):
+            return Resolved(response)
+        return Invalid(response)
+
+    async def _resolve_scim_bearer(self, request: StarletteRequest, call_next: RequestResponseEndpoint) -> Resolution:
+        if not self._is_scim_path(request.url.path):
+            return Absent()
+        return self._classify_terminal(request, await self._try_scim_bearer_auth(request, call_next))
+
+    async def _resolve_browser_session(
+        self, request: StarletteRequest, call_next: RequestResponseEndpoint, session_token: str
+    ) -> Resolution:
+        if not session_token:
+            return Absent()
+        return self._classify_terminal(request, await self._try_browser_session_auth(request, call_next, session_token))
+
+    async def _resolve_trusted_proxy(self, request: StarletteRequest, call_next: RequestResponseEndpoint, raw_key: str) -> Resolution:
+        # Trusted-proxy headers are consulted only when no API key was presented,
+        # preserving the previous ``if not raw_key`` gate.
+        if raw_key:
+            return Absent()
+        proxy_response = await self._try_proxy_header_auth(request, call_next)
+        if proxy_response is None:
+            return Absent()
+        return self._classify_terminal(request, proxy_response)
+
+    async def _resolve_static_key(self, request: StarletteRequest, call_next: RequestResponseEndpoint, raw_key: str) -> Resolution:
         # Simple mode: single static key (backward compatible, all access)
+        if not raw_key:
+            return Absent()
         if self._api_key and secrets.compare_digest(raw_key, self._api_key):
             request.state.api_key_name = "static-key"
             request.state.api_key_role = "admin"
             request.state.tenant_id = "default"
             request.state.auth_method = "static_api_key"
-            return await self._call_with_tenant_context(request, call_next)
+            return Resolved(await self._call_with_tenant_context(request, call_next))
+        return Absent()
 
+    async def _resolve_oidc_bearer(
+        self, request: StarletteRequest, call_next: RequestResponseEndpoint, raw_key: str, auth: str
+    ) -> Resolution:
         # OIDC mode: try JWT verification when AGENT_BOM_OIDC_ISSUER is set
+        if not raw_key:
+            return Absent()
         if not self._oidc_checked:
             from agent_bom.api.oidc import OIDCConfig
 
@@ -1228,100 +1324,136 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             self._oidc_checked = True
 
         oidc_cfg = self._oidc_config
-        if oidc_cfg is not None and getattr(oidc_cfg, "enabled", False) and auth.startswith("Bearer "):
-            from agent_bom.api.oidc import OIDCError, record_oidc_decode_failure
+        if oidc_cfg is None or not getattr(oidc_cfg, "enabled", False) or not auth.startswith("Bearer "):
+            return Absent()
 
-            try:
-                _claims, oidc_role = oidc_cfg.verify(raw_key)
-                required = self._required_role(request.method, request.url.path)
-                from agent_bom.api.auth import Role
+        from agent_bom.api.oidc import OIDCError, record_oidc_decode_failure
 
-                tenant_id = oidc_cfg.resolve_tenant(_claims)
-                subject = _claims.get("email") or _claims.get("preferred_username") or _claims.get("sub", "oidc-user")
-                upstream_role = Role(oidc_role)
-                effective_role, scim_error = self._resolve_runtime_role(
-                    request,
-                    tenant_id=tenant_id,
-                    upstream_role=upstream_role,
-                    subjects=(subject, _claims.get("email"), _claims.get("preferred_username"), _claims.get("upn"), _claims.get("sub")),
-                )
-                if scim_error is not None:
-                    return scim_error
-                required_role = Role(required)
-                if effective_role is not None and self._role_allows(effective_role, required_role):
-                    request.state.api_key_name = subject
-                    request.state.api_key_role = effective_role.value
-                    request.state.tenant_id = tenant_id
-                    request.state.auth_method = "oidc"
-                    # Short issuer suffix helps operators recognize which IdP
-                    # resolved the token without leaking the full URL to all
-                    # request-scoped log fields.
-                    issuer = str(_claims.get("iss") or "")
-                    request.state.auth_issuer = issuer.rsplit("/", 1)[-1][:64] if issuer else None
-                    return await self._call_with_tenant_context(request, call_next)
-                actual_role = effective_role.value if effective_role else oidc_role
-                return JSONResponse(
+        try:
+            _claims, oidc_role = oidc_cfg.verify(raw_key)
+            required = self._required_role(request.method, request.url.path)
+            from agent_bom.api.auth import Role
+
+            tenant_id = oidc_cfg.resolve_tenant(_claims)
+            subject = _claims.get("email") or _claims.get("preferred_username") or _claims.get("sub", "oidc-user")
+            upstream_role = Role(oidc_role)
+            effective_role, scim_error = self._resolve_runtime_role(
+                request,
+                tenant_id=tenant_id,
+                upstream_role=upstream_role,
+                subjects=(subject, _claims.get("email"), _claims.get("preferred_username"), _claims.get("upn"), _claims.get("sub")),
+            )
+            if scim_error is not None:
+                return Invalid(scim_error)
+            required_role = Role(required)
+            if effective_role is not None and self._role_allows(effective_role, required_role):
+                request.state.api_key_name = subject
+                request.state.api_key_role = effective_role.value
+                request.state.tenant_id = tenant_id
+                request.state.auth_method = "oidc"
+                # Short issuer suffix helps operators recognize which IdP
+                # resolved the token without leaking the full URL to all
+                # request-scoped log fields.
+                issuer = str(_claims.get("iss") or "")
+                request.state.auth_issuer = issuer.rsplit("/", 1)[-1][:64] if issuer else None
+                return Resolved(await self._call_with_tenant_context(request, call_next))
+            actual_role = effective_role.value if effective_role else oidc_role
+            return Invalid(
+                JSONResponse(
                     status_code=403,
                     content={"detail": f"Forbidden — requires {required} role, OIDC session has {actual_role}"},
                 )
-            except OIDCError as exc:
-                record_oidc_decode_failure()
-                _logger.debug("OIDC verification failed: %s", sanitize_text(exc))
-                # Fall through to API key check — OIDC failure is non-fatal if keys also configured
+            )
+        except OIDCError as exc:
+            record_oidc_decode_failure()
+            _logger.debug("OIDC verification failed: %s", sanitize_text(exc))
+            # Fall through to API key check — OIDC failure is non-fatal if keys also configured
+            return Absent()
 
+    async def _resolve_api_key(self, request: StarletteRequest, call_next: RequestResponseEndpoint, raw_key: str) -> Resolution:
         # RBAC mode: check against KeyStore
+        if not raw_key:
+            return Absent()
         from agent_bom.api.auth import Role, get_key_store
 
         store = get_key_store()
-        if store.has_keys():
-            # ``store.verify`` runs a ~21ms scrypt derivation (in-memory store) or
-            # a blocking DB read (Postgres store); offload it to a worker thread so
-            # it never stalls the async event loop while unrelated requests wait.
-            api_key = await anyio.to_thread.run_sync(store.verify, raw_key)
-            if api_key:
-                required = self._required_role(request.method, request.url.path)
-                required_role = Role(required)
-                effective_role = api_key.role
-                if api_key.name.startswith("saml:") or api_key.scim_subject_id:
-                    subjects = [api_key.name.removeprefix("saml:"), api_key.name]
-                    if api_key.scim_subject_id:
-                        subjects.append(api_key.scim_subject_id)
-                    effective_role, scim_error = self._resolve_runtime_role(
-                        request,
-                        tenant_id=api_key.tenant_id,
-                        upstream_role=api_key.role,
-                        subjects=tuple(subjects),
-                    )
-                    if scim_error is not None:
-                        return scim_error
-                    effective_role = effective_role or api_key.role
-                if not self._role_allows(effective_role, required_role):
-                    return JSONResponse(
-                        status_code=403,
-                        content={"detail": f"Forbidden — requires {required} role, you have {effective_role.value}"},
-                    )
-                required_scope = self._required_scope(request.method, request.url.path)
-                if not api_key.has_scope(required_scope):
-                    return JSONResponse(
-                        status_code=403,
-                        content={"detail": f"Forbidden — requires scope {required_scope}"},
-                    )
-                request.state.api_key_name = api_key.name
-                request.state.api_key_role = effective_role.value
-                request.state.tenant_id = api_key.tenant_id
-                request.state.api_key_id = api_key.key_id
-                request.state.api_key_scopes = list(api_key.scopes)
-                if api_key.scim_subject_id:
-                    request.state.scim_subject_id = api_key.scim_subject_id
-                # SAML-minted keys are named "saml:<subject>" — surface that
-                # as a distinct auth method so operators can trace who came
-                # in via which IdP path even after the key has been issued.
-                request.state.auth_method = "saml" if api_key.name.startswith("saml:") else "api_key"
-                return await self._call_with_tenant_context(request, call_next)
+        if not store.has_keys():
+            return Absent()
+        # ``store.verify`` runs a ~21ms scrypt derivation (in-memory store) or
+        # a blocking DB read (Postgres store); offload it to a worker thread so
+        # it never stalls the async event loop while unrelated requests wait.
+        api_key = await anyio.to_thread.run_sync(store.verify, raw_key)
+        if not api_key:
+            return Absent()
+        required = self._required_role(request.method, request.url.path)
+        required_role = Role(required)
+        effective_role = api_key.role
+        if api_key.name.startswith("saml:") or api_key.scim_subject_id:
+            subjects = [api_key.name.removeprefix("saml:"), api_key.name]
+            if api_key.scim_subject_id:
+                subjects.append(api_key.scim_subject_id)
+            effective_role, scim_error = self._resolve_runtime_role(
+                request,
+                tenant_id=api_key.tenant_id,
+                upstream_role=api_key.role,
+                subjects=tuple(subjects),
+            )
+            if scim_error is not None:
+                return Invalid(scim_error)
+            effective_role = effective_role or api_key.role
+        if not self._role_allows(effective_role, required_role):
+            return Invalid(
+                JSONResponse(
+                    status_code=403,
+                    content={"detail": f"Forbidden — requires {required} role, you have {effective_role.value}"},
+                )
+            )
+        required_scope = self._required_scope(request.method, request.url.path)
+        if not api_key.has_scope(required_scope):
+            return Invalid(
+                JSONResponse(
+                    status_code=403,
+                    content={"detail": f"Forbidden — requires scope {required_scope}"},
+                )
+            )
+        request.state.api_key_name = api_key.name
+        request.state.api_key_role = effective_role.value
+        request.state.tenant_id = api_key.tenant_id
+        request.state.api_key_id = api_key.key_id
+        request.state.api_key_scopes = list(api_key.scopes)
+        if api_key.scim_subject_id:
+            request.state.scim_subject_id = api_key.scim_subject_id
+        # SAML-minted keys are named "saml:<subject>" — surface that
+        # as a distinct auth method so operators can trace who came
+        # in via which IdP path even after the key has been issued.
+        request.state.auth_method = "saml" if api_key.name.startswith("saml:") else "api_key"
+        return Resolved(await self._call_with_tenant_context(request, call_next))
 
-        return JSONResponse(
-            status_code=401,
-            content={"detail": "Unauthorized — invalid API key"},
+    async def _resolve_terminal(self, request: StarletteRequest, call_next: RequestResponseEndpoint, raw_key: str, auth: str) -> Resolution:
+        """Final resolver: anonymous fallback (opt-in) or a hard 401.
+
+        Reached only after every credential source returned Absent.
+        """
+        if not raw_key:
+            # No API key, no session cookie, no trusted-proxy attestation. If the
+            # operator opted into anonymous read-only access AND no credential
+            # was presented in any form, serve the request as NO_AUTH_ROLE
+            # instead of 401. A present-but-malformed credential (e.g. an
+            # unsupported Authorization scheme) must NOT silently downgrade to
+            # anonymous — it is treated as a presented credential and rejected.
+            if self._allow_unauthenticated and not self._credential_presented(request, auth):
+                return Resolved(await self._serve_anonymous(request, call_next))
+            return Invalid(
+                JSONResponse(
+                    status_code=401,
+                    content={"detail": "Unauthorized — provide API key via Authorization: Bearer <key> or X-API-Key header"},
+                )
+            )
+        return Invalid(
+            JSONResponse(
+                status_code=401,
+                content={"detail": "Unauthorized — invalid API key"},
+            )
         )
 
     def _is_scim_path(self, path: str) -> bool:

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1392,7 +1392,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             subjects = [api_key.name.removeprefix("saml:"), api_key.name]
             if api_key.scim_subject_id:
                 subjects.append(api_key.scim_subject_id)
-            effective_role, scim_error = self._resolve_runtime_role(
+            resolved_role, scim_error = self._resolve_runtime_role(
                 request,
                 tenant_id=api_key.tenant_id,
                 upstream_role=api_key.role,
@@ -1400,7 +1400,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             )
             if scim_error is not None:
                 return Invalid(scim_error)
-            effective_role = effective_role or api_key.role
+            effective_role = resolved_role or api_key.role
         if not self._role_allows(effective_role, required_role):
             return Invalid(
                 JSONResponse(

--- a/tests/api/test_api_resolve_principal_pipeline.py
+++ b/tests/api/test_api_resolve_principal_pipeline.py
@@ -1,0 +1,171 @@
+"""Pipeline invariants for the consolidated ``resolve_principal`` resolver chain.
+
+These assert the structural contract of the single authentication decision point
+(``APIKeyMiddleware.resolve_principal`` / ``run_resolver_chain``):
+
+* ``Absent`` chains to the next resolver.
+* ``Invalid`` is terminal — a presented-but-invalid credential is a hard 401 and
+  never falls through to a later resolver or the anonymous fallback.
+* the anonymous fallback only activates when explicitly opted in.
+* a present-but-invalid credential resolves to 401, never a downgrade to the
+  anonymous VIEWER identity.
+"""
+
+import asyncio
+
+from starlette.responses import JSONResponse
+from starlette.testclient import TestClient
+
+from agent_bom.api.middleware import Absent, Invalid, Resolved, run_resolver_chain
+from agent_bom.api.server import app, configure_api
+
+_CREDENTIAL_ENV = (
+    "AGENT_BOM_API_KEY",
+    "AGENT_BOM_API_KEYS",
+    "AGENT_BOM_OIDC_ISSUER",
+    "AGENT_BOM_OIDC_TENANT_PROVIDERS_JSON",
+    "AGENT_BOM_TRUST_PROXY_AUTH",
+    "AGENT_BOM_SCIM_BEARER_TOKEN",
+)
+
+# A configured static key puts the middleware in "combined" mode: valid
+# credentials authenticate to their role, credential-less callers fall through to
+# the anonymous NO_AUTH_ROLE (clamped to VIEWER), and a presented-but-invalid
+# credential is still rejected. The pure no-auth mode (nothing configured + opt-in)
+# removes the auth middleware entirely, so it cannot exercise these invariants.
+_STATIC_KEY = "static-admin-key-for-pipeline-invariants"
+
+
+def _clear_credential_sources(monkeypatch) -> None:
+    for name in _CREDENTIAL_ENV:
+        monkeypatch.delenv(name, raising=False)
+
+
+# --- run_resolver_chain: control-flow invariants (pure, no HTTP) -----------------
+
+
+def test_absent_chains_to_the_next_resolver() -> None:
+    called: list[str] = []
+
+    async def first() -> Absent:
+        called.append("first")
+        return Absent()
+
+    async def second() -> Resolved:
+        called.append("second")
+        return Resolved(JSONResponse(status_code=200, content={"who": "second"}))
+
+    async def third() -> Resolved:  # pragma: no cover - must never run
+        called.append("third")
+        return Resolved(JSONResponse(status_code=200, content={"who": "third"}))
+
+    response = asyncio.run(run_resolver_chain([first, second, third]))
+
+    assert response is not None
+    assert response.status_code == 200
+    # Absent chained to ``second``; the first non-Absent result won and ``third``
+    # was never consulted.
+    assert called == ["first", "second"]
+
+
+def test_invalid_is_terminal_and_never_falls_through() -> None:
+    called: list[str] = []
+
+    async def absent_resolver() -> Absent:
+        called.append("absent")
+        return Absent()
+
+    async def rejecting_resolver() -> Invalid:
+        called.append("invalid")
+        return Invalid(JSONResponse(status_code=401, content={"detail": "rejected"}))
+
+    async def anonymous_resolver() -> Resolved:  # pragma: no cover - must never run
+        called.append("anonymous")
+        return Resolved(JSONResponse(status_code=200, content={"detail": "anonymous"}))
+
+    response = asyncio.run(run_resolver_chain([absent_resolver, rejecting_resolver, anonymous_resolver]))
+
+    assert response is not None
+    assert response.status_code == 401
+    # Invalid stopped the chain: the anonymous fallback after it never ran.
+    assert called == ["absent", "invalid"]
+    assert "anonymous" not in called
+
+
+def test_resolved_short_circuits_immediately() -> None:
+    called: list[str] = []
+
+    async def resolved_resolver() -> Resolved:
+        called.append("resolved")
+        return Resolved(JSONResponse(status_code=200, content={"who": "resolved"}))
+
+    async def later() -> Absent:  # pragma: no cover - must never run
+        called.append("later")
+        return Absent()
+
+    response = asyncio.run(run_resolver_chain([resolved_resolver, later]))
+
+    assert response is not None
+    assert response.status_code == 200
+    assert called == ["resolved"]
+
+
+def test_all_absent_returns_none() -> None:
+    async def absent_resolver() -> Absent:
+        return Absent()
+
+    assert asyncio.run(run_resolver_chain([absent_resolver, absent_resolver])) is None
+
+
+# --- middleware-level invariants (through the real app) --------------------------
+
+
+def test_anonymous_served_only_when_opted_in(monkeypatch) -> None:
+    _clear_credential_sources(monkeypatch)
+
+    # Opted in (combined mode): a credential-less request is served as the
+    # anonymous NO_AUTH_ROLE, clamped to VIEWER because a credential source is
+    # configured — so a viewer route is 200 but an admin route is 403 (not 200),
+    # proving the anonymous identity is not elevated.
+    monkeypatch.setenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+    configure_api(api_key=_STATIC_KEY, allow_unauthenticated=True)
+    try:
+        client = TestClient(app)
+        assert client.get("/v1/auth/me").status_code == 200
+        assert client.get("/v1/auth/policy").status_code == 403
+    finally:
+        configure_api(api_key=None)
+
+    # Opted out: the same credential-less request fails closed with 401.
+    monkeypatch.delenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", raising=False)
+    configure_api(api_key=_STATIC_KEY, allow_unauthenticated=False)
+    try:
+        assert TestClient(app).get("/v1/auth/me").status_code == 401
+    finally:
+        configure_api(api_key=None)
+
+
+def test_present_but_invalid_credential_is_401_not_anonymous_viewer(monkeypatch) -> None:
+    """Anonymous opt-in must not downgrade a rejected credential to VIEWER."""
+    _clear_credential_sources(monkeypatch)
+    monkeypatch.setenv("AGENT_BOM_ALLOW_UNAUTHENTICATED_API", "1")
+    configure_api(api_key=_STATIC_KEY, allow_unauthenticated=True)
+    try:
+        client = TestClient(app)
+
+        # Baseline: no credential at all -> anonymous VIEWER is served; the valid
+        # static key authenticates to its (admin) role.
+        assert client.get("/v1/auth/me").status_code == 200
+        assert client.get("/v1/auth/me", headers={"Authorization": f"Bearer {_STATIC_KEY}"}).status_code == 200
+
+        # A credential IS presented but cannot resolve to a valid identity. Each
+        # must be a hard 401 — never a silent downgrade to the anonymous VIEWER.
+        # (a) Non-Bearer Authorization scheme: raw key stays empty, but a
+        #     credential is present, so ``_credential_presented`` blocks anonymous.
+        assert client.get("/v1/auth/me", headers={"Authorization": "Basic Zm9vOmJhcg=="}).status_code == 401
+        # (b) Bearer token that matches no configured credential source.
+        assert client.get("/v1/auth/me", headers={"Authorization": "Bearer not-a-real-token"}).status_code == 401
+        # (c) X-API-Key that matches no configured key.
+        assert client.get("/v1/auth/me", headers={"X-API-Key": "not-a-real-key"}).status_code == 401
+    finally:
+        configure_api(api_key=None)


### PR DESCRIPTION
## What

Extract the de-facto authentication chain inside `APIKeyMiddleware.dispatch` into a single ordered **`resolve_principal`** pipeline. Each credential source becomes an explicit resolver returning a tagged `Resolved | Invalid | Absent` result, and one `run_resolver_chain` helper is the single place that expresses the control-flow rule.

- `Absent` -> try the next resolver
- `Resolved` (principal authenticated) / `Invalid` (credential presented and rejected) -> terminal, return the response

Dispatch now delegates every authentication decision to `resolve_principal`, so there is **exactly one code path** that decides authentication. The pre-auth gates (OPTIONS/CORS, exempt paths, dashboard-public assets, the Postgres RLS-bypass guard) stay in `dispatch` ahead of it.

## Why

The resolution logic was a parallel, implicit chain (`_try_scim_bearer_auth` -> browser session -> `_try_proxy_header_auth` -> static key -> OIDC -> key store -> anonymous/401) with the "invalid credential stops here vs. falls through" decision encoded ad hoc at each step. Making the chain explicit is the structural precondition for the epic's contract-test matrix and posture-single-source-of-truth work.

## No behavior change

This is a pure structural refactor. The resolver **order and every per-resolver semantic are identical** to the previous inline dispatch:

- `Invalid` never falls through to a later resolver or to the anonymous fallback — a presented-but-invalid credential is a hard 401 (or 403), never a downgrade to VIEWER.
- `Absent` chains to the next resolver.
- The OIDC decode-failure **fall-through to the key store** (non-fatal when keys are also configured) is preserved as `Absent`.
- The anonymous branch stays a final, opt-in-only resolver, VIEWER-clamped when any credential source is configured.
- SCIM traffic still resolves only through the dedicated bearer resolver; trusted-proxy secret/issuer verification and customer tenant pinning are byte-for-byte unchanged.
- The existing `_try_scim_bearer_auth` / `_try_browser_session_auth` / `_try_proxy_header_auth` / `_serve_anonymous` / `_credential_presented` helpers are **reused unmodified**. Authorization, RBAC, scope, and tenant-context logic are untouched (PR1 is resolution-consolidation only, not an authz refactor).

Behavior preservation was verified by diffing the response-code grid of the refactor vs. `origin/main` (credential-less / non-Bearer / bad-Bearer / bad-key across viewer and admin routes, in both pure-no-auth and combined modes) — identical in every cell — and by the full existing auth suite passing with **zero changes to any test expectation**.

## Verification

- `pytest tests/api/ tests/test_auth.py tests/test_shared_auth_state.py tests/test_hardening.py tests/test_security_hardening.py tests/test_gateway_auth_tenant_e2e.py tests/test_cli_serve_auth_enforce.py tests/test_proxy_audit_dedupe_isolation.py` -> **995 passed**, no expectation changes.
- New `tests/api/test_api_resolve_principal_pipeline.py` asserts the pipeline invariants explicitly: `Absent` chains, `Invalid`/`Resolved` are terminal (a resolver after `Invalid` is never consulted), all-`Absent` returns `None`, anonymous is served only when opted in (and is VIEWER — 200 on a viewer route, 403 on an admin route), and a present-but-invalid credential is 401, not an anonymous-VIEWER 200.
- `ruff check` + `ruff format` clean; `mypy` clean on `middleware.py`; `scripts/check_exception_sanitization.py` exit 0.

## Note for PR2

The OIDC decode-failure -> key-store fall-through is the one place where a presented (but unverifiable) bearer credential does not immediately 401 at its own resolver; it is preserved as-is here. Under the epic's target invariant ("Invalid never falls through"), PR2 should consciously decide whether that remains an `Absent` (try-as-API-key) or becomes an `Invalid`. Net observable behavior today is still a 401 for a truly invalid token.

Part of #4274 (PR1 of the auth-consolidation epic).