### PR TITLE
fix(sarif): carry advisory description and remediation into exported rules

### DIFF
--- a/src/agent_bom/output/advisory_text.py
+++ b/src/agent_bom/output/advisory_text.py
@@ -1,0 +1,100 @@
+"""Export-side sanitization for published advisory prose.
+
+Advisory text — OSV/NVD vulnerability summaries, CIS benchmark remediation
+guidance, IaC rule messages — is upstream *published* data. It is not captured
+runtime evidence, so it must not be routed through
+:func:`agent_bom.evidence.redact_for_persistence`: that redactor's tier-A
+allowlist protects the runtime-capture path by dropping every field name it
+does not recognise, and ``description`` / ``recommendation`` are deliberately
+absent from it. Sending advisory prose through it discarded the text wholesale.
+
+Export still needs defensive redaction, so this module applies it directly:
+credential-shaped substrings, credentials and query strings inside URLs,
+absolute filesystem paths, e-mail addresses, control characters, and disguised
+Markdown links are removed, and the result is length-capped.
+
+The split is by provenance, not by output format. Scanner free text that can
+quote the repository being scanned — SAST and secret finding descriptions,
+model-authored triage rationale — is *not* advisory prose and keeps the
+conservative allowlist at its own call sites.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from agent_bom.security import sanitize_path_label, sanitize_sensitive_payload
+
+ADVISORY_TEXT_MAX_LEN = 1000
+ADVISORY_HELP_MAX_LEN = 4000
+
+# Absolute filesystem paths embedded mid-sentence are scanning-host detail, not
+# published advisory content. The lookbehind keeps URL paths (preceded by ``:``
+# or ``/``) and relative traversal such as ``../../etc/passwd`` intact, and the
+# ``{2,}`` floor keeps single generic roots like ``/tmp`` readable.
+_EMBEDDED_ABSOLUTE_PATH_RE = re.compile(r"(?<![\w:/~.\-])(?:(?:/[\w.\-+@]+){2,}/?|[A-Za-z]:[\\/][\w.\-+@]+(?:[\\/][\w.\-+@]+)*)")
+
+# A Markdown link lets an advisory render arbitrary text over an attacker-chosen
+# target in GitHub's alert pane. Keep the label, drop the target; a bare URL is
+# left alone because the reader can see where it points.
+_MARKDOWN_LINK_RE = re.compile(r"!?\[([^\]]*)\]\([^)]*\)")
+
+# Only an http(s) URI with no Markdown-significant characters is safe to inline
+# as a link target; anything else would let the target break out of ``(...)``.
+_SAFE_LINK_URI_RE = re.compile(r"https?://[^\s()\[\]<>\"'\\]+\Z")
+
+
+def sanitize_advisory_text(
+    field_name: str,
+    value: Any,
+    *,
+    fallback: str = "",
+    max_len: int = ADVISORY_TEXT_MAX_LEN,
+) -> str:
+    """Return *value* as advisory prose that is safe to publish in an export.
+
+    ``field_name`` is passed to :func:`sanitize_sensitive_payload` as a key hint
+    so URL-, path-, and secret-named fields get their stricter treatment.
+    Returns *fallback* when nothing survives sanitization.
+    """
+    sanitized = sanitize_sensitive_payload(str(value or ""), key=field_name, max_str_len=max_len)
+    text = _EMBEDDED_ABSOLUTE_PATH_RE.sub(lambda match: sanitize_path_label(match.group(0)), str(sanitized))
+    text = _MARKDOWN_LINK_RE.sub(r"\1", text).strip()
+    return text[:max_len] if text else fallback
+
+
+def advisory_help(
+    description: str,
+    *,
+    remediation: str = "",
+    reference_uri: str = "",
+    max_len: int = ADVISORY_HELP_MAX_LEN,
+) -> dict[str, str] | None:
+    """Build a SARIF ``help`` object, or ``None`` when there is nothing to say.
+
+    SARIF 2.1.0 §3.49.13 defines ``reportingDescriptor.help`` as a
+    multiformatMessageString (``text`` required, ``markdown`` optional); GitHub
+    code scanning renders it as the alert detail pane. *description* and
+    *remediation* must already be sanitized. *reference_uri* becomes the only
+    link in the pane, and is dropped unless it is a plain http(s) URI — an
+    upstream-supplied target carrying ``)`` would otherwise break out of the
+    Markdown link and render an advisory-controlled one.
+    """
+    body = (description or "").strip()
+    if not body:
+        return None
+    plain = [body]
+    markdown = [body]
+    fix = (remediation or "").strip()
+    if fix and fix != body:
+        plain.append(f"Remediation: {fix}")
+        markdown.append(f"**Remediation:** {fix}")
+    reference = (reference_uri or "").strip()
+    if _SAFE_LINK_URI_RE.fullmatch(reference):
+        plain.append(f"Reference: {reference}")
+        markdown.append(f"[Reference]({reference})")
+    return {
+        "text": "\n\n".join(plain)[:max_len],
+        "markdown": "\n\n".join(markdown)[:max_len],
+    }

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -16,6 +16,7 @@ from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.exploitability import exploitability_tags, parse_cvss_vector_signals
 from agent_bom.finding import Finding, FindingType
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
+from agent_bom.output.advisory_text import advisory_help, sanitize_advisory_text
 from agent_bom.output.exposure_path import (
     exposure_path_blast_summary,
     exposure_path_chain,
@@ -30,7 +31,7 @@ from agent_bom.output.finding_views import (
     package_name,
     package_version,
 )
-from agent_bom.security import sanitize_sensitive_payload, sanitize_text
+from agent_bom.security import sanitize_sensitive_payload, sanitize_text, sanitize_url
 
 _SARIF_SEVERITY_MAP = {
     Severity.CRITICAL: "error",
@@ -158,20 +159,40 @@ def _to_relative_path(path: str, ecosystem: Optional[str] = None) -> str:
 
 
 def _sanitize_sarif_property(value: Any) -> Any:
-    """Apply final defensive redaction before data leaves via SARIF."""
+    """Apply final defensive redaction before data leaves via SARIF.
+
+    Property bags carry arbitrary nested evidence — scanner payloads, runtime
+    capture, provenance — so they keep the conservative tier-A allowlist.
+    """
     sanitized = sanitize_sensitive_payload(value, max_str_len=1000)
     if isinstance(sanitized, str):
         return None
     return redact_for_persistence({"details": sanitized}, EvidenceTier.SAFE_TO_STORE).get("details")
 
 
-def _sanitize_sarif_text(field_name: str, value: Any, *, fallback: str = "") -> str:
-    """Redact free-text SARIF fields using the two-bucket persistence policy."""
+def _sanitize_scanner_text(field_name: str, value: Any, *, fallback: str = "") -> str:
+    """Redact scanner free text that may quote the scanned workspace.
+
+    Descriptions on the unified finding path (SAST, secret, credential
+    exposure) and model-authored triage rationale can echo source lines out of
+    the repository being scanned, so they stay behind the conservative tier-A
+    allowlist: the field name is not on it, the text is dropped, and the caller
+    falls back to the structural title. Published advisory prose is a different
+    provenance and uses :func:`sanitize_advisory_text` instead.
+    """
     sanitized = sanitize_sensitive_payload(str(value or ""), key=field_name, max_str_len=1000)
     redacted = redact_for_persistence({field_name: sanitized}, EvidenceTier.SAFE_TO_STORE).get(field_name)
     if redacted is None:
         return fallback
     return str(redacted)
+
+
+def _cis_remediation_text(remediation: Any) -> str:
+    """Flatten a CIS remediation dict into one sanitized guidance line."""
+    if not isinstance(remediation, dict):
+        return ""
+    parts = [sanitize_advisory_text("recommendation", remediation.get(key)) for key in ("fix_cli", "fix_console")]
+    return " ".join(part for part in parts if part)
 
 
 def _exposure_related_locations(exposure_path: dict[str, Any]) -> list[dict]:
@@ -190,11 +211,11 @@ def _exposure_related_locations(exposure_path: dict[str, Any]) -> list[dict]:
                 "id": index,
                 "logicalLocations": [
                     {
-                        "fullyQualifiedName": _sanitize_sarif_text("title", hop, fallback=hop),
-                        "kind": _sanitize_sarif_text("title", kind or "node", fallback="node"),
+                        "fullyQualifiedName": sanitize_advisory_text("title", hop, fallback=hop),
+                        "kind": sanitize_advisory_text("title", kind or "node", fallback="node"),
                     }
                 ],
-                "message": {"text": _sanitize_sarif_text("title", name or hop, fallback=hop)},
+                "message": {"text": sanitize_advisory_text("title", name or hop, fallback=hop)},
             }
         )
     return related
@@ -479,22 +500,30 @@ def _ensure_cve_sarif_rule(
     tags = list(dict.fromkeys([*finding.cwe_ids, *exploitability_tags(parse_cvss_vector_signals(finding.cvss_vector))]))
     if tags:
         rule_props["tags"] = tags
-    rules.append(
-        {
-            "id": rule_id,
-            "shortDescription": {
-                "text": _sanitize_sarif_text(
-                    "title",
-                    f"{sev.value.upper()}: {rule_id} in {pkg_name}@{pkg_version}",
-                    fallback=f"{rule_id} package vulnerability",
-                )
-            },
-            "fullDescription": {"text": _sanitize_sarif_text("description", finding.description, fallback=f"Vulnerability {rule_id}")},
-            "helpUri": f"https://osv.dev/vulnerability/{rule_id}",
-            "defaultConfiguration": {"level": level},
-            "properties": rule_props,
-        }
+    advisory_uri = f"https://osv.dev/vulnerability/{rule_id}"
+    description = sanitize_advisory_text("description", finding.description, fallback=f"Vulnerability {rule_id}")
+    rule: dict[str, Any] = {
+        "id": rule_id,
+        "shortDescription": {
+            "text": sanitize_advisory_text(
+                "title",
+                f"{sev.value.upper()}: {rule_id} in {pkg_name}@{pkg_version}",
+                fallback=f"{rule_id} package vulnerability",
+            )
+        },
+        "fullDescription": {"text": description},
+        "helpUri": advisory_uri,
+        "defaultConfiguration": {"level": level},
+        "properties": rule_props,
+    }
+    help_body = advisory_help(
+        description,
+        remediation=sanitize_advisory_text("recommendation", finding.remediation_guidance),
+        reference_uri=advisory_uri,
     )
+    if help_body:
+        rule["help"] = help_body
+    rules.append(rule)
 
 
 def _ai_assessment_result_properties(assessment: Any) -> dict[str, Any]:
@@ -512,7 +541,7 @@ def _ai_assessment_result_properties(assessment: Any) -> dict[str, Any]:
     }
     rationale = (assessment.rationale or "").strip()
     if rationale:
-        props["agent-bom:ai_rationale"] = _sanitize_sarif_text("description", rationale, fallback="")
+        props["agent-bom:ai_rationale"] = _sanitize_scanner_text("description", rationale, fallback="")
     if assessment.suggested_controls:
         props["agent-bom:ai_suggested_controls"] = list(assessment.suggested_controls)
     return props
@@ -546,7 +575,7 @@ def _cve_sarif_result(
         "ruleId": rule_id,
         "level": level,
         "kind": kind,
-        "message": {"text": _sanitize_sarif_text("title", message_text, fallback=f"{rule_id} package vulnerability")},
+        "message": {"text": sanitize_advisory_text("title", message_text, fallback=f"{rule_id} package vulnerability")},
         **_sarif_fingerprint_fields(stable_input=fp_input, artifact_uri=config_path, start_line=1),
         "locations": [
             {
@@ -588,7 +617,7 @@ def _cve_sarif_result(
         "ai_summary": finding.ai_summary,
         "suppressed": bool(finding.suppressed),
         "is_malicious": finding.is_malicious,
-        "malicious_reason": (_sanitize_sarif_text("title", finding.malicious_reason) or None) if finding.malicious_reason else None,
+        "malicious_reason": (sanitize_advisory_text("title", finding.malicious_reason) or None) if finding.malicious_reason else None,
     }
     if finding.fixed_version:
         result_properties["fixed_version"] = finding.fixed_version
@@ -726,25 +755,29 @@ def to_sarif(
         level = finding_sev_map.get(finding_severity_name, "warning")
         if rule_id not in seen_rule_ids:
             seen_rule_ids.add(rule_id)
-            rules.append(
-                {
-                    "id": rule_id,
-                    "shortDescription": {"text": _sanitize_sarif_text("title", finding.finding_type.value.replace("_", " ").title())},
-                    "fullDescription": {
-                        "text": _sanitize_sarif_text(
-                            "description",
-                            finding.description,
-                            fallback=_sanitize_sarif_text("title", finding.title or finding.finding_type.value),
-                        )
-                    },
-                    "defaultConfiguration": {"level": level},
-                    "properties": {
-                        "security-severity": finding_sev_score.get(finding_severity_name, "4.0"),
-                        "source": finding.source.value,
-                        "finding_type": finding.finding_type.value,
-                    },
-                }
+            description = _sanitize_scanner_text(
+                "description",
+                finding.description,
+                fallback=sanitize_advisory_text("title", finding.title or finding.finding_type.value),
             )
+            finding_rule: dict[str, Any] = {
+                "id": rule_id,
+                "shortDescription": {"text": sanitize_advisory_text("title", finding.finding_type.value.replace("_", " ").title())},
+                "fullDescription": {"text": description},
+                "defaultConfiguration": {"level": level},
+                "properties": {
+                    "security-severity": finding_sev_score.get(finding_severity_name, "4.0"),
+                    "source": finding.source.value,
+                    "finding_type": finding.finding_type.value,
+                },
+            }
+            help_body = advisory_help(
+                description,
+                remediation=_sanitize_scanner_text("recommendation", finding.remediation_guidance),
+            )
+            if help_body:
+                finding_rule["help"] = help_body
+            rules.append(finding_rule)
 
         file_path = _to_relative_path(
             finding.asset.location or "agent-bom-report.json",
@@ -756,10 +789,10 @@ def to_sarif(
             "level": level,
             "kind": "fail" if level in {"error", "warning"} else "informational",
             "message": {
-                "text": _sanitize_sarif_text(
+                "text": sanitize_advisory_text(
                     "title",
                     finding.title,
-                    fallback=_sanitize_sarif_text("description", finding.description, fallback=finding.finding_type.value),
+                    fallback=_sanitize_scanner_text("description", finding.description, fallback=finding.finding_type.value),
                 )
             },
             **_sarif_fingerprint_fields(stable_input=fp_input, artifact_uri=file_path, start_line=1),
@@ -774,11 +807,13 @@ def to_sarif(
             "properties": {
                 "risk_score": finding.risk_score,
                 "asset_type": finding.asset.asset_type,
-                "asset_name": _sanitize_sarif_text("title", finding.asset.name, fallback=finding.asset.asset_type),
+                "asset_name": sanitize_advisory_text("title", finding.asset.name, fallback=finding.asset.asset_type),
                 "evidence": _sanitize_sarif_property(finding.evidence),
                 "remediation_guidance": _sanitize_sarif_property(finding.remediation_guidance),
                 "is_malicious": finding.is_malicious,
-                "malicious_reason": (_sanitize_sarif_text("title", finding.malicious_reason) or None) if finding.malicious_reason else None,
+                "malicious_reason": (sanitize_advisory_text("title", finding.malicious_reason) or None)
+                if finding.malicious_reason
+                else None,
                 # Structured reach lists + AI-native context (unified Finding parity).
                 "affected_servers": list(finding.affected_servers),
                 "affected_agents": list(finding.affected_agents),
@@ -792,8 +827,7 @@ def to_sarif(
                     {
                         "workload_runtime_evidence": _sanitize_sarif_property(finding.workload_runtime_evidence),
                     }
-                    if isinstance(getattr(finding, "workload_runtime_evidence", None), dict)
-                    and finding.workload_runtime_evidence
+                    if isinstance(getattr(finding, "workload_runtime_evidence", None), dict) and finding.workload_runtime_evidence
                     else {}
                 ),
             },
@@ -817,25 +851,29 @@ def to_sarif(
 
             if rule_id not in seen_rule_ids:
                 seen_rule_ids.add(rule_id)
-                rules.append(
-                    {
-                        "id": rule_id,
-                        "shortDescription": {"text": _sanitize_sarif_text("title", iac_finding.get("title", rule_id), fallback=rule_id)},
-                        "fullDescription": {
-                            "text": _sanitize_sarif_text(
-                                "description",
-                                iac_finding.get("message"),
-                                fallback=_sanitize_sarif_text("title", iac_finding.get("title", rule_id), fallback=rule_id),
-                            )
-                        },
-                        "defaultConfiguration": {"level": level},
-                        "properties": {
-                            "security-severity": iac_sev_score.get(sev, "4.0"),
-                            "category": iac_finding.get("category", "iac"),
-                            "compliance": iac_finding.get("compliance", []),
-                        },
-                    }
+                description = sanitize_advisory_text(
+                    "description",
+                    iac_finding.get("message"),
+                    fallback=sanitize_advisory_text("title", iac_finding.get("title", rule_id), fallback=rule_id),
                 )
+                iac_rule: dict[str, Any] = {
+                    "id": rule_id,
+                    "shortDescription": {"text": sanitize_advisory_text("title", iac_finding.get("title", rule_id), fallback=rule_id)},
+                    "fullDescription": {"text": description},
+                    "defaultConfiguration": {"level": level},
+                    "properties": {
+                        "security-severity": iac_sev_score.get(sev, "4.0"),
+                        "category": iac_finding.get("category", "iac"),
+                        "compliance": iac_finding.get("compliance", []),
+                    },
+                }
+                help_body = advisory_help(
+                    description,
+                    remediation=sanitize_advisory_text("recommendation", iac_finding.get("remediation")),
+                )
+                if help_body:
+                    iac_rule["help"] = help_body
+                rules.append(iac_rule)
 
             fp_input = f"{rule_id}:{file_path}:{line_num}"
             results.append(
@@ -844,10 +882,10 @@ def to_sarif(
                     "level": level,
                     "kind": "fail",
                     "message": {
-                        "text": _sanitize_sarif_text(
+                        "text": sanitize_advisory_text(
                             "description",
                             iac_finding.get("message"),
-                            fallback=_sanitize_sarif_text("title", iac_finding.get("title", "IaC misconfiguration")),
+                            fallback=sanitize_advisory_text("title", iac_finding.get("title", "IaC misconfiguration")),
                         )
                     },
                     **_sarif_fingerprint_fields(stable_input=fp_input, artifact_uri=file_path, start_line=line_num),
@@ -880,28 +918,30 @@ def to_sarif(
 
             if rule_id not in seen_rule_ids:
                 seen_rule_ids.add(rule_id)
-                rules.append(
-                    {
-                        "id": rule_id,
-                        "shortDescription": {
-                            "text": _sanitize_sarif_text("title", f"{sev.upper()}: {comp_type.replace('_', ' ')} - {name}")
-                        },
-                        "fullDescription": {
-                            "text": _sanitize_sarif_text(
-                                "description",
-                                comp.get("description", ""),
-                                fallback=f"AI component finding: {name}",
-                            )
-                        },
-                        "defaultConfiguration": {"level": level},
-                        "properties": {"security-severity": ai_sev_score.get(sev, "0.0")},
-                    }
+                description = sanitize_advisory_text(
+                    "description",
+                    comp.get("description", ""),
+                    fallback=f"AI component finding: {name}",
                 )
+                ai_rule: dict[str, Any] = {
+                    "id": rule_id,
+                    "shortDescription": {"text": sanitize_advisory_text("title", f"{sev.upper()}: {comp_type.replace('_', ' ')} - {name}")},
+                    "fullDescription": {"text": description},
+                    "defaultConfiguration": {"level": level},
+                    "properties": {"security-severity": ai_sev_score.get(sev, "0.0")},
+                }
+                help_body = advisory_help(
+                    description,
+                    remediation=sanitize_advisory_text("recommendation", comp.get("recommendation")),
+                )
+                if help_body:
+                    ai_rule["help"] = help_body
+                rules.append(ai_rule)
 
             file_path = _to_relative_path(comp.get("file", "unknown") or "unknown")
             line_num = int(comp.get("line", 1) or 1)
             fp_input = f"{rule_id}:{file_path}:{line_num}"
-            desc = _sanitize_sarif_text("description", comp.get("description", ""), fallback=f"{comp_type.replace('_', ' ')}: {name}")
+            desc = sanitize_advisory_text("description", comp.get("description", ""), fallback=f"{comp_type.replace('_', ' ')}: {name}")
             results.append(
                 {
                     "ruleId": rule_id,
@@ -939,26 +979,25 @@ def to_sarif(
             level = cis_sev_map.get(cis_severity, "warning")
             remediation = check.get("remediation") or {}
             title = check.get("title") or rule_id
-            help_uri = remediation.get("docs") or ""
+            help_uri = sanitize_url(str(remediation.get("docs") or "")) or ""
 
             if rule_id not in seen_rule_ids:
                 seen_rule_ids.add(rule_id)
+                recommendation = sanitize_advisory_text(
+                    "recommendation",
+                    check.get("recommendation"),
+                    fallback=sanitize_advisory_text("title", title, fallback=rule_id),
+                )
                 cis_rule: dict = {
                     "id": rule_id,
                     "shortDescription": {
-                        "text": _sanitize_sarif_text(
+                        "text": sanitize_advisory_text(
                             "title",
                             f"{cis_severity.upper()}: CIS {cloud_key.upper()} {check_id} - {title}",
                             fallback=rule_id,
                         )
                     },
-                    "fullDescription": {
-                        "text": _sanitize_sarif_text(
-                            "recommendation",
-                            check.get("recommendation"),
-                            fallback=_sanitize_sarif_text("title", title, fallback=rule_id),
-                        )
-                    },
+                    "fullDescription": {"text": recommendation},
                     "defaultConfiguration": {"level": level},
                     "properties": {
                         "security-severity": cis_sev_score.get(cis_severity, "4.0"),
@@ -968,6 +1007,13 @@ def to_sarif(
                 }
                 if help_uri:
                     cis_rule["helpUri"] = help_uri
+                help_body = advisory_help(
+                    recommendation,
+                    remediation=_cis_remediation_text(remediation),
+                    reference_uri=help_uri,
+                )
+                if help_body:
+                    cis_rule["help"] = help_body
                 rules.append(cis_rule)
 
             # Synthetic fingerprint so repeat runs produce stable IDs.
@@ -999,7 +1045,7 @@ def to_sarif(
                     "level": level,
                     "kind": "fail",
                     "message": {
-                        "text": _sanitize_sarif_text(
+                        "text": sanitize_advisory_text(
                             "title",
                             f"CIS {cloud_key.upper()} {check_id} failed: {title}",
                             fallback=rule_id,

--- a/tests/test_sarif_advisory_text.py
+++ b/tests/test_sarif_advisory_text.py
@@ -1,0 +1,411 @@
+"""Advisory prose must survive SARIF export (regression for released 0.97.5).
+
+Every exported SARIF rule carried a placeholder ``fullDescription`` of the form
+``Vulnerability CVE-2020-14343``: the exporter routed advisory text through the
+runtime-evidence tier-A allowlist, which drops any field name it does not know
+— and ``description`` / ``recommendation`` are deliberately absent from that
+allowlist. The result was a useless body on every GitHub code-scanning alert.
+
+Public advisory prose (OSV/NVD summaries, CIS remediation guidance) is upstream
+published data, not captured runtime evidence, so the exporter sanitizes it
+directly instead of routing it through the persistence redactor. The split is
+by provenance: scanner text that can quote the scanned repository stays behind
+the allowlist, and the closing tests pin both halves — the workspace guard and
+the unchanged runtime-evidence redactor.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft7Validator
+
+from agent_bom.evidence import EvidenceTier, redact_for_persistence
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.models import (
+    Agent,
+    AgentType,
+    AIBOMReport,
+    BlastRadius,
+    Package,
+    Severity,
+    Vulnerability,
+)
+from agent_bom.output.sarif import to_sarif
+
+_SCHEMA_PATH = Path(__file__).parent / "fixtures" / "sarif-schema-2.1.0.json"
+
+_CVE_SUMMARY = "PyYAML arbitrary code execution via yaml.full_load on untrusted input"
+_CIS_RECOMMENDATION = "Remove the root account access key and use short-lived role credentials instead."
+_IAC_MESSAGE = "No USER directive; the container runs as root."
+_AI_INVENTORY_DESCRIPTION = "text-davinci-003 is deprecated and no longer receives security fixes."
+_SECRET_DESCRIPTION = "An AWS secret access key was committed to the repository."
+
+
+def _report(*, cve_summary: str = _CVE_SUMMARY) -> AIBOMReport:
+    """A report spanning every SARIF rule family that carries advisory prose."""
+    vuln = Vulnerability(
+        id="CVE-2020-14343",
+        summary=cve_summary,
+        severity=Severity.CRITICAL,
+        cvss_score=9.8,
+        fixed_version="5.4",
+        cwe_ids=["CWE-94"],
+    )
+    pkg = Package(
+        name="pyyaml",
+        version="5.3.1",
+        ecosystem="pypi",
+        purl="pkg:pypi/pyyaml@5.3.1",
+        vulnerabilities=[vuln],
+        is_direct=True,
+    )
+    agent = Agent(
+        name="claude-desktop",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/claude-desktop.json",
+        mcp_servers=[],
+        version="1.0",
+    )
+    blast_radius = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[],
+        affected_agents=[agent],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    blast_radius.calculate_risk_score()
+
+    secret_finding = Finding(
+        finding_type=FindingType.CREDENTIAL_EXPOSURE,
+        source=FindingSource.FILESYSTEM,
+        asset=Asset(name="config.env", asset_type="package", location="/tmp/app/config.env"),
+        severity="high",
+        title="Hardcoded AWS secret key",
+        description=_SECRET_DESCRIPTION,
+        risk_score=8.0,
+    )
+
+    report = AIBOMReport(
+        agents=[agent],
+        blast_radii=[blast_radius],
+        findings=[secret_finding],
+        scan_sources=["agent_discovery"],
+        scan_id="advisory-text-001",
+    )
+    report.iac_findings_data = {
+        "findings": [
+            {
+                "rule_id": "DKR-001",
+                "severity": "high",
+                "file_path": "/tmp/app/Dockerfile",
+                "line_number": 3,
+                "title": "Container runs as root",
+                "message": _IAC_MESSAGE,
+                "category": "iac",
+            }
+        ]
+    }
+    report.cis_benchmark_data = {
+        "checks": [
+            {
+                "check_id": "1.4",
+                "status": "fail",
+                "severity": "high",
+                "title": "Ensure no root account access key exists",
+                "recommendation": _CIS_RECOMMENDATION,
+                "cis_section": "1.4",
+                "resource_ids": ["arn:aws:iam::123456789012:root"],
+                "remediation": {
+                    "docs": "https://docs.aws.amazon.com/iam",
+                    "fix_cli": "aws iam delete-access-key --user-name root",
+                    "effort": "low",
+                    "priority": 1,
+                },
+            }
+        ]
+    }
+    report.ai_inventory_data = {
+        "components": [
+            {
+                "type": "deprecated_model",
+                "severity": "medium",
+                "name": "text-davinci-003",
+                "file": "/tmp/app/llm.py",
+                "line": 12,
+                "description": _AI_INVENTORY_DESCRIPTION,
+            }
+        ]
+    }
+    return report
+
+
+def _rules(doc: dict) -> dict[str, dict]:
+    return {rule["id"]: rule for rule in doc["runs"][0]["tool"]["driver"]["rules"]}
+
+
+@pytest.fixture(scope="module")
+def sarif_doc() -> dict:
+    return to_sarif(_report())
+
+
+@pytest.fixture(scope="module")
+def rules(sarif_doc: dict) -> dict[str, dict]:
+    return _rules(sarif_doc)
+
+
+# ─── fullDescription carries real advisory prose, never the fallback ────────
+
+
+def test_cve_rule_full_description_is_the_advisory_summary(rules: dict[str, dict]) -> None:
+    """The headline defect: every CVE rule body was ``Vulnerability <id>``."""
+    text = rules["CVE-2020-14343"]["fullDescription"]["text"]
+    assert text == _CVE_SUMMARY
+    assert text != "Vulnerability CVE-2020-14343"
+
+
+def test_no_rule_falls_back_to_a_placeholder_body(rules: dict[str, dict]) -> None:
+    placeholders = {
+        rule_id: rule["fullDescription"]["text"]
+        for rule_id, rule in rules.items()
+        if rule.get("fullDescription", {}).get("text", "").startswith("Vulnerability ")
+    }
+    assert not placeholders, f"rules still emit placeholder bodies: {placeholders}"
+
+
+def test_cis_rule_full_description_is_the_recommendation(rules: dict[str, dict]) -> None:
+    assert rules["cis/aws/1.4"]["fullDescription"]["text"] == _CIS_RECOMMENDATION
+
+
+def test_unified_finding_rule_falls_back_to_its_title(rules: dict[str, dict]) -> None:
+    """SAST/secret descriptions can quote the scanned repository, so the unified
+    finding path keeps the conservative allowlist and shows the title instead."""
+    rule = rules["finding/CREDENTIAL_EXPOSURE"]
+    assert rule["fullDescription"]["text"] == "Hardcoded AWS secret key"
+    assert _SECRET_DESCRIPTION not in json.dumps(rule)
+
+
+def test_iac_rule_full_description_is_the_message(rules: dict[str, dict]) -> None:
+    assert rules["iac/DKR-001"]["fullDescription"]["text"] == _IAC_MESSAGE
+
+
+def test_ai_inventory_rule_full_description_is_the_description(rules: dict[str, dict]) -> None:
+    rule_id = "ai-inventory/deprecated_model/text-davinci-003"
+    assert rules[rule_id]["fullDescription"]["text"] == _AI_INVENTORY_DESCRIPTION
+
+
+def test_iac_result_message_is_the_advisory_message(sarif_doc: dict) -> None:
+    [result] = [r for r in sarif_doc["runs"][0]["results"] if r["ruleId"] == "iac/DKR-001"]
+    assert result["message"]["text"] == _IAC_MESSAGE
+
+
+# ─── help: the GitHub alert detail pane (SARIF 2.1.0 §3.49.13) ──────────────
+
+
+def test_every_rule_carries_a_help_object(rules: dict[str, dict]) -> None:
+    missing = [rule_id for rule_id, rule in rules.items() if not rule.get("help", {}).get("text")]
+    assert not missing, f"rules without a help body: {missing}"
+
+
+def test_cve_rule_help_carries_description_and_remediation(rules: dict[str, dict]) -> None:
+    help_obj = rules["CVE-2020-14343"]["help"]
+    assert _CVE_SUMMARY in help_obj["text"]
+    # ``_vulnerability_remediation`` derives "Upgrade pyyaml to 5.4." for a
+    # fixable CVE; the detail pane must carry the fix, not just the problem.
+    assert "5.4" in help_obj["text"]
+    assert _CVE_SUMMARY in help_obj["markdown"]
+    assert "https://osv.dev/vulnerability/CVE-2020-14343" in help_obj["markdown"]
+
+
+def test_cis_rule_help_carries_remediation_command(rules: dict[str, dict]) -> None:
+    help_obj = rules["cis/aws/1.4"]["help"]
+    assert _CIS_RECOMMENDATION in help_obj["text"]
+    assert "aws iam delete-access-key --user-name root" in help_obj["text"]
+
+
+def test_help_reference_link_cannot_be_broken_out_of() -> None:
+    """A CIS ``remediation.docs`` URI is upstream data, so it is not inlined blindly."""
+    report = _report()
+    report.cis_benchmark_data["checks"][0]["remediation"]["docs"] = "https://evil.example.test/a)[click](javascript:alert(1))"
+
+    rule = _rules(to_sarif(report))["cis/aws/1.4"]
+
+    assert "[click](javascript:" not in rule["help"]["markdown"]
+    assert "evil.example.test" not in rule["help"]["markdown"]
+    assert "evil.example.test" not in rule["help"]["text"]
+    # The recommendation itself still renders.
+    assert _CIS_RECOMMENDATION in rule["help"]["markdown"]
+
+
+def test_document_with_help_is_schema_valid(sarif_doc: dict) -> None:
+    """``help`` is a multiformatMessageString on reportingDescriptor."""
+    validator = Draft7Validator(json.loads(_SCHEMA_PATH.read_text()))
+    errors = sorted(validator.iter_errors(sarif_doc), key=lambda e: list(e.path))
+    if errors:
+        rendered = "\n".join(f"  - {'/'.join(str(p) for p in e.path)}: {e.message}" for e in errors[:20])
+        pytest.fail(f"SARIF document is not schema-valid ({len(errors)} error(s)):\n{rendered}")
+
+
+# ─── Export-side sanitization of hostile advisory prose ─────────────────────
+
+
+def test_credential_shaped_advisory_text_is_redacted() -> None:
+    hostile = "Exploit proof: authenticate with AKIAIOSFODNN7EXAMPLE against the metadata service"
+    doc = to_sarif(_report(cve_summary=hostile))
+    text = _rules(doc)["CVE-2020-14343"]["fullDescription"]["text"]
+    assert "AKIAIOSFODNN7EXAMPLE" not in text
+    assert "REDACTED" in text
+    assert "AKIAIOSFODNN7EXAMPLE" not in json.dumps(doc)
+
+
+def test_advisory_url_credentials_and_query_are_stripped() -> None:
+    hostile = "Details at https://attacker:hunter2@evil.example.test/adv?token=abc123 for the writeup"
+    text = _rules(to_sarif(_report(cve_summary=hostile)))["CVE-2020-14343"]["fullDescription"]["text"]
+    assert "hunter2" not in text
+    assert "token=abc123" not in text
+    assert "evil.example.test" in text
+
+
+def test_advisory_absolute_paths_are_reduced_to_a_label() -> None:
+    hostile = "Reproduced by reading /Users/victim/.aws/credentials and /opt/app/settings.yml"
+    text = _rules(to_sarif(_report(cve_summary=hostile)))["CVE-2020-14343"]["fullDescription"]["text"]
+    assert "/Users/victim" not in text
+    assert "/opt/app" not in text
+    # A credential-shaped basename collapses further; a benign one keeps its name.
+    assert "<path:path>" in text
+    assert "<path:settings.yml>" in text
+
+
+def test_advisory_relative_paths_and_urls_keep_their_shape() -> None:
+    """Path scrubbing must not eat published advisory content."""
+    summary = "Traversal via ../../etc/passwd; see https://osv.dev/vulnerability/CVE-2020-14343"
+    text = _rules(to_sarif(_report(cve_summary=summary)))["CVE-2020-14343"]["fullDescription"]["text"]
+    assert "../../etc/passwd" in text
+    assert "https://osv.dev/vulnerability/CVE-2020-14343" in text
+
+
+def test_advisory_control_characters_are_stripped() -> None:
+    hostile = "Line one\r\nLine\x00two\x1b[31m red"
+    text = _rules(to_sarif(_report(cve_summary=hostile)))["CVE-2020-14343"]["fullDescription"]["text"]
+    assert "Line one" in text
+    assert "\n" not in text
+    assert "\x00" not in text
+    assert "\x1b" not in text
+
+
+def test_advisory_markdown_links_are_defanged() -> None:
+    """A hostile advisory cannot render its own disguised link in the alert pane."""
+    hostile = "Apply the [official patch](https://evil.example.test/payload) immediately"
+    rule = _rules(to_sarif(_report(cve_summary=hostile)))["CVE-2020-14343"]
+    assert "official patch" in rule["fullDescription"]["text"]
+    assert "evil.example.test" not in rule["fullDescription"]["text"]
+    assert "](https://evil.example.test/payload)" not in rule["help"]["markdown"]
+    # agent-bom's own reference link is the only one the pane renders.
+    assert "[Reference](https://osv.dev/vulnerability/CVE-2020-14343)" in rule["help"]["markdown"]
+
+
+def test_advisory_text_is_length_capped() -> None:
+    hostile = "A" * 20_000
+    rule = _rules(to_sarif(_report(cve_summary=hostile)))["CVE-2020-14343"]
+    assert len(rule["fullDescription"]["text"]) <= 1000
+    assert len(rule["help"]["text"]) <= 4000
+    assert len(rule["help"]["markdown"]) <= 4000
+
+
+def test_advisory_email_addresses_are_masked() -> None:
+    hostile = "Report issues to security@example.com for coordinated disclosure"
+    text = _rules(to_sarif(_report(cve_summary=hostile)))["CVE-2020-14343"]["fullDescription"]["text"]
+    assert "security@example.com" not in text
+    assert "s***@e***.com" in text
+
+
+# ─── Guard: workspace-quoting scanner text stays behind the allowlist ───────
+
+
+def test_scanner_description_quoting_the_workspace_is_still_dropped() -> None:
+    """The provenance split: published advisory text exports, scanner text does not."""
+    workspace_quote = "Detected in app.py: secret = 'copied-workspace-token'"
+    report = _report()
+    report.findings[0].description = workspace_quote
+    report.findings[0].remediation_guidance = f"Rotate {workspace_quote}"
+
+    encoded = json.dumps(to_sarif(report))
+
+    assert "copied-workspace-token" not in encoded
+    assert "Detected in app.py" not in encoded
+    # …while the CVE rule on the same report still carries its advisory prose.
+    assert _CVE_SUMMARY in encoded
+
+
+def test_runtime_evidence_redaction_still_drops_advisory_field_names() -> None:
+    """The export fix must not loosen the runtime-capture persistence tier.
+
+    ``description`` / ``recommendation`` stay off the tier-A allowlist: a proxy
+    or gateway capture that shovels prompt text into a field with one of those
+    names is still dropped before it reaches durable storage.
+    """
+    runtime_capture = {
+        "tenant_id": "acme",
+        "agent_id": "agent-7",
+        "tool_name": "fs.read",
+        "description": "user prompt text copied out of the workspace",
+        "recommendation": "model output suggesting a fix",
+        "prompt": "you are a helpful assistant",
+        "tool_output": "root:x:0:0:root:/root:/bin/bash",
+        "args": {"path": "/etc/passwd"},
+    }
+
+    redacted = redact_for_persistence(runtime_capture, EvidenceTier.SAFE_TO_STORE)
+
+    assert redacted == {"tenant_id": "acme", "agent_id": "agent-7", "tool_name": "fs.read"}
+    for dropped in ("description", "recommendation", "prompt", "tool_output", "args"):
+        assert dropped not in redacted, f"{dropped} must stay replay-only"
+
+
+def test_proxy_audit_chain_still_drops_runtime_payloads(tmp_path: Path) -> None:
+    """An end-to-end runtime persistence path, not just the redactor helper."""
+    from agent_bom.proxy_audit import RotatingAuditLog, write_audit_record
+
+    log_path = str(tmp_path / "audit.jsonl")
+    log = RotatingAuditLog(log_path)
+    try:
+        write_audit_record(
+            log,
+            {
+                "ts": "2026-07-24T12:00:00Z",
+                "type": "tools/call",
+                "tool": "fs.read",
+                "agent_id": "a-1",
+                "tenant_id": "acme",
+                "policy": "allowed",
+                "description": "free text captured off the wire",
+                "recommendation": "model-authored guidance",
+                "prompt": "this must be dropped",
+                "args": {"path": "/etc/passwd"},
+            },
+        )
+    finally:
+        log.close()
+
+    record = json.loads(Path(log_path).read_text().splitlines()[0])
+    for dropped in ("description", "recommendation", "prompt", "args"):
+        assert dropped not in record, f"{dropped} leaked into the proxy audit chain"
+    assert record["tool"] == "fs.read"
+    assert record["policy"] == "allowed"
+
+
+def test_sarif_property_bags_still_use_the_persistence_allowlist() -> None:
+    """Nested evidence dicts keep the conservative allowlist on export."""
+    from agent_bom.output.sarif import _sanitize_sarif_property
+
+    cleaned = _sanitize_sarif_property(
+        {
+            "tool_name": "fs.read",
+            "prompt": "captured runtime prompt",
+            "stdout": "captured process output",
+        }
+    )
+    assert cleaned == {"tool_name": "fs.read"}


