### PR TITLE
fix(ci): run the Postgres contract job for scheduler and ingest changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,17 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(site-docs/|mkdocs\.yml$|\.github/workflows/(docs|ci)\.yml$|\.github/actions/setup-python/)'; then
             docs=true
           fi
-          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_|deploy/supabase/postgres/)'; then
+          # Scope rule: every module that writes to Postgres through the
+          # tenant-RLS connection helper, plus the callers responsible for
+          # binding the tenant context around such a write. The prefix
+          # `src/agent_bom/api/postgres_` alone missed the scheduler and the
+          # continuous-ingest drain, so the Postgres contract job was skipped
+          # on the very PR that fixed a cloud_connections RLS WITH CHECK
+          # violation. Request-path binders (api/middleware.py, api/pipeline.py)
+          # are deliberately excluded: no integration test drives the ASGI app
+          # against real Postgres, so the job could not observe a regression
+          # there and gating those hot files would cost time for no signal.
+          if printf '%s\n' "$changed" | grep -Eq '^(src/agent_bom/api/(postgres_|storage_schema\.py|connection_store\.py|connection_scheduler\.py|proxy_replay_store\.py)|src/agent_bom/cloud/([a-z_]*event_ingest|runtime_workload_evidence_store)\.py|src/agent_bom/ticketing/postgres_store\.py|tests/test_postgres_|deploy/supabase/postgres/)'; then
             postgres=true
           fi
           # Python test suite: skip only when a PR clearly cannot affect it

