### PR TITLE
docs(agents): add Cursor Cloud dev environment run notes

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -254,3 +254,41 @@ Before a release readiness claim, check:
 - README, Docker Hub README, docs site, version surfaces, and changelog alignment
 
 If a check cannot be run, say so directly and keep the claim narrower.
+
+## Cursor Cloud specific instructions
+
+The startup update script already installs `uv`, runs `uv sync --extra dev-all`
+(Python deps into `.venv`), and `npm install --prefix ui` (dashboard deps). You
+do not need to reinstall.
+
+- **Run Python via `uv run`.** `uv` manages `.venv`; there is no bare `python`
+  on PATH (only `python3`). Use `uv run agent-bom …`, `uv run pytest …`,
+  `uv run ruff check src tests`. `uv` lives in `~/.local/bin`. Note `make dev` /
+  `make _dev-api` invoke bare `python`, so prefer `uv run agent-bom serve …`
+  directly over `make dev`.
+- **Services and ports.** API (FastAPI) on `:8422`, Next.js dashboard on
+  `:3000`. The UI proxies `/v1`, `/health`, `/version`, `/ws` to
+  `NEXT_PUBLIC_API_URL` (default `http://localhost:8422`), so start the API
+  before the UI. SQLite is the default store — no external DB needed for local
+  dev. Postgres/ClickHouse/gateway/proxy/MCP are optional lanes.
+- **Auth gotcha (non-obvious).** The API is auth-by-default and fails closed:
+  protected `/v1/*` endpoints return 401 with no auth configured, so the
+  dashboard shows no data. For local dev, start the API with
+  `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1`. The `--allow-insecure-no-auth` flag
+  alone only relaxes the non-loopback *bind* gate — it does not enable
+  per-request unauthenticated access; the env var does. Full local dev command:
+  `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1 uv run agent-bom serve --port 8422 --cors-allow-all --allow-insecure-no-auth --reload`,
+  then `npm run dev --prefix ui`.
+- **Seeding dashboard data / API-triggered scans.** The dashboard reads the API
+  store, which a local CLI scan does not populate. Trigger scans via
+  `POST /v1/scan` or the UI `/scan` page. The ad-hoc **Workstation** scope needs
+  no inputs and completes quickly. To scan local paths through the API, set
+  `AGENT_BOM_API_LOCAL_PATH_SCANS=enabled` and
+  `AGENT_BOM_API_SCAN_ROOT=<dir>`, then pass paths **relative** to that root
+  (absolute paths are rejected, symlinked components are rejected, and the path
+  must be owned by the API process user). `uv run agent-bom samples first-run
+  --target <dir>` writes a sample inventory to scan.
+- **Lint version drift.** `uv sync` installs the latest `ruff`, which is newer
+  than the pinned `.pre-commit-config.yaml` / CI `ruff`, so `uv run ruff check`
+  may report a small number of pre-existing findings that CI's pinned ruff does
+  not. Match CI by using the pinned version when a discrepancy matters.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Documents the local dev run flow for future Cursor Cloud agents in `.agents/AGENTS.md` under `## Cursor Cloud specific instructions`.
- Captures the non-obvious auth gotcha (per-request unauthenticated access needs `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1`, not just `--allow-insecure-no-auth`) and how to seed dashboard data / run API local-path scans.
- No product code changed — environment setup only (`uv sync --extra dev-all`, `npm install --prefix ui`).

## Related Issues
<!-- none -->

## Test plan
Verified the full development environment end-to-end on the cloud VM:

| Surface | Command | Result |
|---|---|---|
| Python deps | `uv sync --extra dev-all` (Python 3.12.3) | installed, `agent-bom 0.97.1` |
| CLI (hello world) | `uv run agent-bom scan --demo --offline` | scan ran, findings + remediation printed |
| Python lint | `uv run ruff check src tests` | runs (1 pre-existing E501 from newer ruff vs pinned CI ruff) |
| Python tests | `uv run pytest tests/test_cli_scan.py tests/test_cli_check.py tests/test_cli_server.py -p no:randomly` | 196 passed |
| UI deps | `npm install --prefix ui` (Node 22.14) | 600 pkgs, 0 vulns |
| UI toolchain | `npm run verify:toolchain` | verified |
| UI typecheck | `npm run typecheck` | clean |
| UI tests | `npm run test:run` | 776 passed (141 files) |
| API server | `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1 uv run agent-bom serve --port 8422 --cors-allow-all --allow-insecure-no-auth --reload` | `/health` ok, `/v1/overview` 200 |
| Dashboard | `npm run dev --prefix ui` (:3000) | renders posture + findings |

**End-to-end hello-world:** triggered an ad-hoc **Workstation** scan from the dashboard `/scan` page; it completed (discovery found agents) and the `/overview` page shows a real posture grade **C (78%)** with 2 high findings.

[agent_bom_dashboard_scan_hello_world.mp4](https://cursor.com/agents/bc-5a29d16a-19ca-4c43-8317-28326ab922b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagent_bom_dashboard_scan_hello_world.mp4)

[Completed scan result](https://cursor.com/agents/bc-5a29d16a-19ca-4c43-8317-28326ab922b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscan_result_complete.webp)
[Overview posture dashboard](https://cursor.com/agents/bc-5a29d16a-19ca-4c43-8317-28326ab922b6/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Foverview_posture.webp)

## Breaking changes
- [x] None

## Checklist
- [x] No secrets, credentials, or personally identifiable data in diff
- [x] Docs-only change (no code/schema/deploy impact)

## Exceptions
- None

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a29d16a-19ca-4c43-8317-28326ab922b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a29d16a-19ca-4c43-8317-28326ab922b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

