### PR TITLE
fix(mcp,audit): align tool-count honesty and rich audit exit codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ Versions follow [Semantic Versioning](https://semver.org/).
   Deployment Freshness workflow (opens/closes the same supply-chain drift issue
   used for Railway and Smithery).
 
+### Fixed
+- MCP server-card `registry_servers` now tracks the bundled registry total (was
+  stale at 427); card `read_only` is false to match write-gated Shield/identity/
+  ticketing tools; Connections UI and `mcp_server.py` docstring list all 76 tools.
+- Glama freshness checker accepts README's "exposes N MCP tools" phrasing.
+- `agent-bom audit` rich display fails closed on blocked tool calls even when the
+  log has no `proxy_summary` trailer (aligned with `--json`).
+
 ### Changed
 - Drop no-op `dependency-pin-check.yml` and the non-blocking main-only `ci.yml` `agent-bom-scan` job (covered by PR Security Gate + post-merge self-scan).
 - Demo redeploy now triggers on successful `Release` workflow completion

--- a/docs/audits/AUDIT-2026-07-21.md
+++ b/docs/audits/AUDIT-2026-07-21.md
@@ -184,9 +184,9 @@
 | P0 | Public live demo 502 | README first proof link; AE/SE cheapest asset | **Mitigated in-repo:** redeploy `workflow_run` trigger + build-then-up + `/health` freshness monitor + local-demo fallback in README. Host restore remains operator/VM. |
 | P1 | MCP attestation overclaim | Epic closed / changelog “Added” without user surface | **Fixed:** `agent-bom attest mcp sign\|verify` + changelog reword of 0.96.4 foundation line |
 | P1 | Estate-scale graph default | Store-backed UnifiedGraph not default-on | **Fixed:** auto-enable above entity threshold (default 5000); explicit off preserved |
-| P2 | Helm example day-0 traps | Standalone example values fail without Postgres base | Compose examples into validated profile set |
+| P2 | Helm example day-0 traps | Standalone example values fail without Postgres base | **In flight:** #4337 (auth Secret + first-install) |
 | P2 | CronJob evidence evaporates | emptyDir without push | Default push/sync or document fail-loud |
-| P2 | Audit CLI exit-code mismatch | CI gates can false-pass | Align rich path with `--json` blocked detection |
+| P2 | Audit CLI exit-code mismatch | CI gates can false-pass | **Fixed:** rich path fails closed on blocked calls without summary |
 | P3 | Commercial vehicle | AE lens capped | Business decision — not a code defect |
 | P3 | New lane field mileage | CIEM Azure/GCP, DSPM, KSPM days old | Real-estate soak + honesty regressions |
 

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -55,7 +55,9 @@ def _load_version() -> str:
 
 def _load_readme_tool_count() -> str:
     text = README.read_text(encoding="utf-8")
-    match = re.search(r"MCP server mode advertises\s+(\d+)\s+MCP tools", text)
+    # Prefer the current README phrasing ("exposes"); keep "advertises" as a
+    # fallback so older release tags still parse during surface-freshness probes.
+    match = re.search(r"MCP server mode (?:exposes|advertises)\s+(\d+)\s+MCP tools", text)
     if not match:
         raise SystemExit("README.md MCP tool count sentence not found")
     return match.group(1)
@@ -92,10 +94,7 @@ def verify_build_manifest(git_ref: str | None = None) -> list[str]:
             continue
         data = json.loads(manifest_text)
         if data.get("dockerfile") != GLAMA_DOCKERFILE:
-            failures.append(
-                f"{manifest_path} dockerfile must be {GLAMA_DOCKERFILE!r}, "
-                f"found {data.get('dockerfile')!r}"
-            )
+            failures.append(f"{manifest_path} dockerfile must be {GLAMA_DOCKERFILE!r}, found {data.get('dockerfile')!r}")
     return failures
 
 
@@ -108,13 +107,21 @@ def _fetch(url: str, timeout: int) -> str:
 def _check(page: str, version: str, tool_count: str) -> list[str]:
     expected_tokens = [
         f"v{version}",
-        f"MCP server mode advertises {tool_count} MCP tools",
+        # Accept either phrasing while Glama's rendered README catches up.
+        # Presence of the tool-count sentence is what matters for freshness.
     ]
     failures = [f"missing current Glama listing token: {token!r}" for token in expected_tokens if token not in page]
+    tool_count_ok = bool(
+        re.search(rf"MCP server mode (?:exposes|advertises)\s+{re.escape(tool_count)}\s+MCP tools", page)
+        or f"MCP server mode exposes {tool_count} MCP tools" in page
+        or f"MCP server mode advertises {tool_count} MCP tools" in page
+    )
+    if not tool_count_ok:
+        failures.append(f"missing current Glama listing token: 'MCP server mode exposes|advertises {tool_count} MCP tools'")
 
     stale_patterns = [
         r"uses:\s*msaad00/agent-bom@v0\.88\.4",
-        r"MCP server mode advertises\s+55\s+MCP tools",
+        r"MCP server mode (?:exposes|advertises)\s+55\s+MCP tools",
         r"18 tools for CVE scanning",
         r"98c3e543",  # pre-0.92.0 pinned Glama build ref from audit #3472
         r"git checkout 98c3e543",

--- a/src/agent_bom/audit_replay.py
+++ b/src/agent_bom/audit_replay.py
@@ -350,13 +350,19 @@ def display_rich(
     if s and (s.total_blocked > 0 or s.relay_errors > 0):
         exit_code = 1
 
-    # Summary-less logs (partial JSONL without a proxy_summary trailer) must still
-    # fail closed when blocked tool calls or relay errors are present — matching
-    # display_json so CI gates cannot false-pass the rich path.
-    if exit_code == 0 and any(c.policy == "blocked" for c in log.tool_calls):
-        exit_code = 1
-    if exit_code == 0 and log.relay_errors:
-        exit_code = 1
+    # Summary-less logs previously ignored blocked tool_calls for exit (only
+    # summary.total_blocked counted). Align with display_json / module docs when
+    # tool calls are in the active display scope. Relay errors stay filter-aware
+    # via the table block below — do not fail closed on out-of-scope relays.
+    tools_in_scope = not alerts_only and (
+        type_filter_normalized is None or type_filter_normalized == "tools/call"
+    )
+    if exit_code == 0 and not s and tools_in_scope:
+        scoped_calls = log.tool_calls
+        if tool_filter:
+            scoped_calls = [c for c in scoped_calls if tool_filter.lower() in c.tool.lower()]
+        if any(c.policy == "blocked" for c in scoped_calls):
+            exit_code = 1
 
     # ── Tool call table ─────────────────────────────────────────────────────
     if not alerts_only:

--- a/src/agent_bom/audit_replay.py
+++ b/src/agent_bom/audit_replay.py
@@ -350,6 +350,14 @@ def display_rich(
     if s and (s.total_blocked > 0 or s.relay_errors > 0):
         exit_code = 1
 
+    # Summary-less logs (partial JSONL without a proxy_summary trailer) must still
+    # fail closed when blocked tool calls or relay errors are present — matching
+    # display_json so CI gates cannot false-pass the rich path.
+    if exit_code == 0 and any(c.policy == "blocked" for c in log.tool_calls):
+        exit_code = 1
+    if exit_code == 0 and log.relay_errors:
+        exit_code = 1
+
     # ── Tool call table ─────────────────────────────────────────────────────
     if not alerts_only:
         calls = log.tool_calls

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -8,7 +8,12 @@ Start with:
 Tools (76):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
+    intel_lookup        — Look up a CVE, GHSA, or OSV advisory from local threat intel
+    intel_match         — Match package inventory coordinates to local advisory intel
+    intel_sources       — Return canonical intel sources and local feed-run freshness
+    intel_daily_brief   — Return a local analyst threat brief from governed intel sources
     blast_radius        — Look up blast radius for a specific CVE
+    exposure_paths      — Return ranked ExposurePath JSON for headless agents and MCP clients
     should_i_deploy     — Return allow/warn/block from ExposurePath risk
     policy_check        — Evaluate a policy against scan results
     registry_lookup     — Query the MCP server security metadata registry
@@ -29,13 +34,18 @@ Tools (76):
     marketplace_check   — Pre-install trust check with registry cross-reference
     code_scan           — SAST scanning via Semgrep with CWE-based compliance mapping
     context_graph       — Agent context graph with lateral movement analysis
+    graph_export        — Export dependency graph (GraphML, Neo4j Cypher, DOT, JSON-LD)
     analytics_query     — Query vulnerability trends and runtime events from ClickHouse
     cis_benchmark       — Run CIS benchmark checks against cloud accounts
+    kspm_cluster_posture — Evaluate live Kubernetes cluster posture vs CIS Kubernetes Benchmark
     fleet_scan          — Batch registry lookup for fleet inventories
     runtime_correlate   — Cross-reference runtime audit logs with CVE findings
     runtime_production_index — Runtime production posture summary
     runtime_blueprints  — Role/profile blueprints for runtime policy design
     runtime_blueprint_drift — Evaluate runtime posture against a blueprint
+    cost_report         — LLM spend attribution per agent/model/provider with budget posture
+    anomaly_scan        — Detect cost and behavior anomalies
+    drift_incidents     — List open blueprint-drift incidents
     proxy_status        — Current MCP proxy metrics and alert posture
     proxy_alerts        — Recent tenant-scoped runtime proxy alerts
     gateway_status      — Gateway policy and firewall runtime statistics
@@ -54,6 +64,7 @@ Tools (76):
     vector_db_scan      — Scan vector databases for embedding poisoning and access risks
     aisvs_benchmark     — OWASP AI Security Verification Standard benchmark
     gpu_infra_scan      — Scan GPU infrastructure for CVEs and misconfigurations
+    registry_sweep_scan — Sweep a cloud registry (ECR/ACR/GAR) and scan unique images
     dataset_card_scan   — Scan dataset cards for licensing and provenance
     training_pipeline_scan — Scan training pipeline artifacts for lineage
     browser_extension_scan — Scan browser extensions for dangerous permissions
@@ -69,6 +80,8 @@ Tools (76):
     nhi_discover        — Discover non-human identities (Okta / Entra), reference-only
     cloud_inventory     — Estate-wide cloud asset inventory summary, opt-in per provider
     access_review       — List or get NHI access-review / recertification campaigns
+    create_ticket       — File an ITSM ticket for a finding through a stored connector
+    sync_ticket_status  — Refresh a filed ITSM ticket's status through the stored connector
 
 Resources (6):
     registry://servers  — Browse the 1013-entry server security metadata registry

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -524,6 +524,19 @@ _SERVER_CARD_RESOURCES = [
 
 def build_server_card() -> dict[str, Any]:
     from agent_bom import __version__
+    from agent_bom.mcp_server_helpers import get_registry_data
+
+    try:
+        registry_servers = int(get_registry_data().get("_total_servers") or 0)
+    except Exception:
+        registry_servers = 0
+    if registry_servers <= 0:
+        # Fall back to counting the bundled map when the header is missing.
+        try:
+            servers = get_registry_data().get("servers") or {}
+            registry_servers = len(servers) if isinstance(servers, dict) else 0
+        except Exception:
+            registry_servers = 0
 
     return {
         "name": "agent-bom",
@@ -549,8 +562,10 @@ def build_server_card() -> dict[str, Any]:
                 "Kubernetes",
                 "SBOMs",
             ],
-            "registry_servers": 427,
-            "read_only": True,
+            "registry_servers": registry_servers,
+            # Scanner/graph tools are read-only; Shield / identity / ticket tools
+            # are write-gated. Do not claim a fully read-only server.
+            "read_only": False,
         },
         "license": "Apache-2.0",
         "pypi": "agent-bom",

--- a/tests/test_audit_replay.py
+++ b/tests/test_audit_replay.py
@@ -648,6 +648,26 @@ def test_display_rich_with_blocked_calls():
     assert code == 1
 
 
+def test_display_rich_blocked_without_summary_fails_closed():
+    """Rich path must match JSON exit semantics when proxy_summary is absent."""
+    log = AuditLog(
+        tool_calls=[
+            ToolCallEntry(
+                ts="2025-01-01T00:00:00Z",
+                tool="run_shell",
+                policy="blocked",
+                reason="policy",
+                agent_id="agent1",
+                args={},
+                payload_sha256="hash",
+                message_id=1,
+            )
+        ],
+    )
+    assert display_rich(log) == 1
+    assert display_json(log) == 1
+
+
 def test_display_rich_alerts_only():
     log = AuditLog(
         alerts=[

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -423,8 +423,11 @@ def test_server_card_capabilities():
     assert "OWASP LLM Top 10" in caps["frameworks"]
     assert "MITRE ATLAS" in caps["frameworks"]
     assert "NIST AI RMF" in caps["frameworks"]
-    assert caps["read_only"] is True
+    assert caps["read_only"] is False
     assert "OSV.dev" in caps["data_sources"]
+    from agent_bom.mcp_server_helpers import get_registry_data
+
+    assert caps["registry_servers"] == int(get_registry_data().get("_total_servers") or 0)
 
 
 def test_server_card_metadata():

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -2650,7 +2650,7 @@ function CodingAgentDrawer({ open, onClose }: { open: boolean; onClose: () => vo
       }
       headerAside={
         <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-          <Bot className="h-3 w-3" /> 75 MCP tools
+          <Bot className="h-3 w-3" /> 76 MCP tools
         </span>
       }
     >

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -529,7 +529,7 @@ describe("ConnectionsPage — Connect segment", () => {
 
     const drawer = await screen.findByRole("dialog", { name: /Connect a coding agent/ });
     expect(within(drawer).getByText("agent-bom mcp-server")).toBeInTheDocument();
-    expect(within(drawer).getByText(/75 MCP tools/)).toBeInTheDocument();
+    expect(within(drawer).getByText(/76 MCP tools/)).toBeInTheDocument();
   });
 
   it("syncs the segmented tab to the URL", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes remaining Jul-21 audit honesty / P2 audit-exit items that are **not** covered by open `#4337` (Helm first-install).

- MCP Connections UI + `mcp_server.py` docstring list all **76** tools (was 75 / incomplete catalog).
- Server-card `registry_servers` derived from bundled `mcp_registry.json` (was stale **427**); `read_only` set **false** to match write-gated Shield/identity/ticketing tools.
- Glama freshness checker accepts README phrasing `exposes N MCP tools`.
- `agent-bom audit` rich display fails closed on blocked tool calls even without a `proxy_summary` trailer (aligned with `--json`).

## Verification

```bash
uv run pytest -q tests/test_audit_replay.py::test_display_rich_blocked_without_summary_fails_closed \
  tests/test_deployment.py::test_server_card_capabilities \
  tests/test_surface_freshness.py \
  tests/test_stats_alignment.py::TestToolCountFreshness
# 18 passed
cd ui && npm test -- --run tests/connections-page.test.tsx
# 26 passed
```

## Notes

- Leaves Helm day-0 / CronJob volume story to `#4337` (does not duplicate).
- Does **not** cut `0.97.2` — recommend release after `#4337` + this PR land so pip/`uvx` pick up attest/OIDC/store-backed + honesty fixes together.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

