### PR TITLE
fix(cwpp): wire durable workload-evidence store factory

### DIFF
--- a/src/agent_bom/cloud/runtime_workload_evidence_store.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence_store.py
@@ -2,11 +2,17 @@
 
 Three interchangeable backends behind one contract:
 
-* :class:`InMemoryRuntimeWorkloadEvidenceStore` — the default, non-durable tier.
-* :class:`SQLiteRuntimeWorkloadEvidenceStore` — node-local, restart-safe, and
-  safe under cross-process writers (WAL + busy timeout).
+* :class:`InMemoryRuntimeWorkloadEvidenceStore` — explicit ephemeral opt-out
+  (``AGENT_BOM_EPHEMERAL_STORE=1``); process-local, non-durable.
+* :class:`SQLiteRuntimeWorkloadEvidenceStore` — node-local default, restart-safe,
+  and safe under cross-process writers (WAL + busy timeout).
 * :class:`PostgresRuntimeWorkloadEvidenceStore` — shared across control-plane
   replicas.
+
+:func:`get_runtime_workload_evidence_store` selects the tier via
+:func:`agent_bom.storage.factory.resolve_backend` with ``mode="durable"``
+(Postgres → ephemeral opt-out → SQLite), matching the runtime event store so
+CLI ingest and API enrichment share evidence across processes and workers.
 
 Tenant isolation is application-level and follows the stage-1 lifecycle store
 (:mod:`agent_bom.cloud.side_scan_lifecycle`): ``tenant_id`` leads every WHERE
@@ -278,17 +284,41 @@ _default_lock = threading.Lock()
 
 
 def get_runtime_workload_evidence_store() -> RuntimeWorkloadEvidenceStore:
-    """Return the process default runtime workload-evidence store.
+    """Return the process default runtime workload-evidence store, durable by default.
 