### PR DESCRIPTION
## Summary

- Every exported SARIF rule carried a placeholder `fullDescription` of the form `Vulnerability CVE-2020-14343` and no `help` object, so every GitHub code-scanning alert agent-bom produces has a useless body and an empty detail pane. Present in released 0.97.5 — users have it now.
- Root cause: `output/sarif.py` routed advisory prose through `redact_for_persistence(..., EvidenceTier.SAFE_TO_STORE)`. That allowlist exists to protect the runtime-capture path and drops every field name it does not recognise; `description` and `recommendation` are deliberately absent from it, so the text was discarded unconditionally and the fallback always fired. The data was fine — the JSON report carries it verbatim; it just never reached the SARIF.
- Published advisory prose now uses a dedicated export sanitizer (`src/agent_bom/output/advisory_text.py`) instead of the persistence redactor, and rules gain a SARIF 2.1.0 `help` object carrying the description, the remediation, and the advisory reference.

## Verification

Demo scan, `AGENT_BOM_CONFIG=/nonexistent uv run agent-bom scan --demo --offline -f sarif`:

| | before | after |
|---|---|---|
| rules | 18 | 18 |
| placeholder `fullDescription` | **15** | **0** |
| rules with a `help` body | **0** | **18** |
| errors vs vendored SARIF 2.1.0 schema | 0 | 0 |

