### PR TITLE
fix(audit): select the audit chain head by chain link, not timestamp

### DIFF
--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -139,10 +139,7 @@ class PostgresAuditLog:
         """
         try:
             with self._pool.connection() as conn:
-                conn.execute(
-                    f"CREATE UNIQUE INDEX IF NOT EXISTS {_AUDIT_FORK_GUARD_INDEX} "
-                    "ON audit_log (team_id, prev_signature)"
-                )
+                conn.execute(f"CREATE UNIQUE INDEX IF NOT EXISTS {_AUDIT_FORK_GUARD_INDEX} ON audit_log (team_id, prev_signature)")
                 conn.commit()
         except Exception:
             logger.warning(
@@ -171,8 +168,27 @@ class PostgresAuditLog:
                     "SELECT COUNT(*) FROM audit_log WHERE team_id = %s",
                     (tenant_id,),
                 ).fetchone()
+                # The chain tip is the successor-free row (its hmac_signature is
+                # no other row's prev_signature), NOT the max-timestamp row: a
+                # legacy dataset written by the pre-#4284 append path can carry a
+                # true tip whose wall-clock timestamp predates an earlier link, so
+                # a timestamp-ordered bootstrap would bake a stale head into the
+                # checkpoint that the append fast path now trusts. The fork-guard
+                # UNIQUE (team_id, prev_signature) makes the NOT EXISTS an index
+                # probe; this one-time startup rebuild is bounded by tenant size.
                 head_row = conn.execute(
-                    "SELECT hmac_signature FROM audit_log WHERE team_id = %s ORDER BY timestamp DESC, entry_id DESC LIMIT 1",
+                    """
+                    SELECT a.hmac_signature
+                    FROM audit_log a
+                    WHERE a.team_id = %s
+                      AND NOT EXISTS (
+                          SELECT 1 FROM audit_log b
+                          WHERE b.team_id = a.team_id
+                            AND b.prev_signature = a.hmac_signature
+                      )
+                    ORDER BY a.hmac_signature
+                    LIMIT 1
+                    """,
                     (tenant_id,),
                 ).fetchone()
                 if not count_row or not head_row:
@@ -223,16 +239,58 @@ class PostgresAuditLog:
         )
 
     def _latest_signature_for_tenant(self, tenant_id: str) -> str:
-        # audit_log is under FORCE ROW LEVEL SECURITY, so a raw connection (no
-        # tenant session) resolves abom_current_tenant() to 'default' and returns
-        # zero rows for every other tenant — leaving prev_signature empty and
-        # silently breaking the HMAC chain. Bind the requested tenant on a
-        # tenant-scoped connection so RLS returns that tenant's real chain head.
+        # The chain head is the LAST-COMMITTED row, NOT the row with the latest
+        # wall-clock timestamp. `AuditEntry.timestamp` is stamped at entry
+        # creation, so a retried append (a fork-guard loser) re-signs against the
+        # advanced head yet commits later carrying its original, older timestamp.
+        # ORDER BY timestamp then returns a non-tip row whose successor slot is
+        # already taken, so every subsequent append re-links to that stale head,
+        # violates the fork guard, and retries to exhaustion — a permanent
+        # per-tenant livelock (#4284). `audit_chain_checkpoint.head_signature` is
+        # bumped in the SAME transaction as each audit_log insert (and rolled
+        # back with a rejected fork), so it is the authoritative commit-order tip
+        # and an O(1) primary-key read. `_get_checkpoint` binds the requested
+        # tenant on the connection so FORCE ROW LEVEL SECURITY returns that
+        # tenant's own checkpoint row rather than the ambient tenant's.
+        checkpoint = self._get_checkpoint(tenant_id)
+        if checkpoint is not None:
+            return checkpoint.head_signature
+        # No checkpoint row yet. In a migration-owned deployment the checkpoint
+        # table is created empty and never batch-backfilled, so a tenant whose
+        # audit_log rows predate its first checkpoint upsert has none. Treating
+        # that as an empty chain (genesis, prev='') would try to re-insert a
+        # second genesis and livelock against the fork guard, so derive the true
+        # tip directly from audit_log — the successor-free row (its
+        # hmac_signature is no other row's prev_signature), NOT the max-timestamp
+        # row (#4284). The very next append seeds the checkpoint from it.
+        return self._chain_tip_signature_from_log(tenant_id)
+
+    def _chain_tip_signature_from_log(self, tenant_id: str) -> str:
+        """Return the tenant's chain tip derived from audit_log links (no checkpoint).
+
+        The tip is the row whose ``hmac_signature`` is not referenced as any
+        other row's ``prev_signature``. This is chain-order-correct regardless of
+        wall-clock timestamp skew; the fork-guard UNIQUE (team_id, prev_signature)
+        makes the NOT EXISTS an index probe. Returns ``""`` for a tenant with no
+        rows (a genuine genesis). Binds the requested tenant so FORCE ROW LEVEL
+        SECURITY returns that tenant's rows rather than the ambient tenant's.
+        """
         token = _current_tenant.set(tenant_id)
         try:
             with _tenant_connection(self._pool) as conn:
                 row = conn.execute(
-                    "SELECT hmac_signature FROM audit_log WHERE team_id = %s ORDER BY timestamp DESC, entry_id DESC LIMIT 1",
+                    """
+                    SELECT a.hmac_signature
+                    FROM audit_log a
+                    WHERE a.team_id = %s
+                      AND NOT EXISTS (
+                          SELECT 1 FROM audit_log b
+                          WHERE b.team_id = a.team_id
+                            AND b.prev_signature = a.hmac_signature
+                      )
+                    ORDER BY a.hmac_signature
+                    LIMIT 1
+                    """,
                     (tenant_id,),
                 ).fetchone()
         finally:
@@ -368,16 +426,43 @@ class PostgresAuditLog:
         limit: int,
         tenant_id: str | None = None,
     ) -> list[AuditEntry]:
-        clauses: list[str] = []
+        # Walk the entries in true chain-link order (genesis first), NOT by
+        # wall-clock timestamp. `AuditEntry.timestamp` is stamped at entry
+        # creation, so a retried or clock-skewed append can commit out of step
+        # with its chain position (#4284) — a timestamp-ordered walk then mis-
+        # scores a perfectly valid chain as tampered (its `prev_signature` no
+        # longer matches the timestamp-preceding row). Follow the hash links from
+        # the genesis row (`prev_signature = ''`) instead, mirroring the SQLite
+        # path's append-ordered (`rowid ASC`) walk. RLS scopes rows to the bound
+        # tenant and the fork-guard UNIQUE (team_id, prev_signature) makes each
+        # recursive step an index probe; content tampering is still caught by
+        # `entry.verify()` and the checkpoint entry-count/head comparison.
+        anchor_clause = ""
         params: list[object] = []
         if tenant_id is not None:
-            clauses.append("team_id = %s")
+            anchor_clause = "AND a.team_id = %s"
             params.append(tenant_id)
-        where = f" WHERE {' AND '.join(clauses)}" if clauses else ""
-        sql = (
-            "SELECT entry_id, timestamp, action, actor, resource, details, prev_signature, hmac_signature "
-            f"FROM audit_log{where} ORDER BY timestamp ASC, entry_id ASC LIMIT %s"  # nosec B608
-        )
+        sql = f"""
+            WITH RECURSIVE chain AS (
+                SELECT a.entry_id, a.timestamp, a.action, a.actor, a.resource,
+                       a.details, a.prev_signature, a.hmac_signature, a.team_id,
+                       0 AS depth
+                FROM audit_log a
+                WHERE a.prev_signature = '' {anchor_clause}
+                UNION ALL
+                SELECT n.entry_id, n.timestamp, n.action, n.actor, n.resource,
+                       n.details, n.prev_signature, n.hmac_signature, n.team_id,
+                       c.depth + 1
+                FROM audit_log n
+                JOIN chain c
+                  ON n.team_id = c.team_id AND n.prev_signature = c.hmac_signature
+            )
+            SELECT entry_id, timestamp, action, actor, resource, details,
+                   prev_signature, hmac_signature
+            FROM chain
+            ORDER BY depth
+            LIMIT %s
+        """  # nosec B608 - anchor_clause is a constant; values are parameterized
         params.append(limit)
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(sql, tuple(params)).fetchall()

--- a/tests/test_audit_chain_concurrency.py
+++ b/tests/test_audit_chain_concurrency.py
@@ -189,6 +189,89 @@ def test_chain_fork_conflict_detector_matches_only_fork_violations() -> None:
     not os.environ.get("AGENT_BOM_POSTGRES_URL"),
     reason="requires a live PostgreSQL (AGENT_BOM_POSTGRES_URL) — mock pool cannot enforce the unique fork guard",
 )
+def test_postgres_head_read_is_chain_ordered_not_timestamp_ordered() -> None:
+    """A retried/clock-skewed append must not poison the head and livelock (#4284).
+
+    Regression for the audit-chain livelock: the chain head was selected by
+    ``ORDER BY timestamp DESC``, but ``AuditEntry.timestamp`` is stamped at entry
+    creation. A writer that loses the fork race re-signs against the advanced
+    head yet commits *later* with its *original, older* timestamp, so timestamp
+    order diverges from chain order. The head read then returns a non-tip row
+    whose successor slot is already taken — every subsequent append re-links to
+    that stale head, hits the fork-guard UNIQUE violation, re-reads the same
+    stale head, and retries to exhaustion: the tenant can never append again.
+
+    This reproduces the skew deterministically (no threads): a genesis row with a
+    *later* wall-clock timestamp than its own successor. The head must still be
+    the true chain tip (the last-committed row), and a further append must
+    succeed and link to it.
+    """
+    import uuid
+
+    from agent_bom.api.postgres_common import _current_tenant, set_current_tenant
+    from agent_bom.api.postgres_store import PostgresAuditLog
+
+    store = PostgresAuditLog()
+    tenant = f"tenant-skew-{uuid.uuid4().hex[:12]}"
+    token = set_current_tenant(tenant)
+    try:
+        # Genesis carries a LATER timestamp than its successor — the exact skew a
+        # retried append produces (commit order != timestamp order).
+        genesis = AuditEntry(
+            action="scan",
+            actor="w",
+            resource="genesis",
+            details={"tenant_id": tenant},
+            timestamp="2020-01-01T00:00:09+00:00",
+        )
+        store.append(genesis)
+        genesis_sig = genesis.hmac_signature
+
+        successor = AuditEntry(
+            action="scan",
+            actor="w",
+            resource="successor",
+            details={"tenant_id": tenant},
+            timestamp="2020-01-01T00:00:01+00:00",
+        )
+        store.append(successor)
+        true_tip_sig = successor.hmac_signature
+
+        # The genesis has the max timestamp but its successor slot is already
+        # taken; the true chain tip is the last-committed row (`successor`).
+        head = store._latest_signature_for_tenant(tenant)
+        assert head == true_tip_sig, (
+            "head read returned a non-tip row — timestamp-ordered head selection "
+            f"poisons the chain (#4284): got {head!r}, expected tip {true_tip_sig!r}, "
+            f"genesis was {genesis_sig!r}"
+        )
+
+        # A further append must link to the true tip and succeed — on the buggy
+        # code this exhausts every fork-guard retry and raises (livelock).
+        third = AuditEntry(
+            action="scan",
+            actor="w",
+            resource="third",
+            details={"tenant_id": tenant},
+        )
+        store.append(third)
+        assert third.prev_signature == true_tip_sig
+
+        entries = store.list_entries(limit=1000, tenant_id=tenant)
+        prevs = [e.prev_signature for e in entries]
+        assert len(prevs) == len(set(prevs)), "chain forked: rows share a prev_signature"
+
+        verified, tampered = store.verify_integrity(tenant_id=tenant)
+        assert tampered == 0, f"verify_integrity reported {tampered} tampered rows"
+        assert verified == 3
+    finally:
+        _current_tenant.reset(token)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="requires a live PostgreSQL (AGENT_BOM_POSTGRES_URL) — mock pool cannot enforce the unique fork guard",
+)
 def test_postgres_concurrent_append_does_not_fork_chain() -> None:
     """Cross-thread appends against a live Postgres store must not fork the chain.
 

--- a/tests/test_data_store_correctness.py
+++ b/tests/test_data_store_correctness.py
@@ -120,10 +120,21 @@ class _FakeAuditConn:
             if "team_id = %s" in s:
                 rows = [r for r in rows if r["team_id"] == p[0]]
             return _FakeResult([(len(rows),)])
-        if "FROM audit_log" in s and "ORDER BY timestamp ASC" in s:
+        if "WITH RECURSIVE chain" in s and "audit_log" in s:
+            # Model the chain-ordered walk (`_list_entries_chronological`): follow
+            # prev_signature -> hmac_signature links from the genesis row, not
+            # wall-clock timestamp order, so the walk is correct under skew.
             self.pool.audit_read_sessions.append((self.tenant, self.bypass))
-            rows = [r for r in self._visible_audit() if r["team_id"] == p[0]]
-            rows.sort(key=lambda r: (r["timestamp"], r["entry_id"]))
+            visible = self._visible_audit()
+            if "a.team_id = %s" in s:
+                visible = [r for r in visible if r["team_id"] == p[0]]
+            by_prev = {r["prev_signature"]: r for r in visible}
+            ordered: list[dict] = []
+            cursor_sig = ""
+            while cursor_sig in by_prev:
+                row = by_prev[cursor_sig]
+                ordered.append(row)
+                cursor_sig = row["hmac_signature"]
             limit = p[-1]
             return _FakeResult(
                 [
@@ -137,7 +148,7 @@ class _FakeAuditConn:
                         r["prev_signature"],
                         r["hmac_signature"],
                     )
-                    for r in rows[:limit]
+                    for r in ordered[:limit]
                 ]
             )
         if "INSERT INTO audit_log" in s:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -107,6 +107,25 @@ class MockConnection:
                 if table not in self._store:
                     self._store[table] = {}
                 self._store[table][params[0]] = params
