### PR TITLE
fix(deploy): allow demo redeploy session to complete

### DIFF
--- a/.github/workflows/demo-redeploy.yml
+++ b/.github/workflows/demo-redeploy.yml
@@ -89,7 +89,7 @@ jobs:
           role-to-assume: ${{ secrets.DEMO_DEPLOY_ROLE_ARN }}
           aws-region: ${{ vars.AWS_REGION || 'us-east-1' }}
           mask-aws-account-id: true
-          role-duration-seconds: 900
+          role-duration-seconds: 3600
           unset-current-credentials: true
 
       - name: Redeploy over SSM Run Command

--- a/tests/test_compose_secrets_healthcheck.py
+++ b/tests/test_compose_secrets_healthcheck.py
@@ -354,7 +354,7 @@ def test_demo_redeploy_layers_demo_override_and_uses_write_secret() -> None:
     assert "Sending redeploy command to ${DEMO_INSTANCE_ID}" not in workflow
     assert "SSM CommandId: ${command_id}" not in workflow
     assert "mask-aws-account-id: true" in workflow
-    assert "role-duration-seconds: 900" in workflow
+    assert "role-duration-seconds: 3600" in workflow
     assert "unset-current-credentials: true" in workflow
     # Static preflight precedes build and in-place promotion.
     assert workflow.index("hosted_poc_preflight.py --write-secret") < workflow.index("compose build")


### PR DESCRIPTION
## Summary

- allow the protected demo redeploy to retain AWS credentials for the full bounded workflow
- keep the configured session at one hour while deployment job timeouts remain the outer execution limit
- lock the duration into the deployment workflow contract test

## Verification

- `uv run pytest -q tests/test_compose_secrets_healthcheck.py tests/test_deployment.py` — 85 passed
- `uv run ruff check tests/test_compose_secrets_healthcheck.py`
- `python scripts/check_workflow_timeouts.py`
- `git diff --check`

## Notes

- This follow-up changes no AWS resources and does not trigger or approve a deployment.
