### PR TITLE
fix(auth): boot-time non-superuser DB preflight; guard the audit fork-guard index

### DIFF
--- a/src/agent_bom/api/postgres_common.py
+++ b/src/agent_bom/api/postgres_common.py
@@ -235,13 +235,9 @@ def _get_pool() -> ConnectionPool:
         if auth_mode == AUTH_MODE_IAM:
             import psycopg
 
-            base_connect: Callable[..., object] = getattr(
-                psycopg.Connection.connect, "__func__", psycopg.Connection.connect
-            )
+            base_connect: Callable[..., object] = getattr(psycopg.Connection.connect, "__func__", psycopg.Connection.connect)
 
-            def connect_with_iam_token(
-                cls: type[object], conninfo: str = "", **connect_kwargs: object
-            ) -> object:
+            def connect_with_iam_token(cls: type[object], conninfo: str = "", **connect_kwargs: object) -> object:
                 """Resolve a fresh short-lived IAM token for every connection."""
                 connect_kwargs["password"] = resolve_postgres_secret()
                 return base_connect(cls, conninfo, **connect_kwargs)
@@ -321,6 +317,18 @@ def _guard_rls_capable_role(pool: ConnectionPool) -> None:
         )
         return
     raise RlsRolePrivilegeError(message)
+
+
+def preflight_rls_capable_role() -> None:
+    """Enforce the non-RLS-bypass role guard eagerly, at server bind time.
+
+    :func:`_guard_rls_capable_role` otherwise runs lazily on the first pool use
+    (the first request), so an RLS-bypassing role is only detected mid-flight as
+    a per-request 500. Building the pool here triggers the same guard at boot so
+    an unsafe role — or the operator's explicit ``AGENT_BOM_ALLOW_SUPERUSER_DB``
+    acknowledgement — is surfaced before uvicorn accepts traffic (epic #4274).
+    """
+    _get_pool()
 
 
 def reset_pool() -> None:

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -173,6 +173,34 @@ def _enforce_control_plane_listener_posture(host: str) -> None:
         raise click.ClickException(str(exc)) from exc
 
 
+def _enforce_database_role_posture(command: str) -> None:
+    """Fail fast at boot when the configured Postgres role can bypass tenant RLS.
+
+    Tenant isolation on Postgres is enforced solely by ``FORCE ROW LEVEL
+    SECURITY``; a ``SUPERUSER`` / ``BYPASSRLS`` role ignores it and voids the
+    isolation. ``_guard_rls_capable_role`` already refuses such a role, but only
+    lazily on the first pool use (i.e. per request). Running it here — beside the
+    non-loopback auth gate, before uvicorn binds — turns that into a single,
+    actionable boot error instead of a 500 on every request. No-op unless
+    Postgres is the active backend; only an RLS-bypass verdict is fatal, a
+    transient connect/probe failure defers to the request-time guard.
+    """
+    if os.environ.get("SNOWFLAKE_ACCOUNT"):
+        return
+    if not os.environ.get("AGENT_BOM_POSTGRES_URL"):
+        return
+    from agent_bom.api import postgres_common
+
+    try:
+        postgres_common.preflight_rls_capable_role()
+    except postgres_common.RlsRolePrivilegeError as exc:
+        raise click.ClickException(str(exc)) from exc
+    except Exception:  # noqa: BLE001 - connectivity/probe blips defer to the request-time guard
+        # A DB that is briefly unreachable at bind must not block startup; the
+        # same guard re-runs on the next successful pool use (lifespan/request).
+        pass
+
+
 def _enforce_remote_mcp_auth_defaults(host: str, bearer_token: str | None, allow_insecure_no_auth: bool) -> None:
     """Refuse unauthenticated remote MCP transports on non-loopback binds."""
     if bearer_token or _is_loopback_host(host):
