### PR TITLE
fix(audit): backfill legacy audit-chain checkpoints so truncation checks are correct

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260720_01_audit_checkpoint_legacy_backfill.py
+++ b/deploy/supabase/postgres/alembic/versions/20260720_01_audit_checkpoint_legacy_backfill.py
@@ -1,0 +1,68 @@
+"""Backfill legacy audit-chain checkpoints from the audit_log links (#4294).
+
+A tenant whose ``audit_log`` rows predate its first ``audit_chain_checkpoint``
+upsert was seeded at ``entry_count=1`` rather than its true historical count:
+the migration-owned schema creates ``audit_chain_checkpoint`` empty and the
+runtime store never runs ``_hydrate_checkpoints`` on the authoritative path, so
+a legacy tenant's first append seeds the checkpoint from scratch. This one-time,
+idempotent reconciliation recomputes each tenant's ``entry_count`` (row count)
+and ``head_signature`` (the successor-free chain tip, chain-order-correct
+regardless of timestamp skew — #4284/#4293) directly from ``audit_log`` so
+``verify_integrity``'s truncation check stops under-counting for those tenants.
+
+The append seed path is fixed in the same change, so this only heals rows that
+were already under-seeded before the fix shipped; rerunning is a no-op.
+
+Revision ID: 20260720_01
+Revises: 20260719_03
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260720_01"
+down_revision = "20260719_03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # audit_log (team_id) and audit_chain_checkpoint (tenant_id) both enforce
+    # FORCE ROW LEVEL SECURITY, so this cross-tenant maintenance write runs under
+    # the app.bypass_rls GUC the RLS policies honour (transaction-local). The
+    # reconcile is a single idempotent INSERT ... SELECT ... ON CONFLICT: it
+    # seeds missing checkpoints and overwrites under-seeded entry_count/head with
+    # the values derived from the chain, matching the runtime store's
+    # backfill_checkpoints().
+    op.execute("SELECT set_config('app.bypass_rls', '1', true)")
+    op.execute(
+        """
+        INSERT INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature)
+        SELECT a.team_id,
+               COUNT(*),
+               (
+                   SELECT h.hmac_signature
+                   FROM audit_log h
+                   WHERE h.team_id = a.team_id
+                     AND NOT EXISTS (
+                         SELECT 1 FROM audit_log b
+                         WHERE b.team_id = h.team_id
+                           AND b.prev_signature = h.hmac_signature
+                     )
+                   ORDER BY h.hmac_signature
+                   LIMIT 1
+               )
+        FROM audit_log a
+        GROUP BY a.team_id
+        ON CONFLICT (tenant_id) DO UPDATE SET
+            entry_count = EXCLUDED.entry_count,
+            head_signature = EXCLUDED.head_signature
+        """
+    )
+
+
+def downgrade() -> None:
+    # A data reconciliation has no meaningful inverse (the pre-backfill counts
+    # were wrong); leave the corrected checkpoints in place.
+    pass

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -509,10 +509,7 @@ class SQLiteAuditLog:
         _audit_cols = {row[1] for row in self._conn.execute("PRAGMA table_info(audit_log)").fetchall()}
         if "tenant_id" not in _audit_cols:
             self._conn.execute("ALTER TABLE audit_log ADD COLUMN tenant_id TEXT NOT NULL DEFAULT 'default'")
-            self._conn.execute(
-                "UPDATE audit_log SET tenant_id = "
-                "COALESCE(NULLIF(json_extract(details, '$.tenant_id'), ''), 'default')"
-            )
+            self._conn.execute("UPDATE audit_log SET tenant_id = COALESCE(NULLIF(json_extract(details, '$.tenant_id'), ''), 'default')")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_audit_tenant_ts ON audit_log(tenant_id, timestamp DESC)")
         self._conn.execute("""CREATE TABLE IF NOT EXISTS audit_chain_checkpoint (
             tenant_id TEXT PRIMARY KEY,
@@ -535,10 +532,7 @@ class SQLiteAuditLog:
         reconciled.
         """
         try:
-            self._conn.execute(
-                "CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_tenant_prevsig "
-                "ON audit_log(tenant_id, prev_signature)"
-            )
+            self._conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS idx_audit_tenant_prevsig ON audit_log(tenant_id, prev_signature)")
             self._conn.commit()
         except sqlite3.IntegrityError:
             self._conn.rollback()
@@ -585,16 +579,51 @@ class SQLiteAuditLog:
         return _AuditChainCheckpoint(entry_count=int(row[0]), head_signature=str(row[1]))
 
     def _upsert_checkpoint(self, tenant_id: str, head_signature: str) -> None:
+        # First-seed entry_count is the tenant's TRUE audit_log row count, not a
+        # hardcoded 1: a legacy tenant whose rows predate its first checkpoint
+        # upsert would otherwise seed entry_count=1 while N historical rows exist,
+        # so verify_integrity's truncation check under-counts until N further
+        # appends accrue (#4294). The COUNT runs in the same transaction as the
+        # preceding audit_log INSERT (so it includes the just-inserted row) and
+        # only on the INSERT branch; the steady-state ON CONFLICT path stays an
+        # O(1) increment. A genuine genesis (0 prior rows) still seeds 1.
         self._conn.execute(
             """
             INSERT INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature)
