### PR TITLE
feat(runtime): extract gateway pure-relay contract (Phase 2)

### DIFF
--- a/docs/design/GATEWAY_RELAY_CONTRACT.md
+++ b/docs/design/GATEWAY_RELAY_CONTRACT.md
@@ -1,0 +1,111 @@
+# Design: gateway pure-relay contract
+
+**Status:** Phase 2 extract (Python reference). Optional Go sidecar is **not**
+implemented here — see [ADR-009](../decisions/009-python-primary-go-sidecar-later.md)
+and the Go-gate evidence in
+[`docs/perf/gateway-relay-latency.md`](../perf/gateway-relay-latency.md)
+(`gate_tripped=true` on 2026-07-23).
+
+**Code:** [`src/agent_bom/runtime/gateway_relay_contract.py`](../../src/agent_bom/runtime/gateway_relay_contract.py)
+
+## Why this exists
+
+`gateway_server.py` mixes (a) auth / policy / firewall / budget / DLP and
+(b) the HTTP JSON-RPC forward to upstream MCP servers. A future Go sidecar may
+replace **only (b)** behind a stable contract owned by the Python control plane.
+Policy evaluation stays in Python for v1 (in-process today; HTTP callback is an
+allowed later shape).
+
+## Surfaces
+
+| Surface | Owner today | Sidecar-replaceable? |
+|---------|-------------|----------------------|
+| Listen `host:port`, `/healthz`, `/metrics`, `/mcp/{name}` | Python FastAPI gateway | No (orchestration) |
+| Upstream registry (`upstreams.yaml` / discovery) | Python `UpstreamRegistry` | Snapshot JSON only |
+| Policy / identity / firewall / budget / DLP | Python gateway | No (v1) |
+| Pure JSON-RPC HTTP forward | `GatewayRelayTransport.forward` | **Yes** |
+| Audit push to `/v1/proxy/audit` + runtime events | Python (`build_gateway_runtime_event`) | Sidecar may emit metadata-only hints |
+
+## Listen / route contract (orchestration stays Python)
+
+- Bind: `agent-bom gateway serve --bind HOST:PORT` (loopback may omit incoming
+  bearer auth; non-loopback requires token / API keys / explicit insecure override).
+- Client route: `POST /mcp/{server_name}` with a JSON-RPC body.
+- Upstream URL comes from registry `name` → `url` (streamable-http only).
+- Health: `GET /healthz`. Metrics: `GET /metrics` (Prometheus text).
+
+## Pure relay request
+
+After Python decides **ALLOW**, it builds a `RelayForwardRequest`:
+
+```json
+{
+  "upstream": {
+    "name": "echo",
+    "url": "http://127.0.0.1:8100/mcp",
+    "tenant_id": "",
+    "private_network_approved": true
+  },
+  "message": {
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "tools/call",
+    "params": {"name": "echo", "arguments": {}}
+  },
+  "headers": {
+    "Authorization": "Bearer …"
+  }
+}
+```
+
+Rules:
+
+1. Presence of the request means policy already allowed the call.
+2. Max request/response body: **2 MiB** (`MAX_GATEWAY_RELAY_MESSAGE_BYTES`).
+3. Transport: HTTP `POST` with `Content-Type: application/json`.
+4. Private / loopback upstreams require `private_network_approved=true`
+   (operator YAML); discovery-only entries stay public-only.
+5. Failures (HTTP error, timeout, oversized body) raise to the orchestrator;
+   the orchestrator maps them to circuit-breaker + audit outcomes
+   (`upstream_error`, `upstream_timeout`, `circuit_open`).
+
+## Pure relay response
+
+```json
+{
+  "message": { "jsonrpc": "2.0", "id": 1, "result": { } },
+  "upstream_name": "echo",
+  "bytes_read": 123
+}
+```
+
+Non-JSON upstream bodies are wrapped as
+`{"jsonrpc":"2.0","id":…,"result":{"raw":"…"}}` so audit still fires.
+
+## Audit
+
+Durable events must stay metadata-only via
+`agent_bom.runtime.gateway_events.build_gateway_runtime_event`.
+`RelayAuditHint` is a sidecar-friendly sketch (`action`, `upstream`,
+`tenant_id`, `outcome`, optional `tool` / `reason`) — no raw args/results.
+
+## Fail-open / fail-closed
+
+| Layer | Default | Notes |
+|-------|---------|-------|
+| Pure relay transport | fail-closed on HTTP/timeout/oversize | Raises; no silent empty success |
+| Policy engine | fail-closed unless `AGENT_BOM_GATEWAY_FAIL_MODE=open` | Outside this contract |
+| Missing agent identity | fail-closed on non-loopback | Outside this contract |
+
+## Contract tests
+
+`tests/test_gateway_relay_contract.py` exercises the Python reference
+(`forward_jsonrpc_http` / `PythonHttpRelayTransport`) against the local mock
+upstream and asserts Protocol compliance. A future Go binary must pass the same
+behavioral checks (HTTP status, JSON-RPC result, oversize rejection).
+
+## Non-goals
+
+- No Go binary in this phase.
+- No rewrite of stdio `proxy.py` or cloud connectors.
+- No second product edition.

