### PR TITLE
fix(release): unblock 0.97.4 publish from skill SARIF noise

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -990,8 +990,10 @@ jobs:
             # partial and exits non-zero with zero results. pip-audit above is the
             # enforcing dependency gate, so degrade partial-coverage to evidence-
             # only (like the timeout branch) and fail only on real critical
-            # results. Unreadable SARIF counts as non-zero → fail closed.
-            crit_results=$(python3 -c "import json; d=json.load(open('sarif/release-self-dep.sarif')); print(sum(len(r.get('results',[])) for r in d.get('runs',[])))" 2>/dev/null || echo unknown)
+            # results. Count by security-severity >= 9.0 — not raw result count
+            # (skill medium/low SARIF rows are warning/note) and not level=error
+            # alone (high also maps to error). Unreadable SARIF → fail closed.
+            crit_results=$(python3 scripts/count_sarif_critical.py sarif/release-self-dep.sarif 2>/dev/null || echo unknown)
             if [ "$crit_results" != "0" ]; then
               echo "::error::agent-bom release self-scan found ${crit_results} critical finding(s) (exit ${scan_exit})"
               exit "$scan_exit"
@@ -1034,10 +1036,35 @@ jobs:
           # id wins and GitHub derives the category from it (the part before the
           # final "/", i.e. "agent-bom") instead of "agent-bom-release-gate". Drop
           # it so the upload `category` below applies.
+          #
+          # Also drop medium/low SKILL_RISK rows from the code-scanning upload.
+          # Release dependency enforcement is pip-audit/npm/osv; skill hygiene on
+          # first-party CLAUDE.md / docs must not open GitHub Security alerts.
+          # High/critical skill findings (security-severity >= 7.0) still upload.
           path = Path("sarif/release-self-dep.sarif")
           data = json.loads(path.read_text())
           for run in data.get("runs", []):
               run.pop("automationDetails", None)
+              rules = ((run.get("tool") or {}).get("driver") or {}).get("rules") or []
+              rules_by_id = {str(rule.get("id") or ""): rule for rule in rules if isinstance(rule, dict)}
+              kept = []
+              for result in run.get("results") or []:
+                  if not isinstance(result, dict):
+                      continue
+                  rule_id = str(result.get("ruleId") or "")
+                  if rule_id.startswith("finding/SKILL"):
+                      props = result.get("properties") or {}
+                      raw = props.get("security-severity")
+                      if raw is None:
+                          raw = (rules_by_id.get(rule_id) or {}).get("properties", {}).get("security-severity")
+                      try:
+                          score = float(raw)
+                      except (TypeError, ValueError):
+                          score = 0.0
+                      if score < 7.0:
+                          continue
+                  kept.append(result)
+              run["results"] = kept
           path.write_text(json.dumps(data, indent=2) + "\n")
           PY
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.97.4] - 2026-07-22
+
+### Fixed
+- Release self-scan gate counts **critical** SARIF results via
+  `security-severity >= 9.0` (`scripts/count_sarif_critical.py`) instead of
+  raw result cardinality. Medium/low first-party `SKILL_RISK` noise no longer
+  aborts publish when the scan exits non-zero for coverage-limited evidence
+  (v0.97.3 tag publish was blocked by this false positive).
+- Skill auto-discovery skips catalog/index markdown (`README.md` / `index.md`
+  under skills trees) and `site-docs/skills/**` (same as `docs/skills/**`), so
+  first-party docs no longer open medium Skill Risk code-scanning alerts.
+- Release SARIF upload drops medium/low `SKILL_RISK` rows (keeps high/critical)
+  so GitHub Security is not flooded by first-party instruction hygiene.
+
 ## [0.97.3] - 2026-07-22
 
 ### Added
@@ -2559,7 +2573,8 @@ Two new product surfaces (inter-agent firewall + per-run discovery envelope) plu
 
 ---
 
