### PR TITLE
chore(release): prepare 0.97.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.97.3] - 2026-07-22
+
 ### Added
 - Skill audit feeds the unified Finding stream (`FindingType.SKILL_RISK` /
   `FindingSource.SKILL`) on CLI and API scans, matches extracted MCP servers
@@ -31,11 +33,30 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - `graph_build_workspace_nodes` / `graph_build_workspace_edges` now ENABLE+FORCE
   tenant RLS (init.sql + Alembic `20260721_01`); the Postgres workspace backend
   binds `app.tenant_id` per operation so staging rows cannot cross tenants.
+- `--repo` / `repo_url` scans attach an optional GitHub trust card (`repo_trust`:
+  stars, contributors, license, language, pushed_at) to the report and stamp an
+  `APPLICATION` (+ root `DIRECTORY`) on the graph; disable with
+  `AGENT_BOM_REPO_TRUST=0` (#4401).
+- AWS/GCP org discovery emits estate-architecture findings (`ORG-AWS-*` /
+  `ORG-GCP-*`) for standalone / single-account / flat hierarchy / missing
+  SCPs-or-org-policies, with an `architecture` summary promoted to graph
+  misconfigurations and the unified Finding stream (#4402).
+- Graph builder dual-emits account→resource `OWNS` + `CONTAINS` for cloud
+  inventory and Snowflake object layers so attack-path fusion walks the same
+  hierarchy as estate rollup (#4399, #4400).
+- Inventory graph API pages packages/jobs with `has_more`; CWPP durable
+  workload-evidence store factory; runtime-evidence ingest uses the scan write
+  rate-limit bucket (#4383–#4385).
 
 ### Fixed
 - Attack-path Path view always lays hops left-to-right (no odd-row snake), so
   wrapped critical paths no longer draw an inbound arrow into the finding from
-  empty space.
+  empty space (#4397).
+- Graph serve materialises `attack_campaigns` and keeps `attack_path_count` in
+  sync on filtered/attack-path views (#4382).
+- Agents/servers/packages/resources persist `dimensions.environment` from BOM
+  and resource Environment tags so campaigns and Path filters see env facets
+  (#4399).
 - Helm scanner, KSPM, and control-plane backup CronJobs fail loud
   (`jobTemplate.spec.backoffLimit: 0`, `restartPolicy: Never`) so a bad run
   surfaces as a Failed Job instead of retrying quietly under `OnFailure`.
@@ -54,6 +75,8 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Docs honesty: authenticated-hosted overlay matrix points anonymous demo at
   `demo-override.yml`; PRODUCT_BRIEF marks webhook outbox as shipped; store-backed
   graph test module docstring matches auto-enable behavior.
+- README Scan section lists CLI + GitHub Action as peer entry points; Cortex
+  Code skill no longer overclaims agents-for-CVEs (#4398, #4381).
 
 ### Changed
 - CWPP stage-4 honesty: Azure/GCP side-scan capabilities report
@@ -2536,7 +2559,8 @@ Two new product surfaces (inter-agent firewall + per-run discovery envelope) plu
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.97.2...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.97.3...HEAD
+[0.97.3]: https://github.com/msaad00/agent-bom/compare/v0.97.2...v0.97.3
 [0.97.2]: https://github.com/msaad00/agent-bom/compare/v0.97.1...v0.97.2
 [0.97.1]: https://github.com/msaad00/agent-bom/compare/v0.97.0...v0.97.1
 [0.97.0]: https://github.com/msaad00/agent-bom/compare/v0.96.4...v0.97.0

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -216,7 +216,7 @@ Focused agent mesh graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.97.2` | Current stable version (pinned) |
+| `0.97.3` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN set -eu; \
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.6-alpine3.23@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81
 
-ARG VERSION=0.97.2
+ARG VERSION=0.97.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ agent-bom scan .
 CI (GitHub Action):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: agents
     format: sarif
@@ -159,7 +159,7 @@ walkthrough.
 </details>
 
 <details>
-<summary><b>CLI walkthrough</b> — 0.97.2 console demo</summary>
+<summary><b>CLI walkthrough</b> — 0.97.3 console demo</summary>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo showing inventory, findings, remediation, and package gate" width="820" />
@@ -210,7 +210,7 @@ Guides: [Deploy anywhere](docs/DEPLOY_PLATFORM.md) ·
 | Audit package | `agent-bom scan . -f sarif -o findings.sarif` | SARIF, CycloneDX, SPDX, bundles |
 
 Also: `agent-bom graph`, `agent-bom remediate -p .`, CI pin
-`uses: msaad00/agent-bom@v0.97.2`. Maps: [CLI](docs/CLI_MAP.md) ·
+`uses: msaad00/agent-bom@v0.97.3`. Maps: [CLI](docs/CLI_MAP.md) ·
 [start here](docs/START_HERE.md) · [product map](docs/PRODUCT_MAP.md).
 
 </details>

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -39,7 +39,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.97.2
+    image: agentbom/agent-bom:0.97.3
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422
@@ -98,7 +98,7 @@ services:
     build:
       context: ../ui/
       dockerfile: Dockerfile
-    image: agentbom/agent-bom-ui:0.97.2
+    image: agentbom/agent-bom-ui:0.97.3
     container_name: agent-bom-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -20,7 +20,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.97.2
+    image: agentbom/agent-bom:0.97.3
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -58,7 +58,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.97.2
+    image: agentbom/agent-bom-ui:0.97.3
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -157,7 +157,7 @@ services:
     build:
       context: ../ui
       dockerfile: Dockerfile
-    image: agentbom/agent-bom-ui:0.97.2
+    image: agentbom/agent-bom-ui:0.97.3
     container_name: agent-bom-ui
     ports:
       - "${AGENT_BOM_UI_BIND_HOST:-127.0.0.1}:${UI_PORT:-3000}:3000"

--- a/deploy/docker-compose.runtime-example.yml
+++ b/deploy/docker-compose.runtime-example.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.97.2
+    image: agentbom/agent-bom:0.97.3
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.collector
+++ b/deploy/docker/Dockerfile.collector
@@ -65,7 +65,7 @@ FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb
 
 # Baked app-code version (provenance label). Runtime/base security overlays can
 # refresh independently; SDK version changes remain reviewable lockfile updates.
-ARG VERSION=0.97.2
+ARG VERSION=0.97.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -28,7 +28,7 @@ RUN uv sync --locked --no-dev --no-editable --extra mcp-server
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.97.2
+ARG VERSION=0.97.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -18,7 +18,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.10.9@sha256:10902f58a1606787602f303954cea0996
 COPY pyproject.toml uv.lock README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.97.2
+ARG VERSION=0.97.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -41,7 +41,7 @@ RUN uv sync --locked --no-dev --no-editable --extra runtime
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.97.2
+ARG VERSION=0.97.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -27,7 +27,7 @@ RUN uv sync --locked --no-dev --no-editable --extra api --extra snowflake
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.97.2
+ARG VERSION=0.97.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -42,7 +42,7 @@ RUN uv sync --locked --no-dev --no-editable --extra mcp-server
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.97.2
+ARG VERSION=0.97.3
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.97.2
-appVersion: "0.97.2"
+version: 0.97.3
+appVersion: "0.97.3"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -32,17 +32,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.97.2"
+  tag: "0.97.3"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.97.2"
+  tag: "0.97.3"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.97.2"
+  tag: "0.97.3"
   pullPolicy: IfNotPresent
 
 # Cloud-SDK collector image (issue #4239). Ships the boto3/azure/google/snowflake
@@ -56,7 +56,7 @@ runtimeImage:
 # `image.tag`.
 collectorImage:
   repository: agentbom/agent-bom-collector
-  tag: "0.97.2"
+  tag: "0.97.3"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -82,7 +82,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.97.2"
+    tag: "0.97.3"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: agent-bom
           containers:
             - name: scanner
-              image: agentbom/agent-bom:0.97.2
+              image: agentbom/agent-bom:0.97.3
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.97.2
+          image: agentbom/agent-bom:0.97.3
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.97.2
+          image: agentbom/agent-bom:0.97.3
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.97.2
+          image: agentbom/agent-bom:0.97.3
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -1,9 +1,9 @@
 manifest_version: 1
 
 version:
-  name: v0_97_2
+  name: v0_97_3
   patch: 0
-  label: "agent-bom 0.97.2"
+  label: "agent-bom 0.97.3"
   comment: >-
     Map the full trust chain from AI agents and MCP servers to CVEs,
     credentials, and blast radius. Discover, scan, and secure your
@@ -18,10 +18,10 @@ artifacts:
   container_services:
     uses_gpu: false
     images:
-      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom:v0_97_2
-      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-ui:v0_97_2
-      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-scanner:v0_97_2
-      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-mcp-runtime:v0_97_2
+      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom:v0_97_3
+      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-ui:v0_97_3
+      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-scanner:v0_97_3
+      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-mcp-runtime:v0_97_3
   service_roles:
     - name: api
       comment: >-

--- a/deploy/snowflake/native-app/service-spec.yaml
+++ b/deploy/snowflake/native-app/service-spec.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom
-      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom:v0_97_2
+      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom:v0_97_3
       env:
         AGENT_BOM_STORE_BACKEND: snowflake
         AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"
@@ -22,7 +22,7 @@ spec:
           cpu: 2
 
     - name: agent-bom-ui
-      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-ui:v0_97_2
+      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-ui:v0_97_3
       env:
         NEXT_PUBLIC_API_URL: "http://localhost:8422"
         NODE_ENV: production

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-mcp-runtime
-      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-mcp-runtime:v0_97_2
+      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-mcp-runtime:v0_97_3
       env:
         AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"
         AGENT_BOM_MCP_MODE: "1"

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-scanner
-      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-scanner:v0_97_2
+      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-scanner:v0_97_3
       env:
         AGENT_BOM_STORE_BACKEND: snowflake
         AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -57,4 +57,4 @@ attack paths, compliance tags, and runtime audit chain.
 
 ## Version
 
-`0.97.2` — regenerate metrics with `python scripts/product_metrics_snapshot.py --write` and this file with `python scripts/generate_agent_capability_manifest.py --write`.
+`0.97.3` — regenerate metrics with `python scripts/product_metrics_snapshot.py --write` and this file with `python scripts/generate_agent_capability_manifest.py --write`.

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -180,7 +180,7 @@ should not store provider secret values.
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -597,10 +597,13 @@ Azure/GCP disk side-scan remains discovery + injected-SDK lifecycle adapters
 
 ## 8. Why it scales and stays accurate
 
-- **Scale:** AWS Organizations, Azure management-group fan-out, and GCP
-  org/folder/project fan-out discover the whole estate; the graph partitions by
-  account, subscription, or project so multi-account/multi-tenant estates stay
-  separable, with explicit caps to bound a run.
+- **Scale:** When credentials and org fan-out flags are set, AWS Organizations,
+  Azure management-group fan-out, and GCP org/folder/project fan-out walk the
+  reachable estate; the graph partitions by account, subscription, or project
+  so multi-account/multi-tenant estates stay separable, with explicit caps to
+  bound a run. In-repo CI coverage for org fan-out is mocked/fixture-based;
+  live least-privilege org smoke remains environment-owned and is not claimed
+  as proven here.
 - **Alignment:** every datum a connector collects is wired end-to-end —
   data model → graph nodes/edges → JSON output → CLI/API → tests — so nothing is
   "collected but dropped". A guard test keeps the AWS SDK surface honest.

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -71,7 +71,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -89,21 +89,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     auto-update-db: false
     enrich: false
@@ -294,6 +294,12 @@ add the audit log (`audit_events`, append-only) when sizing total disk.
 | 1k agents  |  5,201 |  5,200 |  10,401 |  ~24 MiB | 2 vCPU / 4 GiB / 20 GiB gp3 |
 | 5k agents  | 26,001 | 26,000 |  52,001 | ~120 MiB | 2 vCPU / 4 GiB / 50 GiB gp3 |
 | 10k agents | 52,001 | 52,000 | 104,001 | ~240 MiB | 4 vCPU / 8 GiB / 100 GiB gp3 |
+
+These rows are **disk/floor estimates from synthetic ingest cardinalities**, not
+a proven graph-API read latency ceiling. The checked-in query/API measured
+ceiling remains ~10,479 nodes / 11,242 edges — see
+[`docs/perf/graph-api-postgres-benchmark.md`](perf/graph-api-postgres-benchmark.md).
+Do not cite the 52k-node sizing row as measured read performance.
 
 Verify the actual disk used by the graph tables in your deployment with:
 
@@ -601,7 +607,7 @@ docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v ~/.agent-bom:/home/abom/.agent-bom \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.97.2 agents --format json
+  agentbom/agent-bom:0.97.3 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
+++ b/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: msaad00/agent-bom@v0.97.2
+      - uses: msaad00/agent-bom@v0.97.3
         with:
           scan-type: agents
           format: sarif

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -275,7 +275,7 @@ should_i_deploy     — allow/warn/block guidance from ExposurePath risk
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
-  "generated_on": "2026-07-19",
-  "version": "0.97.2",
+  "generated_on": "2026-07-22",
+  "version": "0.97.3",
   "metrics": [
     {
       "name": "MCP tools",
@@ -22,13 +22,13 @@
     },
     {
       "name": "GitHub workflow files",
-      "value": 39,
+      "value": 38,
       "source": ".github/workflows",
       "notes": "Counts .yml and .yaml workflow definitions."
     },
     {
       "name": "Test files",
-      "value": 968,
+      "value": 1005,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 790,
+      "value": 799,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,19 +5,19 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-07-19`
-- Version: `0.97.2`
+- Generated on: `2026-07-22`
+- Version: `0.97.3`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |
 | MCP tools | 77 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card tools. |
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
-| GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 968 | `tests/` | Counts files matching test_*.py. |
+| GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
+| Test files | 1005 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 790 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 799 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -105,7 +105,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.97.2"
+  --version "0.97.3"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -157,8 +157,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.97.2
-git push origin v0.97.2
+git tag v0.97.3
+git push origin v0.97.3
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -36,7 +36,7 @@ Do not publish a release as hosted-ready when any required line above is red.
 ## Download release assets
 
 ```bash
-TAG=v0.97.2
+TAG=v0.97.3
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -38,7 +38,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.97.2
+docker pull agentbom/agent-bom:0.97.3
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -50,7 +50,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.97.2 \
+  agentbom/agent-bom:0.97.3 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -99,7 +99,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.97.2
+          image: agentbom/agent-bom:0.97.3
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -346,7 +346,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.97.2",
+        "agentbom/agent-bom:0.97.3",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -25,7 +25,7 @@ New here? [`FIRST_RUN.md`](FIRST_RUN.md) is the canonical quickstart —
 CI gate (GitHub Action):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
 ```
 
 - Output formats, exit codes, and the full command set:

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.97.2`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.97.3`) which
    runs on Linux runners
 
 ---

--- a/docs/decisions/006-unified-graph-write-batching.md
+++ b/docs/decisions/006-unified-graph-write-batching.md
@@ -101,8 +101,9 @@ even on exception. CLI / export builders that never pass a container stay
 in-RAM; below-threshold API scans keep the byte-identical in-RAM producer. This
 is a measured peak-RSS reduction (~2.5–3× lower producer peak, residual O(N)
 floor ~0.37), not a claim of strict bounded memory — multi-million-node estates
-still need a server-side backend. Large builds write O(graph) bytes to pod
-ephemeral storage while the throwaway SQLite workspace is open.
+still need a server-side backend (**ADR residual only — not a shipped product
+claim**). Large builds write O(graph) bytes to pod ephemeral storage while the
+throwaway SQLite workspace is open.
 
 Two overlays mutated a *held* node subset across passes (cnapp exposure marks;
 effective-permissions admin-equivalence marks) — a pattern the store's

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.97.2 terminal demo
+# agent-bom v0.97.3 terminal demo
 # Shows: posture-led scan → findings queue → fix-first → package gate
 
 Output docs/images/demo-latest.gif

--- a/docs/images/product-screenshots.json
+++ b/docs/images/product-screenshots.json
@@ -1,85 +1,85 @@
 {
-  "release_version": "0.97.2",
+  "release_version": "0.97.3",
   "captured_at": "2026-07-21T01:58:53.918Z",
-  "capture_note": "Metadata aligned to 0.97.2 release prep without a full screenshot recapture. Images remain the 0.97.1 capture-mode DEMO DATA set (synthetic identifiers only). Captured from real Next.js dashboard routes in capture mode with a visible Demo data \u2014 sample environment label. The deterministic Playwright harness uses unmistakably fictional DEMO-VULN identifiers and synthetic risk signals. These records demonstrate UI states only; they are not advisory, EPSS, KEV, or buyer-environment evidence.",
+  "capture_note": "Metadata aligned to 0.97.3 release prep without a full screenshot recapture. Images remain the 0.97.1 capture-mode DEMO DATA set (synthetic identifiers only). Captured from real Next.js dashboard routes in capture mode with a visible Demo data \u2014 sample environment label. The deterministic Playwright harness uses unmistakably fictional DEMO-VULN identifiers and synthetic risk signals. These records demonstrate UI states only; they are not advisory, EPSS, KEV, or buyer-environment evidence.",
   "screenshots": [
     {
       "path": "dashboard-live.png",
       "page": "/?capture=1",
       "scope": "Overview command center \u2014 posture grade, unique findings breakdown, scan coverage, and operational lanes",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "dashboard-paths-live.png",
       "page": "/?capture=1",
       "scope": "Overview lower frame with unique exposure paths, recent scans, and activity",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "cloud-accounts-live.png",
       "page": "/connections?capture=1",
       "scope": "Connections hub \u2014 scalable connector gallery across cloud, code, AI, and data sources",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "new-scan-live.png",
       "page": "/scan?capture=1",
       "scope": "New Scan workspace with collector plan, read-only boundary, expected evidence, connected sources, and recent job context",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "mesh-live.png",
       "page": "/mesh?capture=1",
       "scope": "Focused agent mesh graph across the active agent, MCP server, package, and CVE path",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "gateway-policies-live.png",
       "page": "/runtime?tab=gateway&capture=1",
       "scope": "Runtime gateway KPI rollup, enforcement posture, and recent tool-call evidence",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "security-graph-live.png",
       "page": "/security-graph?capture=1",
       "scope": "Prioritized attack path with graph evidence export and remediation handoff",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "lineage-graph-live.png",
       "page": "/graph?capture=1&scan=scan-proof-ai-platform",
       "scope": "Focused filtered attack-path lineage across agent, MCP, package, and finding nodes",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "context-map-live.png",
       "page": "/context?capture=1",
       "scope": "Agent-scoped context map showing reachable MCP servers and lateral movement side panel",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "fleet-state-live.png",
       "page": "/fleet?capture=1",
       "scope": "Expanded quarantined fleet row showing lifecycle distribution, owner metadata, environment label, and enforcement state",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "identity-audit-live.png",
       "page": "/audit?capture=1",
       "scope": "Audit log filtered to identity resources with issue, rotate, and revoke events",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "dependency-map-live.png",
       "page": "/findings?capture=1",
       "scope": "Findings queue with seeded package and CVE evidence from the demo estate",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     },
     {
       "path": "remediation-live.png",
       "page": "/remediation?capture=1",
       "scope": "Fix-first remediation table with prioritized packages and framework context",
-      "visible_version": "0.97.2"
+      "visible_version": "0.97.3"
     }
   ]
 }

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5489,7 +5489,7 @@
   "info": {
     "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. agent \u2192 MCP server \u2192 packages \u2192 CVEs \u2192 blast radius.",
     "title": "agent-bom API",
-    "version": "0.97.2"
+    "version": "0.97.3"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3757,7 +3757,7 @@ info:
     \ cloud infrastructure. agent \u2192 MCP server \u2192 packages \u2192 CVEs \u2192\
     \ blast radius."
   title: agent-bom API
-  version: 0.97.2
+  version: 0.97.3
 openapi: 3.1.0
 paths:
   /health:

--- a/docs/perf/graph-api-postgres-benchmark.md
+++ b/docs/perf/graph-api-postgres-benchmark.md
@@ -38,6 +38,10 @@ operator deployment timing, managed graph-backend timing, or production SLOs.
 The current measured ceiling is the checked-in Docker Postgres estate with
 10,479 nodes, 11,242 edges, and 291 materialized attack paths. 100k+ and
 1M-node Postgres claims are not yet measured; they remain follow-on scale work.
+Store-backed live graph builds on the persist path still use a **private
+SQLite staging workspace by default**; shared-Postgres producer wiring is
+implemented but not the default auto-enable path (see
+`src/agent_bom/graph/store_backed.py`).
 Measured local CPU graph timings remain in
 [`p95-p99-graph-query.md`](p95-p99-graph-query.md).
 

--- a/docs/perf/ingest-throughput.md
+++ b/docs/perf/ingest-throughput.md
@@ -78,6 +78,11 @@ add the audit log (`audit_events` is HMAC-chained, append-only) when sizing
 total disk. Production sizing tables for the listed estates live in
 [`docs/ENTERPRISE_DEPLOYMENT.md`](../ENTERPRISE_DEPLOYMENT.md).
 
+These 10k-agent / ~52k-node figures are **ingest cardinality + disk floor
+inputs only**. They are not the graph-API query measured ceiling (that remains
+~10,479 nodes / 11,242 edges in
+[`graph-api-postgres-benchmark.md`](graph-api-postgres-benchmark.md)).
+
 A separate Postgres-backed scale evidence run is tracked in #1806; until it
 publishes, treat the in-process numbers as a CPU-path floor and the row
 counts above as the persistence-side estimate input.

--- a/docs/skills/POLICY.md
+++ b/docs/skills/POLICY.md
@@ -84,7 +84,7 @@ Actions are `warn`, `fail`, or `block`; `block` is treated as a failing gate.
 Run skills scanning as its own CI lane:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: skills
     scan-ref: .

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.97.2",
+  "version": "0.97.3",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.97.2",
+  "version": "0.97.3",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.97.2",
+      "version": "0.97.3",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []
@@ -417,6 +417,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.97.2`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.97.3`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom 0.84.4+. Inventory must conform to the

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom scan
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.97.2`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.97.3`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.2
+    docker: ghcr.io/msaad00/agent-bom:0.97.3
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.97.2
+version: 0.97.3
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.97.2"
+version = "0.97.3"
 description = "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/scripts/bench/agent_bom_scale_bench.py
+++ b/scripts/bench/agent_bom_scale_bench.py
@@ -3,6 +3,10 @@
 
 Stdlib-only — no pip installs required on the runner host.
 
+``TARGET`` counts **findings rows ingested**, not UnifiedGraph node ceiling.
+Do not treat a 1M findings run as proof of 1M-node graph API latency (see
+``docs/perf/graph-api-postgres-benchmark.md`` for the measured graph ceiling).
+
 Environment:
   AGENT_BOM_URL          Base URL (default http://127.0.0.1:8422)
   AGENT_BOM_API_KEY      Bearer token with ingest + read scope

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -155,7 +155,7 @@ AGENT_BOM_NO_AUTO_DEV_KEY
 AGENT_BOM_NO_AUTO_CONNECTIONS_KEY
 # Opt-in flag for the storage-backed graph-build workspace (producer streaming); read in api/pipeline.py, path default in graph/build_workspace.py.
 AGENT_BOM_GRAPH_BUILD_WORKSPACE
-# Opt-in / auto flag (#4055/#4075): build the correlated graph into a per-build store-backed container on a throwaway private SQLite workspace so the producer's peak RSS drops; unset auto-enables above AGENT_BOM_GRAPH_STORE_BACKED_MIN_ENTITIES; explicit 0/false/off forces the in-RAM producer. Read in api/pipeline.py.
+# Opt-in / auto flag (#4055/#4075): build the correlated graph into a per-build store-backed container on a throwaway private SQLite workspace so the producer's peak RSS drops; unset auto-enables above AGENT_BOM_GRAPH_STORE_BACKED_MIN_ENTITIES; explicit 0/false/off forces the in-RAM producer. API persist path always opens backend="sqlite" (shared Postgres producer wiring is not the default). Read in api/pipeline.py. Not declared in config.py — allowlisted intentionally.
 AGENT_BOM_GRAPH_STORE_BACKED_BUILD
 # Entity-count threshold (default 5000) for auto-enabling AGENT_BOM_GRAPH_STORE_BACKED_BUILD when that flag is unset; read in api/pipeline.py.
 AGENT_BOM_GRAPH_STORE_BACKED_MIN_ENTITIES

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -16,7 +16,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.97.2 \
+  --version 0.97.3 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -37,8 +37,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.97.2-linux_amd64.tar.gz
-cd agent-bom-airgap-0.97.2-linux_amd64
+tar -xzf agent-bom-airgap-0.97.3-linux_amd64.tar.gz
+cd agent-bom-airgap-0.97.3-linux_amd64
 ./load-images.sh
 ```
 
@@ -47,7 +47,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.97.2
+VERSION=0.97.3
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -62,13 +62,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.97.2"
+  tag: "0.97.3"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.97.2"
+      tag: "0.97.3"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -332,8 +332,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.97.2 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.97.2.tar.gz \
+  --version 0.97.3 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.97.3.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -189,7 +189,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.97.2 \
+  --version 0.97.3 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -261,7 +261,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.97.2 \
+  --version 0.97.3 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -91,10 +91,10 @@ docker run --rm \
 ## Runtime proxy against a remote MCP endpoint
 
 ```bash
-docker pull agentbom/agent-bom:0.97.2
+docker pull agentbom/agent-bom:0.97.3
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.97.2 \
+  agentbom/agent-bom:0.97.3 \
   proxy \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \

--- a/site-docs/deployment/scaling-slo.md
+++ b/site-docs/deployment/scaling-slo.md
@@ -158,6 +158,13 @@ your `maxReplicas` calibrated to your Postgres connection-pool capacity
 (default chart sets pool size in
 `controlPlane.api.env.AGENT_BOM_POSTGRES_POOL_MAX`).
 
+Graph store-backed builds auto-enable for larger API snapshots, but the
+default producer still stages into a **private SQLite** workspace (shared
+Postgres producer wiring is not the default). The checked-in measured
+ceiling remains ~10,479 nodes / 11,242 edges
+([graph API Postgres benchmark](https://github.com/msaad00/agent-bom/blob/main/docs/perf/graph-api-postgres-benchmark.md));
+100k / 1M-node production claims are unproven.
+
 This gap blocks the "elastic at 1M edges" claim, but it does not block
 pilots and does not prevent the SLOs above from being met for the
 workload sizes they're written for.

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -25,7 +25,7 @@ agent-bom iac Dockerfile k8s/ infra/main.tf --format sarif --output agent-bom-ia
 In GitHub Actions, use the `iac` scan type or the `iac` input:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: iac
     scan-ref: infra/main.tf,k8s/
@@ -47,8 +47,9 @@ Supported pre-cloud inputs include:
 
 ## Runtime posture lane
 
-Run cloud benchmark checks against the actual environment when credentials are
-available:
+Run cloud benchmark checks against the actual environment when operator
+credentials are available (demo-estate CIS is curated sample data, not a live
+connect):
 
 ```bash
 agent-bom cloud aws --cis

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.97.2
+  uses: msaad00/agent-bom@v0.97.3
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -63,7 +63,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | **Local AI BOM** | `agent-bom scan --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom scan . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
 | **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cloud aws --cis` | pre-cloud IaC findings plus point-in-time or scheduled posture evidence |
-| **CI evidence** | `uses: msaad00/agent-bom@v0.97.2` | SARIF, pull-request summary, optional code scanning |
+| **CI evidence** | `uses: msaad00/agent-bom@v0.97.3` | SARIF, pull-request summary, optional code scanning |
 | **Assistant tools** | `agent-bom mcp server` | read-mostly security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
 

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -8,7 +8,7 @@ plane or runtime enforcement rollout.
 |---|---|---|---|---|
 | Local CLI | `agent-bom scan --demo --offline`, then `agent-bom scan .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
 | Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-mostly security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary; Shield write actions require admin role, `shield:write` scope, and an audit reason. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
-| GitHub Actions | `uses: msaad00/agent-bom@v0.97.2` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
+| GitHub Actions | `uses: msaad00/agent-bom@v0.97.3` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan . --policy skills-policy.yaml` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names, policy warn/block result. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
 | Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
@@ -31,7 +31,7 @@ when the buyer or contributor needs to see the first finding path quickly.
 ### CI Security Review
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: agents
     severity-threshold: high
@@ -66,7 +66,7 @@ by setting `skills-ci: true` (equivalent to the CLI `--ci` flag, i.e.
 `fail-on-verdict=suspicious`):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: skills
     scan-ref: .
@@ -80,7 +80,7 @@ For finer control, replace `skills-ci` with explicit gates and an optional
 policy file:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.2
+- uses: msaad00/agent-bom@v0.97.3
   with:
     scan-type: skills
     scan-ref: .

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -45,7 +45,7 @@ remediation remain advisory/manual in this command.
 
 ```json
 {
-  "version": "0.97.2",
+  "version": "0.97.3",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.97.2"
+    __version__ = "0.97.3"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/src/agent_bom/cloud/aws_organizations.py
+++ b/src/agent_bom/cloud/aws_organizations.py
@@ -1,10 +1,11 @@
 """AWS Organizations inventory — org → OUs → accounts → SCPs (read-only, agentless).
 
 Answers "what does our AWS org / multi-account estate look like" for a CISO or an
-agent: the organization hierarchy (organizational units), every member account
-(scales to thousands via pagination), and the Service Control Policies that bound
-them. Emitted as ORG / ACCOUNT / POLICY graph nodes with ``CONTAINS`` hierarchy so
-the estate is traversable top-down then drill-down — the AWS analogue of the Azure
+agent: the organization hierarchy (organizational units), member accounts (SDK
+pagination supports large org lists; live multi-account fan-out size is not
+measured in-repo), and the Service Control Policies that bound them. Emitted as
+ORG / ACCOUNT / POLICY graph nodes with ``CONTAINS`` hierarchy so the estate is
+traversable top-down then drill-down — the AWS analogue of the Azure
 management-group hierarchy.
 
 Trust posture: read-only (``organizations:Describe*`` / ``List*`` only — all in the

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -881,10 +881,11 @@ def test_api_key_middleware_accepts_signed_browser_session(monkeypatch):
     test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
 
     client = TestClient(test_app)
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    client.cookies.set(CSRF_COOKIE_NAME, csrf)
     resp = client.post(
         "/v1/scan",
         headers={CSRF_HEADER_NAME: csrf},
-        cookies={SESSION_COOKIE_NAME: token, CSRF_COOKIE_NAME: csrf},
     )
     assert resp.status_code == 200
     assert resp.json() == {
@@ -935,7 +936,9 @@ def test_api_key_middleware_rejects_browser_session_without_csrf(monkeypatch):
     test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
 
     client = TestClient(test_app)
-    resp = client.post("/v1/scan", cookies={SESSION_COOKIE_NAME: token, CSRF_COOKIE_NAME: csrf})
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    client.cookies.set(CSRF_COOKIE_NAME, csrf)
+    resp = client.post("/v1/scan")
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Forbidden — missing or invalid CSRF token"
 
@@ -969,10 +972,11 @@ def test_api_key_middleware_rejects_csrf_from_another_session(monkeypatch):
     test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
 
     client = TestClient(test_app)
+    client.cookies.set(SESSION_COOKIE_NAME, token_a)
+    client.cookies.set(CSRF_COOKIE_NAME, csrf_b)
     resp = client.post(
         "/v1/scan",
         headers={CSRF_HEADER_NAME: csrf_b},
-        cookies={SESSION_COOKIE_NAME: token_a, CSRF_COOKIE_NAME: csrf_b},
     )
     assert resp.status_code == 403
 
@@ -1000,10 +1004,11 @@ def test_api_key_middleware_rejects_revoked_browser_session(monkeypatch):
     test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
 
     client = TestClient(test_app)
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    client.cookies.set(CSRF_COOKIE_NAME, csrf)
     resp = client.post(
         "/v1/scan",
         headers={CSRF_HEADER_NAME: csrf},
-        cookies={SESSION_COOKIE_NAME: token, CSRF_COOKIE_NAME: csrf},
     )
     assert resp.status_code == 401
 

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.97.2",
+  "version": "0.97.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.97.2",
+      "version": "0.97.3",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.97.2",
+  "version": "0.97.3",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -70,7 +70,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.97.2' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.97.3' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,7 @@ overrides = [
 
 [[package]]
 name = "agent-bom"
-version = "0.97.2"
+version = "0.97.3"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Bump all managed version surfaces from `0.97.2` → **`0.97.3`** (patch only — no 0.98.0) and fold `[Unreleased]` into `## [0.97.3] - 2026-07-22` (includes #4397–#4402 and prior tip work).
- Pin scale/cloud docs to measured evidence: ~10,479 nodes / 11,242 edges ceiling, private SQLite staging default, soft cloud org “whole estate” wording, demo CIS ≠ live connect.
- Clear Starlette `TestClient` request-cookie deprecation warnings in hardening tests.
- Fix Docs Strict Build: `site-docs/deployment/scaling-slo.md` uses an absolute GitHub URL for the graph API benchmark (mkdocs `docs_dir` cannot resolve `../../docs/...`).

**Combined:** absorbs #4404. Squashed to a single **verified SSH-signed** commit (`17f03aef`) so branch protection “Commits must have verified signatures” is satisfied.

This is **release prep only** — does not tag or publish PyPI/Docker. Tag/publish after merge.

## Verification

- `uv run python scripts/check_version_alignment.py` → OK (`0.97.3`)
- `uv run python scripts/check_release_consistency.py` → passed
- `uv run pytest tests/api/test_api_hardening.py -q` → 92 passed
- `mkdocs build --strict` → green after link fix
- GitHub commit verification on tip: `verified: true` / `reason: valid`

## Notes

- Stay on patch `0.97.3`. Live cloud / 50k+ scale / Snowflake host remain deferred.
- Still waiting on code-owner review (`andres-linero`) and fresh CI after the signed squash push.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

