### PR TITLE
fix(output): publish advisory and asset identity contracts

### DIFF
--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -36,7 +36,7 @@ def stable_id(*parts: str) -> str:
 class FindingType(str, Enum):
     """What category of issue this finding represents."""
 
-    CVE = "CVE"  # Software vulnerability (from OSV/GHSA/NVIDIA)
+    CVE = "CVE"  # Legacy software-vulnerability value (from OSV/GHSA/NVIDIA)
     CIS_FAIL = "CIS_FAIL"  # CIS benchmark control failure
     CIS_ERROR = "CIS_ERROR"  # CIS control could not be evaluated reliably
     CLOUD_BEST_PRACTICE_FAIL = "CLOUD_BEST_PRACTICE_FAIL"
@@ -353,7 +353,7 @@ class Finding:
         )
         if not self.id:
             # Deterministic ID: same CVE on same asset always same ID
-            cve_part = self.cve_id or self.title
+            cve_part = self.vulnerability_id or self.title
             pkg_name = ""
             pkg_version = ""
             if self.asset.asset_type == "package" and self.asset.identifier:
@@ -379,6 +379,45 @@ class Finding:
     def canonical_id(self) -> str:
         """Canonical alias for id used by report and graph consumers."""
         return self.id
+
+    @property
+    def vulnerability_id(self) -> Optional[str]:
+        """Canonical advisory identity, regardless of CVE/GHSA/OSV namespace.
+
+        ``cve_id`` remains the wire-compatible legacy field. New producers may
+        populate ``evidence.vulnerability_id`` and consumers should prefer this
+        namespace-neutral alias when joining findings to advisories.
+        """
+        if self.cve_id:
+            return self.cve_id
+        raw = self.evidence.get("vulnerability_id") if isinstance(self.evidence, dict) else None
+        return str(raw).strip() or None if raw is not None else None
+
+    @property
+    def advisory_ids(self) -> list[str]:
+        """Return deterministic, de-duplicated CVE/GHSA/OSV advisory aliases."""
+        raw: list[object] = [self.vulnerability_id]
+        if isinstance(self.evidence, dict):
+            raw.extend(self.evidence.get("cve_ids") or [])
+            raw.extend(self.evidence.get("advisory_aliases") or [])
+            raw.extend(self.evidence.get("advisory_ids") or [])
+        seen: set[str] = set()
+        result: list[str] = []
+        for value in raw:
+            item = str(value or "").strip()
+            if item and item not in seen:
+                seen.add(item)
+                result.append(item)
+        return result
+
+    @property
+    def finding_category(self) -> str:
+        """Stable category for consumers while legacy finding types remain intact."""
+        if self.finding_type is FindingType.CVE:
+            return "vulnerability"
+        if self.finding_type in {FindingType.CIS_FAIL, FindingType.CIS_ERROR}:
+            return "compliance"
+        return self.finding_type.value.lower()
 
     def _legacy_control_tags(self) -> list[ControlTag]:
         """Return normalized controls derived from legacy tag arrays."""
@@ -454,6 +493,7 @@ class Finding:
             "id": self.id,
             "canonical_id": self.canonical_id,
             "finding_type": self.finding_type.value,
+            "finding_category": self.finding_category,
             "source": self.source.value,
             "asset": {
                 "name": self.asset.name,
@@ -481,6 +521,8 @@ class Finding:
             "title": self.title,
             "description": self.description,
             "cve_id": self.cve_id,
+            "vulnerability_id": self.vulnerability_id,
+            "advisory_ids": self.advisory_ids,
             "cve_ids": self.evidence.get("cve_ids") or ([self.cve_id] if self.cve_id else []),
             "match_confidence_tier": self.evidence.get("match_confidence_tier"),
             "advisory_aliases": self.evidence.get("advisory_aliases") or [],

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -736,6 +736,50 @@ def _build_inventory_snapshot(report: AIBOMReport) -> dict:
     }
 
 
