### PR TITLE
fix(demo): separate anonymous demo overlay from hardened hosted-poc profile

### DIFF
--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -133,16 +133,21 @@ jobs:
           docker compose \
             -f deploy/docker-compose.platform.yml \
             -f deploy/docker-compose.hosted-poc.yml \
+            -f deploy/docker-compose.demo-override.yml \
             build
 
           echo "== docker compose up =="
           docker compose \
             -f deploy/docker-compose.platform.yml \
             -f deploy/docker-compose.hosted-poc.yml \
+            -f deploy/docker-compose.demo-override.yml \
             up -d
 
+          # Preflight validates the hardened hosted-poc posture (auth required),
+          # so it runs WITHOUT the demo overlay — the demo's anonymous mode is an
+          # intentional, demo-only opt-in, not the hosted-poc contract.
           echo "== preflight (fail-closed) =="
-          python3 scripts/deploy/hosted_poc_preflight.py --write-postgres-secret
+          python3 scripts/deploy/hosted_poc_preflight.py --write-secret
 
           echo "== smoke =="
           scripts/deploy/hosted_poc_smoke.sh

--- a/deploy/docker-compose.demo-override.yml
+++ b/deploy/docker-compose.demo-override.yml
@@ -1,0 +1,27 @@
+# ── Profile: PUBLIC DEMO OVERLAY ─────────────────────────────────────────────
+# Demo-only overlay for the public showcase estate (demo.agent-bom.com).
+#
+# OVERLAY ONLY — layer it on TOP of platform + hosted-poc:
+#
+#   docker compose \
+#     -f deploy/docker-compose.platform.yml \
+#     -f deploy/docker-compose.hosted-poc.yml \
+#     -f deploy/docker-compose.demo-override.yml \
+#     up -d --build
+#
+# WHY THIS IS SEPARATE FROM hosted-poc.yml:
+# hosted-poc.yml is the hardened, customer-facing POC posture and MUST stay
+# auth-required — `hosted_poc_preflight.py` fails closed on
+# AGENT_BOM_ALLOW_UNAUTHENTICATED_API by design. The public demo is the one
+# deployment that intentionally opens anonymously (read-only viewer) and seeds a
+# curated demo estate, so those flags live here and are opted into only by the
+# demo redeploy path — never by a real customer POC.
+services:
+  api:
+    environment:
+      # Curated demo estate is bootstrapped on boot.
+      - AGENT_BOM_DEMO_ESTATE=1
+      # Open anonymously into a read-only viewer dashboard. NO_AUTH_ROLE only
+      # takes effect once unauthenticated access is enabled, so the two pair.
+      - AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1
+      - AGENT_BOM_NO_AUTH_ROLE=viewer

--- a/deploy/docker-compose.hosted-poc.yml
+++ b/deploy/docker-compose.hosted-poc.yml
@@ -20,11 +20,9 @@
 services:
   api:
     environment:
+      # Hardened, customer-facing POC posture: auth stays REQUIRED. Anonymous
+      # access and demo-estate seeding are NOT set here — that would open every
+      # hosted POC anonymously and trips hosted_poc_preflight (which fails closed
+      # on AGENT_BOM_ALLOW_UNAUTHENTICATED_API). The public demo opts into those
+      # via deploy/docker-compose.demo-override.yml, layered on top.
       - AGENT_BOM_SESSION_COOKIE_SECURE=1
-      - AGENT_BOM_DEMO_ESTATE=1
-      # Public demo opens anonymously into a read-only viewer dashboard.
-      # DEMO_ESTATE + NO_AUTH_ROLE=viewer only take effect once unauthenticated
-      # access is actually enabled — without this flag the demo falls back to the
-      # API-key sign-in wall and can never open anonymously as intended.
-      - AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1
-      - AGENT_BOM_NO_AUTH_ROLE=viewer

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -118,7 +118,7 @@ API/UI ports on all interfaces and does not mount the placeholder Postgres
 password:
 
 ```bash
-python scripts/deploy/hosted_poc_preflight.py --write-postgres-secret
+python scripts/deploy/hosted_poc_preflight.py --write-secret
 ```
 
 The preflight fails closed when required secrets are missing, the browser API
