### PR TITLE
fix(ui): lay attack-path hops left-to-right on wrap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   binds `app.tenant_id` per operation so staging rows cannot cross tenants.
 
 ### Fixed
+- Attack-path Path view always lays hops left-to-right (no odd-row snake), so
+  wrapped critical paths no longer draw an inbound arrow into the finding from
+  empty space.
 - Helm scanner, KSPM, and control-plane backup CronJobs fail loud
   (`jobTemplate.spec.backoffLimit: 0`, `restartPolicy: Never`) so a bad run
   surfaces as a Failed Job instead of retrying quietly under `OnFailure`.

--- a/ui/lib/exposure-path-graph-layout.ts
+++ b/ui/lib/exposure-path-graph-layout.ts
@@ -76,14 +76,16 @@ export function buildPathGraphLayout(path: ExposurePath): PathGraphLayout {
   const pitchX = nodeWidth + COLUMN_GAP;
   const rowGap = nodeHeight + ROW_GAP_EXTRA;
 
+  // Always place hops left-to-right, wrapping to a new row. A prior
+  // boustrophedon (snake) layout made long paths reverse on odd rows while
+  // edges still assumed L→R ports — so the inbound arrow into the finding
+  // looked like it came from empty space (README screenshot regression).
   const nodes: PathGraphNode[] = path.hops.map((hop, index) => {
     const row = Math.floor(index / columns);
     const col = index % columns;
-    // Boustrophedon rows so a wrapped path reads left-to-right, then back.
-    const visualCol = row % 2 === 0 ? col : columns - 1 - col;
     return {
       ...hop,
-      x: MARGIN_X + visualCol * pitchX,
+      x: MARGIN_X + col * pitchX,
       y: MARGIN_Y + row * rowGap,
     };
   });
@@ -99,23 +101,41 @@ export function buildPathGraphLayout(path: ExposurePath): PathGraphLayout {
   const edges: PathGraphEdge[] = nodes.slice(0, -1).map((source, index) => {
     const target = nodes[index + 1]!;
     const relationship = relationshipForPathStep(path, source.id, target.id, index);
-    const startX = source.x + nodeWidth;
-    const startY = source.y + nodeHeight / 2;
-    const endX = target.x;
-    const endY = target.y + nodeHeight / 2;
-    const sameRow = Math.abs(startY - endY) < 10;
-    const control = sameRow ? Math.max(40, Math.abs(endX - startX) / 2) : 56;
-    const pathD = sameRow
-      ? `M ${startX} ${startY} C ${startX + control} ${startY}, ${endX - control} ${endY}, ${endX} ${endY}`
-      : `M ${source.x + nodeWidth / 2} ${source.y + nodeHeight} C ${source.x + nodeWidth / 2} ${source.y + nodeHeight + control}, ${target.x + nodeWidth / 2} ${target.y - control}, ${target.x + nodeWidth / 2} ${target.y}`;
+    const sameRow = Math.abs(source.y - target.y) < 10;
+    const control = sameRow ? Math.max(40, Math.abs(target.x - source.x) / 2) : 56;
+    let pathD: string;
+    let labelX: number;
+    let labelY: number;
+    if (sameRow) {
+      // Direction-aware ports so a same-row edge never draws "into" a node
+      // from empty space on the wrong side.
+      const leftToRight = target.x >= source.x;
+      const startX = leftToRight ? source.x + nodeWidth : source.x;
+      const endX = leftToRight ? target.x : target.x + nodeWidth;
+      const midY = source.y + nodeHeight / 2;
+      const c1 = leftToRight ? startX + control : startX - control;
+      const c2 = leftToRight ? endX - control : endX + control;
+      pathD = `M ${startX} ${midY} C ${c1} ${midY}, ${c2} ${midY}, ${endX} ${midY}`;
+      labelX = (startX + endX) / 2;
+      labelY = midY;
+    } else {
+      // Row wrap: drop from the end of the prior row to the start of the next.
+      const startX = source.x + nodeWidth / 2;
+      const startY = source.y + nodeHeight;
+      const endX = target.x + nodeWidth / 2;
+      const endY = target.y;
+      pathD = `M ${startX} ${startY} C ${startX} ${startY + control}, ${endX} ${endY - control}, ${endX} ${endY}`;
+      labelX = (startX + endX) / 2;
+      labelY = (startY + endY) / 2;
+    }
     const style = GRAPH_ROLE_STYLE[target.role] ?? GRAPH_ROLE_STYLE.unknown;
     return {
       id: `${source.id}->${target.id}`,
       path: pathD,
       stroke: style.stroke,
       label: truncateGraphText(relationship, 16),
-      labelX: sameRow ? (startX + endX) / 2 : source.x + nodeWidth / 2,
-      labelY: sameRow ? startY : (source.y + nodeHeight + target.y) / 2,
+      labelX,
+      labelY,
     };
   });
 

--- a/ui/tests/exposure-path-graph-layout.test.ts
+++ b/ui/tests/exposure-path-graph-layout.test.ts
@@ -123,4 +123,24 @@ describe("buildPathGraphLayout auto-fit", () => {
     expect(layout.edges).toHaveLength(4);
     expect(layout.relationshipLabels).toHaveLength(4);
   });
+
+  it("keeps every row left-to-right so wrapped paths do not snake backwards", () => {
+    // 7 hops is the demo critical-path shape (identity → … → finding): one full
+    // row of 4, then 3 on the next row. Odd-row boustrophedon previously put
+    // the finding on the bottom-left with an inbound arrow from empty space.
+    const layout = buildPathGraphLayout(makePath(7));
+    expect(layout.nodes).toHaveLength(7);
+    const row0 = layout.nodes.slice(0, 4);
+    const row1 = layout.nodes.slice(4);
+    for (let i = 1; i < row0.length; i += 1) {
+      expect(row0[i]!.x).toBeGreaterThan(row0[i - 1]!.x);
+    }
+    for (let i = 1; i < row1.length; i += 1) {
+      expect(row1[i]!.x).toBeGreaterThan(row1[i - 1]!.x);
+    }
+    // Finding (last hop) sits to the right of the first hop on its row.
+    expect(row1[row1.length - 1]!.x).toBeGreaterThan(row1[0]!.x);
+    // Wrap edge: last of row0 is rightmost; first of row1 is leftmost.
+    expect(row0[row0.length - 1]!.x).toBeGreaterThan(row1[0]!.x);
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Path-view layout no longer snakes odd rows right-to-left
- Same-row edges use direction-aware ports; row wrap drops from end of row N to start of row N+1
- Regression test for the 7-hop demo critical-path shape (finding no longer bottom-left with orphan inbound arrow)

## Verification

```bash
cd ui && npm test -- --run tests/exposure-path-graph-layout.test.ts
# 10 passed
```

## Notes

- Does not recapture `docs/images/security-graph-live.png` yet — follow-up after merge when demo estate has data again
- README polish and empty public demo seed are separate focused PRs (not mixed here)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

