### PR TITLE
docs(readme): lead with blast radius and personas, not busy UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
 <p align="center">
+  Scan locally → send evidence to a control plane you run → enforce runtime MCP/tool calls.
+  One Finding + UnifiedGraph model across CLI, API, UI, and MCP.
+</p>
+<p align="center">
   <a href="https://demo.agent-bom.com"><b>Live demo</b></a> ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
   <a href="docs/FIRST_RUN.md">First Run</a> ·
@@ -38,9 +42,14 @@ Inventory, findings, reachability, and fix-first actions — no control plane
 required. Export when another tool needs it:
 `agent-bom scan . -f sarif -o findings.sarif`.
 
-<p align="center">
-  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Prioritized attack path connecting identity, agent, MCP server, package, and critical finding" width="900" />
-</p>
+Offline sample without your repo: `uvx agent-bom scan --demo --offline` ·
+full path: [First Run](docs/FIRST_RUN.md).
+
+## Blast radius
+
+One finding fans out to the MCP servers that load it, reachable tools,
+credential references, and agents that can reach it — not a CVE list in
+isolation.
 
 <p align="center">
   <picture>
@@ -49,12 +58,27 @@ required. Export when another tool needs it:
   </picture>
 </p>
 
-One finding links to the MCP servers that load it, reachable tools, credential
-references, and agents that can reach it. Offline sample without your repo:
-`uvx agent-bom scan --demo --offline` · full first-run path:
-[First Run](docs/FIRST_RUN.md).
+## Who it is for
 
-## Three product lanes
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom personas: AppSec/GRC, Platform/SRE, Developers, and AI/MCP owners with matching outcomes" width="900" />
+  </picture>
+</p>
+
+| Team | Start here | Outcome |
+|---|---|---|
+| Developers / AI builders | `agent-bom scan .` | Inventory, findings, blast radius before changes ship |
+| AppSec / security eng | `agent-bom scan . -f sarif -o findings.sarif` | Reachability triage, graph paths, CI gates |
+| Platform / SRE / cloud | `agent-bom serve` or Helm | Customer-controlled API/UI, fleet evidence, runtime policy |
+| GRC / audit | Compliance exports + control-plane evidence | Framework mappings, signed bundles, review context |
+| AI / MCP owners | `agent-bom mcp server` or `gateway serve` | Tool inventory and allow/warn/block decisions |
+
+Evidence helper, not a GRC system of record, IAM, SIEM, or certification program.
+Boundaries: [PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIES.md).
+
+## How the tool works
 
 1. **Scan** — `agent-bom scan .` → inventory, findings, SARIF/SBOM/HTML, local graph
 2. **Control plane** — `pip install 'agent-bom[ui]' && agent-bom serve` → tenant UI/API, attack paths, compliance, audit (self-host with Docker or Helm + Postgres)
@@ -67,28 +91,54 @@ boundary.
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom three product lanes: local scan, self-hosted control plane, and runtime gateway on one Finding + UnifiedGraph model" width="1100" />
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom three tool lanes: local scan, self-hosted control plane, and runtime gateway on one Finding + UnifiedGraph model" width="1100" />
   </picture>
 </p>
 
-## See the product
+## Graph lenses
 
