### PR TITLE
fix(graph): materialise campaigns on serve and sync attack_path_count

### DIFF
--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -1446,13 +1446,67 @@ async def _graph_compute_call(fn: Callable[..., _GraphCallResult], /, *args: Any
         raise HTTPException(status_code=501, detail=sanitize_error(exc)) from exc
 
 
+def _sync_attack_path_stats(
+    stats: dict[str, Any],
+    *,
+    total: int,
+    paths: list[AttackPath],
+) -> dict[str, Any]:
+    """Align ``attack_path_count`` / ``max_attack_path_risk`` with derived paths.
+
+    Topology-only snapshots store zero rows in ``attack_paths`` while serve
+    surfaces derive paths on read. Without this sync, ``/v1/graph`` can report
+    ``attack_path_count: 0`` next to a non-empty ``/attack-paths`` queue.
+    """
+    if total and int(stats.get("attack_path_count") or 0) == 0:
+        return {
+            **stats,
+            "attack_path_count": total,
+            "max_attack_path_risk": max((path.composite_risk for path in paths), default=0.0),
+        }
+    return stats
+
+
+def _ensure_attack_campaigns(graph: UnifiedGraph, paths: list[AttackPath] | None = None) -> None:
+    """Materialise crown-jewel campaigns on the serve path when the store has none.
+
+    Campaigns are computed at build-time fusion but not persisted today, so
+    store-backed graphs always load ``attack_campaigns=[]``. Recompute from
+    jewel-terminating paths when possible; otherwise run the bounded partitioned
+    engine when the estate actually has crown jewels. Empty stays empty — no
+    fabrication when there is no sensitivity signal.
+    """
+    if getattr(graph, "attack_campaigns", None):
+        return
+    try:
+        from agent_bom.graph.attack_path_campaigns import compute_partitioned_campaigns
+        from agent_bom.graph.attack_path_fusion import _cluster_small_graph_campaigns, _is_crown_jewel
+
+        candidate_paths = list(paths) if paths is not None else list(graph.attack_paths)
+        jewel_paths = [
+            path
+            for path in candidate_paths
+            if (node := graph.nodes.get(path.target)) is not None and _is_crown_jewel(node)
+        ]
+        if jewel_paths:
+            graph.attack_campaigns = _cluster_small_graph_campaigns(graph, jewel_paths)
+            return
+        if any(_is_crown_jewel(node) for node in graph.nodes.values()):
+            result = compute_partitioned_campaigns(graph)
+            graph.attack_campaigns = list(result.campaigns)
+    except Exception:  # noqa: BLE001 — campaigns are additive; never break investigation reads
+        logger.debug("attack campaign serve-path materialisation skipped", exc_info=True)
+
+
 def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) -> dict[str, Any]:
-    stats = graph.stats()
+    derived_paths = _derived_attack_paths(graph)
+    _ensure_attack_campaigns(graph, derived_paths)
+    stats = _sync_attack_path_stats(graph.stats(), total=len(derived_paths), paths=derived_paths)
     all_nodes = list(graph.nodes.values())
     paged_nodes, pagination = _paginate(all_nodes, offset, limit)
     paged_ids = {n.id for n in paged_nodes}
     paged_edges = [e for e in graph.edges if e.source in paged_ids and e.target in paged_ids]
-    matching_paths = [p for p in _derived_attack_paths(graph) if p.hops and p.hops[0] in paged_ids]
+    matching_paths = [p for p in derived_paths if p.hops and p.hops[0] in paged_ids]
     kept_paths = matching_paths[:_FILTERED_GRAPH_ATTACK_PATH_LIMIT]
     off_page_hops = {hop for p in kept_paths for hop in p.hops} - paged_ids
     nodes_by_id = {n.id: n for n in paged_nodes}
