### PR TITLE
feat(cloud): estate architecture verdict for org hierarchy

### DIFF
--- a/src/agent_bom/cloud/aws_organizations.py
+++ b/src/agent_bom/cloud/aws_organizations.py
@@ -128,6 +128,7 @@ def discover_organization(profile: str | None = None, *, force: bool = False) ->
         # AWSOrganizationsNotInUseException → a standalone account, not an error.
         if "NotInUse" in type(exc).__name__ or "AWSOrganizationsNotInUse" in str(exc):
             result["status"] = "not_in_org"
+            _derive_findings(result)
         else:
             result["status"] = "ok"  # partial; record what we can
             warnings.append(f"Could not describe organization: {sanitize_discovery_warning(exc)}")
@@ -218,26 +219,7 @@ def discover_organization(profile: str | None = None, *, force: bool = False) ->
         warnings.append(f"Could not list SCPs: {sanitize_discovery_warning(exc)}")
 
     # Findings.
-    customer_scps = [s for s in result["scps"] if not s["aws_managed"]]
-    if not customer_scps and result["accounts"]:
-        result["findings"].append(
-            {
-                "severity": "medium",
-                "title": "No custom Service Control Policies",
-                "detail": f"{len(result['accounts'])} accounts, no customer SCPs — only the default FullAWSAccess applies.",
-            }
-        )
-    ou_ids = {o["id"] for o in result["organizational_units"]}
-    # accounts are placed via parents; flag the org as flat if there are no non-root OUs
-    non_root_ous = [o for o in result["organizational_units"] if not o.get("is_root")]
-    if result["accounts"] and not non_root_ous:
-        result["findings"].append(
-            {
-                "severity": "low",
-                "title": "Flat organization (no OUs)",
-                "detail": f"{len(result['accounts'])} accounts sit directly under the root with no OUs — no tiered guardrails.",
-            }
-        )
+    _derive_findings(result)
 
     result["status"] = "ok"
     result["discovery_envelope"] = DiscoveryEnvelope(
@@ -246,8 +228,102 @@ def discover_organization(profile: str | None = None, *, force: bool = False) ->
         permissions_used=_AWS_ORG_PERMISSIONS,
         redaction_status=RedactionStatus.CENTRAL_SANITIZER_APPLIED,
     ).to_dict()
-    _ = ou_ids  # reserved for future account→OU placement enrichment
     return result
