### PR TITLE
fix(demo): persist findings with migrated postgres

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -923,7 +923,10 @@ jobs:
       # RLS implicitly even when FORCE ROW LEVEL SECURITY is set on the
       # table, which would silently mask any RLS regression and is not how
       # production runs. The role is created in the setup step below.
-      AGENT_BOM_POSTGRES_URL: postgresql://agent_bom_app:apppass@127.0.0.1:5432/agentbom_test
+      # Mirror Compose: the URL contains no password; the app reads it from a
+      # mounted file through the shared Postgres connection factory.
+      AGENT_BOM_POSTGRES_URL: postgresql://agent_bom_app@127.0.0.1:5432/agentbom_test
+      AGENT_BOM_POSTGRES_PASSWORD_FILE: /tmp/agent-bom-postgres-app-password
       AGENT_BOM_POSTGRES_POOL_MIN_SIZE: "1"
       AGENT_BOM_POSTGRES_POOL_MAX_SIZE: "4"
       AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS: "5"
@@ -937,6 +940,11 @@ jobs:
 
       - name: Install Postgres test dependencies
         run: uv sync --frozen --extra dev --extra api --extra postgres
+
+      - name: Write app-role password file
+        run: |
+          install -m 0600 /dev/null "${AGENT_BOM_POSTGRES_PASSWORD_FILE}"
+          printf '%s' 'apppass' > "${AGENT_BOM_POSTGRES_PASSWORD_FILE}"
 
       - name: Install Postgres client
         run: |
@@ -991,10 +999,8 @@ jobs:
       - name: Provision non-superuser application role
         run: |
           set -euo pipefail
-          # The role is intentionally NOSUPERUSER NOBYPASSRLS so RLS policies
-          # actually apply to it. Granting CREATE on the public schema lets the
-          # storage layer's _ensure_tenant_rls() create and own its tables, so
-          # ALTER TABLE ... FORCE ROW LEVEL SECURITY succeeds.
+          # The role is intentionally DML-only, NOSUPERUSER, and NOBYPASSRLS,
+          # matching Compose. Migrations own every table, policy, and index.
           psql -h 127.0.0.1 -U postgres -d agentbom_test <<'SQL'
           DO $$
           BEGIN
@@ -1004,9 +1010,12 @@ jobs:
           END
           $$;
           GRANT CONNECT ON DATABASE agentbom_test TO agent_bom_app;
-          GRANT USAGE, CREATE ON SCHEMA public TO agent_bom_app;
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO agent_bom_app;
-          ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO agent_bom_app;
+          GRANT USAGE ON SCHEMA public TO agent_bom_app;
+          REVOKE CREATE ON SCHEMA public FROM agent_bom_app;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO agent_bom_app;
+          ALTER DEFAULT PRIVILEGES IN SCHEMA public
+            GRANT USAGE, SELECT ON SEQUENCES TO agent_bom_app;
           SQL
 
       - name: Migrate the integration test database

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -927,6 +927,8 @@ jobs:
       # mounted file through the shared Postgres connection factory.
       AGENT_BOM_POSTGRES_URL: postgresql://agent_bom_app@127.0.0.1:5432/agentbom_test
       AGENT_BOM_POSTGRES_PASSWORD_FILE: /tmp/agent-bom-postgres-app-password
+      # Migrator/admin DSN for DDL-only integration checks (CREATE SCHEMA).
+      AGENT_BOM_POSTGRES_ADMIN_URL: postgresql://postgres:testpass@127.0.0.1:5432/agentbom_test
       AGENT_BOM_POSTGRES_POOL_MIN_SIZE: "1"
       AGENT_BOM_POSTGRES_POOL_MAX_SIZE: "4"
       AGENT_BOM_POSTGRES_CONNECT_TIMEOUT_SECONDS: "5"

--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -12,15 +12,17 @@ name: Demo redeploy
 # vars/secrets documented in docs/HOSTED_POC.md → "Demo redeploy".
 
 on:
-  # Primary trigger: workflow_run fires even when Release publishes with the
-  # default GITHUB_TOKEN (which suppresses `release: published` workflow starts).
+  # Deploy only after the Release workflow succeeds. A direct release trigger
+  # can race the still-running release and would duplicate the deployment.
   workflow_run:
     workflows: ["Release"]
     types: [completed]
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
+      release_ref:
+        description: "Exact main-ancestor tag or commit to deploy (defaults to current main SHA)"
+        type: string
+        required: false
       reset_demo:
         description: "Reset the demo tenant state after the redeploy"
         type: boolean
@@ -36,10 +38,9 @@ concurrency:
 jobs:
   redeploy:
     name: Redeploy hosted demo via SSM
-    # Skip failed Release runs; keep release + manual dispatch always eligible.
+    # Skip failed Release runs; keep protected manual dispatch eligible.
     if: >
       github.event_name == 'workflow_dispatch' ||
-      github.event_name == 'release' ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -89,20 +90,32 @@ jobs:
           DEMO_INSTANCE_ID: ${{ vars.DEMO_INSTANCE_ID }}
           DEMO_DEPLOY_DIR: ${{ vars.DEMO_DEPLOY_DIR || '/opt/agent-bom' }}
           RESET_DEMO: ${{ inputs.reset_demo || 'false' }}
-          RELEASE_REF: ${{ github.event.release.tag_name || github.event.workflow_run.head_sha || github.sha }}
+          RELEASE_REF: ${{ inputs.release_ref || github.event.workflow_run.head_sha || github.sha }}
         run: |
           set -euo pipefail
 
+          case "${RELEASE_REF}" in
+            ''|*[!A-Za-z0-9._/-]*)
+              echo "::error::release_ref must be a tag or commit containing only letters, numbers, '.', '_', '/', or '-'."
+              exit 1
+              ;;
+          esac
+
+          deploy_dir_b64=$(printf '%s' "${DEMO_DEPLOY_DIR}" | base64 -w0)
+          reset_demo_b64=$(printf '%s' "${RESET_DEMO}" | base64 -w0)
+          release_ref_b64=$(printf '%s' "${RELEASE_REF}" | base64 -w0)
+
           # Build the remote script with a quoted heredoc so the runner does
-          # NOT expand any of the VM-side shell variables, then splice in only
-          # the two runner-provided values via sed.
+          # NOT expand any of the VM-side shell variables. Only base64-encoded,
+          # validated runner values are spliced into the script.
           cat > remote.sh <<'REMOTE'
           # SSM AWS-RunShellScript executes this under /bin/sh (dash on Ubuntu),
           # which has no `pipefail` — use POSIX-safe `set -eu` so the script does
           # not abort at line 1 with "Illegal option -o pipefail".
           set -eu
