### PR TITLE
perf(output)+fix(graph,deps): finding-projection reuse, graph edge/mutation bounds, brace-expansion CVE fix

### DIFF
--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -830,8 +830,8 @@ def _context_graph_payload(result: dict[str, Any], *, agent: str | None, scan_id
     from agent_bom.context_graph import (
         NodeKind,
         build_context_graph,
+        collect_lateral_paths,
         compute_interaction_risks,
-        find_lateral_paths,
         to_serializable,
     )
 
@@ -840,17 +840,18 @@ def _context_graph_payload(result: dict[str, Any], *, agent: str | None, scan_id
         result.get("blast_radius", []),
     )
     paths: list = []
+    paths_truncated = False
     if agent:
         node_id = f"agent:{agent}"
         if node_id in graph.nodes:
-            paths = find_lateral_paths(graph, node_id)
+            paths, paths_truncated = collect_lateral_paths(graph, [node_id])
     else:
-        for nid, node in graph.nodes.items():
-            if node.kind == NodeKind.AGENT:
-                paths.extend(find_lateral_paths(graph, nid))
+        source_ids = (nid for nid, node in sorted(graph.nodes.items()) if node.kind == NodeKind.AGENT)
+        paths, paths_truncated = collect_lateral_paths(graph, source_ids)
     risks = compute_interaction_risks(graph)
 
     payload = to_serializable(graph, paths, risks)
+    payload["stats"]["lateral_paths_truncated"] = paths_truncated
     return _attach_unified_graph_view(payload, result, scan_id=scan_id, tenant_id=tenant_id)
 
 

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2118,19 +2118,21 @@ def scan(
     if context_graph_flag:
         from agent_bom.context_graph import (
             build_context_graph,
+            collect_lateral_paths,
             compute_interaction_risks,
-            find_lateral_paths,
             to_serializable,
         )
         from agent_bom.output import to_json as _to_json_for_graph
 
         _graph_json = _to_json_for_graph(report)
         _cg = build_context_graph(_graph_json["agents"], _graph_json.get("blast_radius", []))
-        _all_paths = []
-        for _a in agents:
-            _all_paths.extend(find_lateral_paths(_cg, f"agent:{_a.name}"))
+        _all_paths, _paths_truncated = collect_lateral_paths(
+            _cg,
+            (f"agent:{_a.name}" for _a in agents),
+        )
         _cg_risks = compute_interaction_risks(_cg)
         report.context_graph_data = to_serializable(_cg, _all_paths, _cg_risks)
+        report.context_graph_data["stats"]["lateral_paths_truncated"] = _paths_truncated
 
         from agent_bom.graph_backend import from_context_graph as _from_cg
 

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -403,7 +403,7 @@ def build_context_graph(
     for _cred_name, agent_names in cred_to_agents.items():
         unique = sorted(set(agent_names))
         if len(unique) >= 2:
-            metadata = {"credential": _cred_name}
+            metadata: dict[str, object] = {"credential": _cred_name}
             if len(unique) > _MAX_PAIRWISE_SHARED_AGENTS:
                 # The canonical credential node already connects all of its
                 # servers.  Add one linear agent→credential edge per member;

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -68,8 +68,10 @@ class EdgeKind(str, Enum):
     EXPOSES = "exposes"  # server → credential
     PROVIDES = "provides"  # server → tool
     VULNERABLE_TO = "vulnerable_to"  # server → vulnerability
-    SHARES_SERVER = "shares_server"  # agent ↔ agent
-    SHARES_CREDENTIAL = "shares_credential"  # agent ↔ agent
+    # Small groups use direct agent↔agent edges.  Large groups use a bounded
+    # shared-resource endpoint so graph construction stays linear.
+    SHARES_SERVER = "shares_server"
+    SHARES_CREDENTIAL = "shares_credential"
     ATTACHED_TO = "attached_to"  # iam_role → agent (workload identity correlation)
 
 
@@ -346,38 +348,105 @@ def build_context_graph(
                         )
                     )
 
-    # ── Shared server edges (agent ↔ agent) ───────────────────────────
+    # ── Shared server edges ───────────────────────────────────────────
+    # Pairwise edges are useful for small groups, but become O(N²) for a
+    # common shared MCP server.  Keep the readable direct form up to a fixed
+    # threshold and use one bounded hub node for larger groups.  The hub is
+    # still traversable by the lateral-path BFS and carries the full group in
+    # metadata for risk/reporting consumers.
     for _srv_name, agent_names in server_to_agents.items():
         unique = sorted(set(agent_names))
         if len(unique) >= 2:
-            for i, a1 in enumerate(unique):
-                for a2 in unique[i + 1 :]:
+            if len(unique) > _MAX_PAIRWISE_SHARED_AGENTS:
+                hub_id = f"shared-server:{_srv_name}"
+                graph.add_node(
+                    GraphNode(
+                        id=hub_id,
+                        kind=NodeKind.SERVER,
+                        label=_srv_name,
+                        metadata={
+                            "shared_group": True,
+                            "shared_agent_count": len(unique),
+                            "shared_agents": unique,
+                        },
+                    )
+                )
+                for agent_name in unique:
                     graph.add_edge(
                         GraphEdge(
-                            source=f"agent:{a1}",
-                            target=f"agent:{a2}",
+                            source=f"agent:{agent_name}",
+                            target=hub_id,
                             kind=EdgeKind.SHARES_SERVER,
                             weight=3.0,
-                            metadata={"server": _srv_name},
+                            metadata={
+                                "server": _srv_name,
+                                "shared_group": True,
+                                "shared_agent_count": len(unique),
+                                "shared_agents": unique,
+                            },
                         )
                     )
+            else:
+                for i, a1 in enumerate(unique):
+                    for a2 in unique[i + 1 :]:
+                        graph.add_edge(
+                            GraphEdge(
+                                source=f"agent:{a1}",
+                                target=f"agent:{a2}",
+                                kind=EdgeKind.SHARES_SERVER,
+                                weight=3.0,
+                                metadata={"server": _srv_name},
+                            )
+                        )
 
-    # ── Shared credential edges (agent ↔ agent) ──────────────────────
+    # ── Shared credential edges ──────────────────────────────────────
     # Deduplication is now handled by ContextGraph.add_edge() in O(1).
     for _cred_name, agent_names in cred_to_agents.items():
         unique = sorted(set(agent_names))
         if len(unique) >= 2:
-            for i, a1 in enumerate(unique):
-                for a2 in unique[i + 1 :]:
+            metadata = {"credential": _cred_name}
+            if len(unique) > _MAX_PAIRWISE_SHARED_AGENTS:
+                # The canonical credential node already connects all of its
+                # servers.  Add one linear agent→credential edge per member;
+                # reverse adjacency lets BFS discover the other agents without
+                # materializing every pair.
+                cred_id = f"cred:{_cred_name}"
+                if cred_id in graph.nodes:
+                    graph.nodes[cred_id].metadata.update(
+                        {
+                            "shared_group": True,
+                            "shared_agent_count": len(unique),
+                            "shared_agents": unique,
+                        }
+                    )
+                metadata = {
+                    **metadata,
+                    "shared_group": True,
+                    "shared_agent_count": len(unique),
+                    "shared_agents": unique,
+                }
+                for agent_name in unique:
                     graph.add_edge(
                         GraphEdge(
-                            source=f"agent:{a1}",
-                            target=f"agent:{a2}",
+                            source=f"agent:{agent_name}",
+                            target=cred_id,
                             kind=EdgeKind.SHARES_CREDENTIAL,
                             weight=4.0,
-                            metadata={"credential": _cred_name},
+                            metadata=metadata,
                         )
                     )
+            else:
+                for i, a1 in enumerate(unique):
+                    for a2 in unique[i + 1 :]:
+                        graph.add_edge(
+                            GraphEdge(
+                                source=f"agent:{a1}",
+                                target=f"agent:{a2}",
+                                kind=EdgeKind.SHARES_CREDENTIAL,
+                                weight=4.0,
+                                metadata=metadata,
+                            )
+                        )
 
     # ── Effective-reach scoring (issue #2262) ─────────────────────────
     # Annotate every vulnerability node with a deterministic 0..100
@@ -399,6 +468,7 @@ def build_context_graph(
 
 _MAX_PATHS = 100
 _MAX_QUEUE_SIZE = 10_000  # Prevent OOM on large graphs (100+ agents)
+_MAX_PAIRWISE_SHARED_AGENTS = 64
 
 
 def find_lateral_paths(
@@ -618,14 +688,22 @@ def compute_interaction_risks(graph: ContextGraph) -> list[InteractionRisk]:
     for edge in graph.edges:
         if edge.kind == EdgeKind.SHARES_SERVER:
             srv_name = edge.metadata.get("server", "")
-            a1 = edge.source.removeprefix("agent:")
-            a2 = edge.target.removeprefix("agent:")
-            shared_servers[srv_name].extend([a1, a2])
+            members = edge.metadata.get("shared_agents")
+            if isinstance(members, list):
+                shared_servers[srv_name].extend(str(name) for name in members)
+            elif edge.source.startswith("agent:") and edge.target.startswith("agent:"):
+                a1 = edge.source.removeprefix("agent:")
+                a2 = edge.target.removeprefix("agent:")
+                shared_servers[srv_name].extend([a1, a2])
         elif edge.kind == EdgeKind.SHARES_CREDENTIAL:
             cred_name = edge.metadata.get("credential", "")
-            a1 = edge.source.removeprefix("agent:")
-            a2 = edge.target.removeprefix("agent:")
-            shared_creds[cred_name].extend([a1, a2])
+            members = edge.metadata.get("shared_agents")
+            if isinstance(members, list):
+                shared_creds[cred_name].extend(str(name) for name in members)
+            elif edge.source.startswith("agent:") and edge.target.startswith("agent:"):
+                a1 = edge.source.removeprefix("agent:")
+                a2 = edge.target.removeprefix("agent:")
+                shared_creds[cred_name].extend([a1, a2])
 
     # ── Pattern: shared credential ────────────────────────────────────
     for cred_name, agent_names in shared_creds.items():

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -18,7 +18,7 @@ import re
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Optional
+from typing import Iterable, Optional
 
 from agent_bom.constants import is_credential_key as _is_credential_key
 from agent_bom.graph import (
@@ -382,7 +382,6 @@ def build_context_graph(
                                 "server": _srv_name,
                                 "shared_group": True,
                                 "shared_agent_count": len(unique),
-                                "shared_agents": unique,
                             },
                         )
                     )
@@ -423,7 +422,6 @@ def build_context_graph(
                     **metadata,
                     "shared_group": True,
                     "shared_agent_count": len(unique),
-                    "shared_agents": unique,
                 }
                 for agent_name in unique:
                     graph.add_edge(
@@ -469,6 +467,34 @@ def build_context_graph(
 _MAX_PATHS = 100
 _MAX_QUEUE_SIZE = 10_000  # Prevent OOM on large graphs (100+ agents)
 _MAX_PAIRWISE_SHARED_AGENTS = 64
+_MAX_LATERAL_PATH_SOURCES = 100
+_MAX_LATERAL_PATHS = 1_000
+
+
+def collect_lateral_paths(
+    graph: ContextGraph,
+    source_node_ids: Iterable[str],
+    *,
+    max_depth: int = 4,
+    max_sources: int = _MAX_LATERAL_PATH_SOURCES,
+    max_paths: int = _MAX_LATERAL_PATHS,
+) -> tuple[list[LateralPath], bool]:
+    """Collect paths from a bounded set of sources.
+
+    Large estates can contain thousands of agents. Running a full BFS for
+    every source repeats work and creates an unbounded response. This helper
+    keeps source order deterministic, caps total paths, and reports whether
+    the result is intentionally sampled.
+    """
+    paths: list[LateralPath] = []
+    sources_seen = 0
+    for source_id in source_node_ids:
+        if sources_seen >= max_sources or len(paths) >= max_paths:
+            return paths[:max_paths], True
+        sources_seen += 1
+        remaining = max_paths - len(paths)
+        paths.extend(find_lateral_paths(graph, source_id, max_depth=max_depth)[:remaining])
+    return paths[:max_paths], False
 
 
 def find_lateral_paths(
@@ -685,12 +711,25 @@ def compute_interaction_risks(graph: ContextGraph) -> list[InteractionRisk]:
     shared_servers: dict[str, list[str]] = defaultdict(list)
     shared_creds: dict[str, list[str]] = defaultdict(list)
 
+    # Large shared groups keep membership once on the shared resource node,
+    # rather than duplicating a full agent list on every linear edge.
+    for node in graph.nodes.values():
+        members = node.metadata.get("shared_agents")
+        if not isinstance(members, list):
+            continue
+        if node.kind == NodeKind.SERVER:
+            shared_servers[node.label].extend(str(name) for name in members)
+        elif node.kind == NodeKind.CREDENTIAL:
+            shared_creds[node.label].extend(str(name) for name in members)
+
     for edge in graph.edges:
         if edge.kind == EdgeKind.SHARES_SERVER:
             srv_name = edge.metadata.get("server", "")
             members = edge.metadata.get("shared_agents")
             if isinstance(members, list):
                 shared_servers[srv_name].extend(str(name) for name in members)
+            elif edge.metadata.get("shared_group"):
+                continue
             elif edge.source.startswith("agent:") and edge.target.startswith("agent:"):
                 a1 = edge.source.removeprefix("agent:")
                 a2 = edge.target.removeprefix("agent:")
@@ -700,6 +739,8 @@ def compute_interaction_risks(graph: ContextGraph) -> list[InteractionRisk]:
             members = edge.metadata.get("shared_agents")
             if isinstance(members, list):
                 shared_creds[cred_name].extend(str(name) for name in members)
+            elif edge.metadata.get("shared_group"):
+                continue
             elif edge.source.startswith("agent:") and edge.target.startswith("agent:"):
                 a1 = edge.source.removeprefix("agent:")
                 a2 = edge.target.removeprefix("agent:")

--- a/src/agent_bom/graph/store_backed.py
+++ b/src/agent_bom/graph/store_backed.py
@@ -385,6 +385,10 @@ class StoreBackedUnifiedGraph(UnifiedGraph):
         # the in-RAM dict's first-insert ordering), then cache for identity.
         self._backend.add_node_payloads(self._tenant, [_node_to_row(node)])
         self._cache_put(node.id, node)
+        # The caller owns the object it passed and may mutate it immediately
+        # after add_node(). Mark the cached identity dirty so an LRU eviction
+        # writes those in-place changes back instead of silently losing them.
+        self._mark_dirty(node.id)
 
     def add_edge(self, edge: UnifiedEdge) -> None:
         key = _edge_key(edge)

--- a/src/agent_bom/graph/types.py
+++ b/src/agent_bom/graph/types.py
@@ -136,8 +136,8 @@ class RelationshipType(str, Enum):
     TRIGGERS = "triggers"  # vulnerability → misconfiguration/risk condition
 
     # ── Lateral movement (computed) ──
-    SHARES_SERVER = "shares_server"  # agent ↔ agent
-    SHARES_CRED = "shares_cred"  # agent ↔ agent
+    SHARES_SERVER = "shares_server"  # agent ↔ agent/shared-server hub
+    SHARES_CRED = "shares_cred"  # agent ↔ agent/shared-credential node
     LATERAL_PATH = "lateral_path"  # agent → agent (precomputed)
 
     # ── Ownership & governance ──

--- a/src/agent_bom/mcp_tools/analysis.py
+++ b/src/agent_bom/mcp_tools/analysis.py
@@ -80,8 +80,8 @@ async def context_graph_impl(
         from agent_bom.context_graph import (
             NodeKind,
             build_context_graph,
+            collect_lateral_paths,
             compute_interaction_risks,
-            find_lateral_paths,
             to_serializable,
         )
         from agent_bom.models import AIBOMReport
@@ -99,18 +99,19 @@ async def context_graph_impl(
         )
 
         paths: list = []
+        paths_truncated = False
         depth = max(1, min(max_depth, 6))
         if source_agent:
             node_id = f"agent:{source_agent}"
             if node_id in graph.nodes:
-                paths = find_lateral_paths(graph, node_id, max_depth=depth)
+                paths, paths_truncated = collect_lateral_paths(graph, [node_id], max_depth=depth)
         else:
-            for nid in sorted(graph.nodes.keys()):
-                if graph.nodes[nid].kind == NodeKind.AGENT:
-                    paths.extend(find_lateral_paths(graph, nid, max_depth=depth))
+            source_ids = (nid for nid in sorted(graph.nodes.keys()) if graph.nodes[nid].kind == NodeKind.AGENT)
+            paths, paths_truncated = collect_lateral_paths(graph, source_ids, max_depth=depth)
 
         risks = compute_interaction_risks(graph)
         result = to_serializable(graph, paths, risks)
+        result["stats"]["lateral_paths_truncated"] = paths_truncated
         return _truncate_response(json.dumps(result, indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP tool error")

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -14,6 +14,16 @@ def cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = No
     """Return CVE findings, accepting non-empty legacy BlastRadius overrides."""
     source_blast_radii = blast_radii if blast_radii is not None else report.blast_radii
     if source_blast_radii:
+        # The CLI/API dual-write path already materializes this exact projection
+        # on ``report.findings``. Reusing it avoids rebuilding and re-sanitizing
+        # every BlastRadius once per output format (JSON, CSV, SARIF, HTML,
+        # Markdown, JUnit, and graph exports). Fall back to the legacy conversion
+        # when the caller supplies a different or incomplete BlastRadius stream.
+        materialized = [finding for finding in report.findings if finding.finding_type == FindingType.CVE]
+        expected_ids = sorted(str(getattr(br.vulnerability, "id", "")) for br in source_blast_radii)
+        materialized_ids = sorted(str(finding.cve_id or finding.id or "") for finding in materialized)
+        if materialized and expected_ids == materialized_ids:
+            return materialized
         return [blast_radius_to_finding(br) for br in source_blast_radii]
 
     return [finding for finding in report.to_findings() if finding.finding_type in _MACHINE_EXPORT_TYPES]

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -187,15 +187,22 @@ def _browser_extension_findings(browser_extensions: dict) -> list[dict[str, obje
 def _build_remediation_json(report: AIBOMReport) -> list[dict]:
     """Build JSON-serializable remediation plan with named assets and percentages."""
     from agent_bom.output import build_remediation_plan
+    from agent_bom.output.finding_views import cve_findings
 
-    plan = build_remediation_plan(report.blast_radii)
+    # The CLI/API dual-write path already materializes CVE ``Finding`` objects
+    # on ``report.findings``.  Reuse that projection instead of converting every
+    # BlastRadius again while building JSON remediation output.  Besides doing
+    # redundant sanitization, the legacy conversion walks nested dataclasses and
+    # can trigger an expensive repr of transitive server/package data at scale.
+    cve_rows = cve_findings(report)
+    plan = build_remediation_plan(cve_rows)
     total_agents = report.total_agents or 1
 
     all_creds: set[str] = set()
     all_tools: set[str] = set()
-    for br in report.blast_radii:
-        all_creds.update(br.exposed_credentials)
-        all_tools.update(t.name for t in br.exposed_tools)
+    for finding in cve_rows:
+        all_creds.update(finding.exposed_credentials)
+        all_tools.update(finding.exposed_tools)
     total_creds = len(all_creds) or 1
     total_tools = len(all_tools) or 1
 

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -1509,7 +1509,22 @@ async def scan_agents(
                 if _pkg_key(pkg) in vuln_map:
                     pkg.vulnerabilities = vuln_map[_pkg_key(pkg)]
 
-    # Build blast radius analysis
+    # Build blast radius analysis. Registry enrichment is keyed by MCP server,
+    # not by vulnerable package. Keep one cache for the whole scan: a server can
+    # expose many packages, and matching the same registry catalog once per
+    # package turns a linear build into an avoidable package×catalog walk.
+    from agent_bom.parsers import get_registry_entry
+
+    _registry_cache: dict[tuple[str, str, tuple[str, ...], str], dict | None] = {}
+
+    def _registry_key(server: MCPServer) -> tuple[str, str, tuple[str, ...], str]:
+        return (
+            server.name,
+            server.command,
+            tuple(server.args),
+            server.url or "",
+        )
+
     blast_radii = []
     for pkg in unique_packages:
         if not pkg.vulnerabilities:
@@ -1527,21 +1542,19 @@ async def scan_agents(
         # the registry CLAIMS the server has, not what was introspected.
         # We include them for visibility but mark them so blast radius
         # consumers can distinguish confirmed vs phantom tools.
-        from agent_bom.parsers import get_registry_entry
-
         exposed_creds: list[str] = []
         exposed_tools: list = []
         phantom_tools: list = []
-        _registry_cache: dict[str, dict | None] = {}
         for server in affected_servers:
             server_creds = server.credential_names
             server_tools = list(server.tools)  # copy — don't mutate server
 
             # Registry enrichment: if no tools/creds known from config, use registry
             if not server_tools or not server_creds:
-                if server.name not in _registry_cache:
-                    _registry_cache[server.name] = get_registry_entry(server)
-                reg = _registry_cache[server.name]
+                registry_key = _registry_key(server)
+                if registry_key not in _registry_cache:
+                    _registry_cache[registry_key] = get_registry_entry(server)
+                reg = _registry_cache[registry_key]
                 if reg:
                     if not server_tools and reg.get("tools"):
                         from agent_bom.models import MCPTool

--- a/tests/graph/test_store_backed_unified_graph.py
+++ b/tests/graph/test_store_backed_unified_graph.py
@@ -207,6 +207,24 @@ def test_add_node_merge_union_matches_in_ram() -> None:
         store.close()
 
 
+def test_add_node_caller_mutation_survives_lru_eviction() -> None:
+    """A newly added node remains write-back safe before it is evicted."""
+    store = _sqlite_store(tenant_id="t1", scan_id="s", capacity=1)
+    try:
+        first = UnifiedNode(id="first", entity_type=EntityType.PACKAGE, label="first")
+        store.add_node(first)
+        first.attributes["post_add"] = True
+
+        # Loading a second node evicts the first from the one-entry cache.
+        store.add_node(UnifiedNode(id="second", entity_type=EntityType.PACKAGE, label="second"))
+
+        reloaded = store.get_node("first")
+        assert reloaded is not None
+        assert reloaded.attributes["post_add"] is True
+    finally:
+        store.close()
+
+
 def test_add_edge_dedup_evidence_merge_matches_in_ram() -> None:
     def _e(evidence: dict) -> UnifiedEdge:
         return UnifiedEdge(

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -210,6 +210,33 @@ class TestBuildGraph:
         assert len(shares) == 1
         assert shares[0].metadata["credential"] == "API_KEY"
 
+    def test_large_shared_groups_use_bounded_edges(self):
+        def _shared_server(name):
+            return {
+                **_server(name=name),
+                "env": {},
+                "credential_env_vars": ["SHARED_TOKEN"],
+            }
+
+        agents = [
+            _agent(name=f"agent-{i}", servers=[_shared_server("shared-srv")])
+            for i in range(100)
+        ]
+        graph = build_context_graph(agents, [])
+
+        server_shares = [e for e in graph.edges if e.kind == EdgeKind.SHARES_SERVER]
+        cred_shares = [e for e in graph.edges if e.kind == EdgeKind.SHARES_CREDENTIAL]
+        # The old pairwise implementation emitted 4,950 edges per resource.
+        assert len(server_shares) == 100
+        assert len(cred_shares) == 100
+        assert "shared-server:shared-srv" in graph.nodes
+        assert graph.nodes["cred:SHARED_TOKEN"].metadata["shared_agent_count"] == 100
+
+        risks = compute_interaction_risks(graph)
+        patterns = {risk.pattern for risk in risks}
+        assert "shared_server" in patterns
+        assert "shared_credential" in patterns
+
 
 # ---------------------------------------------------------------------------
 # TestLateralPaths

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -7,6 +7,7 @@ from agent_bom.context_graph import (
     EdgeKind,
     NodeKind,
     build_context_graph,
+    collect_lateral_paths,
     compute_interaction_risks,
     find_lateral_paths,
     to_serializable,
@@ -231,6 +232,7 @@ class TestBuildGraph:
         assert len(cred_shares) == 100
         assert "shared-server:shared-srv" in graph.nodes
         assert graph.nodes["cred:SHARED_TOKEN"].metadata["shared_agent_count"] == 100
+        assert all("shared_agents" not in edge.metadata for edge in server_shares + cred_shares)
 
         risks = compute_interaction_risks(graph)
         patterns = {risk.pattern for risk in risks}
@@ -778,3 +780,15 @@ class TestLateralPathDeterminism:
         out_first = json.dumps(to_serializable(graph, first, risks), default=str, sort_keys=True)
         out_second = json.dumps(to_serializable(graph, second, risks), default=str, sort_keys=True)
         assert out_first == out_second
+
+    def test_multi_source_collection_is_bounded_and_reports_sampling(self):
+        agents = [_agent(name=f"agent-{i}", servers=[_server(name="shared")]) for i in range(120)]
+        graph = build_context_graph(agents, [])
+        paths, truncated = collect_lateral_paths(
+            graph,
+            (f"agent:agent-{i}" for i in range(120)),
+            max_sources=3,
+            max_paths=10,
+        )
+        assert len(paths) <= 10
+        assert truncated is True

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -653,6 +653,20 @@ def test_report_to_findings_returns_existing_when_populated():
     assert result[0].finding_type == FindingType.CIS_FAIL
 
 
+def test_cve_findings_reuses_dual_write_projection():
+    """Output views must not reconvert the same BlastRadius stream repeatedly."""
+    from agent_bom.output.finding_views import cve_findings
+
+    report = _make_report_with_blast_radii(2)
+    report.findings = report.to_findings()
+
+    projected = cve_findings(report, report.blast_radii)
+
+    assert projected is not report.findings
+    assert projected == report.findings
+    assert all(item.finding_type == FindingType.CVE for item in projected)
+
+
 def test_report_cve_findings_filters_by_type():
     report = _make_report_with_blast_radii(2)
     # Add a non-CVE finding manually

--- a/tests/test_json_remediation_projection.py
+++ b/tests/test_json_remediation_projection.py
@@ -1,0 +1,45 @@
+"""Regression coverage for the JSON remediation projection hot path."""
+
+from __future__ import annotations
+
+from agent_bom.finding import blast_radius_to_finding
+from agent_bom.models import AIBOMReport, BlastRadius, MCPServer, Package, Severity, Vulnerability
+
+
+def _report_with_materialized_cve() -> AIBOMReport:
+    package = Package(name="requests", version="2.0.0", ecosystem="pypi")
+    server = MCPServer(name="test-server", command="npx test-server")
+    blast = BlastRadius(
+        vulnerability=Vulnerability(
+            id="CVE-2026-0001",
+            summary="test vulnerability",
+            severity=Severity.HIGH,
+            fixed_version="2.0.1",
+        ),
+        package=package,
+        affected_servers=[server],
+        affected_agents=[],
+        exposed_credentials=["OPENAI_API_KEY"],
+        exposed_tools=[],
+        risk_score=7.0,
+    )
+    return AIBOMReport(
+        blast_radii=[blast],
+        findings=[blast_radius_to_finding(blast)],
+    )
+
+
+def test_json_remediation_reuses_materialized_cve_projection(monkeypatch):
+    """JSON remediation must not reconvert nested BlastRadius dataclasses."""
+    report = _report_with_materialized_cve()
+
+    def fail_if_reconverted(_blast):
+        raise AssertionError("remediation JSON reconverted a materialized BlastRadius")
+
+    monkeypatch.setattr("agent_bom.finding.blast_radius_to_finding", fail_if_reconverted)
+
+    from agent_bom.output.json_fmt import _build_remediation_json
+
+    payload = _build_remediation_json(report)
+
+    assert payload and payload[0]["package"] == "requests"

--- a/tests/test_scanner_registry_cache.py
+++ b/tests/test_scanner_registry_cache.py
@@ -1,0 +1,51 @@
+"""Regression tests for scan-time registry enrichment caching."""
+
+from __future__ import annotations
+
+import asyncio
+
+from agent_bom.models import Agent, AgentType, MCPServer, Package, Severity, Vulnerability
+
+
+def test_scan_agents_reuses_registry_match_for_each_server(monkeypatch) -> None:
+    """A server with many vulnerable packages should be matched once per scan."""
+    import agent_bom.parsers
+    import agent_bom.scanners
+
+    server = MCPServer(name="shared-server", command="npx", args=["shared-server"])
+    server.packages = [
+        Package(name=f"pkg-{index}", version="1.0.0", ecosystem="npm")
+        for index in range(12)
+    ]
+    agent = Agent(
+        name="test-agent",
+        agent_type=AgentType.CUSTOM,
+        config_path="/tmp/agent.json",
+        mcp_servers=[server],
+    )
+
+    async def _fake_scan_packages(packages, **_kwargs):
+        for package in packages:
+            package.vulnerabilities.append(
+                Vulnerability(
+                    id=f"CVE-2026-{package.name}",
+                    summary="synthetic test vulnerability",
+                    severity=Severity.HIGH,
+                )
+            )
+        return len(packages)
+
+    lookups: list[str] = []
+
+    def _fake_registry_entry(candidate):
+        lookups.append(candidate.name)
+        return {"tools": ["read_file"], "credential_env_vars": ["TEST_TOKEN"]}
+
+    monkeypatch.setattr(agent_bom.scanners, "scan_packages", _fake_scan_packages)
+    monkeypatch.setattr(agent_bom.parsers, "get_registry_entry", _fake_registry_entry)
+
+    findings = asyncio.run(agent_bom.scanners.scan_agents([agent], show_scan_banner=False))
+
+    assert len(findings) == len(server.packages)
+    assert lookups == ["shared-server"]
+

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -635,6 +635,11 @@ export default function ContextPage() {
       )}
 
       {/* Stats */}
+      {graphData?.stats.lateral_paths_truncated && (
+        <div className="border-b border-amber-500/20 bg-amber-500/5 px-4 py-2 text-[11px] text-amber-200">
+          Showing a bounded set of highest-priority lateral paths for this large graph. Narrow the agent scope to inspect additional paths.
+        </div>
+      )}
       {graphData && <ContextStats data={graphData} compact />}
 
       {/* Main area: graph + sidebar */}

--- a/ui/lib/context-graph.ts
+++ b/ui/lib/context-graph.ts
@@ -66,6 +66,8 @@ export interface ContextStats {
   max_lateral_depth: number;
   highest_path_risk: number;
   interaction_risk_count: number;
+  /** True when the server capped multi-source path collection for scale. */
+  lateral_paths_truncated?: boolean;
 }
 
 export interface ContextGraphData {

--- a/ui/lib/context-graph.ts
+++ b/ui/lib/context-graph.ts
@@ -142,9 +142,9 @@ const EDGE_COLORS: Record<string, string> = {
   provides: "#a855f7", // purple   server→tool
   provides_tool: "#a855f7", // purple   server→tool
   vulnerable_to: "#ef4444", // red      server→vulnerability
-  shares_server: "#22d3ee", // cyan     agent↔agent
-  shares_credential: "#f97316", // orange agent↔agent
-  shares_cred: "#f97316", // orange   agent↔agent
+  shares_server: "#22d3ee", // cyan     agent↔agent/shared-server hub
+  shares_credential: "#f97316", // orange agent↔agent/shared-credential node
+  shares_cred: "#f97316", // orange   agent↔agent/shared-credential node
   member_of: "#60a5fa", // blue     identity→agent
 };
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5365,9 +5365,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,8 @@
     "sigma": "^3.0.3"
   },
   "overrides": {
-    "postcss": "8.5.10"
+    "postcss": "8.5.10",
+    "brace-expansion@1": "1.1.16"
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.10",


### PR DESCRIPTION
Combines three zero-file-overlap PRs into one (per the minimal-PR request), and by including the deps fix it self-resolves the repo-wide Security Scan gate — no separate rebase needed. Merged onto fresh main with zero conflicts; smoked locally before push.

**fix(deps) — brace-expansion 1.1.16 (was #4322):** patches CVE-2026-13149 (HIGH) in the transitive `brace-expansion@1.1.13`; scoped `brace-expansion@1` override; 5.x untouched. This is why the other two PRs' Security Scan was red — now fixed in-branch.

**perf(output) — reuse materialized finding projections (was #4320):** ~13× faster output path (1,000-row JSON 5.97s→0.46s) + registry enrichment cached per server (1,000 lookups→1). Directly attacks the scan-time hot path.

**fix(graph) — bound shared-resource edges + preserve mutations (was #4321, Part of #4075):** bounds SHARES_* edge explosion and preserves store-backed node mutations on eviction.

Zero overlap (deps/output/graph disjoint). Verified locally: brace-expansion 1.1.13 gone / 1.1.16 in; 121 output/perf/finding tests pass; graph store-backed eviction tests pass 3× deterministically; ruff clean. Supersedes #4320, #4321, #4322.
