### PR TITLE
fix(deploy): run Alembic migrate before Compose API starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Compose platform stack runs a one-shot `migrate` service before `api`
+  (stamp `init.sql` baselines when needed, then `alembic upgrade head`), matching
+  the Helm migration Job so image upgrades apply Postgres schema changes without
+  a manual Alembic step.
+
 ### Fixed
 - Hosted POC hardening overlay no longer opts into anonymous API access.
   `AGENT_BOM_DEMO_ESTATE` / `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` /

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -72,6 +72,31 @@ services:
       - backend
     restart: unless-stopped
 
+  # One-shot schema migrate (Helm equivalent: controlplane-alembic-migration-job).
+  # Uses the bootstrap/admin role for DDL; the API stays on agent_bom_app (DML).
+  # Fresh volumes from init.sql are stamped to baseline 20260416_01 once, then
+  # upgrade head applies later revisions on image upgrades.
+  migrate:
+    build:
+      context: ..
+      dockerfile: Dockerfile
+    image: agent-bom:latest
+    container_name: agent-bom-migrate
+    working_dir: /opt/agent-bom
+    entrypoint: ["python"]
+    command: ["deploy/supabase/postgres/compose_migrate.py"]
+    environment:
+      - AGENT_BOM_POSTGRES_URL=postgresql://agent_bom@postgres:5432/${POSTGRES_DB:-agent_bom}
+      - AGENT_BOM_POSTGRES_PASSWORD_FILE=/run/secrets/postgres_password
+    secrets:
+      - postgres_password
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - backend
+    restart: "no"
+
   api:
     build:
       context: ..
@@ -114,6 +139,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "python -c \"import urllib.request; urllib.request.urlopen('http://localhost:8422/health')\""]
       interval: 15s

--- a/deploy/supabase/postgres/alembic/env.py
+++ b/deploy/supabase/postgres/alembic/env.py
@@ -15,10 +15,37 @@ target_metadata = None
 
 
 def _database_url() -> str:
+    """Resolve the Alembic DSN.
+
+    Prefer ``ALEMBIC_DATABASE_URL``, else ``AGENT_BOM_POSTGRES_URL``. When the
+    URL has a username but no embedded password, load
+    ``AGENT_BOM_POSTGRES_PASSWORD_FILE`` (Docker Compose secret mount) the same
+    way the API does — Compose must not put bootstrap passwords in env values.
+    """
+    from pathlib import Path
+    from urllib.parse import quote_plus, urlsplit, urlunsplit
+
     url = os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("AGENT_BOM_POSTGRES_URL")
     if not url:
         raise RuntimeError("Set ALEMBIC_DATABASE_URL or AGENT_BOM_POSTGRES_URL before running Alembic migrations.")
-    return url
+    parts = urlsplit(url)
+    if parts.password:
+        return url
+    password_file = os.environ.get("AGENT_BOM_POSTGRES_PASSWORD_FILE", "").strip()
+    if not password_file:
+        return url
+    path = Path(password_file)
+    if not path.is_file():
+        raise RuntimeError(f"AGENT_BOM_POSTGRES_PASSWORD_FILE not found: {password_file}")
+    password = path.read_text(encoding="utf-8").strip("\r\n")
+    if not password:
+        raise RuntimeError(f"AGENT_BOM_POSTGRES_PASSWORD_FILE is empty: {password_file}")
+    if not parts.username or not parts.hostname:
+        raise RuntimeError("AGENT_BOM_POSTGRES_URL must include a username and hostname when using a password file.")
+    netloc = f"{quote_plus(parts.username)}:{quote_plus(password)}@{parts.hostname}"
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
 
 
 def run_migrations_offline() -> None:

