### PR TITLE
feat(trial): enforce managed AWS guardrails

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5246,6 +5246,30 @@
             ],
             "title": "Active Scan Jobs"
           },
+          "cloud_connections": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cloud Connections"
+          },
+          "cloud_connections_per_provider": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cloud Connections Per Provider"
+          },
           "fleet_agents": {
             "anyOf": [
               {
@@ -5269,6 +5293,18 @@
               }
             ],
             "title": "Retained Scan Jobs"
+          },
+          "scan_credits_24h": {
+            "anyOf": [
+              {
+                "minimum": 0.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Scan Credits 24H"
           },
           "schedules": {
             "anyOf": [

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3565,6 +3565,18 @@ components:
             type: integer
           - type: 'null'
           title: Active Scan Jobs
+        cloud_connections:
+          anyOf:
+          - minimum: 0.0
+            type: integer
+          - type: 'null'
+          title: Cloud Connections
+        cloud_connections_per_provider:
+          anyOf:
+          - minimum: 0.0
+            type: integer
+          - type: 'null'
+          title: Cloud Connections Per Provider
         fleet_agents:
           anyOf:
           - minimum: 0.0
@@ -3577,6 +3589,12 @@ components:
             type: integer
           - type: 'null'
           title: Retained Scan Jobs
+        scan_credits_24h:
+          anyOf:
+          - minimum: 0.0
+            type: integer
+          - type: 'null'
+          title: Scan Credits 24H
         schedules:
           anyOf:
           - minimum: 0.0

--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -28,12 +28,15 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_API_JOB_TTL` | `int` | `3600` | — |
 | `AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT` | `int` | `API_MAX_CONCURRENT_JOBS` | — |
 | `AGENT_BOM_API_MAX_BATCH_SCAN_TARGETS` | `int` | `100` | Per-request fan-out ceiling: a single POST /v1/scan expands one batchable target field per child job, so an uncapped request could enqueue unbounded work bounded only by the tenant active-scan quota churn. Reject over-cap requests at valida |
+| `AGENT_BOM_API_MAX_CLOUD_CONNECTIONS_PER_PROVIDER` | `int` | `0` | — |
+| `AGENT_BOM_API_MAX_CLOUD_CONNECTIONS_PER_TENANT` | `int` | `0` | — |
 | `AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT` | `int` | `1000` | — |
 | `AGENT_BOM_API_MAX_JOBS` | `int` | `10` | Used by api/server.py for the REST API job queue.  10 concurrent scan jobs prevents resource exhaustion on shared hosts. 1-hour TTL auto-cleans completed jobs.  200 in-memory ceiling triggers LRU eviction for long-running API instances. |
 | `AGENT_BOM_API_MAX_JOB_PROGRESS_EVENTS` | `int` | `500` | — |
 | `AGENT_BOM_API_MAX_MEMORY_JOBS` | `int` | `200` | — |
 | `AGENT_BOM_API_MAX_OCSF_INGEST_EVENTS` | `int` | `1000` | — |
 | `AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT` | `int` | `500` | — |
+| `AGENT_BOM_API_MAX_SCAN_CREDITS_24H_PER_TENANT` | `int` | `0` | — |
 | `AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT` | `int` | `100` | — |
 | `AGENT_BOM_API_SCAN_CLAIM_POLL_SECONDS` | `int` | `3` | — |
 | `AGENT_BOM_API_SCAN_LEASE_SECONDS` | `int` | `600` | Distributed scan dispatch (multi-replica work-stealing). When enabled, scan jobs are enqueued to a shared Postgres dispatch queue and any control-plane replica claims them via FOR UPDATE SKIP LOCKED, so scan throughput scales with replicas  |
@@ -53,6 +56,7 @@ so they cannot regress silently, but they are not part of this reference.
 | `AGENT_BOM_FINDINGS_APPROXIMATE_TOTAL_THRESHOLD` | `int` | `50000` | Skip exact COUNT(*) on /v1/findings once cached total exceeds this threshold (0 = disabled). |
 | `AGENT_BOM_GCP_EVENT_MAX_BATCHES` | `int` | `10` | — |
 | `AGENT_BOM_GCP_EVENT_MAX_MESSAGES` | `int` | `10` | Event-driven GCP posture ingestion. When an operator wires Cloud Asset Inventory feed / audit logs → a Pub/Sub subscription (opt-in via AGENT_BOM_GCP_EVENT_SUBSCRIPTION, read live, default off), the bounded Pub/Sub consumer drains change ev |
+| `AGENT_BOM_MANAGED_TRIAL_MODE` | `bool` | `False` | Explicit opt-in marker for the bounded operator-run evaluation policy. Runtime request guards re-read the environment so tests and process supervisors can validate configuration changes without changing self-hosted defaults. |
 | `AGENT_BOM_NO_AUTH_ROLE` | `str` | `'viewer'` | Role granted when unauthenticated API access is explicitly enabled. Default preserves local/dev compatibility; demo-estate mode clamps this to viewer. |
 | `AGENT_BOM_NO_UI` | `bool` | `False` | Hide the bundled browser UI when serving an API-only/local control-plane process. Some CLI paths set this immediately before loading the API server, so the server still reads the live environment value at request time. |
 

--- a/docs/schemas/v1/TenantQuotaUpdateRequest.json
+++ b/docs/schemas/v1/TenantQuotaUpdateRequest.json
@@ -14,6 +14,32 @@
       "default": null,
       "title": "Active Scan Jobs"
     },
+    "cloud_connections": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cloud Connections"
+    },
+    "cloud_connections_per_provider": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Cloud Connections Per Provider"
+    },
     "fleet_agents": {
       "anyOf": [
         {
@@ -39,6 +65,19 @@
       ],
       "default": null,
       "title": "Retained Scan Jobs"
+    },
+    "scan_credits_24h": {
+      "anyOf": [
+        {
+          "minimum": 0,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "title": "Scan Credits 24H"
     },
     "schedules": {
       "anyOf": [

--- a/src/agent_bom/api/connection_scheduler.py
+++ b/src/agent_bom/api/connection_scheduler.py
@@ -104,6 +104,10 @@ def connections_scheduler_enabled() -> bool:
     so the loop never runs in CLI/dev — only when an operator opts in on the
     control plane.
     """
+    from agent_bom.api.managed_trial import managed_trial_enabled
+
+    if managed_trial_enabled():
+        return False
     raw = os.environ.get("AGENT_BOM_CONNECTIONS_SCHEDULER", "")
     return raw.strip().lower() in {"1", "true", "yes", "on", "enabled"}
 

--- a/src/agent_bom/api/managed_trial.py
+++ b/src/agent_bom/api/managed_trial.py
@@ -8,7 +8,7 @@ an operator-run evaluation environment; it never activates itself implicitly.
 from __future__ import annotations
 
 import os
-from typing import Final
+from typing import Final, Protocol
 
 from fastapi import HTTPException
 
@@ -34,11 +34,68 @@ MANAGED_TRIAL_ANALYST_SCOPES: Final[tuple[str, ...]] = (
     "graph:read",
 )
 
+_MANAGED_TRIAL_AUTH_ROUTES: Final[frozenset[tuple[str, str]]] = frozenset(
+    {
+        ("GET", "/v1/auth/me"),
+        ("POST", "/v1/auth/session"),
+        ("DELETE", "/v1/auth/session"),
+        ("GET", "/v1/auth/oidc/login"),
+        ("GET", "/v1/auth/oidc/callback"),
+    }
+)
+_CONNECTIONS_PATH: Final = "/v1/cloud/connections"
+_GRAPH_PATH: Final = "/v1/graph"
+
+
+class StoredConnection(Protocol):
+    """Minimum persisted connection shape needed by request and worker gates."""
+
+    provider: str
+    regions: list[str]
+    inventory_scope: str
+    scan_mode: str
+    scan_interval_minutes: int | None
+
 
 def managed_trial_enabled() -> bool:
     """Return whether the operator explicitly enabled managed-trial policy."""
 
     return os.environ.get("AGENT_BOM_MANAGED_TRIAL_MODE", "").strip().lower() in _TRUTHY
+
+
+def managed_trial_route_allowed(method: str, path: str) -> bool:
+    """Return whether an API route belongs to the managed-trial surface.
+
+    This is intentionally a pure allowlist independent of principal type. The
+    authentication middleware applies it before resolving API keys, OIDC
+    bearers, or browser sessions, so no broader role can reopen a denied route.
+    Non-API paths remain governed by the normal dashboard/static/health rules.
+    """
+
+    normalized_method = method.upper()
+    if normalized_method == "HEAD":
+        normalized_method = "GET"
+    if normalized_method == "OPTIONS":
+        return True
+    if not (path == "/v1" or path.startswith("/v1/") or path == "/scim" or path.startswith("/scim/")):
+        return True
+    if (normalized_method, path) in _MANAGED_TRIAL_AUTH_ROUTES:
+        return True
+    if normalized_method == "GET" and (path == _GRAPH_PATH or path.startswith(f"{_GRAPH_PATH}/")):
+        return True
+    if normalized_method == "POST" and path in {"/v1/graph/query", "/v1/graph/should-i-deploy"}:
+        return True
+    if normalized_method == "GET" and path == "/v1/findings":
+        return True
+    if path == _CONNECTIONS_PATH:
+        return normalized_method in {"GET", "POST"}
+    if path.startswith(f"{_CONNECTIONS_PATH}/"):
+        suffix = path.removeprefix(f"{_CONNECTIONS_PATH}/")
+        parts = suffix.split("/")
+        if normalized_method == "GET":
+            return len(parts) == 1 and bool(parts[0])
+        return normalized_method == "POST" and len(parts) == 2 and bool(parts[0]) and parts[1] in {"test", "scan"}
+    return False
 
 
 def enforce_connection_envelope(
@@ -68,6 +125,25 @@ def enforce_connection_envelope(
             status_code=403,
             detail=f"Managed trial connections allow at most {MANAGED_TRIAL_MAX_REGIONS} AWS regions.",
         )
+
+
+def enforce_stored_connection_envelope(record: StoredConnection) -> None:
+    """Revalidate persisted settings before test, enqueue, or worker execution.
+
+    Stored rows can predate managed-trial mode or be changed by an operator.
+    Callers must therefore validate the current row at every execution boundary
+    instead of assuming the create-time contract is still true.
+    """
+
+    if not managed_trial_enabled():
+        return
+    enforce_connection_envelope(
+        provider=str(record.provider or "").strip().lower(),
+        regions=[str(region).strip().lower() for region in record.regions],
+        inventory_scope=str(record.inventory_scope or "").strip().lower(),
+        scan_mode=str(record.scan_mode or "").strip().lower(),
+        scan_interval_minutes=record.scan_interval_minutes,
+    )
 
 
 def require_managed_trial_feature(feature: str) -> None:

--- a/src/agent_bom/api/managed_trial.py
+++ b/src/agent_bom/api/managed_trial.py
@@ -1,0 +1,77 @@
+"""Opt-in policy boundary for a small operator-run managed trial.
+
+The OSS control plane remains self-hosted by default. Setting
+``AGENT_BOM_MANAGED_TRIAL_MODE=1`` enables a deliberately narrow envelope for
+an operator-run evaluation environment; it never activates itself implicitly.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Final
+
+from fastapi import HTTPException
+
+from agent_bom.api.connection_store import INVENTORY_SCOPE_ACCOUNT, SCAN_MODE_FULL
+
+_TRUTHY: Final = frozenset({"1", "true", "yes", "on"})
+
+MANAGED_TRIAL_MAX_REGIONS: Final = 5
+MANAGED_TRIAL_QUOTA_CAPS: Final[dict[str, int]] = {
+    "active_scan_jobs": 1,
+    "retained_scan_jobs": 20,
+    "cloud_connections": 2,
+    "cloud_connections_per_provider": 2,
+    "scan_credits_24h": 8,
+}
+
+# Intended for the invitation/session layer. These scopes add fine-grained
+# ceilings without changing the long-standing self-hosted role contract.
+MANAGED_TRIAL_ANALYST_SCOPES: Final[tuple[str, ...]] = (
+    "cloud.connection:read",
+    "cloud.connection:write",
+    "finding:read",
+    "graph:read",
+)
+
+
+def managed_trial_enabled() -> bool:
+    """Return whether the operator explicitly enabled managed-trial policy."""
+
+    return os.environ.get("AGENT_BOM_MANAGED_TRIAL_MODE", "").strip().lower() in _TRUTHY
+
+
+def enforce_connection_envelope(
+    *,
+    provider: str,
+    regions: list[str],
+    inventory_scope: str,
+    scan_mode: str,
+    scan_interval_minutes: int | None,
+) -> None:
+    """Reject connection settings outside the managed-trial blast radius."""
+
+    if not managed_trial_enabled():
+        return
+    if provider != "aws":
+        raise HTTPException(status_code=403, detail="Managed trial connections are limited to AWS.")
+    if inventory_scope != INVENTORY_SCOPE_ACCOUNT:
+        raise HTTPException(status_code=403, detail="Managed trial connections are limited to account scope.")
+    if scan_mode != SCAN_MODE_FULL:
+        raise HTTPException(status_code=403, detail="Continuous connection scanning is disabled in managed trial mode.")
+    if scan_interval_minutes is not None:
+        raise HTTPException(status_code=403, detail="Connection schedules are disabled in managed trial mode.")
+    if not regions or "all" in regions:
+        raise HTTPException(status_code=403, detail="Managed trial connections require explicitly selected AWS regions.")
+    if len(regions) > MANAGED_TRIAL_MAX_REGIONS:
+        raise HTTPException(
+            status_code=403,
+            detail=f"Managed trial connections allow at most {MANAGED_TRIAL_MAX_REGIONS} AWS regions.",
+        )
+
+
+def require_managed_trial_feature(feature: str) -> None:
+    """Deny a feature that is outside the managed-trial product envelope."""
+
+    if managed_trial_enabled():
+        raise HTTPException(status_code=403, detail=f"{feature} is disabled in managed trial mode.")

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -735,6 +735,31 @@ class InMemoryRateLimitStore:
             reset_at = int((timestamps[0] if timestamps else now) + self._window)
             return len(timestamps), reset_at
 
+    def consume_if_below(self, key: str, now: float, limit: int) -> tuple[bool, int, int]:
+        """Atomically consume one sliding-window unit when below ``limit``."""
+
+        with self._lock:
+            self._cleanup(now)
+            timestamps = [timestamp for timestamp in self._hits.get(key, []) if now - timestamp < self._window]
+            accepted = len(timestamps) < limit
+            if accepted:
+                timestamps.append(now)
+                self._hits[key] = timestamps
+            reset_at = int((timestamps[0] if timestamps else now) + self._window)
+            return accepted, len(timestamps), reset_at
+
+    def count(self, key: str, now: float) -> int:
+        """Return current sliding-window usage without consuming a unit."""
+
+        with self._lock:
+            self._cleanup(now)
+            timestamps = [timestamp for timestamp in self._hits.get(key, []) if now - timestamp < self._window]
+            if timestamps:
+                self._hits[key] = timestamps
+            else:
+                self._hits.pop(key, None)
+            return len(timestamps)
+
 
 class PostgresRateLimitStore:
     """Shared sliding-window limiter backed by Postgres for horizontal scaling."""
@@ -787,6 +812,43 @@ class PostgresRateLimitStore:
         oldest = float(row[1]) if row and row[1] is not None else now
         reset_at = int(oldest + self._window)
         return count, reset_at
+
+    @staticmethod
+    def _advisory_key(key: str) -> int:
+        digest = hashlib.sha256(f"rate-limit:{key}".encode()).digest()
+        return int.from_bytes(digest[:8], "big", signed=True)
+
+    def consume_if_below(self, key: str, now: float, limit: int) -> tuple[bool, int, int]:
+        """Atomically consume one unit using a transaction advisory lock."""
+
+        window_start = now - self._window
+        with self._pool.connection() as conn:
+            conn.execute("SELECT pg_advisory_xact_lock(%s)", (self._advisory_key(key),))
+            conn.execute("DELETE FROM api_rate_limit_hits WHERE bucket_key = %s AND hit_at < %s", (key, window_start))
+            row = conn.execute(
+                "SELECT COUNT(*), MIN(hit_at) FROM api_rate_limit_hits WHERE bucket_key = %s AND hit_at >= %s",
+                (key, window_start),
+            ).fetchone()
+            current = int(row[0]) if row and row[0] is not None else 0
+            oldest = float(row[1]) if row and row[1] is not None else now
+            accepted = current < limit
+            if accepted:
+                conn.execute("INSERT INTO api_rate_limit_hits (bucket_key, hit_at) VALUES (%s, %s)", (key, now))
+                current += 1
+                if current == 1:
+                    oldest = now
+        return accepted, current, int(oldest + self._window)
+
+    def count(self, key: str, now: float) -> int:
+        """Return current sliding-window usage without consuming a unit."""
+
+        window_start = now - self._window
+        with self._pool.connection() as conn:
+            row = conn.execute(
+                "SELECT COUNT(*) FROM api_rate_limit_hits WHERE bucket_key = %s AND hit_at >= %s",
+                (key, window_start),
+            ).fetchone()
+        return int(row[0]) if row and row[0] is not None else 0
 
 
 class TrustHeadersMiddleware(BaseHTTPMiddleware):
@@ -1186,6 +1248,14 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
     )
 
     _SCOPE_RULES: tuple[tuple[str, str, str], ...] = (
+        ("GET", "/v1/cloud/connections", "cloud.connection:read"),
+        ("POST", "/v1/cloud/connections", "cloud.connection:write"),
+        ("PATCH", "/v1/cloud/connections/", "cloud.connection:write"),
+        ("DELETE", "/v1/cloud/connections/", "cloud.connection:write"),
+        ("GET", "/v1/findings", "finding:read"),
+        ("GET", "/v1/graph", "graph:read"),
+        ("POST", "/v1/graph/query", "graph:read"),
+        ("POST", "/v1/graph/should-i-deploy", "graph:read"),
         ("GET", "/v1/auth/keys", "auth.keys:read"),
         ("GET", "/v1/auth/secrets/lifecycle", "auth.secrets:read"),
         ("GET", "/v1/auth/secrets/rotation-plan", "auth.secrets:read"),
@@ -2032,6 +2102,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if method != "POST":
             return False
         if path.startswith("/v1/scan"):
+            return True
+        if path.startswith("/v1/cloud/connections"):
             return True
         return path in cls._WRITE_RATE_LIMIT_PATHS
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1490,6 +1490,10 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         # headers for the configured origin set.
         if request.method == "OPTIONS":
             return await call_next(request)
+        from agent_bom.api.managed_trial import managed_trial_enabled, managed_trial_route_allowed
+
+        if managed_trial_enabled() and not managed_trial_route_allowed(request.method, request.url.path):
+            return JSONResponse(status_code=403, content={"detail": "This API route is disabled in managed trial mode."})
         if request.url.path in self._EXEMPT_PATHS:
             return await call_next(request)
         if self._is_dashboard_public_request(request.url.path, request.method):

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -911,6 +911,9 @@ class TenantQuotaUpdateRequest(BaseModel):
     retained_scan_jobs: int | None = Field(default=None, ge=0)
     fleet_agents: int | None = Field(default=None, ge=0)
     schedules: int | None = Field(default=None, ge=0)
+    cloud_connections: int | None = Field(default=None, ge=0)
+    cloud_connections_per_provider: int | None = Field(default=None, ge=0)
+    scan_credits_24h: int | None = Field(default=None, ge=0)
 
 
 class ExecScoreConfigUpdateRequest(BaseModel):

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -1381,6 +1381,9 @@ async def test_connection(request: Request, connection_id: str, _role: Any = _SC
 
     record = _require_connection(request, connection_id)
     _reject_showcase_connection(record)
+    from agent_bom.api.managed_trial import enforce_stored_connection_envelope
+
+    enforce_stored_connection_envelope(record)
     tenant_id = record.tenant_id
     actor = _actor(request)
 
@@ -1453,6 +1456,9 @@ async def scan_connection(request: Request, connection_id: str, _role: Any = _SC
     """
     record = _require_connection(request, connection_id)
     _reject_showcase_connection(record)
+    from agent_bom.api.managed_trial import enforce_stored_connection_envelope
+
+    enforce_stored_connection_envelope(record)
     tenant_id = record.tenant_id
     actor = _actor(request)
 

--- a/src/agent_bom/api/routes/cloud_connections.py
+++ b/src/agent_bom/api/routes/cloud_connections.py
@@ -39,6 +39,7 @@ import logging
 import re
 import uuid
 from collections.abc import Callable
+from contextvars import ContextVar
 from datetime import datetime, timezone
 from typing import Any
 
@@ -62,6 +63,7 @@ from agent_bom.api.connection_store import (
     get_connection_store,
 )
 from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.api.tenant_quota import enforce_cloud_connection_quota, tenant_quota_guard
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.cloud.event_ingest import CloudChangeEvent, dispatch_change_event
 from agent_bom.config import CONNECTIONS_SCHEDULER_MIN_INTERVAL_MINUTES
@@ -77,6 +79,7 @@ _MAX_AUTH_PARAM_VALUE_LEN = 1024
 # Upper bound on a recurring scan interval (1 week) so a typo can't park a
 # connection effectively-never-scanning while still claiming to be scheduled.
 _MAX_SCAN_INTERVAL_MINUTES = 7 * 24 * 60
+_CONNECTION_SCAN_ID: ContextVar[str | None] = ContextVar("agent_bom_connection_scan_id", default=None)
 
 router = APIRouter(tags=["cloud-connections"])
 _logger = logging.getLogger(__name__)
@@ -284,6 +287,18 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
     scan_mode = _validate_scan_mode(body.scan_mode)
     auto_scan_on_create = bool(body.auto_scan_on_create)
 
+    from agent_bom.api.managed_trial import enforce_connection_envelope, managed_trial_enabled
+
+    enforce_connection_envelope(
+        provider=provider,
+        regions=regions,
+        inventory_scope=inventory_scope,
+        scan_mode=scan_mode,
+        scan_interval_minutes=scan_interval_minutes,
+    )
+    if managed_trial_enabled():
+        auto_scan_on_create = False
+
     # Fail closed before doing anything if the store cannot encrypt the secret.
     if not connections_key_configured():
         raise HTTPException(
@@ -317,7 +332,11 @@ async def create_connection(request: Request, body: CloudConnectionCreate, _role
         scan_mode=scan_mode,
         auto_scan_on_create=auto_scan_on_create,
     )
-    get_connection_store().put(record)
+    with tenant_quota_guard(
+        tenant_id,
+        lambda: enforce_cloud_connection_quota(tenant_id, provider),
+    ):
+        get_connection_store().put(record)
     log_action(
         "cloud_connection.create",
         actor=_actor(request),
@@ -454,6 +473,9 @@ async def ingest_connection_events(
     skipped fail-closed (no confused-deputy scan). Heavy dispatch runs off the
     event loop. Errors are sanitized — never returned raw.
     """
+    from agent_bom.api.managed_trial import require_managed_trial_feature
+
+    require_managed_trial_feature("Continuous connection event ingest")
     tenant_id = _tenant(request)
     results: list[dict[str, Any]] = []
     dispatched = 0
@@ -591,14 +613,30 @@ async def update_connection(
     secret is untouched and never returned.
     """
     record = _require_connection(request, connection_id)
+    from agent_bom.api.managed_trial import enforce_connection_envelope, managed_trial_enabled
+
+    next_interval = record.scan_interval_minutes
     if "scan_interval_minutes" in body.model_fields_set:
-        record.scan_interval_minutes = _validate_scan_interval(body.scan_interval_minutes)
+        next_interval = _validate_scan_interval(body.scan_interval_minutes)
+    next_scope = _validate_inventory_scope(body.inventory_scope) if body.inventory_scope is not None else record.inventory_scope
+    next_mode = _validate_scan_mode(body.scan_mode) if body.scan_mode is not None else record.scan_mode
+    enforce_connection_envelope(
+        provider=record.provider,
+        regions=record.regions,
+        inventory_scope=next_scope,
+        scan_mode=next_mode,
+        scan_interval_minutes=next_interval,
+    )
+    if "scan_interval_minutes" in body.model_fields_set:
+        record.scan_interval_minutes = next_interval
     if body.inventory_scope is not None:
         record.inventory_scope = _validate_inventory_scope(body.inventory_scope)
     if body.scan_mode is not None:
         record.scan_mode = _validate_scan_mode(body.scan_mode)
     if body.auto_scan_on_create is not None:
         record.auto_scan_on_create = bool(body.auto_scan_on_create)
+    if managed_trial_enabled():
+        record.auto_scan_on_create = False
     record.updated_at = _now()
     get_connection_store().put(record)
     log_action(
@@ -727,18 +765,19 @@ def _persist_connection_report(record: CloudConnectionRecord, tenant_id: str, re
     report_json = to_json(report)
     _annotate_inventory_counts(report_json.get("cloud_inventory"))
     now = _now()
+    store = _get_store()
+    reserved = store.get(str(report.scan_id), tenant_id=tenant_id)
     job = ScanJob(
         job_id=report.scan_id,
         tenant_id=tenant_id,
-        created_at=now,
-        started_at=now,
+        created_at=reserved.created_at if reserved is not None else now,
+        started_at=reserved.started_at if reserved is not None else now,
         completed_at=now,
         status=JobStatus.DONE,
         request=ScanRequest(),
         result=report_json,
         triggered_by=f"cloud-connection/{record.id}",
     )
-    store = _get_store()
     store.put(job)
     _jobs_put(job.job_id, job, compact_terminal=True)
     _persist_graph_snapshot(job, report_json)
@@ -753,6 +792,71 @@ def _mark_connection_report_sources(report: Any, provider: str) -> None:
 def _scan_audit_metadata(note: str) -> dict[str, Any]:
     """Read-only audit envelope attached to every connection-scan summary."""
     return {"read_only": True, "writes_performed": False, "note": note}
+
+
+def _connection_report_scan_id() -> str:
+    """Use a pre-reserved job id when a request-path scan supplied one."""
+
+    return _CONNECTION_SCAN_ID.get() or str(uuid.uuid4())
+
+
+def _reserve_connection_scan_job(record: CloudConnectionRecord) -> Any:
+    """Atomically reserve tenant job capacity and one managed-trial credit."""
+
+    from agent_bom.api.models import ScanJob, ScanRequest
+    from agent_bom.api.stores import _get_store, _jobs_put
+    from agent_bom.api.tenant_quota import (
+        consume_managed_trial_scan_credit,
+        enforce_active_scan_quota,
+        enforce_retained_jobs_quota,
+    )
+
+    now = _now()
+    job = ScanJob(
+        job_id=str(uuid.uuid4()),
+        tenant_id=record.tenant_id,
+        created_at=now,
+        started_at=now,
+        request=ScanRequest(),
+        triggered_by=f"cloud-connection/{record.id}",
+    )
+    store = _get_store()
+    with tenant_quota_guard(
+        record.tenant_id,
+        lambda: enforce_active_scan_quota(record.tenant_id),
+        lambda: enforce_retained_jobs_quota(record.tenant_id),
+    ):
+        # Consume only after both job checks pass so a capacity denial never
+        # burns a trial credit. The limiter operation is itself atomic across
+        # replicas when Postgres is configured.
+        consume_managed_trial_scan_credit(record.tenant_id)
+        store.put(job)
+        _jobs_put(job.job_id, job)
+    return job
+
+
+def _fail_connection_scan_job(job: Any, detail: str) -> None:
+    """Persist a terminal, sanitized failure for a reserved connection scan."""
+
+    from agent_bom.api.models import JobStatus
+    from agent_bom.api.stores import _get_store, _jobs_put
+
+    job.status = JobStatus.FAILED
+    job.completed_at = _now()
+    job.error = detail
+    _get_store().put(job)
+    _jobs_put(job.job_id, job, compact_terminal=True)
+
+
+def _discard_unused_scan_reservation(job: Any, summary: dict[str, Any]) -> None:
+    """Remove a reservation when an injected runner did not persist its job id."""
+
+    if str(summary.get("scan_id") or "") == job.job_id:
+        return
+    from agent_bom.api.stores import _get_store, _jobs_pop
+
+    _get_store().delete(job.job_id, tenant_id=job.tenant_id)
+    _jobs_pop(job.job_id)
 
 
 def _test_connection_broker(record: CloudConnectionRecord) -> None:
@@ -798,8 +902,6 @@ def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
     across member accounts via the brokered management session — gated by the
     connection's ``inventory_scope``, not ``AGENT_BOM_AWS_ORG_INVENTORY``.
     """
-    import uuid as _uuid
-
     from agent_bom.api.connection_crypto import decrypt_secret
     from agent_bom.cloud import aws_inventory, aws_organizations
     from agent_bom.cloud.aws_cis_benchmark import run_all_account_benchmarks
@@ -844,7 +946,7 @@ def _run_aws_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
 
     cis_dict = cis_report.to_dict()
 
-    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=_connection_report_scan_id())
     _mark_connection_report_sources(report, "aws")
     report.cloud_inventory_data = inventory_payload
     report.cis_benchmark_data = cis_dict
@@ -897,8 +999,6 @@ def _run_azure_connection_scan(record: CloudConnectionRecord, tenant_id: str) ->
     ``azure_inventory.discover_inventory`` and Azure CIS ``run_benchmark`` the
     sibling cloud routes use run against the customer subscription. Read-only.
     """
-    import uuid as _uuid
-
     from agent_bom.cloud import azure_inventory
     from agent_bom.cloud.azure_cis_benchmark import run_benchmark as run_azure_cis
     from agent_bom.cloud.connection_broker import broker_session
@@ -927,7 +1027,7 @@ def _run_azure_connection_scan(record: CloudConnectionRecord, tenant_id: str) ->
         account_ref=account_ref,
     )
 
-    report = AIBOMReport(agents=[], blast_radii=[], findings=dspm_findings, scan_id=str(_uuid.uuid4()))
+    report = AIBOMReport(agents=[], blast_radii=[], findings=dspm_findings, scan_id=_connection_report_scan_id())
     _mark_connection_report_sources(report, "azure")
     report.cloud_inventory_data = inventory_payload
     report.azure_cis_benchmark_data = cis_dict
@@ -966,8 +1066,6 @@ def _run_gcp_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
     same ``gcp_inventory.discover_inventory`` and GCP CIS ``run_benchmark`` the
     sibling cloud routes use run against the customer project. Read-only.
     """
-    import uuid as _uuid
-
     from agent_bom.cloud import gcp_inventory
     from agent_bom.cloud.connection_broker import broker_session
     from agent_bom.cloud.gcp_cis_benchmark import run_benchmark as run_gcp_cis
@@ -984,7 +1082,7 @@ def _run_gcp_connection_scan(record: CloudConnectionRecord, tenant_id: str) -> d
     cis_report = run_gcp_cis(project_id=project_id, credentials=credentials)
     cis_dict = cis_report.to_dict()
 
-    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+    report = AIBOMReport(agents=[], blast_radii=[], findings=[], scan_id=_connection_report_scan_id())
     _mark_connection_report_sources(report, "gcp")
     report.cloud_inventory_data = inventory_payload
     report.gcp_cis_benchmark_data = cis_dict
@@ -1071,8 +1169,6 @@ def _run_snowflake_connection_scan(record: CloudConnectionRecord, tenant_id: str
     have run. The estate sweep is best-effort: a failure still returns agent
     discovery + CIS. Read-only.
     """
-    import uuid as _uuid
-
     from agent_bom.cloud import snowflake as snowflake_discovery
     from agent_bom.cloud.connection_broker import broker_session
     from agent_bom.cloud.snowflake_cis_benchmark import run_benchmark as run_snowflake_cis
@@ -1087,7 +1183,7 @@ def _run_snowflake_connection_scan(record: CloudConnectionRecord, tenant_id: str
     try:
         agents, _warnings = snowflake_discovery.discover(conn=conn)
         cis_report = run_snowflake_cis(conn=conn)
-        report = AIBOMReport(agents=agents, blast_radii=[], findings=[], scan_id=str(_uuid.uuid4()))
+        report = AIBOMReport(agents=agents, blast_radii=[], findings=[], scan_id=_connection_report_scan_id())
         _mark_connection_report_sources(report, "snowflake")
         # Sweep the estate into the report's snowflake_*_data blocks so the graph
         # builder materializes accounts/warehouses/databases/roles/users the same
@@ -1151,8 +1247,6 @@ def _run_database_connection_scan(record: CloudConnectionRecord, tenant_id: str)
     Coverage states (executed/partial/skipped/unevaluable/failed) stay explicit so
     a denied/unreadable table is never reported clean. Read-only throughout.
     """
-    import uuid as _uuid
-
     from agent_bom.cloud.connection_broker import broker_session
     from agent_bom.cloud.db_content_scan import scan_database_content
     from agent_bom.cloud.db_data_classifier import db_sampling_enabled
@@ -1218,7 +1312,7 @@ def _run_database_connection_scan(record: CloudConnectionRecord, tenant_id: str)
     account_ref = f"database:{account}" if account else None
     dspm_findings = build_inventory_dspm_findings(inventory, provider="database", account_ref=account_ref)
 
-    report = AIBOMReport(agents=[], blast_radii=[], findings=dspm_findings, scan_id=str(_uuid.uuid4()))
+    report = AIBOMReport(agents=[], blast_radii=[], findings=dspm_findings, scan_id=_connection_report_scan_id())
     _mark_connection_report_sources(report, "database")
     report.cloud_inventory_data = inventory
     scan_id = _persist_connection_report(record, tenant_id, report)
@@ -1365,13 +1459,19 @@ async def scan_connection(request: Request, connection_id: str, _role: Any = _SC
     if (record.provider or "").strip().lower() not in _SCAN_RUNNERS:
         raise HTTPException(status_code=400, detail=f"Unsupported provider '{record.provider}'.")
 
+    reservation: Any = None
     try:
         # The brokered scan runs synchronous provider inventory + CIS discovery
         # (minutes of network I/O); run it in a worker thread under backpressure
         # so a live scan can never stall the event loop (a burst sheds with a
         # 429 instead).
         async with adaptive_backpressure("cloud_connection_scan"):
-            summary = await anyio.to_thread.run_sync(_run_connection_scan, record, tenant_id)
+            reservation = _reserve_connection_scan_job(record)
+            scan_id_token = _CONNECTION_SCAN_ID.set(reservation.job_id)
+            try:
+                summary = await anyio.to_thread.run_sync(_run_connection_scan, record, tenant_id)
+            finally:
+                _CONNECTION_SCAN_ID.reset(scan_id_token)
     except BackpressureRejectedError as exc:
         # A shed request never started the scan — do not flip the connection to
         # error, just ask the caller to retry.
@@ -1380,11 +1480,15 @@ async def scan_connection(request: Request, connection_id: str, _role: Any = _SC
             detail=exc.to_dict(),
             headers={"Retry-After": str(exc.retry_after_seconds)},
         ) from exc
+    except HTTPException:
+        raise
     except Exception as exc:  # noqa: BLE001 - broker / discovery / persistence failure
         # Persist an actionable, secret-free detail (why + how to fix). Broker and
         # discovery errors are curated safe strings; anything unexpected falls back
         # to a fixed generic message. Full diagnostics go to the server log only.
         detail = _safe_connection_detail(exc)
+        if reservation is not None:
+            _fail_connection_scan_job(reservation, detail)
         _mark_connection(record, status=STATUS_ERROR, status_detail=detail)
         _logger.exception("Cloud connection scan failed for connection %s", record.id)
         log_action(
@@ -1397,6 +1501,8 @@ async def scan_connection(request: Request, connection_id: str, _role: Any = _SC
         )
         raise HTTPException(status_code=502, detail=detail) from exc
 
+    if reservation is not None:
+        _discard_unused_scan_reservation(reservation, summary)
     scan_id = str(summary.get("scan_id") or "")
     _mark_connection(
         record,

--- a/src/agent_bom/api/routes/schedules.py
+++ b/src/agent_bom/api/routes/schedules.py
@@ -26,6 +26,9 @@ router = APIRouter()
 @router.post("/schedules", tags=["schedules"], status_code=201)
 async def create_schedule(request: Request, body: ScheduleCreate) -> dict:
     """Create a recurring scan schedule."""
+    from agent_bom.api.managed_trial import require_managed_trial_feature
+
+    require_managed_trial_feature("Scan schedules")
     from agent_bom.api.audit_log import log_action
     from agent_bom.api.schedule_store import ScanSchedule
     from agent_bom.api.scheduler import parse_cron_next, validate_cron_expression

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -467,8 +467,10 @@ def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
 
     defaults = default_tenant_quotas()
     overrides = get_tenant_quota_overrides(tenant_id)
-    effective = dict(defaults)
-    effective.update(overrides)
+    effective = effective_tenant_quotas(tenant_id)
+    from agent_bom.api.managed_trial import MANAGED_TRIAL_QUOTA_CAPS, managed_trial_enabled
+
+    trial_enabled = managed_trial_enabled()
 
     def _entry(quota_name: QuotaName, current: int) -> dict[str, int | bool | str | None]:
         limit = effective[quota_name]
@@ -486,6 +488,11 @@ def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
             else:
                 status = "ok"
                 recommended_action = "Usage is within the enforced tenant quota."
+        source = "tenant_override" if quota_name in overrides else "global_default"
+        if trial_enabled and quota_name in MANAGED_TRIAL_QUOTA_CAPS:
+            requested = overrides.get(quota_name)
+            if requested is None or requested <= 0 or requested >= MANAGED_TRIAL_QUOTA_CAPS[quota_name]:
+                source = "managed_trial_cap"
         return {
             "limit": limit,
             "default_limit": defaults[quota_name],
@@ -493,7 +500,7 @@ def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
             "current": current,
             "remaining": None if limit <= 0 else max(limit - current, 0),
             "enforced": limit > 0,
-            "source": "tenant_override" if quota_name in overrides else "global_default",
+            "source": source,
             "utilization_pct": utilization_pct,
             "status": status,
             "recommended_action": recommended_action,
@@ -526,12 +533,14 @@ def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
     provider_peak = _safe_count(_provider_peak)
 
     return {
-        "source": "tenant_override" if overrides else "global_default",
+        "source": "managed_trial_policy" if trial_enabled else ("tenant_override" if overrides else "global_default"),
         "per_tenant_overrides": True,
         "active_override": bool(overrides),
         "override_endpoint": "/v1/auth/quota",
         "message": (
-            "Tenant quotas resolve from tenant-specific overrides with global defaults as fallback."
+            "Managed-trial quota caps are enforced; tenant overrides can only tighten them."
+            if trial_enabled
+            else "Tenant quotas resolve from tenant-specific overrides with global defaults as fallback."
             if overrides
             else "Tenant quotas resolve from global defaults. Tenant-specific overrides can be configured when needed."
         ),

--- a/src/agent_bom/api/tenant_quota.py
+++ b/src/agent_bom/api/tenant_quota.py
@@ -7,6 +7,7 @@ import hashlib
 import logging
 import os
 import threading
+import time
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
 from typing import Any, Literal
@@ -18,8 +19,11 @@ from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_schedule_store, _get_store, _get_tenant_quota_store
 from agent_bom.config import (
     API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT,
+    API_MAX_CLOUD_CONNECTIONS_PER_PROVIDER,
+    API_MAX_CLOUD_CONNECTIONS_PER_TENANT,
     API_MAX_FLEET_AGENTS_PER_TENANT,
     API_MAX_RETAINED_JOBS_PER_TENANT,
+    API_MAX_SCAN_CREDITS_24H_PER_TENANT,
     API_MAX_SCHEDULES_PER_TENANT,
 )
 from agent_bom.security import sanitize_text
@@ -39,6 +43,9 @@ _logger = logging.getLogger(__name__)
 # follow-up so the storage layer can carry the lock through.
 _TENANT_QUOTA_LOCKS: dict[str, threading.Lock] = {}
 _TENANT_QUOTA_LOCKS_LOCK = threading.Lock()
+_MANAGED_TRIAL_SCAN_CREDIT_STORE: Any = None
+_MANAGED_TRIAL_SCAN_CREDIT_STORE_LOCK = threading.Lock()
+_SCAN_CREDIT_WINDOW_SECONDS = 24 * 60 * 60
 
 
 def _tenant_quota_lock(tenant_id: str) -> threading.Lock:
@@ -173,18 +180,45 @@ def tenant_quota_guard(tenant_id: str, *checks: Callable[[], None]) -> Iterator[
         yield
 
 
-QuotaName = Literal["active_scan_jobs", "retained_scan_jobs", "fleet_agents", "schedules"]
-QUOTA_NAMES: tuple[QuotaName, ...] = ("active_scan_jobs", "retained_scan_jobs", "fleet_agents", "schedules")
+QuotaName = Literal[
+    "active_scan_jobs",
+    "retained_scan_jobs",
+    "fleet_agents",
+    "schedules",
+    "cloud_connections",
+    "cloud_connections_per_provider",
+    "scan_credits_24h",
+]
+QUOTA_NAMES: tuple[QuotaName, ...] = (
+    "active_scan_jobs",
+    "retained_scan_jobs",
+    "fleet_agents",
+    "schedules",
+    "cloud_connections",
+    "cloud_connections_per_provider",
+    "scan_credits_24h",
+)
 
 
 def default_tenant_quotas() -> dict[QuotaName, int]:
     """Return the process-level default tenant quotas."""
-    return {
+    defaults: dict[QuotaName, int] = {
         "active_scan_jobs": API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT,
         "retained_scan_jobs": API_MAX_RETAINED_JOBS_PER_TENANT,
         "fleet_agents": API_MAX_FLEET_AGENTS_PER_TENANT,
         "schedules": API_MAX_SCHEDULES_PER_TENANT,
+        "cloud_connections": API_MAX_CLOUD_CONNECTIONS_PER_TENANT,
+        "cloud_connections_per_provider": API_MAX_CLOUD_CONNECTIONS_PER_PROVIDER,
+        "scan_credits_24h": API_MAX_SCAN_CREDITS_24H_PER_TENANT,
     }
+    from agent_bom.api.managed_trial import MANAGED_TRIAL_QUOTA_CAPS, managed_trial_enabled
+
+    if managed_trial_enabled():
+        for name in QUOTA_NAMES:
+            if name in MANAGED_TRIAL_QUOTA_CAPS:
+                defaults[name] = MANAGED_TRIAL_QUOTA_CAPS[name]
+        defaults["schedules"] = 0
+    return defaults
 
 
 def get_tenant_quota_overrides(tenant_id: str) -> dict[QuotaName, int]:
@@ -222,11 +256,78 @@ def effective_tenant_quotas(tenant_id: str) -> dict[QuotaName, int]:
     defaults = default_tenant_quotas()
     effective = dict(defaults)
     effective.update(get_tenant_quota_overrides(tenant_id))
+    from agent_bom.api.managed_trial import MANAGED_TRIAL_QUOTA_CAPS, managed_trial_enabled
+
+    if managed_trial_enabled():
+        # Trial quotas are hard ceilings. Overrides can tighten them, never turn
+        # them off (0 means unlimited in the self-hosted contract) or raise them.
+        for name in QUOTA_NAMES:
+            if name not in MANAGED_TRIAL_QUOTA_CAPS:
+                continue
+            cap = MANAGED_TRIAL_QUOTA_CAPS[name]
+            configured = effective[name]
+            effective[name] = cap if configured <= 0 else min(configured, cap)
     return effective
 
 
 def _quota_limit(tenant_id: str, quota_name: QuotaName) -> int:
     return effective_tenant_quotas(tenant_id)[quota_name]
+
+
+def _managed_trial_scan_credit_store() -> Any:
+    global _MANAGED_TRIAL_SCAN_CREDIT_STORE
+    if _MANAGED_TRIAL_SCAN_CREDIT_STORE is None:
+        with _MANAGED_TRIAL_SCAN_CREDIT_STORE_LOCK:
+            if _MANAGED_TRIAL_SCAN_CREDIT_STORE is None:
+                from agent_bom.api.middleware import _build_rate_limit_store
+
+                _MANAGED_TRIAL_SCAN_CREDIT_STORE = _build_rate_limit_store(_SCAN_CREDIT_WINDOW_SECONDS)
+    return _MANAGED_TRIAL_SCAN_CREDIT_STORE
+
+
+def reset_managed_trial_scan_credit_store() -> None:
+    """Reset lazy credit state (test isolation and explicit runtime reconfigure)."""
+
+    global _MANAGED_TRIAL_SCAN_CREDIT_STORE
+    with _MANAGED_TRIAL_SCAN_CREDIT_STORE_LOCK:
+        _MANAGED_TRIAL_SCAN_CREDIT_STORE = None
+
+
+def _scan_credit_key(tenant_id: str) -> str:
+    return f"tenant:{tenant_id}:managed-trial-scan-credit"
+
+
+def consume_managed_trial_scan_credit(tenant_id: str, *, now: float | None = None) -> int:
+    """Consume one rolling-24-hour trial scan credit or reject atomically."""
+
+    from agent_bom.api.managed_trial import managed_trial_enabled
+
+    if not managed_trial_enabled():
+        return 0
+    limit = _quota_limit(tenant_id, "scan_credits_24h")
+    timestamp = time.time() if now is None else float(now)
+    accepted, current, _reset_at = _managed_trial_scan_credit_store().consume_if_below(
+        _scan_credit_key(tenant_id), timestamp, limit
+    )
+    if not accepted:
+        _raise_quota_exceeded(
+            tenant_id=tenant_id,
+            quota_name="scan_credits_24h",
+            limit=limit,
+            current=current,
+        )
+    return int(current)
+
+
+def current_managed_trial_scan_credits(tenant_id: str, *, now: float | None = None) -> int:
+    """Return rolling-24-hour trial scan credits consumed without charging one."""
+
+    from agent_bom.api.managed_trial import managed_trial_enabled
+
+    if not managed_trial_enabled():
+        return 0
+    timestamp = time.time() if now is None else float(now)
+    return int(_managed_trial_scan_credit_store().count(_scan_credit_key(tenant_id), timestamp))
 
 
 def _raise_quota_exceeded(
@@ -329,6 +430,34 @@ def enforce_schedule_quota(tenant_id: str, attempted: int = 1) -> None:
         )
 
 
+def enforce_cloud_connection_quota(tenant_id: str, provider: str, attempted: int = 1) -> None:
+    """Limit total and per-provider cloud connections for a tenant."""
+
+    from agent_bom.api.connection_store import get_connection_store
+
+    records = get_connection_store().list_for_tenant(tenant_id)
+    total_limit = _quota_limit(tenant_id, "cloud_connections")
+    if total_limit > 0 and len(records) + attempted > total_limit:
+        _raise_quota_exceeded(
+            tenant_id=tenant_id,
+            quota_name="cloud_connections",
+            limit=total_limit,
+            current=len(records),
+            attempted=attempted,
+        )
+
+    provider_limit = _quota_limit(tenant_id, "cloud_connections_per_provider")
+    provider_count = sum(1 for record in records if record.provider == provider)
+    if provider_limit > 0 and provider_count + attempted > provider_limit:
+        _raise_quota_exceeded(
+            tenant_id=tenant_id,
+            quota_name="cloud_connections_per_provider",
+            limit=provider_limit,
+            current=provider_count,
+            attempted=attempted,
+        )
+
+
 def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
     """Return operator-facing quota status for a tenant.
 
@@ -384,6 +513,17 @@ def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
     retained_jobs = _safe_count(lambda: len(_get_store().list_all(tenant_id=tenant_id)))
     fleet_agents = _safe_count(lambda: len(_get_fleet_store().list_by_tenant(tenant_id)))
     schedules = _safe_count(lambda: len(_get_schedule_store().list_all(tenant_id=tenant_id)))
+    from agent_bom.api.connection_store import get_connection_store
+
+    connections = _safe_count(lambda: len(get_connection_store().list_for_tenant(tenant_id)))
+
+    def _provider_peak() -> int:
+        counts: dict[str, int] = {}
+        for record in get_connection_store().list_for_tenant(tenant_id):
+            counts[record.provider] = counts.get(record.provider, 0) + 1
+        return max(counts.values(), default=0)
+
+    provider_peak = _safe_count(_provider_peak)
 
     return {
         "source": "tenant_override" if overrides else "global_default",
@@ -401,5 +541,8 @@ def get_tenant_quota_runtime(tenant_id: str) -> dict[str, object]:
             "retained_scan_jobs": _entry("retained_scan_jobs", retained_jobs),
             "fleet_agents": _entry("fleet_agents", fleet_agents),
             "schedules": _entry("schedules", schedules),
+            "cloud_connections": _entry("cloud_connections", connections),
+            "cloud_connections_per_provider": _entry("cloud_connections_per_provider", provider_peak),
+            "scan_credits_24h": _entry("scan_credits_24h", current_managed_trial_scan_credits(tenant_id)),
         },
     }

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -492,6 +492,13 @@ API_MAX_ACTIVE_SCAN_JOBS_PER_TENANT = _int("AGENT_BOM_API_MAX_ACTIVE_SCAN_JOBS_P
 API_MAX_RETAINED_JOBS_PER_TENANT = _int("AGENT_BOM_API_MAX_RETAINED_JOBS_PER_TENANT", 500)
 API_MAX_FLEET_AGENTS_PER_TENANT = _int("AGENT_BOM_API_MAX_FLEET_AGENTS_PER_TENANT", 1_000)
 API_MAX_SCHEDULES_PER_TENANT = _int("AGENT_BOM_API_MAX_SCHEDULES_PER_TENANT", 100)
+API_MAX_CLOUD_CONNECTIONS_PER_TENANT = _int("AGENT_BOM_API_MAX_CLOUD_CONNECTIONS_PER_TENANT", 0)
+API_MAX_CLOUD_CONNECTIONS_PER_PROVIDER = _int("AGENT_BOM_API_MAX_CLOUD_CONNECTIONS_PER_PROVIDER", 0)
+API_MAX_SCAN_CREDITS_24H_PER_TENANT = _int("AGENT_BOM_API_MAX_SCAN_CREDITS_24H_PER_TENANT", 0)
+# Explicit opt-in marker for the bounded operator-run evaluation policy. Runtime
+# request guards re-read the environment so tests and process supervisors can
+# validate configuration changes without changing self-hosted defaults.
+MANAGED_TRIAL_MODE = _bool("AGENT_BOM_MANAGED_TRIAL_MODE", False)
 # Per-request fan-out ceiling: a single POST /v1/scan expands one batchable
 # target field per child job, so an uncapped request could enqueue unbounded
 # work bounded only by the tenant active-scan quota churn. Reject over-cap

--- a/tests/api/test_managed_trial_guardrails.py
+++ b/tests/api/test_managed_trial_guardrails.py
@@ -6,10 +6,18 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 
 import pytest
-from fastapi import HTTPException
+from fastapi import FastAPI, HTTPException
+from starlette.testclient import TestClient
 
+from agent_bom.api import managed_trial
 from agent_bom.api.connection_scheduler import connections_scheduler_enabled
-from agent_bom.api.connection_store import InMemoryConnectionStore, get_connection_store, set_connection_store
+from agent_bom.api.connection_store import (
+    SCAN_MODE_FULL,
+    CloudConnectionRecord,
+    InMemoryConnectionStore,
+    get_connection_store,
+    set_connection_store,
+)
 from agent_bom.api.middleware import APIKeyMiddleware, RateLimitMiddleware
 from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
 from agent_bom.api.routes import cloud_connections
@@ -20,6 +28,7 @@ from agent_bom.api.tenant_quota import (
     consume_managed_trial_scan_credit,
     current_managed_trial_scan_credits,
     effective_tenant_quotas,
+    get_tenant_quota_runtime,
     reset_managed_trial_scan_credit_store,
     set_tenant_quota_overrides,
 )
@@ -54,12 +63,32 @@ def _body(**updates: object) -> CloudConnectionCreate:
     payload: dict[str, object] = {
         "provider": "aws",
         "display_name": "sandbox",
-        "role_ref": "arn:aws:iam::123456789012:role/agent-bom-readonly",
+        "role_ref": "arn:aws:iam::000000000000:role/agent-bom-readonly",
         "external_id": "write-only-secret",
         "regions": ["us-east-1"],
     }
     payload.update(updates)
     return CloudConnectionCreate.model_validate(payload)
+
+
+def _stored_connection(**updates: object) -> CloudConnectionRecord:
+    payload: dict[str, object] = {
+        "id": "connection-stale",
+        "tenant_id": "tenant-trial",
+        "provider": "aws",
+        "display_name": "stale connection",
+        "role_ref": "arn:aws:iam::000000000000:role/agent-bom-readonly",
+        "external_id_encrypted": "encrypted:synthetic",
+        "regions": ["us-east-1"],
+        "inventory_scope": "account",
+        "scan_mode": SCAN_MODE_FULL,
+        "scan_interval_minutes": None,
+        "auto_scan_on_create": False,
+    }
+    payload.update(updates)
+    record = CloudConnectionRecord(**payload)  # type: ignore[arg-type]
+    get_connection_store().put(record)
+    return record
 
 
 def test_managed_trial_defaults_are_bounded() -> None:
@@ -70,6 +99,67 @@ def test_managed_trial_defaults_are_bounded() -> None:
     assert quotas["cloud_connections"] == 2
     assert quotas["cloud_connections_per_provider"] == 2
     assert quotas["scan_credits_24h"] == 8
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/v1/auth/me"),
+        ("POST", "/v1/auth/session"),
+        ("DELETE", "/v1/auth/session"),
+        ("GET", "/v1/auth/oidc/login"),
+        ("GET", "/v1/auth/oidc/callback"),
+        ("GET", "/v1/cloud/connections"),
+        ("POST", "/v1/cloud/connections"),
+        ("GET", "/v1/cloud/connections/connection-one"),
+        ("POST", "/v1/cloud/connections/connection-one/test"),
+        ("POST", "/v1/cloud/connections/connection-one/scan"),
+        ("GET", "/v1/findings"),
+        ("GET", "/v1/graph/node/node-one"),
+        ("POST", "/v1/graph/query"),
+    ],
+)
+def test_managed_trial_route_allowlist_is_explicit(method: str, path: str) -> None:
+    assert managed_trial.managed_trial_route_allowed(method, path) is True
+
+
+@pytest.mark.parametrize(
+    ("method", "path"),
+    [
+        ("GET", "/v1/auth/keys"),
+        ("POST", "/v1/scan"),
+        ("PATCH", "/v1/cloud/connections/connection-one"),
+        ("DELETE", "/v1/cloud/connections/connection-one"),
+        ("POST", "/v1/cloud/connections/events/ingest"),
+        ("POST", "/v1/findings/bulk"),
+        ("POST", "/v1/graph/presets"),
+        ("GET", "/v1/schedules"),
+        ("POST", "/scim/v2/Users"),
+    ],
+)
+def test_managed_trial_route_policy_defaults_to_deny(method: str, path: str) -> None:
+    assert managed_trial.managed_trial_route_allowed(method, path) is False
+
+
+def test_managed_trial_route_denial_precedes_every_principal_resolver() -> None:
+    app = FastAPI()
+
+    @app.get("/v1/auth/keys")
+    async def _forbidden_surface() -> dict[str, bool]:
+        return {"reached": True}
+
+    app.add_middleware(APIKeyMiddleware, api_key="")
+    client = TestClient(app)
+
+    attempts = (
+        {"headers": {"x-api-key": "synthetic-api-key"}},
+        {"headers": {"authorization": "Bearer synthetic.oidc.token"}},
+        {"headers": {"cookie": "agent_bom_session=synthetic-browser-session"}},
+    )
+    for attempt in attempts:
+        response = client.get("/v1/auth/keys", **attempt)
+        assert response.status_code == 403
+        assert response.json() == {"detail": "This API route is disabled in managed trial mode."}
 
 
 def test_managed_trial_disables_connection_scheduler_even_when_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -137,6 +227,71 @@ def test_managed_trial_scan_credits_are_atomic_and_do_not_charge_denials() -> No
     assert statuses.count(200) == 8
     assert statuses.count(429) == 2
     assert current_managed_trial_scan_credits("tenant-trial") == 8
+
+
+def test_managed_trial_runtime_reports_the_same_clamped_quotas_as_enforcement() -> None:
+    set_tenant_quota_overrides(
+        "tenant-trial",
+        {
+            "active_scan_jobs": 9,
+            "retained_scan_jobs": 200,
+            "cloud_connections": 99,
+            "cloud_connections_per_provider": 50,
+            "scan_credits_24h": 100,
+        },
+    )
+
+    effective = effective_tenant_quotas("tenant-trial")
+    runtime = get_tenant_quota_runtime("tenant-trial")
+
+    for quota_name, enforced_limit in effective.items():
+        assert runtime["usage"][quota_name]["limit"] == enforced_limit  # type: ignore[index]
+
+
+@pytest.mark.parametrize(
+    "updates",
+    [
+        {"provider": "database", "regions": []},
+        {"inventory_scope": "organization"},
+        {"regions": []},
+        {"regions": ["ALL"]},
+        {"regions": ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", "eu-west-2"]},
+    ],
+)
+def test_connection_test_and_scan_revalidate_stale_trial_records_before_execution(
+    monkeypatch: pytest.MonkeyPatch,
+    updates: dict[str, object],
+) -> None:
+    record = _stored_connection(**updates)
+    broker_calls: list[str] = []
+    scan_calls: list[str] = []
+    monkeypatch.setattr(cloud_connections, "_test_connection_broker", lambda _record: broker_calls.append("test"))
+    monkeypatch.setattr(
+        cloud_connections,
+        "_run_connection_scan",
+        lambda _record, _tenant_id: scan_calls.append("scan"),
+    )
+
+    with pytest.raises(HTTPException) as test_exc:
+        asyncio.run(cloud_connections.test_connection(request=object(), connection_id=record.id))
+    with pytest.raises(HTTPException) as scan_exc:
+        asyncio.run(cloud_connections.scan_connection(request=object(), connection_id=record.id))
+
+    assert test_exc.value.status_code == 403
+    assert scan_exc.value.status_code == 403
+    assert broker_calls == []
+    assert scan_calls == []
+    assert current_managed_trial_scan_credits("tenant-trial") == 0
+
+
+def test_worker_time_validator_rejects_stale_trial_connection() -> None:
+    record = _stored_connection(inventory_scope="organization")
+
+    with pytest.raises(HTTPException) as exc_info:
+        managed_trial.enforce_stored_connection_envelope(record)
+
+    assert exc_info.value.status_code == 403
+    assert "account scope" in str(exc_info.value.detail)
 
 
 def test_self_hosted_provider_quota_is_configurable_without_trial_restrictions(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/api/test_managed_trial_guardrails.py
+++ b/tests/api/test_managed_trial_guardrails.py
@@ -1,0 +1,210 @@
+"""Managed-trial guardrails stay explicit, fail closed, and opt-in."""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+from fastapi import HTTPException
+
+from agent_bom.api.connection_scheduler import connections_scheduler_enabled
+from agent_bom.api.connection_store import InMemoryConnectionStore, get_connection_store, set_connection_store
+from agent_bom.api.middleware import APIKeyMiddleware, RateLimitMiddleware
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.routes import cloud_connections
+from agent_bom.api.routes.cloud_connections import CloudConnectionCreate
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.api.stores import _get_store, _get_tenant_quota_store, set_job_store, set_tenant_quota_store
+from agent_bom.api.tenant_quota import (
+    consume_managed_trial_scan_credit,
+    current_managed_trial_scan_credits,
+    effective_tenant_quotas,
+    reset_managed_trial_scan_credit_store,
+    set_tenant_quota_overrides,
+)
+from agent_bom.api.tenant_quota_store import InMemoryTenantQuotaStore
+
+
+@pytest.fixture(autouse=True)
+def _isolated_stores(monkeypatch: pytest.MonkeyPatch):
+    original_connection_store = get_connection_store()
+    original_job_store = _get_store()
+    original_quota_store = _get_tenant_quota_store()
+    monkeypatch.setenv("AGENT_BOM_MANAGED_TRIAL_MODE", "1")
+    set_connection_store(InMemoryConnectionStore())
+    set_job_store(InMemoryJobStore())
+    set_tenant_quota_store(InMemoryTenantQuotaStore())
+    reset_managed_trial_scan_credit_store()
+    monkeypatch.setattr(cloud_connections, "connections_key_configured", lambda: True)
+    monkeypatch.setattr(cloud_connections, "encrypt_secret", lambda value: f"encrypted:{value}")
+    monkeypatch.setattr(cloud_connections, "log_action", lambda *args, **kwargs: None)
+    monkeypatch.setattr(cloud_connections, "_tenant", lambda request: "tenant-trial")
+    monkeypatch.setattr(cloud_connections, "_actor", lambda request: "trial-user")
+    try:
+        yield
+    finally:
+        reset_managed_trial_scan_credit_store()
+        set_connection_store(original_connection_store)
+        set_job_store(original_job_store)
+        set_tenant_quota_store(original_quota_store)
+
+
+def _body(**updates: object) -> CloudConnectionCreate:
+    payload: dict[str, object] = {
+        "provider": "aws",
+        "display_name": "sandbox",
+        "role_ref": "arn:aws:iam::123456789012:role/agent-bom-readonly",
+        "external_id": "write-only-secret",
+        "regions": ["us-east-1"],
+    }
+    payload.update(updates)
+    return CloudConnectionCreate.model_validate(payload)
+
+
+def test_managed_trial_defaults_are_bounded() -> None:
+    quotas = effective_tenant_quotas("tenant-trial")
+
+    assert quotas["active_scan_jobs"] == 1
+    assert quotas["retained_scan_jobs"] == 20
+    assert quotas["cloud_connections"] == 2
+    assert quotas["cloud_connections_per_provider"] == 2
+    assert quotas["scan_credits_24h"] == 8
+
+
+def test_managed_trial_disables_connection_scheduler_even_when_flagged(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_CONNECTIONS_SCHEDULER", "1")
+    assert connections_scheduler_enabled() is False
+
+
+@pytest.mark.parametrize(
+    "updates,detail",
+    [
+        ({"provider": "azure"}, "AWS"),
+        ({"provider": "database"}, "AWS"),
+        ({"inventory_scope": "organization"}, "account"),
+        ({"scan_mode": "continuous"}, "continuous"),
+        ({"scan_interval_minutes": 60}, "schedules"),
+        ({"regions": ["us-east-1", "us-east-2", "us-west-1", "us-west-2", "eu-west-1", "eu-west-2"]}, "5"),
+        ({"regions": ["all"]}, "explicit"),
+    ],
+)
+def test_managed_trial_rejects_out_of_envelope_connection(updates: dict[str, object], detail: str) -> None:
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(cloud_connections.create_connection(request=object(), body=_body(**updates)))
+
+    assert exc_info.value.status_code == 403
+    assert detail.lower() in str(exc_info.value.detail).lower()
+
+
+def test_managed_trial_forces_manual_scan_and_atomically_caps_connections() -> None:
+    first = asyncio.run(cloud_connections.create_connection(request=object(), body=_body(display_name="one")))
+    second = asyncio.run(cloud_connections.create_connection(request=object(), body=_body(display_name="two")))
+
+    assert first["auto_scan_on_create"] is False
+    assert second["auto_scan_on_create"] is False
+    assert first["last_scan_id"] is None
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(cloud_connections.create_connection(request=object(), body=_body(display_name="three")))
+    assert exc_info.value.status_code == 429
+    assert "cloud_connections" in str(exc_info.value.detail)
+
+
+def test_connection_mutations_use_write_bucket_and_narrow_scopes() -> None:
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/cloud/connections", "POST") is True
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/cloud/connections/abc/test", "POST") is True
+    assert RateLimitMiddleware._is_write_rate_limited("/v1/cloud/connections/abc/scan", "POST") is True
+
+    middleware = APIKeyMiddleware(app=lambda *_args: None, api_key="")
+    assert middleware._required_scope("GET", "/v1/cloud/connections") == "cloud.connection:read"
+    assert middleware._required_scope("POST", "/v1/cloud/connections") == "cloud.connection:write"
+    assert middleware._required_scope("GET", "/v1/findings") == "finding:read"
+    assert middleware._required_scope("GET", "/v1/graph") == "graph:read"
+
+
+def test_managed_trial_scan_credits_are_atomic_and_do_not_charge_denials() -> None:
+    def _consume() -> int:
+        try:
+            consume_managed_trial_scan_credit("tenant-trial")
+        except HTTPException as exc:
+            return exc.status_code
+        return 200
+
+    with ThreadPoolExecutor(max_workers=10) as executor:
+        statuses = list(executor.map(lambda _index: _consume(), range(10)))
+
+    assert statuses.count(200) == 8
+    assert statuses.count(429) == 2
+    assert current_managed_trial_scan_credits("tenant-trial") == 8
+
+
+def test_self_hosted_provider_quota_is_configurable_without_trial_restrictions(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_MANAGED_TRIAL_MODE", raising=False)
+    set_tenant_quota_overrides(
+        "tenant-trial",
+        {"cloud_connections": 10, "cloud_connections_per_provider": 2},
+    )
+
+    for name in ("aws-one", "aws-two"):
+        created = asyncio.run(
+            cloud_connections.create_connection(request=object(), body=_body(display_name=name, auto_scan_on_create=False))
+        )
+        assert created["provider"] == "aws"
+
+    with pytest.raises(HTTPException) as exc_info:
+        asyncio.run(
+            cloud_connections.create_connection(request=object(), body=_body(display_name="aws-three", auto_scan_on_create=False))
+        )
+    assert exc_info.value.status_code == 429
+    assert "cloud_connections_per_provider" in str(exc_info.value.detail)
+
+    azure = asyncio.run(
+        cloud_connections.create_connection(
+            request=object(),
+            body=_body(provider="azure", display_name="azure-one", regions=[], auto_scan_on_create=False),
+        )
+    )
+    assert azure["provider"] == "azure"
+
+
+def test_connection_scan_reservation_enforces_active_and_retained_job_quotas() -> None:
+    store = InMemoryJobStore()
+    set_job_store(store)
+    pending = ScanJob(
+        job_id="existing-active",
+        tenant_id="tenant-trial",
+        status=JobStatus.PENDING,
+        created_at="2026-07-24T00:00:00+00:00",
+        request=ScanRequest(),
+    )
+    store.put(pending)
+
+    record = type("Record", (), {"id": "connection-one", "tenant_id": "tenant-trial"})()
+    with pytest.raises(HTTPException) as exc_info:
+        cloud_connections._reserve_connection_scan_job(record)
+
+    assert exc_info.value.status_code == 429
+    assert "concurrent scan jobs" in str(exc_info.value.detail).lower()
+    assert current_managed_trial_scan_credits("tenant-trial") == 0
+
+    retained_store = InMemoryJobStore()
+    set_job_store(retained_store)
+    for index in range(20):
+        retained_store.put(
+            ScanJob(
+                job_id=f"retained-{index}",
+                tenant_id="tenant-trial",
+                status=JobStatus.DONE,
+                created_at="2026-07-24T00:00:00+00:00",
+                completed_at="2026-07-24T00:01:00+00:00",
+                request=ScanRequest(),
+            )
+        )
+
+    with pytest.raises(HTTPException) as retained_exc:
+        cloud_connections._reserve_connection_scan_job(record)
+
+    assert retained_exc.value.status_code == 429
+    assert "retained_scan_jobs" in str(retained_exc.value.detail)
+    assert current_managed_trial_scan_credits("tenant-trial") == 0

--- a/tests/test_postgres_rate_limit_store.py
+++ b/tests/test_postgres_rate_limit_store.py
@@ -26,9 +26,18 @@ class _FakeConnection:
         normalized = " ".join(sql.strip().lower().split())
         if normalized.startswith("create table") or normalized.startswith("create index"):
             return _FakeCursor()
+        if normalized.startswith("select pg_advisory_xact_lock"):
+            return _FakeCursor(rows=[(None,)])
         if normalized.startswith("delete from api_rate_limit_hits"):
-            cutoff = float(params[0]) if params else 0.0
-            self.hits = [(key, hit_at) for key, hit_at in self.hits if hit_at >= cutoff]
+            if params and len(params) == 2:
+                bucket_key, raw_cutoff = params
+                cutoff = float(raw_cutoff)
+                self.hits = [
+                    (key, hit_at) for key, hit_at in self.hits if key != bucket_key or hit_at >= cutoff
+                ]
+            else:
+                cutoff = float(params[0]) if params else 0.0
+                self.hits = [(key, hit_at) for key, hit_at in self.hits if hit_at >= cutoff]
             return _FakeCursor()
         if "insert into api_rate_limit_hits" in normalized:
             self.hits.append((params[0], float(params[1])))
@@ -38,6 +47,10 @@ class _FakeConnection:
             matching = [hit_at for key, hit_at in self.hits if key == bucket_key and hit_at >= float(window_start)]
             oldest = min(matching) if matching else None
             return _FakeCursor(rows=[(len(matching), oldest)])
+        if "select count(*)" in normalized:
+            bucket_key, window_start = params
+            matching = [hit_at for key, hit_at in self.hits if key == bucket_key and hit_at >= float(window_start)]
+            return _FakeCursor(rows=[(len(matching),)])
         return _FakeCursor()
 
     def __enter__(self):
@@ -104,3 +117,17 @@ def test_postgres_rate_limit_store_prunes_stale_hits():
     assert any("DELETE FROM api_rate_limit_hits" in sql for sql, _ in pool._conn.executed)
     assert not any(hit_at == base for _, hit_at in pool._conn.hits)
     assert any(hit_at == base + 120.0 for _, hit_at in pool._conn.hits)
+
+
+def test_postgres_rate_limit_store_consumes_below_limit_atomically() -> None:
+    pool = _FakePool()
+    store = PostgresRateLimitStore(window_seconds=60, pool=pool)
+    base = 1_700_000_300.0
+
+    assert store.consume_if_below("tenant:credit", base, 2)[:2] == (True, 1)
+    assert store.consume_if_below("tenant:credit", base + 1, 2)[:2] == (True, 2)
+    assert store.consume_if_below("tenant:credit", base + 2, 2)[:2] == (False, 2)
+    assert store.count("tenant:credit", base + 2) == 2
+
+    statements = [" ".join(sql.lower().split()) for sql, _params in pool._conn.executed]
+    assert any(statement.startswith("select pg_advisory_xact_lock") for statement in statements)


### PR DESCRIPTION
## Summary

- add an opt-in, default-off managed-trial boundary with a principal-independent route allowlist
- enforce AWS account scope, explicit region bounds, manual scans, and atomic connection/job/scan-credit quotas
- revalidate stored connections before credential use and report the same clamped limits the server enforces

## Verification

- 483 focused auth, cloud, quota, and PostgreSQL tests passed; 1 skipped
- Ruff passed across src/tests
- mypy passed across 802 source files
- make preflight passed
- public-doc hygiene, exception sanitization, package layout, diff, and metadata scans passed

## Notes

- managed-trial mode remains disabled unless explicitly configured
- durable worker enqueue and managed OIDC invitation delivery are separate follow-up slices
- examples use synthetic identifiers; no live infrastructure or customer metadata is included