### PR TITLE
fix(auth): provision hosted invitations atomically

### DIFF
--- a/src/agent_bom/api/auth.py
+++ b/src/agent_bom/api/auth.py
@@ -456,6 +456,16 @@ class KeyStore:
         with self._lock:
             self._keys.append(key)
 
+    def provision_tenant_key(self, key: ApiKey, *, team_name: str) -> None:
+        """Provision a tenant's first key for the in-memory self-hosted store.
+
+        The in-memory backend has no separate team registry, so provisioning is
+        equivalent to adding the already tenant-scoped key. Persistent stores
+        override this method to create their tenant FK root atomically.
+        """
+        del team_name
+        self.add(key)
+
     def remove(self, key_id: str) -> bool:
         with self._lock:
             for key in self._keys:
@@ -528,6 +538,7 @@ class KeyStoreProtocol(Protocol):
     """Interface shared by in-memory and persistent API key stores."""
 
     def add(self, key: ApiKey) -> None: ...
+    def provision_tenant_key(self, key: ApiKey, *, team_name: str) -> None: ...
     def remove(self, key_id: str) -> bool: ...
     def revoke_by_principal_id(self, principal_id: str, tenant_id: str | None = None) -> list[str]: ...
     def mark_rotating(self, key_id: str, *, replacement_key_id: str, overlap_until: str) -> bool: ...

--- a/src/agent_bom/api/postgres_access.py
+++ b/src/agent_bom/api/postgres_access.py
@@ -20,6 +20,41 @@ from .postgres_common import (
     set_current_tenant,
 )
 
+_INSERT_API_KEY_SQL = """INSERT INTO api_keys
+    (
+      key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
+      created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
+      scim_subject_id, owner, principal_id, revoked
+    )
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
+"""
+
+_UPSERT_API_KEY_SQL = """INSERT INTO api_keys
+    (
+      key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
+      created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
+      scim_subject_id, owner, principal_id, revoked
+    )
+    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
+    ON CONFLICT (key_id) DO UPDATE SET
+      key_hash = EXCLUDED.key_hash,
+      key_salt = EXCLUDED.key_salt,
+      key_prefix = EXCLUDED.key_prefix,
+      name = EXCLUDED.name,
+      role = EXCLUDED.role,
+      team_id = EXCLUDED.team_id,
+      scopes = EXCLUDED.scopes,
+      created_at = EXCLUDED.created_at,
+      expires_at = EXCLUDED.expires_at,
+      revoked_at = EXCLUDED.revoked_at,
+      rotation_overlap_until = EXCLUDED.rotation_overlap_until,
+      replacement_key_id = EXCLUDED.replacement_key_id,
+      scim_subject_id = EXCLUDED.scim_subject_id,
+      owner = EXCLUDED.owner,
+      principal_id = EXCLUDED.principal_id,
+      revoked = FALSE
+"""
+
 
 class PostgresKeyStore:
     """PostgreSQL-backed API key storage with tenant RLS."""
@@ -145,33 +180,9 @@ class PostgresKeyStore:
 
     @staticmethod
     def _insert_key(conn: Connection, key: ApiKey, *, update_existing: bool) -> None:
