### PR TITLE
fix(output): preserve finding and coverage parity

### DIFF
--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -1347,7 +1347,10 @@ def _run_scan_sync(job: ScanJob) -> None:
                 raise RuntimeError(f"Failed to load VEX file: {vex_exc}") from vex_exc
             _vex_count = apply_vex(report, _vex_doc)
             report.vex_data = vex_to_serializable(_vex_doc)
-            report.findings = [blast_radius_to_finding(br) for br in blast_radii]
+            # Preserve non-CVE policy findings while replacing stale CVE
+            # projections with the VEX-updated blast-radius representation.
+            non_cve_findings = [finding for finding in report.findings if finding.finding_type.value != "CVE"]
+            report.findings = [blast_radius_to_finding(br) for br in blast_radii] + non_cve_findings
             with lock:
                 job.progress.append(f"VEX applied: {_vex_count} vulnerabilities updated from {req.vex}")
         try:

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1396,15 +1396,23 @@ class AIBOMReport:
         secret findings are always appended so machine consumers (JSON/SARIF/CSV)
         see them, not just the console.
         """
-        if self.findings:
-            base = list(self.findings)
-        else:
-            from agent_bom.finding import blast_radius_to_finding
+        from agent_bom.finding import blast_radius_to_finding
 
-            base = [blast_radius_to_finding(br) for br in self.blast_radii]
+        # Keep explicit non-CVE findings even when the legacy blast-radius
+        # projection is also present. API/VEX paths can update the projection
+        # after the unified stream was built; dropping either side makes JSON
+        # disagree with CSV/SARIF and hides policy findings from consumers.
+        base = list(self.findings)
+        existing_ids = {getattr(f, "canonical_id", getattr(f, "id", None)) for f in base}
+        for br in self.blast_radii:
+            finding = blast_radius_to_finding(br)
+            finding_id = getattr(finding, "canonical_id", getattr(finding, "id", None))
+            if finding_id not in existing_ids:
+                base.append(finding)
+                existing_ids.add(finding_id)
         # Avoid double-counting if a dual-write path ever adds the same secret
         # finding, but do not suppress unrelated secret findings in the side block.
-        existing_ids = {getattr(f, "id", None) for f in base}
+        existing_ids = {getattr(f, "canonical_id", getattr(f, "id", None)) for f in base}
         base.extend(finding for finding in self._secret_findings() if finding.id not in existing_ids)
         cis_existing = existing_ids | {getattr(f, "id", None) for f in base}
         base.extend(finding for finding in self._cloud_cis_findings() if finding.id not in cis_existing)

--- a/src/agent_bom/output/badge.py
+++ b/src/agent_bom/output/badge.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run
 from agent_bom.models import AIBOMReport, Severity
-from agent_bom.output.finding_views import cve_findings, nested_vulnerabilities, severity_value
+from agent_bom.output.finding_views import cve_findings, nested_vulnerabilities, severity_value, unified_findings
 
 
 def to_badge(report: AIBOMReport) -> dict:
@@ -17,11 +18,29 @@ def to_badge(report: AIBOMReport) -> dict:
 
     Use with: https://img.shields.io/endpoint?url=<badge-json-url>
     """
-    findings = cve_findings(report)
+    findings = unified_findings(report)
     if findings:
         severities = [severity_value(finding) for finding in findings]
     else:
         severities = [vuln.severity.value for vuln in nested_vulnerabilities(report)]
