### PR TITLE
fix(ui): render attack-path hops as one scrollable row

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,8 @@ drilldowns — not a dense dashboard collage.
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Prioritized attack path connecting identity, agent, MCP server, package, and critical finding" width="820" />
 </p>
 
-Path titles can wrap in narrow frames; use Path / Graph / List toggles in the
-live UI for a single-row hop strip. Recapture notes:
-[docs/CAPTURE.md](docs/CAPTURE.md).
+Path view is a single-row hop strip (scroll horizontally on long chains).
+Recapture notes: [docs/CAPTURE.md](docs/CAPTURE.md).
 
 </details>
 

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -311,14 +311,15 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
   const layout = buildPathGraphLayout(path);
 
   return (
-    <div className="flex justify-center overflow-x-auto p-2">
+    <div className="overflow-x-auto p-2" data-testid="exposure-path-graph-scroll">
       <svg
         viewBox={`0 0 ${layout.width} ${layout.height}`}
-        preserveAspectRatio="xMidYMid meet"
+        width={layout.width}
+        height={layout.height}
+        preserveAspectRatio="xMinYMid meet"
         role="img"
         aria-label={`Selected exposure path graph for ${pathDisplayTitle(path)}`}
-        style={{ maxWidth: `${layout.fitWidth}px` }}
-        className="mx-auto block h-auto w-full"
+        className="mx-auto block shrink-0"
       >
         <defs>
           <marker id="exposure-arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto" markerUnits="strokeWidth">
@@ -407,17 +408,17 @@ function ExposurePathGraph({ path }: { path: ExposurePath }) {
 }
 
 function ExposurePathHopTitle({ hops }: { hops: ExposureEntityRef[] }) {
-  /** Wrap between hops (chip + chevron), never mid-arrow in a long string. */
+  /** Single-row scrollable hop chips — never wrap mid-chain. */
   return (
     <div
-      className="flex flex-wrap items-center gap-x-1.5 gap-y-2"
+      className="flex flex-nowrap items-center gap-x-1.5 overflow-x-auto pb-1"
       aria-hidden="true"
       data-testid="exposure-path-hop-title"
     >
       {hops.map((hop, index) => {
         const meta = ROLE_META[hop.role] ?? ROLE_META.unknown;
         return (
-          <div key={`${hop.id}-${index}`} className="flex items-center gap-1.5">
+          <div key={`${hop.id}-${index}`} className="flex shrink-0 items-center gap-1.5">
             {index > 0 ? (
               <ChevronRight className="h-4 w-4 shrink-0 text-[color:var(--text-tertiary)]" aria-hidden="true" />
             ) : null}

--- a/ui/lib/exposure-path-graph-layout.ts
+++ b/ui/lib/exposure-path-graph-layout.ts
@@ -13,8 +13,9 @@ export const MIN_NODE_HEIGHT = 82;
 const MARGIN_X = 28;
 const MARGIN_Y = 30;
 const COLUMN_GAP = 132;
-const ROW_GAP_EXTRA = 40; // vertical clear channel between wrapped rows
-const MAX_COLUMNS = 4;
+// Path view is always a single horizontal kill-chain. Multi-row wrap made long
+// paths look like a broken DAG (vertical connector + orphan stubs on narrow
+// boards). Overflow scrolls horizontally instead.
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -72,27 +73,21 @@ export interface PathGraphLayout {
 export function buildPathGraphLayout(path: ExposurePath): PathGraphLayout {
   const count = path.hops.length;
   const { width: nodeWidth, height: nodeHeight } = nodeSizeForCount(count);
-  const columns = Math.min(MAX_COLUMNS, Math.max(1, count));
   const pitchX = nodeWidth + COLUMN_GAP;
-  const rowGap = nodeHeight + ROW_GAP_EXTRA;
 
-  // Always place hops left-to-right, wrapping to a new row. A prior
-  // boustrophedon (snake) layout made long paths reverse on odd rows while
-  // edges still assumed L→R ports — so the inbound arrow into the finding
-  // looked like it came from empty space (README screenshot regression).
-  const nodes: PathGraphNode[] = path.hops.map((hop, index) => {
-    const row = Math.floor(index / columns);
-    const col = index % columns;
-    return {
-      ...hop,
-      x: MARGIN_X + col * pitchX,
-      y: MARGIN_Y + row * rowGap,
-    };
-  });
+  // Single left-to-right row: hop N always sits to the right of hop N-1. A prior
+  // 4-column wrap (and an earlier boustrophedon snake) made long demo paths look
+  // disconnected — vertical wrap edges and ports that no longer matched the
+  // visual order. Horizontal scroll keeps the kill-chain readable instead.
+  const nodes: PathGraphNode[] = path.hops.map((hop, index) => ({
+    ...hop,
+    x: MARGIN_X + index * pitchX,
+    y: MARGIN_Y,
+  }));
 
   // Auto-fit: the viewBox is the tight bounding box of every node plus a uniform
   // margin, so the rendered graph always frames its own content — a 1-hop path
-  // is compact, a many-hop path scales down to fit, nothing overflows.
+  // is compact; a many-hop path grows horizontally and the canvas scrolls.
   const maxX = nodes.reduce((acc, node) => Math.max(acc, node.x + nodeWidth), nodeWidth);
   const maxY = nodes.reduce((acc, node) => Math.max(acc, node.y + nodeHeight), nodeHeight);
   const width = maxX + MARGIN_X;
@@ -101,41 +96,19 @@ export function buildPathGraphLayout(path: ExposurePath): PathGraphLayout {
   const edges: PathGraphEdge[] = nodes.slice(0, -1).map((source, index) => {
     const target = nodes[index + 1]!;
     const relationship = relationshipForPathStep(path, source.id, target.id, index);
-    const sameRow = Math.abs(source.y - target.y) < 10;
-    const control = sameRow ? Math.max(40, Math.abs(target.x - source.x) / 2) : 56;
-    let pathD: string;
-    let labelX: number;
-    let labelY: number;
-    if (sameRow) {
-      // Direction-aware ports so a same-row edge never draws "into" a node
-      // from empty space on the wrong side.
-      const leftToRight = target.x >= source.x;
-      const startX = leftToRight ? source.x + nodeWidth : source.x;
-      const endX = leftToRight ? target.x : target.x + nodeWidth;
-      const midY = source.y + nodeHeight / 2;
-      const c1 = leftToRight ? startX + control : startX - control;
-      const c2 = leftToRight ? endX - control : endX + control;
-      pathD = `M ${startX} ${midY} C ${c1} ${midY}, ${c2} ${midY}, ${endX} ${midY}`;
-      labelX = (startX + endX) / 2;
-      labelY = midY;
-    } else {
-      // Row wrap: drop from the end of the prior row to the start of the next.
-      const startX = source.x + nodeWidth / 2;
-      const startY = source.y + nodeHeight;
-      const endX = target.x + nodeWidth / 2;
-      const endY = target.y;
-      pathD = `M ${startX} ${startY} C ${startX} ${startY + control}, ${endX} ${endY - control}, ${endX} ${endY}`;
-      labelX = (startX + endX) / 2;
-      labelY = (startY + endY) / 2;
-    }
+    const control = Math.max(40, Math.abs(target.x - source.x) / 2);
+    const startX = source.x + nodeWidth;
+    const endX = target.x;
+    const midY = source.y + nodeHeight / 2;
+    const pathD = `M ${startX} ${midY} C ${startX + control} ${midY}, ${endX - control} ${midY}, ${endX} ${midY}`;
     const style = GRAPH_ROLE_STYLE[target.role] ?? GRAPH_ROLE_STYLE.unknown;
     return {
       id: `${source.id}->${target.id}`,
       path: pathD,
       stroke: style.stroke,
       label: truncateGraphText(relationship, 16),
-      labelX,
-      labelY,
+      labelX: (startX + endX) / 2,
+      labelY: midY,
     };
   });
 

--- a/ui/tests/exposure-path-graph-layout.test.ts
+++ b/ui/tests/exposure-path-graph-layout.test.ts
@@ -106,14 +106,31 @@ describe("buildPathGraphLayout auto-fit", () => {
     }
   });
 
-  it("wraps a 10-node path into rows that fit instead of one giant row", () => {
-    const layout = buildPathGraphLayout(makePath(10));
-    // At most 4 columns, so the board never grows unbounded horizontally.
-    const distinctX = new Set(layout.nodes.map((node) => Math.round(node.x)));
-    expect(distinctX.size).toBeLessThanOrEqual(4);
-    // Multiple rows means it grew vertically to fit, not off the right edge.
+  it("keeps a long path on one left-to-right row so edges never orphan", () => {
+    // 7 hops is the demo critical-path shape. A prior 4-column wrap put the
+    // finding on a second row with a vertical connector that read as broken.
+    const layout = buildPathGraphLayout(makePath(7));
+    expect(layout.nodes).toHaveLength(7);
     const distinctY = new Set(layout.nodes.map((node) => Math.round(node.y)));
-    expect(distinctY.size).toBeGreaterThan(1);
+    expect(distinctY.size).toBe(1);
+    for (let i = 1; i < layout.nodes.length; i += 1) {
+      expect(layout.nodes[i]!.x).toBeGreaterThan(layout.nodes[i - 1]!.x);
+    }
+    // Finding (last hop) is the rightmost node on the single row.
+    expect(layout.nodes[6]!.x).toBeGreaterThan(layout.nodes[0]!.x);
+    expect(layout.edges).toHaveLength(6);
+    // Same-row cubics only — no vertical wrap connector between hops.
+    for (const edge of layout.edges) {
+      expect(edge.path.split(" ").length).toBeGreaterThan(8);
+      expect(edge.path).toContain(" C ");
+    }
+  });
+
+  it("grows horizontally for dense paths instead of wrapping into rows", () => {
+    const layout = buildPathGraphLayout(makePath(10));
+    const distinctY = new Set(layout.nodes.map((node) => Math.round(node.y)));
+    expect(distinctY.size).toBe(1);
+    expect(layout.width).toBeGreaterThan(buildPathGraphLayout(makePath(2)).width);
     // Dense path uses smaller nodes than a 2-node path.
     expect(layout.nodeWidth).toBeLessThan(buildPathGraphLayout(makePath(2)).nodeWidth);
   });
@@ -122,25 +139,5 @@ describe("buildPathGraphLayout auto-fit", () => {
     const layout = buildPathGraphLayout(makePath(5));
     expect(layout.edges).toHaveLength(4);
     expect(layout.relationshipLabels).toHaveLength(4);
-  });
-
-  it("keeps every row left-to-right so wrapped paths do not snake backwards", () => {
-    // 7 hops is the demo critical-path shape (identity → … → finding): one full
-    // row of 4, then 3 on the next row. Odd-row boustrophedon previously put
-    // the finding on the bottom-left with an inbound arrow from empty space.
-    const layout = buildPathGraphLayout(makePath(7));
-    expect(layout.nodes).toHaveLength(7);
-    const row0 = layout.nodes.slice(0, 4);
-    const row1 = layout.nodes.slice(4);
-    for (let i = 1; i < row0.length; i += 1) {
-      expect(row0[i]!.x).toBeGreaterThan(row0[i - 1]!.x);
-    }
-    for (let i = 1; i < row1.length; i += 1) {
-      expect(row1[i]!.x).toBeGreaterThan(row1[i - 1]!.x);
-    }
-    // Finding (last hop) sits to the right of the first hop on its row.
-    expect(row1[row1.length - 1]!.x).toBeGreaterThan(row1[0]!.x);
-    // Wrap edge: last of row0 is rightmost; first of row1 is leftmost.
-    expect(row0[row0.length - 1]!.x).toBeGreaterThan(row1[0]!.x);
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Investigation Path view wrapped long kill-chains at 4 columns, which still read as a broken DAG (two rows + vertical connector), and stale captures showed orphan arrow stubs from the older snake layout.
- Lay hops in a **single left-to-right row** with horizontal scroll; hop title chips also stop wrapping mid-chain.
- SVG uses intrinsic width (`shrink-0`) so the board no longer `w-full` compresses a long path into an unreadable multi-row fit.

## Verification

```bash
cd ui && npm test -- --run tests/exposure-path-graph-layout.test.ts && npm run typecheck
```

## Notes

- Does not recapture `docs/images/security-graph-live.png` in this PR (README caption updated). Recapture via `docs/CAPTURE.md` when convenient.
- Related earlier fix #4356 stopped reverse-row snake edges; this removes multi-row wrap entirely for Path view.
- Marked ready for review after rebase onto latest `main`; prior CI cancel was supersede (`cancel-in-progress`), not a code failure.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

