### PR TITLE
feat(ui): workload runtime evidence panel in finding drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
+- CWPP stage-4 (D): findings Evidence drawer shows a Workload runtime evidence
+  panel for CWPP/EDR summaries (additive; not a clean-workload assertion)
+  (#4158).
 - Findings carry optional graph FKs (`node_id`, `finding_node_id`, `entity_type`)
   and attack paths expose `finding_ids` so investigation joins typed estate nodes
   instead of CVE-label-only anchors; `asset_type` aliases map to `EntityType`

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -574,11 +574,13 @@ graph edge, so reachability stays edge-derived and is never fabricated.
 Wired today: findings surfaced by `GET /v1/findings` (and the overview /
 compliance / observability reads that share the enricher) gain a
 `workload_runtime_evidence` field on workload-scoped rows once a tenant has
-signals; the JSON API export carries it automatically. A graph-join helper
-annotates CWPP workload nodes for a matching tenant. Not yet locked in (stage 4):
-a dedicated ingest REST endpoint, CLI/MCP ingest surface, a scheduler that pulls
-from sources, typed SARIF/report export fields, the live graph/campaign route
-invocation, and any UI panel. No credentialed live source smoke is claimed.
+signals; the JSON API export carries it automatically. The findings Evidence
+drawer shows a dedicated Workload runtime evidence panel (separate from
+proxy/gateway reach badges). A graph-join helper annotates CWPP workload nodes
+for a matching tenant. Not yet locked in (stage 4 remainder): CLI/MCP ingest
+surfaces, typed SARIF/report export fields, a scheduler that pulls from sources,
+and Azure/GCP side-scan CLI wiring that stays honest until credentialed smoke.
+No credentialed live source smoke is claimed.
 
 ---
 

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -188,6 +188,7 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
       framework_tags?: string[];
       phantom_tools?: string[];
       runtime_evidence?: EnrichedVuln["runtime_evidence"];
+      workload_runtime_evidence?: EnrichedVuln["workload_runtime_evidence"];
       effective_reach_band?: string;
       effective_reach_score?: number;
       attack_vector_summary?: string;
@@ -228,6 +229,7 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
       effective_reach_band: raw.effective_reach_band,
       effective_reach_score: raw.effective_reach_score,
       runtime_evidence: raw.runtime_evidence,
+      workload_runtime_evidence: raw.workload_runtime_evidence ?? finding.workload_runtime_evidence,
       remediation_items: finding.remediation_guidance
         ? [
             {
@@ -571,6 +573,8 @@ function FindingsPage() {
                 existing.effective_reach_band = existing.effective_reach_band ?? blast?.effective_reach_band;
                 existing.effective_reach_score = existing.effective_reach_score ?? blast?.effective_reach_score;
                 existing.runtime_evidence = existing.runtime_evidence ?? blast?.runtime_evidence;
+                existing.workload_runtime_evidence =
+                  existing.workload_runtime_evidence ?? blast?.workload_runtime_evidence;
                 existing.references = uniqueStrings([...existing.references, ...(vuln.references ?? []), ...remediationItems.flatMap((item) => item.references)]);
                 existing.advisory_sources = uniqueStrings([...existing.advisory_sources, ...(vuln.advisory_sources ?? [])]);
                 existing.aliases = uniqueStrings([...(existing.aliases ?? []), ...(vuln.aliases ?? [])]);
@@ -593,6 +597,7 @@ function FindingsPage() {
                   effective_reach_band: blast?.effective_reach_band,
                   effective_reach_score: blast?.effective_reach_score,
                   runtime_evidence: blast?.runtime_evidence,
+                  workload_runtime_evidence: blast?.workload_runtime_evidence,
                   references: uniqueStrings([...(vuln.references ?? []), ...remediationItems.flatMap((item) => item.references)]),
                   advisory_sources: vuln.advisory_sources ?? [],
                   aliases: vuln.aliases ?? [],

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -464,7 +464,60 @@ function EvidenceTab({ vuln }: { vuln: EnrichedVuln }) {
           </div>
         </Panel>
       ) : null}
+
+      <WorkloadRuntimeEvidencePanel evidence={vuln.workload_runtime_evidence} />
     </div>
+  );
+}
+
+function WorkloadRuntimeEvidencePanel({
+  evidence,
+}: {
+  evidence: EnrichedVuln["workload_runtime_evidence"];
+}) {
+  if (!evidence?.state) return null;
+  const state = evidence.state;
+  const label =
+    state === "runtime_ioc_observed"
+      ? "IOC observed"
+      : state === "runtime_alert_observed"
+        ? "Alert observed"
+        : state === "runtime_activity_observed"
+          ? "Activity observed"
+          : state === "no_runtime_signal"
+            ? "No runtime signal"
+            : state.replaceAll("_", " ");
+  const tone =
+    state === "runtime_ioc_observed"
+      ? "border-rose-500/30 dark:border-rose-800/60 bg-rose-500/10 dark:bg-rose-950/40 text-rose-700 dark:text-rose-300"
+      : state === "runtime_alert_observed"
+        ? "border-amber-500/30 dark:border-amber-800/60 bg-amber-500/10 dark:bg-amber-950/40 text-amber-700 dark:text-amber-300"
+        : state === "runtime_activity_observed"
+          ? "border-sky-500/30 dark:border-sky-800/60 bg-sky-500/10 dark:bg-sky-950/40 text-sky-700 dark:text-sky-300"
+          : "border-[color:var(--border-subtle)] bg-[color:var(--surface)] text-[color:var(--text-secondary)]";
+  const sourceKinds = Array.isArray(evidence.source_kinds) ? evidence.source_kinds.filter(Boolean) : [];
+  return (
+    <Panel title="Workload runtime evidence">
+      <div className="space-y-3 text-sm text-[color:var(--text-secondary)]">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className={`rounded border px-2 py-0.5 text-xs font-medium uppercase tracking-wide ${tone}`}>
+            {label}
+          </span>
+          {typeof evidence.signal_count === "number" ? (
+            <span className="text-xs text-[color:var(--text-tertiary)]">{evidence.signal_count} signal{evidence.signal_count === 1 ? "" : "s"}</span>
+          ) : null}
+        </div>
+        {evidence.latest_observed_at ? (
+          <KeyVal label="Latest observed" value={formatFindingTimestamp(evidence.latest_observed_at)} />
+        ) : null}
+        {sourceKinds.length > 0 ? <TagList label="Sources" values={sourceKinds} /> : null}
+        <p className="text-xs leading-5 text-[color:var(--text-tertiary)]">
+          Additive CWPP/EDR metadata only — absence of a signal is not a clean-workload assertion
+          {evidence.clean_workload_assertion === false ? " (clean_workload_assertion: false)" : ""}.
+          Distinct from proxy/gateway runtime evidence on the Overview reach badges.
+        </p>
+      </div>
+    </Panel>
   );
 }
 

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1006,6 +1006,8 @@ export interface UnifiedFinding {
   resolved_at?: string | null | undefined;
   reopened_at?: string | null | undefined;
   scan_count?: number | undefined;
+  /** CWPP runtime/EDR workload evidence (additive; never a clean-workload claim). */
+  workload_runtime_evidence?: WorkloadRuntimeEvidence | undefined;
 }
 
 /**
@@ -1043,6 +1045,24 @@ export interface ReadWindow {
 }
 
 export type FindingsResponse = FindingListEnvelope<UnifiedFinding>;
+
+/** CWPP runtime/EDR evidence fused onto a workload-scoped finding. */
+export interface WorkloadRuntimeEvidence {
+  schema_version?: string;
+  state?:
+    | "runtime_ioc_observed"
+    | "runtime_alert_observed"
+    | "runtime_activity_observed"
+    | "no_runtime_signal"
+    | string;
+  signal_count?: number;
+  signal_types?: Record<string, number>;
+  severity_counts?: Record<string, number>;
+  source_kinds?: string[];
+  latest_observed_at?: string;
+  clean_workload_assertion?: boolean;
+  note?: string;
+}
 
 export interface BlastRadius {
   vulnerability_id: string;
@@ -1089,6 +1109,8 @@ export interface BlastRadius {
     blocked_count?: number;
     observed_count?: number;
   } | undefined;
+  /** CWPP runtime/EDR workload evidence (distinct from proxy/gateway runtime_evidence). */
+  workload_runtime_evidence?: WorkloadRuntimeEvidence | undefined;
   /** Graph-walk reachability (populated by the unified-graph dependency
    *  reach engine). `true` when an agent's USES/DEPENDS_ON closure
    *  reaches the vulnerable package; `false` when the package is in

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -1,4 +1,5 @@
 import type { Vulnerability } from "@/lib/api";
+import type { WorkloadRuntimeEvidence } from "@/lib/api-types";
 
 export interface EnrichedVuln extends Vulnerability {
   /**
@@ -38,6 +39,8 @@ export interface EnrichedVuln extends Vulnerability {
     blocked_count?: number;
     observed_count?: number;
   } | undefined;
+  /** CWPP runtime/EDR evidence — separate from proxy/gateway runtime_evidence. */
+  workload_runtime_evidence?: WorkloadRuntimeEvidence | undefined;
   lifecycle_status?: string | undefined;
   first_seen?: string | undefined;
   last_seen?: string | undefined;

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -287,4 +287,36 @@ describe("FindingsPage", () => {
     expect(await screen.findByText("Page 2 · total unavailable")).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Next/i })).toBeDisabled();
   });
