### PR TITLE
ci(release): enforce version alignment across all deploy surfaces + fix 0.97.0 drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1098,6 +1098,9 @@ jobs:
           PYPROJECT_VER=$(python -c "import re, pathlib; text = pathlib.Path('pyproject.toml').read_text(); print(re.search(r'^version\\s*=\\s*\"([^\"]+)\"', text, re.M).group(1))")
           python scripts/bump-version.py "$PYPROJECT_VER" --check
 
+      - name: Verify version alignment across all deploy/docs surfaces
+        run: python scripts/check_version_alignment.py
+
       - name: Verify README/docs consistency
         run: python scripts/check_release_consistency.py
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,9 @@ jobs:
           )
           PY
 
+      - name: Verify version alignment across all deploy/docs surfaces
+        run: python3 scripts/check_version_alignment.py
+
       - name: Block Finder duplicate artifacts
         run: python3 scripts/check_duplicate_artifacts.py
 

--- a/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
+++ b/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: msaad00/agent-bom@v0.97.0
+      - uses: msaad00/agent-bom@v0.97.1
         with:
           scan-type: agents
           format: sarif

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -25,7 +25,7 @@ New here? [`FIRST_RUN.md`](FIRST_RUN.md) is the canonical quickstart —
 CI gate (GitHub Action):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.0