+
+    scan_run = effective_scan_run(report)
+    if scan_run.outcome is ScanOutcome.FAILED:
+        return {
+            "schemaVersion": 1,
+            "label": "agent-bom",
+            "message": "scan failed",
+            "color": "red",
+            "namedLogo": "shield",
+        }
+    if scan_run.outcome is ScanOutcome.PARTIAL:
+        return {
+            "schemaVersion": 1,
+            "label": "agent-bom",
+            "message": "partial scan",
+            "color": "yellow",
+            "namedLogo": "shield",
+        }
 
     critical = len([severity for severity in severities if severity == Severity.CRITICAL.value])
     high = len([severity for severity in severities if severity == Severity.HIGH.value])

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -56,6 +56,16 @@ def unified_export_findings(report: AIBOMReport, blast_radii: list[BlastRadius] 
     return findings
 
 
+def unified_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[Finding]:
+    """Return the complete finding stream for human and machine summaries.
+
+    Keep this name separate from ``unified_export_findings`` so callers that
+    only need a posture/severity summary do not imply a flat-file export
+    contract.  Both paths intentionally share the same deduplicated stream.
+    """
+    return unified_export_findings(report, blast_radii)
+
+
 def active_cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[Finding]:
     """Return CVE findings that remain active after VEX suppression."""
     from agent_bom.vex import active_blast_radii

--- a/src/agent_bom/output/html/document.py
+++ b/src/agent_bom/output/html/document.py
@@ -27,6 +27,7 @@ from agent_bom.output.html.sections import (
     _non_cve_findings,
     _policy_findings_section,
     _remediation_list,
+    _scan_outcome_banner,
     _skill_audit_section,
     _summary_cards,
     _trust_assessment_section,
@@ -58,7 +59,14 @@ def to_html(
     policy_high = sum(1 for finding in policy_findings if str(finding.severity).lower() == "high")
     total_vulns = len(findings)
 
-    if crit or policy_crit:
+    from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run
+
+    scan_run = effective_scan_run(report)
+    if scan_run.outcome is ScanOutcome.FAILED:
+        status_color, status_label = "#dc2626", "SCAN FAILED"
+    elif scan_run.outcome is ScanOutcome.PARTIAL:
+        status_color, status_label = "#d97706", "PARTIAL COVERAGE"
+    elif crit or policy_crit:
         status_color, status_label = "#dc2626", "CRITICAL FINDINGS"
     elif total_vulns or policy_high or policy_findings:
         status_color, status_label = "#d97706", "SECURITY FINDINGS"
@@ -214,6 +222,7 @@ def to_html(
   <!-- Delta / warn-gate banners (only rendered when applicable) -->
   {_delta_banner(report)}
   {_warn_gate_banner(report)}
+  {_scan_outcome_banner(report)}
 
   <!-- Summary stat cards -->
   <section id="summary">

--- a/src/agent_bom/output/html/sections.py
+++ b/src/agent_bom/output/html/sections.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run
 from agent_bom.finding import FindingType
 from agent_bom.graph.severity import (
     SEVERITY_THRESHOLD_LABELS,
@@ -155,6 +156,24 @@ def _warn_gate_banner(report: "AIBOMReport") -> str:
         f"&#x26a0;&#xfe0f; <b>Warn gate triggered</b>: {count} finding(s) at or above "
         f"<b>{sev}</b> severity &mdash; exit 0 (warning only, not a hard failure)"
         "</div>"
+    )
+
+
+def _scan_outcome_banner(report: "AIBOMReport") -> str:
+    """Render an explicit coverage banner so empty partial scans are not CLEAN."""
+    run = effective_scan_run(report)
+    if run.outcome is ScanOutcome.COMPLETE:
+        return ""
+    failed = run.outcome is ScanOutcome.FAILED
+    color = "#dc2626" if failed else "#d97706"
+    label = "SCAN FAILED" if failed else "PARTIAL COVERAGE"
+    issues = "".join(f"<li>{_esc(issue.source)}: {_esc(issue.message)}</li>" for issue in run.issues)
+    return (
+        f'<div style="background:{color}18;border:1px solid {color};border-radius:8px;'
+        'padding:10px 16px;margin-bottom:12px;font-size:.85rem;'
+        f'color:{color}">&#x26a0;&#xfe0f; <b>{label}</b>: this report does not represent complete '
+        f'coverage. A low or zero finding count is not a clean bill of health.'
+        f'<ul style="margin:6px 0 0 18px">{issues}</ul></div>'
     )
 
 

--- a/src/agent_bom/output/junit.py
+++ b/src/agent_bom/output/junit.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from xml.etree.ElementTree import Element, SubElement, indent, tostring
 
+from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run
 from agent_bom.finding import Finding
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 from agent_bom.output.finding_views import (
@@ -29,12 +30,14 @@ from agent_bom.output.finding_views import (
 def to_junit(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> str:
     """Convert an AIBOMReport to JUnit XML string."""
     findings = cve_findings(report, blast_radii)
+    scan_run = effective_scan_run(report)
+    incomplete_without_findings = scan_run.outcome is not ScanOutcome.COMPLETE and not findings
 
     testsuites = Element("testsuites")
     testsuites.set("name", "agent-bom")
-    testsuites.set("tests", str(len(findings)))
+    testsuites.set("tests", str(len(findings) + int(incomplete_without_findings)))
     testsuites.set("failures", str(sum(1 for finding in findings if has_high_or_critical(finding))))
-    testsuites.set("errors", str(sum(1 for finding in findings if is_medium(finding))))
+    testsuites.set("errors", str(sum(1 for finding in findings if is_medium(finding)) + int(incomplete_without_findings)))
     testsuites.set("time", "0")
 
     # Group by ecosystem
@@ -78,6 +81,18 @@ def to_junit(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) 
                 skipped = SubElement(tc, "skipped")
                 skipped.set("message", f"{sev.upper()}: {summary}")
                 skipped.text = detail
+
+    if incomplete_without_findings:
+        suite = SubElement(testsuites, "testsuite")
+        suite.set("name", "scan-execution")
+        suite.set("tests", "1")
+        suite.set("failures", "0")
+        suite.set("errors", "1")
+        suite.set("time", "0")
+        testcase = SubElement(suite, "testcase", classname="agent-bom.scan", name=f"scan {scan_run.outcome.value}", time="0")
+        error = SubElement(testcase, "error", type="scan_execution")
+        error.set("message", f"Scan {scan_run.outcome.value}: incomplete evidence")
+        error.text = "\n".join(f"{issue.source}: {issue.message}" for issue in scan_run.issues)
 
     indent(testsuites, space="  ")
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + tostring(testsuites, encoding="unicode")

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -6,6 +6,7 @@ Produces a self-contained Markdown report with summary table and detailed findin
 from __future__ import annotations
 
 from agent_bom.compliance_utils import framework_qualified_finding_tags
+from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run
 from agent_bom.finding import Finding, FindingType
 from agent_bom.graph.severity import severity_policy_rank
 from agent_bom.models import AIBOMReport, BlastRadius
@@ -20,6 +21,7 @@ from agent_bom.output.finding_views import (
     reachability_label,
     severity_counts,
     severity_value,
+    unified_findings,
 )
 
 
@@ -28,6 +30,8 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
     brs = blast_radii or report.blast_radii
     cve_rows = cve_findings(report, blast_radii)
     policy_findings = _non_cve_findings(report)
+    all_findings = unified_findings(report, blast_radii)
+    scan_run = effective_scan_run(report)
     lines: list[str] = []
 
     # Header
@@ -38,9 +42,18 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
     lines.append("")
 
     # Summary
-    sev_counts = severity_counts(cve_rows)
+    sev_counts = severity_counts(all_findings)
     lines.append("## Summary")
     lines.append("")
+
+    if scan_run.outcome is not ScanOutcome.COMPLETE:
+        label = scan_run.outcome.value.upper()
+        lines.append(f"## Scan outcome: {label}")
+        lines.append("")
+        lines.append("This report does not represent complete coverage; a low or zero finding count is not a clean bill of health.")
+        for issue in scan_run.issues:
+            lines.append(f"- **{issue.source}**: {issue.message}")
+        lines.append("")
     lines.append("| Metric | Count |")
     lines.append("|--------|-------|")
     lines.append(f"| Agents discovered | {report.total_agents} |")
@@ -58,7 +71,7 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
     if trust_lines:
         lines.extend(trust_lines)
 
-    if not brs and not policy_findings:
+    if not brs and not policy_findings and scan_run.outcome is ScanOutcome.COMPLETE:
         lines.append("No vulnerabilities found.")
         return "\n".join(lines) + "\n"
 

--- a/src/agent_bom/output/prometheus.py
+++ b/src/agent_bom/output/prometheus.py
@@ -22,6 +22,7 @@ import logging
 from pathlib import Path
 from typing import Optional
 
+from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 from agent_bom.output.finding_views import (
     cve_findings,
@@ -105,6 +106,7 @@ def to_prometheus(
     agent_bom_agent_vulnerabilities_total  Gauge  Per-agent, per-severity counts
     """
     findings = cve_findings(report, blast_radii)
+    scan_run = effective_scan_run(report)
     lines: list[str] = []
 
     def header(name: str, help_text: str, metric_type: str = "gauge") -> None:
@@ -114,6 +116,14 @@ def to_prometheus(
     # ── agent_bom_info ────────────────────────────────────────────────────
     header("info", "agent-bom tool metadata (always 1)")
     lines.append(_metric("info", 1, ("version", report.tool_version), ("scan_at", report.generated_at.strftime("%Y-%m-%dT%H:%M:%SZ"))))
+    lines.append("")
+
+    # An empty/partial scan must never look healthy to an alerting system.
+    header("scan_outcome", "Scan execution quality (1 for the current outcome)")
+    for outcome in ScanOutcome:
+        lines.append(_metric("scan_outcome", 1 if scan_run.outcome is outcome else 0, ("outcome", outcome.value)))
+    header("scan_issues_total", "Number of bounded scan execution issues")
+    lines.append(_metric("scan_issues_total", len(scan_run.issues)))
     lines.append("")
 
     # ── agent_bom_scan_timestamp_seconds ─────────────────────────────────

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -30,7 +30,7 @@ from agent_bom.output.finding_views import (
     package_name,
     package_version,
 )
-from agent_bom.security import sanitize_sensitive_payload
+from agent_bom.security import sanitize_sensitive_payload, sanitize_text
 
 _SARIF_SEVERITY_MAP = {
     Severity.CRITICAL: "error",
@@ -1025,7 +1025,7 @@ def to_sarif(
                     {
                         "descriptor": {"id": issue.code},
                         "level": issue.severity,
-                        "message": {"text": _sanitize_sarif_text("scan issue", issue.message, fallback="Scan execution issue")},
+                        "message": {"text": sanitize_text(issue.message) or "Scan execution issue"},
                         "properties": {
                             "stage": issue.stage,
                             "source": issue.source,

--- a/src/agent_bom/parsers/python_parsers.py
+++ b/src/agent_bom/parsers/python_parsers.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from agent_bom.models import Package
 from agent_bom.parsers.file_limits import read_json_limited, read_text_limited
+from agent_bom.version_utils import strip_pip_extras
 
 logger = logging.getLogger(__name__)
 
@@ -305,17 +306,19 @@ def parse_pip_packages(directory: Path) -> list[Package]:
                 packages.append(git_pkg)
                 continue
             # Parse name==version, name>=version, etc.
-            match = re.match(r"^([a-zA-Z0-9_.-]+)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)
+            match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)
             if match:
-                name, operator, version = match.groups()
+                raw_name, operator, version = match.groups()
+                name, _ = strip_pip_extras(raw_name)
                 packages.append(_requirement_package(name, operator, version, is_direct=True))
             else:
                 # Just a name, no version
-                name_match = re.match(r"^([a-zA-Z0-9_.-]+)", line)
+                name_match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)", line)
                 if name_match:
+                    name, _ = strip_pip_extras(name_match.group(1))
                     packages.append(
                         Package(
-                            name=name_match.group(1),
+                            name=name,
                             version="unknown",
                             ecosystem="pypi",
                             is_direct=True,
@@ -353,10 +356,24 @@ def parse_pip_packages(directory: Path) -> list[Package]:
             proj_data = toml.loads(read_text_limited(pyproject))
             deps = proj_data.get("project", {}).get("dependencies", [])
             for dep in deps:
-                match = re.match(r"^([a-zA-Z0-9_.-]+)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", dep)
+                match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", dep)
                 if match:
-                    name, operator, version = match.groups()
+                    raw_name, operator, version = match.groups()
+                    name, _ = strip_pip_extras(raw_name)
                     packages.append(_requirement_package(name, operator, version, is_direct=True))
+                else:
+                    bare = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)", dep)
+                    if bare:
+                        name, _ = strip_pip_extras(bare.group(1))
+                        packages.append(
+                            Package(
+                                name=name,
+                                version="unknown",
+                                ecosystem="pypi",
+                                is_direct=True,
+                                reachability_evidence="declaration_only",
+                            )
+                        )
         except Exception as e:
             logger.debug(f"Failed to parse pyproject.toml at {pyproject}: {e}")
 
@@ -376,16 +393,18 @@ def _parse_requirements_lines(lines: list[str], is_direct: bool = True) -> list[
         line = raw.strip()
         if not line or line.startswith("#") or line.startswith("-"):
             continue
-        m = re.match(r"^([a-zA-Z0-9_.-]+)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)
+        m = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", line)
         if m:
-            req_name, operator, req_version = m.groups()
+            raw_name, operator, req_version = m.groups()
+            req_name, _ = strip_pip_extras(raw_name)
             packages.append(_requirement_package(req_name, operator, req_version, is_direct=is_direct))
         else:
-            bare = re.match(r"^([a-zA-Z0-9_.-]+)", line)
+            bare = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)", line)
             if bare:
+                req_name, _ = strip_pip_extras(bare.group(1))
                 packages.append(
                     Package(
-                        name=bare.group(1),
+                        name=req_name,
                         version="unknown",
                         ecosystem="pypi",
                         is_direct=is_direct,

--- a/src/agent_bom/parsers/python_parsers.py
+++ b/src/agent_bom/parsers/python_parsers.py
@@ -148,6 +148,13 @@ def parse_poetry_lock(directory: Path) -> list[Package]:
             )
     except Exception as exc:
         logger.debug("Failed to parse poetry.lock at %s: %s", lock_file, exc)
+        from agent_bom.coverage import record_manifest_parse_warning
+
+        record_manifest_parse_warning(
+            ecosystem="pypi",
+            path=str(lock_file),
+            detail=f"poetry.lock failed to parse ({exc}); Python dependencies were not scanned",
+        )
 
     return packages
 
@@ -205,6 +212,13 @@ def parse_uv_lock(directory: Path) -> list[Package]:
             )
     except Exception as exc:
         logger.debug("Failed to parse uv.lock at %s: %s", lock_file, exc)
+        from agent_bom.coverage import record_manifest_parse_warning
+
+        record_manifest_parse_warning(
+            ecosystem="pypi",
+            path=str(lock_file),
+            detail=f"uv.lock failed to parse ({exc}); Python dependencies were not scanned",
+        )
 
     return packages
 
@@ -355,6 +369,16 @@ def parse_pip_packages(directory: Path) -> list[Package]:
 
             proj_data = toml.loads(read_text_limited(pyproject))
             deps = proj_data.get("project", {}).get("dependencies", [])
+            if not deps:
+                poetry_deps = proj_data.get("tool", {}).get("poetry", {}).get("dependencies", {})
+                deps = []
+                for raw_name, raw_spec in poetry_deps.items():
+                    if str(raw_name).lower() == "python":
+                        continue
+                    if isinstance(raw_spec, dict):
+                        raw_spec = raw_spec.get("version", "*")
+                    spec = str(raw_spec or "*")
+                    deps.append(f"{raw_name}{spec}")
             for dep in deps:
                 match = re.match(r"^([a-zA-Z0-9_.-]+(?:\[[^\]]+\])?)\s*([=<>!~]+)\s*([a-zA-Z0-9_.*+-]+)", dep)
                 if match:
@@ -376,6 +400,13 @@ def parse_pip_packages(directory: Path) -> list[Package]:
                         )
         except Exception as e:
             logger.debug(f"Failed to parse pyproject.toml at {pyproject}: {e}")
+            from agent_bom.coverage import record_manifest_parse_warning
+
+            record_manifest_parse_warning(
+                ecosystem="pypi",
+                path=str(pyproject),
+                detail=f"pyproject.toml failed to parse ({e}); Python dependencies were not scanned",
+            )
 
     return packages
 

--- a/src/agent_bom/scanners/__init__.py
+++ b/src/agent_bom/scanners/__init__.py
@@ -75,6 +75,7 @@ from agent_bom.scanners.state import (
     record_scan_warning,
     reset_scan_performance,
     reset_scan_warnings,
+    reset_scan_warnings_only,
 )
 
 __all__ = [
@@ -133,6 +134,7 @@ __all__ = [
     "request_with_retry",
     "reset_scan_performance",
     "reset_scan_warnings",
+    "reset_scan_warnings_only",
     "scan_agents",
     "scan_agents_sync",
     "scan_agents_with_enrichment",

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -85,7 +85,7 @@ from agent_bom.scanners.state import (
     record_coverage_warning,
     record_scan_warning,
     reset_scan_performance,
-    reset_scan_warnings,
+    reset_scan_warnings_only,
 )
 from agent_bom.soc2 import tag_blast_radius as tag_soc2
 from agent_bom.vuln_compliance import tag_vulnerability as _tag_vuln
@@ -1035,7 +1035,7 @@ async def scan_packages(
                 pkg.name = _strip_extras(pkg.name)
             pkg.name = normalize_package_name(pkg.name, pkg.ecosystem)
 
-    reset_scan_warnings()
+    reset_scan_warnings_only()
     try:
         from agent_bom.resolver import reset_performance_stats as _reset_resolver_performance
 

--- a/src/agent_bom/scanners/state.py
+++ b/src/agent_bom/scanners/state.py
@@ -53,8 +53,19 @@ def _scan_performance_state() -> dict[str, int]:
 
 
 def reset_scan_warnings() -> None:
+    """Reset all scan warning channels at a command/request boundary."""
     _scan_state_local.warnings = []
     _scan_state_local.coverage_warnings = []
+
+
+def reset_scan_warnings_only() -> None:
+    """Reset transient scanner warnings without discarding parser coverage gaps.
+
+    Project manifest parsers can run before vulnerability scanning and record a
+    structured coverage warning. The package scanner must clear warnings from a
+    prior scan, but must preserve those parser warnings for the final report.
+    """
+    _scan_state_local.warnings = []
 
 
 def record_scan_warning(message: str) -> None:

--- a/tests/test_coverage_warning.py
+++ b/tests/test_coverage_warning.py
@@ -174,6 +174,36 @@ def test_scan_packages_covered_release_no_warning(tmp_path, monkeypatch):
     assert consume_coverage_warnings() == []
 
 
+def test_package_scan_preserves_parser_coverage_warning(tmp_path, monkeypatch):
+    """Vulnerability scanning must not erase a malformed-manifest warning."""
+    from agent_bom.scanners import (
+        ScanOptions,
+        consume_coverage_warnings,
+        record_coverage_warning,
+        scan_packages,
+    )
+
+    db_path = tmp_path / "vulns.db"
+    conn = init_db(db_path)
+    conn.close()
+    monkeypatch.setattr("agent_bom.db.schema.DB_PATH", db_path)
+    monkeypatch.setattr("agent_bom.db.schema.db_freshness_days", lambda path=None: 0)
+    record_coverage_warning(
+        {
+            "ecosystem": "npm",
+            "release": "npm:/tmp/package-lock.json",
+            "reason": "manifest_parse_error",
+            "detail": "package-lock.json failed to parse",
+            "package_count": 0,
+            "advisory_rows": 0,
+        }
+    )
+
+    asyncio.run(scan_packages([], options=ScanOptions(offline=True)))
+
+    assert consume_coverage_warnings()[0]["reason"] == "manifest_parse_error"
+
+
 def test_json_and_console_surface_coverage_warnings():
     """The warning reaches the JSON report summary and the console summary panel."""
     from rich.console import Console

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -653,6 +653,24 @@ def test_report_to_findings_returns_existing_when_populated():
     assert result[0].finding_type == FindingType.CIS_FAIL
 
 
+def test_report_to_findings_merges_explicit_and_blast_radius_findings():
+    """A report must expose CVEs and explicit policy findings together."""
+    report = _make_report_with_blast_radii(1)
+    report.findings = [
+        Finding(
+            finding_type=FindingType.CREDENTIAL_EXPOSURE,
+            source=FindingSource.SECRET_SCAN,
+            asset=Asset(name="OPENAI_API_KEY", asset_type="credential"),
+            severity="HIGH",
+        )
+    ]
+
+    findings = report.to_findings()
+
+    assert {finding.finding_type for finding in findings} == {FindingType.CVE, FindingType.CREDENTIAL_EXPOSURE}
+    assert len(findings) == 2
+
+
 def test_report_cve_findings_filters_by_type():
     report = _make_report_with_blast_radii(2)
     # Add a non-CVE finding manually

--- a/tests/test_output_fidelity_correctness.py
+++ b/tests/test_output_fidelity_correctness.py
@@ -19,6 +19,7 @@ import logging
 
 import pytest
 
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.models import (
     Agent,
     AgentType,
@@ -171,6 +172,39 @@ def test_csv_export_includes_base_reachability():
     expected = machine_export_findings(report, [br])[0].reachability
     assert rows[0]["reachability"] == expected
     assert expected  # non-empty verdict
+
+
+def test_json_csv_and_sarif_include_explicit_and_blast_findings():
+    """All machine exports must retain CVEs alongside explicit policy findings."""
+    from agent_bom.output.csv_fmt import to_csv
+    from agent_bom.output.json_fmt import to_json
+    from agent_bom.output.sarif import to_sarif
+
+    br = _reachability_br()
+    # JSON's legacy blast-radius projection expects object-valued agent/server
+    # entries; keep this parity fixture focused on the mixed finding streams.
+    br.affected_agents = []
+    report = AIBOMReport(
+        agents=[],
+        blast_radii=[br],
+        findings=[
+            Finding(
+                finding_type=FindingType.CREDENTIAL_EXPOSURE,
+                source=FindingSource.SECRET_SCAN,
+                asset=Asset(name="OPENAI_API_KEY", asset_type="credential"),
+                severity="HIGH",
+            )
+        ],
+    )
+
+    payload = to_json(report)
+    csv_rows = list(csv.DictReader(io.StringIO(to_csv(report).lstrip("﻿"))))
+    sarif_results = to_sarif(report)["runs"][0]["results"]
+
+    assert len(payload["findings"]) == 2
+    assert payload["finding_summary"]["total"] == 2
+    assert len(csv_rows) == 2
+    assert len(sarif_results) == 2
 
 
 def test_parquet_export_includes_base_reachability():

--- a/tests/test_output_formats.py
+++ b/tests/test_output_formats.py
@@ -668,6 +668,13 @@ class TestMarkdown:
         assert "Suspicious credential exfiltration MCP server" in md
         assert "No vulnerabilities found" not in md
 
+    def test_summary_severity_counts_include_policy_findings(self):
+        report = _report_with_policy_finding()
+        md = to_markdown(report)
+
+        assert "| High | 1 |" in md
+        assert "| Medium | 1 |" in md
+
     def test_findings_table_preserves_enrichment_and_compliance_metadata(self):
         br = _make_blast_radius(pkg=_make_pkg("web-lib", "1.0.0"), vuln=_make_enriched_vuln())
         br.owasp_tags = ["LLM05"]
@@ -947,6 +954,56 @@ def test_prometheus_uses_unified_findings_without_blast_radii():
     assert 'vuln_id="CVE-2026-4242"' in metrics
     assert 'package="web-lib"' in metrics
     assert "agent_bom_kev_findings_total 1" in metrics
+
+
+def test_badge_includes_non_cve_findings_and_never_calls_them_clean():
+    report = _report_with_policy_finding()
+
+    badge = to_badge(report)
+
+    assert badge["color"] == "orange"
+    assert "high" in badge["message"]
+
+
+def test_partial_scan_is_not_rendered_as_clean_across_outputs():
+    report = _make_report()
+    report.coverage_warnings = [
+        {
+            "ecosystem": "pypi",
+            "release": "python 2.7",
+            "detail": "advisory data unavailable",
+        }
+    ]
+
+    markdown = to_markdown(report)
+    assert "Scan outcome: PARTIAL" in markdown
+    assert "No vulnerabilities found" not in markdown
+
+    badge = to_badge(report)
+    assert badge["message"] == "partial scan"
+    assert badge["color"] == "yellow"
+
+    html = to_html(report, [])
+    assert "PARTIAL COVERAGE" in html
+    assert "CLEAN" not in html
+
+    junit = ET.fromstring(to_junit(report))
+    assert junit.get("tests") == "1"
+    assert junit.get("errors") == "1"
+    assert junit.find("./testsuite/testcase/error") is not None
+
+    metrics = to_prometheus(report)
+    assert 'agent_bom_scan_outcome{outcome="partial"} 1' in metrics
+    assert "agent_bom_scan_issues_total 1" in metrics
+
+
+def test_sarif_preserves_sanitized_scan_issue_message():
+    report = _make_report()
+    report.coverage_warnings = [{"ecosystem": "npm", "release": "old", "detail": "advisory gap"}]
+
+    sarif = to_sarif(report)
+    notification = sarif["runs"][0]["invocations"][0]["toolExecutionNotifications"][0]
+    assert "advisory gap" in notification["message"]["text"]
 
 
 def test_html_renders_unified_non_cve_findings_with_asset_context():

--- a/tests/test_parser_interop.py
+++ b/tests/test_parser_interop.py
@@ -89,6 +89,17 @@ class TestPoetryLock:
         # poetry.lock wins — version from poetry, not requirements.txt
         assert by_name["requests"].version == "2.31.0"
 
+    def test_poetry_declarations_are_used_without_lock(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text(
+            "[tool.poetry.dependencies]\npython = \"^3.11\"\nrequests = \"^2.31\"\n"
+        )
+
+        pkgs = parse_pip_packages(tmp_path)
+
+        assert [pkg.name for pkg in pkgs] == ["requests"]
+        assert pkgs[0].version == "unknown"
+        assert pkgs[0].is_direct is True
+
 
 # ── uv.lock ──────────────────────────────────────────────────────────────────
 

--- a/tests/test_vuln_matching_honesty.py
+++ b/tests/test_vuln_matching_honesty.py
@@ -56,6 +56,27 @@ def test_pyproject_range_not_emitted_as_exact_pin(tmp_path):
     assert pkgs["urllib3"].floating_reference is True
 
 
+def test_pep508_extras_preserve_package_and_version(tmp_path):
+    """Extras are metadata, not part of the PyPI package identity."""
+    (tmp_path / "requirements.txt").write_text("requests[security]==2.31.0\n")
+    pkgs = parse_pip_packages(tmp_path)
+
+    assert len(pkgs) == 1
+    assert pkgs[0].name == "requests"
+    assert pkgs[0].version == "2.31.0"
+    assert pkgs[0].purl == "pkg:pypi/requests@2.31.0"
+
+
+def test_pyproject_unpinned_and_extra_dependencies_are_not_dropped(tmp_path):
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "x"\nversion = "0"\ndependencies = ["requests", "urllib3[secure]==2.2.0"]\n'
+    )
+    pkgs = {p.name: p for p in parse_pip_packages(tmp_path)}
+
+    assert pkgs["requests"].version == "unknown"
+    assert pkgs["urllib3"].version == "2.2.0"
+
+
 # --- Defect 4: declaration-only manifests must not over-claim reachability --
 
 


### PR DESCRIPTION
## Summary
- keep unified policy findings in badge and Markdown severity summaries
- surface partial/failed execution explicitly in Markdown, HTML, badge, JUnit, and Prometheus
- preserve parser coverage warnings when package scanning begins; retain safe SARIF warning text

## Verification
- uv run pytest -q tests/test_output_formats.py tests/test_output_fidelity_correctness.py tests/test_console_reconciliation.py tests/test_coverage_warning.py
- uv run pytest -q tests/test_coverage_warning.py tests/test_output_formats.py tests/test_output_fidelity_correctness.py
- uv run ruff check (affected modules/tests)
- uv run mypy (affected output modules)
- git diff --check

## Notes
- includes the already-reviewed PEP 508 extras/declaration preservation commit on this branch
- post-release correctness PR; no tag or published artifact changes