### PR TITLE
docs: frame scan as CLI/CI/Docker/cloud connect, not local-only

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -61,10 +61,11 @@ High-signal entry points:
 Use this framing when editing public docs, UI copy, release notes, demos, or
 examples:
 
-1. **Scan locally** — CLI, Docker, and GitHub Action produce findings, SARIF,
-   SBOMs, HTML reports, and graph exports.
-2. **Send evidence to a control plane** — fleet sync, REST API, Helm/EKS, and
-   the browser UI centralize inventory, graph state, compliance, audit, and
+1. **Scan** — CLI, Docker, GitHub Action, and cloud connect (from a self-hosted
+   control plane) produce findings, SARIF, SBOMs, HTML reports, and graph
+   exports. “Local” is one entry point, not the product boundary.
+2. **Centralize evidence in a control plane** — fleet sync, REST API, Helm/EKS,
+   and the browser UI centralize inventory, graph state, compliance, audit, and
    governance.
 3. **Enforce runtime behavior** — MCP server mode, proxy/gateway, and Shield
    SDK turn the same model into assistant and tool-call controls.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@
 
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
 <p align="center">
-  Scan locally → send evidence to a control plane you run → enforce runtime MCP/tool calls.
+  Scan from CLI, CI, Docker, or cloud connect on a control plane you run →
+  centralize evidence → enforce runtime MCP/tool calls.
   One Finding + UnifiedGraph model across CLI, API, UI, and MCP.
 </p>
 <p align="center">
@@ -31,16 +32,18 @@
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
-## Scan locally
+## Scan
 
 ```bash
 pip install agent-bom
 agent-bom scan .
 ```
 
-Inventory, findings, reachability, and fix-first actions — no control plane
-required. Export when another tool needs it:
-`agent-bom scan . -f sarif -o findings.sarif`.
+Inventory, findings, reachability, and fix-first actions — works without a
+control plane. Same scanner also runs in CI ([GitHub Action](https://github.com/marketplace/actions/agent-bom)),
+Docker, and from a self-hosted control plane via cloud connect / scheduled
+estate scans — “local” is one entry point, not the only one. Export when
+another tool needs it: `agent-bom scan . -f sarif -o findings.sarif`.
 
 Offline sample without your repo: `uvx agent-bom scan --demo --offline` ·
 full path: [First Run](docs/FIRST_RUN.md).
@@ -80,7 +83,7 @@ Boundaries: [PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIES.md).
 
 ## How the tool works
 
-1. **Scan** — `agent-bom scan .` → inventory, findings, SARIF/SBOM/HTML, local graph
+1. **Scan** — CLI / CI / Docker / cloud connect → inventory, findings, SARIF/SBOM/HTML, graph
 2. **Control plane** — `pip install 'agent-bom[ui]' && agent-bom serve` → tenant UI/API, attack paths, compliance, audit (self-host with Docker or Helm + Postgres)
 3. **Runtime** — `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` → allow/warn/block on live MCP/tool calls
 
@@ -91,7 +94,7 @@ boundary.
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom three tool lanes: local scan, self-hosted control plane, and runtime gateway on one Finding + UnifiedGraph model" width="1100" />
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/how-it-works-light.svg" alt="agent-bom three tool lanes: scan (CLI/CI/Docker/cloud connect), self-hosted control plane, and runtime gateway on one Finding + UnifiedGraph model" width="1100" />
   </picture>
 </p>
 

--- a/docs/PRODUCT_BRIEF.md
+++ b/docs/PRODUCT_BRIEF.md
@@ -48,19 +48,20 @@ to a customer-controlled plane, then enforce selected runtime paths.
 
 ```text
 agent-bom
-├─ generate an AI BOM locally
-│  └─ CLI, Docker, GitHub Action -> findings, SARIF, SBOM, HTML, graph exports
-├─ send evidence to a control plane
+├─ scan the estate (CLI / CI / Docker / cloud connect)
+│  └─ findings, SARIF, SBOM, HTML, graph exports
+├─ centralize evidence in a control plane you run
 │  └─ fleet sync, REST API, Helm/EKS, UI -> inventory, graph, compliance, governance
 └─ enforce runtime behavior
    └─ MCP server, proxy/gateway, Shield SDK -> audit, policy blocks, runtime alerts
 ```
 
-1. **Generate an AI BOM locally** — CLI, Docker, and GitHub Action produce
-   findings, SARIF, SBOMs, HTML reports, and graph exports.
-2. **Send evidence to a control plane** — endpoint fleet, REST API, Helm/EKS,
-   and the browser UI centralize inventory, graph state, compliance, and
-   governance.
+1. **Scan the estate** — CLI, Docker, GitHub Action, and cloud connect from a
+   self-hosted control plane produce findings, SARIF, SBOMs, HTML reports, and
+   graph exports. Local CLI is one entry point, not the only scan surface.
+2. **Centralize evidence in a control plane** — endpoint fleet, REST API,
+   Helm/EKS, and the browser UI centralize inventory, graph state, compliance,
+   and governance.
 3. **Enforce runtime behavior** — MCP server mode, proxy/gateway, and Shield
    SDK turn the same model into agentic workflow controls.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- README lead no longer frames the product as “scan locally” only — CLI, CI, Docker, and cloud connect on a self-hosted control plane are first-class scan surfaces.
- Align product-lane wording in `AGENTS.md` and `PRODUCT_BRIEF.md`.

## Verification
- `git diff --check`
- Manual read of README lead + How the tool works

## Notes
- Docs/copy only. Does not restructure the repo tree.
- Collaborator labels like `msaad00cursoragent` are Cursor bot identities, not directory hygiene.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

