### PR TITLE
feat(runtime): Go gateway-relay sidecar spike (Phase 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ deploy/helm/agent-bom/**/* [0-9].yaml
 *-report.json
 agent-bom-report.json
 .DS_Store
+
+# Go gateway-relay spike build output
+runtime/gateway-relay/bin/

--- a/Makefile
+++ b/Makefile
@@ -151,6 +151,10 @@ git-status:  ## Show git status and current branch
 	@echo ""
 	@git status
 
+
+gateway-relay-go-test:  ## Run Go gateway-relay sidecar unit tests (Phase 3 spike)
+	cd runtime/gateway-relay && go test ./...
+
 analytics:  ## Show adoption metrics (PyPI downloads, GitHub traffic, stars)
 	@echo "=== PyPI downloads (recent) ==="
 	@curl -sf "https://pypistats.org/api/packages/agent-bom/recent" 2>/dev/null \

--- a/deploy/helm/agent-bom/templates/gateway-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/gateway-deployment.yaml
@@ -93,6 +93,12 @@ spec:
             initialDelaySeconds: 2
             periodSeconds: 5
           env:
+            - name: AGENT_BOM_GATEWAY_RELAY_BACKEND
+              value: {{ .Values.gateway.relayBackend | default "python" | quote }}
+            {{- if eq (.Values.gateway.relayBackend | default "python") "go" }}
+            - name: AGENT_BOM_GATEWAY_RELAY_GO_URL
+              value: {{ .Values.gateway.relayGoUrl | default "http://127.0.0.1:8091" | quote }}
+            {{- end }}
             {{- with .Values.gateway.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -117,6 +123,39 @@ spec:
             {{- with .Values.gateway.extraVolumeMounts }}
             {{- toYaml . | nindent 12 }}
             {{- end }}
+        {{- $sidecar := .Values.gateway.relayGoSidecar | default dict }}
+        {{- if and (eq (.Values.gateway.relayBackend | default "python") "go") ($sidecar.enabled | default false) ($sidecar.image).repository }}
+        - name: gateway-relay
+          image: "{{ $sidecar.image.repository }}:{{ $sidecar.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ $sidecar.image.pullPolicy | default "IfNotPresent" }}
+          args:
+            - "-listen"
+            - "127.0.0.1:{{ $sidecar.port | default 8091 }}"
+          ports:
+            - name: relay
+              containerPort: {{ $sidecar.port | default 8091 }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: relay
+            initialDelaySeconds: 3
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: relay
+            initialDelaySeconds: 1
+            periodSeconds: 5
+          resources:
+            {{- toYaml ($sidecar.resources | default dict) | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+        {{- end }}
       volumes:
         - name: upstreams
           configMap:

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -260,6 +260,28 @@ monitor:
 gateway:
   enabled: false
   replicas: 2
+  # Pure-relay backend for JSON-RPC upstream forwards (ADR-009 Phase 3 spike).
+  # python (default): in-process PythonHttpRelayTransport — unchanged install.
+  # go: set AGENT_BOM_GATEWAY_RELAY_BACKEND=go and optionally run the
+  # runtime/gateway-relay sidecar (see gateway.relayGoSidecar).
+  relayBackend: python
+  relayGoUrl: "http://127.0.0.1:8091"
+  relayGoSidecar:
+    # Optional sidecar container when relayBackend=go. Default false so stock
+    # installs stay Python-only. Image must contain the gateway-relay binary.
+    enabled: false
+    port: 8091
+    image:
+      repository: ""  # e.g. agentbom/gateway-relay — empty skips rendering
+      tag: ""
+      pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 500m
+        memory: 256Mi
   autoscaling:
     enabled: false
     minReplicas: 2

--- a/docs/decisions/009-python-primary-go-sidecar-later.md
+++ b/docs/decisions/009-python-primary-go-sidecar-later.md
@@ -63,3 +63,25 @@ a specific hot path under the same policy/audit contract.
 - **Negative:** Some network-daemon workloads may hit Python concurrency limits
   before a sidecar exists; mitigate with horizontal workers and measurement
   rather than speculative rewrites.
+
+### Phase 3 Go spike (2026-07-24) — **defer**
+
+Measured `runtime/gateway-relay` behind `AGENT_BOM_GATEWAY_RELAY_BACKEND=go`
+against the default Python in-process relay
+(`docs/perf/results/gateway-relay-go-spike-2026-07-24.json` and the c=500 soak
+decision in `docs/perf/results/gateway-relay-decision-2026-07-23.json`).
+
+| Backend | p95 @ 50 | p95 @ 500 |
+|---------|---------:|----------:|
+| python  | 1319.6 ms | 1447.6 ms |
+| go      | 1172.8 ms | 1326.6 ms |
+
+Go improved p95 by roughly 8% in the scrubbed 100-req soak and by ~6% vs the
+tuned Python full-ladder artifact at c=500 (Python p95 2572.27 ms → Go p95
+2426.12 ms; ratio ~0.94). Neither run met promote thresholds (Go p95 < 50%
+of Python p95, or Go p95 < 50 ms). **Defer promotion:** Python stays the
+default pure-relay implementation; the Go sidecar remains an optional
+experimental flag + Helm values stub. Revisit only with stronger evidence
+(pool tuning, multi-replica EKS soak, or a clear SLO miss that Python cannot
+close).
+

--- a/docs/design/GATEWAY_RELAY_CONTRACT.md
+++ b/docs/design/GATEWAY_RELAY_CONTRACT.md
@@ -1,10 +1,9 @@
 # Design: gateway pure-relay contract
 
-**Status:** Phase 2 extract (Python reference). Optional Go sidecar is **not**
-implemented here — see [ADR-009](../decisions/009-python-primary-go-sidecar-later.md)
-and the Go-gate evidence in
-[`docs/perf/gateway-relay-latency.md`](../perf/gateway-relay-latency.md)
-(`gate_tripped=true` on 2026-07-23).
+**Status:** Phase 2 extract (Python reference) + Phase 3 optional Go sidecar
+spike under `runtime/gateway-relay` (feature-flagged; default off). See
+[ADR-009](../decisions/009-python-primary-go-sidecar-later.md) and
+[`docs/perf/results/gateway-relay-go-spike-2026-07-24.json`](../perf/results/gateway-relay-go-spike-2026-07-24.json).
 
 **Code:** [`src/agent_bom/runtime/gateway_relay_contract.py`](../../src/agent_bom/runtime/gateway_relay_contract.py)
 
@@ -106,6 +105,6 @@ behavioral checks (HTTP status, JSON-RPC result, oversize rejection).
 
 ## Non-goals
 
-- No Go binary in this phase.
+- Go sidecar is optional and feature-flagged (`AGENT_BOM_GATEWAY_RELAY_BACKEND=go`).
 - No rewrite of stdio `proxy.py` or cloud connectors.
 - No second product edition.

--- a/docs/perf/gateway-relay-latency.md
+++ b/docs/perf/gateway-relay-latency.md
@@ -7,6 +7,9 @@ Raw result artifacts:
 - [`results/gateway-relay-baseline-2026-07-23.json`](results/gateway-relay-baseline-2026-07-23.json)
 - [`results/gateway-relay-tuned-2026-07-23.json`](results/gateway-relay-tuned-2026-07-23.json)
 - [`results/gateway-relay-go-gate-2026-07-23.json`](results/gateway-relay-go-gate-2026-07-23.json)
+- [`results/gateway-relay-go-spike-2026-07-23.json`](results/gateway-relay-go-spike-2026-07-23.json)
+- [`results/gateway-relay-decision-2026-07-23.json`](results/gateway-relay-decision-2026-07-23.json)
+- [`results/gateway-relay-go-spike-2026-07-24.json`](results/gateway-relay-go-spike-2026-07-24.json)
 
 ## Claim
 

--- a/docs/perf/results/gateway-relay-decision-2026-07-23.json
+++ b/docs/perf/results/gateway-relay-decision-2026-07-23.json
@@ -1,0 +1,32 @@
+{
+  "date": "2026-07-23",
+  "comparison_point": "concurrency_500",
+  "python_tuned": {
+    "artifact": "docs/perf/results/gateway-relay-tuned-2026-07-23.json",
+    "p95_ms": 2572.27,
+    "p50_ms": 1378.941,
+    "error_rate": 0.0,
+    "peak_rss_mb": 107.078
+  },
+  "go_spike": {
+    "artifact": "docs/perf/results/gateway-relay-go-spike-2026-07-23.json",
+    "p95_ms": 2426.12,
+    "p50_ms": 1309.894,
+    "error_rate": 0.0,
+    "peak_rss_mb": 91.078,
+    "relay_backend": "go"
+  },
+  "thresholds": {
+    "promote_if_go_p95_lt_half_python": true,
+    "promote_if_go_p95_lt_ms": 50
+  },
+  "ratio_go_over_python_p95": 0.9432,
+  "decision": "defer",
+  "recommendation": "Defer Go promotion; keep Python primary and retain the Go sidecar harness for future soaks.",
+  "notes": [
+    "Policy/auth/audit remain Python-owned; Go only implements POST /v1/forward.",
+    "Default AGENT_BOM_GATEWAY_RELAY_BACKEND=python; Helm gateway.relayBackend defaults to python."
+  ],
+  "timestamp_utc": "2026-07-24T03:20:16.246103+00:00",
+  "git_commit_go_spike": "e93ad4dd3"
+}

--- a/docs/perf/results/gateway-relay-go-spike-2026-07-23.json
+++ b/docs/perf/results/gateway-relay-go-spike-2026-07-23.json
@@ -1,0 +1,163 @@
+{
+  "metadata": {
+    "date": "2026-07-24",
+    "timestamp_utc": "2026-07-24T03:20:16.169298+00:00",
+    "hostname": "local-benchmark-host",
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "machine": "arm64",
+    "python": "3.13.5",
+    "agent_bom_version": "0.97.5",
+    "mode": "tuned",
+    "git_commit": "e93ad4dd3",
+    "uvloop": {
+      "requested": true,
+      "enabled": true,
+      "detail": "uvloop 0.22.1"
+    },
+    "httpx_limits": {
+      "mode": "tuned",
+      "max_connections": 1000,
+      "max_keepalive_connections": 500
+    },
+    "gateway_pool_env": {
+      "note": "GatewaySettings.upstream_http_max_connections defaults to 100 / keepalive 20; not exposed via AGENT_BOM_* env today. Tuned mode cannot enlarge the gateway pool without a code/CLI change.",
+      "upstream_http_max_connections_default": 100,
+      "upstream_http_max_keepalive_connections_default": 20
+    },
+    "bind": {
+      "gateway": "127.0.0.1:8090",
+      "upstream": "127.0.0.1:8100",
+      "go_relay": "http://127.0.0.1:8091"
+    },
+    "relay_backend": "go",
+    "requests_per_level": 200,
+    "concurrency_levels": [
+      1,
+      10,
+      50,
+      100,
+      250,
+      500
+    ],
+    "warmup_requests": 20,
+    "total_wall_s": 16.518
+  },
+  "results": [
+    {
+      "concurrency": 1,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 2.322,
+        "p95_ms": 2.722,
+        "p99_ms": 3.315,
+        "max_ms": 4.184,
+        "mean_ms": 2.423,
+        "samples": 200
+      },
+      "peak_rss_kb": 111088,
+      "peak_rss_mb": 108.484,
+      "wall_s": 2.774
+    },
+    {
+      "concurrency": 10,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 95.058,
+        "p95_ms": 227.719,
+        "p99_ms": 289.097,
+        "max_ms": 403.776,
+        "mean_ms": 115.743,
+        "samples": 200
+      },
+      "peak_rss_kb": 111440,
+      "peak_rss_mb": 108.828,
+      "wall_s": 2.65
+    },
+    {
+      "concurrency": 50,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 431.955,
+        "p95_ms": 1527.607,
+        "p99_ms": 2246.165,
+        "max_ms": 2357.618,
+        "mean_ms": 545.192,
+        "samples": 200
+      },
+      "peak_rss_kb": 111472,
+      "peak_rss_mb": 108.859,
+      "wall_s": 2.578
+    },
+    {
+      "concurrency": 100,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 894.404,
+        "p95_ms": 2467.864,
+        "p99_ms": 2677.096,
+        "max_ms": 2798.075,
+        "mean_ms": 1032.338,
+        "samples": 200
+      },
+      "peak_rss_kb": 111504,
+      "peak_rss_mb": 108.891,
+      "wall_s": 2.84
+    },
+    {
+      "concurrency": 250,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 1480.256,
+        "p95_ms": 2750.178,
+        "p99_ms": 2825.248,
+        "max_ms": 2853.214,
+        "mean_ms": 1488.018,
+        "samples": 200
+      },
+      "peak_rss_kb": 110416,
+      "peak_rss_mb": 107.828,
+      "wall_s": 2.937
+    },
+    {
+      "concurrency": 500,
+      "requests": 200,
+      "error_count": 0,
+      "error_rate": 0.0,
+      "error_kinds": {},
+      "latency_ms": {
+        "p50_ms": 1309.894,
+        "p95_ms": 2426.12,
+        "p99_ms": 2521.055,
+        "max_ms": 2541.603,
+        "mean_ms": 1304.907,
+        "samples": 200
+      },
+      "peak_rss_kb": 93264,
+      "peak_rss_mb": 91.078,
+      "wall_s": 2.598
+    }
+  ],
+  "gateway_metrics_tail": "# HELP agent_bom_auth_failures_total API authentication failures by reason\n# TYPE agent_bom_auth_failures_total counter\nagent_bom_auth_failures_total{reason=\"none\"} 0\n# HELP agent_bom_rate_limit_hits_total Requests rejected by a rate limiter\n# TYPE agent_bom_rate_limit_hits_total counter\nagent_bom_rate_limit_hits_total{bucket=\"none\"} 0\n# HELP agent_bom_compliance_exports_total Compliance evidence bundles exported by signing algorithm\n# TYPE agent_bom_compliance_exports_total counter\nagent_bom_compliance_exports_total{algorithm=\"none\"} 0\n# HELP agent_bom_compliance_export_bytes_total Total bytes of compliance bundles served by framework\n# TYPE agent_bom_compliance_export_bytes_total counter\nagent_bom_compliance_export_bytes_total{framework=\"none\"} 0\n# HELP agent_bom_scan_completions_total Completed scans by final status\n# TYPE agent_bom_scan_completions_total counter\nagent_bom_scan_completions_total{status=\"none\"} 0\n# HELP agent_bom_scan_jobs_active In-flight scans currently queued or running\n# TYPE agent_bom_scan_jobs_active gauge\nagent_bom_scan_jobs_active 0\n# HELP agent_bom_gateway_relays_total Multi-MCP gateway relay events by upstream and outcome\n# TYPE agent_bom_gateway_relays_total counter\nagent_bom_gateway_relays_total{upstream=\"echo\",outcome=\"forwarded\"} 1220\n# HELP agent_bom_authorization_evidence_total Cloud authorization evidence collections by posture\n# TYPE agent_bom_authorization_evidence_total counter\nagent_bom_authorization_evidence_total{provider=\"none\",status=\"indeterminate\"} 0\n# HELP agent_bom_authorization_evidence_gaps_total Cloud authorization evidence gaps by reason code\n# TYPE agent_bom_authorization_evidence_gaps_total counter\nagent_bom_authorization_evidence_gaps_total{provider=\"none\",reason=\"none\"} 0\n",
+  "final_gateway_rss_kb": 93344,
+  "final_gateway_rss_mb": 91.156,
+  "go_gate_inputs_at_500": {
+    "p95_ms": 2426.12,
+    "peak_rss_mb": 91.078,
+    "error_rate": 0.0
+  }
+}

--- a/docs/perf/results/gateway-relay-go-spike-2026-07-24.json
+++ b/docs/perf/results/gateway-relay-go-spike-2026-07-24.json
@@ -1,0 +1,236 @@
+{
+  "metadata": {
+    "date": "2026-07-24",
+    "timestamp_utc": "2026-07-24T03:19:51.572376+00:00",
+    "hostname": "local-benchmark-host",
+    "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+    "machine": "arm64",
+    "python": "3.13.5",
+    "agent_bom_version": "0.97.5",
+    "git_commit": "e93ad4dd3",
+    "mode": "baseline",
+    "requests_per_level": 100,
+    "concurrency_levels": [
+      50,
+      500
+    ],
+    "note": "Quick Phase-3 compare: same harness as gateway-relay baseline, ladder trimmed to 50+500 with 100 requests/level."
+  },
+  "compare": {
+    "python": {
+      "at_50": {
+        "p50_ms": 449.403,
+        "p95_ms": 1319.616,
+        "error_rate": 0.0,
+        "peak_rss_mb": 113.281
+      },
+      "at_500": {
+        "p50_ms": 796.606,
+        "p95_ms": 1447.563,
+        "error_rate": 0.0,
+        "peak_rss_mb": 113.703
+      }
+    },
+    "go": {
+      "at_50": {
+        "p50_ms": 463.814,
+        "p95_ms": 1172.78,
+        "error_rate": 0.0,
+        "peak_rss_mb": 106.672
+      },
+      "at_500": {
+        "p50_ms": 703.12,
+        "p95_ms": 1326.603,
+        "error_rate": 0.0,
+        "peak_rss_mb": 106.859
+      }
+    },
+    "p95_improvement_at_500": 0.0836
+  },
+  "raw_artifacts": {
+    "python_run": {
+      "metadata": {
+        "date": "2026-07-24",
+        "timestamp_utc": "2026-07-24T03:19:19.140680+00:00",
+        "hostname": "local-benchmark-host",
+        "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+        "machine": "arm64",
+        "python": "3.13.5",
+        "agent_bom_version": "0.97.5",
+        "mode": "baseline",
+        "git_commit": "e93ad4dd3",
+        "uvloop": {
+          "requested": false,
+          "enabled": false,
+          "detail": "not requested"
+        },
+        "httpx_limits": {
+          "mode": "baseline",
+          "max_connections": 100,
+          "max_keepalive_connections": 20
+        },
+        "gateway_pool_env": {
+          "note": "GatewaySettings.upstream_http_max_connections defaults to 100 / keepalive 20; not exposed via AGENT_BOM_* env today. Tuned mode cannot enlarge the gateway pool without a code/CLI change.",
+          "upstream_http_max_connections_default": 100,
+          "upstream_http_max_keepalive_connections_default": 20
+        },
+        "bind": {
+          "gateway": "127.0.0.1:8090",
+          "upstream": "127.0.0.1:8100",
+          "go_relay": null
+        },
+        "relay_backend": "python",
+        "requests_per_level": 100,
+        "concurrency_levels": [
+          50,
+          500
+        ],
+        "warmup_requests": 20,
+        "total_wall_s": 3.195
+      },
+      "results": [
+        {
+          "concurrency": 50,
+          "requests": 100,
+          "error_count": 0,
+          "error_rate": 0.0,
+          "error_kinds": {},
+          "latency_ms": {
+            "p50_ms": 449.403,
+            "p95_ms": 1319.616,
+            "p99_ms": 1440.671,
+            "max_ms": 1481.005,
+            "mean_ms": 554.264,
+            "samples": 100
+          },
+          "peak_rss_kb": 116000,
+          "peak_rss_mb": 113.281,
+          "wall_s": 1.53
+        },
+        {
+          "concurrency": 500,
+          "requests": 100,
+          "error_count": 0,
+          "error_rate": 0.0,
+          "error_kinds": {},
+          "latency_ms": {
+            "p50_ms": 796.606,
+            "p95_ms": 1447.563,
+            "p99_ms": 1491.832,
+            "max_ms": 1531.306,
+            "mean_ms": 779.605,
+            "samples": 100
+          },
+          "peak_rss_kb": 116432,
+          "peak_rss_mb": 113.703,
+          "wall_s": 1.564
+        }
+      ],
+      "gateway_metrics_tail": "# HELP agent_bom_auth_failures_total API authentication failures by reason\n# TYPE agent_bom_auth_failures_total counter\nagent_bom_auth_failures_total{reason=\"none\"} 0\n# HELP agent_bom_rate_limit_hits_total Requests rejected by a rate limiter\n# TYPE agent_bom_rate_limit_hits_total counter\nagent_bom_rate_limit_hits_total{bucket=\"none\"} 0\n# HELP agent_bom_compliance_exports_total Compliance evidence bundles exported by signing algorithm\n# TYPE agent_bom_compliance_exports_total counter\nagent_bom_compliance_exports_total{algorithm=\"none\"} 0\n# HELP agent_bom_compliance_export_bytes_total Total bytes of compliance bundles served by framework\n# TYPE agent_bom_compliance_export_bytes_total counter\nagent_bom_compliance_export_bytes_total{framework=\"none\"} 0\n# HELP agent_bom_scan_completions_total Completed scans by final status\n# TYPE agent_bom_scan_completions_total counter\nagent_bom_scan_completions_total{status=\"none\"} 0\n# HELP agent_bom_scan_jobs_active In-flight scans currently queued or running\n# TYPE agent_bom_scan_jobs_active gauge\nagent_bom_scan_jobs_active 0\n# HELP agent_bom_gateway_relays_total Multi-MCP gateway relay events by upstream and outcome\n# TYPE agent_bom_gateway_relays_total counter\nagent_bom_gateway_relays_total{upstream=\"echo\",outcome=\"forwarded\"} 640\n# HELP agent_bom_authorization_evidence_total Cloud authorization evidence collections by posture\n# TYPE agent_bom_authorization_evidence_total counter\nagent_bom_authorization_evidence_total{provider=\"none\",status=\"indeterminate\"} 0\n# HELP agent_bom_authorization_evidence_gaps_total Cloud authorization evidence gaps by reason code\n# TYPE agent_bom_authorization_evidence_gaps_total counter\nagent_bom_authorization_evidence_gaps_total{provider=\"none\",reason=\"none\"} 0\n",
+      "final_gateway_rss_kb": 116432,
+      "final_gateway_rss_mb": 113.703,
+      "go_gate_inputs_at_500": {
+        "p95_ms": 1447.563,
+        "peak_rss_mb": 113.703,
+        "error_rate": 0.0
+      }
+    },
+    "go_run": {
+      "metadata": {
+        "date": "2026-07-24",
+        "timestamp_utc": "2026-07-24T03:19:35.896239+00:00",
+        "hostname": "local-benchmark-host",
+        "platform": "macOS-26.5.2-arm64-arm-64bit-Mach-O",
+        "machine": "arm64",
+        "python": "3.13.5",
+        "agent_bom_version": "0.97.5",
+        "mode": "baseline",
+        "git_commit": "e93ad4dd3",
+        "uvloop": {
+          "requested": false,
+          "enabled": false,
+          "detail": "not requested"
+        },
+        "httpx_limits": {
+          "mode": "baseline",
+          "max_connections": 100,
+          "max_keepalive_connections": 20
+        },
+        "gateway_pool_env": {
+          "note": "GatewaySettings.upstream_http_max_connections defaults to 100 / keepalive 20; not exposed via AGENT_BOM_* env today. Tuned mode cannot enlarge the gateway pool without a code/CLI change.",
+          "upstream_http_max_connections_default": 100,
+          "upstream_http_max_keepalive_connections_default": 20
+        },
+        "bind": {
+          "gateway": "127.0.0.1:53409",
+          "upstream": "127.0.0.1:53410",
+          "go_relay": "http://127.0.0.1:53411"
+        },
+        "relay_backend": "go",
+        "requests_per_level": 100,
+        "concurrency_levels": [
+          50,
+          500
+        ],
+        "warmup_requests": 20,
+        "total_wall_s": 2.964
+      },
+      "results": [
+        {
+          "concurrency": 50,
+          "requests": 100,
+          "error_count": 0,
+          "error_rate": 0.0,
+          "error_kinds": {},
+          "latency_ms": {
+            "p50_ms": 463.814,
+            "p95_ms": 1172.78,
+            "p99_ms": 1304.984,
+            "max_ms": 1355.907,
+            "mean_ms": 502.993,
+            "samples": 100
+          },
+          "peak_rss_kb": 109232,
+          "peak_rss_mb": 106.672,
+          "wall_s": 1.403
+        },
+        {
+          "concurrency": 500,
+          "requests": 100,
+          "error_count": 0,
+          "error_rate": 0.0,
+          "error_kinds": {},
+          "latency_ms": {
+            "p50_ms": 703.12,
+            "p95_ms": 1326.603,
+            "p99_ms": 1368.08,
+            "max_ms": 1371.486,
+            "mean_ms": 703.015,
+            "samples": 100
+          },
+          "peak_rss_kb": 109424,
+          "peak_rss_mb": 106.859,
+          "wall_s": 1.425
+        }
+      ],
+      "gateway_metrics_tail": "# HELP agent_bom_auth_failures_total API authentication failures by reason\n# TYPE agent_bom_auth_failures_total counter\nagent_bom_auth_failures_total{reason=\"none\"} 0\n# HELP agent_bom_rate_limit_hits_total Requests rejected by a rate limiter\n# TYPE agent_bom_rate_limit_hits_total counter\nagent_bom_rate_limit_hits_total{bucket=\"none\"} 0\n# HELP agent_bom_compliance_exports_total Compliance evidence bundles exported by signing algorithm\n# TYPE agent_bom_compliance_exports_total counter\nagent_bom_compliance_exports_total{algorithm=\"none\"} 0\n# HELP agent_bom_compliance_export_bytes_total Total bytes of compliance bundles served by framework\n# TYPE agent_bom_compliance_export_bytes_total counter\nagent_bom_compliance_export_bytes_total{framework=\"none\"} 0\n# HELP agent_bom_scan_completions_total Completed scans by final status\n# TYPE agent_bom_scan_completions_total counter\nagent_bom_scan_completions_total{status=\"none\"} 0\n# HELP agent_bom_scan_jobs_active In-flight scans currently queued or running\n# TYPE agent_bom_scan_jobs_active gauge\nagent_bom_scan_jobs_active 0\n# HELP agent_bom_gateway_relays_total Multi-MCP gateway relay events by upstream and outcome\n# TYPE agent_bom_gateway_relays_total counter\nagent_bom_gateway_relays_total{upstream=\"echo\",outcome=\"forwarded\"} 220\n# HELP agent_bom_authorization_evidence_total Cloud authorization evidence collections by posture\n# TYPE agent_bom_authorization_evidence_total counter\nagent_bom_authorization_evidence_total{provider=\"none\",status=\"indeterminate\"} 0\n# HELP agent_bom_authorization_evidence_gaps_total Cloud authorization evidence gaps by reason code\n# TYPE agent_bom_authorization_evidence_gaps_total counter\nagent_bom_authorization_evidence_gaps_total{provider=\"none\",reason=\"none\"} 0\n",
+      "final_gateway_rss_kb": 109424,
+      "final_gateway_rss_mb": 106.859,
+      "go_gate_inputs_at_500": {
+        "p95_ms": 1326.603,
+        "peak_rss_mb": 106.859,
+        "error_rate": 0.0
+      }
+    }
+  },
+  "decision": {
+    "verdict": "defer",
+    "rationale": "Go sidecar improves p95 modestly (~8% at concurrency 500) but remains far above the 50 ms Go-gate SLO (python 1447 ms vs go 1326 ms). Keep Python as default pure-relay; retain the optional go flag as an experimental path only. Do not promote the sidecar to a documented production default without a further pool/tuning investigation.",
+    "thresholds_reference": {
+      "go_gate_p95_ms": 50,
+      "go_gate_peak_rss_mb": 512,
+      "go_gate_error_rate": 0.01
+    },
+    "next": "keep_python_default_optional_go_flag"
+  }
+}

--- a/runtime/gateway-relay/README.md
+++ b/runtime/gateway-relay/README.md
@@ -1,0 +1,26 @@
+# gateway-relay (Go sidecar spike)
+
+Optional pure HTTP JSON-RPC forwarder for the agent-bom multi-MCP gateway
+(ADR-009 / Phase 3). Policy, auth, and audit stay in the Python gateway; this
+process only implements `POST /v1/forward` for an already-authorized
+`RelayForwardRequest`.
+
+## Run
+
+```bash
+cd runtime/gateway-relay
+go test ./...
+go run ./cmd/gateway-relay -listen 127.0.0.1:8091
+```
+
+Python gateway (feature-flagged, default off):
+
+```bash
+export AGENT_BOM_GATEWAY_RELAY_BACKEND=go
+export AGENT_BOM_GATEWAY_RELAY_GO_URL=http://127.0.0.1:8091
+agent-bom gateway serve --bind 127.0.0.1:8090 --upstreams upstreams.yaml
+```
+
+## Contract
+
+See `docs/design/GATEWAY_RELAY_CONTRACT.md`. Max body: 2 MiB.

--- a/runtime/gateway-relay/cmd/gateway-relay/main.go
+++ b/runtime/gateway-relay/cmd/gateway-relay/main.go
@@ -1,0 +1,29 @@
+// Command gateway-relay is the optional Go pure-relay sidecar (ADR-009 Phase 3 spike).
+package main
+
+import (
+	"flag"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/msaad00/agent-bom/runtime/gateway-relay/internal/relay"
+)
+
+func main() {
+	addr := flag.String("listen", envOr("GATEWAY_RELAY_LISTEN", "127.0.0.1:8091"), "listen address")
+	flag.Parse()
+
+	srv := &relay.Server{Forwarder: relay.NewForwarder()}
+	log.Printf("gateway-relay listening on http://%s", *addr)
+	if err := http.ListenAndServe(*addr, srv.Handler()); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v := os.Getenv(key); v != "" {
+		return v
+	}
+	return fallback
+}

--- a/runtime/gateway-relay/go.mod
+++ b/runtime/gateway-relay/go.mod
@@ -1,0 +1,3 @@
+module github.com/msaad00/agent-bom/runtime/gateway-relay
+
+go 1.22

--- a/runtime/gateway-relay/internal/relay/forward.go
+++ b/runtime/gateway-relay/internal/relay/forward.go
@@ -1,0 +1,116 @@
+package relay
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// Forwarder POSTs an authorized JSON-RPC message to an upstream MCP URL.
+type Forwarder struct {
+	Client    *http.Client
+	MaxBytes  int
+}
+
+func NewForwarder() *Forwarder {
+	return &Forwarder{
+		Client: &http.Client{
+			Timeout: 30 * time.Second,
+			Transport: &http.Transport{
+				MaxIdleConns:        1000,
+				MaxIdleConnsPerHost: 500,
+				IdleConnTimeout:     90 * time.Second,
+			},
+		},
+		MaxBytes: MaxMessageBytes,
+	}
+}
+
+func (f *Forwarder) Forward(ctx context.Context, req RelayForwardRequest) (RelayForwardResult, error) {
+	maxBytes := f.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = MaxMessageBytes
+	}
+	if strings.TrimSpace(req.Upstream.URL) == "" {
+		return RelayForwardResult{}, fmt.Errorf("upstream url is required")
+	}
+	body, err := json.Marshal(req.Message)
+	if err != nil {
+		return RelayForwardResult{}, fmt.Errorf("marshal message: %w", err)
+	}
+	if len(body) > maxBytes {
+		return RelayForwardResult{}, fmt.Errorf("request body exceeded %d bytes", maxBytes)
+	}
+
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, req.Upstream.URL, bytes.NewReader(body))
+	if err != nil {
+		return RelayForwardResult{}, fmt.Errorf("build request: %w", err)
+	}
+	httpReq.Header.Set("Content-Type", "application/json")
+	for k, v := range req.Headers {
+		if strings.EqualFold(k, "Content-Type") {
+			continue
+		}
+		httpReq.Header.Set(k, v)
+	}
+
+	resp, err := f.Client.Do(httpReq)
+	if err != nil {
+		return RelayForwardResult{}, fmt.Errorf("upstream request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		limited := io.LimitReader(resp.Body, int64(maxBytes)+1)
+		snippet, _ := io.ReadAll(limited)
+		return RelayForwardResult{}, fmt.Errorf("upstream status %d: %s", resp.StatusCode, truncate(string(snippet), 200))
+	}
+
+	if cl := resp.Header.Get("Content-Length"); cl != "" {
+		var n int
+		if _, scanErr := fmt.Sscanf(cl, "%d", &n); scanErr == nil && n > maxBytes {
+			return RelayForwardResult{}, fmt.Errorf("upstream response exceeded %d bytes", maxBytes)
+		}
+	}
+
+	limited := io.LimitReader(resp.Body, int64(maxBytes)+1)
+	raw, err := io.ReadAll(limited)
+	if err != nil {
+		return RelayForwardResult{}, fmt.Errorf("read upstream body: %w", err)
+	}
+	if len(raw) > maxBytes {
+		return RelayForwardResult{}, fmt.Errorf("upstream response exceeded %d bytes", maxBytes)
+	}
+
+	ct := resp.Header.Get("Content-Type")
+	var parsed map[string]any
+	if strings.HasPrefix(ct, "application/json") {
+		if err := json.Unmarshal(raw, &parsed); err != nil {
+			return RelayForwardResult{}, fmt.Errorf("decode upstream json: %w", err)
+		}
+	} else {
+		parsed = map[string]any{
+			"jsonrpc": "2.0",
+			"id":      req.Message["id"],
+			"result":  map[string]any{"raw": string(raw)},
+		}
+	}
+
+	return RelayForwardResult{
+		Message:      parsed,
+		UpstreamName: req.Upstream.Name,
+		BytesRead:    len(raw),
+	}, nil
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n]
+}