-[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.97.3...HEAD
+[Unreleased]: https://github.com/msaad00/agent-bom/compare/v0.97.4...HEAD
+[0.97.4]: https://github.com/msaad00/agent-bom/compare/v0.97.3...v0.97.4
 [0.97.3]: https://github.com/msaad00/agent-bom/compare/v0.97.2...v0.97.3
 [0.97.2]: https://github.com/msaad00/agent-bom/compare/v0.97.1...v0.97.2
 [0.97.1]: https://github.com/msaad00/agent-bom/compare/v0.97.0...v0.97.1

--- a/DOCKER_HUB_README.md
+++ b/DOCKER_HUB_README.md
@@ -216,7 +216,7 @@ Focused agent mesh graph:
 | Tag | Description |
 |-----|-------------|
 | `latest` | Most recent stable release |
-| `0.97.3` | Current stable version (pinned) |
+| `0.97.4` | Current stable version (pinned) |
 
 Published images:
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN set -eu; \
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.14.6-alpine3.23@sha256:02da11a8d221ca167aa07de20b3cd7104c1f01227f4b02b1fa13cf6517280a81
 
-ARG VERSION=0.97.3
+ARG VERSION=0.97.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ agent-bom scan .
 CI (GitHub Action):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: agents
     format: sarif
@@ -159,7 +159,7 @@ walkthrough.
 </details>
 
 <details>
-<summary><b>CLI walkthrough</b> — 0.97.3 console demo</summary>
+<summary><b>CLI walkthrough</b> — 0.97.4 console demo</summary>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo showing inventory, findings, remediation, and package gate" width="820" />
@@ -210,7 +210,7 @@ Guides: [Deploy anywhere](docs/DEPLOY_PLATFORM.md) ·
 | Audit package | `agent-bom scan . -f sarif -o findings.sarif` | SARIF, CycloneDX, SPDX, bundles |
 
 Also: `agent-bom graph`, `agent-bom remediate -p .`, CI pin
-`uses: msaad00/agent-bom@v0.97.3`. Maps: [CLI](docs/CLI_MAP.md) ·
+`uses: msaad00/agent-bom@v0.97.4`. Maps: [CLI](docs/CLI_MAP.md) ·
 [start here](docs/START_HERE.md) · [product map](docs/PRODUCT_MAP.md).
 
 </details>

--- a/deploy/docker-compose.fullstack.yml
+++ b/deploy/docker-compose.fullstack.yml
@@ -39,7 +39,7 @@ services:
     build:
       context: ..
       dockerfile: Dockerfile
-    image: agentbom/agent-bom:0.97.3
+    image: agentbom/agent-bom:0.97.4
     container_name: agent-bom-api
     restart: unless-stopped
     command: api --host 0.0.0.0 --port 8422
@@ -98,7 +98,7 @@ services:
     build:
       context: ../ui/
       dockerfile: Dockerfile
-    image: agentbom/agent-bom-ui:0.97.3
+    image: agentbom/agent-bom-ui:0.97.4
     container_name: agent-bom-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -20,7 +20,7 @@
 
 services:
   api:
-    image: agentbom/agent-bom:0.97.3
+    image: agentbom/agent-bom:0.97.4
     container_name: agent-bom-pilot-api
     restart: unless-stopped
     command: >
@@ -58,7 +58,7 @@ services:
       start_period: 10s
 
   ui:
-    image: agentbom/agent-bom-ui:0.97.3
+    image: agentbom/agent-bom-ui:0.97.4
     container_name: agent-bom-pilot-ui
     restart: unless-stopped
     environment:

--- a/deploy/docker-compose.platform.yml
+++ b/deploy/docker-compose.platform.yml
@@ -157,7 +157,7 @@ services:
     build:
       context: ../ui
       dockerfile: Dockerfile
-    image: agentbom/agent-bom-ui:0.97.3
+    image: agentbom/agent-bom-ui:0.97.4
     container_name: agent-bom-ui
     ports:
       - "${AGENT_BOM_UI_BIND_HOST:-127.0.0.1}:${UI_PORT:-3000}:3000"

--- a/deploy/docker-compose.runtime-example.yml
+++ b/deploy/docker-compose.runtime-example.yml
@@ -31,7 +31,7 @@ services:
     build:
       context: ..
       dockerfile: deploy/docker/Dockerfile.runtime
-    image: agentbom/agent-bom:0.97.3
+    image: agentbom/agent-bom:0.97.4
     container_name: agent-bom-runtime-proxy
     depends_on:
       - mcp-server

--- a/deploy/docker/Dockerfile.collector
+++ b/deploy/docker/Dockerfile.collector
@@ -65,7 +65,7 @@ FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb
 
 # Baked app-code version (provenance label). Runtime/base security overlays can
 # refresh independently; SDK version changes remain reviewable lockfile updates.
-ARG VERSION=0.97.3
+ARG VERSION=0.97.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.mcp
+++ b/deploy/docker/Dockerfile.mcp
@@ -28,7 +28,7 @@ RUN uv sync --locked --no-dev --no-editable --extra mcp-server
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.97.3
+ARG VERSION=0.97.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.runtime
+++ b/deploy/docker/Dockerfile.runtime
@@ -18,7 +18,7 @@ COPY --from=ghcr.io/astral-sh/uv:0.10.9@sha256:10902f58a1606787602f303954cea0996
 COPY pyproject.toml uv.lock README.md PYPI_README.md LICENSE ./
 COPY src/ ./src/
 
-ARG VERSION=0.97.3
+ARG VERSION=0.97.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY
@@ -41,7 +41,7 @@ RUN uv sync --locked --no-dev --no-editable --extra runtime
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.97.3
+ARG VERSION=0.97.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.snowpark
+++ b/deploy/docker/Dockerfile.snowpark
@@ -27,7 +27,7 @@ RUN uv sync --locked --no-dev --no-editable --extra api --extra snowflake
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.11.12-slim@sha256:dbf1de478a55d6763afaa39c2f3d7b54b25230614980276de5cacdde79529d0c
 
-ARG VERSION=0.97.3
+ARG VERSION=0.97.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/docker/Dockerfile.sse
+++ b/deploy/docker/Dockerfile.sse
@@ -42,7 +42,7 @@ RUN uv sync --locked --no-dev --no-editable --extra mcp-server
 ## ── Runtime stage ────────────────────────────────────────────────────────────
 FROM python:3.12.13-slim@sha256:7026274c107626d7e940e0e5d6730481a4600ae95d5ca7eb532dd4180313fea9
 
-ARG VERSION=0.97.3
+ARG VERSION=0.97.4
 ARG HTTP_PROXY
 ARG HTTPS_PROXY
 ARG NO_PROXY

--- a/deploy/helm/agent-bom/Chart.yaml
+++ b/deploy/helm/agent-bom/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: agent-bom
 description: Open security scanner and graph for AI supply chain and infrastructure — discover agents and MCP, map blast radius, and inspect runtime.
-version: 0.97.3
-appVersion: "0.97.3"
+version: 0.97.4
+appVersion: "0.97.4"
 type: application
 keywords:
   - security

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -32,17 +32,17 @@
 
 image:
   repository: agentbom/agent-bom
-  tag: "0.97.3"
+  tag: "0.97.4"
   pullPolicy: IfNotPresent
 
 uiImage:
   repository: agentbom/agent-bom-ui
-  tag: "0.97.3"
+  tag: "0.97.4"
   pullPolicy: IfNotPresent
 
 runtimeImage:
   repository: agentbom/agent-bom
-  tag: "0.97.3"
+  tag: "0.97.4"
   pullPolicy: IfNotPresent
 
 # Cloud-SDK collector image (issue #4239). Ships the boto3/azure/google/snowflake
@@ -56,7 +56,7 @@ runtimeImage:
 # `image.tag`.
 collectorImage:
   repository: agentbom/agent-bom-collector
-  tag: "0.97.3"
+  tag: "0.97.4"
   pullPolicy: IfNotPresent
 
 imagePullSecrets: []
@@ -82,7 +82,7 @@ tests:
   includeUi: true
   image:
     repository: agentbom/agent-bom
-    tag: "0.97.3"
+    tag: "0.97.4"
     pullPolicy: IfNotPresent
   resources:
     requests:

--- a/deploy/k8s/cronjob.yaml
+++ b/deploy/k8s/cronjob.yaml
@@ -21,7 +21,7 @@ spec:
           serviceAccountName: agent-bom
           containers:
             - name: scanner
-              image: agentbom/agent-bom:0.97.3
+              image: agentbom/agent-bom:0.97.4
               command: ["agent-bom"]
               args:
                 - "scan"

--- a/deploy/k8s/daemonset.yaml
+++ b/deploy/k8s/daemonset.yaml
@@ -21,7 +21,7 @@ spec:
       serviceAccountName: agent-bom
       containers:
         - name: monitor
-          image: agentbom/agent-bom:0.97.3
+          image: agentbom/agent-bom:0.97.4
           command: ["agent-bom"]
           args:
             - "protect"

--- a/deploy/k8s/proxy-sidecar-pilot.yaml
+++ b/deploy/k8s/proxy-sidecar-pilot.yaml
@@ -109,7 +109,7 @@ spec:
               cpu: "500m"
 
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.97.3
+          image: agentbom/agent-bom:0.97.4
           args:
             - "--policy"
             - "/etc/agent-bom/policy.json"

--- a/deploy/k8s/sidecar-example.yaml
+++ b/deploy/k8s/sidecar-example.yaml
@@ -40,7 +40,7 @@ spec:
 
         # agent-bom proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.97.3
+          image: agentbom/agent-bom:0.97.4
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"

--- a/deploy/snowflake/native-app/manifest.yml
+++ b/deploy/snowflake/native-app/manifest.yml
@@ -1,9 +1,9 @@
 manifest_version: 1
 
 version:
-  name: v0_97_3
+  name: v0_97_4
   patch: 0
-  label: "agent-bom 0.97.3"
+  label: "agent-bom 0.97.4"
   comment: >-
     Map the full trust chain from AI agents and MCP servers to CVEs,
     credentials, and blast radius. Discover, scan, and secure your
@@ -18,10 +18,10 @@ artifacts:
   container_services:
     uses_gpu: false
     images:
-      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom:v0_97_3
-      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-ui:v0_97_3
-      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-scanner:v0_97_3
-      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-mcp-runtime:v0_97_3
+      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom:v0_97_4
+      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-ui:v0_97_4
+      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-scanner:v0_97_4
+      - /agent_bom_provider/spcs/agent_bom_repo/agent-bom-mcp-runtime:v0_97_4
   service_roles:
     - name: api
       comment: >-

--- a/deploy/snowflake/native-app/service-spec.yaml
+++ b/deploy/snowflake/native-app/service-spec.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom
-      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom:v0_97_3
+      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom:v0_97_4
       env:
         AGENT_BOM_STORE_BACKEND: snowflake
         AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"
@@ -22,7 +22,7 @@ spec:
           cpu: 2
 
     - name: agent-bom-ui
-      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-ui:v0_97_3
+      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-ui:v0_97_4
       env:
         NEXT_PUBLIC_API_URL: "http://localhost:8422"
         NODE_ENV: production

--- a/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/mcp-runtime-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-mcp-runtime
-      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-mcp-runtime:v0_97_3
+      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-mcp-runtime:v0_97_4
       env:
         AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"
         AGENT_BOM_MCP_MODE: "1"

--- a/deploy/snowflake/native-app/service-specs/scanner-service.yaml
+++ b/deploy/snowflake/native-app/service-specs/scanner-service.yaml
@@ -1,7 +1,7 @@
 spec:
   containers:
     - name: agent-bom-scanner
-      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-scanner:v0_97_3
+      image: /agent_bom_provider/spcs/agent_bom_repo/agent-bom-scanner:v0_97_4
       env:
         AGENT_BOM_STORE_BACKEND: snowflake
         AGENT_BOM_SNOWFLAKE_NATIVE_APP: "1"

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -57,4 +57,4 @@ attack paths, compliance tags, and runtime audit chain.
 
 ## Version
 
-`0.97.3` — regenerate metrics with `python scripts/product_metrics_snapshot.py --write` and this file with `python scripts/generate_agent_capability_manifest.py --write`.
+`0.97.4` — regenerate metrics with `python scripts/product_metrics_snapshot.py --write` and this file with `python scripts/generate_agent_capability_manifest.py --write`.

--- a/docs/AI_INFRASTRUCTURE_SCANNING.md
+++ b/docs/AI_INFRASTRUCTURE_SCANNING.md
@@ -180,7 +180,7 @@ should not store provider secret values.
 ### GitHub Actions — GPU image gate
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: image
     image: nvcr.io/nvidia/cuda:12.4.1-devel-ubuntu22.04

--- a/docs/ENTERPRISE_DEPLOYMENT.md
+++ b/docs/ENTERPRISE_DEPLOYMENT.md
@@ -71,7 +71,7 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # GitHub Actions
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: agents        # auto-detect MCP configs + deps
     severity-threshold: high # fail PR on HIGH+ CVEs
@@ -89,21 +89,21 @@ Start with a familiar adoption pattern: a single CI step that fails on policy, u
 
 ```yaml
 # Container image gate
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: image
     scan-ref: ghcr.io/acme/agent-runtime:sha-abcdef
     severity-threshold: critical
 
 # IaC gate
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: iac
     iac: Dockerfile,k8s/,infra/main.tf
     severity-threshold: high
 
 # Air-gapped or fully cached CI
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     auto-update-db: false
     enrich: false
@@ -607,7 +607,7 @@ docker run --rm \
   -v ~/.config:/home/abom/.config:ro \
   -v ~/.agent-bom:/home/abom/.agent-bom \
   -v $(pwd):/workspace:ro \
-  agentbom/agent-bom:0.97.3 agents --format json
+  agentbom/agent-bom:0.97.4 agents --format json
 ```
 
 Multi-arch: `linux/amd64` + `linux/arm64`. Non-root container. SHA-pinned base image.

--- a/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
+++ b/docs/GITHUB_ACTION_SARIF_TROUBLESHOOTING.md
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: msaad00/agent-bom@v0.97.3
+      - uses: msaad00/agent-bom@v0.97.4
         with:
           scan-type: agents
           format: sarif

--- a/docs/MCP_SECURITY_MODEL.md
+++ b/docs/MCP_SECURITY_MODEL.md
@@ -275,7 +275,7 @@ should_i_deploy     — allow/warn/block guidance from ExposurePath risk
 ### CI/CD (GitHub Action)
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     format: sarif
     upload-sarif: 'true'

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,6 +1,6 @@
 {
   "generated_on": "2026-07-22",
-  "version": "0.97.3",
+  "version": "0.97.4",
   "metrics": [
     {
       "name": "MCP tools",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -6,7 +6,7 @@ This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
 - Generated on: `2026-07-22`
-- Version: `0.97.3`
+- Version: `0.97.4`
 
 | Metric | Value | Source | Notes |
 | --- | ---: | --- | --- |

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -105,7 +105,7 @@ npm install -g clawhub@latest
 clawhub login --token "$CLAWHUB_TOKEN" --no-browser
 clawhub publish integrations/openclaw/scan \
   --slug agent-bom-scan --name "agent-bom scan" \
-  --version "0.97.3"
+  --version "0.97.4"
 ```
 
 Release automation uses the same official `clawhub` CLI flow, not a custom
@@ -157,8 +157,8 @@ Images published:
 Tag push triggers the full pipeline automatically:
 
 ```bash
-git tag v0.97.3
-git push origin v0.97.3
+git tag v0.97.4
+git push origin v0.97.4
 ```
 
 This triggers:

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -36,7 +36,7 @@ Do not publish a release as hosted-ready when any required line above is red.
 ## Download release assets
 
 ```bash
-TAG=v0.97.3
+TAG=v0.97.4
 VERSION="${TAG#v}"
 mkdir -p /tmp/agent-bom-release && cd /tmp/agent-bom-release
 gh release download "$TAG" --repo msaad00/agent-bom

--- a/docs/RUNTIME_MONITORING.md
+++ b/docs/RUNTIME_MONITORING.md
@@ -38,7 +38,7 @@ The proxy interposes on the stdio channel between an MCP client (Claude Desktop,
 Use the published main runtime image:
 
 ```bash
-docker pull agentbom/agent-bom:0.97.3
+docker pull agentbom/agent-bom:0.97.4
 ```
 
 If you need to rebuild locally from the checked-out repo, you can still use
@@ -50,7 +50,7 @@ Run as a wrapper around any MCP server:
 ```bash
 docker run --rm \
   -v $(pwd)/audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.97.3 \
+  agentbom/agent-bom:0.97.4 \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \
   -- npx -y @modelcontextprotocol/server-filesystem /workspace
@@ -99,7 +99,7 @@ spec:
 
         # agent-bom runtime proxy sidecar
         - name: agent-bom-proxy
-          image: agentbom/agent-bom:0.97.3
+          image: agentbom/agent-bom:0.97.4
           args:
             - "--log"
             - "/var/log/agent-bom/audit.jsonl"
@@ -346,7 +346,7 @@ Use the runtime container directly from Claude Desktop:
         "run", "--rm", "-i",
         "-v", "./workspace:/workspace",
         "-v", "./audit-logs:/var/log/agent-bom",
-        "agentbom/agent-bom:0.97.3",
+        "agentbom/agent-bom:0.97.4",
         "--log", "/var/log/agent-bom/audit.jsonl",
         "--block-undeclared",
         "--",

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -25,7 +25,7 @@ New here? [`FIRST_RUN.md`](FIRST_RUN.md) is the canonical quickstart —
 CI gate (GitHub Action):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
 ```
 
 - Output formats, exit codes, and the full command set:

--- a/docs/archive/WINDOWS_CONTAINERS.md
+++ b/docs/archive/WINDOWS_CONTAINERS.md
@@ -113,7 +113,7 @@ container inspection. Windows Server environments should use:
 
 1. **Python CLI** -- `pip install agent-bom` works on Windows natively
 2. **Docker Desktop** -- run the Linux container images on Windows via WSL 2
-3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.97.3`) which
+3. **CI/CD** -- use the GitHub Action (`uses: msaad00/agent-bom@v0.97.4`) which
    runs on Linux runners
 
 ---

--- a/docs/demo.tape
+++ b/docs/demo.tape
@@ -1,4 +1,4 @@
-# agent-bom v0.97.3 terminal demo
+# agent-bom v0.97.4 terminal demo
 # Shows: posture-led scan → findings queue → fix-first → package gate
 
 Output docs/images/demo-latest.gif

--- a/docs/images/product-screenshots.json
+++ b/docs/images/product-screenshots.json
@@ -1,85 +1,85 @@
 {
-  "release_version": "0.97.3",
+  "release_version": "0.97.4",
   "captured_at": "2026-07-21T01:58:53.918Z",
-  "capture_note": "Metadata aligned to 0.97.3 release prep without a full screenshot recapture. Images remain the 0.97.1 capture-mode DEMO DATA set (synthetic identifiers only). Captured from real Next.js dashboard routes in capture mode with a visible Demo data \u2014 sample environment label. The deterministic Playwright harness uses unmistakably fictional DEMO-VULN identifiers and synthetic risk signals. These records demonstrate UI states only; they are not advisory, EPSS, KEV, or buyer-environment evidence.",
+  "capture_note": "Metadata aligned to 0.97.4 release prep without a full screenshot recapture. Images remain the 0.97.1 capture-mode DEMO DATA set (synthetic identifiers only). Captured from real Next.js dashboard routes in capture mode with a visible Demo data \u2014 sample environment label. The deterministic Playwright harness uses unmistakably fictional DEMO-VULN identifiers and synthetic risk signals. These records demonstrate UI states only; they are not advisory, EPSS, KEV, or buyer-environment evidence.",
   "screenshots": [
     {
       "path": "dashboard-live.png",
       "page": "/?capture=1",
       "scope": "Overview command center \u2014 posture grade, unique findings breakdown, scan coverage, and operational lanes",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "dashboard-paths-live.png",
       "page": "/?capture=1",
       "scope": "Overview lower frame with unique exposure paths, recent scans, and activity",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "cloud-accounts-live.png",
       "page": "/connections?capture=1",
       "scope": "Connections hub \u2014 scalable connector gallery across cloud, code, AI, and data sources",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "new-scan-live.png",
       "page": "/scan?capture=1",
       "scope": "New Scan workspace with collector plan, read-only boundary, expected evidence, connected sources, and recent job context",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "mesh-live.png",
       "page": "/mesh?capture=1",
       "scope": "Focused agent mesh graph across the active agent, MCP server, package, and CVE path",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "gateway-policies-live.png",
       "page": "/runtime?tab=gateway&capture=1",
       "scope": "Runtime gateway KPI rollup, enforcement posture, and recent tool-call evidence",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "security-graph-live.png",
       "page": "/security-graph?capture=1",
       "scope": "Prioritized attack path with graph evidence export and remediation handoff",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "lineage-graph-live.png",
       "page": "/graph?capture=1&scan=scan-proof-ai-platform",
       "scope": "Focused filtered attack-path lineage across agent, MCP, package, and finding nodes",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "context-map-live.png",
       "page": "/context?capture=1",
       "scope": "Agent-scoped context map showing reachable MCP servers and lateral movement side panel",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "fleet-state-live.png",
       "page": "/fleet?capture=1",
       "scope": "Expanded quarantined fleet row showing lifecycle distribution, owner metadata, environment label, and enforcement state",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "identity-audit-live.png",
       "page": "/audit?capture=1",
       "scope": "Audit log filtered to identity resources with issue, rotate, and revoke events",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "dependency-map-live.png",
       "page": "/findings?capture=1",
       "scope": "Findings queue with seeded package and CVE evidence from the demo estate",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     },
     {
       "path": "remediation-live.png",
       "page": "/remediation?capture=1",
       "scope": "Fix-first remediation table with prioritized packages and framework context",
-      "visible_version": "0.97.3"
+      "visible_version": "0.97.4"
     }
   ]
 }

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5489,7 +5489,7 @@
   "info": {
     "description": "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure. agent \u2192 MCP server \u2192 packages \u2192 CVEs \u2192 blast radius.",
     "title": "agent-bom API",
-    "version": "0.97.3"
+    "version": "0.97.4"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3757,7 +3757,7 @@ info:
     \ cloud infrastructure. agent \u2192 MCP server \u2192 packages \u2192 CVEs \u2192\
     \ blast radius."
   title: agent-bom API
-  version: 0.97.3
+  version: 0.97.4
 openapi: 3.1.0
 paths:
   /health:

--- a/docs/skills/POLICY.md
+++ b/docs/skills/POLICY.md
@@ -84,7 +84,7 @@ Actions are `warn`, `fail`, or `block`; `block` is treated as a failing gate.
 Run skills scanning as its own CI lane:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: skills
     scan-ref: .

--- a/integrations/glama/server.json
+++ b/integrations/glama/server.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
-  "version": "0.97.3",
+  "version": "0.97.4",
   "license": "Apache-2.0",
   "repository": "https://github.com/msaad00/agent-bom",
   "transport": "stdio",

--- a/integrations/mcp-registry/server.json
+++ b/integrations/mcp-registry/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.msaad00/agent-bom",
   "description": "Security scanner and graph for agentic infrastructure — agents, MCP, runtime, and blast radius.",
   "title": "agent-bom",
-  "version": "0.97.3",
+  "version": "0.97.4",
   "repository": {
     "url": "https://github.com/msaad00/agent-bom",
     "source": "github"
@@ -12,7 +12,7 @@
     {
       "registryType": "pypi",
       "identifier": "agent-bom",
-      "version": "0.97.3",
+      "version": "0.97.4",
       "transport": {
         "type": "stdio"
       },

--- a/integrations/openclaw/SKILL.md
+++ b/integrations/openclaw/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   security checks. Use when the user mentions vulnerability scanning,
   MCP server trust, compliance, SBOM generation, CIS benchmarks, blast
   radius, or AI supply chain risk.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -25,7 +25,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []
@@ -417,6 +417,6 @@ provider's own APIs.
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.97.3`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.97.4`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/analyze/SKILL.md
+++ b/integrations/openclaw/analyze/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Analyze blast radius, attack paths, and threat landscape across your AI
   infrastructure. Use when: "blast radius", "threat intel", "risk score",
   "attack path", "lateral movement", "context graph", "who can reach what".
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/compliance/SKILL.md
+++ b/integrations/openclaw/compliance/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   Generate SBOMs and compliance reports. Use when:
   "compliance report", "NIST", "SOC 2", "ISO 27001", "OWASP", "EU AI Act",
   "AISVS", "generate SBOM", "policy check".
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. OWASP/NIST/EU AI Act/MITRE
@@ -23,7 +23,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/discover-aws/SKILL.md
+++ b/integrations/openclaw/discover-aws/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   inventory AWS Bedrock, ECS, SageMaker, Lambda, EKS, Step Functions, EC2, or
   agentic AWS infrastructure as canonical inventory. Passing that inventory
   to agent-bom is optional and operator-chosen.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-azure/SKILL.md
+++ b/integrations/openclaw/discover-azure/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived Azure credentials. Use when a user asks to
   inventory Azure OpenAI, Container Apps, AKS, Functions, ML, or agentic Azure
   infrastructure as canonical inventory.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-gcp/SKILL.md
+++ b/integrations/openclaw/discover-gcp/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   giving agent-bom long-lived GCP credentials. Use when a user asks to
   inventory Vertex AI, Cloud Run, Cloud Functions, GKE, or agentic GCP
   infrastructure as canonical inventory.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed from this repository or PyPI, and

--- a/integrations/openclaw/discover-snowflake/SKILL.md
+++ b/integrations/openclaw/discover-snowflake/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   agent-bom inventory JSON, and scan it without giving agent-bom long-lived
   Snowflake credentials. Use when a user asks to inventory Snowflake AI or
   Cortex infrastructure as canonical inventory.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+, agent-bom installed with the snowflake extra, and

--- a/integrations/openclaw/discover/SKILL.md
+++ b/integrations/openclaw/discover/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Discover AI agents, MCP servers, and configurations on this machine or
   environment. Use when: "find agents", "what's configured", "doctor",
   "what MCP servers", "show me what's installed", "mcp inventory".
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/enforce/SKILL.md
+++ b/integrations/openclaw/enforce/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Enforce security policies on MCP tool calls and block dangerous operations at
   runtime. Use when: "block risky calls", "apply policy", "proxy",
   "runtime protection", "policy enforcement", "intercept MCP calls".
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/ingest/SKILL.md
+++ b/integrations/openclaw/ingest/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   GCP, Snowflake, CMDB, or endpoint collectors. Use when a user has canonical
   inventory JSON and wants local findings, graph, policy, provenance, or
   auditor-ready exports without giving agent-bom direct cloud credentials.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom 0.84.4+. Inventory must conform to the

--- a/integrations/openclaw/monitor/SKILL.md
+++ b/integrations/openclaw/monitor/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Monitor agent fleet, track trust scores, and manage lifecycle states. Use
   when: "fleet", "watch agents", "runtime status", "trust scores",
   "fleet sync", "agent lifecycle", "serve dashboard".
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/registry/SKILL.md
+++ b/integrations/openclaw/registry/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   fleet risk scoring, assess skill file trust, and run SAST code scans. Use when
   the user mentions MCP server trust, registry lookup, marketplace check, or
   skill trust assessment.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: Semgrep for SAST

--- a/integrations/openclaw/runtime/SKILL.md
+++ b/integrations/openclaw/runtime/SKILL.md
@@ -5,7 +5,7 @@ description: >-
   correlation with CVE findings, and vulnerability analytics queries. Use when
   the user mentions runtime monitoring, context graphs, lateral movement analysis,
   audit log correlation, or vulnerability analytics.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for

--- a/integrations/openclaw/scan-infra/SKILL.md
+++ b/integrations/openclaw/scan-infra/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Scan infrastructure-as-code, cloud configurations, and find secrets. Use when:
   "check terraform", "scan kubernetes", "IaC", "find secrets",
   "scan dockerfile", "cloud security", "misconfigurations".
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Optional: kubectl for
@@ -20,7 +20,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/scan/SKILL.md
+++ b/integrations/openclaw/scan/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   KEV), container images, provenance, filesystems, and SBOMs. Use
   when: "check package", "scan image", "verify", "is this safe",
   "scan dependencies", "CVE lookup", "blast radius".
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. Native container image
@@ -22,7 +22,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []
@@ -237,6 +237,6 @@ agent-bom scan
 ## Verification
 
 - **Source**: [github.com/msaad00/agent-bom](https://github.com/msaad00/agent-bom) (Apache-2.0)
-- **Sigstore signed**: `agent-bom verify agent-bom@0.97.3`
+- **Sigstore signed**: `agent-bom verify agent-bom@0.97.4`
 - **7,100+ tests** with CodeQL + OpenSSF Scorecard
 - **No telemetry**: Zero tracking, zero analytics

--- a/integrations/openclaw/troubleshoot/SKILL.md
+++ b/integrations/openclaw/troubleshoot/SKILL.md
@@ -4,7 +4,7 @@ description: >-
   Diagnose issues, check prerequisites, and validate configurations. Use when:
   "doctor", "debug", "why failing", "validate config", "check prerequisites",
   "something is broken", "db status", "fix my setup".
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+. Install via pipx or pip. No credentials required.
@@ -19,7 +19,7 @@ metadata:
   install:
     pipx: agent-bom
     pip: agent-bom
-    docker: ghcr.io/msaad00/agent-bom:0.97.3
+    docker: ghcr.io/msaad00/agent-bom:0.97.4
   openclaw:
     requires:
       bins: []

--- a/integrations/openclaw/vulnerability-intel/SKILL.md
+++ b/integrations/openclaw/vulnerability-intel/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   with explicit data-boundary choices. Use when a user asks for CVE lookup,
   advisory intelligence, exploitability context, fix versions, GHSA/OSV/NVD
   enrichment, or package vulnerability triage.
-version: 0.97.3
+version: 0.97.4
 license: Apache-2.0
 compatibility: >-
   Requires Python 3.11+ and agent-bom installed from this repository or PyPI.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "agent-bom"
-version = "0.97.3"
+version = "0.97.4"
 description = "Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure."
 readme = "PYPI_README.md"
 license = "Apache-2.0"

--- a/scripts/count_sarif_critical.py
+++ b/scripts/count_sarif_critical.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Count critical SARIF results for release self-scan gates.
+
+agent-bom maps both ``critical`` and ``high`` findings to SARIF ``level=error``.
+Release gates that use ``--fail-on-severity critical`` must therefore count by
+``security-severity`` (>= 9.0), not by raw result count or ``level==error``.
+
+Usage:
+    python scripts/count_sarif_critical.py path/to/file.sarif
+    # prints an integer count on stdout; exits 2 on unreadable input
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _security_severity(result: dict[str, Any], rules_by_id: dict[str, dict[str, Any]]) -> float | None:
+    props = result.get("properties") or {}
+    raw = props.get("security-severity")
+    if raw is None:
+        rule = rules_by_id.get(str(result.get("ruleId") or ""))
+        if rule is not None:
+            raw = (rule.get("properties") or {}).get("security-severity")
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def count_critical_results(sarif: dict[str, Any]) -> int:
+    """Return the number of SARIF results at critical severity (score >= 9.0)."""
+    total = 0
+    for run in sarif.get("runs") or []:
+        rules = ((run.get("tool") or {}).get("driver") or {}).get("rules") or []
+        rules_by_id = {str(rule.get("id") or ""): rule for rule in rules if isinstance(rule, dict)}
+        for result in run.get("results") or []:
+            if not isinstance(result, dict):
+                continue
+            score = _security_severity(result, rules_by_id)
+            if score is not None and score >= 9.0:
+                total += 1
+    return total
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    if len(args) != 1:
+        print("usage: count_sarif_critical.py <file.sarif>", file=sys.stderr)
+        return 2
+    path = Path(args[0])
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"unreadable SARIF: {exc}", file=sys.stderr)
+        return 2
+    if not isinstance(data, dict):
+        print("unreadable SARIF: root must be an object", file=sys.stderr)
+        return 2
+    print(count_critical_results(data))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/site-docs/deployment/airgapped-image-bundle.md
+++ b/site-docs/deployment/airgapped-image-bundle.md
@@ -16,7 +16,7 @@ From an internet-connected build host:
 
 ```bash
 scripts/release/build-airgap-image-bundle.sh \
-  --version 0.97.3 \
+  --version 0.97.4 \
   --platform linux/amd64 \
   --output-dir dist/airgap
 ```
@@ -37,8 +37,8 @@ machine.
 ## Import On The Disconnected Host
 
 ```bash
-tar -xzf agent-bom-airgap-0.97.3-linux_amd64.tar.gz
-cd agent-bom-airgap-0.97.3-linux_amd64
+tar -xzf agent-bom-airgap-0.97.4-linux_amd64.tar.gz
+cd agent-bom-airgap-0.97.4-linux_amd64
 ./load-images.sh
 ```
 
@@ -47,7 +47,7 @@ The loader verifies archive checksums before running `docker load`.
 ## Push To An Internal Registry
 
 ```bash
-VERSION=0.97.3
+VERSION=0.97.4
 REGISTRY=registry.internal.example.com/security
 
 docker tag "agentbom/agent-bom:${VERSION}" "${REGISTRY}/agent-bom:${VERSION}"
@@ -62,13 +62,13 @@ Then point Helm at the internal registry:
 ```yaml
 image:
   repository: registry.internal.example.com/security/agent-bom
-  tag: "0.97.3"
+  tag: "0.97.4"
 
 controlPlane:
   ui:
     image:
       repository: registry.internal.example.com/security/agent-bom-ui
-      tag: "0.97.3"
+      tag: "0.97.4"
 ```
 
 ## GitHub Actions Bundle Job

--- a/site-docs/deployment/aws-company-rollout.md
+++ b/site-docs/deployment/aws-company-rollout.md
@@ -332,8 +332,8 @@ through a managed tap instead of direct package upload.
 
 ```bash
 python3 scripts/render_homebrew_formula.py \
-  --version 0.97.3 \
-  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.97.3.tar.gz \
+  --version 0.97.4 \
+  --url https://github.com/msaad00/agent-bom/archive/refs/tags/v0.97.4.tar.gz \
   --sha256 <release-sha256>
 ```
 

--- a/site-docs/deployment/control-plane-helm.md
+++ b/site-docs/deployment/control-plane-helm.md
@@ -189,7 +189,7 @@ Install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.97.3 \
+  --version 0.97.4 \
   -n agent-bom --create-namespace \
   -f values.agent-bom.yaml
 ```
@@ -261,7 +261,7 @@ Then install:
 
 ```bash
 helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom \
-  --version 0.97.3 \
+  --version 0.97.4 \
   -n agent-bom --create-namespace \
   -f deploy/helm/agent-bom/examples/eks-control-plane-sqlite-pilot-values.yaml
 ```

--- a/site-docs/deployment/docker.md
+++ b/site-docs/deployment/docker.md
@@ -91,10 +91,10 @@ docker run --rm \
 ## Runtime proxy against a remote MCP endpoint
 
 ```bash
-docker pull agentbom/agent-bom:0.97.3
+docker pull agentbom/agent-bom:0.97.4
 docker run --rm -i \
   -v ./audit-logs:/var/log/agent-bom \
-  agentbom/agent-bom:0.97.3 \
+  agentbom/agent-bom:0.97.4 \
   proxy \
   --log /var/log/agent-bom/audit.jsonl \
   --block-undeclared \

--- a/site-docs/features/cloud-posture.md
+++ b/site-docs/features/cloud-posture.md
@@ -25,7 +25,7 @@ agent-bom iac Dockerfile k8s/ infra/main.tf --format sarif --output agent-bom-ia
 In GitHub Actions, use the `iac` scan type or the `iac` input:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: iac
     scan-ref: infra/main.tf,k8s/

--- a/site-docs/features/policy.md
+++ b/site-docs/features/policy.md
@@ -49,7 +49,7 @@ agent-bom proxy --policy policy.json --block-undeclared -- ...
 
 ```yaml
 - name: Security gate
-  uses: msaad00/agent-bom@v0.97.3
+  uses: msaad00/agent-bom@v0.97.4
   with:
     policy: policy.json
     fail-on-violation: true

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -63,7 +63,7 @@ agent-bom check flask@2.0.0 --ecosystem pypi   # check a specific package
 | **Local AI BOM** | `agent-bom scan --demo --offline` | terminal findings and graph-ready inventory |
 | **Repository scan** | `agent-bom scan . -f html -o agent-bom-report.html` | local HTML review plus exportable evidence |
 | **Cloud posture gate** | `agent-bom iac infra/ && agent-bom cloud aws --cis` | pre-cloud IaC findings plus point-in-time or scheduled posture evidence |
-| **CI evidence** | `uses: msaad00/agent-bom@v0.97.3` | SARIF, pull-request summary, optional code scanning |
+| **CI evidence** | `uses: msaad00/agent-bom@v0.97.4` | SARIF, pull-request summary, optional code scanning |
 | **Assistant tools** | `agent-bom mcp server` | read-mostly security tools for MCP clients |
 | **Self-hosted control plane** | `docker compose -f docker-compose.pilot.yml up -d` | API and dashboard in your infrastructure |
 

--- a/site-docs/reference/agentic-workflows.md
+++ b/site-docs/reference/agentic-workflows.md
@@ -8,7 +8,7 @@ plane or runtime enforcement rollout.
 |---|---|---|---|---|
 | Local CLI | `agent-bom scan --demo --offline`, then `agent-bom scan .` | Reads local agent and MCP configuration from the developer machine. No control-plane credentials required. | Terminal findings, JSON, SARIF, SBOM, HTML, graph export. | Scheduled scan, Docker, GitHub Action. |
 | Claude, Cursor, Windsurf, VS Code, Cortex, Codex CLI | `agent-bom mcp server` | Exposes read-mostly security tools to the assistant. The assistant does not need direct scanner credentials beyond the local process boundary; Shield write actions require admin role, `shield:write` scope, and an audit reason. | MCP tool output, inventory, blast-radius answers, compliance checks, ranked `ExposurePath` JSON, deploy guidance. | Shared MCP configuration, skills, fleet sync. |
-| GitHub Actions | `uses: msaad00/agent-bom@v0.97.3` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
+| GitHub Actions | `uses: msaad00/agent-bom@v0.97.4` with SARIF upload enabled | Runs in CI with repository-scoped token permissions. Fork PR behavior depends on GitHub security policy. | `agent-bom-results.sarif`, pull-request summary, code-scanning alert category. | Branch protection, required code scanning, artifact retention. |
 | Skills and instruction files | `agent-bom skills scan . --policy skills-policy.yaml` | Reads repo-local instructions such as `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, and `skills/*.md`. | Skill trust findings, referenced package and MCP inventory, credential-env names, policy warn/block result. | Signed skills, provenance verification, registry publishing. |
 | Cloud and AI infrastructure | `agent-bom agents --preset enterprise` plus provider-specific flags only where credentials are approved. | Uses read-only provider APIs or local inventory files. Keep provider secrets in the operator boundary, not in repo docs. | Cloud, warehouse, GPU, model, dataset, and runtime package evidence. | Fleet sync, compliance exports, graph-backed findings. |
 | Runtime proxy | `agent-bom proxy --no-isolate --log audit.jsonl --block-undeclared -- ...` | Wraps selected local MCP traffic. Policy can block before an upstream tool receives the call. Container containment requires a stdio MCP path plus a configured sandbox image or an existing container command. | Tier-A audit JSONL, policy decisions, runtime alerts, metrics, and sandbox posture when isolation is enabled. | Sidecar proxy, gateway policy pull, SIEM export. |
@@ -31,7 +31,7 @@ when the buyer or contributor needs to see the first finding path quickly.
 ### CI Security Review
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: agents
     severity-threshold: high
@@ -66,7 +66,7 @@ by setting `skills-ci: true` (equivalent to the CLI `--ci` flag, i.e.
 `fail-on-verdict=suspicious`):
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: skills
     scan-ref: .
@@ -80,7 +80,7 @@ For finer control, replace `skills-ci` with explicit gates and an optional
 policy file:
 
 ```yaml
-- uses: msaad00/agent-bom@v0.97.3
+- uses: msaad00/agent-bom@v0.97.4
   with:
     scan-type: skills
     scan-ref: .

--- a/site-docs/reference/remediate-output.md
+++ b/site-docs/reference/remediate-output.md
@@ -45,7 +45,7 @@ remediation remain advisory/manual in this command.
 
 ```json
 {
-  "version": "0.97.3",
+  "version": "0.97.4",
   "generated_at": "2026-04-21T12:00:00+00:00",
   "remediation_plan": [],
   "summary": {

--- a/src/agent_bom/__init__.py
+++ b/src/agent_bom/__init__.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 try:
     __version__ = version("agent-bom")
 except PackageNotFoundError:
-    __version__ = "0.97.3"
+    __version__ = "0.97.4"
 
 # Cross-check against pyproject.toml for dev installs where the editable
 # install metadata may be stale (i.e. version bumped but not re-installed).

--- a/src/agent_bom/parsers/skills.py
+++ b/src/agent_bom/parsers/skills.py
@@ -511,6 +511,20 @@ _INSTRUCTION_FILE_NAMES: frozenset[str] = frozenset(
     }
 )
 
+# Index / catalog markdown often lives inside skills trees but is not an
+# executable skill surface (e.g. `.agents/skills/README.md`, `skills/index.md`).
+_INSTRUCTION_INDEX_FILE_NAMES: frozenset[str] = frozenset(
+    {
+        "readme.md",
+        "index.md",
+        "summary.md",
+        "overview.md",
+    }
+)
+
+# Published / generated docs trees that mention skills but are not estate skills.
+_DOCS_SKILL_ROOT_NAMES: frozenset[str] = frozenset({"docs", "site-docs"})
+
 # Directory names whose ``*.md`` / ``*.mdc`` descendants are instruction surfaces.
 # Keep this list narrow: bare ``agents/`` / ``commands/`` dirs are common in
 # application code and would flood discovery with false positives.
@@ -563,7 +577,7 @@ def looks_like_instruction_surface(
         return False
     if skip_test_fixtures and _is_test_fixture_path(path):
         return False
-    if not allow_docs_skills and "docs" in path.parts and "skills" in path.parts:
+    if not allow_docs_skills and any(root in path.parts for root in _DOCS_SKILL_ROOT_NAMES) and "skills" in path.parts:
         return False
 
     name = path.name
@@ -575,6 +589,10 @@ def looks_like_instruction_surface(
         return True
 
     if path.suffix.lower() not in _INSTRUCTION_SUFFIXES:
+        return False
+
+    # Catalog/index files under skills trees are documentation, not skills.
+    if name.lower() in _INSTRUCTION_INDEX_FILE_NAMES:
         return False
 
     parents = list(path.parents)
@@ -605,7 +623,7 @@ def discover_skill_files(project_dir: Path) -> list[Path]:
     if not project_dir.is_dir():
         return []
 
-    allow_docs_skills = "docs" in project_dir.parts and "skills" in project_dir.parts
+    allow_docs_skills = any(root in project_dir.parts for root in _DOCS_SKILL_ROOT_NAMES) and "skills" in project_dir.parts
     found: list[Path] = []
     seen: set[Path] = set()
 

--- a/tests/test_count_sarif_critical.py
+++ b/tests/test_count_sarif_critical.py
@@ -1,0 +1,73 @@
+"""Regression: release self-scan must not treat medium/low skill SARIF as critical."""
+
+from __future__ import annotations
+
+from scripts.count_sarif_critical import count_critical_results
+
+
+def test_count_sarif_critical_ignores_skill_warning_and_note() -> None:
+    sarif = {
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "rules": [
+                            {
+                                "id": "finding/SKILL_RISK",
+                                "properties": {"security-severity": "4.0"},
+                            }
+                        ]
+                    }
+                },
+                "results": [
+                    {"ruleId": "finding/SKILL_RISK", "level": "warning", "properties": {}},
+                    {"ruleId": "finding/SKILL_RISK", "level": "note", "properties": {}},
+                ],
+            }
+        ]
+    }
+    assert count_critical_results(sarif) == 0
+
+
+def test_count_sarif_critical_counts_security_severity_ge_9() -> None:
+    sarif = {
+        "runs": [
+            {
+                "tool": {"driver": {"rules": []}},
+                "results": [
+                    {
+                        "ruleId": "CVE-2024-0001",
+                        "level": "error",
+                        "properties": {"security-severity": "9.1"},
+                    },
+                    {
+                        "ruleId": "CVE-2024-0002",
+                        "level": "error",
+                        "properties": {"security-severity": "7.5"},
+                    },
+                ],
+            }
+        ]
+    }
+    assert count_critical_results(sarif) == 1
+
+
+def test_count_sarif_critical_uses_rule_security_severity_fallback() -> None:
+    sarif = {
+        "runs": [
+            {
+                "tool": {
+                    "driver": {
+                        "rules": [
+                            {
+                                "id": "CVE-2024-0003",
+                                "properties": {"security-severity": "9.0"},
+                            }
+                        ]
+                    }
+                },
+                "results": [{"ruleId": "CVE-2024-0003", "level": "error", "properties": {}}],
+            }
+        ]
+    }
+    assert count_critical_results(sarif) == 1

--- a/tests/test_skills_parser.py
+++ b/tests/test_skills_parser.py
@@ -212,17 +212,25 @@ def test_discover_skips_generic_markdown_and_vendored_dirs(tmp_path):
     vendored = tmp_path / "node_modules" / "pkg" / "skills" / "evil.md"
     venv_skill = tmp_path / ".venv" / "lib" / "skills" / "tool.md"
     docs_skill = tmp_path / "docs" / "skills" / "example.md"
-    for path in (vendored, venv_skill, docs_skill):
+    site_docs_skill = tmp_path / "site-docs" / "skills" / "index.md"
+    agents_readme = tmp_path / ".agents" / "skills" / "README.md"
+    agents_skill = tmp_path / ".agents" / "skills" / "review" / "SKILL.md"
+    for path in (vendored, venv_skill, docs_skill, site_docs_skill, agents_readme, agents_skill):
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text("# Third-party or docs skill")
 
     found = discover_skill_files(tmp_path)
     names = {p.name for p in found}
+    rel = {str(p.relative_to(tmp_path)) for p in found}
     assert "CLAUDE.md" in names
     assert "README.md" not in names
     assert "evil.md" not in names
     assert "tool.md" not in names
     assert "example.md" not in names
+    assert "index.md" not in names
+    assert ".agents/skills/README.md" not in rel
+    assert "site-docs/skills/index.md" not in rel
+    assert ".agents/skills/review/SKILL.md" in rel
 
 
 # ── scan_skill_files tests ──────────────────────────────────────────────────

--- a/ui/components/sigma-graph-overview.tsx
+++ b/ui/components/sigma-graph-overview.tsx
@@ -215,12 +215,12 @@ export function SigmaGraphOverview({
       data-testid="sigma-graph-overview"
     >
       <div className="border-b border-[var(--border-subtle)] bg-[var(--background)]/95 p-3">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <span className="inline-flex shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 dark:bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 dark:text-emerald-200">
+        <div className="flex min-w-0 flex-col gap-1 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
+          <span className="inline-flex w-fit shrink-0 items-center gap-2 rounded-full border border-emerald-500/30 bg-emerald-500/10 dark:bg-emerald-950/25 px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.16em] text-emerald-700 dark:text-emerald-200">
             <Sparkles className="h-3.5 w-3.5" />
             WebGL graph overview
           </span>
-          <span className="min-w-0 text-xs text-[var(--text-tertiary)]">
+          <span className="min-w-0 text-xs leading-snug text-[var(--text-tertiary)] sm:min-w-[12rem] sm:flex-1">
             Sigma.js renderer for broad estate scans; focused investigations still use React Flow.
           </span>
         </div>

--- a/ui/e2e/large-graph-overview.spec.ts
+++ b/ui/e2e/large-graph-overview.spec.ts
@@ -315,9 +315,10 @@ test("sigma webgl overview renders when explicitly requested", async ({ page }, 
     waitUntil: "domcontentloaded",
   });
 
-  await expect(page.getByTestId("sigma-graph-overview")).toBeVisible({ timeout: 30_000 });
-  await expect(page.getByText("WebGL graph overview")).toBeVisible();
-  await expect(page.getByText("Sigma.js renderer for broad estate scans")).toBeVisible();
+  const sigma = page.getByTestId("sigma-graph-overview");
+  await expect(sigma).toBeVisible({ timeout: 30_000 });
+  await expect(sigma.getByText("WebGL graph overview")).toBeVisible();
+  await expect(sigma.getByText(/Sigma\.js renderer for broad estate scans/)).toBeVisible();
   await expectSigmaCanvases(page);
   await page.screenshot({ path: testInfo.outputPath("sigma-webgl-overview.png"), fullPage: true });
 });

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ui",
-  "version": "0.97.3",
+  "version": "0.97.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ui",
-      "version": "0.97.3",
+      "version": "0.97.4",
       "dependencies": {
         "@dagrejs/dagre": "^3.0.0",
         "@tanstack/react-table": "^8.21.3",

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ui",
-  "version": "0.97.3",
+  "version": "0.97.4",
   "private": true,
   "packageManager": "npm@10.9.7",
   "engines": {

--- a/ui/tests/nav.test.tsx
+++ b/ui/tests/nav.test.tsx
@@ -70,7 +70,7 @@ vi.mock('@/lib/api', () => ({
       scan_sources: [],
       scan_count: 0,
     }),
-    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.97.3' }),
+    health: vi.fn().mockResolvedValue({ status: 'ok', version: '0.97.4' }),
   },
 }))
 

--- a/uv.lock
+++ b/uv.lock
@@ -23,7 +23,7 @@ overrides = [
 
 [[package]]
 name = "agent-bom"
-version = "0.97.3"
+version = "0.97.4"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Release blocker:** `v0.97.3` Self-scan gate counted all SARIF rows as critical; medium/low first-party `SKILL_RISK` aborted publish (PyPI still `0.97.2`).
- **Gate fix:** Count criticals via `security-severity >= 9.0` (`scripts/count_sarif_critical.py`).
- **Security alerts:** Same noise opened GitHub Skill Risk alerts on `.agents/skills/README.md`, `site-docs/skills/index.md`, `CLAUDE.md`.
  - Discovery skips skills-tree `README.md`/`index.md` and `site-docs/skills/**`.
  - Release SARIF upload drops medium/low `SKILL_RISK` (keeps high/critical).
- **UI:** Keep Sigma overview subtitle visible in narrow CI (e2e flake that failed UI Validate).
- **Release:** Bump to **0.97.4** (forward-only; do not re-tag `0.97.3`).
- Squashed to one verified SSH-signed commit and re-pushed to clear a stuck CI queue (`cancel-in-progress` left a pending run with zero jobs).

## Verification

- `uv run pytest tests/test_count_sarif_critical.py tests/test_skills_parser.py tests/test_skill_audit_finding_stream.py -q` → green
- Local self-scan SARIF after upload filter → 0 medium/low skill rows
- `check_version_alignment` / `check_release_consistency` → OK (`0.97.4`)

## Notes

- Dismiss existing Skill Risk alerts (#1815–#1828) after merge.
- After merge: tag **`v0.97.4`** to run Release publish.
- Re-approve if squash push dismissed prior reviews.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a579ae44-c48d-4515-8cf6-2da701406ba6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

