### PR TITLE
feat(cloud): Connections continuous wizard and CLI parity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -296,6 +296,7 @@ override-dependencies = [
     "python-dotenv>=1.2.2",
     "aiohttp>=3.13.4",
     "openai>=2.30.0",
+    "gitpython>=3.1.54",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/agent_bom/cli/_entry_points.py
+++ b/src/agent_bom/cli/_entry_points.py
@@ -383,6 +383,34 @@ def _connect_options(source: _ConnectSource) -> list[click.Parameter]:
             click.Option(["--api-key"], help="API key for --server registration."),
             click.Option(["--tenant"], help="Control-plane tenant id for --server registration."),
             click.Option(
+                ["--inventory-scope"],
+                type=click.Choice(["account", "organization"], case_sensitive=False),
+                default=None,
+                help=(
+                    "Connections inventory scope for --server registration "
+                    "(account=target only; organization=fan-out on scan). Default: API account."
+                ),
+            ),
+            click.Option(
+                ["--scan-mode"],
+                type=click.Choice(["full", "continuous"], case_sensitive=False),
+                default=None,
+                help=(
+                    "Scan mode for --server registration (full=cadence only; continuous=also "
+                    "drain event queues mid-interval when a queue env is set). Default: API full."
+                ),
+            ),
+            click.Option(
+                ["--no-auto-scan-on-create"],
+                "no_auto_scan_on_create",
+                is_flag=True,
+                default=False,
+                help=(
+                    "Disable auto_scan_on_create for --server registration "
+                    "(API default is on)."
+                ),
+            ),
+            click.Option(
                 ["--scan", "do_scan"],
                 is_flag=True,
                 help="After establishing, trigger a scan (server /scan, else local scan guidance).",
@@ -601,6 +629,9 @@ def _register_via_server(
     api_key: str,
     tenant: str,
     do_scan: bool,
+    inventory_scope: str | None = None,
+    scan_mode: str | None = None,
+    auto_scan_on_create: bool | None = None,
 ) -> None:
     """Register the connection with a control plane, then run its /test (and /scan).
 
@@ -619,6 +650,9 @@ def _register_via_server(
             external_id=external_id,
             regions=regions,
             auth_params=auth_params,
+            inventory_scope=inventory_scope,
+            scan_mode=scan_mode,
+            auto_scan_on_create=auto_scan_on_create,
         )
         connection_id = str(created.get("id") or "")
         con.print(f"[green]Registered[/green] {source.title} connection [bold]{connection_id}[/bold] on {server}.")  # type: ignore[attr-defined]
@@ -653,6 +687,11 @@ def _make_connect_subcommand(source: _ConnectSource) -> click.Command:
         api_key = str(kwargs.get("api_key") or "").strip()
         tenant = str(kwargs.get("tenant") or "").strip()
         do_scan = bool(kwargs.get("do_scan"))
+        inventory_scope_raw = kwargs.get("inventory_scope")
+        inventory_scope = str(inventory_scope_raw).strip().lower() if inventory_scope_raw else None
+        scan_mode_raw = kwargs.get("scan_mode")
+        scan_mode = str(scan_mode_raw).strip().lower() if scan_mode_raw else None
+        auto_scan_on_create: bool | None = False if kwargs.get("no_auto_scan_on_create") else None
 
         if not role_ref or not external_id:
             secret_flag = next(f.flag for f in _CONNECT_FIELDS[source.name] if f.kind in ("secret", "secret_file"))
@@ -676,6 +715,9 @@ def _make_connect_subcommand(source: _ConnectSource) -> click.Command:
                 api_key=api_key,
                 tenant=tenant,
                 do_scan=do_scan,
+                inventory_scope=inventory_scope,
+                scan_mode=scan_mode,
+                auto_scan_on_create=auto_scan_on_create,
             )
         else:
             _local_verify(

--- a/src/agent_bom/client.py
+++ b/src/agent_bom/client.py
@@ -507,6 +507,9 @@ class AgentBomClient:
         regions: Sequence[str] | None = None,
         auth_params: Mapping[str, str] | None = None,
         scan_interval_minutes: int | None = None,
+        inventory_scope: str | None = None,
+        scan_mode: str | None = None,
+        auto_scan_on_create: bool | None = None,
     ) -> JsonObject:
         """Register a read-only cloud connection with the control plane.
 
@@ -525,6 +528,9 @@ class AgentBomClient:
             regions=regions,
             auth_params=auth_params,
             scan_interval_minutes=scan_interval_minutes,
+            inventory_scope=inventory_scope,
+            scan_mode=scan_mode,
+            auto_scan_on_create=auto_scan_on_create,
         )
         return self._request("POST", "/v1/cloud/connections", json=body)
 

--- a/tests/test_cli_connect_establish.py
+++ b/tests/test_cli_connect_establish.py
@@ -207,10 +207,43 @@ class TestServerRegister:
             "external_id": SECRET,
             "regions": ["us-east-1"],
             "auth_params": {},
+            "inventory_scope": None,
+            "scan_mode": None,
+            "auto_scan_on_create": None,
         }
         assert client.tested == ["conn-9"]
         assert client.scanned == []
         assert client.closed is True
