### PR TITLE
perf(output): reuse materialized finding projections

### DIFF
--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -14,6 +14,16 @@ def cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = No
     """Return CVE findings, accepting non-empty legacy BlastRadius overrides."""
     source_blast_radii = blast_radii if blast_radii is not None else report.blast_radii
     if source_blast_radii:
+        # The CLI/API dual-write path already materializes this exact projection
+        # on ``report.findings``. Reusing it avoids rebuilding and re-sanitizing
+        # every BlastRadius once per output format (JSON, CSV, SARIF, HTML,
+        # Markdown, JUnit, and graph exports). Fall back to the legacy conversion
+        # when the caller supplies a different or incomplete BlastRadius stream.
+        materialized = [finding for finding in report.findings if finding.finding_type == FindingType.CVE]
+        expected_ids = sorted(str(getattr(br.vulnerability, "id", "")) for br in source_blast_radii)
+        materialized_ids = sorted(str(finding.cve_id or finding.id or "") for finding in materialized)
+        if materialized and expected_ids == materialized_ids:
+            return materialized
         return [blast_radius_to_finding(br) for br in source_blast_radii]
 
     return [finding for finding in report.to_findings() if finding.finding_type in _MACHINE_EXPORT_TYPES]

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -187,15 +187,22 @@ def _browser_extension_findings(browser_extensions: dict) -> list[dict[str, obje
 def _build_remediation_json(report: AIBOMReport) -> list[dict]:
     """Build JSON-serializable remediation plan with named assets and percentages."""
     from agent_bom.output import build_remediation_plan
+    from agent_bom.output.finding_views import cve_findings
 
-    plan = build_remediation_plan(report.blast_radii)
+    # The CLI/API dual-write path already materializes CVE ``Finding`` objects
+    # on ``report.findings``.  Reuse that projection instead of converting every
+    # BlastRadius again while building JSON remediation output.  Besides doing
+    # redundant sanitization, the legacy conversion walks nested dataclasses and
+    # can trigger an expensive repr of transitive server/package data at scale.
+    cve_rows = cve_findings(report)
+    plan = build_remediation_plan(cve_rows)
     total_agents = report.total_agents or 1
 
     all_creds: set[str] = set()
     all_tools: set[str] = set()
-    for br in report.blast_radii:
-        all_creds.update(br.exposed_credentials)
-        all_tools.update(t.name for t in br.exposed_tools)
+    for finding in cve_rows:
+        all_creds.update(finding.exposed_credentials)
+        all_tools.update(finding.exposed_tools)
     total_creds = len(all_creds) or 1
     total_tools = len(all_tools) or 1
 

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -1509,7 +1509,22 @@ async def scan_agents(
                 if _pkg_key(pkg) in vuln_map:
                     pkg.vulnerabilities = vuln_map[_pkg_key(pkg)]
 
-    # Build blast radius analysis
+    # Build blast radius analysis. Registry enrichment is keyed by MCP server,
+    # not by vulnerable package. Keep one cache for the whole scan: a server can
+    # expose many packages, and matching the same registry catalog once per
+    # package turns a linear build into an avoidable package×catalog walk.
+    from agent_bom.parsers import get_registry_entry
+
+    _registry_cache: dict[tuple[str, str, tuple[str, ...], str], dict | None] = {}
+
+    def _registry_key(server: MCPServer) -> tuple[str, str, tuple[str, ...], str]:
+        return (
+            server.name,
+            server.command,
+            tuple(server.args),
+            server.url or "",
+        )
+
     blast_radii = []
     for pkg in unique_packages:
         if not pkg.vulnerabilities:
@@ -1527,21 +1542,19 @@ async def scan_agents(
         # the registry CLAIMS the server has, not what was introspected.
         # We include them for visibility but mark them so blast radius
         # consumers can distinguish confirmed vs phantom tools.
-        from agent_bom.parsers import get_registry_entry
-
         exposed_creds: list[str] = []
         exposed_tools: list = []
         phantom_tools: list = []
-        _registry_cache: dict[str, dict | None] = {}
         for server in affected_servers:
             server_creds = server.credential_names
             server_tools = list(server.tools)  # copy — don't mutate server
 
             # Registry enrichment: if no tools/creds known from config, use registry
             if not server_tools or not server_creds:
-                if server.name not in _registry_cache:
-                    _registry_cache[server.name] = get_registry_entry(server)
-                reg = _registry_cache[server.name]
+                registry_key = _registry_key(server)
+                if registry_key not in _registry_cache:
+                    _registry_cache[registry_key] = get_registry_entry(server)
+                reg = _registry_cache[registry_key]
                 if reg:
                     if not server_tools and reg.get("tools"):
                         from agent_bom.models import MCPTool

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -653,6 +653,20 @@ def test_report_to_findings_returns_existing_when_populated():
     assert result[0].finding_type == FindingType.CIS_FAIL
 
 
+def test_cve_findings_reuses_dual_write_projection():
+    """Output views must not reconvert the same BlastRadius stream repeatedly."""
+    from agent_bom.output.finding_views import cve_findings
+
+    report = _make_report_with_blast_radii(2)
+    report.findings = report.to_findings()
+
+    projected = cve_findings(report, report.blast_radii)
+
+    assert projected is not report.findings
+    assert projected == report.findings
+    assert all(item.finding_type == FindingType.CVE for item in projected)
+
+
 def test_report_cve_findings_filters_by_type():
     report = _make_report_with_blast_radii(2)
     # Add a non-CVE finding manually

--- a/tests/test_json_remediation_projection.py
+++ b/tests/test_json_remediation_projection.py
@@ -1,0 +1,45 @@
+"""Regression coverage for the JSON remediation projection hot path."""
+
+from __future__ import annotations
+
+from agent_bom.finding import blast_radius_to_finding
+from agent_bom.models import AIBOMReport, BlastRadius, MCPServer, Package, Severity, Vulnerability
+
+
+def _report_with_materialized_cve() -> AIBOMReport:
+    package = Package(name="requests", version="2.0.0", ecosystem="pypi")
+    server = MCPServer(name="test-server", command="npx test-server")
+    blast = BlastRadius(
+        vulnerability=Vulnerability(
+            id="CVE-2026-0001",
+            summary="test vulnerability",
+            severity=Severity.HIGH,
+            fixed_version="2.0.1",
+        ),
+        package=package,
+        affected_servers=[server],
+        affected_agents=[],
+        exposed_credentials=["OPENAI_API_KEY"],
+        exposed_tools=[],
+        risk_score=7.0,
+    )
+    return AIBOMReport(
+        blast_radii=[blast],
+        findings=[blast_radius_to_finding(blast)],
+    )
+
+
+def test_json_remediation_reuses_materialized_cve_projection(monkeypatch):
+    """JSON remediation must not reconvert nested BlastRadius dataclasses."""
+    report = _report_with_materialized_cve()
+
+    def fail_if_reconverted(_blast):
+        raise AssertionError("remediation JSON reconverted a materialized BlastRadius")
+
+    monkeypatch.setattr("agent_bom.finding.blast_radius_to_finding", fail_if_reconverted)
+
+    from agent_bom.output.json_fmt import _build_remediation_json
+
+    payload = _build_remediation_json(report)
+
+    assert payload and payload[0]["package"] == "requests"

--- a/tests/test_scanner_registry_cache.py
+++ b/tests/test_scanner_registry_cache.py
@@ -1,0 +1,51 @@
+"""Regression tests for scan-time registry enrichment caching."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agent_bom.models import Agent, AgentType, MCPServer, Package, Severity, Vulnerability
+
+
+def test_scan_agents_reuses_registry_match_for_each_server(monkeypatch) -> None:
+    """A server with many vulnerable packages should be matched once per scan."""
+    import agent_bom.parsers
+    import agent_bom.scanners
+
+    server = MCPServer(name="shared-server", command="npx", args=["shared-server"])
+    server.packages = [
+        Package(name=f"pkg-{index}", version="1.0.0", ecosystem="npm")
+        for index in range(12)
+    ]
+    agent = Agent(
+        name="test-agent",
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/agent.json",
+        mcp_servers=[server],
+    )
+
+    async def _fake_scan_packages(packages, **_kwargs):
+        for package in packages:
+            package.vulnerabilities.append(
+                Vulnerability(
+                    id=f"CVE-2026-{package.name}",
+                    summary="synthetic test vulnerability",
+                    severity=Severity.HIGH,
+                )
+            )
+        return len(packages)
+
+    lookups: list[str] = []
+
+    def _fake_registry_entry(candidate):
+        lookups.append(candidate.name)
+        return {"tools": ["read_file"], "credential_env_vars": ["TEST_TOKEN"]}
+
+    monkeypatch.setattr(agent_bom.scanners, "scan_packages", _fake_scan_packages)
+    monkeypatch.setattr(agent_bom.parsers, "get_registry_entry", _fake_registry_entry)
+
+    findings = asyncio.run(agent_bom.scanners.scan_agents([agent], show_scan_banner=False))
+
+    assert len(findings) == len(server.packages)
+    assert lookups == ["shared-server"]
+


### PR DESCRIPTION
Summary\n\n- Reuse the materialized Finding projection across JSON, CSV, SARIF, HTML, Markdown, JUnit, and graph views when the report contains the canonical dual-write stream.\n- Reuse that projection in remediation output so large reports do not reconvert every BlastRadius row per output surface.\n- Cache registry enrichment once per server during package scanning instead of repeating catalog lookup for every vulnerable package.\n\nVerification\n\n- uv run pytest -q tests/test_finding.py tests/test_json_remediation_projection.py tests/test_scanner_registry_cache.py tests/test_output_formats.py tests/test_output_fidelity_correctness.py (116 passed)\n- uv run ruff check on changed modules/tests\n- synthetic 1,000-row JSON: 5.97s before projection reuse/remediation fix, 0.46s after (~13x faster)\n- synthetic 1,000-package registry enrichment: 1,000 lookups before, 1 lookup after\n- git diff --check\n\nNotes\n\n- This is a confirmed output-path optimization. The full graph producer remains an independent scale concern addressed by #4321; the store-backed producer is not claimed as wired by either PR.