-          DEPLOY_DIR="__DEPLOY_DIR__"
-          RESET_DEMO="__RESET_DEMO__"
+          DEPLOY_DIR=$(printf '%s' '__DEPLOY_DIR_B64__' | base64 -d)
+          RESET_DEMO=$(printf '%s' '__RESET_DEMO_B64__' | base64 -d)
+          RELEASE_REF=$(printf '%s' '__RELEASE_REF_B64__' | base64 -d)
           # Fail loud when vars.DEMO_DEPLOY_DIR does not match the VM checkout
           # (bare `cd` under dash only prints "can't cd", which hid past failures).
           if [ ! -d "$DEPLOY_DIR/.git" ]; then
@@ -112,6 +125,21 @@ jobs:
             exit 1
           fi
           cd "$DEPLOY_DIR"
+
+          compose() {
+            docker compose \
+              -f deploy/docker-compose.platform.yml \
+              -f deploy/docker-compose.hosted-poc.yml \
+              -f deploy/docker-compose.demo-override.yml "$@"
+          }
+
+          emit_sanitized_logs() {
+            echo "== bounded sanitized API/migration logs ==" >&2
+            compose logs --no-color --tail=120 api migrate 2>&1 \
+              | PYTHONPATH="$DEPLOY_DIR/src" python3 -c \
+                  'import sys; from agent_bom.security import sanitize_text; [print(sanitize_text(line, max_len=500)) for line in sys.stdin]' \
+              | tail -c 24000 >&2 || true
+          }
 
           # Optional on-VM env file carries the non-secret URL wiring the
           # preflight requires (NEXT_PUBLIC_API_URL, CORS_ORIGINS) plus the
@@ -124,7 +152,7 @@ jobs:
           fi
 
           # Before v0.97.4 the public-demo overlay was VM-local. Preserve that
-          # untracked file before pulling the now-canonical tracked overlay;
+          # untracked file before checking out the now-canonical tracked overlay;
           # otherwise git correctly refuses to overwrite it and the release
           # cannot reach the compose/preflight/smoke gates.
           legacy_overlay="deploy/docker-compose.demo-override.yml"
@@ -135,45 +163,43 @@ jobs:
             mv "$legacy_overlay" "$legacy_backup"
           fi
 
-          echo "== git pull =="
-          git pull --ff-only
+          if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+            echo "ERROR: tracked files are modified in $DEPLOY_DIR; refusing an ambiguous deployment." >&2
+            exit 1
+          fi
+
+          PREVIOUS_COMMIT=$(git rev-parse HEAD)
+          echo "== resolve exact release ref =="
+          git fetch --prune --tags origin main
+          TARGET_COMMIT=$(git rev-parse --verify "${RELEASE_REF}^{commit}")
+          if ! git merge-base --is-ancestor "$TARGET_COMMIT" origin/main; then
+            echo "ERROR: requested release ref is not an ancestor of origin/main." >&2
+            exit 1
+          fi
+          git checkout --detach "$TARGET_COMMIT"
+          test "$(git rev-parse HEAD)" = "$TARGET_COMMIT"
+          echo "Previous commit: $PREVIOUS_COMMIT"
+          echo "Target commit:   $TARGET_COMMIT"
+
+          # Preflight validates platform + hosted-poc only (auth-required
+          # hardening). Run it before the build/promotion boundary.
+          echo "== preflight (fail-closed) =="
+          python3 scripts/deploy/hosted_poc_preflight.py --write-secret
 
           # Build images first while the previous stack keeps serving, then
           # restart containers briefly — avoids a long Cloudflare 502 window
           # during `up -d --build`.
           echo "== docker compose build =="
-          docker compose \
-            -f deploy/docker-compose.platform.yml \
-            -f deploy/docker-compose.hosted-poc.yml \
-            -f deploy/docker-compose.demo-override.yml \
-            build
+          compose build
 
-          echo "== docker compose up =="
-          if ! docker compose \
-            -f deploy/docker-compose.platform.yml \
-            -f deploy/docker-compose.hosted-poc.yml \
-            -f deploy/docker-compose.demo-override.yml \
-            up -d; then
+          echo "== docker compose up (in-place promotion boundary) =="
+          if ! compose up -d; then
             echo "== compose failure status ==" >&2
-            docker compose \
-              -f deploy/docker-compose.platform.yml \
-              -f deploy/docker-compose.hosted-poc.yml \
-              -f deploy/docker-compose.demo-override.yml \
-              ps -a >&2 || true
-            echo "== migration failure logs ==" >&2
-            docker compose \
-              -f deploy/docker-compose.platform.yml \
-              -f deploy/docker-compose.hosted-poc.yml \
-              -f deploy/docker-compose.demo-override.yml \
-              logs --no-color --tail=200 migrate >&2 || true
+            compose ps -a >&2 || true
+            emit_sanitized_logs
+            echo "Deployment failed during in-place replacement; automatic rollback was not attempted." >&2
             exit 1
           fi
-
-          # Preflight validates platform + hosted-poc only (auth-required hardening).
-          # The demo-override anonymous flags are intentional for the public demo and
-          # must not be part of that security gate.
-          echo "== preflight (fail-closed) =="
-          python3 scripts/deploy/hosted_poc_preflight.py --write-secret
 
           echo "== smoke =="
           scripts/deploy/hosted_poc_smoke.sh
@@ -190,8 +216,9 @@ jobs:
             | python3 -c 'import json,sys; print(int(json.load(sys.stdin).get("total") or 0))')
           if [ "$findings_total" -lt 1 ]; then
             echo "ERROR: demo estate has zero findings (total=${findings_total})." >&2
-            echo "Bootstrap did not seed a usable scan job — check API logs for" >&2
-            echo "'demo estate scan bootstrap failed' and AGENT_BOM_DEMO_ESTATE=1." >&2
+            emit_sanitized_logs
+            echo "Validation failed after in-place container replacement; target may be serving." >&2
+            echo "Automatic rollback was not attempted because the migration may not be reversible." >&2
             exit 1
           fi
           echo "Demo estate findings total=${findings_total}"
@@ -207,8 +234,9 @@ jobs:
           echo "== redeploy complete =="
           REMOTE
 
-          sed -i "s#__DEPLOY_DIR__#${DEMO_DEPLOY_DIR}#g" remote.sh
-          sed -i "s#__RESET_DEMO__#${RESET_DEMO}#g" remote.sh
+          sed -i "s#__DEPLOY_DIR_B64__#${deploy_dir_b64}#g" remote.sh
+          sed -i "s#__RESET_DEMO_B64__#${reset_demo_b64}#g" remote.sh
+          sed -i "s#__RELEASE_REF_B64__#${release_ref_b64}#g" remote.sh
 
           # SSM `commands` is a JSON array; pass the whole script as one element.
           jq -n --rawfile script remote.sh '{commands: [$script]}' > params.json
