### PR TITLE
test(graph): pin the shipped persist path bounded on a large new snapshot (#4075)

### DIFF
--- a/docs/decisions/006-unified-graph-write-batching.md
+++ b/docs/decisions/006-unified-graph-write-batching.md
@@ -58,3 +58,32 @@ bounded-memory invariant.
 - **Boundary:** This decision covers write-path batching only. Read-path
   windowing, streaming reads, materialized drilldowns, and UI virtualization are
   separate graph-scale concerns.
+
+## Realized bound and residual producer wall
+
+The write path is bounded end to end and regression-guarded:
+
+- The streamed save + the prior-snapshot delta both stay bounded by the batch
+  window / an id-only prior digest rather than the graph size. `save_graph`'s
+  SQLite search-index refresh streams in bounded batches too, not a `fetchall`
+  re-materialization of the node set.
+- Guards: `test_graph_store_streamed_persistence.py` (streamed-save peak flat as
+  N grows), `test_graph_persist_memory_bound.py` (prior digest is a small,
+  non-eroding fraction of a full prior load), `test_search_index_refresh_streaming.py`
+  (bounded search-index refresh), and — at the shipped pipeline entrypoint —
+  `test_graph_persist_pipeline_scale_bound.py`, which pins that persisting a
+  *large new* snapshot through `_persist_graph_snapshot` peaks at a small,
+  non-eroding fraction of materializing that snapshot (≈0.12–0.2 measured, 4x-N
+  span). That last guard exists because a re-materialization of the *incoming*
+  snapshot is invisible to the prior-side guards.
+
+The remaining, un-bounded stage is the graph **producer**:
+`build_unified_graph_from_report` still materializes the whole correlated
+`UnifiedGraph` — nodes, edges, and its adjacency / reverse-adjacency / dedup
+indexes, with correlation overlays that query the whole graph — in memory before
+persist. So peak RSS for a single build+persist is set by the producer, not the
+write path. Removing that wall (streaming/two-pass overlays that emit into the
+storage-backed `GraphBuildWorkspace` instead of a resident graph) is the builder
+re-plumb tracked by #4075; a generator wrapper around the existing builder does
+not move peak RSS because the correlation phase already holds the whole graph.
+Until then, steer multi-million-node graphs to a server-side backend.

--- a/tests/test_graph_persist_pipeline_scale_bound.py
+++ b/tests/test_graph_persist_pipeline_scale_bound.py
@@ -1,0 +1,143 @@
+"""Production persist path adds no second O(N) copy of a *large new* snapshot (#4055/#4075).
+
+The existing production-path guard
+(``test_graph_persist_memory_bound.test_production_persist_path_does_not_materialise_full_prior_graph``)
+pins the *prior* side: a large previous snapshot is digested, not re-materialised.
+It exercises only a 20-node **new** snapshot, so it cannot catch a regression that
+re-materialises the **incoming** snapshot during the streamed save + the SQLite
+search-index refresh — exactly the O(N) second materialisation removed in PR-2 of
+#4075 (the ``_refresh_snapshot_search_index`` ``fetchall`` rebuild).
+
+This test drives the shipped pipeline entrypoint ``_persist_graph_snapshot`` with a
+**scaled** new snapshot and asserts the persist leg's own allocation stays a small
+fraction of a full second copy of that snapshot, and that the fraction does not
+erode as the new snapshot grows 4x. The prior snapshot is kept small so this
+isolates the *incoming-snapshot write path* (streamed save + search-index refresh
++ delta), not the already-covered prior-digest bound.
+
+Scope note (honesty): this bounds the **persist** leg. The graph *producer*
+(``build_unified_graph_from_report``) still materialises the whole correlated
+graph plus its adjacency / dedup indexes before persist — that residual peak-RSS
+wall is the builder re-plumb tracked by #4075 (PR-3/4) and is deliberately
+*outside* this test's boundary. The builder is monkeypatched to return an
+already-resident graph so the measurement captures the persist leg only.
+"""
+
+from __future__ import annotations
+
+import tracemalloc
+from pathlib import Path
+from types import SimpleNamespace
+
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph import RelationshipType, UnifiedEdge
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, NodeStatus
+
+# A 4x span, both well above the write batch window so the ratio reflects the
+# true bounded fraction (batch buffer + prior-id digest) rather than batch noise.
+_N_SMALL = 3000
+_N_LARGE = 12000
+# Force a small write batch so the bounded batch window is a small slice of N even
+# at _N_SMALL — otherwise the default 1000-row batch is ~N/3 and swamps the signal.
+_BATCH = "256"
+
+
+def _synthetic_graph(scan: str, n: int) -> UnifiedGraph:
+    g = UnifiedGraph(scan_id=scan, tenant_id="t1")
+    for i in range(n):
+        g.add_node(
+            UnifiedNode(
+                id=f"n:{i}",
+                entity_type=EntityType.AGENT if i % 50 == 0 else EntityType.VULNERABILITY,
+                label=f"label-{i}",
+                severity="high" if i % 3 else "critical",
+                risk_score=float(i % 10),
+                status=NodeStatus.ACTIVE,
+                compliance_tags=["cis-1.1", "soc2"],
+                data_sources=["mcp-scan"],
+                attributes={"cvss_score": 7.0, "blob": "v" * 64, "purl": f"pkg:pypi/x-{i}@1.0"},
+            )
+        )
+    for i in range(0, n - 1, 2):
+        g.add_edge(UnifiedEdge(source=f"n:{i}", target=f"n:{i + 1}", relationship=RelationshipType.DEPENDS_ON))
+    return g
+
+
+def _persist_peak(tmp_path: Path, monkeypatch, n: int) -> int:
+    """Peak Python-heap allocated *during* the shipped persist of an N-node snapshot.
+
+    The new graph and the prior snapshot are materialised BEFORE ``tracemalloc.start``
+    — so the measured peak reflects only what the persist leg itself allocates, not
+    the resident producer graph (that is the residual builder wall, out of scope).
+    """
+    import agent_bom.api.pipeline as pipeline
+    import agent_bom.graph.builder as builder
+
+    store = SQLiteGraphStore(tmp_path / f"pipe-{n}.db")
+    # A same-size prior snapshot with the same node ids so this mirrors a real
+    # steady-state re-scan: the digest+delta path runs but the delta is bounded (few
+    # changed nodes), not the pathological all-new case. What remains O(N)-shaped in
+    # the persist is only the streamed write of the incoming snapshot + the bounded
+    # prior-id digest — which this test pins as a small fraction of a full copy.
+    store.save_graph(_synthetic_graph("scan-prior", n))
+
+    new = _synthetic_graph("scan-new", n)
+    monkeypatch.setattr(pipeline, "_get_graph_store", lambda: store)
+    monkeypatch.setattr(builder, "build_unified_graph_from_report", lambda report_json, scan_id, tenant_id: new)
+
+    job = SimpleNamespace(job_id="scan-new", tenant_id="t1", progress=[])
+
+    tracemalloc.start()
+    pipeline._persist_graph_snapshot(job, {"scan_id": "scan-new"})
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    # Confirm the scaled snapshot actually persisted (the write path really ran).
+    # Load it back explicitly rather than via ``latest_snapshot_id`` — the prior and
+    # new snapshots share a same-second ``created_at``, so the newest-first ordering
+    # would tie-break on ``scan_id`` rather than prove the new snapshot exists.
+    persisted = store.load_graph(tenant_id="t1", scan_id="scan-new")
+    assert len(persisted.nodes) == n
+    return peak
+
+
+def _full_copy_peak(n: int) -> int:
+    """Peak of building one full N-node graph — the cost of a single second copy."""
+    tracemalloc.start()
+    g = _synthetic_graph("scan-copy", n)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    assert len(g.nodes) == n
+    return peak
+
+
+def test_persist_of_large_new_snapshot_adds_no_second_full_copy(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_GRAPH_WRITE_BATCH_SIZE", _BATCH)
+    # Warm-up: the first ``_persist_graph_snapshot`` call resolves the persist path's
+    # lazy imports (builder / delta_digest / webhooks / postgres_store) and first-use
+    # SQL caches — one-time allocations that would otherwise be charged to the first
+    # measured run. Discard its result.
+    _persist_peak(tmp_path, monkeypatch, 400)
+
+    persist_small = _persist_peak(tmp_path, monkeypatch, _N_SMALL)
+    persist_large = _persist_peak(tmp_path, monkeypatch, _N_LARGE)
+    full_small = _full_copy_peak(_N_SMALL)
+    full_large = _full_copy_peak(_N_LARGE)
+
+    ratio_small = persist_small / full_small
+    ratio_large = persist_large / full_large
+
+    # The streamed save + search-index refresh + delta stream the incoming snapshot
+    # in bounded batches; they never hold a second full copy of it. Measured ~0.12-0.2
+    # — guard at 0.5 with margin. A ``fetchall``/full-list regression pushes this
+    # toward (or past) 1.0.
+    assert ratio_small < 0.5, f"persist peak too close to a full copy at N={_N_SMALL}: {ratio_small:.3f}"
+    assert ratio_large < 0.5, f"persist peak too close to a full copy at N={_N_LARGE}: {ratio_large:.3f}"
+
+    # The advantage must not erode as the incoming snapshot grows 4x: if the persist
+    # leg secretly scaled with N, the ratio would climb.
+    assert ratio_large <= ratio_small * 1.5, (
+        f"persist/full-copy ratio eroded with scale: {ratio_small:.3f} -> {ratio_large:.3f}"
+    )


### PR DESCRIPTION
## Summary

- Adds a production-path peak-heap regression guard at the shipped pipeline entrypoint (`_persist_graph_snapshot`) proving that persisting a **large new** graph snapshot peaks at a small, non-eroding fraction of materializing that snapshot as N grows 4x (≈0.12–0.2 measured).
- Documents the realized write-path bound and the residual **producer** wall in ADR-006.

## Already on main (nothing re-done here)

The persist/streaming/digest legs of #4075 already landed and are bound-tested:

- streamed persist + bounded reconciliation set (`save_graph_streaming`, `iter_graph_*`), bounded prior-snapshot delta digest, atomic retries (#4074/#4087/#4091/#4097);
- storage-backed `GraphBuildWorkspace` foundation + opt-in persist consumer (#4231, PR-1);
- streamed SQLite search-index refresh — no `fetchall` re-materialization (#4237, PR-2).

## The gap this closes

The existing production-path guard (`test_graph_persist_memory_bound.test_production_persist_path_does_not_materialise_full_prior_graph`) pins the **prior** side but exercises only a **20-node** new snapshot, so it cannot catch a re-materialization of the **incoming** snapshot during the streamed save + search-index refresh (the O(N) second-copy class removed earlier in the series).

The new guard `tests/test_graph_persist_pipeline_scale_bound.py` scales the incoming snapshot (N = 3,000 → 12,000) and keeps the prior at the same size so the delta stays bounded — isolating the incoming-snapshot write path (streamed save + search-index refresh + delta) rather than the already-covered prior digest. It asserts the persist leg's own peak stays a small, non-eroding fraction of a full copy. While isolating the legs, the assertion demonstrably fires on O(N) persist allocation (measured 3.4x with an all-new delta, 1.08x with a default batch), so it is a real discriminator.

## Explicitly NOT closed (honest scope)

The graph **producer** `build_unified_graph_from_report` still materializes the whole correlated `UnifiedGraph` plus adjacency / reverse-adjacency / dedup indexes before persist, with correlation overlays that query the whole graph. So single build+persist peak RSS is **producer-bound, not write-path-bound**. Removing that wall is the builder re-plumb (streaming/two-pass overlays emitting into the `GraphBuildWorkspace`) — a generator wrapper would not move peak RSS. This PR does **not** close #4075.

## Verification

- `pytest tests/test_graph_persist_pipeline_scale_bound.py` — pass, stable across 3 runs.
- `pytest` on the neighboring persist suites (`test_graph_persist_memory_bound.py`, `test_search_index_refresh_streaming.py`, `test_persist_graph_workspace_consumer.py`) — 10 passed.
- `ruff check` — clean; `mypy` on the new test — no issues.

Part of #4075.