### PR TITLE
fix(ci): cancel superseded required runs promptly

### DIFF
--- a/.github/workflows/auto-retrigger-stranded.yml
+++ b/.github/workflows/auto-retrigger-stranded.yml
@@ -82,7 +82,7 @@ jobs:
           GH_TOKEN: ${{ secrets.AUTOMATION_GITHUB_TOKEN || github.token }}
           AUTOMATION_TOKEN_CONFIGURED: ${{ secrets.AUTOMATION_GITHUB_TOKEN != '' }}
           AUTOMATION_SSH_SIGNING_KEY: ${{ secrets.AUTOMATION_SSH_SIGNING_KEY }}
-          REQUIRED_CHECKS: "Lint and Type Check,Test (Python 3.11),Test (Python 3.13),Build Package,Security Scan,CodeQL,Test (Python 3.14)"
+          REQUIRED_CHECKS: "Lint and Type Check,Test (Python 3.13),Build Package,Security Scan,CodeQL"
           MIN_AGE_MINUTES: ${{ inputs.min_age_minutes || (github.event_name == 'pull_request' && '0' || '3') }}
           PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number || '' }}
           REQUIRE_AUTO_MERGE: ${{ github.event_name != 'workflow_dispatch' || inputs.require_auto_merge }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -384,7 +384,7 @@ jobs:
     # (issue #3631). Mirrors the exact build invocation in
     # .github/workflows/docs.yml but never publishes.
     if: >-
-      always() && (
+      !cancelled() && (
         (github.event_name != 'pull_request' && github.event_name != 'push') ||
         needs.changes.result != 'success' ||
         needs.changes.outputs.docs == 'true'
@@ -417,7 +417,7 @@ jobs:
     # the standalone app; keeping this required context skipped avoids a
     # second full npm install/build for the same commit.
     if: >-
-      always() && (
+      !cancelled() && (
         github.event_name != 'push' && (
           github.event_name != 'pull_request' ||
           needs.changes.result != 'success' ||
@@ -671,7 +671,7 @@ jobs:
     timeout-minutes: 20
     needs: changes
     if: >-
-      always() && (
+      !cancelled() && (
         (github.event_name != 'pull_request' && github.event_name != 'push') ||
         needs.changes.result != 'success' ||
         needs.changes.outputs.endpoint == 'true'
@@ -747,13 +747,14 @@ jobs:
     permissions:
       contents: read
     needs: changes
-    # The job itself always runs: "Test (Python 3.13)" is a REQUIRED context,
+    # The job itself runs unless the workflow is cancelled: "Test (Python
+    # 3.13)" is a REQUIRED context,
     # and a matrix job skipped at job level never expands its matrix, so the
     # required check would sit at "Expected" forever and block auto-merge.
     # The heavy STEPS below skip instead when the classifier positively says
     # the PR cannot affect Python (docs/UI/deploy-only); the job then reports
     # success in seconds. Fail closed: a classifier failure runs the suite.
-    if: always()
+    if: ${{ !cancelled() }}
     strategy:
       fail-fast: false
       matrix:
@@ -867,7 +868,7 @@ jobs:
     # green while a fresh install loses that discovery path at runtime. Install
     # the cloud extras here and actually execute every extra-gated import line.
     if: >-
-      always() && (
+      !cancelled() && (
         (github.event_name != 'pull_request' && github.event_name != 'push') ||
         needs.changes.result != 'success' ||
         needs.changes.outputs.python == 'true'
@@ -896,7 +897,7 @@ jobs:
     timeout-minutes: 10
     needs: changes
     if: >-
-      always() && (
+      !cancelled() && (
         (github.event_name != 'pull_request' && github.event_name != 'push') ||
         needs.changes.result != 'success' ||
         needs.changes.outputs.postgres == 'true'
@@ -1025,7 +1026,7 @@ jobs:
   test-alpine:
     name: Test (Alpine/musl)
     if: >-
-      always() && (
+      !cancelled() && (
         (github.event_name != 'pull_request' && github.event_name != 'push') ||
         needs.changes.result != 'success' ||
         needs.changes.outputs.alpine == 'true'
@@ -1338,7 +1339,7 @@ jobs:
   action-dogfood:
     name: Dogfood GitHub Action
     if: >-
-      always() && (
+      !cancelled() && (
         (github.event_name != 'pull_request' && github.event_name != 'push') ||
         needs.changes.result != 'success' ||
         needs.changes.outputs.action == 'true'

--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -99,11 +99,16 @@ scripts/retrigger_stranded_pr.sh <PR_NUMBER>
 The script:
 
 1. Resolves the PR's current head SHA.
-2. Checks whether the canonical required check (`Lint and Type Check`) ran
-   against that SHA via `repos/.../commits/<sha>/check-runs`.
-3. If any required check is still active, exits without retriggering. Downstream
-   jobs such as package build are not created until prerequisite jobs finish.
-4. If checks are missing or stale after the run is idle, closes the PR and
+2. Checks the five branch-protection contexts (`Lint and Type Check`, Python
+   3.13, package build, security scan, and CodeQL) against that SHA via
+   `repos/.../commits/<sha>/check-runs`.
+3. Cancels required-workflow runs for older SHAs on the exact PR branch. If a
+   normal cancellation does not finish within a short grace, it uses GitHub's
+   force-cancel endpoint; current-head and unrelated runs are never targeted.
+4. If any current-head required check is still active, exits without
+   retriggering. Downstream jobs such as package build are not created until
+   prerequisite jobs finish.
+5. If checks are missing or stale after the run is idle, closes the PR and
    immediately reopens it. This starts `pull_request` workflows only when the
    token is not `GITHUB_TOKEN`.
 
@@ -114,7 +119,7 @@ run on any PR.
 
 `.github/workflows/auto-retrigger-stranded.yml` runs `scripts/retrigger_stranded_pr.sh`
 against every synchronized PR whose current head SHA has zero or stale
-`Lint and Type Check` runs. It runs immediately after a PR push, after `main`
+required checks. It runs immediately after a PR push, after `main`
 advances, every 15 minutes, and through `workflow_dispatch` for on-demand. Once this workflow is on the
 default branch and `AUTOMATION_GITHUB_TOKEN` is configured, stranded PRs
 unstrand themselves within five minutes — no operator action required.
@@ -132,9 +137,8 @@ Operator-side troubleshooting if a strand persists past ~10 minutes:
   the close/reopen retrigger path.
 - Was the PR younger than `MIN_AGE_MINUTES` (3 min by default)? It's intentionally
   skipped to give the initial `pull_request` workflow a chance to start.
-- Did `gh api commits/{sha}/check-runs` return zero, or is there a
-  different check name now? Update `REQUIRED_CHECK` in the workflow if
-  the canonical check is renamed.
+- Did `gh api commits/{sha}/check-runs` return zero, or did branch protection
+  change? Keep `REQUIRED_CHECKS` aligned with the protected contexts.
 
 ### Permanent fix alternatives (settings change required)
 

--- a/scripts/cancel_superseded_run.sh
+++ b/scripts/cancel_superseded_run.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Cancel an already-vetted superseded workflow run, escalating only when the
+# normal GitHub cancellation request does not complete within a short grace.
+# Callers must first constrain the target to an old head SHA on the exact PR
+# branch and to a required workflow.
+
+set -euo pipefail
+
+if [ "$#" -ne 2 ]; then
+  echo "usage: $0 <OWNER/REPO> <RUN_ID>" >&2
+  exit 64
+fi
+
+REPO="$1"
+RUN_ID="$2"
+
+gh run cancel "${RUN_ID}" --repo "${REPO}"
+
+for attempt in 1 2 3 4 5; do
+  status="$(
+    gh run view "${RUN_ID}" --repo "${REPO}" --json status --jq .status \
+      2>/dev/null || printf 'unknown'
+  )"
+  if [ "${status}" = "completed" ]; then
+    exit 0
+  fi
+  if [ "${attempt}" -lt 5 ]; then
+    sleep "${CANCEL_POLL_SECONDS:-2}"
+  fi
+done
+
+echo "workflow run ${RUN_ID} did not stop after normal cancellation; requesting force-cancel."
+if gh api --method POST "repos/${REPO}/actions/runs/${RUN_ID}/force-cancel" >/dev/null; then
+  exit 0
+fi
+
+# The run can complete between the last poll and the force-cancel request.
+status="$(
+  gh run view "${RUN_ID}" --repo "${REPO}" --json status --jq .status \
+    2>/dev/null || printf 'unknown'
+)"
+if [ "${status}" = "completed" ]; then
+  exit 0
+fi
+
+echo "failed to cancel superseded workflow run ${RUN_ID} (status: ${status})." >&2
+exit 1

--- a/scripts/dispatch_required_ci.sh
+++ b/scripts/dispatch_required_ci.sh
@@ -18,7 +18,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 PR="$1"
-REQUIRED_CHECKS="${REQUIRED_CHECKS:-Lint and Type Check,Test (Python 3.11),Test (Python 3.13),Build Package,Security Scan,CodeQL,Test (Python 3.14)}"
+REQUIRED_CHECKS="${REQUIRED_CHECKS:-Lint and Type Check,Test (Python 3.13),Build Package,Security Scan,CodeQL}"
 REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 
 pr_json="$(
@@ -71,7 +71,7 @@ branch_runs="$(
 while IFS= read -r run_id; do
   [ -n "${run_id}" ] || continue
   echo "PR #${PR}: cancelling superseded required workflow run ${run_id} on ${head_ref}."
-  gh run cancel "${run_id}" --repo "${REPO}"
+  "$(dirname "$0")/cancel_superseded_run.sh" "${REPO}" "${run_id}"
 done < <(
   jq -r --arg current_sha "${head_sha}" \
     '.workflow_runs[]

--- a/scripts/retrigger_stranded_pr.sh
+++ b/scripts/retrigger_stranded_pr.sh
@@ -28,7 +28,7 @@ if [ "$#" -ne 1 ]; then
 fi
 
 PR="$1"
-REQUIRED_CHECK="${REQUIRED_CHECK:-Lint and Type Check}"
+REQUIRED_CHECK="${REQUIRED_CHECK:-Lint and Type Check,Test (Python 3.13),Build Package,Security Scan,CodeQL}"
 REQUIRED_CHECKS="${REQUIRED_CHECKS:-${REQUIRED_CHECK}}"
 REPO="${GH_REPO:-$(gh repo view --json nameWithOwner --jq .nameWithOwner)}"
 
@@ -58,7 +58,7 @@ BRANCH_RUNS="$(
 while IFS= read -r RUN_ID; do
   [ -n "${RUN_ID}" ] || continue
   echo "PR #${PR}: cancelling superseded required workflow run ${RUN_ID} on ${HEAD_REF}."
-  gh run cancel "${RUN_ID}" --repo "${REPO}"
+  "$(dirname "$0")/cancel_superseded_run.sh" "${REPO}" "${RUN_ID}"
 done < <(
   jq -r --arg current_sha "${HEAD_SHA}" \
     '.workflow_runs[]

--- a/tests/test_ci_retrigger_scripts.py
+++ b/tests/test_ci_retrigger_scripts.py
@@ -33,8 +33,32 @@ def test_recovery_scripts_cancel_only_superseded_required_runs_on_branch() -> No
         assert 'actions/runs"' in script
         assert '-f branch=' in script
         assert '.head_sha != $current_sha' in script
-        assert 'gh run cancel "${' in script
+        assert "cancel_superseded_run.sh" in script
         assert '"CI/CD Pipeline" or .name == "PR Security Gate" or .name == "CodeQL"' in script
+
+
+def test_force_cancel_helper_has_bounded_grace_and_race_safe_fallback() -> None:
+    helper = (ROOT / "scripts" / "cancel_superseded_run.sh").read_text(encoding="utf-8")
+
+    assert "for attempt in 1 2 3 4 5" in helper
+    assert 'gh run cancel "${RUN_ID}"' in helper
+    assert 'actions/runs/${RUN_ID}/force-cancel' in helper
+    assert helper.count('if [ "${status}" = "completed" ]') == 2
+
+
+def test_recovery_required_checks_match_branch_protection() -> None:
+    canonical = "Lint and Type Check,Test (Python 3.13),Build Package,Security Scan,CodeQL"
+    paths = (
+        ROOT / "scripts" / "dispatch_required_ci.sh",
+        ROOT / "scripts" / "retrigger_stranded_pr.sh",
+        ROOT / ".github" / "workflows" / "auto-retrigger-stranded.yml",
+    )
+
+    for path in paths:
+        text = path.read_text(encoding="utf-8")
+        assert canonical in text
+        assert "Test (Python 3.11)" not in text
+        assert "Test (Python 3.14)" not in text
 
 
 def test_ci_runbook_documents_fallback_workflows() -> None:

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -53,6 +53,23 @@ def test_path_gated_jobs_fail_closed_when_classifier_fails() -> None:
         assert "needs.changes.result != 'success'" in condition
 
 
+def test_path_gated_jobs_remain_cancellable() -> None:
+    jobs = _ci()["jobs"]
+    for name in (
+        "docs-strict",
+        "ui",
+        "endpoint-packaging",
+        "test",
+        "sdk-import-smoke",
+        "postgres-integration",
+        "test-alpine",
+        "action-dogfood",
+    ):
+        condition = jobs[name]["if"]
+        assert "!cancelled()" in condition
+        assert "always()" not in condition
+
+
 def test_security_reuses_typescript_install_for_build() -> None:
     text = CI_WORKFLOW.read_text(encoding="utf-8")
     security = text.split("  # 2. Linting + Type Checking", 1)[0]


### PR DESCRIPTION
## Summary

- replace cancellation-resistant job-level `always()` conditions with `!cancelled()` while retaining classifier-failure fail-closed behavior
- cancel only superseded required-workflow runs on the exact PR branch, then use the force-cancel endpoint after a bounded normal-cancel grace
- align recovery automation with the five contexts currently enforced by branch protection

## Root cause

Superseded CI run `30066692876` accepted cancellation at 04:28:45Z, but its Python job continued until 04:45:29Z because the job-level `always()` condition remained true during cancellation. The current-head run had no jobs during that interval, leaving branch protection at “Expected — Waiting for status to be reported.”

## Verification

- `uv run pytest -q tests/test_ci_workflow_contract.py tests/test_ci_retrigger_scripts.py`
- `uv run ruff check tests/test_ci_workflow_contract.py tests/test_ci_retrigger_scripts.py`
- `uv run python scripts/check_workflow_timeouts.py`
- `uv run python scripts/lint_release_workflow.py .github/workflows/release.yml`
- `uv run python scripts/check_public_docs_hygiene.py`
- `actionlint .github/workflows/ci.yml .github/workflows/auto-retrigger-stranded.yml`
- `bash -n scripts/cancel_superseded_run.sh scripts/dispatch_required_ci.sh scripts/retrigger_stranded_pr.sh`
- `git diff --check`

## Notes

- step-level cleanup/verdict `always()` conditions remain unchanged
- current-head and unrelated workflow runs are excluded before the cancellation helper is called
