### PR TITLE
feat(inventory): publish bounded evidence completeness

### DIFF
--- a/src/agent_bom/api/inventory_service.py
+++ b/src/agent_bom/api/inventory_service.py
@@ -21,6 +21,7 @@ from typing import Any, Awaitable, Callable, Optional
 
 from agent_bom.api.graph_store import MAX_NODE_PAGE_OFFSET, encode_graph_cursor
 from agent_bom.graph import SEVERITY_RANK, EntityType
+from agent_bom.graph.completeness import graph_completeness
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 from agent_bom.security import sanitize_error
 
@@ -229,6 +230,7 @@ async def build_summary(
         "by_type": dict(sorted(by_type.items(), key=lambda kv: (-kv[1], kv[0]))),
         "by_group": {group: count for group, count in by_group.items() if count or group in _TYPE_GROUPS},
         "finding_count": sum(int(node_types.get(t, 0) or 0) for t in _FINDING_TYPE_VALUES),
+        "completeness": graph_completeness(returned=total_assets, total=total_assets),
     }
 
 
@@ -312,6 +314,7 @@ async def build_asset_list(
     if not facet_active:
         nodes, total, next_cursor = await _fetch(cursor, offset, limit)
         rows = [asset_row(node) for node in nodes]
+        has_more = bool(next_cursor) if cursor else offset + len(rows) < total
         return {
             "schema_version": "inventory.assets.v1",
             "tenant_id": tenant_id,
@@ -330,9 +333,15 @@ async def build_asset_list(
                 "limit": limit,
                 "cursor": cursor or "",
                 "next_cursor": next_cursor or "",
-                "has_more": bool(next_cursor) if cursor else offset + limit < total,
+                "has_more": has_more,
                 "facet_filtered": False,
             },
+            "completeness": graph_completeness(
+                returned=len(rows),
+                total=total,
+                truncated=has_more,
+                reason="asset_page_limit" if has_more else "",
+            ),
         }
 
     # Facet filter active: keyset-page the store and refill until we have a full
@@ -394,6 +403,11 @@ async def build_asset_list(
             "has_more": has_more,
             "facet_filtered": True,
         },
+        "completeness": graph_completeness(
+            returned=len(page_rows),
+            truncated=has_more,
+            reason="facet_page_limit" if has_more else "",
+        ),
     }
 
 
@@ -436,4 +450,5 @@ async def build_asset_detail(
         "neighbors": context["neighbors"],
         "sources": context["sources"],
         "impact": context["impact"],
+        "completeness": graph_completeness(returned=1, total=1),
     }

