### PR TITLE
fix(demo): keep curated estate findings past job TTL

### DIFF
--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -152,6 +152,24 @@ jobs:
           echo "== smoke =="
           scripts/deploy/hosted_poc_smoke.sh
 
+          # Fail closed when the public demo overlay came up without a usable
+          # curated findings spine (empty dashboard). Auth smoke alone is not
+          # enough — visitors land on grade N/A when scan jobs are missing.
+          echo "== demo estate smoke =="
+          DEMO_BASE="${AGENT_BOM_SMOKE_URL:?redeploy.env must set AGENT_BOM_SMOKE_URL}"
+          DEMO_BASE="${DEMO_BASE%/}"
+          findings_total=$(curl -fsS \
+            -H "Authorization: Bearer ${AGENT_BOM_SMOKE_API_KEY:?redeploy.env must set AGENT_BOM_SMOKE_API_KEY}" \
+            "${DEMO_BASE}/v1/findings?limit=1" \
+            | python3 -c 'import json,sys; print(int(json.load(sys.stdin).get("total") or 0))')
+          if [ "$findings_total" -lt 1 ]; then
+            echo "ERROR: demo estate has zero findings (total=${findings_total})." >&2
+            echo "Bootstrap did not seed a usable scan job — check API logs for" >&2
+            echo "'demo estate scan bootstrap failed' and AGENT_BOM_DEMO_ESTATE=1." >&2
+            exit 1
+          fi
+          echo "Demo estate findings total=${findings_total}"
+
           if [ "$RESET_DEMO" = "true" ]; then
             echo "== demo reset =="
             scripts/deploy/demo-reset.sh \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
   auth-required and `hosted_poc_preflight.py` can pass. Demo redeploy layers the
   demo overlay and calls `--write-secret` (was a nonexistent
   `--write-postgres-secret`).
+- Public demo estate no longer goes empty ~1h after boot: curated
+  `demo-estate-bootstrap` scan jobs are exempt from `AGENT_BOM_API_JOB_TTL`
+  cleanup, bootstrap reseeds when only an empty demo marker remains, and the
+  API cleanup loop self-heals a missing findings spine. Demo redeploy now fails
+  closed when `/v1/findings` total is zero.
 - Docs honesty: authenticated-hosted overlay matrix points anonymous demo at
   `demo-override.yml`; PRODUCT_BRIEF marks webhook outbox as shipped; store-backed
   graph test module docstring matches auto-enable behavior.

--- a/scripts/deploy/demo-reset.sh
+++ b/scripts/deploy/demo-reset.sh
@@ -26,7 +26,9 @@ curl -fsS -X DELETE "${BASE}/v1/compliance/hub/findings" "${HDR[@]}" | cat
 echo
 
 if [ "${AGENT_BOM_DEMO_ESTATE:-0}" = "1" ]; then
-  echo "Demo estate bootstrap will re-seed on next API restart."
+  echo "Demo estate bootstrap will re-seed on the next cleanup-loop tick (~60s)"
+  echo "or immediately on API restart. Set AGENT_BOM_DEMO_ESTATE_FORCE=1 to"
+  echo "force a fresh curated scan job even when one is already present."
 fi
 
 echo "Done."

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -172,6 +172,8 @@ AGENT_BOM_DELIVERY_DB  # optional SQLite path for the outbound delivery foundati
 AGENT_BOM_DB_PATH
 AGENT_BOM_DB_SOURCES
 AGENT_BOM_DEFAULT_ROLE
+# Operator override: force demo-estate scan reseed even when a usable curated job exists.
+AGENT_BOM_DEMO_ESTATE_FORCE
 AGENT_BOM_DELEGATION_SIGNING_KEY  # secret: signs scoped agent-to-agent delegation tokens (HMAC); resolved via secret_source in delegation_token.py
 AGENT_BOM_DISABLE_DOCS
 AGENT_BOM_DISTRIBUTED_SCANS

--- a/src/agent_bom/api/postgres_job_store.py
+++ b/src/agent_bom/api/postgres_job_store.py
@@ -19,7 +19,7 @@ from agent_bom.api.postgres_common import (
     set_current_tenant,
 )
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
-from agent_bom.api.store import _require_tenant_scope
+from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY, _require_tenant_scope
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -470,8 +470,9 @@ class PostgresJobStore:
                 """DELETE FROM scan_jobs
                    WHERE status IN ('done', 'failed', 'cancelled')
                      AND completed_at IS NOT NULL
+                     AND COALESCE(triggered_by, '') <> %s
                      AND completed_at::timestamptz < (now() AT TIME ZONE 'UTC') - (%s * INTERVAL '1 second')""",
