### PR TITLE
fix(graph): publish bounded response completeness

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -55,6 +55,7 @@ from agent_bom.graph import (
     UnifiedGraph,
     UnifiedNode,
 )
+from agent_bom.graph.completeness import graph_completeness
 from agent_bom.graph.semantic_clusters import SEMANTIC_CLUSTER_KINDS, build_semantic_clusters, semantic_cluster_stats
 from agent_bom.security import sanitize_error
 
@@ -1414,6 +1415,12 @@ def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) ->
         "interaction_risks": interaction_risks,
         "stats": stats,
         "pagination": pagination,
+        "completeness": graph_completeness(
+            returned=len(paged_nodes),
+            total=len(all_nodes),
+            truncated=pagination["has_more"],
+            reason="node_page_limit" if pagination["has_more"] else "",
+        ),
         "attack_path_pagination": {
             "total": len(matching_paths),
             "limit": _FILTERED_GRAPH_ATTACK_PATH_LIMIT,
@@ -1480,6 +1487,12 @@ def _fix_first_graph_view_payload(graph: UnifiedGraph, *, cve: str, package: str
             "package": package,
             "agent": agent,
         },
+        "completeness": graph_completeness(
+            returned=len(cards),
+            total=len(ranked_paths),
+            truncated=len(ranked_paths) > len(cards),
+            reason="path_card_limit" if len(ranked_paths) > len(cards) else "",
+        ),
     }
 
 
@@ -1521,6 +1534,12 @@ def _serialize_attack_path_queue(
         "interaction_risks": [],
         "stats": stats,
         "pagination": _page_meta(total, offset, limit),
+        "completeness": graph_completeness(
+            returned=len(paths),
+            total=total,
+            truncated=offset + len(paths) < total,
+            reason="path_page_limit" if offset + len(paths) < total else "",
+        ),
     }
 
 