+
+
+def _derive_findings(result: dict[str, Any]) -> None:
+    """Flag estate-architecture risks (single-account / flat OU tree / missing SCPs).
+
+    Appends structured findings with stable ``check_id`` values so the graph and
+    unified Finding stream can promote them without inventing CIS tags.
+    """
+    status = str(result.get("status") or "")
+    accounts = [a for a in (result.get("accounts") or []) if isinstance(a, dict)]
+    non_root_ous = [o for o in (result.get("organizational_units") or []) if isinstance(o, dict) and not o.get("is_root")]
+    customer_scps = [s for s in (result.get("scps") or []) if isinstance(s, dict) and not s.get("aws_managed")]
+
+    account_count = len(accounts)
+    hierarchy_depth = len(non_root_ous)
+    if status == "not_in_org":
+        verdict = "not_in_org"
+    elif account_count <= 1:
+        verdict = "single_account"
+    elif hierarchy_depth == 0:
+        verdict = "flat"
+    else:
+        verdict = "tiered"
+    result["architecture"] = {
+        "provider": "aws",
+        "account_count": account_count,
+        "hierarchy_depth": hierarchy_depth,
+        "custom_scp_count": len(customer_scps),
+        "verdict": verdict,
+    }
+
+    findings = result.setdefault("findings", [])
+    if not isinstance(findings, list):
+        result["findings"] = []
+        findings = result["findings"]
+
+    if status == "not_in_org":
+        findings.append(
+            {
+                "check_id": "ORG-AWS-001",
+                "severity": "medium",
+                "category": "estate_architecture",
+                "title": "Standalone AWS account (not in an Organization)",
+                "detail": (
+                    "This account is not a member of AWS Organizations. Multi-account "
+                    "landing zones with OU-tiered SCPs are the recommended isolation model."
+                ),
+                "account_count": 1,
+                "hierarchy_depth": 0,
+            }
+        )
+        return
+
+    if account_count <= 1 and (account_count > 0 or result.get("org_id")):
+        findings.append(
+            {
+                "check_id": "ORG-AWS-002",
+                "severity": "medium",
+                "category": "estate_architecture",
+                "title": "Single-account AWS Organization",
+                "detail": (
+                    f"{max(account_count, 1)} account under the organization — workloads, identity, "
+                    "and logging share one blast-radius boundary. Prefer separate accounts per "
+                    "environment / workload (landing-zone pattern)."
+                ),
+                "account_count": max(account_count, 1),
+                "hierarchy_depth": hierarchy_depth,
+            }
+        )
+
+    if accounts and not customer_scps:
+        findings.append(
+            {
+                "check_id": "ORG-AWS-003",
+                "severity": "medium",
+                "category": "estate_architecture",
+                "title": "No custom Service Control Policies",
+                "detail": f"{account_count} accounts, no customer SCPs — only the default FullAWSAccess applies.",
+                "account_count": account_count,
+                "hierarchy_depth": hierarchy_depth,
+            }
+        )
+
+    if accounts and not non_root_ous:
+        findings.append(
+            {
+                "check_id": "ORG-AWS-004",
+                "severity": "low",
+                "category": "estate_architecture",
+                "title": "Flat organization (no OUs)",
+                "detail": f"{account_count} accounts sit directly under the root with no OUs — no tiered guardrails.",
+                "account_count": account_count,
+                "hierarchy_depth": 0,
+            }
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/src/agent_bom/cloud/gcp_organizations.py
+++ b/src/agent_bom/cloud/gcp_organizations.py
@@ -429,8 +429,7 @@ def _derive_findings(result: dict[str, Any]) -> None:
                 "category": "estate_architecture",
                 "title": "Standalone GCP project (no organization)",
                 "detail": (
-                    "No GCP organization is visible. Folder hierarchy + org policies are the "
-                    "recommended isolation model across projects."
+                    "No GCP organization is visible. Folder hierarchy + org policies are the recommended isolation model across projects."
                 ),
                 "account_count": 1,
                 "hierarchy_depth": 0,
@@ -461,10 +460,7 @@ def _derive_findings(result: dict[str, Any]) -> None:
                 "severity": "medium",
                 "category": "estate_architecture",
                 "title": "No organization policy constraints",
-                "detail": (
-                    f"{project_count} projects, no org-policy constraints — "
-                    "no org-wide guardrails (the AWS-SCP equivalent) apply."
-                ),
+                "detail": (f"{project_count} projects, no org-policy constraints — no org-wide guardrails (the AWS-SCP equivalent) apply."),
                 "account_count": project_count,
                 "hierarchy_depth": hierarchy_depth,
             }

--- a/src/agent_bom/cloud/gcp_organizations.py
+++ b/src/agent_bom/cloud/gcp_organizations.py
@@ -106,6 +106,7 @@ def discover_organization(credentials: Any = None, *, force: bool = False) -> di
     org_id, org_name = _search_organization(credentials, warnings)
     if not org_id:
         result["status"] = "not_in_org"
+        _derive_findings(result)
         return result
     result["org_id"] = org_id
     result["org_name"] = org_name
