### PR TITLE
fix(deps): bump brace-expansion to 1.1.16 to patch CVE-2026-13149 (HIGH)

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5365,9 +5365,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,8 @@
     "sigma": "^3.0.3"
   },
   "overrides": {
-    "postcss": "8.5.10"
+    "postcss": "8.5.10",
+    "brace-expansion@1": "1.1.16"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.10",


### PR DESCRIPTION
**Repo-wide fix** — the CI Security Scan self-scan gate fails on **CVE-2026-13149 (HIGH)** in the transitive `brace-expansion@1.1.13` (UI lockfile, via a `^1.1.7` range). This blocks main and every open PR (fresh advisory, not caused by any feature PR).

Fix: scoped npm override `"brace-expansion@1": "1.1.16"` — 1.1.16 is the authoritative patched version (1.1.14/1.1.15 are still vulnerable). The 5.x usages are untouched.

Verified locally: `1.1.13` gone from the lockfile (0 occurrences), resolves to `1.1.16`; 5.x entries intact (17); `npm install` reports 0 vulnerabilities.