-                (ttl_seconds,),
+                (DEMO_ESTATE_TRIGGERED_BY, ttl_seconds),
             )
             conn.commit()
             return int(cursor.rowcount)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -1039,6 +1039,20 @@ async def _cleanup_loop() -> None:
         await asyncio.sleep(60)
         store = _get_store()
         store.cleanup_expired(_JOB_TTL_SECONDS)
+        # Public demo self-heal: if AGENT_BOM_DEMO_ESTATE is on and the curated
+        # scan job is missing/empty (TTL wipe, partial boot, operator reset),
+        # reseed without waiting for a container restart. Cheap no-op when a
+        # usable demo job is already present.
+        try:
+            from agent_bom.demo_estate.bootstrap import (
+                demo_estate_enabled,
+                maybe_bootstrap_demo_estate,
+            )
+
+            if demo_estate_enabled():
+                await asyncio.to_thread(maybe_bootstrap_demo_estate)
+        except Exception:  # noqa: BLE001
+            _logger.warning("demo estate cleanup-loop reseed skipped", exc_info=True)
         # Tier-B replay-log TTL purge (#2261). Wrapped so a backend hiccup
         # never takes down the whole cleanup loop.
         try:

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -277,14 +277,18 @@ class SnowflakeJobStore:
             return summaries
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
+        from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+
         with self._connect() as conn:
             cur = conn.cursor()
+            # triggered_by lives inside the VARIANT payload on Snowflake.
             cur.execute(
                 """DELETE FROM scan_jobs
                    WHERE status IN ('done', 'failed', 'cancelled')
                      AND completed_at IS NOT NULL
+                     AND COALESCE(data:triggered_by::STRING, '') <> %s
                      AND TIMESTAMPDIFF(SECOND, completed_at, CURRENT_TIMESTAMP()) > %s""",
-                (ttl_seconds,),
+                (DEMO_ESTATE_TRIGGERED_BY, ttl_seconds),
             )
             return cur.rowcount or 0
 

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -20,6 +20,11 @@ from .server import JobStatus, ScanJob
 
 _JOB_TTL_SECONDS = 3600  # 1 hour
 
+# Curated public-demo scan jobs must outlive AGENT_BOM_API_JOB_TTL. Without this
+# exemption the cleanup loop deletes DONE demo jobs ~1h after bootstrap and the
+# hosted demo serves an empty findings spine until the next API restart.
+DEMO_ESTATE_TRIGGERED_BY = "demo-estate-bootstrap"
+
 
 def _require_tenant_scope(tenant_id: str | None, all_tenants: bool, method: str) -> None:
     """Fail closed when a request-path read/write omits a tenant scope.
@@ -74,7 +79,12 @@ class InMemoryJobStore:
         if len(self._jobs) <= self._max_retained_jobs:
             return
 
-        completed = [(jid, job) for jid, job in self._jobs.items() if job.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)]
+        completed = [
+            (jid, job)
+            for jid, job in self._jobs.items()
+            if job.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)
+            and getattr(job, "triggered_by", None) != DEMO_ESTATE_TRIGGERED_BY
+        ]
         completed.sort(key=lambda item: (item[1].completed_at is None, item[1].completed_at or item[1].created_at))
         for jid, _job in completed[: len(self._jobs) - self._max_retained_jobs]:
             self._jobs.pop(jid, None)
@@ -159,6 +169,7 @@ class InMemoryJobStore:
                 for jid, job in self._jobs.items()
                 if job.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)
                 and job.completed_at
+                and getattr(job, "triggered_by", None) != DEMO_ESTATE_TRIGGERED_BY
                 and (now - datetime.fromisoformat(job.completed_at)).total_seconds() > ttl_seconds
             ]
             for jid in expired:
@@ -413,8 +424,9 @@ class SQLiteJobStore:
                 """DELETE FROM jobs
                    WHERE status IN ('done', 'failed', 'cancelled')
                      AND completed_at IS NOT NULL
