### PR TITLE
chore(ui): raise client JS budget after main UI Validate miss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
+- Raise UI client JS budget to 3600 KiB after criticality/NHI investigation
+  panels measured 3585.9 KiB against the prior 3584 KiB ceiling on main CI.
 - README: clean top-nav Live demo link (offline fallback lives under scan/demo
   body copy), lead with product visuals, and collapse persona / connector /
   architecture tables under `<details>`.

--- a/ui/scripts/check-bundle-budget.mjs
+++ b/ui/scripts/check-bundle-budget.mjs
@@ -58,7 +58,12 @@ const BUDGETS = {
   // 14.7 KiB above the prior ceiling (collector plan, artifact preview, and
   // recent jobs). Keep 17 KiB of bounded headroom without changing either
   // chunk ceiling.
-  totalClientJsBytes: 3_670_016,
+  // Criticality ranking / crown-jewel clusters / NHI governance panels on the
+  // investigation graph measured 3585.9 KiB on Linux CI — 1.9 KiB over the
+  // 3584 KiB line with no headroom. Restore ~16 KiB to 3600 KiB so routine
+  // bundler variance stops failing UI Validate; largest-chunk and shared-
+  // runtime budgets are unchanged.
+  totalClientJsBytes: 3_686_400,
   largestChunkBytes: 950_000,
   sharedAppBytes: 450_000,
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `#4364` merged with UI Validate red on main: measured **3585.9 KiB** against the **3584.0 KiB** client JS ceiling.
- Raise `totalClientJsBytes` to **3600 KiB** (`3_686_400`) — accept real feature weight from investigation/NHI chrome with bounded headroom (not a trim of the feature).
- Largest-chunk and shared-runtime budgets unchanged.

## Verification
- UI Validate **pass** on this PR (measured under 3600 KiB ceiling).
- Same root cause as main run [`29886343291`](https://github.com/msaad00/agent-bom/actions/runs/29886343291).

## Notes
- Merge this first to green main. `#4365` already includes the same budget line; after this lands, merging `#4365` is a no-op on the budget file.
- Policy call: bump (not trim) — the check exists to catch creep; 1.9 KiB over for shipped investigation panels is accepted growth with headroom restored.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

