### PR TITLE
fix(check): fail closed on ambiguous package input

### DIFF
--- a/src/agent_bom/cli/_check.py
+++ b/src/agent_bom/cli/_check.py
@@ -427,6 +427,51 @@ def _resolve_check_ecosystems(name: str, version: str, ecosystem: Optional[str],
     raise click.UsageError(f"Ambiguous package name '{name}'. Specify --ecosystem pypi or --ecosystem npm for a trustworthy verdict.")
 
 
+def _maven_coordinate_error(name: str, ecosystem: str) -> str | None:
+    """Return a fail-closed message when a Maven package lacks its namespace.
+
+    OSV identifies Maven artifacts by ``group:artifact``. Querying a bare
+    artifact name can return no rows and must never be presented as a clean
+    result, because another group may own the vulnerable artifact.
+    """
+    if ecosystem.lower() != "maven":
+        return None
+    parts = name.split(":")
+    if len(parts) == 2 and all(part.strip() for part in parts):
+        return None
+    return (
+        f"Maven package '{name}' is missing its group:artifact coordinate. "
+        "Use --ecosystem maven with a fully qualified coordinate, for example "
+        "org.apache.logging.log4j:log4j-core@2.14.1; a bare artifact name "
+        "cannot produce a trustworthy clean verdict."
+    )
+
+
+def _package_spec_error(name: str, ecosystem: str) -> str | None:
+    """Return a fail-closed message for syntactically invalid package names."""
+    maven_error = _maven_coordinate_error(name, ecosystem)
+    if maven_error:
+        return maven_error
+
+    try:
+        from agent_bom.security import SecurityError, validate_package_name
+
+        if ecosystem.lower() in {"npm", "pypi", "go", "cargo"}:
+            validate_package_name(name, ecosystem.lower())
+            return None
+    except SecurityError:
+        pass
+
+    # Other ecosystems do not share one package-name grammar, but shell and
+    # requirement operators are never part of a package name after parsing.
+    if not name.strip() or any(char in name for char in "\r\n=<>!"):
+        return (
+            f"Invalid {ecosystem} package name '{name}'. "
+            "Provide a package name followed by an explicit version."
+        )
+    return None
+
+
 def _exit_model_verification(
     model_dir: Path,
     repo_id: str | None,
@@ -614,6 +659,27 @@ def check(
     _sync_runtime_consoles(runtime_console)
 
     name, version, detected_eco = _parse_package_spec(package_spec, ecosystem)
+
+    package_error = _package_spec_error(name, detected_eco)
+    if package_error:
+        if structured_output:
+            _write_check_output(
+                _check_result_payload(
+                    name=name,
+                    version=version,
+                    ecosystems=[detected_eco],
+                    verdict="incomplete",
+                    message=package_error,
+                    exit_code=2,
+                ),
+                output_path,
+                agent_mode=agent_mode,
+                exit_code=2,
+                output_format=output_format,
+            )
+        else:
+            raise click.UsageError(package_error)
+        sys.exit(2)
 
     from agent_bom.models import Package
     from agent_bom.parsers.os_parsers import enrich_os_package_context

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -586,6 +586,19 @@ def test_check_maven_bare_artifact_fails_closed(monkeypatch):
     assert "No known vulnerabilities" not in result.output
 
 
+def test_check_maven_coordinate_remains_supported(monkeypatch):
+    """Fully qualified Maven coordinates continue through the scanner."""
+    _patch_check_scan(monkeypatch, [])
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "org.apache.logging.log4j:log4j-core@2.14.1", "--ecosystem", "maven"],
+    )
+
+    assert result.exit_code == 0
+    assert "No known vulnerabilities" in result.output
+
+
 def test_check_maven_bare_artifact_json_is_incomplete(monkeypatch):
     """Machine-readable Maven ambiguity must carry the incomplete contract."""
 

--- a/tests/test_cli_check.py
+++ b/tests/test_cli_check.py
@@ -571,6 +571,56 @@ def test_check_without_version_json_reports_nonzero(monkeypatch):
     assert payload["exit_code"] == 2
 
 
+def test_check_maven_bare_artifact_fails_closed(monkeypatch):
+    """A Maven artifact without group context must not appear clean."""
+
+    async def _unexpected_scan(*_args, **_kwargs):
+        raise AssertionError("ambiguous Maven input must be rejected before scanning")
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _unexpected_scan)
+
+    result = CliRunner().invoke(main, ["check", "log4j-core@2.14.1", "--ecosystem", "maven"])
+
+    assert result.exit_code == 2
+    assert "group:artifact" in result.output
+    assert "No known vulnerabilities" not in result.output
+
+
+def test_check_maven_bare_artifact_json_is_incomplete(monkeypatch):
+    """Machine-readable Maven ambiguity must carry the incomplete contract."""
+
+    async def _unexpected_scan(*_args, **_kwargs):
+        raise AssertionError("ambiguous Maven input must be rejected before scanning")
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _unexpected_scan)
+
+    result = CliRunner().invoke(
+        main,
+        ["check", "log4j-core@2.14.1", "--ecosystem", "maven", "--format", "json"],
+    )
+
+    assert result.exit_code == 2
+    payload = json.loads(result.output)
+    assert payload["verdict"] == "incomplete"
+    assert payload["exit_code"] == 2
+    assert "group:artifact" in payload["message"]
+
+
+def test_check_malformed_requirement_fails_closed(monkeypatch):
+    """Malformed requirement syntax must not be coerced into a clean scan."""
+
+    async def _unexpected_scan(*_args, **_kwargs):
+        raise AssertionError("malformed package input must be rejected before scanning")
+
+    monkeypatch.setattr("agent_bom.scanners.scan_packages", _unexpected_scan)
+
+    result = CliRunner().invoke(main, ["check", "flask==@@@bad", "--ecosystem", "pypi"])
+
+    assert result.exit_code == 2
+    assert "Invalid pypi package name" in result.output
+    assert "No known vulnerabilities" not in result.output
+
+
 def _patch_check_scan_malicious(monkeypatch, reason="Possible typosquat of 'requests'"):
     async def _scan_packages(pkgs, **_kwargs):
         for pkg in pkgs:


### PR DESCRIPTION
Summary\n\n- Reject bare Maven artifact names before advisory lookup; Maven OSV matching requires a fully qualified group:artifact coordinate.\n- Reject malformed package names such as flask==@@@bad instead of allowing a false clean verdict.\n- Return the existing structured incomplete contract (exit 2) for machine-readable callers and add regression coverage.\n\nVerification\n\n- python -m pytest -q tests/test_cli_check.py tests/test_verify.py\n- python -m ruff check src/agent_bom/cli/_check.py tests/test_cli_check.py\n- python -m mypy src/agent_bom/cli/_check.py\n- make preflight\n- python scripts/check-counts.py\n- agent-bom check log4j-core@2.14.1 --ecosystem maven --format json (exit 2, incomplete)\n- agent-bom check flask==@@@bad --ecosystem pypi --offline --format json (exit 2, incomplete)\n- git diff --check\n\nNotes\n\n- This post-release correction follows the merged dogfood feedback; it does not retag or republish v0.97.0.\n- Valid Maven input remains supported as group:artifact@version.