@@ -250,7 +278,7 @@ jobs:
             --query "StandardErrorContent" --output text >&2 || true
 
           if [ "${status}" != "Success" ]; then
-            echo "::error::Hosted demo redeploy failed on the VM (SSM status: ${status}). Preflight/smoke or compose did not pass — the demo was NOT promoted."
+            echo "::error::Hosted demo redeploy failed on the VM (SSM status: ${status}). If compose up started, the target may be serving; inspect the sanitized diagnostics."
             exit 1
           fi
           echo "Hosted demo redeploy succeeded."

--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -170,7 +170,7 @@ jobs:
 
           PREVIOUS_COMMIT=$(git rev-parse HEAD)
           echo "== resolve exact release ref =="
-          git fetch --prune --tags origin main
+          git fetch --prune --tags origin +refs/heads/main:refs/remotes/origin/main
           TARGET_COMMIT=$(git rev-parse --verify "${RELEASE_REF}^{commit}")
           if ! git merge-base --is-ancestor "$TARGET_COMMIT" origin/main; then
             echo "ERROR: requested release ref is not an ancestor of origin/main." >&2

--- a/deploy/supabase/postgres/alembic/versions/20260724_01_runtime_workload_evidence_authority.py
+++ b/deploy/supabase/postgres/alembic/versions/20260724_01_runtime_workload_evidence_authority.py
@@ -1,0 +1,88 @@
+"""Make runtime workload evidence migration-owned and tenant-isolated.
+
+Revision ID: 20260724_01
+Revises: 20260721_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260724_01"
+down_revision = "20260721_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS runtime_workload_evidence (
+            tenant_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            account_id TEXT NOT NULL,
+            workload_ref TEXT NOT NULL,
+            dedup_key TEXT NOT NULL,
+            workload_id TEXT NOT NULL,
+            signal_type TEXT NOT NULL,
+            severity TEXT NOT NULL,
+            observed_at TEXT NOT NULL,
+            source_id TEXT NOT NULL,
+            source_kind TEXT NOT NULL,
+            payload_json TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, provider, account_id, workload_ref, dedup_key)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_runtime_workload_evidence_tenant_observed_dedup
+            ON runtime_workload_evidence (tenant_id, observed_at DESC, dedup_key DESC)
+        """
+    )
+    op.execute("DROP INDEX IF EXISTS idx_runtime_workload_evidence_tenant_time")
+    op.execute("ALTER TABLE runtime_workload_evidence ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE runtime_workload_evidence FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_policies
+                WHERE schemaname = 'public'
+                  AND tablename = 'runtime_workload_evidence'
+                  AND policyname = 'runtime_workload_evidence_tenant_isolation'
+            ) THEN
+                CREATE POLICY runtime_workload_evidence_tenant_isolation
+                    ON runtime_workload_evidence
+                    USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+                    WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+            END IF;
+        END
+        $$
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+                GRANT SELECT, INSERT, UPDATE, DELETE ON runtime_workload_evidence TO agent_bom_app;
+            END IF;
+        END
+        $$
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO control_plane_schema_versions(component, version, updated_at)
+        VALUES ('runtime_workload_evidence', 1, now())
+        ON CONFLICT(component) DO UPDATE SET
+            version = EXCLUDED.version,
+            updated_at = EXCLUDED.updated_at
+        """
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Runtime workload evidence schema authority is additive and intentionally irreversible.")

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -63,6 +63,24 @@ CREATE TABLE IF NOT EXISTS runtime_observations (tenant_id TEXT NOT NULL, observ
 CREATE TABLE IF NOT EXISTS runtime_sessions (tenant_id TEXT NOT NULL, session_id TEXT NOT NULL, last_seen TEXT NOT NULL, data TEXT NOT NULL, PRIMARY KEY(tenant_id,session_id));
 CREATE INDEX IF NOT EXISTS idx_runtime_observations_tenant_session_time ON runtime_observations(tenant_id,session_id,observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_runtime_sessions_tenant_last_seen ON runtime_sessions(tenant_id,last_seen DESC);
+CREATE TABLE IF NOT EXISTS runtime_workload_evidence (
+  tenant_id TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  account_id TEXT NOT NULL,
+  workload_ref TEXT NOT NULL,
+  dedup_key TEXT NOT NULL,
+  workload_id TEXT NOT NULL,
+  signal_type TEXT NOT NULL,
+  severity TEXT NOT NULL,
+  observed_at TEXT NOT NULL,
+  source_id TEXT NOT NULL,
+  source_kind TEXT NOT NULL,
+  payload_json TEXT NOT NULL,
+  PRIMARY KEY(tenant_id,provider,account_id,workload_ref,dedup_key)
+);
+CREATE INDEX IF NOT EXISTS idx_runtime_workload_evidence_tenant_observed_dedup
+  ON runtime_workload_evidence(tenant_id,observed_at DESC,dedup_key DESC);
+DROP INDEX IF EXISTS idx_runtime_workload_evidence_tenant_time;
 
 CREATE TABLE IF NOT EXISTS scim_users (tenant_id TEXT NOT NULL,user_id TEXT NOT NULL,external_id TEXT,user_name TEXT NOT NULL,active BOOLEAN NOT NULL DEFAULT TRUE,updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS"Z"'),data JSONB NOT NULL,PRIMARY KEY(tenant_id,user_id));
 CREATE TABLE IF NOT EXISTS scim_groups (tenant_id TEXT NOT NULL,group_id TEXT NOT NULL,external_id TEXT,display_name TEXT NOT NULL,updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS"Z"'),data JSONB NOT NULL,PRIMARY KEY(tenant_id,group_id));
@@ -142,7 +160,7 @@ DECLARE t TEXT;
 BEGIN
   FOREACH t IN ARRAY ARRAY[
     'access_review_campaigns','access_review_items','agent_identities','agent_identity_jit_grants','agent_conditional_access_policies',
-    'ai_system_blueprints','ai_system_blueprint_versions','runtime_observations','runtime_sessions','scim_users','scim_groups',
+    'ai_system_blueprints','ai_system_blueprint_versions','runtime_observations','runtime_sessions','runtime_workload_evidence','scim_users','scim_groups',
     'idempotency_keys','proxy_replay_log','tenant_quota_overrides','tenant_graph_retention_overrides','tenant_score_config_overrides',
     'mcp_client_configs','model_provider_keys','model_virtual_keys','risk_campaign_workflows','governance_audit_log','cloud_connections',
     'control_plane_sources','credential_refs','audit_chain_checkpoint','compliance_hub_findings','hub_findings_current',
@@ -171,7 +189,7 @@ INSERT INTO control_plane_schema_versions(component,version,updated_at)
 SELECT component,1,now() FROM unnest(ARRAY[
  'scan_jobs','api_keys','exceptions','audit_log','trend_history','gateway_policies','schedules','sources','credential_refs','llm_costs',
  'cloud_connections','compliance_hub','access_review_campaigns','risk_campaign_workflows','fleet','graph','scan_cache','identity_scim',
- 'agent_identities','runtime_events','tenant_quotas','tenant_graph_retention','idempotency','proxy_replay_log','rate_limits',
+ 'agent_identities','runtime_events','runtime_workload_evidence','tenant_quotas','tenant_graph_retention','idempotency','proxy_replay_log','rate_limits',
  'shared_auth_state','governance_audit_log','ai_system_blueprints','mcp_client_configs','model_provider_keys','tenant_score_config'
 ]) component
 ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -63,6 +63,7 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     ),
     # Runtime session/observation timeline is durable by default (same tiering).
     StorageSchemaComponent("runtime_events", "sqlite/postgres", ("runtime_observations", "runtime_sessions")),
+    StorageSchemaComponent("runtime_workload_evidence", "sqlite/postgres", ("runtime_workload_evidence",)),
     StorageSchemaComponent("tenant_quotas", "sqlite/postgres", ("tenant_quota_overrides",)),
     StorageSchemaComponent("tenant_graph_retention", "sqlite/postgres", ("tenant_graph_retention_overrides",)),
     StorageSchemaComponent("sources", "sqlite/postgres", ("sources", "control_plane_sources")),

--- a/src/agent_bom/cloud/runtime_workload_evidence.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence.py
@@ -48,6 +48,7 @@ from enum import Enum
 from typing import Any, Iterable, Mapping
 
 from agent_bom.canonical_ids import canonical_id
+from agent_bom.security import sanitize_text
 
 logger = logging.getLogger(__name__)
 
@@ -620,11 +621,7 @@ def _resolve_finding_workload(row: Mapping[str, Any]) -> tuple[str, str, str] | 
     asset = row.get("asset")
     if isinstance(asset, Mapping):
         provider = provider or str(asset.get("provider") or "").strip().lower()
-        account = (
-            account
-            or _account_from_ref(str(asset.get("account_ref") or ""))
-            or str(asset.get("account_id") or "").strip()
-        )
+        account = account or _account_from_ref(str(asset.get("account_ref") or "")) or str(asset.get("account_id") or "").strip()
         if not workload_ref:
             workload_ref = str(asset.get("identifier") or asset.get("resource_id") or "").strip()
             if not workload_ref:
@@ -635,15 +632,9 @@ def _resolve_finding_workload(row: Mapping[str, Any]) -> tuple[str, str, str] | 
     evidence = row.get("evidence")
     if isinstance(evidence, Mapping):
         provider = provider or str(evidence.get("provider") or "").strip().lower()
-        account = (
-            account
-            or _account_from_ref(str(evidence.get("account_ref") or ""))
-            or str(evidence.get("account_id") or "").strip()
-        )
+        account = account or _account_from_ref(str(evidence.get("account_ref") or "")) or str(evidence.get("account_id") or "").strip()
         if not workload_ref:
-            workload_ref = str(
-                evidence.get("resource_id") or evidence.get("target_id") or evidence.get("workload_ref") or ""
-            ).strip()
+            workload_ref = str(evidence.get("resource_id") or evidence.get("target_id") or evidence.get("workload_ref") or "").strip()
 
     if provider and account and workload_ref:
         return provider, account, workload_ref
@@ -714,13 +705,23 @@ def optional_runtime_workload_evidence_index(
     no-signal rows for tenants that never opted into runtime ingest.
     """
     active_tenant = (tenant_id or os.getenv("AGENT_BOM_TENANT_ID") or "default").strip() or "default"
