### PR TITLE
feat(ui): page inventory graph loads via cursor/has_more

### DIFF
--- a/ui/components/inventory/asset-inventory-view.tsx
+++ b/ui/components/inventory/asset-inventory-view.tsx
@@ -38,7 +38,7 @@ const COLUMN_TO_SORT: Record<string, AssetSortKey> = {
 
 export function AssetInventoryView({ kind }: { kind: AssetKindId }) {
   const config = ASSET_KIND_BY_ID[kind];
-  const { model, loading, error, errorKind, reload } = useInventory();
+  const { model, loading, loadingMore, hasMore, error, errorKind, reload, loadMore } = useInventory();
 
   const [query, setQuery] = useState("");
   const [severity, setSeverity] = useState("all");
@@ -146,11 +146,26 @@ export function AssetInventoryView({ kind }: { kind: AssetKindId }) {
 
       <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs leading-5 text-[color:var(--text-secondary)]">
         <span className="font-medium text-[color:var(--text-secondary)]">Coverage:</span> {config.coverageNote}
-        {total > loadedCount ? (
+        {total > loadedCount || hasMore ? (
           <span className="text-[color:var(--text-tertiary)]">
             {" "}
-            Showing the first {loadedCount.toLocaleString()} of {total.toLocaleString()} — refine with the search box.
+            Showing {loadedCount.toLocaleString()}
+            {total > loadedCount ? ` of ${total.toLocaleString()}` : ""}
+            {hasMore ? " — more pages available from the graph store." : "."}
           </span>
+        ) : null}
+        {hasMore ? (
+          <button
+            type="button"
+            data-testid="inventory-load-more"
+            onClick={() => {
+              void loadMore();
+            }}
+            disabled={loadingMore}
+            className="ml-2 inline-flex rounded-md border border-[color:var(--border-subtle)] px-2 py-0.5 text-[11px] font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)] disabled:opacity-60"
+          >
+            {loadingMore ? "Loading…" : "Load more"}
+          </button>
         ) : null}
       </div>
 

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -854,6 +854,7 @@ export const api = {
     maxDepth?: number | undefined;
     offset?: number | undefined;
     limit?: number | undefined;
+    cursor?: string | undefined;
   }) => {
     const params = new URLSearchParams();
     if (filters?.scanId) params.set("scan_id", filters.scanId);
@@ -869,6 +870,7 @@ export const api = {
     if (filters?.maxDepth != null) params.set("max_depth", String(filters.maxDepth));
     if (filters?.offset != null) params.set("offset", String(filters.offset));
     if (filters?.limit != null) params.set("limit", String(filters.limit));
+    if (filters?.cursor) params.set("cursor", filters.cursor);
     const qs = params.toString();
     return get<UnifiedGraphResponse>(`/v1/graph${qs ? `?${qs}` : ""}`);
   },

--- a/ui/lib/inventory-context.tsx
+++ b/ui/lib/inventory-context.tsx
@@ -11,23 +11,26 @@ import {
 } from "react";
 
 import { api } from "@/lib/api";
+import type { UnifiedGraphResponse } from "@/lib/api-types";
 import { ApiAuthError, ApiError, ApiForbiddenError } from "@/lib/api-errors";
-import { buildInventory, type InventoryModel } from "@/lib/inventory";
+import { buildInventory, mergeGraphPages, type InventoryModel } from "@/lib/inventory";
 
-// Single graph fetch for the whole Inventory section. The graph is the
-// canonical correlation fabric — one read gives every asset kind plus the
-// finding neighbors used for correlation. Loading it once at the section root
-// keeps navigation between asset-type pages instant.
-const GRAPH_NODE_LIMIT = 4000;
+// First page for the Inventory section. The graph is the canonical correlation
+// fabric — one read gives every asset kind plus finding neighbors. Follow
+// pagination.has_more / next_cursor instead of a silent hard cap.
+const GRAPH_NODE_PAGE = 500;
 
 export type InventoryErrorKind = "network" | "auth" | "forbidden" | "empty";
 
 export interface InventoryState {
   model: InventoryModel | null;
   loading: boolean;
+  loadingMore: boolean;
+  hasMore: boolean;
   error: string;
   errorKind: InventoryErrorKind;
   reload: () => void;
+  loadMore: () => Promise<void>;
 }
 
 const InventoryContext = createContext<InventoryState | null>(null);
@@ -53,8 +56,9 @@ function classifyError(err: unknown): { message: string; kind: InventoryErrorKin
 }
 
 export function InventoryProvider({ children }: { children: ReactNode }) {
-  const [model, setModel] = useState<InventoryModel | null>(null);
+  const [graph, setGraph] = useState<UnifiedGraphResponse | null>(null);
   const [loading, setLoading] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [error, setError] = useState("");
   const [errorKind, setErrorKind] = useState<InventoryErrorKind>("network");
   const [nonce, setNonce] = useState(0);
@@ -64,17 +68,19 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let cancelled = false;
     setLoading(true);
+    setLoadingMore(false);
     setError("");
+    setGraph(null);
     api
-      .getGraph({ limit: GRAPH_NODE_LIMIT })
-      .then((graph) => {
+      .getGraph({ limit: GRAPH_NODE_PAGE, offset: 0 })
+      .then((page) => {
         if (cancelled) return;
-        setModel(buildInventory(graph));
+        setGraph(page);
       })
       .catch((err: unknown) => {
         if (cancelled) return;
         const classified = classifyError(err);
-        setModel(null);
+        setGraph(null);
         setError(classified.message);
         setErrorKind(classified.kind);
       })
@@ -86,9 +92,42 @@ export function InventoryProvider({ children }: { children: ReactNode }) {
     };
   }, [nonce]);
 
+  const hasMore = Boolean(graph?.pagination?.has_more);
+  const model = useMemo(() => (graph ? buildInventory(graph) : null), [graph]);
+
+  const loadMore = useCallback(async () => {
+    if (!graph || !graph.pagination?.has_more || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const nextCursor = graph.pagination.next_cursor?.trim();
+      const nextPage = nextCursor
+        ? await api.getGraph({ limit: GRAPH_NODE_PAGE, cursor: nextCursor })
+        : await api.getGraph({
+            limit: GRAPH_NODE_PAGE,
+            offset: (graph.pagination.offset ?? 0) + (graph.pagination.limit ?? GRAPH_NODE_PAGE),
+          });
+      setGraph((current) => (current ? mergeGraphPages(current, nextPage) : nextPage));
+    } catch (err: unknown) {
+      const classified = classifyError(err);
+      setError(classified.message);
+      setErrorKind(classified.kind);
+    } finally {
+      setLoadingMore(false);
+    }
+  }, [graph, loadingMore]);
+
   const value = useMemo<InventoryState>(
-    () => ({ model, loading, error, errorKind, reload }),
-    [model, loading, error, errorKind, reload],
+    () => ({
+      model,
+      loading,
+      loadingMore,
+      hasMore,
+      error,
+      errorKind,
+      reload,
+      loadMore,
+    }),
+    [model, loading, loadingMore, hasMore, error, errorKind, reload, loadMore],
   );
 
   return <InventoryContext.Provider value={value}>{children}</InventoryContext.Provider>;

--- a/ui/lib/inventory.ts
+++ b/ui/lib/inventory.ts
@@ -385,6 +385,32 @@ export function buildInventory(graph: UnifiedGraphResponse): InventoryModel {
   };
 }
 
+/**
+ * Append a later `/v1/graph` node page onto an already-loaded response so the
+ * inventory section can follow `pagination.has_more` / `next_cursor` without
+ * dropping earlier rows or finding-correlation edges.
+ */
+export function mergeGraphPages(
+  current: UnifiedGraphResponse,
+  next: UnifiedGraphResponse,
+): UnifiedGraphResponse {
+  const nodeIds = new Set(current.nodes.map((node) => node.id));
+  const edgeIds = new Set((current.edges ?? []).map((edge) => edge.id));
+  return {
+    ...current,
+    ...next,
+    nodes: [...current.nodes, ...next.nodes.filter((node) => !nodeIds.has(node.id))],
+    edges: [
+      ...(current.edges ?? []),
+      ...(next.edges ?? []).filter((edge) => !edgeIds.has(edge.id)),
+    ],
+    attack_paths: current.attack_paths,
+    interaction_risks: current.interaction_risks,
+    stats: next.stats ?? current.stats,
+    pagination: next.pagination,
+  };
+}
+
 export interface AssetFilter {
   query?: string | undefined;
   /** Minimum asset severity, e.g. "high"; "all" keeps everything. */

--- a/ui/tests/inventory-view.test.tsx
+++ b/ui/tests/inventory-view.test.tsx
@@ -160,6 +160,41 @@ describe("AssetInventoryView", () => {
       expect(screen.getByText(/No cloud resources discovered yet/i)).toBeInTheDocument(),
     );
   });
+
+  it("loads the next graph page when Load more is clicked", async () => {
+    const getGraph = vi.spyOn(api, "getGraph");
+    getGraph.mockResolvedValueOnce({
+      ...graph(
+        [node("pkg-1", "package", { data_sources: ["sbom"] })],
+        [],
+      ),
+      stats: {
+        total_nodes: 2,
+        total_edges: 0,
+        node_types: { package: 2 },
+        severity_counts: {},
+        relationship_types: {},
+        attack_path_count: 0,
+        interaction_risk_count: 0,
+        max_attack_path_risk: 0,
+        highest_interaction_risk: 0,
+      },
+      pagination: { total: 2, offset: 0, limit: 1, has_more: true, next_cursor: "cur-2" },
+    } as unknown as UnifiedGraphResponse);
+    getGraph.mockResolvedValueOnce({
+      ...graph([node("pkg-2", "package", { data_sources: ["sbom"] })], []),
+      pagination: { total: 2, offset: 1, limit: 1, has_more: false, next_cursor: "" },
+    } as unknown as UnifiedGraphResponse);
+
+    renderWithProvider(<AssetInventoryView kind="packages" />);
+    const table = await screen.findByTestId("inventory-table-packages");
+    await waitFor(() => expect(within(table).getByText("pkg-1")).toBeInTheDocument());
+    expect(within(table).queryByText("pkg-2")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("inventory-load-more"));
+    await waitFor(() => expect(within(table).getByText("pkg-2")).toBeInTheDocument());
+    expect(getGraph).toHaveBeenCalledWith(expect.objectContaining({ cursor: "cur-2" }));
+  });
 });
 
 describe("InventoryIndex", () => {

--- a/ui/tests/inventory.test.ts
+++ b/ui/tests/inventory.test.ts
@@ -7,6 +7,7 @@ import {
   buildInventory,
   dataSourceOptions,
   filterAssetRows,
+  mergeGraphPages,
   sortAssetRows,
   summarizeRows,
   type AssetRow,
@@ -274,3 +275,25 @@ function baseRow(overrides: Partial<AssetRow>): AssetRow {
     ...overrides,
   };
 }
+
+describe("mergeGraphPages", () => {
+  it("appends unique nodes/edges and keeps latest pagination", () => {
+    const first = graph(
+      [node("a", "package"), node("b", "package")],
+      [edge("CVE-1", "a")],
+      { package: 3 },
+    );
+    first.pagination = { total: 3, offset: 0, limit: 2, has_more: true, next_cursor: "c1" };
+    const second = graph(
+      [node("b", "package"), node("c", "package")],
+      [edge("CVE-1", "a"), edge("CVE-2", "c")],
+      { package: 3 },
+    );
+    second.pagination = { total: 3, offset: 2, limit: 2, has_more: false, next_cursor: "" };
+
+    const merged = mergeGraphPages(first, second);
+    expect(merged.nodes.map((n) => n.id)).toEqual(["a", "b", "c"]);
+    expect(merged.edges.map((e) => e.id)).toEqual(["CVE-1->a", "CVE-2->c"]);
+    expect(merged.pagination).toEqual(second.pagination);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Inventory section follows `GET /v1/graph` `has_more` / `next_cursor` instead of a silent 4k-node fetch.
- **Load more** merges subsequent pages (nodes + edges) so finding correlation stays intact.
- Client `getGraph` accepts `cursor`; unit coverage for merge + load-more click.

## Verification
- `cd ui && npm test -- --run tests/inventory.test.ts tests/inventory-view.test.tsx` (22 passed)

## Notes
- Kept separate from README lane framing (#docs PR).
- API list-envelope / rate-limit series and CWPP scheduler remain follow-ups.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

