### PR TITLE
docs: pin scale and cloud claims to measured evidence

### DIFF
--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -597,10 +597,13 @@ Azure/GCP disk side-scan remains discovery + injected-SDK lifecycle adapters
 
 ## 8. Why it scales and stays accurate
 
-- **Scale:** AWS Organizations, Azure management-group fan-out, and GCP
-  org/folder/project fan-out discover the whole estate; the graph partitions by
-  account, subscription, or project so multi-account/multi-tenant estates stay
-  separable, with explicit caps to bound a run.
+- **Scale:** When credentials and org fan-out flags are set, AWS Organizations,
+  Azure management-group fan-out, and GCP org/folder/project fan-out walk the
+  reachable estate; the graph partitions by account, subscription, or project
+  so multi-account/multi-tenant estates stay separable, with explicit caps to
+  bound a run. In-repo CI coverage for org fan-out is mocked/fixture-based;
+  live least-privilege org smoke remains environment-owned and is not claimed
+  as proven here.
 - **Alignment:** every datum a connector collects is wired end-to-end —
   data model → graph nodes/edges → JSON output → CLI/API → tests — so nothing is
   "collected but dropped". A guard test keeps the AWS SDK surface honest.

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -295,6 +295,12 @@ add the audit log (`audit_events`, append-only) when sizing total disk.
 | 5k agents  | 26,001 | 26,000 |  52,001 | ~120 MiB | 2 vCPU / 4 GiB / 50 GiB gp3 |
 | 10k agents | 52,001 | 52,000 | 104,001 | ~240 MiB | 4 vCPU / 8 GiB / 100 GiB gp3 |
 
