### PR TITLE
feat(graph)+fix(export): store-backed UnifiedGraph (unwired) and unified-type parquet/lake export

### DIFF
--- a/src/agent_bom/graph/build_workspace.py
+++ b/src/agent_bom/graph/build_workspace.py
@@ -119,11 +119,25 @@ class WorkspaceBackend(Protocol):
     # whole node set. No consumer is wired to these yet.
     def get_node_payload(self, tenant_id: str, node_id: str) -> str | None: ...
 
+    def get_edge_payload(self, tenant_id: str, edge_key: str) -> str | None: ...
+
     def iter_node_payloads_by_type(self, tenant_id: str, entity_type: str, batch_size: int) -> Iterator[str]: ...
 
     def iter_edge_payloads_by_source(self, tenant_id: str, node_id: str, batch_size: int) -> Iterator[str]: ...
 
     def iter_edge_payloads_by_target(self, tenant_id: str, node_id: str, batch_size: int) -> Iterator[str]: ...
+
+    # Keyset-paged reads (#4075 PR-3) — each call runs one bounded, self-contained
+    # query (no server-side cursor left open), so the store-backed live graph
+    # container can interleave write-back between pages without a cursor conflict.
+    # ``fetch_node_page`` rows are ``(seq, node_id, payload)``; ``fetch_edge_page``
+    # rows are ``(seq, payload)``. Both order by ``seq`` (insertion order) and
+    # return rows with ``seq > after_seq`` — keyset the last seq to page forward.
+    def fetch_node_page(self, tenant_id: str, after_seq: int, limit: int, entity_type: str | None = None) -> list[tuple[int, str, str]]: ...
+
+    def fetch_edge_page(
+        self, tenant_id: str, after_seq: int, limit: int, source_id: str | None = None, target_id: str | None = None
+    ) -> list[tuple[int, str]]: ...
 
     def count_nodes(self, tenant_id: str) -> int: ...
 
@@ -235,6 +249,46 @@ class _SQLiteWorkspaceBackend:
             (tenant_id, node_id),
         ).fetchone()
         return str(row[0]) if row else None
+
+    def get_edge_payload(self, tenant_id: str, edge_key: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT payload FROM ws_edges WHERE tenant_id = ? AND edge_key = ?",
+            (tenant_id, edge_key),
+        ).fetchone()
+        return str(row[0]) if row else None
+
+    def fetch_node_page(self, tenant_id: str, after_seq: int, limit: int, entity_type: str | None = None) -> list[tuple[int, str, str]]:
+        params: tuple[Any, ...] = (tenant_id,)
+        predicate = ""
+        if entity_type is not None:
+            predicate = " AND entity_type = ?"
+            params = (tenant_id, entity_type)
+        params = (*params, after_seq, limit)
+        rows = self._conn.execute(
+            f"SELECT seq, node_id, payload FROM ws_nodes WHERE tenant_id = ?{predicate} "  # nosec B608 - static cols
+            "AND seq > ? ORDER BY seq LIMIT ?",
+            params,
+        ).fetchall()
+        return [(int(seq), str(node_id), str(payload)) for seq, node_id, payload in rows]
+
+    def fetch_edge_page(
+        self, tenant_id: str, after_seq: int, limit: int, source_id: str | None = None, target_id: str | None = None
+    ) -> list[tuple[int, str]]:
+        params: tuple[Any, ...] = (tenant_id,)
+        predicate = ""
+        if source_id is not None:
+            predicate = " AND source_id = ?"
+            params = (tenant_id, source_id)
+        elif target_id is not None:
+            predicate = " AND target_id = ?"
+            params = (tenant_id, target_id)
+        params = (*params, after_seq, limit)
+        rows = self._conn.execute(
+            f"SELECT seq, payload FROM ws_edges WHERE tenant_id = ?{predicate} "  # nosec B608 - static cols
+            "AND seq > ? ORDER BY seq LIMIT ?",
+            params,
+        ).fetchall()
+        return [(int(seq), str(payload)) for seq, payload in rows]
 
     def iter_node_payloads_by_type(self, tenant_id: str, entity_type: str, batch_size: int) -> Iterator[str]:
         return self._iter_payloads("ws_nodes", tenant_id, batch_size, where_col="entity_type", where_val=entity_type)
@@ -398,6 +452,49 @@ class _PostgresWorkspaceBackend:
         payload = row[0]
         return payload if isinstance(payload, str) else json.dumps(payload)
 
+    def get_edge_payload(self, tenant_id: str, edge_key: str) -> str | None:
+        row = self._conn.execute(
+            "SELECT payload FROM graph_build_workspace_edges WHERE workspace_id = %s AND tenant_id = %s AND edge_key = %s",
+            (self._workspace_id, tenant_id, edge_key),
+        ).fetchone()
+        if not row:
+            return None
+        payload = row[0]
+        return payload if isinstance(payload, str) else json.dumps(payload)
+
+    def fetch_node_page(self, tenant_id: str, after_seq: int, limit: int, entity_type: str | None = None) -> list[tuple[int, str, str]]:
+        params: tuple[Any, ...] = (self._workspace_id, tenant_id)
+        predicate = ""
+        if entity_type is not None:
+            predicate = " AND entity_type = %s"
+            params = (self._workspace_id, tenant_id, entity_type)
+        params = (*params, after_seq, limit)
+        rows = self._conn.execute(
+            f"SELECT seq, node_id, payload FROM graph_build_workspace_nodes "  # nosec B608 - static cols
+            f"WHERE workspace_id = %s AND tenant_id = %s{predicate} AND seq > %s ORDER BY seq LIMIT %s",
+            params,
+        ).fetchall()
+        return [(int(seq), str(node_id), p if isinstance(p, str) else json.dumps(p)) for seq, node_id, p in rows]
+
+    def fetch_edge_page(
+        self, tenant_id: str, after_seq: int, limit: int, source_id: str | None = None, target_id: str | None = None
+    ) -> list[tuple[int, str]]:
+        params: tuple[Any, ...] = (self._workspace_id, tenant_id)
+        predicate = ""
+        if source_id is not None:
+            predicate = " AND source_id = %s"
+            params = (self._workspace_id, tenant_id, source_id)
+        elif target_id is not None:
+            predicate = " AND target_id = %s"
+            params = (self._workspace_id, tenant_id, target_id)
+        params = (*params, after_seq, limit)
+        rows = self._conn.execute(
+            f"SELECT seq, payload FROM graph_build_workspace_edges "  # nosec B608 - static cols
+            f"WHERE workspace_id = %s AND tenant_id = %s{predicate} AND seq > %s ORDER BY seq LIMIT %s",
+            params,
+        ).fetchall()
+        return [(int(seq), p if isinstance(p, str) else json.dumps(p)) for seq, p in rows]
+
     def iter_node_payloads_by_type(self, tenant_id: str, entity_type: str, batch_size: int) -> Iterator[str]:
         return self._iter_payloads("graph_build_workspace_nodes", tenant_id, batch_size, where_col="entity_type", where_val=entity_type)
 
@@ -516,6 +613,30 @@ def _batched(items: Iterable[_RowT], size: int) -> Iterator[list[_RowT]]:
         yield batch
 
 