+        elif sql_lower.startswith("with recursive chain") and "audit_log" in sql_lower:
+            # Model the chain-ordered walk (`_list_entries_chronological`): follow
+            # prev_signature -> hmac_signature links from the genesis row instead
+            # of ordering by timestamp, so head/verify stay correct under skew.
+            rows = list(self._store.get("audit_log", {}).values())
+            limit = params[-1] if params else None
+            team = params[0] if params and "a.team_id = %s" in sql_lower else None
+            if team is not None:
+                rows = [r for r in rows if r[5] == team]
+            by_prev = {r[7]: r for r in rows}
+            ordered: list[tuple] = []
+            cursor_sig = ""
+            while cursor_sig in by_prev:
+                row = by_prev[cursor_sig]
+                ordered.append(row)
+                cursor_sig = row[8]
+            if limit is not None:
+                ordered = ordered[: int(limit)]
+            cursor.rows = [(r[0], r[1], r[2], r[3], r[4], r[6], r[7], r[8]) for r in ordered]
         elif sql_lower.startswith("select"):
             if "select distinct on (team_id) team_id, hmac_signature" in sql_lower:
                 rows = list(self._store.get("audit_log", {}).values())


### PR DESCRIPTION
## Problem

A single retried or clock-skewed audit append could **permanently livelock** a tenant's hash-chained audit log — no new audit events could ever be written for that tenant again (P1 audit availability). `#4284`.

