### PR TITLE
chore(ci): combine readme quick start and CI test timing fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -743,7 +743,9 @@ jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
-    timeout-minutes: 35
+    # Observed worst case is ~17.6 minutes on the slowest matrix leg; 25 keeps
+    # real headroom while surfacing a hung suite well before a 35-minute burn.
+    timeout-minutes: 25
     permissions:
       contents: read
     needs: changes
@@ -786,7 +788,7 @@ jobs:
           # Keep PR matrix worker count bounded on hosted runners. `-n auto`
           # can overcommit CPU/RAM enough for GitHub to terminate the runner
           # before pytest prints a failure summary.
-          # 3.11 keeps 4 workers (passes, and fewer would risk the 35-min
+          # 3.11 keeps 4 workers (passes, and fewer would risk the job
           # timeout); 3.13/3.14 drop to 2 so the parallel run's peak RAM stays
           # under the hosted-runner limit (4 heavy interpreters OOM the VM,
           # surfacing as "runner received a shutdown signal" / exit 143).
@@ -799,10 +801,12 @@ jobs:
           else
             PYTEST_XDIST_WORKERS="${PYTEST_XDIST_WORKERS:-2}"
           fi
+          # --durations=25 names the slowest tests in the log, so a run that
+          # drifts toward the job timeout comes with its own evidence.
           if [ "${{ matrix.python-version }}" = "3.11" ] && [ "${{ github.event_name }}" != "pull_request" ]; then
-            uv run pytest tests/ -v --tb=short --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
+            uv run pytest tests/ -v --tb=short --durations=25 --cov=agent_bom --cov-report=term-missing --cov-fail-under=75 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
           else