@@ -281,7 +281,7 @@ workflow automates it without any stored SSH keys or long-lived AWS credentials:
 - **Remote steps on the VM:** confirm `DEMO_DEPLOY_DIR` is a git checkout →
   `git pull --ff-only` → `docker compose ... build` (stack keeps serving) →
   `docker compose ... up -d` (brief restart) →
-  `scripts/deploy/hosted_poc_preflight.py --write-postgres-secret` (fail-closed)
+  `scripts/deploy/hosted_poc_preflight.py --write-secret` (fail-closed)
   → `scripts/deploy/hosted_poc_smoke.sh`. The job fails if the preflight or smoke
   fails, so a bad redeploy never gets promoted silently. When dispatched with
   `reset_demo=true` it also runs `scripts/deploy/demo-reset.sh`.

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -29,7 +29,7 @@ signed release evidence.
 | Package build | `uv build --out-dir /tmp/agent-bom-build` | Wheel and sdist build from a clean tree. |
 | PyPI smoke | `python -m venv /tmp/agent-bom-smoke && /tmp/agent-bom-smoke/bin/pip install agent-bom==<version> && /tmp/agent-bom-smoke/bin/agent-bom --version` | Published package installs in a fresh environment. |
 | Quickstart E2E | `agent-bom quickstart --run --offline --force --sample-dir /tmp/agent-bom-quickstart` | Generates a real report, graph, posture, and no coverage warnings. |
-| Hosted preflight | `python scripts/deploy/hosted_poc_preflight.py --write-postgres-secret` | Hosted compose has an HTTPS URL, no unauth mode, non-placeholder secrets, private API/UI binds, and safe CORS. |
+| Hosted preflight | `python scripts/deploy/hosted_poc_preflight.py --write-secret` | Hosted compose has an HTTPS URL, no unauth mode, non-placeholder secrets, private API/UI binds, and safe CORS. |
 
 Do not publish a release as hosted-ready when any required line above is red.
 

--- a/site-docs/deployment/authenticated-hosted-instance.md
+++ b/site-docs/deployment/authenticated-hosted-instance.md
@@ -113,7 +113,7 @@ caddy run --config deploy/caddy/Caddyfile.hosted-poc
 ### 1e. Preflight (fail-closed)
 
 ```bash
-python scripts/deploy/hosted_poc_preflight.py --write-postgres-secret
+python scripts/deploy/hosted_poc_preflight.py --write-secret
 ```
 
 This fails closed when required secrets are missing, `AGENT_BOM_ALLOW_UNAUTHENTICATED_API`

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -44,6 +44,12 @@ HEALTHCHECK_EXEMPT: dict[str, set[str]] = {
         # base platform compose and inherited at merge time.
         "api",
     },