+- uses: msaad00/agent-bom@v0.97.1
 ```
 
 - Output formats, exit codes, and the full command set:

--- a/docs/skills/POLICY.md
+++ b/docs/skills/POLICY.md
@@ -84,7 +84,7 @@ Actions are `warn`, `fail`, or `block`; `block` is treated as a failing gate.
 Run skills scanning as its own CI lane:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.0
+- uses: msaad00/agent-bom@v0.97.1
   with:
     scan-type: skills
     scan-ref: .

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -185,6 +185,24 @@ def bump(new_version: str, *, dry_run: bool = False, check: bool = False) -> int
                 path.write_text(new_text)
                 print(f"  UPDATED ({count} hit): {rel_path}")
 
+    # Structural sweep: align every managed image pin / GitHub Action ref across
+    # the whole shipping-surface tree (deploy + docs + site-docs + integrations),
+    # so files not enumerated above — or added in a future release — can never
+    # silently drift. This is the same scan the CI version-alignment gate runs.
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    import check_version_alignment as cva
+
+    if dry_run or check:
+        sweep_drift = cva.find_drift(new_version)
+        for line in sweep_drift:
+            print(f"  {'DRIFT' if check else 'DRY-RUN'} (align sweep): {line}")
+        changed += len(sweep_drift)
+    else:
+        sweep_count, sweep_files = cva.rewrite(new_version)
+        for path in sweep_files:
+            print(f"  UPDATED (align sweep): {path.relative_to(ROOT)}")
+        changed += sweep_count
+
     print(f"\n{'Would update' if dry_run else 'Updated'} {changed} occurrence(s)")
 
     if check:

--- a/scripts/check_version_alignment.py
+++ b/scripts/check_version_alignment.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Structural version-alignment gate for agent-bom release surfaces.
+
+Every user-facing surface that pins a published image (``agentbom/agent-bom*:X``)
+or a GitHub Action ref (``msaad00/agent-bom@vX``) must track the single canonical
+version declared in ``pyproject.toml``. Unlike a hand-maintained per-file
+allowlist, this gate walks whole shipping-surface *trees*, so a NEW file that
+introduces a managed reference is covered automatically and cannot silently
+drift away from the release version.
+
+Usage::
+
+    python scripts/check_version_alignment.py            # verify, exit 1 on drift
+    python scripts/check_version_alignment.py --fix 0.97.1   # rewrite every ref
+
+``scripts/`` and ``tests/`` are deliberately NOT scanned: they carry these
+patterns as guard literals / fixtures with intentionally-stale versions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+ROOT = Path(__file__).resolve().parent.parent
+PYPROJECT = ROOT / "pyproject.toml"
+
+# Surfaces that ship to users, so any pinned ref inside them must be the current
+# release. Directories are scanned recursively; individual files are scanned as-is.
+SCAN_ROOTS: tuple[Path, ...] = (
+    ROOT / "README.md",
+    ROOT / "PYPI_README.md",
+    ROOT / "DOCKER_HUB_README.md",
+    ROOT / "docs",
+    ROOT / "site-docs",
+    ROOT / "deploy",
+    ROOT / "integrations",
+)
+
+_BINARY_SUFFIXES = {
+    ".gif", ".png", ".jpg", ".jpeg", ".svg", ".ico",
+    ".woff", ".woff2", ".ttf", ".pdf", ".zip", ".gz",
+}
+_EXCLUDE_DIRS = {"node_modules", ".git", ".next", "dist", "build", "__pycache__"}
+
+
+class ManagedPattern(NamedTuple):
+    """A version-bearing reference whose semver must equal the canonical version.
+
+    Group 1 captures the literal prefix; group 2 captures the semver.
+    """
+
+    label: str
+    regex: re.Pattern[str]
+
+
+MANAGED_PATTERNS: tuple[ManagedPattern, ...] = (
+    ManagedPattern(
+        "published image pin",
+        re.compile(r"(agentbom/agent-bom(?:-[a-z]+)?:)(\d+\.\d+\.\d+)"),
+    ),
+    ManagedPattern(
+        "GitHub Action ref",
+        re.compile(r"(msaad00/agent-bom@v)(\d+\.\d+\.\d+)"),
+    ),
+)
+
+# Hosted-demo composes that must ALWAYS run ``:latest`` (redeployed on every
+# release), so they can never be silently frozen on a stale semver pin. Each
+# entry: (path relative to ROOT, literal image ref that must be present).
+LATEST_REQUIRED: tuple[tuple[str, str], ...] = (
+    ("deploy/docker-compose.platform.yml", "image: agent-bom:latest"),
+)
+
+
+def canonical_version() -> str:
+    match = re.search(r'^version\s*=\s*"([^"]+)"', PYPROJECT.read_text(), re.M)
+    if not match:
+        raise SystemExit("pyproject.toml version not found")
+    return match.group(1)
+
+
+def _iter_files() -> Iterator[Path]:
+    for root in SCAN_ROOTS:
+        if not root.exists():
+            continue
+        if root.is_file():
+            yield root
+            continue
+        for path in sorted(root.rglob("*")):
+            if not path.is_file():
+                continue
+            if any(part in _EXCLUDE_DIRS for part in path.parts):
+                continue
+            if path.suffix.lower() in _BINARY_SUFFIXES:
+                continue
+            yield path
+
+
+def scan_text(rel_path: str, text: str, version: str) -> list[str]:
+    """Return one drift line per managed reference in *text* that != *version*."""
+    drift: list[str] = []
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        for managed in MANAGED_PATTERNS:
+            for match in managed.regex.finditer(line):
+                found = match.group(2)
+                if found != version:
+                    drift.append(
+                        f"{rel_path}:{lineno}: {managed.label} pinned to "
+                        f"{found} (expected {version}) -> {line.strip()}"
+                    )
+    return drift
+
+
+def find_drift(version: str) -> list[str]:
+    """Return every version-alignment violation across the shipping surfaces."""
+    drift: list[str] = []
+    for path in _iter_files():
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        drift.extend(scan_text(_rel(path), text, version))
+
+    for rel, needle in LATEST_REQUIRED:
+        path = ROOT / rel
+        if not path.exists():
+            drift.append(f"{rel}: hosted-demo compose missing (expected '{needle}')")
+        elif needle not in path.read_text(encoding="utf-8", errors="ignore"):
+            drift.append(
+                f"{rel}: hosted-demo runtime must stay ':latest' "
+                f"('{needle}' not found) — do not pin the always-redeployed demo"
+            )
+    return sorted(drift)
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT))
+    except ValueError:
+        return str(path)
+
+
+def rewrite(version: str) -> tuple[int, list[Path]]:
+    """Rewrite every managed reference to *version*. Returns (count, changed)."""
+    total = 0
+    changed: list[Path] = []
+    for path in _iter_files():
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        new_text = text
+        file_hits = 0
+        for managed in MANAGED_PATTERNS:
+            new_text, count = managed.regex.subn(rf"\g<1>{version}", new_text)
+            file_hits += count
+        if file_hits and new_text != text:
+            path.write_text(new_text, encoding="utf-8")
+            total += file_hits
+            changed.append(path)
+    return total, changed
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Verify or fix version alignment")
+    parser.add_argument(
+        "--fix",
+        metavar="VERSION",
+        help="Rewrite every managed reference to VERSION instead of checking",
+    )
+    args = parser.parse_args(argv)
+
+    if args.fix:
+        if not re.match(r"^\d+\.\d+\.\d+$", args.fix):
+            print(f"ERROR: invalid semver: {args.fix}", file=sys.stderr)
+            return 1
+        count, changed = rewrite(args.fix)
+        for path in changed:
+            print(f"  UPDATED: {_rel(path)}")
+        print(f"Rewrote {count} managed reference(s) across {len(changed)} file(s)")
+        return 0
+
+    version = canonical_version()
+    drift = find_drift(version)
+    if drift:
+        print(f"ERROR: version drift from canonical {version}:", file=sys.stderr)
+        for line in drift:
+            print(f"  {line}")
+        print(
+            f"\n{len(drift)} drifted reference(s). "
+            f"Fix with: python scripts/check_version_alignment.py --fix {version}",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"Version alignment OK: every managed reference == {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -25,7 +25,7 @@ agent-bom iac Dockerfile k8s/ infra/main.tf --format sarif --output agent-bom-ia
 In GitHub Actions, use the `iac` scan type or the `iac` input:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.0
+- uses: msaad00/agent-bom@v0.97.1
   with:
     scan-type: iac
     scan-ref: infra/main.tf,k8s/

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -8,7 +8,7 @@ plane or runtime enforcement rollout.
 |---|---|---|---|---|
 | Local CLI | `agent-bom scan --demo --offline`, then `agent-bom scan .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
 | Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-mostly security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary; Shield write actions require admin role, `shield:write` scope, and an audit reason. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
