### PR TITLE
docs(perf): gateway relay baseline and Go-gate measurement

### DIFF
--- a/docs/perf/README.md
+++ b/docs/perf/README.md
@@ -18,6 +18,9 @@ Current evidence pages:
 - [`fleet-reconciliation.md`](fleet-reconciliation.md) — fleet and Kubernetes
   reconciliation latency.
 
+- [`gateway-relay-latency.md`](gateway-relay-latency.md) — HTTP gateway JSON-RPC
+  relay p50/p95/p99 + RSS under concurrency (Go-gate evidence for ADR-009).
+
 Current raw result artifact:
 
 - [`results/scale-evidence-local-2026-04-26.json`](results/scale-evidence-local-2026-04-26.json)
@@ -34,6 +37,13 @@ Current raw result artifact:
 - [`results/postgres-graph-explain-sample.json`](results/postgres-graph-explain-sample.json)
   — dry-run Postgres EXPLAIN artifact index; it contains no measured query
   plans.
+
+- [`results/gateway-relay-baseline-2026-07-23.json`](results/gateway-relay-baseline-2026-07-23.json)
+  — local gateway relay baseline (mock MCP upstream, concurrency ladder to 500).
+- [`results/gateway-relay-tuned-2026-07-23.json`](results/gateway-relay-tuned-2026-07-23.json)
+  — same fixture after uvloop + larger client httpx limits.
+- [`results/gateway-relay-go-gate-2026-07-23.json`](results/gateway-relay-go-gate-2026-07-23.json)
+  — Go-gate decision artifact (`gate_tripped`, next step).
 
 Run the structure check before publishing release numbers:
 
@@ -53,4 +63,11 @@ Regenerate the graph API/Postgres scaffold artifacts:
 uv run python scripts/generate_graph_benchmark_estate.py
 uv run python scripts/run_graph_api_benchmark.py --dry-run
 uv run python scripts/run_graph_postgres_explain.py --dry-run
