### PR TITLE
fix(graph): bound shared-resource edges and preserve mutations

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -830,8 +830,8 @@ def _context_graph_payload(result: dict[str, Any], *, agent: str | None, scan_id
     from agent_bom.context_graph import (
         NodeKind,
         build_context_graph,
+        collect_lateral_paths,
         compute_interaction_risks,
-        find_lateral_paths,
         to_serializable,
     )
 
@@ -840,17 +840,18 @@ def _context_graph_payload(result: dict[str, Any], *, agent: str | None, scan_id
         result.get("blast_radius", []),
     )
     paths: list = []
+    paths_truncated = False
     if agent:
         node_id = f"agent:{agent}"
         if node_id in graph.nodes:
-            paths = find_lateral_paths(graph, node_id)
+            paths, paths_truncated = collect_lateral_paths(graph, [node_id])
     else:
-        for nid, node in graph.nodes.items():
-            if node.kind == NodeKind.AGENT:
-                paths.extend(find_lateral_paths(graph, nid))
+        source_ids = (nid for nid, node in sorted(graph.nodes.items()) if node.kind == NodeKind.AGENT)
+        paths, paths_truncated = collect_lateral_paths(graph, source_ids)
     risks = compute_interaction_risks(graph)
 
     payload = to_serializable(graph, paths, risks)
+    payload["stats"]["lateral_paths_truncated"] = paths_truncated
     return _attach_unified_graph_view(payload, result, scan_id=scan_id, tenant_id=tenant_id)
 
 

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2118,19 +2118,21 @@ def scan(
     if context_graph_flag:
         from agent_bom.context_graph import (
             build_context_graph,
+            collect_lateral_paths,
             compute_interaction_risks,
-            find_lateral_paths,
             to_serializable,
         )
         from agent_bom.output import to_json as _to_json_for_graph
 
         _graph_json = _to_json_for_graph(report)
         _cg = build_context_graph(_graph_json["agents"], _graph_json.get("blast_radius", []))
-        _all_paths = []
-        for _a in agents:
-            _all_paths.extend(find_lateral_paths(_cg, f"agent:{_a.name}"))
+        _all_paths, _paths_truncated = collect_lateral_paths(
+            _cg,
+            (f"agent:{_a.name}" for _a in agents),
+        )
         _cg_risks = compute_interaction_risks(_cg)
         report.context_graph_data = to_serializable(_cg, _all_paths, _cg_risks)
+        report.context_graph_data["stats"]["lateral_paths_truncated"] = _paths_truncated
 
         from agent_bom.graph_backend import from_context_graph as _from_cg
 

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -403,7 +403,7 @@ def build_context_graph(
     for _cred_name, agent_names in cred_to_agents.items():
         unique = sorted(set(agent_names))
         if len(unique) >= 2:
-            metadata = {"credential": _cred_name}
+            metadata: dict[str, object] = {"credential": _cred_name}
             if len(unique) > _MAX_PAIRWISE_SHARED_AGENTS:
                 # The canonical credential node already connects all of its
                 # servers.  Add one linear agent→credential edge per member;

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -68,8 +68,10 @@ class EdgeKind(str, Enum):
     EXPOSES = "exposes"  # server → credential
     PROVIDES = "provides"  # server → tool
     VULNERABLE_TO = "vulnerable_to"  # server → vulnerability
-    SHARES_SERVER = "shares_server"  # agent ↔ agent
-    SHARES_CREDENTIAL = "shares_credential"  # agent ↔ agent
+    # Small groups use direct agent↔agent edges.  Large groups use a bounded
+    # shared-resource endpoint so graph construction stays linear.
+    SHARES_SERVER = "shares_server"
+    SHARES_CREDENTIAL = "shares_credential"
     ATTACHED_TO = "attached_to"  # iam_role → agent (workload identity correlation)
 
 
@@ -346,38 +348,105 @@ def build_context_graph(
                         )
                     )
 
-    # ── Shared server edges (agent ↔ agent) ───────────────────────────
+    # ── Shared server edges ───────────────────────────────────────────
+    # Pairwise edges are useful for small groups, but become O(N²) for a
+    # common shared MCP server.  Keep the readable direct form up to a fixed
+    # threshold and use one bounded hub node for larger groups.  The hub is
+    # still traversable by the lateral-path BFS and carries the full group in
+    # metadata for risk/reporting consumers.
     for _srv_name, agent_names in server_to_agents.items():
         unique = sorted(set(agent_names))
         if len(unique) >= 2:
-            for i, a1 in enumerate(unique):
-                for a2 in unique[i + 1 :]:
+            if len(unique) > _MAX_PAIRWISE_SHARED_AGENTS:
+                hub_id = f"shared-server:{_srv_name}"
+                graph.add_node(
+                    GraphNode(
+                        id=hub_id,
+                        kind=NodeKind.SERVER,
+                        label=_srv_name,
+                        metadata={
+                            "shared_group": True,
+                            "shared_agent_count": len(unique),
+                            "shared_agents": unique,
+                        },
+                    )
+                )
+                for agent_name in unique:
                     graph.add_edge(
                         GraphEdge(
-                            source=f"agent:{a1}",
-                            target=f"agent:{a2}",
+                            source=f"agent:{agent_name}",
+                            target=hub_id,
                             kind=EdgeKind.SHARES_SERVER,
                             weight=3.0,
-                            metadata={"server": _srv_name},
+                            metadata={
+                                "server": _srv_name,
+                                "shared_group": True,
+                                "shared_agent_count": len(unique),
+                                "shared_agents": unique,
+                            },
                         )
                     )
+            else:
+                for i, a1 in enumerate(unique):
+                    for a2 in unique[i + 1 :]:
+                        graph.add_edge(
+                            GraphEdge(
+                                source=f"agent:{a1}",
+                                target=f"agent:{a2}",
+                                kind=EdgeKind.SHARES_SERVER,
+                                weight=3.0,
+                                metadata={"server": _srv_name},
+                            )
+                        )
 
-    # ── Shared credential edges (agent ↔ agent) ──────────────────────
+    # ── Shared credential edges ──────────────────────────────────────
     # Deduplication is now handled by ContextGraph.add_edge() in O(1).
     for _cred_name, agent_names in cred_to_agents.items():
         unique = sorted(set(agent_names))
         if len(unique) >= 2:
-            for i, a1 in enumerate(unique):
-                for a2 in unique[i + 1 :]:
+            metadata = {"credential": _cred_name}
+            if len(unique) > _MAX_PAIRWISE_SHARED_AGENTS:
+                # The canonical credential node already connects all of its
+                # servers.  Add one linear agent→credential edge per member;
+                # reverse adjacency lets BFS discover the other agents without
+                # materializing every pair.
+                cred_id = f"cred:{_cred_name}"
+                if cred_id in graph.nodes:
+                    graph.nodes[cred_id].metadata.update(
+                        {
+                            "shared_group": True,
+                            "shared_agent_count": len(unique),
+                            "shared_agents": unique,
+                        }
+                    )
+                metadata = {
+                    **metadata,
+                    "shared_group": True,
+                    "shared_agent_count": len(unique),
+                    "shared_agents": unique,
+                }
+                for agent_name in unique:
                     graph.add_edge(
                         GraphEdge(
-                            source=f"agent:{a1}",
-                            target=f"agent:{a2}",
+                            source=f"agent:{agent_name}",
+                            target=cred_id,
                             kind=EdgeKind.SHARES_CREDENTIAL,
                             weight=4.0,
-                            metadata={"credential": _cred_name},
+                            metadata=metadata,
                         )
                     )
+            else:
+                for i, a1 in enumerate(unique):
+                    for a2 in unique[i + 1 :]:
+                        graph.add_edge(
+                            GraphEdge(
+                                source=f"agent:{a1}",
+                                target=f"agent:{a2}",
+                                kind=EdgeKind.SHARES_CREDENTIAL,
+                                weight=4.0,
+                                metadata=metadata,
+                            )
+                        )
 
     # ── Effective-reach scoring (issue #2262) ─────────────────────────
     # Annotate every vulnerability node with a deterministic 0..100
@@ -399,6 +468,7 @@ def build_context_graph(
 
 _MAX_PATHS = 100
 _MAX_QUEUE_SIZE = 10_000  # Prevent OOM on large graphs (100+ agents)
+_MAX_PAIRWISE_SHARED_AGENTS = 64
 
 
 def find_lateral_paths(
@@ -618,14 +688,22 @@ def compute_interaction_risks(graph: ContextGraph) -> list[InteractionRisk]:
     for edge in graph.edges:
         if edge.kind == EdgeKind.SHARES_SERVER:
             srv_name = edge.metadata.get("server", "")
-            a1 = edge.source.removeprefix("agent:")
-            a2 = edge.target.removeprefix("agent:")
-            shared_servers[srv_name].extend([a1, a2])
+            members = edge.metadata.get("shared_agents")
+            if isinstance(members, list):
+                shared_servers[srv_name].extend(str(name) for name in members)
+            elif edge.source.startswith("agent:") and edge.target.startswith("agent:"):
+                a1 = edge.source.removeprefix("agent:")
+                a2 = edge.target.removeprefix("agent:")
+                shared_servers[srv_name].extend([a1, a2])
         elif edge.kind == EdgeKind.SHARES_CREDENTIAL:
             cred_name = edge.metadata.get("credential", "")
-            a1 = edge.source.removeprefix("agent:")
-            a2 = edge.target.removeprefix("agent:")
-            shared_creds[cred_name].extend([a1, a2])
+            members = edge.metadata.get("shared_agents")
+            if isinstance(members, list):
+                shared_creds[cred_name].extend(str(name) for name in members)
+            elif edge.source.startswith("agent:") and edge.target.startswith("agent:"):
+                a1 = edge.source.removeprefix("agent:")
+                a2 = edge.target.removeprefix("agent:")
+                shared_creds[cred_name].extend([a1, a2])
 
     # ── Pattern: shared credential ────────────────────────────────────
     for cred_name, agent_names in shared_creds.items():

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -18,7 +18,7 @@ import re
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import Iterable, Optional
 
 from agent_bom.constants import is_credential_key as _is_credential_key
 from agent_bom.graph import (
@@ -382,7 +382,6 @@ def build_context_graph(
                                 "server": _srv_name,
                                 "shared_group": True,
                                 "shared_agent_count": len(unique),
-                                "shared_agents": unique,
                             },
                         )
                     )
@@ -423,7 +422,6 @@ def build_context_graph(
                     **metadata,
                     "shared_group": True,
                     "shared_agent_count": len(unique),
-                    "shared_agents": unique,
                 }
                 for agent_name in unique:
                     graph.add_edge(
@@ -469,6 +467,34 @@ def build_context_graph(
 _MAX_PATHS = 100
 _MAX_QUEUE_SIZE = 10_000  # Prevent OOM on large graphs (100+ agents)
 _MAX_PAIRWISE_SHARED_AGENTS = 64
+_MAX_LATERAL_PATH_SOURCES = 100
+_MAX_LATERAL_PATHS = 1_000
+
+
+def collect_lateral_paths(
+    graph: ContextGraph,
+    source_node_ids: Iterable[str],
+    *,
+    max_depth: int = 4,
+    max_sources: int = _MAX_LATERAL_PATH_SOURCES,
+    max_paths: int = _MAX_LATERAL_PATHS,
+) -> tuple[list[LateralPath], bool]:
+    """Collect paths from a bounded set of sources.
+
+    Large estates can contain thousands of agents. Running a full BFS for
+    every source repeats work and creates an unbounded response. This helper
+    keeps source order deterministic, caps total paths, and reports whether
+    the result is intentionally sampled.
+    """
+    paths: list[LateralPath] = []
+    sources_seen = 0
+    for source_id in source_node_ids:
+        if sources_seen >= max_sources or len(paths) >= max_paths:
+            return paths[:max_paths], True
+        sources_seen += 1
+        remaining = max_paths - len(paths)
+        paths.extend(find_lateral_paths(graph, source_id, max_depth=max_depth)[:remaining])
+    return paths[:max_paths], False
 
 
 def find_lateral_paths(
@@ -685,12 +711,25 @@ def compute_interaction_risks(graph: ContextGraph) -> list[InteractionRisk]:
     shared_servers: dict[str, list[str]] = defaultdict(list)
     shared_creds: dict[str, list[str]] = defaultdict(list)
 
+    # Large shared groups keep membership once on the shared resource node,
+    # rather than duplicating a full agent list on every linear edge.
+    for node in graph.nodes.values():
+        members = node.metadata.get("shared_agents")
+        if not isinstance(members, list):
+            continue
+        if node.kind == NodeKind.SERVER:
+            shared_servers[node.label].extend(str(name) for name in members)
+        elif node.kind == NodeKind.CREDENTIAL:
+            shared_creds[node.label].extend(str(name) for name in members)
+
     for edge in graph.edges:
         if edge.kind == EdgeKind.SHARES_SERVER:
             srv_name = edge.metadata.get("server", "")
             members = edge.metadata.get("shared_agents")
             if isinstance(members, list):
                 shared_servers[srv_name].extend(str(name) for name in members)
+            elif edge.metadata.get("shared_group"):
+                continue
             elif edge.source.startswith("agent:") and edge.target.startswith("agent:"):
                 a1 = edge.source.removeprefix("agent:")
                 a2 = edge.target.removeprefix("agent:")
@@ -700,6 +739,8 @@ def compute_interaction_risks(graph: ContextGraph) -> list[InteractionRisk]:
             members = edge.metadata.get("shared_agents")
             if isinstance(members, list):
                 shared_creds[cred_name].extend(str(name) for name in members)
+            elif edge.metadata.get("shared_group"):
+                continue
             elif edge.source.startswith("agent:") and edge.target.startswith("agent:"):
                 a1 = edge.source.removeprefix("agent:")
                 a2 = edge.target.removeprefix("agent:")

--- a/src/agent_bom/graph/store_backed.py
+++ b/src/agent_bom/graph/store_backed.py
@@ -385,6 +385,10 @@ class StoreBackedUnifiedGraph(UnifiedGraph):
         # the in-RAM dict's first-insert ordering), then cache for identity.
         self._backend.add_node_payloads(self._tenant, [_node_to_row(node)])
         self._cache_put(node.id, node)
+        # The caller owns the object it passed and may mutate it immediately
+        # after add_node(). Mark the cached identity dirty so an LRU eviction
+        # writes those in-place changes back instead of silently losing them.
+        self._mark_dirty(node.id)
 
     def add_edge(self, edge: UnifiedEdge) -> None:
         key = _edge_key(edge)

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -136,8 +136,8 @@ class RelationshipType(str, Enum):
     TRIGGERS = "triggers"  # vulnerability → misconfiguration/risk condition
 
     # ── Lateral movement (computed) ──
-    SHARES_SERVER = "shares_server"  # agent ↔ agent
-    SHARES_CRED = "shares_cred"  # agent ↔ agent
+    SHARES_SERVER = "shares_server"  # agent ↔ agent/shared-server hub
+    SHARES_CRED = "shares_cred"  # agent ↔ agent/shared-credential node
     LATERAL_PATH = "lateral_path"  # agent → agent (precomputed)
 
     # ── Ownership & governance ──

--- a/src/agent_bom/mcp_tools/analysis.py
+++ b/src/agent_bom/mcp_tools/analysis.py
@@ -80,8 +80,8 @@ async def context_graph_impl(
         from agent_bom.context_graph import (
             NodeKind,
             build_context_graph,
+            collect_lateral_paths,
             compute_interaction_risks,
-            find_lateral_paths,
             to_serializable,
         )
         from agent_bom.models import AIBOMReport
@@ -99,18 +99,19 @@ async def context_graph_impl(
         )
 
         paths: list = []
+        paths_truncated = False
         depth = max(1, min(max_depth, 6))
         if source_agent:
             node_id = f"agent:{source_agent}"
             if node_id in graph.nodes:
-                paths = find_lateral_paths(graph, node_id, max_depth=depth)
+                paths, paths_truncated = collect_lateral_paths(graph, [node_id], max_depth=depth)
         else:
-            for nid in sorted(graph.nodes.keys()):
-                if graph.nodes[nid].kind == NodeKind.AGENT:
-                    paths.extend(find_lateral_paths(graph, nid, max_depth=depth))
+            source_ids = (nid for nid in sorted(graph.nodes.keys()) if graph.nodes[nid].kind == NodeKind.AGENT)
+            paths, paths_truncated = collect_lateral_paths(graph, source_ids, max_depth=depth)
 
         risks = compute_interaction_risks(graph)
         result = to_serializable(graph, paths, risks)
+        result["stats"]["lateral_paths_truncated"] = paths_truncated
         return _truncate_response(json.dumps(result, indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP tool error")

--- a/tests/graph/test_store_backed_unified_graph.py
+++ b/tests/graph/test_store_backed_unified_graph.py
@@ -207,6 +207,24 @@ def test_add_node_merge_union_matches_in_ram() -> None:
         store.close()
 
 
+def test_add_node_caller_mutation_survives_lru_eviction() -> None:
+    """A newly added node remains write-back safe before it is evicted."""
+    store = _sqlite_store(tenant_id="t1", scan_id="s", capacity=1)
+    try:
+        first = UnifiedNode(id="first", entity_type=EntityType.PACKAGE, label="first")
+        store.add_node(first)
+        first.attributes["post_add"] = True
+
+        # Loading a second node evicts the first from the one-entry cache.
+        store.add_node(UnifiedNode(id="second", entity_type=EntityType.PACKAGE, label="second"))
+
+        reloaded = store.get_node("first")
+        assert reloaded is not None
+        assert reloaded.attributes["post_add"] is True
+    finally:
+        store.close()
+
+
 def test_add_edge_dedup_evidence_merge_matches_in_ram() -> None:
     def _e(evidence: dict) -> UnifiedEdge:
         return UnifiedEdge(

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -210,6 +210,33 @@ class TestBuildGraph:
         assert len(shares) == 1
         assert shares[0].metadata["credential"] == "API_KEY"
 
+    def test_large_shared_groups_use_bounded_edges(self):
+        def _shared_server(name):
+            return {
+                **_server(name=name),
+                "env": {},
+                "credential_env_vars": ["SHARED_TOKEN"],
+            }
+
+        agents = [
+            _agent(name=f"agent-{i}", servers=[_shared_server("shared-srv")])
+            for i in range(100)
+        ]
+        graph = build_context_graph(agents, [])
+
+        server_shares = [e for e in graph.edges if e.kind == EdgeKind.SHARES_SERVER]
+        cred_shares = [e for e in graph.edges if e.kind == EdgeKind.SHARES_CREDENTIAL]
+        # The old pairwise implementation emitted 4,950 edges per resource.
+        assert len(server_shares) == 100
+        assert len(cred_shares) == 100
+        assert "shared-server:shared-srv" in graph.nodes
+        assert graph.nodes["cred:SHARED_TOKEN"].metadata["shared_agent_count"] == 100
+
+        risks = compute_interaction_risks(graph)
+        patterns = {risk.pattern for risk in risks}
+        assert "shared_server" in patterns
+        assert "shared_credential" in patterns
+
 
 # ---------------------------------------------------------------------------
 # TestLateralPaths

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -7,6 +7,7 @@ from agent_bom.context_graph import (
     EdgeKind,
     NodeKind,
     build_context_graph,
+    collect_lateral_paths,
     compute_interaction_risks,
     find_lateral_paths,
     to_serializable,
@@ -231,6 +232,7 @@ class TestBuildGraph:
         assert len(cred_shares) == 100
         assert "shared-server:shared-srv" in graph.nodes
         assert graph.nodes["cred:SHARED_TOKEN"].metadata["shared_agent_count"] == 100
+        assert all("shared_agents" not in edge.metadata for edge in server_shares + cred_shares)
 
         risks = compute_interaction_risks(graph)
         patterns = {risk.pattern for risk in risks}
@@ -778,3 +780,15 @@ class TestLateralPathDeterminism:
         out_first = json.dumps(to_serializable(graph, first, risks), default=str, sort_keys=True)
         out_second = json.dumps(to_serializable(graph, second, risks), default=str, sort_keys=True)
         assert out_first == out_second
+
+    def test_multi_source_collection_is_bounded_and_reports_sampling(self):
+        agents = [_agent(name=f"agent-{i}", servers=[_server(name="shared")]) for i in range(120)]
+        graph = build_context_graph(agents, [])
+        paths, truncated = collect_lateral_paths(
+            graph,
+            (f"agent:agent-{i}" for i in range(120)),
+            max_sources=3,
+            max_paths=10,
+        )
+        assert len(paths) <= 10
+        assert truncated is True

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -635,6 +635,11 @@ export default function ContextPage() {
       )}
 
       {/* Stats */}
+      {graphData?.stats.lateral_paths_truncated && (
+        <div className="border-b border-amber-500/20 bg-amber-500/5 px-4 py-2 text-[11px] text-amber-200">
+          Showing a bounded set of highest-priority lateral paths for this large graph. Narrow the agent scope to inspect additional paths.
+        </div>
+      )}
       {graphData && <ContextStats data={graphData} compact />}
 
       {/* Main area: graph + sidebar */}

--- a/ui/lib/context-graph.ts
+++ b/ui/lib/context-graph.ts
@@ -66,6 +66,8 @@ export interface ContextStats {
   max_lateral_depth: number;
   highest_path_risk: number;
   interaction_risk_count: number;
+  /** True when the server capped multi-source path collection for scale. */
+  lateral_paths_truncated?: boolean;
 }
 
 export interface ContextGraphData {

--- a/ui/lib/context-graph.ts
+++ b/ui/lib/context-graph.ts
@@ -142,9 +142,9 @@ const EDGE_COLORS: Record<string, string> = {
   provides: "#a855f7", // purple   server→tool
   provides_tool: "#a855f7", // purple   server→tool
   vulnerable_to: "#ef4444", // red      server→vulnerability
-  shares_server: "#22d3ee", // cyan     agent↔agent
-  shares_credential: "#f97316", // orange agent↔agent
-  shares_cred: "#f97316", // orange   agent↔agent
+  shares_server: "#22d3ee", // cyan     agent↔agent/shared-server hub
+  shares_credential: "#f97316", // orange agent↔agent/shared-credential node
+  shares_cred: "#f97316", // orange   agent↔agent/shared-credential node
   member_of: "#60a5fa", // blue     identity→agent
 };
 


### PR DESCRIPTION
Summary\n\n- Mark newly inserted store-backed nodes dirty so caller mutations survive LRU eviction.\n- Bound dense shared-server and shared-credential groups with linear hub/resource edges instead of O(N²) pairwise materialization; preserve direct edges for small groups.\n- Bound multi-source lateral-path collection to 1,000 paths / 100 sources and expose an explicit truncation flag.\n- Surface that bounded-result state in the TypeScript context-graph contract and analyst UI.\n\nVerification\n\n- uv run pytest -q tests/test_context_graph.py tests/test_graph_api.py tests/graph/test_store_backed_unified_graph.py tests/graph/test_graph_build_workspace.py (131 passed)\n- make preflight (passed)\n- uv run ruff check on affected Python modules (passed)\n- 8,000-agent synthetic graph: 16,002 nodes / 32,000 edges; build ~0.21s; bounded collection returns at most 1,000 paths\n- npm run typecheck (passed)\n- npm test -- --run (776 passed)\n- npm run build (passed)\n- git diff --check\n\nNotes\n\n- This fixes graph construction, path-response bounding, UI disclosure, and store-backed eviction correctness. The production builder remains default in-memory until the store-backed producer is explicitly wired and benchmarked.