--- a/tests/test_inventory_assets.py
+++ b/tests/test_inventory_assets.py
@@ -123,6 +123,14 @@ def test_summary_counts_assets_by_type_and_group_excluding_findings(inventory_st
     assert body["by_group"]["cloud"] == 6  # ec2, s3, aws-acct, snowflake-acct, warehouse, snowflake-db
     assert body["by_group"]["identity"] == 4  # snowflake role+user, alice, admin
     assert body["by_group"]["secrets"] == 1  # credential
+    assert body["completeness"] == {
+        "status": "complete",
+        "complete": True,
+        "sampled": False,
+        "truncated": False,
+        "returned": 16,
+        "total": 16,
+    }
 
 
 # ── Faceted list ──
@@ -142,6 +150,8 @@ def test_list_returns_asset_rows_and_excludes_findings(inventory_store):
     assert row["environment"] == "production"
     assert row["provider"] == "aws"
     assert row["source"] == "cloud:aws"
+    assert body["completeness"]["status"] == "complete"
+    assert body["completeness"]["returned"] == 16
 
 
 def test_list_type_filter(inventory_store):
@@ -184,6 +194,7 @@ def test_list_environment_facet_filter(inventory_store):
     assert resp.status_code == 200
     body = resp.json()
     assert body["pagination"]["facet_filtered"] is True
+    assert body["completeness"]["status"] == "complete"
     ids = {r["id"] for r in body["assets"]}
     assert ids == {"agent:a", "server:mcp", "cloud_resource:ec2"}
 
@@ -232,6 +243,7 @@ def test_list_facet_filter_paginates_without_dropping_rows(tmp_path):
             assert len(page) <= 40
             seen.extend(row["id"] for row in page)
             pagination = body["pagination"]
+            assert body["completeness"]["truncated"] == pagination["has_more"]
             if not pagination["has_more"] or not pagination["next_cursor"]:
                 break
             cursor = pagination["next_cursor"]
@@ -253,6 +265,7 @@ def test_list_pagination_with_cursor(inventory_store):
         body = client.get(url).json()
         page_ids = [r["id"] for r in body["assets"]]
         assert len(page_ids) <= 5
+        assert body["completeness"]["truncated"] == body["pagination"]["has_more"]
         assert not (set(page_ids) & seen)  # no duplicates across pages
         seen.update(page_ids)
         pages += 1
@@ -272,6 +285,7 @@ def test_detail_returns_node_with_edges(inventory_store):
     assert resp.status_code == 200
     body = resp.json()
     assert body["schema_version"] == "inventory.asset.v1"
+    assert body["completeness"]["status"] == "complete"
     assert body["asset"]["id"] == "server:mcp"
     assert body["node"]["entity_type"] == "server"
     neighbors = set(body["neighbors"]) | set(body["sources"])

--- a/tests/test_mcp_inventory.py
+++ b/tests/test_mcp_inventory.py
@@ -150,6 +150,7 @@ async def test_inventory_summary_counts_by_type_and_group(seeded_store) -> None:
     assert body["by_group"]["cloud"] == 6
     assert body["by_group"]["identity"] == 4
     assert body["by_group"]["secrets"] == 1
+    assert body["completeness"]["status"] == "complete"
 
 
 # ── List ─────────────────────────────────────────────────────────────────────
@@ -172,6 +173,7 @@ async def test_inventory_list_provider_facet(seeded_store) -> None:
     )
     body = json.loads(response)
     assert body["pagination"]["facet_filtered"] is True
+    assert body["completeness"]["truncated"] is False
     assert {r["id"] for r in body["assets"]} == {
         "account:snowflake:acct1",
         "cloud_resource:snowflake:warehouse:WH_ETL",
@@ -215,6 +217,7 @@ async def test_inventory_asset_detail_returns_edges(seeded_store) -> None:
     )
     body = json.loads(response)
     assert body["schema_version"] == "inventory.asset.v1"
+    assert body["completeness"]["status"] == "complete"
     assert body["asset"]["id"] == "server:mcp"
     assert body["node"]["entity_type"] == "server"
     edge_targets = {e["target"] for e in body["edges_out"]} | {e["source"] for e in body["edges_in"]}

