### PR TITLE
fix(ci): pin caplog level for optional enrichment warning

### DIFF
--- a/tests/test_workload_runtime_evidence_exports.py
+++ b/tests/test_workload_runtime_evidence_exports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
 from agent_bom.cloud.runtime_workload_evidence import (
@@ -127,6 +128,15 @@ def test_optional_enrichment_failure_does_not_suppress_core_findings(caplog) -> 
             del tenant_id, limit
             raise RuntimeError("postgresql://agent_bom_app:secret-value@db.internal/agent_bom unavailable")
 
+    # Pin capture to the emitting logger. Under xdist worksteal, an earlier test
+    # (e.g. setup_logging(level="ERROR")) can leave the agent_bom logger tree at
+    # ERROR+, which filters this WARNING and empties caplog.text — the Python
+    # 3.14 main failure mode for this assertion.
+    evidence_logger = logging.getLogger("agent_bom.cloud.runtime_workload_evidence")
+    prev_propagate = evidence_logger.propagate
+    evidence_logger.propagate = True
+    caplog.set_level(logging.WARNING, logger="agent_bom.cloud.runtime_workload_evidence")
+
     set_runtime_workload_evidence_store(UnavailableStore())  # type: ignore[arg-type]
     try:
         finding = _workload_finding()
@@ -138,6 +148,7 @@ def test_optional_enrichment_failure_does_not_suppress_core_findings(caplog) -> 
         assert "optional runtime workload evidence enrichment unavailable" in caplog.text
         assert "secret-value" not in caplog.text
     finally:
+        evidence_logger.propagate = prev_propagate
         set_runtime_workload_evidence_store(None)
 
 


### PR DESCRIPTION
## Summary
- Main CI failed on Python 3.14 when `test_optional_enrichment_failure_does_not_suppress_core_findings` asserted the optional enrichment WARNING in `caplog.text` and got `''`.
- Root cause: under xdist worksteal, an earlier test (`setup_logging(level="ERROR")` and similar) can leave the `agent_bom` logger tree at ERROR+, which filters the WARNING so caplog stays empty. Security Scan was green on the failing run.
- Fix: pin `caplog.set_level(WARNING)` on the emitting logger and restore `propagate=True`, matching the existing watch webhook caplog pattern.

## Verification
- Reproduced empty `caplog.text` after raising `agent_bom` to ERROR, then confirmed the pinned-level assertion passes.
- `uv run pytest -q tests/test_workload_runtime_evidence_exports.py` (4 passed on Python 3.14)
- `ruff check tests/test_workload_runtime_evidence_exports.py`
- Tip `%G? == G`; no `Co-Authored-By` trailer

## Notes
- #4446 (docs persona AppSec/GRC split) is unrelated and still open/mergeable; no change required from this fix.

Closes #4445

Made with [Cursor](https://cursor.com)