### PR TITLE
feat(cloud): Connections scheduler drain concurrency

### DIFF
--- a/deploy/helm/agent-bom/README.md
+++ b/deploy/helm/agent-bom/README.md
@@ -109,6 +109,8 @@ blank `collectorImage.tag` falls back to `image.tag`.
 | `scanner.cloud.azure.allSubscriptions` | `false` | Job/CLI only → `AGENT_BOM_AZURE_ALL_SUBSCRIPTIONS` (same Connections vs Job split as `orgInventory`) |
 | `scanner.cloud.gcp.allProjects` | `false` | Job/CLI only → `AGENT_BOM_GCP_ALL_PROJECTS` (same Connections vs Job split as `orgInventory`) |
 | `controlPlane.connectionsScheduler.enabled` | `false` | Injects `AGENT_BOM_CONNECTIONS_SCHEDULER=1` on the API; still requires per-connection `scan_interval_minutes` |
+| `controlPlane.connectionsScheduler.maxConcurrency` | `4` | Injects `AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY` (due full-scans + continuous event drains) |
+| `controlPlane.connectionsScheduler.pollSeconds` | _(unset)_ | Optional; injects `AGENT_BOM_CONNECTIONS_SCHEDULER_POLL_SECONDS` when set |
 | `collectorImage.repository` | `agentbom/agent-bom-collector` | Cloud-SDK collector image the scan CronJob runs |
 | `collectorImage.tag` | release version | Collector tag — override to bump the SDK layer independently of the control plane; blank falls back to `image.tag` |
 | `controlPlane.enabled` | `false` | Package API + dashboard Deployments |

--- a/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
+++ b/deploy/helm/agent-bom/templates/controlplane-api-deployment.yaml
@@ -64,6 +64,14 @@ spec:
             {{- if .Values.controlPlane.connectionsScheduler.enabled }}
             - name: AGENT_BOM_CONNECTIONS_SCHEDULER
               value: "1"
+            {{- with .Values.controlPlane.connectionsScheduler.maxConcurrency }}
+            - name: AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.controlPlane.connectionsScheduler.pollSeconds }}
+            - name: AGENT_BOM_CONNECTIONS_SCHEDULER_POLL_SECONDS
+              value: {{ . | quote }}
+            {{- end }}
             {{- end }}
           {{- with .Values.controlPlane.api.env }}
             {{- toYaml . | nindent 12 }}

--- a/deploy/helm/agent-bom/values.yaml
+++ b/deploy/helm/agent-bom/values.yaml
@@ -461,8 +461,12 @@ controlPlane:
   # on the API Deployment. Cadence still requires a per-connection interval;
   # scan_mode=continuous additionally drains provider event queues on each
   # tick when AGENT_BOM_{AWS,AZURE,GCP}_EVENT_* is set (stamps last_event_at).
+  # maxConcurrency bounds both due full-scans and continuous event drains;
+  # pollSeconds is how often the loop re-checks for due work (optional).
   connectionsScheduler:
     enabled: false
+    maxConcurrency: 4
+    # pollSeconds: 60
   serviceMesh:
     enabled: false
     provider: istio

--- a/docs/CONCURRENCY_AND_FAILURE_MODEL.md
+++ b/docs/CONCURRENCY_AND_FAILURE_MODEL.md
@@ -59,6 +59,37 @@ deployments should enable the distributed scan queue (claim / lease) and scale
 on the active-scan metric (KEDA / Helm). Do not assume `adaptive_backpressure`
 alone coordinates across pods.
 