--- a/ui/components/inventory/asset-inventory-view.tsx
+++ b/ui/components/inventory/asset-inventory-view.tsx
@@ -137,15 +137,20 @@ export function AssetInventoryView({ kind }: { kind: AssetKindId }) {
       <StatStrip
         items={[
           { label: "Total", value: total, hint: total > loadedCount ? `${loadedCount} loaded` : undefined },
-          { label: "With findings", value: summary.withFindings, accent: summary.withFindings > 0 ? "warn" : "neutral" },
-          { label: "Critical", value: summary.criticalAssets, accent: "critical" },
-          { label: "High", value: summary.highAssets, accent: "high" },
-          { label: "Correlated findings", value: summary.totalFindings },
+          { label: total > loadedCount || hasMore ? "Loaded with findings" : "With findings", value: summary.withFindings, accent: summary.withFindings > 0 ? "warn" : "neutral" },
+          { label: total > loadedCount || hasMore ? "Loaded critical" : "Critical", value: summary.criticalAssets, accent: "critical" },
+          { label: total > loadedCount || hasMore ? "Loaded high" : "High", value: summary.highAssets, accent: "high" },
+          { label: total > loadedCount || hasMore ? "Loaded correlations" : "Correlated findings", value: summary.totalFindings },
         ]}
       />
 
       <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs leading-5 text-[color:var(--text-secondary)]">
         <span className="font-medium text-[color:var(--text-secondary)]">Coverage:</span> {config.coverageNote}
+        {model?.completeness && !model.completeness.complete ? (
+          <span className="ml-1 text-[color:var(--status-warn)]">
+            Current graph page is {model.completeness.status}; load more pages before treating row-level correlations as exhaustive.
+          </span>
+        ) : null}
         {total > loadedCount || hasMore ? (
           <span className="text-[color:var(--text-tertiary)]">
             {" "}

--- a/ui/components/inventory/inventory-index.tsx
+++ b/ui/components/inventory/inventory-index.tsx
@@ -52,6 +52,7 @@ export function InventoryIndex() {
     }
     return { assets, withFindings, critical, findings };
   }, [model]);
+  const complete = model?.completeness?.complete ?? true;
 
   if (loading && !model) {
     return (
@@ -98,11 +99,21 @@ export function InventoryIndex() {
       <StatStrip
         items={[
           { label: "Assets", value: totals.assets.toLocaleString() },
-          { label: "With findings", value: totals.withFindings, accent: totals.withFindings > 0 ? "warn" : "neutral" },
-          { label: "Critical assets", value: totals.critical, accent: "critical" },
-          { label: "Correlated findings", value: totals.findings },
+          { label: complete ? "With findings" : "Loaded with findings", value: totals.withFindings, accent: totals.withFindings > 0 ? "warn" : "neutral" },
+          { label: complete ? "Critical assets" : "Loaded critical assets", value: totals.critical, accent: "critical" },
+          { label: complete ? "Correlated findings" : "Loaded correlations", value: totals.findings },
         ]}
       />
+
+      {model.completeness && !model.completeness.complete ? (
+        <div
+          data-testid="inventory-coverage"
+          className="rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs leading-5 text-[color:var(--text-secondary)]"
+        >
+          <span className="font-medium text-[color:var(--foreground)]">Evidence coverage:</span>{" "}
+          {model.completeness.status}. The totals are authoritative, while findings and relationships are loaded from the current graph page.
+        </div>
+      ) : null}
 
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {cards.map(({ kind, total, criticalAssets, highAssets, withFindings }) => {

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -110,6 +110,21 @@ export interface GraphPagination {
   next_cursor?: string | undefined;
 }
 
+/**
+ * Shared evidence coverage contract. `truncated` means the response is a
+ * bounded page; clients must follow the cursor before treating the lens as
+ * exhaustive. `sampled` is reserved for deterministic representative views.
+ */
+export interface GraphCompleteness {
+  status: "complete" | "truncated" | "sampled";
+  complete: boolean;
+  sampled: boolean;
+  truncated: boolean;
+  returned: number;
+  total?: number | undefined;
+  reason?: string | undefined;
+}
+
 export interface GraphSnapshot {
   scan_id: string;
   created_at: string;
@@ -154,6 +169,56 @@ export interface UnifiedGraphResponse extends Omit<
 > {
   attack_paths: GraphAttackPath[];
   pagination: GraphPagination;
+  completeness?: GraphCompleteness | undefined;
+}
+
+/** Shared HTTP/MCP inventory projection over the tenant-scoped graph store. */
+export interface InventorySummaryResponse {
+  schema_version: string;
+  tenant_id: string;
+  scan_id: string;
+  total_assets: number;
+  by_type: Record<string, number>;
+  by_group: Record<string, number>;
+  finding_count: number;
+  completeness: GraphCompleteness;
+}
+
+export interface InventoryAsset {
+  id: string;
+  type: string;
+  name: string;
+  environment: string;
+  provider: string;
+  risk: number;
+  severity: string;
+  status: string;
+  source: string;
+  sources: string[];
+  first_seen: string;
+  last_seen: string;
+}
+
+export interface InventoryAssetsResponse {
+  schema_version: string;
+  tenant_id: string;
+  assets: InventoryAsset[];
+  filters: Record<string, string | string[]>;
+  pagination: GraphPagination & { facet_filtered: boolean };
+  completeness: GraphCompleteness;
+}
+
+export interface InventoryAssetDetailResponse {
+  schema_version: string;
+  tenant_id: string;
+  asset: InventoryAsset;
+  node: Record<string, unknown>;
+  edges_out: Record<string, unknown>[];
+  edges_in: Record<string, unknown>[];
+  neighbors: string[];
+  sources: string[];
+  impact: Record<string, unknown>;
+  completeness: GraphCompleteness;
 }
 
 export interface AgentBomManifestNode {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -29,6 +29,9 @@ import type {
   GraphAgentsResponse,
   GraphDiffResponse,
   GraphEdgeChangesResponse,
+  InventorySummaryResponse,
+  InventoryAssetsResponse,
+  InventoryAssetDetailResponse,
   GraphExportFormat,
   AgentBomManifestResponse,
   PostureCountsResponse,
@@ -174,11 +177,16 @@ export type {
   ScanJobStatus,
   ScanResult,
   GraphPagination,
+  GraphCompleteness,
   GraphAttackPath,
   GraphSnapshot,
   GraphHistoryResponse,
   GraphHistorySnapshot,
   UnifiedGraphResponse,
+  InventorySummaryResponse,
+  InventoryAssetsResponse,
+  InventoryAsset,
+  InventoryAssetDetailResponse,
   FixFirstGraphViewResponse,
   FixFirstPathCard,
   GraphAttackCampaign,
@@ -873,6 +881,48 @@ export const api = {
     if (filters?.cursor) params.set("cursor", filters.cursor);
     const qs = params.toString();
     return get<UnifiedGraphResponse>(`/v1/graph${qs ? `?${qs}` : ""}`);
+  },
+
+  /** Read the store-backed, tenant-scoped inventory summary. */
+  getInventorySummary: (scanId?: string) => {
+    const qs = scanId ? `?scan_id=${encodeURIComponent(scanId)}` : "";
+    return get<InventorySummaryResponse>(`/v1/inventory/summary${qs}`);
+  },
+
+  /** Read one bounded, cursor-paged inventory page from the shared store. */
+  getInventoryAssets: (filters?: {
+    type?: string[] | undefined;
+    search?: string | undefined;
+    environment?: string | undefined;
+    provider?: string | undefined;
+    source?: string | undefined;
+    minSeverity?: string | undefined;
+    scanId?: string | undefined;
+    cursor?: string | undefined;
+    offset?: number | undefined;
+    limit?: number | undefined;
+  }) => {
+    const params = new URLSearchParams();
+    if (filters?.type?.length) params.set("type", filters.type.join(","));
+    if (filters?.search) params.set("search", filters.search);
+    if (filters?.environment) params.set("environment", filters.environment);
+    if (filters?.provider) params.set("provider", filters.provider);
+    if (filters?.source) params.set("source", filters.source);
+    if (filters?.minSeverity) params.set("min_severity", filters.minSeverity);
+    if (filters?.scanId) params.set("scan_id", filters.scanId);
+    if (filters?.cursor) params.set("cursor", filters.cursor);
+    if (filters?.offset != null) params.set("offset", String(filters.offset));
+    if (filters?.limit != null) params.set("limit", String(filters.limit));
+    const qs = params.toString();
+    return get<InventoryAssetsResponse>(`/v1/inventory/assets${qs ? `?${qs}` : ""}`);
+  },
+
+  /** Lazily load one asset's relationships and blast-radius context. */
+  getInventoryAsset: (assetId: string, scanId?: string) => {
+    const qs = scanId ? `?scan_id=${encodeURIComponent(scanId)}` : "";
+    return get<InventoryAssetDetailResponse>(
+      `/v1/inventory/assets/${encodeURIComponent(assetId)}${qs}`,
+    );
   },
 
   /** Load the ranked fix-first security graph view model */

--- a/ui/lib/inventory.ts
+++ b/ui/lib/inventory.ts
@@ -9,7 +9,7 @@ import {
   type LucideIcon,
 } from "lucide-react";
 
-import type { UnifiedGraphResponse } from "@/lib/api";
+import type { GraphCompleteness, UnifiedGraphResponse } from "@/lib/api";
 import type { PageLane } from "@/lib/page-lanes";
 import { severityRank } from "@/lib/severity";
 
@@ -240,6 +240,8 @@ export interface InventoryModel {
   loadedByKind: Record<AssetKindId, number>;
   scanId: string;
   createdAt: string;
+  /** Whether the current graph page is exhaustive or still cursor-bounded. */
+  completeness?: GraphCompleteness | undefined;
 }
 
 function attrString(node: GraphNode, key: string): string | undefined {
@@ -382,6 +384,7 @@ export function buildInventory(graph: UnifiedGraphResponse): InventoryModel {
     loadedByKind,
     scanId: graph.scan_id,
     createdAt: graph.created_at,
+    completeness: graph.completeness,
   };
 }
 

--- a/ui/tests/inventory-view.test.tsx
+++ b/ui/tests/inventory-view.test.tsx
@@ -180,14 +180,23 @@ describe("AssetInventoryView", () => {
         highest_interaction_risk: 0,
       },
       pagination: { total: 2, offset: 0, limit: 1, has_more: true, next_cursor: "cur-2" },
+      completeness: {
+        status: "truncated",
+        complete: false,
+        sampled: false,
+        truncated: true,
+        returned: 1,
+        total: 2,
+        reason: "node_page_limit",
+      },
     } as unknown as UnifiedGraphResponse);
     getGraph.mockResolvedValueOnce({
       ...graph([node("pkg-2", "package", { data_sources: ["sbom"] })], []),
       pagination: { total: 2, offset: 1, limit: 1, has_more: false, next_cursor: "" },
     } as unknown as UnifiedGraphResponse);
-
     renderWithProvider(<AssetInventoryView kind="packages" />);
     const table = await screen.findByTestId("inventory-table-packages");
+    expect(screen.getByText(/Current graph page is truncated/i)).toBeInTheDocument();
     await waitFor(() => expect(within(table).getByText("pkg-1")).toBeInTheDocument());
     expect(within(table).queryByText("pkg-2")).not.toBeInTheDocument();
 


### PR DESCRIPTION
## Summary
- publish the shared complete/truncated evidence contract on summary, asset-page, facet-page, and detail inventory responses
- add typed inventory API clients for HTTP/MCP parity and carry graph completeness into the dashboard
- make partial graph coverage explicit in inventory KPIs and coverage copy instead of implying page-derived correlations are exhaustive

## Verification
- `uv run pytest -q tests/test_inventory_assets.py tests/test_mcp_inventory.py` (24 passed)
- `uv run ruff check src/agent_bom/api/inventory_service.py tests/test_inventory_assets.py`
- `make preflight`
- `cd ui && npm test -- --run tests/inventory.test.ts tests/inventory-view.test.tsx` (22 passed)
- `cd ui && npm run typecheck`
- `cd ui && npm run build`
- `python scripts/check_exception_sanitization.py`
- `python scripts/check_package_layout.py`
- `git diff --check`

## Notes
- Existing graph correlation and keyset pagination behavior is preserved.
- The response contract is additive and tenant-scoped; no migration is required.
- This PR makes bounded coverage honest; it does not claim that Postgres detail or graph rollup have been converted to SQL-native queries.