--- a/deploy/supabase/postgres/compose_migrate.py
+++ b/deploy/supabase/postgres/compose_migrate.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Compose/Docker one-shot: stamp init.sql baselines if needed, then Alembic upgrade.
+
+Ships inside the control-plane image (copied under deploy/supabase/postgres/).
+Used by ``deploy/docker-compose.platform.yml`` so image upgrades apply schema
+changes the same way Helm's pre-upgrade migration Job does.
+
+Contract:
+  * Connect as the Postgres bootstrap/admin role (DDL), never ``agent_bom_app``.
+  * Prefer ``AGENT_BOM_POSTGRES_PASSWORD_FILE`` (Docker secret) over embedding
+    passwords in ``AGENT_BOM_POSTGRES_URL``.
+  * Databases first created from ``init.sql`` have no ``alembic_version`` row —
+    stamp baseline ``20260416_01`` once, then ``upgrade head``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from urllib.parse import quote_plus, urlsplit, urlunsplit
+
+BASELINE_REVISION = "20260416_01"
+ALEMBIC_CONFIG = "deploy/supabase/postgres/alembic.ini"
+# Presence of this table means init.sql (or an earlier baseline) already landed.
+BOOTSTRAP_MARKER_TABLE = "audit_log"
+
+
+def _repo_root() -> Path:
+    # Image layout: /opt/agent-bom/deploy/supabase/postgres/compose_migrate.py
+    here = Path(__file__).resolve()
+    for candidate in (Path("/opt/agent-bom"), here.parents[3], Path.cwd()):
+        if (candidate / ALEMBIC_CONFIG).is_file():
+            return candidate
+    raise SystemExit(f"error: cannot find {ALEMBIC_CONFIG} from {here}")
+
+
+def _resolve_database_url() -> str:
+    url = (os.environ.get("ALEMBIC_DATABASE_URL") or os.environ.get("AGENT_BOM_POSTGRES_URL") or "").strip()
+    if not url:
+        raise SystemExit(
+            "error: set ALEMBIC_DATABASE_URL or AGENT_BOM_POSTGRES_URL "
+            "(bootstrap/admin role) before compose migrations"
+        )
+    parts = urlsplit(url)
+    if parts.password:
+        return url
+    password_file = os.environ.get("AGENT_BOM_POSTGRES_PASSWORD_FILE", "").strip()
+    if not password_file:
+        return url
+    path = Path(password_file)
+    if not path.is_file():
+        raise SystemExit(f"error: AGENT_BOM_POSTGRES_PASSWORD_FILE not found: {password_file}")
+    password = path.read_text(encoding="utf-8").strip("\r\n")
+    if not password:
+        raise SystemExit(f"error: AGENT_BOM_POSTGRES_PASSWORD_FILE is empty: {password_file}")
+    if not parts.username or not parts.hostname:
+        raise SystemExit("error: AGENT_BOM_POSTGRES_URL must include username and hostname")
+    host = parts.hostname
+    netloc = f"{quote_plus(parts.username)}:{quote_plus(password)}@{host}"
+    if parts.port:
+        netloc = f"{netloc}:{parts.port}"
+    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
+
+
+def _needs_baseline_stamp(url: str) -> bool:
+    try:
+        import sqlalchemy
+    except ImportError as exc:  # pragma: no cover - image always has sqlalchemy via alembic
+        raise SystemExit(f"error: sqlalchemy required for compose migrate: {exc}") from exc
+
+    engine = sqlalchemy.create_engine(url)
+    try:
+        with engine.connect() as conn:
+            has_version = conn.execute(
+                sqlalchemy.text(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = 'public' AND table_name = 'alembic_version'"
+                )
+            ).scalar()
+            if has_version:
+                row = conn.execute(sqlalchemy.text("SELECT version_num FROM alembic_version LIMIT 1")).scalar()
+                if row:
+                    return False
+            has_bootstrap = conn.execute(
+                sqlalchemy.text(
+                    "SELECT 1 FROM information_schema.tables "
+                    "WHERE table_schema = 'public' AND table_name = :table"
+                ),
+                {"table": BOOTSTRAP_MARKER_TABLE},
+            ).scalar()
+            return bool(has_bootstrap)
+    finally:
+        engine.dispose()
+
+
+def _run_alembic(root: Path, *args: str) -> None:
+    cmd = ["alembic", "-c", ALEMBIC_CONFIG, *args]
+    print("+", " ".join(cmd), flush=True)
+    subprocess.check_call(cmd, cwd=str(root))
+
+
+def main() -> int:
+    root = _repo_root()
+    url = _resolve_database_url()
+    os.environ["ALEMBIC_DATABASE_URL"] = url
+    # Keep PASSWORD_FILE for alembic/env.py fallback; URL now carries the secret.
+    if _needs_baseline_stamp(url):
+        print(
+            f"compose-migrate: init.sql baseline detected without alembic_version; "
+            f"stamping {BASELINE_REVISION}",
+            flush=True,
+        )
+        _run_alembic(root, "stamp", BASELINE_REVISION)
+    _run_alembic(root, "upgrade", "head")
+    print("compose-migrate: upgrade head OK", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/DEPLOY_PLATFORM.md
+++ b/docs/DEPLOY_PLATFORM.md
@@ -166,6 +166,13 @@ does not require a manual `alembic upgrade head`. See
 [Control-Plane Helm — migration contract](../site-docs/deployment/control-plane-helm.md)
 for the one-time `init.sql` stamp path and the non-Helm override.
 
+For **Compose** (`deploy/docker-compose.platform.yml` and overlays that layer
+it), a one-shot `migrate` service runs the same contract before `api` starts:
+stamp baseline `20260416_01` when the volume was first created from `init.sql`,
+then `alembic upgrade head`. Image upgrades therefore apply schema changes on
+`docker compose up` without a manual Alembic step. The migrate container uses
+the Postgres bootstrap/admin role (DDL); the API stays on `agent_bom_app` (DML).
+
 ---
 
 ## Tier 3 — Operator-hosted / gated POC

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -99,6 +99,10 @@ docker compose \
   ps
 ```
 
+`up` runs a one-shot `migrate` service before `api` (Alembic stamp + `upgrade
+head`), so image upgrades apply schema changes without a manual migration step.
+See [DEPLOY_PLATFORM.md](DEPLOY_PLATFORM.md) for the Compose vs Helm contract.
+
 Seed a disposable demo graph after the API is healthy:
 
 ```bash

--- a/tests/test_compose_alembic_migrate.py
+++ b/tests/test_compose_alembic_migrate.py
@@ -1,0 +1,31 @@
+"""Unit tests for deploy/supabase/postgres/compose_migrate.py helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from deploy.supabase.postgres import compose_migrate as cm
+
+
+def test_resolve_database_url_injects_password_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    secret = tmp_path / "postgres_password"
+    secret.write_text("s3cret\n", encoding="utf-8")
+    monkeypatch.delenv("ALEMBIC_DATABASE_URL", raising=False)
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom@postgres:5432/agent_bom")
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_PASSWORD_FILE", str(secret))
+
+    url = cm._resolve_database_url()
+    assert url.startswith("postgresql://agent_bom:")
+    assert "@postgres:5432/agent_bom" in url
+    assert "s3cret" in url
+
+
+def test_resolve_database_url_keeps_embedded_password(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_PASSWORD_FILE", raising=False)
+    monkeypatch.setenv(
+        "AGENT_BOM_POSTGRES_URL",
+        "postgresql://agent_bom:already@postgres:5432/agent_bom",
+    )
+    assert cm._resolve_database_url() == "postgresql://agent_bom:already@postgres:5432/agent_bom"

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -33,6 +33,11 @@ HEALTHCHECK_EXEMPT: dict[str, set[str]] = {
         # depends_on uses postgres healthcheck for ordering.
         "agent-bom",
     },
+    "docker-compose.platform.yml": {
+        # One-shot Alembic upgrade (stamp init.sql baseline if needed, then
+        # upgrade head). Exits 0; API waits on service_completed_successfully.
+        "migrate",
+    },
     "docker-compose.runtime-example.yml": {
         # The mcp-server container talks stdio to the proxy and never opens a
         # TCP listener — there is no port to probe.
@@ -181,9 +186,17 @@ def test_compose_stacks_never_interpolate_postgres_passwords(compose_name: str) 
         assert "POSTGRES_APP_PASSWORD" not in env, f"{compose_name}:{name} must not set POSTGRES_APP_PASSWORD"
         for key, value in env.items():
             if key == "AGENT_BOM_POSTGRES_URL":
-                assert value.startswith("postgresql://agent_bom_app@"), (
-                    f"{compose_name}:{name} must connect as agent_bom_app without an embedded password"
-                )
+                # Long-lived API services use the DML-only app role. The one-shot
+                # migrate service is the Helm-equivalent DDL path and uses the
+                # bootstrap/admin role (password still file-mounted).
+                if name == "migrate":
+                    assert value.startswith("postgresql://agent_bom@"), (
+                        f"{compose_name}:migrate must connect as bootstrap agent_bom without an embedded password"
+                    )
+                else:
+                    assert value.startswith("postgresql://agent_bom_app@"), (
+                        f"{compose_name}:{name} must connect as agent_bom_app without an embedded password"
+                    )
 
 
 def test_platform_api_fails_closed_for_auth_docs_and_local_scans() -> None:
@@ -206,6 +219,34 @@ def test_platform_api_fails_closed_for_auth_docs_and_local_scans() -> None:
     assert api.get("ports") == ["${AGENT_BOM_API_BIND_HOST:-127.0.0.1}:${API_PORT:-8422}:8422"]
     secrets = set(api.get("secrets") or [])
     assert {"api_key", "audit_hmac_key", "browser_session_signing_key", "connections_key"} <= secrets
+
+
+def test_platform_migrate_runs_alembic_before_api() -> None:
+    """Compose upgrades must apply Alembic the same way Helm's migrate Job does."""
+    path = COMPOSE_DIR / "docker-compose.platform.yml"
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    services = data.get("services") or {}
+    migrate = services.get("migrate") or {}
+    api = services.get("api") or {}
+
+    assert migrate.get("entrypoint") == ["python"]
+    assert migrate.get("command") == ["deploy/supabase/postgres/compose_migrate.py"]
+    assert migrate.get("working_dir") == "/opt/agent-bom"
+    assert migrate.get("restart") == "no"
+    env = {
+        item.split("=", 1)[0]: item.split("=", 1)[1]
+        for item in (migrate.get("environment") or [])
+        if isinstance(item, str) and "=" in item
+    }
+    assert env.get("AGENT_BOM_POSTGRES_URL", "").startswith("postgresql://agent_bom@")
+    assert env.get("AGENT_BOM_POSTGRES_PASSWORD_FILE") == "/run/secrets/postgres_password"
+    assert "postgres_password" in set(migrate.get("secrets") or [])
+    assert (migrate.get("depends_on") or {}).get("postgres", {}).get("condition") == "service_healthy"
+
+    api_deps = api.get("depends_on") or {}
+    assert api_deps.get("migrate", {}).get("condition") == "service_completed_successfully"
+    script = COMPOSE_DIR / "supabase" / "postgres" / "compose_migrate.py"
+    assert script.is_file(), "migrate script must ship under deploy/supabase/postgres (image COPY path)"
 
 
 def test_platform_ui_binds_loopback_by_default() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Add one-shot `migrate` service to `deploy/docker-compose.platform.yml` that stamps `init.sql` baselines when needed and runs `alembic upgrade head` before `api` starts (Helm migration Job parity for Compose upgrades)
- Resolve `AGENT_BOM_POSTGRES_PASSWORD_FILE` in Alembic `env.py` so bootstrap passwords stay file-mounted
- Document Compose migrate contract in `DEPLOY_PLATFORM.md` / `HOSTED_POC.md`

Tracks #4351 (PR 1/4).

## Verification

```bash
uv run pytest -q tests/test_compose_secrets_healthcheck.py tests/test_compose_alembic_migrate.py
# 38 passed
```

## Notes

- Migrate uses bootstrap/admin role (DDL); API stays on `agent_bom_app` (DML)
- Overlays (hosted-poc / demo / product) inherit this via platform base
- Large open enhancement issues (#4344, #4158, …) explicitly deferred in #4351
- Rebased onto `main` (includes #4350); force-pushed to retrigger required CI after a merge commit left checks unreported.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

