### PR TITLE
feat(cloud): Connections scan-on-create and continuous event drain

### DIFF
--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -58,11 +58,14 @@ connections. Recurring connection scans need both scheduler opt-in
 `controlPlane.connectionsScheduler.enabled=true` which injects that env) and a
 per-connection `scan_interval_minutes` (default concurrency 4). Cadence is the
 **intersection** of those two — an interval alone does nothing until the
-scheduler is enabled. `scan_mode=continuous` records intent for event-driven
-mid-interval refresh; that path still needs a provider event queue and a drain
-loop (not wired in this foundation change). `auto_scan_on_create` defaults true
-on Create and is persisted for a follow-up create-time scan path. Org fan-out
-caps: AWS 200
+scheduler is enabled. `scan_mode=continuous` enables mid-interval event drain
+on each scheduler tick when a provider event queue/subscription env is set
+(`AGENT_BOM_AWS_EVENT_QUEUE_URL`, `AGENT_BOM_AZURE_EVENT_QUEUE`,
+`AGENT_BOM_GCP_EVENT_SUBSCRIPTION`); drain stamps `last_event_at` only — full
+scans still use `claim_due_scan` / `last_scan_at`. `auto_scan_on_create`
+defaults true and runs the brokered scan path immediately after Create
+(failure marks the row `error` with a sanitized detail; the connection is kept).
+Org fan-out caps: AWS 200
 (`AGENT_BOM_AWS_MAX_ACCOUNTS`), Azure 500
 (`AGENT_BOM_AZURE_MAX_SUBSCRIPTIONS`), GCP 200 (`AGENT_BOM_GCP_MAX_PROJECTS`).
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -1242,7 +1242,7 @@
       },
       "CloudConnectionCreate": {
         "additionalProperties": false,
-        "description": "Request body for creating a connection. ``external_id`` is write-only.\n\n``scan_interval_minutes`` opts the connection into recurring background scans\n(Phase B.2). Null (the default) means manual-only \u2014 the scheduler ignores it.\n``scan_mode`` is ``full`` (default) or ``continuous``; continuous intends\nevent-driven mid-interval refresh once an event queue is wired. ``auto_scan_on_create``\ndefaults true and is persisted for a follow-up create-time scan path.",
+        "description": "Request body for creating a connection. ``external_id`` is write-only.\n\n``scan_interval_minutes`` opts the connection into recurring background scans\n(Phase B.2). Null (the default) means manual-only \u2014 the scheduler ignores it.\n``scan_mode`` is ``full`` (default) or ``continuous``; continuous drains\nprovider event queues on each scheduler tick when a queue env is set.\n``auto_scan_on_create`` defaults true and runs the brokered scan path after\npersist (failure marks ``error``; the row is kept).",
         "properties": {
           "auth_params": {
             "additionalProperties": {
@@ -9274,7 +9274,7 @@
         ]
       },
       "post": {
-        "description": "Create a read-only cloud connection for the authenticated tenant.\n\nThe ``external_id`` secret is encrypted at rest before persistence and is\nnever echoed back. If no encryption key is configured the request fails\nclosed with 503 rather than storing the secret in plaintext.",
+        "description": "Create a read-only cloud connection for the authenticated tenant.\n\nThe ``external_id`` secret is encrypted at rest before persistence and is\nnever echoed back. If no encryption key is configured the request fails\nclosed with 503 rather than storing the secret in plaintext. When\n``auto_scan_on_create`` is true (the default), the same brokered scan path\nas ``POST \u2026/scan`` runs after persist; scan failure marks the connection\n``error`` with a sanitized detail but does not roll back the create.",
         "operationId": "create_connection_v1_cloud_connections_post",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -887,9 +887,9 @@ components:
         \n``scan_interval_minutes`` opts the connection into recurring background\
         \ scans\n(Phase B.2). Null (the default) means manual-only \u2014 the scheduler\
         \ ignores it.\n``scan_mode`` is ``full`` (default) or ``continuous``; continuous\
-        \ intends\nevent-driven mid-interval refresh once an event queue is wired.\
-        \ ``auto_scan_on_create``\ndefaults true and is persisted for a follow-up\
-        \ create-time scan path."
+        \ drains\nprovider event queues on each scheduler tick when a queue env is\
+        \ set.\n``auto_scan_on_create`` defaults true and runs the brokered scan path\
+        \ after\npersist (failure marks ``error``; the row is kept)."
       properties:
         auth_params:
           additionalProperties:
@@ -6213,14 +6213,13 @@ paths:
       tags:
       - cloud-connections
     post:
-      description: 'Create a read-only cloud connection for the authenticated tenant.
-
-
-        The ``external_id`` secret is encrypted at rest before persistence and is
-
-        never echoed back. If no encryption key is configured the request fails
-
-        closed with 503 rather than storing the secret in plaintext.'
+      description: "Create a read-only cloud connection for the authenticated tenant.\n\
+        \nThe ``external_id`` secret is encrypted at rest before persistence and is\n\
+        never echoed back. If no encryption key is configured the request fails\n\
+        closed with 503 rather than storing the secret in plaintext. When\n``auto_scan_on_create``\
+        \ is true (the default), the same brokered scan path\nas ``POST \u2026/scan``\
+        \ runs after persist; scan failure marks the connection\n``error`` with a\
+        \ sanitized detail but does not roll back the create."
       operationId: create_connection_v1_cloud_connections_post
       parameters:
       - in: header

--- a/src/agent_bom/api/connection_scheduler.py
+++ b/src/agent_bom/api/connection_scheduler.py
@@ -13,6 +13,11 @@ Design notes:
   ``AGENT_BOM_CONNECTIONS_SCHEDULER`` is truthy (read live), so it never runs in
   CLI/dev. A connection is only eligible when it carries an interval; the field
   is null (manual-only) by default.
+* **Continuous event drain.** Each tick, *before* due full scans, connections
+  with ``scan_mode=continuous`` and a provider event-queue env configured drain
+  a bounded batch via ``consume_*`` (AWS/Azure/GCP). That path stamps
+  ``last_event_at`` only — full-scan cadence still goes through
+  ``claim_due_scan`` / ``last_scan_at``.
 * **Cluster-safe.** Multiple control-plane replicas may run this loop. Each due
   connection is claimed via an atomic compare-and-swap on ``last_scan_at``
   (``ConnectionStore.claim_due_scan``): the first replica to advance the stored
@@ -29,7 +34,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+from collections.abc import Callable
 from datetime import datetime, timedelta, timezone
+from typing import Any
 
 from agent_bom.api.connection_store import (
     STATUS_ACTIVE,
@@ -48,6 +55,13 @@ logger = logging.getLogger(__name__)
 
 # Every supported provider is broker-enabled and therefore schedulable.
 _SCHEDULABLE_PROVIDERS: frozenset[str] = frozenset({"aws", "azure", "gcp", "snowflake"})
+
+# Provider → (event_ingest module, consume_* name). Snowflake has no consumer.
+_CONTINUOUS_CONSUMERS: dict[str, tuple[str, str]] = {
+    "aws": ("agent_bom.cloud.event_ingest", "consume_aws_events"),
+    "azure": ("agent_bom.cloud.azure_event_ingest", "consume_azure_events"),
+    "gcp": ("agent_bom.cloud.gcp_event_ingest", "consume_gcp_events"),
+}
 
 
 def connections_scheduler_enabled() -> bool:
@@ -120,6 +134,64 @@ def claim_due_connections(store: ConnectionStore, now: datetime) -> list[CloudCo
     return won
 
 
+def _load_continuous_consumer(
+    provider: str,
+) -> tuple[Callable[[], bool], Callable[..., dict[str, Any]]] | None:
+    """Return ``(event_ingest_enabled, consume_*)`` for *provider*, or None."""
+    import importlib
+
+    spec = _CONTINUOUS_CONSUMERS.get((provider or "").strip().lower())
+    if spec is None:
+        return None
+    module_name, consume_name = spec
+    module = importlib.import_module(module_name)
+    enabled = getattr(module, "event_ingest_enabled", None)
+    consume = getattr(module, consume_name, None)
+    if not callable(enabled) or not callable(consume):
+        return None
+    return enabled, consume
+
+
+def drain_continuous_events(store: ConnectionStore) -> int:
+    """Drain provider event queues for ``scan_mode=continuous`` connections.
+
+    No-op when the scheduler flag is off. For each continuous connection whose
+    provider has a queue/subscription env configured, call the matching
+    ``consume_*`` (bounded, fail-closed). Events update ``last_event_at`` only
+    inside the consumer — this helper never advances ``last_scan_at``.
+
+    Returns the number of connections for which a consume was attempted.
+    """
+    if not connections_scheduler_enabled():
+        return 0
+
+    attempted = 0
+    for record in store.list_continuous():
+        loaded = _load_continuous_consumer(record.provider)
+        if loaded is None:
+            continue
+        enabled, consume = loaded
+        try:
+            if not enabled():
+                continue
+        except Exception:  # noqa: BLE001 - defensive; never sink the tick
+            logger.exception(
+                "Continuous event-ingest enabled check failed for connection %s",
+                record.id,
+            )
+            continue
+        attempted += 1
+        try:
+            consume(record, tenant_id=record.tenant_id, store=store)
+        except Exception:  # noqa: BLE001 - one bad consume never sinks the tick
+            logger.exception(
+                "Continuous event drain failed for connection %s (provider=%s)",
+                record.id,
+                record.provider,
+            )
+    return attempted
+
+
 def execute_connection_scan(record: CloudConnectionRecord) -> bool:
     """Run the broker scan for a claimed connection and persist the outcome.
 
@@ -175,10 +247,15 @@ async def run_due_scans_once(
 ) -> int:
     """Claim and run every due connection scan once, with bounded concurrency.
 
-    Returns the number of connections this replica claimed and attempted. Each
+    Drains continuous event queues first (when the scheduler is enabled and a
+    provider queue env is set), then claims due full scans. Returns the number
+    of connections this replica claimed and attempted for full scans. Each
     brokered scan runs in a worker thread (boto3 is blocking) under a semaphore
     so at most *max_concurrency* scans run at a time.
     """
+    # Event drain before full scans so mid-interval posture updates land first.
+    await asyncio.to_thread(drain_continuous_events, store)
+
     claimed = claim_due_connections(store, now)
     if not claimed:
         return 0

--- a/src/agent_bom/api/connection_store.py
+++ b/src/agent_bom/api/connection_store.py
@@ -128,6 +128,7 @@ class ConnectionStore(Protocol):
     def list_for_tenant(self, tenant_id: str) -> list[CloudConnectionRecord]: ...
     def delete(self, tenant_id: str, connection_id: str) -> bool: ...
     def list_schedulable(self) -> list[CloudConnectionRecord]: ...
+    def list_continuous(self) -> list[CloudConnectionRecord]: ...
     def claim_due_scan(self, record: CloudConnectionRecord, claimed_at: str) -> bool: ...
 
 
@@ -296,9 +297,7 @@ def _row_to_record(row: Sequence[Any]) -> CloudConnectionRecord:
         last_event_at=row[event_idx] if len(row) > event_idx else None,
         inventory_scope=_decode_inventory_scope(row[scope_idx]) if len(row) > scope_idx else INVENTORY_SCOPE_ACCOUNT,
         scan_mode=_decode_scan_mode(row[scan_mode_idx]) if len(row) > scan_mode_idx else SCAN_MODE_FULL,
-        auto_scan_on_create=(
-            _decode_auto_scan_on_create(row[auto_scan_idx]) if len(row) > auto_scan_idx else True
-        ),
+        auto_scan_on_create=(_decode_auto_scan_on_create(row[auto_scan_idx]) if len(row) > auto_scan_idx else True),
     )
 
 
@@ -357,6 +356,10 @@ class InMemoryConnectionStore:
         with self._lock:
             return [_copy_record(r) for r in self._rows.values() if r.scan_interval_minutes is not None]
 
+    def list_continuous(self) -> list[CloudConnectionRecord]:
+        with self._lock:
+            return [_copy_record(r) for r in self._rows.values() if _decode_scan_mode(r.scan_mode) == SCAN_MODE_CONTINUOUS]
+
     def claim_due_scan(self, record: CloudConnectionRecord, claimed_at: str) -> bool:
         """Atomically claim a due scan, gated on the last-seen ``last_scan_at``.
 
@@ -412,17 +415,11 @@ class SQLiteConnectionStore:
         if "last_event_at" not in columns:
             self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN last_event_at TEXT")
         if "inventory_scope" not in columns:
-            self._conn.execute(
-                "ALTER TABLE cloud_connections ADD COLUMN inventory_scope TEXT NOT NULL DEFAULT 'account'"
-            )
+            self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN inventory_scope TEXT NOT NULL DEFAULT 'account'")
         if "scan_mode" not in columns:
-            self._conn.execute(
-                "ALTER TABLE cloud_connections ADD COLUMN scan_mode TEXT NOT NULL DEFAULT 'full'"
-            )
+            self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN scan_mode TEXT NOT NULL DEFAULT 'full'")
         if "auto_scan_on_create" not in columns:
-            self._conn.execute(
-                "ALTER TABLE cloud_connections ADD COLUMN auto_scan_on_create INTEGER NOT NULL DEFAULT 1"
-            )
+            self._conn.execute("ALTER TABLE cloud_connections ADD COLUMN auto_scan_on_create INTEGER NOT NULL DEFAULT 1")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id, created_at)")
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes, last_scan_at)"
@@ -500,6 +497,17 @@ class SQLiteConnectionStore:
             "last_scan_id, scan_interval_minutes, auth_params, last_event_at, inventory_scope, "
             "scan_mode, auto_scan_on_create "
             "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
+        ).fetchall()
+        return [_row_to_record(row) for row in rows]
+
+    def list_continuous(self) -> list[CloudConnectionRecord]:
+        rows = self._conn.execute(
+            "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
+            "regions, status, status_detail, created_at, updated_at, last_scan_at, "
+            "last_scan_id, scan_interval_minutes, auth_params, last_event_at, inventory_scope, "
+            "scan_mode, auto_scan_on_create "
+            "FROM cloud_connections WHERE scan_mode = ? ORDER BY created_at, id",
+            (SCAN_MODE_CONTINUOUS,),
         ).fetchall()
         return [_row_to_record(row) for row in rows]
 

--- a/src/agent_bom/api/postgres_connection.py
+++ b/src/agent_bom/api/postgres_connection.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 
 from agent_bom.api.connection_store import (
+    SCAN_MODE_CONTINUOUS,
     CloudConnectionRecord,
     _decode_inventory_scope,
     _decode_scan_mode,
@@ -70,15 +71,9 @@ class PostgresConnectionStore:
             # the column stays NOT NULL and legacy connections read as no-params.
             conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS auth_params TEXT NOT NULL DEFAULT '{}'")
             conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS last_event_at TEXT")
-            conn.execute(
-                "ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS inventory_scope TEXT NOT NULL DEFAULT 'account'"
-            )
-            conn.execute(
-                "ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS scan_mode TEXT NOT NULL DEFAULT 'full'"
-            )
-            conn.execute(
-                "ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS auto_scan_on_create BOOLEAN NOT NULL DEFAULT TRUE"
-            )
+            conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS inventory_scope TEXT NOT NULL DEFAULT 'account'")
+            conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS scan_mode TEXT NOT NULL DEFAULT 'full'")
+            conn.execute("ALTER TABLE cloud_connections ADD COLUMN IF NOT EXISTS auto_scan_on_create BOOLEAN NOT NULL DEFAULT TRUE")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id, created_at)")
             conn.execute(
                 "CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes, last_scan_at)"
@@ -185,6 +180,22 @@ class PostgresConnectionStore:
                 "scan_interval_minutes, auth_params, last_event_at, inventory_scope, "
                 "scan_mode, auto_scan_on_create "
                 "FROM cloud_connections WHERE scan_interval_minutes IS NOT NULL ORDER BY created_at, id"
+            ).fetchall()
+        return [_row_to_record(row) for row in rows]
+
+    def list_continuous(self) -> list[CloudConnectionRecord]:
+        """Cross-tenant fetch of ``scan_mode=continuous`` connections (event drain).
+
+        RLS-bypassed like :meth:`list_schedulable` — trusted scheduler task.
+        """
+        with bypass_tenant_rls(), _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT id, tenant_id, provider, display_name, role_ref, external_id_encrypted, "
+                "regions, status, status_detail, created_at, updated_at, last_scan_at, last_scan_id, "
+                "scan_interval_minutes, auth_params, last_event_at, inventory_scope, "
+                "scan_mode, auto_scan_on_create "
+                "FROM cloud_connections WHERE scan_mode = %s ORDER BY created_at, id",
+                (SCAN_MODE_CONTINUOUS,),
             ).fetchall()
         return [_row_to_record(row) for row in rows]
 

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -93,9 +93,10 @@ class CloudConnectionCreate(BaseModel):
 
     ``scan_interval_minutes`` opts the connection into recurring background scans
     (Phase B.2). Null (the default) means manual-only — the scheduler ignores it.
-    ``scan_mode`` is ``full`` (default) or ``continuous``; continuous intends
-    event-driven mid-interval refresh once an event queue is wired. ``auto_scan_on_create``
-    defaults true and is persisted for a follow-up create-time scan path.
+    ``scan_mode`` is ``full`` (default) or ``continuous``; continuous drains
+    provider event queues on each scheduler tick when a queue env is set.
+    ``auto_scan_on_create`` defaults true and runs the brokered scan path after
+    persist (failure marks ``error``; the row is kept).
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -221,7 +222,6 @@ def _validate_scan_mode(mode: str | None) -> str:
     return raw
 
 
-
 def _validate_regions(regions: list[str]) -> list[str]:
     from agent_bom.cloud.aws_inventory import ALL_REGIONS_SENTINEL
 
@@ -250,7 +250,10 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
 
     The ``external_id`` secret is encrypted at rest before persistence and is
     never echoed back. If no encryption key is configured the request fails
-    closed with 503 rather than storing the secret in plaintext.
+    closed with 503 rather than storing the secret in plaintext. When
+    ``auto_scan_on_create`` is true (the default), the same brokered scan path
+    as ``POST …/scan`` runs after persist; scan failure marks the connection
+    ``error`` with a sanitized detail but does not roll back the create.
     """
     tenant_id = _tenant(request)
     provider = body.provider.strip().lower()
@@ -308,6 +311,45 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
         tenant_id=tenant_id,
         provider=record.provider,
     )
+
+    # Default auto_scan_on_create=true: run the same brokered scan path as
+    # POST …/scan. Failure marks the row error (sanitized detail) but never
+    # rolls back the create — the connection stays fetchable for remediation.
+    if auto_scan_on_create:
+        actor = _actor(request)
+        try:
+            summary = await anyio.to_thread.run_sync(_run_connection_scan, record, tenant_id)
+        except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
+            detail = _safe_connection_detail(exc)
+            _mark_connection(record, status=STATUS_ERROR, status_detail=detail)
+            _logger.exception("Cloud connection scan-on-create failed for connection %s", record.id)
+            log_action(
+                "cloud_connection.scan",
+                actor=actor,
+                resource=f"cloud-connection/{record.id}",
+                tenant_id=tenant_id,
+                provider=record.provider,
+                outcome="failure",
+            )
+        else:
+            scan_id = str(summary.get("scan_id") or "")
+            _mark_connection(
+                record,
+                status=STATUS_ACTIVE,
+                status_detail="",
+                last_scan_at=_now(),
+                last_scan_id=scan_id or None,
+            )
+            log_action(
+                "cloud_connection.scan",
+                actor=actor,
+                resource=f"cloud-connection/{record.id}",
+                tenant_id=tenant_id,
+                provider=record.provider,
+                outcome="success",
+                scan_id=scan_id,
+            )
+
     return record.to_public_dict()
 
 
@@ -616,9 +658,7 @@ def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
             "provider": "aws",
             "status": "ok",
             "account_count": len(inventory_payload),
-            "accounts": [
-                _summarize_inventory_payload("aws", item) for item in inventory_payload if isinstance(item, dict)
-            ],
+            "accounts": [_summarize_inventory_payload("aws", item) for item in inventory_payload if isinstance(item, dict)],
         }
     else:
         inventory_summary = _summarize_inventory_payload("aws", inventory_payload)
@@ -664,13 +704,9 @@ def _run_azure_connection_scan(record: CloudConnectionRecord, tenant_id: str) ->
     subscription_id = str(record.auth_params.get("subscription_id") or "").strip() or None
 
     if connection_org_fanout_enabled(record):
-        inventory_payload: Any = azure_inventory.discover_all_subscription_inventories(
-            credential=credential, force=True
-        )
+        inventory_payload: Any = azure_inventory.discover_all_subscription_inventories(credential=credential, force=True)
     else:
-        inventory_payload = azure_inventory.discover_inventory(
-            subscription_id=subscription_id, credential=credential, force=True
-        )
+        inventory_payload = azure_inventory.discover_inventory(subscription_id=subscription_id, credential=credential, force=True)
     cis_report = run_azure_cis(subscription_id=subscription_id, credential=credential)
     cis_dict = cis_report.to_dict()
 
@@ -697,9 +733,7 @@ def _run_azure_connection_scan(record: CloudConnectionRecord, tenant_id: str) ->
             "provider": "azure",
             "status": "ok",
             "account_count": len(inventory_payload),
-            "accounts": [
-                _summarize_inventory_payload("azure", item) for item in inventory_payload if isinstance(item, dict)
-            ],
+            "accounts": [_summarize_inventory_payload("azure", item) for item in inventory_payload if isinstance(item, dict)],
         }
     else:
         inventory_summary = _summarize_inventory_payload("azure", inventory_payload)
@@ -739,13 +773,9 @@ def _run_gcp_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
     project_id = str(record.auth_params.get("project_id") or "").strip() or None
 
     if connection_org_fanout_enabled(record):
-        inventory_payload: Any = gcp_inventory.discover_all_project_inventories(
-            credentials=credentials, force=True
-        )
+        inventory_payload: Any = gcp_inventory.discover_all_project_inventories(credentials=credentials, force=True)
     else:
-        inventory_payload = gcp_inventory.discover_inventory(
-            project_id=project_id, credentials=credentials, force=True
-        )
+        inventory_payload = gcp_inventory.discover_inventory(project_id=project_id, credentials=credentials, force=True)
     cis_report = run_gcp_cis(project_id=project_id, credentials=credentials)
     cis_dict = cis_report.to_dict()
 
@@ -760,9 +790,7 @@ def _run_gcp_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
             "provider": "gcp",
             "status": "ok",
             "account_count": len(inventory_payload),
-            "accounts": [
-                _summarize_inventory_payload("gcp", item) for item in inventory_payload if isinstance(item, dict)
-            ],
+            "accounts": [_summarize_inventory_payload("gcp", item) for item in inventory_payload if isinstance(item, dict)],
         }
     else:
         inventory_summary = _summarize_inventory_payload("gcp", inventory_payload)

--- a/tests/cloud/test_cloud_connections.py
+++ b/tests/cloud/test_cloud_connections.py
@@ -636,12 +636,15 @@ def _app() -> Any:
 
 
 def _create_body() -> dict[str, Any]:
+    # Opt out of create-time scan by default so CRUD / explicit /scan tests stay
+    # focused; product default remains true when the field is omitted.
     return {
         "provider": "aws",
         "display_name": "prod-readonly",
         "role_ref": "arn:aws:iam::123456789012:role/agent-bom-readonly",
         "external_id": "super-secret-external-id",
         "regions": ["us-east-1"],
+        "auto_scan_on_create": False,
     }
 
 
@@ -668,11 +671,14 @@ def test_api_viewer_can_list_and_get_but_not_mutate() -> None:
 
     assert client.get("/v1/cloud/connections", headers=headers).status_code == 200
     assert client.get(f"/v1/cloud/connections/{record.id}", headers=headers).status_code == 200
-    assert client.patch(
-        f"/v1/cloud/connections/{record.id}",
-        json={"scan_interval_minutes": 60},
-        headers=headers,
-    ).status_code == 403
+    assert (
+        client.patch(
+            f"/v1/cloud/connections/{record.id}",
+            json={"scan_interval_minutes": 60},
+            headers=headers,
+        ).status_code
+        == 403
+    )
     assert client.delete(f"/v1/cloud/connections/{record.id}", headers=headers).status_code == 403
 
 
@@ -822,20 +828,38 @@ def test_api_patch_requires_scan_permission() -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_api_create_defaults_scan_mode_full_and_auto_scan_on_create_true() -> None:
+def test_api_create_defaults_scan_mode_full_and_auto_scan_on_create_true(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Omit auto_scan_on_create so the API default (true) applies; stub the runner
+    # so create does not hit a real broker.
+    monkeypatch.setattr(
+        "agent_bom.api.routes.cloud_connections._run_connection_scan",
+        lambda record, tenant_id: {"scan_id": "default-auto", "status": "completed"},
+    )
     client = TestClient(_app())
-    created = client.post("/v1/cloud/connections", json=_create_body(), headers=_proxy_headers()).json()
+    body = _create_body()
+    del body["auto_scan_on_create"]
+    created = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers()).json()
     assert created["scan_mode"] == "full"
     assert created["auto_scan_on_create"] is True
+    assert created["status"] == "active"
+    assert created["last_scan_id"] == "default-auto"
 
 
-def test_api_create_accepts_continuous_scan_mode() -> None:
+def test_api_create_accepts_continuous_scan_mode(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        "agent_bom.api.routes.cloud_connections._run_connection_scan",
+        lambda record, tenant_id: {"scan_id": "cont-auto", "status": "completed"},
+    )
     client = TestClient(_app())
     body = _create_body()
     body["scan_mode"] = "continuous"
+    del body["auto_scan_on_create"]  # product default true
     created = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers()).json()
     assert created["scan_mode"] == "continuous"
     assert created["auto_scan_on_create"] is True
+    assert created["last_scan_id"] == "cont-auto"
 
 
 def test_api_create_rejects_invalid_scan_mode() -> None:
@@ -847,12 +871,84 @@ def test_api_create_rejects_invalid_scan_mode() -> None:
     assert "scan_mode" in resp.json()["detail"]
 
 
-def test_api_create_persists_auto_scan_on_create_false() -> None:
+def test_api_create_persists_auto_scan_on_create_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    scanned: list[str] = []
+    monkeypatch.setattr(
+        "agent_bom.api.routes.cloud_connections._run_connection_scan",
+        lambda record, tenant_id: scanned.append(record.id) or {"scan_id": "should-not-run"},
+    )
     client = TestClient(_app())
     body = _create_body()
     body["auto_scan_on_create"] = False
     created = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers()).json()
     assert created["auto_scan_on_create"] is False
+    assert created["status"] == STATUS_PENDING
+    assert created["last_scan_id"] is None
+    assert scanned == []
+
+
+def test_api_create_auto_scan_on_create_true_invokes_scan_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    scanned: list[tuple[str, str]] = []
+
+    def _fake_scan(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
+        scanned.append((record.id, tenant_id))
+        return {"scan_id": "scan-on-create-1", "status": "completed"}
+
+    monkeypatch.setattr("agent_bom.api.routes.cloud_connections._run_connection_scan", _fake_scan)
+    client = TestClient(_app())
+    body = _create_body()
+    body["auto_scan_on_create"] = True
+    created = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers()).json()
+    assert created["status"] == "active"
+    assert created["last_scan_id"] == "scan-on-create-1"
+    assert created["last_scan_at"] is not None
+    assert scanned == [(created["id"], "tenant-alpha")]
+
+
+def test_api_create_auto_scan_on_create_false_does_not_invoke_scan(monkeypatch: pytest.MonkeyPatch) -> None:
+    scanned: list[str] = []
+    monkeypatch.setattr(
+        "agent_bom.api.routes.cloud_connections._run_connection_scan",
+        lambda record, tenant_id: scanned.append(record.id) or {"scan_id": "x"},
+    )
+    client = TestClient(_app())
+    body = _create_body()
+    body["auto_scan_on_create"] = False
+    created = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers()).json()
+    assert created["id"]
+    assert scanned == []
+    assert created["status"] == STATUS_PENDING
+
+
+def test_api_create_auto_scan_failure_marks_error_connection_still_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from agent_bom.cloud.connection_broker import ConnectionBrokerError
+
+    def _boom(record: CloudConnectionRecord, tenant_id: str) -> dict[str, Any]:
+        raise ConnectionBrokerError(
+            "AssumeRole failed",
+            remediation="Check the role trust policy ExternalId condition.",
+        )
+
+    monkeypatch.setattr("agent_bom.api.routes.cloud_connections._run_connection_scan", _boom)
+    client = TestClient(_app())
+    body = _create_body()
+    body["auto_scan_on_create"] = True
+    resp = client.post("/v1/cloud/connections", json=body, headers=_proxy_headers())
+    # Create itself succeeded — scan failure must not roll back or 5xx the create.
+    assert resp.status_code == 201
+    created = resp.json()
+    cid = created["id"]
+    assert created["status"] == "error"
+    assert created["status_detail"]
+    assert "super-secret-external-id" not in created["status_detail"]
+    assert "AssumeRole failed" not in created["status_detail"]  # raw broker msg not leaked
+    # Connection remains fetchable (not rolled back).
+    fetched = client.get(f"/v1/cloud/connections/{cid}", headers=_proxy_headers())
+    assert fetched.status_code == 200
+    assert fetched.json()["status"] == "error"
+    assert fetched.json()["status_detail"]
 
 
 def test_api_patch_updates_scan_mode_and_auto_scan_on_create() -> None:
@@ -1233,9 +1329,7 @@ def test_broker_secret_failure_does_not_leak(monkeypatch: pytest.MonkeyPatch) ->
 _BROKER_SESSION_SENTINEL = object()
 
 
-def _install_scan_mocks(
-    monkeypatch: pytest.MonkeyPatch, *, fail: bool = False, inventory: dict[str, Any] | None = None
-) -> dict[str, Any]:
+def _install_scan_mocks(monkeypatch: pytest.MonkeyPatch, *, fail: bool = False, inventory: dict[str, Any] | None = None) -> dict[str, Any]:
     """Patch the broker + AWS inventory/CIS the scan route reuses.
 
     Captures the session each discovery call receives so a test can assert the

--- a/tests/test_connection_scheduler.py
+++ b/tests/test_connection_scheduler.py
@@ -23,11 +23,14 @@ from agent_bom.api import connection_crypto
 from agent_bom.api.connection_scheduler import (
     claim_due_connections,
     connections_scheduler_enabled,
+    drain_continuous_events,
     is_due,
     run_due_scans_once,
     select_due_connections,
 )
 from agent_bom.api.connection_store import (
+    SCAN_MODE_CONTINUOUS,
+    SCAN_MODE_FULL,
     STATUS_ACTIVE,
     STATUS_ERROR,
     STATUS_PENDING,
@@ -72,6 +75,7 @@ def _record(
     scan_interval_minutes: int | None = 60,
     last_scan_at: str | None = None,
     status: str = STATUS_PENDING,
+    scan_mode: str = SCAN_MODE_FULL,
 ) -> CloudConnectionRecord:
     return CloudConnectionRecord(
         id=str(uuid.uuid4()),
@@ -86,6 +90,7 @@ def _record(
         updated_at="2026-06-26T00:00:00+00:00",
         last_scan_at=last_scan_at,
         scan_interval_minutes=scan_interval_minutes,
+        scan_mode=scan_mode,
     )
 
 
@@ -350,3 +355,141 @@ def test_scheduler_enabled_when_flag_truthy(value: str) -> None:
 def test_scheduler_disabled_when_flag_falsy(value: str) -> None:
     os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = value
     assert connections_scheduler_enabled() is False
+
+
+# --------------------------------------------------------------------------- #
+# Continuous event drain (before due full scans)
+# --------------------------------------------------------------------------- #
+
+
+def test_drain_continuous_events_invokes_provider_consume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Continuous + provider queue env → consume_* once; last_scan_at untouched."""
+    from agent_bom.api.connection_store import get_connection_store
+
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+    os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
+    consumed: list[str] = []
+
+    def _fake_consume(record: CloudConnectionRecord, **kwargs: Any) -> dict[str, Any]:
+        consumed.append(record.id)
+        # Mimic event_ingest: stamp last_event_at only.
+        fresh = get_connection_store().get(record.tenant_id, record.id)
+        assert fresh is not None
+        fresh.last_event_at = "2026-07-24T12:00:00+00:00"
+        get_connection_store().put(fresh)
+        return {"status": "ok", "processed": 1}
+
+    monkeypatch.setattr("agent_bom.cloud.event_ingest.consume_aws_events", _fake_consume)
+
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    continuous = _record(
+        scan_mode=SCAN_MODE_CONTINUOUS,
+        scan_interval_minutes=60,
+        last_scan_at=(_now() - timedelta(minutes=5)).isoformat(),
+    )
+    store.put(continuous)
+    prior_last_scan = continuous.last_scan_at
+
+    count = drain_continuous_events(store)
+    assert count == 1
+    assert consumed == [continuous.id]
+    fetched = store.get(continuous.tenant_id, continuous.id)
+    assert fetched is not None
+    assert fetched.last_event_at == "2026-07-24T12:00:00+00:00"
+    # Full-scan cadence untouched by event drain.
+    assert fetched.last_scan_at == prior_last_scan
+
+
+def test_drain_continuous_events_scheduler_off_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    os.environ.pop("AGENT_BOM_CONNECTIONS_SCHEDULER", None)
+    os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
+    consumed: list[str] = []
+    monkeypatch.setattr(
+        "agent_bom.cloud.event_ingest.consume_aws_events",
+        lambda record, **k: consumed.append(record.id) or {"status": "ok"},
+    )
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    store.put(_record(scan_mode=SCAN_MODE_CONTINUOUS))
+
+    assert drain_continuous_events(store) == 0
+    assert consumed == []
+
+
+def test_drain_continuous_events_full_mode_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+    os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
+    consumed: list[str] = []
+    monkeypatch.setattr(
+        "agent_bom.cloud.event_ingest.consume_aws_events",
+        lambda record, **k: consumed.append(record.id) or {"status": "ok"},
+    )
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    store.put(_record(scan_mode=SCAN_MODE_FULL))
+
+    assert drain_continuous_events(store) == 0
+    assert consumed == []
+
+
+def test_drain_continuous_events_skips_without_provider_queue(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+    os.environ.pop("AGENT_BOM_AWS_EVENT_QUEUE_URL", None)
+    consumed: list[str] = []
+    monkeypatch.setattr(
+        "agent_bom.cloud.event_ingest.consume_aws_events",
+        lambda record, **k: consumed.append(record.id) or {"status": "ok"},
+    )
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    store.put(_record(scan_mode=SCAN_MODE_CONTINUOUS))
+
+    assert drain_continuous_events(store) == 0
+    assert consumed == []
+
+
+@pytest.mark.asyncio
+async def test_run_once_drains_continuous_before_due_full_scans(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each tick drains continuous events first, then claims due full scans."""
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+    os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
+    order: list[str] = []
+
+    def _fake_consume(record: CloudConnectionRecord, **kwargs: Any) -> dict[str, Any]:
+        order.append(f"drain:{record.id}")
+        return {"status": "ok", "processed": 0}
+
+    monkeypatch.setattr("agent_bom.cloud.event_ingest.consume_aws_events", _fake_consume)
+    calls = _install_scan_mocks(monkeypatch)
+    # Wrap scan so we can assert ordering vs drain.
+    from agent_bom.api import connection_scheduler as sched
+
+    real_execute = sched.execute_connection_scan
+
+    def _tracked_execute(record: CloudConnectionRecord) -> bool:
+        order.append(f"scan:{record.id}")
+        return real_execute(record)
+
+    monkeypatch.setattr(sched, "execute_connection_scan", _tracked_execute)
+
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    continuous_due = _record(
+        scan_mode=SCAN_MODE_CONTINUOUS,
+        scan_interval_minutes=60,
+        last_scan_at=None,
+    )
+    store.put(continuous_due)
+
+    count = await run_due_scans_once(store, _now())
+    assert count == 1
+    assert order[0] == f"drain:{continuous_due.id}"
+    assert order[1] == f"scan:{continuous_due.id}"
+    assert calls["scanned_ids"] == [continuous_due.id]


### PR DESCRIPTION
## Summary
- After `create_connection` persists, honor `auto_scan_on_create` (default true) by running `_run_connection_scan`; on failure mark the row `error` with a sanitized detail and keep the connection.
- Each connections-scheduler tick drains `scan_mode=continuous` connections (AWS/Azure/GCP `consume_*` when the provider queue/subscription env is set) **before** due full scans; events stamp `last_event_at` only — full cadence still uses `claim_due_scan` / `last_scan_at`.
- Docs + OpenAPI: continuous drain and create-time scan behavior are documented; `list_continuous` added across in-memory / SQLite / Postgres stores.

## Verification
- `uv run pytest -q tests/cloud/test_cloud_connections.py tests/test_connection_scheduler.py tests/test_postgres_connection_parity.py` → **118 passed**
- `uv run ruff check` on touched Python files → pass
- `uv run mypy` on touched API/store modules → pass
- `make preflight` → pass (OpenAPI regenerated for Create model docstring)

## Notes
- Stacked on #4431 (`feat/connections-continuous-foundation`). Rebase onto `main` after that merges.

Made with [Cursor](https://cursor.com)