### PR TITLE
fix(helm): make scheduled CronJobs fail loud

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,6 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Helm scanner, KSPM, and control-plane backup CronJobs fail loud
   (`jobTemplate.spec.backoffLimit: 0`, `restartPolicy: Never`) so a bad run
   surfaces as a Failed Job instead of retrying quietly under `OnFailure`.
-
-### Fixed
 - Hosted POC hardening overlay no longer opts into anonymous API access.
   `AGENT_BOM_DEMO_ESTATE` / `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` /
   `AGENT_BOM_NO_AUTH_ROLE=viewer` move to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
   binds `app.tenant_id` per operation so staging rows cannot cross tenants.
 
 ### Fixed
+- Helm scanner, KSPM, and control-plane backup CronJobs fail loud
+  (`jobTemplate.spec.backoffLimit: 0`, `restartPolicy: Never`) so a bad run
+  surfaces as a Failed Job instead of retrying quietly under `OnFailure`.
+
+### Fixed
 - Hosted POC hardening overlay no longer opts into anonymous API access.
   `AGENT_BOM_DEMO_ESTATE` / `AGENT_BOM_ALLOW_UNAUTHENTICATED_API` /
   `AGENT_BOM_NO_AUTH_ROLE=viewer` move to

--- a/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-backup-cronjob.yaml
@@ -14,13 +14,15 @@ spec:
   failedJobsHistoryLimit: {{ .Values.controlPlane.backup.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      # Fail loud: one pod failure marks the Job Failed (no silent retries).
+      backoffLimit: 0
       template:
         metadata:
           labels:
             {{- include "agent-bom.labels" . | nindent 12 }}
             app.kubernetes.io/component: control-plane-backup
         spec:
-          restartPolicy: OnFailure
+          restartPolicy: Never
           serviceAccountName: {{ include "agent-bom.controlPlaneBackupServiceAccountName" . }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}

--- a/deploy/helm/agent-bom/templates/cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/cronjob.yaml
@@ -22,6 +22,8 @@ spec:
   failedJobsHistoryLimit: {{ .Values.scanner.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      # Fail loud: one pod failure marks the Job Failed (no silent retries).
+      backoffLimit: 0
       template:
         metadata:
           labels:
@@ -204,5 +206,5 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          restartPolicy: OnFailure
+          restartPolicy: Never
 {{- end }}

--- a/deploy/helm/agent-bom/templates/kspm-cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/kspm-cronjob.yaml
@@ -20,6 +20,8 @@ spec:
   failedJobsHistoryLimit: {{ .Values.scanner.failedJobsHistoryLimit }}
   jobTemplate:
     spec:
+      # Fail loud: one pod failure marks the Job Failed (no silent retries).
+      backoffLimit: 0
       template:
         metadata:
           labels:
@@ -94,5 +96,5 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          restartPolicy: OnFailure
+          restartPolicy: Never
 {{- end }}

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -797,6 +797,19 @@ def test_alembic_migration_hook_template():
     assert "backoffLimit: {{ $migrations.backoffLimit }}" in template
 
 
+def test_scheduled_cronjobs_are_fail_loud():
+    """Scanner / KSPM / backup CronJobs must not silently retry forever."""
+    for name in (
+        "cronjob.yaml",
+        "kspm-cronjob.yaml",
+        "controlplane-backup-cronjob.yaml",
+    ):
+        template = (HELM_DIR / "templates" / name).read_text()
+        assert "backoffLimit: 0" in template, f"{name} must set jobTemplate.spec.backoffLimit: 0"
+        assert "restartPolicy: Never" in template, f"{name} must use restartPolicy: Never"
+        assert "restartPolicy: OnFailure" not in template, f"{name} must not use OnFailure retries"
+
+
 def test_scanner_only_cronjob_warning_annotation():
     """Scanner-only renders should surface an install-time warning annotation."""
     template = (HELM_DIR / "templates" / "cronjob.yaml").read_text()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Scanner, KSPM, and control-plane backup CronJobs set `jobTemplate.spec.backoffLimit: 0` and `restartPolicy: Never`
- A failed schedule run surfaces as a Failed Job (kept via `failedJobsHistoryLimit`) instead of retrying quietly under `OnFailure`

Tracks #4351 (PR 3/4).

## Verification

```bash
uv run pytest -q tests/test_deploy_manifests.py -k 'cronjob or fail_loud or alembic_migration'
# 5 passed
helm template abom deploy/helm/agent-bom \
  --set scanner.enabled=true --set scanner.kspm.enabled=true \
  --set controlPlane.enabled=true --set controlPlane.backup.enabled=true \
  --set controlPlane.api.envFrom[0].secretRef.name=x \
  | rg 'kind: CronJob|backoffLimit|restartPolicy'
```

## Notes

- Matches the existing Alembic migration Job fail-loud contract
- Teardown hook Jobs keep their own backoffLimit (unchanged)
- PR 4/4 (compliance helper-not-certified labels) remains queued

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