+These rows are **disk/floor estimates from synthetic ingest cardinalities**, not
+a proven graph-API read latency ceiling. The checked-in query/API measured
+ceiling remains ~10,479 nodes / 11,242 edges — see
+[`docs/perf/graph-api-postgres-benchmark.md`](perf/graph-api-postgres-benchmark.md).
+Do not cite the 52k-node sizing row as measured read performance.
+
 Verify the actual disk used by the graph tables in your deployment with:
 
 ```sql

--- a/docs/decisions/006-unified-graph-write-batching.md
+++ b/docs/decisions/006-unified-graph-write-batching.md
@@ -101,8 +101,9 @@ even on exception. CLI / export builders that never pass a container stay
 in-RAM; below-threshold API scans keep the byte-identical in-RAM producer. This
 is a measured peak-RSS reduction (~2.5–3× lower producer peak, residual O(N)
 floor ~0.37), not a claim of strict bounded memory — multi-million-node estates
-still need a server-side backend. Large builds write O(graph) bytes to pod
-ephemeral storage while the throwaway SQLite workspace is open.
+still need a server-side backend (**ADR residual only — not a shipped product
+claim**). Large builds write O(graph) bytes to pod ephemeral storage while the
+throwaway SQLite workspace is open.
 
 Two overlays mutated a *held* node subset across passes (cnapp exposure marks;
 effective-permissions admin-equivalence marks) — a pattern the store's

--- a/docs/perf/graph-api-postgres-benchmark.md
+++ b/docs/perf/graph-api-postgres-benchmark.md
@@ -38,6 +38,10 @@ operator deployment timing, managed graph-backend timing, or production SLOs.
 The current measured ceiling is the checked-in Docker Postgres estate with
 10,479 nodes, 11,242 edges, and 291 materialized attack paths. 100k+ and
 1M-node Postgres claims are not yet measured; they remain follow-on scale work.
+Store-backed live graph builds on the persist path still use a **private
+SQLite staging workspace by default**; shared-Postgres producer wiring is
+implemented but not the default auto-enable path (see
+`src/agent_bom/graph/store_backed.py`).
 Measured local CPU graph timings remain in
 [`p95-p99-graph-query.md`](p95-p99-graph-query.md).
 

--- a/docs/perf/ingest-throughput.md
+++ b/docs/perf/ingest-throughput.md
@@ -78,6 +78,11 @@ add the audit log (`audit_events` is HMAC-chained, append-only) when sizing
 total disk. Production sizing tables for the listed estates live in
 [`docs/ENTERPRISE_DEPLOYMENT.md`](../ENTERPRISE_DEPLOYMENT.md).
 
+These 10k-agent / ~52k-node figures are **ingest cardinality + disk floor
+inputs only**. They are not the graph-API query measured ceiling (that remains
+~10,479 nodes / 11,242 edges in
+[`graph-api-postgres-benchmark.md`](graph-api-postgres-benchmark.md)).
+
 A separate Postgres-backed scale evidence run is tracked in #1806; until it
 publishes, treat the in-process numbers as a CPU-path floor and the row
 counts above as the persistence-side estimate input.

--- a/scripts/bench/agent_bom_scale_bench.py
+++ b/scripts/bench/agent_bom_scale_bench.py
@@ -3,6 +3,10 @@
 
 Stdlib-only — no pip installs required on the runner host.
 
+``TARGET`` counts **findings rows ingested**, not UnifiedGraph node ceiling.
+Do not treat a 1M findings run as proof of 1M-node graph API latency (see
+``docs/perf/graph-api-postgres-benchmark.md`` for the measured graph ceiling).
+
 Environment:
   AGENT_BOM_URL          Base URL (default http://127.0.0.1:8422)
   AGENT_BOM_API_KEY      Bearer token with ingest + read scope

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -155,7 +155,7 @@ AGENT_BOM_NO_AUTO_DEV_KEY
 AGENT_BOM_NO_AUTO_CONNECTIONS_KEY
 # Opt-in flag for the storage-backed graph-build workspace (producer streaming); read in api/pipeline.py, path default in graph/build_workspace.py.
 AGENT_BOM_GRAPH_BUILD_WORKSPACE
-# Opt-in / auto flag (#4055/#4075): build the correlated graph into a per-build store-backed container on a throwaway private SQLite workspace so the producer's peak RSS drops; unset auto-enables above AGENT_BOM_GRAPH_STORE_BACKED_MIN_ENTITIES; explicit 0/false/off forces the in-RAM producer. Read in api/pipeline.py.
+# Opt-in / auto flag (#4055/#4075): build the correlated graph into a per-build store-backed container on a throwaway private SQLite workspace so the producer's peak RSS drops; unset auto-enables above AGENT_BOM_GRAPH_STORE_BACKED_MIN_ENTITIES; explicit 0/false/off forces the in-RAM producer. API persist path always opens backend="sqlite" (shared Postgres producer wiring is not the default). Read in api/pipeline.py. Not declared in config.py — allowlisted intentionally.
 AGENT_BOM_GRAPH_STORE_BACKED_BUILD
 # Entity-count threshold (default 5000) for auto-enabling AGENT_BOM_GRAPH_STORE_BACKED_BUILD when that flag is unset; read in api/pipeline.py.
 AGENT_BOM_GRAPH_STORE_BACKED_MIN_ENTITIES

--- a/site-docs/deployment/scaling-slo.md
+++ b/site-docs/deployment/scaling-slo.md
@@ -158,6 +158,13 @@ your `maxReplicas` calibrated to your Postgres connection-pool capacity
 (default chart sets pool size in
 `controlPlane.api.env.AGENT_BOM_POSTGRES_POOL_MAX`).
 
+Graph store-backed builds auto-enable for larger API snapshots, but the
+default producer still stages into a **private SQLite** workspace (shared
+Postgres producer wiring is not the default). The checked-in measured
+ceiling remains ~10,479 nodes / 11,242 edges
+([graph API Postgres benchmark](../../docs/perf/graph-api-postgres-benchmark.md));
+100k / 1M-node production claims are unproven.
+
 This gap blocks the "elastic at 1M edges" claim, but it does not block
 pilots and does not prevent the SLOs above from being met for the
 workload sizes they're written for.

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -47,8 +47,9 @@ Supported pre-cloud inputs include:
 
 ## Runtime posture lane
 
-Run cloud benchmark checks against the actual environment when credentials are
-available:
+Run cloud benchmark checks against the actual environment when operator
+credentials are available (demo-estate CIS is curated sample data, not a live
+connect):
 
 ```bash
 agent-bom cloud aws --cis