+    "docker-compose.demo-override.yml": {
+        # Public-demo overlay layered on platform + hosted-poc; it only sets the
+        # demo-only anonymous/demo-estate environment. Healthchecks come from the
+        # base platform compose and are inherited at merge time.
+        "api",
+    },
     "docker-compose.product.yml": {
         # Overlay applied on top of docker-compose.platform.yml; it only sets
         # authenticated-product environment. Healthchecks are defined once in
@@ -257,14 +263,23 @@ def test_hosted_poc_overlay_keeps_api_and_ui_loopback_only() -> None:
     api_env = services["api"]["environment"]
     assert "ports" not in services["api"]
     assert "ui" not in services
-    assert api_env == [
-        "AGENT_BOM_SESSION_COOKIE_SECURE=1",
-        "AGENT_BOM_DEMO_ESTATE=1",
-        # Public demo opens anonymously into a read-only viewer; DEMO_ESTATE +
-        # NO_AUTH_ROLE only take effect once unauthenticated access is enabled.
-        "AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1",
-        "AGENT_BOM_NO_AUTH_ROLE=viewer",
-    ]
+    # Hardened POC posture: auth stays required. Anonymous access / demo-estate
+    # seeding must NOT be baked into hosted-poc — they belong in the demo-only
+    # overlay so real customer POCs are not opened anonymously (and so
+    # hosted_poc_preflight, which fails closed on unauth, still passes).
+    assert api_env == ["AGENT_BOM_SESSION_COOKIE_SECURE=1"]
+    assert "AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1" not in api_env
+
+
+def test_demo_override_carries_anonymous_and_demo_estate_flags() -> None:
+    """The public-demo overlay is the ONLY place the anonymous/demo flags live,
+    layered on top of hosted-poc for the showcase estate."""
+    path = COMPOSE_DIR / "docker-compose.demo-override.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    api_env = ((data.get("services") or {}).get("api") or {}).get("environment") or []
+    assert "AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1" in api_env
+    assert "AGENT_BOM_NO_AUTH_ROLE=viewer" in api_env
+    assert "AGENT_BOM_DEMO_ESTATE=1" in api_env
 
 
 def test_postgres_init_resets_app_password_guc_after_reading_it() -> None:


### PR DESCRIPTION
Fixes a security regression + self-contradiction that shipped in 0.97.2 (introduced by #4335), surfaced while debugging why the demo redeploy kept failing after it had already promoted the demo.

## The bug
#4335 baked `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1` + `NO_AUTH_ROLE=viewer` + `DEMO_ESTATE=1` into `docker-compose.hosted-poc.yml`. But that file is the **hardened, customer-facing POC overlay**, and `hosted_poc_preflight.py` **fails closed on `AGENT_BOM_ALLOW_UNAUTHENTICATED_API`** by design (RELEASE_VERIFICATION.md also documents hosted-poc as having *"no unauth mode"*). Consequences:
1. **Security regression** — every `hosted-poc` deployment opened anonymously, not just the public demo.
2. **Self-contradiction** — the preflight gate forbade the exact flag the compose now contained, so `demo-redeploy.yml`'s post-deploy preflight step failed on every release (after the demo was already promoted).

Plus a stale-flag drift: `demo-redeploy.yml` (and 3 docs) called `--write-postgres-secret`, which does not exist — the flag is `--write-secret`.

## Fix
- New `deploy/docker-compose.demo-override.yml` carries the demo-only flags (anonymous viewer + demo-estate). Only the public demo layers it: `platform + hosted-poc + demo-override`.
- `hosted-poc.yml` reverts to hardened posture (just `SESSION_COOKIE_SECURE`) — auth required, passes its own preflight, safe for real customer POCs.
- `demo-redeploy.yml` now layers the demo overlay for `build`/`up` and calls `--write-secret`. Preflight still runs against the **hardened** hosted-poc (no overlay), matching its contract.
- Stale `--write-postgres-secret` corrected in HOSTED_POC.md, RELEASE_VERIFICATION.md, site-docs.

## Verification (real runs)
- `hosted_poc_preflight.run_preflight` on hardened hosted-poc with box-equivalent env + secrets → **0 errors, no unauth complaint** (was failing on the unauth flag before).
- `docker compose config`: hosted-poc renders **0** `ALLOW_UNAUTHENTICATED_API`; with the demo overlay layered → **1** (anon restored for the demo only).
- `pytest tests/test_compose_secrets_healthcheck.py tests/test_hosted_poc_preflight.py` → **45 passed** (updated the hosted-poc env assertion + added a demo-override assertion).

## Note for the demo box
The live demo box has an **untracked** hand-made `deploy/docker-compose.demo-override.yml` from an earlier manual session. When this merges, the next redeploy's `git pull` will refuse to overwrite it — the box needs `rm deploy/docker-compose.demo-override.yml` once before pulling, then the committed overlay takes over.