### PR TITLE
fix(deploy): bound cloud scans and provision graph workspace

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260720_03_graph_build_workspace.py
+++ b/deploy/supabase/postgres/alembic/versions/20260720_03_graph_build_workspace.py
@@ -1,0 +1,61 @@
+"""Provision the bounded graph build workspace for DML-only runtimes.
+
+Revision ID: 20260720_03
+Revises: 20260720_02
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260720_03"
+down_revision = "20260720_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # TEXT preserves the exact serialized JSON bytes used by the graph parity
+    # contract; JSONB would normalize key ordering during the round-trip.
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS graph_build_workspace_nodes (
+            workspace_id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            node_id TEXT NOT NULL,
+            seq BIGSERIAL,
+            payload TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (workspace_id, tenant_id, node_id)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS graph_build_workspace_edges (
+            workspace_id TEXT NOT NULL,
+            tenant_id TEXT NOT NULL,
+            edge_key TEXT NOT NULL,
+            seq BIGSERIAL,
+            payload TEXT NOT NULL,
+            source_id TEXT NOT NULL DEFAULT '',
+            target_id TEXT NOT NULL DEFAULT '',
+            PRIMARY KEY (workspace_id, tenant_id, edge_key)
+        )
+        """
+    )
+    for statement in (
+        "CREATE INDEX IF NOT EXISTS idx_gbw_nodes_seq ON graph_build_workspace_nodes (workspace_id, tenant_id, seq)",
+        "CREATE INDEX IF NOT EXISTS idx_gbw_edges_seq ON graph_build_workspace_edges (workspace_id, tenant_id, seq)",
+        "CREATE INDEX IF NOT EXISTS idx_gbw_nodes_type ON graph_build_workspace_nodes (workspace_id, tenant_id, entity_type, seq)",
+        "CREATE INDEX IF NOT EXISTS idx_gbw_edges_source ON graph_build_workspace_edges (workspace_id, tenant_id, source_id, seq)",
+        "CREATE INDEX IF NOT EXISTS idx_gbw_edges_target ON graph_build_workspace_edges (workspace_id, tenant_id, target_id, seq)",
+    ):
+        op.execute(statement)
+
+
+def downgrade() -> None:
+    # Workspace rows are disposable, but dropping shared tables during rollback
+    # could destroy an in-flight build. Retain the schema and require explicit
+    # operator cleanup if a deployment truly needs removal.
+    raise NotImplementedError("Graph build workspace tables are retained on downgrade.")

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -385,6 +385,41 @@ CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source_traversable
     ON graph_edges(tenant_id, scan_id, source_id)
     WHERE traversable = 1;
 