-    active_store = store
-    if active_store is None:
-        from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+    try:
+        active_store = store
+        if active_store is None:
+            from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
 
-        active_store = get_runtime_workload_evidence_store()
-    index = RuntimeWorkloadEvidenceIndex.from_store(active_store, active_tenant)
-    return None if index.is_empty() else index
+            active_store = get_runtime_workload_evidence_store()
+        index = RuntimeWorkloadEvidenceIndex.from_store(active_store, active_tenant)
+        return None if index.is_empty() else index
+    except Exception as exc:  # noqa: BLE001 - enrichment is explicitly optional
+        # Runtime evidence is additive. A backend outage must not suppress the
+        # primary scan findings or make JSON/SARIF/HTML export fail. Ingest and
+        # durable writes remain fail-closed in their own paths.
+        logger.warning(
+            "optional runtime workload evidence enrichment unavailable: %s",
+            sanitize_text(exc),
+        )
+        return None
 
 
 def _node_attributes(node: Any) -> dict[str, Any] | None:

--- a/src/agent_bom/cloud/runtime_workload_evidence_store.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence_store.py
@@ -28,10 +28,15 @@ from __future__ import annotations
 import json
 import sqlite3
 import threading
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Iterator, Protocol
 
 from agent_bom.cloud.runtime_workload_evidence import RuntimeWorkloadSignal