-            VALUES (?, 1, ?)
+            VALUES (?, (SELECT COUNT(*) FROM audit_log WHERE tenant_id = ?), ?)
             ON CONFLICT(tenant_id) DO UPDATE SET
                 entry_count = entry_count + 1,
                 head_signature = excluded.head_signature
             """,
-            (tenant_id, head_signature),
+            (tenant_id, tenant_id, head_signature),
         )
+
+    def backfill_checkpoints(self) -> int:
+        """Reconcile every tenant's checkpoint to its true chain state (#4294).
+
+        Recomputes ``entry_count`` (the tenant's audit_log row count) and
+        ``head_signature`` (the true chain tip in append/rowid order) directly
+        from ``audit_log``, healing legacy checkpoints seeded at ``entry_count=1``
+        and seeding tenants that have none. Idempotent: rerunning yields the same
+        rows. Returns the number of tenant checkpoints reconciled.
+        """
+        tenants = self._conn.execute("SELECT DISTINCT tenant_id FROM audit_log").fetchall()
+        reconciled = 0
+        for (tenant_id,) in tenants:
+            count_row = self._conn.execute(
+                "SELECT COUNT(*) FROM audit_log WHERE tenant_id = ?",
+                (str(tenant_id),),
+            ).fetchone()
+            head = self._latest_signature_for_tenant(str(tenant_id))
+            if not count_row or not head:
+                continue
+            self._conn.execute(
+                "INSERT OR REPLACE INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature) VALUES (?, ?, ?)",
+                (str(tenant_id), int(count_row[0]), head),
+            )
+            reconciled += 1
+        self._conn.commit()
+        return reconciled
 
     def _latest_signature_for_tenant(self, tenant_id: str) -> str:
         # The chain head is the LAST-APPENDED row (max rowid), not the row with

--- a/src/agent_bom/api/postgres_audit.py
+++ b/src/agent_bom/api/postgres_audit.py
@@ -227,16 +227,70 @@ class PostgresAuditLog:
         return _AuditChainCheckpoint(entry_count=int(row[0]), head_signature=str(row[1]))
 
     def _upsert_checkpoint(self, conn: Any, tenant_id: str, head_signature: str) -> None:
+        # First-seed entry_count is the tenant's TRUE audit_log row count, not a
+        # hardcoded 1: a legacy tenant whose rows predate its first checkpoint
+        # upsert (the migration-owned schema creates the table empty and never
+        # runs _hydrate_checkpoints) would otherwise seed entry_count=1 while N
+        # historical rows exist, so verify_integrity's truncation check
+        # (len(entries) == checkpoint.entry_count) under-counts until N further
+        # appends accrue (#4294). The COUNT runs in the SAME transaction as the
+        # audit_log INSERT that precedes it (so it includes the just-inserted
+        # row) and only on the INSERT branch; the steady-state ON CONFLICT path
+        # stays an O(1) increment, correct because each append adds exactly one
+        # row once the checkpoint is seeded true. A genuine genesis (0 prior
+        # rows) still seeds 1 — the just-inserted row.
         conn.execute(
             """
             INSERT INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature)