--- a/tests/test_postgres_connection_rls_guard.py
+++ b/tests/test_postgres_connection_rls_guard.py
@@ -1,0 +1,251 @@
+"""Row-level-security guard for the Postgres cloud-connections write path.
+
+Cover for the defect class fixed in #4452: a caller that reaches
+``PostgresConnectionStore.put`` without binding the record's tenant writes a row
+whose ``tenant_id`` disagrees with ``app.tenant_id``, and Postgres rejects it
+with ``InsufficientPrivilege`` under the shipped
+``cloud_connections_tenant_isolation`` policy. On a multi-tenant control plane
+that turned every scheduled write for a non-``default`` tenant into a hard
+failure.
+
+The fake pool below models that policy instead of ignoring it. It learns the
+guarded column from the ``WITH CHECK`` clause the store's own DDL emits, tracks
+the ``app.tenant_id`` / ``app.bypass_rls`` settings written by
+``_apply_tenant_session``, and rejects a mismatched INSERT. The semantics-free
+fake in ``tests/test_postgres_connection_parity.py`` cannot see any of this: it
+absorbs the ``set_config`` calls and stores the row regardless, which is exactly
+why the defect reached main with a green unit suite. Deleting that fake's
+``_tenant_connection`` monkeypatch is not enough — the policy has to be modelled.
+
+These tests need no Postgres container, so they run on every PR. The same
+invariant is pinned against a live ``postgres:16-alpine`` and the real
+``psycopg.errors.InsufficientPrivilege`` in ``tests/test_postgres_integration``.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from agent_bom.api.connection_store import CloudConnectionRecord
+from agent_bom.api.postgres_common import bypass_tenant_rls, reset_current_tenant, set_current_tenant
+from agent_bom.api.postgres_connection import PostgresConnectionStore
+
+_SET_CONFIG = re.compile(r"^select set_config\('(?P<name>[^']+)'")
+_FORCE_RLS = re.compile(r"^alter table (?P<table>\w+) force row level security")
+_CREATE_POLICY = re.compile(
+    r"create policy \w+ on (?P<table>\w+) .*?"
+    r"with check \(public\.abom_rls_bypass\(\) or (?P<column>\w+) = public\.abom_current_tenant\(\)\)"
+)
+_INSERT = re.compile(r"^insert into (?P<table>\w+) \((?P<columns>[^)]*)\) values")
+_SELECT = re.compile(r"^select (?P<columns>.*?) from (?P<table>\w+)")
+
+
+class InsufficientPrivilegeError(Exception):
+    """Stand-in for ``psycopg.errors.InsufficientPrivilege``.
+
+    psycopg is an optional extra and is absent from the always-on test job, so
+    the fake raises its own type. The real exception class is asserted against a
+    live server in ``tests/test_postgres_integration.py``.
+    """
+
+
+class _Cursor:
+    def __init__(self, rows=()):
+        self._rows = list(rows)
+
+    def fetchone(self):
+        return self._rows[0] if self._rows else None
+
+    def fetchall(self):
+        return self._rows
+
+
+class _RlsConnection:
+    """A connection that enforces the tenant-isolation policy it was taught."""
+
+    def __init__(self, pool):
+        self._pool = pool
+        self._settings: dict[str, str] = {}
+
+    def _current_tenant(self) -> str:
+        return self._settings.get("app.tenant_id") or "default"
+
+    def _bypassed(self) -> bool:
+        return self._settings.get("app.bypass_rls") == "1"
+
+    def _row_matches_policy(self, table: str, row: dict[str, object]) -> bool:
+        column = self._pool.guarded_columns.get(table)
+        if column is None:
+            return True
+        return self._bypassed() or row.get(column) == self._current_tenant()
+
+    def execute(self, sql, params=None):
+        normalized = " ".join(sql.lower().split())
+        params = tuple(params or ())
+
+        setting = _SET_CONFIG.match(normalized)
+        if setting:
+            self._settings[setting.group("name")] = str(params[0]) if params else ""
+            return _Cursor()
+
+        force = _FORCE_RLS.match(normalized)
+        if force:
+            self._pool.forced_tables.add(force.group("table"))
+            return _Cursor()
+
+        policy = _CREATE_POLICY.search(normalized)
+        if policy and policy.group("table") in self._pool.forced_tables:
+            self._pool.guarded_columns[policy.group("table")] = policy.group("column")
+            return _Cursor()
+
+        insert = _INSERT.match(normalized)
+        if insert:
+            table = insert.group("table")
+            columns = [name.strip() for name in insert.group("columns").split(",")]
+            # Columns backed by a SQL expression rather than a placeholder (the
+            # schema-marker table's ``now()``) simply fall off the end. Every
+            # column of a guarded table is bound to a placeholder.
+            row = dict(zip(columns, params, strict=False))
+            if not self._row_matches_policy(table, row):
+                raise InsufficientPrivilegeError(f'new row violates row-level security policy for table "{table}"')
+            self._pool.rows.setdefault(table, {})[row[columns[0]]] = row
+            return _Cursor()
+
+        select = _SELECT.match(normalized)
+        if select:
+            table = select.group("table")
+            visible = [row for row in self._pool.rows.get(table, {}).values() if self._row_matches_policy(table, row)]
+            if "where tenant_id = %s and id = %s" in normalized:
+                visible = [row for row in visible if (row.get("tenant_id"), row.get("id")) == params[:2]]
+            elif "where tenant_id = %s" in normalized:
+                visible = [row for row in visible if row.get("tenant_id") == params[0]]
+            projection = [name.strip() for name in select.group("columns").split(",")]
+            return _Cursor([tuple(row.get(name) for name in projection) for row in visible])
+
+        return _Cursor()
+
+    def commit(self):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return False
+
+
+class _RlsPool:
+    def __init__(self):
+        self.rows: dict[str, dict[object, dict[str, object]]] = {}
+        self.forced_tables: set[str] = set()
+        self.guarded_columns: dict[str, str] = {}
+
+    def connection(self):
+        return _RlsConnection(self)
+
+
+def _record(connection_id: str, tenant_id: str) -> CloudConnectionRecord:
+    return CloudConnectionRecord(
+        id=connection_id,
+        tenant_id=tenant_id,
+        provider="aws",
+        display_name="Production",
+        role_ref="arn:aws:iam::123:role/read-only",
+        external_id_encrypted="",
+        created_at="2026-07-24T00:00:00Z",
+        updated_at="2026-07-24T00:00:01Z",
+        scan_interval_minutes=60,
+    )
+
+
+@pytest.fixture
+def store(monkeypatch) -> PostgresConnectionStore:
+    """A store over the RLS-modelling pool, using the real tenant helpers.
+
+    ``_tenant_connection`` is deliberately NOT monkeypatched: the point of this
+    module is that ``_apply_tenant_session`` runs for real and the fake reacts
+    to the settings it writes. Clearing the deployment env keeps the store on
+    its bootstrap-DDL path so the fake is taught the policy from the same SQL a
+    fresh deployment executes.
+    """
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    return PostgresConnectionStore(pool=_RlsPool())
+
+
+def test_fake_pool_learns_the_guard_from_the_stores_own_policy_ddl(store):
+    pool = store._pool
+    assert "cloud_connections" in pool.forced_tables, "the store no longer FORCEs row level security on cloud_connections"
+    assert pool.guarded_columns == {"cloud_connections": "tenant_id"}, (
+        "the cloud_connections_tenant_isolation policy no longer carries a "
+        "WITH CHECK clause keyed on tenant_id; the write path is unguarded"
+    )
+
+
+def test_put_under_the_records_bound_tenant_persists_and_reads_back(store):
+    record = _record("conn-bound", "acme")
+
+    token = set_current_tenant(record.tenant_id)
+    try:
+        store.put(record)
+        restored = store.get(record.tenant_id, record.id)
+    finally:
+        reset_current_tenant(token)
+
+    assert restored is not None
+    assert restored.tenant_id == "acme"
+    assert restored.scan_interval_minutes == 60
+
+
+def test_put_without_a_bound_tenant_is_rejected_by_the_with_check_clause(store):
+    """The pre-#4452 scheduler shape: a non-``default`` tenant, no binding."""
+    record = _record("conn-unbound", "acme")
+
+    with pytest.raises(InsufficientPrivilegeError, match="cloud_connections"):
+        store.put(record)
+
+    assert store._pool.rows.get("cloud_connections", {}) == {}
+
+
+def test_put_bound_to_another_tenant_is_rejected(store):
+    record = _record("conn-crossed", "acme")
+
+    token = set_current_tenant("initech")
+    try:
+        with pytest.raises(InsufficientPrivilegeError, match="cloud_connections"):
+            store.put(record)
+    finally:
+        reset_current_tenant(token)
+
+
+def test_a_bound_tenant_cannot_read_another_tenants_connection(store):
+    record = _record("conn-isolated", "acme")
+
+    token = set_current_tenant("acme")
+    try:
+        store.put(record)
+    finally:
+        reset_current_tenant(token)
+
+    other = set_current_tenant("initech")
+    try:
+        assert store.get("acme", record.id) is None
+        assert store.list_for_tenant("initech") == []
+    finally:
+        reset_current_tenant(other)
+
+
+def test_trusted_rls_bypass_accepts_a_write_for_any_tenant(store):
+    """The scheduler's cross-tenant read/claim path must stay usable.
+
+    ``audit=False`` keeps the bypass from emitting a signed audit entry through
+    whichever store happens to be configured for the test session.
+    """
+    record = _record("conn-bypassed", "acme")
+
+    with bypass_tenant_rls(audit=False):
+        store.put(record)
+
+    assert record.id in store._pool.rows["cloud_connections"]

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -508,6 +508,103 @@ def test_postgres_scan_jobs_rls_blocks_cross_tenant_raw_select():
     )
 
 