+
+if TYPE_CHECKING:
+    from psycopg import Connection
+    from psycopg_pool import ConnectionPool
 
 _COLUMNS = (
     "tenant_id",
@@ -138,6 +143,8 @@ class SQLiteRuntimeWorkloadEvidenceStore:
 
     def init_schema(self) -> None:
         with self._connect() as connection:
+            from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+
             connection.execute(
                 """
                 CREATE TABLE IF NOT EXISTS runtime_workload_evidence (
@@ -168,6 +175,7 @@ class SQLiteRuntimeWorkloadEvidenceStore:
             # Drop the stale index that ordered by (tenant_id, workload_id,
             # observed_at) — unusable for the tenant read's ORDER BY.
             connection.execute("DROP INDEX IF EXISTS idx_rwe_tenant_workload_time")
+            ensure_sqlite_schema_version(connection, "runtime_workload_evidence")
 
     def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:
         if not signals:
@@ -189,69 +197,117 @@ class SQLiteRuntimeWorkloadEvidenceStore:
 
 
 class PostgresRuntimeWorkloadEvidenceStore:
-    """Shared Postgres backend with application-level tenant scoping.
+    """Shared Postgres backend with migration-owned schema and tenant RLS.
 
-    Uses a direct connection (not the RLS pool) so tenant isolation is enforced by
-    the leading ``tenant_id`` predicate and the composite dedup key — the same
-    model the stage-1 lifecycle store uses. ``table`` is parameterizable so tests
-    can isolate into a throwaway relation.
+    Production construction uses the shared secret-aware Postgres pool and the
+    same request-scoped tenant session as the rest of the control plane. An
+    explicit ``dsn`` remains available only for isolated development/tests that
+    own a throwaway table.
     """
 
-    def __init__(self, dsn: str, *, table: str = "runtime_workload_evidence") -> None:
+    def __init__(
+        self,
+        dsn: str | None = None,
+        *,
+        table: str = "runtime_workload_evidence",
+        pool: ConnectionPool | None = None,
+    ) -> None:
         if not table.replace("_", "").isalnum():
             raise ValueError("table name must be alphanumeric/underscore")
         self._dsn = dsn
         self.table = table
+        self._pool: Any = None
+        if dsn is not None and pool is not None:
+            raise ValueError("Pass either dsn or pool, not both")
+        if dsn is None:
+            from agent_bom.api.postgres_common import _get_pool
+
+            self._pool = pool or _get_pool()
+        else:
+            self._pool = None
         self.init_schema()
 
     def _connect(self) -> Any:
+        if self._dsn is None:
+            raise RuntimeError("Direct Postgres connections require an explicit development/test DSN")
         import psycopg
 
         return psycopg.connect(self._dsn)
 
+    @contextmanager
+    def _tenant_connection(self, tenant_id: str) -> Iterator[Connection]:
+        if self._pool is None:
+            with self._connect() as conn:
+                yield conn
+            return
+
+        from agent_bom.api.postgres_common import (
+            _tenant_connection,
+            reset_current_tenant,
+            set_current_tenant,
+        )
+
+        token = set_current_tenant(tenant_id)
+        try:
+            with _tenant_connection(self._pool) as conn:
+                yield conn
+        finally:
+            reset_current_tenant(token)
+
+    def _create_schema(self, conn: Connection) -> None:
+        conn.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {self.table} (
+                tenant_id TEXT NOT NULL,
+                provider TEXT NOT NULL,
+                account_id TEXT NOT NULL,
+                workload_ref TEXT NOT NULL,
+                dedup_key TEXT NOT NULL,
+                workload_id TEXT NOT NULL,
+                signal_type TEXT NOT NULL,
+                severity TEXT NOT NULL,
+                observed_at TEXT NOT NULL,
+                source_id TEXT NOT NULL,
+                source_kind TEXT NOT NULL,
+                payload_json TEXT NOT NULL,
+                PRIMARY KEY (tenant_id, provider, account_id, workload_ref, dedup_key)
+            )
+            """  # noqa: S608
+        )
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_{self.table}_tenant_observed_dedup "  # noqa: S608
+            f"ON {self.table} (tenant_id, observed_at DESC, dedup_key DESC)"
+        )
+        conn.execute(f"DROP INDEX IF EXISTS idx_{self.table}_tenant_time")  # noqa: S608
+        conn.commit()
+
     def init_schema(self) -> None:
+        if self._pool is not None:
+            from agent_bom.api.storage_schema import ensure_postgres_schema_version
+
+            with self._pool.connection() as conn:
+                if not ensure_postgres_schema_version(conn, "runtime_workload_evidence"):
+                    return
+                self._create_schema(conn)
+            return
+
         with self._connect() as conn:
-            conn.execute(
-                f"""
-                CREATE TABLE IF NOT EXISTS {self.table} (
-                    tenant_id TEXT NOT NULL,
-                    provider TEXT NOT NULL,
-                    account_id TEXT NOT NULL,
-                    workload_ref TEXT NOT NULL,
-                    dedup_key TEXT NOT NULL,
-                    workload_id TEXT NOT NULL,
-                    signal_type TEXT NOT NULL,
-                    severity TEXT NOT NULL,
-                    observed_at TEXT NOT NULL,
-                    source_id TEXT NOT NULL,
-                    source_kind TEXT NOT NULL,
-                    payload_json TEXT NOT NULL,
-                    PRIMARY KEY (tenant_id, provider, account_id, workload_ref, dedup_key)
-                )
-                """  # noqa: S608
-            )
-            # Match the ``list_for_tenant`` ORDER BY (observed_at DESC, dedup_key
-            # DESC) under the leading tenant predicate so the read is sargable at
-            # scale instead of a seq-scan + sort.
-            conn.execute(
-                f"CREATE INDEX IF NOT EXISTS idx_{self.table}_tenant_observed_dedup "  # noqa: S608
-                f"ON {self.table} (tenant_id, observed_at DESC, dedup_key DESC)"
-            )
-            # Drop the stale (tenant_id, workload_id, observed_at) index that could
-            # not serve that ORDER BY.
-            conn.execute(f"DROP INDEX IF EXISTS idx_{self.table}_tenant_time")  # noqa: S608
-            conn.commit()
+            self._create_schema(conn)
 
     def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:
         if not signals:
             return 0
+        tenant_ids = {signal.tenant_id for signal in signals}
+        if len(tenant_ids) != 1:
+            raise ValueError("A runtime workload evidence batch must contain exactly one tenant")
+        tenant_id = next(iter(tenant_ids))
         placeholders = ",".join("%s" for _ in _COLUMNS)
         sql = (
             f"INSERT INTO {self.table} ({','.join(_COLUMNS)}) VALUES ({placeholders}) "  # noqa: S608  # nosec B608 — table validated in __init__, values parameterized
             "ON CONFLICT (tenant_id, provider, account_id, workload_ref, dedup_key) DO NOTHING"
         )
         inserted = 0
-        with self._connect() as conn:
+        with self._tenant_connection(tenant_id) as conn:
             with conn.cursor() as cur:
                 for signal in signals:
                     cur.execute(sql, _row_values(signal))
@@ -260,7 +316,7 @@ class PostgresRuntimeWorkloadEvidenceStore:
         return inserted
 
     def list_for_tenant(self, tenant_id: str, *, limit: int = 5000) -> list[RuntimeWorkloadSignal]:
-        with self._connect() as conn:
+        with self._tenant_connection(tenant_id) as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     f"SELECT payload_json FROM {self.table} WHERE tenant_id = %s "  # noqa: S608  # nosec B608 — table validated in __init__, values parameterized
@@ -272,6 +328,8 @@ class PostgresRuntimeWorkloadEvidenceStore:
 
     def drop_table(self) -> None:
         """Drop the backing relation (test cleanup helper)."""
+        if self._pool is not None:
+            raise RuntimeError("Migration-owned Postgres tables cannot be dropped by the runtime store")
         with self._connect() as conn:
             conn.execute(f"DROP TABLE IF EXISTS {self.table}")  # noqa: S608
             conn.commit()
@@ -314,7 +372,10 @@ def get_runtime_workload_evidence_store() -> RuntimeWorkloadEvidenceStore:
             dsn = selection.dsn or os.environ.get("AGENT_BOM_POSTGRES_URL") or os.environ.get("AGENT_BOM_DB", "")
             if not dsn.strip():
                 raise RuntimeError("Postgres workload-evidence store selected but no Postgres URL is configured")
-            _default_store = PostgresRuntimeWorkloadEvidenceStore(dsn.strip())
+            # The production store resolves the configured URL, mounted secret
+            # file/IAM token, pool bounds, and tenant RLS through postgres_common.
+            # The raw password-free Compose DSN must never be connected directly.
+            _default_store = PostgresRuntimeWorkloadEvidenceStore()
         elif selection.backend is BackendKind.MEMORY:
             _default_store = InMemoryRuntimeWorkloadEvidenceStore()
         else:

--- a/tests/cloud/test_runtime_workload_evidence_store.py
+++ b/tests/cloud/test_runtime_workload_evidence_store.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import multiprocessing as mp
 import os
+import sqlite3
 import uuid
 
 import pytest
@@ -75,6 +76,12 @@ def test_sqlite_persists_across_reopen(tmp_path):
     assert len(rows) == 1
     assert rows[0].workload_ref == "i-0abc"
     assert rows[0].source_kind == "edr"
+    with sqlite3.connect(path) as connection:
+        marker = connection.execute(
+            "SELECT version FROM control_plane_schema_versions WHERE component = ?",
+            ("runtime_workload_evidence",),
+        ).fetchone()
+    assert marker == (1,)
 
 
 def test_sqlite_cross_tenant_same_dedup_key_both_persist_no_leak(tmp_path):

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -333,16 +333,32 @@ def test_demo_redeploy_layers_demo_override_and_uses_write_secret() -> None:
     assert "demo estate smoke" in workflow
     assert "/v1/findings?limit=1" in workflow
     # v0.97.4 made the demo overlay tracked. The VM's older untracked copy must
-    # be preserved outside the checkout path before git pull can fast-forward.
+    # be preserved outside the checkout path before exact-ref checkout.
     assert 'git ls-files --error-unmatch "$legacy_overlay"' in workflow
     assert "docker-compose.demo-override.pretracked." in workflow
     assert 'mv "$legacy_overlay" "$legacy_backup"' in workflow
-    assert workflow.index('mv "$legacy_overlay" "$legacy_backup"') < workflow.index("git pull --ff-only")
-    # Compose one-shot failures must expose the migration container's state and
-    # bounded logs through SSM; otherwise deployment failures are unactionable.
+    assert workflow.index('mv "$legacy_overlay" "$legacy_backup"') < workflow.index("git fetch --prune --tags origin main")
+    # Release automation must deploy the exact successful release SHA, never
+    # mutable main, and must not race through a second release event trigger.
+    assert "git pull --ff-only" not in workflow
+    assert 'git rev-parse --verify "${RELEASE_REF}^{commit}"' in workflow
+    assert 'git checkout --detach "$TARGET_COMMIT"' in workflow
+    assert 'test "$(git rev-parse HEAD)" = "$TARGET_COMMIT"' in workflow
+    assert "\n  release:\n" not in workflow
+    assert "release_ref:" in workflow
+    # Static preflight precedes build and in-place promotion.
+    assert workflow.index("hosted_poc_preflight.py --write-secret") < workflow.index("compose build")
+    assert workflow.index("compose build") < workflow.index("compose up -d")
+    # Compose failures must expose bounded, sanitized API/migration evidence.
     assert "compose failure status" in workflow
-    assert "migration failure logs" in workflow
-    assert "logs --no-color --tail=200 migrate" in workflow
+    assert "emit_sanitized_logs" in workflow
+    assert "logs --no-color --tail=120 api migrate" in workflow
+    assert "sanitize_text" in workflow
+    assert "tail -c 24000" in workflow
+    assert "logs --no-color --tail=200 migrate >&2" not in workflow
+    assert "demo was NOT promoted" not in workflow
+    assert "in-place container replacement" in workflow
+    assert "Automatic rollback was not attempted" in workflow
 
     # Security gate remains platform + hosted-poc only (no demo anon flags).
     preflight_src = (root / "scripts" / "deploy" / "hosted_poc_preflight.py").read_text(encoding="utf-8")

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -337,7 +337,8 @@ def test_demo_redeploy_layers_demo_override_and_uses_write_secret() -> None:
     assert 'git ls-files --error-unmatch "$legacy_overlay"' in workflow
     assert "docker-compose.demo-override.pretracked." in workflow
     assert 'mv "$legacy_overlay" "$legacy_backup"' in workflow
-    assert workflow.index('mv "$legacy_overlay" "$legacy_backup"') < workflow.index("git fetch --prune --tags origin main")
+    exact_main_fetch = "git fetch --prune --tags origin +refs/heads/main:refs/remotes/origin/main"
+    assert workflow.index('mv "$legacy_overlay" "$legacy_backup"') < workflow.index(exact_main_fetch)
     # Release automation must deploy the exact successful release SHA, never
     # mutable main, and must not race through a second release event trigger.
     assert "git pull --ff-only" not in workflow

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -71,6 +71,28 @@ def test_postgres_job_store_real_roundtrip_and_tenant_filter():
     assert any(item.job_id == job_id for item in results)
 
 
+def test_demo_estate_bootstrap_uses_secret_aware_migrated_postgres(monkeypatch):
+    """Compose's password-free app DSN must still persist demo findings."""
+    from agent_bom.api.postgres_store import PostgresJobStore
+    from agent_bom.api.stores import set_job_store
+    from agent_bom.cloud.runtime_workload_evidence_store import reset_runtime_workload_evidence_store
+    from agent_bom.demo_estate.bootstrap import maybe_bootstrap_demo_estate
+
+    monkeypatch.setenv("AGENT_BOM_DEMO_ESTATE", "1")
+    monkeypatch.setenv("AGENT_BOM_DEMO_ESTATE_FORCE", "1")
+    store = PostgresJobStore()
+    set_job_store(store)
+    reset_runtime_workload_evidence_store()
+
+    summary = maybe_bootstrap_demo_estate()
+
+    assert summary.get("scan_error") is not True
+    assert summary.get("seeded") is True
+    assert int(summary.get("findings") or 0) > 0
+    jobs = store.list_all(tenant_id="default")
+    assert any(job.job_id == summary["job_id"] and job.result and job.result.get("findings") for job in jobs)
+
+
 def test_budget_pk_migration_targets_visible_relation_across_search_path():
     """The inspected and altered table must be the same visible relation."""
     import psycopg
@@ -335,9 +357,7 @@ def test_postgres_graph_build_workspace_rls_blocks_cross_tenant_raw_select():
     finally:
         reset_current_tenant(token_b)
 
-    assert cross_tenant_rows == [], (
-        "graph_build_workspace_nodes RLS leaked tenant A data into a session bound to tenant B"
-    )
+    assert cross_tenant_rows == [], "graph_build_workspace_nodes RLS leaked tenant A data into a session bound to tenant B"
 
     # Cleanup under tenant A (and edges table is unused here).
     token_a = set_current_tenant(tenant_a)

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -139,18 +139,42 @@ def test_runtime_workload_evidence_shared_pool_roundtrip_and_rls():
     assert rls == (True, True)
 
 
+def _postgres_connect(**kwargs):
+    """Connect with the shared password-file/IAM-aware secret resolution."""
+    import psycopg
+
+    from agent_bom.api.postgres_common import resolve_postgres_secret, resolve_postgres_url
+
+    connect_kwargs = dict(kwargs)
+    password = resolve_postgres_secret()
+    if password is not None:
+        connect_kwargs["password"] = password
+    return psycopg.connect(resolve_postgres_url(), **connect_kwargs)
+
+
 def test_budget_pk_migration_targets_visible_relation_across_search_path():
-    """The inspected and altered table must be the same visible relation."""
+    """The inspected and altered table must be the same visible relation.
+
+    Migration DDL needs CREATE SCHEMA; the Compose/CI app role is DML-only, so
+    prefer an explicit migrator/admin DSN when provided and otherwise use the
+    password-file-aware app connection (skipping if schema DDL is denied).
+    """
     import psycopg
 
     from agent_bom.api.postgres_cost import BUDGET_PK_MIGRATION_SQL
 
-    dsn = os.environ["AGENT_BOM_POSTGRES_URL"]
+    admin_dsn = os.environ.get("AGENT_BOM_POSTGRES_ADMIN_URL", "").strip()
     suffix = uuid4().hex[:12]
     first_schema = f"empty_{suffix}"
     data_schema = f"budget_{suffix}"
+
+    def _connect(**kwargs):
+        if admin_dsn:
+            return psycopg.connect(admin_dsn, **kwargs)
+        return _postgres_connect(**kwargs)
+
     try:
-        with psycopg.connect(dsn) as conn:
+        with _connect() as conn:
             try:
                 conn.execute(f'CREATE SCHEMA "{first_schema}"')
                 conn.execute(f'CREATE SCHEMA "{data_schema}"')
@@ -172,7 +196,7 @@ def test_budget_pk_migration_targets_visible_relation_across_search_path():
             ).fetchall()
             assert [row[0] for row in columns] == ["tenant_id", "agent", "cost_center", "owner", "workflow"]
     finally:
-        with psycopg.connect(dsn, autocommit=True) as cleanup:
+        with _connect(autocommit=True) as cleanup:
             cleanup.execute(f'DROP SCHEMA IF EXISTS "{first_schema}" CASCADE')
             cleanup.execute(f'DROP SCHEMA IF EXISTS "{data_schema}" CASCADE')
 

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -21,9 +21,12 @@ pytestmark = pytest.mark.skipif(
 @pytest.fixture(autouse=True)
 def reset_postgres_pool():
     from agent_bom.api import postgres_common
+    from agent_bom.cloud.runtime_workload_evidence_store import reset_runtime_workload_evidence_store
 
     postgres_common.reset_pool()
+    reset_runtime_workload_evidence_store()
     yield
+    reset_runtime_workload_evidence_store()
     pool = postgres_common._pool
     if pool is not None:
         pool.close()
@@ -91,6 +94,49 @@ def test_demo_estate_bootstrap_uses_secret_aware_migrated_postgres(monkeypatch):
     assert int(summary.get("findings") or 0) > 0
     jobs = store.list_all(tenant_id="default")
     assert any(job.job_id == summary["job_id"] and job.result and job.result.get("findings") for job in jobs)
+
+
+def test_runtime_workload_evidence_shared_pool_roundtrip_and_rls():
+    from agent_bom.api.postgres_common import _get_pool
+    from agent_bom.cloud.runtime_workload_evidence import RuntimeWorkloadSignal
+    from agent_bom.cloud.runtime_workload_evidence_store import PostgresRuntimeWorkloadEvidenceStore
+
+    suffix = uuid4().hex
+    tenant_a = f"runtime-a-{suffix}"
+    tenant_b = f"runtime-b-{suffix}"
+
+    def signal(tenant_id: str) -> RuntimeWorkloadSignal:
+        return RuntimeWorkloadSignal(
+            tenant_id=tenant_id,
+            provider="aws",
+            account_id="123456789012",
+            workload_ref="i-shared",
+            signal_type="ioc_detection",
+            severity="high",
+            observed_at="2026-07-24T00:00:00Z",
+            source_id="ci-edr",
+            source_kind="edr",
+            dedup_key="shared-event",
+            title="CI runtime evidence",
+            evidence={"kind": "integration"},
+        )
+
+    store = PostgresRuntimeWorkloadEvidenceStore()
+    assert store.put_batch([signal(tenant_a)]) == 1
+    assert store.put_batch([signal(tenant_b)]) == 1
+    assert [row.tenant_id for row in store.list_for_tenant(tenant_a)] == [tenant_a]
+    assert [row.tenant_id for row in store.list_for_tenant(tenant_b)] == [tenant_b]
+
+    with _get_pool().connection() as connection:
+        marker = connection.execute(
+            "SELECT version FROM control_plane_schema_versions WHERE component = %s",
+            ("runtime_workload_evidence",),
+        ).fetchone()
+        rls = connection.execute(
+            "SELECT relrowsecurity, relforcerowsecurity FROM pg_class WHERE oid = 'public.runtime_workload_evidence'::regclass"
+        ).fetchone()
+    assert marker == (1,)
+    assert rls == (True, True)
 
 
 def test_budget_pk_migration_targets_visible_relation_across_search_path():

--- a/tests/test_postgres_schema_authority.py
+++ b/tests/test_postgres_schema_authority.py
@@ -64,14 +64,12 @@ def test_every_postgres_store_guards_runtime_schema_ddl() -> None:
         ROOT / "src" / "agent_bom" / "api" / name
         for name in ("idempotency_store.py", "middleware.py", "proxy_replay_store.py", "shared_auth_state.py")
     )
+    runtime_schema_files.append(ROOT / "src" / "agent_bom" / "cloud" / "runtime_workload_evidence_store.py")
     for path in sorted(runtime_schema_files):
         for line_number, line in enumerate(path.read_text().splitlines(), start=1):
             if "ensure_postgres_schema_version(" not in line or line.lstrip().startswith("def "):
                 continue
-            if not any(
-                guard in line
-                for guard in ("if not ensure_postgres_schema_version(", "if ensure_postgres_schema_version(")
-            ):
+            if not any(guard in line for guard in ("if not ensure_postgres_schema_version(", "if ensure_postgres_schema_version(")):
                 offenders.append(f"{path.relative_to(ROOT)}:{line_number}")
 
     assert offenders == []
@@ -112,6 +110,7 @@ def test_migration_schema_covers_every_runtime_postgres_table_and_component() ->
             "shared_auth_state.py",
         )
     )
