### PR TITLE
fix(docs): split AppSec and GRC persona cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ isolation.
 <p align="center">
   <picture>
     <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom personas: AppSec/GRC, Platform/SRE, Developers, and AI/MCP owners with matching outcomes" width="900" />
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/persona-value-light.svg" alt="agent-bom personas: AppSec, GRC, Platform/SRE, Agent builders, and Security engineers with matching outcomes" width="900" />
   </picture>
 </p>
 

--- a/docs/VISUAL_LANGUAGE.md
+++ b/docs/VISUAL_LANGUAGE.md
@@ -100,7 +100,7 @@ Current SVG inventory:
 | `brand/logo-{light,dark}.svg` | Brand lockup (mark + wordmark); see Brand basics above | hero |
 | `architecture-{light,dark}.svg` | End-to-end LR data flow: sources → scan/ingest → unified Finding + ContextGraph → control plane (API / Gateway / MCP) → consumers (humans + headless agents) + artifacts | `docs/ARCHITECTURE.md` System Overview; README "What Is agent-bom", collapsed detail |
 | `how-it-works-{light,dark}.svg` | Three product lanes — Scan → Graph → Serve — vuln/advisories in scan, ContextGraph + blast radius at center, `agent-bom serve` as one pane of glass; cloud row uses official marks from `ui/public/logos/` | README "How It Works" |
-| `persona-value-{light,dark}.svg` | Four buyer personas in a compact single-row band — neutral cards, one restrained accent hue and person-with-role-badge icon per persona, value proof pill per card (larger body copy for README scale) | README "What Is agent-bom", collapsed "Who it's for" detail |
+| `persona-value-{light,dark}.svg` | Five buyer personas in a compact single-row band (AppSec ≠ GRC / audit) — neutral cards, one restrained accent hue and person-with-role-badge icon per persona, value proof pill per card (larger body copy for README scale) | README "What Is agent-bom", collapsed "Who it's for" detail |
 | `blast-radius-{light,dark}.svg` | CVE, package, MCP server, agent, credentials, and tools in one blast-radius path | README "What Is agent-bom", collapsed drilldown |
 | `scan-pipeline-{light,dark}.svg` | 5-stage pipeline (discover → scan → analyze → report → enforce) | "How a scan moves" |
 | `engine-internals-{light,dark}.svg` | Inside the scanner | available for deeper architecture docs; not currently embedded in the README |

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -1,76 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="236" viewBox="0 0 1080 236" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="236" viewBox="0 0 1280 236" fill="none">
 <title>agent-bom personas and value</title>