+## Connections scheduler (CAS + drain concurrency)
+
+Cloud Connections cadence is a separate loop from `/v1/schedules`:
+
+- **Opt-in** via `AGENT_BOM_CONNECTIONS_SCHEDULER` (Helm:
+  `controlPlane.connectionsScheduler.enabled`). Per-connection
+  `scan_interval_minutes` still required for due full scans.
+- **Cluster-safe CAS** — due full scans claim via
+  `ConnectionStore.claim_due_scan` (conditional update on `last_scan_at`). The
+  winning replica runs the brokered scan; losers no-op.
+- **Bounded concurrency** — `AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY`
+  (default `4`; Helm `controlPlane.connectionsScheduler.maxConcurrency`) caps
+  both due full-scans and continuous event drains. Each unit of work is one
+  `asyncio.to_thread` under an asyncio semaphore.
+- **Continuous drain** — `scan_mode=continuous` connections drain provider
+  event queues (`consume_aws_events` / Azure / GCP) in parallel before due
+  claims. Scheduler path passes AWS `wait_seconds=0` so empty SQS long-polls
+  do not stall the tick. Events stamp `last_event_at` only; full-scan cadence
+  remains on `last_scan_at`.
+- **Nested org ThreadPool** — when a connection uses
+  `inventory_scope=organization`, the brokered scan itself fans member
+  accounts/subscriptions/projects through a provider `ThreadPoolExecutor`
+  (capped workers). That pool is nested *inside* one scheduler semaphore slot;
+  raise `maxConcurrency` carefully under org-wide Connections.
+- **Scan-on-create** — `auto_scan_on_create` shares the
+  `adaptive_backpressure("cloud_connection_scan")` lane with `POST …/scan`
+  (await `to_thread`; enqueue-to-`scan_queue` is a follow-up).
+
+Optional Helm `controlPlane.connectionsScheduler.pollSeconds` injects
+`AGENT_BOM_CONNECTIONS_SCHEDULER_POLL_SECONDS`.
+
 ## Checklist (when changing this lane)
 
 1. New scanner driver declares `failure_mode` + `execution_state` in the registry.

--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -121,8 +121,8 @@ AGENT_BOM_VAULT_TOKEN
 # connections (Phase B.2); read live in api/connection_scheduler.py. Helm:
 # controlPlane.connectionsScheduler.enabled injects AGENT_BOM_CONNECTIONS_SCHEDULER=1.
 # Cadence requires BOTH this flag and a per-connection scan_interval_minutes.
-# scan_mode=continuous additionally needs a provider event queue for mid-interval
-# refresh; event drain is not wired until a follow-up change.
+# scan_mode=continuous additionally drains provider event queues (parallel under
+# AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY) when a provider EVENT_* env is set.
 AGENT_BOM_CONNECTIONS_SCHEDULER
 # opt-in flag (default OFF) enabling the scheduled findings-export loop (#4040); read live in api/export_scheduler.py
 AGENT_BOM_EXPORT_SCHEDULER

--- a/site-docs/deployment/worker-and-scheduler-concurrency.md
+++ b/site-docs/deployment/worker-and-scheduler-concurrency.md
@@ -87,6 +87,22 @@ What each one protects:
 These are enforced when the API accepts new work. They are not soft dashboard
 warnings; they return quota errors and emit tenant-scoped audit events.
 
+## Connections scheduler vs scan schedules
+
+The Cloud Connections background loop (`AGENT_BOM_CONNECTIONS_SCHEDULER`) is
+separate from `/v1/schedules`:
+
+- due full-scans use a compare-and-swap claim on `last_scan_at` so multi-replica
+  API pods do not double-run the same connection
+- `AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY` (Helm
+  `controlPlane.connectionsScheduler.maxConcurrency`, default `4`) bounds both
+  due full-scans and continuous event drains — one `to_thread` per connection
+  under an asyncio semaphore
+- `scan_mode=continuous` drains provider event queues in parallel before claims;
+  AWS scheduler drains use `WaitTimeSeconds=0` so empty queues do not stall ticks
+- org-scoped Connections nest a provider `ThreadPoolExecutor` inside one
+  semaphore slot — see `docs/CONCURRENCY_AND_FAILURE_MODEL.md`
+
 ## CronJob vs scheduler
 
 The scanner `CronJob` and the recurring schedule subsystem are different