+
+  it("shows workload runtime evidence on the Evidence tab without conflating proxy runtime", async () => {
+    apiMock.listFindings.mockResolvedValue({
+      total: 1,
+      findings: [
+        {
+          id: "uuid-runtime-1",
+          severity: "high",
+          cve_id: "CVE-2026-9999",
+          title: "Workload disk finding",
+          asset: { name: "i-0abc", asset_type: "cloud_resource" },
+          workload_runtime_evidence: {
+            state: "runtime_ioc_observed",
+            signal_count: 2,
+            source_kinds: ["edr"],
+            latest_observed_at: "2026-07-21T12:00:00Z",
+            clean_workload_assertion: false,
+          },
+        },
+      ],
+    });
+
+    render(<FindingsPage />);
+    expect(await screen.findByText("CVE-2026-9999")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Open details for CVE-2026-9999" }));
+    const drawer = await screen.findByRole("dialog", { name: "Finding details for CVE-2026-9999" });
+    fireEvent.click(within(drawer).getByRole("button", { name: "Evidence" }));
+    expect(within(drawer).getByText("Workload runtime evidence")).toBeInTheDocument();
+    expect(within(drawer).getByText("IOC observed")).toBeInTheDocument();
+    expect(within(drawer).getByText(/not a clean-workload assertion/i)).toBeInTheDocument();
+    expect(within(drawer).getByText(/Distinct from proxy\/gateway runtime evidence/i)).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a Workload runtime evidence panel on the findings Evidence drawer for CWPP/EDR summaries (#4158 stage 4 D).
- Pass `workload_runtime_evidence` through UnifiedFinding → EnrichedVuln mapping; keep it separate from proxy/gateway `runtime_evidence` reach badges.
- Honesty copy: additive metadata only; absence is not a clean-workload assertion.

## Verification
- `cd ui && npm test -- --run tests/findings-page.test.tsx`

## Notes
- Part of #4158. Complements #4369 / #4370 / #4371.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