-            VALUES (%s, 1, %s)
+            VALUES (%s, (SELECT COUNT(*) FROM audit_log WHERE team_id = %s), %s)
             ON CONFLICT (tenant_id) DO UPDATE SET
                 entry_count = audit_chain_checkpoint.entry_count + 1,
                 head_signature = EXCLUDED.head_signature
             """,
-            (tenant_id, head_signature),
+            (tenant_id, tenant_id, head_signature),
         )
+
+    def backfill_checkpoints(self) -> int:
+        """Reconcile every tenant's checkpoint to its true chain state (#4294).
+
+        Recomputes ``entry_count`` (the tenant's audit_log row count) and
+        ``head_signature`` (the successor-free chain tip — chain-order-correct
+        regardless of wall-clock timestamp skew, mirroring
+        ``_chain_tip_signature_from_log`` and #4293's head derivation) directly
+        from ``audit_log`` for every tenant, healing legacy checkpoints seeded at
+        ``entry_count=1`` and seeding tenants that have none. Idempotent: rerunning
+        yields the same rows. Runs under an RLS-bypass maintenance session because
+        it spans every tenant (same trusted context as ``_hydrate_checkpoints``).
+        Returns the number of tenant checkpoints reconciled.
+        """
+        with bypass_tenant_rls(audit=False), _tenant_connection(self._pool) as conn:
+            result = conn.execute(
+                """
+                INSERT INTO audit_chain_checkpoint (tenant_id, entry_count, head_signature)
+                SELECT a.team_id,
+                       COUNT(*),
+                       (
+                           SELECT h.hmac_signature
+                           FROM audit_log h
+                           WHERE h.team_id = a.team_id
+                             AND NOT EXISTS (
+                                 SELECT 1 FROM audit_log b
+                                 WHERE b.team_id = h.team_id
+                                   AND b.prev_signature = h.hmac_signature
+                             )
+                           ORDER BY h.hmac_signature
+                           LIMIT 1
+                       )
+                FROM audit_log a
+                GROUP BY a.team_id
+                ON CONFLICT (tenant_id) DO UPDATE SET
+                    entry_count = EXCLUDED.entry_count,
+                    head_signature = EXCLUDED.head_signature
+                """
+            )
+            reconciled = result.rowcount if result.rowcount is not None and result.rowcount >= 0 else 0
+            conn.commit()
+        return reconciled
 
     def _latest_signature_for_tenant(self, tenant_id: str) -> str:
         # The chain head is the LAST-COMMITTED row, NOT the row with the latest

--- a/tests/test_audit_checkpoint_backfill_4294.py
+++ b/tests/test_audit_checkpoint_backfill_4294.py
@@ -1,0 +1,249 @@
+"""Legacy audit-checkpoint backfill regression tests (#4294).
+
+A tenant whose ``audit_log`` rows predate its first ``audit_chain_checkpoint``
+upsert gets seeded at ``entry_count=1`` rather than its true historical count:
+the migration-owned schema creates the checkpoint table empty and never
+backfills it, so a tenant's first append after that seeds the checkpoint from
+scratch. ``verify_integrity``'s truncation check (``len(entries) ==
+checkpoint.entry_count``) then under-counts for that tenant until enough new
+appends accrue, so a valid intact chain is mis-scored and a genuine tail
+truncation can slip under the wrong count.
+
+These tests prove (a) the one-time ``backfill_checkpoints`` reconciler heals an
+already-under-seeded checkpoint from the audit_log chain links, is idempotent,
+and leaves a correctly-seeded tenant untouched, and (b) the append seed path no
+longer bakes ``entry_count=1`` for a legacy tenant.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import uuid
+from pathlib import Path
+
+import pytest
+
+from agent_bom.api.audit_log import AuditEntry, SQLiteAuditLog
+
+_BACKFILL_MIGRATION = (
+    Path(__file__).parent.parent
+    / "deploy"
+    / "supabase"
+    / "postgres"
+    / "alembic"
+    / "versions"
+    / "20260720_01_audit_checkpoint_legacy_backfill.py"
+)
+
+
+def _canonical_sql(text: str) -> str:
+    return re.sub(r"[\s\"]+", "", text).lower()
+
+
+def test_backfill_migration_is_chained_bypasses_rls_and_reconciles() -> None:
+    """The migration-owned backfill heals legacy checkpoints for deployments
+    whose runtime store never runs _hydrate_checkpoints (Postgres authoritative).
+
+    It must chain from the current head, bypass FORCE RLS for the cross-tenant
+    maintenance write, and idempotently reconcile entry_count + head_signature
+    from the audit_log links (ON CONFLICT DO UPDATE)."""
+    assert _BACKFILL_MIGRATION.exists()
+    sql = _BACKFILL_MIGRATION.read_text()
+    assert re.search(r'revision\s*=\s*"20260720_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260719_03"', sql)
+    canon = _canonical_sql(sql)
+    assert "set_config('app.bypass_rls','1',true)".replace("'", "") in canon.replace("'", "")
+    assert "insertintoaudit_chain_checkpoint" in canon
+    assert "onconflict(tenant_id)doupdateset" in canon
+    assert "entry_count=excluded.entry_count" in canon
+    assert "head_signature=excluded.head_signature" in canon
+
+
+_REQUIRES_PG = pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="requires a live PostgreSQL (AGENT_BOM_POSTGRES_URL); the mock pool cannot model the chain walk",
+)
+
+
+# ── SQLite ────────────────────────────────────────────────────────────────
+
+
+def _sqlite_build_chain(log: SQLiteAuditLog, tenant: str, n: int) -> None:
+    for i in range(n):
+        log.append(AuditEntry(action="scan", actor="w", resource=f"pkg-{i}", details={"tenant_id": tenant}))
+
+
+def _sqlite_corrupt_checkpoint_count(log: SQLiteAuditLog, tenant: str, value: int) -> None:
+    log._conn.execute(
+        "UPDATE audit_chain_checkpoint SET entry_count = ? WHERE tenant_id = ?",
+        (value, tenant),
+    )
+    log._conn.commit()
+
+
+def test_sqlite_backfill_heals_underseeded_checkpoint(tmp_path) -> None:
+    log = SQLiteAuditLog(str(tmp_path / "audit.db"))
+    tenant = "tenant-legacy"
+    n = 6
+    _sqlite_build_chain(log, tenant, n)
+    true_tip = log._latest_signature_for_tenant(tenant)
+
+    # Simulate the legacy under-seed: a checkpoint that says 1 while N rows exist.
+    _sqlite_corrupt_checkpoint_count(log, tenant, 1)
+    assert log._get_checkpoint(tenant).entry_count == 1
+    # The truncation check now mis-scores the intact chain (count mismatch).
+    _, tampered_before = log.verify_integrity(tenant_id=tenant)
+    assert tampered_before >= 1
+
+    healed = log.backfill_checkpoints()
+    assert healed >= 1
+
+    cp = log._get_checkpoint(tenant)
+    assert cp.entry_count == n
+    assert cp.head_signature == true_tip
+    verified, tampered = log.verify_integrity(tenant_id=tenant)
+    assert (verified, tampered) == (n, 0)
+
+    # Idempotent: a second run yields the same checkpoint.
+    log.backfill_checkpoints()
+    cp2 = log._get_checkpoint(tenant)
+    assert (cp2.entry_count, cp2.head_signature) == (n, true_tip)
+
+
+def test_sqlite_backfill_leaves_correctly_seeded_tenant_untouched(tmp_path) -> None:
+    log = SQLiteAuditLog(str(tmp_path / "audit.db"))
+    tenant = "tenant-normal"
+    n = 4
+    _sqlite_build_chain(log, tenant, n)
+    before = log._get_checkpoint(tenant)
+    assert before.entry_count == n
+
+    log.backfill_checkpoints()
+
+    after = log._get_checkpoint(tenant)
+    assert (after.entry_count, after.head_signature) == (before.entry_count, before.head_signature)
+    assert log.verify_integrity(tenant_id=tenant) == (n, 0)
+
+
+def test_sqlite_append_seed_uses_true_count_for_legacy_tenant(tmp_path) -> None:
+    log = SQLiteAuditLog(str(tmp_path / "audit.db"))
+    tenant = "tenant-legacy-seed"
+    n = 5
+    _sqlite_build_chain(log, tenant, n)
+    # Drop the checkpoint row to model a tenant whose rows predate any checkpoint
+    # (the migration-owned table is created empty and never batch-backfilled).
+    log._conn.execute("DELETE FROM audit_chain_checkpoint WHERE tenant_id = ?", (tenant,))
+    log._conn.commit()
+    assert log._get_checkpoint(tenant) is None
+
+    log.append(AuditEntry(action="scan", actor="w", resource="pkg-new", details={"tenant_id": tenant}))
+
+    cp = log._get_checkpoint(tenant)
+    # The seed must be the true row count (n + the new append), NOT 1.
+    assert cp.entry_count == n + 1
+    assert log.verify_integrity(tenant_id=tenant) == (n + 1, 0)
+
+
+# ── Postgres (live, migration-owned schema, RLS on) ─────────────────────────
+
+
+def _pg_build_chain(store, tenant: str, n: int) -> None:
+    for i in range(n):
+        store.append(AuditEntry(action="scan", actor="w", resource=f"pkg-{i}", details={"tenant_id": tenant}))
+
+
+def _pg_exec(sql: str, params: tuple) -> None:
+    from agent_bom.api.postgres_common import _get_pool, _tenant_connection, bypass_tenant_rls
+
+    with bypass_tenant_rls(audit=False), _tenant_connection(_get_pool()) as conn:
+        conn.execute(sql, params)
+        conn.commit()
+
+
+@_REQUIRES_PG
+def test_postgres_backfill_heals_underseeded_checkpoint() -> None:
+    from agent_bom.api.postgres_common import _current_tenant, set_current_tenant
+    from agent_bom.api.postgres_store import PostgresAuditLog
+
+    store = PostgresAuditLog()
+    tenant = f"tenant-legacy-{uuid.uuid4().hex[:12]}"
+    n = 6
+    # verify_integrity's entry fetch reads under the ambient tenant RLS context
+    # (matching how #4293's own regression drives it), so hold the tenant bound
+    # for the whole body; the checkpoint mutation + backfill use their own
+    # RLS-bypass connection.
+    token = set_current_tenant(tenant)
+    try:
+        _pg_build_chain(store, tenant, n)
+        true_tip = store._chain_tip_signature_from_log(tenant)
+        assert true_tip
+
+        # Simulate the legacy under-seed: entry_count=1 while N rows exist.
+        _pg_exec("UPDATE audit_chain_checkpoint SET entry_count = 1 WHERE tenant_id = %s", (tenant,))
+        assert store._get_checkpoint(tenant).entry_count == 1
+        # The truncation check now mis-scores the intact chain (count mismatch).
+        _, tampered_before = store.verify_integrity(tenant_id=tenant)
+        assert tampered_before >= 1
+
+        store.backfill_checkpoints()
+
+        cp = store._get_checkpoint(tenant)
+        assert cp.entry_count == n
+        assert cp.head_signature == true_tip
+        verified, tampered = store.verify_integrity(tenant_id=tenant)
+        assert (verified, tampered) == (n, 0)
+
+        # Idempotent.
+        store.backfill_checkpoints()
+        cp2 = store._get_checkpoint(tenant)
+        assert (cp2.entry_count, cp2.head_signature) == (n, true_tip)
+    finally:
+        _current_tenant.reset(token)
+
+
+@_REQUIRES_PG
+def test_postgres_backfill_leaves_correctly_seeded_tenant_untouched() -> None:
+    from agent_bom.api.postgres_common import _current_tenant, set_current_tenant
+    from agent_bom.api.postgres_store import PostgresAuditLog
+
+    store = PostgresAuditLog()
+    tenant = f"tenant-normal-{uuid.uuid4().hex[:12]}"
+    n = 5
+    token = set_current_tenant(tenant)
+    try:
+        _pg_build_chain(store, tenant, n)
+        before = store._get_checkpoint(tenant)
+        assert before.entry_count == n
+
+        store.backfill_checkpoints()
+
+        after = store._get_checkpoint(tenant)
+        assert (after.entry_count, after.head_signature) == (before.entry_count, before.head_signature)
+        assert store.verify_integrity(tenant_id=tenant) == (n, 0)
+    finally:
+        _current_tenant.reset(token)
+
+
+@_REQUIRES_PG
+def test_postgres_append_seed_uses_true_count_for_legacy_tenant() -> None:
+    from agent_bom.api.postgres_common import _current_tenant, set_current_tenant
+    from agent_bom.api.postgres_store import PostgresAuditLog
+
+    store = PostgresAuditLog()
+    tenant = f"tenant-legacy-seed-{uuid.uuid4().hex[:12]}"
+    n = 5
+    token = set_current_tenant(tenant)
+    try:
+        _pg_build_chain(store, tenant, n)
+        # Drop the checkpoint row: a legacy tenant whose rows predate any checkpoint.
+        _pg_exec("DELETE FROM audit_chain_checkpoint WHERE tenant_id = %s", (tenant,))
+        assert store._get_checkpoint(tenant) is None
+
+        store.append(AuditEntry(action="scan", actor="w", resource="pkg-new", details={"tenant_id": tenant}))
+
+        cp = store._get_checkpoint(tenant)
+        assert cp.entry_count == n + 1
+        assert store.verify_integrity(tenant_id=tenant) == (n + 1, 0)
+    finally:
+        _current_tenant.reset(token)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -76,16 +76,28 @@ class MockConnection:
                     table = "gateway_policies"
                 elif "policy_audit_log" in sql:
                     table = "policy_audit_log"
-                elif "audit_log" in sql:
-                    table = "audit_log"
                 elif "audit_chain_checkpoint" in sql:
+                    # Checked before "audit_log" because the seed upsert's
+                    # entry_count subquery `(SELECT COUNT(*) FROM audit_log ...)`
+                    # references audit_log too (#4294).
                     table = "audit_chain_checkpoint"
-                    tenant_id, head_signature = params
+                    # Params are (tenant_id, [count_tenant_id], head_signature):
+                    # the seed form carries the COUNT-subquery tenant param.
+                    tenant_id = params[0]
+                    head_signature = params[-1]
                     existing = self._store.setdefault(table, {}).get(tenant_id)
-                    entry_count = int(existing[1]) + 1 if existing and "on conflict" in sql_lower else 1
+                    if existing and "on conflict" in sql_lower:
+                        entry_count = int(existing[1]) + 1
+                    else:
+                        # Seed = the tenant's TRUE audit_log row count (#4294),
+                        # not a hardcoded 1; the audit_log INSERT already ran.
+                        audit_rows = [r for r in self._store.get("audit_log", {}).values() if r[5] == tenant_id]
+                        entry_count = len(audit_rows) or 1
                     self._store[table][tenant_id] = (tenant_id, entry_count, head_signature)
                     self._cursors.append(cursor)
                     return cursor
+                elif "audit_log" in sql:
+                    table = "audit_log"
                 elif "trend_history" in sql:
                     table = "trend_history"
                 elif "scan_schedules" in sql:


### PR DESCRIPTION
## Problem

For a **legacy** tenant whose `audit_log` rows predate its first `audit_chain_checkpoint` upsert, `_upsert_checkpoint` seeded `entry_count=1` instead of the true historical count. In a migration-owned deployment the checkpoint table is created empty and the runtime store never runs `_hydrate_checkpoints` (Postgres authoritative), so a legacy tenant's first append seeds the checkpoint from scratch. `verify_integrity`'s truncation check (`len(entries) == checkpoint.entry_count`) then **under-counts** for that tenant until enough new appends accrue — mis-scoring a valid intact chain and weakening tail-truncation detection. Pre-existing edge flagged during #4284/#4293, not a regression. `#4294`

## Fix

- **Seed from the true count.** The INSERT branch of `_upsert_checkpoint` (Postgres and SQLite) now sets `entry_count` from `SELECT COUNT(*) FROM audit_log` for the tenant, computed in the **same transaction** as the audit_log INSERT (so it includes the just-inserted row). The steady-state `ON CONFLICT` path stays an O(1) increment; a genuine genesis still seeds 1. This prevents recurrence for every deploy mode.
- **Idempotent reconciler.** New `backfill_checkpoints()` on both stores recomputes `entry_count` and the successor-free chain-tip `head_signature` from `audit_log` links for every tenant, healing already-under-seeded checkpoints. The Postgres path runs under the RLS-bypass maintenance context; head derivation mirrors `_chain_tip_signature_from_log` / #4293 (chain-order-correct under timestamp skew).
- **One-time migration** (`20260720_01`) runs the same reconciliation in SQL under `app.bypass_rls` for migration-owned deployments, where the app never batch-backfills. Idempotent; no meaningful downgrade.

Preserves the #4283 tenant-GUC binding, #4293 chain-order head logic, and the "audit must not block auth" append behavior. No new API/CLI/MCP field — the existing audit-verify surfaces consume `verify_integrity`'s `(verified, tampered)`, which becomes correct for legacy tenants.

## Test / verification (live Postgres, fresh Alembic-migrated DB, RLS on; plus SQLite)

New `tests/test_audit_checkpoint_backfill_4294.py`:
- An under-seeded checkpoint (`entry_count=1` while N rows exist) makes `verify_integrity` mis-score the intact chain **before**; after `backfill_checkpoints()` the checkpoint is `entry_count==N`, `head==true tip`, and `verify_integrity` is clean.
- **Idempotent** — a second run yields the same checkpoint.
- A **correctly-seeded** (non-legacy) tenant is left untouched.
- The append **seed** no longer bakes `entry_count=1` for a legacy tenant (`==N+1`).
- The migration is chained from the current head, bypasses FORCE RLS, and reconciles via `ON CONFLICT DO UPDATE`.

Verified live on the migration-owned schema: the migration healed a corrupted checkpoint `1 -> 7` as the non-superuser `agent_bom_app` role and is idempotent across downgrade+re-upgrade. The mock connection pool was updated to model the seed COUNT subquery. Audit chain/concurrency + `#4293` suites stay green; `ruff` + `ruff format` (pinned) + `mypy` clean on changed files.

Closes #4294