### PR TITLE
feat(cwpp): honest Azure/GCP side-scan CLI surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
+- CWPP stage-4 (E): `agent-bom cloud side-scan --provider` refuses Azure/GCP
+  CLI execution (exit 2); `side-scan-capabilities` prints the honest
+  discovery/contract surface (#4158).
 - Findings carry optional graph FKs (`node_id`, `finding_node_id`, `entity_type`)
   and attack paths expose `finding_ids` so investigation joins typed estate nodes
   instead of CVE-label-only anchors; `asset_type` aliases map to `EntityType`

--- a/docs/CLI_MAP.md
+++ b/docs/CLI_MAP.md
@@ -37,7 +37,7 @@ Inventory, package, image, IaC, cloud, and skills scanning entry points.
 | `iac` | Scan IaC: Dockerfile, Terraform, CloudFormation, Helm, Kubernetes. |
 | `sbom` | Ingest an existing SBOM (CycloneDX / SPDX) and scan its components. |
 | `ingest` | Ingest operator-provided evidence (e.g. `ingest hardware` firmware attestation) into the graph. |
-| `cloud` | Cloud posture + estate inventory for AWS/Azure/GCP, CIS benchmarks, and cloud registry sweeps. Group: `scan` (all configured clouds), `aws`/`azure`/`gcp` aliases, `inventory`, `registry-scan` (ECR/ACR/GAR sweep), `resilience`, and AWS EBS `side-scan`. |
+| `cloud` | Cloud posture + estate inventory for AWS/Azure/GCP, CIS benchmarks, and cloud registry sweeps. Group: `scan` (all configured clouds), `aws`/`azure`/`gcp` aliases, `inventory`, `registry-scan` (ECR/ACR/GAR sweep), `resilience`, AWS EBS `side-scan`, and `side-scan-capabilities` (honest Azure/GCP contract_only surface). |
 | `check` | Pre-install check for one package: allow / warn / block. |
 | `verify` | Package integrity + SLSA provenance verification. |
 | `secrets` | Secret detection. |
@@ -154,7 +154,7 @@ the source is:
 
 | Source | Command home | Why |
 |---|---|---|
-| AWS / Azure / GCP | `agent-bom cloud ...` | provider APIs expose estate inventory, IAM, network posture, CIS checks, and registry sweeps; the side-scan CLI is AWS-only, while Azure/GCP currently expose injected-SDK lifecycle adapters |
+| AWS / Azure / GCP | `agent-bom cloud ...` | provider APIs expose estate inventory, IAM, network posture, CIS checks, and registry sweeps; the side-scan CLI executor is AWS-only (`side-scan --provider azure|gcp` refuses), while `side-scan-capabilities` and inventory `side_scan_targets` stay discovery/contract-only for Azure/GCP |
 | Snowflake | `agent-bom agents --snowflake` plus `connect snowflake` | Snowflake is a warehouse/governance source: Cortex, grants, query/activity evidence, lineage, and CIS/posture metadata |
 
 Both paths normalize into the same `Finding` and `ContextGraph` model; the

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -575,10 +575,13 @@ Wired today: findings surfaced by `GET /v1/findings` (and the overview /
 compliance / observability reads that share the enricher) gain a
 `workload_runtime_evidence` field on workload-scoped rows once a tenant has
 signals; the JSON API export carries it automatically. A graph-join helper
-annotates CWPP workload nodes for a matching tenant. Not yet locked in (stage 4):
-a dedicated ingest REST endpoint, CLI/MCP ingest surface, a scheduler that pulls
-from sources, typed SARIF/report export fields, the live graph/campaign route
-invocation, and any UI panel. No credentialed live source smoke is claimed.
+annotates CWPP workload nodes for a matching tenant. CLI
+`agent-bom cloud side-scan-capabilities` prints the honest provider surface;
+`agent-bom cloud side-scan --provider azure|gcp` refuses execution (exit 2)
+without instantiating adapters. Not yet locked in (stage 4 remainder):
+CLI/MCP runtime-evidence ingest, typed SARIF/report export fields, UI panel,
+and a scheduler that pulls from sources. No credentialed live Azure/GCP
+executor smoke is claimed.
 
 ---
 

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -738,6 +738,13 @@ cloud_group.add_command(inventory_cmd, "inventory")
 
 
 @click.command("side-scan")
+@click.option(
+    "--provider",
+    type=click.Choice(["aws", "azure", "gcp"], case_sensitive=False),
+    default="aws",
+    show_default=True,
+    help="Cloud provider. Only AWS ships a CLI executor today; Azure/GCP stay contract_only.",
+)
 @click.option("--instance-id", default=None, help="EC2 instance whose attached EBS volumes to scan.")
 @click.option("--volume-id", default=None, help="A specific EBS volume to scan (takes precedence over --instance-id).")
 @click.option(
@@ -750,6 +757,7 @@ cloud_group.add_command(inventory_cmd, "inventory")
 @click.option("--no-secrets", is_flag=True, help="Skip the redacted secret scan (SBOM + CVEs only).")
 @click.option("--no-sweep-orphans", is_flag=True, help="Skip the pre-run sweep of snapshots stranded by an earlier crash.")
 def side_scan_cmd(
+    provider: str,
     instance_id: Optional[str],
     volume_id: Optional[str],
     collector_instance_id: Optional[str],
@@ -758,13 +766,19 @@ def side_scan_cmd(
     no_secrets: bool,
     no_sweep_orphans: bool,
 ) -> None:
-    """Agentless EBS disk side-scan — snapshot, mount read-only, SBOM + CVEs + redacted secrets.
+    """Agentless disk side-scan — snapshot, mount read-only, SBOM + CVEs + redacted secrets.
 
-    The single opt-in, non-read-only capability in agent-bom: it takes an EBS
-    snapshot, attaches a temp volume to an *in-account collector* instance, mounts
-    it read-only, parses the package SBOM + secret type/location (never values,
-    never file contents), and tears everything down in a guaranteed cleanup. No
-    disk image or block data ever leaves the account.
+    AWS EBS is the shipped CLI executor: it takes a snapshot, attaches a temp
+    volume to an *in-account collector* instance, mounts it read-only, parses the
+    package SBOM + secret type/location (never values, never file contents), and
+    tears everything down in a guaranteed cleanup. No disk image or block data
+    ever leaves the account.
+
+    Azure Managed Disk and GCP Persistent Disk expose target discovery and an
+    injected-SDK lifecycle adapter boundary only — ``--provider azure|gcp``
+    refuses execution (exit 2) until a credentialed smoke proves a CLI executor.
+    Use ``agent-bom cloud side-scan-capabilities`` and cloud inventory
+    ``side_scan_targets`` for the honest surface.
 
     Requires the scoped snapshot role (deploy/terraform/connect-aws-sidescan) and
     an in-account collector instance. Gated by ``AGENT_BOM_SIDESCAN`` — OFF by
@@ -775,6 +789,7 @@ def side_scan_cmd(
       AGENT_BOM_SIDESCAN=1 agent-bom cloud side-scan \\
         --volume-id vol-0abc --collector-instance-id i-0def \\
         --availability-zone us-east-1a --region us-east-1
+      agent-bom cloud side-scan-capabilities -f json
     """
     import asyncio
 
@@ -782,8 +797,25 @@ def side_scan_cmd(
 
     from agent_bom.cloud.base import CloudDiscoveryError
     from agent_bom.cloud.side_scan import run_side_scan
+    from agent_bom.cloud.side_scan_lifecycle import side_scan_provider_capabilities
 
     con = Console()
+    provider_key = provider.strip().lower()
+    capabilities = side_scan_provider_capabilities()
+    capability = capabilities.get(provider_key)
+    if capability is None or not capability.cli_available:
+        executor = capability.executor if capability is not None else "contract_only"
+        con.print(
+            f"\n  [yellow]side-scan executor unavailable for {provider_key}:[/yellow] "
+            f"executor={executor}, cli_available=false"
+        )
+        con.print(
+            "  [dim]Azure/GCP expose target discovery + lifecycle contract only — "
+            "no CLI executor is claimed. See `agent-bom cloud side-scan-capabilities` "
+            "and inventory `side_scan_targets`.[/dim]\n"
+        )
+        raise SystemExit(2)
+
     try:
         results: list[SideScanResult] = asyncio.run(
             run_side_scan(
@@ -804,6 +836,58 @@ def side_scan_cmd(
         raise SystemExit(1) from None
 
     _render_side_scan_results(con, results)
+
+
+@click.command("side-scan-capabilities")
+@click.option(
+    "-f",
+    "--format",
+    "output_format",
+    type=click.Choice(["table", "json"], case_sensitive=False),
+    default="table",
+    show_default=True,
+    help="Output format.",
+)
+def side_scan_capabilities_cmd(output_format: str) -> None:
+    """Print honest CWPP side-scan provider capabilities (no cloud mutations).
+
+    AWS is the shipped CLI executor. Azure/GCP advertise target discovery and a
+    lifecycle contract only until credentialed smoke proves otherwise.
+    """
+    import json
+
+    from rich.console import Console
+    from rich.table import Table
+
+    from agent_bom.cloud.side_scan_lifecycle import side_scan_provider_capabilities
+
+    capabilities = [cap.to_dict() for cap in side_scan_provider_capabilities().values()]
+    con = Console()
+    if output_format.lower() == "json":
+        con.print_json(json.dumps(capabilities, sort_keys=True))
+        return
+
+    table = Table(title="CWPP side-scan capabilities")
+    table.add_column("Provider")
+    table.add_column("Target discovery")
+    table.add_column("Lifecycle contract")
+    table.add_column("Executor")
+    table.add_column("CLI")
+    table.add_column("Credentialed smoke")
+    for row in capabilities:
+        table.add_row(
+            str(row.get("provider") or ""),
+            "yes" if row.get("target_discovery") else "no",
+            "yes" if row.get("lifecycle_contract") else "no",
+            str(row.get("executor") or ""),
+            "yes" if row.get("cli_available") else "no",
+            "yes" if row.get("credentialed_smoke") else "no",
+        )
+    con.print(table)
+    con.print(
+        "\n  [dim]Azure/GCP CLI execution is refused until a credentialed smoke "
+        "proves an executor. Inventory `side_scan_targets` remains discovery-only.[/dim]\n"
+    )
 
 
 def _render_side_scan_results(con: Console, results: list[SideScanResult]) -> None:
@@ -852,3 +936,4 @@ def _render_side_scan_results(con: Console, results: list[SideScanResult]) -> No
 
 
 cloud_group.add_command(side_scan_cmd, "side-scan")
+cloud_group.add_command(side_scan_capabilities_cmd, "side-scan-capabilities")

--- a/tests/test_cli_side_scan.py
+++ b/tests/test_cli_side_scan.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from click.testing import CliRunner
 
+import pytest
+
 import agent_bom.cli._cloud_group as cg
 from agent_bom.cloud.side_scan import (
     SideScanDisabledError,
@@ -70,8 +72,9 @@ def test_side_scan_invokes_run_side_scan_with_mapped_kwargs(monkeypatch):
     # --no-secrets -> scan_secrets_enabled=False; --no-sweep-orphans -> sweep_orphans=False
     assert captured["scan_secrets_enabled"] is False
     assert captured["sweep_orphans"] is False
-    # Summary table rendered the volume + cleanup status.
-    assert "vol-target" in result.output
+    # Summary table rendered the instance + snapshot + cleanup status
+    # (volume may ellipsize under narrow COLUMNS).
+    assert "i-target" in result.output
     assert "snap-1" in result.output
 
 
@@ -137,3 +140,29 @@ def test_side_scan_disabled_flag_exits_nonzero_with_actionable_message(monkeypat
 
 def test_side_scan_command_registered_on_group():
     assert "side-scan" in cg.cloud_group.commands
+    assert "side-scan-capabilities" in cg.cloud_group.commands
+
+
+@pytest.mark.parametrize("provider", ["azure", "gcp"])
+def test_side_scan_refuses_non_cli_providers_without_calling_executor(monkeypatch, provider: str):
+    called = False
+
+    async def fake_run_side_scan(**kwargs):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr("agent_bom.cloud.side_scan.run_side_scan", fake_run_side_scan)
+    result = CliRunner().invoke(cg.side_scan_cmd, ["--provider", provider, "--volume-id", "vol-x"])
+    assert result.exit_code == 2, result.output
+    assert called is False
+    assert "executor unavailable" in result.output.lower() or "cli_available=false" in result.output.lower()
+    assert "contract" in result.output.lower() or "discovery" in result.output.lower()
+
+
+def test_side_scan_capabilities_json():
+    result = CliRunner().invoke(cg.side_scan_capabilities_cmd, ["-f", "json"])
+    assert result.exit_code == 0, result.output
+    assert '"provider": "aws"' in result.output
+    assert '"provider": "azure"' in result.output
+    assert '"cli_available": false' in result.output or '"cli_available": false' in result.output.replace("False", "false")

--- a/tests/test_side_scan_capability_docs.py
+++ b/tests/test_side_scan_capability_docs.py
@@ -17,3 +17,10 @@ def test_architecture_labels_cross_cloud_surface_as_injected_sdk_only() -> None:
     architecture = (ROOT / "docs" / "ARCHITECTURE.md").read_text()
 
     assert "injected-SDK Azure Managed Disk and GCP Persistent Disk lifecycle adapters" in architecture
+
+
+def test_side_scan_capability_docs_mention_cli_refusal() -> None:
+    cloud_connect = (ROOT / "docs" / "CLOUD_CONNECT.md").read_text()
+    cli_map = (ROOT / "docs" / "CLI_MAP.md").read_text()
+    assert "side-scan-capabilities" in cloud_connect or "side-scan-capabilities" in cli_map
+    assert "side-scan --provider azure|gcp" in cloud_connect or "refuses" in cli_map.lower()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add `agent-bom cloud side-scan --provider` so Azure/GCP refuse CLI execution (exit 2) without calling adapters.
- Add `side-scan-capabilities` for the honest discovery/contract surface; AWS remains the shipped CLI executor (#4158 stage 4 E).

## Verification
- `uv run pytest -q tests/test_cli_side_scan.py tests/test_side_scan_capability_docs.py`

## Notes
- Complements #4369 honesty (`contract_only`) once that lands; this PR gates on `cli_available` so it stays correct on current main too.
- Part of #4158.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