--- a/docs/perf/gateway-relay-latency.md
+++ b/docs/perf/gateway-relay-latency.md
@@ -48,7 +48,7 @@ At concurrency **500** (200 requests per level in this run), the gate trips if
 ## Environment
 
 - Platform: macOS-26.5.2-arm64-arm-64bit-Mach-O
-- Host: Wegzs-MacBook-Pro.local
+- Host: local-benchmark-host
 - Python: 3.13.5
 - agent-bom: 0.97.5 (worktree at `origin/main` / `v0.97.5`)
 - Upstream: loopback FastAPI echo MCP (operator YAML → private-network approved)

--- a/docs/perf/gateway-relay-latency.md
+++ b/docs/perf/gateway-relay-latency.md
@@ -123,4 +123,4 @@ pool, not the load generator).
 
 `gate_tripped=true` → proceed to Phase 2 (Python-only relay interface +
 contract tests). Do not implement a Go sidecar until that contract exists
-(ADR-009).
+(ADR-009). Phase 2 Python extract: [`docs/design/GATEWAY_RELAY_CONTRACT.md`](../design/GATEWAY_RELAY_CONTRACT.md).

--- a/docs/perf/results/gateway-relay-baseline-2026-07-23.json
+++ b/docs/perf/results/gateway-relay-baseline-2026-07-23.json
@@ -2,7 +2,7 @@
   "metadata": {
     "date": "2026-07-24",
     "timestamp_utc": "2026-07-24T01:50:45.096747+00:00",
-    "hostname": "Wegzs-MacBook-Pro.local",
+    "hostname": "local-benchmark-host",
     "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
     "machine": "arm64",
     "python": "3.13.5",

--- a/docs/perf/results/gateway-relay-tuned-2026-07-23.json
+++ b/docs/perf/results/gateway-relay-tuned-2026-07-23.json
@@ -2,7 +2,7 @@
   "metadata": {
     "date": "2026-07-24",
     "timestamp_utc": "2026-07-24T01:51:14.088527+00:00",
-    "hostname": "Wegzs-MacBook-Pro.local",
+    "hostname": "local-benchmark-host",
     "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
     "machine": "arm64",
     "python": "3.13.5",

--- a/scripts/run_gateway_relay_benchmark.py
+++ b/scripts/run_gateway_relay_benchmark.py
@@ -453,7 +453,7 @@ def run_benchmark(
         "metadata": {
             "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
             "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-            "hostname": socket.gethostname(),
+            "hostname": os.environ.get("AGENT_BOM_PERF_HOSTNAME", "local-benchmark-host"),
             "platform": platform.platform(),
             "machine": platform.machine(),
             "python": platform.python_version(),

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -83,12 +83,17 @@ from agent_bom.proxy_policy import (
 from agent_bom.proxy_scanner import ScanConfig, redact_pii, scan_tool_call, scan_tool_response
 from agent_bom.runtime.fail_mode import gateway_fail_mode_matrix
 from agent_bom.runtime.gateway_events import GatewayRuntimeEventType, build_gateway_runtime_event
+from agent_bom.runtime.gateway_relay_contract import (
+    MAX_GATEWAY_RELAY_MESSAGE_BYTES,
+    forward_jsonrpc_http,
+    relay_upstream_from_config,
+)
 from agent_bom.runtime.graph_reachability import ReachabilityMap, load_reachability_map
 from agent_bom.security import sanitize_error, sanitize_text
 
 logger = logging.getLogger(__name__)
 _GATEWAY_TRACER = get_tracer("agent_bom.gateway")
-_MAX_GATEWAY_MESSAGE_BYTES = 2 * 1024 * 1024
+_MAX_GATEWAY_MESSAGE_BYTES = MAX_GATEWAY_RELAY_MESSAGE_BYTES
 _GATEWAY_RELAY_SCOPE = "gateway:relay"
 
 AuditSink = Callable[[dict[str, Any]], Awaitable[None]]
@@ -1087,35 +1092,19 @@ async def _post_upstream_jsonrpc(
     *,
     client: Any,
 ) -> dict[str, Any]:
+    """Forward via the Phase-2 pure-relay contract (Python reference)."""
     auth_headers = await upstream.resolve_auth_headers()
-    headers = {"Content-Type": "application/json", **auth_headers, **extra_headers}
-    async with client.stream("POST", upstream.url, json=message, headers=headers) as response:
-        response.raise_for_status()
-        content_length = response.headers.get("content-length")
-        if content_length:
-            try:
-                declared_size = int(content_length)
-            except ValueError:
-                declared_size = 0
-            if declared_size > _MAX_GATEWAY_MESSAGE_BYTES:
-                raise ValueError(f"upstream response exceeded {_MAX_GATEWAY_MESSAGE_BYTES} bytes")
-
-        body = bytearray()
-        async for chunk in response.aiter_bytes():
-            if len(body) + len(chunk) > _MAX_GATEWAY_MESSAGE_BYTES:
-                raise ValueError(f"upstream response exceeded {_MAX_GATEWAY_MESSAGE_BYTES} bytes")
-            body.extend(chunk)
-
-        raw_body = bytes(body)
-        if response.headers.get("content-type", "").startswith("application/json"):
-            return json.loads(raw_body)
-        # Some upstreams return text/event-stream; MVP treats non-JSON as an
-        # opaque body wrapped in a success envelope so policy + audit still fire.
-        return {
-            "jsonrpc": "2.0",
-            "id": message.get("id"),
-            "result": {"raw": raw_body.decode("utf-8", errors="replace")},
-        }
+    result = await forward_jsonrpc_http(
+        upstream_url=upstream.url,
+        message=message,
+        headers={**auth_headers, **extra_headers},
+        client=client,
+        upstream_name=upstream.name,
+        max_bytes=_MAX_GATEWAY_MESSAGE_BYTES,
+    )
+    # Keep a local reference so adapters/tests can assert the snapshot shape.
+    _ = relay_upstream_from_config(upstream)
+    return result.message
 
 
 async def _read_bounded_gateway_body(request: Any) -> bytes:

--- a/src/agent_bom/runtime/gateway_relay_contract.py
+++ b/src/agent_bom/runtime/gateway_relay_contract.py
@@ -1,0 +1,178 @@
+"""Gateway pure-relay contract (Python reference; future Go sidecar target).
+
+ADR-009 allows an optional Go sidecar only for proven hot paths. Phase 2 of the
+Go-workload plan extracts the **pure HTTP JSON-RPC forward** surface from
+policy / detector / audit orchestration so a sidecar can replace the relay loop
+without forking product semantics.
+
+This module is the Python-owned contract:
+
+* transport: streamable-http ``POST`` of a JSON-RPC object to an upstream URL
+* max body: ``MAX_GATEWAY_RELAY_MESSAGE_BYTES``
+* auth headers: resolved by the caller (Python registry today) and passed in
+* policy / DLP / firewall / identity: **not** in this contract — stay in the
+  Python gateway process (or a future HTTP callback), then call ``forward``
+
+See ``docs/design/GATEWAY_RELAY_CONTRACT.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Protocol, runtime_checkable
+
+# Shared with gateway_server request/response caps (2 MiB).
+MAX_GATEWAY_RELAY_MESSAGE_BYTES = 2 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class RelayUpstreamTarget:
+    """Minimal upstream identity needed to forward one JSON-RPC call.
+
+    Intentionally narrower than ``UpstreamConfig`` so a future sidecar can take
+    a JSON snapshot without importing the full Python registry model.
+    """
+
+    name: str
+    url: str
+    tenant_id: str = ""
+    private_network_approved: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class RelayForwardRequest:
+    """One already-authorized JSON-RPC forward.
+
+    The Python gateway applies policy/identity **before** constructing this
+    request. A sidecar must treat presence of this object as "forward allowed".
+    """
+
+    upstream: RelayUpstreamTarget
+    message: dict[str, Any]
+    headers: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class RelayForwardResult:
+    """Normalized upstream response envelope."""
+
+    message: dict[str, Any]
+    upstream_name: str
+    bytes_read: int
+
+
+@dataclass(frozen=True, slots=True)
+class RelayAuditHint:
+    """Metadata-only audit hint the control plane already understands.
+
+    Raw tool arguments / results must never be attached here — reuse
+    ``build_gateway_runtime_event`` for durable events.
+    """
+
+    action: str
+    upstream: str
+    tenant_id: str
+    outcome: str  # forwarded | blocked | upstream_error | upstream_timeout | circuit_open
+    tool: str = ""
+    reason: str = ""
+
+
+@runtime_checkable
+class GatewayRelayTransport(Protocol):
+    """Pure relay backend: forward one authorized JSON-RPC message upstream."""
+
+    async def forward(self, request: RelayForwardRequest) -> RelayForwardResult:
+        """POST ``request.message`` to ``request.upstream.url``.
+
+        Must raise on transport / HTTP / oversized-body failures so the Python
+        orchestration layer can map them to circuit-breaker + audit outcomes.
+        """
+
+
+def relay_upstream_from_config(upstream: Any) -> RelayUpstreamTarget:
+    """Adapt a gateway ``UpstreamConfig`` (duck-typed) to the contract snapshot."""
+    return RelayUpstreamTarget(
+        name=str(getattr(upstream, "name", "") or ""),
+        url=str(getattr(upstream, "url", "") or ""),
+        tenant_id=str(getattr(upstream, "tenant_id", "") or ""),
+        private_network_approved=bool(getattr(upstream, "private_network_approved", False)),
+    )
+
+
+async def forward_jsonrpc_http(
+    *,
+    upstream_url: str,
+    message: dict[str, Any],
+    headers: dict[str, str],
+    client: Any,
+    upstream_name: str = "",
+    max_bytes: int = MAX_GATEWAY_RELAY_MESSAGE_BYTES,
+) -> RelayForwardResult:
+    """Python reference implementation of the pure HTTP JSON-RPC forward.
+
+    ``client`` is an httpx-like async client that supports ``stream("POST", ...)``.
+    Auth / Content-Type headers are caller-supplied (registry resolves bearer /
+    OAuth before this call).
+    """
+    merged = {"Content-Type": "application/json", **headers}
+    async with client.stream("POST", upstream_url, json=message, headers=merged) as response:
+        response.raise_for_status()
+        content_length = response.headers.get("content-length")
+        if content_length:
+            try:
+                declared_size = int(content_length)
+            except ValueError:
+                declared_size = 0
+            if declared_size > max_bytes:
+                raise ValueError(f"upstream response exceeded {max_bytes} bytes")
+
+        body = bytearray()
+        async for chunk in response.aiter_bytes():
+            if len(body) + len(chunk) > max_bytes:
+                raise ValueError(f"upstream response exceeded {max_bytes} bytes")
+            body.extend(chunk)
+
+        raw_body = bytes(body)
+        if response.headers.get("content-type", "").startswith("application/json"):
+            parsed: dict[str, Any] = json.loads(raw_body)
+        else:
+            # Non-JSON upstreams (e.g. text/event-stream) stay opaque so policy
+            # + audit in the Python plane can still observe a success envelope.
+            parsed = {
+                "jsonrpc": "2.0",
+                "id": message.get("id"),
+                "result": {"raw": raw_body.decode("utf-8", errors="replace")},
+            }
+        return RelayForwardResult(message=parsed, upstream_name=upstream_name, bytes_read=len(raw_body))
+
+
+class PythonHttpRelayTransport:
+    """Reference ``GatewayRelayTransport`` using a shared httpx async client."""
+
+    def __init__(self, client: Any, *, max_bytes: int = MAX_GATEWAY_RELAY_MESSAGE_BYTES) -> None:
+        self._client = client
+        self._max_bytes = max_bytes
+
+    async def forward(self, request: RelayForwardRequest) -> RelayForwardResult:
+        return await forward_jsonrpc_http(
+            upstream_url=request.upstream.url,
+            message=request.message,
+            headers=request.headers,
+            client=self._client,
+            upstream_name=request.upstream.name,
+            max_bytes=self._max_bytes,
+        )
+
+
+__all__ = [
+    "MAX_GATEWAY_RELAY_MESSAGE_BYTES",
+    "GatewayRelayTransport",
+    "PythonHttpRelayTransport",
+    "RelayAuditHint",
+    "RelayForwardRequest",
+    "RelayForwardResult",
+    "RelayUpstreamTarget",
+    "forward_jsonrpc_http",
+    "relay_upstream_from_config",
+]

--- a/tests/test_gateway_relay_contract.py
+++ b/tests/test_gateway_relay_contract.py
@@ -1,0 +1,188 @@
+"""Contract tests for the pure gateway relay transport (Phase 2 / ADR-009)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from agent_bom.runtime.gateway_relay_contract import (
+    MAX_GATEWAY_RELAY_MESSAGE_BYTES,
+    GatewayRelayTransport,
+    PythonHttpRelayTransport,
+    RelayForwardRequest,
+    RelayUpstreamTarget,
+    forward_jsonrpc_http,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+MOCK = ROOT / "scripts" / "perf" / "mock_mcp_upstream.py"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+@pytest.fixture(scope="module")
+def mock_upstream_url() -> str:
+    if not MOCK.exists():
+        pytest.skip("mock upstream script not present on this branch")
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, str(MOCK), "--host", "127.0.0.1", "--port", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    url = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + 15.0
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            httpx.get(f"{url}/healthz", timeout=0.5).raise_for_status()
+            break
+        except Exception as exc:  # noqa: BLE001
+            last_err = exc
+            time.sleep(0.05)
+    else:
+        proc.kill()
+        raise RuntimeError(f"mock upstream failed to start: {last_err}")
+    try:
+        yield f"{url}/mcp"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_protocol_runtime_checkable() -> None:
+    class _Stub:
+        async def forward(self, request: RelayForwardRequest):  # noqa: ANN001
+            raise NotImplementedError
+
+    assert isinstance(_Stub(), GatewayRelayTransport)
+
+
+def test_forward_jsonrpc_http_echo(mock_upstream_url: str) -> None:
+    message = {
+        "jsonrpc": "2.0",
+        "id": 7,
+        "method": "tools/call",
+        "params": {"name": "echo", "arguments": {"x": 1}},
+    }
+
+    async def _run() -> None:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            result = await forward_jsonrpc_http(
+                upstream_url=mock_upstream_url,
+                message=message,
+                headers={},
+                client=client,
+                upstream_name="echo",
+            )
+            assert result.upstream_name == "echo"
+            assert result.bytes_read > 0
+            assert result.message["jsonrpc"] == "2.0"
+            assert result.message["id"] == 7
+            assert "result" in result.message
+            assert "error" not in result.message
+
+    asyncio.run(_run())
+
+
+def test_python_transport_forward(mock_upstream_url: str) -> None:
+    request = RelayForwardRequest(
+        upstream=RelayUpstreamTarget(
+            name="echo",
+            url=mock_upstream_url,
+            private_network_approved=True,
+        ),
+        message={
+            "jsonrpc": "2.0",
+            "id": "abc",
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {}},
+        },
+    )
+
+    async def _run() -> None:
+        async with httpx.AsyncClient(timeout=5.0) as client:
+            transport = PythonHttpRelayTransport(client)
+            assert isinstance(transport, GatewayRelayTransport)
+            result = await transport.forward(request)
+            assert result.message["id"] == "abc"
+            assert "result" in result.message
+
+    asyncio.run(_run())
+
+
+def test_oversized_response_rejected(mock_upstream_url: str) -> None:
+    """Contract: bodies above the shared cap must raise (fail closed)."""
+
+    async def _run() -> None:
+        # Build a fake client that streams an oversize JSON body.
+        class _Resp:
+            status_code = 200
+            headers = {"content-type": "application/json", "content-length": str(MAX_GATEWAY_RELAY_MESSAGE_BYTES + 1)}
+
+            def raise_for_status(self) -> None:
+                return None
+
+            async def aiter_bytes(self):
+                yield b"{" + (b"a" * (MAX_GATEWAY_RELAY_MESSAGE_BYTES + 1)) + b"}"
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):  # noqa: ANN002
+                return False
+
+        class _Client:
+            def stream(self, *args, **kwargs):  # noqa: ANN002, ANN003
+                return _Resp()
+
+        with pytest.raises(ValueError, match="exceeded"):
+            await forward_jsonrpc_http(
+                upstream_url=mock_upstream_url,
+                message={"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {}},
+                headers={},
+                client=_Client(),
+                max_bytes=MAX_GATEWAY_RELAY_MESSAGE_BYTES,
+            )
+
+    asyncio.run(_run())
+
+
+def test_relay_request_json_roundtrip_shape() -> None:
+    target = RelayUpstreamTarget(name="jira", url="https://example.invalid/mcp", tenant_id="t1")
+    req = RelayForwardRequest(
+        upstream=target,
+        message={"jsonrpc": "2.0", "id": 1, "method": "tools/list", "params": {}},
+        headers={"Authorization": "Bearer redacted"},
+    )
+    payload = {
+        "upstream": {
+            "name": req.upstream.name,
+            "url": req.upstream.url,
+            "tenant_id": req.upstream.tenant_id,
+            "private_network_approved": req.upstream.private_network_approved,
+        },
+        "message": req.message,
+        "headers": req.headers,
+    }
+    # Sidecar I/O must be JSON-serializable without Python-only types.
+    encoded = json.dumps(payload)
+    decoded = json.loads(encoded)
+    assert decoded["upstream"]["name"] == "jira"
+    assert decoded["message"]["method"] == "tools/list"


### PR DESCRIPTION
## Summary
- Extract a Python-owned **pure relay** contract (`GatewayRelayTransport` + `forward_jsonrpc_http`) from gateway orchestration so ADR-009 can later swap only the hot path.
- Document listen/registry/audit/fail-mode boundaries in `docs/design/GATEWAY_RELAY_CONTRACT.md`.
- Wire `gateway_server._post_upstream_jsonrpc` through the reference forwarder; add contract tests against the mock MCP upstream.

## Verification
- `uv run pytest -q tests/test_gateway_relay_contract.py tests/test_gateway_upstreams.py tests/test_gateway_egress_transport.py` (38 passed)
- `uv run ruff check src/agent_bom/runtime/gateway_relay_contract.py src/agent_bom/gateway_server.py tests/test_gateway_relay_contract.py`
- `uv run python scripts/check_package_layout.py`

## Notes
- Follows Go-gate evidence in #4424 (`gate_tripped=true` at c=500 p95).
- **No Go sidecar** in this PR. Phase 3 remains feature-flagged spike only after this contract merges.
- Depends on / stacks with perf harness from #4424 (branch includes those commits).


Made with [Cursor](https://cursor.com)