### PR TITLE
fix(graph): dual-emit Snowflake account CONTAINS with OWNS

### DIFF
--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -2198,10 +2198,11 @@ def _add_account_resource_hierarchy(
 ) -> None:
     """Link account → resource as both ``OWNS`` and ``CONTAINS``.
 
-    Cloud inventory historically emitted ``OWNS`` only. Estate rollup special-cases
-    that edge, but attack-path fusion and cost subtrees walk ``CONTAINS``. Dual-emit
-    keeps ownership semantics while making the account hierarchy traversable for
-    kill-chains — matching cloud-origin lineage which already emits ``CONTAINS``.
+    Cloud inventory and Snowflake object layers historically emitted ``OWNS``
+    only. Estate rollup special-cases that edge, but attack-path fusion and cost
+    subtrees walk ``CONTAINS``. Dual-emit keeps ownership semantics while making
+    the account hierarchy traversable for kill-chains — matching cloud-origin
+    lineage which already emits ``CONTAINS``.
     """
     if not account_node_id or not resource_node_id:
         return
@@ -2654,7 +2655,12 @@ def _add_snowflake_object_graph(graph: UnifiedGraph, payload: Any, data_source: 
             )
         )
         if account_node_id:
-            _add_rel_edge(graph, account_node_id, node_id, RelationshipType.OWNS, {"source": "snowflake-objects"})
+            _add_account_resource_hierarchy(
+                graph,
+                account_node_id,
+                node_id,
+                evidence={"source": "snowflake-objects"},
+            )
         return node_id
 
     for obj in payload.get("objects", []) or []:
@@ -2831,7 +2837,12 @@ def _add_snowflake_services(graph: UnifiedGraph, payload: Any, data_source: str)
     def _own(node: UnifiedNode) -> str:
         graph.add_node(node)
         if account_node_id:
-            _add_rel_edge(graph, account_node_id, node.id, RelationshipType.OWNS, {"source": "snowflake-services"})
+            _add_account_resource_hierarchy(
+                graph,
+                account_node_id,
+                node.id,
+                evidence={"source": "snowflake-services"},
+            )
         return node.id
 
     for wh in payload.get("warehouses", []) or []:
@@ -3038,7 +3049,12 @@ def _add_snowflake_external_data(graph: UnifiedGraph, payload: Any, data_source:
             )
         )
         if account_node_id:
-            _add_rel_edge(graph, account_node_id, node_id, RelationshipType.OWNS, {"source": "snowflake-external-data"})
+            _add_account_resource_hierarchy(
+                graph,
+                account_node_id,
+                node_id,
+                evidence={"source": "snowflake-external-data"},
+            )
         return node_id
 
     for tbl in payload.get("iceberg_tables", []) or []:
@@ -3183,7 +3199,12 @@ def _add_snowflake_integrations(graph: UnifiedGraph, payload: Any, data_source: 
             )
         )
         if account_node_id:
-            _add_rel_edge(graph, account_node_id, node_id, RelationshipType.OWNS, {"source": "snowflake-integrations"})
+            _add_account_resource_hierarchy(
+                graph,
+                account_node_id,
+                node_id,
+                evidence={"source": "snowflake-integrations"},
+            )
 
 
 def _add_snowflake_pipeline(graph: UnifiedGraph, payload: Any, data_source: str) -> None:
@@ -3220,7 +3241,12 @@ def _add_snowflake_pipeline(graph: UnifiedGraph, payload: Any, data_source: str)
     def _own(node: UnifiedNode) -> str:
         graph.add_node(node)
         if account_node_id:
-            _add_rel_edge(graph, account_node_id, node.id, RelationshipType.OWNS, {"source": "snowflake-pipeline"})
+            _add_account_resource_hierarchy(
+                graph,
+                account_node_id,
+                node.id,
+                evidence={"source": "snowflake-pipeline"},
+            )
         return node.id
 
     def _thin(node_id: str, entity_type: EntityType, label: str, surface: str) -> None:
@@ -3479,7 +3505,12 @@ def _add_snowflake_exfil(graph: UnifiedGraph, payload: Any, data_source: str) ->
     def _owned(node: UnifiedNode) -> str:
         graph.add_node(node)
         if account_node_id:
-            _add_rel_edge(graph, account_node_id, node.id, RelationshipType.OWNS, {"source": "snowflake-exfil"})
+            _add_account_resource_hierarchy(
+                graph,
+                account_node_id,
+                node.id,
+                evidence={"source": "snowflake-exfil"},
+            )
         return node.id
 
     # ── Outbound shares → consumer accounts ────────────────────────────
@@ -3710,7 +3741,12 @@ def _add_snowflake_governance(graph: UnifiedGraph, payload: Any, data_source: st
                 )
             )
             if account_node_id:
-                _add_rel_edge(graph, account_node_id, object_node_id, RelationshipType.OWNS, {"source": "snowflake-governance"})
+                _add_account_resource_hierarchy(
+                    graph,
+                    account_node_id,
+                    object_node_id,
+                    evidence={"source": "snowflake-governance"},
+                )
         _add_rel_edge(
             graph,
             _ensure_user(user_name),
@@ -3872,12 +3908,11 @@ def _add_cloud_audit_behavioral(graph: UnifiedGraph, payload: Any, data_source: 
                 )
             )
             if account_node_id:
-                _add_rel_edge(
+                _add_account_resource_hierarchy(
                     graph,
                     account_node_id,
                     resource_node_id,
-                    RelationshipType.OWNS,
-                    {"source": "cloud-audit-trail"},
+                    evidence={"source": "cloud-audit-trail"},
                 )
         _add_rel_edge(
             graph,

--- a/tests/test_snowflake_object_graph.py
+++ b/tests/test_snowflake_object_graph.py
@@ -58,7 +58,10 @@ def test_objects_become_owned_data_store_nodes() -> None:
     assert orders.attributes["is_data_store"] is True
     assert orders.attributes["row_count"] == 100
     owns = {(e.source, e.target) for e in edges if e.relationship.value == "owns"}
-    assert ("account:snowflake:acct1", "data_store:snowflake:DB.PUBLIC.ORDERS") in owns
+    contains = {(e.source, e.target) for e in edges if e.relationship.value == "contains"}
+    account_orders = ("account:snowflake:acct1", "data_store:snowflake:DB.PUBLIC.ORDERS")
+    assert account_orders in owns
+    assert account_orders in contains
 
 
 def test_dependencies_become_depends_on_lineage_edges() -> None:

--- a/tests/test_snowflake_services_graph.py
+++ b/tests/test_snowflake_services_graph.py
@@ -44,7 +44,10 @@ def test_warehouse_is_compute_cloud_resource_owned_by_account() -> None:
     assert wh is not None
     assert wh.attributes["resource_kind"] == "snowflake-warehouse"
     owns = {(e.source, e.target) for e in edges if e.relationship.value == "owns"}
-    assert ("account:snowflake:acct1", "cloud_resource:snowflake:warehouse:WH_ETL") in owns
+    contains = {(e.source, e.target) for e in edges if e.relationship.value == "contains"}
+    account_wh = ("account:snowflake:acct1", "cloud_resource:snowflake:warehouse:WH_ETL")
+    assert account_wh in owns
+    assert account_wh in contains
 
 
 def test_database_contains_schema() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Route Snowflake account→warehouse / data-store / integration / pipeline / exfil / governance-object edges through `_add_account_resource_hierarchy` (OWNS + CONTAINS).
- Same for cloud-audit-trail account→observed resource edges.
- Leave account→Cortex agent (and account→principal) as OWNS-only — not resource containment for attack-path fusion.

## Verification

- `uv run pytest -q tests/test_snowflake_object_graph.py tests/test_snowflake_services_graph.py tests/test_snowflake_identity_graph.py tests/test_snowflake_organizations.py tests/test_graph_export_cloud.py`

## Notes

- Follow-up to #4399 (AWS/GCP/Azure inventory already dual-emitted).
- Completes Snowflake parity for `Account -[CONTAINS]-> Resource` kill-chain walks.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

