### PR TITLE
docs(cloud): Connections org gate and sources pane design

### DIFF
--- a/deploy/docker-compose.pilot.yml
+++ b/deploy/docker-compose.pilot.yml
@@ -43,6 +43,10 @@ services:
       # connections.key on first run (persisted in the data volume) so creating a
       # cloud connection does not 503. Set AGENT_BOM_CONNECTIONS_KEY / a managed
       # provider to bring your own; AGENT_BOM_NO_AUTO_CONNECTIONS_KEY=1 disables it.
+      # Recurring connection scans stay OFF here. Opt in with
+      # AGENT_BOM_CONNECTIONS_SCHEDULER=1 (and a per-connection
+      # scan_interval_minutes). Helm: controlPlane.connectionsScheduler.enabled.
+      # See docs/CLOUD_CONNECT.md Practical enable path.
     ports:
       - "127.0.0.1:8422:8422"
     volumes:

--- a/deploy/helm/agent-bom/README.md
+++ b/deploy/helm/agent-bom/README.md
@@ -105,9 +105,10 @@ blank `collectorImage.tag` falls back to `image.tag`.
 | `scanner.enabled` | `true` | Deploy CronJob scanner |
 | `scanner.schedule` | `0 */6 * * *` | Cron schedule |
 | `scanner.allNamespaces` | `true` | Scan all namespaces |
-| `scanner.cloud.aws.orgInventory` | `false` | `AGENT_BOM_AWS_ORG_INVENTORY` — org member-account scan fan-out |
-| `scanner.cloud.azure.allSubscriptions` | `false` | `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS` |
-| `scanner.cloud.gcp.allProjects` | `false` | `AGENT_BOM_GCP_ALL_PROJECTS` |
+| `scanner.cloud.aws.orgInventory` | `false` | Job/CLI only → `AGENT_BOM_AWS_ORG_INVENTORY`. Connections org fan-out uses `inventory_scope=organization` on the connection row, not this value. |
+| `scanner.cloud.azure.allSubscriptions` | `false` | Job/CLI only → `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS` (same Connections vs Job split as `orgInventory`) |
+| `scanner.cloud.gcp.allProjects` | `false` | Job/CLI only → `AGENT_BOM_GCP_ALL_PROJECTS` (same Connections vs Job split as `orgInventory`) |
+| `controlPlane.connectionsScheduler.enabled` | `false` | Injects `AGENT_BOM_CONNECTIONS_SCHEDULER=1` on the API; still requires per-connection `scan_interval_minutes` |
 | `collectorImage.repository` | `agentbom/agent-bom-collector` | Cloud-SDK collector image the scan CronJob runs |
 | `collectorImage.tag` | release version | Collector tag — override to bump the SDK layer independently of the control plane; blank falls back to `image.tag` |
 | `controlPlane.enabled` | `false` | Package API + dashboard Deployments |

--- a/deploy/helm/agent-bom/templates/cronjob.yaml
+++ b/deploy/helm/agent-bom/templates/cronjob.yaml
@@ -90,6 +90,7 @@ spec:
                   value: {{ .maxRegions | quote }}
                 {{- end }}
                 {{- if eq (toString .orgInventory) "true" }}
