### PR TITLE
fix(cloud): align Connections org copy and Helm fan-out flags

### DIFF
--- a/deploy/helm/agent-bom/README.md
+++ b/deploy/helm/agent-bom/README.md
@@ -105,6 +105,9 @@ blank `collectorImage.tag` falls back to `image.tag`.
 | `scanner.enabled` | `true` | Deploy CronJob scanner |
 | `scanner.schedule` | `0 */6 * * *` | Cron schedule |
 | `scanner.allNamespaces` | `true` | Scan all namespaces |
+| `scanner.cloud.aws.orgInventory` | `false` | `AGENT_BOM_AWS_ORG_INVENTORY` — org member-account scan fan-out |
+| `scanner.cloud.azure.allSubscriptions` | `false` | `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS` |
+| `scanner.cloud.gcp.allProjects` | `false` | `AGENT_BOM_GCP_ALL_PROJECTS` |
 | `collectorImage.repository` | `agentbom/agent-bom-collector` | Cloud-SDK collector image the scan CronJob runs |
 | `collectorImage.tag` | release version | Collector tag — override to bump the SDK layer independently of the control plane; blank falls back to `image.tag` |
 | `controlPlane.enabled` | `false` | Package API + dashboard Deployments |

--- a/deploy/helm/agent-bom/templates/cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/cronjob.yaml
@@ -89,6 +89,14 @@ spec:
                 - name: AGENT_BOM_AWS_MAX_REGIONS
                   value: {{ .maxRegions | quote }}
                 {{- end }}
+                {{- if eq (toString .orgInventory) "true" }}
+                - name: AGENT_BOM_AWS_ORG_INVENTORY
+                  value: "1"
+                {{- end }}
+                {{- if .maxAccounts }}
+                - name: AGENT_BOM_AWS_MAX_ACCOUNTS
+                  value: {{ .maxAccounts | quote }}
+                {{- end }}
                 {{- end }}
                 {{- end }}
                 {{- with $cloud.azure }}
@@ -120,6 +128,14 @@ spec:
                 {{- if .impersonateSa }}
                 - name: AGENT_BOM_GCP_IMPERSONATE_SA
                   value: {{ .impersonateSa | quote }}