@@ -1558,6 +1577,11 @@ def _governance_graph_payload(
     for node in graph.nodes.values():
         if node.entity_type in governance_types:
             counts[node.entity_type.value] = counts.get(node.entity_type.value, 0) + 1
+    governance_truncated = (
+        len(nodes) < len(keep_ids)
+        or len(edges) < len(candidate_edges)
+        or len(attack_paths) < len(matching_paths)
+    )
     return {
         "scan_id": graph.scan_id,
         "tenant_id": tenant_id,
@@ -1578,6 +1602,12 @@ def _governance_graph_payload(
             "limit": attack_path_limit,
             "has_more": len(matching_paths) > attack_path_limit,
         },
+        "completeness": graph_completeness(
+            returned=len(nodes),
+            total=len(keep_ids),
+            truncated=governance_truncated,
+            reason="governance_budget" if governance_truncated else "",
+        ),
     }
 
 
@@ -1588,11 +1618,12 @@ def _semantic_cluster_payload(
     min_members: int,
     limit: int,
 ) -> dict[str, Any]:
-    clusters = [
+    all_clusters = [
         cluster
         for cluster in build_semantic_clusters(graph.nodes.values(), graph.edges, min_members=min_members)
         if cluster.kind in selected_kinds
-    ][:limit]
+    ]
+    clusters = all_clusters[:limit]
     return {
         "scan_id": graph.scan_id,
         "tenant_id": graph.tenant_id,
@@ -1600,6 +1631,12 @@ def _semantic_cluster_payload(
         "clusters": [cluster.to_dict() for cluster in clusters],
         "stats": semantic_cluster_stats(clusters),
         "available_kinds": list(SEMANTIC_CLUSTER_KINDS),
+        "completeness": graph_completeness(
+            returned=len(clusters),
+            total=len(all_clusters),
+            truncated=len(all_clusters) > len(clusters),
+            reason="cluster_limit" if len(all_clusters) > len(clusters) else "",
+        ),
     }
 
 
@@ -1874,6 +1911,12 @@ async def get_graph(
             min_severity_rank=min_rank,
         ),
         "pagination": _page_meta(total, offset, limit, cursor=cursor, next_cursor=next_cursor),
+        "completeness": graph_completeness(
+            returned=len(paged_nodes),
+            total=total,
+            truncated=bool(next_cursor) or offset + len(paged_nodes) < total,
+            reason="node_page_limit" if bool(next_cursor) or offset + len(paged_nodes) < total else "",
+        ),
     }
 
 
@@ -1979,7 +2022,9 @@ async def get_graph_diff(
 ) -> dict:
     """Diff two scan snapshots — nodes/edges added, removed, changed."""
     diff = await _graph_store_call(_get_graph_store_or_503().diff_snapshots, old, new, tenant_id=_tenant(request))
-    return _tag_diff_change_kinds(diff)
+    diff = _tag_diff_change_kinds(diff)
+    diff["completeness"] = graph_completeness(returned=1, total=1)
+    return diff
 
 
 @router.get("/graph/edges/active", tags=["graph"])
@@ -1988,7 +2033,10 @@ async def get_active_graph_edges(
     at: str = Query(..., description="ISO timestamp for replay lookup"),
 ) -> list[dict]:
     """Return edge versions active at a timestamp for replay views."""
-    return await _graph_store_call(_get_graph_store_or_503().active_edges_at, at, tenant_id=_tenant(request))
+    edges = await _graph_store_call(_get_graph_store_or_503().active_edges_at, at, tenant_id=_tenant(request))
+    # Preserve the historical list response shape; callers receive all edges
+    # selected by the timestamp query and no page-level sampling is applied.
+    return edges
 
 
 @router.get("/graph/edges/changes", tags=["graph"])
@@ -1998,7 +2046,10 @@ async def get_graph_edge_changes(
     new: str = Query(..., description="New scan ID"),
 ) -> dict:
     """Return edge lifecycle changes between two scan snapshots."""
-    return await _graph_store_call(_get_graph_store_or_503().changed_edges_between_scans, old, new, tenant_id=_tenant(request))
+    changes = await _graph_store_call(_get_graph_store_or_503().changed_edges_between_scans, old, new, tenant_id=_tenant(request))
+    if isinstance(changes, dict):
+        changes["completeness"] = graph_completeness(returned=1, total=1)
+    return changes
 
 
 @router.get("/graph/attack-paths", tags=["graph"], responses={200: _ATTACK_PATHS_OPENAPI_RESPONSE})
@@ -2272,6 +2323,12 @@ async def get_graph_paths(
             if ap.source == source_node_id
         ],
         "pagination": pagination,
+        "completeness": graph_completeness(
+            returned=len(paged_paths),
+            total=len(all_paths),
+            truncated=pagination["has_more"],
+            reason="path_page_limit" if pagination["has_more"] else "",
+        ),
     }
 
 
@@ -2347,6 +2404,12 @@ async def search_graph(
             "next_cursor": next_cursor or "",
             "has_more": bool(next_cursor) if cursor else offset + limit < total,
         },
+        "completeness": graph_completeness(
+            returned=len(results),
+            total=total,
+            truncated=bool(next_cursor) or offset + len(results) < total,
+            reason="search_page_limit" if bool(next_cursor) or offset + len(results) < total else "",
+        ),
     }
 
 
@@ -2439,6 +2502,12 @@ async def list_graph_agents(
             for node in agents
         ],
         "pagination": _page_meta(total, offset, limit, cursor=cursor, next_cursor=next_cursor),
+        "completeness": graph_completeness(
+            returned=len(agents),
+            total=total,
+            truncated=bool(next_cursor) or offset + len(agents) < total,
+            reason="agent_page_limit" if bool(next_cursor) or offset + len(agents) < total else "",
+        ),
     }
 
 
@@ -2538,6 +2607,12 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
             dynamic_only=body.dynamic_only,
             include_ids=set(body.roots),
         ).to_dict(),
+        "completeness": graph_completeness(
+            returned=len(filtered_graph.nodes),
+            total=filtered_graph.stats().get("node_count", len(filtered_graph.nodes)),
+            truncated=truncated,
+            reason="traversal_budget" if truncated else "",
+        ),
     }
 
 
@@ -2564,6 +2639,7 @@ async def get_graph_node(
         "neighbors": node_context["neighbors"],
         "sources": node_context["sources"],
         "impact": node_context["impact"],
+        "completeness": graph_completeness(returned=1, total=1),
     }
 
 
