### PR TITLE
fix(jobs): preserve status counts for legacy responses

### DIFF
--- a/ui/app/jobs/page.tsx
+++ b/ui/app/jobs/page.tsx
@@ -128,7 +128,10 @@ function JobsPageContent() {
       .then((response) => {
         setJobs(response.jobs);
         setTotal(response.total ?? response.count);
-        setStatusCounts(response.status_counts ?? {});
+        setStatusCounts(response.status_counts ?? response.jobs.reduce<Partial<Record<JobStatus, number>>>((counts, job) => {
+          counts[job.status] = (counts[job.status] ?? 0) + 1;
+          return counts;
+        }, {}));
       })
       .catch((err: unknown) => {
         setError(err instanceof Error ? err.message : "Unable to load jobs");


### PR DESCRIPTION
## Summary

- preserve Jobs status counts when a compatible API response omits the newer `status_counts` field
- keep the server-backed Jobs table and source linkage visible during rolling upgrades

## Root cause

The merged Jobs page used only `status_counts` to decide whether to render the table. A response containing jobs but omitting that additive field produced an empty aggregate and hid the registered source row.

## Verification

- focused Playwright Jobs workflow — 1 passed
- UI lint — passed
- UI typecheck — passed
- focused UI unit contracts — 55 passed
- diff is one file / four added lines

## Notes

No infrastructure, customer, reviewer, or session metadata is included.