### PR TITLE
fix(deploy): make Helm defaults self-consistent

### DIFF
--- a/deploy/helm/agent-bom/README.md
+++ b/deploy/helm/agent-bom/README.md
@@ -11,13 +11,18 @@ the scanner CronJob and supporting RBAC only. The API, dashboard, gateway,
 proxy, firewall, MCP server mode, and Postgres wiring stay off until you opt in.
 
 For the full platform (browse findings in the UI, hit the REST API, enforce
-runtime policy), install with:
+runtime policy), start from a shipped profile. Profiles provide the required
+Postgres secret wiring and deployment-specific egress/ingress rules:
 
 ```bash
-helm upgrade --install agent-bom . \
-  -n agent-bom --create-namespace \
-  --set controlPlane.enabled=true
+python scripts/install_helm_profile.py focused-pilot --print-command
+python scripts/install_helm_profile.py focused-pilot
 ```
+
+The chart does not provision Postgres. A direct `--set controlPlane.enabled=true`
+install must supply `AGENT_BOM_POSTGRES_URL` through `controlPlane.api.envFrom`
+or `controlPlane.migrations.env`; otherwise template validation fails before
+Helm creates a partial control plane.
 
 Without that flag, Helm succeeds quietly and only scanner pieces land in the
 cluster. See the `controlPlane:` block in `values.yaml` for every subcomponent
@@ -32,11 +37,8 @@ From a checked-out repo (chart path `deploy/helm/agent-bom/`):
 helm upgrade --install agent-bom deploy/helm/agent-bom \
   -n agent-bom --create-namespace
 
-# API + UI control plane
-helm upgrade --install agent-bom deploy/helm/agent-bom \
-  -n agent-bom --create-namespace \
-  --set controlPlane.enabled=true \
-  --set controlPlane.ingress.enabled=true
+# API + UI control plane (use a shipped profile; it includes Postgres wiring)
+python scripts/install_helm_profile.py focused-pilot
 
 # Custom scan schedule
 helm upgrade --install agent-bom deploy/helm/agent-bom \

--- a/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml
+++ b/deploy/helm/agent-bom/examples/eks-istio-kyverno-values.yaml
@@ -21,6 +21,9 @@ controlPlane:
       background: true
       requireControlPlanePodHardening: true
   api:
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane-db
     env:
       - name: AGENT_BOM_REQUIRE_SHARED_RATE_LIMIT
         value: "1"

--- a/deploy/helm/agent-bom/templates/controlplane-alembic-migration-job.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-alembic-migration-job.yaml
@@ -4,6 +4,9 @@
 {{- if not $envFrom }}
 {{- $envFrom = .Values.controlPlane.api.envFrom }}
 {{- end }}
+{{- if and (not $envFrom) (not $migrations.env) }}
+{{- fail "controlPlane.migrations requires controlPlane.api.envFrom or controlPlane.migrations.env with AGENT_BOM_POSTGRES_URL" }}
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/deploy/helm/agent-bom/templates/networkpolicy.yaml
+++ b/deploy/helm/agent-bom/templates/networkpolicy.yaml
@@ -10,8 +10,12 @@ metadata:
     {{- include "agent-bom.labels" . | nindent 4 }}
 spec:
   podSelector:
+    {{- with .Values.networkPolicy.podSelector }}
+    {{- toYaml . | nindent 4 }}
+    {{- else }}
     matchLabels:
       app.kubernetes.io/name: {{ include "agent-bom.name" . }}
+    {{- end }}
   policyTypes:
     - Egress
     {{- if or .Values.networkPolicy.restrictIngress (gt (len .Values.networkPolicy.ingress) 0) }}

--- a/deploy/helm/agent-bom/templates/tests/test-connection.yaml
+++ b/deploy/helm/agent-bom/templates/tests/test-connection.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.tests.enabled }}
+{{- if and .Values.tests.enabled .Values.controlPlane.enabled }}
 apiVersion: v1
 kind: Pod
 metadata:

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -67,6 +67,9 @@ topologySpread:
     topologyKey: kubernetes.io/hostname
 
 tests:
+  # The hook checks API/UI endpoints and is rendered only when the control
+  # plane is enabled. Keep it available for full-stack profiles without
+  # making the scanner-only default claim a live service check.
   enabled: true
   includeUi: true
   image:
@@ -780,6 +783,12 @@ startupProbe:
 
 networkPolicy:
   enabled: true
+  # The default chart is scanner-only. Scope this baseline policy to scanner
+  # pods so enabling the control plane does not silently block Postgres,
+  # identity, cloud, or UI/API traffic before operators provide egress rules.
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: scanner
   restrictIngress: true
   ingress: []
   allowDns: true

--- a/scripts/validate_helm_profiles.py
+++ b/scripts/validate_helm_profiles.py
@@ -70,6 +70,15 @@ def main() -> int:
 
     chart_dir = helm_chart_dir(REPO_ROOT)
     _run(["helm", "lint", str(chart_dir)])
+
+    default_rendered = _render(["helm", "template", "agent-bom-default", str(chart_dir)])
+    if "agent-bom-test-connection" in default_rendered:
+        print(
+            "error: scanner-only default must not render the control-plane connection test hook",
+            file=sys.stderr,
+        )
+        return 1
+
     for profile in selected:
         cmd = ["helm", "template", f"agent-bom-{profile.name}", str(chart_dir)]
         for values_file in profile.values_files:

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -344,6 +344,16 @@ def test_helm_scanner_defaults():
     assert "schedule" in scanner
 
 
+def test_helm_default_network_policy_is_scoped_to_scanner_pods():
+    """The scanner-only default must not block control-plane traffic."""
+    doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())
+    policy = doc["networkPolicy"]
+    assert policy["enabled"] is True
+    assert policy["podSelector"] == {
+        "matchLabels": {"app.kubernetes.io/component": "scanner"}
+    }
+
+
 def test_helm_control_plane_autoscaling_defaults():
     """Control plane ships explicit HPA defaults without enabling autoscaling by default."""
     doc = yaml.safe_load((HELM_DIR / "values.yaml").read_text())


### PR DESCRIPTION
## Summary

- Scope the default NetworkPolicy to scanner pods so enabling the control plane does not silently block API, Postgres, identity, or cloud traffic.
- Keep the Helm connection test hook out of scanner-only renders and fail clearly when Postgres migrations have no configured URL source.
- Align the packaged profile README and Istio/Kyverno overlay with the required operator-managed Postgres secret.

## Verification

- `python scripts/validate_helm_profiles.py`
- `python -m pytest -q tests/test_deploy_manifests.py tests/test_deploy_profiles.py tests/test_iac_helm.py` (130 passed)
- `make preflight`
- `python scripts/check_package_layout.py`
- `git diff --check`
- Default `helm template` contains no connection test hook and scopes the policy to `app.kubernetes.io/component: scanner`.
- Direct control-plane render without a Postgres secret fails with an actionable template error instead of producing a partial install.

## Notes

This is a post-release deployability fix. It does not change the published `0.97.0` artifacts.
