### PR TITLE
feat(runtime): event-collector Go Phase 1 stub and contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ agent-bom-report.json
 
 # Go gateway-relay spike build output
 runtime/gateway-relay/bin/
+# Go runtime worker binaries (local builds; not release artifacts)
+runtime/event-collector/event-collector
+runtime/event-collector/cmd/event-collector/event-collector
+**/event-collector/event-collector

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint preflight preflight-fix docker-build docker-run scan clean build-ui analytics dev check-dupes clean-dupes secrets platform-up fullstack-up
+.PHONY: help install test lint preflight preflight-fix docker-build docker-run scan clean build-ui analytics dev check-dupes clean-dupes secrets platform-up fullstack-up event-collector-go-test
 
 help:  ## Show this help message
 	@echo 'Usage: make [target]'
@@ -31,6 +31,9 @@ test:  ## Run unit tests
 lint:  ## Run linters (ruff + mypy)
 	ruff check src/ tests/
 	mypy src/ --ignore-missing-imports --disable-error-code import-untyped
+
+event-collector-go-test:  ## Run Go tests for runtime/event-collector (Phase 1 stub)
+	cd runtime/event-collector && go test ./...
 
 format:  ## Format code with ruff
 	ruff format src/ tests/

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -843,3 +843,18 @@ pdb:
   enabled: false
   minAvailable: 1
   maxUnavailable: null
+
+# ─── Event / log collector (Go sidecar — Phase 2) ─────────────────────────────
+# Phase 1 ships contract + stub binary only; Helm Deployment is Phase 2.
+# See docs/design/EVENT_COLLECTOR_CONTRACT.md.
+# eventCollector:
+#   enabled: false
+#   image:
+#     repository: ""   # optional; unset keeps stock installs without the sidecar
+#     tag: ""
+#   listen: ":8092"
+#   mode: stub         # stub | sqs (sqs requires queue URL + IAM)
+#   controlPlaneUrl: ""  # defaults to in-cluster API service when wired in Phase 2
+#   apiKeySecret:
+#     name: ""
+#     key: api-key

--- a/docs/decisions/009-python-primary-go-sidecar-later.md
+++ b/docs/decisions/009-python-primary-go-sidecar-later.md
@@ -85,3 +85,11 @@ experimental flag + Helm values stub. Revisit only with stronger evidence
 (pool tuning, multi-replica EKS soak, or a clear SLO miss that Python cannot
 close).
 