-[Live demo](https://demo.agent-bom.com) is a read-only sandbox with synthetic
-showcase evidence. Prefer the local offline sample above when you want a
-reproducible CLI walkthrough. Captures below are from shipped Next.js routes.
+Shipped graph surfaces for lineage, agent mesh, and filtered attack-path
+drilldowns — not a dense dashboard collage.
 
-| Findings and reach | Remediation |
+| Lineage (filtered path) | Agent mesh |
 |:---:|:---:|
-| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with severity, reachable agents, fixes, and review actions" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Prioritized remediation with risk reduction, ownership, and verification" width="430" /> |
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/lineage-graph-live.png" alt="Filtered attack-path lineage across agent, MCP, package, and finding nodes" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/mesh-live.png" alt="Focused agent mesh across agent, MCP server, package, and finding" width="430" /> |
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/context-map-live.png" alt="Agent-scoped context map with reachable MCP servers and lateral movement" width="820" />
+</p>
 
 <details>
-<summary><b>More views</b> — posture, runtime, connections, new scan</summary>
+<summary><b>Investigation capture</b> — prioritized path with export/handoff chrome</summary>
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Prioritized attack path connecting identity, agent, MCP server, package, and critical finding" width="820" />
+</p>
+
+Path titles can wrap in narrow frames; use Path / Graph / List toggles in the
+live UI for a single-row hop strip. Recapture notes:
+[docs/CAPTURE.md](docs/CAPTURE.md).
+
+</details>
+
+<details>
+<summary><b>Dashboard captures</b> — findings queue, remediation, posture, runtime, connections</summary>
+
+| Findings queue | Remediation |
+|:---:|:---:|
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with severity, reachable agents, fixes, and review actions" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Prioritized remediation with risk reduction, ownership, and verification" width="430" /> |
 
 | Risk overview | Runtime gateway |
 |:---:|:---:|
 | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview with posture grade, findings, and operations" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and tool-call feed" width="430" /> |
-| **Connections** | **New scan** |
+
+| Connections | New scan |
+|:---:|:---:|
 | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/cloud-accounts-live.png" alt="Connections hub across cloud, code, AI, and data sources" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/new-scan-live.png" alt="New Scan workspace with collector plan and read-only boundary" width="430" /> |
+
+[Live demo](https://demo.agent-bom.com) is a read-only sandbox with synthetic
+showcase evidence. Prefer the local offline sample above for a reproducible CLI
+walkthrough.
 
 </details>
 
@@ -146,23 +196,6 @@ Guides: [Deploy anywhere](docs/DEPLOY_PLATFORM.md) ·
 Also: `agent-bom graph`, `agent-bom remediate -p .`, CI pin
 `uses: msaad00/agent-bom@v0.97.2`. Maps: [CLI](docs/CLI_MAP.md) ·
 [start here](docs/START_HERE.md) · [product map](docs/PRODUCT_MAP.md).
-
-</details>
-
-<details>
-<summary><b>Who it is for</b></summary>
-
-| Team | Start here | Outcome |
-|---|---|---|
-| Developers / AI builders | `agent-bom scan .` | Inventory, findings, blast radius before changes ship |
-| AppSec / security eng | `agent-bom scan . -f sarif -o findings.sarif` | Reachability triage, graph paths, CI gates |
-| Platform / SRE / cloud | `agent-bom serve` or Helm | Customer-controlled API/UI, fleet evidence, runtime policy |
-| GRC / audit | Compliance exports + control-plane evidence | Framework mappings, signed bundles, review context |
-| AI / MCP owners | `agent-bom mcp server` or `gateway serve` | Tool inventory and allow/warn/block decisions |
-
-Evidence helper, not a GRC system of record, IAM, SIEM, or certification program.
-Coverage: [AI infrastructure scanning](docs/AI_INFRASTRUCTURE_SCANNING.md) ·
-[product boundaries](docs/PRODUCT_BOUNDARIES.md).
 
 </details>
 

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -8,6 +8,7 @@ import {
   Bug,
   CheckCircle2,
   ChevronDown,
+  ChevronRight,
   Database,
   GitBranch,
   KeyRound,
@@ -18,8 +19,15 @@ import {
   ShieldAlert,
   Wrench,
 } from "lucide-react";
-import { pathDisplayTitle, pathFixLabel, type ExposureEntityRole, type ExposurePath } from "@/lib/exposure-path";
+import {
+  pathDisplayTitle,
+  pathFixLabel,
+  type ExposureEntityRef,
+  type ExposureEntityRole,
+  type ExposurePath,
+} from "@/lib/exposure-path";
 import { GRAPH_ROLE_STYLE } from "@/lib/exposure-path-graph-style";
+import { formatExposureEntityTitle } from "@/lib/entity-display";
 import {
   buildPathGraphLayout,
   wrapGraphText,
@@ -164,9 +172,8 @@ export function ExposurePathCommandCenter({
                 </span>
               ) : null}
             </div>
-            <h2 className="text-xl font-semibold leading-8 text-[color:var(--foreground)] [overflow-wrap:anywhere]">
-              {pathDisplayTitle(path)}
-            </h2>
+            <h2 className="sr-only">{pathDisplayTitle(path)}</h2>
+            <ExposurePathHopTitle hops={path.hops.length > 0 ? path.hops : [path.source, path.target]} />
             <p
               title={pathSummary}
               className="line-clamp-3 max-w-3xl text-sm leading-6 text-[color:var(--text-secondary)] sm:line-clamp-2"
@@ -395,6 +402,34 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
           );
         })}
       </svg>
+    </div>
+  );
+}
+
+function ExposurePathHopTitle({ hops }: { hops: ExposureEntityRef[] }) {
+  /** Wrap between hops (chip + chevron), never mid-arrow in a long string. */
+  return (
+    <div
+      className="flex flex-wrap items-center gap-x-1.5 gap-y-2"
+      aria-hidden="true"
+      data-testid="exposure-path-hop-title"
+    >
+      {hops.map((hop, index) => {
+        const meta = ROLE_META[hop.role] ?? ROLE_META.unknown;
+        return (
+          <div key={`${hop.id}-${index}`} className="flex items-center gap-1.5">
+            {index > 0 ? (
+              <ChevronRight className="h-4 w-4 shrink-0 text-[color:var(--text-tertiary)]" aria-hidden="true" />
+            ) : null}
+            <span
+              title={hop.label}
+              className={`max-w-[14rem] truncate rounded-lg border px-2.5 py-1 text-sm font-semibold text-[color:var(--foreground)] ${meta.tint}`}
+            >
+              {formatExposureEntityTitle(hop.label, hop.role)}
+            </span>
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/ui/tests/exposure-path-command-center.test.tsx
+++ b/ui/tests/exposure-path-command-center.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { ExposurePathCommandCenter } from "@/components/exposure-path-command-center";
@@ -74,9 +74,12 @@ describe("ExposurePathCommandCenter", () => {
       />,
     );
 
-    expect(
-      screen.getByText("Analyst Agent → Database service → werkzeug → CVE-2026-0002 → Execute Sql → DATABASE URL"),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent(
+      "Analyst Agent → Database service → werkzeug → CVE-2026-0002 → Execute Sql → DATABASE URL",
+    );
+    expect(screen.getByTestId("exposure-path-hop-title")).toBeInTheDocument();
+    expect(screen.getByText("Analyst Agent")).toBeInTheDocument();
+    expect(within(screen.getByTestId("exposure-path-hop-title")).getByText("CVE-2026-0002")).toBeInTheDocument();
     expect(screen.queryByText("What is exposed")).not.toBeInTheDocument();
     expect(screen.getByText("Evidence & relationships")).toBeInTheDocument();
     expect(screen.queryByText("Evidence drawer")).not.toBeVisible();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- README lead: badges → tool blurb → blast-radius visual → personas; collapse busy dashboard chrome.
- Product framing tightened to the tool; exposure-path titles wrap as hop chips.

## Verification
- UI exposure-path tests (branch history)
- Rebased onto `main` after #4371 for a clean CI retrigger

## Notes
- Queue hygiene: #4377 folded into #4376; this remains the docs/UI README lane.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

