### PR TITLE
fix(api): rate-limit runtime-evidence ingest as write/scan

### DIFF
--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1940,7 +1940,11 @@ def _validate_rate_limit(name: str, value: int, *, max_rpm: int) -> int:
 
 
 class RateLimitMiddleware(BaseHTTPMiddleware):
-    """Tenant-aware sliding window rate limiter with bounded memory."""
+    """Tenant-aware sliding window rate limiter with bounded memory.
+
+    Write / ingest POSTs (scan jobs and CWPP runtime-evidence ingest) share the
+    tighter ``scan_rpm`` bucket. Everything else uses ``read_rpm``.
+    """
 
     # Health/readiness/liveness probes must never self-throttle: orchestrators
     # (k8s, ELB, uptime monitors) hit these on short intervals and a probe storm
@@ -1955,6 +1959,12 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             "/livez",
             "/readyz",
             "/ping",
+        }
+    )
+    # Write/ingest doors that must not burn the generous read RPM budget.
+    _WRITE_RATE_LIMIT_PATHS = frozenset(
+        {
+            "/v1/cloud/runtime-evidence/ingest",
         }
     )
 
@@ -2015,6 +2025,15 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
             return True
         return False
 
+    @classmethod
+    def _is_write_rate_limited(cls, path: str, method: str) -> bool:
+        """True when the request should consume the tighter scan/write RPM bucket."""
+        if method != "POST":
+            return False
+        if path.startswith("/v1/scan"):
+            return True
+        return path in cls._WRITE_RATE_LIMIT_PATHS
+
     async def dispatch(self, request: StarletteRequest, call_next: RequestResponseEndpoint) -> Response:
         if self._is_dashboard_static_asset(request.url.path, request.method):
             return await call_next(request)
@@ -2024,7 +2043,7 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
 
         now = time.time()
 
-        is_scan = request.url.path.startswith("/v1/scan") and request.method == "POST"
+        is_scan = self._is_write_rate_limited(request.url.path, request.method)
         limit = self._scan_rpm if is_scan else self._read_rpm
 
         key = await self._bucket_key(request, is_scan)

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -1518,6 +1518,49 @@ def test_rate_limit_middleware():
     assert "Retry-After" in resp.headers
 
 
+def test_runtime_evidence_ingest_uses_scan_rate_limit_bucket():
+    """CWPP ingest must not burn the generous read RPM budget."""
+    from starlette.applications import Starlette
+    from starlette.responses import JSONResponse as StarletteJSONResponse
+    from starlette.routing import Route
+
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    path = "/v1/cloud/runtime-evidence/ingest"
+    test_app = Starlette(
+        routes=[
+            Route(path, dummy, methods=["POST"]),
+            Route("/v1/findings", dummy, methods=["GET"]),
+        ]
+    )
+    test_app.add_middleware(RateLimitMiddleware, scan_rpm=3, read_rpm=10)
+
+    client = TestClient(test_app)
+    for _ in range(3):
+        resp = client.post(path)
+        assert resp.status_code == 200
+        assert resp.headers["X-RateLimit-Limit"] == "3"
+
+    resp = client.post(path)
+    assert resp.status_code == 429
+    assert resp.headers["X-RateLimit-Limit"] == "3"
+
+    # Read budget remains independent of the write ingest bucket.
+    read = client.get("/v1/findings")
+    assert read.status_code == 200
+    assert read.headers["X-RateLimit-Limit"] == "10"
+
+
+def test_write_rate_limit_classifier_covers_scan_and_runtime_ingest():
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/scan", "POST") is True
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/scan/dataset-cards", "POST") is True
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/cloud/runtime-evidence/ingest", "POST") is True
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/cloud/runtime-evidence/ingest", "GET") is False
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/findings", "GET") is False
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/findings", "POST") is False
+
+
 def test_audit_and_gateway_limits_are_validated():
     """High-volume audit surfaces must reject invalid limits instead of forwarding them."""
     configure_api(api_key=None, rate_limit_rpm=1000)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- `POST /v1/cloud/runtime-evidence/ingest` previously consumed the generous read RPM bucket (~5× scan).
- Classify it with scan POSTs under `scan_rpm` so CWPP ingest shares the tighter write budget.
- Read endpoints keep an independent read bucket.

## Verification

```bash
uv run pytest tests/api/test_api_hardening.py::test_rate_limit_middleware \
  tests/api/test_api_hardening.py::test_runtime_evidence_ingest_uses_scan_rate_limit_bucket \
  tests/api/test_api_hardening.py::test_write_rate_limit_classifier_covers_scan_and_runtime_ingest -q
```

## Notes

- Companion list-contract PR: #4384 (`GET /v1/inventory` has_more + package/job paging).
- Leaves CWPP pull scheduler and credentialed Azure/GCP smoke parked.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