+
+    def test_register_passes_scope_mode_and_auto_scan_flags(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _FakeClient.instances = []
+        monkeypatch.setattr("agent_bom.client.AgentBomClient", _FakeClient)
+        r = CliRunner().invoke(
+            _main(),
+            [
+                "connect", "aws",
+                "--role-arn", "arn:aws:iam::123456789012:role/ro",
+                "--external-id", SECRET,
+                "--server", "https://cp.example.com",
+                "--api-key", "k-123",
+                "--inventory-scope", "organization",
+                "--scan-mode", "continuous",
+                "--no-auto-scan-on-create",
+            ],
+        )
+        assert r.exit_code == 0, r.output
+        client = _FakeClient.instances[-1]
+        assert client.create_kwargs == {
+            "provider": "aws",
+            "display_name": "Amazon Web Services (read-only)",
+            "role_ref": "arn:aws:iam::123456789012:role/ro",
+            "external_id": SECRET,
+            "regions": [],
+            "auth_params": {},
+            "inventory_scope": "organization",
+            "scan_mode": "continuous",
+            "auto_scan_on_create": False,
+        }
 
     def test_scan_flag_triggers_server_scan(self, monkeypatch: pytest.MonkeyPatch) -> None:
         _FakeClient.instances = []
@@ -255,10 +288,16 @@ class TestSchemaConsistency:
             regions=["us-east-1"],
             auth_params={"k": "v"},
             scan_interval_minutes=60,
+            inventory_scope="organization",
+            scan_mode="continuous",
+            auto_scan_on_create=False,
         )
         assert set(body) <= set(CloudConnectionCreate.model_fields)
         # The body must validate against the API's own request model.
         CloudConnectionCreate(**body)
+        assert body["inventory_scope"] == "organization"
+        assert body["scan_mode"] == "continuous"
+        assert body["auto_scan_on_create"] is False
 
     def test_client_posts_create_body_to_v1_route(self) -> None:
         from agent_bom.api.routes.cloud_connections import CloudConnectionCreate
@@ -285,6 +324,9 @@ class TestSchemaConsistency:
                 role_ref="r",
                 external_id=SECRET,
                 regions=["us-east-1"],
+                inventory_scope="organization",
+                scan_mode="continuous",
+                auto_scan_on_create=False,
             )
         finally:
             client.close()
@@ -293,4 +335,7 @@ class TestSchemaConsistency:
         assert str(captured["url"]).endswith("/v1/cloud/connections")
         body = captured["json"]
         assert body["external_id"] == SECRET
+        assert body["inventory_scope"] == "organization"
+        assert body["scan_mode"] == "continuous"
+        assert body["auto_scan_on_create"] is False
         CloudConnectionCreate(**body)  # type: ignore[arg-type]

--- a/ui/app/connections/page.tsx
+++ b/ui/app/connections/page.tsx
@@ -1066,6 +1066,24 @@ function ConnectionsHub() {
     }
   }
 