+def test_cloud_connections_rls_requires_the_scheduler_to_bind_the_record_tenant():
+    """Regression cover for #4452 against a real server.
+
+    The connections scheduler writes on behalf of whichever tenant owns the
+    record, so it must bind that tenant before touching the store. Without the
+    binding the session still reports the ``default`` fallback and the
+    ``cloud_connections_tenant_isolation`` WITH CHECK clause rejects the row —
+    on a multi-tenant Postgres control plane every scheduled write for a
+    non-``default`` tenant failed.
+
+    Only a live server can prove the three things below: that the owner's write
+    round-trips, that the unbound write raises the real
+    ``psycopg.errors.InsufficientPrivilege`` (which pins the WITH CHECK half of
+    the policy, so a migration that drops it fails here), and that one tenant's
+    rejection does not poison the next tenant's write.
+    """
+    import psycopg
+
+    from agent_bom.api import postgres_common
+    from agent_bom.api.connection_store import CloudConnectionRecord
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_connection import PostgresConnectionStore
+
+    pool = postgres_common._get_pool()
+    with pool.connection() as conn:
+        role_state = conn.execute("SELECT rolsuper, rolbypassrls FROM pg_roles WHERE rolname = current_user").fetchone()
+    if role_state is None or role_state[0] or role_state[1]:
+        pytest.skip(
+            f"Runtime RLS check requires a non-superuser, non-bypassrls role. current_user has (rolsuper, rolbypassrls)={role_state}."
+        )
+
+    store = PostgresConnectionStore()
+    suffix = uuid4().hex
+    tenant_a = f"conn-a-{suffix}"
+    tenant_b = f"conn-b-{suffix}"
+
+    def _record(connection_id: str, tenant_id: str) -> CloudConnectionRecord:
+        return CloudConnectionRecord(
+            id=connection_id,
+            tenant_id=tenant_id,
+            provider="aws",
+            display_name="Scheduled production",
+            role_ref="arn:aws:iam::123456789012:role/agent-bom-read-only",
+            external_id_encrypted="",
+            created_at="2026-07-24T00:00:00Z",
+            updated_at="2026-07-24T00:00:01Z",
+            scan_interval_minutes=60,
+        )
+
+    record_a = _record(f"sched-a-{suffix}", tenant_a)
+    record_b = _record(f"sched-b-{suffix}", tenant_b)
+
+    try:
+        # 1. The scheduler's fixed behaviour: bind the record's tenant, write,
+        #    and read the row back as its owner.
+        token = set_current_tenant(tenant_a)
+        try:
+            store.put(record_a)
+            owned = store.get(tenant_a, record_a.id)
+        finally:
+            reset_current_tenant(token)
+        assert owned is not None, "a tenant-bound scheduled write did not persist"
+        assert owned.tenant_id == tenant_a
+        assert owned.scan_interval_minutes == 60
+
+        # 2. The pre-fix behaviour: no binding, so the session is still on the
+        #    'default' fallback and the WITH CHECK clause must refuse the row.
+        with pytest.raises(psycopg.errors.InsufficientPrivilege):
+            store.put(_record(f"sched-unbound-{suffix}", tenant_a))
+
+        # 3. A rejected write for one tenant must not stop the next tenant's.
+        token = set_current_tenant(tenant_a)
+        try:
+            with pytest.raises(psycopg.errors.InsufficientPrivilege):
+                store.put(record_b)
+        finally:
+            reset_current_tenant(token)
+
+        token = set_current_tenant(tenant_b)
+        try:
+            store.put(record_b)
+            second = store.get(tenant_b, record_b.id)
+            leaked = store.get(tenant_a, record_a.id)
+        finally:
+            reset_current_tenant(token)
+        assert second is not None, "tenant B's write was lost after tenant A's rejection"
+        assert second.tenant_id == tenant_b
+        assert leaked is None, "cloud_connections RLS leaked tenant A's row into a session bound to tenant B"
+    finally:
+        for tenant_id, connection_id in ((tenant_a, record_a.id), (tenant_b, record_b.id)):
+            token = set_current_tenant(tenant_id)
+            try:
+                store.delete(tenant_id, connection_id)
+            finally:
+                reset_current_tenant(token)
+
+
 def test_audit_append_persists_entry_tenant_under_mismatched_ambient_context():
     """Regression for #4276: proxy-header auth emits its audit event BEFORE the
     request tenant context is installed, so ``append`` runs while the ambient


### PR DESCRIPTION
## Summary

- Widen the `postgres` path filter in `ci.yml` so the **Postgres Integration Contract** job runs for every module that writes through the tenant-RLS connection helper and for the callers that bind the tenant context around such a write. The old filter matched only `src/agent_bom/api/postgres_*`, `storage_schema.py`, `tests/test_postgres_*`, and `deploy/supabase/postgres/`.
- Add `tests/test_postgres_connection_rls_guard.py`: an always-on unit guard whose fake pool models the `cloud_connections_tenant_isolation` policy. It learns the guarded column from the `WITH CHECK` clause the store's own DDL emits, tracks the `app.tenant_id` / `app.bypass_rls` settings that `_apply_tenant_session` writes, and rejects an insert whose `tenant_id` differs from the bound tenant. No container required.
- Add the live counterpart to `tests/test_postgres_integration.py`: the owner's scheduled write round-trips, the unbound write raises the real `psycopg.errors.InsufficientPrivilege`, and one tenant's rejection does not stop the next tenant's write.

### What the filter now includes, and what it does not

Included, because each one either writes through `_tenant_connection` or binds the tenant context for such a write:

| Path | Why |
|---|---|
| `src/agent_bom/api/connection_scheduler.py` | binds `set_current_tenant` around the scheduler's writes |
| `src/agent_bom/cloud/*event_ingest.py` | the continuous drain calls `store.put()` under that binding (aws/azure/gcp) |
| `src/agent_bom/cloud/runtime_workload_evidence_store.py` | own `_tenant_connection` wrapper; already covered by a test in this job |
| `src/agent_bom/ticketing/postgres_store.py` | 11 `_tenant_connection` write sites outside the `api/postgres_` prefix |
| `src/agent_bom/api/proxy_replay_store.py` | imports `_tenant_connection` for its writes |
| `src/agent_bom/api/connection_store.py` | `postgres_connection.py` implements its write/read path in terms of this module's record and row decoders |

Deliberately excluded: `src/agent_bom/api/middleware.py` and `src/agent_bom/api/pipeline.py`. Both bind the tenant on the request/job path, but no test in `tests/test_postgres_integration.py` drives the ASGI app or the pipeline against a real server, so the job cannot observe a regression there — gating two very hot files would cost CI time for no added signal. Worth revisiting if an app-level integration test lands.

## Verification

**Behavioural proof of the filter.** The exact `grep -Eq` expression is extracted from `ci.yml` and run against candidate paths, before and after:

Before:

```
extracted regex: ^(src/agent_bom/api/postgres_|src/agent_bom/api/storage_schema\.py|tests/test_postgres_|deploy/supabase/postgres/)

postgres=false  src/agent_bom/api/connection_scheduler.py
postgres=false  src/agent_bom/cloud/event_ingest.py
postgres=false  src/agent_bom/cloud/azure_event_ingest.py
postgres=false  src/agent_bom/cloud/gcp_event_ingest.py
postgres=false  src/agent_bom/cloud/runtime_workload_evidence_store.py
postgres=false  src/agent_bom/ticketing/postgres_store.py
postgres=false  src/agent_bom/api/proxy_replay_store.py
postgres=false  src/agent_bom/api/connection_store.py
```

After:

```
postgres=true   src/agent_bom/api/connection_scheduler.py
postgres=true   src/agent_bom/cloud/event_ingest.py
postgres=true   src/agent_bom/cloud/azure_event_ingest.py
postgres=true   src/agent_bom/cloud/gcp_event_ingest.py
postgres=true   src/agent_bom/cloud/runtime_workload_evidence_store.py
postgres=true   src/agent_bom/ticketing/postgres_store.py
postgres=true   src/agent_bom/api/proxy_replay_store.py
postgres=true   src/agent_bom/api/connection_store.py
postgres=true   src/agent_bom/api/postgres_graph.py
postgres=true   tests/test_postgres_connection_rls_guard.py
postgres=true   deploy/supabase/postgres/alembic/versions/20260724_02_cloud_connections_scope_columns.py
postgres=false  src/agent_bom/api/middleware.py
postgres=false  src/agent_bom/api/pipeline.py
postgres=false  src/agent_bom/scanner_drivers.py
postgres=false  src/agent_bom/cloud/aws_inventory.py
postgres=false  ui/app/page.tsx
postgres=false  docs/CLOUD_CONNECT.md
```

Pre-existing matches still match and unrelated paths still do not, so unrelated PRs stay fast.

**The blind spot the new fake closes.** Running `PostgresConnectionStore.put` with no tenant bound (the pre-#4452 shape) against each fake, with the real `_tenant_connection` in play both times:

```
parity fake  -> unbound put SUCCEEDED (blind spot: no RLS semantics)
RLS-modelling fake -> unbound put REJECTED: new row violates row-level security policy for table "cloud_connections"
```

**Unit guard red/green.** Green as shipped (6 passed). Mutating the fake so `_row_matches_policy` always returns true — simulating a policy that lost its `WITH CHECK` half — turns exactly the guard assertions red:

```
FAILED test_put_without_a_bound_tenant_is_rejected_by_the_with_check_clause - Failed: DID NOT RAISE
FAILED test_put_bound_to_another_tenant_is_rejected - Failed: DID NOT RAISE
FAILED test_a_bound_tenant_cannot_read_another_tenants_connection - AssertionError
3 failed, 3 passed
```

**Live Postgres.** CI's topology reproduced locally (`postgres:16-alpine`, `agent_bom_app` as `NOSUPERUSER NOBYPASSRLS` and DML-only, `alembic upgrade head`), so the new integration test was run rather than skipped:

```
uv run pytest tests/test_postgres_integration.py -q   ->  12 passed, 11 warnings in 5.40s
```

Its unbound-write assertion was mutation-checked too — binding the tenant in that step yields `Failed: DID NOT RAISE InsufficientPrivilege`, confirming the rejection follows from the missing binding and not from something incidental. The test also cleans up after itself and passes on a repeat run against the same database.

**Gates.**

```
uv run pytest -q tests/test_postgres_connection_parity.py          ->  2 passed
uv run pytest -q tests/test_postgres_connection_rls_guard.py       ->  6 passed
uv run pytest -q tests/test_postgres_integration.py                ->  12 skipped (no AGENT_BOM_POSTGRES_URL locally)
uv run pytest -q tests/test_db_persistence_consistency.py tests/test_hub_ingest_atomic.py \
  tests/test_risk_campaigns.py tests/test_findings_status_filter.py \
  tests/test_connection_scheduler.py                               ->  123 passed, 4 skipped
python -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"  ->  ci.yml parses
actionlint .github/workflows/ci.yml                                ->  clean
uv run ruff check / ruff format --check <touched files>            ->  clean
pre-commit run --files <touched files>                             ->  all hooks pass
git diff --check                                                   ->  clean
```

## Notes

- The **Postgres Integration Contract** job was skipped on #4452 — the PR that fixed the `cloud_connections` RLS violation in the scheduler. Any future scheduler-only regression would have been equally invisible; that is the gap this closes.
- Simply removing the `_tenant_connection` monkeypatch from `tests/test_postgres_connection_parity.py` does **not** catch this defect class. That fake has no RLS semantics: it absorbs the `set_config` calls and stores the row regardless, so the unbound `put` still succeeds (first output block above). The policy has to be modelled, which is what the new fake does — and it learns the predicate from the store's own DDL, so it stops enforcing loudly rather than silently if the `WITH CHECK` clause is ever dropped.
- The unit fake raises its own `InsufficientPrivilegeError` because psycopg is an optional extra absent from the always-on test job. The real `psycopg.errors.InsufficientPrivilege` is pinned by the integration test.
- Depends on #4451 (the `inventory_scope` / `scan_mode` / `auto_scan_on_create` columns), which is already merged; this branch is cut from that commit.
