### PR TITLE
fix(graph): honor mounted Postgres workspace secrets

### DIFF
--- a/src/agent_bom/graph/build_workspace.py
+++ b/src/agent_bom/graph/build_workspace.py
@@ -336,13 +336,18 @@ class _PostgresWorkspaceBackend:
     by ``itersize`` rather than the total row count.
     """
 
-    def __init__(self, dsn: str, workspace_id: str) -> None:
+    def __init__(self, dsn: str, workspace_id: str, *, password: str | None = None) -> None:
         import psycopg
 
         self._psycopg = psycopg
         self._dsn = dsn
         self._workspace_id = workspace_id
-        self._conn = psycopg.connect(dsn, autocommit=True)
+        connect_kwargs: dict[str, Any] = {"autocommit": True}
+        if password is not None:
+            # Keep mounted/static/IAM credentials out of the DSN, which can be
+            # exposed by connection diagnostics or server activity views.
+            connect_kwargs["password"] = password
+        self._conn = psycopg.connect(dsn, **connect_kwargs)
         self._verify_tables()
 
     def _verify_tables(self) -> None:
@@ -607,7 +612,18 @@ def open_workspace_backend(*, workspace_id: str = "", backend: str = "auto") -> 
     if chosen == "postgres":
         if not dsn:
             raise ValueError("AGENT_BOM_POSTGRES_URL is required for the postgres workspace backend.")
-        return _PostgresWorkspaceBackend(dsn, wsid)
+        # The API pool already resolves ``*_FILE`` and IAM credentials through
+        # postgres_common. Use the same contract for the graph workspace when
+        # it is opened from the configured application DSN. Direct callers may
+        # still pass an explicit DSN (including a test-only embedded password).
+        password: str | None = None
+        configured_dsn = os.environ.get("AGENT_BOM_POSTGRES_URL", "").strip()
+        if dsn == configured_dsn:
+            from agent_bom.api.postgres_common import resolve_postgres_secret, resolve_postgres_url
+
+            dsn = resolve_postgres_url()
+            password = resolve_postgres_secret()
+        return _PostgresWorkspaceBackend(dsn, wsid, password=password)
     if chosen == "sqlite":
         return _SQLiteWorkspaceBackend()
     raise ValueError(f"unknown workspace backend {backend!r}")

--- a/tests/graph/test_graph_build_workspace.py
+++ b/tests/graph/test_graph_build_workspace.py
@@ -26,7 +26,7 @@ from pathlib import Path
 import pytest
 
 from agent_bom.api.graph_store import SQLiteGraphStore
-from agent_bom.graph import RelationshipType, UnifiedEdge
+from agent_bom.graph import RelationshipType, UnifiedEdge, build_workspace
 from agent_bom.graph.build_workspace import (
     GraphBuildWorkspace,
     _SQLiteWorkspaceBackend,
@@ -43,6 +43,30 @@ def _force_sqlite_backends(monkeypatch: pytest.MonkeyPatch) -> None:
     # retention lookup local (it routes to the Postgres pool when this env is
     # set) so the suite is deterministic regardless of an ambient Postgres URL.
     monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+
+
+def test_postgres_workspace_resolves_mounted_password_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The workspace uses the same secret-file contract as the API pool."""
+    secret_file = tmp_path / "postgres-password"
+    secret_file.write_text("app-secret\n", encoding="utf-8")
+    configured_dsn = "postgresql://agent_bom_app@db.example:5432/agent_bom"
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", configured_dsn)
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PASSWORD_FILE", str(secret_file))
+
+    seen: dict[str, object] = {}
+
+    class _FakePostgresBackend:
+        def __init__(self, dsn: str, workspace_id: str, *, password: str | None = None) -> None:
+            seen.update(dsn=dsn, workspace_id=workspace_id, password=password)
+
+    monkeypatch.setattr(build_workspace, "_PostgresWorkspaceBackend", _FakePostgresBackend)
+    build_workspace.open_workspace_backend(backend="postgres", workspace_id="secret-file")
+
+    assert seen == {
+        "dsn": "postgresql://agent_bom_app@db.example:5432/agent_bom",
+        "workspace_id": "secret-file",
+        "password": "app-secret",
+    }
 
 
 def _synthetic_graph(scan: str, n: int, tenant: str = "t1") -> UnifiedGraph:


### PR DESCRIPTION
## Summary
- Resolve the configured Postgres URL and mounted password/IAM secret through the shared hardened helpers before opening a store-backed graph workspace.
- Keep credentials out of DSNs and preserve explicit direct-DSN callers.
- Add a regression test for the Docker secret-file contract.

## Verification
- `uv run pytest -q tests/graph/test_graph_build_workspace.py::test_postgres_workspace_resolves_mounted_password_file tests/graph/test_graph_build_workspace.py` (10 passed)
- `uv run ruff check src/agent_bom/graph/build_workspace.py tests/graph/test_graph_build_workspace.py`
- `uv run mypy src/agent_bom/graph/build_workspace.py`
- `make preflight`
- Live Compose smoke: API health 200, anonymous API 401, UI 200, store-backed Postgres workspace write/read succeeded with mounted app secret; app role has DML but no schema CREATE.

## Notes
- This fixes the opt-in store-backed path; it does not flip the default without fleet-scale load evidence.