### PR TITLE
fix(demo)+docs(readme): persist demo estate past job TTL + clean Live demo nav

### DIFF
--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -152,6 +152,24 @@ jobs:
           echo "== smoke =="
           scripts/deploy/hosted_poc_smoke.sh
 
+          # Fail closed when the public demo overlay came up without a usable
+          # curated findings spine (empty dashboard). Auth smoke alone is not
+          # enough — visitors land on grade N/A when scan jobs are missing.
+          echo "== demo estate smoke =="
+          DEMO_BASE="${AGENT_BOM_SMOKE_URL:?redeploy.env must set AGENT_BOM_SMOKE_URL}"
+          DEMO_BASE="${DEMO_BASE%/}"
+          findings_total=$(curl -fsS \
+            -H "Authorization: Bearer ${AGENT_BOM_SMOKE_API_KEY:?redeploy.env must set AGENT_BOM_SMOKE_API_KEY}" \
+            "${DEMO_BASE}/v1/findings?limit=1" \
+            | python3 -c 'import json,sys; print(int(json.load(sys.stdin).get("total") or 0))')
+          if [ "$findings_total" -lt 1 ]; then
+            echo "ERROR: demo estate has zero findings (total=${findings_total})." >&2
+            echo "Bootstrap did not seed a usable scan job — check API logs for" >&2
+            echo "'demo estate scan bootstrap failed' and AGENT_BOM_DEMO_ESTATE=1." >&2
+            exit 1
+          fi
+          echo "Demo estate findings total=${findings_total}"
+
           if [ "$RESET_DEMO" = "true" ]; then
             echo "== demo reset =="
             scripts/deploy/demo-reset.sh \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
+- README: clean top-nav Live demo link (offline fallback lives under scan/demo
+  body copy), lead with product visuals, and collapse persona / connector /
+  architecture tables under `<details>`.
 - Remove private strategy and agent-session audit ledgers from the public tree
   (`docs/archive/STRATEGIC_AUDIT_*`, `docs/archive/AUDIT.md`, `docs/audits/`);
   soften large-enterprise procurement phrasing. CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
   auth-required and `hosted_poc_preflight.py` can pass. Demo redeploy layers the
   demo overlay and calls `--write-secret` (was a nonexistent
   `--write-postgres-secret`).
+- Public demo estate no longer goes empty ~1h after boot: curated
+  `demo-estate-bootstrap` scan jobs are exempt from `AGENT_BOM_API_JOB_TTL`
+  cleanup, bootstrap reseeds when only an empty demo marker remains, and the
+  API cleanup loop self-heals a missing findings spine. Demo redeploy now fails
+  closed when `/v1/findings` total is zero.
 - Docs honesty: authenticated-hosted overlay matrix points anonymous demo at
   `demo-override.yml`; PRODUCT_BRIEF marks webhook outbox as shipped; store-backed
   graph test module docstring matches auto-enable behavior.

--- a/README.md
+++ b/README.md
@@ -17,10 +17,8 @@
 <!-- mcp-name: io.github.msaad00/agent-bom -->
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
-<p align="center">Discover assets, scan and enrich findings, map blast radius and compliance, and enforce runtime policy—from a local CLI or your self-hosted control plane.</p>
-
 <p align="center">
-  <a href="https://demo.agent-bom.com"><b>Live demo</b></a> (read-only sandbox; if unreachable run <code>uvx agent-bom scan --demo --offline</code>) ·
+  <a href="https://demo.agent-bom.com"><b>Live demo</b></a> ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
   <a href="docs/FIRST_RUN.md">First Run</a> ·
   <a href="site-docs/deployment/overview.md">Self-host</a> ·
@@ -29,48 +27,20 @@
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
-## Scan your project in two commands
+## Scan locally
 
 ```bash
 pip install agent-bom
 agent-bom scan .
 ```
 
-`.` means the current project. The local CLI reads it directly and prints
-inventory, findings, reachable context, and fix-first actions; no control plane
-is required. Export evidence when another tool needs it:
-`agent-bom scan . -f sarif -o findings.sarif`. For scripts,
-`--project .` (short form: `-p .`) is equivalent.
+Inventory, findings, reachability, and fix-first actions — no control plane
+required. Export when another tool needs it:
+`agent-bom scan . -f sarif -o findings.sarif`.
 
-`-p`/`--project` expects a directory, not a manifest file. For large
-monorepos, point it at the workspace or service under review and run one scan
-per CI workspace; the current CLI does not pretend to provide an arbitrary
-path-exclude language.
-
-## Three ways to use it
-
-| Product lane | First command | Evidence you get | Natural next step |
-|---|---|---|---|
-| **Scan and understand risk** — repos, images, SBOMs, agent/MCP config, IaC | `agent-bom scan .` | inventory, findings, fix priority, graph and standard report formats | gate CI or open the local report |
-| **Centralize and visualize evidence** — fleet, cloud, identity, findings, compliance | `pip install 'agent-bom[ui]' && agent-bom serve` | tenant-scoped inventory, attack paths, compliance, jobs and audit | self-host with Docker or Helm + Postgres |
-| **Enforce runtime behavior** — MCP and tool calls | `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` | allow/warn/block decisions and audit events | bind policies to agents and upstream MCPs |
-
-Discovery and static/cloud scanning are read-only. The self-hosted control plane
-stores evidence, and runtime modes make explicit policy decisions; those are
-separate operational boundaries, not all one read-only pipeline.
-
-## Who it is for
-
-| Team | Start here | Outcome |
-|---|---|---|
-| Developers and AI builders | `agent-bom scan .` | Inventory, findings, blast radius, and fix-first actions before code or agent changes ship |
-| AppSec and security engineering | `agent-bom scan . -f sarif -o findings.sarif` | Reachability-aware triage, graph paths, SBOMs, and CI gates |
-| Platform, SRE, and cloud teams | `agent-bom serve` or a shipped Helm profile | Customer-controlled API/UI, fleet evidence, Postgres tenancy, and runtime policy |
-| GRC, audit, and governance | Compliance exports and control-plane evidence views | Framework mappings, signed evidence bundles, audit history, and review context |
-| AI/MCP owners | `agent-bom mcp server` or `agent-bom gateway serve ...` | Tool/server inventory and explicit allow, warn, or block decisions |
-
-The product generates security and compliance evidence; it is not a replacement
-for a GRC system of record, IAM, SIEM, or a complete certification program.
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Prioritized attack path connecting identity, agent, MCP server, package, and critical finding" width="900" />
+</p>
 
 <p align="center">
   <picture>
