### PR TITLE
docs(ui): label compliance mappings as evidence helper, not certification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   (`docs/archive/STRATEGIC_AUDIT_*`, `docs/archive/AUDIT.md`, `docs/audits/`);
   soften large-enterprise procurement phrasing. CI
   (`scripts/check_public_docs_hygiene.py`) blocks reintroduction.
+- Compliance UI and docs label framework mappings as a curated evidence helper,
+  not a certification or complete control catalog (dashboard disclaimer +
+  `site-docs/features/compliance.md` / `CONTROL_MAPPING.md` / `ARCHITECTURE.md`).
 
 ## [0.97.2] - 2026-07-21
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -348,7 +348,7 @@ LLM spend onto nodes and rolls it up along `CONTAINS` into `subtree_cost_usd`.
 
 ## 4. Compliance Tagging
 
-Every finding is tagged against curated compliance frameworks, grouped into four families. OWASP AISVS is exposed as a separate benchmark result with per-check evidence. The bundled mappings are a curated subset of each framework focused on AI/MCP/agent risk-relevant controls — they are not a complete catalog. See [Coverage per framework](#coverage-per-framework) below for the generated control counts.
+Every finding is tagged against curated compliance frameworks, grouped into four families. OWASP AISVS is exposed as a separate benchmark result with per-check evidence. The bundled mappings are a curated **evidence helper** — a subset of each framework focused on AI/MCP/agent risk-relevant controls — not a certification claim, audit opinion, or complete catalog. See [Coverage per framework](#coverage-per-framework) below for the generated control counts.
 
 ```mermaid
 graph LR

--- a/docs/CONTROL_MAPPING.md
+++ b/docs/CONTROL_MAPPING.md
@@ -1,9 +1,10 @@
 # Enterprise Control Mapping
 
 This page maps common procurement and audit questions to implemented
-`agent-bom` controls. It is an evidence index, not a certification claim.
-Auditors should validate the linked code, tests, workflows, and deployment
-settings in the customer environment.
+`agent-bom` controls. It is a curated **evidence helper / index**, not a
+certification claim, audit opinion, or complete control catalog. Auditors should
+validate the linked code, tests, workflows, and deployment settings in the
+customer environment.
 
 ## How To Use This Map
 

--- a/site-docs/features/compliance.md
+++ b/site-docs/features/compliance.md
@@ -5,8 +5,9 @@ agent-bom maps scan findings to curated security and compliance frameworks and e
 **Scope:** these mappings are a curated **evidence helper** for AI/MCP/agent risk
 triage. They are **not** a certification, audit opinion, attestation of
 compliance, or a complete framework catalog. Operators and auditors must validate
-controls against the customer environment and the exact release in use. See also
-[`docs/CONTROL_MAPPING.md`](../../docs/CONTROL_MAPPING.md).
+controls against the customer environment and the exact release in use. For
+procurement-oriented product evidence mapping, see `docs/CONTROL_MAPPING.md` in
+the repository (not published on this docs site).
 
 Framework catalogs are pinned in-repo by default so scans stay deterministic,
 offline-friendly, and reproducible. Catalog refreshes can happen out of band;

--- a/site-docs/features/compliance.md
+++ b/site-docs/features/compliance.md
@@ -2,6 +2,12 @@
 
 agent-bom maps scan findings to curated security and compliance frameworks and exposes OWASP AISVS as benchmark evidence.
 
+**Scope:** these mappings are a curated **evidence helper** for AI/MCP/agent risk
+triage. They are **not** a certification, audit opinion, attestation of
+compliance, or a complete framework catalog. Operators and auditors must validate
+controls against the customer environment and the exact release in use. See also
+[`docs/CONTROL_MAPPING.md`](../../docs/CONTROL_MAPPING.md).
+
 Framework catalogs are pinned in-repo by default so scans stay deterministic,
 offline-friendly, and reproducible. Catalog refreshes can happen out of band;
 the scan hot path does not fetch MITRE or other framework data at runtime.

--- a/ui/app/compliance/page.tsx
+++ b/ui/app/compliance/page.tsx
@@ -583,10 +583,14 @@ function CompliancePageContent() {
             </span>
             {data.latest_scan ? <span>Latest {formatDate(data.latest_scan)}</span> : null}
             <span>{totalFail} failing controls</span>
-            <span>
-              AI supply-chain frameworks + cloud CIS posture when accounts are connected — not a full CNAPP claim.
-            </span>
           </div>
+          <p
+            className="mt-2 max-w-3xl text-xs leading-relaxed text-[color:var(--text-secondary)]"
+            data-testid="compliance-helper-disclaimer"
+          >
+            Curated evidence helper for AI/MCP/agent risk — not a certification, audit opinion, or complete
+            control catalog. Validate mapped controls against your environment and auditor scope.
+          </p>
         </div>
         <button
           onClick={() => void handleExportPack()}

--- a/ui/components/compliance-matrix.tsx
+++ b/ui/components/compliance-matrix.tsx
@@ -262,6 +262,13 @@ export function ComplianceMatrix({ data }: { data: ComplianceResponse }) {
 
   return (
     <div className="space-y-4">
+      <p
+        className="text-xs leading-relaxed text-[color:var(--text-secondary)]"
+        data-testid="compliance-matrix-helper-disclaimer"
+      >
+        Matrix rows are curated control mappings for evidence triage — not a certification claim or complete
+        framework catalog.
+      </p>
       {/* Toolbar */}
       <div className="flex flex-wrap items-center gap-3">
         {/* Search */}

--- a/ui/tests/compliance-page.test.tsx
+++ b/ui/tests/compliance-page.test.tsx
@@ -119,6 +119,10 @@ describe("CompliancePage (dense restyle)", () => {
     expect(within(strip).getByText("Passing")).toBeInTheDocument();
     expect(within(strip).getByText("Failing")).toBeInTheDocument();
 
+    const disclaimer = screen.getByTestId("compliance-helper-disclaimer");
+    expect(disclaimer).toHaveTextContent(/not a certification/i);
+    expect(disclaimer).toHaveTextContent(/evidence helper/i);
+
     const table = screen.getByTestId("compliance-frameworks-table");
     // Short labels appear as the primary framework name.
     expect(within(table).getByText("LLM")).toBeInTheDocument();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Compliance dashboard trust-center header shows an explicit “curated evidence helper — not a certification / complete catalog” disclaimer (`data-testid="compliance-helper-disclaimer"`)
- Matrix view carries the same honesty line
- Align `site-docs/features/compliance.md`, `docs/CONTROL_MAPPING.md`, and `docs/ARCHITECTURE.md`

Tracks #4351 (PR 4/4).

## Verification

```bash
cd ui && npm test -- --run tests/compliance-page.test.tsx
# 2 passed
python3 scripts/check_public_docs_hygiene.py
```

## Notes

- Rebased onto `main` (includes #4354 CronJob fail-loud)
- Fixed Docs Strict Build: site-docs must not link to unpublished `docs/CONTROL_MAPPING.md`
- No scoring or API behavior change — copy honesty only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