@@ -392,23 +393,92 @@ def _collect_org_policies(
 
 def _derive_findings(result: dict[str, Any]) -> None:
     """Flag estate-shape risks, mirroring the AWS-org findings (read-only signal)."""
-    if not result["org_policies"] and result["projects"]:
-        result["findings"].append(
+    status = str(result.get("status") or "")
+    projects = [p for p in (result.get("projects") or []) if isinstance(p, dict)]
+    folders = [f for f in (result.get("folders") or []) if isinstance(f, dict)]
+    org_policies = [p for p in (result.get("org_policies") or []) if isinstance(p, dict)]
+
+    project_count = len(projects)
+    hierarchy_depth = len(folders)
+    if status == "not_in_org":
+        verdict = "not_in_org"
+    elif project_count <= 1:
+        verdict = "single_account"
+    elif hierarchy_depth == 0:
+        verdict = "flat"
+    else:
+        verdict = "tiered"
+    result["architecture"] = {
+        "provider": "gcp",
+        "account_count": project_count,
+        "hierarchy_depth": hierarchy_depth,
+        "org_policy_count": len(org_policies),
+        "verdict": verdict,
+    }
+
+    findings = result.setdefault("findings", [])
+    if not isinstance(findings, list):
+        result["findings"] = []
+        findings = result["findings"]
+
+    if status == "not_in_org":
+        findings.append(
             {
+                "check_id": "ORG-GCP-001",
                 "severity": "medium",
-                "title": "No organization policy constraints",
+                "category": "estate_architecture",
+                "title": "Standalone GCP project (no organization)",
                 "detail": (
-                    f"{len(result['projects'])} projects, no org-policy constraints — "
-                    "no org-wide guardrails (the AWS-SCP equivalent) apply."
+                    "No GCP organization is visible. Folder hierarchy + org policies are the "
+                    "recommended isolation model across projects."
                 ),
+                "account_count": 1,
+                "hierarchy_depth": 0,
             }
         )
-    if result["projects"] and not result["folders"]:
-        result["findings"].append(
+        return
+
+    if project_count <= 1 and (project_count > 0 or result.get("org_id")):
+        findings.append(
             {
+                "check_id": "ORG-GCP-002",
+                "severity": "medium",
+                "category": "estate_architecture",
+                "title": "Single-project GCP Organization",
+                "detail": (
+                    f"{max(project_count, 1)} project under the organization — prefer separate "
+                    "projects per environment / workload with folder-tiered org policies."
+                ),
+                "account_count": max(project_count, 1),
+                "hierarchy_depth": hierarchy_depth,
+            }
+        )
+
+    if not org_policies and projects:
+        findings.append(
+            {
+                "check_id": "ORG-GCP-003",
+                "severity": "medium",
+                "category": "estate_architecture",
+                "title": "No organization policy constraints",
+                "detail": (
+                    f"{project_count} projects, no org-policy constraints — "
+                    "no org-wide guardrails (the AWS-SCP equivalent) apply."
+                ),
+                "account_count": project_count,
+                "hierarchy_depth": hierarchy_depth,
+            }
+        )
+    if projects and not folders:
+        findings.append(
+            {
+                "check_id": "ORG-GCP-004",
                 "severity": "low",
+                "category": "estate_architecture",
                 "title": "Flat organization (no folders)",
-                "detail": (f"{len(result['projects'])} projects sit directly under the org with no folders — no tiered guardrails."),
+                "detail": f"{project_count} projects sit directly under the org with no folders — no tiered guardrails.",
+                "account_count": project_count,
+                "hierarchy_depth": 0,
             }
         )
 

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -1046,6 +1046,50 @@ def snowflake_governance_finding_to_finding(finding: dict, account: str) -> "Fin
     )
 
 
+def cloud_org_architecture_finding_to_finding(finding: dict, *, provider: str, org_id: str = "") -> "Finding":
+    """Convert an AWS/GCP org-architecture finding into a unified Finding."""
+    from agent_bom.finding_scope import normalize_account_ref
+    from agent_bom.security import sanitize_text
+
+    provider_key = sanitize_text(str(provider or "cloud"), max_len=40).lower() or "cloud"
+    check_id = sanitize_text(str(finding.get("check_id") or finding.get("title") or "ORG"), max_len=80)
+    severity = sanitize_text(str(finding.get("severity") or "medium"), max_len=40).lower() or "medium"
+    title = sanitize_text(str(finding.get("title") or check_id), max_len=300)
+    detail = sanitize_text(str(finding.get("detail") or ""), max_len=800)
+    org_label = sanitize_text(str(org_id or "standalone"), max_len=120)
+    account_ref = normalize_account_ref(provider_key, org_label)
+
+    return Finding(
+        finding_type=FindingType.CLOUD_BEST_PRACTICE_FAIL,
+        source=FindingSource.CLOUD_SECURITY,
+        asset=Asset(
+            name=f"{provider_key}-org:{org_label}",
+            asset_type="cloud_resource",
+            identifier=f"{provider_key}-org:{org_label}",
+            location=provider_key,
+            provider=provider_key,
+            account_ref=account_ref,
+        ),
+        severity=severity,
+        provider=provider_key,
+        account_ref=account_ref,
+        title=title,
+        description=detail or title,
+        compliance_tags=[f"CLOUD-ORG-{check_id}"],
+        evidence={
+            "provider": provider_key,
+            "org_id": org_id,
+            "check_id": check_id,
+            "category": finding.get("category") or "estate_architecture",
+            "account_count": finding.get("account_count"),
+            "hierarchy_depth": finding.get("hierarchy_depth"),
+        },
+        is_actionable=True,
+        impact_category="estate_architecture",
+        id=stable_id("cloud-org", provider_key, check_id, org_label),
+    )
+
+
 def blast_radius_to_finding(br: object) -> "Finding":
     """Convert a BlastRadius instance to a unified Finding.
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -4153,11 +4153,7 @@ def _add_aws_organization(graph: UnifiedGraph, payload: Any, data_source: str) -
                 "cloud_provider": "aws",
                 "master_account_id": _clean_graph_part(payload.get("master_account_id")),
                 "feature_set": _clean_graph_part(payload.get("feature_set")),
-                **(
-                    {"architecture": payload.get("architecture")}
-                    if isinstance(payload.get("architecture"), dict)
-                    else {}
-                ),
+                **({"architecture": payload.get("architecture")} if isinstance(payload.get("architecture"), dict) else {}),
             },
             data_sources=data_sources,
             dimensions=NodeDimensions(cloud_provider="aws", surface="identity"),

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -991,6 +991,7 @@ def build_unified_graph_from_report(
         )
 
     _add_aws_organization(graph, report_json.get("aws_organization"), data_source_tag)
+    _add_cloud_org_architecture_findings(graph, report_json, data_source_tag)
     _add_snowflake_object_graph(graph, report_json.get("snowflake_object_graph"), data_source_tag)
     _add_snowflake_exfil(graph, report_json.get("snowflake_exfil_graph"), data_source_tag)
     _add_snowflake_identity(
@@ -4038,6 +4039,95 @@ _RBAC_PRIVILEGED_ROLES = {
 }
 
 
+def _add_cloud_org_architecture_findings(graph: UnifiedGraph, report_json: Mapping[str, Any], data_source: str) -> None:
+    """Promote org-architecture findings (single-account / flat hierarchy) to MISCONFIGURATION nodes.
+
+    Reads ``aws_organization.findings`` and nested ``cloud_inventory[].gcp_organization.findings``.
+    Works even when status is ``not_in_org`` (hierarchy builder no-ops) so the architecture
+    verdict still lands on the graph. Does not invent CIS tags.
+    """
+    payloads: list[tuple[str, dict[str, Any]]] = []
+    aws_org = report_json.get("aws_organization")
+    if isinstance(aws_org, dict):
+        payloads.append(("aws", aws_org))
+
+    inventory = report_json.get("cloud_inventory")
+    inv_list = inventory if isinstance(inventory, list) else ([inventory] if isinstance(inventory, dict) else [])
+    for entry in inv_list:
+        if not isinstance(entry, dict):
+            continue
+        gcp_org = entry.get("gcp_organization")
+        if isinstance(gcp_org, dict):
+            payloads.append(("gcp", gcp_org))
+
+    for provider, payload in payloads:
+        findings = payload.get("findings")
+        if not isinstance(findings, list):
+            continue
+        org_id = _clean_graph_part(payload.get("org_id"))
+        if provider == "aws":
+            target_id = f"org:aws:{org_id}" if org_id else "org:aws:standalone"
+            target_label = f"AWS org: {org_id or 'standalone account'}"
+        else:
+            target_id = f"org:gcp:{org_id}" if org_id else "org:gcp:standalone"
+            target_label = f"GCP org: {org_id or 'standalone project'}"
+
+        # Ensure a target ORG node exists even for not_in_org (hierarchy layer skipped).
+        if target_id not in graph.nodes:
+            arch = payload.get("architecture") if isinstance(payload.get("architecture"), dict) else {}
+            graph.add_node(
+                UnifiedNode(
+                    id=target_id,
+                    entity_type=EntityType.ORG,
+                    label=target_label,
+                    attributes={
+                        "org_id": org_id,
+                        "cloud_provider": provider,
+                        "status": _clean_graph_part(payload.get("status")),
+                        **({"architecture": arch} if arch else {}),
+                    },
+                    data_sources=sorted({data_source, f"{provider}-organizations"} - {""}),
+                    dimensions=NodeDimensions(cloud_provider=provider, surface="identity"),
+                )
+            )
+
+        for raw in findings:
+            if not isinstance(raw, dict):
+                continue
+            check_id = _clean_graph_part(raw.get("check_id")) or _clean_graph_part(raw.get("title"))
+            if not check_id:
+                continue
+            misconfig_id = f"misconfig:cloud-org:{provider}:{check_id}"
+            if misconfig_id in graph.nodes:
+                continue
+            graph.add_node(
+                UnifiedNode(
+                    id=misconfig_id,
+                    entity_type=EntityType.MISCONFIGURATION,
+                    label=_clean_graph_part(raw.get("title")) or check_id,
+                    severity=str(raw.get("severity") or "medium").lower(),
+                    attributes={
+                        "check_id": check_id,
+                        "category": _clean_graph_part(raw.get("category")) or "estate_architecture",
+                        "evidence": _clean_graph_part(raw.get("detail")),
+                        "cloud_provider": provider,
+                        "account_count": raw.get("account_count"),
+                        "hierarchy_depth": raw.get("hierarchy_depth"),
+                    },
+                    compliance_tags=[f"CLOUD-ORG-{check_id}"],
+                    data_sources=sorted({data_source, f"{provider}-organizations"} - {""}),
+                    dimensions=NodeDimensions(cloud_provider=provider),
+                )
+            )
+            graph.add_edge(
+                UnifiedEdge(
+                    source=misconfig_id,
+                    target=target_id,
+                    relationship=RelationshipType.AFFECTS,
+                )
+            )
+
+
 def _add_aws_organization(graph: UnifiedGraph, payload: Any, data_source: str) -> None:
     """Promote the AWS Organization (org → OUs → accounts → SCPs) into the graph.
 
@@ -4063,6 +4153,11 @@ def _add_aws_organization(graph: UnifiedGraph, payload: Any, data_source: str) -
                 "cloud_provider": "aws",
                 "master_account_id": _clean_graph_part(payload.get("master_account_id")),
                 "feature_set": _clean_graph_part(payload.get("feature_set")),
+                **(
+                    {"architecture": payload.get("architecture")}
+                    if isinstance(payload.get("architecture"), dict)
+                    else {}
+                ),
             },
             data_sources=data_sources,
             dimensions=NodeDimensions(cloud_provider="aws", surface="identity"),

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1509,9 +1509,7 @@ class AIBOMReport:
             org_id = str(payload.get("org_id") or "")
             for raw in payload.get("findings", []) or []:
                 if isinstance(raw, dict):
-                    findings.append(
-                        cloud_org_architecture_finding_to_finding(raw, provider=provider, org_id=org_id)
-                    )
+                    findings.append(cloud_org_architecture_finding_to_finding(raw, provider=provider, org_id=org_id))
         return findings
 
     def _iac_findings(self) -> "list[Finding]":

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1494,7 +1494,7 @@ class AIBOMReport:
         """AWS/GCP org-architecture findings (single-account / flat hierarchy)."""
         from agent_bom.finding import cloud_org_architecture_finding_to_finding
 
-        payloads: list[tuple[str, dict]] = []
+        payloads: list[tuple[str, dict[str, Any]]] = []
         aws = self.aws_organization_data
         if isinstance(aws, dict):
             payloads.append(("aws", aws))

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1432,6 +1432,8 @@ class AIBOMReport:
         base.extend(finding for finding in self._iac_findings() if finding.id not in iac_existing)
         gov_existing = {getattr(f, "id", None) for f in base}
         base.extend(finding for finding in self._snowflake_governance_findings() if finding.id not in gov_existing)
+        org_existing = {getattr(f, "id", None) for f in base}
+        base.extend(finding for finding in self._cloud_org_architecture_findings() if finding.id not in org_existing)
         malicious_existing = {getattr(f, "id", None) for f in base}
         base.extend(finding for finding in self._malicious_package_findings() if finding.id not in malicious_existing)
         return base
@@ -1486,6 +1488,30 @@ class AIBOMReport:
         for raw in data.get("findings", []) or []:
             if isinstance(raw, dict):
                 findings.append(snowflake_governance_finding_to_finding(raw, account))
+        return findings
+
+    def _cloud_org_architecture_findings(self) -> "list[Finding]":
+        """AWS/GCP org-architecture findings (single-account / flat hierarchy)."""
+        from agent_bom.finding import cloud_org_architecture_finding_to_finding
+
+        payloads: list[tuple[str, dict]] = []
+        aws = self.aws_organization_data
+        if isinstance(aws, dict):
+            payloads.append(("aws", aws))
+        inventory = self.cloud_inventory_data
+        inv_list = inventory if isinstance(inventory, list) else ([inventory] if isinstance(inventory, dict) else [])
+        for entry in inv_list:
+            if isinstance(entry, dict) and isinstance(entry.get("gcp_organization"), dict):
+                payloads.append(("gcp", entry["gcp_organization"]))
+
+        findings: list[Finding] = []
+        for provider, payload in payloads:
+            org_id = str(payload.get("org_id") or "")
+            for raw in payload.get("findings", []) or []:
+                if isinstance(raw, dict):
+                    findings.append(
+                        cloud_org_architecture_finding_to_finding(raw, provider=provider, org_id=org_id)
+                    )
         return findings
 
     def _iac_findings(self) -> "list[Finding]":

--- a/tests/test_azure_identity_graph.py
+++ b/tests/test_azure_identity_graph.py
@@ -220,7 +220,10 @@ def test_security_defaults_pass_fail_unevaluable():
 # Access reviews: 1.3, 1.4
 # ---------------------------------------------------------------------------
 
-_GUEST_REVIEW = {"displayName": "Quarterly guest review", "scope": {"query": "/groups/x/members/microsoft.graph.user/?$filter=(userType eq 'Guest')"}}
+_GUEST_REVIEW = {
+    "displayName": "Quarterly guest review",
+    "scope": {"query": "/groups/x/members/microsoft.graph.user/?$filter=(userType eq 'Guest')"},
+}
 _GROUP_REVIEW = {"displayName": "Group owners review", "scope": {"query": "/groups/x/owners"}}
 
 

--- a/tests/test_cloud_org_architecture.py
+++ b/tests/test_cloud_org_architecture.py
@@ -1,0 +1,99 @@
+"""Cloud org architecture verdict findings (single-account / flat hierarchy)."""
+
+from __future__ import annotations
+
+from agent_bom.cloud import aws_organizations, gcp_organizations
+from agent_bom.graph.builder import build_unified_graph_from_report
+from agent_bom.graph.types import EntityType, RelationshipType
+from agent_bom.models import AIBOMReport
+
+
+def test_aws_single_account_and_flat_findings() -> None:
+    payload = {
+        "status": "ok",
+        "org_id": "o-abc",
+        "accounts": [{"id": "111", "name": "only"}],
+        "organizational_units": [{"id": "r-root", "name": "Root", "parent_id": "", "is_root": True}],
+        "scps": [{"id": "p-full", "name": "FullAWSAccess", "aws_managed": True, "targets": []}],
+        "findings": [],
+    }
+    aws_organizations._derive_findings(payload)
+    assert payload["architecture"]["verdict"] == "single_account"
+    check_ids = {f["check_id"] for f in payload["findings"]}
+    assert "ORG-AWS-002" in check_ids  # single-account
+    assert "ORG-AWS-004" in check_ids  # flat (no non-root OUs)
+    assert "ORG-AWS-003" in check_ids  # no custom SCPs
+
+
+def test_aws_not_in_org_finding() -> None:
+    payload = {"status": "not_in_org", "accounts": [], "organizational_units": [], "scps": [], "findings": []}
+    aws_organizations._derive_findings(payload)
+    assert payload["architecture"]["verdict"] == "not_in_org"
+    assert payload["findings"][0]["check_id"] == "ORG-AWS-001"
+
+
+def test_gcp_single_project_finding() -> None:
+    payload = {
+        "status": "ok",
+        "org_id": "123",
+        "projects": [{"id": "proj-a"}],
+        "folders": [],
+        "org_policies": [],
+        "findings": [],
+    }
+    gcp_organizations._derive_findings(payload)
+    assert payload["architecture"]["verdict"] == "single_account"
+    check_ids = {f["check_id"] for f in payload["findings"]}
+    assert "ORG-GCP-002" in check_ids
+    assert "ORG-GCP-004" in check_ids
+
+
+def test_graph_promotes_org_architecture_misconfigs() -> None:
+    g = build_unified_graph_from_report(
+        {
+            "aws_organization": {
+                "status": "not_in_org",
+                "org_id": "",
+                "architecture": {"provider": "aws", "verdict": "not_in_org", "account_count": 1, "hierarchy_depth": 0},
+                "findings": [
+                    {
+                        "check_id": "ORG-AWS-001",
+                        "severity": "medium",
+                        "title": "Standalone AWS account",
+                        "detail": "not in org",
+                        "category": "estate_architecture",
+                    }
+                ],
+            }
+        }
+    )
+    node = g.nodes.get("misconfig:cloud-org:aws:ORG-AWS-001")
+    assert node is not None
+    assert node.entity_type == EntityType.MISCONFIGURATION
+    edges = list(g.edges.values()) if isinstance(g.edges, dict) else list(g.edges)
+    assert any(
+        e.source == "misconfig:cloud-org:aws:ORG-AWS-001"
+        and e.target == "org:aws:standalone"
+        and e.relationship == RelationshipType.AFFECTS
+        for e in edges
+    )
+
+
+def test_unified_findings_include_org_architecture() -> None:
+    report = AIBOMReport(agents=[], blast_radii=[])
+    report.aws_organization_data = {
+        "status": "ok",
+        "org_id": "o-1",
+        "findings": [
+            {
+                "check_id": "ORG-AWS-002",
+                "severity": "medium",
+                "title": "Single-account AWS Organization",
+                "detail": "one account",
+            }
+        ],
+    }
+    findings = report.to_findings()
+    matches = [f for f in findings if any("ORG-AWS-002" in tag for tag in (f.compliance_tags or []))]
+    assert len(matches) == 1
+    assert matches[0].finding_type.value == "CLOUD_BEST_PRACTICE_FAIL"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- AWS/GCP org discovery now emits structured estate-architecture findings (`ORG-AWS-*` / `ORG-GCP-*`) for standalone account, single-account/org, flat hierarchy, and missing SCPs/org policies — plus an `architecture` summary (`verdict`, counts).
- Graph builder promotes those findings to `MISCONFIGURATION` nodes that `AFFECTS` the org (including `not_in_org` targets).
- Unified Finding stream lifts them as `CLOUD_BEST_PRACTICE_FAIL` so gates/SARIF see landing-zone posture.

## Verification

- `uv run pytest -q tests/test_cloud_org_architecture.py tests/test_aws_organizations.py tests/test_gcp_organizations.py`
- `uv run ruff check` on touched modules

## Notes

- Complements repo trust card (#4401): point-at-repo vs point-at-cloud-org.
- `/v1/graph/diff` still structural; CIS pass-rate % compare remains a follow-up helper.
- Azure management-group flatness not in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