@@ -79,13 +49,20 @@ for a GRC system of record, IAM, SIEM, or a complete certification program.
   </picture>
 </p>
 
-Blast radius links package risk to the MCP servers that load it, exposed tools,
-credential references, and agents that can reach it. Coverage and boundaries:
-[AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
-[product boundaries](docs/PRODUCT_BOUNDARIES.md) ·
-[first-run guide](docs/FIRST_RUN.md).
+One finding links to the MCP servers that load it, reachable tools, credential
+references, and agents that can reach it. Offline sample without your repo:
+`uvx agent-bom scan --demo --offline` · full first-run path:
+[First Run](docs/FIRST_RUN.md).
 
-## How it works
+## Three product lanes
+
+1. **Scan** — `agent-bom scan .` → inventory, findings, SARIF/SBOM/HTML, local graph
+2. **Control plane** — `pip install 'agent-bom[ui]' && agent-bom serve` → tenant UI/API, attack paths, compliance, audit (self-host with Docker or Helm + Postgres)
+3. **Runtime** — `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` → allow/warn/block on live MCP/tool calls
+
+Discovery and static/cloud scanning are read-only. The control plane stores
+evidence; gateway/proxy modes make explicit policy decisions at a separate
+boundary.
 
 <p align="center">
   <picture>
@@ -94,145 +71,45 @@ credential references, and agents that can reach it. Coverage and boundaries:
   </picture>
 </p>
 
-Local CLI and CI call the scanner directly and do not require a server. The
-self-hosted control plane adds an authenticated API and UI, tenant-scoped
-persistence, fleet jobs, attack paths, compliance, and audit. Gateway and proxy
-modes enforce live tool traffic at a separate runtime boundary.
-
-<details>
-<summary><b>Execution paths and persistence</b></summary>
-
-| Boundary | Entry point | Service path | Persistence or artifact |
-|---|---|---|---|
-| Local scan | CLI, CI, Docker | Python scanner and correlation engine | console/files; optional SQLite history |
-| Control plane | Next.js UI, REST SDK | TLS/HTTPS ingress → authentication/tenant/rate-limit/audit middleware → FastAPI services | Postgres + RLS for shared deployments; SQLite for a local pilot |
-| Agent interface | MCP clients | MCP server → shared scanning, finding and graph services | the same normalized evidence contracts |
-| Runtime enforcement | MCP/tool traffic | gateway or proxy → policy, detectors and audit | SQLite or Postgres audit records |
-
-Neptune is an optional graph backend and ClickHouse is optional analytics.
-Snowflake supports selected warehouse/store paths with documented parity
-limits. MCP server mode exposes 76 MCP tools, 6 resources, and 8 workflow prompts
-over strict arguments. Agent distribution includes a committed
-[Smithery manifest](integrations/smithery.yaml); external catalog liveness is
-verified separately. The implementation-level diagram and component
-boundaries live in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md).
-
-</details>
-
-<details>
-<summary><b>Evidence and accuracy boundaries</b></summary>
-
-agent-bom normalizes advisory and distro evidence into canonical CVE findings
-with match-confidence tiers:
-
-`distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`
-
-Distro-confirmed findings are treated as confirmed. Optional NVD CPE candidate
-matching widens long-tail OS/vendor software coverage, but remains review-grade
-and off by default.
-
-**NVD key model.** End users do not need an NVD API key. CVE/CPE enrichment
-ships through the distributed vulnerability database. `NVD_API_KEY` is only an
-optional self-hosted freshness knob for operators rebuilding or refreshing the
-database.
-
-Matching mechanics and release evidence:
-[vulnerability matching](docs/VULNERABILITY_MATCHING.md) ·
-[scanner accuracy baseline](docs/SCANNER_ACCURACY_BASELINE.md) ·
-[graph contract](docs/graph/CONTRACT.md) ·
-[architecture deep dive](docs/ARCHITECTURE.md)
-
-</details>
-
 ## See the product
 