--- a/src/agent_bom/cloud/aws_organizations.py
+++ b/src/agent_bom/cloud/aws_organizations.py
@@ -1,10 +1,11 @@
 """AWS Organizations inventory — org → OUs → accounts → SCPs (read-only, agentless).
 
 Answers "what does our AWS org / multi-account estate look like" for a CISO or an
-agent: the organization hierarchy (organizational units), every member account
-(scales to thousands via pagination), and the Service Control Policies that bound
-them. Emitted as ORG / ACCOUNT / POLICY graph nodes with ``CONTAINS`` hierarchy so
-the estate is traversable top-down then drill-down — the AWS analogue of the Azure
+agent: the organization hierarchy (organizational units), member accounts (SDK
+pagination supports large org lists; live multi-account fan-out size is not
+measured in-repo), and the Service Control Policies that bound them. Emitted as
+ORG / ACCOUNT / POLICY graph nodes with ``CONTAINS`` hierarchy so the estate is
+traversable top-down then drill-down — the AWS analogue of the Azure
 management-group hierarchy.
 
 Trust posture: read-only (``organizations:Describe*`` / ``List*`` only — all in the

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -881,10 +881,11 @@ def test_api_key_middleware_accepts_signed_browser_session(monkeypatch):
     test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
 
     client = TestClient(test_app)
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    client.cookies.set(CSRF_COOKIE_NAME, csrf)
     resp = client.post(
         "/v1/scan",
         headers={CSRF_HEADER_NAME: csrf},
-        cookies={SESSION_COOKIE_NAME: token, CSRF_COOKIE_NAME: csrf},
     )
     assert resp.status_code == 200
     assert resp.json() == {
@@ -935,7 +936,9 @@ def test_api_key_middleware_rejects_browser_session_without_csrf(monkeypatch):
     test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
 
     client = TestClient(test_app)
-    resp = client.post("/v1/scan", cookies={SESSION_COOKIE_NAME: token, CSRF_COOKIE_NAME: csrf})
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    client.cookies.set(CSRF_COOKIE_NAME, csrf)
+    resp = client.post("/v1/scan")
     assert resp.status_code == 403
     assert resp.json()["detail"] == "Forbidden — missing or invalid CSRF token"
 
@@ -969,10 +972,11 @@ def test_api_key_middleware_rejects_csrf_from_another_session(monkeypatch):
     test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
 
     client = TestClient(test_app)
+    client.cookies.set(SESSION_COOKIE_NAME, token_a)
+    client.cookies.set(CSRF_COOKIE_NAME, csrf_b)
     resp = client.post(
         "/v1/scan",
         headers={CSRF_HEADER_NAME: csrf_b},
-        cookies={SESSION_COOKIE_NAME: token_a, CSRF_COOKIE_NAME: csrf_b},
     )
     assert resp.status_code == 403
 
@@ -1000,10 +1004,11 @@ def test_api_key_middleware_rejects_revoked_browser_session(monkeypatch):
     test_app.add_middleware(APIKeyMiddleware, api_key="static-key")
 
     client = TestClient(test_app)
+    client.cookies.set(SESSION_COOKIE_NAME, token)
+    client.cookies.set(CSRF_COOKIE_NAME, csrf)
     resp = client.post(
         "/v1/scan",
         headers={CSRF_HEADER_NAME: csrf},
-        cookies={SESSION_COOKIE_NAME: token, CSRF_COOKIE_NAME: csrf},
     )
     assert resp.status_code == 401
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Pin scale/docs claims to the measured graph API ceiling (~10,479 nodes / 11,242 edges) and call out private SQLite staging as the store-backed persist default.
- Soften cloud org “whole estate” / “thousands” wording to credential-owned smoke; demo CIS is curated, not live connect.
- Clear Starlette `TestClient` request-cookie deprecation warnings in `tests/api/test_api_hardening.py`.

Does **not** bump the package version (release prep follows after merge + tip audit). Live AWS/Azure/GCP least-privilege smoke and 50k/100k-node benchmarks remain deferred evidence lanes (no cloud credentials in this environment).

## Verification

- `uv run pytest tests/api/test_api_hardening.py -q` → 92 passed; cookie DeprecationWarnings gone (remaining: httpx vs starlette.testclient / httpx2)
- `uv run python scripts/generate_env_var_reference.py --check` → OK (store-backed flags stay allowlisted; honesty note in allowlist comment)

## Notes

- Overlaps cookie + SQLite callouts from draft #4403; this PR lands them without a version bump so tip can be audited before a **0.98.0** minor cut.
- No LLM `Co-Authored-By` in the local commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

