### PR TITLE
feat(cwpp): CLI and MCP runtime-evidence ingest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,10 +42,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
+<<<<<<< HEAD
 - CWPP stage-4 honesty: Azure/GCP side-scan capabilities report
   `executor: contract_only` (discovery + injected-SDK adapters only); runtime
   evidence ingest + graph persist/investigation loads are documented as wired;
   Azure/GCP CLI executor and credentialed smoke remain unclaimed (#4158).
+=======
+- CWPP stage-4 (B): CLI `agent-bom cloud runtime-evidence-ingest` and MCP
+  `runtime_evidence_ingest` share the authenticated runtime-evidence door with
+  the REST ingest route (#4158).
+>>>>>>> cd080ac5 (feat(cwpp): CLI and MCP runtime-evidence ingest)
 - Findings carry optional graph FKs (`node_id`, `finding_node_id`, `entity_type`)
   and attack paths expose `finding_ids` so investigation joins typed estate nodes
   instead of CVE-label-only anchors; `asset_type` aliases map to `EntityType`

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -87,7 +87,7 @@ The self-hosted operator surface. Same evidence, multi-tenant, audited.
 | Subsystem | Path | Responsibility |
 |---|---|---|
 | API | `api/` | FastAPI app and route modules; middleware handles HTTP auth/tenant/limits/audit. SQLite and Postgres are the primary stores, Neptune is optional graph persistence, ClickHouse is optional analytics, and Snowflake implements selected store/warehouse paths. |
-| MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 76 tools, 6 resources, and 8 workflow prompts (mostly read-only; Shield write actions fail closed). |
+| MCP server | `mcp_server*.py`, `mcp_tools/` | FastMCP server advertising 77 tools, 6 resources, and 8 workflow prompts (mostly read-only; Shield write actions fail closed). |
 | Runtime enforcement | `proxy*.py`, `gateway*.py`, `firewall*.py`, `shield.py`, `runtime/`, `enforcement.py` | MCP traffic proxy, secure-by-default gateway, inline firewall, Shield enforcement. **Spread by design** — see [Runtime enforcement spread](#runtime-enforcement-spread). |
 | Auth / tenancy | `rbac.py`, `permissions.py`, `entitlements.py`, `mcp_tenant.py`, `api/auth.py`, `api/oidc.py` | RBAC roles, tenant scoping, API keys, OIDC/SAML/SCIM. |
 | Fleet | `fleet/`, `fleet_scan.py` | Endpoint/collector inventory pushed into one control plane. |

--- a/PYPI_README.md
+++ b/PYPI_README.md
@@ -115,7 +115,7 @@ helm upgrade --install agent-bom deploy/helm/agent-bom \
 - **Blast radius + attack-path fusion** — multi-hop exposure paths over one unified `ContextGraph`, from package → finding → MCP server → credentials → connected agents
 - **CWE-aware impact** — RCE shows credential exposure, DoS does not; symbol-level CVE reachability joins CWE/CVE/CPE advisory context when OSV/GHSA carry affected symbols (Python, npm, Go)
 - **Portable outputs** — SARIF, CycloneDX, SPDX, OCSF, HTML, graph, JSON, ZIP evidence bundles, and more
-- **MCP server mode** — 76 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
+- **MCP server mode** — 77 MCP tools, 6 resources, and 8 workflow prompts exposed to MCP clients like Claude, Cursor, Windsurf, and Cortex CoCo / Cortex Code
 - **Skill bundle identity** — stable bundle hashes for skill and instruction file review
 - **Dependency confusion detection** — flags internal naming patterns
 - **VEX generation** — auto-triage with CWE/CVE/CPE-aware reachability (package + function-level when advisory symbols exist)

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ deploys terminate TLS at the edge; API/UI stay on loopback or a private network.
 **Accuracy:** match tiers
 `distro_confirmed` > `osv_range` > `osv_ecosystem` > `unfixed_distro` > `nvd_cpe_candidate`.
 End users do not need an NVD API key; `NVD_API_KEY` is an optional operator
-freshness knob. MCP server mode exposes 76 MCP tools, 6 resources, and 8 workflow prompts
+freshness knob. MCP server mode exposes 77 MCP tools, 6 resources, and 8 workflow prompts
 over strict arguments. Agent distribution includes a committed
 [Smithery manifest](integrations/smithery.yaml); external catalog liveness is
 verified separately. Deep dive: [ARCHITECTURE.md](docs/ARCHITECTURE.md) ·

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -1,6 +1,6 @@
 # MCP Server — Streamable HTTP transport for remote clients.
 #
-# Exposes agent-bom's 76 MCP tools over streamable HTTP so that Smithery, Claude
+# Exposes agent-bom's 77 MCP tools over streamable HTTP so that Smithery, Claude
 # Desktop (remote mode), and any other MCP client can connect via public URL.
 #
 # Build:   docker build -f deploy/docker/Dockerfile.sse -t agent-bom-sse .

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -16,7 +16,7 @@ attack paths, compliance tags, and runtime audit chain.
 
 | Area | Shipped today |
 |---|---|
-| MCP security tools | 76 tools, 6 resources, 8 workflow prompts |
+| MCP security tools | 77 tools, 6 resources, 8 workflow prompts |
 | REST API | 369 operations across 44 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -454,7 +454,7 @@ graph TB
 | Output | `src/agent_bom/output/__init__.py` | JSON, CycloneDX, SARIF, SPDX, console |
 | Policy | `src/agent_bom/policy.py` | Policy-as-code engine (17 conditions) |
 | Proxy | `src/agent_bom/proxy.py` | Runtime MCP proxy (7 inline detectors) |
-| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (76 tools across core, operator, runtime-catalog, and specialized modules) |
+| MCP Server | `src/agent_bom/mcp_server*.py` | FastMCP server (77 tools across core, operator, runtime-catalog, and specialized modules) |
 | Cloud | `src/agent_bom/cloud/` | AWS, Azure, GCP, Snowflake, Databricks, ClickHouse estate inventory; CIS posture where published and Databricks security best practices |
 | Cloud side-scan | `src/agent_bom/cloud/side_scan.py`, `src/agent_bom/cloud/side_scan_targets.py`, `src/agent_bom/cloud/side_scan_lifecycle.py`, `src/agent_bom/cloud/side_scan_provider_adapters.py` | Agentless workload side-scan (CWPP) — AWS EBS CLI executor; injected-SDK Azure Managed Disk and GCP Persistent Disk lifecycle adapters with durable ownership/cleanup state; Azure/GCP scheduler/CLI wiring and live credentialed proof are not shipped |
 | Registry sweep | `src/agent_bom/cloud/registry_sweep.py` | Registry-wide image enumeration + scan (ECR/ACR/GAR), digest-deduped, capped |

--- a/docs/CLAUDE_INTEGRATION.md
+++ b/docs/CLAUDE_INTEGRATION.md
@@ -59,7 +59,7 @@ claude mcp add agent-bom -- uvx agent-bom mcp server
 
 ## What users get inside Claude
 
-`agent-bom mcp server` exposes 76 MCP tools for:
+`agent-bom mcp server` exposes 77 MCP tools for:
 
 - agent and MCP discovery
 - package and registry checks

--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -37,7 +37,7 @@ Inventory, package, image, IaC, cloud, and skills scanning entry points.
 | `iac` | Scan IaC: Dockerfile, Terraform, CloudFormation, Helm, Kubernetes. |
 | `sbom` | Ingest an existing SBOM (CycloneDX / SPDX) and scan its components. |
 | `ingest` | Ingest operator-provided evidence (e.g. `ingest hardware` firmware attestation) into the graph. |
-| `cloud` | Cloud posture + estate inventory for AWS/Azure/GCP, CIS benchmarks, and cloud registry sweeps. Group: `scan` (all configured clouds), `aws`/`azure`/`gcp` aliases, `inventory`, `registry-scan` (ECR/ACR/GAR sweep), `resilience`, and AWS EBS `side-scan`. |
+| `cloud` | Cloud posture + estate inventory for AWS/Azure/GCP, CIS benchmarks, and cloud registry sweeps. Group: `scan` (all configured clouds), `aws`/`azure`/`gcp` aliases, `inventory`, `registry-scan` (ECR/ACR/GAR sweep), `resilience`, AWS EBS `side-scan`, and CWPP `runtime-evidence-ingest`. |
 | `check` | Pre-install check for one package: allow / warn / block. |
 | `verify` | Package integrity + SLSA provenance verification. |
 | `secrets` | Secret detection. |

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -575,6 +575,7 @@ Wired today: findings surfaced by `GET /v1/findings` (and the overview /
 compliance / observability reads that share the enricher) gain a
 `workload_runtime_evidence` field on workload-scoped rows once a tenant has
 signals; the JSON API export carries it automatically. Authenticated ingest is
+<<<<<<< HEAD
 available at `POST /v1/cloud/runtime-evidence/ingest` (sources provisioned via
 `AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`; empty registry fails closed). Graph
 persist and investigation graph loads annotate matching CWPP workload nodes
@@ -586,6 +587,19 @@ pulls from sources, typed SARIF/report export fields, and any UI panel for
 workload runtime evidence. Azure/GCP disk side-scan remains discovery +
 injected-SDK lifecycle adapters (`executor: contract_only`) — no CLI executor
 and no credentialed live smoke is claimed.
+=======
+available at `POST /v1/cloud/runtime-evidence/ingest`, CLI
+`agent-bom cloud runtime-evidence-ingest`, and the MCP tool
+`runtime_evidence_ingest` (sources via `AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`;
+empty registry fails closed). A graph-join helper annotates CWPP workload nodes
+for a matching tenant.
+
+Not yet locked in (stage 4 remainder): a scheduler that pulls from sources,
+typed SARIF/report export fields, the live graph/campaign route invocation, and
+any UI panel for workload runtime evidence. No credentialed live source smoke is
+claimed. Azure/GCP disk side-scan remains discovery + injected-SDK adapters —
+no CLI executor is claimed.
+>>>>>>> cd080ac5 (feat(cwpp): CLI and MCP runtime-evidence ingest)
 
 ---
 

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -155,7 +155,7 @@ The same machine-readable mapping is exposed to assistants through
 |-----------|-------------------|-------------------|
 | Choose supported MCP projects | `registry_lookup`, `marketplace_check`, `fleet_scan`, MCP registry freshness gate | Registry metadata, package provenance, source freshness, advisory matches |
 | Design for boundaries | `context_graph`, `exposure_paths`, `runtime_blueprints`, gateway policy | Graph edges, allowed tool categories, drift decisions, gateway metrics |
-| Validate parameters | 76 strict-args MCP tools, API validation errors, `policy_check` | `tools/list` schemas, `additionalProperties:false`, correlation IDs |
+| Validate parameters | 77 strict-args MCP tools, API validation errors, `policy_check` | `tools/list` schemas, `additionalProperties:false`, correlation IDs |
 | Constrain and sandbox execution | `tool_risk_assessment`, proxy, gateway, deployment profiles | Capability classes, block decisions, sandbox posture, Helm/Docker settings |
 | Sign and verify sensitive actions | `audit_integrity`, signed posture outbox, Shield admin-gated tools | HMAC chain status, source-agent labels, audit reasons, posture events |
 | Filter chained outputs | prompt-injection sentinels, `runtime_correlate`, proxy response inspection | Runtime alerts, detector findings, redaction mode, policy decisions |
@@ -177,7 +177,7 @@ The same machine-readable mapping is exposed to assistants through
 │  2. PROXY         Sits between client and server, intercepts     │
 │     (agent-bom proxy) every JSON-RPC message, enforces policy    │
 │                                                                  │
-│  3. MCP SERVER    Exposes 76 scan/governance tools to any agent  │
+│  3. MCP SERVER    Exposes 77 scan/governance tools to any agent  │
 │     (agent-bom mcp server)  — scan, check, registry, compliance  │
 └─────────────────────────────────────────────────────────────────┘
 ```
@@ -237,7 +237,7 @@ For cross-agent correlation, use the broader runtime protection engine (`agent-b
 agent-bom mcp server
 ```
 
-Exposes 76 tools to any MCP-compatible AI assistant. Your agent can run scans,
+Exposes 77 tools to any MCP-compatible AI assistant. Your agent can run scans,
 check packages, query ExposurePaths, ask for deploy decisions, query threat
 intel, inspect runtime posture, run admin-gated Shield actions, and generate
 compliance reports without leaving the chat:

--- a/docs/MCP_SERVER.md
+++ b/docs/MCP_SERVER.md
@@ -1,6 +1,6 @@
 # MCP Server — Connect agent-bom to AI Assistants
 
-agent-bom exposes 76 MCP tools as an MCP server. Any MCP-compatible client can
+agent-bom exposes 77 MCP tools as an MCP server. Any MCP-compatible client can
 connect and get vulnerability scanning, blast radius analysis, compliance
 checks, runtime posture, and supply-chain verification through natural
 conversation.
@@ -165,7 +165,7 @@ agent-bom proxy-bootstrap \
 
 `proxy-configure` is best for JSON MCP clients such as Claude Desktop, Cursor, Windsurf, and Cortex CoCo. TOML-based clients like Codex CLI need manual proxy wrapping.
 
-## Tool Categories (76 tools)
+## Tool Categories (77 tools)
 
 | Category | Tools | What They Do |
 |----------|-------|-------------|
@@ -179,10 +179,10 @@ agent-bom proxy-bootstrap \
 | **Trust** | `marketplace_check`, `runtime_correlate`, `tool_risk_assessment` | Score package trust, correlate runtime usage, and assess live tool capability risk |
 | **Skills** | `skill_scan`, `skill_verify`, `skill_trust` | Instruction-file trust, provenance, and tool-poisoning detection |
 | **Graph / Runtime** | `exposure_paths`, `should_i_deploy`, `context_graph`, `graph_export`, `runtime_correlate`, `runtime_production_index`, `runtime_blueprints`, `runtime_blueprint_drift`, `proxy_status`, `proxy_alerts`, `gateway_status`, `shield_status`, `shield_start`, `shield_unblock`, `shield_break_glass`, `firewall_check`, `audit_query`, `audit_integrity`, `tool_risk_assessment` | Return ranked investigation paths, deploy decisions, graph exports, runtime posture, blueprints, drift checks, proxy alerts, audit-chain evidence, read-only firewall decisions, and audited Shield actions |
-| **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan` | Scan AI artifacts, prompts, model files, and browser extensions; import tool-agnostic SARIF/SBOM/scanner evidence without executing its producer |
+| **AI supply chain** | `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`, `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ingest_external_scan`, `runtime_evidence_ingest` | Scan AI artifacts, prompts, model files, and browser extensions; import tool-agnostic SARIF/SBOM/scanner evidence without executing its producer; merge CWPP runtime signals |
 
 <details>
-<summary>Complete current catalog (76 tools)</summary>
+<summary>Complete current catalog (77 tools)</summary>
 
 `scan`, `check`, `intel_lookup`, `intel_match`, `intel_sources`,
 `intel_daily_brief`, `blast_radius`, `exposure_paths`, `should_i_deploy`,
@@ -200,9 +200,9 @@ agent-bom proxy-bootstrap \
 `vector_db_scan`, `aisvs_benchmark`, `gpu_infra_scan`, `registry_sweep_scan`,
 `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`,
 `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ai_inventory_scan`,
-`license_compliance_scan`, `ingest_external_scan`, `cost_forecast`,
-`cost_allocation`, `credential_expiry`, `nhi_discover`, `cloud_inventory`,
-`access_review`, `create_ticket`, `sync_ticket_status`.
+`license_compliance_scan`, `ingest_external_scan`, `runtime_evidence_ingest`,
+`cost_forecast`, `cost_allocation`, `credential_expiry`, `nhi_discover`,
+`cloud_inventory`, `access_review`, `create_ticket`, `sync_ticket_status`.
 
 </details>
 
@@ -240,8 +240,9 @@ live runtime traffic rather than static reachability.
 ## Security Model
 
 - **Read-mostly**: scanner, graph, audit, and posture tools are read-only.
-  The 13 write-annotated tools cover scan-history diff, Shield, identity,
-  external ingest, access review, and ticket workflows. They require an
+  The 14 write-annotated tools cover scan-history diff, Shield, identity,
+  external ingest, CWPP runtime-evidence ingest, access review, and ticket
+  workflows. They require an
   authenticated MCP operator token plus admin role, their specific write
   scope (`findings:write`, `identity:write`, `shield:write`, or
   `ticketing:write`), and an audit reason; stdio cannot invoke them.

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -130,7 +130,7 @@ notes discuss agent-native product direction.
 | Area | Shipped today | Not yet shipped |
 |---|---|---|
 | Human cockpit | Next.js dashboard, graph cockpit, reports, compliance and audit views | every UI action backed by a source registry and persisted workflow state |
-| Agent interface | 76 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated write actions | long-lived posture subscription tool, autonomous remediation actions |
+| Agent interface | 77 MCP tools, strict arguments, `exposure_paths`, `should_i_deploy`, threat-intel lookup, runtime posture, admin-gated write actions | long-lived posture subscription tool, autonomous remediation actions |
 | Scanner/data plane | CLI, Docker, GitHub Action, REST API, imports, graph exports, Python/Go/TypeScript control-plane clients, TypeScript runtime detector package | full scanner SDKs |
 | Runtime | MCP proxy, gateway, Shield SDK, runtime audit and policy decisions, **webhook outbox** for posture events | Kafka connectors, cloud-log ingestion connectors, Kinesis/Firehose adapter, and MCP posture subscriptions |
 | Graph scale | SQLite/Postgres default path, WebGL overview, optional Neptune adapter work | production Neptune SLOs, public openCypher endpoint, mandatory graph-database backend |

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -4,7 +4,7 @@
   "metrics": [
     {
       "name": "MCP tools",
-      "value": 76,
+      "value": 77,
       "source": "src/agent_bom/mcp_server_metadata.py",
       "notes": "Counted from the advertised server-card tools."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -10,7 +10,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
-| MCP tools | 76 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
+| MCP tools | 77 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |

--- a/docs/README.md
+++ b/docs/README.md
@@ -59,7 +59,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 
 ## AI / agent developers (MCP · clients · tools)
 
-- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 76 tools
+- [`MCP_SERVER.md`](MCP_SERVER.md) — run the MCP server, 77 tools
 - [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md) — connect MCP clients
 - [`PYTHON_API.md`](PYTHON_API.md) — Python control-plane client
 - [`PLUGIN_ENTRYPOINTS.md`](PLUGIN_ENTRYPOINTS.md) — opt-in plugin entry-point loader and author contract

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -102,13 +102,13 @@ scan a repo by URL.
 
 ```bash
 pip install 'agent-bom[mcp-server]'
-agent-bom mcp server                      # stdio MCP server: 76 tools, 6 resources, 8 prompts
+agent-bom mcp server                      # stdio MCP server: 77 tools, 6 resources, 8 prompts
 ```
 
 - MCP server setup + client guides: [`MCP_SERVER.md`](MCP_SERVER.md),
   [`MCP_CLIENT_GUIDES.md`](MCP_CLIENT_GUIDES.md)
-- Tool catalog (76 tools; sensitive writes remain admin-gated): see the
-  `Tools (76)` block in
+- Tool catalog (77 tools; sensitive writes remain admin-gated): see the
+  `Tools (77)` block in
   [`../src/agent_bom/mcp_server.py`](../src/agent_bom/mcp_server.py)
 - Typed control-plane clients: [`PYTHON_API.md`](PYTHON_API.md),
   [`../sdks/go/README.md`](../sdks/go/README.md)

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -91,7 +91,7 @@
 <rect x="488" y="370" width="213" height="32" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="374" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,378) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
 <text x="526" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="526" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">76 tools</text>
+<text x="526" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">77 tools</text>
 <rect x="707" y="370" width="213" height="32" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="715" y="374" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(719,378) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="745" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Fleet jobs</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -91,7 +91,7 @@
 <rect x="488" y="370" width="213" height="32" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="374" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,378) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
 <text x="526" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">MCP server</text>
-<text x="526" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">76 tools</text>
+<text x="526" y="396" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">77 tools</text>
 <rect x="707" y="370" width="213" height="32" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="715" y="374" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(719,378) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
 <text x="745" y="385" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Fleet jobs</text>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -71,6 +71,6 @@
 <rect x="821" y="126" width="224" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="829" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
 <text x="839" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="839" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">369 API ops · 76 MCP tools · SARIF</text>
+<text x="839" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">369 API ops · 77 MCP tools · SARIF</text>
 <rect x="24" y="196" width="1032" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="540" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -71,6 +71,6 @@
 <rect x="821" y="126" width="224" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="829" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
 <text x="839" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="839" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">369 API ops · 76 MCP tools · SARIF</text>
+<text x="839" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">369 API ops · 77 MCP tools · SARIF</text>
 <rect x="24" y="196" width="1032" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="540" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/glama.json
+++ b/glama.json
@@ -5,7 +5,7 @@
   ],
   "name": "agent-bom",
   "title": "agent-bom",
-  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 76 read-first MCP tools for headless security agents.",
+  "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. Discovers agents, MCP servers, models, and runtime traffic; scans for vulnerable packages, prompt-injection, license violations, and risky tool capabilities; and maps blast radius across a security graph. Exposes 77 read-first MCP tools for headless security agents.",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/integrations/docker-mcp-registry/SUBMISSION.md
+++ b/integrations/docker-mcp-registry/SUBMISSION.md
@@ -5,7 +5,7 @@ Submission files for listing agent-bom in the Docker Desktop MCP Toolkit catalog
 ## Files
 
 - `server.yaml` — server metadata, image, allowed hosts, optional secrets
-- `tools.json` — all 76 MCP tools with descriptions and parameters
+- `tools.json` — all 77 MCP tools with descriptions and parameters
 - `readme.md` — Docker MCP Toolkit detail page content
 
 ## How to submit

--- a/integrations/docker-mcp-registry/tools.json
+++ b/integrations/docker-mcp-registry/tools.json
@@ -1237,6 +1237,27 @@
     ]
   },
   {
+    "name": "runtime_evidence_ingest",
+    "description": "Ingest CWPP runtime/EDR workload signals into the durable evidence store (authenticated source; metadata only; never writes to a customer cloud target).",
+    "arguments": [
+      {
+        "name": "source_id",
+        "type": "string",
+        "desc": "Pre-registered runtime evidence source id"
+      },
+      {
+        "name": "secret",
+        "type": "string",
+        "desc": "Shared secret for the source (never logged)"
+      },
+      {
+        "name": "signals_json",
+        "type": "string",
+        "desc": "JSON string: a list of signal objects, or {\"signals\": [...]} matching the REST ingest body"
+      }
+    ]
+  },
+  {
     "name": "cost_forecast",
     "description": "Project LLM spend burn rate and budget runway for the active tenant \u2014 reference-only forecast with projected period spend, days of runway, and exhaustion date.",
     "arguments": [

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -309,6 +309,7 @@ agent-bom where             # show all discovery paths
 | `model_file_scan` | Scan model files for unsafe serialization (pickle, etc.) |
 | `license_compliance_scan` | Full SPDX license catalog scan with copyleft and network-copyleft detection |
 | `ingest_external_scan` | Import external scan results (CycloneDX/SPDX/JSON) and merge into agent-bom findings |
+| `runtime_evidence_ingest` | Ingest CWPP runtime/EDR workload signals (authenticated source; metadata only) |
 
 ### Resources
 | Resource | Description |

--- a/integrations/smithery.yaml
+++ b/integrations/smithery.yaml
@@ -3,7 +3,7 @@
 # The startCommand / configSchema / commandFunction block below is the runtime
 # contract Smithery executes — do not change its shape.
 name: agent-bom
-description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 76 MCP tools for scanning, compliance, and graph analysis."
+description: "Open security scanner and self-hosted control plane for AI/MCP infrastructure — agents, MCP servers, runtime, and blast radius. Exposes 77 MCP tools for scanning, compliance, and graph analysis."
 homepage: "https://github.com/msaad00/agent-bom"
 
 runtime: "python"

--- a/scripts/check_release_consistency.py
+++ b/scripts/check_release_consistency.py
@@ -454,7 +454,7 @@ def main() -> int:
     tools = len(tool_names)
     resources = len(resource_uris)
     prompts = len(prompt_names)
-    if (tools, resources, prompts) != (76, 6, 8):
+    if (tools, resources, prompts) != (77, 6, 8):
         _fail(f"MCP server card count changed unexpectedly: tools={tools}, resources={resources}, prompts={prompts}")
     docker_mcp_tool_names = [str(tool["name"]) for tool in json.loads(DOCKER_MCP_TOOLS.read_text())]
     if docker_mcp_tool_names != tool_names:

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -241,6 +241,8 @@ AGENT_BOM_GCP_INVENTORY
 AGENT_BOM_GCP_MAX_PROJECTS
 # JSON array provisioning CWPP runtime-evidence ingest sources (source_id/tenant/provider/account/secret_hash); read once to build the process-global source registry. Fail-closed: empty/malformed registers no source.
 AGENT_BOM_RUNTIME_EVIDENCE_SOURCES
+# CLI/MCP convenience secret for one ingest call (never logged); prefer hashed secrets in AGENT_BOM_RUNTIME_EVIDENCE_SOURCES for durable sources.
+AGENT_BOM_RUNTIME_EVIDENCE_SOURCE_SECRET
 AGENT_BOM_GRAPH_DB
 AGENT_BOM_GRAPH_DELTA_SLACK_WEBHOOK
 AGENT_BOM_GRAPH_DELTA_WEBHOOK

--- a/site-docs/getting-started/mcp-server.md
+++ b/site-docs/getting-started/mcp-server.md
@@ -1,10 +1,11 @@
 # MCP Server Setup
 
-agent-bom runs as an MCP server, exposing 76 MCP tools to any MCP client.
+agent-bom runs as an MCP server, exposing 77 MCP tools to any MCP client.
 The server card also advertises 6 resources and 8 workflow prompts so agents can
 choose structured playbooks instead of guessing tool order.
-Most tools are read-only. Thirteen write-annotated tools cover scan-history
-diff, Shield, identity, external ingest, access review, and ticket workflows.
+Most tools are read-only. Fourteen write-annotated tools cover scan-history
+diff, Shield, identity, external ingest, CWPP runtime-evidence ingest, access
+review, and ticket workflows.
 Each requires `operator_role=admin`, its tool-specific write scope, and an audit
 reason. The registered scope families are `findings:write`, `identity:write`,
 `shield:write`, and `ticketing:write`.

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -73,7 +73,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 |---|---|---|
 | **CLI / CI** | developers and pipelines | local scans, SARIF/SBOM/HTML/JSON, graph exports, deterministic gates |
 | **REST API** | security platforms, SIEM jobs, custom services | self-hosted control-plane routes for scans, normalized bulk findings, dataset versions, evaluation runs, graph evidence, audit, and governance |
-| **MCP tools** | AI agents and coding assistants | 76 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited write actions |
+| **MCP tools** | AI agents and coding assistants | 77 tools, strict args, `exposure_paths`, `should_i_deploy`, runtime posture, audited write actions |
 | **TypeScript client** | services and agent runtimes calling the control plane | typed helper for stable REST endpoints; not a scanner SDK |
 | **TypeScript runtime detectors** | MCP/runtime enforcement integrations | local detector package for runtime policy checks; separate from the control-plane client |
 | **UI cockpit** | security teams and auditors | graph cockpit, compliance, audit, and evidence review over the same backend data |

--- a/site-docs/reference/mcp-tools.md
+++ b/site-docs/reference/mcp-tools.md
@@ -3,14 +3,15 @@
 agent-bom exposes MCP tools for scanning, blast radius, trust, compliance,
 runtime, and remediation. The tools are read-only by default: agent consumers
 can request evidence and deploy guidance without mutating repos, cloud
-resources, or runtime targets. Thirteen write-annotated tools cover scan-history
-diff, Shield, identity, external ingest, access review, and ticket workflows.
+resources, or runtime targets. Fourteen write-annotated tools cover scan-history
+diff, Shield, identity, external ingest, CWPP runtime-evidence ingest, access
+review, and ticket workflows.
 They fail closed unless a remote caller uses the operator token and supplies an
 admin role, the tool-specific write scope, and an audit reason; stdio cannot
 invoke them.
 
 <details>
-<summary>Complete current catalog (76 tools)</summary>
+<summary>Complete current catalog (77 tools)</summary>
 
 `scan`, `check`, `intel_lookup`, `intel_match`, `intel_sources`,
 `intel_daily_brief`, `blast_radius`, `exposure_paths`, `should_i_deploy`,
@@ -28,9 +29,9 @@ invoke them.
 `vector_db_scan`, `aisvs_benchmark`, `gpu_infra_scan`, `registry_sweep_scan`,
 `dataset_card_scan`, `training_pipeline_scan`, `browser_extension_scan`,
 `model_provenance_scan`, `prompt_scan`, `model_file_scan`, `ai_inventory_scan`,
-`license_compliance_scan`, `ingest_external_scan`, `cost_forecast`,
-`cost_allocation`, `credential_expiry`, `nhi_discover`, `cloud_inventory`,
-`access_review`, `create_ticket`, `sync_ticket_status`.
+`license_compliance_scan`, `ingest_external_scan`, `runtime_evidence_ingest`,
+`cost_forecast`, `cost_allocation`, `credential_expiry`, `nhi_discover`,
+`cloud_inventory`, `access_review`, `create_ticket`, `sync_ticket_status`.
 
 </details>
 
@@ -397,6 +398,15 @@ JSON) and return packages with blast-radius analysis. This parses an existing
 artifact and does not execute Semgrep or any other producer.
 ```
 ingest_external_scan(scan_json="<SARIF or scanner JSON>", parse_only=true)
+```
+
+### runtime_evidence_ingest
+Ingest CWPP runtime/EDR workload signals into the durable evidence store.
+Requires a pre-registered source (`AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`) and
+shared secret. Metadata only; never writes to a customer cloud target. Fail-closed
+on auth. Write-annotated (`findings:write`).
+```
+runtime_evidence_ingest(source_id="edr-1", secret="...", signals_json="[]")
 ```
 
 ## Resources

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -852,3 +852,77 @@ def _render_side_scan_results(con: Console, results: list[SideScanResult]) -> No
 
 
 cloud_group.add_command(side_scan_cmd, "side-scan")
+
+
+@click.command("runtime-evidence-ingest")
+@click.option("--source-id", required=True, help="Pre-registered runtime evidence source id.")
+@click.option(
+    "--secret",
+    required=True,
+    envvar="AGENT_BOM_RUNTIME_EVIDENCE_SOURCE_SECRET",
+    help="Shared secret for the source (or set AGENT_BOM_RUNTIME_EVIDENCE_SOURCE_SECRET).",
+)
+@click.option(
+    "--file",
+    "signals_file",
+    type=click.Path(exists=True, dir_okay=False, path_type=str),
+    required=True,
+    help="JSON file: a list of signals, or {\"signals\": [...]}.",
+)
+@click.option("--no-persist", is_flag=True, help="Authenticate + validate only; do not write the durable store.")
+def runtime_evidence_ingest_cmd(source_id: str, secret: str, signals_file: str, no_persist: bool) -> None:
+    """Ingest CWPP runtime/EDR workload signals into the local evidence store.
+
+    Sources must already be registered via ``AGENT_BOM_RUNTIME_EVIDENCE_SOURCES``
+    (hashed shared secret). Read-only toward customer targets: agent-bom never
+    writes to a cloud workload; only redacted metadata is persisted. Fail-closed
+    authentication — unknown source or bad secret exits non-zero.
+
+    \b
+    Examples:
+      agent-bom cloud runtime-evidence-ingest \\
+        --source-id edr-1 --secret \"$SECRET\" --file signals.json
+    """
+    import json
+    from pathlib import Path
+
+    from rich.console import Console
+
+    from agent_bom.cloud.runtime_workload_evidence import (
+        SourceAuthenticationError,
+        ingest_runtime_signals_payload,
+    )
+
+    con = Console()
+    try:
+        payload = json.loads(Path(signals_file).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        con.print(f"\n  [red]invalid signals file:[/red] {exc}\n")
+        raise SystemExit(2) from exc
+
+    try:
+        result = ingest_runtime_signals_payload(
+            source_id=source_id,
+            secret=secret,
+            payload=payload,
+            persist=not no_persist,
+        )
+    except SourceAuthenticationError:
+        con.print("\n  [red]runtime evidence source authentication failed[/red]\n")
+        raise SystemExit(1)
+    except ValueError as exc:
+        con.print(f"\n  [red]invalid payload:[/red] {exc}\n")
+        raise SystemExit(2) from exc
+
+    summary = result.to_dict()
+    con.print("\n  [bold]runtime evidence ingest[/bold] [dim]· metadata only · additive[/dim]")
+    con.print(
+        f"  source={summary['source_id']} tenant={summary['tenant_id']} "
+        f"accepted={summary['accepted']} persisted={summary['persisted']} "
+        f"deduped={summary['deduped']} stale={summary['rejected_stale']} "
+        f"incomplete={summary['rejected_incomplete']}"
+    )
+    con.print()
+
+
+cloud_group.add_command(runtime_evidence_ingest_cmd, "runtime-evidence-ingest")

--- a/src/agent_bom/cli/_server.py
+++ b/src/agent_bom/cli/_server.py
@@ -1064,7 +1064,7 @@ def mcp_server_cmd(
       docs/MCP_WORKFLOWS.md
 
     \b
-    Exposes 76 security tools via MCP protocol, organized behind 8 workflow
+    Exposes 77 security tools via MCP protocol, organized behind 8 workflow
     prompts. Advanced direct tools include skill_scan, skill_verify,
     compliance, and remediate.
 

--- a/src/agent_bom/cloud/runtime_workload_evidence.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence.py
@@ -479,6 +479,46 @@ def ingest_runtime_signals(
     return result
 
 
+def ingest_runtime_signals_payload(
+    *,
+    source_id: str,
+    secret: str,
+    payload: Any,
+    persist: bool = True,
+    now: str | None = None,
+    max_age_seconds: int = DEFAULT_MAX_SIGNAL_AGE_SECONDS,
+    registry: RuntimeSourceRegistry | None = None,
+    store: Any = None,
+) -> IngestResult:
+    """CLI/MCP helper: ingest a JSON list (or ``{"signals": [...]}``) of raw signals.
+
+    Uses the process registry and durable store by default so operator surfaces
+    share the same door as ``POST /v1/cloud/runtime-evidence/ingest``.
+    """
+    if isinstance(payload, Mapping) and "signals" in payload:
+        raw_signals = payload.get("signals")
+    else:
+        raw_signals = payload
+    if not isinstance(raw_signals, list):
+        raise ValueError('runtime evidence payload must be a list of signals or {"signals": [...]}')
+    cleaned = [row for row in raw_signals if isinstance(row, Mapping)]
+    active_registry = registry if registry is not None else get_runtime_source_registry()
+    active_store = store
+    if persist and active_store is None:
+        from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+
+        active_store = get_runtime_workload_evidence_store()
+    return ingest_runtime_signals(
+        registry=active_registry,
+        source_id=source_id,
+        secret=secret,
+        raw_signals=cleaned,
+        now=now,
+        max_age_seconds=max_age_seconds,
+        store=active_store if persist else None,
+    )
+
+
 # ── Enrichment (additive, honest, tenant-isolated) ───────────────────────────
 
 
@@ -773,6 +813,7 @@ __all__ = [
     "enrich_graph_workload_runtime_evidence",
     "get_runtime_source_registry",
     "ingest_runtime_signals",
+    "ingest_runtime_signals_payload",
     "no_runtime_signal_summary",
     "set_runtime_source_registry",
     "workload_runtime_summary",

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -5,7 +5,7 @@ Start with:
     agent-bom mcp server --transport sse          # SSE transport (for remote clients)
     agent-bom mcp server --transport streamable-http
 
-Tools (76):
+Tools (77):
     scan                — Full discovery → scan → output pipeline
     check               — Check a specific package for CVEs before installing
     intel_lookup        — Look up a CVE, GHSA, or OSV advisory from local threat intel
@@ -74,6 +74,7 @@ Tools (76):
     ai_inventory_scan   — Scan source code for AI SDK imports, model references, shadow AI
     license_compliance_scan — Evaluate package licenses against SPDX compliance policy
     ingest_external_scan   — Ingest tool-agnostic SARIF, SBOM, or scanner JSON with blast radius analysis
+    runtime_evidence_ingest — Ingest CWPP runtime/EDR workload signals (authenticated source; metadata only)
     cost_forecast       — Project LLM spend burn rate and budget runway
     cost_allocation     — Chargeback / showback spend rollups by cost-center and tag
     credential_expiry   — Expiring / overdue credential and rotation posture

--- a/src/agent_bom/mcp_server_metadata.py
+++ b/src/agent_bom/mcp_server_metadata.py
@@ -351,6 +351,14 @@ _SERVER_CARD_TOOLS = [
         "annotations": {"readOnlyHint": False, "destructiveHint": True, "idempotentHint": False},
     },
     {
+        "name": "runtime_evidence_ingest",
+        "description": (
+            "Ingest CWPP runtime/EDR workload signals into the durable evidence store "
+            "(authenticated source; metadata only; never writes to a customer cloud target)"
+        ),
+        "annotations": {"readOnlyHint": False, "destructiveHint": False, "idempotentHint": True},
+    },
+    {
         "name": "cost_forecast",
         "description": "Project LLM spend burn rate and budget runway (reference-only forecast)",
         "annotations": {"readOnlyHint": True},
@@ -461,6 +469,7 @@ _TOOL_CAPABILITY_CLASSES = {
     "ai_inventory_scan": ["READ", "LOCAL_FILE_READ"],
     "license_compliance_scan": ["READ", "LOCAL_FILE_READ", "COMPLIANCE"],
     "ingest_external_scan": ["WRITE", "LOCAL_FILE_READ", "INGEST"],
+    "runtime_evidence_ingest": ["WRITE", "INGEST"],
     # access_review recomputes and persists campaign status as a side effect of
     # a read-shaped call → WRITE (idempotent, non-destructive).
     "access_review": ["WRITE", "READ", "IDENTITY", "GOVERNANCE", "AUDIT"],

--- a/src/agent_bom/mcp_server_specialized.py
+++ b/src/agent_bom/mcp_server_specialized.py
@@ -22,6 +22,7 @@ def register_specialized_ai_tools(
     """Register specialized AI, model, and external-ingest MCP tools."""
     from agent_bom.mcp_tools.cloud import gpu_infra_scan_impl, registry_sweep_scan_impl, vector_db_scan_impl
     from agent_bom.mcp_tools.compliance import aisvs_benchmark_impl, license_compliance_scan_impl
+    from agent_bom.mcp_tools.runtime_evidence import runtime_evidence_ingest_impl
     from agent_bom.mcp_tools.specialized import (
         ai_inventory_scan_impl,
         browser_extension_scan_impl,
@@ -298,6 +299,38 @@ def register_specialized_ai_tools(
             license_compliance_scan_impl,
             scan_json=scan_json,
             policy_json=policy_json,
+            _truncate_response=truncate_response,
+        )
+
+    @mcp.tool(annotations=write_action, title="Ingest CWPP Runtime Evidence")
+    async def runtime_evidence_ingest(
+        source_id: Annotated[str, Field(description="Pre-registered runtime evidence source id.")],
+        secret: Annotated[
+            str,
+            Field(description="Shared secret for the source (never logged)."),
+        ],
+        signals_json: Annotated[
+            str,
+            Field(
+                description=(
+                    "JSON string: a list of signal objects, or {\"signals\": [...]} matching the "
+                    "POST /v1/cloud/runtime-evidence/ingest body shape (metadata only)."
+                ),
+            ),
+        ],
+    ) -> str:
+        """Ingest CWPP runtime/EDR workload signals into the local evidence store.
+
+        Mutates the durable runtime-evidence store for the authenticated source's
+        tenant. Sources are provisioned via ``AGENT_BOM_RUNTIME_EVIDENCE_SOURCES``.
+        Fail-closed on auth; never writes to a customer cloud target.
+        """
+        return await execute_tool_async(
+            "runtime_evidence_ingest",
+            runtime_evidence_ingest_impl,
+            source_id=source_id,
+            secret=secret,
+            signals_json=signals_json,
             _truncate_response=truncate_response,
         )
 

--- a/src/agent_bom/mcp_tools/runtime_evidence.py
+++ b/src/agent_bom/mcp_tools/runtime_evidence.py
@@ -1,0 +1,45 @@
+"""MCP tool: ingest CWPP runtime/EDR workload signals (#4158 stage 4)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from agent_bom.security import sanitize_error
+
+logger = logging.getLogger(__name__)
+
+
+async def runtime_evidence_ingest_impl(
+    *,
+    source_id: str,
+    secret: str,
+    signals_json: str,
+    _truncate_response: Any,
+) -> str:
+    """Authenticate a registered source and ingest a JSON array of signals."""
+    try:
+        from agent_bom.cloud.runtime_workload_evidence import (
+            SourceAuthenticationError,
+            ingest_runtime_signals_payload,
+        )
+
+        payload = json.loads(signals_json)
+        result = ingest_runtime_signals_payload(
+            source_id=source_id,
+            secret=secret,
+            payload=payload,
+            persist=True,
+        )
+        return _truncate_response(json.dumps(result.to_dict(), indent=2, sort_keys=True))
+    except SourceAuthenticationError:
+        return json.dumps({"error": "runtime evidence source authentication failed"})
+    except (json.JSONDecodeError, ValueError, TypeError) as exc:
+        return json.dumps({"error": sanitize_error(exc)})
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("MCP runtime_evidence_ingest error")
+        return json.dumps({"error": sanitize_error(exc)})
+
+
+__all__ = ["runtime_evidence_ingest_impl"]

--- a/tests/test_cli_entry_points.py
+++ b/tests/test_cli_entry_points.py
@@ -121,7 +121,7 @@ class TestAgentBom:
         assert "quick-audit" in r.output
         assert "gateway-fleet-live-demo" in r.output
         assert "full tool catalog" in r.output
-        assert "Exposes 76 security tools via MCP protocol" in r.output
+        assert "Exposes 77 security tools via MCP protocol" in r.output
         assert "organized behind 8 workflow" in r.output
 
     def test_secrets_help_has_common_output_flags(self):

--- a/tests/test_cli_runtime_evidence_ingest.py
+++ b/tests/test_cli_runtime_evidence_ingest.py
@@ -1,0 +1,107 @@
+"""CLI/MCP helper for CWPP runtime evidence ingest (#4158 stage 4)."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from agent_bom.cli._cloud_group import cloud_group
+from agent_bom.cloud.runtime_workload_evidence import (
+    RuntimeEvidenceSource,
+    RuntimeSourceRegistry,
+    ingest_runtime_signals_payload,
+    set_runtime_source_registry,
+)
+from agent_bom.cloud.runtime_workload_evidence_store import (
+    InMemoryRuntimeWorkloadEvidenceStore,
+    set_runtime_workload_evidence_store,
+)
+
+SOURCE_SECRET = "s3cr3t-token-value-1234"
+
+
+def setup_function() -> None:
+    registry = RuntimeSourceRegistry()
+    registry.add(
+        RuntimeEvidenceSource.register(
+            source_id="edr-1",
+            tenant_id="tenant-alpha",
+            provider="aws",
+            account_id="123456789012",
+            kind="edr",
+            secret=SOURCE_SECRET,
+        )
+    )
+    set_runtime_source_registry(registry)
+    set_runtime_workload_evidence_store(InMemoryRuntimeWorkloadEvidenceStore())
+
+
+def teardown_function() -> None:
+    set_runtime_source_registry(None)
+    set_runtime_workload_evidence_store(None)
+
+
+def _signal(workload_ref: str = "i-0abc", dedup_key: str = "evt-1") -> dict:
+    now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    return {
+        "workload_ref": workload_ref,
+        "dedup_key": dedup_key,
+        "signal_type": "ioc_detection",
+        "severity": "high",
+        "observed_at": now,
+        "title": "demo ioc",
+    }
+
+
+def test_ingest_runtime_signals_payload_accepts_wrapped_list() -> None:
+    result = ingest_runtime_signals_payload(
+        source_id="edr-1",
+        secret=SOURCE_SECRET,
+        payload={"signals": [_signal()]},
+        persist=True,
+    )
+    assert result.persisted == 1
+    assert result.accepted
+
+
+def test_cli_runtime_evidence_ingest_persists(tmp_path: Path) -> None:
+    path = tmp_path / "signals.json"
+    path.write_text(json.dumps([_signal(dedup_key="cli-1")]), encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        cloud_group,
+        [
+            "runtime-evidence-ingest",
+            "--source-id",
+            "edr-1",
+            "--secret",
+            SOURCE_SECRET,
+            "--file",
+            str(path),
+        ],
+    )
+    assert result.exit_code == 0, result.output
+    assert "persisted=1" in result.output
+
+
+def test_cli_runtime_evidence_ingest_auth_fail_closed(tmp_path: Path) -> None:
+    path = tmp_path / "signals.json"
+    path.write_text(json.dumps([_signal(dedup_key="cli-2")]), encoding="utf-8")
+    runner = CliRunner()
+    result = runner.invoke(
+        cloud_group,
+        [
+            "runtime-evidence-ingest",
+            "--source-id",
+            "edr-1",
+            "--secret",
+            "wrong-secret",
+            "--file",
+            str(path),
+        ],
+    )
+    assert result.exit_code == 1
+    assert "authentication failed" in result.output

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -283,6 +283,7 @@ def test_server_card_tools_expose_capability_classes():
         "identity_grant_jit",
         "identity_revoke_jit",
         "ingest_external_scan",
+        "runtime_evidence_ingest",
         # access_review recomputes+persists campaign status on read; diff persists
         # the fresh scan to history and prunes old reports.
         "access_review",
@@ -373,6 +374,7 @@ def test_mcp_docs_match_resource_and_prompt_catalog():
         "identity_revoke_jit",
         "identity_rotate",
         "ingest_external_scan",
+        "runtime_evidence_ingest",
         "shield_break_glass",
         "shield_start",
         "shield_unblock",

--- a/tests/test_mcp_tool_output_contract.py
+++ b/tests/test_mcp_tool_output_contract.py
@@ -99,6 +99,11 @@ def _minimal_args(name: str, workdir: Path) -> dict[str, Any]:
         "identity_revoke_jit": {"grant_id": "grant-x"},
         "identity_rotate": {"identity_id": "id-x"},
         "ingest_external_scan": {"scan_json": "{}", "parse_only": True},
+        "runtime_evidence_ingest": {
+            "source_id": "edr-missing",
+            "secret": "x",
+            "signals_json": "[]",
+        },
         "intel_lookup": {"advisory_id": "GHSA-xxxx-xxxx-xxxx"},
         "inventory_asset": {"asset_id": "asset-does-not-exist"},
         "license_compliance_scan": {"scan_json": "{}"},

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -2650,7 +2650,7 @@ function CodingAgentDrawer({ open, onClose }: { open: boolean; onClose: () => vo
       }
       headerAside={
         <span className="inline-flex items-center gap-1.5 rounded-full border border-emerald-500/30 dark:border-emerald-900/60 bg-emerald-500/10 dark:bg-emerald-950/30 px-2.5 py-0.5 text-[11px] font-medium text-emerald-700 dark:text-emerald-300">
-          <Bot className="h-3 w-3" /> 76 MCP tools
+          <Bot className="h-3 w-3" /> 77 MCP tools
         </span>
       }
     >

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -529,7 +529,7 @@ describe("ConnectionsPage — Connect segment", () => {
 
     const drawer = await screen.findByRole("dialog", { name: /Connect a coding agent/ });
     expect(within(drawer).getByText("agent-bom mcp-server")).toBeInTheDocument();
-    expect(within(drawer).getByText(/76 MCP tools/)).toBeInTheDocument();
+    expect(within(drawer).getByText(/77 MCP tools/)).toBeInTheDocument();
   });
 
   it("syncs the segmented tab to the URL", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add CLI `agent-bom cloud runtime-evidence-ingest` and MCP `runtime_evidence_ingest` on the same authenticated ingest path as `POST /v1/cloud/runtime-evidence/ingest` (#4158 stage 4 B).
- Align MCP catalog counts to 77 tools / 14 write-annotated tools across docs, Docker registry `tools.json`, SSE Dockerfile, Connections UI, and release consistency.
- Allowlist `AGENT_BOM_RUNTIME_EVIDENCE_SOURCE_SECRET` for the env-var reference gate.
- Rebased onto main after #4369; docs keep graph enrich + CLI/MCP ingest as wired.

## Verification
- `uv run pytest -q tests/test_cli_runtime_evidence_ingest.py tests/test_public_release_contracts.py::test_each_mcp_reference_contains_complete_catalog tests/test_deployment.py::test_mcp_docs_match_resource_and_prompt_catalog tests/cloud/test_side_scan_lifecycle_contract.py::test_provider_capabilities_do_not_claim_unshipped_executors`
- `uv run python scripts/generate_env_var_reference.py --check`
- `uv run python scripts/check_release_consistency.py`

## Notes
- Fail-closed source auth; metadata-only; `clean_workload_assertion` remains false (additive evidence, not a cleanliness claim).
- Part of #4158. Complements #4369 (graph enrich + Azure/GCP `contract_only` honesty).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

