### PR TITLE
fix(graph): align investigation path evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,36 +32,6 @@
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
-## Scan
-
-The same scanner runs from four entry points — pick the one for your surface;
-none is "the" way in.
-
-CLI (local or one-off):
-
-```bash
-pip install agent-bom
-agent-bom scan .
-```
-
-CI (GitHub Action):
-
-```yaml
-- uses: msaad00/agent-bom@v0.97.4
-  with:
-    scan-type: agents
-    format: sarif
-    upload-sarif: true
-```
-
-Also: Docker, and a self-hosted control plane via cloud connect / scheduled
-estate scans. Inventory, findings, reachability, and fix-first actions work
-without a control plane; export when another tool needs it:
-`agent-bom scan . -f sarif -o findings.sarif`.
-
-Offline sample without your repo: `uvx agent-bom scan --demo --offline` ·
-full path: [First Run](docs/FIRST_RUN.md).
-
 ## Blast radius
 
 One finding fans out to the MCP servers that load it, reachable tools,

--- a/docs/FIRST_RUN.md
+++ b/docs/FIRST_RUN.md
@@ -26,6 +26,12 @@ add `-f html -o agent-bom-report.html` (or `-f json`, `-f sarif`); run
 agent-bom scan --demo --offline
 ```
 
+The command's status `1` is expected: the curated sample deliberately contains
+blocking findings, so the CLI behaves like the same security gate used in CI.
+The printed report is still valid; this status is not a scanner crash. Offline
+mode also limits enrichment to bundled demo evidence. After reviewing the
+sample, run `agent-bom scan -p .` against your own repository.
+
 Use this when you need reproducible output — for example a screenshot or a bug
 report. The package versions and advisory-backed ranges are curated in code and
 guarded by tests, so it does not depend on fabricated CVEs or a machine-specific

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -69,7 +69,11 @@ OPENCLAW_SKILL_PATTERNS: list[tuple[str, re.Pattern, str]] = [
 DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     # README.md + docs — GitHub Action version references
     ("README.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
-    ("README.md", re.compile(r"(current )\d+\.\d+\.\d+( console demo)"), r"\g<1>{v}\g<2>"),
+    (
+        "README.md",
+        re.compile(r"(CLI walkthrough</b> — )\d+\.\d+\.\d+( console demo</summary>)"),
+        r"\g<1>{v}\g<2>",
+    ),
     ("docs/AI_INFRASTRUCTURE_SCANNING.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
     ("docs/ENTERPRISE_DEPLOYMENT.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
     ("docs/archive/WINDOWS_CONTAINERS.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
@@ -141,8 +145,6 @@ DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
     ),
     ("site-docs/reference/remediate-output.md", re.compile(r'("version":\s*")\d+\.\d+\.\d+(")'), r"\g<1>{v}\g<2>"),
     ("docs/RUNTIME_MONITORING.md", re.compile(r"(agentbom/agent-bom:)\d+\.\d+\.\d+"), r"\g<1>{v}"),
-    # mcp-change-scan.yml — pinned agent-bom install version
-    (".github/workflows/mcp-change-scan.yml", re.compile(r"(agent-bom==)\d+\.\d+\.\d+"), r"\g<1>{v}"),
     # docs/demo.tape — version header
     ("docs/demo.tape", re.compile(r"^(# agent-bom v)\d+\.\d+\.\d+(\s+.*demo.*)$", re.M), r"\g<1>{v}\g<2>"),
 ]

--- a/scripts/release_smoke.sh
+++ b/scripts/release_smoke.sh
@@ -27,6 +27,15 @@ fail() { printf "  \033[31m✗\033[0m %s\n" "$*" >&2; exit 1; }
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
 
+# Keep the smoke hermetic. A release check must neither depend on nor mutate a
+# developer's existing ~/.agent-bom databases, and it must work when $HOME is
+# read-only (as it is in some CI/sandbox runners).
+export AGENT_BOM_STATE_DIR="${AGENT_BOM_STATE_DIR:-$tmp/state}"
+export AGENT_BOM_DB_PATH="${AGENT_BOM_DB_PATH:-$AGENT_BOM_STATE_DIR/db/vulns.db}"
+export AGENT_BOM_SCAN_CACHE="${AGENT_BOM_SCAN_CACHE:-$AGENT_BOM_STATE_DIR/scan-cache.db}"
+export AGENT_BOM_LOCAL_ANALYTICS_DB="${AGENT_BOM_LOCAL_ANALYTICS_DB:-$AGENT_BOM_STATE_DIR/local-analytics.sqlite}"
+mkdir -p "$AGENT_BOM_STATE_DIR/db"
+
 bold "1/5 CLI install surface"
 if command -v uv >/dev/null 2>&1; then
   AGENT_BOM_BIN=(uv run agent-bom)

--- a/tests/test_first_run_sample.py
+++ b/tests/test_first_run_sample.py
@@ -159,6 +159,13 @@ def test_first_run_docs_reference_real_paths() -> None:
         assert (ROOT / relative).exists()
 
 
+def test_first_run_docs_explain_demo_exit_status() -> None:
+    guide = (ROOT / "docs" / "FIRST_RUN.md").read_text(encoding="utf-8")
+
+    assert "status `1` is expected" in guide
+    assert "not a scanner crash" in guide
+
+
 def test_packaged_first_run_sample_can_be_written_and_scanned(tmp_path: Path) -> None:
     target = tmp_path / "agent-bom-first-run"
     written = write_first_run_sample(target)

--- a/tests/test_release_smoke.py
+++ b/tests/test_release_smoke.py
@@ -11,6 +11,14 @@ def test_release_smoke_script_is_valid_shell() -> None:
     subprocess.run(["bash", "-n", str(ROOT / "scripts" / "release_smoke.sh")], check=True)
 
 
+def test_release_smoke_isolates_local_state() -> None:
+    script = (ROOT / "scripts" / "release_smoke.sh").read_text(encoding="utf-8")
+    assert 'AGENT_BOM_STATE_DIR="${AGENT_BOM_STATE_DIR:-$tmp/state}"' in script
+    assert 'AGENT_BOM_DB_PATH="${AGENT_BOM_DB_PATH:-$AGENT_BOM_STATE_DIR/db/vulns.db}"' in script
+    assert 'AGENT_BOM_SCAN_CACHE="${AGENT_BOM_SCAN_CACHE:-$AGENT_BOM_STATE_DIR/scan-cache.db}"' in script
+    assert "mkdir -p \"$AGENT_BOM_STATE_DIR/db\"" in script
+
+
 def test_release_smoke_golden_path(tmp_path: Path) -> None:
     """Offline demo scan smoke must pass on every CI run."""
     env = {key: value for key, value in os.environ.items() if not key.startswith("AGENT_BOM_")}

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -404,7 +404,7 @@ function SecurityGraphPageContent() {
           title: descriptiveAttackPathTitle(card?.title, pathNodes),
           cve: path.vuln_ids[0] ?? null,
           riskScore: path.composite_risk,
-          hops: Math.max(0, path.hops.length - 1),
+          nodeCount: path.hops.length,
           agents: labelsForAttackPathType(path, graphNodeById, "agent").length,
         };
         if (card?.rank_meta?.tool_capabilities?.length) {

--- a/ui/components/exposure-path-command-center.tsx
+++ b/ui/components/exposure-path-command-center.tsx
@@ -22,6 +22,7 @@ import {
 import {
   pathDisplayTitle,
   pathFixLabel,
+  pathSpanLabel,
   type ExposureEntityRef,
   type ExposureEntityRole,
   type ExposurePath,
@@ -148,7 +149,6 @@ export function ExposurePathCommandCenter({
     path.summary ||
     "A reachable package or service on this path inherits downstream credential and tool exposure from the agent runtime.";
   const primaryAction = actions[0];
-  const hopCount = Math.max(0, path.hops.length - 1);
   const severityTone =
     path.severity === "critical"
       ? "from-red-500/80 via-red-500/20 to-transparent"
@@ -183,7 +183,7 @@ export function ExposurePathCommandCenter({
           </div>
           <div className="grid w-full grid-cols-3 gap-2 text-xs sm:w-auto sm:grid-cols-4">
             <MetricPill label="Path risk" value={path.riskScore.toFixed(1)} tone="red" />
-            <MetricPill label="Hops" value={String(hopCount)} />
+            <MetricPill label="Path span" value={pathSpanLabel(path.hops.length)} />
             <MetricPill label="Agents" value={String(path.affectedAgents.length)} />
             {fixLabel ? <MetricPill label="Fix" value={fixLabel} tone="green" /> : null}
           </div>

--- a/ui/components/ranked-path-list.tsx
+++ b/ui/components/ranked-path-list.tsx
@@ -2,6 +2,8 @@
 
 import { ChevronRight } from "lucide-react";
 
+import { pathSpanLabel } from "@/lib/exposure-path";
+
 export interface RankedPathRow {
   /** Collision-free React key (index-suffixed) for stable list rendering. */
   key: string;
@@ -11,7 +13,7 @@ export interface RankedPathRow {
   title: string;
   cve: string | null;
   riskScore: number;
-  hops: number;
+  nodeCount: number;
   agents: number;
   /** MCP tool capability tags (read/write/exec/net) feeding path scoring. */
   capabilityTags?: string[] | undefined;
@@ -72,7 +74,7 @@ export function RankedPathList({
                 {row.title}
               </span>
               <span className="mt-0.5 block text-[11px] text-[color:var(--text-tertiary)]">
-                {row.hops} hop{row.hops === 1 ? "" : "s"} · {row.agents} agent{row.agents === 1 ? "" : "s"}
+                {pathSpanLabel(row.nodeCount)} · {row.agents} agent{row.agents === 1 ? "" : "s"}
               </span>
               {(row.capabilityTags?.length || row.environmentTags?.length) ? (
                 <span className="mt-1 flex flex-wrap gap-1">

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -310,7 +310,7 @@ async function expectCockpitVisible(page: Page) {
   // Progressive disclosure summary — avoid /Evidence/ which also matches "Evidence drawer".
   await expect(page.getByText("Evidence & relationships")).toBeVisible();
   await expect(page.getByText("Path risk", { exact: true }).first()).toBeVisible();
-  await expect(page.getByText("Hops", { exact: true }).first()).toBeVisible();
+  await expect(page.getByText("Path span", { exact: true }).first()).toBeVisible();
 }
 
 for (const theme of ["dark", "light"] as const) {

--- a/ui/lib/attack-paths.ts
+++ b/ui/lib/attack-paths.ts
@@ -184,16 +184,27 @@ export function descriptiveAttackPathTitle(cardTitle: string | undefined, nodes:
 }
 
 /**
- * Pair each sorted path with its fix-first card by position and stamp a rank
- * that equals the row's index in the sorted list. This is the single source of
- * truth for rank so duplicate ranks (#6 three times) — caused by looking rank up
- * through a lossy `source::target::hops` key that collides across distinct
- * paths — can never happen. The composite `key` is guaranteed unique per row.
+ * Pair each sorted path with the fix-first card derived from the same path and
+ * stamp a rank that equals the row's index in the sorted list. Matching by path
+ * identity prevents independently filtered or ordered API responses from
+ * cross-pollinating a card title with another path's hop and agent counters.
+ * The composite `key` remains unique when structurally identical paths repeat.
  */
-export function rankedAttackPathRows<C>(paths: AttackPath[], cards: readonly C[] = []): RankedAttackPathRow<C>[] {
+export function rankedAttackPathRows<C extends { attack_path: AttackPath }>(
+  paths: AttackPath[],
+  cards: readonly C[] = [],
+): RankedAttackPathRow<C>[] {
+  const cardsByPath = new Map<string, C[]>();
+  for (const card of cards) {
+    const key = attackPathKey(card.attack_path);
+    const matchingCards = cardsByPath.get(key) ?? [];
+    matchingCards.push(card);
+    cardsByPath.set(key, matchingCards);
+  }
+
   return paths.map((path, index) => ({
     path,
-    card: cards[index],
+    card: cardsByPath.get(attackPathKey(path))?.shift(),
     rank: index + 1,
     key: `${attackPathKey(path)}::${index}`,
   }));

--- a/ui/lib/exposure-path.ts
+++ b/ui/lib/exposure-path.ts
@@ -166,6 +166,20 @@ export function pathFixLabel(path: ExposurePath): string | undefined {
   return undefined;
 }
 
+/**
+ * Describe path length without presenting a single-node risk signal as an
+ * impossible-looking zero-hop route. Multi-node paths report traversed edges;
+ * zero- and one-node signals report their node count instead.
+ */
+export function pathSpanLabel(nodeCount: number): string {
+  const normalizedNodeCount = Math.max(0, nodeCount);
+  if (normalizedNodeCount <= 1) {
+    return `${normalizedNodeCount} node${normalizedNodeCount === 1 ? "" : "s"}`;
+  }
+  const hopCount = normalizedNodeCount - 1;
+  return `${hopCount} hop${hopCount === 1 ? "" : "s"}`;
+}
+
 export function pathSequenceLabels(path: ExposurePath): string[] {
   return path.hops.map((hop) => hop.label);
 }

--- a/ui/tests/attack-paths.test.ts
+++ b/ui/tests/attack-paths.test.ts
@@ -256,13 +256,46 @@ describe("attack path helpers", () => {
       vuln_ids: [],
     });
     const paths = [collidingPath(9.9), collidingPath(9.9), collidingPath(9.9)];
-    const cards = [{ rank: 6, title: "a" }, { rank: 2, title: "b" }, { rank: 6, title: "c" }];
 
-    const rows = rankedAttackPathRows(paths, cards);
+    const rows = rankedAttackPathRows(paths);
 
     expect(rows.map((row) => row.rank)).toEqual([1, 2, 3]);
     expect(new Set(rows.map((row) => row.key)).size).toBe(3);
-    expect(rows.map((row) => row.card?.title)).toEqual(["a", "b", "c"]);
+  });
+
+  it("matches fix-first cards to their attack paths after filtering or reordering", () => {
+    const pathA: AttackPath = {
+      source: "finding-a",
+      target: "agent-a",
+      hops: ["finding-a", "tool-a", "agent-a"],
+      edges: [],
+      composite_risk: 9.8,
+      summary: "path A",
+      credential_exposure: [],
+      tool_exposure: ["tool-a"],
+      vuln_ids: ["CVE-A"],
+    };
+    const pathB: AttackPath = {
+      source: "finding-b",
+      target: "agent-b",
+      hops: ["finding-b", "agent-b"],
+      edges: [],
+      composite_risk: 8.7,
+      summary: "path B",
+      credential_exposure: [],
+      tool_exposure: [],
+      vuln_ids: ["CVE-B"],
+    };
+    const cards = [
+      { title: "Finding B via agent-b", attack_path: pathB },
+      { title: "Finding A via agent-a", attack_path: pathA },
+    ];
+
+    expect(rankedAttackPathRows([pathA, pathB], cards).map((row) => row.card?.title)).toEqual([
+      "Finding A via agent-a",
+      "Finding B via agent-b",
+    ]);
+    expect(rankedAttackPathRows([pathB], cards)[0]?.card?.title).toBe("Finding B via agent-b");
   });
 
   it("builds a focused security-graph href from canonical context", () => {

--- a/ui/tests/exposure-path-command-center.test.tsx
+++ b/ui/tests/exposure-path-command-center.test.tsx
@@ -94,6 +94,25 @@ describe("ExposurePathCommandCenter", () => {
     expect(screen.getByText(basePath.summary!)).toHaveClass("line-clamp-3");
   });
 
+  it("presents a single-node risk signal as one node instead of zero hops", () => {
+    const resource = { id: "resource-1", label: "Prod Bastion", role: "server" as const };
+    render(
+      <ExposurePathCommandCenter
+        path={{
+          ...basePath,
+          source: resource,
+          target: resource,
+          hops: [resource],
+          affectedAgents: [],
+        }}
+      />,
+    );
+
+    expect(screen.getByText("Path span")).toBeInTheDocument();
+    expect(screen.getByText("1 node")).toBeInTheDocument();
+    expect(screen.queryByText("Hops")).not.toBeInTheDocument();
+  });
+
   it("shows one representation at a time and defaults to the path view", () => {
     render(<ExposurePathCommandCenter path={basePath} />);
 

--- a/ui/tests/exposure-path.test.ts
+++ b/ui/tests/exposure-path.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { compareExposurePaths, pathDisplayTitle, pathFixLabel, type ExposurePath } from "@/lib/exposure-path";
+import {
+  compareExposurePaths,
+  pathDisplayTitle,
+  pathFixLabel,
+  pathSpanLabel,
+  type ExposurePath,
+} from "@/lib/exposure-path";
 
 function path(overrides: Partial<ExposurePath>): ExposurePath {
   return {
@@ -59,6 +65,12 @@ describe("ExposurePath", () => {
   it("prefers fix versions for compact remediation labels", () => {
     expect(pathFixLabel(path({ fix: { label: "Upgrade werkzeug", version: "2.2.3" } }))).toBe("2.2.3");
     expect(pathFixLabel(path({ fix: { label: "Rotate credential" } }))).toBe("Rotate credential");
+  });
+
+  it("describes single-node risk signals without claiming zero hops", () => {
+    expect(pathSpanLabel(0)).toBe("0 nodes");
+    expect(pathSpanLabel(1)).toBe("1 node");
+    expect(pathSpanLabel(3)).toBe("2 hops");
   });
 
   it("ranks by risk, then severity, then KEV, then affected agents", () => {

--- a/ui/tests/ranked-path-list.test.tsx
+++ b/ui/tests/ranked-path-list.test.tsx
@@ -11,7 +11,7 @@ const rows: RankedPathRow[] = [
     title: "Agent → Database → werkzeug",
     cve: "CVE-2026-0002",
     riskScore: 9.6,
-    hops: 3,
+    nodeCount: 4,
     agents: 2,
   },
   {
@@ -21,7 +21,7 @@ const rows: RankedPathRow[] = [
     title: "Agent → API → flask",
     cve: null,
     riskScore: 7.1,
-    hops: 2,
+    nodeCount: 3,
     agents: 1,
   },
 ];
@@ -36,6 +36,19 @@ describe("RankedPathList", () => {
     expect(screen.getByText(/3 hops · 2 agents/)).toBeInTheDocument();
     // The single DAG renders in the command-center panel, not per row here.
     expect(screen.queryByRole("img")).not.toBeInTheDocument();
+  });
+
+  it("labels a single-node risk signal as one node instead of zero hops", () => {
+    render(
+      <RankedPathList
+        rows={[{ ...rows[0]!, key: "single::0", selectionKey: "single", nodeCount: 1 }]}
+        selectedKey="single"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/1 node · 2 agents/)).toBeInTheDocument();
+    expect(screen.queryByText(/0 hops/)).not.toBeInTheDocument();
   });
 
   it("selects a path into the shared panel when a collapsed row is clicked", () => {


### PR DESCRIPTION
## Summary

- match fix-first card titles and metadata to the same canonical attack path after filtering, paging, or independent API ordering
- present single-node toxic-risk signals as `1 node` instead of the misleading `0 hops`, with the cockpit E2E contract aligned to `Path span`
- document the curated demo's intentional status 1, remove the prescriptive opening `Scan` block from the README, and keep release verification hermetic
- align the version-bump sweep with the current README marker and the source-installed MCP change scanner

## Verification

- `PYTHONPATH=src pytest -q tests/test_first_run_sample.py` (11 passed)
- `pytest -q tests/test_release_smoke.py` (3 passed)
- `pytest -q tests/test_mcp_inventory.py tests/test_mcp_strict_args.py tests/test_mcp_hardening.py tests/test_gateway_server.py tests/test_proxy.py tests/test_runtime_evidence_pack.py` (158 passed)
- `npm run verify:toolchain`; `npm run lint`; `npm run typecheck`; `npm test -- --run` (150 files, 804 tests); `npm run build`
- `npm run test:e2e -- e2e/security-graph-cockpit.spec.ts` (5 passed: dark, light, mobile, large-estate dark/light)
- `make preflight`; `scripts/preflight_release.sh 0.97.4`; `python scripts/check_version_alignment.py`
- fresh wheel install plus `scan --demo --offline`: 5 agents, 25 findings, expected status 1
- `python scripts/validate_helm_profiles.py` (all shipped profiles rendered)
- authenticated live API: health/docs/OpenAPI 200, anonymous graph 401, authenticated graph 200 with 112 nodes and 142 edges
- runtime Docker proxy smoke: image build/run passed; undeclared tool blocked; execution posture and audit evidence recorded
- live `--demo-estate` browser review of `/security-graph` in light and dark themes
- `git diff --check`

## Notes

- No API route or model contract changed; generated API artifacts remain unchanged and preflight passes.
- `v0.97.4` remains untagged; merge this and the CI optimization PR before tagging forward.