@@ -2610,6 +2686,7 @@ async def get_graph_node_neighbors(
             "truncated": False,
             "neighbors": [],
             "edges": [],
+            "completeness": graph_completeness(returned=0, total=0),
         }
 
     selected_edges: list = []
@@ -2657,6 +2734,12 @@ async def get_graph_node_neighbors(
         "truncated": truncated,
         "neighbors": [node.to_dict() for node in ordered_nodes],
         "edges": [edge.to_dict() for edge in bounded_edges],
+        "completeness": graph_completeness(
+            returned=len(ordered_nodes),
+            total=total_neighbors,
+            truncated=truncated,
+            reason="neighbor_limit" if truncated else "",
+        ),
     }
 
 

--- a/src/agent_bom/graph/completeness.py
+++ b/src/agent_bom/graph/completeness.py
@@ -1,0 +1,35 @@
+"""Completeness metadata shared by graph API and agent-facing projections."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def graph_completeness(
+    *,
+    returned: int,
+    total: int | None = None,
+    truncated: bool = False,
+    sampled: bool = False,
+    reason: str = "",
+) -> dict[str, Any]:
+    """Describe whether a graph response is exhaustive or intentionally bounded.
+
+    ``sampled`` means the producer selected a deterministic representative
+    subset; ``truncated`` means a caller/request limit cut off an otherwise
+    exhaustive result. The booleans are retained alongside ``status`` so
+    clients can branch without string parsing.
+    """
+    status = "truncated" if truncated else "sampled" if sampled else "complete"
+    payload: dict[str, Any] = {
+        "status": status,
+        "complete": status == "complete",
+        "sampled": sampled,
+        "truncated": truncated,
+        "returned": max(0, returned),
+    }
+    if total is not None:
+        payload["total"] = max(0, total)
+    if reason:
+        payload["reason"] = reason
+    return payload

--- a/src/agent_bom/graph/rollup.py
+++ b/src/agent_bom/graph/rollup.py
@@ -22,6 +22,7 @@ from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from agent_bom.graph.completeness import graph_completeness
 from agent_bom.graph.container import UnifiedGraph
 from agent_bom.graph.node import UnifiedNode
 from agent_bom.graph.severity import OCSF_SEVERITY_NAMES, SEVERITY_BUCKETS_WORST_FIRST, SEVERITY_RANK
@@ -438,6 +439,12 @@ def rollup_view(
             "orphan_shown_count": len(orphans),
             "orphan_truncated_count": len(truncated_orphan_ids),
         },
+        "completeness": graph_completeness(
+            returned=len(top_level),
+            total=len(containers) + len(orphan_ids),
+            truncated=bool(truncated_orphan_ids),
+            reason="orphan_limit" if truncated_orphan_ids else "",
+        ),
     }
 
 
@@ -462,6 +469,7 @@ def drill_down(
             "filters": _filters_dict(filters),
             "children": [],
             "summary": {"direct_child_count": 0, "returned_child_count": 0},
+            "completeness": graph_completeness(returned=0, total=0),
         }
 
     children = _contains_children(graph)
@@ -509,6 +517,7 @@ def drill_down(
             "direct_child_count": len(direct),
             "returned_child_count": len(child_entries),
         },
+        "completeness": graph_completeness(returned=len(child_entries), total=len(direct)),
     }
 
 
@@ -527,11 +536,12 @@ def attack_path_view(
     ``edges``) the caller already materialised — this function does not derive
     paths, it only assembles the readable view around them.
     """
-    ranked = sorted(
+    ranked_all = sorted(
         attack_paths,
         key=lambda p: (getattr(p, "composite_risk", 0.0), len(getattr(p, "hops", []))),
         reverse=True,
-    )[: max(0, max_paths)]
+    )
+    ranked = ranked_all[: max(0, max_paths)]
 
     path_node_ids: list[str] = []
     seen_nodes: set[str] = set()
@@ -580,6 +590,12 @@ def attack_path_view(
             "path_edge_count": len(path_edges),
             "collapsed_count": len(collapsed_off_path),
         },
+        "completeness": graph_completeness(
+            returned=len(ranked),
+            total=len(ranked_all),
+            truncated=len(ranked_all) > len(ranked),
+            reason="path_limit" if len(ranked_all) > len(ranked) else "",
+        ),
     }
 
 