+```
+
+Regenerate the gateway relay baseline / tuned measurements:
+
+```bash
+uv run python scripts/run_gateway_relay_benchmark.py --mode baseline --output docs/perf/results/gateway-relay-baseline-2026-07-23.json
+uv run python scripts/run_gateway_relay_benchmark.py --mode tuned --output docs/perf/results/gateway-relay-tuned-2026-07-23.json
 ```

--- a/docs/perf/gateway-relay-latency.md
+++ b/docs/perf/gateway-relay-latency.md
@@ -1,0 +1,126 @@
+# Gateway Relay Latency Evidence
+
+Evidence status: measured
+Related decision: [ADR-009](../decisions/009-python-primary-go-sidecar-later.md)
+Raw result artifacts:
+
+- [`results/gateway-relay-baseline-2026-07-23.json`](results/gateway-relay-baseline-2026-07-23.json)
+- [`results/gateway-relay-tuned-2026-07-23.json`](results/gateway-relay-tuned-2026-07-23.json)
+- [`results/gateway-relay-go-gate-2026-07-23.json`](results/gateway-relay-go-gate-2026-07-23.json)
+
+## Claim
+
+Local full-stack `agent-bom gateway serve` JSON-RPC relay latency and process RSS
+were measured against a loopback mock MCP upstream across a concurrency ladder
+up to 500 in-flight client requests. This page supports the Go-workload
+isolation gate (ADR-009): whether Python remains adequate for the HTTP gateway
+relay hot path, or whether Phase 2 contract extraction for an optional Go
+sidecar is justified.
+
+This page does **not** claim Helm/EKS multi-replica gateway latency, policy /
+DLP / visual-leak paths, or stdio proxy performance.
+
+## Scope
+
+- Harness: `scripts/run_gateway_relay_benchmark.py`
+- Mock upstream: `scripts/perf/mock_mcp_upstream.py` (`POST /mcp` JSON-RPC echo)
+- Gateway: `agent-bom gateway serve --bind 127.0.0.1:<port> --upstreams <tmp.yaml>`
+- Client path: `POST /mcp/echo` with `tools/call`
+- Modes:
+  - **baseline** — default asyncio event loop; default httpx client limits
+  - **tuned** — uvloop when installable; larger httpx client connection /
+    keepalive limits on the load generator
+
+## Go-gate SLO
+
+At concurrency **500** (200 requests per level in this run), the gate trips if
+**any** of the following hold on baseline **or** tuned:
+
+| Metric | Threshold |
+|--------|-----------|
+| `p95_ms` | `> 50` |
+| `peak_rss_mb` | `> 512` |
+| `error_rate` | `> 0.01` (1%) |
+
+**gate_tripped: true** (see decision artifact). Next step: `proceed_phase2`
+(Python relay interface + contract tests; no Go sidecar in this PR).
+
+## Environment
+
+- Platform: macOS-26.5.2-arm64-arm-64bit-Mach-O
+- Host: Wegzs-MacBook-Pro.local
+- Python: 3.13.5
+- agent-bom: 0.97.5 (worktree at `origin/main` / `v0.97.5`)
+- Upstream: loopback FastAPI echo MCP (operator YAML → private-network approved)
+- Gateway fail mode for this microbenchmark: `AGENT_BOM_GATEWAY_FAIL_MODE=open`
+  (policy engine not under test)
+- Tuned uvloop: enabled (`uvloop` present in the api extra / venv)
+- Gateway upstream pool: `GatewaySettings.upstream_http_max_connections=100`
+  / keepalive `20` — **not** env-configurable today; tuned mode could not enlarge
+  the gateway pool without a CLI/settings change
+
+## Commands
+
+```bash
+uv run python scripts/run_gateway_relay_benchmark.py \
+  --mode baseline \
+  --output docs/perf/results/gateway-relay-baseline-2026-07-23.json
+
+uv run python scripts/run_gateway_relay_benchmark.py \
+  --mode tuned \
+  --output docs/perf/results/gateway-relay-tuned-2026-07-23.json
+```
+
+## Results (excerpt)
+
+Requests per concurrency level: **200**. Warmup: 20.
+
+### Baseline
+
+| Concurrency | p50 (ms) | p95 (ms) | p99 (ms) | error_rate | peak_rss_mb |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 2.183 | 2.432 | 3.676 | 0.0 | 106.656 |
+| 10 | 105.438 | 145.799 | 151.805 | 0.0 | 107.016 |
+| 50 | 434.488 | 1632.071 | 2081.149 | 0.0 | 107.516 |
+| 100 | 944.923 | 2534.814 | 2721.605 | 0.0 | 107.531 |
+| 250 | 1384.837 | 2594.884 | 2674.59 | 0.0 | 107.656 |
+| 500 | 1360.29 | **2547.357** | 2647.461 | 0.0 | 107.656 |
+
+### Tuned (uvloop + larger client httpx limits)
+
+| Concurrency | p50 (ms) | p95 (ms) | p99 (ms) | error_rate | peak_rss_mb |
+|---:|---:|---:|---:|---:|---:|
+| 1 | 2.142 | 2.553 | 3.471 | 0.0 | 106.141 |
+| 10 | 103.556 | 235.799 | 302.326 | 0.0 | 106.672 |
+| 50 | 507.455 | 1409.049 | 2185.622 | 0.0 | 107.031 |
+| 100 | 879.809 | 2515.841 | 2669.775 | 0.0 | 107.047 |
+| 250 | 1370.296 | 2572.973 | 2701.919 | 0.0 | 107.078 |
+| 500 | 1378.941 | **2572.27** | 2669.068 | 0.0 | 107.078 |
+
+### Gate inputs at concurrency=500
+
+| Mode | p95_ms | peak_rss_mb | error_rate | Trips? |
+|------|-------:|------------:|-----------:|--------|
+| baseline | 2547.357 | 107.656 | 0.0 | yes (p95) |
+| tuned | 2572.27 | 107.078 | 0.0 | yes (p95) |
+
+RSS stays well under 512 MiB; errors stay at 0%. Latency under fan-in is the
+failing dimension. Client-side uvloop / httpx keepalive did not close the gap
+to the 50 ms p95 SLO (expected: bottleneck is gateway relay + default upstream
+pool, not the load generator).
+
+## Gaps
+
+- Gateway upstream pool size is not exposed via `AGENT_BOM_*` env; a follow-up
+  settings/CLI knob is required before claiming a “fully tuned” Python pool.
+- Single-process loopback only — no multi-replica Helm gateway, TLS, or auth.
+- Empty / fail-open policy path only — no enforce-mode policy, DLP, firewall,
+  or visual-leak cost in the samples.
+- Mock upstream is an in-process FastAPI echo; real SaaS MCP RTT is excluded.
+- EKS lab soak deferred to Phase 3/4 if a Go sidecar spike lands.
+
+## Next
+
+`gate_tripped=true` → proceed to Phase 2 (Python-only relay interface +
+contract tests). Do not implement a Go sidecar until that contract exists
+(ADR-009).

--- a/docs/perf/results/gateway-relay-baseline-2026-07-23.json
+++ b/docs/perf/results/gateway-relay-baseline-2026-07-23.json
@@ -1,0 +1,161 @@
+{
+  "metadata": {
+    "date": "2026-07-24",
+    "timestamp_utc": "2026-07-24T01:50:45.096747+00:00",
+    "hostname": "Wegzs-MacBook-Pro.local",
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "machine": "arm64",
+    "python": "3.13.5",
+    "agent_bom_version": "0.97.5",
+    "mode": "baseline",
+    "git_commit": "100c53a1a",
+    "uvloop": {
+      "requested": false,
+      "enabled": false,
+      "detail": "not requested"
+    },
+    "httpx_limits": {
+      "mode": "baseline",
+      "max_connections": 100,
+      "max_keepalive_connections": 20
+    },
+    "gateway_pool_env": {
+      "note": "GatewaySettings.upstream_http_max_connections defaults to 100 / keepalive 20; not exposed via AGENT_BOM_* env today. Tuned mode cannot enlarge the gateway pool without a code/CLI change.",
+      "upstream_http_max_connections_default": 100,
+      "upstream_http_max_keepalive_connections_default": 20
+    },
+    "bind": {
+      "gateway": "127.0.0.1:49757",
+      "upstream": "127.0.0.1:49758"
+    },
+    "requests_per_level": 200,
+    "concurrency_levels": [
+      1,
+      10,
+      50,
+      100,
+      250,
+      500
+    ],
+    "warmup_requests": 20,
+    "total_wall_s": 16.645
+  },
+  "results": [
+    {
+      "concurrency": 1,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 2.183,
+        "p95_ms": 2.432,
+        "p99_ms": 3.676,
+        "max_ms": 4.224,
+        "mean_ms": 2.237,
+        "samples": 200
+      },
+      "peak_rss_kb": 109216,
+      "peak_rss_mb": 106.656,
+      "wall_s": 2.812
+    },
+    {
+      "concurrency": 10,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 105.438,
+        "p95_ms": 145.799,
+        "p99_ms": 151.805,
+        "max_ms": 263.302,
+        "mean_ms": 110.534,
+        "samples": 200
+      },
+      "peak_rss_kb": 109584,
+      "peak_rss_mb": 107.016,
+      "wall_s": 2.64
+    },
+    {
+      "concurrency": 50,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 434.488,
+        "p95_ms": 1632.071,
+        "p99_ms": 2081.149,
+        "max_ms": 2457.494,
+        "mean_ms": 588.391,
+        "samples": 200
+      },
+      "peak_rss_kb": 110096,
+      "peak_rss_mb": 107.516,
+      "wall_s": 2.776
+    },
+    {
+      "concurrency": 100,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 944.923,
+        "p95_ms": 2534.814,
+        "p99_ms": 2721.605,
+        "max_ms": 2759.255,
+        "mean_ms": 1046.196,
+        "samples": 200
+      },
+      "peak_rss_kb": 110112,
+      "peak_rss_mb": 107.531,
+      "wall_s": 2.809
+    },
+    {
+      "concurrency": 250,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 1384.837,
+        "p95_ms": 2594.884,
+        "p99_ms": 2674.59,
+        "max_ms": 2732.334,
+        "mean_ms": 1383.608,
+        "samples": 200
+      },
+      "peak_rss_kb": 110240,
+      "peak_rss_mb": 107.656,
+      "wall_s": 2.775
+    },
+    {
+      "concurrency": 500,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 1360.29,
+        "p95_ms": 2547.357,
+        "p99_ms": 2647.461,
+        "max_ms": 2680.473,
+        "mean_ms": 1359.477,
+        "samples": 200
+      },
+      "peak_rss_kb": 110240,
+      "peak_rss_mb": 107.656,
+      "wall_s": 2.723
+    }
+  ],
+  "gateway_metrics_tail": "# HELP agent_bom_auth_failures_total API authentication failures by reason\n# TYPE agent_bom_auth_failures_total counter\nagent_bom_auth_failures_total{reason=\"none\"} 0\n# HELP agent_bom_rate_limit_hits_total Requests rejected by a rate limiter\n# TYPE agent_bom_rate_limit_hits_total counter\nagent_bom_rate_limit_hits_total{bucket=\"none\"} 0\n# HELP agent_bom_compliance_exports_total Compliance evidence bundles exported by signing algorithm\n# TYPE agent_bom_compliance_exports_total counter\nagent_bom_compliance_exports_total{algorithm=\"none\"} 0\n# HELP agent_bom_compliance_export_bytes_total Total bytes of compliance bundles served by framework\n# TYPE agent_bom_compliance_export_bytes_total counter\nagent_bom_compliance_export_bytes_total{framework=\"none\"} 0\n# HELP agent_bom_scan_completions_total Completed scans by final status\n# TYPE agent_bom_scan_completions_total counter\nagent_bom_scan_completions_total{status=\"none\"} 0\n# HELP agent_bom_scan_jobs_active In-flight scans currently queued or running\n# TYPE agent_bom_scan_jobs_active gauge\nagent_bom_scan_jobs_active 0\n# HELP agent_bom_gateway_relays_total Multi-MCP gateway relay events by upstream and outcome\n# TYPE agent_bom_gateway_relays_total counter\nagent_bom_gateway_relays_total{upstream=\"echo\",outcome=\"forwarded\"} 1220\n# HELP agent_bom_authorization_evidence_total Cloud authorization evidence collections by posture\n# TYPE agent_bom_authorization_evidence_total counter\nagent_bom_authorization_evidence_total{provider=\"none\",status=\"indeterminate\"} 0\n# HELP agent_bom_authorization_evidence_gaps_total Cloud authorization evidence gaps by reason code\n# TYPE agent_bom_authorization_evidence_gaps_total counter\nagent_bom_authorization_evidence_gaps_total{provider=\"none\",reason=\"none\"} 0\n",
+  "final_gateway_rss_kb": 110240,
+  "final_gateway_rss_mb": 107.656,
+  "go_gate_inputs_at_500": {
+    "p95_ms": 2547.357,
+    "peak_rss_mb": 107.656,
+    "error_rate": 0.0
+  }
+}

--- a/docs/perf/results/gateway-relay-go-gate-2026-07-23.json
+++ b/docs/perf/results/gateway-relay-go-gate-2026-07-23.json
@@ -1,0 +1,29 @@
+{
+  "date": "2026-07-23",
+  "baseline_p95_at_500": 2547.357,
+  "tuned_p95_at_500": 2572.27,
+  "baseline_peak_rss_mb_at_500": 107.656,
+  "tuned_peak_rss_mb_at_500": 107.078,
+  "baseline_error_rate_at_500": 0.0,
+  "tuned_error_rate_at_500": 0.0,
+  "rss": {
+    "baseline_peak_rss_mb": 107.656,
+    "tuned_peak_rss_mb": 107.078
+  },
+  "error_rate": {
+    "baseline": 0.0,
+    "tuned": 0.0
+  },
+  "thresholds": {
+    "p95_ms": 50,
+    "peak_rss_mb": 512,
+    "error_rate": 0.01
+  },
+  "gate_tripped": true,
+  "next": "proceed_phase2",
+  "artifacts": {
+    "baseline": "docs/perf/results/gateway-relay-baseline-2026-07-23.json",
+    "tuned": "docs/perf/results/gateway-relay-tuned-2026-07-23.json",
+    "evidence": "docs/perf/gateway-relay-latency.md"
+  }
+}

--- a/docs/perf/results/gateway-relay-tuned-2026-07-23.json
+++ b/docs/perf/results/gateway-relay-tuned-2026-07-23.json
@@ -1,0 +1,161 @@
+{
+  "metadata": {
+    "date": "2026-07-24",
+    "timestamp_utc": "2026-07-24T01:51:14.088527+00:00",
+    "hostname": "Wegzs-MacBook-Pro.local",
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "machine": "arm64",
+    "python": "3.13.5",
+    "agent_bom_version": "0.97.5",
+    "mode": "tuned",
+    "git_commit": "100c53a1a",
+    "uvloop": {
+      "requested": true,
+      "enabled": true,
+      "detail": "uvloop 0.22.1"
+    },
+    "httpx_limits": {
+      "mode": "tuned",
+      "max_connections": 1000,
+      "max_keepalive_connections": 500
+    },
+    "gateway_pool_env": {
+      "note": "GatewaySettings.upstream_http_max_connections defaults to 100 / keepalive 20; not exposed via AGENT_BOM_* env today. Tuned mode cannot enlarge the gateway pool without a code/CLI change.",
+      "upstream_http_max_connections_default": 100,
+      "upstream_http_max_keepalive_connections_default": 20
+    },
+    "bind": {
+      "gateway": "127.0.0.1:8090",
+      "upstream": "127.0.0.1:8100"
+    },
+    "requests_per_level": 200,
+    "concurrency_levels": [
+      1,
+      10,
+      50,
+      100,
+      250,
+      500
+    ],
+    "warmup_requests": 20,
+    "total_wall_s": 16.776
+  },
+  "results": [
+    {
+      "concurrency": 1,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 2.142,
+        "p95_ms": 2.553,
+        "p99_ms": 3.471,
+        "max_ms": 3.74,
+        "mean_ms": 2.222,
+        "samples": 200
+      },
+      "peak_rss_kb": 108688,
+      "peak_rss_mb": 106.141,
+      "wall_s": 2.837
+    },
+    {
+      "concurrency": 10,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 103.556,
+        "p95_ms": 235.799,
+        "p99_ms": 302.326,
+        "max_ms": 553.898,
+        "mean_ms": 121.127,
+        "samples": 200
+      },
+      "peak_rss_kb": 109232,
+      "peak_rss_mb": 106.672,
+      "wall_s": 2.767
+    },
+    {
+      "concurrency": 50,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 507.455,
+        "p95_ms": 1409.049,
+        "p99_ms": 2185.622,
+        "max_ms": 2690.659,
+        "mean_ms": 581.208,
+        "samples": 200
+      },
+      "peak_rss_kb": 109600,
+      "peak_rss_mb": 107.031,
+      "wall_s": 2.747
+    },
+    {
+      "concurrency": 100,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 879.809,
+        "p95_ms": 2515.841,
+        "p99_ms": 2669.775,
+        "max_ms": 2748.73,
+        "mean_ms": 1035.632,
+        "samples": 200
+      },
+      "peak_rss_kb": 109616,
+      "peak_rss_mb": 107.047,
+      "wall_s": 2.783
+    },
+    {
+      "concurrency": 250,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 1370.296,
+        "p95_ms": 2572.973,
+        "p99_ms": 2701.919,
+        "max_ms": 2713.389,
+        "mean_ms": 1372.294,
+        "samples": 200
+      },
+      "peak_rss_kb": 109648,
+      "peak_rss_mb": 107.078,
+      "wall_s": 2.769
+    },
+    {
+      "concurrency": 500,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 1378.941,
+        "p95_ms": 2572.27,
+        "p99_ms": 2669.068,
+        "max_ms": 2720.425,
+        "mean_ms": 1373.417,
+        "samples": 200
+      },
+      "peak_rss_kb": 109648,
+      "peak_rss_mb": 107.078,
+      "wall_s": 2.76
+    }
+  ],
+  "gateway_metrics_tail": "# HELP agent_bom_auth_failures_total API authentication failures by reason\n# TYPE agent_bom_auth_failures_total counter\nagent_bom_auth_failures_total{reason=\"none\"} 0\n# HELP agent_bom_rate_limit_hits_total Requests rejected by a rate limiter\n# TYPE agent_bom_rate_limit_hits_total counter\nagent_bom_rate_limit_hits_total{bucket=\"none\"} 0\n# HELP agent_bom_compliance_exports_total Compliance evidence bundles exported by signing algorithm\n# TYPE agent_bom_compliance_exports_total counter\nagent_bom_compliance_exports_total{algorithm=\"none\"} 0\n# HELP agent_bom_compliance_export_bytes_total Total bytes of compliance bundles served by framework\n# TYPE agent_bom_compliance_export_bytes_total counter\nagent_bom_compliance_export_bytes_total{framework=\"none\"} 0\n# HELP agent_bom_scan_completions_total Completed scans by final status\n# TYPE agent_bom_scan_completions_total counter\nagent_bom_scan_completions_total{status=\"none\"} 0\n# HELP agent_bom_scan_jobs_active In-flight scans currently queued or running\n# TYPE agent_bom_scan_jobs_active gauge\nagent_bom_scan_jobs_active 0\n# HELP agent_bom_gateway_relays_total Multi-MCP gateway relay events by upstream and outcome\n# TYPE agent_bom_gateway_relays_total counter\nagent_bom_gateway_relays_total{upstream=\"echo\",outcome=\"forwarded\"} 1220\n# HELP agent_bom_authorization_evidence_total Cloud authorization evidence collections by posture\n# TYPE agent_bom_authorization_evidence_total counter\nagent_bom_authorization_evidence_total{provider=\"none\",status=\"indeterminate\"} 0\n# HELP agent_bom_authorization_evidence_gaps_total Cloud authorization evidence gaps by reason code\n# TYPE agent_bom_authorization_evidence_gaps_total counter\nagent_bom_authorization_evidence_gaps_total{provider=\"none\",reason=\"none\"} 0\n",
+  "final_gateway_rss_kb": 109648,
+  "final_gateway_rss_mb": 107.078,
+  "go_gate_inputs_at_500": {
+    "p95_ms": 2572.27,
+    "peak_rss_mb": 107.078,
+    "error_rate": 0.0
+  }
+}

--- a/scripts/perf/mock_mcp_upstream.py
+++ b/scripts/perf/mock_mcp_upstream.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Minimal FastAPI echo MCP upstream for gateway relay benchmarks.
+
+Listens on ``--port`` (default 8100). ``POST /mcp`` returns a JSON-RPC result
+echoing the request id and tool name. Intended only for local perf harnesses.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="mock-mcp-upstream", docs_url=None, redoc_url=None)
+
+    @app.get("/healthz")
+    async def healthz() -> dict[str, str]:
+        return {"status": "ok"}
+
+    @app.post("/mcp")
+    async def mcp(request: Request) -> JSONResponse:
+        try:
+            body: Any = await request.json()
+        except Exception:
+            return JSONResponse(
+                {"jsonrpc": "2.0", "id": None, "error": {"code": -32700, "message": "Parse error"}},
+                status_code=200,
+            )
+        if not isinstance(body, dict):
+            return JSONResponse(
+                {"jsonrpc": "2.0", "id": None, "error": {"code": -32600, "message": "Invalid Request"}},
+                status_code=200,
+            )
+        req_id = body.get("id")
+        method = str(body.get("method") or "")
+        params = body.get("params") if isinstance(body.get("params"), dict) else {}
+        tool_name = str(params.get("name") or "")
+        return JSONResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": req_id,
+                "result": {
+                    "content": [{"type": "text", "text": f"echo method={method} tool={tool_name}"}],
+                    "isError": False,
+                },
+            }
+        )
+
+    return app
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=8100, help="Listen port (default 8100)")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default 127.0.0.1)")
+    args = parser.parse_args()
+
+    import uvicorn
+
+    uvicorn.run(create_app(), host=args.host, port=args.port, log_level="warning")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_gateway_relay_benchmark.py
+++ b/scripts/run_gateway_relay_benchmark.py
@@ -1,0 +1,548 @@
+#!/usr/bin/env python3
+"""Full-stack gateway relay latency / RSS benchmark harness.
+
+Starts a mock MCP upstream and ``agent-bom gateway serve``, then drives
+``POST /mcp/echo`` with JSON-RPC ``tools/call`` across a concurrency ladder.
+
+Modes:
+  baseline — stock asyncio + default httpx limits; gateway defaults
+  tuned    — uvloop when installable, larger httpx pool/keepalive on the
+             load generator. Gateway upstream pool size is not currently
+             exposed via AGENT_BOM_* env vars (GatewaySettings fields only),
+             so tuned mode documents that gap rather than inventing knobs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import platform
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_CONCURRENCY = [1, 10, 50, 100, 250, 500]
+DEFAULT_REQUESTS = 200
+GATEWAY_BIND_HOST = "127.0.0.1"
+GATEWAY_BIND_PORT = 8090
+UPSTREAM_PORT = 8100
+WARMUP_REQUESTS = 20
+HEALTH_TIMEOUT_S = 45.0
+REQUEST_TIMEOUT_S = 30.0
+
+
+def _percentiles(values_ms: list[float]) -> dict[str, float | int]:
+    if not values_ms:
+        return {"p50_ms": 0.0, "p95_ms": 0.0, "p99_ms": 0.0, "max_ms": 0.0, "mean_ms": 0.0, "samples": 0}
+    ordered = sorted(values_ms)
+
+    def pct(percent: float) -> float:
+        idx = min(len(ordered) - 1, max(0, round((percent / 100.0) * (len(ordered) - 1))))
+        return round(ordered[idx], 3)
+
+    return {
+        "p50_ms": pct(50),
+        "p95_ms": pct(95),
+        "p99_ms": pct(99),
+        "max_ms": round(max(ordered), 3),
+        "mean_ms": round(statistics.fmean(ordered), 3),
+        "samples": len(ordered),
+    }
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _rss_kb(pid: int) -> int | None:
+    try:
+        out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)], text=True).strip()
+        if not out:
+            return None
+        return int(out.split()[0])
+    except (subprocess.CalledProcessError, ValueError, FileNotFoundError, OSError):
+        return None
+
+
+def _descendant_pids(root_pid: int) -> list[int]:
+    """Return root + descendants via repeated ``pgrep -P`` walks."""
+    seen: set[int] = {root_pid}
+    frontier = [root_pid]
+    while frontier:
+        parent = frontier.pop()
+        try:
+            out = subprocess.check_output(["pgrep", "-P", str(parent)], text=True).strip()
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+            continue
+        for line in out.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                child = int(line)
+            except ValueError:
+                continue
+            if child not in seen:
+                seen.add(child)
+                frontier.append(child)
+    return sorted(seen)
+
+
+def _peak_rss_kb_tree(root_pid: int) -> int | None:
+    """Peak RSS across the process tree (uv wrapper + real gateway python)."""
+    peak: int | None = None
+    for pid in _descendant_pids(root_pid):
+        rss = _rss_kb(pid)
+        if rss is None:
+            continue
+        if peak is None or rss > peak:
+            peak = rss
+    return peak
+
+
+def _agent_bom_version() -> str:
+    try:
+        from importlib.metadata import version
+
+        return version("agent-bom")
+    except Exception:
+        try:
+            from agent_bom import __version__
+
+            return str(__version__)
+        except Exception:
+            return "unknown"
+
+
+def _wait_http_ok(url: str, *, timeout_s: float = HEALTH_TIMEOUT_S) -> None:
+    import urllib.error
+    import urllib.request
+
+    deadline = time.monotonic() + timeout_s
+    last_err: str | None = None
+    while time.monotonic() < deadline:
+        try:
+            with urllib.request.urlopen(url, timeout=2.0) as resp:
+                if 200 <= int(resp.status) < 300:
+                    return
+                last_err = f"status={resp.status}"
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_err = str(exc)
+        time.sleep(0.15)
+    raise RuntimeError(f"timed out waiting for {url}: {last_err}")
+
+
+def _write_upstreams_yaml(path: Path, upstream_port: int) -> None:
+    path.write_text(
+        "upstreams:\n"
+        "  - name: echo\n"
+        f"    url: http://127.0.0.1:{upstream_port}/mcp\n"
+        "    auth: none\n"
+        "    transport: streamable-http\n",
+        encoding="utf-8",
+    )
+
+
+def _spawn(cmd: list[str], *, env: dict[str, str] | None = None) -> subprocess.Popen[bytes]:
+    merged = os.environ.copy()
+    if env:
+        merged.update(env)
+    return subprocess.Popen(
+        cmd,
+        cwd=str(ROOT),
+        env=merged,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+
+
+def _terminate(proc: subprocess.Popen[bytes] | None) -> None:
+    if proc is None or proc.poll() is not None:
+        return
+    try:
+        os.killpg(proc.pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError, OSError):
+        proc.terminate()
+    try:
+        proc.wait(timeout=8)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            proc.kill()
+        proc.wait(timeout=5)
+
+
+def _venv_python() -> str:
+    candidate = ROOT / ".venv" / "bin" / "python"
+    if candidate.exists():
+        return str(candidate)
+    return sys.executable
+
+
+def _gateway_cmd(bind: str, upstreams: Path) -> list[str]:
+    # Prefer the worktree venv binary so RSS belongs to the gateway process,
+    # not an intermediate ``uv run`` wrapper.
+    venv_cli = ROOT / ".venv" / "bin" / "agent-bom"
+    if venv_cli.exists():
+        base = [str(venv_cli), "gateway", "serve"]
+    else:
+        base = [_venv_python(), "-m", "agent_bom", "gateway", "serve"]
+    return [
+        *base,
+        "--bind",
+        bind,
+        "--upstreams",
+        str(upstreams),
+        "--log-level",
+        "warning",
+        "--allow-anonymous-agents",
+    ]
+
+
+def _mock_cmd(port: int) -> list[str]:
+    script = ROOT / "scripts" / "perf" / "mock_mcp_upstream.py"
+    return [_venv_python(), str(script), "--port", str(port), "--host", "127.0.0.1"]
+
+
+def _apply_uvloop_if_requested(mode: str) -> dict[str, Any]:
+    note: dict[str, Any] = {"requested": mode == "tuned", "enabled": False, "detail": "not requested"}
+    if mode != "tuned":
+        return note
+    if os.environ.get("UVLOOP", "").strip() in {"0", "false", "no"}:
+        note["detail"] = "UVLOOP disabled via env"
+        return note
+    try:
+        import uvloop
+
+        asyncio.set_event_loop_policy(uvloop.EventLoopPolicy())
+        note["enabled"] = True
+        note["detail"] = f"uvloop {getattr(uvloop, '__version__', 'unknown')}"
+    except Exception as exc:  # noqa: BLE001 — optional dep
+        note["detail"] = f"uvloop unavailable: {type(exc).__name__}"
+    return note
+
+
+def _httpx_limits(mode: str) -> Any:
+    import httpx
+
+    if mode == "tuned":
+        return httpx.Limits(max_connections=1000, max_keepalive_connections=500, keepalive_expiry=30.0)
+    return httpx.Limits(max_connections=100, max_keepalive_connections=20)
+
+
+def _gateway_env(mode: str) -> dict[str, str]:
+    """Env for the gateway child process.
+
+    ``GatewaySettings.upstream_http_max_connections`` / keepalive are dataclass
+    fields wired only from the CLI constructor today — there is no
+    ``AGENT_BOM_GATEWAY_UPSTREAM_*`` env. Tuned mode records that gap and still
+    sets benign high-concurrency client hints where they exist.
+    """
+    env: dict[str, str] = {
+        "AGENT_BOM_GATEWAY_ALLOW_ANONYMOUS_AGENTS": "1",
+        # Empty policy + fail-open keeps the relay path free of DENY noise for
+        # this microbenchmark (policy engine is not under test here).
+        "AGENT_BOM_GATEWAY_FAIL_MODE": "open",
+    }
+    if mode == "tuned":
+        env["UVLOOP"] = "1"
+        # Documented non-knobs: pool size is not env-configurable yet.
+        env["AGENT_BOM_GATEWAY_PERF_TUNE"] = "1"
+    return env
+
+
+async def _one_call(client: Any, url: str, req_id: int) -> tuple[float, bool, str | None]:
+    payload = {
+        "jsonrpc": "2.0",
+        "id": req_id,
+        "method": "tools/call",
+        "params": {"name": "echo", "arguments": {"n": req_id}},
+    }
+    started = time.perf_counter()
+    try:
+        resp = await client.post(url, json=payload)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        if resp.status_code != 200:
+            return elapsed_ms, False, f"http_{resp.status_code}"
+        body = resp.json()
+        if isinstance(body, dict) and body.get("error"):
+            return elapsed_ms, False, "jsonrpc_error"
+        if not isinstance(body, dict) or "result" not in body:
+            return elapsed_ms, False, "missing_result"
+        return elapsed_ms, True, None
+    except Exception as exc:  # noqa: BLE001 — count as error sample
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        return elapsed_ms, False, type(exc).__name__
+
+
+async def _run_level(
+    *,
+    client: Any,
+    url: str,
+    concurrency: int,
+    requests: int,
+    gateway_pid: int,
+) -> dict[str, Any]:
+    sem = asyncio.Semaphore(concurrency)
+    latencies: list[float] = []
+    errors = 0
+    error_kinds: dict[str, int] = {}
+    peak_rss_kb: int | None = _peak_rss_kb_tree(gateway_pid)
+
+    async def worker(req_id: int) -> None:
+        nonlocal errors, peak_rss_kb
+        async with sem:
+            ms, ok, kind = await _one_call(client, url, req_id)
+            latencies.append(ms)
+            if not ok:
+                errors += 1
+                error_kinds[kind or "unknown"] = error_kinds.get(kind or "unknown", 0) + 1
+            rss = _peak_rss_kb_tree(gateway_pid)
+            if rss is not None and (peak_rss_kb is None or rss > peak_rss_kb):
+                peak_rss_kb = rss
+
+    await asyncio.gather(*(worker(i) for i in range(requests)))
+    pct = _percentiles(latencies)
+    error_rate = (errors / requests) if requests else 0.0
+    peak_rss_mb = round((peak_rss_kb or 0) / 1024.0, 3) if peak_rss_kb is not None else None
+    return {
+        "concurrency": concurrency,
+        "requests": requests,
+        "error_count": errors,
+        "error_rate": round(error_rate, 6),
+        "error_kinds": error_kinds,
+        "latency_ms": pct,
+        "peak_rss_kb": peak_rss_kb,
+        "peak_rss_mb": peak_rss_mb,
+        "wall_s": None,  # filled by caller
+    }
+
+
+async def _drive(
+    *,
+    gateway_base: str,
+    gateway_pid: int,
+    mode: str,
+    concurrency_levels: list[int],
+    requests_per_level: int,
+) -> list[dict[str, Any]]:
+    import httpx
+
+    url = f"{gateway_base}/mcp/echo"
+    timeout = httpx.Timeout(REQUEST_TIMEOUT_S)
+    limits = _httpx_limits(mode)
+    results: list[dict[str, Any]] = []
+
+    async with httpx.AsyncClient(timeout=timeout, limits=limits) as client:
+        # Warmup
+        for i in range(WARMUP_REQUESTS):
+            await _one_call(client, url, i)
+
+        for conc in concurrency_levels:
+            started = time.perf_counter()
+            level = await _run_level(
+                client=client,
+                url=url,
+                concurrency=conc,
+                requests=requests_per_level,
+                gateway_pid=gateway_pid,
+            )
+            level["wall_s"] = round(time.perf_counter() - started, 3)
+            results.append(level)
+            # Soft cap: if a mid level already exceeds ~90s wall, still continue
+            # to 500 (required for Go gate) but keep request count.
+            print(
+                f"concurrency={conc} p95_ms={level['latency_ms']['p95_ms']} "
+                f"error_rate={level['error_rate']} peak_rss_mb={level['peak_rss_mb']} "
+                f"wall_s={level['wall_s']}",
+                flush=True,
+            )
+    return results
+
+
+def _fetch_metrics(gateway_base: str) -> str | None:
+    import urllib.error
+    import urllib.request
+
+    try:
+        with urllib.request.urlopen(f"{gateway_base}/metrics", timeout=5.0) as resp:
+            return resp.read().decode("utf-8", errors="replace")
+    except (urllib.error.URLError, TimeoutError, OSError):
+        return None
+
+
+def run_benchmark(
+    *,
+    mode: str,
+    output: Path,
+    concurrency_levels: list[int],
+    requests_per_level: int,
+    gateway_port: int | None,
+    upstream_port: int | None,
+) -> dict[str, Any]:
+    uvloop_note = _apply_uvloop_if_requested(mode)
+    gport = gateway_port or _free_port()
+    uport = upstream_port or _free_port()
+    # Prefer the documented default ports when free.
+    if gateway_port is None:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind((GATEWAY_BIND_HOST, GATEWAY_BIND_PORT))
+                gport = GATEWAY_BIND_PORT
+        except OSError:
+            pass
+    if upstream_port is None:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("127.0.0.1", UPSTREAM_PORT))
+                uport = UPSTREAM_PORT
+        except OSError:
+            pass
+
+    gateway_base = f"http://{GATEWAY_BIND_HOST}:{gport}"
+    upstream_proc: subprocess.Popen[bytes] | None = None
+    gateway_proc: subprocess.Popen[bytes] | None = None
+
+    with tempfile.TemporaryDirectory(prefix="abom-gateway-perf-") as tmp:
+        upstreams = Path(tmp) / "upstreams.yaml"
+        _write_upstreams_yaml(upstreams, uport)
+
+        try:
+            upstream_proc = _spawn(_mock_cmd(uport))
+            _wait_http_ok(f"http://127.0.0.1:{uport}/healthz")
+
+            gateway_proc = _spawn(
+                _gateway_cmd(f"{GATEWAY_BIND_HOST}:{gport}", upstreams),
+                env=_gateway_env(mode),
+            )
+            _wait_http_ok(f"{gateway_base}/healthz")
+
+            started = time.perf_counter()
+            results = asyncio.run(
+                _drive(
+                    gateway_base=gateway_base,
+                    gateway_pid=gateway_proc.pid,
+                    mode=mode,
+                    concurrency_levels=concurrency_levels,
+                    requests_per_level=requests_per_level,
+                )
+            )
+            total_wall_s = round(time.perf_counter() - started, 3)
+            metrics_snippet = _fetch_metrics(gateway_base)
+            final_rss_kb = _peak_rss_kb_tree(gateway_proc.pid)
+        finally:
+            _terminate(gateway_proc)
+            _terminate(upstream_proc)
+
+    at_500 = next((r for r in results if r["concurrency"] == 500), None)
+    artifact: dict[str, Any] = {
+        "metadata": {
+            "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
+            "timestamp_utc": datetime.now(timezone.utc).isoformat(),
+            "hostname": socket.gethostname(),
+            "platform": platform.platform(),
+            "machine": platform.machine(),
+            "python": platform.python_version(),
+            "agent_bom_version": _agent_bom_version(),
+            "mode": mode,
+            "git_commit": _git_commit(),
+            "uvloop": uvloop_note,
+            "httpx_limits": {
+                "mode": mode,
+                "max_connections": 1000 if mode == "tuned" else 100,
+                "max_keepalive_connections": 500 if mode == "tuned" else 20,
+            },
+            "gateway_pool_env": {
+                "note": (
+                    "GatewaySettings.upstream_http_max_connections defaults to 100 / "
+                    "keepalive 20; not exposed via AGENT_BOM_* env today. Tuned mode "
+                    "cannot enlarge the gateway pool without a code/CLI change."
+                ),
+                "upstream_http_max_connections_default": 100,
+                "upstream_http_max_keepalive_connections_default": 20,
+            },
+            "bind": {"gateway": f"{GATEWAY_BIND_HOST}:{gport}", "upstream": f"127.0.0.1:{uport}"},
+            "requests_per_level": requests_per_level,
+            "concurrency_levels": concurrency_levels,
+            "warmup_requests": WARMUP_REQUESTS,
+            "total_wall_s": total_wall_s,
+        },
+        "results": results,
+        "gateway_metrics_tail": (metrics_snippet[-2000:] if metrics_snippet else None),
+        "final_gateway_rss_kb": final_rss_kb,
+        "final_gateway_rss_mb": round((final_rss_kb or 0) / 1024.0, 3) if final_rss_kb is not None else None,
+        "go_gate_inputs_at_500": {
+            "p95_ms": (at_500 or {}).get("latency_ms", {}).get("p95_ms"),
+            "peak_rss_mb": (at_500 or {}).get("peak_rss_mb"),
+            "error_rate": (at_500 or {}).get("error_rate"),
+        },
+    }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(artifact, indent=2) + "\n", encoding="utf-8")
+    print(f"wrote {output}", flush=True)
+    return artifact
+
+
+def _git_commit() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], cwd=str(ROOT), text=True).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return "unknown"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--mode",
+        "--tune",
+        dest="mode",
+        choices=("baseline", "tuned", "python"),
+        default="baseline",
+        help="baseline (default) or tuned/python (uvloop + larger httpx limits)",
+    )
+    parser.add_argument("--output", type=Path, required=True, help="JSON result path")
+    parser.add_argument(
+        "--requests-per-level",
+        type=int,
+        default=DEFAULT_REQUESTS,
+        help=f"Requests at each concurrency (default {DEFAULT_REQUESTS})",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        nargs="+",
+        default=DEFAULT_CONCURRENCY,
+        help="Concurrency ladder (must include 500 for Go gate)",
+    )
+    parser.add_argument("--gateway-port", type=int, default=None)
+    parser.add_argument("--upstream-port", type=int, default=None)
+    args = parser.parse_args()
+    mode = "tuned" if args.mode == "python" else args.mode
+    if 500 not in args.concurrency:
+        parser.error("concurrency ladder must include 500 (Go-gate measurement point)")
+    run_benchmark(
+        mode=mode,
+        output=args.output,
+        concurrency_levels=list(args.concurrency),
+        requests_per_level=args.requests_per_level,
+        gateway_port=args.gateway_port,
+        upstream_port=args.upstream_port,
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `scripts/perf/mock_mcp_upstream.py` and `scripts/run_gateway_relay_benchmark.py` to measure full-stack `gateway serve` JSON-RPC relay latency + RSS across concurrency 1→500.
- Publish baseline + tuned result JSON and evidence page under `docs/perf/`; update the perf index.
- Record Go-gate decision artifact: at concurrency=500, **p95 ≫ 50 ms** (RSS and error rate stay under thresholds) → `gate_tripped=true`, next=`proceed_phase2` (ADR-009).

## Verification
- `uv run python scripts/run_gateway_relay_benchmark.py --mode baseline --output docs/perf/results/gateway-relay-baseline-2026-07-23.json`
- `uv run python scripts/run_gateway_relay_benchmark.py --mode tuned --output docs/perf/results/gateway-relay-tuned-2026-07-23.json`
- Gate inputs at c=500:
  - baseline: p95_ms=2547.357, peak_rss_mb=107.656, error_rate=0.0
  - tuned: p95_ms=2572.27, peak_rss_mb=107.078, error_rate=0.0
  - **gate_tripped=true** (p95 threshold)

## Notes
- Freeze allows docs/perf evidence. No Go sidecar or relay interface in this PR.
- Phase 2 (Python relay interface + contract tests) follows in a sequential PR because the gate tripped.
- Tuned mode enables uvloop + larger client httpx limits; gateway upstream pool size is not env-configurable today (`GatewaySettings` defaults only).


Made with [Cursor](https://cursor.com)