### PR TITLE
feat(cwpp): runtime evidence in exports and findings drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
+- CWPP stage-4 (D): findings Evidence drawer shows a Workload runtime evidence
+  panel for CWPP/EDR summaries (additive; not a clean-workload assertion)
+  (#4158).
 - Findings carry optional graph FKs (`node_id`, `finding_node_id`, `entity_type`)
   and attack paths expose `finding_ids` so investigation joins typed estate nodes
   instead of CVE-label-only anchors; `asset_type` aliases map to `EntityType`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Changed
 <<<<<<< HEAD
+<<<<<<< HEAD
 - CWPP stage-4 honesty: Azure/GCP side-scan capabilities report
   `executor: contract_only` (discovery + injected-SDK adapters only); runtime
   evidence ingest + graph persist/investigation loads are documented as wired;
@@ -52,6 +53,11 @@ Versions follow [Semantic Versioning](https://semver.org/).
   `runtime_evidence_ingest` share the authenticated runtime-evidence door with
   the REST ingest route (#4158).
 >>>>>>> cd080ac5 (feat(cwpp): CLI and MCP runtime-evidence ingest)
+=======
+- CWPP stage-4 (C): JSON / SARIF / HTML exports surface
+  `workload_runtime_evidence` on workload-scoped findings (additive;
+  `clean_workload_assertion` stays false) (#4158).
+>>>>>>> 5730acbc (feat(cwpp): surface workload_runtime_evidence in exports)
 - Findings carry optional graph FKs (`node_id`, `finding_node_id`, `entity_type`)
   and attack paths expose `finding_ids` so investigation joins typed estate nodes
   instead of CVE-label-only anchors; `asset_type` aliases map to `EntityType`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,22 +42,16 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
-<<<<<<< HEAD
-<<<<<<< HEAD
 - CWPP stage-4 honesty: Azure/GCP side-scan capabilities report
   `executor: contract_only` (discovery + injected-SDK adapters only); runtime
   evidence ingest + graph persist/investigation loads are documented as wired;
   Azure/GCP CLI executor and credentialed smoke remain unclaimed (#4158).
-=======
 - CWPP stage-4 (B): CLI `agent-bom cloud runtime-evidence-ingest` and MCP
   `runtime_evidence_ingest` share the authenticated runtime-evidence door with
   the REST ingest route (#4158).
->>>>>>> cd080ac5 (feat(cwpp): CLI and MCP runtime-evidence ingest)
-=======
 - CWPP stage-4 (C): JSON / SARIF / HTML exports surface
   `workload_runtime_evidence` on workload-scoped findings (additive;
   `clean_workload_assertion` stays false) (#4158).
->>>>>>> 5730acbc (feat(cwpp): surface workload_runtime_evidence in exports)
 - Findings carry optional graph FKs (`node_id`, `finding_node_id`, `entity_type`)
   and attack paths expose `finding_ids` so investigation joins typed estate nodes
   instead of CVE-label-only anchors; `asset_type` aliases map to `EntityType`

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -574,43 +574,20 @@ graph edge, so reachability stays edge-derived and is never fabricated.
 Wired today: findings surfaced by `GET /v1/findings` (and the overview /
 compliance / observability reads that share the enricher) gain a
 `workload_runtime_evidence` field on workload-scoped rows once a tenant has
-<<<<<<< HEAD
 signals; the JSON API export carries it automatically. Authenticated ingest is
-<<<<<<< HEAD
-available at `POST /v1/cloud/runtime-evidence/ingest` (sources provisioned via
-`AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`; empty registry fails closed). Graph
-persist and investigation graph loads annotate matching CWPP workload nodes
-via the same index (tenant-scoped; absence stays `no_runtime_signal`, never
-"clean").
-
-Not yet locked in (stage 4 remainder): CLI/MCP ingest surface, a scheduler that
-pulls from sources, typed SARIF/report export fields, and any UI panel for
-workload runtime evidence. Azure/GCP disk side-scan remains discovery +
-injected-SDK lifecycle adapters (`executor: contract_only`) — no CLI executor
-and no credentialed live smoke is claimed.
-=======
 available at `POST /v1/cloud/runtime-evidence/ingest`, CLI
 `agent-bom cloud runtime-evidence-ingest`, and the MCP tool
 `runtime_evidence_ingest` (sources via `AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`;
-empty registry fails closed). A graph-join helper annotates CWPP workload nodes
-for a matching tenant.
+empty registry fails closed). Graph persist and investigation graph loads
+annotate matching CWPP workload nodes via the same index (tenant-scoped;
+absence stays `no_runtime_signal`, never "clean"). JSON / SARIF / HTML report
+exports carry the same field when it is already attached on a finding or when
+the tenant durable evidence store is non-empty (`AGENT_BOM_TENANT_ID`).
 
-Not yet locked in (stage 4 remainder): a scheduler that pulls from sources,
-typed SARIF/report export fields, the live graph/campaign route invocation, and
-any UI panel for workload runtime evidence. No credentialed live source smoke is
-claimed. Azure/GCP disk side-scan remains discovery + injected-SDK adapters —
-no CLI executor is claimed.
->>>>>>> cd080ac5 (feat(cwpp): CLI and MCP runtime-evidence ingest)
-=======
-signals; the JSON API export carries it automatically. JSON / SARIF / HTML
-report exports carry the same field when it is already attached on a finding or
-when the tenant durable evidence store is non-empty (`AGENT_BOM_TENANT_ID`). A
-graph-join helper annotates CWPP workload nodes for a matching tenant. Not yet
-locked in (stage 4 remainder): CLI/MCP ingest surfaces, a scheduler that pulls
-from sources, the UI panel for workload runtime evidence, and Azure/GCP
-side-scan CLI wiring that stays honest until credentialed smoke. No credentialed
-live source smoke is claimed.
->>>>>>> 5730acbc (feat(cwpp): surface workload_runtime_evidence in exports)
+Not yet locked in (stage 4 remainder): a scheduler that pulls from sources and
+any UI panel for workload runtime evidence. Azure/GCP disk side-scan remains
+discovery + injected-SDK lifecycle adapters (`executor: contract_only`) — no
+CLI executor and no credentialed live smoke is claimed.
 
 ---
 

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -574,11 +574,13 @@ graph edge, so reachability stays edge-derived and is never fabricated.
 Wired today: findings surfaced by `GET /v1/findings` (and the overview /
 compliance / observability reads that share the enricher) gain a
 `workload_runtime_evidence` field on workload-scoped rows once a tenant has
-signals; the JSON API export carries it automatically. A graph-join helper
-annotates CWPP workload nodes for a matching tenant. Not yet locked in (stage 4):
-a dedicated ingest REST endpoint, CLI/MCP ingest surface, a scheduler that pulls
-from sources, typed SARIF/report export fields, the live graph/campaign route
-invocation, and any UI panel. No credentialed live source smoke is claimed.
+signals; the JSON API export carries it automatically. The findings Evidence
+drawer shows a dedicated Workload runtime evidence panel (separate from
+proxy/gateway reach badges). A graph-join helper annotates CWPP workload nodes
+for a matching tenant. Not yet locked in (stage 4 remainder): CLI/MCP ingest
+surfaces, typed SARIF/report export fields, a scheduler that pulls from sources,
+and Azure/GCP side-scan CLI wiring that stays honest until credentialed smoke.
+No credentialed live source smoke is claimed.
 
 ---
 

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -574,6 +574,7 @@ graph edge, so reachability stays edge-derived and is never fabricated.
 Wired today: findings surfaced by `GET /v1/findings` (and the overview /
 compliance / observability reads that share the enricher) gain a
 `workload_runtime_evidence` field on workload-scoped rows once a tenant has
+<<<<<<< HEAD
 signals; the JSON API export carries it automatically. Authenticated ingest is
 <<<<<<< HEAD
 available at `POST /v1/cloud/runtime-evidence/ingest` (sources provisioned via
@@ -600,6 +601,16 @@ any UI panel for workload runtime evidence. No credentialed live source smoke is
 claimed. Azure/GCP disk side-scan remains discovery + injected-SDK adapters —
 no CLI executor is claimed.
 >>>>>>> cd080ac5 (feat(cwpp): CLI and MCP runtime-evidence ingest)
+=======
+signals; the JSON API export carries it automatically. JSON / SARIF / HTML
+report exports carry the same field when it is already attached on a finding or
+when the tenant durable evidence store is non-empty (`AGENT_BOM_TENANT_ID`). A
+graph-join helper annotates CWPP workload nodes for a matching tenant. Not yet
+locked in (stage 4 remainder): CLI/MCP ingest surfaces, a scheduler that pulls
+from sources, the UI panel for workload runtime evidence, and Azure/GCP
+side-scan CLI wiring that stays honest until credentialed smoke. No credentialed
+live source smoke is claimed.
+>>>>>>> 5730acbc (feat(cwpp): surface workload_runtime_evidence in exports)
 
 ---
 

--- a/src/agent_bom/cloud/runtime_workload_evidence.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence.py
@@ -616,6 +616,35 @@ def _resolve_finding_workload(row: Mapping[str, Any]) -> tuple[str, str, str] | 
     provider = str(row.get("provider") or "").strip().lower()
     account = _account_from_ref(str(row.get("account_ref") or "")) or str(row.get("account_id") or "").strip()
     workload_ref = str(row.get("resource_id") or row.get("target_id") or row.get("asset_id") or row.get("workload_ref") or "").strip()
+
+    asset = row.get("asset")
+    if isinstance(asset, Mapping):
+        provider = provider or str(asset.get("provider") or "").strip().lower()
+        account = (
+            account
+            or _account_from_ref(str(asset.get("account_ref") or ""))
+            or str(asset.get("account_id") or "").strip()
+        )
+        if not workload_ref:
+            workload_ref = str(asset.get("identifier") or asset.get("resource_id") or "").strip()
+            if not workload_ref:
+                source_ids = asset.get("source_ids")
+                if isinstance(source_ids, list) and source_ids:
+                    workload_ref = str(source_ids[0] or "").strip()
+
+    evidence = row.get("evidence")
+    if isinstance(evidence, Mapping):
+        provider = provider or str(evidence.get("provider") or "").strip().lower()
+        account = (
+            account
+            or _account_from_ref(str(evidence.get("account_ref") or ""))
+            or str(evidence.get("account_id") or "").strip()
+        )
+        if not workload_ref:
+            workload_ref = str(
+                evidence.get("resource_id") or evidence.get("target_id") or evidence.get("workload_ref") or ""
+            ).strip()
+
     if provider and account and workload_ref:
         return provider, account, workload_ref
     return None
@@ -635,6 +664,63 @@ def attach_workload_runtime_evidence_to_finding(row: dict[str, Any], index: Runt
         return row
     row["workload_runtime_evidence"] = index.summary_for(*resolved)
     return row
+
+
+def attach_workload_runtime_evidence_to_finding_model(
+    finding: Any,
+    index: RuntimeWorkloadEvidenceIndex | None,
+) -> bool:
+    """Annotate a Finding in place for JSON/SARIF/HTML export surfaces.
+
+    Returns True when ``workload_runtime_evidence`` was set. Absence of a matching
+    signal still annotates ``no_runtime_signal`` with ``clean_workload_assertion``
+    false whenever the finding resolves to a workload identity and the tenant
+    index is non-empty.
+    """
+    if index is None or index.is_empty():
+        return False
+    if not hasattr(finding, "workload_runtime_evidence"):
+        return False
+    row = finding.to_dict() if hasattr(finding, "to_dict") else {}
+    if not isinstance(row, dict):
+        return False
+    attach_workload_runtime_evidence_to_finding(row, index)
+    evidence = row.get("workload_runtime_evidence")
+    if not isinstance(evidence, dict):
+        return False
+    finding.workload_runtime_evidence = evidence
+    return True
+
+
+def enrich_findings_workload_runtime_evidence(
+    findings: Iterable[Any],
+    index: RuntimeWorkloadEvidenceIndex | None,
+) -> int:
+    """Annotate an iterable of Finding models; return how many were annotated."""
+    if index is None or index.is_empty():
+        return 0
+    return sum(1 for finding in findings if attach_workload_runtime_evidence_to_finding_model(finding, index))
+
+
+def optional_runtime_workload_evidence_index(
+    *,
+    tenant_id: str | None = None,
+    store: Any = None,
+) -> RuntimeWorkloadEvidenceIndex | None:
+    """Load a tenant evidence index for export enrichment, or None when empty.
+
+    Prefer an explicit ``tenant_id``; otherwise use ``AGENT_BOM_TENANT_ID`` and
+    finally ``default``. An empty store yields None so exporters do not invent
+    no-signal rows for tenants that never opted into runtime ingest.
+    """
+    active_tenant = (tenant_id or os.getenv("AGENT_BOM_TENANT_ID") or "default").strip() or "default"
+    active_store = store
+    if active_store is None:
+        from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+
+        active_store = get_runtime_workload_evidence_store()
+    index = RuntimeWorkloadEvidenceIndex.from_store(active_store, active_tenant)
+    return None if index.is_empty() else index
 
 
 def _node_attributes(node: Any) -> dict[str, Any] | None:
@@ -807,14 +893,17 @@ __all__ = [
     "SourceAuthenticationError",
     "StaleSignalError",
     "attach_workload_runtime_evidence_to_finding",
+    "attach_workload_runtime_evidence_to_finding_model",
     "attach_workload_runtime_evidence_to_node",
     "build_runtime_signal",
     "canonical_workload_id",
+    "enrich_findings_workload_runtime_evidence",
     "enrich_graph_workload_runtime_evidence",
     "get_runtime_source_registry",
     "ingest_runtime_signals",
     "ingest_runtime_signals_payload",
     "no_runtime_signal_summary",
+    "optional_runtime_workload_evidence_index",
     "set_runtime_source_registry",
     "workload_runtime_summary",
 ]

--- a/src/agent_bom/evidence/policy.py
+++ b/src/agent_bom/evidence/policy.py
@@ -158,10 +158,18 @@ TIER_A_FIELDS: frozenset[str] = frozenset(
         "declared_version",
         "resolved_version",
         "observed_at",
+        "latest_observed_at",
         "version_resolved_at",
         "floating_reference",
         "floating_reference_reason",
         "scan_sources",
+        # CWPP runtime/EDR workload evidence (metadata only; never secret values)
+        "workload_runtime_evidence",
+        "signal_count",
+        "signal_types",
+        "source_kinds",
+        "clean_workload_assertion",
+        "additive_note",
         # Quantitative scores (no PII)
         "cvss_score",
         "epss_score",
@@ -273,6 +281,7 @@ TIER_A_COUNT_MAP_FIELDS: frozenset[str] = frozenset(
     {
         "class_counts",
         "severity_counts",
+        "signal_types",
     }
 )
 

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -328,6 +328,10 @@ class Finding:
     exposed_credentials: list[str] = field(default_factory=list)  # credential env-var names at risk
     exposed_tools: list[str] = field(default_factory=list)  # tool names accessible through the path
 
+    # CWPP runtime/EDR workload evidence (optional, additive). Never implies the
+    # workload is clean — summaries carry clean_workload_assertion=False.
+    workload_runtime_evidence: Optional[dict] = None
+
     # Unique ID — deterministic UUID v5 based on content (computed in __post_init__)
     # Pass an explicit id= to override (e.g. when ingesting from external scanner)
     id: str = field(default="")
@@ -604,6 +608,12 @@ class Finding:
             "affected_agents": list(self.affected_agents),
             "exposed_credentials": list(self.exposed_credentials),
             "exposed_tools": list(self.exposed_tools),
+            # CWPP runtime/EDR — omit when unset so plain findings stay unchanged
+            **(
+                {"workload_runtime_evidence": dict(self.workload_runtime_evidence)}
+                if isinstance(self.workload_runtime_evidence, dict)
+                else {}
+            ),
         }
 
 

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -29,6 +29,24 @@ def cve_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = No
     return [finding for finding in report.to_findings() if finding.finding_type in _MACHINE_EXPORT_TYPES]
 
 
+def apply_workload_runtime_evidence_for_export(findings: list[Finding]) -> list[Finding]:
+    """Annotate findings with CWPP runtime evidence when a tenant index is present.
+
+    Additive only: findings without a resolvable workload identity are unchanged.
+    An empty store leaves findings untouched (no fabricated no-signal rows).
+    Findings that already carry ``workload_runtime_evidence`` keep it.
+    """
+    from agent_bom.cloud.runtime_workload_evidence import (
+        enrich_findings_workload_runtime_evidence,
+        optional_runtime_workload_evidence_index,
+    )
+
+    pending = [finding for finding in findings if not getattr(finding, "workload_runtime_evidence", None)]
+    if pending:
+        enrich_findings_workload_runtime_evidence(pending, optional_runtime_workload_evidence_index())
+    return findings
+
+
 def machine_export_findings(report: AIBOMReport, blast_radii: list[BlastRadius] | None = None) -> list[Finding]:
     """Rows for flat machine exports (CSV/Parquet): CVE findings plus synthesized
     malicious-package findings.

--- a/src/agent_bom/output/html/document.py
+++ b/src/agent_bom/output/html/document.py
@@ -47,9 +47,11 @@ def to_html(
     *,
     offline_assets: bool = False,
 ) -> str:
+    from agent_bom.output.finding_views import apply_workload_runtime_evidence_for_export
+
     blast_radii = blast_radii or []
-    findings = cve_findings(report, blast_radii)
-    policy_findings = _non_cve_findings(report)
+    findings = apply_workload_runtime_evidence_for_export(cve_findings(report, blast_radii))
+    policy_findings = apply_workload_runtime_evidence_for_export(_non_cve_findings(report))
     generated = report.generated_at.strftime("%Y-%m-%d %H:%M:%S UTC")
     elements_json = _cytoscape_elements(report, blast_radii)
     attack_flow_json = _attack_flow_elements(report, blast_radii)

--- a/src/agent_bom/output/html/sections.py
+++ b/src/agent_bom/output/html/sections.py
@@ -312,6 +312,7 @@ def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
                 f'title="match confidence: {_esc(tier)}" '
                 f'style="font-size:.6rem;color:{_tier_color}">{_esc(str(tier).replace("_", " "))}</span>'
             )
+        runtime_hint = _workload_runtime_evidence_hint(finding)
         vuln_id = finding.cve_id or finding.id
         pkg_name = package_name(finding)
         pkg_version = package_version(finding)
@@ -322,7 +323,7 @@ def _vuln_table(report: "AIBOMReport", blast_radii: list["BlastRadius"]) -> str:
             f'data-reachability="{reach_state}" '
             f'data-match-tier="{_esc(tier or "")}" '
             f'data-cvss="{finding.cvss_score if finding.cvss_score else 0}">'
-            f'<td><code class="vuln-id">{_esc(vuln_id)}</code>{tier_hint}</td>'
+            f'<td><code class="vuln-id">{_esc(vuln_id)}</code>{tier_hint}{runtime_hint}</td>'
             f"<td>{_sev_badge(sev)}{vendor_hint}</td>"
             f'<td><strong style="color:#e2e8f0">{_esc(pkg_name)}</strong>'
             f'<span style="color:#475569;font-size:.78rem">@{_esc(pkg_version)}</span></td>'
@@ -491,6 +492,32 @@ def _remediation_list(findings: list["Finding"]) -> str:
     return "".join(items) + nf_html
 
 
+def _workload_runtime_evidence_hint(finding: object) -> str:
+    """Compact HTML badge for CWPP runtime/EDR evidence. Never labels absence as clean."""
+    payload = getattr(finding, "workload_runtime_evidence", None)
+    if not isinstance(payload, dict) or not payload:
+        return ""
+    state = str(payload.get("state") or "").strip() or "unknown"
+    label_map = {
+        "runtime_ioc_observed": "Runtime IOC",
+        "runtime_alert_observed": "Runtime alert",
+        "runtime_activity_observed": "Runtime observed",
+        "no_runtime_signal": "No runtime signal",
+    }
+    label = label_map.get(state, f"Runtime {state.replace('_', ' ')}")
+    color = {
+        "runtime_ioc_observed": "#f87171",
+        "runtime_alert_observed": "#fb923c",
+        "runtime_activity_observed": "#38bdf8",
+        "no_runtime_signal": "#94a3b8",
+    }.get(state, "#94a3b8")
+    title = "CWPP runtime/EDR evidence — additive; not a clean-workload assertion"
+    return (
+        f'<br><span class="workload-runtime-evidence" data-state="{_esc(state)}" '
+        f'title="{title}" style="font-size:.6rem;color:{color}">{_esc(label)}</span>'
+    )
+
+
 def _non_cve_findings(report: "AIBOMReport") -> list["Finding"]:
     """Return unified findings not already represented in the CVE or CIS tables.
 
@@ -536,6 +563,9 @@ def _policy_findings_section(findings: list["Finding"]) -> str:
             if evidence_items
             else '<span style="color:#334155">&mdash;</span>'
         )
+        runtime_hint = _workload_runtime_evidence_hint(finding)
+        if runtime_hint:
+            evidence = f"{evidence}{runtime_hint}"
         remediation = finding.remediation_guidance or ""
         description_html = f'<br><span style="color:#94a3b8">{_esc(description)}</span>' if description else ""
         remediation_html = _esc(remediation) if remediation else '<span style="color:#334155">&mdash;</span>'

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -984,7 +984,10 @@ def to_json(report: AIBOMReport) -> dict:
     all_packages = [pkg for agent in report.agents for server in agent.mcp_servers for pkg in server.packages]
     cve_pairs = list(zip(cve_findings(report, report.blast_radii), report.blast_radii, strict=True)) if report.blast_radii else []
     exposure_paths = [exposure_path_for_report_finding(finding, br=br, rank=rank) for rank, (finding, br) in enumerate(cve_pairs, start=1)]
-    unified_findings = [finding.to_dict() for finding in report.to_findings()]
+    from agent_bom.output.finding_views import apply_workload_runtime_evidence_for_export
+
+    export_findings = apply_workload_runtime_evidence_for_export(list(report.to_findings()))
+    unified_findings = [finding.to_dict() for finding in export_findings]
     asset_inventory = _build_asset_inventory(unified_findings)
     finding_summary = _build_finding_summary(unified_findings)
     from agent_bom.evidence.scan_run import effective_scan_run

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -615,6 +615,9 @@ def _cve_sarif_result(
         result_properties.update(framework_props)
     if ai_assessment is not None:
         result_properties.update(_ai_assessment_result_properties(ai_assessment))
+    workload_runtime = getattr(finding, "workload_runtime_evidence", None)
+    if isinstance(workload_runtime, dict) and workload_runtime:
+        result_properties["workload_runtime_evidence"] = _sanitize_sarif_property(workload_runtime)
     result["properties"] = result_properties
     suppressions = _suppression_entries(finding)
     if suppressions:
@@ -639,6 +642,7 @@ def to_sarif(
             from CVEs that can't be acted on.
     """
     from agent_bom.evidence.scan_run import ScanOutcome, effective_scan_run
+    from agent_bom.output.finding_views import apply_workload_runtime_evidence_for_export
 
     scan_run = effective_scan_run(report)
     rules: list[dict[str, Any]] = []
@@ -654,7 +658,7 @@ def to_sarif(
     # primary key is descending unified risk, tie-broken by finding id. This keeps
     # rank (and therefore SARIF/JSON bytes) deterministic across identical runs.
     ordered_cve_findings = sorted(
-        cve_findings(report, blast_radii),
+        apply_workload_runtime_evidence_for_export(cve_findings(report, blast_radii)),
         key=lambda finding: (-float(finding.risk_score or 0.0), finding.cve_id or finding.id or ""),
     )
     for rank, finding in enumerate(ordered_cve_findings, 1):
@@ -695,7 +699,7 @@ def to_sarif(
     # Unified non-CVE findings, including MCP intelligence/blocklist matches.
     finding_sev_map = {"critical": "error", "high": "error", "medium": "warning", "low": "note", "info": "none"}
     finding_sev_score = {"critical": "9.0", "high": "7.0", "medium": "4.0", "low": "1.0", "info": "0.0"}
-    for finding in report.to_findings():
+    for finding in apply_workload_runtime_evidence_for_export(list(report.to_findings())):
         if finding.finding_type == FindingType.CVE:
             continue
         # Cloud CIS benchmark failures for the dedicated-loop providers are
@@ -784,6 +788,14 @@ def to_sarif(
                 "ai_summary": finding.ai_summary,
                 "attack_vector_summary": finding.attack_vector_summary,
                 "suppressed": finding.suppressed,
+                **(
+                    {
+                        "workload_runtime_evidence": _sanitize_sarif_property(finding.workload_runtime_evidence),
+                    }
+                    if isinstance(getattr(finding, "workload_runtime_evidence", None), dict)
+                    and finding.workload_runtime_evidence
+                    else {}
+                ),
             },
         }
         suppressions = _suppression_entries(finding)

--- a/tests/test_workload_runtime_evidence_exports.py
+++ b/tests/test_workload_runtime_evidence_exports.py
@@ -1,0 +1,142 @@
+"""JSON/SARIF/HTML export parity for CWPP ``workload_runtime_evidence`` (#4158 C)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from agent_bom.cloud.runtime_workload_evidence import (
+    STATE_HAS_IOC,
+    STATE_NO_SIGNAL,
+    RuntimeEvidenceSource,
+    RuntimeSourceRegistry,
+    RuntimeWorkloadEvidenceIndex,
+    attach_workload_runtime_evidence_to_finding_model,
+    ingest_runtime_signals,
+    no_runtime_signal_summary,
+)
+from agent_bom.cloud.runtime_workload_evidence_store import (
+    InMemoryRuntimeWorkloadEvidenceStore,
+    set_runtime_workload_evidence_store,
+)
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.models import AIBOMReport
+from agent_bom.output.html.document import to_html
+from agent_bom.output.json_fmt import to_json
+from agent_bom.output.sarif import to_sarif
+
+
+def _workload_finding(*, with_ioc_summary: bool = False) -> Finding:
+    finding = Finding(
+        finding_type=FindingType.CIS_FAIL,
+        source=FindingSource.CLOUD_CIS,
+        asset=Asset(
+            name="web",
+            asset_type="cloud_resource",
+            identifier="i-0abc",
+            provider="aws",
+            account_ref="aws:123456789012",
+        ),
+        severity="high",
+        title="workload disk finding",
+        description="demo",
+        provider="aws",
+        account_ref="aws:123456789012",
+        evidence={"resource_id": "i-0abc", "provider": "aws"},
+    )
+    if with_ioc_summary:
+        finding.workload_runtime_evidence = {
+            "schema_version": "1.0",
+            "state": STATE_HAS_IOC,
+            "signal_count": 1,
+            "clean_workload_assertion": False,
+            "note": "Runtime evidence is additive and never a clean-workload claim.",
+        }
+    return finding
+
+
+def test_json_sarif_html_carry_preattached_workload_runtime_evidence() -> None:
+    finding = _workload_finding(with_ioc_summary=True)
+    report = AIBOMReport(generated_at=datetime.now(timezone.utc), tool_version="0.0.0", findings=[finding])
+
+    payload = to_json(report)
+    exported = next(row for row in payload["findings"] if row["id"] == finding.id)
+    assert exported["workload_runtime_evidence"]["state"] == STATE_HAS_IOC
+    assert exported["workload_runtime_evidence"]["clean_workload_assertion"] is False
+
+    sarif = to_sarif(report)
+    props = next(
+        result["properties"]
+        for result in sarif["runs"][0]["results"]
+        if result["properties"].get("workload_runtime_evidence")
+    )
+    assert props["workload_runtime_evidence"]["state"] == STATE_HAS_IOC
+    assert props["workload_runtime_evidence"]["clean_workload_assertion"] is False
+
+    html = to_html(report)
+    assert 'class="workload-runtime-evidence"' in html
+    assert "Runtime IOC" in html
+    assert "clean-workload assertion" in html
+
+
+def test_export_enrichment_from_store_marks_no_signal_honestly(monkeypatch) -> None:
+    store = InMemoryRuntimeWorkloadEvidenceStore()
+    set_runtime_workload_evidence_store(store)
+    monkeypatch.setenv("AGENT_BOM_TENANT_ID", "tenant-export")
+    try:
+        registry = RuntimeSourceRegistry()
+        registry.add(
+            RuntimeEvidenceSource.register(
+                source_id="edr-1",
+                tenant_id="tenant-export",
+                provider="aws",
+                account_id="123456789012",
+                kind="edr",
+                secret="s3cr3t-token-value-1234",
+            )
+        )
+        now = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        ingest_runtime_signals(
+            registry=registry,
+            source_id="edr-1",
+            secret="s3cr3t-token-value-1234",
+            raw_signals=[
+                {
+                    "workload_ref": "i-other",
+                    "dedup_key": "evt-1",
+                    "signal_type": "ioc_detection",
+                    "severity": "high",
+                    "observed_at": now,
+                    "title": "other workload",
+                }
+            ],
+            store=store,
+        )
+
+        finding = _workload_finding()
+        report = AIBOMReport(generated_at=datetime.now(timezone.utc), tool_version="0.0.0", findings=[finding])
+        payload = to_json(report)
+        exported = next(row for row in payload["findings"] if row["id"] == finding.id)
+        assert exported["workload_runtime_evidence"]["state"] == STATE_NO_SIGNAL
+        assert exported["workload_runtime_evidence"]["clean_workload_assertion"] is False
+
+        html = to_html(report)
+        assert "No runtime signal" in html
+    finally:
+        set_runtime_workload_evidence_store(None)
+
+
+def test_attach_model_uses_asset_identity() -> None:
+    finding = _workload_finding()
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", [])
+    # Empty index must not annotate (callers use optional_* which returns None).
+    assert attach_workload_runtime_evidence_to_finding_model(finding, index) is False
+
+    summary = no_runtime_signal_summary()
+    # Non-empty index with no matching signals still annotates no_runtime_signal.
+    index._by_workload["aws\x1f123456789012\x1fi-other"] = []  # type: ignore[attr-defined]
+    # Force non-empty via a real signal-shaped key presence:
+    index._by_workload["aws\x1f123456789012\x1fi-other"] = []  # noqa: SLF001
+    # RuntimeWorkloadEvidenceIndex.is_empty checks the map; empty lists still count.
+    assert index.is_empty() is False
+    assert attach_workload_runtime_evidence_to_finding_model(finding, index) is True
+    assert finding.workload_runtime_evidence == summary

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -188,6 +188,7 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
       framework_tags?: string[];
       phantom_tools?: string[];
       runtime_evidence?: EnrichedVuln["runtime_evidence"];
+      workload_runtime_evidence?: EnrichedVuln["workload_runtime_evidence"];
       effective_reach_band?: string;
       effective_reach_score?: number;
       attack_vector_summary?: string;
@@ -228,6 +229,7 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
       effective_reach_band: raw.effective_reach_band,
       effective_reach_score: raw.effective_reach_score,
       runtime_evidence: raw.runtime_evidence,
+      workload_runtime_evidence: raw.workload_runtime_evidence ?? finding.workload_runtime_evidence,
       remediation_items: finding.remediation_guidance
         ? [
             {
@@ -571,6 +573,8 @@ function FindingsPage() {
                 existing.effective_reach_band = existing.effective_reach_band ?? blast?.effective_reach_band;
                 existing.effective_reach_score = existing.effective_reach_score ?? blast?.effective_reach_score;
                 existing.runtime_evidence = existing.runtime_evidence ?? blast?.runtime_evidence;
+                existing.workload_runtime_evidence =
+                  existing.workload_runtime_evidence ?? blast?.workload_runtime_evidence;
                 existing.references = uniqueStrings([...existing.references, ...(vuln.references ?? []), ...remediationItems.flatMap((item) => item.references)]);
                 existing.advisory_sources = uniqueStrings([...existing.advisory_sources, ...(vuln.advisory_sources ?? [])]);
                 existing.aliases = uniqueStrings([...(existing.aliases ?? []), ...(vuln.aliases ?? [])]);
@@ -593,6 +597,7 @@ function FindingsPage() {
                   effective_reach_band: blast?.effective_reach_band,
                   effective_reach_score: blast?.effective_reach_score,
                   runtime_evidence: blast?.runtime_evidence,
+                  workload_runtime_evidence: blast?.workload_runtime_evidence,
                   references: uniqueStrings([...(vuln.references ?? []), ...remediationItems.flatMap((item) => item.references)]),
                   advisory_sources: vuln.advisory_sources ?? [],
                   aliases: vuln.aliases ?? [],

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -464,7 +464,60 @@ function EvidenceTab({ vuln }: { vuln: EnrichedVuln }) {
           </div>
         </Panel>
       ) : null}
+
+      <WorkloadRuntimeEvidencePanel evidence={vuln.workload_runtime_evidence} />
     </div>
+  );
+}
+
+function WorkloadRuntimeEvidencePanel({
+  evidence,
+}: {
+  evidence: EnrichedVuln["workload_runtime_evidence"];
+}) {
+  if (!evidence?.state) return null;
+  const state = evidence.state;
+  const label =
+    state === "runtime_ioc_observed"
+      ? "IOC observed"
+      : state === "runtime_alert_observed"
+        ? "Alert observed"
+        : state === "runtime_activity_observed"
+          ? "Activity observed"
+          : state === "no_runtime_signal"
+            ? "No runtime signal"
+            : state.replaceAll("_", " ");
+  const tone =
+    state === "runtime_ioc_observed"
+      ? "border-rose-500/30 dark:border-rose-800/60 bg-rose-500/10 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300"
+      : state === "runtime_alert_observed"
+        ? "border-amber-500/30 dark:border-amber-800/60 bg-amber-500/10 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300"
+        : state === "runtime_activity_observed"
+          ? "border-sky-500/30 dark:border-sky-800/60 bg-sky-500/10 dark:bg-sky-950/40 text-sky-700 dark:text-sky-300"
+          : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)]";
+  const sourceKinds = Array.isArray(evidence.source_kinds) ? evidence.source_kinds.filter(Boolean) : [];
+  return (
+    <Panel title="Workload runtime evidence">
+      <div className="space-y-3 text-sm text-[color:var(--text-secondary)]">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`rounded border px-2 py-0.5 text-xs font-medium uppercase tracking-wide ${tone}`}>
+            {label}
+          </span>
+          {typeof evidence.signal_count === "number" ? (
+            <span className="text-xs text-[color:var(--text-tertiary)]">{evidence.signal_count} signal{evidence.signal_count === 1 ? "" : "s"}</span>
+          ) : null}
+        </div>
+        {evidence.latest_observed_at ? (
+          <KeyVal label="Latest observed" value={formatFindingTimestamp(evidence.latest_observed_at)} />
+        ) : null}
+        {sourceKinds.length > 0 ? <TagList label="Sources" values={sourceKinds} /> : null}
+        <p className="text-xs leading-5 text-[color:var(--text-tertiary)]">
+          Additive CWPP/EDR metadata only — absence of a signal is not a clean-workload assertion
+          {evidence.clean_workload_assertion === false ? " (clean_workload_assertion: false)" : ""}.
+          Distinct from proxy/gateway runtime evidence on the Overview reach badges.
+        </p>
+      </div>
+    </Panel>
   );
 }
 

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1006,6 +1006,8 @@ export interface UnifiedFinding {
   resolved_at?: string | null | undefined;
   reopened_at?: string | null | undefined;
   scan_count?: number | undefined;
+  /** CWPP runtime/EDR workload evidence (additive; never a clean-workload claim). */
+  workload_runtime_evidence?: WorkloadRuntimeEvidence | undefined;
 }
 
 /**
@@ -1043,6 +1045,24 @@ export interface ReadWindow {
 }
 
 export type FindingsResponse = FindingListEnvelope<UnifiedFinding>;
+
+/** CWPP runtime/EDR evidence fused onto a workload-scoped finding. */
+export interface WorkloadRuntimeEvidence {
+  schema_version?: string;
+  state?:
+    | "runtime_ioc_observed"
+    | "runtime_alert_observed"
+    | "runtime_activity_observed"
+    | "no_runtime_signal"
+    | string;
+  signal_count?: number;
+  signal_types?: Record<string, number>;
+  severity_counts?: Record<string, number>;
+  source_kinds?: string[];
+  latest_observed_at?: string;
+  clean_workload_assertion?: boolean;
+  note?: string;
+}
 
 export interface BlastRadius {
   vulnerability_id: string;
@@ -1089,6 +1109,8 @@ export interface BlastRadius {
     blocked_count?: number;
     observed_count?: number;
   } | undefined;
+  /** CWPP runtime/EDR workload evidence (distinct from proxy/gateway runtime_evidence). */
+  workload_runtime_evidence?: WorkloadRuntimeEvidence | undefined;
   /** Graph-walk reachability (populated by the unified-graph dependency
    *  reach engine). `true` when an agent's USES/DEPENDS_ON closure
    *  reaches the vulnerable package; `false` when the package is in

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -1,4 +1,5 @@
 import type { Vulnerability } from "@/lib/api";
+import type { WorkloadRuntimeEvidence } from "@/lib/api-types";
 
 export interface EnrichedVuln extends Vulnerability {
   /**
@@ -38,6 +39,8 @@ export interface EnrichedVuln extends Vulnerability {
     blocked_count?: number;
     observed_count?: number;
   } | undefined;
+  /** CWPP runtime/EDR evidence — separate from proxy/gateway runtime_evidence. */
+  workload_runtime_evidence?: WorkloadRuntimeEvidence | undefined;
   lifecycle_status?: string | undefined;
   first_seen?: string | undefined;
   last_seen?: string | undefined;

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -287,4 +287,36 @@ describe("FindingsPage", () => {
     expect(await screen.findByText("Page 2 · total unavailable")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
   });
+
+  it("shows workload runtime evidence on the Evidence tab without conflating proxy runtime", async () => {
+    apiMock.listFindings.mockResolvedValue({
+      total: 1,
+      findings: [
+        {
+          id: "uuid-runtime-1",
+          severity: "high",
+          cve_id: "CVE-2026-9999",
+          title: "Workload disk finding",
+          asset: { name: "i-0abc", asset_type: "cloud_resource" },
+          workload_runtime_evidence: {
+            state: "runtime_ioc_observed",
+            signal_count: 2,
+            source_kinds: ["edr"],
+            latest_observed_at: "2026-07-21T12:00:00Z",
+            clean_workload_assertion: false,
+          },
+        },
+      ],
+    });
+
+    render(<FindingsPage />);
+    expect(await screen.findByText("CVE-2026-9999")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open details for CVE-2026-9999" }));
+    const drawer = await screen.findByRole("dialog", { name: "Finding details for CVE-2026-9999" });
+    fireEvent.click(within(drawer).getByRole("button", { name: "Evidence" }));
+    expect(within(drawer).getByText("Workload runtime evidence")).toBeInTheDocument();
+    expect(within(drawer).getByText("IOC observed")).toBeInTheDocument();
+    expect(within(drawer).getByText(/not a clean-workload assertion/i)).toBeInTheDocument();
+    expect(within(drawer).getByText(/Distinct from proxy\/gateway runtime evidence/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- **C:** `workload_runtime_evidence` on Finding JSON, SARIF properties, HTML badges.
- **D:** Findings Evidence drawer Workload runtime evidence panel (folded from closed #4372).
- Tenant-store enrich when non-empty; absence = `no_runtime_signal` / `clean_workload_assertion: false`.
- Docs Wired today covers ingest + graph + exports + UI panel.

## Verification
- Export/wiring pytest from C path
- UI panel files + findings page tests from former #4372

## Notes
- Consolidated stage-4 C+D to keep the open-PR queue at three: this PR, #4376 (skills), #4373 (readme).
- Additive only. Part of #4158.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