+def open_workspace_backend(*, workspace_id: str = "", backend: str = "auto") -> WorkspaceBackend:
+    """Open a raw :class:`WorkspaceBackend` on the appropriate store.
+
+    ``backend="auto"`` selects Postgres when ``AGENT_BOM_POSTGRES_URL`` is set,
+    otherwise a private SQLite temp database. ``workspace_id`` namespaces a build
+    on the shared Postgres tables (defaults to a fresh UUID); it is ignored by the
+    process-local SQLite backend. Shared by :func:`open_graph_build_workspace` and
+    the store-backed live graph container.
+    """
+    wsid = workspace_id or uuid.uuid4().hex
+    dsn = os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip()
+    chosen = backend
+    if chosen == "auto":
+        chosen = "postgres" if dsn else "sqlite"
+
+    if chosen == "postgres":
+        if not dsn:
+            raise ValueError("AGENT_BOM_POSTGRES_URL is required for the postgres workspace backend.")
+        return _PostgresWorkspaceBackend(dsn, wsid)
+    if chosen == "sqlite":
+        return _SQLiteWorkspaceBackend()
+    raise ValueError(f"unknown workspace backend {backend!r}")
+
+
 def open_graph_build_workspace(
     *,
     tenant_id: str = "",
@@ -530,19 +651,5 @@ def open_graph_build_workspace(
     on the shared Postgres tables (defaults to a fresh UUID); it is ignored by
     the process-local SQLite backend.
     """
-    wsid = workspace_id or uuid.uuid4().hex
-    dsn = os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip()
-    chosen = backend
-    if chosen == "auto":
-        chosen = "postgres" if dsn else "sqlite"
-
-    impl: WorkspaceBackend
-    if chosen == "postgres":
-        if not dsn:
-            raise ValueError("AGENT_BOM_POSTGRES_URL is required for the postgres workspace backend.")
-        impl = _PostgresWorkspaceBackend(dsn, wsid)
-    elif chosen == "sqlite":
-        impl = _SQLiteWorkspaceBackend()
-    else:
-        raise ValueError(f"unknown workspace backend {backend!r}")
+    impl = open_workspace_backend(workspace_id=workspace_id, backend=backend)
     return GraphBuildWorkspace(impl, tenant_id=tenant_id, batch_size=batch_size)

--- a/src/agent_bom/graph/store_backed.py
+++ b/src/agent_bom/graph/store_backed.py
@@ -1,0 +1,502 @@
+"""Store-backed live :class:`UnifiedGraph` (#4075 PR-3 — proven but unwired).
+
+The graph *producer* (:func:`agent_bom.graph.builder.build_unified_graph_from_report`)
+and its Phase-B overlays build the whole correlated graph in RAM: they add and
+merge nodes/edges, then random-access + mutate the full node set in a forward-
+feeding chain. That in-RAM materialisation is the remaining wall on the #4055
+write-path peak-RSS bound.
+
+:class:`StoreBackedUnifiedGraph` presents the **exact** public
+:class:`~agent_bom.graph.container.UnifiedGraph` interface while backing storage
+with the #4295 indexed build workspace (SQLite temp DB or shared Postgres). Only
+a bounded working set lives in RAM:
+
+* a bounded **LRU node cache** (``capacity`` objects) that also serves as the
+  identity map — while a node is cached it is the one canonical object, so an
+  in-place mutation is visible to the next accessor (``UnifiedNode`` is
+  ``slots=True`` and not weak-referenceable, so a strong-ref LRU, not a weak map,
+  holds identity);
+* **dirty-tracking write-back**: any node handed to a caller is tracked and its
+  in-place mutations (``graph.get_node(id).attributes.update(...)`` /
+  ``graph.nodes[id].attributes[...] = ...`` / ``for n in graph.nodes.values(): n.…``)
+  are persisted on eviction and before serialisation. A node must be mutated
+  within ``capacity`` node-accesses of being handed out (every current overlay
+  mutates a node immediately or within a bounded window — see the audit); the
+  default ``capacity`` is sized well above any overlay's working set;
+* adjacency / reverse-adjacency served by **keyset-paged indexed queries**, with
+  bidirectional-reverse edges synthesised on read exactly as the in-RAM
+  container materialises them.
+
+``add_node`` merge-union and ``add_edge`` dedup + bidirectional-reverse semantics
+are byte-identical to :class:`UnifiedGraph`; ``to_dict()`` on the same build is
+byte-identical. Every traversal / filter / view algorithm is **inherited
+unchanged** from :class:`UnifiedGraph` and runs against the store-backed
+``nodes`` / ``edges`` / ``adjacency`` / ``reverse_adjacency`` views.
+
+**Default-off and unwired.** No builder, overlay, or persist caller constructs
+this container in production; the shipped path still materialises the in-RAM
+:class:`UnifiedGraph`. Tests are the only callers. Wiring the builder/overlays
+through it (and the deferred build-latency + PG-workspace-RLS decisions) is held
+for owner sign-off as PR-4.
+"""
+
+from __future__ import annotations
+
+import json
+from collections import OrderedDict
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any, Optional
+
+from agent_bom.graph.analysis import GraphAnalysisStatus
+from agent_bom.graph.build_workspace import (
+    WorkspaceBackend,
+    _edge_from_payload,
+    _edge_key,
+    _node_entity_type,
+    _node_from_payload,
+    _normalize_tenant,
+    open_workspace_backend,
+)
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.severity import SEVERITY_RANK
+from agent_bom.graph.types import EntityType
+from agent_bom.graph.util import _now_iso
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+_DEFAULT_CAPACITY = 4096
+_DEFAULT_PAGE_SIZE = 1000
+
+
+def _node_to_row(node: UnifiedNode) -> tuple[str, str, str]:
+    return (node.id, json.dumps(node.to_dict(), default=str), _node_entity_type(node))
+
+
+def _edge_to_row(edge: UnifiedEdge) -> tuple[str, str, str, str]:
+    return (_edge_key(edge), json.dumps(edge.to_dict(), default=str), edge.source, edge.target)
+
+
+def _reverse_edge(edge: UnifiedEdge) -> UnifiedEdge:
+    """Synthesise the reverse of a bidirectional edge, matching container.add_edge."""
+    return UnifiedEdge(
+        source=edge.target,
+        target=edge.source,
+        relationship=edge.relationship,
+        direction=edge.direction,
+        weight=edge.weight,
+        traversable=edge.traversable,
+        first_seen=edge.first_seen,
+        last_seen=edge.last_seen,
+        valid_from=edge.valid_from,
+        valid_to=edge.valid_to,
+        source_scan_id=edge.source_scan_id,
+        source_run_id=edge.source_run_id,
+        evidence=edge.evidence,
+        confidence=edge.confidence,
+        provenance=edge.provenance,
+        activity_id=edge.activity_id,
+    )
+
+
+class _NodesView:
+    """Read mapping-view over the store-backed node set.
+
+    Supports exactly what the overlays + inherited algorithms use — ``[id]``,
+    ``in``, ``.get``, ``.values()``, ``.items()``, iteration (keys), ``len`` — and
+    dirty-tracks every node it hands out so in-place mutations are written back.
+    No ``__setitem__`` / ``__delitem__``: the overlays never assign or delete
+    ``graph.nodes[id]`` (verified by the interface-identity audit).
+    """
+
+    __slots__ = ("_g",)
+
+    def __init__(self, graph: StoreBackedUnifiedGraph) -> None:
+        self._g = graph
+
+    def __getitem__(self, node_id: str) -> UnifiedNode:
+        node = self._g._resolve_node(node_id)
+        if node is None:
+            raise KeyError(node_id)
+        self._g._mark_dirty(node_id)
+        return node
+
+    def get(self, node_id: str, default: Any = None) -> Any:
+        node = self._g._resolve_node(node_id)
+        if node is None:
+            return default
+        self._g._mark_dirty(node_id)
+        return node
+
+    def __contains__(self, node_id: object) -> bool:
+        return isinstance(node_id, str) and self._g._has_node(node_id)
+
+    def __iter__(self) -> Iterator[str]:
+        for _seq, node_id, _payload in self._g._iter_node_rows():
+            yield node_id
+
+    def keys(self) -> Iterator[str]:
+        return iter(self)
+
+    def values(self) -> Iterator[UnifiedNode]:
+        return self._g._iter_nodes(mark_dirty=True)
+
+    def items(self) -> Iterator[tuple[str, UnifiedNode]]:
+        for node in self._g._iter_nodes(mark_dirty=True):
+            yield node.id, node
+
+    def __len__(self) -> int:
+        return self._g._node_count()
+
+
+class _EdgesView:
+    """Read sequence-view over the store-backed edge set (originals only, by seq).
+
+    Mirrors the in-RAM ``UnifiedGraph.edges`` list for the surface overlays and
+    inherited algorithms use: iteration and ``len``.
+    """
+
+    __slots__ = ("_g",)
+
+    def __init__(self, graph: StoreBackedUnifiedGraph) -> None:
+        self._g = graph
+
+    def __iter__(self) -> Iterator[UnifiedEdge]:
+        return self._g._iter_edges()
+
+    def __len__(self) -> int:
+        return self._g._edge_count()
+
+
+class _AdjacencyView:
+    """``.get(node_id, default)`` view returning the adjacency edge list.
+
+    Forward and reverse orientations reconstruct the in-RAM container's
+    adjacency — original edges plus synthesised reverses for bidirectional edges —
+    from indexed source/target queries.
+    """
+
+    __slots__ = ("_g", "_reverse")
+
+    def __init__(self, graph: StoreBackedUnifiedGraph, *, reverse: bool) -> None:
+        self._g = graph
+        self._reverse = reverse
+
+    def get(self, node_id: str, default: Any = None) -> Any:
+        edges = self._g._reverse_adjacency(node_id) if self._reverse else self._g._adjacency(node_id)
+        if edges:
+            return edges
+        return default if default is not None else edges
+
+    def __getitem__(self, node_id: str) -> list[UnifiedEdge]:
+        return self._g._reverse_adjacency(node_id) if self._reverse else self._g._adjacency(node_id)
+
+
+class StoreBackedUnifiedGraph(UnifiedGraph):
+    """A :class:`UnifiedGraph` whose node/edge storage lives in the build workspace.
+
+    Constructed only in tests for PR-3 (see the module docstring). Instances own
+    the backend when created via :func:`open_store_backed_unified_graph`; when
+    handed an existing backend (a shared, tenant-scoped store) they do not.
+    """
+
+    # This subclass deliberately does NOT run the ``@dataclass`` __init__: it
+    # provides its own, and exposes ``nodes`` / ``edges`` / ``adjacency`` /
+    # ``reverse_adjacency`` as store-backed properties instead of dict fields.
+    def __init__(
+        self,
+        backend: WorkspaceBackend,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        created_at: str = "",
+        analysis_status: Optional[dict[str, GraphAnalysisStatus]] = None,
+        capacity: int = _DEFAULT_CAPACITY,
+        page_size: int = _DEFAULT_PAGE_SIZE,
+        owns_backend: bool = False,
+    ) -> None:
+        self._backend = backend
+        self._tenant = _normalize_tenant(tenant_id)
+        self._capacity = max(1, capacity)
+        self._page_size = max(1, page_size)
+        self._owns_backend = owns_backend
+
+        # Strong-ref LRU cache: a node stays canonical (one object, mutations
+        # visible) while cached. ``capacity`` must exceed the largest working set
+        # any single caller holds-and-mutates across other node accesses — all
+        # current overlays mutate a node within a bounded window of handing it out
+        # (see the interface-identity audit); the default is sized well above that.
+        self._cache: OrderedDict[str, UnifiedNode] = OrderedDict()
+        self._dirty: set[str] = set()
+
+        self._nodes_view = _NodesView(self)
+        self._edges_view = _EdgesView(self)
+        self._adjacency_view = _AdjacencyView(self, reverse=False)
+        self._reverse_adjacency_view = _AdjacencyView(self, reverse=True)
+
+        # Graph-level fields mirror the in-RAM dataclass (small, bounded, in RAM).
+        self.attack_paths = []
+        self.attack_campaigns = []
+        self.interaction_risks = []
+        self.analysis_status = dict(analysis_status or {})
+        self.nhi_governance_findings = []
+        self.scan_id = scan_id
+        self.tenant_id = tenant_id
+        self.created_at = created_at or _now_iso()
+
+    # ── Store-backed views (shadow the dataclass fields) ─────────────────────
+
+    @property
+    def nodes(self) -> Any:  # type: ignore[override]
+        return self._nodes_view
+
+    @property
+    def edges(self) -> Any:  # type: ignore[override]
+        return self._edges_view
+
+    @property
+    def adjacency(self) -> Any:  # type: ignore[override]
+        return self._adjacency_view
+
+    @property
+    def reverse_adjacency(self) -> Any:  # type: ignore[override]
+        return self._reverse_adjacency_view
+
+    # ── Node cache / dirty write-back ────────────────────────────────────────
+
+    def _cache_put(self, node_id: str, node: UnifiedNode) -> None:
+        self._cache[node_id] = node
+        self._cache.move_to_end(node_id)
+        while len(self._cache) > self._capacity:
+            old_id, old_node = self._cache.popitem(last=False)
+            if old_id in self._dirty:
+                self._write_back(old_id, old_node)
+                self._dirty.discard(old_id)
+
+    def _resolve_node(self, node_id: str) -> Optional[UnifiedNode]:
+        """Return the canonical cached object for ``node_id`` (or load it, or ``None``)."""
+        cached = self._cache.get(node_id)
+        if cached is not None:
+            self._cache.move_to_end(node_id)
+            return cached
+        payload = self._backend.get_node_payload(self._tenant, node_id)
+        if payload is None:
+            return None
+        node = _node_from_payload(json.loads(payload))
+        self._cache_put(node_id, node)
+        return node
+
+    def _mark_dirty(self, node_id: str) -> None:
+        self._dirty.add(node_id)
+
+    def _write_back(self, node_id: str, node: UnifiedNode) -> None:
+        self._backend.add_node_payloads(self._tenant, [_node_to_row(node)])
+
+    def flush(self) -> None:
+        """Persist all dirty (mutated / handed-out) nodes to the store."""
+        if not self._dirty:
+            return
+        for node_id in list(self._dirty):
+            node = self._cache.get(node_id)
+            if node is not None:
+                self._write_back(node_id, node)
+        self._dirty.clear()
+
+    def _has_node(self, node_id: str) -> bool:
+        if node_id in self._cache:
+            return True
+        return self._backend.get_node_payload(self._tenant, node_id) is not None
+
+    def _node_count(self) -> int:
+        return self._backend.count_nodes(self._tenant)
+
+    def _edge_count(self) -> int:
+        return self._backend.count_edges(self._tenant)
+
+    # ── Keyset-paged iteration (write-back safe between pages) ────────────────
+
+    def _iter_node_rows(self, *, entity_type: str | None = None) -> Iterator[tuple[int, str, str]]:
+        self.flush()
+        after = 0
+        while True:
+            page = self._backend.fetch_node_page(self._tenant, after, self._page_size, entity_type)
+            if not page:
+                return
+            for seq, node_id, payload in page:
+                after = seq
+                yield seq, node_id, payload
+
+    def _iter_nodes(self, *, mark_dirty: bool, entity_type: str | None = None) -> Iterator[UnifiedNode]:
+        for _seq, node_id, payload in self._iter_node_rows(entity_type=entity_type):
+            cached = self._cache.get(node_id)
+            node = cached if cached is not None else _node_from_payload(json.loads(payload))
+            if cached is None:
+                self._cache_put(node_id, node)
+            if mark_dirty:
+                self._mark_dirty(node_id)
+            yield node
+
+    def _iter_edges(self) -> Iterator[UnifiedEdge]:
+        after = 0
+        while True:
+            page = self._backend.fetch_edge_page(self._tenant, after, self._page_size)
+            if not page:
+                return
+            for seq, payload in page:
+                after = seq
+                yield _edge_from_payload(json.loads(payload))
+
+    def _collect_edges(self, *, source: str | None = None, target: str | None = None) -> list[UnifiedEdge]:
+        out: list[UnifiedEdge] = []
+        after = 0
+        while True:
+            page = self._backend.fetch_edge_page(self._tenant, after, self._page_size, source_id=source, target_id=target)
+            if not page:
+                return out
+            for seq, payload in page:
+                after = seq
+                out.append(_edge_from_payload(json.loads(payload)))
+
+    def _adjacency(self, node_id: str) -> list[UnifiedEdge]:
+        out: list[UnifiedEdge] = list(self._collect_edges(source=node_id))
+        for edge in self._collect_edges(target=node_id):
+            if edge.is_bidirectional:
+                out.append(_reverse_edge(edge))
+        return out
+
+    def _reverse_adjacency(self, node_id: str) -> list[UnifiedEdge]:
+        out: list[UnifiedEdge] = list(self._collect_edges(target=node_id))
+        for edge in self._collect_edges(source=node_id):
+            if edge.is_bidirectional:
+                out.append(_reverse_edge(edge))
+        return out
+
+    # ── Mutation (store-backed overrides) ────────────────────────────────────
+
+    def add_node(self, node: UnifiedNode) -> None:
+        existing = self._resolve_node(node.id)
+        if existing is not None:
+            _merge_node(existing, node)
+            self._mark_dirty(node.id)
+            return
+        # New node: insert immediately so ``seq`` fixes insertion order (matching
+        # the in-RAM dict's first-insert ordering), then cache for identity.
+        self._backend.add_node_payloads(self._tenant, [_node_to_row(node)])
+        self._cache_put(node.id, node)
+
+    def add_edge(self, edge: UnifiedEdge) -> None:
+        key = _edge_key(edge)
+        existing_payload = self._backend.get_edge_payload(self._tenant, key)
+        if existing_payload is not None:
+            if edge.evidence:
+                stored = _edge_from_payload(json.loads(existing_payload))
+                changed = False
+                for evidence_key, value in edge.evidence.items():
+                    if value in (None, "", [], {}):
+                        continue
+                    if evidence_key not in stored.evidence or stored.evidence[evidence_key] in (None, "", [], {}):
+                        stored.evidence[evidence_key] = value
+                        changed = True
+                if changed:
+                    self._backend.add_edge_payloads(self._tenant, [_edge_to_row(stored)])
+            return
+        self._backend.add_edge_payloads(self._tenant, [_edge_to_row(edge)])
+
+    # ── Query overrides that must not fan out over the whole node set ─────────
+
+    def get_node(self, node_id: str) -> Optional[UnifiedNode]:
+        node = self._resolve_node(node_id)
+        if node is not None:
+            self._mark_dirty(node_id)
+        return node
+
+    def has_node(self, node_id: str) -> bool:
+        return self._has_node(node_id)
+
+    def nodes_by_type(self, entity_type: EntityType) -> list[UnifiedNode]:
+        et = entity_type.value if isinstance(entity_type, EntityType) else str(entity_type)
+        return list(self._iter_nodes(mark_dirty=True, entity_type=et))
+
+    def to_dict(self) -> dict[str, Any]:
+        self.flush()
+        return super().to_dict()
+
+    @classmethod
+    def from_dict(cls, data: "Mapping[str, Any]") -> "StoreBackedUnifiedGraph":  # type: ignore[override]
+        raise NotImplementedError(
+            "StoreBackedUnifiedGraph is built via add_node/add_edge against a store backend; "
+            "use open_store_backed_unified_graph(...) then replay nodes/edges."
+        )
+
+    # ── Lifecycle ────────────────────────────────────────────────────────────
+
+    def close(self) -> None:
+        if self._owns_backend:
+            self._backend.close()
+
+    def __enter__(self) -> "StoreBackedUnifiedGraph":
+        return self
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
+        self.close()
+
+    def __repr__(self) -> str:
+        return f"StoreBackedUnifiedGraph(tenant={self._tenant!r}, nodes={self._node_count()}, edges={self._edge_count()})"
+
+    __eq__ = object.__eq__
+    __hash__ = object.__hash__
+
+
+def _merge_node(existing: UnifiedNode, incoming: UnifiedNode) -> None:
+    """In-place merge-union mirroring :meth:`UnifiedGraph.add_node` exactly."""
+    existing.last_seen = incoming.last_seen or _now_iso()
+    existing.attributes.update(incoming.attributes)
+    if SEVERITY_RANK.get(incoming.severity, 0) > SEVERITY_RANK.get(existing.severity, 0):
+        existing.severity = incoming.severity
+        existing.severity_id = incoming.severity_id
+    if incoming.risk_score > existing.risk_score:
+        existing.risk_score = incoming.risk_score
+    existing_sources = set(existing.data_sources)
+    for ds in incoming.data_sources:
+        if ds not in existing_sources:
+            existing.data_sources.append(ds)
+            existing_sources.add(ds)
+    existing_tags = set(existing.compliance_tags)
+    for tag in incoming.compliance_tags:
+        if tag not in existing_tags:
+            existing.compliance_tags.append(tag)
+            existing_tags.add(tag)
+    existing.dimensions = existing.dimensions.merge(incoming.dimensions)
+
+
+def open_store_backed_unified_graph(
+    *,
+    tenant_id: str = "",
+    scan_id: str = "",
+    created_at: str = "",
+    analysis_status: Optional[dict[str, GraphAnalysisStatus]] = None,
+    workspace_id: str = "",
+    backend: str = "auto",
+    capacity: int = _DEFAULT_CAPACITY,
+    page_size: int | None = None,
+) -> StoreBackedUnifiedGraph:
+    """Open a store-backed live graph on the appropriate workspace backend.
+
+    ``backend="auto"`` selects Postgres when ``AGENT_BOM_POSTGRES_URL`` is set,
+    otherwise a private SQLite temp database (mirrors
+    :func:`~agent_bom.graph.build_workspace.open_graph_build_workspace`). The
+    returned container owns and closes its backend.
+    """
+    impl = open_workspace_backend(workspace_id=workspace_id, backend=backend)
+    return StoreBackedUnifiedGraph(
+        impl,
+        tenant_id=tenant_id,
+        scan_id=scan_id,
+        created_at=created_at,
+        analysis_status=analysis_status,
+        capacity=capacity,
+        page_size=page_size or _DEFAULT_PAGE_SIZE,
+        owns_backend=True,
+    )

--- a/src/agent_bom/output/iceberg_catalog.py
+++ b/src/agent_bom/output/iceberg_catalog.py
@@ -108,9 +108,10 @@ def register_findings(
     *,
     catalog: Any | None = None,
 ) -> dict[str, Any]:
-    """Append the report's CVE findings to the Iceberg table as a new snapshot.
+    """Append the report's unified findings to the Iceberg table as a new snapshot.
 
-    Creates the namespace and table (matching the shared 28-col Parquet schema)
+    Creates the namespace and table (matching the shared unified Parquet schema —
+    the 28 v1 CVE columns plus the appended finding_type/finding_id/title, #4280)
     if they do not yet exist, then appends a data file and commits a snapshot.
     Returns a small summary dict for logging.
 

--- a/src/agent_bom/output/parquet_fmt.py
+++ b/src/agent_bom/output/parquet_fmt.py
@@ -14,12 +14,19 @@ from agent_bom.models import AIBOMReport, BlastRadius
 from agent_bom.output.finding_views import (
     evidence,
     is_package_malicious,
-    machine_export_findings,
     package_ecosystem,
     package_name,
     package_version,
     severity_value,
+    unified_export_findings,
 )
+
+# Lake/Parquet schema version. v1 = the CVE+malicious 28-column table; v2 adds
+# the three appended unified columns (``finding_type``/``finding_id``/``title``)
+# and widens the row set to every unified finding type (#4280). The bump is
+# purely additive: no v1 column is renamed, retyped, or reordered, so existing
+# Iceberg/lake consumers keep reading the same columns unchanged.
+PARQUET_SCHEMA_VERSION = "2"
 
 _COLUMNS = [
     "cve_id",
@@ -50,6 +57,13 @@ _COLUMNS = [
     "reachable_affected_symbols",
     "graph_reachable",
     "graph_min_hop_distance",
+    # Appended (not inserted) so positional consumers of the original CVE
+    # columns keep working; new nullable columns for the unified finding types
+    # (COMBINATION / PROMPT_SECURITY / CIS / SAST / secret) that a CVE-only row
+    # leaves null. Mirrors the CSV export (#4279).
+    "finding_type",
+    "finding_id",
+    "title",
 ]
 
 
@@ -92,22 +106,29 @@ def _row_dict(finding) -> dict[str, Any]:
         "reachable_affected_symbols": ";".join(evidence(finding, "reachable_affected_symbols", []) or []) or None,
         "graph_reachable": evidence(finding, "graph_reachable", None),
         "graph_min_hop_distance": evidence(finding, "graph_min_hop_distance", None),
+        "finding_type": finding.finding_type.value,
+        "finding_id": finding.id,
+        "title": finding.title or None,
     }
 
 
 def to_arrow_table(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None):
-    """Build a PyArrow table of CVE findings using the shared 28-col schema.
+    """Build a PyArrow table of every unified finding using the shared schema.
 
     Shared by the Parquet file writer and the Iceberg catalog exporter so lake
-    consumers always see one consistent table shape.
+    consumers always see one consistent table shape. Rows cover the full unified
+    stream — CVE + malicious-package plus COMBINATION / PROMPT_SECURITY / CIS /
+    SAST / secret findings (#4280) — with the CVE-specific columns null for
+    non-CVE rows and the appended ``finding_type``/``finding_id``/``title``
+    columns populated for every row.
     """
     pa, _ = _require_pyarrow()
-    rows = [_row_dict(finding) for finding in machine_export_findings(report, blast_radii)]
+    rows = [_row_dict(finding) for finding in unified_export_findings(report, blast_radii)]
     return pa.Table.from_pylist(rows, schema=_schema(pa))
 
 
 def to_parquet_bytes(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> bytes:
-    """Serialize CVE findings to an in-memory Parquet file."""
+    """Serialize every unified finding to an in-memory Parquet file."""
     pa, pq = _require_pyarrow()
     table = to_arrow_table(report, blast_radii)
     sink = pa.BufferOutputStream()
@@ -120,7 +141,7 @@ def export_parquet(
     output_path: str,
     blast_radii: list[BlastRadius] | None = None,
 ) -> None:
-    """Write CVE findings as a Parquet file."""
+    """Write every unified finding as a Parquet file."""
     Path(output_path).write_bytes(to_parquet_bytes(report, blast_radii))
 
 
@@ -155,8 +176,12 @@ def _schema(pa):
             ("reachable_affected_symbols", pa.string()),
             ("graph_reachable", pa.bool_()),
             ("graph_min_hop_distance", pa.int64()),
+            ("finding_type", pa.string()),
+            ("finding_id", pa.string()),
+            ("title", pa.string()),
         ],
+        metadata={b"agent_bom.parquet_schema_version": PARQUET_SCHEMA_VERSION.encode()},
     )
 
 
-__all__ = ["export_parquet", "to_arrow_table", "to_parquet_bytes"]
+__all__ = ["PARQUET_SCHEMA_VERSION", "export_parquet", "to_arrow_table", "to_parquet_bytes"]

--- a/tests/graph/test_store_backed_unified_graph.py
+++ b/tests/graph/test_store_backed_unified_graph.py
@@ -1,0 +1,477 @@
+"""Store-backed live UnifiedGraph — byte-identical differential + memory bound (#4075 PR-3).
+
+Proves :class:`StoreBackedUnifiedGraph` is a drop-in for the in-RAM
+:class:`~agent_bom.graph.container.UnifiedGraph`:
+
+* ``to_dict()`` is **byte-identical** to the in-RAM graph on the real self-scan
+  fixture, a constructed report, and synthetic scaled graphs;
+* the overlay mutation pattern (get node → mutate ``attributes`` in place, and
+  ``for node in graph.nodes.values(): mutate``) **persists** and appears in
+  ``to_dict()``;
+* ``add_edge`` bidirectional-reverse materialisation + dedup evidence-merge match
+  the in-RAM semantics;
+* adjacency / traversal (``edges_from`` / ``edges_to`` / ``neighbors`` / ``bfs`` /
+  ``reachable_from``) match the in-RAM graph;
+* peak RAM grows **sub-linearly** vs a full in-RAM copy as the graph scales;
+* tenant isolation holds on a shared backend.
+
+The store-backed container is **default-off and unwired** — no builder, overlay,
+or persist caller constructs it in production. These tests are the only callers.
+"""
+
+from __future__ import annotations
+
+import json
+import tracemalloc
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.store_backed import StoreBackedUnifiedGraph, open_store_backed_unified_graph
+from agent_bom.graph.types import EntityType, NodeStatus, RelationshipType
+
+_FIXTURES = Path(__file__).resolve().parents[1] / "fixtures"
+
+
+def _dumps(graph: UnifiedGraph) -> str:
+    return json.dumps(graph.to_dict(), default=str, sort_keys=False)
+
+
+def _replay(graph: UnifiedGraph, store: StoreBackedUnifiedGraph) -> None:
+    """Feed the exact node/edge objects of a built in-RAM graph into the store.
+
+    Node/edge storage is what the store backs; the graph-level analysis/paths
+    fields are plain attributes the builder sets identically on either container,
+    so mirror them here (in PR-4 the builder would set them on the store directly).
+    """
+    for node in graph.nodes.values():
+        store.add_node(node)
+    for edge in graph.edges:
+        store.add_edge(edge)
+    store.analysis_status = dict(graph.analysis_status)
+    store.attack_paths = list(graph.attack_paths)
+    store.attack_campaigns = list(graph.attack_campaigns)
+    store.interaction_risks = list(graph.interaction_risks)
+    store.nhi_governance_findings = list(graph.nhi_governance_findings)
+
+
+def _sqlite_store(**kwargs) -> StoreBackedUnifiedGraph:
+    kwargs.setdefault("backend", "sqlite")
+    return open_store_backed_unified_graph(**kwargs)
+
+
+# ── Fixtures / synthetic builders ────────────────────────────────────────────
+
+
+def _report_fixtures() -> list[dict]:
+    self_scan = json.loads((_FIXTURES / "agent_bom_self_scan_inventory.json").read_text())
+    constructed = {
+        "scan_id": "constructed",
+        "scan_sources": ["mcp-scan"],
+        "agents": [
+            {
+                "name": "planner",
+                "type": "claude",
+                "source": "local",
+                "mcp_servers": [
+                    {
+                        "name": "files",
+                        "packages": [
+                            {
+                                "name": "requests",
+                                "version": "2.0.0",
+                                "ecosystem": "pypi",
+                                "vulnerabilities": [{"id": "CVE-1", "severity": "critical"}],
+                            }
+                        ],
+                        "tools": [{"name": "read_file"}],
+                    }
+                ],
+            }
+        ],
+        "blast_radius": [],
+    }
+    return [self_scan, constructed]
+
+
+def _gen_nodes(n: int) -> Iterator[UnifiedNode]:
+    for i in range(n):
+        yield UnifiedNode(
+            id=f"n:{i}",
+            entity_type=EntityType.AGENT if i % 50 == 0 else EntityType.VULNERABILITY,
+            label=f"L{i}",
+            severity="high" if i % 3 else "critical",
+            risk_score=float(i % 10),
+            status=NodeStatus.ACTIVE,
+            first_seen="2026-07-20T00:00:00Z",
+            last_seen="2026-07-20T00:00:00Z",
+            attributes={"cvss_score": 7.0, "blob": "v" * 24},
+        )
+
+
+def _gen_edges(n: int) -> Iterator[UnifiedEdge]:
+    for i in range(0, n - 1, 2):
+        yield UnifiedEdge(
+            source=f"n:{i}",
+            target=f"n:{i + 1}",
+            relationship=RelationshipType.DEPENDS_ON,
+            first_seen="2026-07-20T00:00:00Z",
+            last_seen="2026-07-20T00:00:00Z",
+            valid_from="2026-07-20T00:00:00Z",
+        )
+
+
+def _synthetic_graph(scan: str, n: int) -> UnifiedGraph:
+    g = UnifiedGraph(scan_id=scan, tenant_id="t1", created_at="2026-07-20T00:00:00Z")
+    for node in _gen_nodes(n):
+        g.add_node(node)
+    for edge in _gen_edges(n):
+        g.add_edge(edge)
+    return g
+
+
+# ── Byte-identical differential ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("report", _report_fixtures(), ids=["self_scan_fixture", "constructed_report"])
+def test_to_dict_byte_identical_on_real_report(report: dict) -> None:
+    graph = build_unified_graph_from_report(report, scan_id="s", tenant_id="t1")
+    store = _sqlite_store(tenant_id="t1", scan_id=graph.scan_id, created_at=graph.created_at)
+    try:
+        _replay(graph, store)
+        assert _dumps(store) == _dumps(graph)
+        assert len(graph.nodes) > 0
+    finally:
+        store.close()
+
+
+@pytest.mark.parametrize("n", [1, 200, 2000])
+def test_to_dict_byte_identical_on_synthetic(n: int) -> None:
+    graph = _synthetic_graph("s", n)
+    store = _sqlite_store(tenant_id="t1", scan_id="s", created_at=graph.created_at)
+    try:
+        _replay(graph, store)
+        assert _dumps(store) == _dumps(graph)
+    finally:
+        store.close()
+
+
+def test_add_node_merge_union_matches_in_ram() -> None:
+    """Second add of the same id must merge-union identically (severity/risk/sources/tags/attrs)."""
+
+    def _v1() -> UnifiedNode:
+        return UnifiedNode(
+            id="x",
+            entity_type=EntityType.PACKAGE,
+            label="pkg",
+            severity="low",
+            severity_id=2,
+            risk_score=1.0,
+            first_seen="2026-07-20T00:00:00Z",
+            last_seen="2026-07-20T00:00:00Z",
+            attributes={"a": 1},
+            data_sources=["sca"],
+            compliance_tags=["CIS-1"],
+        )
+
+    def _v2() -> UnifiedNode:
+        return UnifiedNode(
+            id="x",
+            entity_type=EntityType.PACKAGE,
+            label="pkg",
+            severity="critical",
+            severity_id=5,
+            risk_score=9.0,
+            first_seen="2026-07-20T00:00:00Z",
+            last_seen="2026-07-20T00:00:00Z",
+            attributes={"b": 2},
+            data_sources=["osv"],
+            compliance_tags=["CIS-2"],
+        )
+
+    g = UnifiedGraph(scan_id="s", tenant_id="t1", created_at="2026-07-20T00:00:00Z")
+    g.add_node(_v1())
+    g.add_node(_v2())
+
+    store = _sqlite_store(tenant_id="t1", scan_id="s", created_at="2026-07-20T00:00:00Z")
+    try:
+        store.add_node(_v1())
+        store.add_node(_v2())
+        assert _dumps(store) == _dumps(g)
+    finally:
+        store.close()
+
+
+def test_add_edge_dedup_evidence_merge_matches_in_ram() -> None:
+    def _e(evidence: dict) -> UnifiedEdge:
+        return UnifiedEdge(
+            source="a",
+            target="b",
+            relationship=RelationshipType.DEPENDS_ON,
+            first_seen="2026-07-20T00:00:00Z",
+            last_seen="2026-07-20T00:00:00Z",
+            valid_from="2026-07-20T00:00:00Z",
+            evidence=dict(evidence),
+        )
+
+    def _nodes(g) -> None:
+        for nid in ("a", "b"):
+            g.add_node(
+                UnifiedNode(
+                    id=nid,
+                    entity_type=EntityType.PACKAGE,
+                    label=nid,
+                    first_seen="2026-07-20T00:00:00Z",
+                    last_seen="2026-07-20T00:00:00Z",
+                )
+            )
+
+    g = UnifiedGraph(scan_id="s", tenant_id="t1", created_at="2026-07-20T00:00:00Z")
+    _nodes(g)
+    g.add_edge(_e({"cvss": 7.0, "empty": ""}))
+    g.add_edge(_e({"cvss": 9.9, "kev": True}))  # dup triple: cvss kept (present), kev merged in
+
+    store = _sqlite_store(tenant_id="t1", scan_id="s", created_at="2026-07-20T00:00:00Z")
+    try:
+        _nodes(store)
+        store.add_edge(_e({"cvss": 7.0, "empty": ""}))
+        store.add_edge(_e({"cvss": 9.9, "kev": True}))
+        assert _dumps(store) == _dumps(g)
+        edges = list(store.edges)
+        assert len(edges) == 1
+        assert edges[0].evidence == {"cvss": 7.0, "empty": "", "kev": True}
+    finally:
+        store.close()
+
+
+def _bidir_graph(g) -> None:
+    for nid in ("a", "b", "c"):
+        g.add_node(
+            UnifiedNode(
+                id=nid,
+                entity_type=EntityType.SERVER,
+                label=nid,
+                first_seen="2026-07-20T00:00:00Z",
+                last_seen="2026-07-20T00:00:00Z",
+            )
+        )
+    g.add_edge(
+        UnifiedEdge(
+            source="a",
+            target="b",
+            relationship=RelationshipType.SHARES_SERVER,
+            direction="bidirectional",
+            first_seen="2026-07-20T00:00:00Z",
+            last_seen="2026-07-20T00:00:00Z",
+            valid_from="2026-07-20T00:00:00Z",
+        )
+    )
+    g.add_edge(
+        UnifiedEdge(
+            source="b",
+            target="c",
+            relationship=RelationshipType.DEPENDS_ON,
+            first_seen="2026-07-20T00:00:00Z",
+            last_seen="2026-07-20T00:00:00Z",
+            valid_from="2026-07-20T00:00:00Z",
+        )
+    )
+
+
+def test_bidirectional_adjacency_and_traversal_match_in_ram() -> None:
+    g = UnifiedGraph(scan_id="s", tenant_id="t1", created_at="2026-07-20T00:00:00Z")
+    _bidir_graph(g)
+    store = _sqlite_store(tenant_id="t1", scan_id="s", created_at="2026-07-20T00:00:00Z")
+    try:
+        _bidir_graph(store)
+        # to_dict byte-identical (edges list holds only original edges, not reverse)
+        assert _dumps(store) == _dumps(g)
+
+        def _adj(graph, nid):
+            return sorted((e.source, e.target, e.relationship.value) for e in graph.adjacency.get(nid, []))
+
+        def _radj(graph, nid):
+            return sorted((e.source, e.target, e.relationship.value) for e in graph.reverse_adjacency.get(nid, []))
+
+        for nid in ("a", "b", "c"):
+            assert _adj(store, nid) == _adj(g, nid), nid
+            assert _radj(store, nid) == _radj(g, nid), nid
+            assert sorted(store.neighbors(nid)) == sorted(g.neighbors(nid)), nid
+            assert sorted(store.sources_of(nid)) == sorted(g.sources_of(nid)), nid
+
+        # Bidirectional edge is traversable both ways; directed one only forward.
+        assert store.reachable_from("a") == g.reachable_from("a")
+        assert store.reachable_from("c") == g.reachable_from("c")
+        assert store.has_edge("a", "b") == g.has_edge("a", "b")
+        assert store.has_edge("b", "a") == g.has_edge("b", "a")  # via bidirectional reverse
+    finally:
+        store.close()
+
+
+# ── Mutation write-back (the crux) ───────────────────────────────────────────
+
+
+def test_get_node_mutation_persists_in_to_dict() -> None:
+    g = _synthetic_graph("s", 60)
+    store = _sqlite_store(tenant_id="t1", scan_id="s", created_at=g.created_at, capacity=8)
+    try:
+        _replay(g, store)
+        # Simulate the cnapp/effective-permissions overlay pattern on BOTH graphs.
+        for nid in ("n:0", "n:25", "n:59"):
+            g.get_node(nid).attributes["cnapp_exposed"] = True
+            store.get_node(nid).attributes["cnapp_exposed"] = True
+        # And the getitem-then-mutate pattern used by the builder.
+        g.nodes["n:10"].attributes["internet_exposed"] = True
+        store.nodes["n:10"].attributes["internet_exposed"] = True
+        assert _dumps(store) == _dumps(g)
+        # Independently confirm the value round-tripped through the store.
+        reread = store.get_node("n:0")
+        assert reread.attributes["cnapp_exposed"] is True
+    finally:
+        store.close()
+
+
+def test_values_iteration_mutation_persists() -> None:
+    """The overlay pattern `for node in graph.nodes.values(): node.attributes[...] = ...`."""
+    g = _synthetic_graph("s", 120)
+    store = _sqlite_store(tenant_id="t1", scan_id="s", created_at=g.created_at, capacity=8)
+    try:
+        _replay(g, store)
+        for node in g.nodes.values():
+            node.attributes["swept"] = 1
+        for node in store.nodes.values():  # capacity(8) << 120 forces mid-iteration write-back eviction
+            node.attributes["swept"] = 1
+        assert _dumps(store) == _dumps(g)
+    finally:
+        store.close()
+
+
+# ── Memory bound ─────────────────────────────────────────────────────────────
+
+
+def _peak_full_in_ram(n: int) -> int:
+    tracemalloc.start()
+    g = _synthetic_graph("s", n)
+    # Touch a bounded working set (the overlay random-access pattern).
+    for i in range(0, n, max(1, n // 200)):
+        node = g.get_node(f"n:{i}")
+        if node:
+            node.attributes["touched"] = True
+    _ = len(g.nodes)
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    del g
+    return peak
+
+
+def _peak_store_backed(n: int) -> int:
+    tracemalloc.start()
+    store = _sqlite_store(tenant_id="t1", scan_id="s", created_at="2026-07-20T00:00:00Z", capacity=256)
+    try:
+        for node in _gen_nodes(n):
+            store.add_node(node)
+        for edge in _gen_edges(n):
+            store.add_edge(edge)
+        for i in range(0, n, max(1, n // 200)):
+            node = store.get_node(f"n:{i}")
+            if node:
+                node.attributes["touched"] = True
+        store.flush()
+        _, peak = tracemalloc.get_traced_memory()
+    finally:
+        store.close()
+    tracemalloc.stop()
+    return peak
+
+
+def test_store_backed_peak_is_sublinear_vs_full_in_ram() -> None:
+    small_full, small_store = _peak_full_in_ram(2000), _peak_store_backed(2000)
+    large_full, large_store = _peak_full_in_ram(8000), _peak_store_backed(8000)
+
+    ratio_small = small_store / small_full
+    ratio_large = large_store / large_full
+
+    # The store-backed container holds only a bounded LRU cache + one page, never
+    # the full node set — its peak is a small fraction of the full in-RAM graph.
+    assert ratio_small < 0.6, f"store/full peak ratio too high at N=2000: {ratio_small:.3f}"
+    assert ratio_large < 0.6, f"store/full peak ratio too high at N=8000: {ratio_large:.3f}"
+    # Sub-linear: as the graph grows 4x, the store advantage must widen, not erode.
+    assert ratio_large < ratio_small, f"store advantage did not widen with scale: {ratio_small:.3f} -> {ratio_large:.3f}"
+
+
+# ── Tenant isolation ─────────────────────────────────────────────────────────
+
+
+def test_tenant_isolation_on_shared_backend() -> None:
+    from agent_bom.graph.build_workspace import open_workspace_backend
+
+    backend = open_workspace_backend(backend="sqlite")
+    try:
+        alpha = StoreBackedUnifiedGraph(backend, tenant_id="alpha", scan_id="a", created_at="2026-07-20T00:00:00Z")
+        beta = StoreBackedUnifiedGraph(backend, tenant_id="beta", scan_id="b", created_at="2026-07-20T00:00:00Z")
+        for graph, extra in ((alpha, "vuln:alpha-only"), (beta, "vuln:beta-only")):
+            graph.add_node(
+                UnifiedNode(
+                    id="shared:1",
+                    entity_type=EntityType.AGENT,
+                    label="agent",
+                    first_seen="2026-07-20T00:00:00Z",
+                    last_seen="2026-07-20T00:00:00Z",
+                )
+            )
+            graph.add_node(
+                UnifiedNode(
+                    id=extra,
+                    entity_type=EntityType.VULNERABILITY,
+                    label="v",
+                    severity="high",
+                    first_seen="2026-07-20T00:00:00Z",
+                    last_seen="2026-07-20T00:00:00Z",
+                )
+            )
+
+        assert alpha.has_node("shared:1") and beta.has_node("shared:1")
+        assert alpha.has_node("vuln:alpha-only") and not alpha.has_node("vuln:beta-only")
+        assert beta.has_node("vuln:beta-only") and not beta.has_node("vuln:alpha-only")
+        assert {n.id for n in alpha.nodes.values()} == {"shared:1", "vuln:alpha-only"}
+    finally:
+        backend.close()
+
+
+# ── Inherited algorithms run unchanged against the store-backed views ─────────
+
+
+def test_inherited_algorithms_match_in_ram() -> None:
+    """bfs / shortest_path / filter_nodes / search_nodes / impact_of /
+    traverse_subgraph / to_ocsf_events are inherited from UnifiedGraph and must
+    produce the same results when driven by the store-backed views."""
+    g = _synthetic_graph("s", 40)
+    store = _sqlite_store(tenant_id="t1", scan_id="s", created_at=g.created_at, capacity=8)
+    try:
+        _replay(g, store)
+
+        assert store.bfs("n:0", max_depth=3, traversable_only=False) == g.bfs("n:0", max_depth=3, traversable_only=False)
+        assert store.shortest_path("n:0", "n:1") == g.shortest_path("n:0", "n:1")
+        assert store.reachable_from("n:0") == g.reachable_from("n:0")
+        assert store.impact_of("n:1") == g.impact_of("n:1")
+
+        def _ids(nodes):
+            return sorted(n.id for n in nodes)
+
+        assert _ids(store.filter_nodes(min_severity="critical")) == _ids(g.filter_nodes(min_severity="critical"))
+        assert _ids(store.nodes_by_type(EntityType.AGENT)) == _ids(g.nodes_by_type(EntityType.AGENT))
+        assert _ids(store.search_nodes("L1")) == _ids(g.search_nodes("L1"))
+
+        sub_store, depth_s, trunc_s = store.traverse_subgraph(["n:0"], max_depth=4)
+        sub_g, depth_g, trunc_g = g.traverse_subgraph(["n:0"], max_depth=4)
+        assert set(sub_store.nodes) == set(sub_g.nodes)
+        assert depth_s == depth_g and trunc_s == trunc_g
+
+        assert len(store.to_ocsf_events()) == len(g.to_ocsf_events())
+    finally:
+        store.close()

--- a/tests/graph/test_store_backed_unified_graph_postgres.py
+++ b/tests/graph/test_store_backed_unified_graph_postgres.py
@@ -1,0 +1,100 @@
+"""Real-Postgres contract for the store-backed live UnifiedGraph (#4075 PR-3).
+
+Requires ``AGENT_BOM_POSTGRES_URL`` (skipped otherwise). Proves the store-backed
+container is byte-identical to the in-RAM graph on the shared PG workspace, that
+in-place mutation persists, and — the PG-specific hazard — that mid-iteration
+write-back does **not** collide with an open server-side read cursor: the keyset-
+paged iterators run one bounded, self-contained query per page, freeing the
+connection for write-back between pages. Small ``capacity`` + ``page_size`` force
+many pages and many evictions during a single ``values()`` sweep.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+
+_DSN = os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip()
+pytestmark = pytest.mark.skipif(not _DSN, reason="AGENT_BOM_POSTGRES_URL not set")
+
+from test_store_backed_unified_graph import (  # noqa: E402  (sibling module; tests/graph is not a package)
+    _bidir_graph,
+    _dumps,
+    _replay,
+    _synthetic_graph,
+)
+
+from agent_bom.graph.build_workspace import _PostgresWorkspaceBackend  # noqa: E402
+from agent_bom.graph.node import UnifiedNode  # noqa: E402
+from agent_bom.graph.store_backed import StoreBackedUnifiedGraph  # noqa: E402
+from agent_bom.graph.types import EntityType  # noqa: E402
+
+
+def _pg_store(**kwargs) -> StoreBackedUnifiedGraph:
+    wsid = f"sbg-{uuid.uuid4().hex}"
+    backend = _PostgresWorkspaceBackend(_DSN, wsid)
+    kwargs.setdefault("owns_backend", True)
+    return StoreBackedUnifiedGraph(backend, **kwargs)
+
+
+def test_pg_to_dict_byte_identical_on_synthetic() -> None:
+    graph = _synthetic_graph("s", 500)
+    store = _pg_store(tenant_id="t1", scan_id="s", created_at=graph.created_at, capacity=32, page_size=64)
+    try:
+        _replay(graph, store)
+        assert _dumps(store) == _dumps(graph)
+    finally:
+        store.close()
+
+
+def test_pg_values_iteration_mutation_persists_without_cursor_conflict() -> None:
+    graph = _synthetic_graph("s", 500)
+    # capacity(16) and page_size(50) << 500 => many keyset pages + many dirty
+    # evictions (write-back) DURING the sweep. On a single PG connection this only
+    # works because each page is a closed query, not an open server-side cursor.
+    store = _pg_store(tenant_id="t1", scan_id="s", created_at=graph.created_at, capacity=16, page_size=50)
+    try:
+        _replay(graph, store)
+        for node in graph.nodes.values():
+            node.attributes["swept"] = 1
+        for node in store.nodes.values():
+            node.attributes["swept"] = 1
+        assert _dumps(store) == _dumps(graph)
+    finally:
+        store.close()
+
+
+def test_pg_bidirectional_adjacency_matches_in_ram() -> None:
+    from agent_bom.graph.container import UnifiedGraph
+
+    g = UnifiedGraph(scan_id="s", tenant_id="t1", created_at="2026-07-20T00:00:00Z")
+    _bidir_graph(g)
+    store = _pg_store(tenant_id="t1", scan_id="s", created_at="2026-07-20T00:00:00Z", capacity=2, page_size=2)
+    try:
+        _bidir_graph(store)
+        assert _dumps(store) == _dumps(g)
+        for nid in ("a", "b", "c"):
+            got = sorted((e.source, e.target, e.relationship.value) for e in store.adjacency.get(nid, []))
+            want = sorted((e.source, e.target, e.relationship.value) for e in g.adjacency.get(nid, []))
+            assert got == want, nid
+        assert store.reachable_from("a") == g.reachable_from("a")
+    finally:
+        store.close()
+
+
+def test_pg_tenant_isolation_on_shared_backend() -> None:
+    wsid = f"sbg-iso-{uuid.uuid4().hex}"
+    backend = _PostgresWorkspaceBackend(_DSN, wsid)
+    try:
+        alpha = StoreBackedUnifiedGraph(backend, tenant_id="alpha", scan_id="a", created_at="2026-07-20T00:00:00Z")
+        beta = StoreBackedUnifiedGraph(backend, tenant_id="beta", scan_id="b", created_at="2026-07-20T00:00:00Z")
+        for graph, extra in ((alpha, "vuln:alpha-only"), (beta, "vuln:beta-only")):
+            graph.add_node(UnifiedNode(id="shared:1", entity_type=EntityType.AGENT, label="agent"))
+            graph.add_node(UnifiedNode(id=extra, entity_type=EntityType.VULNERABILITY, label="v", severity="high"))
+        assert alpha.has_node("vuln:alpha-only") and not alpha.has_node("vuln:beta-only")
+        assert beta.has_node("vuln:beta-only") and not beta.has_node("vuln:alpha-only")
+        assert {n.id for n in alpha.nodes.values()} == {"shared:1", "vuln:alpha-only"}
+    finally:
+        backend.close()  # DELETE by workspace_id clears both tenants' rows

--- a/tests/test_iceberg_catalog.py
+++ b/tests/test_iceberg_catalog.py
@@ -165,9 +165,11 @@ def test_round_trip_against_fake_catalog() -> None:
     assert fake.namespaces == [("lake",)]
     assert "lake.cves" in fake.tables
     table = fake.tables["lake.cves"]
-    # schema handed to Iceberg must match the shared 28-col Parquet schema
-    assert len(table.schema) == 28
+    # schema handed to Iceberg must match the shared unified Parquet schema:
+    # the 28 v1 CVE columns plus the appended finding_type/finding_id/title (#4280)
+    assert len(table.schema) == 31
     assert table.schema.names[0] == "cve_id"
+    assert table.schema.names[-3:] == ["finding_type", "finding_id", "title"]
     assert len(table.appended) == 1
     assert table.appended[0].num_rows == 1
     assert result == {

--- a/tests/test_parquet_export.py
+++ b/tests/test_parquet_export.py
@@ -5,12 +5,51 @@ from __future__ import annotations
 import pytest
 
 from agent_bom.ast_models import ASTAnalysisResult, DependencySymbolReach
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.graph.blast_reach import apply_symbol_reachability_to_blast_radii
 from agent_bom.models import AIBOMReport, BlastRadius, Package, Severity, Vulnerability
-from agent_bom.output.parquet_fmt import export_parquet, to_parquet_bytes
+from agent_bom.output.parquet_fmt import (
+    PARQUET_SCHEMA_VERSION,
+    export_parquet,
+    to_arrow_table,
+    to_parquet_bytes,
+)
 from agent_bom.reachability_cve import FUNCTION_REACHABLE
 
 pyarrow = pytest.importorskip("pyarrow")
+
+# The original CVE+malicious lake schema (v1). New unified columns are appended
+# AFTER these so existing Iceberg/lake consumers keep reading the same shape.
+_V1_COLUMNS = (
+    "cve_id",
+    "package",
+    "version",
+    "ecosystem",
+    "severity",
+    "cvss_score",
+    "epss_score",
+    "is_kev",
+    "is_malicious",
+    "malicious_reason",
+    "published_at",
+    "modified_at",
+    "fixed_version",
+    "cwe_ids",
+    "affected_agents",
+    "affected_servers",
+    "exposed_credentials",
+    "summary",
+    "severity_source",
+    "epss_percentile",
+    "kev_date_added",
+    "kev_due_date",
+    "compliance_tags",
+    "reachability",
+    "symbol_reachability",
+    "reachable_affected_symbols",
+    "graph_reachable",
+    "graph_min_hop_distance",
+)
 
 
 def _stamped_br() -> BlastRadius:
@@ -75,6 +114,119 @@ def test_parquet_bytes_round_trip() -> None:
     payload = to_parquet_bytes(report, [br])
     table = pyarrow.parquet.read_table(pyarrow.BufferReader(payload))
     assert table.num_rows == 1
+
+
+def _mixed_report() -> AIBOMReport:
+    """Report carrying a CVE finding plus non-CVE unified types (#4280)."""
+    report = AIBOMReport(agents=[], scan_id="parquet-unified")
+    report.findings = [
+        Finding(
+            finding_type=FindingType.CVE,
+            source=FindingSource.SBOM,
+            asset=Asset(name="web-lib", asset_type="package", identifier="pkg:npm/web-lib@1.0.0"),
+            severity="high",
+            title="CVE-2026-4242: web-lib@1.0.0",
+            description="Unified vulnerability",
+            cve_id="CVE-2026-4242",
+            cwe_ids=["CWE-79"],
+            cvss_score=8.8,
+            epss_score=0.812345,
+            fixed_version="2.0.0",
+            is_kev=True,
+            evidence={
+                "package_name": "web-lib",
+                "package_version": "1.0.0",
+                "ecosystem": "npm",
+                "published_at": "2026-01-01T00:00:00Z",
+                "severity_source": "nvd:cvss_v3",
+                "epss_percentile": 99.1234,
+            },
+            affected_agents=["prod-agent"],
+        ),
+        Finding(
+            finding_type=FindingType.COMBINATION,
+            source=FindingSource.GRAPH_ANALYSIS,
+            asset=Asset(name="prod-agent", asset_type="agent", identifier="agent:prod-agent"),
+            severity="critical",
+            title="Toxic combination: KEV CVE + exposed credential",
+            description="KEV-listed CVE chained with an exposed credential on one path",
+        ),
+        Finding(
+            finding_type=FindingType.PROMPT_SECURITY,
+            source=FindingSource.PROMPT_SCAN,
+            asset=Asset(name="system-prompt", asset_type="prompt", identifier="prompt:system-prompt"),
+            severity="high",
+            title="Prompt injection sink in template",
+            description="Untrusted input interpolated into system prompt",
+        ),
+    ]
+    return report
+
+
+def test_parquet_exports_all_unified_finding_types(tmp_path) -> None:
+    """Parquet must carry COMBINATION / PROMPT_SECURITY, not just CVE+malicious (#4280)."""
+    report = _mixed_report()
+    out_path = tmp_path / "unified.parquet"
+
+    export_parquet(report, str(out_path))
+
+    table = pyarrow.parquet.read_table(out_path)
+    # Row count reconciles to the full unified stream, not just CVE+malicious.
+    assert table.num_rows == len(report.to_findings()) == 3
+    rows = table.to_pylist()
+    by_type = {row["finding_type"]: row for row in rows}
+    assert {"CVE", "COMBINATION", "PROMPT_SECURITY"} <= set(by_type)
+
+    combo = by_type["COMBINATION"]
+    assert combo["severity"] == "critical"
+    assert combo["title"] == "Toxic combination: KEV CVE + exposed credential"
+    assert combo["summary"]
+    assert combo["finding_id"]
+    prompt = by_type["PROMPT_SECURITY"]
+    assert prompt["severity"] == "high"
+    assert prompt["finding_type"] == "PROMPT_SECURITY"
+
+
+def test_parquet_cve_columns_byte_identical_to_cve_only_export(tmp_path) -> None:
+    """Widening must not perturb any existing CVE column value/dtype (#4280).
+
+    A CVE row exported from the mixed estate must be byte-identical (across the
+    v1 columns) to the same CVE exported alone — existing Iceberg consumers of
+    those columns cannot break.
+    """
+    mixed = _mixed_report()
+    cve_only = AIBOMReport(agents=[], scan_id="cve-only")
+    cve_only.findings = [mixed.findings[0]]
+
+    mixed_table = to_arrow_table(mixed)
+    cve_only_table = to_arrow_table(cve_only)
+
+    # Every original column keeps its exact type in the widened schema.
+    for name in _V1_COLUMNS:
+        assert mixed_table.schema.field(name).type == cve_only_table.schema.field(name).type
+
+    mixed_cve = next(r for r in mixed_table.to_pylist() if r["finding_type"] == "CVE")
+    cve_row = cve_only_table.to_pylist()[0]
+    for name in _V1_COLUMNS:
+        assert mixed_cve[name] == cve_row[name], name
+
+
+def test_parquet_schema_is_additive_and_versioned() -> None:
+    """New columns are appended after the v1 block; schema carries a version bump."""
+    table = to_arrow_table(_mixed_report())
+    # v1 columns preserved, in order, at the front.
+    assert tuple(table.schema.names[: len(_V1_COLUMNS)]) == _V1_COLUMNS
+    # New nullable columns appended at the end.
+    assert table.schema.names[len(_V1_COLUMNS) :] == ["finding_type", "finding_id", "title"]
+    for name in ("finding_type", "finding_id", "title"):
+        assert table.schema.field(name).nullable
+    # A CVE-only consumer view still resolves every original column.
+    for name in _V1_COLUMNS:
+        assert name in table.schema.names
+    # Additive change is signalled via a schema-version bump in file metadata.
+    assert PARQUET_SCHEMA_VERSION == "2"
+    meta = table.schema.metadata or {}
+    assert meta.get(b"agent_bom.parquet_schema_version") == b"2"
 
 
 def test_parquet_requires_pyarrow(monkeypatch) -> None:


### PR DESCRIPTION
Combines two independently reviewed, zero-file-overlap branches into one additive, non-security PR, rebuilt on current `main`.

## What changed

### 1. Store-backed live `UnifiedGraph` (#4306) — Part of #4075
- New `src/agent_bom/graph/store_backed.py`: `StoreBackedUnifiedGraph` presents the exact `UnifiedGraph` public surface while streaming nodes/edges from a workspace store instead of holding the whole graph in RAM.
- `build_workspace.py`: additive backend protocol methods (`get_edge_payload`, keyset-paged `fetch_node_page`/`fetch_edge_page`) on both SQLite and Postgres backends, plus an extracted `open_workspace_backend` factory. Keyset paging runs one bounded self-contained query per page so mid-iteration write-back never collides with an open server-side cursor.
- **Default-off / unwired**: no builder, overlay, route, or caller references `StoreBackedUnifiedGraph`; no production flag is flipped. The container is proven in isolation; the PR-4 wiring is intentionally held for owner sign-off.

### 2. Unified-type parquet/lake export (#4307) — Closes #4280
- `parquet_fmt.py`: the lake/Parquet table now covers the full unified finding stream (CVE + malicious-package plus COMBINATION / PROMPT_SECURITY / CIS / SAST / secret) instead of CVE-only.
- Additive schema v2 (`PARQUET_SCHEMA_VERSION = "2"`): the 28 existing v1 columns are unchanged in name, type, and order; three nullable columns (`finding_type`, `finding_id`, `title`) are **appended** (not inserted), and a `parquet_schema_version` file-metadata key is set. Existing Iceberg/lake consumers keep reading the same columns unchanged.
- `iceberg_catalog.py`: docstring/schema alignment to the shared unified table.

Zero file overlap between the two (graph/ vs output/); merged cleanly with `--no-ff`, no conflicts.

## Verification (all on the merged result, fresh `main` base)
- `tests/graph/test_store_backed_unified_graph.py` + `tests/graph/test_graph_build_workspace.py` + `tests/test_parquet_export.py` + `tests/test_iceberg_catalog.py` — **39 passed**. Includes store-backed byte-identical (synthetic 1/200/2000 + real report), sublinear-peak-memory vs full-in-RAM, and tenant-isolation tests.
- Live Postgres variant `tests/graph/test_store_backed_unified_graph_postgres.py` against a clean database — **4 passed**, including byte-identical on PG and mid-iteration write-back without cursor conflict.
- Real round-trip: `agent-bom agents --demo --offline -f parquet`, read back with pyarrow — 25 rows = full unified stream (CVE 15 + MALICIOUS_PACKAGE 1 + PROMPT_SECURITY 4 + COMBINATION 5) vs the prior CVE-only 16; file metadata `agent_bom.parquet_schema_version = 2`; the 28 v1 CVE columns are an unchanged same-order same-type prefix of the new 31-column schema.
- `ruff check` + `ruff format --check` on all 8 changed files — clean.
- `mypy` on the 4 changed source files — clean (a numpy-stub `type`-statement note reproduces identically on untouched `main` files and is an environment/target-version artifact, not from this change).

## Notes
- Graph container stays default-off/unwired; do not merge as a wiring change.
- Do not close #4306 / #4307 here — the parent will.