+                {{/* Job/CLI org fan-out only — Connections uses inventory_scope=organization */}}
                 - name: AGENT_BOM_AWS_ORG_INVENTORY
                   value: "1"
                 {{- end }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -155,9 +155,10 @@ scanner:
       #   - EKS: IRSA — set serviceAccount.annotations
       #     eks.amazonaws.com/role-arn to the scanner/control-plane role. That
       #     role reads THIS account directly and, cross-account, can AssumeRole
-      #     into connect-aws read-only roles (hosted connect / org fan-out when
-      #     orgInventory is also true). The baseline module attaches the
-      #     least-privilege sts:AssumeRole policy; see
+      #     into connect-aws read-only roles. For Connections org fan-out, set
+      #     inventory_scope=organization on the connection row (not this flag).
+      #     For Helm/CLI Job org fan-out, also set orgInventory below. The
+      #     baseline module attaches least-privilege sts:AssumeRole; see
       #     deploy/terraform/aws/baseline (connect_role_arns).
       #   - Self-managed k8s on EC2 / ECS: the pod inherits the node instance
       #     profile or ECS task role from the AWS SDK default chain — still
@@ -168,14 +169,18 @@ scanner:
       allRegions: false       # AGENT_BOM_AWS_ALL_REGIONS
       regions: ""             # AGENT_BOM_AWS_REGIONS (comma list, e.g. "us-east-1,eu-west-1")
       maxRegions: ""          # AGENT_BOM_AWS_MAX_REGIONS
-      # Org scan fan-out (default OFF). StackSet/org grant onboarding is separate —
-      # set this so the scanner enumerates member accounts and AssumeRoles into each.
+      # Job/CLI ONLY (scanner CronJob → AGENT_BOM_AWS_ORG_INVENTORY). Does NOT
+      # drive Connections /scan. Connections org fan-out =
+      # inventory_scope=organization on the connection row (+ StackSet grants).
+      # StackSet/org grant onboarding is separate from either path.
       orgInventory: false     # AGENT_BOM_AWS_ORG_INVENTORY
       maxAccounts: ""         # AGENT_BOM_AWS_MAX_ACCOUNTS (default 200 in code)
     azure:
       # Sets AGENT_BOM_AZURE_INVENTORY=1. Auth = AKS workload identity federated
       # to the connect-azure Reader principal (see cloud.azure block below).
       inventory: false
+      # Job/CLI ONLY (AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS). Connections org =
+      # inventory_scope=organization on the row.
       allSubscriptions: false # AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS
       maxSubscriptions: ""    # AGENT_BOM_AZURE_MAX_SUBSCRIPTIONS
       # Client ID of the user-assigned managed identity / app federated to the
@@ -190,7 +195,8 @@ scanner:
       # AGENT_BOM_GCP_IMPERSONATE_SA — the connect-gcp read-only SA email. The
       # ambient KSA token is exchanged for short-lived impersonated creds.
       impersonateSa: ""
-      # Multi-project scan fan-out (default OFF). Mirrors azure.allSubscriptions.
+      # Job/CLI ONLY (AGENT_BOM_GCP_ALL_PROJECTS). Connections org =
+      # inventory_scope=organization on the row. Mirrors azure.allSubscriptions.
       allProjects: false      # AGENT_BOM_GCP_ALL_PROJECTS
       maxProjects: ""         # AGENT_BOM_GCP_MAX_PROJECTS (default 200 in code)
     snowflake:
@@ -453,8 +459,8 @@ controlPlane:
   # Opt-in background loop that re-scans due cloud connections (row
   # scan_interval_minutes). When true, injects AGENT_BOM_CONNECTIONS_SCHEDULER=1
   # on the API Deployment. Cadence still requires a per-connection interval;
-  # scan_mode=continuous also needs an event queue for mid-interval refresh
-  # (event drain is not wired until a follow-up PR).
+  # scan_mode=continuous additionally drains provider event queues on each
+  # tick when AGENT_BOM_{AWS,AZURE,GCP}_EVENT_* is set (stamps last_event_at).
   connectionsScheduler:
     enabled: false
   serviceMesh:

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -44,13 +44,15 @@ across member accounts / subscriptions / projects via the brokered management
 credential. StackSet (or equivalent) is still required so member accounts have
 the read-only role to assume. CLI enrichment and Helm scanner Jobs remain gated
 by env flags (`AGENT_BOM_AWS_ORG_INVENTORY`, `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`,
-`AGENT_BOM_GCP_ALL_PROJECTS`; see §§3–5) — those flags are unchanged and are
-**not** required for per-connection fan-out. On the Helm CronJob, first-class
+`AGENT_BOM_GCP_ALL_PROJECTS`; see §§3–5) — those flags are **Job/CLI only** and
+are **not** required for per-connection fan-out. On the Helm CronJob, first-class
 chart values map to those CLI flags:
 `scanner.cloud.aws.orgInventory` → `AGENT_BOM_AWS_ORG_INVENTORY`,
 `scanner.cloud.azure.allSubscriptions` → `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS`,
 `scanner.cloud.gcp.allProjects` → `AGENT_BOM_GCP_ALL_PROJECTS` (optional
-`maxAccounts` / `maxSubscriptions` / `maxProjects` cap the run). Control-plane
+`maxAccounts` / `maxSubscriptions` / `maxProjects` cap the run). Connections org
+gate = the row's `inventory_scope=organization`; Helm `orgInventory` never
+flips that row. Control-plane
 `tenant_id` is the agent-bom tenancy key — it is
 **not** an Azure AD tenant or AWS account ID; one CP tenant can own many
 connections. Recurring connection scans need both scheduler opt-in