+                {{- end }}
+                {{- if eq (toString .allProjects) "true" }}
+                - name: AGENT_BOM_GCP_ALL_PROJECTS
+                  value: "1"
+                {{- end }}
+                {{- if .maxProjects }}
+                - name: AGENT_BOM_GCP_MAX_PROJECTS
+                  value: {{ .maxProjects | quote }}
                 {{- end }}
                 {{- end }}
                 {{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -154,11 +154,11 @@ scanner:
       # of preference:
       #   - EKS: IRSA — set serviceAccount.annotations
       #     eks.amazonaws.com/role-arn to the scanner/control-plane role. That
-      #     role reads THIS account directly and, cross-account, assumes each
-      #     connect-aws read-only role via sts:AssumeRole (org fan-out / hosted
-      #     connect). The baseline module attaches the least-privilege
-      #     sts:AssumeRole policy; see deploy/terraform/aws/baseline
-      #     (connect_role_arns).
+      #     role reads THIS account directly and, cross-account, can AssumeRole
+      #     into connect-aws read-only roles (hosted connect / org fan-out when
+      #     orgInventory is also true). The baseline module attaches the
+      #     least-privilege sts:AssumeRole policy; see
+      #     deploy/terraform/aws/baseline (connect_role_arns).
       #   - Self-managed k8s on EC2 / ECS: the pod inherits the node instance
       #     profile or ECS task role from the AWS SDK default chain — still
       #     keyless, no annotation needed. Give that role sts:AssumeRole on the
@@ -168,6 +168,10 @@ scanner:
       allRegions: false       # AGENT_BOM_AWS_ALL_REGIONS
       regions: ""             # AGENT_BOM_AWS_REGIONS (comma list, e.g. "us-east-1,eu-west-1")
       maxRegions: ""          # AGENT_BOM_AWS_MAX_REGIONS
+      # Org scan fan-out (default OFF). StackSet/org grant onboarding is separate —
+      # set this so the scanner enumerates member accounts and AssumeRoles into each.
+      orgInventory: false     # AGENT_BOM_AWS_ORG_INVENTORY
+      maxAccounts: ""         # AGENT_BOM_AWS_MAX_ACCOUNTS (default 200 in code)
     azure:
       # Sets AGENT_BOM_AZURE_INVENTORY=1. Auth = AKS workload identity federated
       # to the connect-azure Reader principal (see cloud.azure block below).
@@ -186,6 +190,9 @@ scanner:
       # AGENT_BOM_GCP_IMPERSONATE_SA — the connect-gcp read-only SA email. The
       # ambient KSA token is exchanged for short-lived impersonated creds.
       impersonateSa: ""
+      # Multi-project scan fan-out (default OFF). Mirrors azure.allSubscriptions.
+      allProjects: false      # AGENT_BOM_GCP_ALL_PROJECTS
+      maxProjects: ""         # AGENT_BOM_GCP_MAX_PROJECTS (default 200 in code)
     snowflake:
       # Sets AGENT_BOM_SNOWFLAKE_INVENTORY=1. Snowflake has no cloud workload
       # identity; it uses key-pair auth. Provide the private key ONLY via a

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -35,6 +35,22 @@ brokered catalog.
 The dashboard **Connections** page runs the same read-only grant flow as a
 three-step wizard: **Provider → Setup → Details**.
 
+**Scope (single target vs org fan-out).** Each connection — and
+`POST /v1/cloud/connections/{id}/scan` — covers **one** AWS account, Azure
+subscription, or GCP project. Cross-account / all-subscriptions / all-projects
+fan-out is **not** a Connections-wizard option today; use the env-flag CLI or
+Helm CronJob paths (`AGENT_BOM_AWS_ORG_INVENTORY`,
+`AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`, `AGENT_BOM_GCP_ALL_PROJECTS`; see §§3–5).
+Control-plane `tenant_id` is the agent-bom tenancy key — it is **not** an Azure
+AD tenant or AWS account ID; one CP tenant can own many connections. Recurring
+connection scans are scheduler opt-in (`AGENT_BOM_CONNECTIONS_SCHEDULER`,
+default concurrency 4). Org fan-out caps: AWS 200
+(`AGENT_BOM_AWS_MAX_ACCOUNTS`), Azure 500
+(`AGENT_BOM_AZURE_MAX_SUBSCRIPTIONS`), GCP 200 (`AGENT_BOM_GCP_MAX_PROJECTS`).
+
+- **Next:** expose org fan-out as a per-connection option in Connections and
+  shard the scheduler — on the existing Python control plane (not a Go rewrite).
+
 - **One ExternalId, carried end-to-end.** For AWS the wizard generates a single
   high-entropy `sts:ExternalId` **once** and carries it unchanged from Setup into
   Details. The value embedded in the copy-ready grant script (the one you paste

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -37,14 +37,22 @@ three-step wizard: **Provider → Setup → Details**.
 
 **Scope (single target vs org fan-out).** Each connection — and
 `POST /v1/cloud/connections/{id}/scan` — covers **one** AWS account, Azure
-subscription, or GCP project. Cross-account / all-subscriptions / all-projects
-fan-out is **not** a Connections-wizard option today; use the env-flag CLI or
-Helm CronJob paths (`AGENT_BOM_AWS_ORG_INVENTORY`,
-`AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`, `AGENT_BOM_GCP_ALL_PROJECTS`; see §§3–5).
-Control-plane `tenant_id` is the agent-bom tenancy key — it is **not** an Azure
-AD tenant or AWS account ID; one CP tenant can own many connections. Recurring
-connection scans are scheduler opt-in (`AGENT_BOM_CONNECTIONS_SCHEDULER`,
-default concurrency 4). Org fan-out caps: AWS 200
+subscription, or GCP project (AWS "All enabled regions" is still that one
+account). The AWS Connections wizard may offer **Whole organization**
+CloudFormation StackSet scripts: that is **grant onboarding** (mint the
+read-only role across member accounts), not scan fan-out. Org /
+all-subscriptions / all-projects **scan** fan-out requires the scanner/CLI
+env flags on the control plane, CLI process, or Helm scanner Job
+(`AGENT_BOM_AWS_ORG_INVENTORY`, `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`,
+`AGENT_BOM_GCP_ALL_PROJECTS`; see §§3–5) — Connections `/scan` does not turn
+them on. On the Helm CronJob, only Azure has a first-class chart value today
+(`scanner.cloud.azure.allSubscriptions` → `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`);
+AWS org and GCP all-projects go through `scanner.env` (or CLI), not dedicated
+chart keys. Control-plane `tenant_id` is the agent-bom tenancy key — it is
+**not** an Azure AD tenant or AWS account ID; one CP tenant can own many
+connections. Recurring connection scans need both scheduler opt-in
+(`AGENT_BOM_CONNECTIONS_SCHEDULER`) and a per-connection
+`scan_interval_minutes` (default concurrency 4). Org fan-out caps: AWS 200
 (`AGENT_BOM_AWS_MAX_ACCOUNTS`), Azure 500
 (`AGENT_BOM_AZURE_MAX_SUBSCRIPTIONS`), GCP 200 (`AGENT_BOM_GCP_MAX_PROJECTS`).
 

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -45,10 +45,12 @@ all-subscriptions / all-projects **scan** fan-out requires the scanner/CLI
 env flags on the control plane, CLI process, or Helm scanner Job
 (`AGENT_BOM_AWS_ORG_INVENTORY`, `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`,
 `AGENT_BOM_GCP_ALL_PROJECTS`; see §§3–5) — Connections `/scan` does not turn
-them on. On the Helm CronJob, only Azure has a first-class chart value today
-(`scanner.cloud.azure.allSubscriptions` → `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`);
-AWS org and GCP all-projects go through `scanner.env` (or CLI), not dedicated
-chart keys. Control-plane `tenant_id` is the agent-bom tenancy key — it is
+them on. On the Helm CronJob, first-class chart values map to those flags:
+`scanner.cloud.aws.orgInventory` → `AGENT_BOM_AWS_ORG_INVENTORY`,
+`scanner.cloud.azure.allSubscriptions` → `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`,
+`scanner.cloud.gcp.allProjects` → `AGENT_BOM_GCP_ALL_PROJECTS` (optional
+`maxAccounts` / `maxSubscriptions` / `maxProjects` cap the run). Control-plane
+`tenant_id` is the agent-bom tenancy key — it is
 **not** an Azure AD tenant or AWS account ID; one CP tenant can own many
 connections. Recurring connection scans need both scheduler opt-in
 (`AGENT_BOM_CONNECTIONS_SCHEDULER`) and a per-connection

--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -118,9 +118,10 @@ collectors execute. See
 | Runtime | `/runtime`, `/proxy`, `/gateway`, `/traces` | Policy + audit + HITL queue |
 | Compliance | `/compliance` | Framework evidence + exports |
 
-Each Connections entry (and `POST /v1/cloud/connections/{id}/scan`) is one AWS
-account / Azure subscription / GCP project; org-wide fan-out remains CLI/CronJob
-env flags — see [`CLOUD_CONNECT.md`](CLOUD_CONNECT.md) §1c.
+Each Connections entry (and `POST /v1/cloud/connections/{id}/scan`) is one
+AWS account / Azure subscription / GCP project; org **scan** fan-out is an
+env flag on the scanner/CLI (the AWS wizard StackSet path is grant-only) — see
+[`CLOUD_CONNECT.md`](CLOUD_CONNECT.md) §1c.
 
 Proof-path nav in the UI: **Queue · Graph · Runtime · Reports · Connections**.
 

--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -118,6 +118,10 @@ collectors execute. See
 | Runtime | `/runtime`, `/proxy`, `/gateway`, `/traces` | Policy + audit + HITL queue |
 | Compliance | `/compliance` | Framework evidence + exports |
 
+Each Connections entry (and `POST /v1/cloud/connections/{id}/scan`) is one AWS
+account / Azure subscription / GCP project; org-wide fan-out remains CLI/CronJob
+env flags — see [`CLOUD_CONNECT.md`](CLOUD_CONNECT.md) §1c.
+
 Proof-path nav in the UI: **Queue · Graph · Runtime · Reports · Connections**.
 
 ---

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -3641,7 +3641,7 @@ function AddConnectionWizard({
                   ) : null}
                   <p className="text-[var(--foreground)]">
                     {isOrgScope ? (
-                      "Deploy one CloudFormation StackSet from your AWS Organization management (or delegated-admin) account. It mints the read-only role in every member account and auto-enrolls new ones — then paste this management account's role ARN in the next step."
+                      "Deploy one CloudFormation StackSet from your AWS Organization management (or delegated-admin) account. That grant mints the read-only role in every member account and auto-enrolls new ones — then paste this management account's role ARN in the next step. Org-wide scan fan-out still needs AGENT_BOM_AWS_ORG_INVENTORY on the control plane / scanner; a connection scan covers the management-account role only until that flag is set."
                     ) : (
                       <>
                         Run this in your {provider.label} to create the read-only grant, then paste the{" "}
@@ -3677,6 +3677,13 @@ function AddConnectionWizard({
                           <Lock className="mt-0.5 h-3 w-3 shrink-0 text-emerald-400" />
                           Read-only least-privilege (SecurityAudit / ViewOnlyAccess), assumed via short-lived STS with
                           this ExternalId — no static keys, no per-action credentials.
+                        </li>
+                        <li className="flex items-start gap-1.5">
+                          <CheckCircle2 className="mt-0.5 h-3 w-3 shrink-0 text-emerald-400" />
+                          Scan fan-out across member accounts requires{" "}
+                          <code className="font-mono">AGENT_BOM_AWS_ORG_INVENTORY</code> on the control plane /
+                          scanner (Helm: <code className="font-mono">scanner.cloud.aws.orgInventory</code>). Until
+                          then, a connection scan covers the management-account role only.
                         </li>
                       </ul>
                     </div>

--- a/ui/lib/cloud-connect-wizard.ts
+++ b/ui/lib/cloud-connect-wizard.ts
@@ -498,17 +498,21 @@ export function buildCloudShellGrantScript(provider: string, externalId?: string
 
 /**
  * Consistent read-only role name minted in every member account by the org
- * StackSet — the same name the org fan-out assumes per account
- * (`AGENT_BOM_AWS_ORG_ROLE_NAME`, default `agent-bom-readonly` in
- * `src/agent_bom/cloud/aws_organizations.py`). Keep the two in lockstep.
+ * StackSet — the same name org scan fan-out assumes when
+ * `AGENT_BOM_AWS_ORG_INVENTORY` is enabled (`AGENT_BOM_AWS_ORG_ROLE_NAME`,
+ * default `agent-bom-readonly` in `src/agent_bom/cloud/aws_organizations.py`).
+ * Keep the two in lockstep.
  */
 export const DEFAULT_AWS_ORG_ROLE_NAME = "agent-bom-readonly";
 
 /**
- * Whole-AWS-Organization onboarding via a CloudFormation StackSet — the
- * org-scale path (deploy ONCE from the management / delegated-admin account,
- * every member account gets an identical read-only role, and new accounts
- * auto-enroll) instead of onboarding accounts one at a time.
+ * Whole-AWS-Organization *grant* onboarding via a CloudFormation StackSet —
+ * deploy ONCE from the management / delegated-admin account so every member
+ * account gets an identical read-only role (new accounts auto-enroll). This
+ * is role deployment only — it does not enable org-wide scan fan-out.
+ * Scanner fan-out still requires `AGENT_BOM_AWS_ORG_INVENTORY` on the control
+ * plane / scanner (a Connections scan covers the registered management-account
+ * role only until that flag is set).
  *
  * Mirrors the commands in `deploy/cloudformation/README.md` and deploys the
  * shipped `deploy/cloudformation/agent-bom-readonly-role.yaml` template. The
@@ -552,8 +556,10 @@ export function buildAwsOrgStackSetScript(
     `  --operation-preferences MaxConcurrentPercentage=100,FailureTolerancePercentage=20`,
     ``,
     `# 3. Register THIS management account's ${name} role ARN in the next step.`,
-    `#    agent-bom enumerates the org and assumes the same read-only role in each`,
-    `#    member account (short-lived STS + this ExternalId) — read-only, no keys.`,
+    `#    StackSet deploys the read-only role into member accounts (grant only).`,
+    `#    Org scan fan-out needs AGENT_BOM_AWS_ORG_INVENTORY on the control plane /`,
+    `#    scanner; a Connections scan covers the management-account role only until`,
+    `#    that flag is set. STS + this ExternalId — read-only, no keys.`,
   ].join("\n");
 }
 

--- a/ui/tests/cloud-connect-wizard.test.ts
+++ b/ui/tests/cloud-connect-wizard.test.ts
@@ -89,9 +89,9 @@ describe("cloud-connect-wizard", () => {
   });
 
   it("builds an org-wide CloudFormation StackSet grant (deploy once, auto-enroll)", () => {
-    // The org-scale path: one StackSet from the management account mints an
-    // identical read-only role in every member account and auto-enrolls new ones,
-    // instead of onboarding accounts one by one.
+    // Grant-only path: one StackSet from the management account mints an
+    // identical read-only role in every member account and auto-enrolls new ones.
+    // Scan fan-out is a separate AGENT_BOM_AWS_ORG_INVENTORY opt-in.
     const script = buildAwsOrgStackSetScript("abc123");
     expect(DEFAULT_AWS_ORG_ROLE_NAME).toBe("agent-bom-readonly");
     // StackSet create + rollout commands, matching deploy/cloudformation/README.md.
@@ -101,7 +101,7 @@ describe("cloud-connect-wizard", () => {
     expect(script).toContain("--auto-deployment Enabled=true");
     expect(script).toContain('OrganizationalUnitIds="${ROOT_OU_ID}"');
     expect(script).toContain("CAPABILITY_NAMED_IAM");
-    // The consistent role name the org fan-out assumes in each account.
+    // The consistent role name StackSet mints (and org scan fan-out assumes).
     expect(script).toContain("agent-bom-readonly");
     // The ExternalId round-trips into the StackSet parameters.
     expect(script).toContain("EXTERNAL_ID=abc123");
@@ -110,6 +110,10 @@ describe("cloud-connect-wizard", () => {
     expect(script).toContain("deploy/cloudformation/agent-bom-readonly-role.yaml");
     // Honest: register the management account's role ARN afterwards.
     expect(script.toLowerCase()).toContain("management");
+    // Honest: grant ≠ scan fan-out.
+    expect(script).toContain("AGENT_BOM_AWS_ORG_INVENTORY");
+    expect(script).toMatch(/grant only/i);
+    expect(script).not.toMatch(/enumerates the org and assumes/i);
   });
 
   it("defaults the StackSet role name and falls back to a placeholder ExternalId", () => {

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -368,12 +368,16 @@ describe("ConnectionsPage — Connect segment", () => {
     expect(stackSet.textContent).toContain("agent-bom-readonly");
     expect(stackSet.textContent).toContain(`EXTERNAL_ID=${setupId}`);
 
-    // Honest copy: read-only, every member account, new accounts auto-enroll.
+    // Honest copy: StackSet is grant onboarding; scan fan-out needs the env flag.
     const explainer = within(wizard).getByTestId("wizard-org-explainer").textContent ?? "";
     expect(explainer).toMatch(/every member account/i);
     expect(explainer).toMatch(/auto-enroll|automatically/i);
     expect(explainer).toMatch(/read-only/i);
     expect(explainer).toMatch(/management account|delegated admin/i);
+    expect(explainer).toMatch(/AGENT_BOM_AWS_ORG_INVENTORY/);
+    expect(explainer).toMatch(/management-account role only|management.account role only/i);
+    expect(stackSet.textContent).toContain("AGENT_BOM_AWS_ORG_INVENTORY");
+    expect(stackSet.textContent).not.toMatch(/enumerates the org and assumes/i);
 
     // The single-account CLI grant script is hidden while in org scope.
     expect(within(wizard).queryByText(/aws iam create-role/)).toBeNull();


### PR DESCRIPTION
## Summary
- Honest AWS Connections / StackSet copy: org grant deploys read-only roles into member accounts; scan fan-out still requires `AGENT_BOM_AWS_ORG_INVENTORY` (connection scan stays management-account until set).
- Helm first-class flags: `scanner.cloud.aws.orgInventory` (+ optional `maxAccounts`), `scanner.cloud.gcp.allProjects` (+ optional `maxProjects`), mirroring Azure `allSubscriptions`.
- Docs (`CLOUD_CONNECT` §1c) updated for the chart keys; closes honesty gap from the #4428 review.

## Verification
- `helm template` with org/GCP fan-out flags → env present; defaults omit them
- `npm test -- --run tests/cloud-connect-wizard.test.ts tests/connections-page.test.tsx` (44 passed)
- Azure/GCP wizard: no parallel “whole org/all projects scans via Connections” overclaim (AWS-only StackSet path)

## Notes
- StackSet feature retained; only misleading scan claims removed.
- No competitor names.