--- a/src/agent_bom/api/connection_scheduler.py
+++ b/src/agent_bom/api/connection_scheduler.py
@@ -15,7 +15,10 @@ Design notes:
   is null (manual-only) by default.
 * **Continuous event drain.** Each tick, *before* due full scans, connections
   with ``scan_mode=continuous`` and a provider event-queue env configured drain
-  a bounded batch via ``consume_*`` (AWS/Azure/GCP). That path stamps
+  a bounded batch via ``consume_*`` (AWS/Azure/GCP). Drains run in parallel under
+  the same ``CONNECTIONS_SCHEDULER_MAX_CONCURRENCY`` semaphore (one
+  ``asyncio.to_thread`` per connection), with AWS ``WaitTimeSeconds=0`` on the
+  scheduler path so empty queues do not stall ticks. That path stamps
   ``last_event_at`` only — full-scan cadence still goes through
   ``claim_due_scan`` / ``last_scan_at``.
 * **Cluster-safe.** Multiple control-plane replicas may run this loop. Each due
@@ -152,25 +155,43 @@ def _load_continuous_consumer(
     return enabled, consume
 
 
-def drain_continuous_events(store: ConnectionStore) -> int:
-    """Drain provider event queues for ``scan_mode=continuous`` connections.
+def _consume_continuous_events(
+    record: CloudConnectionRecord,
+    store: ConnectionStore,
+    *,
+    wait_seconds: int = 0,
+) -> None:
+    """Run one connection's ``consume_*`` in a worker thread (scheduler path).
 
-    No-op when the scheduler flag is off. For each continuous connection whose
-    provider has a queue/subscription env configured, call the matching
-    ``consume_*`` (bounded, fail-closed). Events update ``last_event_at`` only
-    inside the consumer — this helper never advances ``last_scan_at``.
-
-    Returns the number of connections for which a consume was attempted.
+    Passes a short ``wait_seconds`` for AWS SQS so empty queues do not stall the
+    tick on long-poll. Azure/GCP consumers have no WaitTimeSeconds equivalent.
+    Never raises — one bad consume cannot sink the tick.
     """
-    if not connections_scheduler_enabled():
-        return 0
+    loaded = _load_continuous_consumer(record.provider)
+    if loaded is None:
+        return
+    _enabled, consume = loaded
+    kwargs: dict[str, Any] = {"tenant_id": record.tenant_id, "store": store}
+    if (record.provider or "").strip().lower() == "aws":
+        kwargs["wait_seconds"] = max(0, int(wait_seconds))
+    try:
+        consume(record, **kwargs)
+    except Exception:  # noqa: BLE001 - one bad consume never sinks the tick
+        logger.exception(
+            "Continuous event drain failed for connection %s (provider=%s)",
+            record.id,
+            record.provider,
+        )
 
-    attempted = 0
+
+def _select_continuous_drain_targets(store: ConnectionStore) -> list[CloudConnectionRecord]:
+    """Return continuous connections whose provider event ingest is enabled."""
+    targets: list[CloudConnectionRecord] = []
     for record in store.list_continuous():
         loaded = _load_continuous_consumer(record.provider)
         if loaded is None:
             continue
-        enabled, consume = loaded
+        enabled, _consume = loaded
         try:
             if not enabled():
                 continue
@@ -180,16 +201,46 @@ def drain_continuous_events(store: ConnectionStore) -> int:
                 record.id,
             )
             continue
-        attempted += 1
-        try:
-            consume(record, tenant_id=record.tenant_id, store=store)
-        except Exception:  # noqa: BLE001 - one bad consume never sinks the tick
-            logger.exception(
-                "Continuous event drain failed for connection %s (provider=%s)",
-                record.id,
-                record.provider,
+        targets.append(record)
+    return targets
+
+
+async def drain_continuous_events(
+    store: ConnectionStore,
+    *,
+    max_concurrency: int = CONNECTIONS_SCHEDULER_MAX_CONCURRENCY,
+    wait_seconds: int = 0,
+) -> int:
+    """Drain provider event queues for ``scan_mode=continuous`` connections.
+
+    No-op when the scheduler flag is off. Eligible continuous connections drain
+    in parallel under a semaphore (one ``asyncio.to_thread(consume_*)`` each),
+    bounded by *max_concurrency* (defaults to
+    ``CONNECTIONS_SCHEDULER_MAX_CONCURRENCY``). Events update ``last_event_at``
+    only inside the consumer — this helper never advances ``last_scan_at``.
+
+    Returns the number of connections for which a consume was attempted.
+    """
+    if not connections_scheduler_enabled():
+        return 0
+
+    targets = _select_continuous_drain_targets(store)
+    if not targets:
+        return 0
+
+    semaphore = asyncio.Semaphore(max(1, max_concurrency))
+
+    async def _guarded(record: CloudConnectionRecord) -> None:
+        async with semaphore:
+            await asyncio.to_thread(
+                _consume_continuous_events,
+                record,
+                store,
+                wait_seconds=wait_seconds,
             )
-    return attempted
+
+    await asyncio.gather(*(_guarded(record) for record in targets))
+    return len(targets)
 
 
 def execute_connection_scan(record: CloudConnectionRecord) -> bool:
@@ -254,7 +305,8 @@ async def run_due_scans_once(
     so at most *max_concurrency* scans run at a time.
     """
     # Event drain before full scans so mid-interval posture updates land first.
-    await asyncio.to_thread(drain_continuous_events, store)
+    # Short wait (0) so empty SQS queues do not stall the tick on long-poll.
+    await drain_continuous_events(store, max_concurrency=max_concurrency, wait_seconds=0)
 
     claimed = claim_due_connections(store, now)
     if not claimed:

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -314,12 +314,21 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
     )
 
     # Default auto_scan_on_create=true: run the same brokered scan path as