-            uv run pytest tests/ -q --tb=short -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
+            uv run pytest tests/ -q --tb=short --durations=25 -m "not network and not slow" -n "$PYTEST_XDIST_WORKERS" --dist worksteal
           fi
 
       - name: Graph accuracy fixture guard (#2259)

--- a/README.md
+++ b/README.md
@@ -23,27 +23,37 @@
   One Finding + UnifiedGraph model across CLI, API, UI, and MCP.
 </p>
 <p align="center">
+  Brand lockup above is the product logo. The CLI prints the wordmark as text
+  (<code>agent-bom</code>); the UI and
+  <a href="https://demo.agent-bom.com">live demo</a> show the logo in app nav.
+</p>
+<p align="center">
   <a href="https://demo.agent-bom.com"><b>Live demo</b></a> ·
   <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
-  <a href="docs/FIRST_RUN.md">First Run</a> ·
-  <a href="site-docs/deployment/overview.md">Self-host</a> ·
+  <a href="#quick-start"><b>Quick start</b></a> ·
+  <a href="#deploy--self-host"><b>Deploy</b></a> ·
+  <a href="docs/FIRST_RUN.md">First run</a> ·
   <a href="https://github.com/marketplace/actions/agent-bom">GitHub Action</a> ·
   <a href="https://hub.docker.com/r/agentbom/agent-bom">Docker</a> ·
   <a href="https://github.com/msaad00/agent-bom/releases">Changelog</a>
 </p>
 
-## Blast radius
+## Quick start
 
-One finding fans out to the MCP servers that load it, reachable tools,
-credential references, and agents that can reach it — not a CVE list in
-isolation.
+Three commands to see value locally (no cloud account required):
 
-<p align="center">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-dark.svg">
-    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="agent-bom blast radius: one package finding fans out to MCP servers, agents, secrets, and tools" width="900" />
-  </picture>
-</p>
+```bash
+pip install agent-bom
+agent-bom scan --demo --offline
+# optional control plane (loopback UI + API)
+pip install 'agent-bom[ui]' && agent-bom serve
+```
+
+- Console report prints inventory, findings, and blast radius inline.
+- Optional file artifacts: `-f html -o agent-bom-report.html` (also `json`, `sarif`, SBOM).
+- Demo exit status `1` is expected — the sample includes blocking findings (same gate as CI).
+
+Full walkthrough: [docs/FIRST_RUN.md](docs/FIRST_RUN.md).
 
 ## Who it is for
 
@@ -67,6 +77,8 @@ Boundaries: [PRODUCT_BOUNDARIES.md](docs/PRODUCT_BOUNDARIES.md).
 
 ## How the tool works
 
+Three product lanes on one Finding + UnifiedGraph model:
+
 1. **Scan** — CLI / CI / Docker / cloud connect → inventory, findings, SARIF/SBOM/HTML, graph
 2. **Control plane** — `pip install 'agent-bom[ui]' && agent-bom serve` → tenant UI/API, attack paths, compliance, audit (self-host with Docker or Helm + Postgres). Loopback is the default; non-loopback hosts need real auth or an explicit `--allow-insecure-no-auth` (env vars alone are not enough).
 3. **Runtime** — `agent-bom gateway serve --upstreams upstreams.yaml --bind 127.0.0.1:8090` → allow/warn/block on live MCP/tool calls
@@ -82,7 +94,43 @@ boundary.
   </picture>
 </p>
 
-## Graph lenses
+One finding fans out to the MCP servers that load it, reachable tools,
+credential references, and agents that can reach it — not a CVE list in
+isolation.
+
+<p align="center">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-dark.svg">
+    <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/blast-radius-light.svg" alt="agent-bom blast radius: one package finding fans out to MCP servers, agents, secrets, and tools" width="900" />
+  </picture>
+</p>
+
+## See the product
+
+Story order: **Scan → Connect → Posture → Investigate → Enforce**
+(findings + remediation together under Scan). Screenshots are the same UI as
+the [live demo](https://demo.agent-bom.com) (logo in app nav). Capture notes:
+[docs/CAPTURE.md](docs/CAPTURE.md).
+
+### Scan — findings and remediation
+
+| Findings queue | Remediation |
+|:---:|:---:|
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with severity, reachable agents, fixes, and review actions" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Prioritized remediation with risk reduction, ownership, and verification" width="430" /> |
+
+### Connect — sources and new scan
+
+| Connections | New scan |
+|:---:|:---:|
+| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/cloud-accounts-live.png" alt="Connections hub across cloud, code, AI, and data sources" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/new-scan-live.png" alt="New Scan workspace with collector plan and read-only boundary" width="430" /> |
+
+### Posture — risk overview
+
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview with posture grade, findings, and operations" width="820" />
+</p>
+
+### Investigate — lineage, mesh, context
 
 Three graph lenses tell different stories: package-level lineage, multi-agent
 mesh overlap, and lateral context — not three copies of the same CVE chain.
@@ -99,37 +147,21 @@ mesh overlap, and lateral context — not three copies of the same CVE chain.
 <p align="center"><em>Context map: neighborhood topology (tools, creds, servers) — not the same hero CVE strip as lineage.</em></p>
 
 <details>
-<summary><b>Investigation capture</b> — prioritized path with export/handoff chrome</summary>
+<summary><b>Attack path</b> — prioritized path with export/handoff chrome</summary>
 
 <p align="center">
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/security-graph-live.png" alt="Prioritized attack path connecting identity, agent, MCP server, package, and critical finding" width="820" />
 </p>
 
 Path view is a single-row hop strip (scroll horizontally on long chains).
-Recapture notes: [docs/CAPTURE.md](docs/CAPTURE.md).
 
 </details>
 
-<details>
-<summary><b>Dashboard captures</b> — findings queue, remediation, posture, runtime, connections</summary>
+### Enforce — runtime gateway
 
-| Findings queue | Remediation |
-|:---:|:---:|
-| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dependency-map-live.png" alt="Findings queue with severity, reachable agents, fixes, and review actions" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/remediation-live.png" alt="Prioritized remediation with risk reduction, ownership, and verification" width="430" /> |
-
-| Risk overview | Runtime gateway |
-|:---:|:---:|
-| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/dashboard-live.png" alt="Overview with posture grade, findings, and operations" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and tool-call feed" width="430" /> |
-
-| Connections | New scan |
-|:---:|:---:|
-| <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/cloud-accounts-live.png" alt="Connections hub across cloud, code, AI, and data sources" width="430" /> | <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/new-scan-live.png" alt="New Scan workspace with collector plan and read-only boundary" width="430" /> |
-
-[Live demo](https://demo.agent-bom.com) is a read-only sandbox with synthetic
-showcase evidence. Prefer the local offline sample above for a reproducible CLI
-walkthrough.
-
-</details>
+<p align="center">
+  <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/gateway-policies-live.png" alt="Runtime gateway KPI rollup and tool-call feed" width="820" />
+</p>
 
 <details>
 <summary><b>CLI walkthrough</b> — 0.97.5 console demo</summary>
@@ -138,14 +170,13 @@ walkthrough.
   <img src="https://raw.githubusercontent.com/msaad00/agent-bom/main/docs/images/demo-latest.gif" alt="agent-bom terminal demo showing inventory, findings, remediation, and package gate" width="820" />
 </p>
 
+In the terminal the brand is the text wordmark (`agent-bom`), not the SVG logo.
 Seeded `requests` typosquat produces an expected non-zero security-gate exit —
 a demonstrated finding, not a failed recording.
 
 </details>
 
-Capture list: [docs/CAPTURE.md](docs/CAPTURE.md).
-
-## Self-host
+## Deploy & self-host
 
 You run the control plane in your own boundary (no managed public SaaS in this
 repo yet):
@@ -162,13 +193,14 @@ Pilot compose binds `127.0.0.1` with loopback CORS. Before sharing a link, use
 | Target | Start here |
 |---|---|
 | Docker Compose | [pilot compose](deploy/docker-compose.pilot.yml) |
-| Helm / Kubernetes | [chart](deploy/helm/agent-bom) — `helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom --version 0.97.4` |
+| Helm / Kubernetes | [chart](deploy/helm/agent-bom) — `helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom --version 0.97.5` |
 | EKS | [Terraform module](deploy/terraform/platform-eks) |
 | CloudFormation | [templates](deploy/cloudformation) |
 | Snowflake SPCS | [install guide](docs/snowflake-native-app/INSTALL.md) |
 
 Guides: [Deploy anywhere](docs/DEPLOY_PLATFORM.md) ·
-[deployment overview](site-docs/deployment/overview.md).
+[deployment overview](site-docs/deployment/overview.md) ·
+[HOSTED_POC](docs/HOSTED_POC.md).
 
 <details>
 <summary><b>Surfaces and entry points</b></summary>

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -74,6 +74,11 @@ DOC_TEST_LOCATIONS: list[tuple[str, re.Pattern, str]] = [
         re.compile(r"(CLI walkthrough</b> — )\d+\.\d+\.\d+( console demo</summary>)"),
         r"\g<1>{v}\g<2>",
     ),
+    (
+        "README.md",
+        re.compile(r"(oci://ghcr\.io/msaad00/charts/agent-bom --version )\d+\.\d+\.\d+"),
+        r"\g<1>{v}",
+    ),
     ("docs/AI_INFRASTRUCTURE_SCANNING.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
     ("docs/ENTERPRISE_DEPLOYMENT.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),
     ("docs/archive/WINDOWS_CONTAINERS.md", re.compile(r"(msaad00/agent-bom@v)\d+(?:\.\d+){0,2}"), r"\g<1>{v}"),

--- a/scripts/cancel_superseded_run.sh
+++ b/scripts/cancel_superseded_run.sh
@@ -14,7 +14,20 @@ fi
 REPO="$1"
 RUN_ID="$2"
 
-gh run cancel "${RUN_ID}" --repo "${REPO}"
+if ! gh run cancel "${RUN_ID}" --repo "${REPO}"; then
+  # The run can finish between the caller listing it as active and this
+  # request landing; GitHub then rejects the cancel ("Cannot cancel a
+  # workflow run that is completed"). That is the end state we wanted, so
+  # only a still-active run is worth escalating — or failing — over.
+  status="$(
+    gh run view "${RUN_ID}" --repo "${REPO}" --json status --jq .status \
+      2>/dev/null || printf 'unknown'
+  )"
+  if [ "${status}" = "completed" ]; then
+    exit 0
+  fi
+  echo "cancel request for workflow run ${RUN_ID} was rejected (status: ${status}); escalating."
+fi
 
 for attempt in 1 2 3 4 5; do
   status="$(

--- a/tests/test_ci_retrigger_scripts.py
+++ b/tests/test_ci_retrigger_scripts.py
@@ -2,9 +2,40 @@
 
 from __future__ import annotations
 
+import os
+import shutil
+import stat
+import subprocess
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[1]
+
+CANCEL_HELPER = ROOT / "scripts" / "cancel_superseded_run.sh"
+
+
+def _gh_stub(tmp_path: Path, body: str) -> Path:
+    """Install a fake `gh` on PATH and return the directory holding it."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir(exist_ok=True)
+    stub = bin_dir / "gh"
+    stub.write_text(body, encoding="utf-8")
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def _run_cancel_helper(bin_dir: Path) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["PATH"] = f"{bin_dir}{os.pathsep}{env['PATH']}"
+    env["CANCEL_POLL_SECONDS"] = "0"
+    return subprocess.run(
+        ["bash", str(CANCEL_HELPER), "owner/repo", "12345"],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=60,
+    )
 
 
 def test_dispatch_required_ci_runs_all_required_workflows() -> None:
@@ -38,12 +69,72 @@ def test_recovery_scripts_cancel_only_superseded_required_runs_on_branch() -> No
 
 
 def test_force_cancel_helper_has_bounded_grace_and_race_safe_fallback() -> None:
-    helper = (ROOT / "scripts" / "cancel_superseded_run.sh").read_text(encoding="utf-8")
+    helper = CANCEL_HELPER.read_text(encoding="utf-8")
 
     assert "for attempt in 1 2 3 4 5" in helper
     assert 'gh run cancel "${RUN_ID}"' in helper
     assert 'actions/runs/${RUN_ID}/force-cancel' in helper
-    assert helper.count('if [ "${status}" = "completed" ]') == 2
+    assert helper.count('if [ "${status}" = "completed" ]') == 3
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash is required")
+def test_cancel_helper_treats_already_completed_run_as_success(tmp_path: Path) -> None:
+    """A run that finishes between listing and cancel is the desired end state.
+
+    GitHub rejects `gh run cancel` on a completed run ("Cannot cancel a workflow
+    run that is completed"). Under `set -e` that aborted the whole stranded-PR
+    recovery step, which is how the recovery workflow went red on an otherwise
+    healthy PR.
+    """
+    bin_dir = _gh_stub(
+        tmp_path,
+        """#!/usr/bin/env bash
+if [ "$1 $2" = "run cancel" ]; then
+  echo "Cannot cancel a workflow run that is completed" >&2
+  exit 1
+fi
+if [ "$1 $2" = "run view" ]; then
+  echo completed
+  exit 0
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 70
+""",
+    )
+
+    result = _run_cancel_helper(bin_dir)
+
+    assert result.returncode == 0, result.stderr
+    assert "force-cancel" not in result.stdout
+
+
+@pytest.mark.skipif(shutil.which("bash") is None, reason="bash is required")
+def test_cancel_helper_still_fails_when_run_stays_active(tmp_path: Path) -> None:
+    """A rejected cancel on a still-running workflow must not be swallowed."""
+    bin_dir = _gh_stub(
+        tmp_path,
+        """#!/usr/bin/env bash
+if [ "$1 $2" = "run cancel" ]; then
+  echo "HTTP 409" >&2
+  exit 1
+fi
+if [ "$1 $2" = "run view" ]; then
+  echo in_progress
+  exit 0
+fi
+if [ "$1" = "api" ]; then
+  echo "HTTP 403" >&2
+  exit 1
+fi
+echo "unexpected gh invocation: $*" >&2
+exit 70
+""",
+    )
+
+    result = _run_cancel_helper(bin_dir)
+
+    assert result.returncode == 1
+    assert "failed to cancel superseded workflow run 12345" in result.stderr
 
 
 def test_recovery_required_checks_match_branch_protection() -> None:

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -70,6 +70,29 @@ def test_path_gated_jobs_remain_cancellable() -> None:
         assert "always()" not in condition
 
 
+def test_test_job_timeout_leaves_margin_over_observed_worst_case() -> None:
+    """25 minutes keeps ~40% headroom over the ~17.6 min worst case seen on main.
+
+    A 35-minute ceiling let a hung suite burn a runner for another quarter hour
+    before anyone saw it.
+    """
+    assert _ci()["jobs"]["test"]["timeout-minutes"] == 25
+
+
+def test_pull_request_pytest_reports_slowest_tests() -> None:
+    """PR runs surface the slowest tests so timeout regressions have evidence."""
+    text = CI_WORKFLOW.read_text(encoding="utf-8")
+    run_tests = text.split("      - name: Run tests", 1)[1].split(
+        "      - name: Graph accuracy fixture guard", 1
+    )[0]
+
+    pytest_lines = [line.strip() for line in run_tests.splitlines() if "uv run pytest tests/" in line]
+    assert len(pytest_lines) == 2
+    assert all("--durations=25" in line for line in pytest_lines)
+    coverage_line = next(line for line in pytest_lines if "--cov=agent_bom" in line)
+    assert "--cov-fail-under=75" in coverage_line
+
+
 def test_security_reuses_typescript_install_for_build() -> None:
     text = CI_WORKFLOW.read_text(encoding="utf-8")
     security = text.split("  # 2. Linting + Type Checking", 1)[0]

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -94,6 +94,33 @@ def test_public_docs_do_not_overclaim_smithery_catalog_liveness() -> None:
     assert "Smithery manifest" in readme
 
 
+def test_readme_storefront_keeps_quick_start_deploy_and_version_pins() -> None:
+    """README storefront: visible Quick start + Deploy, honest version, AppSec ≠ GRC."""
+    import re
+    import tomllib
+
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    version = tomllib.loads((ROOT / "pyproject.toml").read_text(encoding="utf-8"))["project"]["version"]
+
+    # Top-level sections stay visible (not only buried in <details>).
+    assert re.search(r"^## Quick start\s*$", readme, re.M)
+    assert re.search(r"^## Deploy & self-host\s*$", readme, re.M)
+    assert re.search(r"^## See the product\s*$", readme, re.M)
+
+    # Persona alt text keeps AppSec and GRC as separate lanes.
+    assert "AppSec/GRC" not in readme
+    assert "AppSec / GRC" not in readme
+    assert "AppSec, GRC" in readme
+
+    # Helm OCI pin and CLI walkthrough label match pyproject.
+    assert f"oci://ghcr.io/msaad00/charts/agent-bom --version {version}" in readme
+    assert f"CLI walkthrough</b> — {version} console demo" in readme
+    assert f"msaad00/agent-bom@v{version}" in readme
+
+    # Logo honesty: CLI is text wordmark; UI/demo show the mark.
+    assert "wordmark as text" in readme or "text wordmark" in readme
+
+
 def test_permissions_doc_keeps_network_boundary_scoped() -> None:
     permissions = (ROOT / "docs" / "PERMISSIONS.md").read_text(encoding="utf-8")
 

--- a/tests/test_workload_runtime_evidence_exports.py
+++ b/tests/test_workload_runtime_evidence_exports.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 
 from agent_bom.cloud.runtime_workload_evidence import (
@@ -127,6 +128,15 @@ def test_optional_enrichment_failure_does_not_suppress_core_findings(caplog) -> 
             del tenant_id, limit
             raise RuntimeError("postgresql://agent_bom_app:secret-value@db.internal/agent_bom unavailable")
 
+    # Pin capture to the emitting logger. Under xdist worksteal, an earlier test
+    # (e.g. setup_logging(level="ERROR")) can leave the agent_bom logger tree at
+    # ERROR+, which filters this WARNING and empties caplog.text — the Python
+    # 3.14 main failure mode for this assertion.
+    evidence_logger = logging.getLogger("agent_bom.cloud.runtime_workload_evidence")
+    prev_propagate = evidence_logger.propagate
+    evidence_logger.propagate = True
+    caplog.set_level(logging.WARNING, logger="agent_bom.cloud.runtime_workload_evidence")
+
     set_runtime_workload_evidence_store(UnavailableStore())  # type: ignore[arg-type]
     try:
         finding = _workload_finding()
@@ -138,6 +148,7 @@ def test_optional_enrichment_failure_does_not_suppress_core_findings(caplog) -> 
         assert "optional runtime workload evidence enrichment unavailable" in caplog.text
         assert "secret-value" not in caplog.text
     finally:
+        evidence_logger.propagate = prev_propagate
         set_runtime_workload_evidence_store(None)
 
 


### PR DESCRIPTION
## Summary
- Pin caplog level and propagation for the optional enrichment warning assertion so the Python 3.14 matrix no longer flakes under xdist worksteal (supersedes #4447, closes #4445)
- Restructure README around a visible Quick start and Deploy & self-host section, order product screenshots as scan -> connect -> posture -> investigate -> enforce, and correct stale version pins (supersedes #4448)
- Report the 25 slowest tests on pull_request runs and lower the test job ceiling from 35 to 25 minutes so a hung suite surfaces sooner
- Fix the red check that was sitting on #4447: the stranded-PR recovery step aborted whenever a superseded run finished between being listed as active and the cancel request landing

## Root cause of the failing check on #4447
`Scan and retrigger` was red with `Cannot cancel a workflow run that is completed` followed by `Process completed with exit code 1`. `scripts/cancel_superseded_run.sh` ran `gh run cancel` under `set -euo pipefail`, so a benign time-of-check/time-of-use race — the run reaching `completed` between the caller listing it and the cancel request landing — killed the whole recovery step and reported a red required-context check on a healthy PR. The helper now re-reads the run status when a cancel is rejected and treats `completed` as success; a run that is still active keeps the existing force-cancel escalation and the hard failure.

## Verification
All commands run in an isolated worktree off `origin/main` (`eeee4dde8`).

- `uv run pytest tests/ -q --tb=short --durations=25 -m "not network and not slow" -n 4 --dist worksteal` -> **16229 passed, 174 skipped** in 13:47 (full suite on the merged result)
- `uv run pytest -q tests/test_workload_runtime_evidence_exports.py` -> 4 passed
- `uv run pytest -q tests/test_doc_architecture_svgs.py` -> 7 passed
- `uv run pytest -q tests/test_public_docs_cli_alignment.py` -> 8 passed
- `uv run pytest -q tests/test_ci_retrigger_scripts.py tests/test_ci_workflow_contract.py` -> 18 passed (5 of them red before the fixes)
- `uv run pytest -q tests/test_duplicate_artifact_guard.py tests/test_deployment.py tests/test_deploy_manifests.py tests/test_first_run_sample.py tests/test_focused_security_gates.py tests/test_stats_alignment.py tests/test_skills_cli.py tests/test_dataset_cards.py` -> 237 passed, 2 skipped (every other suite that reads README)
- `uv run make preflight` -> all seven drift gates OK (OpenAPI, v1 schemas, capability manifest, product surface, release/README consistency, env-var reference, SDK patterns)
- `uv run python scripts/bump-version.py 0.97.5 --check` -> `Updated 0 occurrence(s)`, including the new Helm OCI pin coverage
- `uv run python scripts/check_public_docs_hygiene.py` -> passed, 685 files scanned
- `uv run ruff check` on all touched Python files -> All checks passed
- `shellcheck scripts/cancel_superseded_run.sh` -> clean
- `uv run python -c "import yaml; ..."` -> `ci.yml parses; test timeout = 25`
- `git diff --check origin/main..HEAD` -> no whitespace errors

Adversarial checks, not just happy path:

- Reproduced the #4445 failure directly: with the `agent_bom` logger tree forced to `ERROR` and `propagate=False` (what an earlier `setup_logging` call leaves behind under worksteal), the pre-fix test fails with `assert '...' in ''` — the exact main failure — and passes with the pinned caplog level.
- The cancel-race fix has two tests driving the real script through a stubbed `gh`: a rejected cancel on a completed run must exit 0, and a rejected cancel on a still-running workflow must still exit 1 with the existing error. Both were red before the change.
- `--durations=25` is proven by output, not assertion: the full-suite run above printed the slowest-25 table.

## Notes
- Supersedes #4447 and #4448; both can be closed once this lands.
- The Change Path Classifier python filter is unchanged: any `scripts/` or `tests/` change still runs the full suite (fail-closed).
- #4446 landed on main as `eeee4dde8` while #4448 was open, so the persona-split content is already upstream; the squash of #4448 carries only the remaining README, `bump-version`, and contract-test changes.
- Coverage gating on the 3.11 push leg is untouched (`--cov-fail-under=75` retained).

Made with [Cursor](https://cursor.com)