+### Next Go candidate
+
+**Event/log collector** (queue poll → normalize → control-plane ingest) is the
+next measured Go migration target. See
+[`docs/design/EVENT_COLLECTOR_CONTRACT.md`](../design/EVENT_COLLECTOR_CONTRACT.md).
+Gateway pure-relay remains a **deferred** experimental path (issue #4427); do
+not promote a Go gateway-relay sidecar until new evidence trips the gate.
+

--- a/docs/design/EVENT_COLLECTOR_CONTRACT.md
+++ b/docs/design/EVENT_COLLECTOR_CONTRACT.md
@@ -1,0 +1,102 @@
+# Design: event/log collector contract (posture change events)
+
+**Status:** Phase 1 foundation (Go stub + contract). Control-plane ingest
+route and Helm Deployment land in **Phase 2**.
+
+**Relates to:** [ADR-009](../decisions/009-python-primary-go-sidecar-later.md)
+(Python-primary; optional Go sidecar for proven hot paths).
+
+## Lane
+
+**Posture change events** — not CWPP / runtime-evidence ingest.
+
+```text
+SQS / queue poll  →  normalize (CloudTrail / EventBridge)  →  POST batch to control plane
+                                                              →  Python dispatch / CIS / persist
+```
+
+| Lane | Path / owner | Purpose |
+|------|----------------|---------|
+| Posture change events (this contract) | Go collector → `POST /v1/cloud/connections/events/ingest` (Phase 2) | Queue-driven resource-change signals for scoped CIS re-eval |
+| Runtime evidence (separate) | `POST /v1/cloud/runtime-evidence/ingest` | CWPP / EDR workload signals (metadata only) |
+
+Do not merge these lanes. The collector never writes CIS findings itself.
+
+## Ownership split
+
+| Concern | Owner |
+|---------|--------|
+| Bounded queue poll loop (SQS later; stub mode today) | **Go** `runtime/event-collector` |
+| Minimal CloudTrail / EventBridge → `CloudChangeEvent` normalize | **Go** (parity with `parse_cloudtrail_event`) |
+| Forward batch to control plane (`Authorization: Bearer …`) | **Go** |
+| `dispatch_change_event`, connection broker, CIS subset, persist | **Python** control plane |
+| Auth, tenant, RBAC, account-bound fail-closed checks | **Python** (on ingest) |
+
+## Intended control-plane path (Phase 2 — not in OpenAPI yet)
+
+```http
+POST {control-plane}/v1/cloud/connections/events/ingest
+Authorization: Bearer <api-key>
+Content-Type: application/json
+
+{
+  "events": [
+    {
+      "provider": "aws",
+      "account": "123456789012",
+      "region": "us-east-1",
+      "resource_type": "s3",
+      "resource_id": "my-bucket",
+      "action": "PutBucketPolicy",
+      "arn": "",
+      "raw": { }
+    }
+  ]
+}
+```
+
+Until Phase 2 lands the route, the Go forwarder may receive **HTTP 404**. That is
+expected for Phase 1; operators should run `--mode stub` (no AWS calls, no
+forward required for CI) and rely on `go test` for normalize coverage.
+
+## Go binary surfaces (Phase 1)
+
+- Module: `github.com/msaad00/agent-bom/runtime/event-collector`
+- Listen: `--listen :8092` (default)
+- Flags: `--control-plane-url`, `--api-key-file`, `--mode stub|sqs`
+- `GET /healthz` — liveness
+- Dev helper (optional): `POST /v1/normalize/cloudtrail` — body = EventBridge /
+  CloudTrail JSON; response = normalized `CloudChangeEvent` or 400
+- `--mode stub`: no AWS SDK calls; process serves health/normalize only
+- `--mode sqs`: reserved for Phase 2+ (bounded poll); Phase 1 may refuse or no-op
+  with a clear log line
+
+## Fail-open / fail-closed
+
+| Layer | Default | Notes |
+|-------|---------|-------|
+| Normalize | fail-closed | Malformed / unsupported service → skip (no crash) |
+| Forward | fail-closed on non-2xx / transport error | Leave message for redelivery when SQS lands; stub has nothing to redrive |
+| Account / tenant binding | Python on ingest | Collector does not broaden trust |
+
+## Non-goals
+
+- No dual product (Python edition vs Go edition) — see ADR-009.
+- No cloud inventory rewrite into Go.
+- No Azure / GCP collectors in Phase 1.
+- No moving CIS evaluation into Go.
+- No OpenAPI route in Phase 1 (avoids `make preflight` churn).
+- **Helm Deployment in Phase 2** — Phase 1 may leave a commented values stub only.
+
+## Verification
+
+```bash
+make event-collector-go-test
+# equivalent: cd runtime/event-collector && go test ./...
+```
+
+## Code
+
+- Go: [`runtime/event-collector/`](../../runtime/event-collector/)
+- Python reference normalize / dispatch:
+  [`src/agent_bom/cloud/event_ingest.py`](../../src/agent_bom/cloud/event_ingest.py)

--- a/runtime/event-collector/cmd/event-collector/main.go
+++ b/runtime/event-collector/cmd/event-collector/main.go
@@ -1,0 +1,113 @@
+// Command event-collector is the Phase 1 Go stub for posture change-event collection.
+//
+// Lane: queue poll → normalize CloudTrail → POST batch to control plane.
+// See docs/design/EVENT_COLLECTOR_CONTRACT.md. Python keeps dispatch/CIS/persist.
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/msaad00/agent-bom/runtime/event-collector/internal/forward"
+	"github.com/msaad00/agent-bom/runtime/event-collector/internal/normalize"
+)
+
+func main() {
+	listen := flag.String("listen", ":8092", "HTTP listen address")
+	controlPlaneURL := flag.String("control-plane-url", "", "Control plane base URL (for forward; unused in stub mode)")
+	apiKeyFile := flag.String("api-key-file", "", "Path to file containing Bearer API key for control-plane ingest")
+	mode := flag.String("mode", "stub", "Collector mode: stub (no AWS) or sqs (Phase 2+)")
+	flag.Parse()
+
+	modeVal := strings.ToLower(strings.TrimSpace(*mode))
+	switch modeVal {
+	case "stub", "sqs":
+	default:
+		log.Fatalf("unsupported --mode %q (want stub|sqs)", *mode)
+	}
+
+	apiKey := ""
+	if *apiKeyFile != "" {
+		b, err := os.ReadFile(*apiKeyFile)
+		if err != nil {
+			log.Fatalf("read --api-key-file: %v", err)
+		}
+		apiKey = strings.TrimSpace(string(b))
+	}
+
+	fwd := forward.NewClient(*controlPlaneURL, apiKey)
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"status":"ok","mode":"` + modeVal + `"}`))
+	})
+	mux.HandleFunc("/v1/normalize/cloudtrail", func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		body, err := io.ReadAll(io.LimitReader(r.Body, 1<<20))
+		if err != nil {
+			http.Error(w, "read body", http.StatusBadRequest)
+			return
+		}
+		ev, err := normalize.ParseCloudTrail(body)
+		if err != nil {
+			http.Error(w, "parse error", http.StatusBadRequest)
+			return
+		}
+		if ev == nil {
+			http.Error(w, "unrecognized or unsupported cloudtrail event", http.StatusBadRequest)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		enc := json.NewEncoder(w)
+		enc.SetEscapeHTML(true)
+		_ = enc.Encode(ev)
+	})
+
+	srv := &http.Server{
+		Addr:              *listen,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+
+	go func() {
+		log.Printf("event-collector listening on %s mode=%s (ingest path %s; may 404 until Phase 2)", *listen, modeVal, forward.IngestPath)
+		if modeVal == "sqs" {
+			log.Printf("mode=sqs: Phase 1 stub does not poll AWS; configure SQS in Phase 2")
+		}
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			log.Fatalf("listen: %v", err)
+		}
+	}()
+
+	// Keep forward client referenced so operators can wire Phase 2 without API churn.
+	_ = fwd
+
+	<-ctx.Done()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Printf("shutdown: %v", err)
+	}
+	fmt.Fprintln(os.Stderr, "event-collector stopped")
+}

--- a/runtime/event-collector/go.mod
+++ b/runtime/event-collector/go.mod
@@ -1,0 +1,3 @@
+module github.com/msaad00/agent-bom/runtime/event-collector
+
+go 1.22

--- a/runtime/event-collector/internal/forward/forward.go
+++ b/runtime/event-collector/internal/forward/forward.go
@@ -1,0 +1,78 @@
+// Package forward posts normalized change-event batches to the control plane.
+package forward
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/msaad00/agent-bom/runtime/event-collector/internal/normalize"
+)
+
+// IngestPath is the intended Phase 2 control-plane route.
+// Until that route ships, callers may observe HTTP 404 — that is expected in Phase 1.
+const IngestPath = "/v1/cloud/connections/events/ingest"
+
+// Batch is the JSON body for ingest.
+type Batch struct {
+	Events []*normalize.CloudChangeEvent `json:"events"`
+}
+
+// Client POSTs batches to {ControlPlaneURL}{IngestPath}.
+type Client struct {
+	ControlPlaneURL string
+	APIKey          string
+	HTTPClient      *http.Client
+}
+
+// NewClient builds a forwarder. controlPlaneURL should be a base URL without a trailing slash.
+func NewClient(controlPlaneURL, apiKey string) *Client {
+	return &Client{
+		ControlPlaneURL: strings.TrimRight(controlPlaneURL, "/"),
+		APIKey:          apiKey,
+		HTTPClient:      &http.Client{Timeout: 30 * time.Second},
+	}
+}
+
+// ForwardBatch POSTs events to the control plane ingest path.
+// Phase 1: a 404 means the OpenAPI route is not shipped yet — callers should
+// treat that as "not ready", not as a successful drop.
+func (c *Client) ForwardBatch(ctx context.Context, events []*normalize.CloudChangeEvent) error {
+	if c == nil || c.ControlPlaneURL == "" {
+		return fmt.Errorf("forward: control-plane URL is required")
+	}
+	if len(events) == 0 {
+		return nil
+	}
+	body, err := json.Marshal(Batch{Events: events})
+	if err != nil {
+		return fmt.Errorf("forward: marshal: %w", err)
+	}
+	url := c.ControlPlaneURL + IngestPath
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return fmt.Errorf("forward: new request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if c.APIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+c.APIKey)
+	}
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("forward: post: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+	if resp.StatusCode == http.StatusNotFound {
+		return fmt.Errorf("forward: ingest path not found (Phase 2 route pending): %s returned 404: %s", IngestPath, strings.TrimSpace(string(respBody)))
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return fmt.Errorf("forward: control plane returned %d: %s", resp.StatusCode, strings.TrimSpace(string(respBody)))
+	}
+	return nil
+}

--- a/runtime/event-collector/internal/normalize/cloudtrail.go
+++ b/runtime/event-collector/internal/normalize/cloudtrail.go
@@ -1,0 +1,170 @@
+// Package normalize turns EventBridge/CloudTrail envelopes into CloudChangeEvent JSON.
+package normalize
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// CloudTrailDetailType is the EventBridge detail-type for CloudTrail API calls.
+const CloudTrailDetailType = "AWS API Call via CloudTrail"
+
+// resource types with posture rules in the Python control plane (parity subset).
+var supportedResourceTypes = map[string]struct{}{
+	"s3":         {},
+	"ec2":        {},
+	"iam":        {},
+	"rds":        {},
+	"kms":        {},
+	"cloudtrail": {},
+}
+
+var resourceIDKeys = map[string][]string{
+	"s3":         {"bucketName"},
+	"ec2":        {"groupId", "instanceId", "networkAclId", "routeTableId", "vpcId"},
+	"iam":        {"roleName", "userName", "groupName", "policyArn", "policyName"},
+	"rds":        {"dBInstanceIdentifier"},
+	"kms":        {"keyId"},
+	"cloudtrail": {"name", "trailName"},
+}
+
+// CloudChangeEvent is the provider-neutral shape forwarded to the control plane.
+// Field names match the Python dataclass / intended Phase 2 ingest JSON.
+type CloudChangeEvent struct {
+	Provider     string         `json:"provider"`
+	Account      string         `json:"account"`
+	Region       string         `json:"region"`
+	ResourceType string         `json:"resource_type"`
+	ResourceID   string         `json:"resource_id"`
+	Action       string         `json:"action"`
+	ARN          string         `json:"arn,omitempty"`
+	Raw          map[string]any `json:"raw,omitempty"`
+}
+
+// ParseCloudTrail parses an EventBridge envelope or bare CloudTrail record.
+// Returns (nil, nil) for skippable/malformed input (fail-closed, no crash).
+func ParseCloudTrail(message []byte) (*CloudChangeEvent, error) {
+	var obj map[string]any
+	if err := json.Unmarshal(message, &obj); err != nil {
+		return nil, nil
+	}
+	return ParseCloudTrailObject(obj), nil
+}
+
+// ParseCloudTrailObject normalizes a decoded JSON object.
+func ParseCloudTrailObject(obj map[string]any) *CloudChangeEvent {
+	if obj == nil {
+		return nil
+	}
+
+	detail, _ := obj["detail"].(map[string]any)
+	if detail == nil {
+		detail = obj
+	}
+
+	if dt, ok := obj["detail-type"]; ok && dt != nil {
+		if s, ok := dt.(string); !ok || s != CloudTrailDetailType {
+			return nil
+		}
+	}
+
+	source := asString(obj["source"])
+	if source == "" {
+		source = asString(detail["eventSource"])
+	}
+	token := canonicalResourceType(source)
+	if _, ok := supportedResourceTypes[token]; !ok {
+		return nil
+	}
+
+	account := strings.TrimSpace(asString(obj["account"]))
+	if account == "" {
+		account = strings.TrimSpace(asString(detail["recipientAccountId"]))
+	}
+	if account == "" {
+		if ui, ok := detail["userIdentity"].(map[string]any); ok {
+			account = strings.TrimSpace(asString(ui["accountId"]))
+		}
+	}
+
+	action := strings.TrimSpace(asString(detail["eventName"]))
+	region := strings.TrimSpace(asString(obj["region"]))
+	if region == "" {
+		region = strings.TrimSpace(asString(detail["awsRegion"]))
+	}
+	resourceID := extractResourceID(token, detail)
+
+	if account == "" || action == "" || resourceID == "" {
+		return nil
+	}
+
+	arn := ""
+	if resources, ok := detail["resources"]; ok {
+		switch v := resources.(type) {
+		case string:
+			arn = v
+		default:
+			// list or other shapes: leave empty (Python does the same for lists)
+			arn = ""
+		}
+	}
+
+	return &CloudChangeEvent{
+		Provider:     "aws",
+		Account:      account,
+		Region:       region,
+		ResourceType: token,
+		ResourceID:   resourceID,
+		Action:       action,
+		ARN:          arn,
+		Raw:          obj,
+	}
+}
+
+func canonicalResourceType(source string) string {
+	token := strings.ToLower(strings.TrimSpace(source))
+	if strings.HasPrefix(token, "aws.") {
+		token = token[len("aws."):]
+	}
+	if strings.HasSuffix(token, ".amazonaws.com") {
+		token = token[:len(token)-len(".amazonaws.com")]
+	}
+	return token
+}
+
+func extractResourceID(token string, detail map[string]any) string {
+	params := map[string]any{}
+	for _, key := range []string{"requestParameters", "responseElements"} {
+		if m, ok := detail[key].(map[string]any); ok {
+			for k, v := range m {
+				params[k] = v
+			}
+		}
+	}
+	for _, candidate := range resourceIDKeys[token] {
+		if v, ok := params[candidate]; ok {
+			if s, ok := v.(string); ok && strings.TrimSpace(s) != "" {
+				return strings.TrimSpace(s)
+			}
+		}
+	}
+	return ""
+}
+
+func asString(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case fmt.Stringer:
+		return t.String()
+	case float64:
+		// JSON numbers — account ids should be strings; ignore numeric
+		return ""
+	default:
+		if t == nil {
+			return ""
+		}
+		return fmt.Sprint(t)
+	}
+}

--- a/runtime/event-collector/internal/normalize/cloudtrail_test.go
+++ b/runtime/event-collector/internal/normalize/cloudtrail_test.go
@@ -1,0 +1,83 @@
+package normalize
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func sampleS3Envelope(account, bucket string) []byte {
+	obj := map[string]any{
+		"detail-type": "AWS API Call via CloudTrail",
+		"source":      "aws.s3",
+		"account":     account,
+		"region":      "us-east-1",
+		"detail": map[string]any{
+			"eventSource":        "s3.amazonaws.com",
+			"eventName":          "PutBucketPolicy",
+			"awsRegion":          "us-east-1",
+			"recipientAccountId": account,
+			"userIdentity":       map[string]any{"accountId": account},
+			"requestParameters":  map[string]any{"bucketName": bucket},
+		},
+	}
+	b, err := json.Marshal(obj)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+func TestParseCloudTrailS3PutBucketPolicy(t *testing.T) {
+	ev, err := ParseCloudTrail(sampleS3Envelope("123456789012", "public-bucket"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev == nil {
+		t.Fatal("expected event, got nil")
+	}
+	if ev.Provider != "aws" || ev.Account != "123456789012" || ev.Region != "us-east-1" {
+		t.Fatalf("unexpected identity fields: %+v", ev)
+	}
+	if ev.ResourceType != "s3" || ev.ResourceID != "public-bucket" || ev.Action != "PutBucketPolicy" {
+		t.Fatalf("unexpected resource fields: %+v", ev)
+	}
+}
+
+func TestParseCloudTrailMalformedReturnsNil(t *testing.T) {
+	cases := []string{
+		`{"detail-type":"Some Other Event","source":"aws.s3","account":"123456789012","detail":{}}`,
+		`{"source":"aws.s3","account":"123456789012","detail":{"eventName":"PutBucketPolicy"}}`,
+		`{"source":"aws.s3","detail":{"eventName":"Put","requestParameters":{"bucketName":"b"}}}`,
+		`{"source":"aws.dynamodb","account":"123456789012","detail":{"eventName":"X","requestParameters":{"k":"v"}}}`,
+		`not-json`,
+	}
+	for _, msg := range cases {
+		ev, err := ParseCloudTrail([]byte(msg))
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", msg, err)
+		}
+		if ev != nil {
+			t.Fatalf("expected nil for %q, got %+v", msg, ev)
+		}
+	}
+}
+
+func TestParseCloudTrailBareRecord(t *testing.T) {
+	bare := []byte(`{
+		"eventSource": "iam.amazonaws.com",
+		"eventName": "CreateUser",
+		"awsRegion": "us-west-2",
+		"recipientAccountId": "111122223333",
+		"requestParameters": {"userName": "alice"}
+	}`)
+	ev, err := ParseCloudTrail(bare)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ev == nil {
+		t.Fatal("expected event")
+	}
+	if ev.ResourceType != "iam" || ev.ResourceID != "alice" || ev.Action != "CreateUser" {
+		t.Fatalf("unexpected: %+v", ev)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `docs/design/EVENT_COLLECTOR_CONTRACT.md` for the posture change-event lane (queue poll → normalize → CP ingest), separate from runtime-evidence ingest; Python keeps `dispatch_change_event` / broker / CIS / persist.
- ADR-009 Consequences: mark event/log collector as the next measured Go migration target; gateway relay stays deferred (#4427).
- Ship `runtime/event-collector` Phase 1 stub (`--mode stub|sqs`, `--listen :8092`, `/healthz`, CloudTrail normalize + forward helper targeting `POST /v1/cloud/connections/events/ingest` — path may 404 until Phase 2).
- `make event-collector-go-test`, `.gitignore` for local Go binaries, commented Helm values only (Deployment in Phase 2).

## Verification
- [x] `make event-collector-go-test` (`cd runtime/event-collector && go test ./...`)
- [x] `python3 scripts/check_package_layout.py` (still passes; `runtime/` outside flat freeze)

## Notes
- Follows the gateway-relay contract-first pattern; does not rewrite `event_ingest.py` or add OpenAPI (Phase 2) to avoid preflight churn.
- Next: control-plane ingest route + real SQS poll + Helm Deployment.
- Related: #4427 (defer gateway-relay Go sidecar).

Made with [Cursor](https://cursor.com)