-Try the [live demo](https://demo.agent-bom.com) (read-only sandbox; if
-unreachable, run `uvx agent-bom scan --demo --offline`). These
-captures come from the shipped Next.js routes using explicitly labeled,
-synthetic demo evidence.
+[Live demo](https://demo.agent-bom.com) is a read-only sandbox with synthetic
+showcase evidence. Prefer the local offline sample above when you want a
+reproducible CLI walkthrough. Captures below are from shipped Next.js routes.
 
-### Prioritize an attack path, not just a CVE
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Prioritized attack path connecting identity, agent, MCP server, package, and critical finding with evidence export and remediation handoff" width="900" />
-</p>
-
-The investigation lens connects identity and agent reachability to the MCP
-server, package, and finding that create the exposure. Operators can export the
-graph evidence or hand the path directly to remediation.
-
-### See every finding and its reach
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with severity, reachable agents, available fixes, and false-positive review actions" width="900" />
-</p>
-
-### Move from risk to owner-ready work
-
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Prioritized remediation campaign with modeled risk reduction, reach, framework mappings, ownership, and verification state" width="900" />
-</p>
+| Findings and reach | Remediation |
+|:---:|:---:|
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with severity, reachable agents, fixes, and review actions" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Prioritized remediation with risk reduction, ownership, and verification" width="430" /> |
 
 <details>
-<summary><b>More control-plane views</b> — posture, runtime, and evidence intake</summary>
+<summary><b>More views</b> — posture, runtime, connections, new scan</summary>
 
-| Risk overview | Review runtime decisions |
+| Risk overview | Runtime gateway |
 |:---:|:---:|
-| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview command center with posture grade, unique findings, scan coverage, and operations" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and tool-call feed" width="430" /> |
-| **Connect evidence sources** | **Start a scan** |
-| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/cloud-accounts-live.png" alt="Connections hub across cloud, code, AI, and data sources" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/new-scan-live.png" alt="New Scan evidence workspace with expected outputs, collector plan, and read-only boundary" width="430" /> |
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview with posture grade, findings, and operations" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and tool-call feed" width="430" /> |
+| **Connections** | **New scan** |
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/cloud-accounts-live.png" alt="Connections hub across cloud, code, AI, and data sources" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/new-scan-live.png" alt="New Scan workspace with collector plan and read-only boundary" width="430" /> |
 
 </details>
 
 <details>
-<summary><b>Full CLI walkthrough</b> — current 0.97.2 console demo</summary>
+<summary><b>CLI walkthrough</b> — 0.97.2 console demo</summary>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo showing inventory, findings, remediation, and package gate" width="820" />
 </p>
 
-The demo is intentionally comprehensive, so it is kept collapsed at README
-display width. Its seeded `requests` typosquat produces an expected non-zero
-security-gate exit; that is a demonstrated finding, not a failed recording.
+Seeded `requests` typosquat produces an expected non-zero security-gate exit —
+a demonstrated finding, not a failed recording.
 
 </details>
 
-Full capture list and reproducible commands: [docs/CAPTURE.md](docs/CAPTURE.md).
+Capture list: [docs/CAPTURE.md](docs/CAPTURE.md).
 
-## Run it anywhere
+## Self-host
 
-The surfaces share normalized finding and graph contracts while keeping their
-execution and authentication boundaries explicit. Pick the entry point that
-matches your role:
-
-| Need | Surface | First action | Main artifact |
-|---|---|---|---|
-| Scan a repo, image, or local agent config | CLI / CI | `agent-bom scan .` (or the [GitHub Action](https://github.com/marketplace/actions/agent-bom)) | JSON, SARIF, SBOM, HTML |
-| Connect cloud and data-estate evidence | Cloud connectors | `agent-bom connect aws` then `agent-bom cloud scan` | assets, CIS findings, graph edges |
-| Review posture as a team | API + dashboard | `pip install 'agent-bom[ui]' && agent-bom serve` | findings, graph, audit, compliance |
-| Give agents security tools | MCP server | `agent-bom mcp server` | strict MCP tool responses |
-| Govern runtime tool calls | Proxy / gateway | `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` | allow/warn/block audit trail |
-| Package evidence for audit | Reports / exports | `agent-bom scan . -f sarif -o findings.sarif` | SARIF, CycloneDX, SPDX, HTML/PDF, compliance bundle |
-
-Beyond the basics — `agent-bom graph` (multi-hop exposure paths),
-`agent-bom remediate -p .` (advisory fix plan),
-`agent-bom identity credential-expiry`, `agent-bom cost forecast`, and the CI
-gate `uses: msaad00/agent-bom@v0.97.2`. Full command map:
-[docs/CLI_MAP.md](docs/CLI_MAP.md) · role routing:
-[docs/START_HERE.md](docs/START_HERE.md) · all entry points and auth
-boundaries: [docs/PRODUCT_MAP.md](docs/PRODUCT_MAP.md)
-
-**Deploy targets** — you run the control plane in your own boundary (no managed
-public SaaS in this repo yet), fastest → most-managed:
-
-- **Docker Compose** — fastest; one file, loopback by default → [pilot compose](deploy/docker-compose.pilot.yml)
-- **Helm / Kubernetes** — cluster-native chart → [chart](deploy/helm/agent-bom)
-- **EKS** — opinionated Terraform module → [module](deploy/terraform/platform-eks)
-- **CloudFormation** — one-click AWS stack → [templates](deploy/cloudformation)
-- **Snowflake (SPCS native app)** — host entirely inside your own Snowflake account → [install guide](docs/snowflake-native-app/INSTALL.md)
-
-<details>
-<summary><b>Local bring-up</b> — Docker Compose in two commands</summary>
+You run the control plane in your own boundary (no managed public SaaS in this
+repo yet):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/msaad00/agent-bom/main/deploy/docker-compose.pilot.yml -o docker-compose.pilot.yml
@@ -240,60 +117,90 @@ docker compose -f docker-compose.pilot.yml up -d
 # Dashboard -> http://localhost:3000
 ```
 
-Pilot compose binds to `127.0.0.1` with loopback CORS only. Use
-`docker-compose.platform.yml` or [docs/HOSTED_POC.md](docs/HOSTED_POC.md) before
-sharing a link. Full guides: [Deploy anywhere](docs/DEPLOY_PLATFORM.md).
+Pilot compose binds `127.0.0.1` with loopback CORS. Before sharing a link, use
+`docker-compose.platform.yml` or [docs/HOSTED_POC.md](docs/HOSTED_POC.md).
+
+| Target | Start here |
+|---|---|
+| Docker Compose | [pilot compose](deploy/docker-compose.pilot.yml) |
+| Helm / Kubernetes | [chart](deploy/helm/agent-bom) |
+| EKS | [Terraform module](deploy/terraform/platform-eks) |
+| CloudFormation | [templates](deploy/cloudformation) |
+| Snowflake SPCS | [install guide](docs/snowflake-native-app/INSTALL.md) |
+
+Guides: [Deploy anywhere](docs/DEPLOY_PLATFORM.md) ·
+[deployment overview](site-docs/deployment/overview.md).
+
+<details>
+<summary><b>Surfaces and entry points</b></summary>
+
+| Need | First action | Artifact |
+|---|---|---|
+| Scan repo / image / agent config | `agent-bom scan .` or [GitHub Action](https://github.com/marketplace/actions/agent-bom) | JSON, SARIF, SBOM, HTML |
+| Cloud / data estate | `agent-bom connect aws` then `agent-bom cloud scan` | assets, CIS findings, graph edges |
+| Team posture UI | `pip install 'agent-bom[ui]' && agent-bom serve` | findings, graph, audit, compliance |
+| MCP tools for agents | `agent-bom mcp server` | strict MCP tool responses |
+| Runtime tool governance | `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` | allow/warn/block audit |
+| Audit package | `agent-bom scan . -f sarif -o findings.sarif` | SARIF, CycloneDX, SPDX, bundles |
+
+Also: `agent-bom graph`, `agent-bom remediate -p .`, CI pin
+`uses: msaad00/agent-bom@v0.97.2`. Maps: [CLI](docs/CLI_MAP.md) ·
+[start here](docs/START_HERE.md) · [product map](docs/PRODUCT_MAP.md).
 
 </details>
 
-## Connected control plane
+<details>
+<summary><b>Who it is for</b></summary>
 
-For brokered control-plane sources, **connect once, then scheduled and operator
-actions use the stored connection reference**—not a fresh credential prompt.
-Standalone CLI scans remain independent: they read local files or explicitly
-configured provider credentials and do not require a control-plane connection.
+| Team | Start here | Outcome |
+|---|---|---|
+| Developers / AI builders | `agent-bom scan .` | Inventory, findings, blast radius before changes ship |
+| AppSec / security eng | `agent-bom scan . -f sarif -o findings.sarif` | Reachability triage, graph paths, CI gates |
+| Platform / SRE / cloud | `agent-bom serve` or Helm | Customer-controlled API/UI, fleet evidence, runtime policy |
+| GRC / audit | Compliance exports + control-plane evidence | Framework mappings, signed bundles, review context |
+| AI / MCP owners | `agent-bom mcp server` or `gateway serve` | Tool inventory and allow/warn/block decisions |
 
-- **Humans** sign in via **OAuth / OIDC / SAML SSO** (standard providers plus a
-  Snowflake OAuth authorization-code + PKCE flow), with **SCIM** for user and
-  group provisioning (`src/agent_bom/api/{oidc,saml,scim}.py`,
-  `snowflake_oauth.py`).
-- **Agents / CI** authenticate with **scoped API keys / tokens**.
-- **Sources** are onboarded **once** through read-only, agentless, brokered
-  connectors — a single least-privilege managed role per source with
-  short-lived, brokered credentials (e.g. AWS `sts:AssumeRole`); connection
-  secrets are write-only (encrypted at rest, never read back).
+Evidence helper, not a GRC system of record, IAM, SIEM, or certification program.
+Coverage: [AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
+[product boundaries](docs/PRODUCT_BOUNDARIES.md).
 
-Application-layer authentication, tenant isolation, rate limits, and audit are
-enforced in middleware for UI and API/SDK requests. Non-loopback deployments
-terminate HTTPS/TLS at Caddy, an ingress, an ALB, or an equivalent trusted edge;
-the API and UI remain on loopback or a private network. MCP server and
-gateway/proxy modes enforce their own documented transport authentication and
-policy boundaries; none receives a privileged UI-only path.
+</details>
 
-Cloud connectors are opt-in, default-off, and read no secret values.
-`agent-bom connect <provider>` prints the grant template and enable flag
-without network I/O until you opt in:
+<details>
+<summary><b>Auth, connectors, and architecture</b></summary>
+
+**Control plane:** connect once; later jobs use the stored connection reference.
+Humans: OAuth / OIDC / SAML (+ Snowflake OAuth PKCE) and SCIM. Agents/CI: scoped
+API keys. Secrets are write-only (encrypted at rest, never read back). Non-loopback
+deploys terminate TLS at the edge; API/UI stay on loopback or a private network.
+
+**Cloud connectors** (opt-in, default-off, no secret values read):
 
 | Cloud | Enable | Scan |
 |---|---|---|
 | AWS | `AGENT_BOM_AWS_INVENTORY=1` | `agent-bom cloud aws` |
 | Azure | `AGENT_BOM_AZURE_INVENTORY=1` | `agent-bom cloud azure` |
 | GCP | `AGENT_BOM_GCP_INVENTORY=1` | `agent-bom cloud gcp` |
-| Snowflake | SSO or key-pair auth | `pip install 'agent-bom[snowflake]'` then `agent-bom scan --snowflake` |
+| Snowflake | SSO or key-pair | `pip install 'agent-bom[snowflake]'` then `agent-bom scan --snowflake` |
 
-Snowflake auth defaults to browser SSO (`externalbrowser`); use
-`SNOWFLAKE_AUTHENTICATOR=snowflake_jwt` with `SNOWFLAKE_PRIVATE_KEY_PATH` for
-CI. Setup and the exact grant per provider:
-[docs/CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md) · intake map:
-[docs/DATA_SOURCES.md](docs/DATA_SOURCES.md) · enterprise auth surface:
-[docs/ENTERPRISE.md](docs/ENTERPRISE.md)
+[CLOUD_CONNECT.md](docs/CLOUD_CONNECT.md) · [DATA_SOURCES.md](docs/DATA_SOURCES.md) ·
+[ENTERPRISE.md](docs/ENTERPRISE.md).
+
+**Accuracy:** match tiers
+`distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`.
+End users do not need an NVD API key; `NVD_API_KEY` is an optional operator
+freshness knob. MCP server mode exposes 76 MCP tools, 6 resources, and 8 workflow
+prompts over strict arguments. Deep dive: [ARCHITECTURE.md](docs/ARCHITECTURE.md) ·
+[vulnerability matching](docs/VULNERABILITY_MATCHING.md).
+
+</details>
 
 ## Trust
 
-- Read-only discovery by default; no mandatory telemetry.
-- Credential values redacted; env names preserved for explainable exposure paths.
-- Exports: JSON, SARIF, CycloneDX, SPDX, Parquet, CSV, Markdown, HTML, PDF, compliance bundles.
-- Tenant scope, auth boundaries, and audit evidence on API/runtime paths.
+- Read-only discovery by default; no mandatory telemetry
+- Credential values redacted; env names kept for explainable exposure paths
+- Exports: JSON, SARIF, CycloneDX, SPDX, Parquet, CSV, Markdown, HTML, PDF, compliance bundles
+- Tenant scope, auth boundaries, and audit evidence on API/runtime paths
 
 [Threat model](docs/THREAT_MODEL.md) · [Pentest readiness](docs/PENTEST_READINESS.md) ·
 [Python client](docs/PYTHON_API.md) · [Go client](sdks/go/README.md) ·
@@ -302,8 +209,7 @@ CI. Setup and the exact grant per provider:
 
 ## Contributing
 
-Contributions are welcome. Start with [CONTRIBUTING.md](CONTRIBUTING.md),
-[.agents/AGENTS.md](.agents/AGENTS.md), and the
-[open issues](https://github.com/msaad00/agent-bom/issues).
+Start with [CONTRIBUTING.md](CONTRIBUTING.md), [.agents/AGENTS.md](.agents/AGENTS.md),
+and the [open issues](https://github.com/msaad00/agent-bom/issues).
 
 License: Apache-2.0.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,9 @@ deploys terminate TLS at the edge; API/UI stay on loopback or a private network.
 `distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`.
 End users do not need an NVD API key; `NVD_API_KEY` is an optional operator
 freshness knob. MCP server mode exposes 76 MCP tools, 6 resources, and 8 workflow prompts
-over strict arguments. Deep dive: [ARCHITECTURE.md](docs/ARCHITECTURE.md) ·
+over strict arguments. Agent distribution includes a committed
+[Smithery manifest](integrations/smithery.yaml); external catalog liveness is
+verified separately. Deep dive: [ARCHITECTURE.md](docs/ARCHITECTURE.md) ·
 [vulnerability matching](docs/VULNERABILITY_MATCHING.md).
 
 </details>

--- a/README.md
+++ b/README.md
@@ -189,8 +189,8 @@ deploys terminate TLS at the edge; API/UI stay on loopback or a private network.
 **Accuracy:** match tiers
 `distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`.
 End users do not need an NVD API key; `NVD_API_KEY` is an optional operator
-freshness knob. MCP server mode exposes 76 MCP tools, 6 resources, and 8 workflow
-prompts over strict arguments. Deep dive: [ARCHITECTURE.md](docs/ARCHITECTURE.md) ·
+freshness knob. MCP server mode exposes 76 MCP tools, 6 resources, and 8 workflow prompts
+over strict arguments. Deep dive: [ARCHITECTURE.md](docs/ARCHITECTURE.md) ·
 [vulnerability matching](docs/VULNERABILITY_MATCHING.md).
 
 </details>

--- a/scripts/deploy/demo-reset.sh
+++ b/scripts/deploy/demo-reset.sh
@@ -26,7 +26,9 @@ curl -fsS -X DELETE "${BASE}/v1/compliance/hub/findings" "${HDR[@]}" | cat
 echo
 
 if [ "${AGENT_BOM_DEMO_ESTATE:-0}" = "1" ]; then
-  echo "Demo estate bootstrap will re-seed on next API restart."
+  echo "Demo estate bootstrap will re-seed on the next cleanup-loop tick (~60s)"
+  echo "or immediately on API restart. Set AGENT_BOM_DEMO_ESTATE_FORCE=1 to"
+  echo "force a fresh curated scan job even when one is already present."
 fi
 
 echo "Done."

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -172,6 +172,8 @@ AGENT_BOM_DELIVERY_DB  # optional SQLite path for the outbound delivery foundati
 AGENT_BOM_DB_PATH
 AGENT_BOM_DB_SOURCES
 AGENT_BOM_DEFAULT_ROLE
+# Operator override: force demo-estate scan reseed even when a usable curated job exists.
+AGENT_BOM_DEMO_ESTATE_FORCE
 AGENT_BOM_DELEGATION_SIGNING_KEY  # secret: signs scoped agent-to-agent delegation tokens (HMAC); resolved via secret_source in delegation_token.py
 AGENT_BOM_DISABLE_DOCS
 AGENT_BOM_DISTRIBUTED_SCANS

--- a/src/agent_bom/api/postgres_job_store.py
+++ b/src/agent_bom/api/postgres_job_store.py
@@ -19,7 +19,7 @@ from agent_bom.api.postgres_common import (
     set_current_tenant,
 )
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
-from agent_bom.api.store import _require_tenant_scope
+from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY, _require_tenant_scope
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -470,8 +470,9 @@ class PostgresJobStore:
                 """DELETE FROM scan_jobs
                    WHERE status IN ('done', 'failed', 'cancelled')
                      AND completed_at IS NOT NULL
+                     AND COALESCE(triggered_by, '') <> %s
                      AND completed_at::timestamptz < (now() AT TIME ZONE 'UTC') - (%s * INTERVAL '1 second')""",
-                (ttl_seconds,),
+                (DEMO_ESTATE_TRIGGERED_BY, ttl_seconds),
             )
             conn.commit()
             return int(cursor.rowcount)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -1039,6 +1039,20 @@ async def _cleanup_loop() -> None:
         await asyncio.sleep(60)
         store = _get_store()
         store.cleanup_expired(_JOB_TTL_SECONDS)
+        # Public demo self-heal: if AGENT_BOM_DEMO_ESTATE is on and the curated
+        # scan job is missing/empty (TTL wipe, partial boot, operator reset),
+        # reseed without waiting for a container restart. Cheap no-op when a
+        # usable demo job is already present.
+        try:
+            from agent_bom.demo_estate.bootstrap import (
+                demo_estate_enabled,
+                maybe_bootstrap_demo_estate,
+            )
+
+            if demo_estate_enabled():
+                await asyncio.to_thread(maybe_bootstrap_demo_estate)
+        except Exception:  # noqa: BLE001
+            _logger.warning("demo estate cleanup-loop reseed skipped", exc_info=True)
         # Tier-B replay-log TTL purge (#2261). Wrapped so a backend hiccup
         # never takes down the whole cleanup loop.
         try:

--- a/src/agent_bom/api/snowflake_store.py
+++ b/src/agent_bom/api/snowflake_store.py
@@ -277,14 +277,18 @@ class SnowflakeJobStore:
             return summaries
 
     def cleanup_expired(self, ttl_seconds: int = _JOB_TTL_SECONDS) -> int:
+        from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+
         with self._connect() as conn:
             cur = conn.cursor()
+            # triggered_by lives inside the VARIANT payload on Snowflake.
             cur.execute(
                 """DELETE FROM scan_jobs
                    WHERE status IN ('done', 'failed', 'cancelled')
                      AND completed_at IS NOT NULL
+                     AND COALESCE(data:triggered_by::STRING, '') <> %s
                      AND TIMESTAMPDIFF(SECOND, completed_at, CURRENT_TIMESTAMP()) > %s""",
-                (ttl_seconds,),
+                (DEMO_ESTATE_TRIGGERED_BY, ttl_seconds),
             )
             return cur.rowcount or 0
 

--- a/src/agent_bom/api/store.py
+++ b/src/agent_bom/api/store.py
@@ -20,6 +20,11 @@ from .server import JobStatus, ScanJob
 
 _JOB_TTL_SECONDS = 3600  # 1 hour
 
+# Curated public-demo scan jobs must outlive AGENT_BOM_API_JOB_TTL. Without this
+# exemption the cleanup loop deletes DONE demo jobs ~1h after bootstrap and the
+# hosted demo serves an empty findings spine until the next API restart.
+DEMO_ESTATE_TRIGGERED_BY = "demo-estate-bootstrap"
+
 
 def _require_tenant_scope(tenant_id: str | None, all_tenants: bool, method: str) -> None:
     """Fail closed when a request-path read/write omits a tenant scope.
@@ -74,7 +79,12 @@ class InMemoryJobStore:
         if len(self._jobs) <= self._max_retained_jobs:
             return
 
-        completed = [(jid, job) for jid, job in self._jobs.items() if job.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)]
+        completed = [
+            (jid, job)
+            for jid, job in self._jobs.items()
+            if job.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)
+            and getattr(job, "triggered_by", None) != DEMO_ESTATE_TRIGGERED_BY
+        ]
         completed.sort(key=lambda item: (item[1].completed_at is None, item[1].completed_at or item[1].created_at))
         for jid, _job in completed[: len(self._jobs) - self._max_retained_jobs]:
             self._jobs.pop(jid, None)
@@ -159,6 +169,7 @@ class InMemoryJobStore:
                 for jid, job in self._jobs.items()
                 if job.status in (JobStatus.DONE, JobStatus.FAILED, JobStatus.CANCELLED)
                 and job.completed_at
+                and getattr(job, "triggered_by", None) != DEMO_ESTATE_TRIGGERED_BY
                 and (now - datetime.fromisoformat(job.completed_at)).total_seconds() > ttl_seconds
             ]
             for jid in expired:
@@ -413,8 +424,9 @@ class SQLiteJobStore:
                 """DELETE FROM jobs
                    WHERE status IN ('done', 'failed', 'cancelled')
                      AND completed_at IS NOT NULL
+                     AND IFNULL(triggered_by, '') != ?
                      AND julianday(?) - julianday(completed_at) > ?""",
-                (now, ttl_seconds / 86400.0),
+                (DEMO_ESTATE_TRIGGERED_BY, now, ttl_seconds / 86400.0),
             )
             self._conn.commit()
             return cursor.rowcount

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.pipeline import _now
+from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
 from agent_bom.demo_estate.showcase_graph import (
     SHOWCASE_TENANT,
     seed_showcase_graph_if_empty,
@@ -24,15 +25,41 @@ def demo_estate_enabled() -> bool:
     return os.environ.get("AGENT_BOM_DEMO_ESTATE", "").strip().lower() in _TRUTHY
 
 
+def demo_estate_force_reseed() -> bool:
+    """Operator override: always reseed scan jobs even when usable ones exist."""
+    return os.environ.get("AGENT_BOM_DEMO_ESTATE_FORCE", "").strip().lower() in _TRUTHY
+
+
+def _job_has_demo_source(job: Any) -> bool:
+    result = getattr(job, "result", None) or {}
+    sources = result.get("scan_sources") or []
+    if any("demo" in str(src).lower() for src in sources):
+        return True
+    return getattr(job, "triggered_by", None) == DEMO_ESTATE_TRIGGERED_BY
+
+
+def _job_has_findings(job: Any) -> bool:
+    result = getattr(job, "result", None) or {}
+    findings = result.get("findings") or result.get("vulnerabilities") or []
+    return bool(findings)
+
+
 def _tenant_has_demo_jobs(store: Any, tenant_id: str) -> bool:
+    """True when the tenant already has a *usable* demo scan job.
+
+    Presence alone is not enough: an empty or FAILED demo marker (or a job
+    whose findings were never persisted) must not block reseed — that is how
+    the public demo can boot with graph/catalog populated but findings=[].
+    """
     list_fn = getattr(store, "list_all", None)
     if not callable(list_fn):
         return False
     jobs = list_fn(tenant_id=tenant_id)
     for job in jobs:
-        result = getattr(job, "result", None) or {}
-        sources = result.get("scan_sources") or []
-        if any("demo" in str(src).lower() for src in sources):
+        status = getattr(job, "status", None)
+        if status is not None and status != JobStatus.DONE and str(status).lower() != "done":
+            continue
+        if _job_has_demo_source(job) and _job_has_findings(job):
             return True
     return False
 
@@ -90,7 +117,7 @@ def _store_demo_scan_job(report: dict[str, Any], *, tenant_id: str) -> str:
     job = ScanJob(
         job_id=str(uuid.uuid4()),
         tenant_id=tenant_id,
-        triggered_by="demo-estate-bootstrap",
+        triggered_by=DEMO_ESTATE_TRIGGERED_BY,
         created_at=_now(),
         request=ScanRequest(offline=True),
     )
@@ -114,6 +141,9 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     store = _get_store()
     graph_store = _get_graph_store()
     summary: dict[str, Any] = {"enabled": True, "tenant_id": tenant_id, "seeded": False}
+    force = demo_estate_force_reseed()
+    if force:
+        summary["force"] = True
 
     # Graph seed is isolated and stale-aware: a real scan is left untouched, a
     # current demo seed is a no-op, and a stale demo seed is refreshed (see
@@ -156,19 +186,22 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
         _logger.warning("demo estate catalog seeding failed", exc_info=True)
         summary["catalog_error"] = True
 
-    if _tenant_has_demo_jobs(store, tenant_id):
+    if not force and _tenant_has_demo_jobs(store, tenant_id):
         summary["reason"] = "demo_jobs_present"
         return summary
 
     try:
         report = _run_demo_scan_report()
+        finding_count = len(report.get("findings") or report.get("vulnerabilities") or [])
+        if finding_count < 1:
+            raise RuntimeError("demo estate scan produced zero findings")
         job_id = _store_demo_scan_job(report, tenant_id=tenant_id)
         summary.update(
             {
                 "seeded": True,
                 "job_id": job_id,
                 "agents": len(report.get("agents") or []),
-                "findings": len(report.get("findings") or report.get("vulnerabilities") or []),
+                "findings": finding_count,
             }
         )
         _logger.info(

--- a/tests/api/test_api_store.py
+++ b/tests/api/test_api_store.py
@@ -73,6 +73,25 @@ def test_in_memory_cleanup():
     assert store.get("j2", all_tenants=True) is not None
 
 
+def test_in_memory_cleanup_preserves_demo_estate_jobs():
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+
+    store = InMemoryJobStore()
+    store.put(
+        _make_job(
+            "demo",
+            status=JobStatus.DONE,
+            completed_at="2020-01-01T00:00:00+00:00",
+            triggered_by=DEMO_ESTATE_TRIGGERED_BY,
+        )
+    )
+    store.put(_make_job("other", status=JobStatus.DONE, completed_at="2020-01-01T00:00:00+00:00"))
+    removed = store.cleanup_expired(ttl_seconds=1)
+    assert removed == 1
+    assert store.get("demo", all_tenants=True) is not None
+    assert store.get("other", all_tenants=True) is None
+
+
 def test_in_memory_retention_evicts_oldest_completed_jobs():
     store = InMemoryJobStore(max_retained_jobs=2)
     old = _make_job("old", status=JobStatus.DONE, completed_at="2026-02-23T12:00:00+00:00")
@@ -374,6 +393,30 @@ def test_sqlite_cleanup_expired():
         assert store.get("j1", all_tenants=True) is None
         assert store.get("j2", all_tenants=True) is not None
         assert store.get("j3", all_tenants=True) is None
+    finally:
+        Path(db_path).unlink(missing_ok=True)
+
+
+def test_sqlite_cleanup_preserves_demo_estate_jobs():
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+
+    with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+        db_path = f.name
+    try:
+        store = SQLiteJobStore(db_path=db_path)
+        store.put(
+            _make_job(
+                "demo",
+                status=JobStatus.DONE,
+                completed_at="2020-01-01T00:00:00+00:00",
+                triggered_by=DEMO_ESTATE_TRIGGERED_BY,
+            )
+        )
+        store.put(_make_job("other", status=JobStatus.DONE, completed_at="2020-01-01T00:00:00+00:00"))
+        removed = store.cleanup_expired(ttl_seconds=1)
+        assert removed == 1
+        assert store.get("demo", all_tenants=True) is not None
+        assert store.get("other", all_tenants=True) is None
     finally:
         Path(db_path).unlink(missing_ok=True)
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -329,6 +329,9 @@ def test_demo_redeploy_layers_demo_override_and_uses_write_secret() -> None:
     assert "deploy/docker-compose.demo-override.yml" in workflow
     assert "hosted_poc_preflight.py --write-secret" in workflow
     assert "--write-postgres-secret" not in workflow
+    # Empty findings spine is a demo outage — redeploy must fail closed on it.
+    assert "demo estate smoke" in workflow
+    assert "/v1/findings?limit=1" in workflow
 
     # Security gate remains platform + hosted-poc only (no demo anon flags).
     preflight_src = (root / "scripts" / "deploy" / "hosted_poc_preflight.py").read_text(encoding="utf-8")

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -477,6 +477,81 @@ def test_demo_estate_bootstrap_is_idempotent(demo_estate_client: TestClient) -> 
     assert again.get("total") == first.get("total")
 
 
+def test_demo_estate_reseeds_when_marker_job_has_no_findings(
+    demo_estate_client: TestClient,
+) -> None:
+    """A demo-tagged job with empty findings must not block reseed (empty demo)."""
+    import uuid
+
+    from agent_bom.api import stores as api_stores
+    from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+    from agent_bom.api.pipeline import _now
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+    from agent_bom.demo_estate.bootstrap import maybe_bootstrap_demo_estate
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT
+
+    store = api_stores._get_store()
+    for job in list(store.list_all(tenant_id=SHOWCASE_TENANT)):
+        store.delete(job.job_id, tenant_id=SHOWCASE_TENANT)
+
+    empty = ScanJob(
+        job_id=str(uuid.uuid4()),
+        tenant_id=SHOWCASE_TENANT,
+        triggered_by=DEMO_ESTATE_TRIGGERED_BY,
+        created_at=_now(),
+        request=ScanRequest(offline=True),
+    )
+    empty.status = JobStatus.DONE
+    empty.completed_at = _now()
+    empty.result = {"scan_sources": ["demo", "demo-estate"], "findings": [], "agents": []}
+    store.put(empty)
+
+    before_total = demo_estate_client.get("/v1/findings", headers=ADMIN, params={"limit": 1}).json()
+    assert before_total.get("total", 0) == 0
+
+    summary = maybe_bootstrap_demo_estate()
+    assert summary.get("seeded") is True, summary
+    assert (summary.get("findings") or 0) >= 1
+
+    after = demo_estate_client.get("/v1/findings", headers=ADMIN, params={"limit": 1}).json()
+    assert after.get("total", 0) > 0
+
+
+def test_demo_estate_survives_job_ttl_cleanup(demo_estate_client: TestClient) -> None:
+    """API job TTL must not delete curated demo-estate scan jobs."""
+    from agent_bom.api import stores as api_stores
+    from agent_bom.api.pipeline import _now
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT
+
+    store = api_stores._get_store()
+    demo_jobs = [
+        job
+        for job in store.list_all(tenant_id=SHOWCASE_TENANT)
+        if getattr(job, "triggered_by", None) == DEMO_ESTATE_TRIGGERED_BY
+    ]
+    assert demo_jobs, "precondition: bootstrap seeded a demo-estate job"
+    for job in demo_jobs:
+        job.completed_at = "2020-01-01T00:00:00+00:00"
+        store.put(job)
+
+    removed = store.cleanup_expired(ttl_seconds=1)
+    remaining = [
+        job
+        for job in store.list_all(tenant_id=SHOWCASE_TENANT)
+        if getattr(job, "triggered_by", None) == DEMO_ESTATE_TRIGGERED_BY
+    ]
+    assert remaining, f"demo estate jobs were purged by TTL (removed={removed})"
+
+    # Restore a current completed_at so the default findings window still sees them.
+    now = _now()
+    for job in remaining:
+        job.completed_at = now
+        store.put(job)
+    findings = demo_estate_client.get("/v1/findings", headers=ADMIN, params={"limit": 1}).json()
+    assert findings.get("total", 0) > 0
+
+
 def test_demo_estate_exposure_paths_materialized(demo_estate_client: TestClient) -> None:
     """The materialized exposure-path queue (read by /v1/graph/exposure-paths) is
     non-empty and headlines the seeded hero chains."""

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -497,6 +497,7 @@ def test_job_store_list_summary_includes_tenant(mock_pool):
 
 def test_job_store_cleanup(mock_pool):
     from agent_bom.api.postgres_store import PostgresJobStore
+    from agent_bom.api.store import DEMO_ESTATE_TRIGGERED_BY
 
     store = PostgresJobStore(pool=mock_pool)
     count = store.cleanup_expired(ttl_seconds=7200)
@@ -505,7 +506,8 @@ def test_job_store_cleanup(mock_pool):
     )
     assert isinstance(count, int)
     assert "INTERVAL '1 second'" in delete_sql
-    assert delete_params == (7200,)
+    assert "triggered_by" in delete_sql
+    assert delete_params == (DEMO_ESTATE_TRIGGERED_BY, 7200)
 
 
 def test_job_store_init_migrates_triggered_by_column(mock_pool):


### PR DESCRIPTION
Combines #4357 and #4358 — both are the demo follow-ups from the earlier review (empty live demo + misleading README nav line). Disjoint files except CHANGELOG (merged). Rebased fresh onto current main via real commits, so CI fires cleanly.

## #4357 — keep curated estate findings past job TTL (the empty-demo root cause)
The public demo went blank ~1h after boot because the seeded `demo-estate-bootstrap` findings were tied to a scan job that `AGENT_BOM_API_JOB_TTL` cleanup expired. Now: bootstrap scan jobs are exempt from TTL cleanup, bootstrap reseeds when only an empty demo marker remains, the API cleanup loop self-heals a missing findings spine, and demo redeploy fails closed when `/v1/findings` total is zero.

## #4358 — clean the Live demo nav + lead with visuals
Top-nav shows just `Live demo` (the offline fallback moves to the scan/demo body copy — no more "if unreachable…" hedge in the header), leads with product visuals, and collapses persona/connector/architecture tables under `<details>`.

## Verified locally
- `pytest test_demo_estate_bootstrap / test_api_store / test_compose_secrets_healthcheck` → 97 passed
- `check_release_consistency.py` → passed; surface-freshness OK
- sharp CVE fix inherited from main (#4359, already merged) — security gate clean
- diff scanned clean of private infra identifiers

Closes #4357, closes #4358.