### PR TITLE
fix(graph): FORCE RLS on graph build workspace staging tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   (stamp `init.sql` baselines when needed, then `alembic upgrade head`), matching
   the Helm migration Job so image upgrades apply Postgres schema changes without
   a manual Alembic step.
+- `graph_build_workspace_nodes` / `graph_build_workspace_edges` now ENABLE+FORCE
+  tenant RLS (init.sql + Alembic `20260721_01`); the Postgres workspace backend
+  binds `app.tenant_id` per operation so staging rows cannot cross tenants.
 
 ### Fixed
 - Hosted POC hardening overlay no longer opts into anonymous API access.

--- a/deploy/supabase/postgres/alembic/versions/20260721_01_graph_build_workspace_rls.py
+++ b/deploy/supabase/postgres/alembic/versions/20260721_01_graph_build_workspace_rls.py
@@ -1,0 +1,55 @@
+"""Enable FORCE RLS on graph build workspace staging tables.
+
+Revision ID: 20260721_01
+Revises: 20260720_03
+
+The bounded graph producer stages nodes/edges in shared Postgres tables.
+Application filters alone are not enough — enable the same tenant isolation
+contract used by graph_nodes / graph_edges so a raw SELECT under tenant B
+cannot read tenant A's workspace rows.
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260721_01"
+down_revision = "20260720_03"
+branch_labels = None
+depends_on = None
+
+_TABLES = (
+    "graph_build_workspace_nodes",
+    "graph_build_workspace_edges",
+)
+
+
+def upgrade() -> None:
+    for table in _TABLES:
+        op.execute(f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY")
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_policies
+                    WHERE schemaname = 'public'
+                      AND tablename = '{table}'
+                      AND policyname = '{table}_tenant_isolation'
+                ) THEN
+                    EXECUTE 'CREATE POLICY {table}_tenant_isolation ON {table}
+                        USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+                        WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())';
+                END IF;
+            END
+            $$;
+            """
+        )
+
+
+def downgrade() -> None:
+    for table in _TABLES:
+        op.execute(f"DROP POLICY IF EXISTS {table}_tenant_isolation ON {table}")
+        op.execute(f"ALTER TABLE {table} NO FORCE ROW LEVEL SECURITY")
+        op.execute(f"ALTER TABLE {table} DISABLE ROW LEVEL SECURITY")

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -1054,6 +1054,42 @@ BEGIN
 END
 $$;
 
+ALTER TABLE graph_build_workspace_nodes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE graph_build_workspace_nodes FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'graph_build_workspace_nodes'
+          AND policyname = 'graph_build_workspace_nodes_tenant_isolation'
+    ) THEN
+        CREATE POLICY graph_build_workspace_nodes_tenant_isolation ON graph_build_workspace_nodes
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
+ALTER TABLE graph_build_workspace_edges ENABLE ROW LEVEL SECURITY;
+ALTER TABLE graph_build_workspace_edges FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'graph_build_workspace_edges'
+          AND policyname = 'graph_build_workspace_edges_tenant_isolation'
+    ) THEN
+        CREATE POLICY graph_build_workspace_edges_tenant_isolation ON graph_build_workspace_edges
+            USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
+
 ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY;
 ALTER TABLE api_keys FORCE ROW LEVEL SECURITY;
 

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -441,6 +441,8 @@ class PostgresGraphStore:
             _ensure_tenant_rls(conn, "interaction_risks", "tenant_id")
             _ensure_tenant_rls(conn, "graph_filter_presets", "tenant_id")
             _ensure_tenant_rls(conn, "graph_node_search", "tenant_id")
+            _ensure_tenant_rls(conn, "graph_build_workspace_nodes", "tenant_id")
+            _ensure_tenant_rls(conn, "graph_build_workspace_edges", "tenant_id")
             conn.commit()
         self._init_optional_search_indexes()
 

--- a/src/agent_bom/graph/build_workspace.py
+++ b/src/agent_bom/graph/build_workspace.py
@@ -362,6 +362,16 @@ class _PostgresWorkspaceBackend:
                 "Postgres graph workspace schema is not migrated; run Alembic upgrade head before starting the service."
             )
 