--- a/src/agent_bom/mcp_tools/analysis.py
+++ b/src/agent_bom/mcp_tools/analysis.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 
+from agent_bom.graph.completeness import graph_completeness
 from agent_bom.mcp_errors import (
     CODE_INTERNAL_UNEXPECTED,
     CODE_NOT_FOUND_AGENTS,
@@ -112,6 +113,15 @@ async def context_graph_impl(
         risks = compute_interaction_risks(graph)
         result = to_serializable(graph, paths, risks)
         result["stats"]["lateral_paths_truncated"] = paths_truncated
+        result["completeness"] = graph_completeness(
+            returned=len(paths),
+            sampled=paths_truncated,
+            reason=(
+                "multi-source path budget reached; request a source_agent for exhaustive local traversal"
+                if paths_truncated
+                else ""
+            ),
+        )
         return _truncate_response(json.dumps(result, indent=2, default=str))
     except Exception as exc:
         logger.exception("MCP tool error")

--- a/src/agent_bom/mcp_tools/graph.py
+++ b/src/agent_bom/mcp_tools/graph.py
@@ -7,6 +7,7 @@ import json
 import logging
 from typing import Any
 
+from agent_bom.graph.completeness import graph_completeness
 from agent_bom.graph.severity import severity_rank
 from agent_bom.mcp_errors import CODE_INTERNAL_UNEXPECTED, CODE_VALIDATION_INVALID_ARGUMENT, mcp_error_json
 from agent_bom.mcp_tenant import resolve_mcp_tool_tenant_id
@@ -202,6 +203,12 @@ async def exposure_paths_impl(
             "nodes": [node.to_dict() for node in nodes],
             "edges": [edge.to_dict() for edge in edges],
             "stats": stats,
+            "completeness": graph_completeness(
+                returned=len(ranked_paths),
+                total=total,
+                truncated=len(ranked_paths) < total,
+                reason="path_limit_or_filter" if len(ranked_paths) < total else "",
+            ),
         }
         if not ranked_paths:
             payload["message"] = _empty_exposure_paths_message(total=total, min_risk=min_risk)

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2308,6 +2308,7 @@ class TestGraphStoreBackendSelection:
         second = client.get("/v1/graph/search", params={"q": "server", "limit": 2, "cursor": next_cursor})
         assert second.status_code == 200
         assert second.json()["pagination"]["cursor"] == next_cursor
+        assert second.json()["completeness"]["status"] == "truncated"
 
     def test_graph_cursor_rejects_invalid_values(self, recording_graph_store):
         client = TestClient(app)
@@ -2353,6 +2354,7 @@ class TestGraphStoreBackendSelection:
         assert [path["target"] for path in body["paths"]] == ["server:s", "vuln:cve"]
         assert body["attack_paths"][0]["exposure_path"]["nodeIds"] == ["agent:a", "server:s", "vuln:cve"]
         assert body["attack_paths"][0]["exposure_path"]["severity"] == "critical"
+        assert body["completeness"]["status"] == "complete"
         assert any(call[0] == "bfs_paths" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
@@ -2555,6 +2557,14 @@ class TestGraphStoreBackendSelection:
         body = response.json()
         assert body["roots"] == ["agent:a"]
         assert body["truncated"] is False
+        assert body["completeness"] == {
+            "status": "complete",
+            "complete": True,
+            "sampled": False,
+            "truncated": False,
+            "returned": 3,
+            "total": 3,
+        }
         assert set(body["depth_by_node"]) == {"agent:a", "server:s", "vuln:CVE-2026-1"}
         assert {node["id"] for node in body["nodes"]} == {"agent:a", "server:s", "vuln:CVE-2026-1"}
         assert {(edge["source"], edge["target"]) for edge in body["edges"]} == {
@@ -2836,6 +2846,8 @@ class TestGraphStoreBackendSelection:
         assert body["total_neighbors"] == 5
         assert len(body["neighbors"]) == 2
         assert body["truncated"] is True
+        assert body["completeness"]["status"] == "truncated"
+        assert body["completeness"]["total"] == 5
         # Bounded set is deterministic so repeated expands are stable.
         assert [node["id"] for node in body["neighbors"]] == ["pkg:p0", "pkg:p1"]
 

--- a/tests/test_graph_completeness.py
+++ b/tests/test_graph_completeness.py
@@ -1,0 +1,21 @@
+from agent_bom.graph.completeness import graph_completeness
+
+
+def test_graph_completeness_defaults_to_complete():
+    assert graph_completeness(returned=3, total=3) == {
+        "status": "complete",
+        "complete": True,
+        "sampled": False,
+        "truncated": False,
+        "returned": 3,
+        "total": 3,
+    }
+
+
+def test_graph_completeness_distinguishes_sampled_and_truncated():
+    sampled = graph_completeness(returned=10, sampled=True, reason="source budget")
+    truncated = graph_completeness(returned=10, total=100, truncated=True, reason="page limit")
+    assert sampled["status"] == "sampled"
+    assert sampled["complete"] is False
+    assert truncated["status"] == "truncated"
+    assert truncated["total"] == 100

--- a/tests/test_graph_rollup.py
+++ b/tests/test_graph_rollup.py
@@ -327,10 +327,12 @@ def test_rollup_endpoint_returns_top_level(tmp_path) -> None:
         assert body["mode"] == "rollup"
         assert body["summary"]["top_level_count"] == 1
         assert body["top_level"][0]["id"] == "org:acme"
+        assert body["completeness"]["status"] == "complete"
 
         drill = client.get("/v1/graph/rollup?scan_id=estate-scan&node=app:web")
         assert drill.status_code == 200
         assert {c["id"] for c in drill.json()["children"]} == {"server:s1", "server:s2"}
+        assert drill.json()["completeness"]["status"] == "complete"
     finally:
         set_graph_store(original)
 

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -641,6 +641,15 @@ export default function ContextPage() {
         </div>
       )}
       {graphData && <ContextStats data={graphData} compact />}
+      {graphData?.completeness && !graphData.completeness.complete && (
+        <div className="mx-4 mt-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
+          This is a bounded {graphData.completeness.status} view
+          {graphData.completeness.total != null
+            ? ` (${graphData.completeness.returned} of ${graphData.completeness.total} returned)`
+            : ""}
+          . Expand or filter the graph to investigate more evidence.
+        </div>
+      )}
 
       {/* Main area: graph + sidebar */}
       <div className="flex-1 flex overflow-hidden">

--- a/ui/lib/context-graph.ts
+++ b/ui/lib/context-graph.ts
@@ -70,12 +70,23 @@ export interface ContextStats {
   lateral_paths_truncated?: boolean;
 }
 
+export interface GraphCompleteness {
+  status: "complete" | "sampled" | "truncated";
+  complete: boolean;
+  sampled: boolean;
+  truncated: boolean;
+  returned: number;
+  total?: number;
+  reason?: string;
+}
+
 export interface ContextGraphData {
   nodes: ContextGraphNode[];
   edges: ContextGraphEdge[];
   lateral_paths: LateralPath[];
   interaction_risks: InteractionRisk[];
   stats: ContextStats;
+  completeness?: GraphCompleteness;
 }
 
 // ─── Kind → ReactFlow node type ──────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- publish a shared `complete` / `sampled` / `truncated` contract on bounded graph API, rollup, search, neighborhood, attack-path, governance, and MCP responses
- preserve legacy list response shapes while making UI context graphs render an explicit bounded-view warning
- keep existing node/edge/database contracts unchanged and add regression coverage for deterministic counts and truncation semantics

## Verification
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run pytest -q tests/test_graph_api.py tests/test_graph_rollup.py tests/test_graph_scale_quickwins.py tests/test_graph_completeness.py tests/test_mcp_exposure_paths.py` (99 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run ruff check ...` (passed)
- `UV_CACHE_DIR=/tmp/agent-bom-uv-cache uv run mypy src/agent_bom/api/routes/graph.py src/agent_bom/graph/completeness.py src/agent_bom/graph/rollup.py src/agent_bom/mcp_tools/graph.py src/agent_bom/mcp_tools/analysis.py --python-version 3.11 --ignore-missing-imports --disable-error-code import-untyped` (passed)
- `npm run typecheck` (passed)
- `make preflight` (passed)
- `git diff --check` (passed)

## Notes
- This is a contract/readability fix, not a claim that the in-memory producer is store-backed by default. Fleet-scale proof remains a separate follow-up.