### PR TITLE
fix(tests): restore full-suite lint compliance

### DIFF
--- a/tests/test_aws_org_scan_fanout.py
+++ b/tests/test_aws_org_scan_fanout.py
@@ -174,7 +174,11 @@ def _inv(account_id: str, *, status: str = "ok") -> dict:
 
 def test_inventory_fanout_merges_each_account(monkeypatch) -> None:
     monkeypatch.setattr(aws_inv, "inventory_enabled", lambda: True)
-    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile=None, *, force=False, session=None: ["111111111111", "222222222222"])
+    monkeypatch.setattr(
+        aws_orgs,
+        "list_member_account_ids",
+        lambda profile=None, *, force=False, session=None: ["111111111111", "222222222222"],
+    )
     monkeypatch.setattr(aws_orgs, "assume_account_session", lambda aid, **kw: f"session::{aid}")
 
     scanned: list[str] = []
@@ -316,7 +320,11 @@ def _cis_report(account_id: str) -> CISBenchmarkReport:
 
 
 def test_cis_fanout_per_account_attribution(monkeypatch) -> None:
-    monkeypatch.setattr(aws_orgs, "list_member_account_ids", lambda profile=None, *, force=False, session=None: ["111111111111", "222222222222"])
+    monkeypatch.setattr(
+        aws_orgs,
+        "list_member_account_ids",
+        lambda profile=None, *, force=False, session=None: ["111111111111", "222222222222"],
+    )
     monkeypatch.setattr(aws_orgs, "assume_account_session", lambda aid, **kw: f"session::{aid}")
 
     def _fake_run(*, session=None, checks=None):


### PR DESCRIPTION
Summary
- wrap the two AWS Organizations fan-out fixtures that exceed the enforced 140-column Ruff limit
- keep the test behavior unchanged while restoring the full release lint gate

Verification
- `uv run ruff check src tests`
- `uv run pytest -q tests/test_aws_org_scan_fanout.py` (22 passed)
- `git diff --check`

Notes
- found by the fresh 0.98.0 release audit; no production code changes