The new regression suite fails on the pre-fix tree — 15 of 23 red, including
`test_cve_rule_full_description_is_the_advisory_summary`
(`assert 'Vulnerability CVE-2020-14343' == 'PyYAML arbitrary code execution via yaml.full_load on untrusted input'`)
and `test_every_rule_carries_a_help_object`.

Commands run:

- `pytest tests/ -k "sarif"` — 152 passed, 1 skipped
- `pytest tests/ -k "redact or evidence_policy or persistence"` — 199 passed, 5 skipped
- `pytest` on all 25 test files that exercise `to_sarif` — 626 passed
- `ruff check` + `ruff format` on the touched files — clean
- `mypy src/agent_bom/output/sarif.py src/agent_bom/output/advisory_text.py src/agent_bom/evidence/policy.py` — no issues
- `make preflight` — passed
- `git diff --check` — clean

**Runtime evidence redaction is unchanged.** `src/agent_bom/evidence/policy.py` is not touched by this PR — the allowlist has the same 202 entries and `description` / `recommendation` are still off it. Three tests pin that: `test_runtime_evidence_redaction_still_drops_advisory_field_names`, `test_proxy_audit_chain_still_drops_runtime_payloads` (an end-to-end persistence path, not just the helper), and `test_sarif_property_bags_still_use_the_persistence_allowlist`. The pre-existing `tests/test_evidence_policy.py` suite passes unmodified.