@@ -68,6 +70,33 @@ defaults true and runs the brokered scan path immediately after Create
 Org fan-out caps: AWS 200
 (`AGENT_BOM_AWS_MAX_ACCOUNTS`), Azure 500
 (`AGENT_BOM_AZURE_MAX_SUBSCRIPTIONS`), GCP 200 (`AGENT_BOM_GCP_MAX_PROJECTS`).
+
+### Practical enable path
+
+End-to-end for one org-scoped AWS connection that keeps evaluating:
+
+1. **Wizard** — dashboard **Connections** → Provider (AWS) → Setup. Prefer
+   **Whole organization** so the grant script is StackSet-shaped and Details
+   will store `inventory_scope=organization`.
+2. **StackSet (or equivalent)** — apply the generated grant so every member
+   account has the read-only role (ExternalId match). Confirm Role ARN output.
+3. **Connection** — Details: paste Role ARN + ExternalId, set cadence
+   (`scan_interval_minutes`), optional `scan_mode=continuous`, create. With
+   `auto_scan_on_create` (default true) the first brokered `/scan` runs
+   immediately and fans members when `inventory_scope=organization`.
+4. **Cadence** — interval on the row alone is inert until the control-plane
+   scheduler is on.
+5. **Helm scheduler** — `--set controlPlane.connectionsScheduler.enabled=true`
+   (injects `AGENT_BOM_CONNECTIONS_SCHEDULER=1` on the API). Pilot compose leaves
+   this off; set the env explicitly if you want recurrence locally.
+6. **Continuous + queue** — for mid-interval event drain, keep
+   `scan_mode=continuous` and set the provider queue/subscription env on the
+   API (`AGENT_BOM_AWS_EVENT_QUEUE_URL` / Azure / GCP equivalents). Drain stamps
+   `last_event_at`; full inventory still follows the due-scan claim path.
+
+Do **not** set `scanner.cloud.aws.orgInventory` unless you also want the
+**Helm CronJob / CLI** org-inventory Job path. That flag does not substitute
+for `inventory_scope=organization` on the Connections row.
 
 - **One ExternalId, carried end-to-end.** For AWS the wizard generates a single
   high-entropy `sts:ExternalId` **once** and carries it unchanged from Setup into

--- a/docs/DEPLOY_QUICKSTART.md
+++ b/docs/DEPLOY_QUICKSTART.md
@@ -430,8 +430,8 @@ See [`docs/operations/ENV_VARS.md`](operations/ENV_VARS.md) for the full enrichm
 
 ## What is not automatic yet (honest boundaries)
 