-        conflict_clause = """
-                   ON CONFLICT (key_id) DO UPDATE SET
-                     key_hash = EXCLUDED.key_hash,
-                     key_salt = EXCLUDED.key_salt,
-                     key_prefix = EXCLUDED.key_prefix,
-                     name = EXCLUDED.name,
-                     role = EXCLUDED.role,
-                     team_id = EXCLUDED.team_id,
-                     scopes = EXCLUDED.scopes,
-                     created_at = EXCLUDED.created_at,
-                     expires_at = EXCLUDED.expires_at,
-                     revoked_at = EXCLUDED.revoked_at,
-                     rotation_overlap_until = EXCLUDED.rotation_overlap_until,
-                     replacement_key_id = EXCLUDED.replacement_key_id,
-                     scim_subject_id = EXCLUDED.scim_subject_id,
-                     owner = EXCLUDED.owner,
-                     principal_id = EXCLUDED.principal_id,
-                     revoked = FALSE""" if update_existing else ""
+        statement = _UPSERT_API_KEY_SQL if update_existing else _INSERT_API_KEY_SQL
         conn.execute(
-            """INSERT INTO api_keys
-                   (
-                     key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
-                     created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
-                     scim_subject_id, owner, principal_id, revoked
-                   )
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
-                   """ + conflict_clause,
+            statement,
             (
                 key.key_id,
                 key.key_hash,

--- a/src/agent_bom/api/postgres_access.py
+++ b/src/agent_bom/api/postgres_access.py
@@ -9,7 +9,16 @@ from agent_bom.api.auth import ApiKey, Role, verify_api_key
 from agent_bom.api.exception_store import ExceptionStatus, VulnException
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
-from .postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection, bypass_tenant_rls
+from .postgres_common import (
+    Connection,
+    ConnectionPool,
+    _ensure_tenant_rls,
+    _get_pool,
+    _tenant_connection,
+    bypass_tenant_rls,
+    reset_current_tenant,
+    set_current_tenant,
+)
 
 
 class PostgresKeyStore:
@@ -134,16 +143,9 @@ class PostgresKeyStore:
             principal_id=row[15] if len(row) > 15 else None,
         )
 
-    def add(self, key: ApiKey) -> None:
-        with _tenant_connection(self._pool) as conn:
-            conn.execute(
-                """INSERT INTO api_keys
-                   (
-                     key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
-                     created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
-                     scim_subject_id, owner, principal_id, revoked
-                   )
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
+    @staticmethod
+    def _insert_key(conn: Connection, key: ApiKey, *, update_existing: bool) -> None:
+        conflict_clause = """
                    ON CONFLICT (key_id) DO UPDATE SET
                      key_hash = EXCLUDED.key_hash,
                      key_salt = EXCLUDED.key_salt,
@@ -160,27 +162,63 @@ class PostgresKeyStore:
                      scim_subject_id = EXCLUDED.scim_subject_id,
                      owner = EXCLUDED.owner,
                      principal_id = EXCLUDED.principal_id,
-                     revoked = FALSE""",
-                (
-                    key.key_id,
-                    key.key_hash,
-                    key.key_salt,
-                    key.key_prefix,
-                    key.name,
-                    key.role.value,
-                    key.tenant_id,
-                    json.dumps(key.scopes),
-                    key.created_at,
-                    key.expires_at,
-                    key.revoked_at,
-                    key.rotation_overlap_until,
-                    key.replacement_key_id,
-                    key.scim_subject_id,
-                    key.owner,
-                    key.principal_id,
-                ),
-            )
+                     revoked = FALSE""" if update_existing else ""
+        conn.execute(
+            """INSERT INTO api_keys
+                   (
+                     key_id, key_hash, key_salt, key_prefix, name, role, team_id, scopes,
+                     created_at, expires_at, revoked_at, rotation_overlap_until, replacement_key_id,
+                     scim_subject_id, owner, principal_id, revoked
+                   )
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, FALSE)
+                   """ + conflict_clause,
+            (
+                key.key_id,
+                key.key_hash,
+                key.key_salt,
+                key.key_prefix,
+                key.name,
+                key.role.value,
+                key.tenant_id,
+                json.dumps(key.scopes),
+                key.created_at,
+                key.expires_at,
+                key.revoked_at,
+                key.rotation_overlap_until,
+                key.replacement_key_id,
+                key.scim_subject_id,
+                key.owner,
+                key.principal_id,
+            ),
+        )
+
+    def add(self, key: ApiKey) -> None:
+        with _tenant_connection(self._pool) as conn:
+            self._insert_key(conn, key, update_existing=True)
             conn.commit()
+
+    def provision_tenant_key(self, key: ApiKey, *, team_name: str) -> None:
+        """Create a tenant FK root and its first key in one RLS-scoped transaction.
+
+        The invitation request begins under the operator tenant. Temporarily
+        binding the new tenant lets the ``api_keys`` FORCE-RLS ``WITH CHECK``
+        policy authorize only that tenant's key without enabling the global RLS
+        bypass. A key-id conflict is deliberately not upserted: the exception
+        rolls back the preceding team insert instead of moving an existing key
+        across tenants.
+        """
+        tenant_id = key.tenant_id
+        token = set_current_tenant(tenant_id)
+        try:
+            with _tenant_connection(self._pool) as conn:
+                conn.execute(
+                    "INSERT INTO teams (team_id, name, slug) VALUES (%s, %s, %s)",
+                    (tenant_id, team_name.strip() or tenant_id, tenant_id),
+                )
+                self._insert_key(conn, key, update_existing=False)
+                conn.commit()
+        finally:
+            reset_current_tenant(token)
 
     def remove(self, key_id: str) -> bool:
         with _tenant_connection(self._pool) as conn:

--- a/src/agent_bom/api/routes/enterprise.py
+++ b/src/agent_bom/api/routes/enterprise.py
@@ -945,7 +945,7 @@ def _hosted_invite_url(tenant_id: str) -> str | None:
         return None
     from urllib.parse import quote
 
-    return f"{base.rstrip('/')}/signin?tenant={quote(tenant_id, safe='')}"
+    return f"{base.rstrip('/')}/login?tenant={quote(tenant_id, safe='')}"
 
 
 @router.post("/auth/invitations", tags=["enterprise"], status_code=201)
@@ -987,7 +987,10 @@ async def create_invitation(request: Request, req: InvitationRequest) -> dict:
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=sanitize_error(exc)) from exc
-    get_key_store().add(api_key)
+    get_key_store().provision_tenant_key(
+        api_key,
+        team_name=(req.organization or "").strip() or tenant_id,
+    )
 
     # The new tenant carries no quota overrides, so the process-level defaults
     # bound it immediately — surface them so the operator sees the applied cap.

--- a/tests/api/test_api_hosted_invitations.py
+++ b/tests/api/test_api_hosted_invitations.py
@@ -184,5 +184,6 @@ def test_invite_url_present_only_when_base_configured_and_carries_no_secret(invi
     assert body["invite_url"] is not None
     parsed = urlparse(body["invite_url"])
     assert (parsed.scheme, parsed.netloc) == ("https", "app.example.com")
+    assert parsed.path == "/login"
     assert body["tenant_id"] in parsed.path + "?" + parsed.query
     assert body["raw_key"] not in body["invite_url"]

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -8,6 +8,7 @@ against a real server instead of the MockConnection unit-test harness.
 from __future__ import annotations
 
 import os
+from dataclasses import replace
 from uuid import uuid4
 
 import pytest
@@ -72,6 +73,54 @@ def test_postgres_job_store_real_roundtrip_and_tenant_filter():
     assert same_tenant.triggered_by == "ci-postgres-contract"
     assert other_tenant is None
     assert any(item.job_id == job_id for item in results)
+
+
+def test_postgres_invitation_provisions_team_and_key_atomically_under_new_tenant_rls():
+    """An operator admin may provision a distinct tenant without an RLS or FK failure."""
+    import psycopg
+
+    from agent_bom.api.auth import Role, create_api_key
+    from agent_bom.api.postgres_access import PostgresKeyStore
+    from agent_bom.api.postgres_common import _get_pool, reset_current_tenant, set_current_tenant
+
+    suffix = uuid4().hex
+    tenant_id = f"invite-{suffix}"
+    raw_key, api_key = create_api_key("invited-owner", Role.ADMIN, tenant_id=tenant_id)
+    store = PostgresKeyStore()
+
+    operator_token = set_current_tenant(f"operator-{suffix}")
+    try:
+        store.provision_tenant_key(api_key, team_name="Example Organization")
+    finally:
+        reset_current_tenant(operator_token)
+
+    invited_token = set_current_tenant(tenant_id)
+    try:
+        assert store.verify(raw_key) is not None
+        stored = store.get(api_key.key_id)
+        assert stored is not None
+        assert stored.tenant_id == tenant_id
+        with _get_pool().connection() as conn:
+            team = conn.execute("SELECT team_id, name, slug FROM teams WHERE team_id = %s", (tenant_id,)).fetchone()
+    finally:
+        reset_current_tenant(invited_token)
+
+    assert team == (tenant_id, "Example Organization", tenant_id)
+
+    # Reusing an existing key id must fail closed and roll back the team row;
+    # otherwise a partial invitation leaves an orphan tenant behind.
+    rejected_tenant_id = f"invite-rejected-{suffix}"
+    colliding_key = replace(api_key, tenant_id=rejected_tenant_id)
+    operator_token = set_current_tenant(f"operator-{suffix}")
+    try:
+        with pytest.raises(psycopg.errors.UniqueViolation):
+            store.provision_tenant_key(colliding_key, team_name="Rejected Organization")
+    finally:
+        reset_current_tenant(operator_token)
+
+    with _get_pool().connection() as conn:
+        rejected_team = conn.execute("SELECT team_id FROM teams WHERE team_id = %s", (rejected_tenant_id,)).fetchone()
+    assert rejected_team is None
 
 
 def test_demo_estate_bootstrap_uses_secret_aware_migrated_postgres(monkeypatch):

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -759,6 +759,34 @@ def test_key_store_add_get_list_verify_remove(mock_pool):
     assert store.remove(api_key.key_id) is True
 
 
+def test_key_store_provisions_tenant_and_first_key_in_one_rls_scope(mock_pool):
+    """Hosted provisioning must create the FK root before the RLS-scoped key."""
+    from agent_bom.api.auth import Role, create_api_key
+    from agent_bom.api.postgres_common import _current_tenant, reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_store import PostgresKeyStore
+
+    store = PostgresKeyStore(pool=mock_pool)
+    _, api_key = create_api_key("example-owner", Role.ADMIN, tenant_id="example-tenant")
+    mock_pool._conn.executed.clear()
+    mock_pool._conn.transaction_events.clear()
+
+    operator_token = set_current_tenant("operator")
+    try:
+        store.provision_tenant_key(api_key, team_name="Example Organization")
+        assert _current_tenant.get() == "operator"
+    finally:
+        reset_current_tenant(operator_token)
+
+    statements = [(sql.strip().lower(), params) for sql, params in mock_pool._conn.executed]
+    tenant_session = next(params for sql, params in statements if "set_config('app.tenant_id'" in sql)
+    team_insert = next(index for index, (sql, _params) in enumerate(statements) if sql.startswith("insert into teams"))
+    key_insert = next(index for index, (sql, _params) in enumerate(statements) if sql.startswith("insert into api_keys"))
+
+    assert tenant_session == (api_key.tenant_id,)
+    assert team_insert < key_insert
+    assert mock_pool._conn.transaction_events == ["commit"]
+
+
 def test_key_store_mark_rotating_updates_overlap_metadata(mock_pool):
     from agent_bom.api.auth import Role, create_api_key
     from agent_bom.api.postgres_store import PostgresKeyStore


### PR DESCRIPTION
## Summary

- create the tenant FK root and first API key in one tenant-scoped PostgreSQL transaction
- preserve the in-memory self-hosted invitation behavior without enabling an RLS bypass
- send hosted invitation links to the implemented /login route

## Verification

- 95 focused invitation and PostgreSQL store tests passed before rebase
- 13 disposable PostgreSQL integration tests passed
- 10 focused post-rebase tests passed
- Ruff, mypy, make preflight, public-doc hygiene, exception sanitization, package-layout, and diff checks passed

## Notes

- Existing API-key invitation compatibility is retained
- Test identities and organizations are synthetic
- No live infrastructure or customer metadata is included