## Notes

**Sanitization approach.** The split is by *provenance*, not by output format:

- **Published advisory prose** — OSV/NVD summaries, CIS benchmark recommendations, IaC rule messages, AI-inventory descriptions — is upstream published data, not captured runtime evidence, so it never belonged in the persistence redactor. It goes through `sanitize_advisory_text()`, which keeps the existing `sanitize_sensitive_payload` defences and adds path scrubbing, Markdown-link defanging, and a hard length cap.
- **Scanner free text that can quote the scanned repository** — SAST/secret/credential-exposure descriptions on the unified finding path, and model-authored triage rationale — keeps the conservative allowlist via `_sanitize_scanner_text()` and still falls back to the structural title. This preserves the existing tested guarantee in `test_pr_gate_sarif_action_contract.py` that copied workspace content never reaches an uploaded SARIF; both of those tests pass unmodified.
- **Property bags** (`_sanitize_sarif_property`) are unchanged and keep the allowlist, because they carry arbitrary nested evidence.

**What a hostile advisory string can and cannot do after this change.** It *cannot*: carry a credential (an AWS key, GitHub PAT, JWT, or high-entropy secret collapses the whole string to `***REDACTED***`); carry credentials or a query string inside a URL (stripped to scheme + host + path); disclose the scanning host's directory layout (absolute paths are reduced to `<path:basename>`, and a credential-shaped basename collapses further to `<path:path>`); inject control characters or ANSI escapes into a terminal (stripped); leak an e-mail address (masked to `a***@e***.com`); exceed 1000 characters per field or 4000 for the composed `help`; render a disguised Markdown link in the alert pane (`[label](target)` keeps the label and drops the target, and the one agent-bom-authored `[Reference](…)` link is only emitted for a plain `http(s)` URI with no Markdown-significant characters, so an upstream `remediation.docs` value carrying `)` cannot break out of it).