-- **No single UI wizard** for “click Connect AWS” — today: Terraform connect modules + API `POST /v1/cloud/connections`. UI connections tab is the registration surface.
-- **No agentless continuous CSPM agent** — inventory is scheduled CronJob + opt-in CLI/API scans + fleet push.
+- **Connections wizard ships** — browser **Connections** (`/connections`) walks Provider → Setup → Details (grant script + `POST /v1/cloud/connections`). Headless parity: Terraform connect modules and the same API. See [`CLOUD_CONNECT.md`](CLOUD_CONNECT.md) §1c and the Practical enable path.
+- **Continuous mid-interval refresh needs a queue** — cadence (`AGENT_BOM_CONNECTIONS_SCHEDULER` + `scan_interval_minutes`) is opt-in; `scan_mode=continuous` additionally needs a provider event queue env. Helm scanner CronJob remains a separate Job/CLI path.
 - **AKS/GKE platform Terraform** — collector Helm overlays exist; full one-apply platform modules are EKS-only today.
 - **MSSP multi-tenant provider ops** — self-hosted team tenancy (OIDC/SCIM) ships; provider-style tenant automation is a later track.
 
@@ -444,4 +444,5 @@ See [`docs/operations/ENV_VARS.md`](operations/ENV_VARS.md) for the full enrichm
 - [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md) — long enterprise rollout
 - [`deploy/RUNBOOK.md`](../deploy/RUNBOOK.md) — cross-cloud collector federation
 - [`docs/design/OIDC_DISCOVERY_SHIM.md`](design/OIDC_DISCOVERY_SHIM.md) — legacy IdP MCP OIDC discovery
+- [`docs/design/CONNECTIONS_AND_SOURCES_PANE.md`](design/CONNECTIONS_AND_SOURCES_PANE.md) — Connections / Sources hub taxonomy
 - [`site-docs/deployment/overview.md`](../site-docs/deployment/overview.md) — published chooser