-| GitHub Actions | `uses: msaad00/agent-bom@v0.97.0` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
+| GitHub Actions | `uses: msaad00/agent-bom@v0.97.1` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan . --policy skills-policy.yaml` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names, policy warn/block result. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
 | Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
@@ -31,7 +31,7 @@ when the buyer or contributor needs to see the first finding path quickly.
 ### CI Security Review
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.0
+- uses: msaad00/agent-bom@v0.97.1
   with:
     scan-type: agents
     severity-threshold: high
@@ -66,7 +66,7 @@ by setting `skills-ci: true` (equivalent to the CLI `--ci` flag, i.e.
 `fail-on-verdict=suspicious`):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.0
+- uses: msaad00/agent-bom@v0.97.1
   with:
     scan-type: skills
     scan-ref: .
@@ -80,7 +80,7 @@ For finer control, replace `skills-ci` with explicit gates and an optional
 policy file:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.0
+- uses: msaad00/agent-bom@v0.97.1
   with:
     scan-type: skills
     scan-ref: .

--- a/tests/test_version_alignment.py
+++ b/tests/test_version_alignment.py
@@ -1,0 +1,103 @@
+"""Structural version-alignment gate regression tests.
+
+The gate scans whole shipping-surface trees (not a hand-maintained per-file
+allowlist) for managed version/image references, so a NEW file that introduces a
+pinned image or GitHub Action ref is covered automatically and cannot silently
+drift away from the canonical pyproject version.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_script(name: str) -> ModuleType:
+    path = ROOT / "scripts" / name
+    mod_name = name.removesuffix(".py")
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repo_is_aligned_to_canonical_version() -> None:
+    """Every managed reference in the shipping surfaces equals pyproject version."""
+    cva = _load_script("check_version_alignment.py")
+    version = cva.canonical_version()
+    drift = cva.find_drift(version)
+    assert drift == [], "version drift detected:\n" + "\n".join(drift)
+
+
+def test_scan_text_flags_stale_image_pin() -> None:
+    cva = _load_script("check_version_alignment.py")
+    text = "    image: agentbom/agent-bom-ui:0.97.0\n"
+    drift = cva.scan_text("deploy/example.yml", text, "0.97.1")
+    assert len(drift) == 1
+    assert "deploy/example.yml:1" in drift[0]
+    assert "0.97.0" in drift[0]
+    assert "0.97.1" in drift[0]
+
+
+def test_scan_text_flags_stale_action_ref() -> None:
+    cva = _load_script("check_version_alignment.py")
+    text = "- uses: msaad00/agent-bom@v0.90.0 # example\n"
+    drift = cva.scan_text("docs/example.md", text, "0.97.1")
+    assert len(drift) == 1
+    assert "GitHub Action ref" in drift[0]
+
+
+def test_scan_text_passes_when_aligned() -> None:
+    cva = _load_script("check_version_alignment.py")
+    text = "image: agentbom/agent-bom:0.97.1\nuses: msaad00/agent-bom@v0.97.1\n"
+    assert cva.scan_text("deploy/example.yml", text, "0.97.1") == []
+
+
+def test_latest_demo_image_must_not_be_pinned(tmp_path, monkeypatch) -> None:
+    """A demo compose designated :latest can't silently freeze on an old pin."""
+    cva = _load_script("check_version_alignment.py")
+    demo = tmp_path / "docker-compose.demo.yml"
+    demo.write_text("services:\n  api:\n    image: agent-bom:0.97.1\n")
+    monkeypatch.setattr(cva, "SCAN_ROOTS", ())
+    monkeypatch.setattr(cva, "LATEST_REQUIRED", (("docker-compose.demo.yml", "agent-bom:latest"),))
+    monkeypatch.setattr(cva, "ROOT", tmp_path)
+    drift = cva.find_drift("0.97.1")
+    assert any("latest" in line for line in drift), drift
+
+    demo.write_text("services:\n  api:\n    image: agent-bom:latest\n")
+    assert cva.find_drift("0.97.1") == []
+
+
+def test_rewrite_aligns_stale_refs(tmp_path, monkeypatch) -> None:
+    cva = _load_script("check_version_alignment.py")
+    stale = tmp_path / "guide.md"
+    stale.write_text(
+        "run: uses: msaad00/agent-bom@v0.90.0\nimage: agentbom/agent-bom:0.90.0\n"
+    )
+    monkeypatch.setattr(cva, "SCAN_ROOTS", (stale,))
+    monkeypatch.setattr(cva, "LATEST_REQUIRED", ())
+    monkeypatch.setattr(cva, "ROOT", tmp_path)
+    count, changed = cva.rewrite("0.97.1")
+    assert count == 2
+    assert changed == [stale]
+    assert "0.90.0" not in stale.read_text()
+    assert cva.find_drift("0.97.1") == []
+
+
+def test_main_exits_nonzero_on_drift(tmp_path, monkeypatch, capsys) -> None:
+    cva = _load_script("check_version_alignment.py")
+    stale = tmp_path / "deploy.yml"
+    stale.write_text("image: agentbom/agent-bom:0.90.0\n")
+    monkeypatch.setattr(cva, "SCAN_ROOTS", (stale,))
+    monkeypatch.setattr(cva, "LATEST_REQUIRED", ())
+    monkeypatch.setattr(cva, "ROOT", tmp_path)
+    monkeypatch.setattr(cva, "canonical_version", lambda: "0.97.1")
+    assert cva.main([]) == 1
+    out = capsys.readouterr().out
+    assert "0.90.0" in out


### PR DESCRIPTION
## Problem

Version drift across `deploy/`, `docs/`, and `site-docs/` surfaces was possible because both the release-prep bump script (`scripts/bump-version.py`) and the CI version-guard (`scripts/check_release_consistency.py`) relied on **hand-maintained, per-file allowlists**. Any file that introduced a pinned image or GitHub Action ref without being registered in those lists silently escaped enforcement and went stale on the next release.

Concretely, 8 `msaad00/agent-bom@v0.97.0` GitHub Action refs in 5 files were never registered and had gone stale while canonical was already `0.97.1`.

## Fix: make drift structurally impossible

**New glob-based gate — `scripts/check_version_alignment.py`.** Walks whole shipping-surface *trees* (README, PYPI/DOCKER_HUB README, `docs/`, `site-docs/`, `deploy/`, `integrations/`) for the two managed patterns:
- published image pins `agentbom/agent-bom*:X`
- GitHub Action refs `msaad00/agent-bom@vX`

Every match must equal the canonical `pyproject.toml` version. Because it scans trees rather than a file list, **a new file cannot silently drift** — it is covered the moment it is added. Hosted-demo composes designated `:latest` are asserted to *stay* `:latest` (so they can't be silently frozen on a stale pin either). Exits non-zero listing every drifted `file:line`; `--fix <version>` rewrites them.

`scripts/` and `tests/` are deliberately not scanned (they carry these patterns as guard literals / fixtures with intentionally-stale versions).

**Wired into CI** — the `Version Alignment` job in `ci.yml` (every PR) and `release.yml`'s `version-guard` job (tag time).

**Release-prep now bumps everything in one shot.** `scripts/bump-version.py` delegates a final structural sweep to the same module, so a bump rewrites every managed reference from the single canonical source — including files not enumerated in its per-file list — and its `--check` mode fails on any unregistered drift.

## Drift fixed (old -> new)

| File | Change |
|---|---|
| `docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md` | `@v0.97.0` -> `@v0.97.1` |
| `docs/START_HERE.md` | `@v0.97.0` -> `@v0.97.1` |
| `docs/skills/POLICY.md` | `@v0.97.0` -> `@v0.97.1` |
| `site-docs/features/cloud-posture.md` | `@v0.97.0` -> `@v0.97.1` |
| `site-docs/reference/agentic-workflows.md` | `@v0.97.0` -> `@v0.97.1` (x4) |

All `deploy/` compose + k8s image pins were already aligned at `0.97.1` (the release prep covered them); the residual drift was only these unregistered Action refs.

## `:latest` policy (deliberate)

`deploy/docker-compose.platform.yml` runtime service stays `image: agent-bom:latest` (locally-built, always-current image used by the hosted-demo redeploy, which composes `platform.yml` + `hosted-poc.yml`). The gate enforces it stays `:latest`. The published UI image `agentbom/agent-bom-ui` remains pinned to the release version for reproducibility, kept current by the bump sweep.

## Verification

- New gate + 7 unit tests green; `check_release_consistency.py`, `lint_release_workflow.py`, `test_surface_freshness.py` all pass (no regressions).
- `ruff` + `mypy` clean on changed Python.
- **Gate proven to bite:** injecting `agentbom/agent-bom:0.97.0` into `deploy/k8s/daemonset.yaml` makes the gate exit 1 with the drifted `file:line`; reverting returns exit 0.
- Combined demo compose (`platform.yml` + `hosted-poc.yml`) validates with `docker compose config -q` and resolves to `agent-bom:latest` + `agentbom/agent-bom-ui:0.97.1`.