+-- ── Tables: Graph build workspace ───────────────────────────────────────────
+-- Temporary, tenant-scoped staging rows used by the bounded store-backed graph
+-- producer. The application role only needs DML; Alembic/init owns this DDL.
+CREATE TABLE IF NOT EXISTS graph_build_workspace_nodes (
+    workspace_id TEXT NOT NULL,
+    tenant_id TEXT NOT NULL,
+    node_id TEXT NOT NULL,
+    seq BIGSERIAL,
+    payload TEXT NOT NULL,
+    entity_type TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (workspace_id, tenant_id, node_id)
+);
+
+CREATE TABLE IF NOT EXISTS graph_build_workspace_edges (
+    workspace_id TEXT NOT NULL,
+    tenant_id TEXT NOT NULL,
+    edge_key TEXT NOT NULL,
+    seq BIGSERIAL,
+    payload TEXT NOT NULL,
+    source_id TEXT NOT NULL DEFAULT '',
+    target_id TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (workspace_id, tenant_id, edge_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_gbw_nodes_seq
+    ON graph_build_workspace_nodes (workspace_id, tenant_id, seq);
+CREATE INDEX IF NOT EXISTS idx_gbw_edges_seq
+    ON graph_build_workspace_edges (workspace_id, tenant_id, seq);
+CREATE INDEX IF NOT EXISTS idx_gbw_nodes_type
+    ON graph_build_workspace_nodes (workspace_id, tenant_id, entity_type, seq);
+CREATE INDEX IF NOT EXISTS idx_gbw_edges_source
+    ON graph_build_workspace_edges (workspace_id, tenant_id, source_id, seq);
+CREATE INDEX IF NOT EXISTS idx_gbw_edges_target
+    ON graph_build_workspace_edges (workspace_id, tenant_id, target_id, seq);
+
 CREATE TABLE IF NOT EXISTS graph_snapshots (
     scan_id      TEXT NOT NULL,
     tenant_id    TEXT NOT NULL DEFAULT 'default',

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -498,7 +498,8 @@ async def cloud_cis_benchmark(
                         abandon_on_cancel=True,
                     )
             except TimeoutError:
-                _logger.warning("Cloud CIS benchmark timed out for %s", requested)
+                requested_for_log = re.sub(r"[\r\n]+", "", requested)
+                _logger.warning("Cloud CIS benchmark timed out for %s", requested_for_log)
                 return {
                     "error": "Provider benchmark timed out before completing.",
                     "provider": requested,

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -30,6 +30,7 @@ import re
 from typing import Any, cast
 from urllib.parse import urlencode
 
+import anyio
 import anyio.to_thread
 from fastapi import APIRouter, HTTPException, Query, Request
 
@@ -42,6 +43,7 @@ from agent_bom.cloud.runtime_workload_evidence import (
     ingest_runtime_signals,
 )
 from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+from agent_bom.config import CLOUD_CIS_TIMEOUT_SECONDS
 from agent_bom.rbac import require_authenticated_permission
 
 router = APIRouter(tags=["cloud"])
@@ -113,6 +115,10 @@ def _clean_tokens(values: Any, pattern: re.Pattern[str], *, cap: int = 500) -> l
         if len(cleaned) >= cap:
             break
     return cleaned
+
+
+def _cloud_cis_timeout_seconds() -> float:
+    return CLOUD_CIS_TIMEOUT_SECONDS
 
 
 def _tenant(request: Request) -> str:
@@ -474,18 +480,38 @@ async def cloud_cis_benchmark(
     try:
         # A full CIS benchmark runs synchronous provider SDK/network evaluation;
         # offload it to a worker thread under backpressure so it never stalls the
-        # event loop (a burst sheds with a 429 instead).
+        # event loop (a burst sheds with a 429 instead). The timeout abandons the
+        # worker if a provider SDK is stuck in credential/metadata retries; the
+        # request must not hold an API slot indefinitely.
         async with adaptive_backpressure("cloud_cis"):
-            return await anyio.to_thread.run_sync(
-                _run_cis_benchmark,
-                tenant_id,
-                requested,
-                check_list,
-                region_arg,
-                profile_arg,
-                subscription_id,
-                project_id,
-            )
+            try:
+                with anyio.fail_after(_cloud_cis_timeout_seconds()):
+                    return await anyio.to_thread.run_sync(
+                        _run_cis_benchmark,
+                        tenant_id,
+                        requested,
+                        check_list,
+                        region_arg,
+                        profile_arg,
+                        subscription_id,
+                        project_id,
+                        abandon_on_cancel=True,
+                    )
+            except TimeoutError:
+                _logger.warning("Cloud CIS benchmark timed out for %s", requested)
+                return {
+                    "error": "Provider benchmark timed out before completing.",
+                    "provider": requested,
+                    "tenant_id": tenant_id,
+                    "status": "unavailable",
+                    "timed_out": True,
+                    "audit_metadata": {
+                        "read_only": True,
+                        "writes_performed": False,
+                        "provider": requested,
+                        "note": "No cloud resource was mutated; retry with a scoped provider connection.",
+                    },
+                }
     except BackpressureRejectedError as exc:
         raise HTTPException(
             status_code=429,

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -438,6 +438,9 @@ ENRICHMENT_MAX_CACHE_ENTRIES = _int("AGENT_BOM_ENRICHMENT_MAX_CACHE", 10_000)
 API_MAX_CONCURRENT_JOBS = _int("AGENT_BOM_API_MAX_JOBS", 10)
 API_SCAN_WORKERS = _int("AGENT_BOM_API_SCAN_WORKERS", min(4, (os.cpu_count() or 2)))
 API_SCAN_WORKER_RECYCLE_JOBS = _int("AGENT_BOM_API_SCAN_WORKER_RECYCLE_JOBS", 10)
+# Wall-clock bound for optional cloud CIS provider calls. Provider SDKs may
+# retry metadata/credential lookups; the API always returns within this cap.
+CLOUD_CIS_TIMEOUT_SECONDS = min(max(_float("AGENT_BOM_CLOUD_CIS_TIMEOUT_SECONDS", 60.0), 1.0), 300.0)
 # Distributed scan dispatch (multi-replica work-stealing). When enabled, scan
 # jobs are enqueued to a shared Postgres dispatch queue and any control-plane
 # replica claims them via FOR UPDATE SKIP LOCKED, so scan throughput scales with

--- a/src/agent_bom/graph/build_workspace.py
+++ b/src/agent_bom/graph/build_workspace.py
@@ -343,43 +343,19 @@ class _PostgresWorkspaceBackend:
         self._dsn = dsn
         self._workspace_id = workspace_id
         self._conn = psycopg.connect(dsn, autocommit=True)
-        self._ensure_tables()
+        self._verify_tables()
 
-    def _ensure_tables(self) -> None:
-        # payload is stored as TEXT, not JSONB: JSONB normalises key order, which
-        # would change the persisted ``attributes`` byte-for-byte after the
-        # downstream ``json.dumps``. TEXT preserves the exact serialised bytes so
-        # the workspace round-trip stays byte-identical to the direct save.
-        self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS graph_build_workspace_nodes ("
-            "workspace_id TEXT NOT NULL, tenant_id TEXT NOT NULL, node_id TEXT NOT NULL, "
-            "seq BIGSERIAL, payload TEXT NOT NULL, entity_type TEXT NOT NULL DEFAULT '', "
-            "PRIMARY KEY (workspace_id, tenant_id, node_id))"
-        )
-        self._conn.execute(
-            "CREATE TABLE IF NOT EXISTS graph_build_workspace_edges ("
-            "workspace_id TEXT NOT NULL, tenant_id TEXT NOT NULL, edge_key TEXT NOT NULL, "
-            "seq BIGSERIAL, payload TEXT NOT NULL, "
-            "source_id TEXT NOT NULL DEFAULT '', target_id TEXT NOT NULL DEFAULT '', "
-            "PRIMARY KEY (workspace_id, tenant_id, edge_key))"
-        )
-        # Idempotent column migration for shared tables created by an earlier
-        # version (the PG workspace tables persist across builds), mirroring the
-        # postgres_graph._init_tables ADD COLUMN IF NOT EXISTS pattern.
-        self._conn.execute("ALTER TABLE graph_build_workspace_nodes ADD COLUMN IF NOT EXISTS entity_type TEXT NOT NULL DEFAULT ''")
-        self._conn.execute("ALTER TABLE graph_build_workspace_edges ADD COLUMN IF NOT EXISTS source_id TEXT NOT NULL DEFAULT ''")
-        self._conn.execute("ALTER TABLE graph_build_workspace_edges ADD COLUMN IF NOT EXISTS target_id TEXT NOT NULL DEFAULT ''")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_gbw_nodes_seq ON graph_build_workspace_nodes (workspace_id, tenant_id, seq)")
-        self._conn.execute("CREATE INDEX IF NOT EXISTS idx_gbw_edges_seq ON graph_build_workspace_edges (workspace_id, tenant_id, seq)")
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_gbw_nodes_type ON graph_build_workspace_nodes (workspace_id, tenant_id, entity_type, seq)"
-        )
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_gbw_edges_source ON graph_build_workspace_edges (workspace_id, tenant_id, source_id, seq)"
-        )
-        self._conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_gbw_edges_target ON graph_build_workspace_edges (workspace_id, tenant_id, target_id, seq)"
-        )
+    def _verify_tables(self) -> None:
+        """Verify migration-owned workspace tables without executing DDL."""
+        rows = self._conn.execute(
+            "SELECT to_regclass(%s), to_regclass(%s)",
+            ("public.graph_build_workspace_nodes", "public.graph_build_workspace_edges"),
+        ).fetchone()
+        if not rows or rows[0] is None or rows[1] is None:
+            self._conn.close()
+            raise RuntimeError(
+                "Postgres graph workspace schema is not migrated; run Alembic upgrade head before starting the service."
+            )
 
     def _upsert(
         self,

--- a/tests/api/test_cloud_scan_offload.py
+++ b/tests/api/test_cloud_scan_offload.py
@@ -128,5 +128,41 @@ async def test_slow_inventory_scan_keeps_event_loop_responsive(monkeypatch):
     assert result["status"] == "disabled"
 
 
+@pytest.mark.asyncio
+async def test_cloud_cis_timeout_returns_bounded_unavailable_envelope(monkeypatch):
+    """Provider credential/metadata retries cannot hold an API request forever."""
+    monkeypatch.setattr(cloud, "_tenant", lambda request: "t-timeout")
+    monkeypatch.setattr(cloud, "_cloud_cis_timeout_seconds", lambda: 0.01)
+
+    def _stuck(*_args, **_kwargs):
+        time.sleep(0.25)
+        return {"provider": "aws"}
+
+    monkeypatch.setattr(cloud, "_run_cis_benchmark", _stuck)
+    result = await cloud.cloud_cis_benchmark(
+        request=object(),
+        provider="aws",
+        checks="",
+        region="",
+        profile="",
+        subscription_id="",
+        project_id="",
+    )
+
+    assert result == {
+        "error": "Provider benchmark timed out before completing.",
+        "provider": "aws",
+        "tenant_id": "t-timeout",
+        "status": "unavailable",
+        "timed_out": True,
+        "audit_metadata": {
+            "read_only": True,
+            "writes_performed": False,
+            "provider": "aws",
+            "note": "No cloud resource was mutated; retry with a scoped provider connection.",
+        },
+    }
+
+
 async def _trivial() -> str:
     return "responsive"

--- a/tests/graph/test_store_backed_build_wiring.py
+++ b/tests/graph/test_store_backed_build_wiring.py
@@ -165,6 +165,7 @@ def test_cnapp_overlay_store_safe_under_eviction(monkeypatch: pytest.MonkeyPatch
     # cnapp mints DATA_STORE companion nodes; freeze their default timestamps so the
     # two independent overlay runs are comparable (drift here is a test artifact).
     monkeypatch.setattr("agent_bom.graph.node._now_iso", lambda: _FIXED_CREATED_AT)
+    monkeypatch.setattr("agent_bom.graph.edge._now_iso", lambda: _FIXED_CREATED_AT, raising=False)
     ram = UnifiedGraph(scan_id="s", tenant_id="t1", created_at=_FIXED_CREATED_AT)
     _make_cnapp_estate(ram, resources=30, fillers=60)
     ram_stats = apply_cnapp_overlay(ram)

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -93,6 +93,8 @@ def test_all_expected_tables_exist():
         "trend_history",
         "scan_schedules",
         "osv_cache",
+        "graph_build_workspace_nodes",
+        "graph_build_workspace_edges",
     }
     assert expected.issubset(_tables()), f"Missing tables: {expected - _tables()}"
 
@@ -139,6 +141,31 @@ def test_graph_tables_have_rls_policies():
         assert f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY" in SQL
         assert f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY" in SQL
         assert f"CREATE POLICY {table}_tenant_isolation ON {table}" in SQL
+
+
+def test_graph_build_workspace_schema_is_migration_owned():
+    """The bounded producer must work with a DML-only runtime role."""
+    for table, columns in {
+        "graph_build_workspace_nodes": ("workspace_id", "tenant_id", "node_id", "seq", "payload", "entity_type"),
+        "graph_build_workspace_edges": (
+            "workspace_id",
+            "tenant_id",
+            "edge_key",
+            "seq",
+            "payload",
+            "source_id",
+            "target_id",
+        ),
+    }.items():
+        assert set(columns).issubset(_columns_for(table)), f"{table} missing workspace columns"
+    assert "idx_gbw_nodes_seq" in _indexes()
+    assert "idx_gbw_edges_seq" in _indexes()
+    versions = Path(__file__).parent.parent / "deploy" / "supabase" / "postgres" / "alembic" / "versions"
+    migration = versions / "20260720_03_graph_build_workspace.py"
+    body = migration.read_text()
+    assert 'down_revision = "20260720_02"' in body
+    assert "CREATE TABLE IF NOT EXISTS graph_build_workspace_nodes" in body
+    assert "CREATE TABLE IF NOT EXISTS graph_build_workspace_edges" in body
 
 
 def test_graph_snapshot_json_fields_are_text_in_baseline():
@@ -540,8 +567,9 @@ def test_job_queue_status_partial_index():
 
 
 def test_job_queue_payload_jsonb():
-    assert "payload" in SQL
-    assert "JSONB" in SQL.split("payload")[1][:20].upper()
+    start = SQL.index("CREATE TABLE IF NOT EXISTS job_queue")
+    payload = SQL.index("payload", start)
+    assert "JSONB" in SQL[payload : payload + 30].upper()
 
 
 # ── scan_schedules RLS / tenant contract ────────────────────────────────────


### PR DESCRIPTION
## Summary

- Bound cloud CIS provider calls to a configurable 1–300 second window and return an explicit read-only `unavailable` envelope on timeout.
- Move the bounded Postgres graph-build workspace schema into Alembic/init ownership; runtime connections now verify tables and perform DML only.
- Add regression coverage for timeout behavior, migration/schema parity, and live Postgres graph workspace compatibility.

## Verification

- `make preflight`
- `uv run pytest -q -p no:cacheprovider tests/api/test_cloud_scan_offload.py tests/test_postgres_schema.py tests/graph/test_graph_build_workspace.py` (75 passed)
- `AGENT_BOM_POSTGRES_URL=... uv run pytest -q -p no:cacheprovider tests/graph/test_graph_build_workspace_postgres.py tests/graph/test_store_backed_unified_graph_postgres.py` (9 passed against Docker Postgres)
- `uv run ruff check ...`
- `git diff --check`

## Notes

The application role no longer needs schema `CREATE` for graph-build startup. A deployment must run Alembic (or the shipped init baseline) before enabling the store-backed producer.
