### PR TITLE
docs: surface-aware Scan section + fix agents-for-CVEs overclaim

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,16 +34,30 @@
 
 ## Scan
 
+The same scanner runs from four entry points — pick the one for your surface;
+none is "the" way in.
+
+CLI (local or one-off):
+
 ```bash
 pip install agent-bom
 agent-bom scan .
 ```
 
-Inventory, findings, reachability, and fix-first actions — works without a
-control plane. Same scanner also runs in CI ([GitHub Action](https://github.com/marketplace/actions/agent-bom)),
-Docker, and from a self-hosted control plane via cloud connect / scheduled
-estate scans — “local” is one entry point, not the only one. Export when
-another tool needs it: `agent-bom scan . -f sarif -o findings.sarif`.
+CI (GitHub Action):
+
+```yaml
+- uses: msaad00/agent-bom@v0.97.2
+  with:
+    scan-type: agents
+    format: sarif
+    upload-sarif: true
+```
+
+Also: Docker, and a self-hosted control plane via cloud connect / scheduled
+estate scans. Inventory, findings, reachability, and fix-first actions work
+without a control plane; export when another tool needs it:
+`agent-bom scan . -f sarif -o findings.sarif`.
 
 Offline sample without your repo: `uvx agent-bom scan --demo --offline` ·
 full path: [First Run](docs/FIRST_RUN.md).

--- a/integrations/cortex-code/SKILL.md
+++ b/integrations/cortex-code/SKILL.md
@@ -10,9 +10,10 @@ tools:
 
 # agent-bom — Security Platform for Agentic Infrastructure
 
-Scan your MCP servers, packages, and AI agent configurations for CVEs,
-credential exposure, and supply chain risks. Maps blast radius from
-vulnerable packages to the credentials and tools they can reach.
+Scan your MCP servers, AI agents, and their packages: CVEs and supply-chain
+risk (malicious/typosquat) in the packages, plus credential exposure,
+identity/auth/access posture, and MCP config risk on the servers and agents.
+Maps blast radius from a finding to the credentials and tools it can reach.
 
 ## When to Use
 


### PR DESCRIPTION
Two accuracy/positioning fixes surfaced from the GitHub Marketplace Action listing.

## 1. Scan section wasn't surface-aware
The Action-marketplace listing renders this repo README, whose `## Scan` led with `pip install; agent-bom scan .` — so the **CI surface headlined a local command**. Now the section shows both entry points side by side (CLI **and** the GitHub Action `uses:` snippet), so each surface sees its own usage. "local is one entry point" is now shown, not just claimed.

## 2. "AI agent configurations for CVEs" overclaim
CVEs are **package/dependency-level** — you don't scan an agent or a config *for a CVE*. Reworded `integrations/cortex-code/SKILL.md` to the accurate split: CVEs + malicious/typosquat in the **packages**; credential exposure, identity/auth/access posture, and MCP config risk on the **servers/agents**.

Verified: release-consistency + public-docs alignment tests pass; Action inputs (`scan-type`/`format`/`upload-sarif`) are valid in `action.yml`.

Note (not in this PR, GitHub-side): the Marketplace *listing* "About" text ("scan AI agents and MCP servers for CVEs") is listing metadata edited in the Marketplace UI, not the repo — `action.yml` + the repo description are already accurate.