+def _build_asset_inventory(findings: list[dict[str, object]]) -> list[dict[str, object]]:
+    """Materialize unique finding assets for cross-surface joins.
+
+    Findings may repeat the same package, cloud resource, or MCP server. Keep
+    one stable asset record and attach the finding IDs that reference it so the
+    UI/control plane can navigate from inventory to evidence without treating
+    repeated finding rows as duplicate assets.
+    """
+    assets: dict[str, dict[str, object]] = {}
+    for finding in findings:
+        raw_asset = finding.get("asset")
+        if not isinstance(raw_asset, dict):
+            continue
+        stable_id = str(raw_asset.get("stable_id") or raw_asset.get("canonical_id") or "").strip()
+        if not stable_id:
+            continue
+        asset = assets.setdefault(
+            stable_id,
+            {
+                "schema_version": "1",
+                "stable_id": stable_id,
+                "canonical_id": str(raw_asset.get("canonical_id") or stable_id),
+                "name": raw_asset.get("name"),
+                "asset_type": raw_asset.get("asset_type"),
+                "identifier": raw_asset.get("identifier"),
+                "location": raw_asset.get("location"),
+                "provider": raw_asset.get("provider"),
+                "account_ref": raw_asset.get("account_ref"),
+                "region": raw_asset.get("region"),
+                "environment": raw_asset.get("environment"),
+                "finding_ids": [],
+            },
+        )
+        finding_id = str(finding.get("canonical_id") or finding.get("id") or "").strip()
+        finding_ids = asset["finding_ids"]
+        if isinstance(finding_ids, list) and finding_id and finding_id not in finding_ids:
+            finding_ids.append(finding_id)
+    for asset in assets.values():
+        finding_ids = asset["finding_ids"]
+        if isinstance(finding_ids, list):
+            asset["finding_ids"] = sorted(str(item) for item in finding_ids)
+    return [assets[key] for key in sorted(assets)]
+
+
 def _build_mcp_runtime_diff(report: AIBOMReport) -> dict | None:
     """Compare configured servers against observed/runtime evidence."""
     introspection_results = {
@@ -941,6 +985,7 @@ def to_json(report: AIBOMReport) -> dict:
     cve_pairs = list(zip(cve_findings(report, report.blast_radii), report.blast_radii, strict=True)) if report.blast_radii else []
     exposure_paths = [exposure_path_for_report_finding(finding, br=br, rank=rank) for rank, (finding, br) in enumerate(cve_pairs, start=1)]
     unified_findings = [finding.to_dict() for finding in report.to_findings()]
+    asset_inventory = _build_asset_inventory(unified_findings)
     finding_summary = _build_finding_summary(unified_findings)
     from agent_bom.evidence.scan_run import effective_scan_run
 
@@ -980,11 +1025,13 @@ def to_json(report: AIBOMReport) -> dict:
             "total_vulnerabilities": report.total_vulnerabilities,
             "critical_findings": len(report.critical_vulns),
             "total_findings": finding_summary["total"],
+            "unique_assets": len(asset_inventory),
             "critical_unified_findings": finding_summary["by_severity"]["critical"],
             "high_unified_findings": finding_summary["by_severity"]["high"],
             "coverage_warnings": list(report.coverage_warnings),
         },
         "finding_summary": finding_summary,
+        "assets": asset_inventory,
         "coverage_warnings": list(report.coverage_warnings),
         "inventory_snapshot": inventory_snapshot,
         "agents": [

--- a/tests/test_output_fidelity_correctness.py
+++ b/tests/test_output_fidelity_correctness.py
@@ -207,6 +207,36 @@ def test_json_csv_and_sarif_include_explicit_and_blast_findings():
     assert len(sarif_results) == 2
 
 
+def test_json_exposes_namespace_neutral_advisory_and_unique_asset_contract():
+    """GHSA/OSV identifiers and repeated assets remain joinable without renaming legacy fields."""
+    from agent_bom.output.json_fmt import to_json
+
+    asset = Asset(name="shared-package", asset_type="package", identifier="pkg:pypi/shared-package@1.0.0")
+    first = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.SBOM,
+        asset=asset,
+        severity="high",
+        cve_id="GHSA-demo-1234",
+        evidence={"advisory_aliases": ["OSV-demo-1234"]},
+    )
+    second = Finding(
+        finding_type=FindingType.CVE,
+        source=first.source,
+        asset=asset,
+        severity="medium",
+        cve_id="GHSA-other-5678",
+    )
+    payload = to_json(AIBOMReport(findings=[first, second]))
+
+    assert payload["findings"][0]["finding_category"] == "vulnerability"
+    assert payload["findings"][0]["vulnerability_id"] == "GHSA-demo-1234"
+    assert payload["findings"][0]["advisory_ids"] == ["GHSA-demo-1234", "OSV-demo-1234"]
+    assert payload["summary"]["unique_assets"] == 1
+    assert payload["assets"][0]["stable_id"] == asset.stable_id
+    assert len(payload["assets"][0]["finding_ids"]) == 2
+
+
 def test_parquet_export_includes_base_reachability():
     pytest.importorskip("pyarrow")
     import pyarrow as pa


### PR DESCRIPTION
## Summary

- Publish namespace-neutral `vulnerability_id`, deterministic `advisory_ids`, and `finding_category` fields while retaining `cve_id`, `cve_ids`, and `FindingType.CVE` for compatibility.
- Materialize a deduplicated top-level `assets` inventory with stable/canonical IDs and reverse `finding_ids`, so repeated finding rows do not look like duplicate assets.
- Make stable finding IDs use the canonical advisory identity and add regression coverage for GHSA/OSV aliases and asset joins.

## Verification

- `make preflight`
- `uv run pytest -q -p no:cacheprovider tests/test_output_fidelity_correctness.py tests/test_output_formats.py tests/test_stable_ids.py tests/test_finding.py tests/api/test_api_scan_findings_wiring.py` (145 passed)
- `uv run ruff check ...`
- `uv run mypy src/agent_bom/finding.py src/agent_bom/output/json_fmt.py`
- `git diff --check`

## Compatibility

This is additive. Existing consumers can continue using `finding_type=CVE`, `cve_id`, and `cve_ids`; new integrations should join on `vulnerability_id`, `advisory_ids`, and the asset `stable_id`.