-    # POST …/scan. Failure marks the row error (sanitized detail) but never
-    # rolls back the create — the connection stays fetchable for remediation.
+    # POST …/scan under the same adaptive_backpressure lane. Failure marks the
+    # row error (sanitized detail) but never rolls back the create — the
+    # connection stays fetchable for remediation. Shed (429) leaves the row
+    # pending so the client can retry via POST …/scan.
     if auto_scan_on_create:
         actor = _actor(request)
         try:
-            summary = await anyio.to_thread.run_sync(_run_connection_scan, record, tenant_id)
+            async with adaptive_backpressure("cloud_connection_scan"):
+                summary = await anyio.to_thread.run_sync(_run_connection_scan, record, tenant_id)
+        except BackpressureRejectedError as exc:
+            raise HTTPException(
+                status_code=429,
+                detail=exc.to_dict(),
+                headers={"Retry-After": str(exc.retry_after_seconds)},
+            ) from exc
         except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
             detail = _safe_connection_detail(exc)
             _mark_connection(record, status=STATUS_ERROR, status_detail=detail)

--- a/tests/api/test_cloud_connections_offload.py
+++ b/tests/api/test_cloud_connections_offload.py
@@ -124,6 +124,99 @@ def test_scan_connection_backpressure_shed_is_429_not_error(monkeypatch, wired):
     assert marks == [], "a shed request must not flip the connection to error"
 
 