## Root cause

`PostgresAuditLog._latest_signature_for_tenant` read the chain head with `ORDER BY timestamp DESC`, but `AuditEntry.timestamp` is stamped at **entry creation**. A writer that loses the fork-guard race re-signs against the advanced head yet commits **later** carrying its **original, older** timestamp, so timestamp order diverges from chain order. The head read then returns a non-tip row whose successor slot is already taken; every subsequent append re-links to that stale head, violates the `UNIQUE (team_id, prev_signature)` fork guard, re-reads the same stale head, and retries to exhaustion. `verify_integrity`'s timestamp-ordered walk likewise mis-scored a valid-but-skewed chain as tampered.

## Fix (make head selection commit-order / chain aware)

- **`_latest_signature_for_tenant`** now reads `audit_chain_checkpoint.head_signature` — bumped in the **same transaction** as each insert (and rolled back with a rejected fork), so it is the authoritative commit-order tip and an O(1) primary-key read. When no checkpoint row exists yet (a migration-owned deployment creates the table empty and never backfills it), it falls back to the **successor-free** row derived from `audit_log` links rather than re-inserting a second genesis and livelocking.
- **`verify_integrity`** walks the chain in link order via a recursive CTE from genesis, mirroring the SQLite path's append-ordered (`rowid ASC`) walk, so a timestamp-skewed but valid chain is no longer mis-scored as tampered. Content tampering is still caught by `entry.verify()` and the checkpoint entry-count/head comparison.
- The **startup checkpoint rebuild** derives the head from chain links too, so a legacy dataset cannot bake a stale head into the checkpoint.

Preserves the `#4283` tenant-GUC binding, the "audit must not block auth" retry/swallow behavior, and the SQLite path (already chain-ordered).

## Test / verification (live Postgres, fresh Alembic-migrated DB, RLS on)

- New deterministic regression `test_postgres_head_read_is_chain_ordered_not_timestamp_ordered`: forces a genesis row with a **later** timestamp than its own successor, then asserts the head read returns the true tip and a further append succeeds.
  - **Before fix:** head read returns the genesis (max-timestamp) row; the third append raises `UniqueViolation` on `audit_log_team_prevsig_uniq` after exhausting all 50 retries (livelock reproduced).
  - **After fix:** passes.
- The barrier-aligned `test_postgres_concurrent_append_does_not_fork_chain` and the per-tenant isolation / `verify_integrity` suites pass.
- Deployment-mode empty-checkpoint fallback validated live (append proceeds and seeds the checkpoint from the true tip).
- Gates: `ruff` + `ruff format` clean, `mypy` clean on the changed module, live-PG audit/governance/integration + mock-pool suites green.

Mock/fake connection pools updated to model the chain-link walk.

Closes #4284