### PR TITLE
feat(brand): align BOM mark across CLI, reports, and API docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,16 +42,13 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
-<<<<<<< HEAD
 - README: clean top-nav Live demo link (offline fallback lives under scan/demo
   body copy), lead with product visuals, and collapse persona / connector /
   architecture tables under `<details>`.
-=======
 - Brand shell consistency: CLI serve/gateway startup prints the BOM agent-HUD
   mark; console/PDF/HTML report titles use `agent-bom scan report`; OpenAPI
   `/docs` favicon serves `/brand/mark.svg`; login/auth unreachable states show
   the canonical `BrandLogo` lockup.
->>>>>>> 684bda81 (feat(brand): align BOM mark across CLI, reports, and API docs)
 - Remove private strategy and agent-session audit ledgers from the public tree
   (`docs/archive/STRATEGIC_AUDIT_*`, `docs/archive/AUDIT.md`, `docs/audits/`);
   soften large-enterprise procurement phrasing. CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,9 +42,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
+<<<<<<< HEAD
 - README: clean top-nav Live demo link (offline fallback lives under scan/demo
   body copy), lead with product visuals, and collapse persona / connector /
   architecture tables under `<details>`.
+=======
+- Brand shell consistency: CLI serve/gateway startup prints the BOM agent-HUD
+  mark; console/PDF/HTML report titles use `agent-bom scan report`; OpenAPI
+  `/docs` favicon serves `/brand/mark.svg`; login/auth unreachable states show
+  the canonical `BrandLogo` lockup.
+>>>>>>> 684bda81 (feat(brand): align BOM mark across CLI, reports, and API docs)
 - Remove private strategy and agent-session audit ledgers from the public tree
   (`docs/archive/STRATEGIC_AUDIT_*`, `docs/archive/AUDIT.md`, `docs/audits/`);
   soften large-enterprise procurement phrasing. CI

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5487,7 +5487,7 @@
     }
   },
   "info": {
-    "description": "Security scanner for AI supply chain and infrastructure \u2014 map the full trust chain from agents to CVEs, credentials, and blast radius.",
+    "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. agent \u2192 MCP server \u2192 packages \u2192 CVEs \u2192 blast radius.",
     "title": "agent-bom API",
     "version": "0.97.2"
   },

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3753,8 +3753,9 @@ components:
       title: _HitlDecisionBody
       type: object
 info:
