### PR TITLE
feat(graph): estate completeness, drift timeline, CODE/CI emission

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2857,17 +2857,9 @@ _SHAPE_TO_ICON: dict[str, str] = {
 
 
 _RESERVED_GRAPH_NODE_KINDS: dict[str, tuple[list[str], str]] = {
-    EntityType.CODE_MODULE.value: (
-        ["code_graph"],
-        "Reserved for source-code topology; static supply-chain scans do not emit module-level nodes yet.",
-    ),
     EntityType.EXTERNAL_IMPORT.value: (
         ["code_graph"],
         "Reserved for source-code import topology; static supply-chain scans do not emit import nodes yet.",
-    ),
-    EntityType.CI_JOB.value: (
-        ["ci_graph"],
-        "Reserved for CI/CD topology; scan jobs are tracked operationally but are not emitted as graph nodes yet.",
     ),
 }
 
@@ -2876,18 +2868,6 @@ _RESERVED_GRAPH_EDGE_KINDS: dict[str, tuple[list[str], str]] = {
     RelationshipType.IMPORTS.value: (
         ["code_graph"],
         "Reserved for source-code topology linking files, modules, packages, and imports.",
-    ),
-    RelationshipType.DEFINES.value: (
-        ["code_graph"],
-        "Reserved for source-code topology linking source files to modules, tools, and CI jobs.",
-    ),
-    RelationshipType.RUNS.value: (
-        ["ci_graph"],
-        "Reserved for CI/CD topology linking workflow jobs to tools, servers, and agents.",
-    ),
-    RelationshipType.CONFIGURES.value: (
-        ["code_graph"],
-        "Reserved for configuration topology linking config files to agents, servers, CI jobs, and tools.",
     ),
     RelationshipType.OWNS.value: (
         ["identity_graph"],
@@ -2913,6 +2893,8 @@ _EMITTED_GRAPH_NODE_SURFACES: dict[str, list[str]] = {
     EntityType.DIRECTORY.value: ["repo_structure_overlay"],
     EntityType.SOURCE_FILE.value: ["repo_structure_overlay"],
     EntityType.CONFIG_FILE.value: ["repo_structure_overlay"],
+    EntityType.CODE_MODULE.value: ["code_graph_overlay"],
+    EntityType.CI_JOB.value: ["ci_graph_overlay", "github_actions"],
 }
 
 
@@ -2921,6 +2903,9 @@ _EMITTED_GRAPH_EDGE_SURFACES: dict[str, list[str]] = {
     RelationshipType.USED_CREDENTIAL.value: ["runtime_proxy", "gateway_event_projection"],
     RelationshipType.USES_FRAMEWORK.value: ["ai_inventory", "framework_agents"],
     RelationshipType.OBSERVES.value: ["ai_inventory"],
+    RelationshipType.DEFINES.value: ["code_graph_overlay"],
+    RelationshipType.RUNS.value: ["ci_graph_overlay", "github_actions"],
+    RelationshipType.CONFIGURES.value: ["ci_graph_overlay", "github_actions"],
 }
 
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -1160,6 +1160,18 @@ def build_unified_graph_from_report(
     except Exception:  # noqa: BLE001
         _logger.warning("repo-structure overlay failed", exc_info=True)
 
+    # CODE_MODULE from SOURCE_FILE evidence (after repo-structure places files).
+    try:
+        _apply_code_graph_overlay(graph, report_json)
+    except Exception:  # noqa: BLE001
+        _logger.warning("code-graph overlay failed", exc_info=True)
+
+    # CI_JOB / RUNS / CONFIGURES from github-actions agents already in the report.
+    try:
+        _apply_ci_graph_overlay(graph, report_json)
+    except Exception:  # noqa: BLE001
+        _logger.warning("ci-graph overlay failed", exc_info=True)
+
     if span is not None:
         span.set_attribute("agent_bom.graph.scan_id", sid)
         span.set_attribute("agent_bom.graph.tenant_id", tenant_id or "default")
@@ -1244,6 +1256,31 @@ def _apply_repo_structure_overlay(graph: UnifiedGraph, report_json: Mapping[str,
     from agent_bom.graph.repo_structure_overlay import apply_repo_structure_overlay
 
     apply_repo_structure_overlay(graph, dict(report_json), datetime.now(timezone.utc))
+
+
+def _apply_code_graph_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any]) -> None:
+    """Emit CODE_MODULE nodes from SOURCE_FILE evidence already on the graph."""
+    if not any(node.entity_type == EntityType.SOURCE_FILE for node in graph.nodes.values()):
+        return
+    from datetime import datetime, timezone
+
+    from agent_bom.graph.code_graph_overlay import apply_code_graph_overlay
+
+    apply_code_graph_overlay(graph, dict(report_json), datetime.now(timezone.utc))
+
+
+def _apply_ci_graph_overlay(graph: UnifiedGraph, report_json: Mapping[str, Any]) -> None:
+    """Emit CI_JOB topology from github-actions agents in the report."""
+    agents = report_json.get("agents")
+    if not isinstance(agents, list):
+        return
+    if not any(isinstance(agent, dict) and agent.get("source") == "github-actions" for agent in agents):
+        return
+    from datetime import datetime, timezone
+
+    from agent_bom.graph.ci_graph_overlay import apply_ci_graph_overlay
+
+    apply_ci_graph_overlay(graph, dict(report_json), datetime.now(timezone.utc))
 
 
 def _iter_agentic_identity_graph_projections(report_json: Mapping[str, Any]) -> list[Mapping[str, Any]]:

--- a/src/agent_bom/graph/ci_graph_overlay.py
+++ b/src/agent_bom/graph/ci_graph_overlay.py
@@ -112,11 +112,13 @@ def apply_ci_graph_overlay(
             )
             counts["configures_edges"] += 1
 
-        servers = agent.get("mcp_servers") if isinstance(agent.get("mcp_servers"), list) else []
+        raw_servers = agent.get("mcp_servers")
+        servers = raw_servers if isinstance(raw_servers, list) else []
         for server in servers:
             if not isinstance(server, dict):
                 continue
-            tools = server.get("tools") if isinstance(server.get("tools"), list) else []
+            raw_tools = server.get("tools")
+            tools = raw_tools if isinstance(raw_tools, list) else []
             for tool in tools:
                 tool_name = ""
                 if isinstance(tool, dict):

--- a/src/agent_bom/graph/ci_graph_overlay.py
+++ b/src/agent_bom/graph/ci_graph_overlay.py
@@ -1,0 +1,139 @@
+"""CI/CD graph overlay — emit ``ci_job`` nodes from GitHub Actions evidence.
+
+When a scan already carries agents with ``source="github-actions"`` (from
+``agent_bom.github_actions.scan_github_actions``), this overlay materialises
+reserved CI vocabulary instead of leaving workflow topology only as synthetic
+agent/server nodes:
+
+- ``CI_JOB`` per workflow (stable id ``ci_job:<workflow-stem>``)
+- ``CONFIGURES`` from matching ``CONFIG_FILE`` / agent ``config_path`` when present
+- ``RUNS`` from the CI job to tool nodes already linked under the GHA server
+
+Complete no-op when the report has no github-actions agents. Idempotent.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.types import EntityType, GraphSemanticLayer, RelationshipType
+
+_OVERLAY_SOURCE = "ci_graph_overlay"
+_GHA_SOURCE = "github-actions"
+
+
+def _norm_path(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    return text.lstrip("/")
+
+
+def _ci_job_id(workflow_stem: str) -> str:
+    return f"ci_job:{workflow_stem}"
+
+
+def apply_ci_graph_overlay(
+    graph: UnifiedGraph,
+    report_json: dict[str, Any],
+    now: datetime,
+) -> dict[str, int]:
+    """Emit CI_JOB / RUNS / CONFIGURES from github-actions scan evidence."""
+    counts = {"ci_jobs": 0, "runs_edges": 0, "configures_edges": 0}
+    agents = report_json.get("agents") if isinstance(report_json, dict) else None
+    if not isinstance(agents, list):
+        return counts
+
+    gha_agents = [
+        agent
+        for agent in agents
+        if isinstance(agent, dict) and str(agent.get("source") or "") == _GHA_SOURCE
+    ]
+    if not gha_agents:
+        return counts
+
+    now_iso = now.isoformat()
+    config_by_path: dict[str, str] = {}
+    for node in graph.nodes.values():
+        if node.entity_type not in {EntityType.CONFIG_FILE, EntityType.SOURCE_FILE}:
+            continue
+        path = _norm_path((node.attributes or {}).get("path") or node.label)
+        if path:
+            config_by_path[path] = node.id
+
+    tool_ids_by_label = {
+        node.label: node.id
+        for node in graph.nodes.values()
+        if node.entity_type == EntityType.TOOL
+    }
+
+    for agent in sorted(gha_agents, key=lambda item: str(item.get("name") or "")):
+        name = str(agent.get("name") or "")
+        stem = name.removeprefix("gha:") if name.startswith("gha:") else name
+        if not stem:
+            continue
+        job_id = _ci_job_id(stem)
+        config_path = _norm_path(agent.get("config_path") or "")
+        if job_id not in graph.nodes:
+            counts["ci_jobs"] += 1
+        graph.add_node(
+            UnifiedNode(
+                id=job_id,
+                entity_type=EntityType.CI_JOB,
+                label=stem,
+                first_seen=now_iso,
+                last_seen=now_iso,
+                attributes={
+                    "workflow": stem,
+                    "config_path": config_path,
+                    "agent_name": name,
+                    "evidence_tier": "static_scan",
+                    "source": _GHA_SOURCE,
+                },
+                data_sources=[_OVERLAY_SOURCE, _GHA_SOURCE],
+                dimensions=NodeDimensions(surface=GraphSemanticLayer.CI.value),
+            )
+        )
+
+        if config_path and config_path in config_by_path:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=config_by_path[config_path],
+                    target=job_id,
+                    relationship=RelationshipType.CONFIGURES,
+                    evidence={"source": _OVERLAY_SOURCE, "config_path": config_path},
+                )
+            )
+            counts["configures_edges"] += 1
+
+        servers = agent.get("mcp_servers") if isinstance(agent.get("mcp_servers"), list) else []
+        for server in servers:
+            if not isinstance(server, dict):
+                continue
+            tools = server.get("tools") if isinstance(server.get("tools"), list) else []
+            for tool in tools:
+                tool_name = ""
+                if isinstance(tool, dict):
+                    tool_name = str(tool.get("name") or "")
+                elif isinstance(tool, str):
+                    tool_name = tool
+                tool_id = tool_ids_by_label.get(tool_name)
+                if not tool_id:
+                    continue
+                graph.add_edge(
+                    UnifiedEdge(
+                        source=job_id,
+                        target=tool_id,
+                        relationship=RelationshipType.RUNS,
+                        evidence={"source": _OVERLAY_SOURCE, "tool": tool_name},
+                    )
+                )
+                counts["runs_edges"] += 1
+
+    return counts

--- a/src/agent_bom/graph/code_graph_overlay.py
+++ b/src/agent_bom/graph/code_graph_overlay.py
@@ -1,0 +1,121 @@
+"""Code-module overlay — emit ``code_module`` nodes from existing source files.
+
+When the repo-structure overlay (or prior builders) already placed ``SOURCE_FILE``
+nodes under directories, this layer groups them into ``CODE_MODULE`` nodes so the
+reserved code vocabulary is honest about evidence we already have:
+
+- one ``CODE_MODULE`` per directory that owns ≥1 ``SOURCE_FILE``
+- ``DEFINES`` edges from each source file → its module
+- ``CONTAINS`` from the directory → module (when the directory node exists)
+
+No-op when there are no source-file nodes. Does not invent import graphs
+(``IMPORTS`` / ``EXTERNAL_IMPORT`` stay reserved until parsers emit them).
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import datetime
+from typing import Any
+
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.types import EntityType, GraphSemanticLayer, RelationshipType
+
+_OVERLAY_SOURCE = "code_graph_overlay"
+
+
+def _norm_path(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    text = value.strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    return text.lstrip("/")
+
+
+def _file_dir(path: str) -> str:
+    if "/" not in path:
+        return ""
+    return path.rsplit("/", 1)[0]
+
+
+def _module_id(dir_path: str) -> str:
+    key = dir_path or "."
+    return f"code_module:{key}"
+
+
+def _dir_node_id(dir_path: str) -> str:
+    return "directory:." if dir_path == "" else f"directory:{dir_path}"
+
+
+def apply_code_graph_overlay(
+    graph: UnifiedGraph,
+    report_json: dict[str, Any],  # noqa: ARG001 — signature mirrors sibling overlays
+    now: datetime,
+) -> dict[str, int]:
+    """Emit CODE_MODULE / DEFINES from existing SOURCE_FILE evidence."""
+    del report_json  # reserved for future inventory-backed module names
+    counts = {"code_modules": 0, "defines_edges": 0, "contains_edges": 0}
+    now_iso = now.isoformat()
+
+    files_by_dir: dict[str, list[str]] = defaultdict(list)
+    for node in graph.nodes.values():
+        if node.entity_type != EntityType.SOURCE_FILE:
+            continue
+        path = _norm_path((node.attributes or {}).get("path") or node.label)
+        if not path:
+            continue
+        files_by_dir[_file_dir(path)].append(node.id)
+
+    if not files_by_dir:
+        return counts
+
+    for dir_path in sorted(files_by_dir):
+        module_id = _module_id(dir_path)
+        file_ids = sorted(files_by_dir[dir_path])
+        if module_id not in graph.nodes:
+            counts["code_modules"] += 1
+        label = dir_path.rsplit("/", 1)[-1] if dir_path else "(repo root)"
+        graph.add_node(
+            UnifiedNode(
+                id=module_id,
+                entity_type=EntityType.CODE_MODULE,
+                label=label,
+                first_seen=now_iso,
+                last_seen=now_iso,
+                attributes={
+                    "path": dir_path or ".",
+                    "source_file_count": len(file_ids),
+                    "evidence_tier": "static_scan",
+                },
+                data_sources=[_OVERLAY_SOURCE],
+                dimensions=NodeDimensions(surface=GraphSemanticLayer.CODE.value),
+            )
+        )
+
+        dir_id = _dir_node_id(dir_path)
+        if dir_id in graph.nodes:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=dir_id,
+                    target=module_id,
+                    relationship=RelationshipType.CONTAINS,
+                    evidence={"source": _OVERLAY_SOURCE},
+                )
+            )
+            counts["contains_edges"] += 1
+
+        for file_id in file_ids:
+            graph.add_edge(
+                UnifiedEdge(
+                    source=file_id,
+                    target=module_id,
+                    relationship=RelationshipType.DEFINES,
+                    evidence={"source": _OVERLAY_SOURCE},
+                )
+            )
+            counts["defines_edges"] += 1
+
+    return counts

--- a/tests/test_graph_code_ci_overlays.py
+++ b/tests/test_graph_code_ci_overlays.py
@@ -1,0 +1,86 @@
+"""CODE/CI graph overlays — emit reserved kinds only when evidence exists."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agent_bom.graph.ci_graph_overlay import apply_ci_graph_overlay
+from agent_bom.graph.code_graph_overlay import apply_code_graph_overlay
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+
+def test_code_graph_overlay_emits_modules_from_source_files() -> None:
+    graph = UnifiedGraph(scan_id="s1", tenant_id="default", created_at="2026-07-01T00:00:00Z")
+    graph.add_node(
+        UnifiedNode(
+            id="directory:src",
+            entity_type=EntityType.DIRECTORY,
+            label="src",
+            attributes={"path": "src"},
+        )
+    )
+    graph.add_node(
+        UnifiedNode(
+            id="source_file:src/main.py",
+            entity_type=EntityType.SOURCE_FILE,
+            label="main.py",
+            attributes={"path": "src/main.py"},
+        )
+    )
+
+    counts = apply_code_graph_overlay(graph, {}, datetime(2026, 7, 1, tzinfo=timezone.utc))
+    assert counts["code_modules"] == 1
+    assert "code_module:src" in graph.nodes
+    assert any(edge.relationship == RelationshipType.DEFINES for edge in graph.edges)
+
+
+def test_code_graph_overlay_noop_without_source_files() -> None:
+    graph = UnifiedGraph(scan_id="s1", tenant_id="default", created_at="2026-07-01T00:00:00Z")
+    counts = apply_code_graph_overlay(graph, {}, datetime(2026, 7, 1, tzinfo=timezone.utc))
+    assert counts == {"code_modules": 0, "defines_edges": 0, "contains_edges": 0}
+    assert graph.nodes == {}
+
+
+def test_ci_graph_overlay_emits_jobs_from_github_actions_agents() -> None:
+    graph = UnifiedGraph(scan_id="s1", tenant_id="default", created_at="2026-07-01T00:00:00Z")
+    graph.add_node(
+        UnifiedNode(
+            id="tool:checkout",
+            entity_type=EntityType.TOOL,
+            label="actions/checkout",
+        )
+    )
+    report = {
+        "agents": [
+            {
+                "name": "gha:ci",
+                "source": "github-actions",
+                "config_path": ".github/workflows/ci.yml",
+                "mcp_servers": [
+                    {
+                        "name": "gha:ci",
+                        "tools": [{"name": "actions/checkout"}],
+                    }
+                ],
+            }
+        ]
+    }
+
+    counts = apply_ci_graph_overlay(graph, report, datetime(2026, 7, 1, tzinfo=timezone.utc))
+    assert counts["ci_jobs"] == 1
+    assert counts["runs_edges"] == 1
+    assert "ci_job:ci" in graph.nodes
+    assert graph.nodes["ci_job:ci"].entity_type == EntityType.CI_JOB
+    assert any(edge.relationship == RelationshipType.RUNS for edge in graph.edges)
+
+
+def test_ci_graph_overlay_noop_without_github_actions() -> None:
+    graph = UnifiedGraph(scan_id="s1", tenant_id="default", created_at="2026-07-01T00:00:00Z")
+    counts = apply_ci_graph_overlay(
+        graph,
+        {"agents": [{"name": "cursor", "source": "cursor"}]},
+        datetime(2026, 7, 1, tzinfo=timezone.utc),
+    )
+    assert counts == {"ci_jobs": 0, "runs_edges": 0, "configures_edges": 0}

--- a/tests/test_graph_schema.py
+++ b/tests/test_graph_schema.py
@@ -1214,8 +1214,8 @@ class TestGraphSchemaEndpoint:
         node_entries = {entry["key"]: entry for entry in body["node_kinds"]}
         edge_entries = {entry["key"]: entry for entry in body["edge_kinds"]}
 
-        reserved_nodes = {"code_module", "external_import", "ci_job"}
-        reserved_edges = {"imports", "defines", "runs", "configures", "owns", "remediates", "acted_as"}
+        reserved_nodes = {"external_import"}
+        reserved_edges = {"imports", "owns", "remediates", "acted_as"}
         for key in reserved_nodes:
             assert node_entries[key]["emission_status"] == "reserved"
             assert "Reserved" in node_entries[key]["emission_notes"]
@@ -1238,6 +1238,14 @@ class TestGraphSchemaEndpoint:
         for key in repo_structure_nodes:
             assert node_entries[key]["emission_status"] == "emitted"
             assert any("repo_structure" in surface for surface in node_entries[key]["emission_surfaces"])
+
+        # CODE/CI kinds emit when scanners already carry the evidence
+        # (source files → code_module; github-actions → ci_job).
+        code_ci_nodes = {"code_module", "ci_job"}
+        for key in code_ci_nodes:
+            assert node_entries[key]["emission_status"] == "emitted"
+        for key in ("defines", "runs", "configures"):
+            assert edge_entries[key]["emission_status"] == "emitted"
 
     def test_every_entity_type_has_semantic_layer(self):
         from agent_bom.graph import ENTITY_LEGEND, GraphSemanticLayer

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -29,6 +29,7 @@ import {
   lineageNodeTypes,
   type LineageNodeData,
 } from "@/components/lineage-nodes";
+import { GraphCompletenessBanner } from "@/components/graph-completeness-banner";
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import { getConnectedIds, searchNodes } from "@/lib/mesh-graph";
 import {
@@ -642,12 +643,8 @@ export default function ContextPage() {
       )}
       {graphData && <ContextStats data={graphData} compact />}
       {graphData?.completeness && !graphData.completeness.complete && (
-        <div className="mx-4 mt-3 rounded-md border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-200">
-          This is a bounded {graphData.completeness.status} view
-          {graphData.completeness.total != null
-            ? ` (${graphData.completeness.returned} of ${graphData.completeness.total} returned)`
-            : ""}
-          . Expand or filter the graph to investigate more evidence.
+        <div className="mx-4 mt-3">
+          <GraphCompletenessBanner completeness={graphData.completeness} />
         </div>
       )}
 

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -24,6 +24,11 @@ import {
   GraphEvidenceExportButton,
   FullscreenButton,
 } from "@/components/graph-chrome";
+import { GraphCompletenessBanner } from "@/components/graph-completeness-banner";
+import {
+  GraphDriftTimeline,
+  type DriftScrubberPair,
+} from "@/components/graph-drift-timeline";
 import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
 import { LargeGraphOverview } from "@/components/large-graph-overview";
 import { LineageDetailPanel } from "@/components/lineage-detail";
@@ -102,6 +107,7 @@ import {
   ApiRateLimitError,
   type GraphDiffResponse,
   type GraphEdgeChangesResponse,
+  type GraphHistorySnapshot,
   type GraphNodeDetailResponse,
   type GraphQueryResponse,
   type GraphSnapshot,
@@ -705,6 +711,12 @@ function GraphPageInner() {
   );
   const [loadingEdgeChanges, setLoadingEdgeChanges] = useState(false);
   const [edgeChangesError, setEdgeChangesError] = useState<string | null>(null);
+  const [historySnapshots, setHistorySnapshots] = useState<GraphHistorySnapshot[]>(
+    [],
+  );
+  const [loadingHistory, setLoadingHistory] = useState(false);
+  const [driftScrubberPair, setDriftScrubberPair] =
+    useState<DriftScrubberPair | null>(null);
   const [driftLensActive, setDriftLensActive] = useState(false);
   const [driftFilter, setDriftFilter] = useState<DriftLensFilter>("all");
   const [evidenceLensActive, setEvidenceLensActive] = useState(false);
@@ -1001,13 +1013,24 @@ function GraphPageInner() {
     return snapshots[index + 1];
   }, [snapshots, selectedScanId]);
 
+  const diffPair = useMemo(() => {
+    if (driftScrubberPair) return driftScrubberPair;
+    if (previousSnapshot && selectedScanId) {
+      return {
+        oldScanId: previousSnapshot.scan_id,
+        newScanId: selectedScanId,
+      } satisfies DriftScrubberPair;
+    }
+    return null;
+  }, [driftScrubberPair, previousSnapshot, selectedScanId]);
+
   useEffect(() => {
     let cancelled = false;
     setGraphDiff(null);
     setDiffError(null);
     setEdgeChanges(null);
     setEdgeChangesError(null);
-    if (!selectedScanId || !previousSnapshot) {
+    if (!diffPair) {
       setLoadingDiff(false);
       setLoadingEdgeChanges(false);
       return;
@@ -1015,8 +1038,8 @@ function GraphPageInner() {
     setLoadingDiff(true);
     setLoadingEdgeChanges(true);
     Promise.all([
-      api.getGraphDiff(previousSnapshot.scan_id, selectedScanId),
-      api.getGraphEdgeChanges(previousSnapshot.scan_id, selectedScanId),
+      api.getGraphDiff(diffPair.oldScanId, diffPair.newScanId),
+      api.getGraphEdgeChanges(diffPair.oldScanId, diffPair.newScanId),
     ])
       .then(([diffResult, edgeResult]) => {
         if (cancelled) return;
@@ -1037,7 +1060,7 @@ function GraphPageInner() {
     return () => {
       cancelled = true;
     };
-  }, [previousSnapshot, selectedScanId]);
+  }, [diffPair]);
 
   useEffect(() => {
     if (!selectedNodeId || !selectedScanId) return;
@@ -1067,6 +1090,28 @@ function GraphPageInner() {
     [mergedGraphData?.nodes],
   );
   const activeScopePreset = graphScopePresetForFilters(filters);
+
+  useEffect(() => {
+    if (activeScopePreset !== "assetDrift") return;
+    let cancelled = false;
+    setLoadingHistory(true);
+    api
+      .getGraphHistory(50, 0)
+      .then((history) => {
+        if (cancelled) return;
+        setHistorySnapshots(history.snapshots ?? []);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setHistorySnapshots([]);
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingHistory(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [activeScopePreset]);
 
   const attackPaths = useMemo(
     () =>
@@ -2389,18 +2434,35 @@ function GraphPageInner() {
           </div>
 
           {activeScopePreset === "assetDrift" && (
-            <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-orange-500/30 bg-orange-500/10 px-3 py-2 text-xs text-orange-100">
-              <span>
-                Asset lifecycle drift lens — governance and{" "}
-                <span className="font-mono">exhibits_drift</span> edges with
-                drift incidents on estate containers.
-              </span>
-              <a
-                href="/drift"
-                className="rounded-lg border border-orange-400/30 bg-orange-950/60 px-2.5 py-1 text-orange-100 transition hover:border-orange-300"
-              >
-                Open drift incidents
-              </a>
+            <div className="mt-3 space-y-3">
+              <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-orange-500/30 bg-orange-500/10 px-3 py-2 text-xs text-orange-100">
+                <span>
+                  Asset lifecycle drift lens — governance and{" "}
+                  <span className="font-mono">exhibits_drift</span> edges with
+                  drift incidents on estate containers.
+                </span>
+                <a
+                  href="/drift"
+                  className="rounded-lg border border-orange-400/30 bg-orange-950/60 px-2.5 py-1 text-orange-100 transition hover:border-orange-300"
+                >
+                  Open drift incidents
+                </a>
+              </div>
+              <GraphDriftTimeline
+                snapshots={historySnapshots}
+                selected={diffPair}
+                loading={loadingHistory}
+                onSelect={(pair) => {
+                  setDriftScrubberPair(pair);
+                  setDriftLensActive(true);
+                  setDriftFilter((current) =>
+                    current === "all" ? "changed" : current,
+                  );
+                  if (pair.newScanId !== selectedScanId) {
+                    setSelectedScanId(pair.newScanId);
+                  }
+                }}
+              />
             </div>
           )}
 
@@ -2758,7 +2820,7 @@ function GraphPageInner() {
                 onFilterChange={setDriftFilter}
                 counts={drift.counts}
                 criticalCount={drift.critical}
-                comparedLabel={previousSnapshot?.scan_id.slice(0, 12)}
+                comparedLabel={diffPair?.oldScanId.slice(0, 12)}
                 attributeSummaries={driftAttributeSummaryList}
               />
             </div>
@@ -2770,7 +2832,7 @@ function GraphPageInner() {
             changes={edgeChanges}
             loading={loadingEdgeChanges}
             error={edgeChangesError}
-            comparedLabel={previousSnapshot?.scan_id.slice(0, 12)}
+            comparedLabel={diffPair?.oldScanId.slice(0, 12)}
           />
         ) : null}
 
@@ -3103,16 +3165,24 @@ function GraphPageInner() {
           {loadingGraph && graphData && <GraphRefreshOverlay />}
 
           {graphTruncated && (
-            <div className="mt-2 flex flex-wrap items-center gap-2 border-t border-[var(--border-subtle)]/80 px-1 pt-2 text-xs text-[var(--text-tertiary)]">
-              <span className="text-amber-400">
-                This scan exceeds the interactive render budget of{" "}
-                {GRAPH_FULL_FETCH_LIMIT.toLocaleString()} nodes.
-              </span>
-              <span>
-                The highest-signal topology is shown and dense neighborhoods are
-                aggregated — zoom, filter by layer/severity, or focus an agent or
-                attack path to drill in. Nothing is split across pages.
-              </span>
+            <div className="mt-2 border-t border-[var(--border-subtle)]/80 px-1 pt-2">
+              <GraphCompletenessBanner
+                completeness={{
+                  status: "truncated",
+                  truncated: true,
+                  complete: false,
+                  sampled: false,
+                  returned: displayNodes.length,
+                  total: graphData?.pagination.total ?? GRAPH_FULL_FETCH_LIMIT,
+                  reason: `Interactive render budget is ${GRAPH_FULL_FETCH_LIMIT.toLocaleString()} nodes. Dense neighborhoods are aggregated — filter or focus rather than treating this canvas as the full estate.`,
+                }}
+                visibleCount={displayNodes.length}
+                omittedCount={Math.max(
+                  0,
+                  (graphData?.pagination.total ?? displayNodes.length) -
+                    displayNodes.length,
+                )}
+              />
             </div>
           )}
 

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -29,6 +29,7 @@ import { ExposurePathLens } from "@/components/exposure-path-lens";
 import { Collapsible } from "@/components/collapsible";
 import { GraphEmptyState, GraphPanelSkeleton } from "@/components/graph-state-panels";
 import { GraphAnalysisStatusBanner, graphAnalysisStatusCopy } from "@/components/graph-analysis-status";
+import { GraphCompletenessBanner } from "@/components/graph-completeness-banner";
 import {
   api,
   formatDate,
@@ -729,21 +730,17 @@ function SecurityGraphPageContent() {
               onKeyDown={handleAttackPathQueueKeyDown}
             />
             {hiddenAttackPathCount > 0 && (
-              <div className="mt-4 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-4 py-3">
-                <p className="text-xs text-[color:var(--text-tertiary)]">
-                  Showing {visibleAttackPaths.length} of {attackPaths.length} ranked paths.
-                </p>
-                <button
-                  type="button"
-                  onClick={() =>
+              <div className="mt-4">
+                <GraphCompletenessBanner
+                  visibleCount={visibleAttackPaths.length}
+                  omittedCount={hiddenAttackPathCount}
+                  loadMoreLabel={`Show ${Math.min(ATTACK_PATH_QUEUE_PAGE_SIZE, hiddenAttackPathCount)} more`}
+                  onLoadMore={() =>
                     setVisibleAttackPathCount((current) =>
                       Math.min(attackPaths.length, current + ATTACK_PATH_QUEUE_PAGE_SIZE),
                     )
                   }
-                  className="rounded-lg border border-[color:var(--border-subtle)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
-                >
-                  Show {Math.min(ATTACK_PATH_QUEUE_PAGE_SIZE, hiddenAttackPathCount)} more
-                </button>
+                />
               </div>
             )}
           </section>

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -48,6 +48,8 @@ const LAYER_ORDER = [
   "asset",
   "infra",
   "finding",
+  "code",
+  "ci",
 ] as const;
 
 const LAYER_LABELS: Record<string, string> = {
@@ -69,6 +71,8 @@ const LAYER_LABELS: Record<string, string> = {
   asset: "Assets",
   infra: "Infrastructure",
   finding: "Findings",
+  code: "Code",
+  ci: "CI/CD",
   other: "Other",
 };
 

--- a/ui/components/graph-completeness-banner.tsx
+++ b/ui/components/graph-completeness-banner.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+/**
+ * Honest truncation / LOD banner for estate graph lists.
+ * Accepts API `graph_completeness` shapes or local visible/omitted counts.
+ */
+
+export type GraphCompletenessLike = {
+  status?: "complete" | "sampled" | "truncated" | string;
+  complete?: boolean;
+  truncated?: boolean;
+  sampled?: boolean;
+  returned?: number;
+  total?: number;
+  reason?: string;
+};
+
+export function GraphCompletenessBanner({
+  completeness,
+  visibleCount,
+  omittedCount,
+  onLoadMore,
+  loadMoreLabel = "Load more",
+}: {
+  completeness?: GraphCompletenessLike | null | undefined;
+  visibleCount?: number | undefined;
+  omittedCount?: number | undefined;
+  onLoadMore?: (() => void) | undefined;
+  loadMoreLabel?: string;
+}) {
+  const returned = completeness?.returned ?? visibleCount;
+  const total =
+    completeness?.total ??
+    (returned != null && omittedCount != null ? returned + omittedCount : undefined);
+  const omitted =
+    omittedCount ??
+    (returned != null && total != null ? Math.max(0, total - returned) : 0);
+  const truncated =
+    Boolean(completeness?.truncated) ||
+    completeness?.status === "truncated" ||
+    completeness?.status === "sampled" ||
+    omitted > 0;
+
+  if (!truncated) return null;
+
+  const shown = returned ?? visibleCount;
+  const detail =
+    shown != null && total != null
+      ? `Showing ${shown.toLocaleString()} of ${total.toLocaleString()}`
+      : shown != null
+        ? `Showing ${shown.toLocaleString()} items`
+        : "Result set is bounded";
+  const reason = completeness?.reason?.trim();
+
+  return (
+    <div
+      role="status"
+      data-testid="graph-completeness-banner"
+      className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-900 dark:text-amber-100"
+    >
+      <div className="min-w-0 space-y-0.5">
+        <p className="font-medium">
+          {detail}
+          {omitted > 0 ? ` · ${omitted.toLocaleString()} omitted` : ""}
+        </p>
+        <p className="text-[11px] opacity-90">
+          {reason ||
+            (completeness?.status === "sampled"
+              ? "Sampled for readability — expand, filter, or page to see more."
+              : "Truncated for the interactive render budget — filter or page rather than treating this as the full estate.")}
+        </p>
+      </div>
+      {onLoadMore ? (
+        <button
+          type="button"
+          onClick={onLoadMore}
+          className="shrink-0 rounded-lg border border-amber-500/40 bg-[color:var(--surface)] px-2.5 py-1 font-medium text-[color:var(--foreground)] transition hover:border-amber-400"
+        >
+          {loadMoreLabel}
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/ui/components/graph-drift-timeline.tsx
+++ b/ui/components/graph-drift-timeline.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useMemo } from "react";
+import type { GraphHistorySnapshot } from "@/lib/api";
+
+export type DriftScrubberPair = {
+  oldScanId: string;
+  newScanId: string;
+};
+
+function changeTotal(summary: GraphHistorySnapshot["diff_summary"] | undefined): number {
+  if (!summary) return 0;
+  return (
+    (summary.nodes_added ?? 0) +
+    (summary.nodes_removed ?? 0) +
+    (summary.nodes_changed ?? 0) +
+    (summary.edges_added ?? 0) +
+    (summary.edges_removed ?? 0)
+  );
+}
+
+function criticalPill(summary: GraphHistorySnapshot["diff_summary"] | undefined): boolean {
+  if (!summary) return false;
+  return (summary.nodes_removed ?? 0) + (summary.edges_removed ?? 0) > 0 || (summary.nodes_changed ?? 0) >= 3;
+}
+
+/**
+ * Scan-pair scrubber for the Asset Drift lens.
+ * Threshold = "what changed" (honest adjacent diffs), not SLA claims.
+ */
+export function GraphDriftTimeline({
+  snapshots,
+  selected,
+  onSelect,
+  loading = false,
+}: {
+  snapshots: GraphHistorySnapshot[];
+  selected: DriftScrubberPair | null;
+  onSelect: (pair: DriftScrubberPair) => void;
+  loading?: boolean;
+}) {
+  const pairs = useMemo(() => {
+    const items: Array<{
+      oldScanId: string;
+      newScanId: string;
+      summary: GraphHistorySnapshot["diff_summary"];
+      createdAt: string;
+    }> = [];
+    for (const snapshot of snapshots) {
+      const baseline = snapshot.diff_baseline_scan_id;
+      if (!baseline) continue;
+      items.push({
+        oldScanId: baseline,
+        newScanId: snapshot.scan_id,
+        summary: snapshot.diff_summary,
+        createdAt: snapshot.created_at ?? "",
+      });
+    }
+    return items;
+  }, [snapshots]);
+
+  if (loading) {
+    return (
+      <div
+        data-testid="graph-drift-timeline"
+        className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-xs text-[color:var(--text-tertiary)]"
+      >
+        Loading drift history…
+      </div>
+    );
+  }
+
+  if (pairs.length === 0) {
+    return (
+      <div
+        data-testid="graph-drift-timeline"
+        className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-xs text-[color:var(--text-tertiary)]"
+      >
+        No adjacent scan pairs yet. Run another scan to compare what changed.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="graph-drift-timeline"
+      className="space-y-2 rounded-xl border border-orange-500/25 bg-orange-500/5 p-3"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-orange-800 dark:text-orange-200">
+          Drift timeline
+        </p>
+        <p className="text-[11px] text-[color:var(--text-tertiary)]">
+          Threshold = what changed between adjacent snapshots
+        </p>
+      </div>
+      <div className="flex gap-2 overflow-x-auto pb-1">
+        {pairs.map((pair) => {
+          const active =
+            selected?.oldScanId === pair.oldScanId && selected?.newScanId === pair.newScanId;
+          const total = changeTotal(pair.summary);
+          const critical = criticalPill(pair.summary);
+          return (
+            <button
+              key={`${pair.oldScanId}->${pair.newScanId}`}
+              type="button"
+              onClick={() =>
+                onSelect({ oldScanId: pair.oldScanId, newScanId: pair.newScanId })
+              }
+              className={`min-w-[9.5rem] shrink-0 rounded-lg border px-3 py-2 text-left transition ${
+                active
+                  ? "border-orange-400/70 bg-orange-500/15 ring-1 ring-orange-400/50"
+                  : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] hover:border-orange-400/40"
+              }`}
+            >
+              <div className="font-mono text-[11px] text-[color:var(--foreground)]">
+                {pair.newScanId.slice(0, 8)}…
+              </div>
+              <div className="mt-1 flex flex-wrap items-center gap-1">
+                {critical ? (
+                  <span className="rounded border border-red-500/40 bg-red-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-red-700 dark:text-red-200">
+                    Critical
+                  </span>
+                ) : (
+                  <span className="rounded border border-[color:var(--border-subtle)] px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-[color:var(--text-tertiary)]">
+                    Changed
+                  </span>
+                )}
+                <span className="font-mono text-[10px] text-[color:var(--text-secondary)]">
+                  {total} Δ
+                </span>
+              </div>
+              <div className="mt-1 text-[10px] text-[color:var(--text-tertiary)]">
+                vs {pair.oldScanId.slice(0, 8)}…
+              </div>
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -119,6 +119,31 @@ export interface GraphSnapshot {
   analysis_status?: import("./graph-schema").GraphStats["analysis_status"] | undefined;
 }
 
+/** Adjacent-pair entry from GET /v1/graph/history */
+export interface GraphHistoryDiffSummary {
+  nodes_added?: number;
+  nodes_removed?: number;
+  nodes_changed?: number;
+  edges_added?: number;
+  edges_removed?: number;
+  [key: string]: unknown;
+}
+
+export interface GraphHistorySnapshot {
+  scan_id: string;
+  created_at?: string;
+  node_count?: number;
+  edge_count?: number;
+  diff_baseline_scan_id?: string;
+  diff_summary?: GraphHistoryDiffSummary;
+}
+
+export interface GraphHistoryResponse {
+  schema_version?: string;
+  snapshots: GraphHistorySnapshot[];
+  window?: Record<string, unknown>;
+}
+
 export interface GraphAttackPath extends AttackPath {
   exposure_path?: ExposurePath | undefined;
 }

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -11,6 +11,7 @@ import type {
   ScanJob,
   ScanJobStatus,
   GraphSnapshot,
+  GraphHistoryResponse,
   UnifiedGraphResponse,
   FixFirstGraphViewResponse,
   GraphQueryRequest,
@@ -172,6 +173,8 @@ export type {
   GraphPagination,
   GraphAttackPath,
   GraphSnapshot,
+  GraphHistoryResponse,
+  GraphHistorySnapshot,
   UnifiedGraphResponse,
   FixFirstGraphViewResponse,
   FixFirstPathCard,
@@ -808,6 +811,13 @@ export const api = {
     // widen to all retained snapshots so old history is never silently hidden.
     if (windowDays != null) params.set("window_days", String(windowDays));
     return get<GraphSnapshot[]>(`/v1/graph/snapshots?${params.toString()}`);
+  },
+
+  /** Retained graph history with adjacent diff summaries — GET /v1/graph/history */
+  getGraphHistory: (limit = 50, windowDays?: number) => {
+    const params = new URLSearchParams({ limit: String(limit) });
+    if (windowDays != null) params.set("window_days", String(windowDays));
+    return get<GraphHistoryResponse>(`/v1/graph/history?${params.toString()}`);
   },
 
   /** Diff two persisted graph snapshots without loading either full graph */

--- a/ui/tests/graph-chrome.test.tsx
+++ b/ui/tests/graph-chrome.test.tsx
@@ -18,6 +18,8 @@ describe("GraphLegend", () => {
           { label: "MCP Server", color: "#3b82f6", layer: "mcp_server", kind: "node", shape: "square" },
           { label: "Package", color: "#52525b", layer: "package", kind: "node", shape: "pill" },
           { label: "Vulnerability", color: "#ef4444", layer: "finding", kind: "node", shape: "diamond" },
+          { label: "Code Module", color: "#06b6d4", layer: "code", kind: "node", shape: "dot" },
+          { label: "CI/CD Job", color: "#a855f7", layer: "ci", kind: "node", shape: "diamond" },
           { label: "Uses", color: "#10b981", kind: "edge", lineStyle: "solid" },
         ]}
       />,
@@ -27,6 +29,8 @@ describe("GraphLegend", () => {
     expect(screen.getByText("MCP Servers")).toBeInTheDocument();
     expect(screen.getByText("Packages")).toBeInTheDocument();
     expect(screen.getByText("Findings")).toBeInTheDocument();
+    expect(screen.getByText("Code")).toBeInTheDocument();
+    expect(screen.getByText("CI/CD")).toBeInTheDocument();
     expect(screen.getByText("Relationships")).toBeInTheDocument();
     expect(screen.getByText("Uses")).toBeInTheDocument();
   });

--- a/ui/tests/graph-completeness-banner.test.tsx
+++ b/ui/tests/graph-completeness-banner.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { GraphCompletenessBanner } from "@/components/graph-completeness-banner";
+
+describe("GraphCompletenessBanner", () => {
+  it("hides when the result set is complete", () => {
+    const { container } = render(
+      <GraphCompletenessBanner
+        completeness={{
+          status: "complete",
+          complete: true,
+          truncated: false,
+          sampled: false,
+          returned: 10,
+          total: 10,
+        }}
+      />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows visible/omitted honesty and load-more", async () => {
+    const user = userEvent.setup();
+    const onLoadMore = vi.fn();
+    render(
+      <GraphCompletenessBanner
+        visibleCount={12}
+        omittedCount={40}
+        onLoadMore={onLoadMore}
+      />,
+    );
+    expect(screen.getByTestId("graph-completeness-banner")).toHaveTextContent(
+      "Showing 12 of 52",
+    );
+    expect(screen.getByText(/40 omitted/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /Load more/i }));
+    expect(onLoadMore).toHaveBeenCalled();
+  });
+});

--- a/ui/tests/graph-drift-timeline.test.tsx
+++ b/ui/tests/graph-drift-timeline.test.tsx
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { GraphDriftTimeline } from "@/components/graph-drift-timeline";
+
+describe("GraphDriftTimeline", () => {
+  it("renders adjacent scan pairs with change pills", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <GraphDriftTimeline
+        selected={null}
+        onSelect={onSelect}
+        snapshots={[
+          {
+            scan_id: "scan-new-aaaaaaaa",
+            created_at: "2026-07-02T00:00:00Z",
+            diff_baseline_scan_id: "scan-old-bbbbbbbb",
+            diff_summary: {
+              nodes_added: 2,
+              nodes_removed: 1,
+              nodes_changed: 0,
+              edges_added: 0,
+              edges_removed: 0,
+            },
+          },
+          {
+            scan_id: "scan-old-bbbbbbbb",
+            created_at: "2026-07-01T00:00:00Z",
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByTestId("graph-drift-timeline")).toHaveTextContent("Drift timeline");
+    expect(screen.getByText(/Critical/i)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /scan-new/i }));
+    expect(onSelect).toHaveBeenCalledWith({
+      oldScanId: "scan-old-bbbbbbbb",
+      newScanId: "scan-new-aaaaaaaa",
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Estate completeness banner (`GraphCompletenessBanner`) on security-graph path queue when inventory is truncated / layers incomplete; also wired on context map.
- Drift timeline via `getGraphHistory` + `GraphDriftTimeline` for scan-to-scan graph deltas.
- CODE/CI overlays emit `code_module` / `ci_job` nodes and edges when static evidence exists; legend layers updated.
- mypy: narrow `mcp_servers` / `tools` list checks in `ci_graph_overlay.py`.
- Rebased/merged onto `main` after #4362: context page keeps completeness banner + `GraphEntityDrawer`.

## Verification
- `uv run mypy src/agent_bom/graph/ci_graph_overlay.py --ignore-missing-imports --disable-error-code import-untyped`
- `uv run ruff check src/agent_bom/graph/ci_graph_overlay.py src/agent_bom/graph/code_graph_overlay.py`
- Targeted graph/UI tests from series PR3 commits
- Conflict resolution: `ui/app/context/page.tsx` imports both `GraphCompletenessBanner` and `GraphEntityDrawer`

## Notes
- Series PR3 of graph investigation OS + brand alignment. Merge after #4361 (merged) and #4362 (merged).
- Next: #4364 rank/govern, then finding-chain #4365 / #4366.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

