### PR TITLE
fix(export): widen parquet/lake export to all unified finding types

### DIFF
--- a/src/agent_bom/output/iceberg_catalog.py
+++ b/src/agent_bom/output/iceberg_catalog.py
@@ -108,9 +108,10 @@ def register_findings(
     *,
     catalog: Any | None = None,
 ) -> dict[str, Any]:
-    """Append the report's CVE findings to the Iceberg table as a new snapshot.
+    """Append the report's unified findings to the Iceberg table as a new snapshot.
 
-    Creates the namespace and table (matching the shared 28-col Parquet schema)
+    Creates the namespace and table (matching the shared unified Parquet schema —
+    the 28 v1 CVE columns plus the appended finding_type/finding_id/title, #4280)
     if they do not yet exist, then appends a data file and commits a snapshot.
     Returns a small summary dict for logging.
 

--- a/src/agent_bom/output/parquet_fmt.py
+++ b/src/agent_bom/output/parquet_fmt.py
@@ -14,12 +14,19 @@ from agent_bom.models import AIBOMReport, BlastRadius
 from agent_bom.output.finding_views import (
     evidence,
     is_package_malicious,
-    machine_export_findings,
     package_ecosystem,
     package_name,
     package_version,
     severity_value,
+    unified_export_findings,
 )
+
+# Lake/Parquet schema version. v1 = the CVE+malicious 28-column table; v2 adds
+# the three appended unified columns (``finding_type``/``finding_id``/``title``)
+# and widens the row set to every unified finding type (#4280). The bump is
+# purely additive: no v1 column is renamed, retyped, or reordered, so existing
+# Iceberg/lake consumers keep reading the same columns unchanged.
+PARQUET_SCHEMA_VERSION = "2"
 
 _COLUMNS = [
     "cve_id",
@@ -50,6 +57,13 @@ _COLUMNS = [
     "reachable_affected_symbols",
     "graph_reachable",
     "graph_min_hop_distance",
+    # Appended (not inserted) so positional consumers of the original CVE
+    # columns keep working; new nullable columns for the unified finding types
+    # (COMBINATION / PROMPT_SECURITY / CIS / SAST / secret) that a CVE-only row
+    # leaves null. Mirrors the CSV export (#4279).
+    "finding_type",
+    "finding_id",
+    "title",
 ]
 
 
@@ -92,22 +106,29 @@ def _row_dict(finding) -> dict[str, Any]:
         "reachable_affected_symbols": ";".join(evidence(finding, "reachable_affected_symbols", []) or []) or None,
         "graph_reachable": evidence(finding, "graph_reachable", None),
         "graph_min_hop_distance": evidence(finding, "graph_min_hop_distance", None),
+        "finding_type": finding.finding_type.value,
+        "finding_id": finding.id,
+        "title": finding.title or None,
     }
 
 
 def to_arrow_table(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None):
-    """Build a PyArrow table of CVE findings using the shared 28-col schema.
+    """Build a PyArrow table of every unified finding using the shared schema.
 
     Shared by the Parquet file writer and the Iceberg catalog exporter so lake
-    consumers always see one consistent table shape.
+    consumers always see one consistent table shape. Rows cover the full unified
+    stream — CVE + malicious-package plus COMBINATION / PROMPT_SECURITY / CIS /
+    SAST / secret findings (#4280) — with the CVE-specific columns null for
+    non-CVE rows and the appended ``finding_type``/``finding_id``/``title``
+    columns populated for every row.
     """
     pa, _ = _require_pyarrow()
-    rows = [_row_dict(finding) for finding in machine_export_findings(report, blast_radii)]
+    rows = [_row_dict(finding) for finding in unified_export_findings(report, blast_radii)]
     return pa.Table.from_pylist(rows, schema=_schema(pa))
 
 
 def to_parquet_bytes(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> bytes:
-    """Serialize CVE findings to an in-memory Parquet file."""
+    """Serialize every unified finding to an in-memory Parquet file."""
     pa, pq = _require_pyarrow()
     table = to_arrow_table(report, blast_radii)
     sink = pa.BufferOutputStream()
@@ -120,7 +141,7 @@ def export_parquet(
     output_path: str,
     blast_radii: list[BlastRadius] | None = None,
 ) -> None:
-    """Write CVE findings as a Parquet file."""
+    """Write every unified finding as a Parquet file."""
     Path(output_path).write_bytes(to_parquet_bytes(report, blast_radii))
 
 
@@ -155,8 +176,12 @@ def _schema(pa):
             ("reachable_affected_symbols", pa.string()),
             ("graph_reachable", pa.bool_()),
             ("graph_min_hop_distance", pa.int64()),
+            ("finding_type", pa.string()),
+            ("finding_id", pa.string()),
+            ("title", pa.string()),
         ],
+        metadata={b"agent_bom.parquet_schema_version": PARQUET_SCHEMA_VERSION.encode()},
     )
 
 
-__all__ = ["export_parquet", "to_arrow_table", "to_parquet_bytes"]
+__all__ = ["PARQUET_SCHEMA_VERSION", "export_parquet", "to_arrow_table", "to_parquet_bytes"]

--- a/tests/test_iceberg_catalog.py
+++ b/tests/test_iceberg_catalog.py
@@ -165,9 +165,11 @@ def test_round_trip_against_fake_catalog() -> None:
     assert fake.namespaces == [("lake",)]
     assert "lake.cves" in fake.tables
     table = fake.tables["lake.cves"]
-    # schema handed to Iceberg must match the shared 28-col Parquet schema
-    assert len(table.schema) == 28
+    # schema handed to Iceberg must match the shared unified Parquet schema:
+    # the 28 v1 CVE columns plus the appended finding_type/finding_id/title (#4280)
+    assert len(table.schema) == 31
     assert table.schema.names[0] == "cve_id"
+    assert table.schema.names[-3:] == ["finding_type", "finding_id", "title"]
     assert len(table.appended) == 1
     assert table.appended[0].num_rows == 1
     assert result == {

--- a/tests/test_parquet_export.py
+++ b/tests/test_parquet_export.py
@@ -5,12 +5,51 @@ from __future__ import annotations
 import pytest
 
 from agent_bom.ast_models import ASTAnalysisResult, DependencySymbolReach
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.graph.blast_reach import apply_symbol_reachability_to_blast_radii
 from agent_bom.models import AIBOMReport, BlastRadius, Package, Severity, Vulnerability
-from agent_bom.output.parquet_fmt import export_parquet, to_parquet_bytes
+from agent_bom.output.parquet_fmt import (
+    PARQUET_SCHEMA_VERSION,
+    export_parquet,
+    to_arrow_table,
+    to_parquet_bytes,
+)
 from agent_bom.reachability_cve import FUNCTION_REACHABLE
 
 pyarrow = pytest.importorskip("pyarrow")
+
+# The original CVE+malicious lake schema (v1). New unified columns are appended
+# AFTER these so existing Iceberg/lake consumers keep reading the same shape.
+_V1_COLUMNS = (
+    "cve_id",
+    "package",
+    "version",
+    "ecosystem",
+    "severity",
+    "cvss_score",
+    "epss_score",
+    "is_kev",
+    "is_malicious",
+    "malicious_reason",
+    "published_at",
+    "modified_at",
+    "fixed_version",
+    "cwe_ids",
+    "affected_agents",
+    "affected_servers",
+    "exposed_credentials",
+    "summary",
+    "severity_source",
+    "epss_percentile",
+    "kev_date_added",
+    "kev_due_date",
+    "compliance_tags",
+    "reachability",
+    "symbol_reachability",
+    "reachable_affected_symbols",
+    "graph_reachable",
+    "graph_min_hop_distance",
+)
 
 
 def _stamped_br() -> BlastRadius:
@@ -75,6 +114,119 @@ def test_parquet_bytes_round_trip() -> None:
     payload = to_parquet_bytes(report, [br])
     table = pyarrow.parquet.read_table(pyarrow.BufferReader(payload))
     assert table.num_rows == 1
+
+
+def _mixed_report() -> AIBOMReport:
+    """Report carrying a CVE finding plus non-CVE unified types (#4280)."""
+    report = AIBOMReport(agents=[], scan_id="parquet-unified")
+    report.findings = [
+        Finding(
+            finding_type=FindingType.CVE,
+            source=FindingSource.SBOM,
+            asset=Asset(name="web-lib", asset_type="package", identifier="pkg:npm/web-lib@1.0.0"),
+            severity="high",
+            title="CVE-2026-4242: web-lib@1.0.0",
+            description="Unified vulnerability",
+            cve_id="CVE-2026-4242",
+            cwe_ids=["CWE-79"],
+            cvss_score=8.8,
+            epss_score=0.812345,
+            fixed_version="2.0.0",
+            is_kev=True,
+            evidence={
+                "package_name": "web-lib",
+                "package_version": "1.0.0",
+                "ecosystem": "npm",
+                "published_at": "2026-01-01T00:00:00Z",
+                "severity_source": "nvd:cvss_v3",
+                "epss_percentile": 99.1234,
+            },
+            affected_agents=["prod-agent"],
+        ),
+        Finding(
+            finding_type=FindingType.COMBINATION,
+            source=FindingSource.GRAPH_ANALYSIS,
+            asset=Asset(name="prod-agent", asset_type="agent", identifier="agent:prod-agent"),
+            severity="critical",
+            title="Toxic combination: KEV CVE + exposed credential",
+            description="KEV-listed CVE chained with an exposed credential on one path",
+        ),
+        Finding(
+            finding_type=FindingType.PROMPT_SECURITY,
+            source=FindingSource.PROMPT_SCAN,
+            asset=Asset(name="system-prompt", asset_type="prompt", identifier="prompt:system-prompt"),
+            severity="high",
+            title="Prompt injection sink in template",
+            description="Untrusted input interpolated into system prompt",
+        ),
+    ]
+    return report
+
+
+def test_parquet_exports_all_unified_finding_types(tmp_path) -> None:
+    """Parquet must carry COMBINATION / PROMPT_SECURITY, not just CVE+malicious (#4280)."""
+    report = _mixed_report()
+    out_path = tmp_path / "unified.parquet"
+
+    export_parquet(report, str(out_path))
+
+    table = pyarrow.parquet.read_table(out_path)
+    # Row count reconciles to the full unified stream, not just CVE+malicious.
+    assert table.num_rows == len(report.to_findings()) == 3
+    rows = table.to_pylist()
+    by_type = {row["finding_type"]: row for row in rows}
+    assert {"CVE", "COMBINATION", "PROMPT_SECURITY"} <= set(by_type)
+
+    combo = by_type["COMBINATION"]
+    assert combo["severity"] == "critical"
+    assert combo["title"] == "Toxic combination: KEV CVE + exposed credential"
+    assert combo["summary"]
+    assert combo["finding_id"]
+    prompt = by_type["PROMPT_SECURITY"]
+    assert prompt["severity"] == "high"
+    assert prompt["finding_type"] == "PROMPT_SECURITY"
+
+
+def test_parquet_cve_columns_byte_identical_to_cve_only_export(tmp_path) -> None:
+    """Widening must not perturb any existing CVE column value/dtype (#4280).
+
+    A CVE row exported from the mixed estate must be byte-identical (across the
+    v1 columns) to the same CVE exported alone — existing Iceberg consumers of
+    those columns cannot break.
+    """
+    mixed = _mixed_report()
+    cve_only = AIBOMReport(agents=[], scan_id="cve-only")
+    cve_only.findings = [mixed.findings[0]]
+
+    mixed_table = to_arrow_table(mixed)
+    cve_only_table = to_arrow_table(cve_only)
+
+    # Every original column keeps its exact type in the widened schema.
+    for name in _V1_COLUMNS:
+        assert mixed_table.schema.field(name).type == cve_only_table.schema.field(name).type
+
+    mixed_cve = next(r for r in mixed_table.to_pylist() if r["finding_type"] == "CVE")
+    cve_row = cve_only_table.to_pylist()[0]
+    for name in _V1_COLUMNS:
+        assert mixed_cve[name] == cve_row[name], name
+
+
+def test_parquet_schema_is_additive_and_versioned() -> None:
+    """New columns are appended after the v1 block; schema carries a version bump."""
+    table = to_arrow_table(_mixed_report())
+    # v1 columns preserved, in order, at the front.
+    assert tuple(table.schema.names[: len(_V1_COLUMNS)]) == _V1_COLUMNS
+    # New nullable columns appended at the end.
+    assert table.schema.names[len(_V1_COLUMNS) :] == ["finding_type", "finding_id", "title"]
+    for name in ("finding_type", "finding_id", "title"):
+        assert table.schema.field(name).nullable
+    # A CVE-only consumer view still resolves every original column.
+    for name in _V1_COLUMNS:
+        assert name in table.schema.names
+    # Additive change is signalled via a schema-version bump in file metadata.
+    assert PARQUET_SCHEMA_VERSION == "2"
+    meta = table.schema.metadata or {}
+    assert meta.get(b"agent_bom.parquet_schema_version") == b"2"
 
 
 def test_parquet_requires_pyarrow(monkeypatch) -> None:


### PR DESCRIPTION
## Problem
`parquet_fmt.to_arrow_table` built rows from `machine_export_findings`, which carries only **CVE + malicious-package** findings. `COMBINATION` / `PROMPT_SECURITY` (and other unified/graph-derived types) never reached the Parquet file or the Iceberg lake table — even though JSON/SARIF/CSV all surface them after #4279. On `scan --demo --offline` the Parquet file held **16 rows for a 25-finding stream** (sibling of the CSV gap fixed in #4279).

## Fix — additive, schema-versioned
Reuse `unified_export_findings` (the same helper #4279 used for CSV) so parquet covers every finding type. The schema change is **strictly additive** so downstream Iceberg/lake consumers do not break:

- Every existing **v1 CVE column keeps its exact name, order, dtype, and value** — CVE rows are byte-identical to before.
- Three new **nullable** columns (`finding_type`, `finding_id`, `title`) are **appended at the END**, mirroring the CSV fix. CVE-specific columns are null for non-CVE rows and vice-versa.
- No schema-version mechanism existed for the lake table, so this **adds one**: `PARQUET_SCHEMA_VERSION = "2"` embedded as pyarrow schema key-value metadata (`agent_bom.parquet_schema_version`). v1 = the 28-col CVE+malicious table; **v2** = the additive unified widening. No breaking rename/retype.

The Iceberg catalog exporter shares `to_arrow_table`, so the lake table is aligned automatically (docstring + shape test updated 28→31 cols). The scheduled lake-export path (`agent_bom/export/runner.py`) reads hub finding-dicts — a separate stream already carrying all types — so it was never affected.

## Row counts (demo, `scan --demo --offline -f parquet`)
- **Before:** 16 rows — CVE 15 + MALICIOUS_PACKAGE 1
- **After:** 25 rows — + PROMPT_SECURITY 4 + COMBINATION 5 (now matches CSV/JSON/SARIF)

## Surfaces reconciled
Parquet file · Iceberg lake table · CLI `-f parquet`. Scheduled warehouse export already carried all types (verified independent path).

## Tests (TDD, red→green)
- `test_parquet_exports_all_unified_finding_types` — row count == unified count; COMBINATION/PROMPT_SECURITY present with `finding_type`.
- `test_parquet_cve_columns_byte_identical_to_cve_only_export` — every v1 column value + dtype identical between a mixed-estate CVE row and the same CVE exported alone.
- `test_parquet_schema_is_additive_and_versioned` — v1 columns preserved in order at the front, new columns appended + nullable, schema-version metadata = `2`.
- `test_iceberg_catalog` shape assertion updated to 31 cols (additive widening).
- Gates: `ruff` + `ruff format --check` clean, `mypy` clean on changed files, 155 tests across parquet/iceberg/output-formats/scheduled-lake/malicious/interop/reachability/scan-parity green.

Closes #4280