### PR TITLE
fix(deploy): preserve legacy demo overlay before pull

### DIFF
--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -123,6 +123,18 @@ jobs:
             set +a
           fi
 
+          # Before v0.97.4 the public-demo overlay was VM-local. Preserve that
+          # untracked file before pulling the now-canonical tracked overlay;
+          # otherwise git correctly refuses to overwrite it and the release
+          # cannot reach the compose/preflight/smoke gates.
+          legacy_overlay="deploy/docker-compose.demo-override.yml"
+          if [ -f "$legacy_overlay" ] && \
+             ! git ls-files --error-unmatch "$legacy_overlay" >/dev/null 2>&1; then
+            legacy_backup="deploy/secrets/docker-compose.demo-override.pretracked.$(date -u +%Y%m%dT%H%M%SZ).yml"
+            echo "Preserving legacy demo overlay at $legacy_backup"
+            mv "$legacy_overlay" "$legacy_backup"
+          fi
+
           echo "== git pull =="
           git pull --ff-only
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -332,6 +332,12 @@ def test_demo_redeploy_layers_demo_override_and_uses_write_secret() -> None:
     # Empty findings spine is a demo outage — redeploy must fail closed on it.
     assert "demo estate smoke" in workflow
     assert "/v1/findings?limit=1" in workflow
+    # v0.97.4 made the demo overlay tracked. The VM's older untracked copy must
+    # be preserved outside the checkout path before git pull can fast-forward.
+    assert 'git ls-files --error-unmatch "$legacy_overlay"' in workflow
+    assert "docker-compose.demo-override.pretracked." in workflow
+    assert 'mv "$legacy_overlay" "$legacy_backup"' in workflow
+    assert workflow.index('mv "$legacy_overlay" "$legacy_backup"') < workflow.index("git pull --ff-only")
 
     # Security gate remains platform + hosted-poc only (no demo anon flags).
     preflight_src = (root / "scripts" / "deploy" / "hosted_poc_preflight.py").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- preserve the pre-v0.97.4 VM-local demo overlay under `deploy/secrets/` before pulling the now-tracked canonical overlay
- keep the migration recoverable and limited to the exact untracked path blocking the hosted-demo fast-forward
- lock the ordering contract with a deployment workflow regression test

## Verification
- `uv run pytest -q tests/test_compose_secrets_healthcheck.py` (34 passed)
- `actionlint .github/workflows/demo-redeploy.yml`
- `git diff --check`

## Notes
The v0.97.4 hosted-demo redeploy failed before compose execution because Git refused to overwrite the VM's untracked `deploy/docker-compose.demo-override.yml`. Release artifacts and registries are unaffected.