-    Defaults to the in-memory tier so the finding/graph read path is a no-op until
-    an operator configures a durable backend or seeds signals. Durable SQLite /
-    Postgres backends are wired by stage-4 lock-in (scheduler + config); tests and
-    callers can inject one with :func:`set_runtime_workload_evidence_store`.
+    Selection (highest precedence first), via :mod:`agent_bom.storage.factory`:
+    - Postgres (``AGENT_BOM_POSTGRES_URL`` / ``AGENT_BOM_DB`` Postgres URL):
+      multi-replica — CLI ingest and API enrichment share one evidence table.
+    - in-memory (``AGENT_BOM_EPHEMERAL_STORE=1``): explicit opt-out; signals are
+      lost on restart and across processes/workers.
+    - SQLite (default, or ``AGENT_BOM_DB`` file path): single-node durable —
+      evidence survives a restart and is visible to a co-located API process.
+
+    Tests and callers can still inject a store with
+    :func:`set_runtime_workload_evidence_store`.
     """
     global _default_store
     with _default_lock:
-        if _default_store is None:
+        if _default_store is not None:
+            return _default_store
+        from agent_bom.storage.base import BackendKind
+        from agent_bom.storage.factory import resolve_backend
+
+        # mode="durable" matches runtime_event_store: Postgres → ephemeral only
+        # on explicit opt-out → SQLite default. The prior always-InMemory factory
+        # silently dropped CLI→API and multi-worker evidence.
+        selection = resolve_backend(mode="durable")
+        if selection.backend is BackendKind.POSTGRES:
+            import os
+
+            dsn = selection.dsn or os.environ.get("AGENT_BOM_POSTGRES_URL") or os.environ.get("AGENT_BOM_DB", "")
+            if not dsn.strip():
+                raise RuntimeError("Postgres workload-evidence store selected but no Postgres URL is configured")
+            _default_store = PostgresRuntimeWorkloadEvidenceStore(dsn.strip())
+        elif selection.backend is BackendKind.MEMORY:
             _default_store = InMemoryRuntimeWorkloadEvidenceStore()
+        else:
+            _default_store = SQLiteRuntimeWorkloadEvidenceStore(selection.sqlite_path or "agent_bom.db")
         return _default_store
 
 
@@ -298,11 +328,16 @@ def set_runtime_workload_evidence_store(store: RuntimeWorkloadEvidenceStore | No
         _default_store = store
 
 
+def reset_runtime_workload_evidence_store() -> None:
+    set_runtime_workload_evidence_store(None)
+
+
 __all__ = [
     "InMemoryRuntimeWorkloadEvidenceStore",
     "PostgresRuntimeWorkloadEvidenceStore",
     "RuntimeWorkloadEvidenceStore",
     "SQLiteRuntimeWorkloadEvidenceStore",
     "get_runtime_workload_evidence_store",
+    "reset_runtime_workload_evidence_store",
     "set_runtime_workload_evidence_store",
 ]

--- a/src/agent_bom/storage/factory.py
+++ b/src/agent_bom/storage/factory.py
@@ -4,8 +4,9 @@ Before this module, three stores each decided their backend by hand:
 
 * ``cost_store.get_cost_store`` and ``proxy_replay_store.get_proxy_replay_store``
   branched on ``AGENT_BOM_POSTGRES_URL`` then ``AGENT_BOM_DB`` then in-memory;
-* ``runtime_event_store`` delegated to ``durable_store.select_backend()`` (which
-  is durable-by-default: SQLite unless an explicit ephemeral opt-out).
+* ``runtime_event_store`` / ``runtime_workload_evidence_store`` delegated to
+  ``durable_store.select_backend()`` (which is durable-by-default: SQLite unless
+  an explicit ephemeral opt-out).
 
 Two subtly different precedence ladders for the same decision is exactly how a
 store ends up on the wrong tier. :func:`resolve_backend` centralises the choice

--- a/tests/test_durable_store_default.py
+++ b/tests/test_durable_store_default.py
@@ -30,6 +30,13 @@ from agent_bom.api.runtime_event_store import (
     get_runtime_event_store,
     set_runtime_event_store,
 )
+from agent_bom.cloud.runtime_workload_evidence import RuntimeWorkloadSignal
+from agent_bom.cloud.runtime_workload_evidence_store import (
+    InMemoryRuntimeWorkloadEvidenceStore,
+    SQLiteRuntimeWorkloadEvidenceStore,
+    get_runtime_workload_evidence_store,
+    set_runtime_workload_evidence_store,
+)
 
 
 @pytest.fixture()
@@ -47,11 +54,13 @@ def durable_state_dir(tmp_path, monkeypatch):
     monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
     set_agent_identity_store(None)
     set_runtime_event_store(None)
+    set_runtime_workload_evidence_store(None)
     try:
         yield tmp_path
     finally:
         set_agent_identity_store(None)
         set_runtime_event_store(None)
+        set_runtime_workload_evidence_store(None)
 
 
 def test_default_backend_is_durable_sqlite(durable_state_dir):
@@ -141,6 +150,41 @@ def test_runtime_session_survives_restart(durable_state_dir):
     assert observations[0].tool_name == "search"
 
 
+def test_runtime_workload_evidence_survives_restart(durable_state_dir):
+    store = get_runtime_workload_evidence_store()
+    assert isinstance(store, SQLiteRuntimeWorkloadEvidenceStore)
+    assert (
+        store.put_batch(
+            [
+                RuntimeWorkloadSignal(
+                    tenant_id="t-cwpp",
+                    provider="aws",
+                    account_id="123456789012",
+                    workload_ref="i-0restart",
+                    signal_type="ioc_detection",  # type: ignore[arg-type]
+                    severity="high",
+                    observed_at="2026-07-18T12:00:00Z",
+                    source_id="edr-1",
+                    source_kind="edr",
+                    dedup_key="evt-restart",
+                    title="known C2 domain contacted",
+                )
+            ]
+        )
+        == 1
+    )
+
+    set_runtime_workload_evidence_store(None)
+
+    store2 = get_runtime_workload_evidence_store()
+    assert store2 is not store
+    assert isinstance(store2, SQLiteRuntimeWorkloadEvidenceStore)
+    rows = store2.list_for_tenant("t-cwpp")
+    assert len(rows) == 1
+    assert rows[0].workload_ref == "i-0restart"
+    assert rows[0].dedup_key == "evt-restart"
+
+
 def test_postgres_url_routes_to_postgres_store(durable_state_dir, monkeypatch):
     # When a Postgres URL is configured the selector must pick the shared
     # Postgres-backed store (multi-replica), not the SQLite default. Patch the
@@ -149,19 +193,24 @@ def test_postgres_url_routes_to_postgres_store(durable_state_dir, monkeypatch):
     import agent_bom.api.postgres_agent_identity as pai
     import agent_bom.api.postgres_runtime_event as pre
     import agent_bom.api.runtime_event_store as res
+    import agent_bom.cloud.runtime_workload_evidence_store as rwes
 
     monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://unused/db")
     assert durable_store.select_backend() == "postgres"
 
     sentinel_identity = object()
     sentinel_runtime = object()
+    sentinel_workload = object()
     monkeypatch.setattr(pai, "PostgresAgentIdentityStore", lambda *a, **k: sentinel_identity)
     monkeypatch.setattr(pre, "PostgresRuntimeEventStore", lambda *a, **k: sentinel_runtime)
+    monkeypatch.setattr(rwes, "PostgresRuntimeWorkloadEvidenceStore", lambda *a, **k: sentinel_workload)
     ais.set_agent_identity_store(None)
     res.set_runtime_event_store(None)
+    rwes.set_runtime_workload_evidence_store(None)
 
     assert ais.get_agent_identity_store() is sentinel_identity
     assert res.get_runtime_event_store() is sentinel_runtime
+    assert rwes.get_runtime_workload_evidence_store() is sentinel_workload
 
 
 def test_postgres_stores_import_and_expose_store_protocol():
@@ -169,11 +218,14 @@ def test_postgres_stores_import_and_expose_store_protocol():
     # surface the SQLite/in-memory tiers do, so the selector can swap them in.
     from agent_bom.api.postgres_agent_identity import PostgresAgentIdentityStore
     from agent_bom.api.postgres_runtime_event import PostgresRuntimeEventStore
+    from agent_bom.cloud.runtime_workload_evidence_store import PostgresRuntimeWorkloadEvidenceStore
 
     for method in ("put", "get", "get_by_token_hash", "list", "put_jit_grant", "active_jit_grant"):
         assert callable(getattr(PostgresAgentIdentityStore, method))
     for method in ("put_observation", "list_sessions", "get_session", "list_observations"):
         assert callable(getattr(PostgresRuntimeEventStore, method))
+    for method in ("init_schema", "put_batch", "list_for_tenant"):
+        assert callable(getattr(PostgresRuntimeWorkloadEvidenceStore, method))
 
 
 def test_ephemeral_opt_out_does_not_persist(durable_state_dir, monkeypatch):
@@ -181,14 +233,35 @@ def test_ephemeral_opt_out_does_not_persist(durable_state_dir, monkeypatch):
     # store instance does NOT see what a prior instance issued.
     monkeypatch.setenv("AGENT_BOM_EPHEMERAL_STORE", "1")
     set_agent_identity_store(None)
+    set_runtime_workload_evidence_store(None)
     assert durable_store.select_backend() == "memory"
 
     store = get_agent_identity_store()
     identity, _ = issue_identity(store, agent_id="ephemeral", tenant_id="t-eph")
+    workload = get_runtime_workload_evidence_store()
+    assert isinstance(workload, InMemoryRuntimeWorkloadEvidenceStore)
+    workload.put_batch(
+        [
+            RuntimeWorkloadSignal(
+                tenant_id="t-eph",
+                provider="aws",
+                account_id="123456789012",
+                workload_ref="i-eph",
+                signal_type="ioc_detection",  # type: ignore[arg-type]
+                severity="high",
+                observed_at="2026-07-18T12:00:00Z",
+                source_id="edr-1",
+                source_kind="edr",
+                dedup_key="evt-eph",
+            )
+        ]
+    )
     set_agent_identity_store(None)
+    set_runtime_workload_evidence_store(None)
 
     store2 = get_agent_identity_store()
     assert store2.get(identity.identity_id, tenant_id="t-eph") is None
+    assert get_runtime_workload_evidence_store().list_for_tenant("t-eph") == []
     # No durable file is created for the ephemeral tier.
     assert not (durable_state_dir / durable_store.DEFAULT_STATE_DB_FILENAME).exists()
     assert not os.path.exists(durable_state_dir / durable_store.DEFAULT_STATE_DB_FILENAME)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Wire `get_runtime_workload_evidence_store()` through `resolve_backend(mode="durable")` — Postgres → explicit ephemeral opt-out → SQLite default — matching the runtime event store ladder.
- CLI ingest and API enrichment now share durable evidence across process restarts and co-located workers instead of silently using a process-local in-memory store.
- Regression coverage: restart survival, Postgres routing, ephemeral opt-out.

## Verification

```bash
uv run pytest tests/test_durable_store_default.py \
  tests/cloud/test_runtime_workload_evidence_store.py \
  tests/cloud/test_runtime_workload_evidence_wiring.py -q
```

## Notes

- Does not add the pull scheduler; this only fixes factory selection so existing ingest/read paths persist.
- Companion PR: graph serve-path campaign materialisation + `attack_path_count` sync (#4382).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

