### PR TITLE
docs(arch): Python-primary runtime; optional Go sidecar later

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -121,6 +121,17 @@ Operational consequences:
 - Wheels build cleanly on `linux/amd64` and `linux/arm64` — no per-arch native toolchain.
 - Slower than Rust/Go scanners on huge fanouts; per-package memory is higher. For VM disk-image scanning at scale, install `syft` alongside agent-bom and let the fallback path take over.
 
+Forward-looking runtime note:
+
+- An **optional Go sidecar** for proven hot paths (high-concurrency gateway
+  relay, long-lived collectors) is an accepted direction — see
+  [ADR-009](decisions/009-python-primary-go-sidecar-later.md). It is **not**
+  required on the scan path today and is not a second product edition.
+- `sdks/go` is a **control-plane CLIENT SDK** for calling the API. It is not a
+  second runtime engine alongside the Python scanners, connectors, MCP server,
+  or proxy/gateway.
+
+
 ---
 
 ## 1c. Data Flow - one scan request

--- a/docs/decisions/009-python-primary-go-sidecar-later.md
+++ b/docs/decisions/009-python-primary-go-sidecar-later.md
@@ -1,0 +1,65 @@
+# ADR-009: Python-Primary Runtime; Optional Go Sidecar Later
+
+**Status:** Accepted
+**Date:** 2026-07-23
+
+## Context
+
+Dogfood deployments and scale discussions keep surfacing the same tension:
+Go’s concurrency model is attractive for long-lived network daemons (high
+connection fanout, cheap goroutines, predictable memory under load), while
+shipping two full product stacks (Python edition vs Go edition) would double
+maintenance across scanners, cloud connectors, API contracts, CLI, MCP tools,
+docs, and release artifacts.
+
+We already have a Go tree under `sdks/go`, and operators sometimes assume that
+implies a second runtime engine. We need a clear product boundary so
+contributors do not fork the architecture prematurely, and so scale work stays
+evidence-driven rather than language-fashion-driven.
+
+ADR-004 already chose a Python stdio/HTTP proxy path for runtime enforcement.
+That choice stands until measurement shows a hot path that Python cannot meet
+under a stable control-plane contract.
+
+## Decision
+
+**One product. Python-primary today. Optional Go worker/sidecar later — only
+for proven hot paths.**
+
+1. **Primary runtime** remains Python for scanners, cloud connectors, FastAPI
+   control plane, MCP server, CLI, and proxy/gateway as shipped today.
+2. **Optional Go sidecar/worker** may be introduced later only where profilers
+   and production load prove a hot path — for example high-concurrency gateway
+   relay or long-lived collectors — behind a **stable HTTP/gRPC contract** owned
+   by the Python control plane.
+3. **`sdks/go` remains a CLIENT SDK** for calling the control-plane API. It is
+   not a second product runtime and must not grow into a parallel scanner/API
+   engine without a new ADR.
+
+**Non-goals**
+
+- No “Python edition” vs “Go edition” of agent-bom.
+- No wholesale rewrite of cloud connectors (or the scan path) into Go without
+  profiler evidence and an explicit ADR update.
+- No requirement that scan, CLI, or MCP paths depend on a Go binary today.
+
+**Relates to:** [ADR-004](004-proxy-runtime-enforcement.md) — proxy/runtime
+enforcement stays Python until measured need justifies an optional sidecar for
+a specific hot path under the same policy/audit contract.
+
+## Consequences
+
+- **Orchestration stays Python.** Job scheduling, auth, RBAC, tenant scope,
+  graph writes, and policy remain in the control plane; any future Go process is
+  a worker the control plane starts and supervises.
+- **Release shape unchanged for now.** Primary artifacts remain the Python
+  wheel (and Docker images built from it) plus the Next.js UI. A future Go
+  sidecar would be an *additional* optional artifact, not a replacement edition.
+- **Contract-first if/when Go lands.** Sidecar I/O must be covered by contract
+  tests (HTTP/gRPC schemas, fail-open/fail-closed behavior, audit relay) so the
+  Python plane can swap or roll back without dual product semantics.
+- **Positive:** Contributors have a clear default — extend Python — and a
+  narrow, evidence-gated path for Go where concurrency truly matters.
+- **Negative:** Some network-daemon workloads may hit Python concurrency limits
+  before a sidecar exists; mitigate with horizontal workers and measurement
+  rather than speculative rewrites.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -26,6 +26,7 @@ Each ADR follows this structure:
 | 006 | [Unified Graph Write Batching](006-unified-graph-write-batching.md) | Accepted | 2026-04-25 |
 | 007 | [MCP Package Version Provenance](007-mcp-package-version-provenance.md) | Accepted | 2026-05-01 |
 | 008 | [Pluggable Neptune Graph Backend](008-pluggable-neptune-graph-backend.md) | Proposed | 2026-05-13 |
+| 009 | [Python-Primary Runtime; Optional Go Sidecar Later](009-python-primary-go-sidecar-later.md) | Accepted | 2026-07-23 |
 
 ## Adding a New ADR
 

--- a/site-docs/architecture/self-hosted-product-architecture.md
+++ b/site-docs/architecture/self-hosted-product-architecture.md
@@ -33,6 +33,8 @@ For the detailed browser-to-API trust contract, see
 
 ## Deployment truth
 
+Today the proxy, gateway, and workers run as Python processes under the control-plane contract. A future **optional Go sidecar** may host high-concurrency relay or collector workloads under that same contract ([ADR-009](https://github.com/msaad00/agent-bom/blob/main/docs/decisions/009-python-primary-go-sidecar-later.md)); it is not a separate product edition.
+
 In a normal self-hosted rollout:
 
 1. operators use the UI through the customer's ingress


### PR DESCRIPTION
## Summary
- Add [ADR-009](docs/decisions/009-python-primary-go-sidecar-later.md): one product, Python-primary for scanners/cloud connectors/API/MCP/CLI/proxy-gateway; optional Go worker/sidecar later only for proven hot paths behind a stable HTTP/gRPC contract; `sdks/go` remains a client SDK.
- Index the ADR in `docs/decisions/README.md` and document the forward-looking stack note in `docs/ARCHITECTURE.md` §1b.
- Clarify self-hosted deployment truth in `site-docs/architecture/self-hosted-product-architecture.md` (Python today; optional Go sidecar is not a separate edition).

## Verification
- Docs-only change; reviewed ADR against template and ADR-004 cross-link.
- Confirmed index row 009 and architecture/site-doc paragraphs link to ADR-009.

## Notes
- No Go runtime code in this PR.
- Follows the wrap plan for architecture clarity.
- Independent of the 0.97.5 bump PR #4422.

Made with [Cursor](https://cursor.com)