@@ -1521,6 +1575,7 @@ def _fix_first_graph_view_payload(graph: UnifiedGraph, *, cve: str, package: str
     from agent_bom.graph.path_ranking import criticality_rank_meta, path_rank_tuple
 
     available_paths = _derived_attack_paths(graph)
+    _ensure_attack_campaigns(graph, available_paths)
     ranked_paths = sorted(
         (path for path in available_paths if _path_matches_focus(graph, path, cve=cve, package=package, agent=agent)),
         key=lambda path: path_rank_tuple(graph, path),
@@ -1583,12 +1638,7 @@ def _serialize_attack_path_queue(
     stats: dict[str, Any],
 ) -> dict[str, Any]:
     nodes_by_id = {node.id: node for node in nodes}
-    if total and int(stats.get("attack_path_count") or 0) == 0:
-        stats = {
-            **stats,
-            "attack_path_count": total,
-            "max_attack_path_risk": max((path.composite_risk for path in paths), default=0.0),
-        }
+    stats = _sync_attack_path_stats(stats, total=total, paths=paths)
     return {
         "scan_id": scan_id,
         "tenant_id": tenant,

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1845,6 +1845,104 @@ class TestGraphStoreBackendSelection:
             ("pkg:npm:form-data", "vuln:cve"),
         }
 
+    def test_fix_first_materialises_crown_jewel_campaigns_when_store_has_none(self, recording_graph_store):
+        """Store-backed loads wipe campaigns; serve path must recompute them."""
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="cloud:entry",
+                entity_type=EntityType.CLOUD_RESOURCE,
+                label="public-api",
+                attributes={"internet_exposed": True, "account_id": "acct-a"},
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="ds:crown",
+                entity_type=EntityType.DATA_STORE,
+                label="pci-db",
+                attributes={
+                    "account_id": "acct-a",
+                    "data_sensitivity": "sensitive",
+                    "data_regulatory_frameworks": ["PCI-DSS"],
+                    "owner": "payments",
+                },
+            )
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="cloud:entry", target="ds:crown", relationship=RelationshipType.STORES)
+        )
+        # Persist a jewel-terminating path (fusion does this at build time) but leave
+        # attack_campaigns empty — matching store_backed.StoreBackedUnifiedGraph.
+        recording_graph_store.graph.attack_paths.append(
+            AttackPath(
+                source="cloud:entry",
+                target="ds:crown",
+                hops=["cloud:entry", "ds:crown"],
+                edges=["stores"],
+                composite_risk=88.0,
+                summary="Internet-exposed public-api reaches pci-db (2-hop chain)",
+            )
+        )
+        assert recording_graph_store.graph.attack_campaigns == []
+        client = TestClient(app)
+
+        response = client.get("/v1/graph/views/fix-first", params={"scan_id": "store-scan"})
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["summary"]["campaign_count"] >= 1
+        assert body["attack_campaigns"]
+        assert body["attack_campaigns"][0]["crown_jewel"] == "ds:crown"
+
+    def test_filtered_graph_syncs_attack_path_stats_and_campaigns(self, recording_graph_store):
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="cloud:entry",
+                entity_type=EntityType.CLOUD_RESOURCE,
+                label="public-api",
+                attributes={"internet_exposed": True, "account_id": "acct-a"},
+            )
+        )
+        recording_graph_store.graph.add_node(
+            UnifiedNode(
+                id="ds:crown",
+                entity_type=EntityType.DATA_STORE,
+                label="pci-db",
+                attributes={
+                    "account_id": "acct-a",
+                    "data_sensitivity": "sensitive",
+                    "owner": "payments",
+                },
+            )
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="cloud:entry", target="ds:crown", relationship=RelationshipType.STORES)
+        )
+        recording_graph_store.graph.attack_paths.append(
+            AttackPath(
+                source="cloud:entry",
+                target="ds:crown",
+                hops=["cloud:entry", "ds:crown"],
+                edges=["stores"],
+                composite_risk=88.0,
+                summary="Internet-exposed public-api reaches pci-db (2-hop chain)",
+            )
+        )
+        client = TestClient(app)
+
+        # Relationship filter forces the investigation/load_graph path that
+        # materialises campaigns and syncs derived path stats.
+        response = client.get(
+            "/v1/graph",
+            params={"scan_id": "store-scan", "relationships": "stores", "limit": 50},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["stats"]["attack_path_count"] >= 1
+        assert body["attack_campaigns"]
+        assert body["attack_campaigns"][0]["crown_jewel"] == "ds:crown"
+
     def test_graph_overview_filtered_page_stays_store_backed(self, recording_graph_store):
         recording_graph_store.graph.add_node(
             UnifiedNode(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Recompute crown-jewel `attack_campaigns` on fix-first and filtered `/v1/graph` reads when the store-backed graph loads an empty campaign list (campaigns were build-time only and never persisted).
- Sync `attack_path_count` / `max_attack_path_risk` on `/v1/graph/attack-paths` and filtered overview responses when topology-only snapshots derive paths on read but stored path counts are zero.
- Empty estates stay empty — no fabrication when there is no crown-jewel sensitivity signal.

## Verification

```bash
uv run pytest tests/test_graph_api.py::TestGraphStoreBackendSelection::test_fix_first_materialises_crown_jewel_campaigns_when_store_has_none \
  tests/test_graph_api.py::TestGraphStoreBackendSelection::test_filtered_graph_syncs_attack_path_stats_and_campaigns \
  tests/test_graph_api.py::TestGraphStoreBackendSelection::test_fix_first_graph_view_derives_paths_when_snapshot_has_topology_but_no_path_rows -q
```

## Notes

- Unfiltered store-backed `/v1/graph` paging remains page_nodes-only (no full-graph load for stats sync) to preserve the overview performance contract; path-count honesty for topology-only snapshots is on `/attack-paths` and relationship-filtered overview.
- Companion PR wires the CWPP durable workload-evidence store factory (separate change).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

