### PR TITLE
fix(docs): correct SECURITY.md CSP claim for the UI preview config

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,7 +57,7 @@ agent-bom is a **read-only scanner**. It does not modify agent configurations, e
 - WebSocket endpoints require the same auth when `AGENT_BOM_API_KEY` is set
 - JWKS public key caching (1h TTL); RS256/RS384/RS512/ES256/ES384/ES512 supported; `alg: none` rejected
 - Dashboard HTML uses a route-specific CSP. The packaged FastAPI-served UI allows `script-src 'self' 'unsafe-inline'` for the Next.js runtime bootstrap; API JSON routes keep the stricter `default-src 'self'` policy.
-- The standalone Vercel preview config in `ui/vercel.json` is looser and still includes `unsafe-eval` for that hosting path. Treat it as a preview-only constraint, not the recommended self-hosted control-plane policy.
+- `ui/vercel.json` is generated from the same CSP module as the standalone UI server (`ui/lib/security-headers.mjs`), so the two policies cannot drift and neither permits `eval`-style execution. Only the local development server relaxes `script-src`, for the Next.js dev runtime. That config exists for static UI previews and is not a supported control-plane deployment path: self-hosted control planes serve the dashboard from the Python API or the standalone UI container.
 
 ## Security Testing
 

--- a/tests/api/test_api_endpoints.py
+++ b/tests/api/test_api_endpoints.py
@@ -360,6 +360,13 @@ def test_ui_csp_headers_do_not_allow_eval():
     assert "'unsafe-eval'" not in vercel_config
     assert "script-src-attr 'none'" in canonical
     assert "script-src-attr 'none'" in vercel_config
+
+    # SECURITY.md is read by buyers and auditors, so it must not overstate the
+    # policy it documents. Only the local dev server relaxes script-src.
+    security_md = (root / "SECURITY.md").read_text(encoding="utf-8")
+    for line in security_md.splitlines():
+        if "vercel.json" in line:
+            assert "unsafe-eval" not in line, f"SECURITY.md claims eval is allowed in vercel.json: {line!r}"
     # Removing 'unsafe-inline' from script-src is a #1954 follow-up that
     # needs a build-time hash collector for Next.js streaming inline scripts.
     # The hash of THEME_BOOTSTRAP_SCRIPT is already inventoried in


### PR DESCRIPTION
## Summary
- `SECURITY.md` claimed `ui/vercel.json` is looser than the packaged dashboard policy and "still includes `unsafe-eval`". Both halves are false: `vercel.json` is generated from `ui/lib/security-headers.mjs` by `ui/scripts/sync-vercel-headers.mjs`, so the two policies cannot drift, and `tests/api/test_api_endpoints.py::test_ui_csp_headers_do_not_allow_eval` already asserts that neither the module nor the rendered config contains `unsafe-eval`. Only the local development server relaxes `script-src`.
- Replace the bullet with the accurate behavior and state that the preview config is not a supported control-plane deployment path — self-hosted control planes serve the dashboard from the Python API or the standalone UI container.
- Extend the existing CSP test to read `SECURITY.md` so the overstatement cannot return.

## Verification
- `uv run pytest -q tests/api/test_api_endpoints.py` -> 54 passed (the new assertion fails against the old wording: "SECURITY.md claims eval is allowed in vercel.json")
- `node ui/scripts/sync-vercel-headers.mjs --check` -> `OK: ui/vercel.json headers match lib/security-headers.mjs (6 headers)`
- `uv run python scripts/check_public_docs_hygiene.py` -> passed, 685 files
- `uv run ruff check tests/api/test_api_endpoints.py` -> All checks passed
- `git diff --check` -> clean

## Notes
- Docs and test only; no `ui/` files changed, so the UI suite was not run.
- An overstatement of risk in a security doc is still a docs-honesty defect: the file is read by buyers and auditors and contradicted an enforced CI assertion.

Made with [Cursor](https://cursor.com)