+    runtime_paths.append(ROOT / "src" / "agent_bom" / "cloud" / "runtime_workload_evidence_store.py")
     runtime_source = "\n".join(path.read_text() for path in runtime_paths)
     migration_sql = (ROOT / "deploy" / "supabase" / "postgres" / "runtime-schema.sql").read_text()
     baseline_sql = (ROOT / "deploy" / "supabase" / "postgres" / "init.sql").read_text()

--- a/tests/test_workload_runtime_evidence_exports.py
+++ b/tests/test_workload_runtime_evidence_exports.py
@@ -64,11 +64,7 @@ def test_json_sarif_html_carry_preattached_workload_runtime_evidence() -> None:
     assert exported["workload_runtime_evidence"]["clean_workload_assertion"] is False
 
     sarif = to_sarif(report)
-    props = next(
-        result["properties"]
-        for result in sarif["runs"][0]["results"]
-        if result["properties"].get("workload_runtime_evidence")
-    )
+    props = next(result["properties"] for result in sarif["runs"][0]["results"] if result["properties"].get("workload_runtime_evidence"))
     assert props["workload_runtime_evidence"]["state"] == STATE_HAS_IOC
     assert props["workload_runtime_evidence"]["clean_workload_assertion"] is False
 
@@ -121,6 +117,26 @@ def test_export_enrichment_from_store_marks_no_signal_honestly(monkeypatch) -> N
 
         html = to_html(report)
         assert "No runtime signal" in html
