### PR TITLE
feat(ui,graph): page attack-path queue and fix drift theme contrast

### DIFF
--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -60,6 +60,7 @@ import {
   investigationRootForAttackPath,
   labelsForAttackPathType,
   matchesAttackPathFocus,
+  mergeAttackPathGraphPages,
   rankedAttackPathRows,
   recommendedAttackPathActions,
   moveAttackPathSelection,
@@ -82,7 +83,8 @@ const EMPTY_INVESTIGATION_FILTERS: InvestigationPresetFilters = {
   environment: null,
 };
 
-const ATTACK_PATH_QUEUE_LIMIT = 75;
+/** First/next fetch size for GET /v1/graph/attack-paths (API offset paging). */
+const ATTACK_PATH_FETCH_PAGE = 25;
 const ATTACK_PATH_QUEUE_PAGE_SIZE = 12;
 const FIX_FIRST_CARD_LIMIT = 12;
 const DEFAULT_SNAPSHOT_CHIP_COUNT = 3;
@@ -105,6 +107,7 @@ function SecurityGraphPageContent() {
   const [focusApplied, setFocusApplied] = useState(false);
   const [showAllSnapshots, setShowAllSnapshots] = useState(false);
   const [visibleAttackPathCount, setVisibleAttackPathCount] = useState(ATTACK_PATH_QUEUE_PAGE_SIZE);
+  const [loadingMorePaths, setLoadingMorePaths] = useState(false);
   const [investigationFocusMode, setInvestigationFocusMode] = useState(true);
   const [pathView, setPathView] = useState<ExposurePathView>("path");
   const [investigationFilters, setInvestigationFilters] =
@@ -219,11 +222,14 @@ function SecurityGraphPageContent() {
 
     async function loadGraph() {
       setLoadingGraph(true);
+      setLoadingMorePaths(false);
+      setVisibleAttackPathCount(ATTACK_PATH_QUEUE_PAGE_SIZE);
       try {
         const [graph, view] = await Promise.all([
           api.getGraphAttackPaths({
             scanId: selectedScanId,
-            limit: ATTACK_PATH_QUEUE_LIMIT,
+            offset: 0,
+            limit: ATTACK_PATH_FETCH_PAGE,
           }),
           api.getFixFirstGraphView({
             scanId: selectedScanId,
@@ -307,13 +313,17 @@ function SecurityGraphPageContent() {
     [campaigns, selectedCampaignId],
   );
 
+  // Authoritative queue is the attack-paths API (offset + has_more). Fix-first
+  // cards enrich titles/actions but must not silently cap the global queue at
+  // FIX_FIRST_CARD_LIMIT when more ranked paths exist server-side.
   const allAttackPaths = useMemo(() => {
+    const fromApi = [...(graphData?.attack_paths ?? [])].sort(
+      (left, right) => right.composite_risk - left.composite_risk,
+    );
     const base =
-      fixFirstCards.length > 0
-        ? fixFirstCards.map((card) => card.attack_path)
-        : [...(graphData?.attack_paths ?? [])].sort(
-            (left, right) => right.composite_risk - left.composite_risk,
-          );
+      fromApi.length > 0
+        ? fromApi
+        : fixFirstCards.map((card) => card.attack_path);
     if (!selectedCampaign?.member_paths?.length) return base;
     const members = new Set(selectedCampaign.member_paths);
     return base.filter((path) => members.has(`${path.source}->${path.target}`));
@@ -330,7 +340,57 @@ function SecurityGraphPageContent() {
     () => attackPaths.slice(0, Math.min(visibleAttackPathCount, attackPaths.length)),
     [attackPaths, visibleAttackPathCount],
   );
-  const hiddenAttackPathCount = Math.max(0, attackPaths.length - visibleAttackPaths.length);
+  const filtersNarrowQueue =
+    Boolean(selectedCampaign?.member_paths?.length) ||
+    Object.values(investigationFilters).some((value) => Boolean(value));
+  const pathHasMoreFromApi = Boolean(graphData?.pagination?.has_more) && !filtersNarrowQueue;
+  const hiddenLoadedAttackPathCount = Math.max(0, attackPaths.length - visibleAttackPaths.length);
+  const hiddenAttackPathCount =
+    hiddenLoadedAttackPathCount +
+    (pathHasMoreFromApi
+      ? Math.max(
+          0,
+          (graphData?.pagination?.total ?? attackPaths.length) - attackPaths.length,
+        )
+      : 0);
+
+  const loadMoreAttackPaths = useCallback(async () => {
+    if (hiddenLoadedAttackPathCount > 0) {
+      setVisibleAttackPathCount((current) =>
+        Math.min(attackPaths.length, current + ATTACK_PATH_QUEUE_PAGE_SIZE),
+      );
+      return;
+    }
+    if (!pathHasMoreFromApi || !selectedScanId || !graphData || loadingMorePaths) return;
+    const offset = graphData.pagination?.offset ?? 0;
+    const limit = graphData.pagination?.limit ?? ATTACK_PATH_FETCH_PAGE;
+    // Server has_more uses offset+limit < total; advance by the requested page size.
+    const nextOffset = offset + limit;
+    setLoadingMorePaths(true);
+    try {
+      const nextPage = await api.getGraphAttackPaths({
+        scanId: selectedScanId,
+        offset: nextOffset,
+        limit: ATTACK_PATH_FETCH_PAGE,
+      });
+      setGraphData((current) =>
+        current ? mergeAttackPathGraphPages(current, nextPage) : nextPage,
+      );
+      setVisibleAttackPathCount((current) => current + ATTACK_PATH_QUEUE_PAGE_SIZE);
+    } catch (error) {
+      setGraphLoadError(userFacingApiErrorMessage(error, "Failed to load more attack paths"));
+      setApiErrorKind(_classifyGraphErrorKind(error));
+    } finally {
+      setLoadingMorePaths(false);
+    }
+  }, [
+    attackPaths.length,
+    graphData,
+    hiddenLoadedAttackPathCount,
+    loadingMorePaths,
+    pathHasMoreFromApi,
+    selectedScanId,
+  ]);
 
   const rankedRows = useMemo<RankedPathRow[]>(
     () =>
@@ -857,9 +917,13 @@ function SecurityGraphPageContent() {
                 <div>
                   <h2 className="text-base font-semibold text-[color:var(--foreground)]">
                     {attackPaths.length} ranked path{attackPaths.length !== 1 ? "s" : ""}
-                    {allAttackPaths.length !== attackPaths.length
-                      ? ` of ${allAttackPaths.length}`
-                      : ""}
+                    {!filtersNarrowQueue &&
+                    typeof graphData?.pagination?.total === "number" &&
+                    graphData.pagination.total > attackPaths.length
+                      ? ` of ${graphData.pagination.total}`
+                      : allAttackPaths.length !== attackPaths.length
+                        ? ` of ${allAttackPaths.length}`
+                        : ""}
                   </h2>
                   <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
                     Select a path to open its graph and evidence above.
@@ -868,15 +932,19 @@ function SecurityGraphPageContent() {
                       : ""}
                   </p>
                   {focusLabel && (
-                    <p className="mt-1 text-xs text-emerald-300">Focused: {focusLabel}</p>
+                    <p className="mt-1 text-xs text-emerald-700 dark:text-emerald-300">
+                      Focused: {focusLabel}
+                    </p>
                   )}
                   {focus.traceId ? (
-                    <p className="mt-1 text-xs text-sky-300">
+                    <p className="mt-1 text-xs text-sky-700 dark:text-sky-300">
                       Runtime trace pin: <span className="font-mono">{focus.traceId}</span>
                     </p>
                   ) : null}
                 </div>
-                <div className="font-mono text-lg text-red-300">{attackPaths[0]!.composite_risk.toFixed(1)}</div>
+                <div className="font-mono text-lg text-red-700 dark:text-red-300">
+                  {attackPaths[0]!.composite_risk.toFixed(1)}
+                </div>
               </div>
 
               <div className="mt-4 space-y-3">
@@ -903,17 +971,19 @@ function SecurityGraphPageContent() {
                 }}
                 onKeyDown={handleAttackPathQueueKeyDown}
               />
-              {hiddenAttackPathCount > 0 && (
+              {(hiddenAttackPathCount > 0 || loadingMorePaths) && (
                 <div className="mt-4">
                   <GraphCompletenessBanner
                     visibleCount={visibleAttackPaths.length}
-                    omittedCount={hiddenAttackPathCount}
-                    loadMoreLabel={`Show ${Math.min(ATTACK_PATH_QUEUE_PAGE_SIZE, hiddenAttackPathCount)} more`}
-                    onLoadMore={() =>
-                      setVisibleAttackPathCount((current) =>
-                        Math.min(attackPaths.length, current + ATTACK_PATH_QUEUE_PAGE_SIZE),
-                      )
+                    omittedCount={Math.max(hiddenAttackPathCount, loadingMorePaths ? 1 : 0)}
+                    loadMoreLabel={
+                      loadingMorePaths
+                        ? "Loading more paths…"
+                        : `Show ${Math.min(ATTACK_PATH_QUEUE_PAGE_SIZE, Math.max(hiddenAttackPathCount, 1))} more`
                     }
+                    onLoadMore={() => {
+                      void loadMoreAttackPaths();
+                    }}
                   />
                 </div>
               )}

--- a/ui/components/finding-drawer.tsx
+++ b/ui/components/finding-drawer.tsx
@@ -613,7 +613,10 @@ function ReachBadges({ vuln }: { vuln: EnrichedVuln }) {
         </span>
       ) : null}
       {vuln.runtime_evidence?.state === "blocked" ? (
-        <Link href="/traces" className="text-xs text-emerald-300 hover:underline">
+        <Link
+          href="/traces"
+          className="text-xs text-emerald-700 hover:underline dark:text-emerald-300"
+        >
           Open trace explorer
         </Link>
       ) : null}

--- a/ui/components/graph-edge-changes-panel.tsx
+++ b/ui/components/graph-edge-changes-panel.tsx
@@ -15,6 +15,12 @@ import type {
   GraphEdgeChangesResponse,
   GraphEdgeHistoryRecord,
 } from "@/lib/api-types";
+import {
+  graphEdgeChangeHeadingClass,
+  graphEdgeChangeMetaClass,
+  graphEdgeChangeRowClass,
+  type GraphEdgeChangeTone,
+} from "@/lib/graph-edge-change-tones";
 
 function edgeKey(edge: GraphEdgeHistoryRecord): string {
   return `${edge.source_id} → ${edge.target_id} (${edge.relationship})`;
@@ -25,17 +31,11 @@ function EdgeRow({
   tone,
 }: {
   edge: GraphEdgeHistoryRecord;
-  tone: "added" | "removed" | "changed";
+  tone: GraphEdgeChangeTone;
 }) {
-  const toneClass =
-    tone === "added"
-      ? "border-emerald-500/25 bg-emerald-500/10 text-emerald-100"
-      : tone === "removed"
-        ? "border-rose-500/25 bg-rose-500/10 text-rose-100"
-        : "border-amber-500/25 bg-amber-500/10 text-amber-100";
   return (
     <li
-      className={`rounded-lg border px-2.5 py-1.5 font-mono text-[11px] ${toneClass}`}
+      className={`rounded-lg border px-2.5 py-1.5 font-mono text-[11px] ${graphEdgeChangeRowClass(tone)}`}
       data-testid={`graph-edge-change-${tone}`}
     >
       {edgeKey(edge)}
@@ -46,11 +46,11 @@ function EdgeRow({
 function ChangedEdgeRow({ pair }: { pair: GraphEdgeChangePair }) {
   return (
     <li
-      className="rounded-lg border border-amber-500/25 bg-amber-500/10 px-2.5 py-1.5 text-[11px] text-amber-100"
+      className={`rounded-lg border px-2.5 py-1.5 text-[11px] ${graphEdgeChangeRowClass("changed")}`}
       data-testid="graph-edge-change-changed"
     >
       <div className="font-mono">{edgeKey(pair.after)}</div>
-      <div className="mt-1 text-[10px] text-amber-200/80">
+      <div className={`mt-1 text-[10px] ${graphEdgeChangeMetaClass("changed")}`}>
         weight {pair.before.weight} → {pair.after.weight}
         {pair.before.traversable !== pair.after.traversable
           ? ` · traversable ${String(pair.before.traversable)} → ${String(pair.after.traversable)}`
@@ -85,8 +85,8 @@ export function GraphEdgeChangesPanel({
     >
       <div className="flex flex-wrap items-center justify-between gap-3">
         <div className="flex items-center gap-2">
-          <ArrowRightLeft className="h-4 w-4 text-violet-400" />
-          <span className="text-[10px] uppercase tracking-[0.24em] text-violet-400">
+          <ArrowRightLeft className="h-4 w-4 text-violet-600 dark:text-violet-400" />
+          <span className="text-[10px] uppercase tracking-[0.24em] text-violet-700 dark:text-violet-400">
             Edge changes
           </span>
           {comparedLabel ? (
@@ -96,7 +96,7 @@ export function GraphEdgeChangesPanel({
           ) : null}
         </div>
         {loading ? (
-          <span className="flex items-center gap-1 text-xs text-violet-300">
+          <span className="flex items-center gap-1 text-xs text-violet-700 dark:text-violet-300">
             <Loader2 className="h-3 w-3 animate-spin" />
             loading
           </span>
@@ -108,7 +108,7 @@ export function GraphEdgeChangesPanel({
       </div>
 
       {error ? (
-        <p className="mt-2 text-xs text-amber-200">{error}</p>
+        <p className="mt-2 text-xs text-amber-700 dark:text-amber-200">{error}</p>
       ) : loading && !changes ? (
         <p className="mt-2 text-xs text-[var(--text-tertiary)]">Loading edge lifecycle diff…</p>
       ) : !hasDrillDown ? (
@@ -120,7 +120,7 @@ export function GraphEdgeChangesPanel({
         <div className="mt-3 grid gap-3 lg:grid-cols-3">
           {changes!.edges_added.length > 0 ? (
             <div>
-              <p className="mb-1.5 text-[10px] uppercase tracking-[0.18em] text-emerald-400">
+              <p className={`mb-1.5 text-[10px] uppercase tracking-[0.18em] ${graphEdgeChangeHeadingClass("added")}`}>
                 Added ({changes!.edges_added.length})
               </p>
               <ul className="space-y-1.5">
@@ -132,7 +132,7 @@ export function GraphEdgeChangesPanel({
           ) : null}
           {changes!.edges_removed.length > 0 ? (
             <div>
-              <p className="mb-1.5 text-[10px] uppercase tracking-[0.18em] text-rose-400">
+              <p className={`mb-1.5 text-[10px] uppercase tracking-[0.18em] ${graphEdgeChangeHeadingClass("removed")}`}>
                 Removed ({changes!.edges_removed.length})
               </p>
               <ul className="space-y-1.5">
@@ -144,7 +144,7 @@ export function GraphEdgeChangesPanel({
           ) : null}
           {changes!.edges_changed.length > 0 ? (
             <div>
-              <p className="mb-1.5 text-[10px] uppercase tracking-[0.18em] text-amber-400">
+              <p className={`mb-1.5 text-[10px] uppercase tracking-[0.18em] ${graphEdgeChangeHeadingClass("changed")}`}>
                 Changed ({changes!.edges_changed.length})
               </p>
               <ul className="space-y-1.5">

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -1,4 +1,5 @@
 import { EntityType, type AttackPath, type UnifiedNode } from "./graph-schema";
+import type { UnifiedGraphResponse } from "./api-types";
 import {
   formatExposureEntityDisplay,
   formatExposureEntityTitle,
@@ -599,15 +600,10 @@ export function matchesAttackPathFocus(
  * Dedupes nodes/edges/paths so "Show more" can follow `pagination.has_more`
  * without resetting the investigation canvas.
  */
-export function mergeAttackPathGraphPages<
-  T extends {
-    nodes: Array<{ id: string }>;
-    edges: Array<{ id: string }>;
-    attack_paths: AttackPath[];
-    pagination?: { total: number; offset: number; limit: number; has_more: boolean };
-    stats?: Record<string, unknown>;
-  },
->(current: T, next: T): T {
+export function mergeAttackPathGraphPages(
+  current: UnifiedGraphResponse,
+  next: UnifiedGraphResponse,
+): UnifiedGraphResponse {
   const nodeIds = new Set(current.nodes.map((node) => node.id));
   const edgeIds = new Set(current.edges.map((edge) => edge.id));
   const pathKeys = new Set(current.attack_paths.map((path) => attackPathKey(path)));
@@ -616,18 +612,17 @@ export function mergeAttackPathGraphPages<
     ...current.attack_paths,
     ...next.attack_paths.filter((path) => !pathKeys.has(attackPathKey(path))),
   ];
-  const nextTotal = next.pagination?.total;
   return {
     ...current,
     ...next,
     nodes: [...current.nodes, ...next.nodes.filter((node) => !nodeIds.has(node.id))],
     edges: [...current.edges, ...next.edges.filter((edge) => !edgeIds.has(edge.id))],
     attack_paths: mergedPaths,
-    pagination: next.pagination ?? current.pagination,
+    pagination: next.pagination,
     stats: {
-      ...(current.stats ?? {}),
-      ...(next.stats ?? {}),
-      ...(typeof nextTotal === "number" ? { attack_path_count: nextTotal } : {}),
+      ...current.stats,
+      ...next.stats,
+      attack_path_count: next.pagination.total,
     },
   };
 }

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -593,3 +593,41 @@ export function matchesAttackPathFocus(
 
   return true;
 }
+
+/**
+ * Append a later `/v1/graph/attack-paths` page onto an already-loaded response.
+ * Dedupes nodes/edges/paths so "Show more" can follow `pagination.has_more`
+ * without resetting the investigation canvas.
+ */
+export function mergeAttackPathGraphPages<
+  T extends {
+    nodes: Array<{ id: string }>;
+    edges: Array<{ id: string }>;
+    attack_paths: AttackPath[];
+    pagination?: { total: number; offset: number; limit: number; has_more: boolean };
+    stats?: Record<string, unknown>;
+  },
+>(current: T, next: T): T {
+  const nodeIds = new Set(current.nodes.map((node) => node.id));
+  const edgeIds = new Set(current.edges.map((edge) => edge.id));
+  const pathKeys = new Set(current.attack_paths.map((path) => attackPathKey(path)));
+
+  const mergedPaths = [
+    ...current.attack_paths,
+    ...next.attack_paths.filter((path) => !pathKeys.has(attackPathKey(path))),
+  ];
+  const nextTotal = next.pagination?.total;
+  return {
+    ...current,
+    ...next,
+    nodes: [...current.nodes, ...next.nodes.filter((node) => !nodeIds.has(node.id))],
+    edges: [...current.edges, ...next.edges.filter((edge) => !edgeIds.has(edge.id))],
+    attack_paths: mergedPaths,
+    pagination: next.pagination ?? current.pagination,
+    stats: {
+      ...(current.stats ?? {}),
+      ...(next.stats ?? {}),
+      ...(typeof nextTotal === "number" ? { attack_path_count: nextTotal } : {}),
+    },
+  };
+}

--- a/ui/lib/graph-edge-change-tones.ts
+++ b/ui/lib/graph-edge-change-tones.ts
@@ -1,0 +1,38 @@
+/**
+ * Both-theme tone classes for graph edge lifecycle rows.
+ * Avoids pale-on-pale chips that only read on the dark canvas.
+ */
+export type GraphEdgeChangeTone = "added" | "removed" | "changed";
+
+const ROW_TONE: Readonly<Record<GraphEdgeChangeTone, string>> = {
+  added:
+    "border-emerald-500/30 bg-emerald-500/10 text-emerald-800 dark:border-emerald-500/25 dark:bg-emerald-500/10 dark:text-emerald-100",
+  removed:
+    "border-rose-500/30 bg-rose-500/10 text-rose-800 dark:border-rose-500/25 dark:bg-rose-500/10 dark:text-rose-100",
+  changed:
+    "border-amber-500/30 bg-amber-500/10 text-amber-800 dark:border-amber-500/25 dark:bg-amber-500/10 dark:text-amber-100",
+};
+
+const META_TONE: Readonly<Record<GraphEdgeChangeTone, string>> = {
+  added: "text-emerald-700/80 dark:text-emerald-200/80",
+  removed: "text-rose-700/80 dark:text-rose-200/80",
+  changed: "text-amber-700/80 dark:text-amber-200/80",
+};
+
+const HEADING_TONE: Readonly<Record<GraphEdgeChangeTone, string>> = {
+  added: "text-emerald-700 dark:text-emerald-400",
+  removed: "text-rose-700 dark:text-rose-400",
+  changed: "text-amber-700 dark:text-amber-400",
+};
+
+export function graphEdgeChangeRowClass(tone: GraphEdgeChangeTone): string {
+  return ROW_TONE[tone];
+}
+
+export function graphEdgeChangeMetaClass(tone: GraphEdgeChangeTone): string {
+  return META_TONE[tone];
+}
+
+export function graphEdgeChangeHeadingClass(tone: GraphEdgeChangeTone): string {
+  return HEADING_TONE[tone];
+}

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -12,6 +12,7 @@ import {
   mapAttackPathChainType,
   mapAttackPathNodeType,
   matchesAttackPathFocus,
+  mergeAttackPathGraphPages,
   moveAttackPathSelection,
   rankedAttackPathRows,
   recommendedInteractionRiskActions,
@@ -752,5 +753,43 @@ describe("attack path helpers", () => {
         href: "/compliance?q=AGENT-001",
       },
     ]);
+  });
+});
+
+describe("mergeAttackPathGraphPages", () => {
+  const path = (source: string, target: string, risk: number): AttackPath =>
+    ({
+      source,
+      target,
+      hops: [source, target],
+      vuln_ids: [],
+      composite_risk: risk,
+      techniques: [],
+    }) as AttackPath;
+
+  it("appends unique paths/nodes/edges and keeps latest pagination", () => {
+    const first = {
+      nodes: [{ id: "a" }, { id: "b" }],
+      edges: [{ id: "e1" }],
+      attack_paths: [path("a", "b", 9)],
+      pagination: { total: 3, offset: 0, limit: 1, has_more: true },
+      stats: { attack_path_count: 1 },
+    };
+    const second = {
+      nodes: [{ id: "b" }, { id: "c" }],
+      edges: [{ id: "e1" }, { id: "e2" }],
+      attack_paths: [path("b", "c", 8)],
+      pagination: { total: 3, offset: 1, limit: 1, has_more: true },
+      stats: { attack_path_count: 3 },
+    };
+    const merged = mergeAttackPathGraphPages(first, second);
+    expect(merged.nodes.map((n) => n.id)).toEqual(["a", "b", "c"]);
+    expect(merged.edges.map((e) => e.id)).toEqual(["e1", "e2"]);
+    expect(merged.attack_paths.map((p) => attackPathKey(p))).toEqual([
+      attackPathKey(path("a", "b", 9)),
+      attackPathKey(path("b", "c", 8)),
+    ]);
+    expect(merged.pagination).toEqual(second.pagination);
+    expect(merged.stats?.attack_path_count).toBe(3);
   });
 });

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -762,26 +762,57 @@ describe("mergeAttackPathGraphPages", () => {
       source,
       target,
       hops: [source, target],
-      vuln_ids: [],
+      edges: [],
       composite_risk: risk,
-      techniques: [],
-    }) as AttackPath;
+      summary: `${source}->${target}`,
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: [],
+    });
+
+  const emptyStats = {
+    total_nodes: 0,
+    total_edges: 0,
+    node_types: {},
+    severity_counts: {},
+    relationship_types: {},
+    attack_path_count: 0,
+    interaction_risk_count: 0,
+    max_attack_path_risk: 0,
+    highest_interaction_risk: 0,
+  };
+
+  const page = (
+    paths: AttackPath[],
+    nodeIds: string[],
+    edgeIds: string[],
+    pagination: { total: number; offset: number; limit: number; has_more: boolean },
+  ): import("@/lib/api-types").UnifiedGraphResponse =>
+    ({
+      scan_id: "scan-1",
+      tenant_id: "default",
+      created_at: "2026-07-22T00:00:00Z",
+      nodes: nodeIds.map((id) => ({ id })) as import("@/lib/api-types").UnifiedGraphResponse["nodes"],
+      edges: edgeIds.map((id) => ({ id })) as import("@/lib/api-types").UnifiedGraphResponse["edges"],
+      attack_paths: paths,
+      interaction_risks: [],
+      stats: { ...emptyStats, attack_path_count: pagination.total },
+      pagination,
+    });
 
   it("appends unique paths/nodes/edges and keeps latest pagination", () => {
-    const first = {
-      nodes: [{ id: "a" }, { id: "b" }],
-      edges: [{ id: "e1" }],
-      attack_paths: [path("a", "b", 9)],
-      pagination: { total: 3, offset: 0, limit: 1, has_more: true },
-      stats: { attack_path_count: 1 },
-    };
-    const second = {
-      nodes: [{ id: "b" }, { id: "c" }],
-      edges: [{ id: "e1" }, { id: "e2" }],
-      attack_paths: [path("b", "c", 8)],
-      pagination: { total: 3, offset: 1, limit: 1, has_more: true },
-      stats: { attack_path_count: 3 },
-    };
+    const first = page([path("a", "b", 9)], ["a", "b"], ["e1"], {
+      total: 3,
+      offset: 0,
+      limit: 1,
+      has_more: true,
+    });
+    const second = page([path("b", "c", 8)], ["b", "c"], ["e1", "e2"], {
+      total: 3,
+      offset: 1,
+      limit: 1,
+      has_more: true,
+    });
     const merged = mergeAttackPathGraphPages(first, second);
     expect(merged.nodes.map((n) => n.id)).toEqual(["a", "b", "c"]);
     expect(merged.edges.map((e) => e.id)).toEqual(["e1", "e2"]);
@@ -790,6 +821,6 @@ describe("mergeAttackPathGraphPages", () => {
       attackPathKey(path("b", "c", 8)),
     ]);
     expect(merged.pagination).toEqual(second.pagination);
-    expect(merged.stats?.attack_path_count).toBe(3);
+    expect(merged.stats.attack_path_count).toBe(3);
   });
 });

--- a/ui/tests/graph-edge-change-tones.test.ts
+++ b/ui/tests/graph-edge-change-tones.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  graphEdgeChangeHeadingClass,
+  graphEdgeChangeMetaClass,
+  graphEdgeChangeRowClass,
+} from "@/lib/graph-edge-change-tones";
+
+describe("graphEdgeChange tones", () => {
+  it("includes light and dark pairs for each lifecycle tone", () => {
+    for (const tone of ["added", "removed", "changed"] as const) {
+      const row = graphEdgeChangeRowClass(tone);
+      expect(row).toContain("dark:");
+      expect(row).toMatch(/text-(emerald|rose|amber)-800/);
+      expect(graphEdgeChangeHeadingClass(tone)).toContain("dark:");
+      expect(graphEdgeChangeMetaClass(tone)).toContain("dark:");
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Security graph attack-path queue follows `GET /v1/graph/attack-paths` offset/`has_more` instead of a silent 75-path client cap.
- Prefer the API path queue over the fix-first card limit so investigation "Show more" can fetch additional ranked paths.
- Both-theme contrast for edge-change lifecycle rows and a few investigation accent strings (light + dark).

## Verification
- `cd ui && npm test -- --run tests/attack-paths.test.ts tests/graph-edge-change-tones.test.ts tests/graph-edge-changes-panel.test.tsx`
- `cd ui && npx tsc --noEmit -p tsconfig.json` (no security-graph / mergeAttack errors after typing fix)

## Notes
- Follow-up commit: specialize `mergeAttackPathGraphPages` to `UnifiedGraphResponse` so Next production typecheck accepts `setGraphData` page merges.
- Inventory cursor paging and snapshot/history envelopes remain follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

