### PR TITLE
feat(cwpp): stage-4 honesty + runtime evidence on graph loads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,10 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
+- CWPP stage-4 honesty: Azure/GCP side-scan capabilities report
+  `executor: contract_only` (discovery + injected-SDK adapters only); runtime
+  evidence ingest + graph persist/investigation loads are documented as wired;
+  Azure/GCP CLI executor and credentialed smoke remain unclaimed (#4158).
 - Findings carry optional graph FKs (`node_id`, `finding_node_id`, `entity_type`)
   and attack paths expose `finding_ids` so investigation joins typed estate nodes
   instead of CVE-label-only anchors; `asset_type` aliases map to `EntityType`

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -574,11 +574,18 @@ graph edge, so reachability stays edge-derived and is never fabricated.
 Wired today: findings surfaced by `GET /v1/findings` (and the overview /
 compliance / observability reads that share the enricher) gain a
 `workload_runtime_evidence` field on workload-scoped rows once a tenant has
-signals; the JSON API export carries it automatically. A graph-join helper
-annotates CWPP workload nodes for a matching tenant. Not yet locked in (stage 4):
-a dedicated ingest REST endpoint, CLI/MCP ingest surface, a scheduler that pulls
-from sources, typed SARIF/report export fields, the live graph/campaign route
-invocation, and any UI panel. No credentialed live source smoke is claimed.
+signals; the JSON API export carries it automatically. Authenticated ingest is
+available at `POST /v1/cloud/runtime-evidence/ingest` (sources provisioned via
+`AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`; empty registry fails closed). Graph
+persist and investigation graph loads annotate matching CWPP workload nodes
+via the same index (tenant-scoped; absence stays `no_runtime_signal`, never
+"clean").
+
+Not yet locked in (stage 4 remainder): CLI/MCP ingest surface, a scheduler that
+pulls from sources, typed SARIF/report export fields, and any UI panel for
+workload runtime evidence. Azure/GCP disk side-scan remains discovery +
+injected-SDK lifecycle adapters (`executor: contract_only`) — no CLI executor
+and no credentialed live smoke is claimed.
 
 ---
 

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -505,6 +505,21 @@ def _persist_graph_snapshot(
         except Exception as link_exc:  # noqa: BLE001 — never fail persist on FK stamping
             _logger.debug("finding↔node persist linking skipped: %s", link_exc)
 
+        # Annotate CWPP workload nodes with tenant-scoped runtime evidence before
+        # persist so investigation loads see it without a second enrich pass.
+        # Absence stays no_runtime_signal — never a cleanliness claim (#4158).
+        try:
+            from agent_bom.cloud.runtime_workload_evidence import (
+                RuntimeWorkloadEvidenceIndex,
+                enrich_graph_workload_runtime_evidence,
+            )
+            from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+
+            wl_index = RuntimeWorkloadEvidenceIndex.from_store(get_runtime_workload_evidence_store(), tenant_id)
+            enrich_graph_workload_runtime_evidence(graph, wl_index)
+        except Exception as runtime_exc:  # noqa: BLE001 — never fail persist on enrich
+            _logger.debug("workload runtime evidence graph enrich skipped: %s", runtime_exc)
+
         from agent_bom.api.postgres_store import reset_current_tenant, set_current_tenant
 
         tenant_token = set_current_tenant(tenant_id)

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1399,6 +1399,42 @@ async def _graph_store_call(fn: Callable[..., _GraphCallResult], /, *args: Any, 
         raise HTTPException(status_code=501, detail=sanitize_error(exc)) from exc
 
 
+def _enrich_loaded_graph_runtime_evidence(graph: Any, tenant_id: str) -> Any:
+    """Best-effort CWPP workload runtime-evidence annotate on a loaded graph.
+
+    Covers snapshots persisted before enrich-at-persist landed. Tenant mismatch
+    or empty store is a no-op; never raises into graph routes.
+    """
+    try:
+        from agent_bom.cloud.runtime_workload_evidence import (
+            RuntimeWorkloadEvidenceIndex,
+            enrich_graph_workload_runtime_evidence,
+        )
+        from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+
+        index = RuntimeWorkloadEvidenceIndex.from_store(get_runtime_workload_evidence_store(), tenant_id)
+        enrich_graph_workload_runtime_evidence(graph, index)
+    except Exception:  # noqa: BLE001 — investigation reads must not fail closed on enrich
+        logger.debug("workload runtime evidence load enrich skipped", exc_info=True)
+    return graph
+
+
+async def _load_graph_for_investigation(
+    graph_store: Any,
+    *,
+    scan_id: str | None,
+    tenant_id: str,
+    **load_kwargs: Any,
+) -> Any:
+    """load_graph + runtime-evidence enrich for investigation surfaces."""
+    graph = await _graph_store_call(
+        graph_store.load_graph,
+        scan_id=scan_id or "",
+        tenant_id=tenant_id,
+        **load_kwargs,
+    )
+    return _enrich_loaded_graph_runtime_evidence(graph, tenant_id)
+
 async def _graph_compute_call(fn: Callable[..., _GraphCallResult], /, *args: Any, **kwargs: Any) -> _GraphCallResult:
     """Run CPU-heavy graph derivation and serialization off the event loop."""
     try:
@@ -1864,8 +1900,8 @@ async def get_graph(
         min_rank = SEVERITY_RANK.get(min_severity.lower(), 0)
 
     if relationships or static_only or dynamic_only:
-        graph = await _graph_store_call(
-            graph_store.load_graph,
+        graph = await _load_graph_for_investigation(
+            graph_store,
             scan_id=requested_scan_id,
             tenant_id=tenant,
             entity_types=et_set,
@@ -1976,8 +2012,8 @@ async def get_fix_first_graph_view(
     if not requested_scan_id and not await _graph_store_call(graph_store.latest_snapshot_id, tenant_id=tenant):
         raise HTTPException(status_code=503, detail="Graph snapshots not found. Run a scan first.")
 
-    graph = await _graph_store_call(
-        graph_store.load_graph,
+    graph = await _load_graph_for_investigation(
+        graph_store,
         scan_id=requested_scan_id,
         tenant_id=tenant,
     )
@@ -2108,8 +2144,8 @@ async def get_graph_attack_paths(
         limit=limit,
     )
     if total == 0:
-        graph = await _graph_store_call(
-            graph_store.load_graph,
+        graph = await _load_graph_for_investigation(
+            graph_store,
             scan_id=effective_scan_id,
             tenant_id=tenant,
         )

--- a/src/agent_bom/cloud/side_scan_lifecycle.py
+++ b/src/agent_bom/cloud/side_scan_lifecycle.py
@@ -149,11 +149,16 @@ class SideScanProviderCapability:
 
 
 def side_scan_provider_capabilities() -> dict[SideScanProvider, SideScanProviderCapability]:
-    """Return the shipped side-scan surface without inferring adapter availability."""
+    """Return the shipped side-scan surface without inferring adapter availability.
+
+    Azure/GCP expose target discovery and an injected-SDK lifecycle adapter
+    boundary. They are ``contract_only`` until a CLI/scheduler executor and
+    credentialed smoke are proven — never advertise them as shipped executors.
+    """
     return {
         "aws": SideScanProviderCapability("aws", True, True, "shipped", True, False),
-        "azure": SideScanProviderCapability("azure", True, True, "shipped", False, False),
-        "gcp": SideScanProviderCapability("gcp", True, True, "shipped", False, False),
+        "azure": SideScanProviderCapability("azure", True, True, "contract_only", False, False),
+        "gcp": SideScanProviderCapability("gcp", True, True, "contract_only", False, False),
     }
 
 

--- a/tests/cloud/test_side_scan_lifecycle_contract.py
+++ b/tests/cloud/test_side_scan_lifecycle_contract.py
@@ -35,11 +35,12 @@ def test_provider_capabilities_do_not_claim_unshipped_executors() -> None:
 
     assert capabilities["aws"].executor == "shipped"
     assert capabilities["aws"].cli_available is True
-    assert capabilities["azure"].executor == "shipped"
-    assert capabilities["gcp"].executor == "shipped"
+    assert capabilities["azure"].executor == "contract_only"
+    assert capabilities["gcp"].executor == "contract_only"
     assert capabilities["azure"].cli_available is False
     assert capabilities["gcp"].cli_available is False
-
+    assert capabilities["azure"].credentialed_smoke is False
+    assert capabilities["gcp"].credentialed_smoke is False
 
 @pytest.mark.parametrize("status", [ExecutionStatus.DISABLED, ExecutionStatus.DENIED, ExecutionStatus.FAILED])
 def test_non_execution_states_are_unevaluable_not_clean(status: ExecutionStatus) -> None:

--- a/tests/test_side_scan_capability_docs.py
+++ b/tests/test_side_scan_capability_docs.py
@@ -9,8 +9,11 @@ def test_cloud_connect_scopes_azure_and_gcp_execution_claims() -> None:
     cloud_connect = (ROOT / "docs" / "CLOUD_CONNECT.md").read_text()
 
     assert "concrete Azure Managed Disk and GCP Persistent Disk adapters" in cloud_connect
-    assert "no live credentialed" in cloud_connect
+    assert "no live credentialed" in cloud_connect or "no credentialed live" in cloud_connect
     assert "execution is wired for connection/scheduler integrations" not in cloud_connect
+    assert "POST /v1/cloud/runtime-evidence/ingest" in cloud_connect
+    assert "contract_only" in cloud_connect
+    assert "a dedicated ingest REST endpoint" not in cloud_connect
 
 
 def test_architecture_labels_cross_cloud_surface_as_injected_sdk_only() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **#4158 stage-4 slice:** Azure/GCP side-scan capabilities report `executor: contract_only` (discovery + injected-SDK adapters only) — no longer mislabeled as shipped executors.
- Graph persist and investigation loads (`/v1/graph` filtered path, `/v1/graph/views/fix-first`, attack-path derive path) annotate CWPP workload nodes from the tenant runtime-evidence store.
- `CLOUD_CONNECT.md` honesty: ingest REST is wired; remaining stage-4 gaps (CLI/MCP ingest, pull scheduler, SARIF/UI, Azure/GCP credentialed smoke) stay explicitly unclaimed.

## Verification
- `uv run pytest -q tests/cloud/test_side_scan_lifecycle_contract.py::test_provider_capabilities_do_not_claim_unshipped_executors tests/test_side_scan_capability_docs.py tests/cloud/test_runtime_workload_evidence_graph.py` (6 passed)
- `uv run ruff check` on touched modules

## Notes
- Addresses part of #4158 (does **not** close it — Azure/GCP CLI executors + live smoke + CLI/MCP/UI still open).
- Stages 1–3 already on main via prior merges; this is lock-in honesty + live graph enrich only.
- Related: auto issue #4368 (main UI Validate after `#4364`) is resolved on tip by `#4365` budget — please close #4368 manually (this agent lacks `issues: write`).

## Alignment
- Capability map ↔ docs ↔ tests ↔ graph persist/API investigation reads stay consistent; no Azure/GCP “shipped executor” claim.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

