### PR TITLE
fix(cloud): bind tenant context and sanitize scheduler scan failures

### DIFF
--- a/src/agent_bom/api/connection_scheduler.py
+++ b/src/agent_bom/api/connection_scheduler.py
@@ -26,10 +26,23 @@ Design notes:
   (``ConnectionStore.claim_due_scan``): the first replica to advance the stored
   timestamp wins, every racing replica's conditional UPDATE then no-ops. Exactly
   one replica runs a given due scan. Bounded concurrency caps brokered scans.
-* **Safe.** Read-only scans only. A failing connection is marked ``error`` with a
-  sanitized, secret-free detail and the loop continues — one bad connection never
-  stops the loop. All four providers (AWS, Azure, GCP, Snowflake) are
-  broker-enabled and schedulable.
+* **Tenant-bound.** Store *reads* run under ``bypass_tenant_rls()`` because the
+  loop polls every tenant's connections, but each per-connection unit of work
+  binds ``set_current_tenant(record.tenant_id)`` before touching a write path.
+  On Postgres the ``WITH CHECK`` half of each tenant-isolation policy compares
+  the written row against ``app.tenant_id``, so an unbound tenant makes every
+  scheduled write for a non-``default`` tenant fail closed.
+* **Safe.** Read-only scans only. A failing connection is marked ``error`` with
+  the same curated, secret-free detail the HTTP scan route persists
+  (``_safe_connection_detail``) — the broker's free-form message is never stored,
+  because ``status_detail`` is returned verbatim by
+  ``GET /v1/cloud/connections``. All four providers (AWS, Azure, GCP, Snowflake)
+  are broker-enabled and schedulable.
+* **Fail-soft per connection, fail-closed on data.** Every failure mode —
+  broker, discovery, event drain, *and* persistence — is contained to the one
+  connection it belongs to: the tick completes, other tenants keep scanning, and
+  the loop's backoff stays reserved for a genuinely broken control plane. A
+  write that cannot be persisted is never retried outside its tenant.
 """
 
 from __future__ import annotations
@@ -37,7 +50,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
@@ -48,6 +61,10 @@ from agent_bom.api.connection_store import (
     ConnectionStore,
     get_connection_store,
 )
+
+# ``postgres_common`` imports psycopg lazily, so this stays safe on the SQLite
+# default deployment where the driver is not installed.
+from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
 from agent_bom.config import (
     CONNECTIONS_SCHEDULER_MAX_CONCURRENCY,
     CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES,
@@ -165,7 +182,9 @@ def _consume_continuous_events(
 
     Passes a short ``wait_seconds`` for AWS SQS so empty queues do not stall the
     tick on long-poll. Azure/GCP consumers have no WaitTimeSeconds equivalent.
-    Never raises — one bad consume cannot sink the tick.
+    Runs with the connection's tenant bound so the consumer's ``last_event_at``
+    stamp satisfies the Postgres RLS ``WITH CHECK`` clause. Never raises — one
+    bad consume cannot sink the tick.
     """
     loaded = _load_continuous_consumer(record.provider)
     if loaded is None:
@@ -174,6 +193,7 @@ def _consume_continuous_events(
     kwargs: dict[str, Any] = {"tenant_id": record.tenant_id, "store": store}
     if (record.provider or "").strip().lower() == "aws":
         kwargs["wait_seconds"] = max(0, int(wait_seconds))
+    token = set_current_tenant(record.tenant_id)
     try:
         consume(record, **kwargs)
     except Exception:  # noqa: BLE001 - one bad consume never sinks the tick
@@ -182,12 +202,24 @@ def _consume_continuous_events(
             record.id,
             record.provider,
         )
+    finally:
+        reset_current_tenant(token)
 
 
 def _select_continuous_drain_targets(store: ConnectionStore) -> list[CloudConnectionRecord]:
-    """Return continuous connections whose provider event ingest is enabled."""
+    """Return continuous connections whose provider event ingest is enabled.
+
+    Never raises: a store outage while listing yields no targets so the tick
+    falls through to due full scans instead of escalating the loop's backoff.
+    """
+    try:
+        candidates = store.list_continuous()
+    except Exception:  # noqa: BLE001 - a store outage never sinks the tick
+        logger.exception("Listing continuous cloud connections failed")
+        return []
+
     targets: list[CloudConnectionRecord] = []
-    for record in store.list_continuous():
+    for record in candidates:
         loaded = _load_continuous_consumer(record.provider)
         if loaded is None:
             continue
@@ -203,6 +235,35 @@ def _select_continuous_drain_targets(store: ConnectionStore) -> list[CloudConnec
             continue
         targets.append(record)
     return targets
+
+
+async def _gather_isolated(
+    records: list[CloudConnectionRecord],
+    task: Callable[[CloudConnectionRecord], Coroutine[Any, Any, None]],
+    *,
+    activity: str,
+) -> None:
+    """Run one *task* per record concurrently, isolating per-task failures.
+
+    ``asyncio.gather`` without ``return_exceptions=True`` cancels the remaining
+    tasks and re-raises on the first error, which would let a single connection
+    abort the whole tick and drive the loop into escalating backoff for every
+    tenant. Collect the results instead and log each failure against its own
+    connection.
+    """
+    results = await asyncio.gather(*(task(record) for record in records), return_exceptions=True)
+    for record, result in zip(records, results, strict=True):
+        if isinstance(result, asyncio.CancelledError):
+            # Shutdown, not a connection failure — let the loop unwind.
+            raise result
+        if isinstance(result, BaseException):
+            logger.error(
+                "Connection scheduler %s failed for connection %s (provider=%s)",
+                activity,
+                record.id,
+                record.provider,
+                exc_info=result,
+            )
 
 
 async def drain_continuous_events(
@@ -239,8 +300,55 @@ async def drain_continuous_events(
                 wait_seconds=wait_seconds,
             )
 
-    await asyncio.gather(*(_guarded(record) for record in targets))
+    await _gather_isolated(targets, _guarded, activity="continuous event drain")
     return len(targets)
+
+
+def _persist_scan_outcome(
+    record: CloudConnectionRecord,
+    *,
+    status: str,
+    status_detail: str,
+    outcome: str,
+    last_scan_at: str | None = None,
+    scan_id: str | None = None,
+) -> bool:
+    """Persist one scan attempt's lifecycle transition and audit entry.
+
+    Never raises. A rejected write (database down, or an RLS ``WITH CHECK``
+    refusal) is logged and reported as a failed attempt, because the exception
+    handler in :func:`execute_connection_scan` is itself a write path — an
+    unguarded failure there escapes the "never raises" contract and sinks the
+    whole tick.
+    """
+    # Imported lazily to avoid a route-module import at server startup time.
+    from agent_bom.api.audit_log import log_action
+    from agent_bom.api.routes.cloud_connections import _mark_connection
+
+    details: dict[str, Any] = {
+        "tenant_id": record.tenant_id,
+        "provider": record.provider,
+        "outcome": outcome,
+    }
+    if scan_id is not None:
+        details["scan_id"] = scan_id
+    try:
+        _mark_connection(
+            record,
+            status=status,
+            status_detail=status_detail,
+            last_scan_at=last_scan_at,
+        )
+        log_action(
+            "cloud_connection.scheduled_scan",
+            actor="scheduler",
+            resource=f"cloud-connection/{record.id}",
+            **details,
+        )
+    except Exception:  # noqa: BLE001 - persistence failure never sinks the tick
+        logger.exception("Persisting the scheduled scan outcome failed for connection %s", record.id)
+        return False
+    return outcome == "success"
 
 
 def execute_connection_scan(record: CloudConnectionRecord) -> bool:
@@ -249,45 +357,57 @@ def execute_connection_scan(record: CloudConnectionRecord) -> bool:
     Reuses the provider-dispatching scan-launch path (``_run_connection_scan``)
     and the lifecycle mutator (``_mark_connection``). On success the connection
     moves to ``active`` + a fresh ``last_scan_at``; on failure it is marked
-    ``error`` with a sanitized, secret-free detail. Never raises — returns
-    whether the scan succeeded so one bad connection cannot sink the loop.
+    ``error`` with the same curated detail the HTTP scan route persists.
+
+    The connection's tenant is bound for the whole unit of work — the loop runs
+    outside any HTTP request, so nothing else populates the tenant contextvar
+    and the scan's writes would otherwise be checked against ``default``. The
+    reset lives in a ``finally`` so a raising scan cannot carry one tenant into
+    the next connection's work.
+
+    Never raises — returns whether the scan ran *and* was recorded, so one bad
+    connection cannot sink the loop.
     """
-    # Imported lazily to avoid a route-module import at server startup time.
-    from agent_bom.api.audit_log import log_action
     from agent_bom.api.routes.cloud_connections import (
-        _mark_connection,
         _now,
         _run_connection_scan,
+        _safe_connection_detail,
     )
-    from agent_bom.security import sanitize_error
 
+    token = set_current_tenant(record.tenant_id)
     try:
-        summary = _run_connection_scan(record, record.tenant_id)
-    except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
-        detail = sanitize_error(exc)
-        _mark_connection(record, status=STATUS_ERROR, status_detail=detail)
-        logger.exception("Scheduled cloud connection scan failed for connection %s", record.id)
-        log_action(
-            "cloud_connection.scheduled_scan",
-            actor="scheduler",
-            resource=f"cloud-connection/{record.id}",
-            tenant_id=record.tenant_id,
-            provider=record.provider,
-            outcome="failure",
+        try:
+            summary = _run_connection_scan(record, record.tenant_id)
+        except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
+            logger.exception("Scheduled cloud connection scan failed for connection %s", record.id)
+            _persist_scan_outcome(
+                record,
+                status=STATUS_ERROR,
+                # ``status_detail`` is returned verbatim by
+                # ``GET /v1/cloud/connections``, so it follows the HTTP scan
+                # route's policy: only curated remediation text, never the
+                # broker's free-form message (which can carry an ARN, an
+                # account id, or the ExternalId).
+                status_detail=_safe_connection_detail(exc),
+                outcome="failure",
+            )
+            return False
+        return _persist_scan_outcome(
+            record,
+            status=STATUS_ACTIVE,
+            status_detail="",
+            last_scan_at=_now(),
+            outcome="success",
+            scan_id=summary.get("scan_id"),
+        )
+    except Exception:  # noqa: BLE001 - contract: this function never raises
+        logger.exception(
+            "Scheduled cloud connection scan bookkeeping failed for connection %s",
+            record.id,
         )
         return False
-
-    _mark_connection(record, status=STATUS_ACTIVE, status_detail="", last_scan_at=_now())
-    log_action(
-        "cloud_connection.scheduled_scan",
-        actor="scheduler",
-        resource=f"cloud-connection/{record.id}",
-        tenant_id=record.tenant_id,
-        provider=record.provider,
-        outcome="success",
-        scan_id=summary.get("scan_id"),
-    )
-    return True
+    finally:
+        reset_current_tenant(token)
 
 
 async def run_due_scans_once(
@@ -318,7 +438,7 @@ async def run_due_scans_once(
         async with semaphore:
             await asyncio.to_thread(execute_connection_scan, record)
 
-    await asyncio.gather(*(_guarded(record) for record in claimed))
+    await _gather_isolated(claimed, _guarded, activity="scheduled scan")
     return len(claimed)
 
 

--- a/tests/test_connection_scheduler.py
+++ b/tests/test_connection_scheduler.py
@@ -6,6 +6,15 @@ claimed scan), the run-once orchestration (scan triggered + ``last_scan_at``
 advanced + status ``active``), failure isolation (a failing connection is marked
 ``error`` and the loop continues), non-AWS skip (the broker is AWS-only), and the
 env toggle that keeps the loop off in CLI/dev.
+
+Also covers the three hardening invariants the scheduler must hold:
+
+* the persisted ``status_detail`` follows the same policy as the HTTP scan route
+  (``_safe_connection_detail``) so no broker text reaches ``GET /v1/cloud/connections``;
+* every per-connection unit of work runs with the connection's Postgres tenant
+  bound, and a raising scan restores the previous tenant;
+* no persistence failure escapes a tick — ``execute_connection_scan`` never
+  raises and both ``gather`` fan-outs survive a raising task.
 """
 
 from __future__ import annotations
@@ -24,6 +33,7 @@ from agent_bom.api.connection_scheduler import (
     claim_due_connections,
     connections_scheduler_enabled,
     drain_continuous_events,
+    execute_connection_scan,
     is_due,
     run_due_scans_once,
     select_due_connections,
@@ -39,8 +49,23 @@ from agent_bom.api.connection_store import (
     SQLiteConnectionStore,
     set_connection_store,
 )
+from agent_bom.api.postgres_common import _current_tenant
 
 _TEST_KEY = Fernet.generate_key().decode("ascii")
+
+# A realistic boto3 ``AssumeRole`` denial. ``sanitize_error`` without
+# ``generic=True`` strips URLs, absolute paths, and ``key=value`` credential
+# assignments — it leaves the account-bearing ARN prefix and the ExternalId
+# value intact, and the message is short enough to survive both the 200-char
+# sanitizer truncation and the 300-char ``status_detail`` cap. Anything that
+# persists this text verbatim leaks a secret to ``GET /v1/cloud/connections``.
+_LEAK_EXTERNAL_ID = "super-secret-external-id"
+_LEAK_ACCOUNT_ARN = "arn:aws:sts::111122223333:assumed-role"
+_BROKER_FAILURE_MESSAGE = (
+    "An error occurred (AccessDenied) when calling the AssumeRole operation: "
+    f"{_LEAK_ACCOUNT_ARN}/abom is not authorized "
+    f"(ExternalId {_LEAK_EXTERNAL_ID})"
+)
 
 
 @pytest.fixture(autouse=True)
@@ -97,16 +122,56 @@ def _record(
 _BROKER_SESSION_SENTINEL = object()
 
 
-def _install_scan_mocks(monkeypatch: pytest.MonkeyPatch, *, fail: bool = False) -> dict[str, Any]:
-    """Patch the broker + AWS inventory/CIS the scheduler's scan path reuses."""
+class _TenantRecordingStore(InMemoryConnectionStore):
+    """In-memory store that records the bound Postgres tenant on every write.
+
+    ``put`` is the scheduler's write path (via ``_mark_connection``). On
+    Postgres the ``WITH CHECK`` half of each ``*_tenant_isolation`` policy
+    compares the row's ``tenant_id`` against ``app.tenant_id``, which
+    ``_apply_tenant_session`` reads from the ``_current_tenant`` contextvar —
+    so an unbound tenant means the write is rejected. Ids added to
+    ``fail_ids`` raise on write to simulate that rejection.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.put_tenants: list[tuple[str, str]] = []
+        self.fail_ids: set[str] = set()
+
+    def put(self, record: CloudConnectionRecord) -> None:
+        self.put_tenants.append((record.id, _current_tenant.get()))
+        if record.id in self.fail_ids:
+            raise RuntimeError('new row violates row-level security policy for table "cloud_connections"')
+        super().put(record)
+
+    def observed_tenant(self, connection_id: str) -> str | None:
+        """Tenant bound during the most recent write for *connection_id*."""
+        for record_id, tenant in reversed(self.put_tenants):
+            if record_id == connection_id:
+                return tenant
+        return None
+
+
+def _install_scan_mocks(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    fail: bool = False,
+    fail_ids: set[str] | None = None,
+) -> dict[str, Any]:
+    """Patch the broker + AWS inventory/CIS the scheduler's scan path reuses.
+
+    *fail* fails every broker exchange; *fail_ids* fails only those connections
+    so a tick can mix a failing and a healthy connection.
+    """
     from agent_bom.cloud import aws_cis_benchmark, aws_inventory, connection_broker
 
-    calls: dict[str, Any] = {"scanned_ids": []}
+    calls: dict[str, Any] = {"scanned_ids": [], "scan_tenants": []}
 
     def _fake_broker(record: CloudConnectionRecord, **kwargs: Any) -> Any:
         calls["scanned_ids"].append(record.id)
-        if fail:
-            raise connection_broker.ConnectionBrokerError(f"AssumeRole failed for connection {record.id}.")
+        calls["scan_tenants"].append((record.id, _current_tenant.get()))
+        if fail or (fail_ids is not None and record.id in fail_ids):
+            raise connection_broker.ConnectionBrokerError(_BROKER_FAILURE_MESSAGE)
         return _BROKER_SESSION_SENTINEL
 
     def _fake_inventory(region: str | None = None, force: bool = False, session: Any = None, **kwargs: Any) -> dict[str, Any]:
@@ -290,7 +355,240 @@ async def test_run_once_failing_connection_marked_error_and_loop_continues(monke
         assert fetched is not None
         assert fetched.status == STATUS_ERROR
         assert fetched.status_detail
-        assert "super-secret-external-id" not in fetched.status_detail
+        assert _LEAK_EXTERNAL_ID not in fetched.status_detail
+        assert _LEAK_ACCOUNT_ARN not in fetched.status_detail
+
+
+@pytest.mark.asyncio
+async def test_scheduled_failure_detail_matches_http_scan_route_policy(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The persisted detail must be exactly what the HTTP scan route would store.
+
+    ``status_detail`` is returned verbatim by ``GET /v1/cloud/connections``, so
+    the scheduler cannot apply a weaker policy than the route: both go through
+    ``_safe_connection_detail``, which never surfaces the broker's free-form
+    message.
+    """
+    from agent_bom.api.routes.cloud_connections import _safe_connection_detail
+    from agent_bom.cloud.connection_broker import ConnectionBrokerError
+
+    _install_scan_mocks(monkeypatch, fail=True)
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    record = _record(scan_interval_minutes=60, last_scan_at=None)
+    store.put(record)
+
+    assert await run_due_scans_once(store, _now()) == 1
+
+    expected = _safe_connection_detail(ConnectionBrokerError(_BROKER_FAILURE_MESSAGE))
+    fetched = store.get(record.tenant_id, record.id)
+    assert fetched is not None
+    assert fetched.status_detail == expected
+    assert "AccessDenied" not in fetched.status_detail
+
+
+# --------------------------------------------------------------------------- #
+# Tenant context binding (Postgres RLS WITH CHECK)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_run_once_binds_each_connections_tenant_for_writes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each connection's writes run under its own tenant, not the default one."""
+    _install_scan_mocks(monkeypatch)
+    store = _TenantRecordingStore()
+    set_connection_store(store)
+    first = _record(tenant_id="tenant-a", scan_interval_minutes=60, last_scan_at=None)
+    second = _record(tenant_id="tenant-b", scan_interval_minutes=60, last_scan_at=None)
+    store.put(first)
+    store.put(second)
+    store.put_tenants.clear()
+
+    assert await run_due_scans_once(store, _now()) == 2
+
+    assert store.observed_tenant(first.id) == "tenant-a"
+    assert store.observed_tenant(second.id) == "tenant-b"
+    assert "default" not in {tenant for _id, tenant in store.put_tenants}
+
+
+def test_execute_connection_scan_restores_tenant_after_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raising scan resets the tenant so it cannot leak into the next unit."""
+    _install_scan_mocks(monkeypatch, fail=True)
+    store = _TenantRecordingStore()
+    set_connection_store(store)
+    record = _record(tenant_id="tenant-a")
+    store.put(record)
+    store.put_tenants.clear()
+
+    assert execute_connection_scan(record) is False
+    assert store.observed_tenant(record.id) == "tenant-a"
+    assert _current_tenant.get() == "default"
+
+
+def test_failing_scan_does_not_leak_tenant_into_next_connection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Two tenants in one tick: the first raising must not taint the second."""
+    store = _TenantRecordingStore()
+    set_connection_store(store)
+    failing = _record(tenant_id="tenant-a", scan_interval_minutes=60, last_scan_at=None)
+    healthy = _record(tenant_id="tenant-b", scan_interval_minutes=60, last_scan_at=None)
+    store.put(failing)
+    store.put(healthy)
+    store.put_tenants.clear()
+    calls = _install_scan_mocks(monkeypatch, fail_ids={failing.id})
+
+    # Sequential in-thread calls share one context, so a missing reset shows up.
+    assert execute_connection_scan(failing) is False
+    assert execute_connection_scan(healthy) is True
+
+    assert dict(calls["scan_tenants"]) == {failing.id: "tenant-a", healthy.id: "tenant-b"}
+    assert store.observed_tenant(healthy.id) == "tenant-b"
+    assert _current_tenant.get() == "default"
+
+
+@pytest.mark.asyncio
+async def test_drain_continuous_events_binds_connection_tenant(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The event drain's ``last_event_at`` stamp also needs the tenant bound."""
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+    os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
+    observed: list[str] = []
+
+    def _fake_consume(record: CloudConnectionRecord, **kwargs: Any) -> dict[str, Any]:
+        observed.append(_current_tenant.get())
+        return {"status": "ok", "processed": 0}
+
+    monkeypatch.setattr("agent_bom.cloud.event_ingest.consume_aws_events", _fake_consume)
+
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    store.put(_record(tenant_id="tenant-b", scan_mode=SCAN_MODE_CONTINUOUS))
+
+    assert await drain_continuous_events(store) == 1
+    assert observed == ["tenant-b"]
+
+
+# --------------------------------------------------------------------------- #
+# Persistence failures never sink a tick
+# --------------------------------------------------------------------------- #
+
+
+def test_execute_connection_scan_never_raises_when_store_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected store write is reported as a failed scan, not raised."""
+    _install_scan_mocks(monkeypatch)
+    store = _TenantRecordingStore()
+    set_connection_store(store)
+    record = _record(scan_interval_minutes=60, last_scan_at=None)
+    store.put(record)
+    store.fail_ids.add(record.id)
+
+    assert execute_connection_scan(record) is False
+
+
+@pytest.mark.asyncio
+async def test_run_once_survives_a_connection_whose_store_write_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """One connection's persistence failure cannot abort the whole tick."""
+    calls = _install_scan_mocks(monkeypatch)
+    store = _TenantRecordingStore()
+    set_connection_store(store)
+    broken = _record(scan_interval_minutes=60, last_scan_at=None)
+    healthy = _record(scan_interval_minutes=60, last_scan_at=None)
+    store.put(broken)
+    store.put(healthy)
+    store.fail_ids.add(broken.id)
+
+    count = await run_due_scans_once(store, _now())
+
+    assert count == 2
+    assert set(calls["scanned_ids"]) == {broken.id, healthy.id}
+    fetched = store.get(healthy.tenant_id, healthy.id)
+    assert fetched is not None
+    assert fetched.status == STATUS_ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_run_once_survives_a_raising_scan_task(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The due-scan gather must collect task errors instead of aborting the tick."""
+    from agent_bom.api import connection_scheduler as sched
+
+    _install_scan_mocks(monkeypatch)
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    boom = _record(scan_interval_minutes=60, last_scan_at=None)
+    healthy = _record(scan_interval_minutes=60, last_scan_at=None)
+    store.put(boom)
+    store.put(healthy)
+    ran: list[str] = []
+
+    def _explode(record: CloudConnectionRecord) -> bool:
+        if record.id == boom.id:
+            raise RuntimeError("worker thread failure")
+        ran.append(record.id)
+        return True
+
+    monkeypatch.setattr(sched, "execute_connection_scan", _explode)
+
+    assert await run_due_scans_once(store, _now()) == 2
+    assert ran == [healthy.id]
+
+
+@pytest.mark.asyncio
+async def test_drain_continuous_events_survives_store_listing_failure() -> None:
+    """A store outage while listing continuous connections cannot sink the tick."""
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+
+    class _BrokenListing(InMemoryConnectionStore):
+        def list_continuous(self) -> list[CloudConnectionRecord]:
+            raise RuntimeError("connection pool exhausted")
+
+    store = _BrokenListing()
+    set_connection_store(store)
+
+    assert await drain_continuous_events(store) == 0
+
+
+@pytest.mark.asyncio
+async def test_drain_continuous_events_survives_a_raising_drain_task(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The drain gather must collect task errors instead of aborting the tick."""
+    from agent_bom.api import connection_scheduler as sched
+
+    os.environ["AGENT_BOM_CONNECTIONS_SCHEDULER"] = "1"
+    os.environ["AGENT_BOM_AWS_EVENT_QUEUE_URL"] = "https://sqs.example/queue"
+    monkeypatch.setattr(
+        "agent_bom.cloud.event_ingest.consume_aws_events",
+        lambda record, **k: {"status": "ok"},
+    )
+
+    store = InMemoryConnectionStore()
+    set_connection_store(store)
+    boom = _record(scan_mode=SCAN_MODE_CONTINUOUS)
+    healthy = _record(scan_mode=SCAN_MODE_CONTINUOUS)
+    store.put(boom)
+    store.put(healthy)
+    drained: list[str] = []
+
+    def _explode(record: CloudConnectionRecord, store_arg: Any, **kwargs: Any) -> None:
+        if record.id == boom.id:
+            raise RuntimeError("worker thread failure")
+        drained.append(record.id)
+
+    monkeypatch.setattr(sched, "_consume_continuous_events", _explode)
+
+    assert await drain_continuous_events(store) == 2
+    assert drained == [healthy.id]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- **Secret-free failure detail.** `execute_connection_scan` persisted `sanitize_error(exc)` into `status_detail`, which `GET /v1/cloud/connections` returns verbatim. Without `generic=True` that helper only strips URLs, absolute paths, and `key=value` credential assignments — ARNs, AWS account ids, and ExternalId values pass straight through. The HTTP scan route already routes the identical exception through `_safe_connection_detail` ("a broker's free-form message is never surfaced"). The scheduler now uses the same helper, so one policy governs both paths.
- **Postgres tenant context bound for scheduler writes.** The loop runs outside any HTTP request, so nothing populated the `_current_tenant` contextvar. Reads were already wrapped in `bypass_tenant_rls()`, but every write — `_mark_connection`, the persisted report, and the continuous drain's `last_event_at` stamp — was checked against `default`, and the `WITH CHECK` half of each `*_tenant_isolation` policy rejected it. On a multi-tenant Postgres control plane, "connect once, keeps evaluating" silently stopped being true for every non-`default` tenant. Each per-connection unit of work now binds `set_current_tenant(record.tenant_id)`, with the reset in a `finally` so a raising scan cannot carry one tenant into the next connection's work.
- **The "never raises" contract is now honored.** The exception handler was itself an unguarded store write, and neither `asyncio.gather` passed `return_exceptions=True`, so one connection whose persistence failed aborted the entire tick, propagated into `connection_scheduler_loop`, and drove `consecutive_failures` into escalating backoff (60s → 900s) for **all** tenants. Persistence is now guarded, both fan-outs collect per-task failures and log them against the owning connection, and `_select_continuous_drain_targets`' `list_continuous()` call is guarded.

The existing secret-leak assertion was vacuous: it asserted `"super-secret-external-id" not in status_detail` against a mocked broker message that never contained the secret, so it could not fail. It now raises a boto3-shaped `AccessDenied` embedding both an ExternalId value and an account-bearing `arn:aws:sts::111122223333:...` ARN, sized to survive the sanitizer's 200-char truncation and the 300-char `status_detail` cap.

## Verification

Each defect was reproduced with a failing test before the change.

**Before (on `origin/main` code, new/corrected assertions only):**

```
FAILED tests/test_connection_scheduler.py::test_run_once_failing_connection_marked_error_and_loop_continues - AssertionError: assert 'super-secret-external-id' not in 'An error oc...external-id)'
FAILED tests/test_connection_scheduler.py::test_scheduled_failure_detail_matches_http_scan_route_policy - AssertionError: assert 'An error occ...-external-id)' == 'An internal ...tact support.'
FAILED tests/test_connection_scheduler.py::test_run_once_binds_each_connections_tenant_for_writes - AssertionError: assert 'default' == 'tenant-a'
FAILED tests/test_connection_scheduler.py::test_execute_connection_scan_restores_tenant_after_failure - AssertionError: assert 'default' == 'tenant-a'
FAILED tests/test_connection_scheduler.py::test_failing_scan_does_not_leak_tenant_into_next_connection - AssertionError: assert {'3c47428e-2c...d': 'default'} == {'3c47428e-2c...': 'tenant-b'}
FAILED tests/test_connection_scheduler.py::test_drain_continuous_events_binds_connection_tenant - AssertionError: assert ['default'] == ['tenant-b']
FAILED tests/test_connection_scheduler.py::test_execute_connection_scan_never_raises_when_store_write_fails - RuntimeError: new row violates row-level security policy for table "cloud_connections"
FAILED tests/test_connection_scheduler.py::test_run_once_survives_a_connection_whose_store_write_fails - RuntimeError: new row violates row-level security policy for table "cloud_connections"
FAILED tests/test_connection_scheduler.py::test_run_once_survives_a_raising_scan_task - RuntimeError: worker thread failure
FAILED tests/test_connection_scheduler.py::test_drain_continuous_events_survives_store_listing_failure - RuntimeError: connection pool exhausted
FAILED tests/test_connection_scheduler.py::test_drain_continuous_events_survives_a_raising_drain_task - RuntimeError: worker thread failure
11 failed, 30 passed in 1.46s
```

**After:**

```
$ uv run pytest -q tests/test_connection_scheduler.py
41 passed in 1.59s

$ uv run pytest -q tests/cloud/ tests/api/test_connections_events_ingest_route.py
694 passed, 3 skipped, 1 warning in 18.26s

$ uv run pytest -q tests/api/ tests/test_connection_scheduler.py tests/test_postgres_connection_parity.py tests/test_db_persistence_consistency.py
1007 passed, 1 skipped, 1 warning in 78.26s

$ uv run python scripts/check_exception_sanitization.py
exit=0

$ uv run ruff check src/agent_bom/api/connection_scheduler.py tests/test_connection_scheduler.py
All checks passed!

$ uv run ruff format --check src/agent_bom/api/connection_scheduler.py tests/test_connection_scheduler.py
2 files already formatted

$ uv run mypy src/agent_bom/api/connection_scheduler.py
Success: no issues found in 1 source file

$ uv run python scripts/check_package_layout.py
ok: 242 top-level src/agent_bom/*.py modules (frozen)

$ git diff --check
exit=0
```

`make preflight` was not run: no route, model, or generated-artifact surface is touched.

## Notes

**Fail-open / fail-closed, before and after.** The data plane was and remains **fail-closed**: scans are read-only, no credential is ever persisted, and an RLS-rejected write is refused rather than written under the wrong tenant — the tenant-context defect never leaked a row across tenants. What changed is the **control plane's availability posture**:

| | Before | After |
|---|---|---|
| Broker / discovery / event-drain failure | Isolated to the connection; tick completes | Unchanged |
| Persistence failure inside the error handler | Escaped `execute_connection_scan`, aborted the tick via `gather`, escalated the loop backoff to 900s for **all** tenants | Isolated to the connection; logged; reported as a failed attempt; tick completes |
| Continuous-target listing failure | Escaped and aborted the tick | Returns no targets; tick falls through to due full scans |
| Writes for a non-`default` tenant on Postgres | Rejected by `WITH CHECK` on every tick (fail-closed, but the connection never progressed) | Bound to the connection's tenant and persisted |
| Loop backoff | Fired on a single connection's persistence failure | Reserved for a genuinely broken control plane |

Cancellation is deliberately **not** swallowed: `_gather_isolated` re-raises a child `CancelledError` so shutdown still unwinds through `connection_scheduler_loop`.

**Postgres verification.** `AGENT_BOM_POSTGRES_URL` was not set and no live Postgres was reachable, so Defect 2 is covered by the contextvar-observing store rather than a live RLS rejection. Worth knowing: `tests/test_postgres_connection_parity.py` monkeypatches `_tenant_connection` away, so nothing in-repo exercises `_apply_tenant_session` for the connections table — the `WITH CHECK` behavior itself is unverified by the suite in either direction.

**Import safety.** `set_current_tenant` / `reset_current_tenant` are imported from `agent_bom.api.postgres_common`, which imports psycopg lazily, so the SQLite default deployment is unaffected.