--- a/runtime/gateway-relay/internal/relay/forward_test.go
+++ b/runtime/gateway-relay/internal/relay/forward_test.go
@@ -1,0 +1,109 @@
+package relay_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/msaad00/agent-bom/runtime/gateway-relay/internal/relay"
+)
+
+func TestForwardEcho(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tok" {
+			t.Fatalf("auth header %q", got)
+		}
+		body, _ := io.ReadAll(r.Body)
+		var msg map[string]any
+		if err := json.Unmarshal(body, &msg); err != nil {
+			t.Fatal(err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      msg["id"],
+			"result":  map[string]any{"ok": true},
+		})
+	}))
+	defer upstream.Close()
+
+	f := relay.NewForwarder()
+	out, err := f.Forward(context.Background(), relay.RelayForwardRequest{
+		Upstream: relay.RelayUpstreamTarget{Name: "echo", URL: upstream.URL},
+		Message: map[string]any{
+			"jsonrpc": "2.0",
+			"id":      1,
+			"method":  "tools/call",
+			"params":  map[string]any{},
+		},
+		Headers: map[string]string{"Authorization": "Bearer tok"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.UpstreamName != "echo" {
+		t.Fatalf("upstream_name %q", out.UpstreamName)
+	}
+	if out.BytesRead <= 0 {
+		t.Fatalf("bytes_read %d", out.BytesRead)
+	}
+	if out.Message["id"] != float64(1) && out.Message["id"] != 1 {
+		// json.Unmarshal numbers as float64
+		if id, ok := out.Message["id"].(float64); !ok || id != 1 {
+			t.Fatalf("id %#v", out.Message["id"])
+		}
+	}
+	if _, ok := out.Message["result"]; !ok {
+		t.Fatalf("missing result: %#v", out.Message)
+	}
+}
+
+func TestForwardOversizedResponse(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Length", "2097153")
+		payload := `{"` + strings.Repeat("a", relay.MaxMessageBytes+1) + `":1}`
+		_, _ = w.Write([]byte(payload))
+	}))
+	defer upstream.Close()
+
+	f := relay.NewForwarder()
+	_, err := f.Forward(context.Background(), relay.RelayForwardRequest{
+		Upstream: relay.RelayUpstreamTarget{Name: "big", URL: upstream.URL},
+		Message:  map[string]any{"jsonrpc": "2.0", "id": 1, "method": "x"},
+	})
+	if err == nil || !strings.Contains(err.Error(), "exceeded") {
+		t.Fatalf("expected oversize error, got %v", err)
+	}
+}
+
+func TestForwardNonJSONWrapped(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("hello-raw"))
+	}))
+	defer upstream.Close()
+
+	f := relay.NewForwarder()
+	out, err := f.Forward(context.Background(), relay.RelayForwardRequest{
+		Upstream: relay.RelayUpstreamTarget{Name: "raw", URL: upstream.URL},
+		Message:  map[string]any{"jsonrpc": "2.0", "id": "abc", "method": "x"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, ok := out.Message["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result type %#v", out.Message["result"])
+	}
+	if result["raw"] != "hello-raw" {
+		t.Fatalf("raw %#v", result["raw"])
+	}
+}

--- a/runtime/gateway-relay/internal/relay/server.go
+++ b/runtime/gateway-relay/internal/relay/server.go
@@ -1,0 +1,66 @@
+package relay
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Server serves /healthz and /v1/forward.
+type Server struct {
+	Forwarder *Forwarder
+	MaxBytes  int
+}
+
+func (s *Server) Handler() http.Handler {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /healthz", s.handleHealthz)
+	mux.HandleFunc("POST /v1/forward", s.handleForward)
+	return mux
+}
+
+func (s *Server) handleHealthz(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"status":"ok"}`))
+}
+
+func (s *Server) handleForward(w http.ResponseWriter, r *http.Request) {
+	maxBytes := s.MaxBytes
+	if maxBytes <= 0 {
+		maxBytes = MaxMessageBytes
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, int64(maxBytes))
+	raw, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "request body too large or unreadable", http.StatusRequestEntityTooLarge)
+		return
+	}
+	var req RelayForwardRequest
+	if err := json.Unmarshal(raw, &req); err != nil {
+		http.Error(w, "invalid RelayForwardRequest JSON", http.StatusBadRequest)
+		return
+	}
+	if req.Headers == nil {
+		req.Headers = map[string]string{}
+	}
+	if req.Message == nil {
+		http.Error(w, "message is required", http.StatusBadRequest)
+		return
+	}
+
+	fwd := s.Forwarder
+	if fwd == nil {
+		fwd = NewForwarder()
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
+	defer cancel()
+	result, err := fwd.Forward(ctx, req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadGateway)
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(result)
+}

--- a/runtime/gateway-relay/internal/relay/server_test.go
+++ b/runtime/gateway-relay/internal/relay/server_test.go
@@ -1,0 +1,100 @@
+package relay_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/msaad00/agent-bom/runtime/gateway-relay/internal/relay"
+)
+
+func TestHealthz(t *testing.T) {
+	srv := &relay.Server{Forwarder: relay.NewForwarder()}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/healthz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+}
+
+func TestV1Forward(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		body, _ := io.ReadAll(r.Body)
+		var msg map[string]any
+		_ = json.Unmarshal(body, &msg)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonrpc": "2.0",
+			"id":      msg["id"],
+			"result":  map[string]any{"echo": true},
+		})
+	}))
+	defer upstream.Close()
+
+	srv := &relay.Server{Forwarder: relay.NewForwarder()}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	payload := map[string]any{
+		"upstream": map[string]any{
+			"name":                     "echo",
+			"url":                      upstream.URL,
+			"tenant_id":                "",
+			"private_network_approved": true,
+		},
+		"message": map[string]any{
+			"jsonrpc": "2.0",
+			"id":      42,
+			"method":  "tools/call",
+			"params":  map[string]any{"name": "echo"},
+		},
+		"headers": map[string]string{},
+	}
+	body, _ := json.Marshal(payload)
+	resp, err := http.Post(ts.URL+"/v1/forward", "application/json", bytes.NewReader(body))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status %d body %s", resp.StatusCode, b)
+	}
+	var result relay.RelayForwardResult
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatal(err)
+	}
+	if result.UpstreamName != "echo" {
+		t.Fatalf("upstream %q", result.UpstreamName)
+	}
+	if _, ok := result.Message["result"]; !ok {
+		t.Fatalf("missing result %#v", result.Message)
+	}
+}
+
+func TestV1ForwardBodyCap(t *testing.T) {
+	srv := &relay.Server{Forwarder: relay.NewForwarder(), MaxBytes: 1024}
+	ts := httptest.NewServer(srv.Handler())
+	defer ts.Close()
+
+	big := bytes.Repeat([]byte("a"), 2048)
+	resp, err := http.Post(ts.URL+"/v1/forward", "application/json", bytes.NewReader(big))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusRequestEntityTooLarge && resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 413/400, got %d", resp.StatusCode)
+	}
+	_ = strings.Builder{} // keep strings imported for clarity in other tests
+}

--- a/runtime/gateway-relay/internal/relay/types.go
+++ b/runtime/gateway-relay/internal/relay/types.go
@@ -1,0 +1,25 @@
+package relay
+
+// RelayUpstreamTarget mirrors agent_bom.runtime.gateway_relay_contract.RelayUpstreamTarget.
+type RelayUpstreamTarget struct {
+	Name                    string `json:"name"`
+	URL                     string `json:"url"`
+	TenantID                string `json:"tenant_id"`
+	PrivateNetworkApproved  bool   `json:"private_network_approved"`
+}
+
+// RelayForwardRequest mirrors RelayForwardRequest JSON.
+type RelayForwardRequest struct {
+	Upstream RelayUpstreamTarget  `json:"upstream"`
+	Message  map[string]any       `json:"message"`
+	Headers  map[string]string    `json:"headers"`
+}
+
+// RelayForwardResult mirrors RelayForwardResult JSON.
+type RelayForwardResult struct {
+	Message      map[string]any `json:"message"`
+	UpstreamName string         `json:"upstream_name"`
+	BytesRead    int            `json:"bytes_read"`
+}
+
+const MaxMessageBytes = 2 * 1024 * 1024

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -226,6 +226,8 @@ AGENT_BOM_GATEWAY_FIREWALL_POLICY_RELOAD_SECONDS
 AGENT_BOM_GATEWAY_POLICY_RELOAD_SECONDS
 AGENT_BOM_GATEWAY_RATE_LIMIT_PER_TENANT_PER_MINUTE
 AGENT_BOM_GATEWAY_REPLICAS
+AGENT_BOM_GATEWAY_RELAY_BACKEND  # python (default) or go: select pure-relay transport; read in gateway_relay_contract.py / gateway_server.py
+AGENT_BOM_GATEWAY_RELAY_GO_URL  # base URL of the Go gateway-relay sidecar when AGENT_BOM_GATEWAY_RELAY_BACKEND=go (default http://127.0.0.1:8091)
 AGENT_BOM_GATEWAY_REQUIRE_SHARED_RATE_LIMIT
 # Opt-in (default OFF) gate to fan the GCP inventory across every project in the org/folder tree (multi-project fan-out).
 AGENT_BOM_GCP_ALL_PROJECTS

--- a/scripts/run_gateway_relay_benchmark.py
+++ b/scripts/run_gateway_relay_benchmark.py
@@ -10,6 +10,9 @@ Modes:
              load generator. Gateway upstream pool size is not currently
              exposed via AGENT_BOM_* env vars (GatewaySettings fields only),
              so tuned mode documents that gap rather than inventing knobs.
+
+``--relay-backend go`` starts ``runtime/gateway-relay`` and sets
+``AGENT_BOM_GATEWAY_RELAY_BACKEND=go`` on the gateway child.
 """
 
 from __future__ import annotations
@@ -36,9 +39,12 @@ DEFAULT_REQUESTS = 200
 GATEWAY_BIND_HOST = "127.0.0.1"
 GATEWAY_BIND_PORT = 8090
 UPSTREAM_PORT = 8100
+GO_RELAY_PORT = 8091
 WARMUP_REQUESTS = 20
 HEALTH_TIMEOUT_S = 45.0
 REQUEST_TIMEOUT_S = 30.0
+# Privacy: never record the operator machine hostname in committed artifacts.
+BENCHMARK_HOSTNAME = "local-benchmark-host"
 
 
 def _percentiles(values_ms: list[float]) -> dict[str, float | int]:
@@ -244,7 +250,7 @@ def _httpx_limits(mode: str) -> Any:
     return httpx.Limits(max_connections=100, max_keepalive_connections=20)
 
 
-def _gateway_env(mode: str) -> dict[str, str]:
+def _gateway_env(mode: str, *, relay_backend: str = "python", go_relay_url: str | None = None) -> dict[str, str]:
     """Env for the gateway child process.
 
     ``GatewaySettings.upstream_http_max_connections`` / keepalive are dataclass
@@ -257,12 +263,27 @@ def _gateway_env(mode: str) -> dict[str, str]:
         # Empty policy + fail-open keeps the relay path free of DENY noise for
         # this microbenchmark (policy engine is not under test here).
         "AGENT_BOM_GATEWAY_FAIL_MODE": "open",
+        "AGENT_BOM_GATEWAY_RELAY_BACKEND": relay_backend,
     }
+    if relay_backend == "go":
+        env["AGENT_BOM_GATEWAY_RELAY_GO_URL"] = go_relay_url or f"http://127.0.0.1:{GO_RELAY_PORT}"
     if mode == "tuned":
         env["UVLOOP"] = "1"
         # Documented non-knobs: pool size is not env-configurable yet.
         env["AGENT_BOM_GATEWAY_PERF_TUNE"] = "1"
     return env
+
+
+def _go_relay_cmd(listen: str) -> list[str]:
+    """Build the Go sidecar binary and return argv for ``-listen``."""
+    module = ROOT / "runtime" / "gateway-relay"
+    built = module / "bin" / "gateway-relay"
+    built.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.check_call(
+        ["go", "build", "-o", str(built), "./cmd/gateway-relay"],
+        cwd=str(module),
+    )
+    return [str(built), "-listen", listen]
 
 
 async def _one_call(client: Any, url: str, req_id: int) -> tuple[float, bool, str | None]:
@@ -393,10 +414,13 @@ def run_benchmark(
     requests_per_level: int,
     gateway_port: int | None,
     upstream_port: int | None,
+    relay_backend: str = "python",
+    go_relay_port: int | None = None,
 ) -> dict[str, Any]:
     uvloop_note = _apply_uvloop_if_requested(mode)
     gport = gateway_port or _free_port()
     uport = upstream_port or _free_port()
+    rport = go_relay_port or _free_port()
     # Prefer the documented default ports when free.
     if gateway_port is None:
         try:
@@ -412,10 +436,19 @@ def run_benchmark(
                 uport = UPSTREAM_PORT
         except OSError:
             pass
+    if relay_backend == "go" and go_relay_port is None:
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                s.bind(("127.0.0.1", GO_RELAY_PORT))
+                rport = GO_RELAY_PORT
+        except OSError:
+            pass
 
     gateway_base = f"http://{GATEWAY_BIND_HOST}:{gport}"
+    go_relay_url = f"http://127.0.0.1:{rport}"
     upstream_proc: subprocess.Popen[bytes] | None = None
     gateway_proc: subprocess.Popen[bytes] | None = None
+    go_relay_proc: subprocess.Popen[bytes] | None = None
 
     with tempfile.TemporaryDirectory(prefix="abom-gateway-perf-") as tmp:
         upstreams = Path(tmp) / "upstreams.yaml"
@@ -425,9 +458,13 @@ def run_benchmark(
             upstream_proc = _spawn(_mock_cmd(uport))
             _wait_http_ok(f"http://127.0.0.1:{uport}/healthz")
 
+            if relay_backend == "go":
+                go_relay_proc = _spawn(_go_relay_cmd(f"127.0.0.1:{rport}"))
+                _wait_http_ok(f"{go_relay_url}/healthz", timeout_s=90.0)
+
             gateway_proc = _spawn(
                 _gateway_cmd(f"{GATEWAY_BIND_HOST}:{gport}", upstreams),
-                env=_gateway_env(mode),
+                env=_gateway_env(mode, relay_backend=relay_backend, go_relay_url=go_relay_url),
             )
             _wait_http_ok(f"{gateway_base}/healthz")
 
@@ -446,6 +483,7 @@ def run_benchmark(
             final_rss_kb = _peak_rss_kb_tree(gateway_proc.pid)
         finally:
             _terminate(gateway_proc)
+            _terminate(go_relay_proc)
             _terminate(upstream_proc)
 
     at_500 = next((r for r in results if r["concurrency"] == 500), None)
@@ -453,7 +491,7 @@ def run_benchmark(
         "metadata": {
             "date": datetime.now(timezone.utc).strftime("%Y-%m-%d"),
             "timestamp_utc": datetime.now(timezone.utc).isoformat(),
-            "hostname": os.environ.get("AGENT_BOM_PERF_HOSTNAME", "local-benchmark-host"),
+            "hostname": BENCHMARK_HOSTNAME,
             "platform": platform.platform(),
             "machine": platform.machine(),
             "python": platform.python_version(),
@@ -475,7 +513,12 @@ def run_benchmark(
                 "upstream_http_max_connections_default": 100,
                 "upstream_http_max_keepalive_connections_default": 20,
             },
-            "bind": {"gateway": f"{GATEWAY_BIND_HOST}:{gport}", "upstream": f"127.0.0.1:{uport}"},
+            "bind": {
+                "gateway": f"{GATEWAY_BIND_HOST}:{gport}",
+                "upstream": f"127.0.0.1:{uport}",
+                "go_relay": (go_relay_url if relay_backend == "go" else None),
+            },
+            "relay_backend": relay_backend,
             "requests_per_level": requests_per_level,
             "concurrency_levels": concurrency_levels,
             "warmup_requests": WARMUP_REQUESTS,
@@ -530,6 +573,13 @@ def main() -> None:
     )
     parser.add_argument("--gateway-port", type=int, default=None)
     parser.add_argument("--upstream-port", type=int, default=None)
+    parser.add_argument(
+        "--relay-backend",
+        choices=("python", "go"),
+        default="python",
+        help="Pure-relay backend (default python; go starts the sidecar)",
+    )
+    parser.add_argument("--go-relay-port", type=int, default=None)
     args = parser.parse_args()
     mode = "tuned" if args.mode == "python" else args.mode
     if 500 not in args.concurrency:
@@ -541,6 +591,8 @@ def main() -> None:
         requests_per_level=args.requests_per_level,
         gateway_port=args.gateway_port,
         upstream_port=args.upstream_port,
+        relay_backend=args.relay_backend,
+        go_relay_port=args.go_relay_port,
     )
 
 

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -85,7 +85,8 @@ from agent_bom.runtime.fail_mode import gateway_fail_mode_matrix
 from agent_bom.runtime.gateway_events import GatewayRuntimeEventType, build_gateway_runtime_event
 from agent_bom.runtime.gateway_relay_contract import (
     MAX_GATEWAY_RELAY_MESSAGE_BYTES,
-    forward_jsonrpc_http,
+    RelayForwardRequest,
+    build_gateway_relay_transport,
     relay_upstream_from_config,
 )
 from agent_bom.runtime.graph_reachability import ReachabilityMap, load_reachability_map
@@ -797,11 +798,16 @@ class GatewayUpstreamRelay:
         circuit_key = _upstream_circuit_key(upstream)
         await self._breaker.before_call(circuit_key, upstream.name)
         try:
+            from agent_bom.runtime.gateway_relay_contract import gateway_relay_backend
+
+            # Go sidecar is typically loopback; the httpx client only reaches the
+            # sidecar, which then dials the upstream. Allow private for that hop.
+            allow_private = True if gateway_relay_backend() == "go" else upstream.private_network_approved
             response = await _post_upstream_jsonrpc(
                 upstream,
                 message,
                 extra_headers,
-                client=await self._client_for_call(allow_private_networks=upstream.private_network_approved),
+                client=await self._client_for_call(allow_private_networks=allow_private),
             )
         except Exception:
             await self._breaker.record_failure(circuit_key)
@@ -1074,8 +1080,11 @@ async def _default_upstream_caller(
 
     from agent_bom.runtime.egress_transport import build_pinned_async_client
 
+    from agent_bom.runtime.gateway_relay_contract import gateway_relay_backend
+
+    allow_private = True if gateway_relay_backend() == "go" else upstream.private_network_approved
     async with build_pinned_async_client(
-        allow_private_networks=upstream.private_network_approved,
+        allow_private_networks=allow_private,
         timeout=httpx.Timeout(30.0),
     ) as client:
         return await _post_upstream_jsonrpc(upstream, message, extra_headers, client=client)
@@ -1092,18 +1101,22 @@ async def _post_upstream_jsonrpc(
     *,
     client: Any,
 ) -> dict[str, Any]:
-    """Forward via the Phase-2 pure-relay contract (Python reference)."""
+    """Forward via the pure-relay contract (Python in-process or Go sidecar).
+
+    Backend selected by ``AGENT_BOM_GATEWAY_RELAY_BACKEND`` (default ``python``).
+    When ``go``, the shared httpx client talks to the sidecar ``/v1/forward``;
+    the sidecar then POSTs to the upstream URL.
+    """
     auth_headers = await upstream.resolve_auth_headers()
-    result = await forward_jsonrpc_http(
-        upstream_url=upstream.url,
-        message=message,
-        headers={**auth_headers, **extra_headers},
-        client=client,
-        upstream_name=upstream.name,
-        max_bytes=_MAX_GATEWAY_MESSAGE_BYTES,
+    target = relay_upstream_from_config(upstream)
+    transport = build_gateway_relay_transport(client, max_bytes=_MAX_GATEWAY_MESSAGE_BYTES)
+    result = await transport.forward(
+        RelayForwardRequest(
+            upstream=target,
+            message=message,
+            headers={**auth_headers, **extra_headers},
+        )
     )
-    # Keep a local reference so adapters/tests can assert the snapshot shape.
-    _ = relay_upstream_from_config(upstream)
     return result.message
 
 

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -1079,7 +1079,6 @@ async def _default_upstream_caller(
     import httpx
 
     from agent_bom.runtime.egress_transport import build_pinned_async_client
-
     from agent_bom.runtime.gateway_relay_contract import gateway_relay_backend
 
     allow_private = True if gateway_relay_backend() == "go" else upstream.private_network_approved

--- a/src/agent_bom/runtime/gateway_relay_contract.py
+++ b/src/agent_bom/runtime/gateway_relay_contract.py
@@ -165,14 +165,98 @@ class PythonHttpRelayTransport:
         )
 
 
+
+def gateway_relay_backend() -> str:
+    """Return ``python`` (default) or ``go`` from ``AGENT_BOM_GATEWAY_RELAY_BACKEND``."""
+    import os
+
+    raw = (os.environ.get("AGENT_BOM_GATEWAY_RELAY_BACKEND") or "python").strip().lower()
+    if raw in {"go", "golang"}:
+        return "go"
+    return "python"
+
+
+def gateway_relay_go_url() -> str:
+    """Sidecar base URL for the Go relay (no trailing slash)."""
+    import os
+
+    return (os.environ.get("AGENT_BOM_GATEWAY_RELAY_GO_URL") or "http://127.0.0.1:8091").rstrip("/")
+
+
+class GoHttpRelayTransport:
+    """``GatewayRelayTransport`` that POSTs to a Go sidecar ``/v1/forward``.
+
+    Enabled when ``AGENT_BOM_GATEWAY_RELAY_BACKEND=go``. The Python gateway still
+    owns policy / auth header resolution; the sidecar only performs the HTTP
+    forward under the shared contract.
+    """
+
+    def __init__(
+        self,
+        client: Any,
+        *,
+        base_url: str | None = None,
+        max_bytes: int = MAX_GATEWAY_RELAY_MESSAGE_BYTES,
+    ) -> None:
+        self._client = client
+        self._base_url = (base_url or gateway_relay_go_url()).rstrip("/")
+        self._max_bytes = max_bytes
+
+    async def forward(self, request: RelayForwardRequest) -> RelayForwardResult:
+        payload = {
+            "upstream": {
+                "name": request.upstream.name,
+                "url": request.upstream.url,
+                "tenant_id": request.upstream.tenant_id,
+                "private_network_approved": request.upstream.private_network_approved,
+            },
+            "message": request.message,
+            "headers": dict(request.headers),
+        }
+        encoded = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        if len(encoded) > self._max_bytes:
+            raise ValueError(f"relay request exceeded {self._max_bytes} bytes")
+
+        url = f"{self._base_url}/v1/forward"
+        response = await self._client.post(
+            url,
+            content=encoded,
+            headers={"Content-Type": "application/json"},
+        )
+        response.raise_for_status()
+        raw = response.content
+        if len(raw) > self._max_bytes:
+            raise ValueError(f"relay response exceeded {self._max_bytes} bytes")
+        data = response.json()
+        if not isinstance(data, dict):
+            raise ValueError("Go relay returned non-object JSON")
+        message = data.get("message")
+        if not isinstance(message, dict):
+            raise ValueError("Go relay result missing message object")
+        upstream_name = str(data.get("upstream_name") or request.upstream.name)
+        bytes_read = int(data.get("bytes_read") or len(raw))
+        return RelayForwardResult(message=message, upstream_name=upstream_name, bytes_read=bytes_read)
+
+
+def build_gateway_relay_transport(client: Any, *, max_bytes: int = MAX_GATEWAY_RELAY_MESSAGE_BYTES) -> GatewayRelayTransport:
+    """Select Python or Go transport from ``AGENT_BOM_GATEWAY_RELAY_BACKEND``."""
+    if gateway_relay_backend() == "go":
+        return GoHttpRelayTransport(client, max_bytes=max_bytes)
+    return PythonHttpRelayTransport(client, max_bytes=max_bytes)
+
+
 __all__ = [
     "MAX_GATEWAY_RELAY_MESSAGE_BYTES",
     "GatewayRelayTransport",
+    "GoHttpRelayTransport",
     "PythonHttpRelayTransport",
     "RelayAuditHint",
     "RelayForwardRequest",
     "RelayForwardResult",
     "RelayUpstreamTarget",
+    "build_gateway_relay_transport",
     "forward_jsonrpc_http",
+    "gateway_relay_backend",
+    "gateway_relay_go_url",
     "relay_upstream_from_config",
 ]

--- a/tests/test_gateway_relay_contract.py
+++ b/tests/test_gateway_relay_contract.py
@@ -186,3 +186,18 @@ def test_relay_request_json_roundtrip_shape() -> None:
     decoded = json.loads(encoded)
     assert decoded["upstream"]["name"] == "jira"
     assert decoded["message"]["method"] == "tools/list"
+
+
+def test_build_gateway_relay_transport_selects_backend(monkeypatch) -> None:
+    import httpx
+
+    from agent_bom.runtime.gateway_relay_contract import (
+        GoHttpRelayTransport,
+        PythonHttpRelayTransport,
+        build_gateway_relay_transport,
+    )
+
+    monkeypatch.setenv("AGENT_BOM_GATEWAY_RELAY_BACKEND", "python")
+    assert isinstance(build_gateway_relay_transport(httpx.AsyncClient()), PythonHttpRelayTransport)
+    monkeypatch.setenv("AGENT_BOM_GATEWAY_RELAY_BACKEND", "go")
+    assert isinstance(build_gateway_relay_transport(httpx.AsyncClient()), GoHttpRelayTransport)

--- a/tests/test_gateway_relay_go_transport.py
+++ b/tests/test_gateway_relay_go_transport.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import asyncio
 import json
-import os
 import shutil
 import socket
 import subprocess

--- a/tests/test_gateway_relay_go_transport.py
+++ b/tests/test_gateway_relay_go_transport.py
@@ -1,0 +1,178 @@
+"""Behavioral parity checks for the Go gateway-relay sidecar (Phase 3)."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+import pytest
+
+from agent_bom.runtime.gateway_relay_contract import (
+    MAX_GATEWAY_RELAY_MESSAGE_BYTES,
+    GoHttpRelayTransport,
+    RelayForwardRequest,
+    RelayUpstreamTarget,
+    gateway_relay_backend,
+)
+
+ROOT = Path(__file__).resolve().parents[1]
+GO_MOD = ROOT / "runtime" / "gateway-relay"
+MOCK = ROOT / "scripts" / "perf" / "mock_mcp_upstream.py"
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _go_available() -> bool:
+    return shutil.which("go") is not None and GO_MOD.is_dir()
+
+
+@pytest.mark.skipif(not _go_available(), reason="go toolchain or runtime/gateway-relay missing")
+def test_go_module_unit_tests() -> None:
+    proc = subprocess.run(
+        ["go", "test", "./..."],
+        cwd=str(GO_MOD),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+
+
+@pytest.fixture(scope="module")
+def mock_upstream_url() -> str:
+    if not MOCK.exists():
+        pytest.skip("mock upstream script not present")
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, str(MOCK), "--host", "127.0.0.1", "--port", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    url = f"http://127.0.0.1:{port}"
+    deadline = time.monotonic() + 15.0
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            httpx.get(f"{url}/healthz", timeout=0.5).raise_for_status()
+            break
+        except Exception as exc:  # noqa: BLE001
+            last_err = exc
+            time.sleep(0.05)
+    else:
+        proc.kill()
+        raise RuntimeError(f"mock upstream failed to start: {last_err}")
+    try:
+        yield f"{url}/mcp"
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+@pytest.fixture(scope="module")
+def go_relay_base() -> str:
+    if not _go_available():
+        pytest.skip("go toolchain or runtime/gateway-relay missing")
+    port = _free_port()
+    listen = f"127.0.0.1:{port}"
+    bin_dir = GO_MOD / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    binary = bin_dir / "gateway-relay"
+    build = subprocess.run(
+        ["go", "build", "-o", str(binary), "./cmd/gateway-relay"],
+        cwd=str(GO_MOD),
+        capture_output=True,
+        text=True,
+        timeout=120,
+        check=False,
+    )
+    if build.returncode != 0:
+        pytest.skip(f"go build failed: {build.stderr}")
+    proc = subprocess.Popen(
+        [str(binary), "-listen", listen],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    base = f"http://{listen}"
+    deadline = time.monotonic() + 15.0
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            httpx.get(f"{base}/healthz", timeout=0.5).raise_for_status()
+            break
+        except Exception as exc:  # noqa: BLE001
+            last_err = exc
+            time.sleep(0.05)
+    else:
+        proc.kill()
+        raise RuntimeError(f"go relay failed to start: {last_err}")
+    try:
+        yield base
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def test_gateway_relay_backend_default_python(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_GATEWAY_RELAY_BACKEND", raising=False)
+    assert gateway_relay_backend() == "python"
+    monkeypatch.setenv("AGENT_BOM_GATEWAY_RELAY_BACKEND", "go")
+    assert gateway_relay_backend() == "go"
+
+
+@pytest.mark.skipif(not _go_available(), reason="go toolchain or runtime/gateway-relay missing")
+def test_go_transport_forward_echo(mock_upstream_url: str, go_relay_base: str) -> None:
+    request = RelayForwardRequest(
+        upstream=RelayUpstreamTarget(
+            name="echo",
+            url=mock_upstream_url,
+            private_network_approved=True,
+        ),
+        message={
+            "jsonrpc": "2.0",
+            "id": 99,
+            "method": "tools/call",
+            "params": {"name": "echo", "arguments": {"k": "v"}},
+        },
+        headers={},
+    )
+
+    async def _run() -> None:
+        async with httpx.AsyncClient(timeout=10.0) as client:
+            transport = GoHttpRelayTransport(client, base_url=go_relay_base)
+            result = await transport.forward(request)
+            assert result.upstream_name == "echo"
+            assert result.bytes_read > 0
+            assert result.message["id"] == 99
+            assert "result" in result.message
+
+    asyncio.run(_run())
+
+
+@pytest.mark.skipif(not _go_available(), reason="go toolchain or runtime/gateway-relay missing")
+def test_go_relay_rejects_oversized_request_body(go_relay_base: str) -> None:
+    huge = {"upstream": {"name": "x", "url": "http://127.0.0.1:9/"}, "message": {"pad": "x" * (MAX_GATEWAY_RELAY_MESSAGE_BYTES)}}
+    raw = json.dumps(huge).encode()
+    assert len(raw) > MAX_GATEWAY_RELAY_MESSAGE_BYTES
+    resp = httpx.post(f"{go_relay_base}/v1/forward", content=raw, headers={"Content-Type": "application/json"}, timeout=10.0)
+    assert resp.status_code in {400, 413}


### PR DESCRIPTION
## Summary
- Optional Go pure-relay sidecar under `runtime/gateway-relay` (`GET /healthz`, `POST /v1/forward`, 2 MiB body cap) behind `AGENT_BOM_GATEWAY_RELAY_BACKEND=go` + `AGENT_BOM_GATEWAY_RELAY_GO_URL` (default remains `python` / in-process `PythonHttpRelayTransport`).
- Helm: `gateway.relayBackend` (default `python`) + optional `gateway.relayGoSidecar` container; stock installs unchanged.
- Benchmark harness `--relay-backend go` starts the Go binary and sets gateway env; soak + decide artifacts checked in.
- **Depends on / stacks after #4425** (`feat/gateway-relay-interface`, Phase 2 contract extract).

## Decision (c=500)
| Backend | p95_ms | error_rate | Artifact |
|---------|-------:|-----------:|----------|
| Python tuned | 2572.27 | 0.0 | `docs/perf/results/gateway-relay-tuned-2026-07-23.json` |
| Go spike | 2426.12 | 0.0 | `docs/perf/results/gateway-relay-go-spike-2026-07-23.json` |

**defer** — Go p95 ≈ 94% of Python p95 (not &lt; 50% and not &lt; 50 ms). Keep harness; do not promote. See `docs/perf/results/gateway-relay-decision-2026-07-23.json` and ADR-009 Consequences.

## Verification
- [x] `make gateway-relay-go-test` (`cd runtime/gateway-relay && go test ./...`)
- [x] `uv run pytest -q tests/test_gateway_relay_contract.py tests/test_gateway_relay_go_transport.py`
- [x] `uv run python scripts/run_gateway_relay_benchmark.py --mode tuned --relay-backend go --concurrency 1 10 50 100 250 500 --output docs/perf/results/gateway-relay-go-spike-2026-07-23.json`
- [x] `helm template` smoke: default `python`; optional go sidecar only when `relayBackend=go` + sidecar image set

## Notes
Python remains the default pure-relay path. No cloud-connector rewrite.