-<rect width="1080" height="236" rx="12" fill="#16161d"/>
-<rect x="23" y="18" width="248" height="174" rx="12" fill="#2dd4bf"/>
-<rect x="23" y="22" width="248" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect width="1280" height="236" rx="12" fill="#16161d"/>
+<rect x="23" y="18" width="235" height="174" rx="12" fill="#2dd4bf"/>
+<rect x="23" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="37" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(41,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#0f0f13" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#2dd4bf" stroke-width="1.05"/></g></g>
-<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">AppSec / GRC</text>
+<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">AppSec</text>
 <rect x="37" y="82" width="40" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
 <text x="57.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">SARIF</text>
-<rect x="83" y="82" width="65" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="115.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">compliance</text>
-<rect x="154" y="82" width="69" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="188.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">audit chain</text>
-<line x1="39" y1="110" x2="255" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="147,120 142,113 152,113" fill="#2dd4bf" opacity="0.9"/>
-<rect x="35" y="126" width="224" height="52" rx="8" fill="#2dd4bf" opacity="0.10"/>
-<rect x="35" y="126" width="224" height="52" rx="8" fill="none" stroke="#2dd4bf" opacity="0.4"/>
+<rect x="83" y="82" width="74" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
+<text x="120.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">reachability</text>
+<rect x="163" y="82" width="55" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
+<text x="190.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">CI gates</text>
+<line x1="39" y1="110" x2="242" y2="110" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="140,120 135,113 145,113" fill="#2dd4bf" opacity="0.9"/>
+<rect x="35" y="126" width="211" height="52" rx="8" fill="#2dd4bf" opacity="0.10"/>
+<rect x="35" y="126" width="211" height="52" rx="8" fill="none" stroke="#2dd4bf" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#2dd4bf"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Accurate SCA</text>
 <text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro-aware</text>
-<rect x="285" y="18" width="248" height="174" rx="12" fill="#38bdf8"/>
-<rect x="285" y="22" width="248" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
-<rect x="299" y="32" width="40" height="40" rx="11" fill="#38bdf8" opacity="0.16"/><g transform="translate(303,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#38bdf8"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#38bdf8"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#38bdf8"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
-<text x="347" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
-<rect x="299" y="82" width="65" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="331.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">fleet sync</text>
-<rect x="370" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="387.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">Helm</text>
-<rect x="411" y="82" width="25" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="423.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">CI</text>
-<rect x="442" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="459.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">SBOM</text>
-<line x1="301" y1="110" x2="517" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="409,120 404,113 414,113" fill="#38bdf8" opacity="0.9"/>
-<rect x="297" y="126" width="224" height="52" rx="8" fill="#38bdf8" opacity="0.10"/>
-<rect x="297" y="126" width="224" height="52" rx="8" fill="none" stroke="#38bdf8" opacity="0.4"/>
-<rect x="305" y="142" width="3" height="14" rx="1.5" fill="#38bdf8"/>
-<text x="315" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Container coverage</text>
-<text x="315" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">OCI native · Grype · CIS posture</text>
-<rect x="547" y="18" width="248" height="174" rx="12" fill="#a78bfa"/>
-<rect x="547" y="22" width="248" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
-<rect x="561" y="32" width="40" height="40" rx="11" fill="#a78bfa" opacity="0.16"/><g transform="translate(565,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#a78bfa"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#a78bfa"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#a78bfa"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
-<text x="609" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Agent builders</text>
-<rect x="561" y="82" width="79" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="600.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">MCP inventory</text>
-<rect x="646" y="82" width="45" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="668.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">Shield</text>
-<rect x="697" y="82" width="50" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="722.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">runtime</text>
-<line x1="563" y1="110" x2="779" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="671,120 666,113 676,113" fill="#a78bfa" opacity="0.9"/>
-<rect x="559" y="126" width="224" height="52" rx="8" fill="#a78bfa" opacity="0.10"/>
-<rect x="559" y="126" width="224" height="52" rx="8" fill="none" stroke="#a78bfa" opacity="0.4"/>
-<rect x="567" y="142" width="3" height="14" rx="1.5" fill="#a78bfa"/>
-<text x="577" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
-<text x="577" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">your VPC · signed audit · Helm</text>
-<rect x="809" y="18" width="248" height="174" rx="12" fill="#fb7185"/>
-<rect x="809" y="22" width="248" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
-<rect x="823" y="32" width="40" height="40" rx="11" fill="#fb7185" opacity="0.16"/><g transform="translate(827,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fb7185"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fb7185"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fb7185"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#fb7185" stroke-width="1.05"/></g></g>
-<text x="871" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Security engineers</text>
-<rect x="823" y="82" width="84" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="865.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">findings queue</text>
-<rect x="913" y="82" width="40" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="933.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">paths</text>
-<rect x="959" y="82" width="40" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="979.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">graph</text>
-<line x1="825" y1="110" x2="1041" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="933,120 928,113 938,113" fill="#fb7185" opacity="0.9"/>
-<rect x="821" y="126" width="224" height="52" rx="8" fill="#fb7185" opacity="0.10"/>
-<rect x="821" y="126" width="224" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
-<rect x="829" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
-<text x="839" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="839" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">369 API ops · 77 MCP tools · SARIF</text>
-<rect x="24" y="196" width="1032" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="540" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<rect x="272" y="18" width="235" height="174" rx="12" fill="#fbbf24"/>
+<rect x="272" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="286" y="32" width="40" height="40" rx="11" fill="#fbbf24" opacity="0.16"/><g transform="translate(290,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fbbf24"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fbbf24"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fbbf24"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#0f0f13" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#0f0f13" stroke-width="1.0"/></g></g>
+<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">GRC / audit</text>
+<rect x="286" y="82" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
+<text x="318.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">compliance</text>
+<rect x="357" y="82" width="55" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
+<text x="384.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">evidence</text>
+<rect x="418" y="82" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
+<text x="450.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">frameworks</text>
+<line x1="288" y1="110" x2="491" y2="110" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="389,120 384,113 394,113" fill="#fbbf24" opacity="0.9"/>
+<rect x="284" y="126" width="211" height="52" rx="8" fill="#fbbf24" opacity="0.10"/>
+<rect x="284" y="126" width="211" height="52" rx="8" fill="none" stroke="#fbbf24" opacity="0.4"/>
+<rect x="292" y="142" width="3" height="14" rx="1.5" fill="#fbbf24"/>
+<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Audit-ready exports</text>
+<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">control mappings · signed bundles · review context</text>
+<rect x="521" y="18" width="235" height="174" rx="12" fill="#38bdf8"/>
+<rect x="521" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="535" y="32" width="40" height="40" rx="11" fill="#38bdf8" opacity="0.16"/><g transform="translate(539,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#38bdf8"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#38bdf8"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#38bdf8"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
+<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
+<rect x="535" y="82" width="65" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
+<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">fleet sync</text>
+<rect x="606" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
+<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">Helm</text>
+<rect x="647" y="82" width="25" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
+<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">CI</text>
+<rect x="678" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
+<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">SBOM</text>
+<line x1="537" y1="110" x2="740" y2="110" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="638,120 633,113 643,113" fill="#38bdf8" opacity="0.9"/>
+<rect x="533" y="126" width="211" height="52" rx="8" fill="#38bdf8" opacity="0.10"/>
+<rect x="533" y="126" width="211" height="52" rx="8" fill="none" stroke="#38bdf8" opacity="0.4"/>
+<rect x="541" y="142" width="3" height="14" rx="1.5" fill="#38bdf8"/>
+<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Container coverage</text>
+<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">OCI native · Grype · CIS posture</text>
+<rect x="770" y="18" width="235" height="174" rx="12" fill="#a78bfa"/>
+<rect x="770" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="784" y="32" width="40" height="40" rx="11" fill="#a78bfa" opacity="0.16"/><g transform="translate(788,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#a78bfa"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#a78bfa"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#a78bfa"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
+<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Agent builders</text>
+<rect x="784" y="82" width="79" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
+<text x="823.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">MCP inventory</text>
+<rect x="869" y="82" width="45" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
+<text x="891.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">Shield</text>
+<rect x="920" y="82" width="50" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
+<text x="945.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">runtime</text>
+<line x1="786" y1="110" x2="989" y2="110" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="887,120 882,113 892,113" fill="#a78bfa" opacity="0.9"/>
+<rect x="782" y="126" width="211" height="52" rx="8" fill="#a78bfa" opacity="0.10"/>
+<rect x="782" y="126" width="211" height="52" rx="8" fill="none" stroke="#a78bfa" opacity="0.4"/>
+<rect x="790" y="142" width="3" height="14" rx="1.5" fill="#a78bfa"/>
+<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
+<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">your VPC · signed audit · Helm</text>
+<rect x="1019" y="18" width="235" height="174" rx="12" fill="#fb7185"/>
+<rect x="1019" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="1033" y="32" width="40" height="40" rx="11" fill="#fb7185" opacity="0.16"/><g transform="translate(1037,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fb7185"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fb7185"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fb7185"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#fb7185" stroke-width="1.05"/></g></g>
+<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Security engineers</text>
+<rect x="1033" y="82" width="84" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
+<text x="1075.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">findings queue</text>
+<rect x="1123" y="82" width="40" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
+<text x="1143.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">paths</text>
+<rect x="1169" y="82" width="40" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
+<text x="1189.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">graph</text>
+<line x1="1035" y1="110" x2="1238" y2="110" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="1136,120 1131,113 1141,113" fill="#fb7185" opacity="0.9"/>
+<rect x="1031" y="126" width="211" height="52" rx="8" fill="#fb7185" opacity="0.10"/>
+<rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
+<rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
+<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
+<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">371 API ops · 77 MCP tools · SARIF</text>
+<rect x="24" y="196" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -1,76 +1,93 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1080" height="236" viewBox="0 0 1080 236" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="236" viewBox="0 0 1280 236" fill="none">
 <title>agent-bom personas and value</title>
-<rect width="1080" height="236" rx="12" fill="#ffffff"/>
-<rect x="23" y="18" width="248" height="174" rx="12" fill="#0d9488"/>
-<rect x="23" y="22" width="248" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect width="1280" height="236" rx="12" fill="#ffffff"/>
+<rect x="23" y="18" width="235" height="174" rx="12" fill="#0d9488"/>
+<rect x="23" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="37" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(41,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#ffffff" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#0d9488" stroke-width="1.05"/></g></g>
-<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">AppSec / GRC</text>
+<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">AppSec</text>
 <rect x="37" y="82" width="40" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
 <text x="57.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">SARIF</text>
-<rect x="83" y="82" width="65" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="115.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">compliance</text>
-<rect x="154" y="82" width="69" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="188.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">audit chain</text>
-<line x1="39" y1="110" x2="255" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="147,120 142,113 152,113" fill="#0d9488" opacity="0.9"/>
-<rect x="35" y="126" width="224" height="52" rx="8" fill="#0d9488" opacity="0.07"/>
-<rect x="35" y="126" width="224" height="52" rx="8" fill="none" stroke="#0d9488" opacity="0.4"/>
+<rect x="83" y="82" width="74" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
+<text x="120.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">reachability</text>
+<rect x="163" y="82" width="55" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
+<text x="190.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">CI gates</text>
+<line x1="39" y1="110" x2="242" y2="110" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="140,120 135,113 145,113" fill="#0d9488" opacity="0.9"/>
+<rect x="35" y="126" width="211" height="52" rx="8" fill="#0d9488" opacity="0.07"/>
+<rect x="35" y="126" width="211" height="52" rx="8" fill="none" stroke="#0d9488" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#0d9488"/>
 <text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Accurate SCA</text>
 <text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
-<rect x="285" y="18" width="248" height="174" rx="12" fill="#0284c7"/>
-<rect x="285" y="22" width="248" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
-<rect x="299" y="32" width="40" height="40" rx="11" fill="#0284c7" opacity="0.10"/><g transform="translate(303,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0284c7"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0284c7"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0284c7"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
-<text x="347" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Platform / SRE</text>
-<rect x="299" y="82" width="65" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="331.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">fleet sync</text>
-<rect x="370" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="387.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">Helm</text>
-<rect x="411" y="82" width="25" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="423.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">CI</text>
-<rect x="442" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="459.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">SBOM</text>
-<line x1="301" y1="110" x2="517" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="409,120 404,113 414,113" fill="#0284c7" opacity="0.9"/>
-<rect x="297" y="126" width="224" height="52" rx="8" fill="#0284c7" opacity="0.07"/>
-<rect x="297" y="126" width="224" height="52" rx="8" fill="none" stroke="#0284c7" opacity="0.4"/>
-<rect x="305" y="142" width="3" height="14" rx="1.5" fill="#0284c7"/>
-<text x="315" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Container coverage</text>
-<text x="315" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">OCI native · Grype · CIS posture</text>
-<rect x="547" y="18" width="248" height="174" rx="12" fill="#7c3aed"/>
-<rect x="547" y="22" width="248" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
-<rect x="561" y="32" width="40" height="40" rx="11" fill="#7c3aed" opacity="0.10"/><g transform="translate(565,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#7c3aed"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#7c3aed"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#7c3aed"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
-<text x="609" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Agent builders</text>
-<rect x="561" y="82" width="79" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="600.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">MCP inventory</text>
-<rect x="646" y="82" width="45" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="668.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">Shield</text>
-<rect x="697" y="82" width="50" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="722.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">runtime</text>
-<line x1="563" y1="110" x2="779" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="671,120 666,113 676,113" fill="#7c3aed" opacity="0.9"/>
-<rect x="559" y="126" width="224" height="52" rx="8" fill="#7c3aed" opacity="0.07"/>
-<rect x="559" y="126" width="224" height="52" rx="8" fill="none" stroke="#7c3aed" opacity="0.4"/>
-<rect x="567" y="142" width="3" height="14" rx="1.5" fill="#7c3aed"/>
-<text x="577" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Self-hosted control plane</text>
-<text x="577" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">your VPC · signed audit · Helm</text>
-<rect x="809" y="18" width="248" height="174" rx="12" fill="#e11d48"/>
-<rect x="809" y="22" width="248" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
-<rect x="823" y="32" width="40" height="40" rx="11" fill="#e11d48" opacity="0.10"/><g transform="translate(827,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#e11d48"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#e11d48"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#e11d48"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#e11d48" stroke-width="1.05"/></g></g>
-<text x="871" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Security engineers</text>
-<rect x="823" y="82" width="84" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="865.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">findings queue</text>
-<rect x="913" y="82" width="40" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="933.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">paths</text>
-<rect x="959" y="82" width="40" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="979.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">graph</text>
-<line x1="825" y1="110" x2="1041" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="933,120 928,113 938,113" fill="#e11d48" opacity="0.9"/>
-<rect x="821" y="126" width="224" height="52" rx="8" fill="#e11d48" opacity="0.07"/>
-<rect x="821" y="126" width="224" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
-<rect x="829" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
-<text x="839" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="839" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">369 API ops · 77 MCP tools · SARIF</text>
-<rect x="24" y="196" width="1032" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="540" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<rect x="272" y="18" width="235" height="174" rx="12" fill="#d97706"/>
+<rect x="272" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="286" y="32" width="40" height="40" rx="11" fill="#d97706" opacity="0.10"/><g transform="translate(290,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#d97706"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#d97706"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#d97706"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#ffffff" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#ffffff" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#ffffff" stroke-width="1.0"/></g></g>
+<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">GRC / audit</text>
+<rect x="286" y="82" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
+<text x="318.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">compliance</text>
+<rect x="357" y="82" width="55" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
+<text x="384.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">evidence</text>
+<rect x="418" y="82" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
+<text x="450.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">frameworks</text>
+<line x1="288" y1="110" x2="491" y2="110" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="389,120 384,113 394,113" fill="#d97706" opacity="0.9"/>
+<rect x="284" y="126" width="211" height="52" rx="8" fill="#d97706" opacity="0.07"/>
+<rect x="284" y="126" width="211" height="52" rx="8" fill="none" stroke="#d97706" opacity="0.4"/>
+<rect x="292" y="142" width="3" height="14" rx="1.5" fill="#d97706"/>
+<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Audit-ready exports</text>
+<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">control mappings · signed bundles · review context</text>
+<rect x="521" y="18" width="235" height="174" rx="12" fill="#0284c7"/>
+<rect x="521" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="535" y="32" width="40" height="40" rx="11" fill="#0284c7" opacity="0.10"/><g transform="translate(539,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0284c7"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0284c7"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0284c7"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
+<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Platform / SRE</text>
+<rect x="535" y="82" width="65" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
+<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">fleet sync</text>
+<rect x="606" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
+<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">Helm</text>
+<rect x="647" y="82" width="25" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
+<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">CI</text>
+<rect x="678" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
+<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">SBOM</text>
+<line x1="537" y1="110" x2="740" y2="110" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="638,120 633,113 643,113" fill="#0284c7" opacity="0.9"/>
+<rect x="533" y="126" width="211" height="52" rx="8" fill="#0284c7" opacity="0.07"/>
+<rect x="533" y="126" width="211" height="52" rx="8" fill="none" stroke="#0284c7" opacity="0.4"/>
+<rect x="541" y="142" width="3" height="14" rx="1.5" fill="#0284c7"/>
+<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Container coverage</text>
+<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">OCI native · Grype · CIS posture</text>
+<rect x="770" y="18" width="235" height="174" rx="12" fill="#7c3aed"/>
+<rect x="770" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="784" y="32" width="40" height="40" rx="11" fill="#7c3aed" opacity="0.10"/><g transform="translate(788,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#7c3aed"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#7c3aed"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#7c3aed"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
+<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Agent builders</text>
+<rect x="784" y="82" width="79" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
+<text x="823.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">MCP inventory</text>
+<rect x="869" y="82" width="45" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
+<text x="891.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">Shield</text>
+<rect x="920" y="82" width="50" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
+<text x="945.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">runtime</text>
+<line x1="786" y1="110" x2="989" y2="110" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="887,120 882,113 892,113" fill="#7c3aed" opacity="0.9"/>
+<rect x="782" y="126" width="211" height="52" rx="8" fill="#7c3aed" opacity="0.07"/>
+<rect x="782" y="126" width="211" height="52" rx="8" fill="none" stroke="#7c3aed" opacity="0.4"/>
+<rect x="790" y="142" width="3" height="14" rx="1.5" fill="#7c3aed"/>
+<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Self-hosted control plane</text>
+<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">your VPC · signed audit · Helm</text>
+<rect x="1019" y="18" width="235" height="174" rx="12" fill="#e11d48"/>
+<rect x="1019" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="1033" y="32" width="40" height="40" rx="11" fill="#e11d48" opacity="0.10"/><g transform="translate(1037,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#e11d48"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#e11d48"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#e11d48"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#e11d48" stroke-width="1.05"/></g></g>
+<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Security engineers</text>
+<rect x="1033" y="82" width="84" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
+<text x="1075.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">findings queue</text>
+<rect x="1123" y="82" width="40" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
+<text x="1143.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">paths</text>
+<rect x="1169" y="82" width="40" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
+<text x="1189.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">graph</text>
+<line x1="1035" y1="110" x2="1238" y2="110" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="1136,120 1131,113 1141,113" fill="#e11d48" opacity="0.9"/>
+<rect x="1031" y="126" width="211" height="52" rx="8" fill="#e11d48" opacity="0.07"/>
+<rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
+<rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
+<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Agent-native surface</text>
+<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">371 API ops · 77 MCP tools · SARIF</text>
+<rect x="24" y="196" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -1218,18 +1218,25 @@ def architecture(theme_name: str) -> str:
 # Persona band accents — one restrained hue per buyer lane, on neutral cards.
 PERSONA_ACCENTS = {
     "appsec": ("#2dd4bf", "#0d9488"),
+    "grc": ("#fbbf24", "#d97706"),
     "platform": ("#38bdf8", "#0284c7"),
     "builders": ("#a78bfa", "#7c3aed"),
     "seceng": ("#fb7185", "#e11d48"),
 }
 
-# Role badge glyphs on the solid accent badge circle at (18.5, 18): compliance
-# doc-with-check, platform layers, agent bot, security shield-with-check.
-# GLYPH / ACCENT tokens are substituted per theme when the card is drawn.
+# Role badge glyphs on the solid accent badge circle at (18.5, 18): AppSec
+# doc-with-check, GRC clipboard/checklist, platform layers, agent bot,
+# security shield-with-check. GLYPH / ACCENT tokens are substituted per theme
+# when the card is drawn.
 PERSONA_BADGES = {
     "appsec": (
         '<rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="GLYPH" stroke="none"/>'
         '<path d="M17.3 17.9l.95.95 1.75-1.75" stroke="ACCENT" stroke-width="1.05"/>'
+    ),
+    "grc": (
+        '<rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="GLYPH" stroke-width="1.05"/>'
+        '<path d="M17.2 14.2h2.6v1.2h-2.6z" fill="GLYPH" stroke="none"/>'
+        '<path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="GLYPH" stroke-width="1.0"/>'
     ),
     "platform": '<path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/>',
     "builders": '<rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/>',
@@ -1365,11 +1372,19 @@ def _persona_lane_card(
 def persona_value(theme: str) -> str:
     """Compact single-row buyer-lane band — persona -> value proof per card."""
     t = THEMES[theme]
-    w, h = 1080, 236
+    # Five cards need extra width so titles/tags fit without overflow.
+    w, h = 1280, 236
     persona_bg = "#16161d" if theme == "dark" else t["bg"]
 
     cards = [
-        ("AppSec / GRC", "SARIF · compliance · audit chain", "Accurate SCA", "15 ecosystems · EPSS/KEV · distro-aware", "appsec"),
+        ("AppSec", "SARIF · reachability · CI gates", "Accurate SCA", "15 ecosystems · EPSS/KEV · distro-aware", "appsec"),
+        (
+            "GRC / audit",
+            "compliance · evidence · frameworks",
+            "Audit-ready exports",
+            "control mappings · signed bundles · review context",
+            "grc",
+        ),
         ("Platform / SRE", "fleet sync · Helm · CI · SBOM", "Container coverage", "OCI native · Grype · CIS posture", "platform"),
         ("Agent builders", "MCP inventory · Shield · runtime", "Self-hosted control plane", "your VPC · signed audit · Helm", "builders"),
         (
@@ -1383,7 +1398,7 @@ def persona_value(theme: str) -> str:
 
     margin_x, margin_y = 23, 18
     gap = 14
-    card_w = (w - margin_x * 2 - gap * 3) // 4
+    card_w = (w - margin_x * 2 - gap * 4) // 5
     card_h = 174
 
     parts = _svg_open(w, h, "agent-bom personas and value")

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -57,10 +57,15 @@ def test_architecture_includes_core_surfaces() -> None:
 
 def test_persona_value_renders_buyer_lanes() -> None:
     svg = persona_value("dark")
-    assert "AppSec / GRC" in svg
+    assert "AppSec" in svg
+    assert "GRC / audit" in svg
+    assert "AppSec / GRC" not in svg
     assert "findings queue" in svg
     assert f"{REST_OPERATION_COUNT} API ops" in svg
     assert "Self-hosted control plane" in svg
+    assert "Accurate SCA" in svg
+    assert "Audit-ready exports" in svg
+    assert _audit_layout(svg) == []
 
 
 def test_blast_radius_text_is_clipped_in_cards() -> None:


### PR DESCRIPTION
## Summary
- Split the lumped "AppSec / GRC" persona-value SVG card into two buyer lanes: **AppSec** (SARIF / reachability / CI gates → Accurate SCA) and **GRC / audit** (compliance / evidence / frameworks → Audit-ready exports), with a new amber `grc` accent and clipboard badge.
- README alt text and `docs/VISUAL_LANGUAGE.md` now describe five personas and note AppSec ≠ GRC.
- The README who-it's-for table already listed AppSec and GRC separately; only the SVG (and related docs copy) was wrong.

## Verification
```bash
uv run pytest -q tests/test_doc_architecture_svgs.py
# 7 passed
uv run ruff check scripts/generate_doc_architecture_svgs.py
# All checks passed
uv run python scripts/generate_doc_architecture_svgs.py
# regenerated persona-value-{dark,light}.svg (1280px, 5 cards)
```

## Notes
- Open #4441 (combined deps) is still open — not touched here.
- Scoped commit keeps how-it-works / architecture SVG regenerations out; those files currently drift from the generator on main (ops count / how-it-works layout) and are unrelated to this persona fix.


Made with [Cursor](https://cursor.com)