-  description: "Security scanner for AI supply chain and infrastructure \u2014 map\
-    \ the full trust chain from agents to CVEs, credentials, and blast radius."
+  description: "Open security scanner and self-hosted control plane for AI, MCP, and\
+    \ cloud infrastructure. agent \u2192 MCP server \u2192 packages \u2192 CVEs \u2192\
+    \ blast radius."
   title: agent-bom API
   version: 0.97.2
 openapi: 3.1.0

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -77,7 +77,8 @@ _DOCS_CSP = (
     "default-src 'self'; "
     "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
     "style-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net; "
-    "img-src 'self' data: https://fastapi.tiangolo.com https://cdn.jsdelivr.net; "
+    # Favicon is served from /brand/mark.svg (self); keep jsdelivr for swagger assets.
+    "img-src 'self' data: https://cdn.jsdelivr.net; "
     "font-src 'self' data: https://cdn.jsdelivr.net; "
     "worker-src 'self' blob:; "
     "connect-src 'self'"
@@ -963,6 +964,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             "/ping",
             "/readyz",
             "/version",
+            "/brand/mark.svg",
             "/docs",
             "/redoc",
             "/openapi.json",
@@ -984,6 +986,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             "/ping",
             "/readyz",
             "/version",
+            "/brand/mark.svg",
             "/v1/auth/session",
             "/v1/auth/oidc/login",
             "/v1/auth/oidc/callback",
@@ -1005,7 +1008,15 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             return False
         if path.startswith("/_next/"):
             return True
-        if path in {"/favicon.ico", "/robots.txt", "/manifest.json", "/apple-touch-icon.png"}:
+        if path in {
+            "/favicon.ico",
+            "/robots.txt",
+            "/manifest.json",
+            "/apple-touch-icon.png",
+            "/brand/mark.svg",
+        }:
+            return True
+        if path.startswith("/brand/"):
             return True
         dashboard_routes = {
             "",

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -74,6 +74,7 @@ from agent_bom.api.stores import (
 from agent_bom.api.tracing import configure_otel_tracing, get_tracing_health
 from agent_bom.config import API_JOB_TTL_SECONDS as _JOB_TTL_SECONDS
 from agent_bom.config import resolved_cors_origins_raw
+from agent_bom.output.brand_tokens import POSITIONING_META, PRODUCT_NAME, TAGLINE_CHAIN
 
 _logger = logging.getLogger(__name__)
 _DASHBOARD_CSP_META_RE = re.compile(
@@ -629,15 +630,13 @@ async def _lifespan(app_instance: FastAPI) -> AsyncIterator[None]:
 
 
 app = FastAPI(
-    title="agent-bom API",
-    description=(
-        "Security scanner for AI supply chain and infrastructure — "
-        "map the full trust chain from agents to CVEs, credentials, and blast radius."
-    ),
+    title=f"{PRODUCT_NAME} API",
+    description=f"{POSITIONING_META}. {TAGLINE_CHAIN}.",
     version=__version__,
     docs_url="/docs",
     redoc_url="/redoc",
     lifespan=_lifespan,
+    swagger_ui_parameters={"favicon_url": "/brand/mark.svg"},
 )
 
 _default_origins = [
@@ -1301,6 +1300,23 @@ def _public_health() -> PublicHealthResponse:
         configured_auth_modes=list(cast(list[str], auth_runtime["configured_modes"])),
         unauthenticated_allowed=bool(auth_runtime.get("unauthenticated_allowed", False)),
     )
+
+
+@app.get("/brand/mark.svg", include_in_schema=False, tags=["meta"])
+async def brand_mark_svg() -> Any:
+    """Serve the canonical BOM agent-HUD mark for OpenAPI /docs favicon chrome."""
+    from fastapi.responses import FileResponse, Response
+
+    from agent_bom.output.brand_tokens import MARK_SVG_DARK
+
+    root = Path(__file__).resolve().parents[3]
+    for candidate in (
+        root / "docs" / "images" / "brand" / "mark-dark.svg",
+        root / "ui" / "public" / "brand" / "mark-dark.svg",
+    ):
+        if candidate.is_file():
+            return FileResponse(candidate, media_type="image/svg+xml")
+    return Response(content=MARK_SVG_DARK, media_type="image/svg+xml")
 
 
 @app.get("/health", response_model=PublicHealthResponse, tags=["meta"])

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -582,7 +582,8 @@ def serve_cmd(
     # service mesh terminates external traffic in front of this pod. Set
     # --bind 127.0.0.1:8090 on a dev workstation to restrict.
     host = host  # nosec B104
-    click.echo(f"agent-bom gateway serving on http://{host}:{port_num} fronting {len(registry)} upstream(s): {', '.join(registry.names())}")
+    from agent_bom.output.brand_tokens import emit_cli_runtime_summary
+
     rows = [
         ("Bind", f"http://{host}:{port_num}"),
         ("Upstreams", f"{len(registry)} configured: {', '.join(registry.names()) or '(none)'}"),
@@ -629,11 +630,7 @@ def serve_cmd(
                 f"Firewall hot reload: enabled every {firewall_policy_reload_seconds}s from {firewall_policy_path}",
             )
         )
-    click.echo("")
-    click.echo("  agent-bom gateway")
-    for label, value in rows:
-        click.echo(f"  {label:<11} {value}")
-    click.echo("  Press Ctrl+C to stop.\n")
+    emit_cli_runtime_summary("agent-bom gateway", rows)
     emit_runtime_status_strip("gateway", calls=0, blocked=0, last_decision="listening")
     uvicorn.run(app, host=host, port=port_num, log_level=log_level.lower())
 

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -260,12 +260,10 @@ def _configure_analytics_backend(
 
 
 def _emit_runtime_summary(title: str, rows: list[tuple[str, str]], *, err: bool = False) -> None:
-    """Print a compact, aligned startup summary block."""
-    click.echo("", err=err)
-    click.echo(f"  {title}", err=err)
-    for label, value in rows:
-        click.echo(f"  {label:<11} {value}", err=err)
-    click.echo("  Press Ctrl+C to stop.\n", err=err)
+    """Print a compact, aligned startup summary block with the BOM mark."""
+    from agent_bom.output.brand_tokens import emit_cli_runtime_summary
+
+    emit_cli_runtime_summary(title, rows, err=err)
 
 
 _MCP_WORKFLOW_NAMES = (

--- a/src/agent_bom/output/brand_tokens.py
+++ b/src/agent_bom/output/brand_tokens.py
@@ -11,8 +11,31 @@ from dataclasses import dataclass
 PRODUCT_NAME = "agent-bom"
 # Capability line for meta/prose — not shown under the nav lockup.
 POSITIONING_SHORT = "Open security scanner for AI infrastructure"
+# Longer meta line for OpenAPI / HTML <title> chrome (matches VISUAL_LANGUAGE).
+POSITIONING_META = (
+    "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure"
+)
 TAGLINE_CHAIN = "agent → MCP server → packages → CVEs → blast radius"
 DOCS_URL = "https://github.com/msaad00/agent-bom"
+REPORT_TITLE = f"{PRODUCT_NAME} scan report"
+
+# Minimal dark mark for API /docs favicon when package data is unavailable.
+MARK_SVG_DARK = """<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="agent-bom mark">
+  <defs>
+    <linearGradient id="abm" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#34d399"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abm)" stroke-width="2"/>
+  <circle cx="32" cy="30.2" r="12" fill="#0f1a17" stroke="url(#abm)" stroke-width="2.4"/>
+  <path d="M32 18.4V13.5" stroke="url(#abm)" stroke-width="2.2" stroke-linecap="round"/>
+  <circle cx="32" cy="11.9" r="2.1" fill="url(#abm)"/>
+  <circle cx="28" cy="28.9" r="2.7" fill="#34d399"/>
+  <circle cx="36" cy="28.9" r="2.7" fill="#22d3ee"/>
+  <path d="M28.3 35.4h7.4" stroke="url(#abm)" stroke-width="1.9" stroke-linecap="round"/>
+</svg>
+"""
 
 # Terminal mark: BOM with agent HUD in the O (visor + antenna cue).
 _MARK_UNICODE = (
@@ -111,15 +134,39 @@ def print_cli_startup_banner(console: object, *, version: str) -> None:
     print_()
 
 
+def emit_cli_runtime_summary(
+    title: str,
+    rows: list[tuple[str, str]],
+    *,
+    err: bool = False,
+    force_ascii: bool = False,
+) -> None:
+    """Print the BOM mark + product title + aligned key/value rows for serve/gateway."""
+
+    import click
+
+    click.echo("", err=err)
+    for line in cli_mark_lines(force_ascii=force_ascii):
+        click.echo(line, err=err)
+    click.echo(f"  {title}", err=err)
+    for label, value in rows:
+        click.echo(f"  {label:<11} {value}", err=err)
+    click.echo("  Press Ctrl+C to stop.\n", err=err)
+
+
 __all__ = [
     "DOCS_URL",
     "LANE_TOKENS",
+    "MARK_SVG_DARK",
+    "POSITIONING_META",
     "POSITIONING_SHORT",
     "PRODUCT_NAME",
+    "REPORT_TITLE",
     "TAGLINE_CHAIN",
     "LaneToken",
     "cli_banner_plain",
     "cli_mark_lines",
+    "emit_cli_runtime_summary",
     "lane_title",
     "lane_token",
     "print_cli_startup_banner",

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -90,13 +90,15 @@ def _console() -> Console:
 
 
 def print_summary(report: AIBOMReport) -> None:
-    """Print a summary of the AI-BOM report to console."""
+    """Print a summary of the agent-bom scan report to console."""
+    from agent_bom.output.brand_tokens import PRODUCT_NAME, REPORT_TITLE
+
     _console().print("\n")
     _console().print(
         Panel.fit(
-            f"[bold]AI-BOM Report[/bold]\n"
+            f"[bold]{REPORT_TITLE}[/bold]\n"
             f"Generated: {report.generated_at.strftime('%Y-%m-%d %H:%M:%S UTC')}\n"
-            f"agent-bom v{report.tool_version}",
+            f"{PRODUCT_NAME} v{report.tool_version}",
             border_style="blue",
         )
     )

--- a/src/agent_bom/output/html/document.py
+++ b/src/agent_bom/output/html/document.py
@@ -135,7 +135,7 @@ def to_html(
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1">
-  <title>agent-bom AI-BOM &mdash; {_esc(generated)}</title>
+  <title>agent-bom scan report &mdash; {_esc(generated)}</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.2/dist/chart.umd.min.js"></script>
   <script src="https://unpkg.com/cytoscape@3.30.2/dist/cytoscape.min.js"></script>
   <script src="https://unpkg.com/dagre@0.8.5/dist/dagre.min.js"></script>
@@ -151,10 +151,25 @@ def to_html(
 <!-- Sidebar Navigation -->
 <div class="sidebar" id="mainSidebar">
   <div class="sidebar-brand">
-    <div class="brand-icon">&#x1f6e1;&#xfe0f;</div>
+    <div class="brand-icon" aria-hidden="true" title="agent-bom mark">
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="28" height="28" role="img">
+        <defs>
+          <linearGradient id="abmHtmlMark" x1="8" y1="6" x2="56" y2="58" gradientUnits="userSpaceOnUse">
+            <stop offset="0%" stop-color="#34d399"/>
+            <stop offset="100%" stop-color="#06b6d4"/>
+          </linearGradient>
+        </defs>
+        <rect x="3.5" y="3.5" width="57" height="57" rx="15" fill="#0c1210" stroke="url(#abmHtmlMark)" stroke-width="2"/>
+        <circle cx="32" cy="30.2" r="12" fill="#0f1a17" stroke="url(#abmHtmlMark)" stroke-width="2.4"/>
+        <path d="M32 18.4V13.5" stroke="url(#abmHtmlMark)" stroke-width="2.2" stroke-linecap="round"/>
+        <circle cx="32" cy="11.9" r="2.1" fill="url(#abmHtmlMark)"/>
+        <circle cx="28" cy="28.9" r="2.7" fill="#34d399"/>
+        <circle cx="36" cy="28.9" r="2.7" fill="#22d3ee"/>
+        <path d="M28.3 35.4h7.4" stroke="url(#abmHtmlMark)" stroke-width="1.9" stroke-linecap="round"/>
+      </svg>
+    </div>
     <div>
       <div class="brand-text">agent-bom</div>
-      <div class="brand-sub">Open security scanner for AI infrastructure</div>
     </div>
   </div>
   <div class="sidebar-status">

--- a/src/agent_bom/output/pdf.py
+++ b/src/agent_bom/output/pdf.py
@@ -73,7 +73,9 @@ def _append_wrapped(lines: list[str], value: object = "", *, indent: str = "") -
 
 def _build_report_lines(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[str]:
     lines: list[str] = []
-    lines.append("Agent-BOM Scan Report")
+    from agent_bom.output.brand_tokens import REPORT_TITLE
+
+    lines.append(REPORT_TITLE)
     lines.append("=" * 76)
     lines.append(f"Generated: {_sanitize_text(report.generated_at.isoformat())}")
     lines.append(f"Version: {_sanitize_text(report.tool_version or 'unknown')}")
@@ -136,7 +138,9 @@ def _build_report_lines(report: AIBOMReport, blast_radii: list[BlastRadius] | No
 def _split_pages(lines: list[str]) -> list[list[str]]:
     usable_height = _TOP_START - _BOTTOM_MARGIN
     page_capacity = max(12, usable_height // _LINE_HEIGHT)
-    return [lines[i : i + page_capacity] for i in range(0, len(lines), page_capacity)] or [["Agent-BOM Scan Report"]]
+    from agent_bom.output.brand_tokens import REPORT_TITLE
+
+    return [lines[i : i + page_capacity] for i in range(0, len(lines), page_capacity)] or [[REPORT_TITLE]]
 
 
 def _page_stream(lines: list[str]) -> bytes:

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -54,6 +54,24 @@ def _fresh_client():
 # ---------------------------------------------------------------------------
 
 
+def test_brand_mark_svg_is_public() -> None:
+    client, _store = _fresh_client()
+    resp = client.get("/brand/mark.svg")
+    assert resp.status_code == 200
+    assert "image/svg" in resp.headers.get("content-type", "")
+    assert b"<svg" in resp.content
+    assert b"agent-bom" in resp.content or b"linearGradient" in resp.content
+
+
+def test_openapi_uses_brand_favicon() -> None:
+    client, _store = _fresh_client()
+    schema = client.get("/openapi.json").json()
+    assert schema["info"]["title"] == "agent-bom API"
+    docs = client.get("/docs")
+    assert docs.status_code == 200
+    assert "/brand/mark.svg" in docs.text
+
+
 def test_health_endpoint():
     """Public liveness is minimal; authenticated status carries diagnostics."""
     client, _ = _fresh_client()

--- a/tests/test_cli_brand.py
+++ b/tests/test_cli_brand.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 from agent_bom.output.brand_tokens import (
     POSITIONING_SHORT,
     PRODUCT_NAME,
+    REPORT_TITLE,
     cli_banner_plain,
     cli_mark_lines,
+    emit_cli_runtime_summary,
     print_cli_startup_banner,
 )
 
@@ -40,3 +42,22 @@ def test_startup_banner_renders_mark_and_quick_start() -> None:
     assert "9.9.9" in blob
     assert f"{PRODUCT_NAME} scan" in blob
     assert "Quick start" in blob
+
+
+def test_runtime_summary_includes_bom_mark(capsys) -> None:
+    emit_cli_runtime_summary(
+        "agent-bom serve",
+        [("Bind", "http://127.0.0.1:8422")],
+        force_ascii=True,
+    )
+    out = capsys.readouterr().out
+    assert "B" in out and "M" in out
+    assert "agent-bom serve" in out
+    assert "Bind" in out
+    assert REPORT_TITLE  # locked constant for report headers
+
+
+def test_report_title_uses_product_name() -> None:
+    assert REPORT_TITLE.startswith(PRODUCT_NAME)
+    assert "Agent-BOM" not in REPORT_TITLE
+    assert "AI-BOM Report" != REPORT_TITLE

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -598,7 +598,8 @@ def test_gateway_serve_empty_upstreams_yaml_reaches_uvicorn(tmp_path):
         result = runner.invoke(gateway_serve_cmd, ["--bind", "127.0.0.1:8090", "--upstreams", str(upstreams)])
 
     assert result.exit_code == 0
-    assert "fronting 0 upstream(s)" in result.output
+    # Branded runtime summary renders the upstream count as an "Upstreams" row.
+    assert "0 configured: (none)" in result.output
     mock_run.assert_called_once()
 
 

--- a/tests/test_pdf_output.py
+++ b/tests/test_pdf_output.py
@@ -18,7 +18,7 @@ def test_to_pdf_renders_pdf_bytes():
 
     assert data.startswith(b"%PDF")
     assert b"/Type /Catalog" in data
-    assert b"Agent-BOM Scan Report" in data
+    assert b"agent-bom scan report" in data
 
 
 def test_export_pdf_writes_file(tmp_path):
@@ -28,4 +28,4 @@ def test_export_pdf_writes_file(tmp_path):
     export_pdf(_report(), str(out), [])
 
     assert out.read_bytes().startswith(b"%PDF")
-    assert b"Agent-BOM Scan Report" in out.read_bytes()
+    assert b"agent-bom scan report" in out.read_bytes()

--- a/ui/components/auth-gate.tsx
+++ b/ui/components/auth-gate.tsx
@@ -5,6 +5,7 @@ import { usePathname, useRouter } from "next/navigation";
 import { Loader2 } from "lucide-react";
 
 import { useAuthState } from "@/components/auth-provider";
+import { BrandLogo } from "@/components/brand-logo";
 
 function isAuthFailure(message: string): boolean {
   const normalized = message.toLowerCase();
@@ -61,6 +62,9 @@ export function AuthGate({ children }: { children: React.ReactNode }) {
     return (
       <div className="flex min-h-[calc(100vh-5rem)] items-center justify-center px-4 py-10">
         <div className="w-full max-w-xl rounded-3xl border border-amber-900/50 bg-amber-950/20 p-8 text-center shadow-2xl shadow-black/20">
+          <div className="mx-auto mb-4 flex justify-center">
+            <BrandLogo />
+          </div>
           <h1 className="text-xl font-semibold tracking-tight text-[var(--foreground)]">Control plane unreachable</h1>
           <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
             Authentication could not be verified because the API is offline or returned a server error.

--- a/ui/components/login-panel.tsx
+++ b/ui/components/login-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { KeyRound, Loader2, ShieldCheck, Snowflake } from "lucide-react";
+import { KeyRound, Loader2, Snowflake } from "lucide-react";
 
 import { useAuthState } from "@/components/auth-provider";
 import { BrandLogo } from "@/components/brand-logo";
@@ -59,7 +59,9 @@ export function LoginPanel({
     return (
       <div className="flex min-h-[calc(100vh-4rem)] items-center justify-center px-4 py-10">
         <div className="w-full max-w-xl rounded-3xl border border-amber-900/50 bg-amber-950/20 p-8 text-center shadow-2xl shadow-black/20">
-          <ShieldCheck className="mx-auto mb-4 h-8 w-8 text-amber-300" />
+          <div className="mx-auto mb-4 flex justify-center">
+            <BrandLogo />
+          </div>
           <h1 className="text-xl font-semibold tracking-tight text-[var(--foreground)]">Control plane unreachable</h1>
           <p className="mt-3 text-sm leading-6 text-[var(--text-secondary)]">
             Authentication could not be verified because the API is offline or returned a server error. The dashboard


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- CLI serve / gateway startup summaries print the BOM agent-HUD mark via `emit_cli_runtime_summary`.
- Console, PDF, and HTML report titles use `agent-bom scan report` (drops Title-Case / shield-emoji lockup drift).
- OpenAPI `/docs` favicon points at public `GET /brand/mark.svg` (file or embedded SVG fallback); docs CSP no longer needs the FastAPI CDN favicon host.
- Login and auth-gate unreachable states show the canonical `BrandLogo`.
- CHANGELOG Unresolved rebase markers after `#4360` merge cleaned; Unreleased keeps both README Live demo polish and brand shell Changed entries.

## Verification
- `uv run ruff check` on touched files
- `uv run pytest -q tests/test_cli_brand.py tests/test_pdf_output.py tests/api/test_api_endpoints.py::test_brand_mark_svg_is_public tests/api/test_api_endpoints.py::test_openapi_uses_brand_favicon tests/api/test_api_endpoints.py::test_docs_csp_relaxation_is_exact_route_scoped`
- Confirmed remote tip `CHANGELOG.md` has no conflict markers; PR mergeable against `main` after `#4360`.

## Notes
- Series PR1 of graph investigation OS + brand alignment. Does not invent a new mascot.
- Independent of `fix(demo)+docs(readme): persist demo estate past job TTL + clean Live demo nav` (#4360, merged).
- Merge before #4362 / #4363 / #4364; rebase those onto `main` after this lands.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