It *can*: place arbitrary printable prose into the alert body, including a visible bare URL that GitHub will autolink. GitHub renders `help.markdown` through its own sanitizer, so the worst case is misleading text or a link to an attacker-controlled domain the reader can see — a social-engineering surface, not code execution or exfiltration. This is the same exposure `shortDescription` already has today, and the trade is deliberate: the alternative is the shipped behaviour where the field is empty.

**Deliberate trade-off.** Absolute-path scrubbing means a remediation line mentioning `/etc/docker/daemon.json` renders as `<path:daemon.json>`. The basename keeps it intelligible, the verbatim command remains machine-readable in `properties.remediation.fix_cli`, and `helpUri` still points at the authoritative doc.

**Blast radius.** `src/agent_bom/output/skills_sarif.py` has the same helper shape, but its `detail` field embeds workspace snippets by construction (`skill_audit_behavior.py:623` formats `Detected in {filename}: "{snippet}"`), so the allowlist is correct there and it is left alone. Its unrelated raw `properties.context` passthrough is a separate issue and not bundled here.

**Spec.** `reportingDescriptor.help` is a `multiformatMessageString` (`text` required, `markdown` optional) per OASIS SARIF 2.1.0 §3.49.13, confirmed against the spec text and the vendored `tests/fixtures/sarif-schema-2.1.0.json`; the emitted document validates with zero errors.