### PR TITLE
fix(deploy): tighten public demo AWS boundary

### DIFF
--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -9,7 +9,8 @@ name: Demo redeploy
 #
 # Auth is short-lived OIDC role assumption (no stored SSH keys, no long-lived
 # AWS access keys). The workflow stays inert until the owner sets the repo
-# vars/secrets documented in docs/HOSTED_POC.md → "Demo redeploy".
+# protected `demo` environment vars/secrets documented in
+# docs/HOSTED_POC.md → "Demo redeploy".
 
 on:
   # Deploy only after the Release workflow succeeds. A direct release trigger
@@ -65,7 +66,7 @@ jobs:
               echo ""
               echo "\`DEMO_INSTANCE_ID\` is not set, so the hosted-demo redeploy is inert."
               echo ""
-              echo "To enable it, configure these repo settings:"
+              echo "To enable it, configure these protected \`demo\` environment settings:"
               echo "- **vars.DEMO_INSTANCE_ID** — EC2 instance id of the demo VM (\`i-...\`)"
               echo "- **vars.AWS_REGION** — region of the demo VM (defaults to \`us-east-1\`)"
               echo "- **vars.DEMO_DEPLOY_DIR** — repo checkout dir on the VM (defaults to \`/opt/agent-bom\`)"
@@ -74,6 +75,10 @@ jobs:
             echo "::notice::DEMO_INSTANCE_ID unset — hosted demo redeploy is inert. See job summary for the vars/secrets to configure."
             echo "configured=false" >> "$GITHUB_OUTPUT"
           else
+            # Actions variables are not secrets and the repository is public.
+            # Treat the target identifier as operational metadata and mask it
+            # before any AWS command can echo it.
+            echo "::add-mask::${DEMO_INSTANCE_ID}"
             echo "configured=true" >> "$GITHUB_OUTPUT"
           fi
 
