### PR TITLE
fix(deps): bump postcss to 8.5.12 for CVE-2026-45623

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -9368,9 +9368,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.10",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "funding": [
         {
           "type": "opencollective",

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,7 @@
     "sigma": "^3.0.3"
   },
   "overrides": {
-    "postcss": "8.5.10",
+    "postcss": "8.5.12",
     "brace-expansion@1": "1.1.16",
     "sharp": "^0.35.0"
   },


### PR DESCRIPTION
## Summary
- Bump `ui/` npm `overrides.postcss` from 8.5.10 to 8.5.12 to clear CVE-2026-45623 / GHSA-6g55-p6wh-862q (arbitrary file read), which was failing Security Scan on `main`.
- Refresh `ui/package-lock.json` so resolved `node_modules/postcss` is 8.5.12.

Fixes #4419

## Verification
- `npm install --package-lock-only` in `ui/` (0 vulnerabilities reported)
- `npm audit --audit-level=high` in `ui/` → found 0 vulnerabilities
- Confirmed lockfile entry `node_modules/postcss` version `8.5.12`

## Notes
- Scoped to the UI override + lockfile only; no application code changes.

Made with [Cursor](https://cursor.com)