### PR TITLE
fix(ci): treat blank surface-freshness env vars as unset

### DIFF
--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -8,7 +8,7 @@ name: Surface Freshness
 #
 # Optional repo variables (Settings -> Secrets and variables -> Actions -> Variables):
 #   SMITHERY_SERVER_QUALIFIED_NAME — override Smithery listing name; defaults to agent-bom/agent-bom
-#   GLAMA_LISTING_URL  — Glama public listing JSON endpoint (enables Glama probe)
+#   GLAMA_LISTING_URL  — override Glama listing URL (default: glama.ai/.../msaad00/agent-bom)
 #   DOCKER_IMAGE       — override default ghcr.io/msaad00/agent-bom
 
 on:
@@ -81,7 +81,7 @@ jobs:
               "- `unmonitored (misconfigured)` — a required repo variable is unset, so this surface is NOT being watched. Set the named variable.",
               "- `unreachable` — the surface URL is configured but the probe failed (network / HTTP / parse).",
               "",
-              "Required repo variables for full coverage: `GLAMA_LISTING_URL`. Smithery defaults to `agent-bom/agent-bom`; set `SMITHERY_SERVER_QUALIFIED_NAME` only if the listing name changes.",
+              "Optional overrides (blank/unset repo vars fall back to defaults): `DOCKER_IMAGE` (`ghcr.io/msaad00/agent-bom`), `GLAMA_LISTING_URL`, `SMITHERY_SERVER_QUALIFIED_NAME` (`agent-bom/agent-bom`).",
               "",
               "_Maintained automatically by the surface-freshness workflow. Self-closes when every surface is fresh and monitored._",
             ].join("\n");

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -18,6 +18,17 @@ ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
 README = ROOT / "README.md"
 DEFAULT_URL = "https://glama.ai/mcp/servers/msaad00/agent-bom"
+
+
+def _env_or(name: str, default: str) -> str:
+    """Return env var if non-blank; otherwise ``default``.
+
+    GitHub Actions injects unset ``vars.*`` as empty strings into ``env:``,
+    so ``os.environ.get(name, default)`` would keep ``""`` and skip the default.
+    """
+    value = (os.environ.get(name) or "").strip()
+    return value or default
+
 GLAMA_DOCKERFILE = "integrations/glama/Dockerfile"
 GLAMA_MANIFESTS = (ROOT / "glama.json", ROOT / "integrations" / "glama" / "server.json")
 
@@ -146,7 +157,7 @@ def _extract_listing_version(page: str) -> str:
 
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--url", default=os.environ.get("GLAMA_LISTING_URL", DEFAULT_URL))
+    parser.add_argument("--url", default=_env_or("GLAMA_LISTING_URL", DEFAULT_URL))
     parser.add_argument("--expected", default=None, help="Expected version; defaults to pyproject.toml.")
     parser.add_argument("--json", action="store_true", help="Emit a machine-readable freshness result.")
     parser.add_argument("--timeout", type=int, default=20)

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -44,12 +44,24 @@ GLAMA_SCRIPT = ROOT / "scripts" / "check_glama_listing.py"
 
 PYPI_PACKAGE = "agent-bom"
 DEFAULT_DOCKER_IMAGE = "ghcr.io/msaad00/agent-bom"
+DEFAULT_SMITHERY_SERVER = "agent-bom/agent-bom"
 DEFAULT_TIMEOUT = 15.0
 DEFAULT_ATTEMPTS = 3
 DEFAULT_BACKOFF = 5.0
 
 OK_STATUSES = {"fresh"}
 ALERT_STATUSES = {"stale", "not_configured", "unreachable"}
+
+
+
+def _env_or(name: str, default: str) -> str:
+    """Return env var if non-blank; otherwise ``default``.
+
+    GitHub Actions injects unset ``vars.*`` as empty strings into ``env:``, so
+    ``os.environ.get(name, default)`` would keep ``""`` and skip the default.
+    """
+    value = (os.environ.get(name) or "").strip()
+    return value or default
 
 
 def _expected_version() -> str:
@@ -266,8 +278,8 @@ def probe_smithery(expected: str, qualified_name: str, **kw: Any) -> dict[str, A
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--expected", default=None, help="Override expected version (defaults to pyproject.toml).")
-    parser.add_argument("--docker-image", default=os.environ.get("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
-    parser.add_argument("--smithery-server", default=os.environ.get("SMITHERY_SERVER_QUALIFIED_NAME", "agent-bom/agent-bom"))
+    parser.add_argument("--docker-image", default=_env_or("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
+    parser.add_argument("--smithery-server", default=_env_or("SMITHERY_SERVER_QUALIFIED_NAME", DEFAULT_SMITHERY_SERVER))
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
     parser.add_argument("--attempts", type=int, default=DEFAULT_ATTEMPTS)
     parser.add_argument("--backoff-seconds", type=float, default=DEFAULT_BACKOFF)

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -160,3 +160,62 @@ def test_surface_freshness_reads_paginated_ghcr_tags(monkeypatch):
     assert result["surface"] == "Docker"
     assert result["status"] == "fresh"
     assert result["version"] == "0.89.2"
+
+
+def test_env_or_treats_blank_as_unset():
+    script = _load_script("check_surface_freshness.py")
+    glama = _load_script("check_glama_listing.py")
+
+    assert script._env_or("MISSING_VAR_XYZ", "fallback") == "fallback"
+    assert glama._env_or("MISSING_VAR_XYZ", "fallback") == "fallback"
+
+
+def test_surface_freshness_blank_env_vars_use_defaults(monkeypatch):
+    """GitHub Actions injects unset vars.* as empty strings into env:."""
+    script = _load_script("check_surface_freshness.py")
+    monkeypatch.setenv("DOCKER_IMAGE", "")
+    monkeypatch.setenv("SMITHERY_SERVER_QUALIFIED_NAME", "   ")
+    monkeypatch.setenv("GLAMA_LISTING_URL", "")
+
+    assert script._env_or("DOCKER_IMAGE", script.DEFAULT_DOCKER_IMAGE) == script.DEFAULT_DOCKER_IMAGE
+    assert (
+        script._env_or("SMITHERY_SERVER_QUALIFIED_NAME", script.DEFAULT_SMITHERY_SERVER)
+        == script.DEFAULT_SMITHERY_SERVER
+    )
+
+    glama = _load_script("check_glama_listing.py")
+    assert glama._env_or("GLAMA_LISTING_URL", glama.DEFAULT_URL) == glama.DEFAULT_URL
+
+
+def test_surface_freshness_main_skips_blank_docker_and_smithery_env(monkeypatch, tmp_path):
+    script = _load_script("check_surface_freshness.py")
+    monkeypatch.setenv("DOCKER_IMAGE", "")
+    monkeypatch.setenv("SMITHERY_SERVER_QUALIFIED_NAME", "")
+
+    monkeypatch.setattr(script, "probe_pypi", lambda expected, **_kw: {
+        "surface": "PyPI", "status": "fresh", "version": expected, "expected": expected,
+    })
+    monkeypatch.setattr(script, "probe_glama", lambda expected, **_kw: {
+        "surface": "Glama", "status": "fresh", "version": expected, "expected": expected,
+    })
+
+    seen: dict[str, str] = {}
+
+    def fake_docker(expected, image, **_kw):
+        seen["docker"] = image
+        return {"surface": "Docker", "status": "fresh", "version": expected, "expected": expected}
+
+    def fake_smithery(expected, qualified_name, **_kw):
+        seen["smithery"] = qualified_name
+        return {"surface": "Smithery", "status": "fresh", "version": "catalog-live", "expected": expected}
+
+    monkeypatch.setattr(script, "probe_docker", fake_docker)
+    monkeypatch.setattr(script, "probe_smithery", fake_smithery)
+
+    out = tmp_path / "report.json"
+    assert script.main(["--expected", "0.97.5", "--out", str(out)]) == 0
+    report = json.loads(out.read_text())
+    assert report["all_fresh"] is True
+    assert seen["docker"] == script.DEFAULT_DOCKER_IMAGE
+    assert seen["smithery"] == script.DEFAULT_SMITHERY_SERVER
+


### PR DESCRIPTION
## Summary
- Fixes false `supply-chain-drift` unreachables when Actions injects empty `vars.DOCKER_IMAGE` / `vars.SMITHERY_SERVER_QUALIFIED_NAME` / `vars.GLAMA_LISTING_URL` (unset vars become `""`, which skipped Python defaults).
- Adds `_env_or()` in `check_surface_freshness.py` and `check_glama_listing.py` so blank/whitespace falls back to `ghcr.io/msaad00/agent-bom`, `agent-bom/agent-bom`, and the Glama default listing URL.
- Regression tests cover blank-env defaults; workflow issue copy clarifies overrides are optional.

Closes #4440

## Drift items (issue #4440)
| Surface | Issue finding | Root cause | After fix |
|---------|---------------|------------|-----------|
| PyPI | fresh @ 0.97.5 | — | fresh |
| Docker | unreachable — empty image reference | empty `DOCKER_IMAGE` env | fresh @ 0.97.5 |
| Smithery | unreachable — invalid qualified name `''` | empty `SMITHERY_SERVER_QUALIFIED_NAME` | fresh (catalog-live) |
| Glama | unreachable (probe never used default URL) | empty `GLAMA_LISTING_URL` | probes correctly; listing content still **stale** at 0.96.3 (needs Glama rebuild / `GLAMA_WEBHOOK_URL`) |

#4443 is a separate main CI failure (unrelated); this PR stays scoped to surface-freshness empty-env handling.

## Verification
- `DOCKER_IMAGE= SMITHERY_SERVER_QUALIFIED_NAME= GLAMA_LISTING_URL= python3 scripts/check_surface_freshness.py` — no longer reports empty image / invalid Smithery name; Docker+Smithery fresh
- `uv run pytest -q tests/test_surface_freshness.py` — 12 passed
- `uv run ruff check scripts/check_surface_freshness.py scripts/check_glama_listing.py tests/test_surface_freshness.py`

## Notes
After merge, the next surface-freshness run should stop filing empty-env unreachables. Remaining Glama **content** drift (0.96.3 vs 0.97.5) is real marketplace lag until a Glama rebuild is triggered (`GLAMA_WEBHOOK_URL` is not set on the repo today).


Made with [Cursor](https://cursor.com)