+  async function handleScanModeChange(connection: CloudConnectionRecord, continuous: boolean) {
+    setScheduleErrors((prev) => {
+      const next = { ...prev };
+      delete next[connection.id];
+      return next;
+    });
+    try {
+      const updated = await api.updateCloudConnection(connection.id, {
+        scan_mode: continuous ? "continuous" : "full",
+      });
+      setConnections((prev) => prev.map((item) => (item.id === updated.id ? updated : item)));
+      setMessage(`${updated.display_name} scan mode updated.`);
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : "Failed to update scan mode.";
+      setScheduleErrors((prev) => ({ ...prev, [connection.id]: detail }));
+    }
+  }
+
   async function handleFleetSync() {
     setSyncingFleet(true);
     setFleetSyncSummary(null);
@@ -1435,6 +1453,7 @@ function ConnectionsHub() {
           onCloudScan={(c) => void handleScan(c)}
           onCloudDelete={(c) => void handleDelete(c)}
           onCloudScheduleChange={(c, v) => void handleScheduleChange(c, v)}
+          onCloudScanModeChange={(c, continuous) => void handleScanModeChange(c, continuous)}
           isDemoMode={isDemoMode}
           dataSourcesService={dataSourcesService}
           servicesRegistry={counts?.services}
@@ -1671,6 +1690,7 @@ interface SourcesSegmentProps {
   onCloudScan: (connection: CloudConnectionRecord) => void;
   onCloudDelete: (connection: CloudConnectionRecord) => void;
   onCloudScheduleChange: (connection: CloudConnectionRecord, value: string) => void;
+  onCloudScanModeChange: (connection: CloudConnectionRecord, continuous: boolean) => void;
   isDemoMode: boolean;
   dataSourcesService: ReturnType<typeof serviceEntry>;
   servicesRegistry: Parameters<typeof serviceEntry>[0];
@@ -1719,6 +1739,7 @@ function SourcesSegment(props: SourcesSegmentProps) {
     onCloudScan,
     onCloudDelete,
     onCloudScheduleChange,
+    onCloudScanModeChange,
     isDemoMode,
     dataSourcesService,
     servicesRegistry,
@@ -1865,6 +1886,7 @@ function SourcesSegment(props: SourcesSegmentProps) {
                   onCloudScan={onCloudScan}
                   onCloudDelete={onCloudDelete}
                   onCloudScheduleChange={onCloudScheduleChange}
+                  onCloudScanModeChange={onCloudScanModeChange}
                 />
               ))}
             </tbody>
@@ -2162,6 +2184,7 @@ function UnifiedRow({
   onCloudScan,
   onCloudDelete,
   onCloudScheduleChange,
+  onCloudScanModeChange,
 }: {
   row: UnifiedSourceRow;
   connection: CloudConnectionRecord | null;
@@ -2172,11 +2195,13 @@ function UnifiedRow({
   onCloudScan: (connection: CloudConnectionRecord) => void;
   onCloudDelete: (connection: CloudConnectionRecord) => void;
   onCloudScheduleChange: (connection: CloudConnectionRecord, value: string) => void;
+  onCloudScanModeChange: (connection: CloudConnectionRecord, continuous: boolean) => void;
 }) {
   const isCloud = row.origin === "cloud" && connection != null;
   const isBusy = isCloud ? busyId === connection!.id : false;
   const scannable = isCloud ? SCANNABLE_PROVIDERS.has(connection!.provider) : false;
   const mode = isCloud ? eventMode(connection!) : null;
+  const continuous = isCloud && isContinuousMode(connection!);
 
   return (
     <tr className="group border-b border-[color:var(--border-subtle)] last:border-b-0 align-top">
@@ -2218,7 +2243,7 @@ function UnifiedRow({
                 Organization
               </span>
             ) : null}
-            {isCloud && isContinuousMode(connection!) ? (
+            {continuous ? (
               <span
                 className="inline-flex items-center rounded-full border border-sky-500/30 bg-sky-500/10 px-2 py-0.5 text-[10px] font-medium text-sky-700 dark:text-sky-200"
                 title="Continuous mode: event-driven refresh between full scans"
@@ -2248,24 +2273,45 @@ function UnifiedRow({
       <td className="whitespace-nowrap px-4 py-3 text-[var(--text-secondary)]">{formatWhen(row.lastScanAt)}</td>
       <td className="px-4 py-3">
         {isCloud ? (
-          <>
-            <label className="sr-only" htmlFor={`schedule-${connection!.id}`}>
-              Scan schedule
-            </label>
-            <select
-              id={`schedule-${connection!.id}`}
-              value={connection!.scan_interval_minutes?.toString() ?? ""}
-              disabled={!canManage}
-              onChange={(event) => onCloudScheduleChange(connection!, event.target.value)}
-              className="w-36 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5 text-xs text-[var(--foreground)] outline-none transition focus:border-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              {SCHEDULE_OPTIONS.map(([label, value]) => (
-                <option key={label} value={value}>
-                  {label}
-                </option>
-              ))}
-            </select>
-          </>
+          <div className="flex flex-col gap-1.5">
+            <div className="flex flex-wrap items-center gap-2">
+              <label className="sr-only" htmlFor={`schedule-${connection!.id}`}>
+                Scan schedule
+              </label>
+              <select
+                id={`schedule-${connection!.id}`}
+                value={connection!.scan_interval_minutes?.toString() ?? ""}
+                disabled={!canManage}
+                onChange={(event) => onCloudScheduleChange(connection!, event.target.value)}
+                className="w-36 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-2.5 py-1.5 text-xs text-[var(--foreground)] outline-none transition focus:border-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {SCHEDULE_OPTIONS.map(([label, value]) => (
+                  <option key={label} value={value}>
+                    {label}
+                  </option>
+                ))}
+              </select>
+              <label className="inline-flex cursor-pointer items-center gap-1.5 text-[11px] text-[var(--text-secondary)]">
+                <input
+                  type="checkbox"
+                  checked={continuous}
+                  disabled={!canManage}
+                  onChange={(event) => onCloudScanModeChange(connection!, event.target.checked)}
+                  className="h-3.5 w-3.5 shrink-0 accent-sky-500 disabled:cursor-not-allowed"
+                  data-testid="schedule-scan-mode-continuous"
+                />
+                Continuous
+              </label>
+            </div>
+            {continuous ? (
+              <p
+                className="max-w-[16rem] text-[10px] leading-snug text-[var(--text-tertiary)]"
+                data-testid="schedule-continuous-queue-hint"
+              >
+                Mid-interval refresh needs a provider event queue env on the control plane.
+              </p>
+            ) : null}
+          </div>
         ) : (
           <span className="tabular-nums text-[var(--text-secondary)]">
             {row.scheduleCount} schedule{row.scheduleCount === 1 ? "" : "s"}
@@ -3367,6 +3413,7 @@ interface WizardForm {
   regions: string;
   auth: Record<string, string>;
   auto_scan_on_create: boolean;
+  scan_mode: "full" | "continuous";
 }
 
 function buildWizardForm(provider: string): WizardForm {
@@ -3378,6 +3425,7 @@ function buildWizardForm(provider: string): WizardForm {
     regions: "",
     auth: {},
     auto_scan_on_create: true,
+    scan_mode: "full",
   };
 }
 
@@ -3587,6 +3635,7 @@ function AddConnectionWizard({
       regions,
       auth_params: authParams,
       inventory_scope: isAws && awsScope === "organization" ? "organization" : "account",
+      scan_mode: form.scan_mode,
       auto_scan_on_create: form.auto_scan_on_create,
     };
 
@@ -3962,6 +4011,35 @@ function AddConnectionWizard({
                     <span className="mt-0.5 block text-[11px] text-[var(--text-secondary)]">
                       Default on. Starts a read-only inventory + CIS scan once the connection is saved.
                     </span>
+                  </span>
+                </label>
+                <label className="flex cursor-pointer items-start gap-2.5 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2.5">
+                  <input
+                    type="checkbox"
+                    checked={form.scan_mode === "continuous"}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        scan_mode: event.target.checked ? "continuous" : "full",
+                      }))
+                    }
+                    className="mt-0.5 h-4 w-4 shrink-0 accent-sky-500"
+                    data-testid="wizard-scan-mode-continuous"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-sm font-medium text-[var(--foreground)]">Continuous</span>
+                    <span className="mt-0.5 block text-[11px] text-[var(--text-secondary)]">
+                      Event-driven mid-interval refresh between full cadence scans.
+                    </span>
+                    {form.scan_mode === "continuous" ? (
+                      <span
+                        className="mt-1.5 block text-[11px] text-[var(--text-tertiary)]"
+                        data-testid="wizard-continuous-queue-hint"
+                      >
+                        Mid-interval refresh needs a provider event queue env on the control plane
+                        (for example AGENT_BOM_AWS_EVENT_QUEUE_URL).
+                      </span>
+                    ) : null}
                   </span>
                 </label>
                 {provider.usesRegions ? (

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -3492,8 +3492,8 @@ export interface CloudConnectionCreateRequest {
 }
 
 export interface CloudConnectionUpdateRequest {
-  /** Recurring read-only scan cadence. Null disables scheduling. */
-  scan_interval_minutes: number | null;
+  /** Recurring read-only scan cadence. Null disables scheduling. Omitted = leave unchanged. */
+  scan_interval_minutes?: number | null;
   /** Optional org fan-out scope for subsequent Connections scans. */
   inventory_scope?: "account" | "organization";
   /** Optional scan cadence mode. */

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8785,9 +8785,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -9368,9 +9368,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.12",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
-      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -9387,7 +9387,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,7 @@
     "sigma": "^3.0.3"
   },
   "overrides": {
-    "postcss": "8.5.12",
+    "postcss": "8.5.18",
     "brace-expansion@1": "1.1.16",
     "sharp": "^0.35.0"
   },

--- a/ui/tests/connections-page.test.tsx
+++ b/ui/tests/connections-page.test.tsx
@@ -262,6 +262,7 @@ describe("ConnectionsPage — Connect segment", () => {
         regions: ["us-east-1"],
         auth_params: {},
         inventory_scope: "account",
+        scan_mode: "full",
         auto_scan_on_create: true,
       }),
     );
@@ -427,6 +428,7 @@ describe("ConnectionsPage — Connect segment", () => {
           display_name: "Org production",
           external_id: setupId,
           inventory_scope: "organization",
+          scan_mode: "full",
           auto_scan_on_create: true,
         }),
       ),
@@ -468,6 +470,7 @@ describe("ConnectionsPage — Connect segment", () => {
         regions: [],
         auth_params: { project_id: "proj-123" },
         inventory_scope: "account",
+        scan_mode: "full",
         auto_scan_on_create: true,
       }),
     );
@@ -514,6 +517,42 @@ describe("ConnectionsPage — Connect segment", () => {
       expect(apiMock.createCloudConnection).toHaveBeenCalledWith(
         expect.objectContaining({
           auto_scan_on_create: true,
+          scan_mode: "full",
+          display_name: "Production account",
+          external_id: setupId,
+        }),
+      ),
+    );
+  });
+
+  it("create payload includes scan_mode=continuous when Continuous is checked", async () => {
+    apiMock.createCloudConnection.mockResolvedValue({
+      ...CREATED_RECORD,
+      scan_mode: "continuous",
+    });
+    apiMock.testCloudConnection.mockResolvedValue(TEST_OK);
+
+    render(<ConnectionsPage />);
+    await waitForConnectTab();
+    const wizard = openAwsWizard();
+    const setupId = fillAwsDetails(wizard);
+
+    const continuous = within(wizard).getByTestId("wizard-scan-mode-continuous");
+    expect(continuous).not.toBeChecked();
+    expect(within(wizard).queryByTestId("wizard-continuous-queue-hint")).toBeNull();
+
+    fireEvent.click(continuous);
+    expect(continuous).toBeChecked();
+    expect(within(wizard).getByTestId("wizard-continuous-queue-hint")).toHaveTextContent(
+      /event queue/i,
+    );
+
+    fireEvent.click(within(wizard).getByRole("button", { name: "Create connection" }));
+
+    await waitFor(() =>
+      expect(apiMock.createCloudConnection).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scan_mode: "continuous",
           display_name: "Production account",
           external_id: setupId,
         }),
@@ -913,6 +952,42 @@ describe("ConnectionsPage — Sources segment (unified table)", () => {
       expect(screen.getByText("Production account scan schedule updated.")).toBeInTheDocument(),
     );
     expect(document.body.textContent).not.toContain(SECRET);
+  });
+
+  it("patches scan_mode from the schedule Continuous checkbox", async () => {
+    apiMock.listCloudConnections.mockResolvedValue({
+      schema_version: "cloud.connections.v1",
+      tenant_id: "tenant-acme",
+      connections: [{ ...CREATED_RECORD, status: "active", scan_interval_minutes: 60 }],
+      count: 1,
+      connections_scheduler_enabled: true,
+    });
+    apiMock.updateCloudConnection.mockResolvedValue({
+      ...CREATED_RECORD,
+      status: "active",
+      scan_interval_minutes: 60,
+      scan_mode: "continuous",
+      updated_at: "2026-06-27T02:00:00Z",
+    });
+
+    render(<ConnectionsPage />);
+    await waitFor(() => expect(screen.getByText("Production account")).toBeInTheDocument());
+
+    const continuous = screen.getByTestId("schedule-scan-mode-continuous");
+    expect(continuous).not.toBeChecked();
+    expect(screen.queryByTestId("schedule-continuous-queue-hint")).toBeNull();
+
+    fireEvent.click(continuous);
+
+    await waitFor(() =>
+      expect(apiMock.updateCloudConnection).toHaveBeenCalledWith("conn-1", {
+        scan_mode: "continuous",
+      }),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Production account scan mode updated.")).toBeInTheDocument(),
+    );
+    expect(screen.getByTestId("schedule-continuous-queue-hint")).toHaveTextContent(/event queue/i);
   });
 
   it("deletes a connection through the API", async () => {

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ resolution-markers = [
 [manifest]
 overrides = [
     { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "gitpython", specifier = ">=3.1.54" },
     { name = "openai", specifier = ">=2.30.0" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
@@ -2086,14 +2087,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.52"
+version = "3.1.55"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e5/fd/df0bafa4eb5ea2f51e1adee9f7a94c8e62c5d180e65117045dfca3439c8a/gitpython-3.1.52.tar.gz", hash = "sha256:de0a8ad86274c6e75ae8b37dd055ba68f19818c813108642263227b20775b48e", size = 223726, upload-time = "2026-07-16T03:15:59.599Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ab/ba0d29f2fa2277ed6256b2ac09003494045355f3a10bf32f351761287870/gitpython-3.1.55.tar.gz", hash = "sha256:781e3b1624dad81b24e9524bf0297b69786a0706db2cbceec1e2b05c38e5152f", size = 225071, upload-time = "2026-07-23T02:52:43.246Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8d/90/04dff7c1e176bb1c3011ef1647393d368790da710d8dde1cdcfad301f45a/gitpython-3.1.52-py3-none-any.whl", hash = "sha256:79a36ee1f83523214a3f72d56cf1c4e490d577dc61af77e43dfe5862bd9da01a", size = 215366, upload-time = "2026-07-16T03:15:58.239Z" },
+    { url = "https://files.pythonhosted.org/packages/20/6a/d3b8208d2f8aac66abe8ccc1c23fa2c89464ec42cc71a601e95d05902428/gitpython-3.1.55-py3-none-any.whl", hash = "sha256:7c9ec1e69c158c081632ab35c41471e302c96db2ae42165036a5d2403378812e", size = 216590, upload-time = "2026-07-23T02:52:41.932Z" },
 ]
 
 [[package]]
@@ -5454,7 +5455,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5535,7 +5536,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- Connections wizard create payload now sends `scan_mode` (`full` default; Continuous checkbox → `continuous`) with a short helper that mid-interval refresh needs a provider event queue env
- Schedule column Continuous checkbox PATCHes `scan_mode` next to cadence
- `AgentBomClient.create_cloud_connection` and CLI `connect --server` pass through `inventory_scope`, `scan_mode`, and `auto_scan_on_create` (`--inventory-scope`, `--scan-mode`, `--no-auto-scan-on-create`)

## Verification
- `uv run pytest -q tests/test_cli_connect_establish.py tests/cloud/test_cloud_connections.py tests/test_connection_scheduler.py` → 135 passed
- `uv run ruff check` + `uv run mypy` on touched Python files → pass
- `cd ui && npm ci && npm run typecheck && npm test -- --run connections-page cloud-connect-wizard` → 51 passed
- `npm run build` and `NEXT_EXPORT=1 npm run build` → pass
- OpenAPI unchanged; `make preflight` skipped

## Notes
- Depends on nothing; closes PR-B wire-align gaps from the continuous plan
- Evidence/lake Source kinds deferred; version not bumped
- Tip `%G?` = `G` (good signature) on `6e7bef3ec`


Made with [Cursor](https://cursor.com)