+    finally:
+        set_runtime_workload_evidence_store(None)
+
+
+def test_optional_enrichment_failure_does_not_suppress_core_findings(caplog) -> None:
+    class UnavailableStore:
+        def list_for_tenant(self, tenant_id: str, *, limit: int = 5000):
+            del tenant_id, limit
+            raise RuntimeError("postgresql://agent_bom_app:secret-value@db.internal/agent_bom unavailable")
+
+    set_runtime_workload_evidence_store(UnavailableStore())  # type: ignore[arg-type]
+    try:
+        finding = _workload_finding()
+        report = AIBOMReport(generated_at=datetime.now(timezone.utc), tool_version="0.0.0", findings=[finding])
+
+        payload = to_json(report)
+
+        assert any(row["id"] == finding.id for row in payload["findings"])
+        assert "optional runtime workload evidence enrichment unavailable" in caplog.text
+        assert "secret-value" not in caplog.text
     finally:
         set_runtime_workload_evidence_store(None)
 


### PR DESCRIPTION
## Summary

- move runtime workload-evidence schema ownership into Alembic with DML grants, FORCE RLS, and a readiness marker
- route the Postgres evidence store through the shared password-file/IAM-aware pool and tenant context; keep optional export enrichment fail-open
- make hosted-demo redeploys target the exact release commit, remove the duplicate release trigger, and emit bounded sanitized failure diagnostics
- exercise the production password-free DSN plus DML-only role in Postgres CI and lock the demo findings regression
- fix Postgres Integration Contract: budget PK migration test now uses secret-aware connect (and optional admin DSN for CREATE SCHEMA) after CI mirrored Compose password-file auth