--- a/docs/design/CONNECTIONS_AND_SOURCES_PANE.md
+++ b/docs/design/CONNECTIONS_AND_SOURCES_PANE.md
@@ -1,0 +1,64 @@
+# Design: Connections and Sources pane
+
+**Status:** lock-in taxonomy for the dashboard Connections hub and related
+ingest/export surfaces. Describes what already ships and how rows should be
+grouped — not a roadmap or GTM plan.
+
+**Canonical UI merge:** [`ui/lib/connections-sources.ts`](../../ui/lib/connections-sources.ts)
+unifies `/v1/cloud/connections` and `/v1/sources` into one table (cloud row
+wins on name collision). Operator onboarding for cloud grants lives in
+[`docs/CLOUD_CONNECT.md`](../CLOUD_CONNECT.md) (§1c + Practical enable path).
+
+## Connector taxonomy
+
+Use these product nouns when extending the pane, API kinds, or docs. They are
+capability classes, not vendor product names.
+
+| Class | Meaning | Primary surface today |
+|-------|---------|------------------------|
+| `cloud_account` | One brokered cloud target (AWS account, Azure subscription, GCP project, Snowflake account). Default `inventory_scope=account`. | Connections wizard + `POST /v1/cloud/connections` |
+| `org_fanout` | Same connection row with `inventory_scope=organization` — `/scan` fans members via the management credential. StackSet (or equivalent) still deploys member roles. Distinct from Helm Job/CLI `scanner.cloud.*.orgInventory` / `allSubscriptions` / `allProjects`. | Connections row field; see CLOUD_CONNECT §1c |
+| `runtime_mcp` | MCP proxy / gateway runtimes and MCP config scans as first-class sources. | `/v1/sources` kinds `runtime.proxy`, `runtime.gateway`, `scan.mcp_config`; Runtime UI |
+| `endpoint_fleet` | Endpoint / agent inventory pushed into the tenant fleet registry. | `POST /v1/fleet/sync` — [`docs/SESSION_FLOWS.md`](../SESSION_FLOWS.md) (Fleet sync) |
+| `evidence_ingest` | Push of scan results, artifacts, traces, or fleet sync into the control plane without a live cloud assume. | `/v1/sources` ingest kinds (`ingest.fleet_sync`, `ingest.trace_push`, `ingest.result_push`, `ingest.artifact_import`); OCSF ingest at the wire boundary |
+| `findings_export` | Outbound findings / events to customer-owned sinks (SIEM, lake, OTLP). Not a “connection” row — an integration / export path. | SIEM connectors + OCSF projection; report / delta export |
+
+Display categories in the hub (`cloud` / `code` / `ai` / `data` / `runtime` /
+`ingest`) are the UI filter chips mapped from `SourceKind` in
+`connections-sources.ts`. Prefer extending that map over inventing a parallel
+taxonomy in React.
+
+## Related existing paths (point, do not duplicate)
+
+| Concern | Where |
+|---------|--------|
+| Cloud grant + org gate + scheduler / continuous | [`docs/CLOUD_CONNECT.md`](../CLOUD_CONNECT.md) |
+| SIEM push / OCSF wire formats | [`site-docs/deployment/siem-integration.md`](../../site-docs/deployment/siem-integration.md), [`docs/OCSF_BOUNDARY.md`](../OCSF_BOUNDARY.md) |
+| OTEL as operator telemetry + trace ingest | [`docs/PRODUCT_BRIEF.md`](../PRODUCT_BRIEF.md) (Observability and OTEL); site-docs deployment overview |
+| Fleet sync contract | [`docs/SESSION_FLOWS.md`](../SESSION_FLOWS.md) |
+| Posture change event collector (queue → CP) | [`docs/design/EVENT_COLLECTOR_CONTRACT.md`](EVENT_COLLECTOR_CONTRACT.md) |
+| Unified table rules | [`ui/lib/connections-sources.ts`](../../ui/lib/connections-sources.ts) |
+
+## Non-goals
+
+- Replacing SIEM, warehouse, or observability products — we export / ingest at
+  the boundary; we do not host customer SIEM storage.
+- Treating Helm CronJob `orgInventory` as the Connections org control — Job/CLI
+  flags stay separate from `inventory_scope` on the row.
+- Collapsing runtime MCP, fleet endpoints, and cloud accounts into one backend
+  table — the hub is a **display** merge; persistence stays split.
+- Private strategy, parity scorecards, or named third-party product comparisons
+  in this tree.
+- Claiming continuous CSPM without scheduler opt-in + (for mid-interval drain)
+  a configured provider event queue.
+
+## Operator read of the pane
+
+1. Cloud rows come from Connections (richer status, scan cadence, org scope).
+2. Non-cloud sources come from `/v1/sources` with kind labels from
+   `sourceKindLabel`.
+3. Dedup: a `scan.cloud` / `connector.cloud_read_only` source with the same
+   display name as a cloud connection is dropped so the account appears once.
+4. Schedules attach by source id count — cloud recurrence is still the
+   Connections scheduler + `scan_interval_minutes` intersection documented in
+   CLOUD_CONNECT.


### PR DESCRIPTION
## Summary
- Align Helm CronJob values/README/comments: `scanner.cloud.aws.orgInventory` (and Azure/GCP peers) are Job/CLI only; Connections org fan-out is `inventory_scope=organization` on the row.
- Add one Practical enable path in `docs/CLOUD_CONNECT.md` (wizard → StackSet → connection → cadence → Helm scheduler → continuous + queue).
- Add `docs/design/CONNECTIONS_AND_SOURCES_PANE.md` connector taxonomy (`cloud_account`, `org_fanout`, `runtime_mcp`, `endpoint_fleet`, `evidence_ingest`, `findings_export`) with non-goals and pointers to SIEM/OCSF, OTEL, fleet, and `ui/lib/connections-sources.ts`.
- Fix stale DEPLOY_QUICKSTART “no UI wizard” boundary; note pilot compose leaves `AGENT_BOM_CONNECTIONS_SCHEDULER` off.

## Verification
- `git diff --check` (clean)
- `python scripts/check_public_docs_hygiene.py` (passed, 685 files)
- Signed commit `%G?` = G

## Notes
- Base: `feat/connections-continuous-foundation` (includes continuous foundation through event drain).
- No OpenAPI / preflight in this PR.

Made with [Cursor](https://cursor.com)