@@ -83,6 +88,9 @@ jobs:
         with:
           role-to-assume: ${{ secrets.DEMO_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
+          mask-aws-account-id: true
+          role-duration-seconds: 900
+          unset-current-credentials: true
 
       - name: Redeploy over SSM Run Command
         if: steps.guard.outputs.configured == 'true'
@@ -241,7 +249,7 @@ jobs:
           # SSM `commands` is a JSON array; pass the whole script as one element.
           jq -n --rawfile script remote.sh '{commands: [$script]}' > params.json
 
-          echo "Sending redeploy command to ${DEMO_INSTANCE_ID} (ref ${RELEASE_REF}) ..."
+          echo "Sending redeploy command to the protected demo target (ref ${RELEASE_REF}) ..."
           command_id=$(aws ssm send-command \
             --instance-ids "${DEMO_INSTANCE_ID}" \
             --document-name "AWS-RunShellScript" \
@@ -249,7 +257,8 @@ jobs:
             --parameters file://params.json \
             --query "Command.CommandId" \
             --output text)
-          echo "SSM CommandId: ${command_id}"
+          echo "::add-mask::${command_id}"
+          echo "SSM command submitted."
 
           status="Pending"
           # Poll up to ~20 min (well under the 30 min job timeout) so a long

--- a/deploy/terraform/demo-deploy-oidc/README.md
+++ b/deploy/terraform/demo-deploy-oidc/README.md
@@ -49,18 +49,19 @@ terraform output -raw role_arn
 
 ## Wire it up
 
-1. **Repo secret** — paste `role_arn` into the repo Actions secret
-   `DEMO_DEPLOY_ROLE_ARN`.
-2. **Repo vars** — set `DEMO_INSTANCE_ID`, `AWS_REGION`, and (optionally)
-   `DEMO_DEPLOY_DIR`. See `docs/HOSTED_POC.md` → "Demo redeploy".
+1. **Environment secret** — paste `role_arn` into the protected `demo`
+   environment secret `DEMO_DEPLOY_ROLE_ARN`; do not store it at repository
+   scope.
+2. **Environment vars** — on `demo`, set `DEMO_INSTANCE_ID`, `AWS_REGION`, and
+   (optionally) `DEMO_DEPLOY_DIR`. See `docs/HOSTED_POC.md` → "Demo redeploy".
 3. **Protected environment** — in the repo, create an Actions **Environment**
-   named `demo` and add **yourself as a required reviewer**. Optionally restrict
-   its deployment branches/tags to the default branch and `v*.*.*` tags. This
+   named `demo`, add **yourself as a required reviewer**, disable administrator
+   bypass, and restrict deployments to protected branches. This
    makes every `release` / `workflow_dispatch` run **pause for your approval**
    before any AWS call, and the environment name is what the trust policy above
    is scoped to — the two defenses reinforce each other.
 
-Once configured, a published release (or a manual dispatch) queues a redeploy
+Once configured, a successful release (or a manual dispatch) queues a redeploy
 that waits for your approval, then runs `git pull` → `docker compose up -d
 --build` → fail-closed preflight → smoke on the VM, failing the job if the demo
 is unhealthy.

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -30,10 +30,12 @@ Run one small CPU-only VM. Recommended starting point:
 - Instance: `t3.large` or equivalent, 4 vCPU / 8-16 GB RAM
 - OS: Ubuntu LTS or Amazon Linux
 - Region: closest to you and the first demo users
-- Security group: `443` open; SSH/admin only from your IP
+- Security group: `443` from the trusted edge only; no inbound SSH/admin
 
 1. Create DNS, for example `demo.agent-bom.com`, pointing to the VM.
-2. Open inbound `443` only. Restrict SSH/admin access to known IPs.
+2. Allow inbound `443` only from the trusted edge (for example, Cloudflare's
+   published proxy CIDRs). Do not open SSH/admin ingress; use SSM for operator
+   access.
 3. Install Docker, Compose, and Caddy.
 4. Deploy `deploy/docker-compose.platform.yml`.
 5. Use Caddy or an ALB for HTTPS. Do not expose plain HTTP.
@@ -314,14 +316,15 @@ workflow automates it without any stored SSH keys or long-lived AWS credentials:
 
 The workflow is **inert until configured** — if `DEMO_INSTANCE_ID` is unset it
 logs the required settings and exits successfully instead of failing. To enable
-it, set these repo Actions **variables** and **secret**:
+it, set these values on the protected `demo` Actions **environment**, not at
+repository scope:
 
 | Setting | Kind | Purpose |
 |---|---|---|
-| `DEMO_INSTANCE_ID` | var | EC2 instance id of the demo VM (`i-...`). Gate: unset ⇒ workflow no-ops. |
-| `AWS_REGION` | var | Region of the demo VM. Defaults to `us-east-1` if unset. |
-| `DEMO_DEPLOY_DIR` | var | Repo checkout dir on the VM. Defaults to `/opt/agent-bom`. Must contain a `.git` directory — the remote script fails loud if it does not. |
-| `DEMO_DEPLOY_ROLE_ARN` | secret | IAM role ARN the workflow assumes via OIDC. Its trust policy must allow this repo's GitHub OIDC subject, and its permissions must allow `ssm:SendCommand` / `ssm:GetCommandInvocation` on the instance. |
+| `DEMO_INSTANCE_ID` | environment var | EC2 instance id of the demo VM (`i-...`). Gate: unset ⇒ workflow no-ops. |
+| `AWS_REGION` | environment var | Region of the demo VM. Defaults to `us-east-1` if unset. |
+| `DEMO_DEPLOY_DIR` | environment var | Repo checkout dir on the VM. Defaults to `/opt/agent-bom`. Must contain a `.git` directory — the remote script fails loud if it does not. |
+| `DEMO_DEPLOY_ROLE_ARN` | environment secret | IAM role ARN the workflow assumes via OIDC. Its trust policy must allow this repo's GitHub OIDC subject, and its permissions must allow `ssm:SendCommand` / `ssm:GetCommandInvocation` on the instance. |
 
 The instance also needs the SSM agent running and an instance profile granting
 `AmazonSSMManagedInstanceCore` so Run Command can reach it.
@@ -333,8 +336,8 @@ deploy or assume the AWS role. Two independent defenses:
 
 - **Protected environment.** The deploy job declares `environment: demo`. Create
   a repo Actions **Environment** named `demo` with **yourself as a required
-  reviewer**, and optionally restrict its deployment branches/tags to the default
-  branch and `v*.*.*` tags. Then every `release` / `workflow_dispatch` run
+  reviewer**, disable administrator bypass, and restrict deployments to protected
+  branches. Then every release-driven / `workflow_dispatch` run
   **pauses for your approval** before any AWS call. The workflow has **no**
   `pull_request` / `pull_request_target` trigger — it is release +
   `workflow_dispatch` only, so PRs cannot start it at all.
@@ -345,6 +348,10 @@ deploy or assume the AWS role. Two independent defenses:
   `ssm:GetCommandInvocation`. Fork/PR runs present a different `sub` and STS
   rejects them. `terraform output -raw role_arn` gives the value for
   `DEMO_DEPLOY_ROLE_ARN`.
+- **Public-log hygiene.** Mask the EC2 instance ID, SSM command ID, and AWS
+  account ID before emitting workflow diagnostics. Keep the OIDC session at the
+  15-minute minimum; no deployment identifier is an authentication credential,
+  but public logs should not disclose private infrastructure inventory.
 
 ## Snowflake Native App lane
 

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -347,6 +347,15 @@ def test_demo_redeploy_layers_demo_override_and_uses_write_secret() -> None:
     assert 'test "$(git rev-parse HEAD)" = "$TARGET_COMMIT"' in workflow
     assert "\n  release:\n" not in workflow
     assert "release_ref:" in workflow
+    # Public Actions logs must not disclose private infrastructure inventory,
+    # and the short-lived AWS session should expire shortly after the deploy.
+    assert 'echo "::add-mask::${DEMO_INSTANCE_ID}"' in workflow
+    assert 'echo "::add-mask::${command_id}"' in workflow
+    assert "Sending redeploy command to ${DEMO_INSTANCE_ID}" not in workflow
+    assert "SSM CommandId: ${command_id}" not in workflow
+    assert "mask-aws-account-id: true" in workflow
+    assert "role-duration-seconds: 900" in workflow
+    assert "unset-current-credentials: true" in workflow
     # Static preflight precedes build and in-place promotion.
     assert workflow.index("hosted_poc_preflight.py --write-secret") < workflow.index("compose build")
     assert workflow.index("compose build") < workflow.index("compose up -d")


### PR DESCRIPTION
## Summary

- mask EC2, SSM command, and AWS account identifiers in the public demo deployment logs
- limit the GitHub OIDC session to 15 minutes and clear inherited runner credentials before assuming the role
- document environment-scoped deploy settings, protected-branch-only deployments, no admin bypass, and SSM-only administration
- add regression coverage for the public-log and short-lived-credential contract

## Root cause

The deployment correctly required the protected `demo` environment, but operational identifiers were printed into public Actions logs and the AWS credential action used its default one-hour session. The live environment settings were also stored at repository scope rather than under the protected environment.

The live GitHub settings have separately been tightened to protected branches only with administrator bypass disabled. Demo variables and the role ARN were moved from repository scope into the protected `demo` environment.

## Verification

- `uv run pytest -q tests/test_compose_secrets_healthcheck.py tests/test_provisioning_readonly_guard.py` — 52 passed
- `uv run ruff check tests/test_compose_secrets_healthcheck.py tests/test_provisioning_readonly_guard.py`
- `python scripts/check_public_docs_hygiene.py`
- `python scripts/check_workflow_timeouts.py`
- `actionlint .github/workflows/demo-redeploy.yml`
- `git diff --check`

## Notes

The deploy remains gated by the owner-only `demo` environment and the AWS OIDC trust policy remains pinned to `repo:msaad00/agent-bom:environment:demo`. No application behavior or release artifact changes are included.