+def test_create_connection_scan_on_create_uses_backpressure(monkeypatch):
+    """auto_scan_on_create must share the cloud_connection_scan backpressure lane."""
+    from agent_bom.api.connection_store import InMemoryConnectionStore, set_connection_store
+    from agent_bom.api.routes.cloud_connections import CloudConnectionCreate
+
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    monkeypatch.setattr(cloud_connections, "connections_key_configured", lambda: True)
+    monkeypatch.setattr(cloud_connections, "encrypt_secret", lambda value: f"enc:{value}")
+    monkeypatch.setattr(cloud_connections, "log_action", lambda *a, **k: None)
+    monkeypatch.setattr(cloud_connections, "_actor", lambda request: "tester")
+    monkeypatch.setattr(cloud_connections, "_tenant", lambda request: "tenant-bp")
+    monkeypatch.setattr(
+        cloud_connections,
+        "_run_connection_scan",
+        lambda record, tenant_id: {"scan_id": "s-create", "status": "completed"},
+    )
+
+    paths: list[str] = []
+
+    @contextlib.asynccontextmanager
+    async def _track(path):
+        paths.append(path)
+        yield
+
+    monkeypatch.setattr(cloud_connections, "adaptive_backpressure", _track)
+
+    body = CloudConnectionCreate(
+        provider="aws",
+        display_name="bp-conn",
+        role_ref="arn:aws:iam::123456789012:role/agent-bom-readonly",
+        external_id="ext-secret",
+        regions=["us-east-1"],
+        auto_scan_on_create=True,
+    )
+    result = asyncio.run(cloud_connections.create_connection(request=object(), body=body))
+
+    assert paths == ["cloud_connection_scan"]
+    assert result["status"] == "active"
+    assert result["last_scan_id"] == "s-create"
+    fetched = store.get("tenant-bp", result["id"])
+    assert fetched is not None
+    assert fetched.status == "active"
+
+
+def test_create_connection_scan_on_create_backpressure_shed_is_429(monkeypatch):
+    """Shed on create leaves the row pending and returns 429 (retry via POST …/scan)."""
+    from fastapi import HTTPException
+
+    from agent_bom.api.connection_store import InMemoryConnectionStore, set_connection_store
+    from agent_bom.api.routes.cloud_connections import CloudConnectionCreate
+
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    monkeypatch.setattr(cloud_connections, "connections_key_configured", lambda: True)
+    monkeypatch.setattr(cloud_connections, "encrypt_secret", lambda value: f"enc:{value}")
+    monkeypatch.setattr(cloud_connections, "log_action", lambda *a, **k: None)
+    monkeypatch.setattr(cloud_connections, "_actor", lambda request: "tester")
+    monkeypatch.setattr(cloud_connections, "_tenant", lambda request: "tenant-bp")
+
+    scanned: list[str] = []
+    monkeypatch.setattr(
+        cloud_connections,
+        "_run_connection_scan",
+        lambda record, tenant_id: scanned.append(record.id) or {"scan_id": "x"},
+    )
+
+    @contextlib.asynccontextmanager
+    async def _shedding(path):
+        raise BackpressureRejectedError(path, "concurrency limit", 5)
+        yield  # pragma: no cover
+
+    monkeypatch.setattr(cloud_connections, "adaptive_backpressure", _shedding)
+
+    body = CloudConnectionCreate(
+        provider="aws",
+        display_name="bp-shed",
+        role_ref="arn:aws:iam::123456789012:role/agent-bom-readonly",
+        external_id="ext-secret",
+        regions=["us-east-1"],
+        auto_scan_on_create=True,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(cloud_connections.create_connection(request=object(), body=body))
+
+    assert exc_info.value.status_code == 429
+    assert (exc_info.value.headers or {}).get("Retry-After") == "5"
+    assert scanned == []
+    rows = store.list_for_tenant("tenant-bp")
+    assert len(rows) == 1
+    assert rows[0].status == "pending"
+
+
 @pytest.mark.asyncio
 async def test_slow_connection_test_keeps_event_loop_responsive(monkeypatch, wired):
     """A hung broker endpoint must not pin the loop — the offload proves it."""

--- a/tests/test_connection_scheduler.py
+++ b/tests/test_connection_scheduler.py
@@ -362,7 +362,8 @@ def test_scheduler_disabled_when_flag_falsy(value: str) -> None:
 # --------------------------------------------------------------------------- #
 
 
-def test_drain_continuous_events_invokes_provider_consume(
+@pytest.mark.asyncio
+async def test_drain_continuous_events_invokes_provider_consume(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Continuous + provider queue env → consume_* once; last_scan_at untouched."""
@@ -393,7 +394,7 @@ def test_drain_continuous_events_invokes_provider_consume(
     store.put(continuous)
     prior_last_scan = continuous.last_scan_at
 
-    count = drain_continuous_events(store)
+    count = await drain_continuous_events(store)
     assert count == 1
     assert consumed == [continuous.id]
     fetched = store.get(continuous.tenant_id, continuous.id)
@@ -403,7 +404,8 @@ def test_drain_continuous_events_invokes_provider_consume(
     assert fetched.last_scan_at == prior_last_scan
 
 
-def test_drain_continuous_events_scheduler_off_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_drain_continuous_events_scheduler_off_is_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ.pop("AGENT_BOM_CONNECTIONS_SCHEDULER", None)
     os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
     consumed: list[str] = []
@@ -415,11 +417,12 @@ def test_drain_continuous_events_scheduler_off_is_noop(monkeypatch: pytest.Monke
     set_connection_store(store)
     store.put(_record(scan_mode=SCAN_MODE_CONTINUOUS))
 
-    assert drain_continuous_events(store) == 0
+    assert await drain_continuous_events(store) == 0
     assert consumed == []
 
 
-def test_drain_continuous_events_full_mode_skips(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_drain_continuous_events_full_mode_skips(monkeypatch: pytest.MonkeyPatch) -> None:
     os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
     os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
     consumed: list[str] = []
@@ -431,11 +434,12 @@ def test_drain_continuous_events_full_mode_skips(monkeypatch: pytest.MonkeyPatch
     set_connection_store(store)
     store.put(_record(scan_mode=SCAN_MODE_FULL))
 
-    assert drain_continuous_events(store) == 0
+    assert await drain_continuous_events(store) == 0
     assert consumed == []
 
 
-def test_drain_continuous_events_skips_without_provider_queue(
+@pytest.mark.asyncio
+async def test_drain_continuous_events_skips_without_provider_queue(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
@@ -449,8 +453,88 @@ def test_drain_continuous_events_skips_without_provider_queue(
     set_connection_store(store)
     store.put(_record(scan_mode=SCAN_MODE_CONTINUOUS))
 
-    assert drain_continuous_events(store) == 0
+    assert await drain_continuous_events(store) == 0
     assert consumed == []
+
+
+@pytest.mark.asyncio
+async def test_drain_continuous_events_parallel_under_semaphore(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Multiple continuous connections drain via concurrent to_thread, not a serial loop."""
+    import threading
+    import time
+
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+    os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
+
+    lock = threading.Lock()
+    in_flight = 0
+    max_in_flight = 0
+    wait_kwargs: list[int | None] = []
+
+    def _fake_consume(record: CloudConnectionRecord, **kwargs: Any) -> dict[str, Any]:
+        nonlocal in_flight, max_in_flight
+        wait_kwargs.append(kwargs.get("wait_seconds"))
+        with lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        time.sleep(0.08)
+        with lock:
+            in_flight -= 1
+        return {"status": "ok", "processed": 0}
+
+    monkeypatch.setattr("agent_bom.cloud.event_ingest.consume_aws_events", _fake_consume)
+
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    for _ in range(4):
+        store.put(_record(scan_mode=SCAN_MODE_CONTINUOUS, last_scan_at=_now().isoformat()))
+
+    started = time.monotonic()
+    count = await drain_continuous_events(store, max_concurrency=4)
+    elapsed = time.monotonic() - started
+
+    assert count == 4
+    assert max_in_flight >= 2, f"expected overlapping consumes, max_in_flight={max_in_flight}"
+    # Serial 4×0.08s ≈ 0.32s; parallel under concurrency 4 should finish closer to one sleep.
+    assert elapsed < 0.28, f"drain looked serial (elapsed={elapsed:.3f}s)"
+    assert wait_kwargs == [0, 0, 0, 0], "scheduler path must shorten SQS WaitTimeSeconds"
+
+
+@pytest.mark.asyncio
+async def test_drain_continuous_events_respects_max_concurrency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import threading
+    import time
+
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+    os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
+
+    lock = threading.Lock()
+    in_flight = 0
+    max_in_flight = 0
+
+    def _fake_consume(record: CloudConnectionRecord, **kwargs: Any) -> dict[str, Any]:
+        nonlocal in_flight, max_in_flight
+        with lock:
+            in_flight += 1
+            max_in_flight = max(max_in_flight, in_flight)
+        time.sleep(0.05)
+        with lock:
+            in_flight -= 1
+        return {"status": "ok"}
+
+    monkeypatch.setattr("agent_bom.cloud.event_ingest.consume_aws_events", _fake_consume)
+
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    for _ in range(4):
+        store.put(_record(scan_mode=SCAN_MODE_CONTINUOUS, last_scan_at=_now().isoformat()))
+
+    assert await drain_continuous_events(store, max_concurrency=2) == 4
+    assert max_in_flight == 2
 
 
 @pytest.mark.asyncio

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -940,13 +940,20 @@ def test_helm_connections_scheduler_env_gated_by_values():
         "controlPlane.connectionsScheduler.enabled=false",
     )
     assert "AGENT_BOM_CONNECTIONS_SCHEDULER" not in off
+    assert "AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY" not in off
 
     on = _render(
         "controlPlane.migrations.enabled=false",
         "controlPlane.connectionsScheduler.enabled=true",
+        "controlPlane.connectionsScheduler.maxConcurrency=6",
+        "controlPlane.connectionsScheduler.pollSeconds=30",
     )
     assert "name: AGENT_BOM_CONNECTIONS_SCHEDULER" in on
     assert 'value: "1"' in on
+    assert "name: AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY" in on
+    assert 'value: "6"' in on
+    assert "name: AGENT_BOM_CONNECTIONS_SCHEDULER_POLL_SECONDS" in on
+    assert 'value: "30"' in on
 
 
 def test_helm_event_collector_deployment_gated_by_values():


### PR DESCRIPTION
## Summary
- Continuous event drain runs in parallel under `AGENT_BOM_CONNECTIONS_SCHEDULER_MAX_CONCURRENCY` (one `asyncio.to_thread(consume_*)` per connection); AWS scheduler path uses `wait_seconds=0` so empty SQS long-polls do not stall ticks
- Scan-on-create shares `adaptive_backpressure("cloud_connection_scan")` with `POST …/scan` (still awaits `to_thread`; shed → 429, row stays pending)
- Helm exposes `controlPlane.connectionsScheduler.maxConcurrency` (+ optional `pollSeconds`) → scheduler env vars; docs cover CAS + drain concurrency + nested org ThreadPool

## Verification
- `uv run pytest -q tests/test_connection_scheduler.py tests/api/test_cloud_connections_offload.py tests/test_deploy_manifests.py::test_helm_connections_scheduler_env_gated_by_values` (+ create auto_scan cloud tests) — pass
- `uv run ruff check` on touched Python — pass
- `helm template` with `maxConcurrency=6` / `pollSeconds=30` injects both env vars — pass
- OpenAPI unchanged — skipped `make preflight`
- Tip commit `%G?` = `G`

## Follow-up (out of scope)
- Full Go SQS poll sidecar
- Rewrite scan-on-create / connection scans onto the distributed `scan_queue` job system (enqueue-and-return)

## Notes
- Due full-scans already used the semaphore; this PR aligns continuous drain with the same bound and wires Helm/docs/tests


Made with [Cursor](https://cursor.com)