+    def _bind_tenant(self, tenant_id: str) -> None:
+        """Bind ``app.tenant_id`` for FORCE RLS (transaction-local).
+
+        Workspace methods take an explicit ``tenant_id``; the session must match
+        that value so ``WITH CHECK`` / ``USING`` policies accept the rows.
+        """
+        tid = _normalize_tenant(tenant_id)
+        self._conn.execute("SELECT set_config('app.tenant_id', %s, true)", (tid,))
+        self._conn.execute("SELECT set_config('app.bypass_rls', %s, true)", ("0",))
+
     def _upsert(
         self,
         table: str,
@@ -377,9 +387,12 @@ class _PostgresWorkspaceBackend:
             f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({placeholders}) "  # nosec B608 - static table/cols
             f"ON CONFLICT (workspace_id, tenant_id, {key_col}) DO UPDATE SET {updates}"
         )
-        with self._conn.cursor() as cur:
-            params = ((self._workspace_id, tenant_id, *row) for row in rows)
-            cur.executemany(sql, params)
+        # Materialize once — the transaction may retry and generators are one-shot.
+        batch = tuple((self._workspace_id, tenant_id, *row) for row in rows)
+        with self._conn.transaction():
+            self._bind_tenant(tenant_id)
+            with self._conn.cursor() as cur:
+                cur.executemany(sql, batch)
 
     def add_node_payloads(self, tenant_id: str, rows: Iterable[tuple[str, str, str]]) -> None:
         self._upsert("graph_build_workspace_nodes", "node_id", ("entity_type",), tenant_id, rows)
@@ -408,6 +421,7 @@ class _PostgresWorkspaceBackend:
             params = (self._workspace_id, tenant_id, str(where_val))
         name = f"gbw_{uuid.uuid4().hex}"
         with self._conn.transaction(), self._conn.cursor(name=name) as cur:
+            self._bind_tenant(tenant_id)
             cur.itersize = batch_size
             cur.execute(
                 f"SELECT payload FROM {table} WHERE workspace_id = %s AND tenant_id = %s{predicate} ORDER BY seq",  # nosec B608
@@ -424,20 +438,24 @@ class _PostgresWorkspaceBackend:
         return self._iter_payloads("graph_build_workspace_edges", tenant_id, batch_size)
 
     def get_node_payload(self, tenant_id: str, node_id: str) -> str | None:
-        row = self._conn.execute(
-            "SELECT payload FROM graph_build_workspace_nodes WHERE workspace_id = %s AND tenant_id = %s AND node_id = %s",
-            (self._workspace_id, tenant_id, node_id),
-        ).fetchone()
+        with self._conn.transaction():
+            self._bind_tenant(tenant_id)
+            row = self._conn.execute(
+                "SELECT payload FROM graph_build_workspace_nodes WHERE workspace_id = %s AND tenant_id = %s AND node_id = %s",
+                (self._workspace_id, tenant_id, node_id),
+            ).fetchone()
         if not row:
             return None
         payload = row[0]
         return payload if isinstance(payload, str) else json.dumps(payload)
 
     def get_edge_payload(self, tenant_id: str, edge_key: str) -> str | None:
-        row = self._conn.execute(
-            "SELECT payload FROM graph_build_workspace_edges WHERE workspace_id = %s AND tenant_id = %s AND edge_key = %s",
-            (self._workspace_id, tenant_id, edge_key),
-        ).fetchone()
+        with self._conn.transaction():
+            self._bind_tenant(tenant_id)
+            row = self._conn.execute(
+                "SELECT payload FROM graph_build_workspace_edges WHERE workspace_id = %s AND tenant_id = %s AND edge_key = %s",
+                (self._workspace_id, tenant_id, edge_key),
+            ).fetchone()
         if not row:
             return None
         payload = row[0]
@@ -450,11 +468,13 @@ class _PostgresWorkspaceBackend:
             predicate = " AND entity_type = %s"
             params = (self._workspace_id, tenant_id, entity_type)
         params = (*params, after_seq, limit)
-        rows = self._conn.execute(
-            f"SELECT seq, node_id, payload FROM graph_build_workspace_nodes "  # nosec B608 - static cols
-            f"WHERE workspace_id = %s AND tenant_id = %s{predicate} AND seq > %s ORDER BY seq LIMIT %s",
-            params,
-        ).fetchall()
+        with self._conn.transaction():
+            self._bind_tenant(tenant_id)
+            rows = self._conn.execute(
+                f"SELECT seq, node_id, payload FROM graph_build_workspace_nodes "  # nosec B608 - static cols
+                f"WHERE workspace_id = %s AND tenant_id = %s{predicate} AND seq > %s ORDER BY seq LIMIT %s",
+                params,
+            ).fetchall()
         return [(int(seq), str(node_id), p if isinstance(p, str) else json.dumps(p)) for seq, node_id, p in rows]
 
     def fetch_edge_page(
@@ -469,11 +489,13 @@ class _PostgresWorkspaceBackend:
             predicate = " AND target_id = %s"
             params = (self._workspace_id, tenant_id, target_id)
         params = (*params, after_seq, limit)
-        rows = self._conn.execute(
-            f"SELECT seq, payload FROM graph_build_workspace_edges "  # nosec B608 - static cols
-            f"WHERE workspace_id = %s AND tenant_id = %s{predicate} AND seq > %s ORDER BY seq LIMIT %s",
-            params,
-        ).fetchall()
+        with self._conn.transaction():
+            self._bind_tenant(tenant_id)
+            rows = self._conn.execute(
+                f"SELECT seq, payload FROM graph_build_workspace_edges "  # nosec B608 - static cols
+                f"WHERE workspace_id = %s AND tenant_id = %s{predicate} AND seq > %s ORDER BY seq LIMIT %s",
+                params,
+            ).fetchall()
         return [(int(seq), p if isinstance(p, str) else json.dumps(p)) for seq, p in rows]
 
     def iter_node_payloads_by_type(self, tenant_id: str, entity_type: str, batch_size: int) -> Iterator[str]:
@@ -486,10 +508,12 @@ class _PostgresWorkspaceBackend:
         return self._iter_payloads("graph_build_workspace_edges", tenant_id, batch_size, where_col="target_id", where_val=node_id)
 
     def _count(self, table: str, tenant_id: str) -> int:
-        row = self._conn.execute(
-            f"SELECT COUNT(*) FROM {table} WHERE workspace_id = %s AND tenant_id = %s",  # nosec B608 - static table
-            (self._workspace_id, tenant_id),
-        ).fetchone()
+        with self._conn.transaction():
+            self._bind_tenant(tenant_id)
+            row = self._conn.execute(
+                f"SELECT COUNT(*) FROM {table} WHERE workspace_id = %s AND tenant_id = %s",  # nosec B608 - static table
+                (self._workspace_id, tenant_id),
+            ).fetchone()
         return int(row[0]) if row else 0
 
     def count_nodes(self, tenant_id: str) -> int:
@@ -500,15 +524,19 @@ class _PostgresWorkspaceBackend:
 
     def close(self) -> None:
         # Drop only this workspace's rows; the shared tables persist for reuse.
+        # Bypass RLS so cleanup clears every tenant that staged into this
+        # workspace_id (multi-tenant tests share one workspace backend).
         try:
-            self._conn.execute(
-                "DELETE FROM graph_build_workspace_nodes WHERE workspace_id = %s",
-                (self._workspace_id,),
-            )
-            self._conn.execute(
-                "DELETE FROM graph_build_workspace_edges WHERE workspace_id = %s",
-                (self._workspace_id,),
-            )
+            with self._conn.transaction():
+                self._conn.execute("SELECT set_config('app.bypass_rls', %s, true)", ("1",))
+                self._conn.execute(
+                    "DELETE FROM graph_build_workspace_nodes WHERE workspace_id = %s",
+                    (self._workspace_id,),
+                )
+                self._conn.execute(
+                    "DELETE FROM graph_build_workspace_edges WHERE workspace_id = %s",
+                    (self._workspace_id,),
+                )
         finally:
             self._conn.close()
 

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -248,6 +248,111 @@ def test_postgres_scan_jobs_rls_schema_is_locked_down():
     )
 
 
+def test_postgres_graph_build_workspace_rls_schema_is_locked_down():
+    """Structural RLS guard for graph_build_workspace_* staging tables."""
+    from agent_bom.api.postgres_common import _get_pool
+    from agent_bom.api.postgres_graph import PostgresGraphStore
+
+    PostgresGraphStore()  # registers _ensure_tenant_rls on workspace tables
+
+    pool = _get_pool()
+    with pool.connection() as conn:
+        for table in ("graph_build_workspace_nodes", "graph_build_workspace_edges"):
+            rls_state = conn.execute(
+                """
+                SELECT relrowsecurity, relforcerowsecurity
+                FROM pg_class
+                WHERE relname = %s AND relnamespace = 'public'::regnamespace
+                """,
+                (table,),
+            ).fetchone()
+            policy_rows = conn.execute(
+                """
+                SELECT policyname, cmd, qual, with_check
+                FROM pg_policies
+                WHERE schemaname = 'public' AND tablename = %s
+                """,
+                (table,),
+            ).fetchall()
+            assert rls_state == (True, True), f"{table} must ENABLE+FORCE RLS; got {rls_state}"
+            isolation = [row for row in policy_rows if row[0] == f"{table}_tenant_isolation"]
+            assert isolation, f"{table} missing tenant_isolation policy"
+            _, cmd, qual, with_check = isolation[0]
+            assert cmd in {"ALL", "*"}
+            assert "abom_current_tenant" in (qual or "")
+            assert "abom_current_tenant" in (with_check or "")
+
+
+def test_postgres_graph_build_workspace_rls_blocks_cross_tenant_raw_select():
+    """Insert workspace rows under tenant A; tenant B raw SELECT must see zero."""
+    from agent_bom.api import postgres_common
+    from agent_bom.api.postgres_common import (
+        _apply_tenant_session,
+        reset_current_tenant,
+        set_current_tenant,
+    )
+    from agent_bom.api.postgres_graph import PostgresGraphStore
+
+    PostgresGraphStore()
+    pool = postgres_common._get_pool()
+    with pool.connection() as conn:
+        role_state = conn.execute("SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user").fetchone()
+    if role_state is None or role_state[0] or role_state[1]:
+        pytest.skip(
+            f"Runtime RLS check requires a non-superuser, non-bypassrls role. current_user has (rolsuper, rolbypassrls)={role_state}."
+        )
+
+    suffix = uuid4().hex
+    workspace_id = f"gbw-rls-{suffix}"
+    tenant_a = f"tenant-a-{suffix}"
+    tenant_b = f"tenant-b-{suffix}"
+    node_id = f"node-{suffix}"
+
+    token_a = set_current_tenant(tenant_a)
+    try:
+        with pool.connection() as conn:
+            _apply_tenant_session(conn)
+            conn.execute(
+                """
+                INSERT INTO graph_build_workspace_nodes
+                    (workspace_id, tenant_id, node_id, payload, entity_type)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (workspace_id, tenant_a, node_id, '{"id":"x"}', "agent"),
+            )
+            conn.commit()
+    finally:
+        reset_current_tenant(token_a)
+
+    token_b = set_current_tenant(tenant_b)
+    try:
+        with pool.connection() as conn:
+            _apply_tenant_session(conn)
+            cross_tenant_rows = conn.execute(
+                "SELECT node_id FROM graph_build_workspace_nodes WHERE workspace_id = %s AND node_id = %s",
+                (workspace_id, node_id),
+            ).fetchall()
+    finally:
+        reset_current_tenant(token_b)
+
+    assert cross_tenant_rows == [], (
+        "graph_build_workspace_nodes RLS leaked tenant A data into a session bound to tenant B"
+    )
+
+    # Cleanup under tenant A (and edges table is unused here).
+    token_a = set_current_tenant(tenant_a)
+    try:
+        with pool.connection() as conn:
+            _apply_tenant_session(conn)
+            conn.execute(
+                "DELETE FROM graph_build_workspace_nodes WHERE workspace_id = %s",
+                (workspace_id,),
+            )
+            conn.commit()
+    finally:
+        reset_current_tenant(token_a)
+
+
 def test_postgres_scan_jobs_rls_blocks_cross_tenant_raw_select():
     # Runtime red-team for #1815: insert under tenant A, then run a
     # tenant-blind raw SELECT under a session bound to tenant B. RLS must

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -137,6 +137,8 @@ def test_graph_tables_have_rls_policies():
         "interaction_risks",
         "graph_filter_presets",
         "graph_node_search",
+        "graph_build_workspace_nodes",
+        "graph_build_workspace_edges",
     ):
         assert f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY" in SQL
         assert f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY" in SQL
@@ -166,6 +168,11 @@ def test_graph_build_workspace_schema_is_migration_owned():
     assert 'down_revision = "20260720_02"' in body
     assert "CREATE TABLE IF NOT EXISTS graph_build_workspace_nodes" in body
     assert "CREATE TABLE IF NOT EXISTS graph_build_workspace_edges" in body
+    rls = versions / "20260721_01_graph_build_workspace_rls.py"
+    rls_body = rls.read_text()
+    assert 'down_revision = "20260720_03"' in rls_body
+    assert "graph_build_workspace_nodes" in rls_body
+    assert "FORCE ROW LEVEL SECURITY" in rls_body
 
 
 def test_graph_snapshot_json_fields_are_text_in_baseline():

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1490,6 +1490,12 @@ def test_graph_store_init_tolerates_restricted_pg_trgm_extension():
     assert pool._conn.transaction_events == ["commit", "rollback"]
     assert any("CREATE TABLE IF NOT EXISTS graph_nodes" in sql for sql, _ in pool._conn.executed)
     assert any("ALTER TABLE graph_nodes ENABLE ROW LEVEL SECURITY" in sql for sql, _ in pool._conn.executed)
+    assert any(
+        "ALTER TABLE graph_build_workspace_nodes ENABLE ROW LEVEL SECURITY" in sql for sql, _ in pool._conn.executed
+    )
+    assert any(
+        "ALTER TABLE graph_build_workspace_edges ENABLE ROW LEVEL SECURITY" in sql for sql, _ in pool._conn.executed
+    )
     assert any("CREATE EXTENSION IF NOT EXISTS pg_trgm" in sql for sql, _ in pool._conn.executed)
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- ENABLE+FORCE tenant RLS on `graph_build_workspace_nodes` / `graph_build_workspace_edges` (init.sql + Alembic `20260721_01`)
- Register both tables in `PostgresGraphStore` RLS backstop
- Postgres workspace backend binds `app.tenant_id` per operation (transaction-local) so FORCE RLS accepts same-tenant DML and blocks cross-tenant raw SELECT
- Workspace `close()` uses RLS bypass only for cleanup of that `workspace_id`

Tracks #4351 (PR 2/4).

## Verification

```bash
uv run pytest -q tests/test_postgres_schema.py \
  tests/test_postgres_store.py -k 'graph_store_init or graph_tables_have_rls or graph_build_workspace_schema' \
  tests/graph/test_graph_build_workspace.py
# 6+ workspace suite passed
python3 scripts/check_public_docs_hygiene.py
```

Live Postgres red-team (CI when `AGENT_BOM_POSTGRES_URL` is set):
`tests/test_postgres_integration.py::test_postgres_graph_build_workspace_rls_*`

## Notes

- Fresh volumes get RLS from init.sql; upgrades get it via Compose/Helm Alembic (`20260721_01`)
- PR 3/4 (CronJob fail-loud) remains queued until this merges

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

