### PR TITLE
fix(docs): remove merge conflict markers from stage-4 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,16 +42,13 @@ Versions follow [Semantic Versioning](https://semver.org/).
   graph test module docstring matches auto-enable behavior.
 
 ### Changed
-<<<<<<< HEAD
 - CWPP stage-4 honesty: Azure/GCP side-scan capabilities report
   `executor: contract_only` (discovery + injected-SDK adapters only); runtime
   evidence ingest + graph persist/investigation loads are documented as wired;
   Azure/GCP CLI executor and credentialed smoke remain unclaimed (#4158).
-=======
 - CWPP stage-4 (B): CLI `agent-bom cloud runtime-evidence-ingest` and MCP
   `runtime_evidence_ingest` share the authenticated runtime-evidence door with
   the REST ingest route (#4158).
->>>>>>> cd080ac5 (feat(cwpp): CLI and MCP runtime-evidence ingest)
 - Findings carry optional graph FKs (`node_id`, `finding_node_id`, `entity_type`)
   and attack paths expose `finding_ids` so investigation joins typed estate nodes
   instead of CVE-label-only anchors; `asset_type` aliases map to `EntityType`

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -575,31 +575,18 @@ Wired today: findings surfaced by `GET /v1/findings` (and the overview /
 compliance / observability reads that share the enricher) gain a
 `workload_runtime_evidence` field on workload-scoped rows once a tenant has
 signals; the JSON API export carries it automatically. Authenticated ingest is
-<<<<<<< HEAD
-available at `POST /v1/cloud/runtime-evidence/ingest` (sources provisioned via
-`AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`; empty registry fails closed). Graph
-persist and investigation graph loads annotate matching CWPP workload nodes
-via the same index (tenant-scoped; absence stays `no_runtime_signal`, never
-"clean").
-
-Not yet locked in (stage 4 remainder): CLI/MCP ingest surface, a scheduler that
-pulls from sources, typed SARIF/report export fields, and any UI panel for
-workload runtime evidence. Azure/GCP disk side-scan remains discovery +
-injected-SDK lifecycle adapters (`executor: contract_only`) — no CLI executor
-and no credentialed live smoke is claimed.
-=======
 available at `POST /v1/cloud/runtime-evidence/ingest`, CLI
 `agent-bom cloud runtime-evidence-ingest`, and the MCP tool
 `runtime_evidence_ingest` (sources via `AGENT_BOM_RUNTIME_EVIDENCE_SOURCES`;
-empty registry fails closed). A graph-join helper annotates CWPP workload nodes
-for a matching tenant.
+empty registry fails closed). Graph persist and investigation graph loads
+annotate matching CWPP workload nodes via the same index (tenant-scoped;
+absence stays `no_runtime_signal`, never "clean").
 
 Not yet locked in (stage 4 remainder): a scheduler that pulls from sources,
-typed SARIF/report export fields, the live graph/campaign route invocation, and
-any UI panel for workload runtime evidence. No credentialed live source smoke is
-claimed. Azure/GCP disk side-scan remains discovery + injected-SDK adapters —
-no CLI executor is claimed.
->>>>>>> cd080ac5 (feat(cwpp): CLI and MCP runtime-evidence ingest)
+typed SARIF/report export fields, and any UI panel for workload runtime
+evidence. Azure/GCP disk side-scan remains discovery + injected-SDK lifecycle
+adapters (`executor: contract_only`) — no CLI executor and no credentialed live
+smoke is claimed.
 
 ---
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- `CHANGELOG.md` and `docs/CLOUD_CONNECT.md` on `main` still contained unresolved merge conflict markers from the runtime-evidence ingest merge (#4370).
- Keep both the stage-4 honesty bullet and the CLI/MCP ingest bullet; restore a combined **Wired today** section (REST + CLI + MCP ingest, graph enrich) with exports/UI/scheduler still under **Not yet**.

## Verification
- `rg '^(<<<<<<<|=======|>>>>>>>)' CHANGELOG.md docs/CLOUD_CONNECT.md` — no matches after fix
- Docs-only; no code path change

## Notes
- Blocks clean rebases of #4371 / #4372. Merge this before those PR refreshes when possible.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