## Root cause

The demo scan found vulnerabilities, but JSON export initialized an optional Postgres evidence store that connected directly to the password-free Compose DSN and attempted runtime DDL as `agent_bom_app`. Authentication or DDL failure aborted export before the demo scan job was persisted, leaving graph data present while `/v1/findings` returned zero.

The deploy workflow also logged a release SHA while running `git pull`, so the v0.97.5 redeploy built newer `main`, and it reported that a failed candidate was not promoted after containers had already been replaced.

CI follow-up: after the app DSN became password-free with `AGENT_BOM_POSTGRES_PASSWORD_FILE`, `test_budget_pk_migration_targets_visible_relation_across_search_path` still called `psycopg.connect(dsn)` without injecting the file secret, so auth failed before the InsufficientPrivilege skip path.

## Verification

- `uv run pytest -q tests/test_workload_runtime_evidence_exports.py tests/test_postgres_schema_authority.py tests/test_compose_secrets_healthcheck.py tests/cloud/test_runtime_workload_evidence_store.py tests/test_durable_store_default.py tests/test_demo_estate_bootstrap.py tests/test_db_secret_handling.py tests/test_postgres_store.py::test_resolve_postgres_url_keeps_password_file_out_of_dsn --tb=line` (`101 passed, 3 skipped`)
- prior suite on branch: `tests/test_workload_runtime_evidence_exports.py` … `tests/test_demo_estate_bootstrap.py` (`86 passed, 3 skipped`)
- `uv run ruff check` on touched Python (ci.yml not linted as Python)
- `uv run mypy src/agent_bom/cloud/runtime_workload_evidence.py src/agent_bom/cloud/runtime_workload_evidence_store.py` (prior)
- `actionlint .github/workflows/demo-redeploy.yml .github/workflows/ci.yml` (prior)
- `make preflight` (prior)
- full platform + hosted-POC + demo Compose build/start with mounted Postgres password files and DML-only `agent_bom_app` (prior)
- live Compose smoke: 19 findings, one persisted demo job, schema marker `1`, ENABLE/FORCE RLS true, schema CREATE denied; 19 findings remained after API restart without a duplicate reseed (prior)
- live shared-pool write smoke: identical evidence keys persisted independently for tenants A/B and each tenant read returned only its own row (prior)
- all commits on branch `%G? == G`; no `Co-Authored-By` trailers

## Notes

- automatic rollback remains intentionally disabled because the in-place migration may not be backward-compatible; post-promotion failures now report that state accurately
- no API schemas or generated SDK artifacts changed
- `AGENT_BOM_POSTGRES_ADMIN_URL` is CI-only for the budget PK migration DDL check; app role remains DML-only