+                     AND IFNULL(triggered_by, '') != ?
                      AND julianday(?) - julianday(completed_at) > ?""",
-                (now, ttl_seconds / 86400.0),
+                (DEMO_ESTATE_TRIGGERED_BY, now, ttl_seconds / 86400.0),
             )
             self._conn.commit()
             return cursor.rowcount

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _now
+from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
 from agent_bom.demo_estate.showcase_graph import (
     SHOWCASE_TENANT,
     seed_showcase_graph_if_empty,
@@ -24,15 +25,41 @@ def demo_estate_enabled() -> bool:
     return os.environ.get("AGENT_BOM_DEMO_ESTATE", "").strip().lower() in _TRUTHY
 
 
+def demo_estate_force_reseed() -> bool:
+    """Operator override: always reseed scan jobs even when usable ones exist."""
+    return os.environ.get("AGENT_BOM_DEMO_ESTATE_FORCE", "").strip().lower() in _TRUTHY
+
+
+def _job_has_demo_source(job: Any) -> bool:
+    result = getattr(job, "result", None) or {}
+    sources = result.get("scan_sources") or []
+    if any("demo" in str(src).lower() for src in sources):
+        return True
+    return getattr(job, "triggered_by", None) == DEMO_ESTATE_TRIGGERED_BY
+
+
+def _job_has_findings(job: Any) -> bool:
+    result = getattr(job, "result", None) or {}
+    findings = result.get("findings") or result.get("vulnerabilities") or []
+    return bool(findings)
+
+
 def _tenant_has_demo_jobs(store: Any, tenant_id: str) -> bool:
+    """True when the tenant already has a *usable* demo scan job.
+
+    Presence alone is not enough: an empty or FAILED demo marker (or a job
+    whose findings were never persisted) must not block reseed — that is how
+    the public demo can boot with graph/catalog populated but findings=[].
+    """
     list_fn = getattr(store, "list_all", None)
     if not callable(list_fn):
         return False
     jobs = list_fn(tenant_id=tenant_id)
     for job in jobs:
-        result = getattr(job, "result", None) or {}
-        sources = result.get("scan_sources") or []
-        if any("demo" in str(src).lower() for src in sources):
+        status = getattr(job, "status", None)
+        if status is not None and status != JobStatus.DONE and str(status).lower() != "done":
+            continue
+        if _job_has_demo_source(job) and _job_has_findings(job):
             return True
     return False
 
@@ -90,7 +117,7 @@ def _store_demo_scan_job(report: dict[str, Any], *, tenant_id: str) -> str:
     job = ScanJob(
         job_id=str(uuid.uuid4()),
         tenant_id=tenant_id,
-        triggered_by="demo-estate-bootstrap",
+        triggered_by=DEMO_ESTATE_TRIGGERED_BY,
         created_at=_now(),
         request=ScanRequest(offline=True),
     )
@@ -114,6 +141,9 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     store = _get_store()
     graph_store = _get_graph_store()
     summary: dict[str, Any] = {"enabled": True, "tenant_id": tenant_id, "seeded": False}
+    force = demo_estate_force_reseed()
+    if force:
+        summary["force"] = True
 
     # Graph seed is isolated and stale-aware: a real scan is left untouched, a
     # current demo seed is a no-op, and a stale demo seed is refreshed (see
@@ -156,19 +186,22 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
         _logger.warning("demo estate catalog seeding failed", exc_info=True)
         summary["catalog_error"] = True
 
-    if _tenant_has_demo_jobs(store, tenant_id):
+    if not force and _tenant_has_demo_jobs(store, tenant_id):
         summary["reason"] = "demo_jobs_present"
         return summary
 
     try:
         report = _run_demo_scan_report()
+        finding_count = len(report.get("findings") or report.get("vulnerabilities") or [])
+        if finding_count < 1:
+            raise RuntimeError("demo estate scan produced zero findings")
         job_id = _store_demo_scan_job(report, tenant_id=tenant_id)
         summary.update(
             {
                 "seeded": True,
                 "job_id": job_id,
                 "agents": len(report.get("agents") or []),
-                "findings": len(report.get("findings") or report.get("vulnerabilities") or []),
+                "findings": finding_count,
             }
         )
         _logger.info(

--- a/tests/api/test_api_store.py
+++ b/tests/api/test_api_store.py
@@ -73,6 +73,25 @@ def test_in_memory_cleanup():
     assert store.get("j2", all_tenants=True) is not None
 
 
+def test_in_memory_cleanup_preserves_demo_estate_jobs():
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+
+    store = InMemoryJobStore()
+    store.put(
+        _make_job(
+            "demo",
+            status=JobStatus.DONE,
+            completed_at="2020-01-01T00:00:00+00:00",
+            triggered_by=DEMO_ESTATE_TRIGGERED_BY,
+        )
+    )
+    store.put(_make_job("other", status=JobStatus.DONE, completed_at="2020-01-01T00:00:00+00:00"))
+    removed = store.cleanup_expired(ttl_seconds=1)
+    assert removed == 1
+    assert store.get("demo", all_tenants=True) is not None
+    assert store.get("other", all_tenants=True) is None
+
+
 def test_in_memory_retention_evicts_oldest_completed_jobs():
     store = InMemoryJobStore(max_retained_jobs=2)
     old = _make_job("old", status=JobStatus.DONE, completed_at="2026-02-23T12:00:00+00:00")
@@ -374,6 +393,30 @@ def test_sqlite_cleanup_expired():
         assert store.get("j1", all_tenants=True) is None
         assert store.get("j2", all_tenants=True) is not None
         assert store.get("j3", all_tenants=True) is None
+    finally:
+        Path(db_path).unlink(missing_ok=True)
+
+
+def test_sqlite_cleanup_preserves_demo_estate_jobs():
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        store = SQLiteJobStore(db_path=db_path)
+        store.put(
+            _make_job(
+                "demo",
+                status=JobStatus.DONE,
+                completed_at="2020-01-01T00:00:00+00:00",
+                triggered_by=DEMO_ESTATE_TRIGGERED_BY,
+            )
+        )
+        store.put(_make_job("other", status=JobStatus.DONE, completed_at="2020-01-01T00:00:00+00:00"))
+        removed = store.cleanup_expired(ttl_seconds=1)
+        assert removed == 1
+        assert store.get("demo", all_tenants=True) is not None
+        assert store.get("other", all_tenants=True) is None
     finally:
         Path(db_path).unlink(missing_ok=True)
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -329,6 +329,9 @@ def test_demo_redeploy_layers_demo_override_and_uses_write_secret() -> None:
     assert "deploy/docker-compose.demo-override.yml" in workflow
     assert "hosted_poc_preflight.py --write-secret" in workflow
     assert "--write-postgres-secret" not in workflow
+    # Empty findings spine is a demo outage — redeploy must fail closed on it.
+    assert "demo estate smoke" in workflow
+    assert "/v1/findings?limit=1" in workflow
 
     # Security gate remains platform + hosted-poc only (no demo anon flags).
     preflight_src = (root / "scripts" / "deploy" / "hosted_poc_preflight.py").read_text(encoding="utf-8")

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -477,6 +477,81 @@ def test_demo_estate_bootstrap_is_idempotent(demo_estate_client: TestClient) -> 
     assert again.get("total") == first.get("total")
 
 
+def test_demo_estate_reseeds_when_marker_job_has_no_findings(
+    demo_estate_client: TestClient,
+) -> None:
+    """A demo-tagged job with empty findings must not block reseed (empty demo)."""
+    import uuid
+
+    from agent_bom.api import stores as api_stores
+    from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+    from agent_bom.api.pipeline import _now
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+    from agent_bom.demo_estate.bootstrap import maybe_bootstrap_demo_estate
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT
+
+    store = api_stores._get_store()
+    for job in list(store.list_all(tenant_id=SHOWCASE_TENANT)):
+        store.delete(job.job_id, tenant_id=SHOWCASE_TENANT)
+
+    empty = ScanJob(
+        job_id=str(uuid.uuid4()),
+        tenant_id=SHOWCASE_TENANT,
+        triggered_by=DEMO_ESTATE_TRIGGERED_BY,
+        created_at=_now(),
+        request=ScanRequest(offline=True),
+    )
+    empty.status = JobStatus.DONE
+    empty.completed_at = _now()
+    empty.result = {"scan_sources": ["demo", "demo-estate"], "findings": [], "agents": []}
+    store.put(empty)
+
+    before_total = demo_estate_client.get("/v1/findings", headers=ADMIN, params={"limit": 1}).json()
+    assert before_total.get("total", 0) == 0
+
+    summary = maybe_bootstrap_demo_estate()
+    assert summary.get("seeded") is True, summary
+    assert (summary.get("findings") or 0) >= 1
+
+    after = demo_estate_client.get("/v1/findings", headers=ADMIN, params={"limit": 1}).json()
+    assert after.get("total", 0) > 0
+
+
+def test_demo_estate_survives_job_ttl_cleanup(demo_estate_client: TestClient) -> None:
+    """API job TTL must not delete curated demo-estate scan jobs."""
+    from agent_bom.api import stores as api_stores
+    from agent_bom.api.pipeline import _now
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT
+
+    store = api_stores._get_store()
+    demo_jobs = [
+        job
+        for job in store.list_all(tenant_id=SHOWCASE_TENANT)
+        if getattr(job, "triggered_by", None) == DEMO_ESTATE_TRIGGERED_BY
+    ]
+    assert demo_jobs, "precondition: bootstrap seeded a demo-estate job"
+    for job in demo_jobs:
+        job.completed_at = "2020-01-01T00:00:00+00:00"
+        store.put(job)
+
+    removed = store.cleanup_expired(ttl_seconds=1)
+    remaining = [
+        job
+        for job in store.list_all(tenant_id=SHOWCASE_TENANT)
+        if getattr(job, "triggered_by", None) == DEMO_ESTATE_TRIGGERED_BY
+    ]
+    assert remaining, f"demo estate jobs were purged by TTL (removed={removed})"
+
+    # Restore a current completed_at so the default findings window still sees them.
+    now = _now()
+    for job in remaining:
+        job.completed_at = now
+        store.put(job)
+    findings = demo_estate_client.get("/v1/findings", headers=ADMIN, params={"limit": 1}).json()
+    assert findings.get("total", 0) > 0
+
+
 def test_demo_estate_exposure_paths_materialized(demo_estate_client: TestClient) -> None:
     """The materialized exposure-path queue (read by /v1/graph/exposure-paths) is
     non-empty and headlines the seeded hero chains."""

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -497,6 +497,7 @@ def test_job_store_list_summary_includes_tenant(mock_pool):
 
 def test_job_store_cleanup(mock_pool):
     from agent_bom.api.postgres_store import PostgresJobStore
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
 
     store = PostgresJobStore(pool=mock_pool)
     count = store.cleanup_expired(ttl_seconds=7200)
@@ -505,7 +506,8 @@ def test_job_store_cleanup(mock_pool):
     )
     assert isinstance(count, int)
     assert "INTERVAL '1 second'" in delete_sql
-    assert delete_params == (7200,)
+    assert "triggered_by" in delete_sql
+    assert delete_params == (DEMO_ESTATE_TRIGGERED_BY, 7200)
 
 
 def test_job_store_init_migrates_triggered_by_column(mock_pool):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Root cause of the empty public demo: `AGENT_BOM_API_JOB_TTL` (1h) deleted DONE curated scan jobs while graph/catalog/gateway seeds persisted, so anonymous visitors saw grade N/A with `findings:[]`.
- Exempt `triggered_by=demo-estate-bootstrap` jobs from job TTL cleanup (memory / SQLite / Postgres / Snowflake) and from in-memory completed-job eviction.
- Bootstrap now treats only DONE demo jobs with non-empty findings as present; empty markers reseed. Cleanup loop self-heals when `AGENT_BOM_DEMO_ESTATE=1`. Optional `AGENT_BOM_DEMO_ESTATE_FORCE=1` forces reseed.
- Demo redeploy fails closed when `/v1/findings` total is zero after smoke.

## Verification
- `uv run ruff check` on touched Python files
- `uv run pytest -q tests/test_demo_estate_bootstrap.py tests/api/test_api_store.py tests/test_compose_secrets_healthcheck.py` (97 passed)
- `uv run pytest -q tests/test_postgres_store.py::test_job_store_cleanup` (pass)

## Notes
- Live `demo.agent-bom.com` still needs a successful **Demo redeploy** (or API restart) after merge so the box picks up the fix. Recent redeploy failed earlier on stale `--write-postgres-secret` (already fixed on main via #4348).
- Path-graph wrap fix remains #4356; README polish is #4358.
- CI **Security Scan** may still fail on `sharp@0.34.5` (GHSA-f88m-g3jw-g9cj) across open PRs — that is a UI dependency gate on main, not introduced by this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