@@ -610,6 +638,7 @@ def serve_cmd(
 
     _enforce_auth_defaults("serve", host, api_key, allow_insecure_no_auth)
     _enforce_control_plane_listener_posture(host)
+    _enforce_database_role_posture("serve")
     tls_kwargs = _uvicorn_tls_kwargs()
 
     seeded_connection_key = _maybe_seed_local_connection_key(host=host, allow_insecure_no_auth=allow_insecure_no_auth)
@@ -889,6 +918,7 @@ def api_cmd(
 
     _enforce_auth_defaults("api", host, api_key, allow_insecure_no_auth)
     _enforce_control_plane_listener_posture(host)
+    _enforce_database_role_posture("api")
     tls_kwargs = _uvicorn_tls_kwargs()
 
     seeded_connection_key = _maybe_seed_local_connection_key(host=host, allow_insecure_no_auth=allow_insecure_no_auth)

--- a/tests/test_cli_serve_db_role_preflight.py
+++ b/tests/test_cli_serve_db_role_preflight.py
@@ -1,0 +1,89 @@
+"""Startup preflight for the Postgres RLS-bypass role (epic #4274 item 5).
+
+Tenant isolation on Postgres is enforced entirely by ``FORCE ROW LEVEL
+SECURITY``. A ``SUPERUSER`` / ``BYPASSRLS`` role ignores those policies, so the
+control plane must refuse such a role. ``_guard_rls_capable_role`` already does
+this, but only lazily on the first pool use — i.e. the first request. These
+tests cover the CLI bind-path preflight that surfaces the same failure at boot,
+before uvicorn accepts traffic, mirroring the existing non-loopback auth gate.
+"""
+
+from __future__ import annotations
+
+import click
+import pytest
+
+from agent_bom.api.postgres_common import RlsRolePrivilegeError
+from agent_bom.cli._server import _enforce_database_role_posture
+
+
+def test_preflight_noop_without_postgres_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No Postgres configured => the DB-role gate never touches a pool."""
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+
+    called = False
+
+    def _boom() -> None:
+        nonlocal called
+        called = True
+        raise AssertionError("preflight must not run without Postgres configured")
+
+    monkeypatch.setattr("agent_bom.api.postgres_common.preflight_rls_capable_role", _boom)
+    _enforce_database_role_posture("serve")
+    assert called is False
+
+
+def test_preflight_noop_when_snowflake_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Snowflake takes precedence over Postgres; the PG role gate is inert."""
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgres://agent_bom_app@localhost/x")
+    monkeypatch.setenv("SNOWFLAKE_ACCOUNT", "acme")
+
+    monkeypatch.setattr(
+        "agent_bom.api.postgres_common.preflight_rls_capable_role",
+        lambda: (_ for _ in ()).throw(AssertionError("must not run for Snowflake backend")),
+    )
+    _enforce_database_role_posture("serve")
+
+
+def test_preflight_raises_click_exception_on_rls_bypass_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A SUPERUSER/BYPASSRLS role aborts the bind with an actionable CLI error."""
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgres://postgres@localhost/x")
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+
+    def _raise() -> None:
+        raise RlsRolePrivilegeError("Postgres role 'postgres' has SUPERUSER, which bypasses FORCE ROW LEVEL SECURITY")
+
+    monkeypatch.setattr("agent_bom.api.postgres_common.preflight_rls_capable_role", _raise)
+    with pytest.raises(click.ClickException, match="FORCE ROW LEVEL SECURITY"):
+        _enforce_database_role_posture("serve")
+
+
+def test_preflight_passes_for_non_superuser_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A NOSUPERUSER NOBYPASSRLS role returns cleanly — bind proceeds."""
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgres://agent_bom_app@localhost/x")
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+
+    ran = False
+
+    def _ok() -> None:
+        nonlocal ran
+        ran = True
+
+    monkeypatch.setattr("agent_bom.api.postgres_common.preflight_rls_capable_role", _ok)
+    _enforce_database_role_posture("serve")
+    assert ran is True
+
+
+def test_preflight_connectivity_error_does_not_block_bind(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A transient connect/probe failure defers to the request-time guard rather
+    than aborting the bind — only an RLS-bypass verdict is fatal here."""
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgres://agent_bom_app@localhost/x")
+    monkeypatch.delenv("SNOWFLAKE_ACCOUNT", raising=False)
+
+    def _connect_error() -> None:
+        raise OSError("connection refused")
+
+    monkeypatch.setattr("agent_bom.api.postgres_common.preflight_rls_capable_role", _connect_error)
+    # Must not raise ClickException — a DB blip should not abort the bind.
+    _enforce_database_role_posture("serve")

--- a/tests/test_db_role_preflight_live.py
+++ b/tests/test_db_role_preflight_live.py
@@ -1,0 +1,96 @@
+"""Live-Postgres tier for the RLS-bypass role preflight (epic #4274 item 5).
+
+Two opt-in env vars gate this:
+- ``AGENT_BOM_POSTGRES_URL`` — the app-role URL. The role behind it MUST be
+  ``NOSUPERUSER NOBYPASSRLS`` (this is the CI assertion the epic asks for).
+- ``AGENT_BOM_POSTGRES_ADMIN_URL`` — a role that can ``CREATE ROLE`` / ``DROP
+  ROLE`` (never used by the app). Used to spin up a throwaway ``BYPASSRLS`` role
+  and prove the runtime ``pg_roles`` guard rejects it — the name blocklist alone
+  does not cover a superuser role with a non-obvious name.
+"""
+
+from __future__ import annotations
+
+import os
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+import click
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="AGENT_BOM_POSTGRES_URL is required for the live DB-role preflight tests",
+)
+
+
+def _reset_pool() -> None:
+    from agent_bom.api import postgres_common
+
+    pool = postgres_common._pool
+    if pool is not None:
+        pool.close()
+    postgres_common.reset_pool()
+
+
+def test_configured_app_role_is_non_superuser_and_passes_preflight() -> None:
+    """The deployed app role must not be able to bypass RLS — preflight is clean."""
+    from agent_bom.api import postgres_common
+
+    _reset_pool()
+    try:
+        postgres_common.preflight_rls_capable_role()  # must not raise
+    finally:
+        _reset_pool()
+
+
+def test_cli_gate_passes_for_configured_app_role() -> None:
+    """The CLI bind-path gate is a no-op boot success for the safe app role."""
+    from agent_bom.cli._server import _enforce_database_role_posture
+
+    _reset_pool()
+    try:
+        _enforce_database_role_posture("serve")  # must not raise
+    finally:
+        _reset_pool()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_ADMIN_URL"),
+    reason="AGENT_BOM_POSTGRES_ADMIN_URL (CREATE ROLE) required to prove the BYPASSRLS rejection",
+)
+def test_bypassrls_role_is_rejected_by_runtime_guard(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A BYPASSRLS role with a non-blocklisted name is caught by the pg_roles
+    guard (not just the URL name blocklist) and aborts the bind."""
+    import psycopg
+
+    from agent_bom.api import postgres_common
+
+    admin_url = os.environ["AGENT_BOM_POSTGRES_ADMIN_URL"]
+    role = f"abom_bypass_{uuid4().hex[:10]}"
+    password = "preflightprobe"  # literal (DDL cannot be parameterized); no quotes to escape
+
+    with psycopg.connect(admin_url, autocommit=True) as conn:
+        conn.execute(f"CREATE ROLE \"{role}\" LOGIN PASSWORD '{password}' BYPASSRLS")
+    try:
+        parts = urlsplit(os.environ["AGENT_BOM_POSTGRES_URL"])
+        netloc = f"{role}:{password}@{parts.hostname}"
+        if parts.port:
+            netloc += f":{parts.port}"
+        bypass_url = urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+        monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", bypass_url)
+        _reset_pool()
+
+        with pytest.raises(postgres_common.RlsRolePrivilegeError, match="BYPASSRLS"):
+            postgres_common.preflight_rls_capable_role()
+
+        _reset_pool()
+        from agent_bom.cli._server import _enforce_database_role_posture
+
+        with pytest.raises(click.ClickException, match="BYPASSRLS"):
+            _enforce_database_role_posture("serve")
+    finally:
+        _reset_pool()
+        with psycopg.connect(admin_url, autocommit=True) as conn:
+            conn.execute(f'DROP ROLE IF EXISTS "{role}"')

--- a/tests/test_postgres_migrated_graph_parity.py
+++ b/tests/test_postgres_migrated_graph_parity.py
@@ -117,3 +117,25 @@ def test_attack_paths_round_trip_on_migration_owned_schema(migrated_fresh_databa
     assert got.credential_exposure == ["prod-db-password"]
     assert got.vuln_ids == ["CVE-2026-0001"]
     assert [m.technique_id for m in got.technique_mappings] == ["T1078"]
+
+
+def test_audit_fork_guard_unique_index_present_after_migrate_to_head(migrated_fresh_database):
+    """The hash-chain fork guard must exist in a schema built ONLY by Alembic.
+
+    ``PostgresAuditLog._ensure_fork_guard_index`` never runs when Postgres is
+    authoritative (``_init_tables`` early-returns), so a migration that dropped
+    ``UNIQUE (team_id, prev_signature)`` (#4232) would leave concurrent appends
+    across ``uvicorn --workers N`` able to fork the chain with nothing to catch
+    it. Assert the index exists, is UNIQUE, and covers exactly the head key.
+    """
+    import psycopg
+
+    with psycopg.connect(os.environ["AGENT_BOM_POSTGRES_URL"]) as conn:
+        row = conn.execute(
+            "SELECT indexdef FROM pg_indexes WHERE tablename = 'audit_log' AND indexname = 'audit_log_team_prevsig_uniq'"
+        ).fetchone()
+
+    assert row is not None, "audit_log fork-guard index missing from migration-owned schema"
+    indexdef = row[0]
+    assert "UNIQUE INDEX" in indexdef
+    assert "team_id" in indexdef and "prev_signature" in indexdef

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -17,8 +17,21 @@ POSTGRES_STORE_PARITY = VERSIONS_DIR / "20260717_01_postgres_store_parity.py"
 GRAPH_ANALYSIS_STATUS = VERSIONS_DIR / "20260717_02_graph_analysis_status.py"
 GRAPH_SNAPSHOT_JSON_PARITY = VERSIONS_DIR / "20260717_03_graph_snapshot_json_parity.py"
 RUNTIME_SCHEMA_AUTHORITY = VERSIONS_DIR / "20260718_01_runtime_schema_authority.py"
+AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
+RUNTIME_SCHEMA_SQL = POSTGRES_DIR / "runtime-schema.sql"
+
+# The fork-guard UNIQUE index is spelled differently in its two schema sources:
+# the dedicated migration concatenates two quoted Python string literals, while
+# runtime-schema.sql packs the columns with no spaces. Canonicalise both (drop
+# quotes + all whitespace, lowercase) before matching so the assertion tracks
+# the DDL, not the formatting.
+_FORK_GUARD_INDEX_CANON = "createuniqueindexifnotexistsaudit_log_team_prevsig_uniqonaudit_log(team_id,prev_signature)"
+
+
+def _canonical_sql(text: str) -> str:
+    return re.sub(r"[\s\"]+", "", text).lower()
 
 
 def _load_module(path: Path, name: str):
@@ -140,6 +153,32 @@ def test_graph_snapshot_json_parity_migration_is_idempotent_and_chained():
         assert f"ALTER COLUMN {column} DROP DEFAULT" in sql
         assert f"ALTER COLUMN {column} TYPE TEXT" in sql
         assert f"ALTER COLUMN {column} SET DEFAULT '{{}}'" in sql
+
+
+def test_audit_fork_guard_index_migration_is_chained_and_recreates_the_index() -> None:
+    """The hash-chain fork-guard UNIQUE index must live in migration-owned SQL.
+
+    ``PostgresAuditLog._ensure_fork_guard_index`` no longer runs when Postgres is
+    authoritative (``_init_tables`` early-returns), so the ``UNIQUE (team_id,
+    prev_signature)`` guard was left in no migration after #4232 — silently,
+    because nothing asserted it. This is that missing regression guard: the
+    dedicated migration must exist, chain from the runtime-schema-authority head,
+    and (idempotently) recreate the index with the exact head key.
+    """
+    sql = AUDIT_FORK_GUARD_INDEX.read_text()
+    assert re.search(r'revision\s*=\s*"20260719_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260718_01"', sql)
+    assert _FORK_GUARD_INDEX_CANON in _canonical_sql(sql), "migration must CREATE UNIQUE INDEX audit_log_team_prevsig_uniq"
+    assert "DROP INDEX IF EXISTS audit_log_team_prevsig_uniq" in sql  # reversible
+
+
+def test_audit_fork_guard_index_is_present_in_runtime_schema_authority() -> None:
+    """runtime-schema.sql is applied wholesale by the 20260718_01 head-authority
+    migration, so the fork guard must be present there too (belt-and-suspenders
+    with the dedicated 20260719_01 migration). A future edit that drops it from
+    the migration-owned schema — the #4232 class of regression — fails here."""
+    sql = RUNTIME_SCHEMA_SQL.read_text()
+    assert _FORK_GUARD_INDEX_CANON in _canonical_sql(sql), "runtime-schema.sql must define audit_log_team_prevsig_uniq"
 
 
 def test_runtime_schema_authority_is_the_alembic_head() -> None:


### PR DESCRIPTION
Part of #4274 — epic residual closures (item 5). This PR is independent of the resolver-chain work in #4290 and touches no `api/middleware.py`.

## Item B — non-superuser DB role preflight (net-new)

Tenant isolation on Postgres is enforced solely by `FORCE ROW LEVEL SECURITY`; a `SUPERUSER`/`BYPASSRLS` role silently voids every `*_tenant_isolation` policy. `_guard_rls_capable_role` already refuses such a role, but only lazily on the **first pool use** — i.e. the first request — so an unsafe role surfaced as a per-request 500 rather than a boot failure.

- Add `postgres_common.preflight_rls_capable_role()` that runs the same guard eagerly (builds the pool at bind).
- Wire a `_enforce_database_role_posture()` gate into the CLI `serve`/`api` bind path, right beside the existing non-loopback auth and control-plane listener gates, so an unsafe role **fails fast at boot** with the guard's actionable message before uvicorn binds.
- No-op unless Postgres is the active backend. Only an RLS-bypass verdict is fatal; a transient connect/probe blip defers to the request-time guard (a brief DB outage must not block startup). The `AGENT_BOM_ALLOW_SUPERUSER_DB` warn-instead-of-fail escape hatch is unchanged.

## Item A — audit fork-guard index (already restored; the missing guard is the deliverable)

The `UNIQUE (team_id, prev_signature)` hash-chain fork guard **was not missing** from migrations: it is present both in `runtime-schema.sql` (applied wholesale by the `20260718_01` head-authority migration) and in the dedicated `20260719_01` migration. Verified empirically that a fresh `alembic upgrade head` on an Alembic-only database creates `audit_log_team_prevsig_uniq`. So no schema change is shipped.

The #4232 drop was silent precisely because **nothing asserted the index**. This PR adds that regression guard:
- Static assertions that both the dedicated migration and `runtime-schema.sql` define the `UNIQUE` index on `(team_id, prev_signature)`.
- A live-tier test asserting the index exists after migrate-to-head on a schema built only by Alembic (the store's dev-mode `_ensure_fork_guard_index` never runs when Postgres is authoritative).

## Tests

- **Unit** (`test_cli_serve_db_role_preflight.py`): gate is a no-op without Postgres / for a Snowflake backend, raises `ClickException` on an RLS-bypass verdict, passes for a safe role, and treats a connectivity blip as non-fatal.
- **Static** (`test_postgres_migrations.py`): fork-guard index present + chained in the dedicated migration and in `runtime-schema.sql`.
- **Live-PG** (`test_db_role_preflight_live.py`, `test_postgres_migrated_graph_parity.py`): the app role (`agent_bom_app`, NOSUPERUSER/NOBYPASSRLS) passes preflight while a `BYPASSRLS` role with a non-blocklisted name is rejected by the runtime `pg_roles` guard; the fork-guard `UNIQUE` index exists after migrate-to-head.

### Verification
- `ruff check` + `ruff format` clean; changed source files mypy-clean (no new errors).
- Touched non-live suites: 120 passed, 1 skipped.
- Live-PG tier (localhost:5433, fresh DB): 4 passed — app-role preflight pass, BYPASSRLS rejection, CLI gate pass, and fork-guard index present after `alembic upgrade head`.