### PR TITLE
refactor(ui): simplify workspaces and make graphs interactive

### DIFF
--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -63,6 +63,8 @@ import { DataTable, type DataTableColumn } from "@/components/data-table";
 import { StatStrip } from "@/components/stat-strip";
 import { Collapsible } from "@/components/collapsible";
 import { Drawer } from "@/components/drawer";
+import { GraphInteractionToolbar } from "@/components/graph-chrome";
+import { useGraphPresentation } from "@/hooks/use-graph-presentation";
 
 // ─── Agents List Helpers ────────────────────────────────────────────────────
 
@@ -1414,16 +1416,40 @@ function LifecycleFlow({
   data: AgentLifecycleResponse;
   agentName: string;
 }) {
-  const { fitView } = useReactFlow();
+  const flowInstance = useReactFlow();
   const [selectedNode, setSelectedNode] = useState<Node<AttackFlowNodeData> | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const presentation = useGraphPresentation({
+    nodes: data.nodes as Node[],
+    scope: {
+      tenantId: "local",
+      subject: "local-viewer",
+      snapshotId: agentName,
+      lens: "agent-lifecycle",
+      scope: "full",
+    },
+    layout: "agent-lifecycle",
+  });
 
   useEffect(() => {
-    setTimeout(() => fitView({ padding: 0.2 }), 100);
-  }, [fitView, data]);
+    if (!presentation.hasSavedState) {
+      setTimeout(() => flowInstance.fitView({ padding: 0.2 }), 100);
+    }
+  }, [data, flowInstance, presentation.hasSavedState]);
 
   const onNodeClick = useCallback((_: unknown, node: Node) => {
     setSelectedNode(node as Node<AttackFlowNodeData>);
+    setSelectedNodeId(node.id);
   }, []);
+
+  const fitVisible = useCallback(
+    () => void flowInstance.fitView({ padding: 0.2, duration: 240 }),
+    [flowInstance],
+  );
+  const fitSelection = useCallback(() => {
+    const node = selectedNodeId ? flowInstance.getNode(selectedNodeId) : undefined;
+    if (node) void flowInstance.fitView({ nodes: [node], padding: 0.7, duration: 240 });
+  }, [flowInstance, selectedNodeId]);
 
   const handleExport = () => {
     const blob = new Blob([JSON.stringify(data, null, 2)], { type: "application/json" });
@@ -1451,6 +1477,15 @@ function LifecycleFlow({
         </div>
         <div className="flex items-center gap-4">
           <StatsBar stats={data.stats} />
+          <GraphInteractionToolbar
+            editing={presentation.editing}
+            hasSelection={Boolean(selectedNodeId)}
+            onFitVisible={fitVisible}
+            onFitSelection={fitSelection}
+            onAutoLayout={() => { presentation.autoLayout(); window.setTimeout(fitVisible, 0); }}
+            onReset={() => { presentation.reset(); window.setTimeout(fitVisible, 0); }}
+            onToggleEditing={presentation.toggleEditing}
+          />
           <button
             onClick={handleExport}
             className="text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] flex items-center gap-1 text-xs border border-[color:var(--border-subtle)] rounded px-2 py-1"
@@ -1461,13 +1496,22 @@ function LifecycleFlow({
       </div>
 
       <ReactFlow
-        nodes={data.nodes as Node[]}
+        key={presentation.storageKey}
+        nodes={presentation.nodes}
         edges={data.edges as Edge[]}
         nodeTypes={nodeTypes}
         onNodeClick={onNodeClick}
-        fitView
+        onPaneClick={() => { setSelectedNode(null); setSelectedNodeId(null); }}
+        fitView={!presentation.hasSavedState}
+        defaultViewport={presentation.viewport}
         minZoom={0.1}
         maxZoom={2}
+        deleteKeyCode={null}
+        nodesDraggable={presentation.editing}
+        nodesConnectable={false}
+        onNodesChange={presentation.onNodesChange}
+        onNodeDragStop={presentation.onNodeDragStop}
+        onMoveEnd={presentation.onMoveEnd}
         className="!bg-[color:var(--surface)]"
       >
         <Background color="#27272a" gap={20} />
@@ -1480,7 +1524,7 @@ function LifecycleFlow({
       </ReactFlow>
 
       {selectedNode && (
-        <DetailPanel node={selectedNode} onClose={() => setSelectedNode(null)} />
+        <DetailPanel node={selectedNode} onClose={() => { setSelectedNode(null); setSelectedNodeId(null); }} />
       )}
     </div>
   );

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Suspense, useCallback, useEffect, useState } from "react";
+import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
@@ -65,6 +65,9 @@ import { Collapsible } from "@/components/collapsible";
 import { Drawer } from "@/components/drawer";
 import { GraphInteractionToolbar } from "@/components/graph-chrome";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
+import { graphTopologyKey } from "@/lib/graph-presentation";
+import { graphNodeDisplayLabels, readableGraphEdges } from "@/lib/graph-utils";
+import { useAuthState } from "@/components/auth-provider";
 
 // ─── Agents List Helpers ────────────────────────────────────────────────────
 
@@ -157,7 +160,7 @@ function DiscoveryProvenanceTags({ provenance }: { provenance: DiscoveryProvenan
   return (
     <div className="flex flex-wrap gap-1.5">
       {tags.map((tag) => (
-        <span key={tag} className="rounded border border-sky-500/30 dark:border-sky-900/60 bg-sky-500/10 dark:bg-sky-950/30 px-1.5 py-0.5 text-[10px] font-mono text-sky-700 dark:text-sky-300">
+        <span key={tag} className="agents-cloud-chip">
           {tag}
         </span>
       ))}
@@ -367,14 +370,14 @@ function AgentsList() {
         <div className="flex flex-wrap items-center gap-2">
           <Link
             href="/agents/topology"
-            className="flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)]"
+            className="agents-secondary-action"
           >
             <Network className="h-4 w-4" />
             Agent mesh
           </Link>
           <Link
             href="/mesh"
-            className="flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)]"
+            className="agents-secondary-action"
           >
             <GitBranch className="h-4 w-4" />
             Mesh View
@@ -383,7 +386,7 @@ function AgentsList() {
       </div>
 
       {!loading && agents.length > 0 && !hintDismissed && (
-        <div className="flex items-start gap-2 rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-xs leading-5 text-[color:var(--text-secondary)]">
+          <div className="agents-info-callout">
           <Shield className="mt-0.5 h-3.5 w-3.5 shrink-0 text-[color:var(--accent)]" />
           <p className="min-w-0 flex-1">
             <span className="font-semibold text-[color:var(--foreground)]">Inventory-first:</span> this page is useful on
@@ -394,7 +397,7 @@ function AgentsList() {
             type="button"
             onClick={() => setHintDismissed(true)}
             aria-label="Dismiss hint"
-            className="shrink-0 rounded p-0.5 text-[color:var(--text-tertiary)] transition-colors hover:text-[color:var(--foreground)]"
+            className="agents-icon-button"
           >
             <X className="h-3.5 w-3.5" />
           </button>
@@ -438,13 +441,13 @@ function AgentsList() {
       {!loading && agents.length > 0 && (
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
           <div className="relative w-full sm:max-w-sm">
-            <Search className="pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[color:var(--text-tertiary)]" />
+            <Search className="agents-search-icon" />
             <input
               type="text"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
               placeholder="Search agents or agent type"
-              className="w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none"
+              className="agents-search"
             />
           </div>
           <p className="text-xs text-[color:var(--text-tertiary)]">
@@ -572,14 +575,14 @@ function AgentDetailDrawer({
         <div className="flex flex-wrap gap-2">
           <Link
             href={`/agents?name=${encodeURIComponent(agent.name)}`}
-            className="inline-flex items-center gap-2 rounded-lg bg-[color:var(--accent)] px-3 py-2 text-xs font-medium text-[color:var(--accent-contrast)] transition hover:bg-[color:var(--accent-strong)]"
+            className="agents-primary-action"
           >
             <ArrowRight className="h-3.5 w-3.5" />
             Full detail
           </Link>
           <Link
             href={`/agents?name=${encodeURIComponent(agent.name)}&view=lifecycle`}
-            className="inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]"
+            className="agents-toolbar-action"
           >
             <GitBranch className="h-3.5 w-3.5" />
             Lifecycle graph
@@ -598,8 +601,8 @@ function AgentDetailDrawer({
         />
 
         {agent.discovery_provenance ? (
-          <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3">
-            <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+          <div className="agents-elevated-card">
+            <div className="agents-section-label mb-2">
               <Shield className="h-3.5 w-3.5" />
               Asset discovery provenance
             </div>
@@ -620,7 +623,7 @@ function AgentDetailDrawer({
             return (
               <div
                 key={`${srv.name}-${index}`}
-                className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3"
+                className="agents-elevated-card"
               >
                 <div className="flex flex-wrap items-center justify-between gap-2">
                   <div className="flex flex-wrap items-center gap-2">
@@ -728,7 +731,7 @@ function AgentDetailDrawer({
                       {srv.tools.map((tool) => (
                         <span
                           key={tool.name}
-                          className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2 py-0.5 text-[11px] text-[color:var(--text-secondary)]"
+                          className="agents-chip"
                         >
                           {tool.name}
                         </span>
@@ -796,7 +799,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
   if (error || !data) {
     return (
       <div className="min-h-screen bg-[color:var(--surface)] p-8">
-        <Link href="/agents" className="text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] flex items-center gap-1 mb-6">
+        <Link href="/agents" className="agents-back-link">
           <ArrowLeft className="w-4 h-4" /> Back to agents
         </Link>
         <div className="text-red-400 bg-red-950 border border-red-800 rounded-lg p-4">
@@ -826,9 +829,9 @@ function AgentDetail({ agentName }: { agentName: string }) {
   return (
     <div className="min-h-screen bg-[color:var(--surface)] text-[color:var(--foreground)]">
       {/* Header */}
-      <div className="border-b border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 backdrop-blur-sm sticky top-0 z-10">
+      <div className="agents-sticky-header">
         <div className="max-w-7xl mx-auto px-6 py-4">
-          <Link href="/agents" className="text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)] flex items-center gap-1 text-sm mb-2">
+          <Link href="/agents" className="agents-back-link-sm">
             <ArrowLeft className="w-3.5 h-3.5" /> All Agents
           </Link>
           <div className="flex items-center justify-between">
@@ -850,7 +853,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
             </div>
             <Link
               href={`/agents?name=${encodeURIComponent(agentName)}&view=lifecycle`}
-              className="bg-emerald-600 hover:bg-emerald-500 text-white px-4 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition-colors"
+              className="agents-scan-action"
             >
               <GitBranch className="w-4 h-4" />
               View Lifecycle Graph
@@ -864,23 +867,23 @@ function AgentDetail({ agentName }: { agentName: string }) {
           <div className="rounded-xl border border-sky-900/60 bg-sky-950/20 p-4">
             <p className="text-[11px] font-mono uppercase tracking-[0.2em] text-sky-400">Observed state</p>
             <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-5">
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
+              <div className="agents-stat-card">
                 <div className="text-[color:var(--text-tertiary)] text-xs">Lifecycle state</div>
                 <div className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">{fleet.lifecycle_state}</div>
               </div>
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
+              <div className="agents-stat-card">
                 <div className="text-[color:var(--text-tertiary)] text-xs">Trust score</div>
                 <div className="mt-1 text-sm font-semibold text-emerald-400">{fleet.trust_score.toFixed(1)}</div>
               </div>
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
+              <div className="agents-stat-card">
                 <div className="text-[color:var(--text-tertiary)] text-xs">Last discovery</div>
                 <div className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">{fleet.last_discovery || "not synced yet"}</div>
               </div>
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
+              <div className="agents-stat-card">
                 <div className="text-[color:var(--text-tertiary)] text-xs">Last scan</div>
                 <div className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">{fleet.last_scan || "not scanned yet"}</div>
               </div>
-              <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2">
+              <div className="agents-stat-card">
                 <div className="text-[color:var(--text-tertiary)] text-xs">Updated</div>
                 <div className="mt-1 text-sm font-semibold text-[color:var(--foreground)]">{fleet.updated_at || "unknown"}</div>
               </div>
@@ -947,15 +950,15 @@ function AgentDetail({ agentName }: { agentName: string }) {
                 0
               );
               return (
-                <div key={srv.name} className="bg-[color:var(--surface-muted)] border border-[color:var(--border-subtle)] rounded-xl overflow-hidden">
+                <div key={srv.name} className="agents-panel">
                   <button
                     onClick={() => toggleServer(srv.name)}
-                    className="w-full px-4 py-3 flex items-center justify-between hover:bg-[color:var(--surface-elevated)]/50 transition-colors"
+                    className="agents-row-button"
                   >
                     <div className="flex items-center gap-3">
                       {isExpanded ? <ChevronDown className="w-4 h-4 text-[color:var(--text-tertiary)]" /> : <ChevronRight className="w-4 h-4 text-[color:var(--text-tertiary)]" />}
                       <span className="font-medium">{srv.name}</span>
-                      <span className="text-xs bg-[color:var(--surface-elevated)] text-[color:var(--text-secondary)] px-2 py-0.5 rounded">
+                      <span className="agents-mini-badge">
                         {srv.transport || "stdio"}
                       </span>
                       {srv.security_blocked && (
@@ -976,7 +979,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                       {srv.provenance?.observed_via?.map((source) => (
                         <span
                           key={source}
-                          className="rounded border border-emerald-900 bg-emerald-950 px-1.5 py-0.5 text-[10px] font-mono text-emerald-300"
+                          className="agents-emerald-chip"
                         >
                           {source}
                         </span>
@@ -995,7 +998,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                       <div className="grid gap-3 md:grid-cols-2">
                         {srv.command && (
                           <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/60 px-3 py-2">
-                            <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                            <div className="agents-section-label mb-1">
                               <TerminalSquare className="h-3.5 w-3.5" />
                               Command
                             </div>
@@ -1006,7 +1009,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                         )}
                         {srv.url && (
                           <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/60 px-3 py-2">
-                            <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                            <div className="agents-section-label mb-1">
                               <Link2 className="h-3.5 w-3.5" />
                               Remote URL
                             </div>
@@ -1028,7 +1031,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                           </div>
                         )}
                         <div className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/60 px-3 py-2">
-                          <div className="mb-1 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]">
+                          <div className="agents-section-label mb-1">
                             <Clock3 className="h-3.5 w-3.5" />
                             Discovery context
                           </div>
@@ -1043,7 +1046,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                               {srv.provenance.observed_via.map((source) => (
                                 <span
                                   key={source}
-                                  className="rounded border border-emerald-900 bg-emerald-950 px-1.5 py-0.5 text-[10px] font-mono text-emerald-300"
+                                  className="agents-emerald-chip"
                                 >
                                   {source}
                                 </span>
@@ -1103,12 +1106,12 @@ function AgentDetail({ agentName }: { agentName: string }) {
                                         {entry.confidence}
                                       </span>
                                       {entry.source_type && (
-                                        <span className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-[10px] uppercase text-[color:var(--text-secondary)]">
+                                        <span className="agents-type-chip">
                                           {entry.source_type}
                                         </span>
                                       )}
                                       {entry.last_verified && (
-                                        <span className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-[10px] text-[color:var(--text-secondary)]">
+                                        <span className="agents-small-chip">
                                           Verified {entry.last_verified}
                                         </span>
                                       )}
@@ -1154,7 +1157,7 @@ function AgentDetail({ agentName }: { agentName: string }) {
                           <h4 className="text-xs font-semibold text-yellow-400 mb-1">Credential-backed env vars</h4>
                           <div className="flex flex-wrap gap-1.5">
                             {srv.credential_env_vars?.map((envVar) => (
-                              <span key={envVar} className="rounded border border-yellow-800 bg-yellow-950 px-2 py-0.5 text-[11px] font-mono text-yellow-300">
+                              <span key={envVar} className="agents-warning-chip">
                                 {envVar}
                               </span>
                             ))}
@@ -1345,7 +1348,7 @@ function DetailPanel({
   const d = node.data;
   const Icon = NODE_ICONS[d.nodeType] ?? Bug;
   return (
-    <div className="absolute top-4 right-4 w-72 bg-[color:var(--surface-muted)] border border-[color:var(--border-subtle)] rounded-xl shadow-2xl z-50 overflow-hidden">
+    <div className="agents-flow-drawer">
       <div className="flex items-center justify-between px-4 py-3 border-b border-[color:var(--border-subtle)]">
         <div className="flex items-center gap-2">
           <Icon className="w-4 h-4 text-[color:var(--text-secondary)]" />
@@ -1416,19 +1419,27 @@ function LifecycleFlow({
   data: AgentLifecycleResponse;
   agentName: string;
 }) {
+  const { session, loading: authLoading } = useAuthState();
   const flowInstance = useReactFlow();
   const [selectedNode, setSelectedNode] = useState<Node<AttackFlowNodeData> | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const lifecycleEdges = useMemo(
+    () => readableGraphEdges(data.edges as Edge[], undefined, { nodeLabels: graphNodeDisplayLabels(data.nodes as Node[]) }),
+    [data.edges, data.nodes],
+  );
   const presentation = useGraphPresentation({
     nodes: data.nodes as Node[],
     scope: {
-      tenantId: "local",
-      subject: "local-viewer",
+      tenantId: session?.tenant_id || "local",
+      subject: session?.subject || session?.auth_method || "local-viewer",
       snapshotId: agentName,
       lens: "agent-lifecycle",
-      scope: "full",
+      scope: graphTopologyKey(data.nodes as Node[], lifecycleEdges),
     },
     layout: "agent-lifecycle",
+    enabled: !authLoading && Boolean(session),
+    ownerActive: Boolean(session),
+    localMode: session?.recommended_ui_mode === "no_auth",
   });
 
   useEffect(() => {
@@ -1464,11 +1475,11 @@ function LifecycleFlow({
   return (
     <div className="relative w-full h-full">
       {/* Header bar */}
-      <div className="absolute top-0 left-0 right-0 z-10 bg-[color:var(--surface)]/90 backdrop-blur-sm border-b border-[color:var(--border-subtle)] px-4 py-3 flex items-center justify-between">
+      <div className="agents-flow-header">
         <div className="flex items-center gap-4">
           <Link
             href={`/agents?name=${encodeURIComponent(agentName)}`}
-            className="text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] flex items-center gap-1 text-sm"
+            className="agents-inline-link"
           >
             <ArrowLeft className="w-4 h-4" /> {agentName}
           </Link>
@@ -1477,7 +1488,7 @@ function LifecycleFlow({
         </div>
         <div className="flex items-center gap-4">
           <StatsBar stats={data.stats} />
-          <GraphInteractionToolbar
+          {presentation.enabled && presentation.nodes.length > 0 && <GraphInteractionToolbar
             editing={presentation.editing}
             hasSelection={Boolean(selectedNodeId)}
             onFitVisible={fitVisible}
@@ -1485,10 +1496,10 @@ function LifecycleFlow({
             onAutoLayout={() => { presentation.autoLayout(); window.setTimeout(fitVisible, 0); }}
             onReset={() => { presentation.reset(); window.setTimeout(fitVisible, 0); }}
             onToggleEditing={presentation.toggleEditing}
-          />
+          />}
           <button
             onClick={handleExport}
-            className="text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] flex items-center gap-1 text-xs border border-[color:var(--border-subtle)] rounded px-2 py-1"
+            className="agents-flow-export"
           >
             <Download className="w-3.5 h-3.5" /> Export
           </button>
@@ -1498,7 +1509,7 @@ function LifecycleFlow({
       <ReactFlow
         key={presentation.storageKey}
         nodes={presentation.nodes}
-        edges={data.edges as Edge[]}
+        edges={lifecycleEdges}
         nodeTypes={nodeTypes}
         onNodeClick={onNodeClick}
         onPaneClick={() => { setSelectedNode(null); setSelectedNodeId(null); }}
@@ -1515,7 +1526,7 @@ function LifecycleFlow({
         className="!bg-[color:var(--surface)]"
       >
         <Background color="#27272a" gap={20} />
-        <Controls className="!bg-[color:var(--surface-muted)] !border-[color:var(--border-subtle)] !rounded-lg [&>button]:!bg-[color:var(--surface-elevated)] [&>button]:!border-[color:var(--border-subtle)] [&>button]:!text-[color:var(--text-secondary)]" />
+        <Controls className="agents-flow-controls" />
         <MiniMap
           nodeColor={(n) => MINIMAP_COLORS[(n.data as AttackFlowNodeData)?.nodeType] ?? "#52525b"}
           className="!bg-[color:var(--surface-muted)] !border-[color:var(--border-subtle)] !rounded-lg"
@@ -1556,7 +1567,7 @@ function AgentLifecycle({ agentName }: { agentName: string }) {
   if (error || !data) {
     return (
       <div className="h-screen bg-[color:var(--surface)] p-8">
-        <Link href="/agents" className="text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)] flex items-center gap-1 mb-6">
+        <Link href="/agents" className="agents-back-link">
           <ArrowLeft className="w-4 h-4" /> Back to agents
         </Link>
         <div className="text-red-400 bg-red-950 border border-red-800 rounded-lg p-4">
@@ -1629,7 +1640,7 @@ function DiscoveryEnvelopeCard({ envelope }: { envelope: DiscoveryEnvelope }) {
   const redaction = REDACTION_LABEL[envelope.redaction_status] ?? envelope.redaction_status;
   return (
     <div className="rounded-lg border border-emerald-900/60 bg-emerald-950/20 p-3">
-      <div className="mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-300">
+      <div className="agents-section-label-emerald">
         <Shield className="h-3.5 w-3.5" />
         Scan trust contract
       </div>
@@ -1637,10 +1648,10 @@ function DiscoveryEnvelopeCard({ envelope }: { envelope: DiscoveryEnvelope }) {
         Scan ran from your local or self-hosted deployment boundary with read-only roles. Sensitive values are never collected or are redacted before storage.
       </p>
       <div className="mb-2 flex flex-wrap gap-1.5">
-        <span className="rounded border border-emerald-800 bg-emerald-950/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-emerald-300">
+        <span className="agents-status-chip">
           {mode}
         </span>
-        <span className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-secondary)]">
+        <span className="agents-section-chip">
           redaction: {redaction}
         </span>
       </div>
@@ -1649,7 +1660,7 @@ function DiscoveryEnvelopeCard({ envelope }: { envelope: DiscoveryEnvelope }) {
           <div className="mb-1 text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)]">Scope</div>
           <div className="flex flex-wrap gap-1.5">
             {envelope.discovery_scope.map((s) => (
-              <span key={s} className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-1.5 py-0.5 font-mono text-[color:var(--text-secondary)]">
+              <span key={s} className="agents-mono-chip">
                 {s}
               </span>
             ))}
@@ -1658,12 +1669,12 @@ function DiscoveryEnvelopeCard({ envelope }: { envelope: DiscoveryEnvelope }) {
       )}
       {envelope.permissions_used.length > 0 && (
         <details className="mt-2 text-[11px] text-[color:var(--text-secondary)]">
-          <summary className="cursor-pointer text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]">
+          <summary className="agents-collapse-toggle">
             Permissions used ({envelope.permissions_used.length})
           </summary>
           <div className="mt-2 flex flex-wrap gap-1.5">
             {envelope.permissions_used.map((p) => (
-              <span key={p} className="rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-1.5 py-0.5 font-mono text-[color:var(--text-secondary)]">
+              <span key={p} className="agents-mono-chip">
                 {p}
               </span>
             ))}

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -54,6 +54,7 @@ import {
   MINIMAP_MASK,
   BACKGROUND_COLOR,
   BACKGROUND_GAP,
+  graphNodeDisplayLabels,
   legendItemsForVisibleGraph,
   minimapNodeColor,
   readableGraphEdges,
@@ -61,6 +62,7 @@ import {
 import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
 import { FullscreenButton, GraphInteractionToolbar } from "@/components/graph-chrome";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
+import { graphTopologyKey } from "@/lib/graph-presentation";
 import { useAuthState } from "@/components/auth-provider";
 import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
 import { GraphEmptyState, GraphPanelSkeleton, GraphRefreshOverlay } from "@/components/graph-state-panels";
@@ -303,7 +305,7 @@ export default function ContextPage() {
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
   const { counts } = useDeploymentContext();
   const captureMode = useCaptureMode();
-  const { session } = useAuthState();
+  const { session, loading: authLoading } = useAuthState();
 
   useEffect(() => {
     if (captureMode) {
@@ -475,10 +477,12 @@ export default function ContextPage() {
       subject: session?.subject || session?.auth_method || "local-viewer",
       snapshotId: selectedJobId || "unselected",
       lens: "context",
-      scope: JSON.stringify({ agent: selectedAgent, pathFocusEnabled }),
+      scope: JSON.stringify({ agent: selectedAgent, pathFocusEnabled, topology: graphTopologyKey(displayNodes, layoutEdges) }),
     },
     layout: "dagre-lr",
-    enabled: !captureMode,
+    enabled: !captureMode && !authLoading && Boolean(session),
+    ownerActive: Boolean(session),
+    localMode: session?.recommended_ui_mode === "no_auth",
   });
 
   const displayEdges = useMemo(() => {
@@ -496,8 +500,9 @@ export default function ContextPage() {
       inactiveOpacity: 0.06,
       captureMode,
       zoom: presentation.viewport.zoom,
+      nodeLabels: graphNodeDisplayLabels(displayNodes),
     });
-  }, [layoutEdges, connectedIds, searchMatches, pathFocusIds, captureMode, presentation.viewport.zoom]);
+  }, [layoutEdges, connectedIds, searchMatches, pathFocusIds, captureMode, presentation.viewport.zoom, displayNodes]);
 
   const legendItems = useMemo(() => {
     const extras =
@@ -661,7 +666,7 @@ export default function ContextPage() {
             </button>
           )}
           <FullscreenButton />
-          <GraphInteractionToolbar
+          {presentation.enabled && !captureMode && displayNodes.length > 0 && <GraphInteractionToolbar
             editing={presentation.editing}
             hasSelection={Boolean(selectedNodeId)}
             onFitVisible={fitVisible}
@@ -669,7 +674,7 @@ export default function ContextPage() {
             onAutoLayout={() => { presentation.autoLayout(); window.setTimeout(fitVisible, 0); }}
             onReset={() => { presentation.reset(); window.setTimeout(fitVisible, 0); }}
             onToggleEditing={presentation.toggleEditing}
-          />
+          />}
         </div>
         <GraphLensSwitcher variant="compact" {...(!captureMode ? { legendItems } : {})} />
       </div>

--- a/ui/app/context/page.tsx
+++ b/ui/app/context/page.tsx
@@ -14,6 +14,7 @@ import {
   MiniMap,
   type Node,
   type Edge,
+  type ReactFlowInstance,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import {
@@ -58,7 +59,9 @@ import {
   readableGraphEdges,
 } from "@/lib/graph-utils";
 import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
-import { FullscreenButton } from "@/components/graph-chrome";
+import { FullscreenButton, GraphInteractionToolbar } from "@/components/graph-chrome";
+import { useGraphPresentation } from "@/hooks/use-graph-presentation";
+import { useAuthState } from "@/components/auth-provider";
 import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
 import { GraphEmptyState, GraphPanelSkeleton, GraphRefreshOverlay } from "@/components/graph-state-panels";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
@@ -289,6 +292,8 @@ export default function ContextPage() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [flowInstance, setFlowInstance] = useState<ReactFlowInstance<Node<LineageNodeData>, Edge> | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [selectedAgent, setSelectedAgent] = useState<string | null>(null);
   const [searchQuery, setSearchQuery] = useState("");
@@ -298,6 +303,7 @@ export default function ContextPage() {
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
   const { counts } = useDeploymentContext();
   const captureMode = useCaptureMode();
+  const { session } = useAuthState();
 
   useEffect(() => {
     if (captureMode) {
@@ -462,6 +468,19 @@ export default function ContextPage() {
     }));
   }, [layoutNodes, connectedIds, searchMatches, pathFocusIds]);
 
+  const presentation = useGraphPresentation({
+    nodes: displayNodes as Node<LineageNodeData>[],
+    scope: {
+      tenantId: session?.tenant_id || "local",
+      subject: session?.subject || session?.auth_method || "local-viewer",
+      snapshotId: selectedJobId || "unselected",
+      lens: "context",
+      scope: JSON.stringify({ agent: selectedAgent, pathFocusEnabled }),
+    },
+    layout: "dagre-lr",
+    enabled: !captureMode,
+  });
+
   const displayEdges = useMemo(() => {
     const activeSet =
       searchMatches && searchMatches.size > 0 ? searchMatches : connectedIds ?? pathFocusIds;
@@ -476,8 +495,9 @@ export default function ContextPage() {
       highSignalOpacity: pathFocusIds ? 0.95 : 0.56,
       inactiveOpacity: 0.06,
       captureMode,
+      zoom: presentation.viewport.zoom,
     });
-  }, [layoutEdges, connectedIds, searchMatches, pathFocusIds, captureMode]);
+  }, [layoutEdges, connectedIds, searchMatches, pathFocusIds, captureMode, presentation.viewport.zoom]);
 
   const legendItems = useMemo(() => {
     const extras =
@@ -511,8 +531,15 @@ export default function ContextPage() {
 
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
     setSelectedNode(node.data as LineageNodeData);
+    setSelectedNodeId(node.id);
     setHoveredNodeId(null);
   }, []);
+
+  const fitVisible = useCallback(() => void flowInstance?.fitView({ ...viewportOptions, duration: 240 }), [flowInstance, viewportOptions]);
+  const fitSelection = useCallback(() => {
+    const node = selectedNodeId ? flowInstance?.getNode(selectedNodeId) : undefined;
+    if (node) void flowInstance?.fitView({ nodes: [node], padding: 0.7, duration: 240, maxZoom: 1.4 });
+  }, [flowInstance, selectedNodeId]);
 
   const onNodeMouseEnter = useCallback(
     (_event: React.MouseEvent, node: Node) => {
@@ -634,6 +661,15 @@ export default function ContextPage() {
             </button>
           )}
           <FullscreenButton />
+          <GraphInteractionToolbar
+            editing={presentation.editing}
+            hasSelection={Boolean(selectedNodeId)}
+            onFitVisible={fitVisible}
+            onFitSelection={fitSelection}
+            onAutoLayout={() => { presentation.autoLayout(); window.setTimeout(fitVisible, 0); }}
+            onReset={() => { presentation.reset(); window.setTimeout(fitVisible, 0); }}
+            onToggleEditing={presentation.toggleEditing}
+          />
         </div>
         <GraphLensSwitcher variant="compact" {...(!captureMode ? { legendItems } : {})} />
       </div>
@@ -696,22 +732,31 @@ export default function ContextPage() {
                 }`}
               >
             <ReactFlow
-              key={captureMode ? "context-capture" : "context-interactive"}
-              nodes={displayNodes}
+              key={captureMode ? "context-capture" : presentation.storageKey}
+              nodes={presentation.nodes}
               edges={displayEdges}
               nodeTypes={lineageNodeTypes}
-              fitView
+              fitView={!presentation.hasSavedState}
+              defaultViewport={presentation.viewport}
               fitViewOptions={viewportOptions}
               minZoom={0.16}
               maxZoom={2.8}
               onlyRenderVisibleElements
               defaultEdgeOptions={{ type: "smoothstep" }}
               proOptions={{ hideAttribution: true }}
+              deleteKeyCode={null}
+              nodesDraggable={!captureMode && presentation.editing}
+              nodesConnectable={false}
+              onNodesChange={presentation.onNodesChange}
+              onNodeDragStop={presentation.onNodeDragStop}
+              onMoveEnd={presentation.onMoveEnd}
+              onInit={setFlowInstance}
               onNodeClick={onNodeClick}
               onNodeMouseEnter={onNodeMouseEnter}
               onNodeMouseLeave={onNodeMouseLeave}
               onPaneClick={() => {
                 setSelectedNode(null);
+                setSelectedNodeId(null);
                 setHoveredNodeId(null);
               }}
             >
@@ -733,7 +778,7 @@ export default function ContextPage() {
           {selectedNode && (
             <GraphEntityDrawer
               data={selectedNode}
-              onClose={() => setSelectedNode(null)}
+              onClose={() => { setSelectedNode(null); setSelectedNodeId(null); }}
               enrich={false}
             />
           )}

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -350,6 +350,182 @@ body {
   @apply gap-2 bg-[#29B5E8] text-white hover:bg-[#1a9fd0];
 }
 
+/* Dense remediation rows share these styles outside route JavaScript so the
+   command center stays compact without duplicating long utility strings. */
+.risk-campaign-card { @apply rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] shadow-sm; }
+.risk-campaign-summary { @apply grid cursor-pointer list-none gap-2 px-3 py-3 md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center; }
+.risk-campaign-summary::-webkit-details-marker,
+.risk-campaign-queue-summary::-webkit-details-marker { display: none; }
+.risk-campaign-severity { @apply rounded-full border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--status-danger)]; }
+.risk-campaign-priority { @apply rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1 text-xs text-[color:var(--text-secondary)]; }
+.risk-campaign-reduction { @apply rounded-lg border border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] px-2.5 py-1 text-xs font-medium text-[color:var(--status-success)]; }
+.risk-campaign-body { @apply border-t border-[color:var(--border-subtle)] px-3 pb-3; }
+.risk-campaign-explainer { @apply mt-4 grid gap-3 border-t border-[color:var(--border-subtle)] pt-4 lg:grid-cols-[1fr_1.3fr]; }
+.risk-campaign-evidence-label { @apply col-span-2 text-[10px] uppercase tracking-wide text-[color:var(--text-tertiary)] sm:col-span-4; }
+.risk-campaign-factor { @apply rounded-lg bg-[color:var(--surface-muted)] p-2.5; }
+.risk-campaign-factor-label,
+.risk-campaign-factor-status { @apply text-[10px] uppercase tracking-wide text-[color:var(--text-tertiary)]; }
+.risk-campaign-factor-status { @apply mt-0.5; }
+.risk-campaign-factor-value { @apply mt-1 text-sm font-semibold tabular-nums text-[color:var(--foreground)]; }
+.risk-campaign-evidence-note { @apply col-span-2 text-[10px] leading-4 text-[color:var(--text-tertiary)] sm:col-span-4; }
+.risk-campaign-method { @apply rounded-lg border border-[color:var(--border-subtle)] p-3 text-xs leading-5 text-[color:var(--text-secondary)]; }
+.risk-campaign-method-cell { @apply rounded-md bg-[color:var(--surface-muted)] px-2 py-1.5; }
+.risk-campaign-method-label { @apply text-[9px] uppercase tracking-wide text-[color:var(--text-tertiary)]; }
+.risk-campaign-actions { @apply mt-4 flex flex-col gap-3 border-t border-[color:var(--border-subtle)] pt-4 sm:flex-row sm:items-center sm:justify-between; }
+.risk-campaign-select { @apply rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--background)] px-2.5 py-1.5 text-xs text-[color:var(--foreground)]; }
+.risk-campaign-status-pill { @apply rounded-full border border-[color:var(--border-subtle)] px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-[color:var(--text-secondary)]; }
+.risk-campaign-link-action { @apply inline-flex items-center gap-1 text-xs font-medium text-[color:var(--accent)] disabled:cursor-not-allowed disabled:opacity-50; }
+.risk-campaign-ticket-primary,
+.risk-campaign-verify-button { @apply inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-xs font-medium text-[color:var(--accent)] disabled:opacity-50; }
+.risk-campaign-ticket-primary { @apply disabled:cursor-not-allowed; }
+.risk-campaign-verify-button { @apply shrink-0 justify-center disabled:cursor-wait; }
+.risk-campaign-ticket-secondary { @apply inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs font-medium text-[color:var(--text-secondary)] disabled:cursor-not-allowed disabled:opacity-50; }
+.risk-campaign-warning { @apply mt-3 rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs text-[color:var(--text-secondary)]; }
+.risk-campaign-assignment { @apply mt-3 grid gap-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3 sm:grid-cols-[1fr_12rem_auto] sm:items-end; }
+.risk-campaign-input { @apply mt-1 block w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--background)] px-2.5 py-2 text-xs text-[color:var(--foreground)]; }
+.risk-campaign-save { @apply rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-xs font-medium text-[color:var(--accent)] disabled:opacity-50; }
+.risk-campaign-verification-result { @apply mt-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--text-secondary)]; }
+.risk-campaign-reload { @apply rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs font-medium text-[color:var(--status-warn)]; }
+.risk-campaign-card .risk-campaign-reload { @apply mt-2; }
+.risk-campaign-queue { @apply rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]; }
+.risk-campaign-queue-summary { @apply flex cursor-pointer list-none flex-wrap items-center justify-between gap-2 px-3 py-2.5; }
+.risk-campaign-queue-label { @apply text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--status-warn)]; }
+.risk-campaign-count-pill { @apply rounded-full border border-[color:var(--border-subtle)] px-2 py-0.5 text-[10px] text-[color:var(--text-tertiary)]; }
+.risk-campaign-queue-entry { @apply rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3; }
+.risk-campaign-load-more { @apply mt-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs font-medium text-[color:var(--accent)] disabled:cursor-wait disabled:opacity-50; }
+.risk-campaign-header { @apply flex flex-col gap-3 md:flex-row md:items-end md:justify-between; }
+.risk-campaign-kicker { @apply text-[11px] font-medium uppercase tracking-[0.18em] text-[color:var(--accent)]; }
+.risk-campaign-investigate { @apply rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-[color:var(--text-secondary)]; }
+.risk-campaign-window { @apply rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-[color:var(--text-tertiary)]; }
+.risk-campaign-truncated { @apply flex items-start gap-2 rounded-xl border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2.5 text-xs text-[color:var(--text-secondary)]; }
+.risk-link-button { @apply text-xs font-medium text-[color:var(--accent)] disabled:cursor-not-allowed disabled:opacity-50; }
+.risk-collapsed-label { @apply text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)] group-open:hidden; }
+.risk-priority-toggle { @apply mt-3 inline-flex items-center gap-1 text-xs font-medium text-[color:var(--accent)]; }
+.risk-entry-meta { @apply mt-1 text-[10px] uppercase tracking-wide text-[color:var(--text-tertiary)]; }
+.risk-page-title { @apply mt-1 text-xl font-semibold tracking-tight text-[color:var(--foreground)]; }
+.risk-entry-layout { @apply flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between; }
+.risk-proof-note { @apply flex items-center gap-2 text-xs text-[color:var(--text-tertiary)]; }
+.risk-card-title { @apply truncate text-sm font-semibold text-[color:var(--foreground)]; }
+.risk-card-meta { @apply mt-1 truncate text-[11px] text-[color:var(--text-tertiary)]; }
+.risk-number { @apply font-semibold tabular-nums text-[color:var(--foreground)]; }
+.risk-queue-body { @apply border-t border-[color:var(--border-subtle)] px-3 pb-3; }
+.risk-entry-title { @apply text-sm font-semibold text-[color:var(--foreground)]; }
+.risk-status-copy { @apply mt-3 text-xs text-[color:var(--text-secondary)]; }
+.risk-helper-copy { @apply mt-2 text-xs text-[color:var(--text-secondary)]; }
+.risk-entry-copy { @apply mt-1 text-xs text-[color:var(--text-secondary)]; }
+.risk-page-copy { @apply mt-1 text-sm text-[color:var(--text-secondary)]; }
+.risk-error-copy { @apply mt-3 text-xs text-[color:var(--status-danger)]; }
+.risk-empty-copy { @apply mt-3 text-xs text-[color:var(--text-tertiary)]; }
+
+/* Shared graph chrome is loaded by several routes. Keep its presentation in
+   CSS so route chunks carry behavior and evidence only, not repeated tokens. */
+.graph-legend-toggle { @apply items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] backdrop-blur-sm transition-colors hover:bg-[var(--surface-elevated)]; }
+.graph-legend-count { @apply rounded-full bg-[var(--surface)] px-1.5 py-0.5 text-[10px] text-[var(--text-tertiary)]; }
+.graph-legend-popover { @apply max-h-[60vh] w-[min(30rem,calc(100vw-2rem))] overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] p-3 text-[var(--foreground)] backdrop-blur-md; }
+.graph-legend-dock { @apply border-t border-[var(--border-subtle)] pt-2 open:pt-3; }
+.graph-legend-dock-summary { @apply flex cursor-pointer list-none flex-wrap items-center gap-x-3 gap-y-1.5 text-xs; }
+.graph-legend-dock-summary::-webkit-details-marker { display: none; }
+.graph-legend-dock-label { @apply shrink-0 font-medium uppercase tracking-[0.16em] text-[var(--text-tertiary)]; }
+.graph-legend-preview { @apply flex min-w-0 flex-1 flex-wrap items-center gap-x-2.5 gap-y-1 group-open:hidden; }
+.graph-legend-preview-item { @apply inline-flex max-w-[8rem] items-center gap-1 text-[10px] text-[var(--text-secondary)]; }
+.graph-legend-expand { @apply ml-auto shrink-0 text-[10px] uppercase tracking-[0.14em] text-[var(--text-tertiary)]; }
+.graph-legend-dock-content { @apply mt-2 max-h-[min(40vh,18rem)] overflow-y-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] p-3; }
+.graph-icon-button { @apply flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] backdrop-blur-sm transition-colors hover:bg-[var(--surface-elevated)]; }
+.graph-layout-toolbar { @apply flex max-w-full items-center gap-0.5 overflow-x-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/90 p-1; }
+.graph-layout-button { @apply inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40; }
+.graph-flow-controls { @apply !rounded-lg !border-[var(--border-subtle)] !bg-[var(--surface)]/90 !backdrop-blur-sm [&>button]:!border-[var(--border-subtle)] [&>button]:!bg-[var(--surface-elevated)] [&>button]:!text-[var(--text-secondary)] [&>button:hover]:!bg-[var(--surface-muted)]; }
+.graph-flow-minimap { @apply !rounded-lg !border-[var(--border-subtle)] !bg-[var(--surface)]/90 !backdrop-blur-sm; }
+.graph-export-select { @apply rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] focus:border-sky-600 focus:outline-none; }
+.graph-export-button { @apply inline-flex items-center gap-1.5 rounded-lg border border-cyan-700/45 bg-cyan-50 px-2.5 py-1.5 text-xs font-medium text-cyan-800 transition-colors hover:border-cyan-700 hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-cyan-900/60 dark:bg-cyan-950/30 dark:text-cyan-200 dark:hover:border-cyan-800 dark:hover:bg-cyan-950/50; }
+.graph-evidence-summary { @apply grid gap-2 md:grid-cols-3; }
+.graph-evidence-item { @apply rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-3 py-2; }
+.graph-evidence-label { @apply flex items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]; }
+.graph-evidence-value { @apply mt-1 truncate text-xs font-medium text-[var(--foreground)]; }
+.graph-evidence-detail { @apply mt-0.5 text-[10px] capitalize text-[var(--text-tertiary)]; }
+.attack-flow-node { @apply min-w-[140px] max-w-[220px] rounded-lg border-2 px-3 py-2 shadow-lg backdrop-blur; }
+.attack-flow-handle { @apply !h-2 !w-2 !border-[var(--border-strong)] !bg-[var(--text-tertiary)]; }
+.attack-flow-node-label { @apply truncate text-xs font-semibold text-[var(--foreground)]; }
+.attack-flow-kev { @apply rounded border border-red-700 bg-red-950 px-1 py-0.5 font-mono text-[10px] text-red-400; }
+.attack-flow-tag { @apply rounded border px-1 font-mono text-[9px]; }
+.attack-flow-tag-purple { @apply border-purple-800/50 bg-purple-950/60 text-purple-400; }
+.attack-flow-tag-amber { @apply border-amber-800/50 bg-amber-950/60 text-amber-400; }
+.attack-flow-tag-cyan { @apply border-cyan-800/50 bg-cyan-950/60 text-cyan-400; }
+.attack-flow-kev-banner { @apply flex items-center gap-1.5 rounded border border-red-800 bg-red-950 px-2 py-1.5 font-mono text-xs text-red-400; }
+.attack-flow-export { @apply flex items-center gap-1.5 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)] px-3 py-1.5 text-xs text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-muted)]; }
+.attack-flow-select { @apply rounded-md border border-[var(--border-subtle)] bg-[var(--surface)] px-2 py-1 text-xs text-[var(--text-secondary)] focus:border-emerald-600 focus:outline-none; }
+.attack-flow-header { @apply space-y-2 border-b border-[var(--border-subtle)] px-4 py-3; }
+.attack-flow-legend { @apply flex items-center gap-4 border-t border-[var(--border-subtle)] px-4 py-2 text-[10px] text-[var(--text-tertiary)]; }
+.attack-flow-meta { @apply font-mono text-[10px] text-[var(--text-secondary)]; }
+.attack-flow-meta-muted { @apply font-mono text-[10px] text-[var(--text-tertiary)]; }
+.attack-flow-drawer-kicker { @apply text-[10px] uppercase tracking-wider text-[var(--text-tertiary)]; }
+.attack-flow-drawer-title { @apply mt-0.5 break-all text-sm font-semibold text-[var(--foreground)]; }
+.attack-flow-close { @apply p-1 text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-secondary)]; }
+.attack-flow-stat-value { @apply font-mono text-lg font-bold text-[var(--foreground)]; }
+.attack-flow-external-link { @apply flex items-center gap-1.5 text-xs text-emerald-400 transition-colors hover:text-emerald-300; }
+.attack-flow-filter-label { @apply mb-1 text-[10px] uppercase tracking-wider text-[var(--text-tertiary)]; }
+.attack-flow-clear-small { @apply text-[10px] text-[var(--text-tertiary)] underline transition-colors hover:text-[var(--text-secondary)]; }
+.attack-flow-back { @apply text-[var(--text-tertiary)] transition-colors hover:text-[var(--text-secondary)]; }
+.attack-flow-empty { @apply flex h-full flex-col items-center justify-center gap-3 text-[var(--text-secondary)]; }
+.attack-flow-clear { @apply text-xs text-emerald-400 underline hover:text-emerald-300; }
+.attack-flow-swatch { @apply h-2.5 w-2.5 rounded border-2; }
+.attack-flow-loading { @apply flex h-[80vh] items-center justify-center text-[var(--text-secondary)]; }
+.attack-flow-error { @apply flex h-[80vh] flex-col items-center justify-center gap-3 text-[var(--text-secondary)]; }
+.graph-page-header { @apply border-b border-[var(--border-subtle)] bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.10),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.96))] px-4 py-3; }
+.graph-page-select { @apply rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-3 py-2 text-sm text-[var(--text-secondary)] focus:border-sky-600 focus:outline-none; }
+.graph-page-search { @apply min-w-[260px] flex-1 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-3 py-2 text-sm text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:border-sky-600 focus:outline-none; }
+.graph-page-action { @apply rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40; }
+.graph-page-result { @apply rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-2 text-left transition hover:border-[var(--border-strong)] hover:bg-[var(--surface)]; }
+.graph-page-secondary-action { @apply rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-1.5 text-xs text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]; }
+.graph-callout-orange { @apply flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-orange-500/30 bg-orange-500/10 px-3 py-2 text-xs text-orange-100; }
+.graph-callout-orange-compact { @apply mb-2 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-orange-500/30 bg-orange-500/10 px-3 py-2 text-xs text-orange-100; }
+.graph-callout-sky { @apply mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs text-sky-100; }
+.graph-callout-amber { @apply mt-3 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-200; }
+.graph-chip-neutral { @apply rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-2.5 py-1 text-[var(--text-secondary)]; }
+.graph-chip-sky-soft { @apply flex items-center gap-1 rounded-lg border border-sky-500/20 bg-sky-500/10 px-2.5 py-1 text-sky-700 dark:text-sky-200; }
+.graph-chip-orange { @apply rounded-lg border border-orange-400/30 bg-orange-950/60 px-2.5 py-1 text-orange-100 transition hover:border-orange-300; }
+.graph-chip-orange-muted { @apply rounded-lg border border-orange-400/30 bg-orange-950/40 px-2.5 py-1 text-orange-100 transition hover:border-orange-300; }
+.graph-chip-rose { @apply rounded-lg border border-rose-400/30 bg-rose-950/60 px-2.5 py-1 text-rose-100 transition hover:border-rose-300; }
+.graph-chip-violet { @apply rounded-lg border border-violet-400/30 bg-violet-950/60 px-2.5 py-1 text-violet-100 transition hover:border-violet-300; }
+.graph-chip-emerald { @apply rounded-lg border border-emerald-400/30 bg-emerald-950/60 px-2.5 py-1 text-emerald-100 transition hover:border-emerald-300; }
+.graph-chip-emerald-truncate { @apply max-w-[12rem] truncate rounded border border-emerald-400/20 bg-emerald-950/50 px-2 py-0.5 transition hover:border-emerald-300; }
+.graph-chip-elevated { @apply rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/80 px-2 py-1 text-[11px] text-[var(--text-secondary)]; }
+.graph-drawer-summary { @apply flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 px-3 py-2; }
+.graph-drawer-summary::-webkit-details-marker { display: none; }
+.graph-drawer-section { @apply rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3; }
+.agents-secondary-action { @apply flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-2 text-sm text-[color:var(--text-secondary)] transition-colors hover:border-[color:var(--border-strong)]; }
+.agents-search { @apply w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] py-2 pl-9 pr-3 text-sm text-[color:var(--foreground)] placeholder-[color:var(--text-tertiary)] focus:border-[color:var(--border-strong)] focus:outline-none; }
+.agents-primary-action { @apply inline-flex items-center gap-2 rounded-lg bg-[color:var(--accent)] px-3 py-2 text-xs font-medium text-[color:var(--accent-contrast)] transition hover:bg-[color:var(--accent-strong)]; }
+.agents-toolbar-action { @apply inline-flex items-center gap-2 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs font-medium text-[color:var(--foreground)] transition hover:border-[color:var(--border-strong)]; }
+.agents-chip { @apply rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2 py-0.5 text-[11px] text-[color:var(--text-secondary)]; }
+.agents-type-chip { @apply rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-[10px] uppercase text-[color:var(--text-secondary)]; }
+.agents-small-chip { @apply rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-1.5 py-0.5 text-[10px] text-[color:var(--text-secondary)]; }
+.agents-flow-controls { @apply !rounded-lg !border-[color:var(--border-subtle)] !bg-[color:var(--surface-muted)] [&>button]:!border-[color:var(--border-subtle)] [&>button]:!bg-[color:var(--surface-elevated)] [&>button]:!text-[color:var(--text-secondary)]; }
+.agents-section-chip { @apply rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-[color:var(--text-secondary)]; }
+.agents-mono-chip { @apply rounded border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-1.5 py-0.5 font-mono text-[color:var(--text-secondary)]; }
+.agents-info-callout { @apply flex items-start gap-2 rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-xs leading-5 text-[color:var(--text-secondary)]; }
+.agents-flow-header { @apply absolute inset-x-0 top-0 z-10 flex items-center justify-between border-b border-[color:var(--border-subtle)] bg-[color:var(--surface)]/90 px-4 py-3 backdrop-blur-sm; }
+.agents-flow-export { @apply flex items-center gap-1 rounded border border-[color:var(--border-subtle)] px-2 py-1 text-xs text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)]; }
+.agents-status-chip { @apply rounded border border-emerald-800 bg-emerald-950/60 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-[0.14em] text-emerald-300; }
+.agents-cloud-chip { @apply rounded border border-sky-500/30 bg-sky-500/10 px-1.5 py-0.5 font-mono text-[10px] text-sky-700 dark:border-sky-900/60 dark:bg-sky-950/30 dark:text-sky-300; }
+.agents-flow-drawer { @apply absolute right-4 top-4 z-50 w-72 overflow-hidden rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] shadow-2xl; }
+.agents-collapse-toggle { @apply cursor-pointer text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]; }
+.agents-scan-action { @apply flex items-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-500; }
+.agents-section-label { @apply flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-[color:var(--text-tertiary)]; }
+.agents-row-button { @apply flex w-full items-center justify-between px-4 py-3 transition-colors hover:bg-[color:var(--surface-elevated)]/50; }
+.agents-icon-button { @apply shrink-0 rounded p-0.5 text-[color:var(--text-tertiary)] transition-colors hover:text-[color:var(--foreground)]; }
+.agents-back-link-sm { @apply mb-2 flex items-center gap-1 text-sm text-[color:var(--text-tertiary)] hover:text-[color:var(--text-secondary)]; }
+.agents-sticky-header { @apply sticky top-0 z-10 border-b border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 backdrop-blur-sm; }
+.agents-search-icon { @apply pointer-events-none absolute left-3 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-[color:var(--text-tertiary)]; }
+.agents-inline-link { @apply flex items-center gap-1 text-sm text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)]; }
+.agents-panel { @apply overflow-hidden rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)]; }
+.agents-emerald-chip { @apply rounded border border-emerald-900 bg-emerald-950 px-1.5 py-0.5 font-mono text-[10px] text-emerald-300; }
+.agents-section-label-emerald { @apply mb-2 flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-emerald-300; }
+.agents-back-link { @apply mb-6 flex items-center gap-1 text-[color:var(--text-secondary)] hover:text-[color:var(--foreground)]; }
+.agents-mini-badge { @apply rounded bg-[color:var(--surface-elevated)] px-2 py-0.5 text-xs text-[color:var(--text-secondary)]; }
+.agents-warning-chip { @apply rounded border border-yellow-800 bg-yellow-950 px-2 py-0.5 font-mono text-[11px] text-yellow-300; }
+.agents-elevated-card { @apply rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] p-3; }
+.agents-stat-card { @apply rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)]/80 px-3 py-2; }
+
 /* Stat card gradient backgrounds — driven by severity/status tokens */
 .stat-critical {
   background: linear-gradient(

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -89,6 +89,7 @@ import {
   changeKindForNode,
   CHANGE_KIND_META,
   CONTROLS_CLASS,
+  graphNodeDisplayLabels,
   legendItemsForVisibleGraph,
   MINIMAP_BG,
   MINIMAP_CLASS,
@@ -148,7 +149,7 @@ import {
 import { useCaptureMode } from "@/lib/use-capture-mode";
 import { useAuthState } from "@/components/auth-provider";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
-import { selectGraphSubgraph } from "@/lib/graph-presentation";
+import { graphTopologyKey, selectGraphSubgraph } from "@/lib/graph-presentation";
 
 // The whole current-scan graph loads in one request (no numbered pagination).
 // The bound matches the interactive render budget: past it, the overview
@@ -701,7 +702,7 @@ export default function GraphPageClient() {
 function GraphPageInner() {
   const reactFlow = useReactFlow();
   const graphViewport = useViewport();
-  const { session } = useAuthState();
+  const { session, loading: authLoading } = useAuthState();
   const [snapshots, setSnapshots] = useState<GraphSnapshot[]>([]);
   const [selectedScanId, setSelectedScanId] = useState("");
   const [graphData, setGraphData] = useState<UnifiedGraphResponse | null>(null);
@@ -1853,6 +1854,7 @@ function GraphPageInner() {
       inactiveOpacity: 0.06,
       captureMode,
       zoom: graphViewport.zoom,
+      nodeLabels: graphNodeDisplayLabels(displayNodes),
     });
   }, [
     layoutEdges,
@@ -1863,14 +1865,25 @@ function GraphPageInner() {
     graphLayoutKind,
     captureMode,
     graphViewport.zoom,
+    displayNodes,
   ]);
+
+  const accessibleBaseDisplayEdges = useMemo(
+    () => readableGraphEdges(baseDisplayEdges, undefined, {
+      captureMode,
+      zoom: graphViewport.zoom,
+      nodeLabels: graphNodeDisplayLabels(displayNodes),
+      preserveVisualStyle: true,
+    }),
+    [baseDisplayEdges, captureMode, displayNodes, graphViewport.zoom],
+  );
 
   // Drift lens edge emphasis — new/changed edges adopt their change-kind colour
   // so the lens reads as one system with the node rings. Inert (identity) when
   // the lens is disengaged.
   const displayEdges = useMemo(() => {
-    if (!driftLensEngaged) return baseDisplayEdges;
-    return baseDisplayEdges.map((edge): Edge => {
+    if (!driftLensEngaged) return accessibleBaseDisplayEdges;
+    return accessibleBaseDisplayEdges.map((edge): Edge => {
       const relationship =
         typeof edge.data?.relationship === "string"
           ? edge.data.relationship
@@ -1901,7 +1914,7 @@ function GraphPageInner() {
         },
       };
     });
-  }, [baseDisplayEdges, driftLensEngaged, driftIndex]);
+  }, [accessibleBaseDisplayEdges, driftLensEngaged, driftIndex]);
 
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
@@ -1941,15 +1954,18 @@ function GraphPageInner() {
         severity: filters.severity,
         path: selectedAttackPathKey,
         rollup: rollupStack.at(-1)?.id ?? null,
+        topology: graphTopologyKey(displayNodes, displayEdges),
       }),
     }),
-    [filters, rollupStack, selectedAttackPath, selectedAttackPathKey, selectedScanId, session?.auth_method, session?.subject, session?.tenant_id],
+    [displayEdges, displayNodes, filters, rollupStack, selectedAttackPath, selectedAttackPathKey, selectedScanId, session?.auth_method, session?.subject, session?.tenant_id],
   );
   const presentation = useGraphPresentation({
     nodes: displayNodes,
     scope: presentationScope,
     layout: graphLayoutKind,
-    enabled: !captureMode,
+    enabled: !captureMode && !authLoading && Boolean(session),
+    ownerActive: Boolean(session),
+    localMode: session?.recommended_ui_mode === "no_auth",
   });
   const fitVisible = useCallback(() => {
     void reactFlow.fitView({ ...viewportOptions, duration: 240 });
@@ -2375,7 +2391,7 @@ function GraphPageInner() {
     <div className="min-h-[calc(100vh-3.5rem)] flex flex-col">
       <PulseStyles />
 
-      <div className="border-b border-[var(--border-subtle)] bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.10),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.96))] px-4 py-3">
+      <div className="graph-page-header">
         <div className="flex flex-col gap-3 xl:flex-row xl:items-center xl:justify-between">
           <div>
             <p className="text-[10px] uppercase tracking-[0.24em] text-sky-400">
@@ -2420,7 +2436,7 @@ function GraphPageInner() {
             <select
               value={selectedScanId}
               onChange={(event) => setSelectedScanId(event.target.value)}
-              className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-3 py-2 text-sm text-[var(--text-secondary)] focus:border-sky-600 focus:outline-none"
+              className="graph-page-select"
             >
               {snapshots.map((snapshot) => (
                 <option key={snapshot.scan_id} value={snapshot.scan_id}>
@@ -2437,7 +2453,7 @@ function GraphPageInner() {
               }
             />
             <FullscreenButton />
-            <GraphInteractionToolbar
+            {presentation.enabled && !captureMode && displayNodes.length > 0 && graphRenderer.kind === "react-flow" && <GraphInteractionToolbar
               editing={presentation.editing}
               hasSelection={Boolean(selectedNodeId)}
               onFitVisible={fitVisible}
@@ -2445,7 +2461,7 @@ function GraphPageInner() {
               onAutoLayout={autoLayout}
               onReset={resetLayout}
               onToggleEditing={presentation.toggleEditing}
-            />
+            />}
           </div>
         </div>
 
@@ -2461,12 +2477,12 @@ function GraphPageInner() {
               value={searchQuery}
               onChange={(event) => setSearchQuery(event.target.value)}
               placeholder="Search nodes, tags, severities, or attributes"
-              className="min-w-[260px] flex-1 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-3 py-2 text-sm text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:border-sky-600 focus:outline-none"
+              className="graph-page-search"
             />
             <button
               type="submit"
               disabled={searching || !selectedScanId}
-              className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40"
+              className="graph-page-action"
             >
               {searching ? "Searching..." : "Search"}
             </button>
@@ -2485,7 +2501,7 @@ function GraphPageInner() {
             {sourceNodeCount > 0 && (
               <span
                 data-testid="graph-compression-summary"
-                className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-2.5 py-1 text-[var(--text-secondary)]"
+                className="graph-chip-neutral"
               >
                 {compressedGroupCount > 0
                   ? `${compressedGroupCount} compressed groups`
@@ -2493,7 +2509,7 @@ function GraphPageInner() {
               </span>
             )}
             {loadingGraph && (
-              <span className="flex items-center gap-1 rounded-lg border border-sky-500/20 bg-sky-500/10 px-2.5 py-1 text-sky-700 dark:text-sky-200">
+              <span className="graph-chip-sky-soft">
                 <Loader2 className="h-3 w-3 animate-spin" />
                 refreshing
               </span>
@@ -2505,7 +2521,7 @@ function GraphPageInner() {
 
           {activeScopePreset === "assetDrift" && (
             <div className="mt-3 space-y-3">
-              <div className="flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-orange-500/30 bg-orange-500/10 px-3 py-2 text-xs text-orange-100">
+              <div className="graph-callout-orange">
                 <span>
                   Asset lifecycle drift lens — governance and{" "}
                   <span className="font-mono">exhibits_drift</span> edges with
@@ -2513,7 +2529,7 @@ function GraphPageInner() {
                 </span>
                 <a
                   href="/drift"
-                  className="rounded-lg border border-orange-400/30 bg-orange-950/60 px-2.5 py-1 text-orange-100 transition hover:border-orange-300"
+                  className="graph-chip-orange"
                 >
                   Open drift incidents
                 </a>
@@ -2537,7 +2553,7 @@ function GraphPageInner() {
           )}
 
           {investigationMode && (
-            <div className="mt-3 flex flex-wrap items-center justify-between gap-3 rounded-2xl border border-sky-500/30 bg-sky-500/10 px-3 py-2 text-xs text-sky-100">
+            <div className="graph-callout-sky">
               <span>
                 Root-centered investigation:{" "}
                 <span className="font-mono">{investigationMode.rootId}</span>
@@ -2606,7 +2622,7 @@ function GraphPageInner() {
                     type="button"
                     data-testid={`graph-search-result-${result.id}`}
                     onClick={() => void focusSearchResult(result)}
-                    className="rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-2 text-left transition hover:border-[var(--border-strong)] hover:bg-[var(--surface)]"
+                    className="graph-page-result"
                   >
                     <p className="truncate text-sm font-medium text-[var(--foreground)]">
                       {result.label}
@@ -2669,7 +2685,7 @@ function GraphPageInner() {
         {/* One collapsed drawer keeps secondary controls off the default path.
             Its content uses flat sections rather than nested control drawers. */}
         <details className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 group">
-          <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 px-3 py-2 [&::-webkit-details-marker]:hidden">
+          <summary className="graph-drawer-summary">
             <div>
               <span className="text-[10px] uppercase tracking-[0.22em] text-[var(--text-tertiary)]">
                 Advanced controls
@@ -2742,7 +2758,7 @@ function GraphPageInner() {
                   type="button"
                   onClick={() => setFilters(createCloudEstateGraphFilters())}
                   className={scopeButtonClass(activeScopePreset === "cloudEstate")}
-                  title="Observed cloud accounts, identities, resources, and attached findings"
+                  title="Type-based view of cloud accounts, identities, resources, and attached findings; does not assert collection provenance"
                 >
                   Cloud estate
                 </button>
@@ -2750,7 +2766,7 @@ function GraphPageInner() {
                   type="button"
                   onClick={() => setFilters(createRepositoryGraphFilters())}
                   className={scopeButtonClass(activeScopePreset === "repository")}
-                  title="Observed repository files, packages, and attached findings; no inferred import edges"
+                  title="Type-based view of repository files, packages, and attached findings; does not assert collection provenance"
                 >
                   Repository
                 </button>
@@ -2758,7 +2774,7 @@ function GraphPageInner() {
                   type="button"
                   onClick={() => setFilters(createEnvironmentGraphFilters())}
                   className={scopeButtonClass(activeScopePreset === "environment")}
-                  title="Observed environment, agent, service, resource, and finding relationships"
+                  title="Type-based view of environment, agent, service, resource, and finding nodes; does not assert collection provenance"
                 >
                   Environment
                 </button>
@@ -2813,7 +2829,7 @@ function GraphPageInner() {
             stop them from owning a full screen of vertical space on every
             page-load. */}
         {activeSnapshot && (
-          <details className="rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3 group">
+          <details className="group graph-drawer-section">
             <summary className="flex flex-wrap items-center justify-between gap-3 cursor-pointer list-none [&::-webkit-details-marker]:hidden">
               <div className="flex items-center gap-3">
                 <span className="text-[10px] uppercase tracking-[0.24em] text-sky-400">
@@ -2843,7 +2859,7 @@ function GraphPageInner() {
               </div>
             </summary>
             {diffError ? (
-              <div className="mt-3 rounded-xl border border-amber-500/20 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-200">
+              <div className="graph-callout-amber">
                 {diffError}
               </div>
             ) : loadingDiff && !graphDiff ? (
@@ -3029,7 +3045,7 @@ function GraphPageInner() {
                   onClick={() => {
                     setSelectedAttackPathKey(null);
                   }}
-                  className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-1.5 text-xs text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)]"
+                  className="graph-page-secondary-action"
                 >
                   Clear path focus
                 </button>
@@ -3137,7 +3153,7 @@ function GraphPageInner() {
       <div className="flex-1 flex relative min-h-[68vh]">
         <div className="flex-1 relative min-h-[60vh] flex flex-col">
           {selectedAttackPath && (
-            <div className="mb-2 flex flex-wrap items-center justify-between gap-2 rounded-xl border border-orange-500/30 bg-orange-500/10 px-3 py-2 text-xs text-orange-100">
+            <div className="graph-callout-orange-compact">
               <span>
                 Focused attack path · risk{" "}
                 {selectedAttackPath.composite_risk.toFixed(1)} ·{" "}
@@ -3149,7 +3165,7 @@ function GraphPageInner() {
                   onClick={() => {
                     setSelectedAttackPathKey(null);
                   }}
-                  className="rounded-lg border border-orange-400/30 bg-orange-950/40 px-2.5 py-1 text-orange-100 transition hover:border-orange-300"
+                  className="graph-chip-orange-muted"
                 >
                   Clear focus
                 </button>
@@ -3399,7 +3415,7 @@ function ReachabilityDrillInPanel({
         <button
           type="button"
           onClick={onClear}
-          className="rounded-lg border border-rose-400/30 bg-rose-950/60 px-2.5 py-1 text-rose-100 transition hover:border-rose-300"
+          className="graph-chip-rose"
         >
           Clear reachability
         </button>
@@ -3514,7 +3530,7 @@ function BlastRadiusPanel({
         <button
           type="button"
           onClick={onClear}
-          className="rounded-lg border border-violet-400/30 bg-violet-950/60 px-2.5 py-1 text-violet-100 transition hover:border-violet-300"
+          className="graph-chip-violet"
         >
           Clear blast radius
         </button>
@@ -3609,7 +3625,7 @@ function RollupNavigationPanel({
         <button
           type="button"
           onClick={onDismiss}
-          className="rounded-lg border border-emerald-400/30 bg-emerald-950/60 px-2.5 py-1 text-emerald-100 transition hover:border-emerald-300"
+          className="graph-chip-emerald"
         >
           Open node view
         </button>
@@ -3633,7 +3649,7 @@ function RollupNavigationPanel({
               <button
                 type="button"
                 onClick={() => onBreadcrumb(index)}
-                className="max-w-[12rem] truncate rounded border border-emerald-400/20 bg-emerald-950/50 px-2 py-0.5 transition hover:border-emerald-300"
+                className="graph-chip-emerald-truncate"
               >
                 {crumb.label}
               </button>
@@ -3699,7 +3715,7 @@ function PathTagList({
         {tags.map((tag) => (
           <span
             key={`${label}-${tag}`}
-            className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/80 px-2 py-1 text-[11px] text-[var(--text-secondary)]"
+            className="graph-chip-elevated"
           >
             {tag}
           </span>

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -10,6 +10,7 @@ import {
   ReactFlow,
   ReactFlowProvider,
   useReactFlow,
+  useViewport,
   type Edge,
   type Node,
 } from "@xyflow/react";
@@ -147,6 +148,7 @@ import {
 import { useCaptureMode } from "@/lib/use-capture-mode";
 import { useAuthState } from "@/components/auth-provider";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
+import { selectGraphSubgraph } from "@/lib/graph-presentation";
 
 // The whole current-scan graph loads in one request (no numbered pagination).
 // The bound matches the interactive render budget: past it, the overview
@@ -698,6 +700,7 @@ export default function GraphPageClient() {
 
 function GraphPageInner() {
   const reactFlow = useReactFlow();
+  const graphViewport = useViewport();
   const { session } = useAuthState();
   const [snapshots, setSnapshots] = useState<GraphSnapshot[]>([]);
   const [selectedScanId, setSelectedScanId] = useState("");
@@ -1375,6 +1378,10 @@ function GraphPageInner() {
     () => new Map(flow.nodes.map((node) => [node.id, node.data])),
     [flow.nodes],
   );
+  const attackPathNodeIds = useMemo(
+    () => (selectedAttackPath ? new Set(selectedAttackPath.hops) : null),
+    [selectedAttackPath],
+  );
 
   // Sibling aggregation (#2257). Threshold tracks the active filter
   // preset — operator triage (focused) collapses faster than topology
@@ -1447,10 +1454,14 @@ function GraphPageInner() {
   // renderers upstream, so ReactFlow only ever lays out small/medium graphs
   // where dagre is the better fit.
   const graphLayoutKind = "dagre-lr";
+  const layoutInput = useMemo(
+    () => selectGraphSubgraph(aggregated.nodes, aggregated.edges, attackPathNodeIds),
+    [aggregated.edges, aggregated.nodes, attackPathNodeIds],
+  );
   const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout(
     graphLayoutKind,
-    aggregated.nodes,
-    aggregated.edges,
+    layoutInput.nodes,
+    layoutInput.edges,
     {
       force: {
         idealEdgeLength: filters.agentName ? 168 : 196,
@@ -1479,11 +1490,6 @@ function GraphPageInner() {
         ? getLocalNeighborhoodIds(activeFocusId, layoutEdges)
         : null,
     [activeFocusId, layoutEdges],
-  );
-
-  const attackPathNodeIds = useMemo(
-    () => (selectedAttackPath ? new Set(selectedAttackPath.hops) : null),
-    [selectedAttackPath],
   );
 
   const attackPathEdgeKeys = useMemo(
@@ -1767,7 +1773,7 @@ function GraphPageInner() {
             },
             labelStyle: {
               fill: "#f4f4f5",
-              fontSize: 12,
+              fontSize: Math.max(10, Math.min(24, 12 / Math.max(graphViewport.zoom, 0.2))),
               fontWeight: 650,
             },
             animated: captureMode ? false : Boolean(inPath || edge.animated),
@@ -1846,6 +1852,7 @@ function GraphPageInner() {
       highSignalOpacity: graphLayoutKind === "dagre-lr" ? 0.6 : 0.48,
       inactiveOpacity: 0.06,
       captureMode,
+      zoom: graphViewport.zoom,
     });
   }, [
     layoutEdges,
@@ -1855,6 +1862,7 @@ function GraphPageInner() {
     blastRadius,
     graphLayoutKind,
     captureMode,
+    graphViewport.zoom,
   ]);
 
   // Drift lens edge emphasis — new/changed edges adopt their change-kind colour
@@ -3219,6 +3227,7 @@ function GraphPageInner() {
               nodesFocusable
               edgesFocusable
               elementsSelectable
+              deleteKeyCode={null}
               onlyRenderVisibleElements={shouldVirtualizeReactFlowNodes({
                 rollupActive: rollupNavigationActive,
               })}

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -18,11 +18,12 @@ import { AlertTriangle, Layers, Loader2, Radar, Route, ShieldAlert } from "lucid
 
 import { AttackPathCard } from "@/components/attack-path-card";
 import { AttackPathTechniqueChain } from "@/components/attack-path-technique-chain";
-import { GraphEvaluationSummary } from "@/components/graph-evaluation-summary";
+import { GraphEvidenceSummary } from "@/components/graph-evidence-summary";
 import { GraphAnalysisStatusBanner } from "@/components/graph-analysis-status";
 import {
   GraphEvidenceExportButton,
   FullscreenButton,
+  GraphInteractionToolbar,
 } from "@/components/graph-chrome";
 import { GraphCompletenessBanner } from "@/components/graph-completeness-banner";
 import {
@@ -43,9 +44,12 @@ import {
   ASSET_DRIFT_GRAPH_SCOPE_PARAM,
   DEFAULT_FILTERS,
   createAssetLifecycleDriftGraphFilters,
+  createCloudEstateGraphFilters,
+  createEnvironmentGraphFilters,
   createExpandedGraphFilters,
   createFocusedGraphFilters,
   createImmediateGraphFilters,
+  createRepositoryGraphFilters,
   graphScopeLabelForFilters,
   graphScopePresetForFilters,
   type FilterState,
@@ -101,7 +105,6 @@ import {
   summarizeReachability,
   type ReachabilitySummary,
 } from "@/lib/graph-reachability";
-import { evaluateGraphUx } from "@/lib/graph-ux-evaluation";
 import {
   api,
   ApiRateLimitError,
@@ -142,6 +145,8 @@ import {
   type EvidenceLensFilter,
 } from "@/lib/filter-algebra";
 import { useCaptureMode } from "@/lib/use-capture-mode";
+import { useAuthState } from "@/components/auth-provider";
+import { useGraphPresentation } from "@/hooks/use-graph-presentation";
 
 // The whole current-scan graph loads in one request (no numbered pagination).
 // The bound matches the interactive render budget: past it, the overview
@@ -693,6 +698,7 @@ export default function GraphPageClient() {
 
 function GraphPageInner() {
   const reactFlow = useReactFlow();
+  const { session } = useAuthState();
   const [snapshots, setSnapshots] = useState<GraphSnapshot[]>([]);
   const [selectedScanId, setSelectedScanId] = useState("");
   const [graphData, setGraphData] = useState<UnifiedGraphResponse | null>(null);
@@ -1761,8 +1767,8 @@ function GraphPageInner() {
             },
             labelStyle: {
               fill: "#f4f4f5",
-              fontSize: 11,
-              fontWeight: 600,
+              fontSize: 12,
+              fontWeight: 650,
             },
             animated: captureMode ? false : Boolean(inPath || edge.animated),
             style: {
@@ -1889,11 +1895,6 @@ function GraphPageInner() {
     });
   }, [baseDisplayEdges, driftLensEngaged, driftIndex]);
 
-  const graphEvaluation = useMemo(
-    () => evaluateGraphUx(graphData, displayNodes, displayEdges),
-    [displayEdges, displayNodes, graphData],
-  );
-
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
     [displayEdges, displayNodes],
@@ -1919,6 +1920,58 @@ function GraphPageInner() {
         mode: "lineage",
       }),
     [captureMode, displayEdges.length, displayNodes.length, selectedNode],
+  );
+  const presentationScope = useMemo(
+    () => ({
+      tenantId: session?.tenant_id || "local",
+      subject: session?.subject || session?.auth_method || "local-viewer",
+      snapshotId: selectedScanId || "unselected",
+      lens: selectedAttackPath ? "investigation" : "lineage",
+      scope: JSON.stringify({
+        preset: graphScopePresetForFilters(filters),
+        agent: filters.agentName,
+        severity: filters.severity,
+        path: selectedAttackPathKey,
+        rollup: rollupStack.at(-1)?.id ?? null,
+      }),
+    }),
+    [filters, rollupStack, selectedAttackPath, selectedAttackPathKey, selectedScanId, session?.auth_method, session?.subject, session?.tenant_id],
+  );
+  const presentation = useGraphPresentation({
+    nodes: displayNodes,
+    scope: presentationScope,
+    layout: graphLayoutKind,
+    enabled: !captureMode,
+  });
+  const fitVisible = useCallback(() => {
+    void reactFlow.fitView({ ...viewportOptions, duration: 240 });
+  }, [reactFlow, viewportOptions]);
+  const fitSelection = useCallback(() => {
+    if (!selectedNodeId) return;
+    const node = reactFlow.getNode(selectedNodeId);
+    if (node) {
+      void reactFlow.fitView({
+        nodes: [node],
+        padding: 0.7,
+        duration: 240,
+        maxZoom: 1.4,
+      });
+    }
+  }, [reactFlow, selectedNodeId]);
+  const autoLayout = useCallback(() => {
+    presentation.autoLayout();
+    window.setTimeout(fitVisible, 0);
+  }, [fitVisible, presentation]);
+  const resetLayout = useCallback(() => {
+    presentation.reset();
+    window.setTimeout(fitVisible, 0);
+  }, [fitVisible, presentation]);
+  const relationshipEvidenceCount = useMemo(
+    () =>
+      graphData?.edges.filter(
+        (edge) => Object.keys(edge.evidence ?? {}).length > 0,
+      ).length ?? null,
+    [graphData],
   );
 
   const hasContextualGraph = useMemo(
@@ -2376,6 +2429,15 @@ function GraphPageInner() {
               }
             />
             <FullscreenButton />
+            <GraphInteractionToolbar
+              editing={presentation.editing}
+              hasSelection={Boolean(selectedNodeId)}
+              onFitVisible={fitVisible}
+              onFitSelection={fitSelection}
+              onAutoLayout={autoLayout}
+              onReset={resetLayout}
+              onToggleEditing={presentation.toggleEditing}
+            />
           </div>
         </div>
 
@@ -2578,11 +2640,26 @@ function GraphPageInner() {
           )}
         </div>
 
-        {/* #3932: one collapsed-by-default "Advanced controls" shelf keeps the
-            canvas above the fold. It nests the three former full-width bands —
-            View controls, operator evaluation/diff lenses, and the ranked
-            attack-path queue — so the operator reaches them in one place
-            without any of them stacking on the default page load. */}
+        <div className="mt-2">
+          <GraphEvidenceSummary
+            capturedAt={activeSnapshot?.created_at ?? null}
+            returnedNodes={graphData?.completeness?.returned ?? graphData?.nodes.length ?? null}
+            totalNodes={graphData?.completeness?.total ?? graphData?.pagination.total ?? null}
+            evidencedEdges={relationshipEvidenceCount}
+            totalEdges={graphData?.edges.length ?? null}
+            completeness={
+              graphData?.completeness?.status ??
+              (graphData && graphData.nodes.length < graphData.pagination.total
+                ? "truncated"
+                : graphData
+                  ? "complete"
+                  : null)
+            }
+          />
+        </div>
+
+        {/* One collapsed drawer keeps secondary controls off the default path.
+            Its content uses flat sections rather than nested control drawers. */}
         <details className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 group">
           <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 px-3 py-2 [&::-webkit-details-marker]:hidden">
             <div>
@@ -2590,8 +2667,7 @@ function GraphPageInner() {
                 Advanced controls
               </span>
               <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                View controls, operator evaluation and diff lenses, and the
-                ranked attack-path queue.
+                Scope, evidence overlays, snapshot diff, and the ranked path queue.
               </p>
             </div>
             <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:hidden">
@@ -2602,24 +2678,18 @@ function GraphPageInner() {
             </span>
           </summary>
           <div className="space-y-3 border-t border-[var(--border-subtle)]/80 p-3">
-          <details className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3 group">
-            <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 [&::-webkit-details-marker]:hidden">
+          <section aria-labelledby="graph-view-controls" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70 p-3">
+            <div className="flex flex-wrap items-center justify-between gap-3">
               <div>
-                <span className="text-[10px] uppercase tracking-[0.22em] text-[var(--text-tertiary)]">
+                <h3 id="graph-view-controls" className="text-[10px] uppercase tracking-[0.22em] text-[var(--text-tertiary)]">
                   View controls
-                </span>
+                </h3>
                 <p className="mt-1 text-xs text-[var(--text-secondary)]">
                   Change scope, layers, severity, traversal, and page size
                   without changing the persisted graph.
                 </p>
               </div>
-              <span className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:hidden">
-                show
-              </span>
-              <span className="hidden text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)] group-open:inline">
-                hide
-              </span>
-            </summary>
+            </div>
             <div className="mt-3 space-y-3">
               <div className="flex flex-wrap gap-2 text-[11px]">
                 <button
@@ -2662,6 +2732,30 @@ function GraphPageInner() {
                 </button>
                 <button
                   type="button"
+                  onClick={() => setFilters(createCloudEstateGraphFilters())}
+                  className={scopeButtonClass(activeScopePreset === "cloudEstate")}
+                  title="Observed cloud accounts, identities, resources, and attached findings"
+                >
+                  Cloud estate
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setFilters(createRepositoryGraphFilters())}
+                  className={scopeButtonClass(activeScopePreset === "repository")}
+                  title="Observed repository files, packages, and attached findings; no inferred import edges"
+                >
+                  Repository
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setFilters(createEnvironmentGraphFilters())}
+                  className={scopeButtonClass(activeScopePreset === "environment")}
+                  title="Observed environment, agent, service, resource, and finding relationships"
+                >
+                  Environment
+                </button>
+                <button
+                  type="button"
                   onClick={() =>
                     setFilters(
                       createAssetLifecycleDriftGraphFilters(
@@ -2696,23 +2790,13 @@ function GraphPageInner() {
                 variant="panel"
               />
             </div>
-          </details>
+          </section>
 
-        <details className="mt-3 rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70">
-          <summary className="cursor-pointer list-none px-3 py-2 text-xs font-medium text-[var(--text-secondary)] [&::-webkit-details-marker]:hidden">
-            Operator details · evaluation, diff, lenses
-          </summary>
+        <section aria-labelledby="graph-operator-tools" className="rounded-xl border border-[var(--border-subtle)] bg-[var(--background)]/70">
+          <h3 id="graph-operator-tools" className="px-3 py-2 text-xs font-medium text-[var(--text-secondary)]">
+            Evidence, drift, and operator tools
+          </h3>
           <div className="space-y-3 border-t border-[var(--border-subtle)]/80 px-3 py-3">
-            <div className="rounded-xl border border-[var(--border-subtle)]/80 bg-[var(--background)]/50 px-3 py-2">
-              <p className="text-[10px] uppercase tracking-[0.18em] text-[var(--text-tertiary)]">
-                Graph evaluation
-              </p>
-              <p className="mt-1 text-xs text-[var(--text-secondary)]">
-                Score {Math.round(graphEvaluation.score)} ({graphEvaluation.grade})
-              </p>
-              <GraphEvaluationSummary evaluation={graphEvaluation} />
-            </div>
-
         {/* Snapshot diff + how-to-read default-collapsed so the canvas owns the
             viewport. The four redundant SnapshotMetaCards (Snapshot/Topology/
             Scope/Window) were removed — the inline summary above already
@@ -2902,7 +2986,7 @@ function GraphPageInner() {
           </ul>
         </details>
           </div>
-        </details>
+        </section>
 
         {attackPaths.length > 0 && (
           <details className="mt-3 rounded-2xl border border-[var(--border-subtle)] bg-[var(--background)]/60 p-3 group">
@@ -3116,17 +3200,25 @@ function GraphPageInner() {
             />
           ) : (
             <ReactFlow
-              key={captureMode ? "lineage-capture" : "lineage-interactive"}
-              nodes={displayNodes}
+              key={captureMode ? "lineage-capture" : presentation.storageKey}
+              nodes={presentation.nodes}
               edges={displayEdges}
               nodeTypes={lineageNodeTypesAdaptive}
-              fitView
+              fitView={!presentation.hasSavedState}
               fitViewOptions={viewportOptions}
+              defaultViewport={presentation.viewport}
               minZoom={0.16}
               maxZoom={2.5}
-              zoomOnScroll={false}
+              zoomOnScroll={!captureMode}
+              zoomOnPinch={!captureMode}
               panOnScroll={false}
-              preventScrolling={false}
+              panOnDrag={!captureMode}
+              preventScrolling={!captureMode}
+              nodesDraggable={!captureMode && presentation.editing}
+              nodesConnectable={false}
+              nodesFocusable
+              edgesFocusable
+              elementsSelectable
               onlyRenderVisibleElements={shouldVirtualizeReactFlowNodes({
                 rollupActive: rollupNavigationActive,
               })}
@@ -3135,6 +3227,9 @@ function GraphPageInner() {
               onNodeClick={onNodeClick}
               onNodeMouseEnter={onNodeMouseEnter}
               onNodeMouseLeave={onNodeMouseLeave}
+              onNodesChange={presentation.onNodesChange}
+              onNodeDragStop={presentation.onNodeDragStop}
+              onMoveEnd={presentation.onMoveEnd}
               onPaneClick={() => {
                 setSelectedNode(null);
                 setSelectedNodeId(null);

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -45,6 +45,7 @@ import {
   MINIMAP_MASK,
   BACKGROUND_COLOR,
   BACKGROUND_GAP,
+  graphNodeDisplayLabels,
   legendItemsForVisibleGraph,
   minimapNodeColor,
   readableGraphEdges,
@@ -58,7 +59,7 @@ import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 import { useCaptureMode } from "@/lib/use-capture-mode";
 import { useAuthState } from "@/components/auth-provider";
-import { selectGraphSubgraph } from "@/lib/graph-presentation";
+import { graphTopologyKey, selectGraphSubgraph } from "@/lib/graph-presentation";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
 
 // ─── Filter Toolbar ─────────────────────────────────────────────────────────
@@ -217,7 +218,7 @@ export default function MeshPage() {
   const [selectedAgents, setSelectedAgents] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const { counts } = useDeploymentContext();
-  const { session } = useAuthState();
+  const { session, loading: authLoading } = useAuthState();
   const captureMode = useCaptureMode();
 
   useEffect(() => {
@@ -445,8 +446,9 @@ export default function MeshPage() {
       highSignalOpacity: pathFocusActive ? 0.95 : 0.58,
       inactiveOpacity: 0.06,
       captureMode,
+      nodeLabels: graphNodeDisplayLabels(displayNodes),
     });
-  }, [visibleEdges, connectedIds, searchMatches, pathFocusIds, pathFocusActive, captureMode]);
+  }, [visibleEdges, connectedIds, searchMatches, pathFocusIds, pathFocusActive, captureMode, displayNodes]);
 
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(displayNodes, displayEdges),
@@ -484,15 +486,18 @@ export default function MeshPage() {
         agents: [...selectedAgents].sort(),
         severity: severityFilter,
         vulnerableOnly,
+        topology: graphTopologyKey(displayNodes, displayEdges),
       }),
     }),
-    [selectedAgents, selectedJob, session?.auth_method, session?.subject, session?.tenant_id, severityFilter, vulnerableOnly],
+    [displayEdges, displayNodes, selectedAgents, selectedJob, session?.auth_method, session?.subject, session?.tenant_id, severityFilter, vulnerableOnly],
   );
   const presentation = useGraphPresentation({
     nodes: displayNodes,
     scope: presentationScope,
     layout: layoutMode,
-    enabled: !captureMode,
+    enabled: !captureMode && !authLoading && Boolean(session),
+    ownerActive: Boolean(session),
+    localMode: session?.recommended_ui_mode === "no_auth",
   });
 
   const fitVisible = useCallback(() => {
@@ -628,7 +633,7 @@ export default function MeshPage() {
               ))}
             </select>
             <FullscreenButton />
-            <GraphInteractionToolbar
+            {presentation.enabled && !captureMode && displayNodes.length > 0 && <GraphInteractionToolbar
               editing={presentation.editing}
               hasSelection={Boolean(selectedNodeId)}
               onFitVisible={fitVisible}
@@ -636,7 +641,7 @@ export default function MeshPage() {
               onAutoLayout={autoLayout}
               onReset={resetLayout}
               onToggleEditing={presentation.toggleEditing}
-            />
+            />}
           </div>
         </div>
         <GraphLensSwitcher variant="compact" legendItems={legendItems} />

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -714,6 +714,7 @@ export default function MeshPage() {
             nodesFocusable
             edgesFocusable
             elementsSelectable
+            deleteKeyCode={null}
             onlyRenderVisibleElements
             defaultEdgeOptions={{ type: "smoothstep" }}
             proOptions={{ hideAttribution: true }}

--- a/ui/app/mesh/page.tsx
+++ b/ui/app/mesh/page.tsx
@@ -8,6 +8,7 @@ import {
   MiniMap,
   type Node,
   type Edge,
+  type ReactFlowInstance,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import {
@@ -49,13 +50,16 @@ import {
   readableGraphEdges,
 } from "@/lib/graph-utils";
 import { graphFitViewOptions, shouldShowGraphMiniMap } from "@/lib/graph-viewport";
-import { FullscreenButton } from "@/components/graph-chrome";
+import { FullscreenButton, GraphInteractionToolbar } from "@/components/graph-chrome";
 import { GraphLensSwitcher } from "@/components/graph-lens-switcher";
 import { GraphEmptyState, GraphPanelSkeleton, GraphRefreshOverlay } from "@/components/graph-state-panels";
 import { DeploymentSurfaceRequiredState } from "@/components/deployment-surface-required-state";
 import { useDeploymentContext } from "@/hooks/use-deployment-context";
 import { isDeploymentSurfaceAvailable } from "@/lib/deployment-context";
 import { useCaptureMode } from "@/lib/use-capture-mode";
+import { useAuthState } from "@/components/auth-provider";
+import { selectGraphSubgraph } from "@/lib/graph-presentation";
+import { useGraphPresentation } from "@/hooks/use-graph-presentation";
 
 // ─── Filter Toolbar ─────────────────────────────────────────────────────────
 
@@ -194,10 +198,12 @@ export default function MeshPage() {
   const [detailLoading, setDetailLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [activeJob, setActiveJob] = useState<ScanJob | null>(null);
   const [layoutMode, setLayoutMode] = useState<MeshLayoutMode>("topology");
   const [pathFocusEnabled, setPathFocusEnabled] = useState(true);
+  const [flowInstance, setFlowInstance] = useState<ReactFlowInstance<Node<LineageNodeData>, Edge> | null>(null);
 
   // Filters
   const [nodeFilter, setNodeFilter] = useState<NodeTypeFilter>({
@@ -211,6 +217,7 @@ export default function MeshPage() {
   const [selectedAgents, setSelectedAgents] = useState<string[]>([]);
   const [searchQuery, setSearchQuery] = useState("");
   const { counts } = useDeploymentContext();
+  const { session } = useAuthState();
   const captureMode = useCaptureMode();
 
   useEffect(() => {
@@ -344,7 +351,17 @@ export default function MeshPage() {
     return { rawNodes: nodes, rawEdges: edges, stats };
   }, [activeResult, nodeFilter, severityFilter, selectedAgents, vulnerableOnly]);
 
-  const { nodes: visibleNodes, edges: visibleEdges } = useGraphLayout(layoutMode, rawNodes, rawEdges, {
+  const pathFocusIds = useMemo(() => {
+    if (!pathFocusEnabled || !stats.topExposurePath || searchQuery || hoveredNodeId) return null;
+    return new Set(stats.topExposurePath.nodeIds);
+  }, [hoveredNodeId, pathFocusEnabled, searchQuery, stats.topExposurePath]);
+  const pathFocusActive = Boolean(pathFocusIds);
+  const layoutInput = useMemo(
+    () => selectGraphSubgraph(rawNodes, rawEdges, pathFocusIds),
+    [pathFocusIds, rawEdges, rawNodes],
+  );
+
+  const { nodes: visibleNodes, edges: visibleEdges } = useGraphLayout(layoutMode, layoutInput.nodes, layoutInput.edges, {
     radial: {
       baseRadius: captureMode ? 170 : 260,
       ringSpacing: captureMode ? 150 : 240,
@@ -360,11 +377,12 @@ export default function MeshPage() {
       minSeparation: LINEAGE_MIN_SEPARATION,
     },
   });
+  const typedVisibleNodes = visibleNodes as Node<LineageNodeData>[];
 
   // Search highlighting
   const searchMatches = useMemo(
-    () => (searchQuery ? searchNodes(visibleNodes, searchQuery) : null),
-    [visibleNodes, searchQuery]
+    () => (searchQuery ? searchNodes(typedVisibleNodes, searchQuery) : null),
+    [typedVisibleNodes, searchQuery]
   );
 
   const toggleAgent = useCallback((name: string) => {
@@ -382,35 +400,28 @@ export default function MeshPage() {
     [hoveredNodeId, visibleEdges]
   );
 
-  const pathFocusIds = useMemo(() => {
-    if (!pathFocusEnabled || !stats.topExposurePath || searchQuery || hoveredNodeId) return null;
-    return new Set(stats.topExposurePath.nodeIds);
-  }, [hoveredNodeId, pathFocusEnabled, searchQuery, stats.topExposurePath]);
-
-  const pathFocusActive = Boolean(pathFocusIds);
-
-  const displayNodes = useMemo(() => {
+  const displayNodes = useMemo<Node<LineageNodeData>[]>(() => {
     if (searchMatches && searchMatches.size > 0) {
-      return visibleNodes?.map((n) => ({
+      return typedVisibleNodes.map((n) => ({
         ...n,
         data: { ...n.data, dimmed: !searchMatches.has(n.id), highlighted: searchMatches.has(n.id), renderBand: "detail" as const },
       }));
     }
     if (pathFocusIds) {
-      return visibleNodes
-        ?.filter((n) => pathFocusIds.has(n.id))
+      return typedVisibleNodes
+        .filter((n) => pathFocusIds.has(n.id))
         .map((n) => ({
           ...n,
           data: { ...n.data, dimmed: false, highlighted: true, renderBand: "detail" as const },
         }));
     }
     if (!connectedIds) {
-      return visibleNodes?.map((n) => ({
+      return typedVisibleNodes.map((n) => ({
         ...n,
         data: { ...n.data, renderBand: "detail" as const },
       }));
     }
-    return visibleNodes?.map((n) => ({
+    return typedVisibleNodes.map((n) => ({
       ...n,
       data: {
         ...n.data,
@@ -419,7 +430,7 @@ export default function MeshPage() {
         renderBand: "detail" as const,
       },
     }));
-  }, [visibleNodes, connectedIds, searchMatches, pathFocusIds]);
+  }, [typedVisibleNodes, connectedIds, searchMatches, pathFocusIds]);
 
   const displayEdges = useMemo(() => {
     const activeSet = searchMatches && searchMatches.size > 0 ? searchMatches : connectedIds ?? pathFocusIds;
@@ -463,8 +474,47 @@ export default function MeshPage() {
     [captureMode, displayEdges.length, displayNodes.length, selectedNode],
   );
 
+  const presentationScope = useMemo(
+    () => ({
+      tenantId: session?.tenant_id || "local",
+      subject: session?.subject || session?.auth_method || "local-viewer",
+      snapshotId: selectedJob || "unselected",
+      lens: "mesh",
+      scope: JSON.stringify({
+        agents: [...selectedAgents].sort(),
+        severity: severityFilter,
+        vulnerableOnly,
+      }),
+    }),
+    [selectedAgents, selectedJob, session?.auth_method, session?.subject, session?.tenant_id, severityFilter, vulnerableOnly],
+  );
+  const presentation = useGraphPresentation({
+    nodes: displayNodes,
+    scope: presentationScope,
+    layout: layoutMode,
+    enabled: !captureMode,
+  });
+
+  const fitVisible = useCallback(() => {
+    void flowInstance?.fitView({ ...viewportOptions, duration: 240 });
+  }, [flowInstance, viewportOptions]);
+  const fitSelection = useCallback(() => {
+    if (!flowInstance || !selectedNodeId) return;
+    const node = flowInstance.getNode(selectedNodeId);
+    if (node) void flowInstance.fitView({ nodes: [node], padding: 0.7, duration: 240, maxZoom: 1.4 });
+  }, [flowInstance, selectedNodeId]);
+  const autoLayout = useCallback(() => {
+    presentation.autoLayout();
+    window.setTimeout(fitVisible, 0);
+  }, [fitVisible, presentation]);
+  const resetLayout = useCallback(() => {
+    presentation.reset();
+    window.setTimeout(fitVisible, 0);
+  }, [fitVisible, presentation]);
+
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => {
     setSelectedNode(node.data as LineageNodeData);
+    setSelectedNodeId(node.id);
     setHoveredNodeId(null);
   }, []);
 
@@ -578,6 +628,15 @@ export default function MeshPage() {
               ))}
             </select>
             <FullscreenButton />
+            <GraphInteractionToolbar
+              editing={presentation.editing}
+              hasSelection={Boolean(selectedNodeId)}
+              onFitVisible={fitVisible}
+              onFitSelection={fitSelection}
+              onAutoLayout={autoLayout}
+              onReset={resetLayout}
+              onToggleEditing={presentation.toggleEditing}
+            />
           </div>
         </div>
         <GraphLensSwitcher variant="compact" legendItems={legendItems} />
@@ -635,25 +694,40 @@ export default function MeshPage() {
             command="agent-bom scan -p . -f graph"
           />
         ) : (
-          <ReactFlow
-            key={captureMode ? "mesh-capture" : "mesh-interactive"}
-            nodes={displayNodes}
+          <ReactFlow<Node<LineageNodeData>, Edge>
+            key={captureMode ? "mesh-capture" : presentation.storageKey}
+            nodes={presentation.nodes}
             edges={displayEdges}
             nodeTypes={lineageNodeTypes}
-            fitView
+            fitView={!presentation.hasSavedState}
             fitViewOptions={viewportOptions}
+            defaultViewport={presentation.viewport}
             minZoom={0.16}
             maxZoom={2.5}
-            zoomOnScroll={false}
+            zoomOnScroll={!captureMode}
+            zoomOnPinch={!captureMode}
             panOnScroll={false}
-            preventScrolling={false}
+            panOnDrag={!captureMode}
+            preventScrolling={!captureMode}
+            nodesDraggable={!captureMode && presentation.editing}
+            nodesConnectable={false}
+            nodesFocusable
+            edgesFocusable
+            elementsSelectable
             onlyRenderVisibleElements
             defaultEdgeOptions={{ type: "smoothstep" }}
             proOptions={{ hideAttribution: true }}
             onNodeClick={onNodeClick}
             onNodeMouseEnter={onNodeMouseEnter}
             onNodeMouseLeave={onNodeMouseLeave}
-            onPaneClick={() => { setSelectedNode(null); setHoveredNodeId(null); }}
+            onNodesChange={presentation.onNodesChange}
+            onNodeDragStop={presentation.onNodeDragStop}
+            onMoveEnd={presentation.onMoveEnd}
+            onInit={(instance) => {
+              setFlowInstance(instance);
+              void instance.setViewport(presentation.viewport);
+            }}
+            onPaneClick={() => { setSelectedNode(null); setSelectedNodeId(null); setHoveredNodeId(null); }}
           >
             <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
             {!captureMode && <Controls className={CONTROLS_CLASS} />}
@@ -671,7 +745,7 @@ export default function MeshPage() {
         {selectedNode && (
           <GraphEntityDrawer
             data={selectedNode}
-            onClose={() => setSelectedNode(null)}
+            onClose={() => { setSelectedNode(null); setSelectedNodeId(null); }}
             enrich={false}
           />
         )}

--- a/ui/components/agent-topology.tsx
+++ b/ui/components/agent-topology.tsx
@@ -9,6 +9,7 @@ import {
   useReactFlow,
   Handle,
   Position,
+  type Edge,
   type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -28,6 +29,7 @@ import {
 import { useDagreLrLayout } from "@/lib/use-dagre-lr";
 import { useThemeMode } from "@/lib/theme-mode";
 import { TopologyDetailDrawer } from "@/components/topology-detail-drawer";
+import { graphNodeDisplayLabels, readableGraphEdges } from "@/lib/graph-utils";
 
 const TOPOLOGY_CONTROLS_CLASS =
   "!rounded-lg !border !border-[color:var(--border-subtle)] !bg-[color:var(--surface-elevated)] !backdrop-blur-sm [&>button]:!border-[color:var(--border-subtle)] [&>button]:!bg-[color:var(--surface)] [&>button]:!text-[color:var(--text-secondary)] [&>button:hover]:!bg-[color:var(--surface-muted)] [&>button:hover]:!text-[color:var(--foreground)]";
@@ -130,6 +132,14 @@ function TopologyFlow({
     rankSep: 120,
     nodeSep: 28,
   });
+  const displayEdges = useMemo(
+    () =>
+      readableGraphEdges(edges as Edge[], undefined, {
+        nodeLabels: graphNodeDisplayLabels(nodes),
+        preserveVisualStyle: true,
+      }),
+    [edges, nodes],
+  );
   const backgroundDot = theme === "light" ? "#94a3b8" : "#5b6472";
 
   useEffect(() => {
@@ -158,7 +168,7 @@ function TopologyFlow({
   return (
     <ReactFlow
       nodes={nodes}
-      edges={edges}
+      edges={displayEdges}
       nodeTypes={nodeTypes}
       onNodeClick={handleNodeClick}
       fitView

--- a/ui/components/attack-flow.tsx
+++ b/ui/components/attack-flow.tsx
@@ -19,10 +19,12 @@ import {
 } from "@/lib/api";
 import type { AttackFlowNodeData, AttackFlowResponse } from "@/lib/api";
 import { SeverityBadge } from "@/components/severity-badge";
-import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, ATTACK_FLOW_MINIMAP_COLORS } from "@/lib/graph-utils";
+import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, ATTACK_FLOW_MINIMAP_COLORS, graphNodeDisplayLabels, readableGraphEdges } from "@/lib/graph-utils";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
 import { FullscreenButton, GraphInteractionToolbar } from "@/components/graph-chrome";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
+import { graphTopologyKey } from "@/lib/graph-presentation";
+import { useAuthState } from "@/components/auth-provider";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -59,40 +61,40 @@ function AttackFlowNode({ data }: { data: AttackFlowNodeData }) {
   const showSource = nodeType !== "agent" && nodeType !== "credential" && nodeType !== "tool";
 
   return (
-    <div className={`rounded-lg border-2 px-3 py-2 min-w-[140px] max-w-[220px] shadow-lg backdrop-blur ${colorClass}`}>
-      {showTarget && <Handle type="target" position={Position.Left} className="!bg-[var(--text-tertiary)] !w-2 !h-2 !border-[var(--border-strong)]" />}
+    <div className={`attack-flow-node ${colorClass}`}>
+      {showTarget && <Handle type="target" position={Position.Left} className="attack-flow-handle" />}
       <div className="flex items-center gap-1.5 mb-0.5">
         <Icon className="w-3.5 h-3.5 shrink-0" />
-        <span className="text-xs font-semibold text-[var(--foreground)] truncate">{data.label}</span>
+        <span className="attack-flow-node-label">{data.label}</span>
       </div>
       <div className="flex flex-wrap gap-1 mt-1">
         {nodeType === "cve" && data.severity && (
           <span className={`text-[10px] px-1.5 py-0.5 rounded border font-mono uppercase ${severityColor(data.severity)}`}>{data.severity}</span>
         )}
         {nodeType === "cve" && data.is_kev && (
-          <span className="text-[10px] px-1 py-0.5 rounded border font-mono border-red-700 bg-red-950 text-red-400">KEV</span>
+          <span className="attack-flow-kev">KEV</span>
         )}
         {nodeType === "cve" && data.cvss_score != null && (
-          <span className="text-[10px] text-[var(--text-secondary)] font-mono">CVSS {data.cvss_score.toFixed(1)}</span>
+          <span className="attack-flow-meta">CVSS {data.cvss_score.toFixed(1)}</span>
         )}
-        {nodeType === "package" && data.version && <span className="text-[10px] text-[var(--text-secondary)] font-mono">@{data.version}</span>}
-        {nodeType === "package" && data.ecosystem && <span className="text-[10px] text-[var(--text-tertiary)] font-mono">{data.ecosystem}</span>}
-        {nodeType === "agent" && data.agent_type && <span className="text-[10px] text-[var(--text-secondary)] font-mono">{data.agent_type}</span>}
+        {nodeType === "package" && data.version && <span className="attack-flow-meta">@{data.version}</span>}
+        {nodeType === "package" && data.ecosystem && <span className="attack-flow-meta-muted">{data.ecosystem}</span>}
+        {nodeType === "agent" && data.agent_type && <span className="attack-flow-meta">{data.agent_type}</span>}
       </div>
       {nodeType === "cve" && (data.owasp_tags?.length || data.atlas_tags?.length || data.owasp_mcp_tags?.length) ? (
         <div className="flex flex-wrap gap-0.5 mt-1">
           {data.owasp_tags?.slice(0, 2).map((tag) => (
-            <span key={tag} className="text-[9px] font-mono bg-purple-950/60 border border-purple-800/50 text-purple-400 rounded px-1">{tag}</span>
+            <span key={tag} className="attack-flow-tag attack-flow-tag-purple">{tag}</span>
           ))}
           {data.owasp_mcp_tags?.slice(0, 2).map((tag) => (
-            <span key={tag} className="text-[9px] font-mono bg-amber-950/60 border border-amber-800/50 text-amber-400 rounded px-1">{tag}</span>
+            <span key={tag} className="attack-flow-tag attack-flow-tag-amber">{tag}</span>
           ))}
           {data.atlas_tags?.slice(0, 1).map((tag) => (
-            <span key={tag} className="text-[9px] font-mono bg-cyan-950/60 border border-cyan-800/50 text-cyan-400 rounded px-1">{tag}</span>
+            <span key={tag} className="attack-flow-tag attack-flow-tag-cyan">{tag}</span>
           ))}
         </div>
       ) : null}
-      {showSource && <Handle type="source" position={Position.Right} className="!bg-[var(--text-tertiary)] !w-2 !h-2 !border-[var(--border-strong)]" />}
+      {showSource && <Handle type="source" position={Position.Right} className="attack-flow-handle" />}
     </div>
   );
 }
@@ -111,26 +113,26 @@ function DetailPanel({ data, onClose }: { data: AttackFlowNodeData; onClose: () 
       <div className="p-4 space-y-4">
         <div className="flex items-start justify-between">
           <div>
-            <span className="text-[10px] uppercase tracking-wider text-[var(--text-tertiary)]">{typeLabels[data.nodeType] ?? data.nodeType}</span>
-            <h3 className="text-sm font-semibold text-[var(--foreground)] mt-0.5 break-all">{data.label}</h3>
+            <span className="attack-flow-drawer-kicker">{typeLabels[data.nodeType] ?? data.nodeType}</span>
+            <h3 className="attack-flow-drawer-title">{data.label}</h3>
           </div>
-          <button onClick={onClose} className="p-1 text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"><X className="w-4 h-4" /></button>
+          <button onClick={onClose} className="attack-flow-close"><X className="w-4 h-4" /></button>
         </div>
         {data.nodeType === "cve" && (
           <div className="space-y-3">
             {data.severity && <SeverityBadge severity={data.severity} />}
             <div className="grid grid-cols-2 gap-2">
-              {data.cvss_score != null && <div className="bg-[var(--surface)] rounded-lg p-2 text-center"><div className="text-lg font-bold font-mono text-[var(--foreground)]">{data.cvss_score.toFixed(1)}</div><div className="text-[10px] text-[var(--text-tertiary)]">CVSS</div></div>}
-              {data.epss_score != null && <div className="bg-[var(--surface)] rounded-lg p-2 text-center"><div className="text-lg font-bold font-mono text-[var(--foreground)]">{(data.epss_score * 100).toFixed(1)}%</div><div className="text-[10px] text-[var(--text-tertiary)]">EPSS</div></div>}
+              {data.cvss_score != null && <div className="bg-[var(--surface)] rounded-lg p-2 text-center"><div className="attack-flow-stat-value">{data.cvss_score.toFixed(1)}</div><div className="text-[10px] text-[var(--text-tertiary)]">CVSS</div></div>}
+              {data.epss_score != null && <div className="bg-[var(--surface)] rounded-lg p-2 text-center"><div className="attack-flow-stat-value">{(data.epss_score * 100).toFixed(1)}%</div><div className="text-[10px] text-[var(--text-tertiary)]">EPSS</div></div>}
             </div>
-            {data.is_kev && <div className="text-xs font-mono bg-red-950 border border-red-800 text-red-400 rounded px-2 py-1.5 flex items-center gap-1.5"><AlertTriangle className="w-3 h-3" />CISA Known Exploited Vulnerability</div>}
+            {data.is_kev && <div className="attack-flow-kev-banner"><AlertTriangle className="w-3 h-3" />CISA Known Exploited Vulnerability</div>}
             {data.fixed_version && <div className="text-xs text-[var(--text-secondary)]">Fix available: <span className="text-emerald-400 font-mono font-semibold">{data.fixed_version}</span></div>}
             {data.owasp_tags && data.owasp_tags.length > 0 && <FrameworkTags title="OWASP LLM Top 10" tags={data.owasp_tags} catalog={OWASP_LLM_TOP10} color="purple" />}
             {data.owasp_mcp_tags && data.owasp_mcp_tags.length > 0 && <FrameworkTags title="OWASP MCP Top 10" tags={data.owasp_mcp_tags} catalog={OWASP_MCP_TOP10} color="amber" />}
             {data.atlas_tags && data.atlas_tags.length > 0 && <FrameworkTags title="MITRE ATLAS" tags={data.atlas_tags} catalog={MITRE_ATLAS} color="cyan" />}
             {data.risk_score != null && <div className="text-xs text-[var(--text-secondary)]">Risk score: <span className="text-red-400 font-mono font-bold">{data.risk_score}</span></div>}
             {osvUrl && (
-              <a href={osvUrl} target="_blank" rel="noopener noreferrer" className="flex items-center gap-1.5 text-xs text-emerald-400 hover:text-emerald-300 transition-colors">
+              <a href={osvUrl} target="_blank" rel="noopener noreferrer" className="attack-flow-external-link">
                 <ExternalLink className="w-3 h-3" />View on OSV
               </a>
             )}
@@ -149,7 +151,7 @@ function DetailPanel({ data, onClose }: { data: AttackFlowNodeData; onClose: () 
 function FrameworkTags({ title, tags, catalog, color }: { title: string; tags: string[]; catalog: Record<string, string>; color: string }) {
   return (
     <div>
-      <div className="text-[10px] text-[var(--text-tertiary)] uppercase tracking-wider mb-1">{title}</div>
+      <div className="attack-flow-filter-label">{title}</div>
       <div className="space-y-1">
         {tags?.map((tag) => (
           <div key={tag} className={`text-xs font-mono bg-${color}-950/40 border border-${color}-800/50 text-${color}-400 rounded px-2 py-1`}>
@@ -175,7 +177,7 @@ function ExportButton() {
   }, [getNodes, getEdges]);
 
   return (
-    <button onClick={handleExport} className="flex items-center gap-1.5 px-3 py-1.5 bg-[var(--surface-elevated)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-muted)] transition-colors">
+    <button onClick={handleExport} className="attack-flow-export">
       <Download className="w-3 h-3" />Export JSON
     </button>
   );
@@ -204,7 +206,7 @@ function FilterBar({ filters, onChange, blastRadius }: { filters: AttackFlowFilt
   return (
     <div className="flex items-center gap-2 flex-wrap">
       <Filter className="w-3.5 h-3.5 text-[var(--text-tertiary)]" />
-      <select value={filters.cve} onChange={(e) => onChange({ ...filters, cve: e.target.value })} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600">
+      <select value={filters.cve} onChange={(e) => onChange({ ...filters, cve: e.target.value })} className="attack-flow-select">
         <option value="">All CVEs</option>
         {cveIds?.map((id) => <option key={id} value={id}>{id}</option>)}
       </select>
@@ -214,19 +216,19 @@ function FilterBar({ filters, onChange, blastRadius }: { filters: AttackFlowFilt
         ))}
       </div>
       {frameworkTags.length > 0 && (
-        <select value={filters.framework} onChange={(e) => onChange({ ...filters, framework: e.target.value })} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600">
+        <select value={filters.framework} onChange={(e) => onChange({ ...filters, framework: e.target.value })} className="attack-flow-select">
           <option value="">All Frameworks</option>
           {frameworkTags?.map((tag) => <option key={tag} value={tag}>{tag} {OWASP_LLM_TOP10[tag] ? `- ${OWASP_LLM_TOP10[tag]}` : OWASP_MCP_TOP10[tag] ? `- ${OWASP_MCP_TOP10[tag]}` : MITRE_ATLAS[tag] ? `- ${MITRE_ATLAS[tag]}` : ""}</option>)}
         </select>
       )}
       {agentNames.length > 0 && (
-        <select value={filters.agent} onChange={(e) => onChange({ ...filters, agent: e.target.value })} className="bg-[var(--surface)] border border-[var(--border-subtle)] rounded-md px-2 py-1 text-xs text-[var(--text-secondary)] focus:outline-none focus:border-emerald-600">
+        <select value={filters.agent} onChange={(e) => onChange({ ...filters, agent: e.target.value })} className="attack-flow-select">
           <option value="">All Agents</option>
           {agentNames?.map((name) => <option key={name} value={name}>{name}</option>)}
         </select>
       )}
       {(filters.cve || filters.severity || filters.framework || filters.agent) && (
-        <button onClick={() => onChange({ cve: "", severity: "", framework: "", agent: "" })} className="text-[10px] text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors underline">Clear filters</button>
+        <button onClick={() => onChange({ cve: "", severity: "", framework: "", agent: "" })} className="attack-flow-clear-small">Clear filters</button>
       )}
     </div>
   );
@@ -262,6 +264,7 @@ function StatsBar({ stats }: { stats: AttackFlowResponse["stats"] }) {
 // ─── Flow Content ───────────────────────────────────────────────────────────
 
 function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id: string; job: ScanJob; flowData: AttackFlowResponse; filters: AttackFlowFilters; onFiltersChange: (f: AttackFlowFilters) => void }) {
+  const { session, loading: authLoading } = useAuthState();
   const [selectedNode, setSelectedNode] = useState<AttackFlowNodeData | null>(null);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const flowInstance = useReactFlow();
@@ -271,17 +274,23 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
     () => flowData.nodes?.map((n) => ({ ...n, type: "attackFlowNode" as const, data: n.data as unknown as Record<string, unknown> })) as Node[],
     [flowData.nodes],
   );
-  const edges = flowData.edges as unknown as Edge[];
+  const edges = useMemo(
+    () => readableGraphEdges(flowData.edges as unknown as Edge[], undefined, { nodeLabels: graphNodeDisplayLabels(nodes) }),
+    [flowData.edges, nodes],
+  );
   const presentation = useGraphPresentation({
     nodes,
     scope: {
-      tenantId: "local",
-      subject: "local-viewer",
+      tenantId: session?.tenant_id || "local",
+      subject: session?.subject || session?.auth_method || "local-viewer",
       snapshotId: id,
       lens: "attack-flow",
-      scope: JSON.stringify(filters),
+      scope: JSON.stringify({ filters, topology: graphTopologyKey(nodes, edges) }),
     },
     layout: "attack-flow",
+    enabled: !authLoading && Boolean(session),
+    ownerActive: Boolean(session),
+    localMode: session?.recommended_ui_mode === "no_auth",
   });
 
   const fitVisible = useCallback(
@@ -295,10 +304,10 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
 
   return (
     <div className="h-[calc(100vh-3.5rem)] flex flex-col">
-      <div className="px-4 py-3 border-b border-[var(--border-subtle)] space-y-2">
+      <div className="attack-flow-header">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <Link href={`/scan?id=${id}`} className="text-[var(--text-tertiary)] hover:text-[var(--text-secondary)] transition-colors"><ArrowLeft className="w-4 h-4" /></Link>
+            <Link href={`/scan?id=${id}`} className="attack-flow-back"><ArrowLeft className="w-4 h-4" /></Link>
             <div>
               <h1 className="text-lg font-semibold text-[var(--foreground)]">Attack Flow</h1>
               <p className="text-xs text-[var(--text-tertiary)]">CVE &rarr; Package &rarr; Server &rarr; Agent blast radius chain</p>
@@ -306,7 +315,7 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
           </div>
           <div className="flex items-center gap-3">
             <StatsBar stats={flowData.stats} />
-            <GraphInteractionToolbar
+            {presentation.enabled && nodes.length > 0 && <GraphInteractionToolbar
               editing={presentation.editing}
               hasSelection={Boolean(selectedNodeId)}
               onFitVisible={fitVisible}
@@ -314,7 +323,7 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
               onAutoLayout={() => { presentation.autoLayout(); window.setTimeout(fitVisible, 0); }}
               onReset={() => { presentation.reset(); window.setTimeout(fitVisible, 0); }}
               onToggleEditing={presentation.toggleEditing}
-            />
+            />}
             <FullscreenButton />
             <ExportButton />
           </div>
@@ -323,10 +332,10 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
       </div>
       <div className="flex-1 relative">
         {flowData.nodes.length === 0 ? (
-          <div className="flex flex-col items-center justify-center h-full text-[var(--text-secondary)] gap-3">
+          <div className="attack-flow-empty">
             <Filter className="w-8 h-8 text-[var(--text-tertiary)]" />
             <p className="text-sm">No results match the current filters</p>
-            <button onClick={() => onFiltersChange({ cve: "", severity: "", framework: "", agent: "" })} className="text-xs text-emerald-400 hover:text-emerald-300 underline">Clear all filters</button>
+            <button onClick={() => onFiltersChange({ cve: "", severity: "", framework: "", agent: "" })} className="attack-flow-clear">Clear all filters</button>
           </div>
         ) : (
           <ReactFlow
@@ -356,13 +365,13 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
         )}
         {selectedNode && <DetailPanel data={selectedNode} onClose={() => { setSelectedNode(null); setSelectedNodeId(null); }} />}
       </div>
-      <div className="px-4 py-2 border-t border-[var(--border-subtle)] flex items-center gap-4 text-[10px] text-[var(--text-tertiary)]">
-        <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-red-600 bg-red-950" /> CVE</span>
-        <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-[var(--border-strong)] bg-[var(--surface)]" /> Package</span>
-        <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-blue-600 bg-blue-950" /> Server</span>
-        <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-emerald-600 bg-emerald-950" /> Agent</span>
-        <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-yellow-600 bg-yellow-950" /> Credential</span>
-        <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-purple-600 bg-purple-950" /> Tool</span>
+      <div className="attack-flow-legend">
+        <span className="flex items-center gap-1"><span className="attack-flow-swatch border-red-600 bg-red-950" /> CVE</span>
+        <span className="flex items-center gap-1"><span className="attack-flow-swatch border-[var(--border-strong)] bg-[var(--surface)]" /> Package</span>
+        <span className="flex items-center gap-1"><span className="attack-flow-swatch border-blue-600 bg-blue-950" /> Server</span>
+        <span className="flex items-center gap-1"><span className="attack-flow-swatch border-emerald-600 bg-emerald-950" /> Agent</span>
+        <span className="flex items-center gap-1"><span className="attack-flow-swatch border-yellow-600 bg-yellow-950" /> Credential</span>
+        <span className="flex items-center gap-1"><span className="attack-flow-swatch border-purple-600 bg-purple-950" /> Tool</span>
       </div>
     </div>
   );
@@ -392,8 +401,8 @@ export function AttackFlowView({ id }: { id: string }) {
     return () => window.clearTimeout(timer);
   }, [id, filters]);
 
-  if (loading && !flowData) return <div className="flex items-center justify-center h-[80vh] text-[var(--text-secondary)]"><Loader2 className="w-5 h-5 animate-spin mr-2" />Loading attack flow...</div>;
-  if (error) return <div className="flex flex-col items-center justify-center h-[80vh] text-[var(--text-secondary)] gap-3"><AlertTriangle className="w-8 h-8 text-amber-500" /><p className="text-sm">Could not load attack flow</p><p className="text-xs text-[var(--text-tertiary)]">{error}</p><Link href={`/scan?id=${id}`} className="text-xs text-emerald-400 hover:text-emerald-300 underline">Back to scan results</Link></div>;
+  if (loading && !flowData) return <div className="attack-flow-loading"><Loader2 className="w-5 h-5 animate-spin mr-2" />Loading attack flow...</div>;
+  if (error) return <div className="attack-flow-error"><AlertTriangle className="w-8 h-8 text-amber-500" /><p className="text-sm">Could not load attack flow</p><p className="text-xs text-[var(--text-tertiary)]">{error}</p><Link href={`/scan?id=${id}`} className="attack-flow-clear">Back to scan results</Link></div>;
   if (!job || !flowData) return null;
 
   return <ReactFlowProvider><AttackFlowContent id={id} job={job} flowData={flowData} filters={filters} onFiltersChange={setFilters} /></ReactFlowProvider>;

--- a/ui/components/attack-flow.tsx
+++ b/ui/components/attack-flow.tsx
@@ -6,6 +6,7 @@ import {
   ReactFlow, Background, Controls, MiniMap, Handle, Position,
   useReactFlow, ReactFlowProvider,
   type Edge,
+  type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import {
@@ -20,7 +21,8 @@ import type { AttackFlowNodeData, AttackFlowResponse } from "@/lib/api";
 import { SeverityBadge } from "@/components/severity-badge";
 import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, ATTACK_FLOW_MINIMAP_COLORS } from "@/lib/graph-utils";
 import { getOsvVulnerabilityUrl } from "@/lib/vulnerabilities";
-import { FullscreenButton } from "@/components/graph-chrome";
+import { FullscreenButton, GraphInteractionToolbar } from "@/components/graph-chrome";
+import { useGraphPresentation } from "@/hooks/use-graph-presentation";
 
 // ─── Constants ──────────────────────────────────────────────────────────────
 
@@ -261,10 +263,35 @@ function StatsBar({ stats }: { stats: AttackFlowResponse["stats"] }) {
 
 function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id: string; job: ScanJob; flowData: AttackFlowResponse; filters: AttackFlowFilters; onFiltersChange: (f: AttackFlowFilters) => void }) {
   const [selectedNode, setSelectedNode] = useState<AttackFlowNodeData | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const flowInstance = useReactFlow();
   const blastRadius = job.result?.blast_radius ?? [];
 
-  const nodes = flowData.nodes?.map((n) => ({ ...n, type: "attackFlowNode" as const, data: n.data as unknown as Record<string, unknown> }));
+  const nodes = useMemo(
+    () => flowData.nodes?.map((n) => ({ ...n, type: "attackFlowNode" as const, data: n.data as unknown as Record<string, unknown> })) as Node[],
+    [flowData.nodes],
+  );
   const edges = flowData.edges as unknown as Edge[];
+  const presentation = useGraphPresentation({
+    nodes,
+    scope: {
+      tenantId: "local",
+      subject: "local-viewer",
+      snapshotId: id,
+      lens: "attack-flow",
+      scope: JSON.stringify(filters),
+    },
+    layout: "attack-flow",
+  });
+
+  const fitVisible = useCallback(
+    () => void flowInstance.fitView({ padding: 0.2, duration: 240 }),
+    [flowInstance],
+  );
+  const fitSelection = useCallback(() => {
+    const node = selectedNodeId ? flowInstance.getNode(selectedNodeId) : undefined;
+    if (node) void flowInstance.fitView({ nodes: [node], padding: 0.7, duration: 240 });
+  }, [flowInstance, selectedNodeId]);
 
   return (
     <div className="h-[calc(100vh-3.5rem)] flex flex-col">
@@ -279,6 +306,15 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
           </div>
           <div className="flex items-center gap-3">
             <StatsBar stats={flowData.stats} />
+            <GraphInteractionToolbar
+              editing={presentation.editing}
+              hasSelection={Boolean(selectedNodeId)}
+              onFitVisible={fitVisible}
+              onFitSelection={fitSelection}
+              onAutoLayout={() => { presentation.autoLayout(); window.setTimeout(fitVisible, 0); }}
+              onReset={() => { presentation.reset(); window.setTimeout(fitVisible, 0); }}
+              onToggleEditing={presentation.toggleEditing}
+            />
             <FullscreenButton />
             <ExportButton />
           </div>
@@ -293,13 +329,32 @@ function AttackFlowContent({ id, job, flowData, filters, onFiltersChange }: { id
             <button onClick={() => onFiltersChange({ cve: "", severity: "", framework: "", agent: "" })} className="text-xs text-emerald-400 hover:text-emerald-300 underline">Clear all filters</button>
           </div>
         ) : (
-          <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes} fitView minZoom={0.1} maxZoom={2} defaultEdgeOptions={{ type: "smoothstep" }} proOptions={{ hideAttribution: true }} onNodeClick={(_event, node) => setSelectedNode(node.data as unknown as AttackFlowNodeData)} onPaneClick={() => setSelectedNode(null)}>
+          <ReactFlow
+            key={presentation.storageKey}
+            nodes={presentation.nodes}
+            edges={edges}
+            nodeTypes={nodeTypes}
+            fitView={!presentation.hasSavedState}
+            defaultViewport={presentation.viewport}
+            minZoom={0.1}
+            maxZoom={2}
+            deleteKeyCode={null}
+            nodesDraggable={presentation.editing}
+            nodesConnectable={false}
+            onNodesChange={presentation.onNodesChange}
+            onNodeDragStop={presentation.onNodeDragStop}
+            onMoveEnd={presentation.onMoveEnd}
+            defaultEdgeOptions={{ type: "smoothstep" }}
+            proOptions={{ hideAttribution: true }}
+            onNodeClick={(_event, node) => { setSelectedNode(node.data as unknown as AttackFlowNodeData); setSelectedNodeId(node.id); }}
+            onPaneClick={() => { setSelectedNode(null); setSelectedNodeId(null); }}
+          >
             <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
             <Controls className={CONTROLS_CLASS} />
             <MiniMap nodeColor={(n) => { const d = n.data as unknown as AttackFlowNodeData; return ATTACK_FLOW_MINIMAP_COLORS[d.nodeType] ?? "#52525b"; }} className={MINIMAP_CLASS} />
           </ReactFlow>
         )}
-        {selectedNode && <DetailPanel data={selectedNode} onClose={() => setSelectedNode(null)} />}
+        {selectedNode && <DetailPanel data={selectedNode} onClose={() => { setSelectedNode(null); setSelectedNodeId(null); }} />}
       </div>
       <div className="px-4 py-2 border-t border-[var(--border-subtle)] flex items-center gap-4 text-[10px] text-[var(--text-tertiary)]">
         <span className="flex items-center gap-1"><span className="w-2.5 h-2.5 rounded border-2 border-red-600 bg-red-950" /> CVE</span>

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -16,11 +16,16 @@ import {
   FolderTree,
   KeyRound,
   Loader2,
+  Focus,
+  Lock,
   Maximize2,
   Minimize2,
+  Move,
+  RotateCcw,
   Server,
   Shield,
   Wrench,
+  WandSparkles,
 } from "lucide-react";
 import { useReactFlow } from "@xyflow/react";
 import { api, type GraphExportFormat } from "@/lib/api";
@@ -365,6 +370,52 @@ export function FullscreenButton() {
     >
       {isFullscreen ? <Minimize2 className="w-3.5 h-3.5" aria-hidden="true" /> : <Maximize2 className="w-3.5 h-3.5" aria-hidden="true" />}
     </button>
+  );
+}
+
+export function GraphInteractionToolbar({
+  editing,
+  hasSelection,
+  onFitVisible,
+  onFitSelection,
+  onReset,
+  onAutoLayout,
+  onToggleEditing,
+}: {
+  editing: boolean;
+  hasSelection: boolean;
+  onFitVisible: () => void;
+  onFitSelection: () => void;
+  onReset: () => void;
+  onAutoLayout: () => void;
+  onToggleEditing: () => void;
+}) {
+  const buttonClass = "inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40";
+  return (
+    <div aria-label="Graph layout controls" className="flex max-w-full items-center gap-0.5 overflow-x-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/90 p-1">
+      <button type="button" className={buttonClass} onClick={onFitVisible} aria-label="Fit visible graph">
+        <Focus className="h-3.5 w-3.5" aria-hidden="true" /> Fit
+      </button>
+      <button type="button" className={buttonClass} onClick={onFitSelection} disabled={!hasSelection} aria-label="Fit selection">
+        <Move className="h-3.5 w-3.5" aria-hidden="true" /> Selection
+      </button>
+      <button type="button" className={buttonClass} onClick={onAutoLayout} aria-label="Auto-layout graph">
+        <WandSparkles className="h-3.5 w-3.5" aria-hidden="true" /> Auto
+      </button>
+      <button type="button" className={buttonClass} onClick={onReset} aria-label="Reset layout">
+        <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" /> Reset
+      </button>
+      <button
+        type="button"
+        className={`${buttonClass} ${editing ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-200" : ""}`}
+        onClick={onToggleEditing}
+        aria-label={editing ? "Lock layout" : "Edit layout"}
+        aria-pressed={editing}
+      >
+        {editing ? <Lock className="h-3.5 w-3.5" aria-hidden="true" /> : <Move className="h-3.5 w-3.5" aria-hidden="true" />}
+        {editing ? "Lock" : "Edit"}
+      </button>
+    </div>
   );
 }
 

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -392,7 +392,7 @@ export function GraphInteractionToolbar({
 }) {
   const buttonClass = "inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40";
   return (
-    <div aria-label="Graph layout controls" className="flex max-w-full items-center gap-0.5 overflow-x-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/90 p-1">
+    <div role="toolbar" aria-label="Graph layout controls" className="flex max-w-full items-center gap-0.5 overflow-x-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/90 p-1">
       <button type="button" className={buttonClass} onClick={onFitVisible} aria-label="Fit visible graph">
         <Focus className="h-3.5 w-3.5" aria-hidden="true" /> Fit
       </button>

--- a/ui/components/graph-chrome.tsx
+++ b/ui/components/graph-chrome.tsx
@@ -16,16 +16,11 @@ import {
   FolderTree,
   KeyRound,
   Loader2,
-  Focus,
-  Lock,
   Maximize2,
   Minimize2,
-  Move,
-  RotateCcw,
   Server,
   Shield,
   Wrench,
-  WandSparkles,
 } from "lucide-react";
 import { useReactFlow } from "@xyflow/react";
 import { api, type GraphExportFormat } from "@/lib/api";
@@ -104,16 +99,16 @@ export function GraphLegend({
       <button
         type="button"
         onClick={() => setOpen((current) => !current)}
-        className={`${embedded ? "hidden" : "flex"} items-center gap-2 rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] transition-colors hover:bg-[var(--surface-elevated)] backdrop-blur-sm`}
+        className={`${embedded ? "hidden" : "flex"} graph-legend-toggle`}
         aria-expanded={visible}
         aria-label={visible ? "Hide legend" : "Show legend"}
       >
         <span className="font-medium">Legend</span>
-        <span className="rounded-full bg-[var(--surface)] px-1.5 py-0.5 text-[10px] text-[var(--text-tertiary)]">{items.length}</span>
+        <span className="graph-legend-count">{items.length}</span>
         <ChevronDown className={`h-3.5 w-3.5 transition-transform ${visible ? "rotate-180" : ""}`} />
       </button>
       {visible && (
-        <div className={`${embedded ? "relative w-[min(30rem,calc(100vw-2rem))] shadow-none" : "absolute right-0 top-full z-20 mt-2 w-[min(30rem,calc(100vw-2rem))] shadow-2xl shadow-[var(--shadow-color)]"} max-h-[60vh] overflow-y-auto rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)] p-3 text-[var(--foreground)] backdrop-blur-md`}>
+        <div className={`${embedded ? "relative shadow-none" : "absolute right-0 top-full z-20 mt-2 shadow-2xl shadow-[var(--shadow-color)]"} graph-legend-popover`}>
           <GraphLegendContent items={items} />
         </div>
       )}
@@ -134,18 +129,18 @@ export function GraphLegendDock({
 
   return (
     <details
-      className="group border-t border-[var(--border-subtle)] pt-2 open:pt-3"
+      className="group graph-legend-dock"
       {...(defaultOpen ? { open: true } : {})}
     >
-      <summary className="flex cursor-pointer list-none flex-wrap items-center gap-x-3 gap-y-1.5 text-xs [&::-webkit-details-marker]:hidden">
-        <span className="shrink-0 font-medium uppercase tracking-[0.16em] text-[var(--text-tertiary)]">
+      <summary className="graph-legend-dock-summary">
+        <span className="graph-legend-dock-label">
           Legend
         </span>
-        <span className="flex min-w-0 flex-1 flex-wrap items-center gap-x-2.5 gap-y-1 group-open:hidden">
+        <span className="graph-legend-preview">
           {preview.map((item) => (
             <span
               key={`preview:${item.label}:${item.kind}`}
-              className="inline-flex max-w-[8rem] items-center gap-1 text-[10px] text-[var(--text-secondary)]"
+              className="graph-legend-preview-item"
               title={item.label}
             >
               <LegendGlyph item={item} />
@@ -156,14 +151,14 @@ export function GraphLegendDock({
             <span className="text-[10px] text-[var(--text-tertiary)]">+{items.length - preview.length}</span>
           ) : null}
         </span>
-        <span className="ml-auto shrink-0 text-[10px] uppercase tracking-[0.14em] text-[var(--text-tertiary)] group-open:hidden">
+        <span className="graph-legend-expand group-open:hidden">
           expand
         </span>
-        <span className="ml-auto hidden shrink-0 text-[10px] uppercase tracking-[0.14em] text-[var(--text-tertiary)] group-open:inline">
+        <span className="graph-legend-expand hidden group-open:inline">
           collapse
         </span>
       </summary>
-      <div className="mt-2 max-h-[min(40vh,18rem)] overflow-y-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-muted)] p-3">
+      <div className="graph-legend-dock-content">
         <GraphLegendContent items={items} />
       </div>
     </details>
@@ -364,7 +359,7 @@ export function FullscreenButton() {
   return (
     <button
       onClick={toggle}
-      className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)] transition-colors backdrop-blur-sm"
+      className="graph-icon-button"
       title={isFullscreen ? "Exit fullscreen" : "Fullscreen"}
       aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
     >
@@ -390,20 +385,20 @@ export function GraphInteractionToolbar({
   onAutoLayout: () => void;
   onToggleEditing: () => void;
 }) {
-  const buttonClass = "inline-flex items-center gap-1 rounded-md px-2 py-1 text-[11px] font-medium text-[var(--text-secondary)] transition hover:bg-[var(--surface-elevated)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40";
+  const buttonClass = "graph-layout-button";
   return (
-    <div role="toolbar" aria-label="Graph layout controls" className="flex max-w-full items-center gap-0.5 overflow-x-auto rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/90 p-1">
+    <div role="toolbar" aria-label="Graph layout controls" className="graph-layout-toolbar">
       <button type="button" className={buttonClass} onClick={onFitVisible} aria-label="Fit visible graph">
-        <Focus className="h-3.5 w-3.5" aria-hidden="true" /> Fit
+        Fit
       </button>
       <button type="button" className={buttonClass} onClick={onFitSelection} disabled={!hasSelection} aria-label="Fit selection">
-        <Move className="h-3.5 w-3.5" aria-hidden="true" /> Selection
+        Selection
       </button>
       <button type="button" className={buttonClass} onClick={onAutoLayout} aria-label="Auto-layout graph">
-        <WandSparkles className="h-3.5 w-3.5" aria-hidden="true" /> Auto
+        Auto
       </button>
       <button type="button" className={buttonClass} onClick={onReset} aria-label="Reset layout">
-        <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" /> Reset
+        Reset
       </button>
       <button
         type="button"
@@ -412,7 +407,6 @@ export function GraphInteractionToolbar({
         aria-label={editing ? "Lock layout" : "Edit layout"}
         aria-pressed={editing}
       >
-        {editing ? <Lock className="h-3.5 w-3.5" aria-hidden="true" /> : <Move className="h-3.5 w-3.5" aria-hidden="true" />}
         {editing ? "Lock" : "Edit"}
       </button>
     </div>
@@ -438,7 +432,7 @@ export function GraphExportButton({ filename }: { filename?: string }) {
   return (
     <button
       onClick={handleExport}
-      className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[var(--surface-muted)] border border-[var(--border-subtle)] rounded-lg text-xs text-[var(--text-secondary)] hover:bg-[var(--surface-elevated)] transition-colors backdrop-blur-sm"
+      className="graph-icon-button"
     >
       <Download className="w-3.5 h-3.5" />
       Export
@@ -492,7 +486,7 @@ export function GraphEvidenceExportButton({
         aria-label="Graph evidence format"
         value={format}
         onChange={(event) => setFormat(event.target.value as GraphExportFormat)}
-        className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)] px-2.5 py-1.5 text-xs text-[var(--text-secondary)] focus:border-sky-600 focus:outline-none"
+        className="graph-export-select"
       >
         {formats.map((item) => (
           <option key={item} value={item}>
@@ -504,7 +498,7 @@ export function GraphEvidenceExportButton({
         type="button"
         onClick={() => void handleDownload()}
         disabled={!scanId || exporting}
-        className="inline-flex items-center gap-1.5 rounded-lg border border-cyan-700/45 bg-cyan-50 px-2.5 py-1.5 text-xs font-medium text-cyan-800 transition-colors hover:border-cyan-700 hover:bg-cyan-100 disabled:cursor-not-allowed disabled:opacity-50 dark:border-cyan-900/60 dark:bg-cyan-950/30 dark:text-cyan-200 dark:hover:border-cyan-800 dark:hover:bg-cyan-950/50"
+        className="graph-export-button"
         title="Download the selected scan graph in an evidence format for review, import, or audit handoff."
       >
         {exporting ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Download className="h-3.5 w-3.5" />}

--- a/ui/components/graph-evidence-summary.tsx
+++ b/ui/components/graph-evidence-summary.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Clock3, Database, GitBranch } from "lucide-react";
+
+function countLabel(value: number | null, total: number | null, noun: string): string {
+  if (value === null || total === null) return "Unavailable";
+  return `${value.toLocaleString()} of ${total.toLocaleString()} ${noun}`;
+}
+
+function capturedLabel(value: string | null): string {
+  if (!value) return "Unavailable";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? "Unavailable" : date.toLocaleString();
+}
+
+export function GraphEvidenceSummary({
+  capturedAt,
+  returnedNodes,
+  totalNodes,
+  evidencedEdges,
+  totalEdges,
+  completeness,
+}: {
+  capturedAt: string | null;
+  returnedNodes: number | null;
+  totalNodes: number | null;
+  evidencedEdges: number | null;
+  totalEdges: number | null;
+  completeness: string | null;
+}) {
+  const items = [
+    {
+      label: "Snapshot freshness",
+      value: capturedLabel(capturedAt),
+      detail: capturedAt ? "Captured" : undefined,
+      Icon: Clock3,
+    },
+    {
+      label: "Completeness",
+      value: countLabel(returnedNodes, totalNodes, "nodes"),
+      detail: completeness ? completeness.replaceAll("_", " ") : "Unavailable",
+      Icon: Database,
+    },
+    {
+      label: "Relationship provenance",
+      value: countLabel(evidencedEdges, totalEdges, "relationships"),
+      detail: evidencedEdges === null ? "Evidence metadata not reported" : "with evidence metadata",
+      Icon: GitBranch,
+    },
+  ];
+
+  return (
+    <section aria-label="Graph evidence status" className="grid gap-2 md:grid-cols-3">
+      {items.map(({ label, value, detail, Icon }) => (
+        <div key={label} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-3 py-2">
+          <div className="flex items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">
+            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+            {label}
+          </div>
+          <p className="mt-1 truncate text-xs font-medium text-[var(--foreground)]" title={value}>{value}</p>
+          {detail ? <p className="mt-0.5 text-[10px] capitalize text-[var(--text-tertiary)]">{detail}</p> : null}
+        </div>
+      ))}
+    </section>
+  );
+}

--- a/ui/components/graph-evidence-summary.tsx
+++ b/ui/components/graph-evidence-summary.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { Clock3, Database, GitBranch } from "lucide-react";
-
 function countLabel(value: number | null, total: number | null, noun: string): string {
   if (value === null || total === null) return "Unavailable";
   return `${value.toLocaleString()} of ${total.toLocaleString()} ${noun}`;
@@ -33,32 +31,28 @@ export function GraphEvidenceSummary({
       label: "Snapshot freshness",
       value: capturedLabel(capturedAt),
       detail: capturedAt ? "Captured" : undefined,
-      Icon: Clock3,
     },
     {
       label: "Completeness",
       value: countLabel(returnedNodes, totalNodes, "nodes"),
       detail: completeness ? completeness.replaceAll("_", " ") : "Unavailable",
-      Icon: Database,
     },
     {
       label: "Relationship provenance",
       value: countLabel(evidencedEdges, totalEdges, "relationships"),
       detail: evidencedEdges === null ? "Evidence metadata not reported" : "with evidence metadata",
-      Icon: GitBranch,
     },
   ];
 
   return (
-    <section aria-label="Graph evidence status" className="grid gap-2 md:grid-cols-3">
-      {items.map(({ label, value, detail, Icon }) => (
-        <div key={label} className="rounded-lg border border-[var(--border-subtle)] bg-[var(--surface)]/70 px-3 py-2">
-          <div className="flex items-center gap-2 text-[10px] font-medium uppercase tracking-[0.14em] text-[var(--text-tertiary)]">
-            <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+    <section aria-label="Graph evidence status" className="graph-evidence-summary">
+      {items.map(({ label, value, detail }) => (
+        <div key={label} className="graph-evidence-item">
+          <div className="graph-evidence-label">
             {label}
           </div>
-          <p className="mt-1 truncate text-xs font-medium text-[var(--foreground)]" title={value}>{value}</p>
-          {detail ? <p className="mt-0.5 text-[10px] capitalize text-[var(--text-tertiary)]">{detail}</p> : null}
+          <p className="graph-evidence-value" title={value}>{value}</p>
+          {detail ? <p className="graph-evidence-detail">{detail}</p> : null}
         </div>
       ))}
     </section>

--- a/ui/components/lineage-filter.tsx
+++ b/ui/components/lineage-filter.tsx
@@ -113,9 +113,9 @@ export const GRAPH_SCOPE_LABELS: Record<GraphScopePreset, string> = {
 export const GRAPH_SCOPE_DESCRIPTIONS: Record<GraphScopePreset, string> = {
   immediate: "One-hop triage around a selected agent.",
   relevant: "Default fix-first graph with bounded path context.",
-  cloudEstate: "Observed cloud, account, identity, resource, and finding relationships.",
-  repository: "Observed repository files, packages, and attached findings.",
-  environment: "Observed environment, agent, service, resource, and finding relationships.",
+  cloudEstate: "Type-based view of cloud, account, identity, resource, and finding nodes.",
+  repository: "Type-based view of repository file, package, and finding nodes.",
+  environment: "Type-based view of environment, agent, service, resource, and finding nodes.",
   expanded: "Broader topology review with lower-priority context included.",
   assetDrift:
     "Governance and exhibits_drift paths tying estate containers to drift incidents.",

--- a/ui/components/lineage-filter.tsx
+++ b/ui/components/lineage-filter.tsx
@@ -94,12 +94,18 @@ export const EXPANDED_LAYER_DEFAULTS: Record<LineageNodeType, boolean> = {
 export type GraphScopePreset =
   | "immediate"
   | "relevant"
+  | "cloudEstate"
+  | "repository"
+  | "environment"
   | "expanded"
   | "assetDrift";
 
 export const GRAPH_SCOPE_LABELS: Record<GraphScopePreset, string> = {
   immediate: "Immediate",
   relevant: "Relevant paths",
+  cloudEstate: "Cloud estate",
+  repository: "Repository",
+  environment: "Environment",
   expanded: "Expanded",
   assetDrift: "Asset lifecycle drift",
 };
@@ -107,6 +113,9 @@ export const GRAPH_SCOPE_LABELS: Record<GraphScopePreset, string> = {
 export const GRAPH_SCOPE_DESCRIPTIONS: Record<GraphScopePreset, string> = {
   immediate: "One-hop triage around a selected agent.",
   relevant: "Default fix-first graph with bounded path context.",
+  cloudEstate: "Observed cloud, account, identity, resource, and finding relationships.",
+  repository: "Observed repository files, packages, and attached findings.",
+  environment: "Observed environment, agent, service, resource, and finding relationships.",
   expanded: "Broader topology review with lower-priority context included.",
   assetDrift:
     "Governance and exhibits_drift paths tying estate containers to drift incidents.",
@@ -157,6 +166,54 @@ export function createExpandedGraphFilters(
     maxDepth: 3,
     pageSize: 250,
   };
+}
+
+function selectObservedLayers(
+  enabled: LineageNodeType[],
+): Record<LineageNodeType, boolean> {
+  const layers = { ...EXPANDED_LAYER_DEFAULTS };
+  for (const key of Object.keys(layers) as LineageNodeType[]) layers[key] = false;
+  for (const key of enabled) layers[key] = true;
+  return layers;
+}
+
+function observedScopeFilters(layers: LineageNodeType[]): FilterState {
+  return {
+    layers: selectObservedLayers(layers),
+    severity: null,
+    agentName: null,
+    vulnOnly: false,
+    runtimeMode: "all",
+    relationshipScope: "all",
+    maxDepth: 3,
+    pageSize: 150,
+  };
+}
+
+export function createCloudEstateGraphFilters(): FilterState {
+  return observedScopeFilters([
+    "provider", "org", "account", "environment", "fleet", "cluster",
+    "cloudResource", "container", "dataStore", "user", "group", "role",
+    "policy", "serviceAccount", "servicePrincipal", "federatedIdentity",
+    "managedIdentity", "accessGrant", "accessPolicy", "vulnerability",
+    "misconfiguration", "driftIncident",
+  ]);
+}
+
+export function createRepositoryGraphFilters(): FilterState {
+  return observedScopeFilters([
+    "directory", "sourceFile", "configFile", "package", "framework",
+    "container", "vulnerability", "misconfiguration",
+  ]);
+}
+
+export function createEnvironmentGraphFilters(): FilterState {
+  return observedScopeFilters([
+    "environment", "fleet", "cluster", "agent", "server", "sharedServer",
+    "tool", "credential", "package", "model", "dataset", "container",
+    "cloudResource", "dataStore", "managedIdentity", "accessGrant",
+    "vulnerability", "misconfiguration",
+  ]);
 }
 
 /** Governance-scoped lens for asset lifecycle drift evidence on the lineage graph. */
@@ -215,12 +272,30 @@ export function matchesAssetLifecycleDriftFilters(filters: FilterState): boolean
   );
 }
 
+function matchesObservedScope(filters: FilterState, baseline: FilterState): boolean {
+  return (
+    filters.relationshipScope === baseline.relationshipScope &&
+    filters.vulnOnly === baseline.vulnOnly &&
+    filters.maxDepth === baseline.maxDepth &&
+    filters.pageSize === baseline.pageSize &&
+    filters.severity === baseline.severity &&
+    filters.runtimeMode === baseline.runtimeMode &&
+    filters.agentName === baseline.agentName &&
+    (Object.keys(baseline.layers) as LineageNodeType[]).every(
+      (key) => filters.layers[key] === baseline.layers[key],
+    )
+  );
+}
+
 export const DEFAULT_FILTERS: FilterState = createFocusedGraphFilters();
 
 export function graphScopePresetForFilters(
   filters: FilterState,
 ): GraphScopePreset {
   if (matchesAssetLifecycleDriftFilters(filters)) return "assetDrift";
+  if (matchesObservedScope(filters, createCloudEstateGraphFilters())) return "cloudEstate";
+  if (matchesObservedScope(filters, createRepositoryGraphFilters())) return "repository";
+  if (matchesObservedScope(filters, createEnvironmentGraphFilters())) return "environment";
   if (filters.maxDepth <= 1 && filters.pageSize <= 25 && filters.vulnOnly)
     return "immediate";
   if (

--- a/ui/components/risk-campaign-command-center.tsx
+++ b/ui/components/risk-campaign-command-center.tsx
@@ -235,21 +235,21 @@ function CampaignCard({
   >;
 
   return (
-    <details className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] shadow-sm">
-      <summary className="grid cursor-pointer list-none gap-2 px-3 py-3 [&::-webkit-details-marker]:hidden md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center">
+    <details className="group risk-campaign-card">
+      <summary className="risk-campaign-summary">
         <div className="min-w-0">
           <div className="flex items-center gap-2">
-            <span className="rounded-full border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--status-danger)]">{campaign.severity}</span>
-            <h3 className="truncate text-sm font-semibold text-[color:var(--foreground)]">{campaign.title}</h3>
+            <span className="risk-campaign-severity">{campaign.severity}</span>
+            <h3 className="risk-card-title">{campaign.title}</h3>
           </div>
-          <p className="mt-1 truncate text-[11px] text-[color:var(--text-tertiary)]">
+          <p className="risk-card-meta">
             {campaign.finding_count} finding{campaign.finding_count === 1 ? "" : "s"} · {campaign.owner || "Unassigned"} · {formatDate(campaign.sla_due_at)} · {VERIFICATION_LABELS[campaign.verification_status]}
           </p>
         </div>
-        <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1 text-xs text-[color:var(--text-secondary)]">
+        <span className="risk-campaign-priority">
           Priority <strong className="ml-1 tabular-nums text-[color:var(--foreground)]">{campaign.priority_score}</strong>
         </span>
-        <span className="rounded-lg border border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] px-2.5 py-1 text-xs font-medium text-[color:var(--status-success)]">
+        <span className="risk-campaign-reduction">
           <span className="block">{campaign.expected_risk_reduction.modeled_window_percent}% modeled window risk</span>
           {!campaign.expected_risk_reduction.portfolio_complete ? (
             <span className="block text-[9px] font-normal text-[color:var(--status-warn)]">Bounded; not full portfolio</span>
@@ -257,41 +257,41 @@ function CampaignCard({
         </span>
         <ChevronDown className="h-4 w-4 text-[color:var(--text-tertiary)] transition group-open:rotate-180" aria-hidden="true" />
       </summary>
-      <div className="border-t border-[color:var(--border-subtle)] px-3 pb-3">
+      <div className="risk-campaign-body">
         <button
           type="button"
           onClick={() => setExpanded((current) => !current)}
-          className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-[color:var(--accent)]"
+          className="risk-priority-toggle"
           aria-expanded={expanded}
         >
           Why this priority {expanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
         </button>
 
       {expanded ? (
-        <div className="mt-4 grid gap-3 border-t border-[color:var(--border-subtle)] pt-4 lg:grid-cols-[1fr_1.3fr]">
+        <div className="risk-campaign-explainer">
           <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
-            <p className="col-span-2 text-[10px] uppercase tracking-wide text-[color:var(--text-tertiary)] sm:col-span-4">
+            <p className="risk-campaign-evidence-label">
               Observed priority evidence
             </p>
             {factors.map(([factor, evidence]) => (
-              <div key={factor} className="rounded-lg bg-[color:var(--surface-muted)] p-2.5">
-                <div className="text-[10px] uppercase tracking-wide text-[color:var(--text-tertiary)]">{factor.replace("_", " ")}</div>
-                <div className="mt-1 text-sm font-semibold tabular-nums text-[color:var(--foreground)]">
+              <div key={factor} className="risk-campaign-factor">
+                <div className="risk-campaign-factor-label">{factor.replace("_", " ")}</div>
+                <div className="risk-campaign-factor-value">
                   {factorValue(factor, evidence.value)}
                 </div>
-                <div className="mt-0.5 text-[10px] uppercase tracking-wide text-[color:var(--text-tertiary)]">{evidence.status}</div>
+                <div className="risk-campaign-factor-status">{evidence.status}</div>
               </div>
             ))}
-            <p className="col-span-2 text-[10px] leading-4 text-[color:var(--text-tertiary)] sm:col-span-4">
+            <p className="risk-campaign-evidence-note">
               Unknown evidence is neutral and adds no priority boost.
             </p>
           </div>
-          <div className="rounded-lg border border-[color:var(--border-subtle)] p-3 text-xs leading-5 text-[color:var(--text-secondary)]">
+          <div className="risk-campaign-method">
             <div className="mb-3 grid grid-cols-2 gap-2 sm:grid-cols-5">
               {Object.entries(campaign.priority_score_components).map(([component, value]) => (
-                <div key={component} className="rounded-md bg-[color:var(--surface-muted)] px-2 py-1.5">
-                  <div className="text-[9px] uppercase tracking-wide text-[color:var(--text-tertiary)]">{component.replaceAll("_", " ")}</div>
-                  <div className="font-semibold tabular-nums text-[color:var(--foreground)]">{value}</div>
+                <div key={component} className="risk-campaign-method-cell">
+                  <div className="risk-campaign-method-label">{component.replaceAll("_", " ")}</div>
+                  <div className="risk-number">{value}</div>
                 </div>
               ))}
             </div>
@@ -303,7 +303,7 @@ function CampaignCard({
         </div>
       ) : null}
 
-      <div className="mt-4 flex flex-col gap-3 border-t border-[color:var(--border-subtle)] pt-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="risk-campaign-actions">
         <div className="flex flex-wrap items-center gap-2">
           <label className="text-xs text-[color:var(--text-tertiary)]" htmlFor={`campaign-state-${campaign.id}`}>Campaign state</label>
           <select
@@ -312,60 +312,60 @@ function CampaignCard({
             value={campaign.state}
             disabled={busy || !workflowActionable}
             onChange={(event) => void updateState(event.target.value as RiskCampaignState)}
-            className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--background)] px-2.5 py-1.5 text-xs text-[color:var(--foreground)]"
+            className="risk-campaign-select"
           >
             {Object.entries(STATE_LABELS).map(([value, label]) => <option key={value} value={value}>{label}</option>)}
           </select>
-          <span className="rounded-full border border-[color:var(--border-subtle)] px-2 py-1 text-[10px] font-medium uppercase tracking-wide text-[color:var(--text-secondary)]">
+          <span className="risk-campaign-status-pill">
             {VERIFICATION_LABELS[campaign.verification_status]}
           </span>
           <button
             type="button"
             disabled={busy || !workflowActionable}
             onClick={() => void verifyRemediation()}
-            className="inline-flex items-center gap-1 text-xs font-medium text-[color:var(--accent)] disabled:cursor-not-allowed disabled:opacity-50"
+            className="risk-campaign-link-action"
           >
             <ShieldCheck className="h-3.5 w-3.5" /> Re-verify remediation
           </button>
-          <button type="button" disabled={!workflowActionable} onClick={() => setEditingAssignment((current) => !current)} className="text-xs font-medium text-[color:var(--accent)] disabled:cursor-not-allowed disabled:opacity-50">
+          <button type="button" disabled={!workflowActionable} onClick={() => setEditingAssignment((current) => !current)} className="risk-link-button">
             Edit owner and SLA
           </button>
         </div>
         <div className="flex flex-wrap gap-2">
           {connections.length > 1 ? (
-            <select aria-label="Ticketing connection" value={connectionId} onChange={(event) => setConnectionId(event.target.value)} className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--background)] px-2.5 py-1.5 text-xs text-[color:var(--foreground)]">
+            <select aria-label="Ticketing connection" value={connectionId} onChange={(event) => setConnectionId(event.target.value)} className="risk-campaign-select">
               {connections.map((connection) => <option key={connection.id} value={connection.id}>{connection.display_name || connection.provider}</option>)}
             </select>
           ) : null}
-          <button type="button" disabled={busy || !workflowActionable || !connectionId} onClick={() => void ticketAction("create")} className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-xs font-medium text-[color:var(--accent)] disabled:cursor-not-allowed disabled:opacity-50">
+          <button type="button" disabled={busy || !workflowActionable || !connectionId} onClick={() => void ticketAction("create")} className="risk-campaign-ticket-primary">
             <Ticket className="h-3.5 w-3.5" /> {ticketProgress?.mode === "create" && ticketProgress.hasMore ? `Continue tickets (${ticketProgress.processed}/${ticketProgress.total})` : "Create campaign tickets"}
           </button>
-          <button type="button" disabled={busy || !workflowActionable} onClick={() => void ticketAction("sync")} className="inline-flex items-center gap-1.5 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs font-medium text-[color:var(--text-secondary)] disabled:cursor-not-allowed disabled:opacity-50">
+          <button type="button" disabled={busy || !workflowActionable} onClick={() => void ticketAction("sync")} className="risk-campaign-ticket-secondary">
             <RefreshCw className={`h-3.5 w-3.5 ${busy ? "animate-spin" : ""}`} /> {ticketProgress?.mode === "sync" && ticketProgress.hasMore ? `Continue sync (${ticketProgress.processed}/${ticketProgress.total})` : "Sync tickets"}
           </button>
         </div>
       </div>
       {!workflowActionable ? (
-        <p role="status" className="mt-3 rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs text-[color:var(--text-secondary)]">
+        <p role="status" className="risk-campaign-warning">
           Workflow actions are paused until the complete campaign membership is available. No partial ticket or verification state will be written.
         </p>
       ) : null}
       {editingAssignment ? (
-        <div className="mt-3 grid gap-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3 sm:grid-cols-[1fr_12rem_auto] sm:items-end">
+        <div className="risk-campaign-assignment">
           <label className="text-xs text-[color:var(--text-secondary)]">
             Campaign owner
-            <input aria-label="Campaign owner" value={owner} onChange={(event) => setOwner(event.target.value)} className="mt-1 block w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--background)] px-2.5 py-2 text-xs text-[color:var(--foreground)]" />
+            <input aria-label="Campaign owner" value={owner} onChange={(event) => setOwner(event.target.value)} className="risk-campaign-input" />
           </label>
           <label className="text-xs text-[color:var(--text-secondary)]">
             Campaign SLA
-            <input aria-label="Campaign SLA" type="date" value={slaDate} onChange={(event) => setSlaDate(event.target.value)} className="mt-1 block w-full rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--background)] px-2.5 py-2 text-xs text-[color:var(--foreground)]" />
+            <input aria-label="Campaign SLA" type="date" value={slaDate} onChange={(event) => setSlaDate(event.target.value)} className="risk-campaign-input" />
           </label>
-          <button type="button" disabled={busy} onClick={() => void saveAssignment()} className="rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-xs font-medium text-[color:var(--accent)] disabled:opacity-50">Save owner and SLA</button>
+          <button type="button" disabled={busy} onClick={() => void saveAssignment()} className="risk-campaign-save">Save owner and SLA</button>
         </div>
       ) : null}
-      {actionMessage ? <p role="status" className="mt-3 text-xs text-[color:var(--text-secondary)]">{actionMessage}</p> : null}
+      {actionMessage ? <p role="status" className="risk-status-copy">{actionMessage}</p> : null}
       {verificationResult ? (
-        <div role="status" className="mt-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--text-secondary)]">
+        <div role="status" className="risk-campaign-verification-result">
           <strong className="text-[color:var(--foreground)]">
             {verificationResult.remaining_count === 0
               ? "No original findings remain."
@@ -374,11 +374,11 @@ function CampaignCard({
           Evidence: {verificationResult.evidence_scope.source.replaceAll("_", " ")}, complete {verificationResult.evidence_scope.finding_window_days}-day window.
         </div>
       ) : null}
-      {actionError ? <p role="alert" className="mt-3 text-xs text-[color:var(--status-danger)]">{actionError}</p> : null}
+      {actionError ? <p role="alert" className="risk-error-copy">{actionError}</p> : null}
       {versionConflict ? (
-        <button type="button" onClick={onReload} className="mt-2 rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs font-medium text-[color:var(--status-warn)]">Reload campaigns</button>
+        <button type="button" onClick={onReload} className="risk-campaign-reload">Reload campaigns</button>
       ) : null}
-      {connections.length === 0 ? <p className="mt-3 text-xs text-[color:var(--text-tertiary)]"><Link href="/connections">Connect ticketing</Link> to create new campaign tickets. Existing ticket links can still be synced.</p> : null}
+      {connections.length === 0 ? <p className="risk-empty-copy"><Link href="/connections">Connect ticketing</Link> to create new campaign tickets. Existing ticket links can still be synced.</p> : null}
       </div>
     </details>
   );
@@ -458,47 +458,47 @@ function VerificationQueue() {
 
   return (
     <details
-      className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]"
+      className="group risk-campaign-queue"
       open={entries.length > 0 || Boolean(error)}
     >
-      <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-2 px-3 py-2.5 [&::-webkit-details-marker]:hidden">
+      <summary className="risk-campaign-queue-summary">
         <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <span className="text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--status-warn)]">Re-verification</span>
-          <h3 id="verification-queue-title" className="text-sm font-semibold text-[color:var(--foreground)]">Awaiting re-verification</h3>
-          <span className="rounded-full border border-[color:var(--border-subtle)] px-2 py-0.5 text-[10px] text-[color:var(--text-tertiary)]">{entries.length} waiting</span>
+          <span className="risk-campaign-queue-label">Re-verification</span>
+          <h3 id="verification-queue-title" className="risk-entry-title">Awaiting re-verification</h3>
+          <span className="risk-campaign-count-pill">{entries.length} waiting</span>
         </div>
         {error ? (
-          <button type="button" onClick={() => void load(retryCursor)} className="rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs font-medium text-[color:var(--status-warn)]">Retry verification queue</button>
-        ) : <span className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)] group-open:hidden">show</span>}
+          <button type="button" onClick={() => void load(retryCursor)} className="risk-campaign-reload">Retry verification queue</button>
+        ) : <span className="risk-collapsed-label">show</span>}
       </summary>
-      <div className="border-t border-[color:var(--border-subtle)] px-3 pb-3">
-      <p className="mt-2 text-xs text-[color:var(--text-secondary)]">Inactive campaigns stay here until canonical evidence confirms the original findings are gone.</p>
-      {loading ? <p role="status" className="mt-3 text-xs text-[color:var(--text-tertiary)]">Loading verification queue…</p> : null}
-      {error ? <p role="alert" className="mt-3 text-xs text-[color:var(--status-danger)]">{error}</p> : null}
+      <div className="risk-queue-body">
+      <p className="risk-helper-copy">Inactive campaigns stay here until canonical evidence confirms the original findings are gone.</p>
+      {loading ? <p role="status" className="risk-empty-copy">Loading verification queue…</p> : null}
+      {error ? <p role="alert" className="risk-error-copy">{error}</p> : null}
       {successMessage ? <p role="status" className="mt-3 text-xs text-[color:var(--status-success)]">{successMessage}</p> : null}
       {!loading && entries.length === 0 && !error ? (
-        <p className="mt-3 text-xs text-[color:var(--text-tertiary)]">No inactive campaigns await re-verification.</p>
+        <p className="risk-empty-copy">No inactive campaigns await re-verification.</p>
       ) : null}
       {!loading && entries.length > 0 ? (
         <div className="mt-3 grid gap-2 lg:grid-cols-2">
           {entries.map((entry) => {
             const result = results[entry.campaign_id];
             return (
-              <article key={entry.campaign_id} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+              <article key={entry.campaign_id} className="risk-campaign-queue-entry">
+                <div className="risk-entry-layout">
                   <div className="min-w-0">
-                    <h4 className="text-sm font-semibold text-[color:var(--foreground)]">{entry.title}</h4>
-                    <p className="mt-1 text-xs text-[color:var(--text-secondary)]">
+                    <h4 className="risk-entry-title">{entry.title}</h4>
+                    <p className="risk-entry-copy">
                       {entry.original_member_count} original findings · Owner: {entry.owner || "Unassigned"} · {formatDate(entry.sla_due_at)}
                     </p>
-                    <p className="mt-1 text-[10px] uppercase tracking-wide text-[color:var(--text-tertiary)]">{VERIFICATION_LABELS[entry.verification_status]} · inactive snapshot</p>
+                    <p className="risk-entry-meta">{VERIFICATION_LABELS[entry.verification_status]} · inactive snapshot</p>
                   </div>
                   <button
                     type="button"
                     disabled={busyId === entry.campaign_id}
                     onClick={() => void verify(entry)}
                     aria-label={`Re-verify ${entry.title}`}
-                    className="inline-flex shrink-0 items-center justify-center gap-1.5 rounded-lg border border-[color:var(--accent-border)] bg-[color:var(--accent-soft)] px-3 py-2 text-xs font-medium text-[color:var(--accent)] disabled:cursor-wait disabled:opacity-50"
+                    className="risk-campaign-verify-button"
                   >
                     <ShieldCheck className="h-3.5 w-3.5" /> {busyId === entry.campaign_id ? "Verifying…" : "Re-verify"}
                   </button>
@@ -518,7 +518,7 @@ function VerificationQueue() {
           type="button"
           disabled={loadingMore || nextCursor === null}
           onClick={() => void load(nextCursor)}
-          className="mt-3 rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs font-medium text-[color:var(--accent)] disabled:cursor-wait disabled:opacity-50"
+          className="risk-campaign-load-more"
         >
           {loadingMore ? "Loading more…" : "Load more awaiting verification"}
         </button>
@@ -576,19 +576,19 @@ export function RiskCampaignCommandCenter() {
         <PageErrorState title={error} detail="No campaign status has been inferred. Retry the authoritative API." action={{ label: "Retry campaigns", onClick: () => void load() }} />
       ) : campaigns.length === 0 ? (
         <PageEmptyState title="No prioritized campaigns yet" detail="No campaign was returned for the current 90-day findings window. This is not an all-clear result." icon={Network} actions={[{ label: "Run a scan", href: "/scan" }, { label: "Review findings", href: "/findings", variant: "secondary" }]} />
-      ) : <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+      ) : <div className="risk-campaign-header">
         <div>
-          <div className="text-[11px] font-medium uppercase tracking-[0.18em] text-[color:var(--accent)]">Prioritized remediation</div>
-          <h2 id="risk-campaigns-title" className="mt-1 text-xl font-semibold tracking-tight text-[color:var(--foreground)]">Risk campaigns</h2>
-          <p className="mt-1 text-sm text-[color:var(--text-secondary)]">{campaigns.length} campaigns cluster {campaignFindingCount} finding{campaignFindingCount === 1 ? "" : "s"} into owner-ready work.</p>
+          <div className="risk-campaign-kicker">Prioritized remediation</div>
+          <h2 id="risk-campaigns-title" className="risk-page-title">Risk campaigns</h2>
+          <p className="risk-page-copy">{campaigns.length} campaigns cluster {campaignFindingCount} finding{campaignFindingCount === 1 ? "" : "s"} into owner-ready work.</p>
         </div>
         <div className="flex flex-wrap gap-2 text-xs">
-          <Link href="/security-graph" className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface)] px-3 py-2 text-[color:var(--text-secondary)]">Open investigation</Link>
-          <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-[color:var(--text-tertiary)]">Last {windowDays} days</span>
+          <Link href="/security-graph" className="risk-campaign-investigate">Open investigation</Link>
+          <span className="risk-campaign-window">Last {windowDays} days</span>
         </div>
       </div>}
       {!loading && !error && campaigns.length > 0 && truncated ? (
-        <div role="status" className="flex items-start gap-2 rounded-xl border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2.5 text-xs text-[color:var(--text-secondary)]">
+        <div role="status" className="risk-campaign-truncated">
           <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-[color:var(--status-warn)]" />
           <span>
             <strong className="text-[color:var(--foreground)]">Results may be incomplete.</strong>{" "}
@@ -602,7 +602,7 @@ export function RiskCampaignCommandCenter() {
           <div className="grid gap-2">
             {campaigns.map((campaign) => <CampaignCard key={campaign.id} campaign={campaign} onChanged={updateCampaign} connections={connections} onReload={() => void load()} />)}
           </div>
-          <div className="flex items-center gap-2 text-xs text-[color:var(--text-tertiary)]">
+          <div className="risk-proof-note">
             <CheckCircle2 className="h-3.5 w-3.5" /> Priority and expected reduction are supplied by the server; ticket actions use stored connections.
           </div>
         </>

--- a/ui/components/risk-campaign-command-center.tsx
+++ b/ui/components/risk-campaign-command-center.tsx
@@ -7,7 +7,6 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
-  Clock3,
   Network,
   RefreshCw,
   ShieldCheck,
@@ -236,53 +235,37 @@ function CampaignCard({
   >;
 
   return (
-    <article className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4 shadow-sm md:p-5">
-      <div className="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.16em] text-[color:var(--status-danger)]">
-              {campaign.severity}
-            </span>
-            <span className="text-xs text-[color:var(--text-tertiary)]">
-              {campaign.finding_count} correlated finding{campaign.finding_count === 1 ? "" : "s"}
-            </span>
-            <span className="text-xs text-[color:var(--text-tertiary)]">Source: {campaign.source.replaceAll("_", " ")}</span>
+    <details className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] shadow-sm">
+      <summary className="grid cursor-pointer list-none gap-2 px-3 py-3 [&::-webkit-details-marker]:hidden md:grid-cols-[minmax(0,1fr)_auto_auto_auto] md:items-center">
+        <div className="min-w-0">
+          <div className="flex items-center gap-2">
+            <span className="rounded-full border border-[color:var(--status-danger-border)] bg-[color:var(--status-danger-bg)] px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.14em] text-[color:var(--status-danger)]">{campaign.severity}</span>
+            <h3 className="truncate text-sm font-semibold text-[color:var(--foreground)]">{campaign.title}</h3>
           </div>
-          <h3 className="mt-2 text-base font-semibold leading-6 text-[color:var(--foreground)] md:text-lg">
-            {campaign.title}
-          </h3>
-          <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2 text-xs text-[color:var(--text-secondary)]">
-            <span><strong className="text-[color:var(--foreground)]">Owner:</strong> {campaign.owner || "Unassigned"}</span>
-            <span className="inline-flex items-center gap-1"><Clock3 className="h-3.5 w-3.5" />{formatDate(campaign.sla_due_at)}</span>
-            <span className="inline-flex items-center gap-1"><ShieldCheck className="h-3.5 w-3.5" />{VERIFICATION_LABELS[campaign.verification_status]}</span>
-          </div>
+          <p className="mt-1 truncate text-[11px] text-[color:var(--text-tertiary)]">
+            {campaign.finding_count} finding{campaign.finding_count === 1 ? "" : "s"} · {campaign.owner || "Unassigned"} · {formatDate(campaign.sla_due_at)} · {VERIFICATION_LABELS[campaign.verification_status]}
+          </p>
         </div>
-
-        <div className="grid shrink-0 grid-cols-2 gap-2 sm:min-w-[19rem]">
-          <div className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-3">
-            <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">Priority</div>
-            <div className="mt-1 text-2xl font-semibold tabular-nums text-[color:var(--foreground)]">{campaign.priority_score}</div>
-            <button
-              type="button"
-              onClick={() => setExpanded((current) => !current)}
-              className="mt-1 inline-flex items-center gap-1 text-xs font-medium text-[color:var(--accent)]"
-              aria-expanded={expanded}
-            >
-              Why this priority {expanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
-            </button>
-          </div>
-          <div className="rounded-xl border border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] p-3">
-            <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">Expected reduction</div>
-            <div className="mt-1 text-lg font-semibold tabular-nums text-[color:var(--status-success)]">
-              {campaign.expected_risk_reduction.modeled_window_percent}% modeled window risk
-            </div>
-            <div className="text-[10px] text-[color:var(--text-tertiary)]">{campaign.expected_risk_reduction.modeled_risk_points} modeled points</div>
-            {!campaign.expected_risk_reduction.portfolio_complete ? (
-              <div className="mt-1 text-[10px] text-[color:var(--status-warn)]">Bounded window; not full portfolio</div>
-            ) : null}
-          </div>
-        </div>
-      </div>
+        <span className="rounded-lg border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-2.5 py-1 text-xs text-[color:var(--text-secondary)]">
+          Priority <strong className="ml-1 tabular-nums text-[color:var(--foreground)]">{campaign.priority_score}</strong>
+        </span>
+        <span className="rounded-lg border border-[color:var(--status-success-border)] bg-[color:var(--status-success-bg)] px-2.5 py-1 text-xs font-medium text-[color:var(--status-success)]">
+          <span className="block">{campaign.expected_risk_reduction.modeled_window_percent}% modeled window risk</span>
+          {!campaign.expected_risk_reduction.portfolio_complete ? (
+            <span className="block text-[9px] font-normal text-[color:var(--status-warn)]">Bounded; not full portfolio</span>
+          ) : null}
+        </span>
+        <ChevronDown className="h-4 w-4 text-[color:var(--text-tertiary)] transition group-open:rotate-180" aria-hidden="true" />
+      </summary>
+      <div className="border-t border-[color:var(--border-subtle)] px-3 pb-3">
+        <button
+          type="button"
+          onClick={() => setExpanded((current) => !current)}
+          className="mt-3 inline-flex items-center gap-1 text-xs font-medium text-[color:var(--accent)]"
+          aria-expanded={expanded}
+        >
+          Why this priority {expanded ? <ChevronUp className="h-3 w-3" /> : <ChevronDown className="h-3 w-3" />}
+        </button>
 
       {expanded ? (
         <div className="mt-4 grid gap-3 border-t border-[color:var(--border-subtle)] pt-4 lg:grid-cols-[1fr_1.3fr]">
@@ -396,7 +379,8 @@ function CampaignCard({
         <button type="button" onClick={onReload} className="mt-2 rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs font-medium text-[color:var(--status-warn)]">Reload campaigns</button>
       ) : null}
       {connections.length === 0 ? <p className="mt-3 text-xs text-[color:var(--text-tertiary)]"><Link href="/connections">Connect ticketing</Link> to create new campaign tickets. Existing ticket links can still be synced.</p> : null}
-    </article>
+      </div>
+    </details>
   );
 }
 
@@ -473,17 +457,22 @@ function VerificationQueue() {
   }, []);
 
   return (
-    <section aria-labelledby="verification-queue-title" className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-4">
-      <div className="flex flex-wrap items-start justify-between gap-2">
-        <div>
-          <div className="text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--status-warn)]">Durable workflow evidence</div>
-          <h3 id="verification-queue-title" className="mt-1 text-base font-semibold text-[color:var(--foreground)]">Awaiting re-verification</h3>
-          <p className="mt-1 text-xs text-[color:var(--text-secondary)]">Inactive campaigns remain here after a rescan until canonical evidence confirms the original findings are gone.</p>
+    <details
+      className="group rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)]"
+      open={entries.length > 0 || Boolean(error)}
+    >
+      <summary className="flex cursor-pointer list-none flex-wrap items-center justify-between gap-2 px-3 py-2.5 [&::-webkit-details-marker]:hidden">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="text-[10px] font-medium uppercase tracking-[0.16em] text-[color:var(--status-warn)]">Re-verification</span>
+          <h3 id="verification-queue-title" className="text-sm font-semibold text-[color:var(--foreground)]">Awaiting re-verification</h3>
+          <span className="rounded-full border border-[color:var(--border-subtle)] px-2 py-0.5 text-[10px] text-[color:var(--text-tertiary)]">{entries.length} waiting</span>
         </div>
         {error ? (
           <button type="button" onClick={() => void load(retryCursor)} className="rounded-lg border border-[color:var(--status-warn-border)] bg-[color:var(--status-warn-bg)] px-3 py-2 text-xs font-medium text-[color:var(--status-warn)]">Retry verification queue</button>
-        ) : null}
-      </div>
+        ) : <span className="text-[10px] uppercase tracking-[0.14em] text-[color:var(--text-tertiary)] group-open:hidden">show</span>}
+      </summary>
+      <div className="border-t border-[color:var(--border-subtle)] px-3 pb-3">
+      <p className="mt-2 text-xs text-[color:var(--text-secondary)]">Inactive campaigns stay here until canonical evidence confirms the original findings are gone.</p>
       {loading ? <p role="status" className="mt-3 text-xs text-[color:var(--text-tertiary)]">Loading verification queue…</p> : null}
       {error ? <p role="alert" className="mt-3 text-xs text-[color:var(--status-danger)]">{error}</p> : null}
       {successMessage ? <p role="status" className="mt-3 text-xs text-[color:var(--status-success)]">{successMessage}</p> : null}
@@ -534,7 +523,8 @@ function VerificationQueue() {
           {loadingMore ? "Loading more…" : "Load more awaiting verification"}
         </button>
       ) : null}
-    </section>
+      </div>
+    </details>
   );
 }
 
@@ -609,7 +599,7 @@ export function RiskCampaignCommandCenter() {
       <VerificationQueue />
       {!loading && !error && campaigns.length > 0 ? (
         <>
-          <div className="grid gap-4 2xl:grid-cols-2">
+          <div className="grid gap-2">
             {campaigns.map((campaign) => <CampaignCard key={campaign.id} campaign={campaign} onChanged={updateCampaign} connections={connections} onReload={() => void load()} />)}
           </div>
           <div className="flex items-center gap-2 text-xs text-[color:var(--text-tertiary)]">

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -13,13 +13,15 @@ import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nod
 import { GraphEntityDrawer } from "@/components/graph-entity-drawer";
 import { MeshStats } from "@/components/mesh-stats";
 import { buildMeshGraph, getConnectedIds, type MeshStatsData } from "@/lib/mesh-graph";
-import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, legendItemsForVisibleNodes, minimapNodeColor, readableGraphEdges } from "@/lib/graph-utils";
+import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, graphNodeDisplayLabels, legendItemsForVisibleNodes, minimapNodeColor, readableGraphEdges } from "@/lib/graph-utils";
 import { READABLE_LINEAGE_DAGRE_LR } from "@/lib/graph-node-dimensions";
 import { GraphInteractionToolbar, GraphLegend } from "@/components/graph-chrome";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
-import { selectGraphSubgraph } from "@/lib/graph-presentation";
+import { graphTopologyKey, selectGraphSubgraph } from "@/lib/graph-presentation";
+import { useAuthState } from "@/components/auth-provider";
 
 export function ScanMeshView({ id }: { id: string }) {
+  const { session, loading: authLoading } = useAuthState();
   const [job, setJob] = useState<ScanJob | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -68,8 +70,17 @@ export function ScanMeshView({ id }: { id: string }) {
 
   const presentation = useGraphPresentation({
     nodes: displayNodes as Node<LineageNodeData>[],
-    scope: { tenantId: "local", subject: "local-viewer", snapshotId: id, lens: "mesh", scope: pathFocusEnabled ? "path" : "full" },
+    scope: {
+      tenantId: session?.tenant_id || "local",
+      subject: session?.subject || session?.auth_method || "local-viewer",
+      snapshotId: id,
+      lens: "mesh",
+      scope: JSON.stringify({ pathFocusEnabled, topology: graphTopologyKey(displayNodes, layoutEdges) }),
+    },
     layout: "dagre-lr",
+    enabled: !authLoading && Boolean(session),
+    ownerActive: Boolean(session),
+    localMode: session?.recommended_ui_mode === "no_auth",
   });
 
   const displayEdges = useMemo(() => {
@@ -78,14 +89,27 @@ export function ScanMeshView({ id }: { id: string }) {
       highSignalOpacity: 0.58,
       inactiveOpacity: 0.06,
       zoom: presentation.viewport.zoom,
+      nodeLabels: graphNodeDisplayLabels(displayNodes),
     });
-  }, [layoutEdges, connectedIds, pathFocusIds, presentation.viewport.zoom]);
+  }, [layoutEdges, connectedIds, pathFocusIds, presentation.viewport.zoom, displayNodes]);
 
   const legendItems = useMemo(() => legendItemsForVisibleNodes(displayNodes), [displayNodes]);
 
   const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => { setSelectedNode(node.data as LineageNodeData); setSelectedNodeId(node.id); setHoveredNodeId(null); }, []);
   const onNodeMouseEnter = useCallback((_event: React.MouseEvent, node: Node) => { setHoveredNodeId(node.id); }, []);
   const onNodeMouseLeave = useCallback(() => { setHoveredNodeId(null); }, []);
+  const fitVisible = useCallback(
+    () => void flowInstance?.fitView({ padding: 0.2, duration: 240 }),
+    [flowInstance],
+  );
+  const autoLayout = useCallback(() => {
+    presentation.autoLayout();
+    window.setTimeout(fitVisible, 0);
+  }, [fitVisible, presentation]);
+  const resetLayout = useCallback(() => {
+    presentation.reset();
+    window.setTimeout(fitVisible, 0);
+  }, [fitVisible, presentation]);
 
   if (loading) return <div className="flex items-center justify-center h-[80vh] text-[var(--text-secondary)]"><Loader2 className="w-5 h-5 animate-spin mr-2" />Loading mesh...</div>;
 
@@ -111,12 +135,12 @@ export function ScanMeshView({ id }: { id: string }) {
         </div>
         <div className="flex items-center gap-2">
           <GraphLegend items={legendItems} />
-          <GraphInteractionToolbar
+          {presentation.enabled && presentation.nodes.length > 0 && <GraphInteractionToolbar
             editing={presentation.editing} hasSelection={Boolean(selectedNodeId)}
-            onFitVisible={() => void flowInstance?.fitView({ padding: 0.2, duration: 240 })}
+            onFitVisible={fitVisible}
             onFitSelection={() => { const node = selectedNodeId ? flowInstance?.getNode(selectedNodeId) : undefined; if (node) void flowInstance?.fitView({ nodes: [node], padding: 0.7, duration: 240 }); }}
-            onAutoLayout={presentation.autoLayout} onReset={presentation.reset} onToggleEditing={presentation.toggleEditing}
-          />
+            onAutoLayout={autoLayout} onReset={resetLayout} onToggleEditing={presentation.toggleEditing}
+          />}
         </div>
       </div>
       <MeshStats

--- a/ui/components/scan-mesh.tsx
+++ b/ui/components/scan-mesh.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useMemo, useEffect } from "react";
 import Link from "next/link";
 import {
-  ReactFlow, Background, Controls, MiniMap, type Node, type Edge,
+  ReactFlow, Background, Controls, MiniMap, type Node, type Edge, type ReactFlowInstance,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { useGraphLayout } from "@/lib/use-graph-layout";
@@ -15,13 +15,17 @@ import { MeshStats } from "@/components/mesh-stats";
 import { buildMeshGraph, getConnectedIds, type MeshStatsData } from "@/lib/mesh-graph";
 import { CONTROLS_CLASS, MINIMAP_CLASS, BACKGROUND_COLOR, BACKGROUND_GAP, legendItemsForVisibleNodes, minimapNodeColor, readableGraphEdges } from "@/lib/graph-utils";
 import { READABLE_LINEAGE_DAGRE_LR } from "@/lib/graph-node-dimensions";
-import { GraphLegend } from "@/components/graph-chrome";
+import { GraphInteractionToolbar, GraphLegend } from "@/components/graph-chrome";
+import { useGraphPresentation } from "@/hooks/use-graph-presentation";
+import { selectGraphSubgraph } from "@/lib/graph-presentation";
 
 export function ScanMeshView({ id }: { id: string }) {
   const [job, setJob] = useState<ScanJob | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedNode, setSelectedNode] = useState<LineageNodeData | null>(null);
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [flowInstance, setFlowInstance] = useState<ReactFlowInstance<Node<LineageNodeData>, Edge> | null>(null);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [pathFocusEnabled, setPathFocusEnabled] = useState(true);
 
@@ -41,16 +45,16 @@ export function ScanMeshView({ id }: { id: string }) {
     return { rawNodes: nodes, rawEdges: edges, stats };
   }, [job]);
 
-  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout("dagre-lr", rawNodes, rawEdges, {
-    dagreLr: READABLE_LINEAGE_DAGRE_LR,
-  });
-
-  const connectedIds = useMemo(() => (hoveredNodeId ? getConnectedIds(hoveredNodeId, layoutEdges) : null), [hoveredNodeId, layoutEdges]);
   const pathFocusIds = useMemo(() => {
     if (!pathFocusEnabled || !stats.topExposurePath || hoveredNodeId) return null;
     return new Set(stats.topExposurePath.nodeIds);
   }, [hoveredNodeId, pathFocusEnabled, stats.topExposurePath]);
+  const layoutInput = useMemo(() => selectGraphSubgraph(rawNodes, rawEdges, pathFocusIds), [pathFocusIds, rawEdges, rawNodes]);
+  const { nodes: layoutNodes, edges: layoutEdges } = useGraphLayout("dagre-lr", layoutInput.nodes, layoutInput.edges, {
+    dagreLr: READABLE_LINEAGE_DAGRE_LR,
+  });
 
+  const connectedIds = useMemo(() => (hoveredNodeId ? getConnectedIds(hoveredNodeId, layoutEdges) : null), [hoveredNodeId, layoutEdges]);
   const displayNodes = useMemo(() => {
     if (pathFocusIds) {
       return layoutNodes?.map((n) => ({
@@ -62,17 +66,24 @@ export function ScanMeshView({ id }: { id: string }) {
     return layoutNodes?.map((n) => ({ ...n, data: { ...n.data, dimmed: !connectedIds.has(n.id), highlighted: connectedIds.has(n.id) } }));
   }, [layoutNodes, connectedIds, pathFocusIds]);
 
+  const presentation = useGraphPresentation({
+    nodes: displayNodes as Node<LineageNodeData>[],
+    scope: { tenantId: "local", subject: "local-viewer", snapshotId: id, lens: "mesh", scope: pathFocusEnabled ? "path" : "full" },
+    layout: "dagre-lr",
+  });
+
   const displayEdges = useMemo(() => {
     return readableGraphEdges(layoutEdges, connectedIds ?? pathFocusIds, {
       baseOpacity: 0.3,
       highSignalOpacity: 0.58,
       inactiveOpacity: 0.06,
+      zoom: presentation.viewport.zoom,
     });
-  }, [layoutEdges, connectedIds, pathFocusIds]);
+  }, [layoutEdges, connectedIds, pathFocusIds, presentation.viewport.zoom]);
 
   const legendItems = useMemo(() => legendItemsForVisibleNodes(displayNodes), [displayNodes]);
 
-  const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => { setSelectedNode(node.data as LineageNodeData); setHoveredNodeId(null); }, []);
+  const onNodeClick = useCallback((_event: React.MouseEvent, node: Node) => { setSelectedNode(node.data as LineageNodeData); setSelectedNodeId(node.id); setHoveredNodeId(null); }, []);
   const onNodeMouseEnter = useCallback((_event: React.MouseEvent, node: Node) => { setHoveredNodeId(node.id); }, []);
   const onNodeMouseLeave = useCallback(() => { setHoveredNodeId(null); }, []);
 
@@ -98,7 +109,15 @@ export function ScanMeshView({ id }: { id: string }) {
             Agent-centered shared infrastructure for scan {id.slice(0, 8)} — {job.created_at ? new Date(job.created_at).toLocaleDateString() : ""}
           </p>
         </div>
-        <GraphLegend items={legendItems} />
+        <div className="flex items-center gap-2">
+          <GraphLegend items={legendItems} />
+          <GraphInteractionToolbar
+            editing={presentation.editing} hasSelection={Boolean(selectedNodeId)}
+            onFitVisible={() => void flowInstance?.fitView({ padding: 0.2, duration: 240 })}
+            onFitSelection={() => { const node = selectedNodeId ? flowInstance?.getNode(selectedNodeId) : undefined; if (node) void flowInstance?.fitView({ nodes: [node], padding: 0.7, duration: 240 }); }}
+            onAutoLayout={presentation.autoLayout} onReset={presentation.reset} onToggleEditing={presentation.toggleEditing}
+          />
+        </div>
       </div>
       <MeshStats
         stats={stats}
@@ -107,12 +126,19 @@ export function ScanMeshView({ id }: { id: string }) {
       />
       <div className="flex-1 relative">
         <ReactFlow
-          nodes={displayNodes} edges={displayEdges} nodeTypes={lineageNodeTypes}
-          fitView minZoom={0.05} maxZoom={2.5}
+          key={presentation.storageKey}
+          nodes={presentation.nodes} edges={displayEdges} nodeTypes={lineageNodeTypes}
+          fitView={!presentation.hasSavedState}
+          defaultViewport={presentation.viewport}
+          minZoom={0.05} maxZoom={2.5}
           defaultEdgeOptions={{ type: "smoothstep" }}
           proOptions={{ hideAttribution: true }}
+          deleteKeyCode={null}
+          nodesDraggable={presentation.editing} nodesConnectable={false}
+          onNodesChange={presentation.onNodesChange} onNodeDragStop={presentation.onNodeDragStop}
+          onMoveEnd={presentation.onMoveEnd} onInit={setFlowInstance}
           onNodeClick={onNodeClick} onNodeMouseEnter={onNodeMouseEnter} onNodeMouseLeave={onNodeMouseLeave}
-          onPaneClick={() => { setSelectedNode(null); setHoveredNodeId(null); }}
+          onPaneClick={() => { setSelectedNode(null); setSelectedNodeId(null); setHoveredNodeId(null); }}
         >
           <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
           <Controls className={CONTROLS_CLASS} />
@@ -121,7 +147,7 @@ export function ScanMeshView({ id }: { id: string }) {
         {selectedNode && (
           <GraphEntityDrawer
             data={selectedNode}
-            onClose={() => setSelectedNode(null)}
+            onClose={() => { setSelectedNode(null); setSelectedNodeId(null); }}
             enrich={false}
           />
         )}

--- a/ui/components/scan-pipeline.tsx
+++ b/ui/components/scan-pipeline.tsx
@@ -19,6 +19,7 @@ import {
   Handle,
   Position,
   ReactFlowProvider,
+  type Edge,
   type Node,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
@@ -48,6 +49,7 @@ import {
   type PipelineNodeKind,
   type ScannerDomain,
 } from "@/lib/scan-pipeline-graph";
+import { graphNodeDisplayLabels, readableGraphEdges } from "@/lib/graph-utils";
 
 // ── Step node component ─────────────────────────────────────────────────────
 
@@ -274,6 +276,14 @@ function ScanPipelineInner({
       rowGap: 16,
     },
   });
+  const displayEdges = useMemo(
+    () =>
+      readableGraphEdges(edges as Edge[], undefined, {
+        nodeLabels: graphNodeDisplayLabels(nodes),
+        preserveVisualStyle: true,
+      }),
+    [edges, nodes],
+  );
 
   const handleNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
@@ -286,7 +296,7 @@ function ScanPipelineInner({
     <div className={`relative h-[180px] ${className ?? ""}`}>
       <ReactFlow
         nodes={nodes}
-        edges={edges}
+        edges={displayEdges}
         nodeTypes={nodeTypes}
         fitView
         // Re-fit whenever the node set changes so a live pipeline that grows

--- a/ui/components/security-graph-investigation.tsx
+++ b/ui/components/security-graph-investigation.tsx
@@ -25,6 +25,7 @@ import {
   BACKGROUND_COLOR,
   BACKGROUND_GAP,
   CONTROLS_CLASS,
+  graphNodeDisplayLabels,
   MINIMAP_BG,
   MINIMAP_CLASS,
   MINIMAP_MASK,
@@ -38,7 +39,7 @@ import { buildFocusedGraphData } from "@/lib/security-graph-focus";
 import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
 import { useGraphLayout } from "@/lib/use-graph-layout";
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
-import type { GraphPresentationScope } from "@/lib/graph-presentation";
+import { graphTopologyKey, type GraphPresentationScope } from "@/lib/graph-presentation";
 
 const INVESTIGATION_LAYERS = {
   provider: false,
@@ -92,6 +93,9 @@ function InvestigationFlow({
   onNodeSelect,
   selectedNodeId,
   presentationScope,
+  persistenceEnabled,
+  ownerActive,
+  localMode,
 }: {
   nodes: Node<LineageNodeData>[];
   edges: Edge[];
@@ -104,6 +108,9 @@ function InvestigationFlow({
   onNodeSelect: (id: string) => void;
   selectedNodeId: string | null;
   presentationScope: GraphPresentationScope;
+  persistenceEnabled: boolean;
+  ownerActive: boolean;
+  localMode: boolean;
 }) {
   const reactFlow = useReactFlow<Node<LineageNodeData>, Edge>();
   const { fitView } = reactFlow;
@@ -115,10 +122,16 @@ function InvestigationFlow({
     nodes,
     scope: presentationScope,
     layout: "dagre-lr",
+    enabled: persistenceEnabled,
+    ownerActive,
+    localMode,
   });
   const presentedEdges = useMemo(
-    () => readableGraphEdges(edges, undefined, { zoom: presentation.viewport.zoom }),
-    [edges, presentation.viewport.zoom],
+    () => readableGraphEdges(edges, undefined, {
+      zoom: presentation.viewport.zoom,
+      nodeLabels: graphNodeDisplayLabels(nodes),
+    }),
+    [edges, nodes, presentation.viewport.zoom],
   );
   useEffect(() => {
     if (nodes.length === 0 || presentation.hasSavedState) return;
@@ -146,7 +159,7 @@ function InvestigationFlow({
 
   return (
     <div className="relative h-full">
-      <div className="absolute right-3 top-3 z-20">
+      {presentation.enabled && nodes.length > 0 && <div className="absolute right-3 top-3 z-20">
         <GraphInteractionToolbar
           editing={presentation.editing}
           hasSelection={Boolean(selectedNodeId)}
@@ -156,7 +169,7 @@ function InvestigationFlow({
           onReset={resetLayout}
           onToggleEditing={presentation.toggleEditing}
         />
-      </div>
+      </div>}
       <ReactFlow
         key={presentation.storageKey}
         nodes={presentation.nodes}
@@ -220,7 +233,7 @@ export function SecurityGraphInvestigation({
   /** Notify parent when expand/impact actions advance the investigation step. */
   onStepHint?: ((step: "expand" | "impact" | "fix") => void) | undefined;
 }) {
-  const { session } = useAuthState();
+  const { session, loading: authLoading } = useAuthState();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [drawerData, setDrawerData] = useState<LineageNodeData | null>(null);
   const [blastLoading, setBlastLoading] = useState(false);
@@ -251,7 +264,10 @@ export function SecurityGraphInvestigation({
   const layout = useGraphLayout("dagre-lr", flow.nodes, flow.edges, {
     dagreLr: { rankSep: 128, nodeSep: 48 },
   });
-  const displayEdges = useMemo(() => readableGraphEdges(layout.edges), [layout.edges]);
+  const displayEdges = useMemo(
+    () => readableGraphEdges(layout.edges, undefined, { nodeLabels: graphNodeDisplayLabels(layout.nodes) }),
+    [layout.edges, layout.nodes],
+  );
   const legendItems = useMemo(
     () => legendItemsForVisibleGraph(layout.nodes, displayEdges),
     [displayEdges, layout.nodes],
@@ -273,9 +289,12 @@ export function SecurityGraphInvestigation({
       subject: session?.subject || session?.auth_method || "local-viewer",
       snapshotId: scanId || "unselected",
       lens: "investigation",
-      scope: focusMode && attackPath ? attackPath.hops.join("=>") : "full-snapshot",
+      scope: JSON.stringify({
+        focus: focusMode && attackPath ? attackPath.hops.join("=>") : "full-snapshot",
+        topology: graphTopologyKey(layout.nodes, displayEdges),
+      }),
     }),
-    [attackPath, focusMode, scanId, session?.auth_method, session?.subject, session?.tenant_id],
+    [attackPath, displayEdges, focusMode, layout.nodes, scanId, session?.auth_method, session?.subject, session?.tenant_id],
   );
 
   const selectedNode = useMemo(
@@ -426,6 +445,9 @@ export function SecurityGraphInvestigation({
               onNodeSelect={setSelectedNodeId}
               selectedNodeId={selectedNodeId}
               presentationScope={presentationScope}
+              persistenceEnabled={!authLoading && Boolean(session)}
+              ownerActive={Boolean(session)}
+              localMode={session?.recommended_ui_mode === "no_auth"}
             />
           </ReactFlowProvider>
         )}

--- a/ui/components/security-graph-investigation.tsx
+++ b/ui/components/security-graph-investigation.tsx
@@ -116,6 +116,10 @@ function InvestigationFlow({
     scope: presentationScope,
     layout: "dagre-lr",
   });
+  const presentedEdges = useMemo(
+    () => readableGraphEdges(edges, undefined, { zoom: presentation.viewport.zoom }),
+    [edges, presentation.viewport.zoom],
+  );
   useEffect(() => {
     if (nodes.length === 0 || presentation.hasSavedState) return;
     const raf = requestAnimationFrame(() => {
@@ -156,7 +160,7 @@ function InvestigationFlow({
       <ReactFlow
         key={presentation.storageKey}
         nodes={presentation.nodes}
-        edges={edges}
+        edges={presentedEdges}
         nodeTypes={lineageNodeTypes}
         fitView={!presentation.hasSavedState}
         fitViewOptions={fitOptions}
@@ -172,6 +176,7 @@ function InvestigationFlow({
         nodesFocusable
         edgesFocusable
         elementsSelectable
+        deleteKeyCode={null}
         onNodesChange={presentation.onNodesChange}
         onNodeDragStop={presentation.onNodeDragStop}
         onMoveEnd={presentation.onMoveEnd}
@@ -425,7 +430,7 @@ export function SecurityGraphInvestigation({
           </ReactFlowProvider>
         )}
 
-        <div className="pointer-events-none absolute left-3 top-3 max-w-[min(24rem,calc(100vw-2rem))]">
+        <div className="pointer-events-auto absolute left-3 top-3 max-w-[min(24rem,calc(100vw-2rem))]">
           <GraphLegend items={legendItems} />
         </div>
       </div>

--- a/ui/components/security-graph-investigation.tsx
+++ b/ui/components/security-graph-investigation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   Background,
   Controls,
@@ -16,7 +16,8 @@ import "@xyflow/react/dist/style.css";
 import { Focus, GitBranch, Loader2 } from "lucide-react";
 
 import { GraphEntityDrawer } from "@/components/graph-entity-drawer";
-import { FullscreenButton, GraphLegend } from "@/components/graph-chrome";
+import { FullscreenButton, GraphInteractionToolbar, GraphLegend } from "@/components/graph-chrome";
+import { useAuthState } from "@/components/auth-provider";
 import { lineageNodeTypes, type LineageNodeData } from "@/components/lineage-nodes";
 import { api } from "@/lib/api";
 import type { AttackPath, UnifiedGraphData } from "@/lib/graph-schema";
@@ -36,6 +37,8 @@ import { mergeGraphNodeDetail } from "@/lib/graph-entity-detail";
 import { buildFocusedGraphData } from "@/lib/security-graph-focus";
 import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
 import { useGraphLayout } from "@/lib/use-graph-layout";
+import { useGraphPresentation } from "@/hooks/use-graph-presentation";
+import type { GraphPresentationScope } from "@/lib/graph-presentation";
 
 const INVESTIGATION_LAYERS = {
   provider: false,
@@ -87,6 +90,8 @@ function InvestigationFlow({
   edges,
   viewportInput,
   onNodeSelect,
+  selectedNodeId,
+  presentationScope,
 }: {
   nodes: Node<LineageNodeData>[];
   edges: Edge[];
@@ -97,46 +102,94 @@ function InvestigationFlow({
     mode: "lineage" | "context";
   };
   onNodeSelect: (id: string) => void;
+  selectedNodeId: string | null;
+  presentationScope: GraphPresentationScope;
 }) {
-  const { fitView } = useReactFlow();
+  const reactFlow = useReactFlow<Node<LineageNodeData>, Edge>();
+  const { fitView } = reactFlow;
   const fitOptions = useMemo(() => graphFitViewOptions(viewportInput), [viewportInput]);
   const fitOptionsRef = useRef(fitOptions);
   fitOptionsRef.current = fitOptions;
 
+  const presentation = useGraphPresentation({
+    nodes,
+    scope: presentationScope,
+    layout: "dagre-lr",
+  });
   useEffect(() => {
-    if (nodes.length === 0) return;
+    if (nodes.length === 0 || presentation.hasSavedState) return;
     const raf = requestAnimationFrame(() => {
       void fitView(fitOptionsRef.current);
     });
     return () => cancelAnimationFrame(raf);
-  }, [fitView, nodes]);
+  }, [fitView, nodes, presentation.hasSavedState]);
+  const fitVisible = useCallback(() => {
+    void fitView({ ...fitOptions, duration: 240 });
+  }, [fitOptions, fitView]);
+  const fitSelection = useCallback(() => {
+    if (!selectedNodeId) return;
+    const node = reactFlow.getNode(selectedNodeId);
+    if (node) void fitView({ nodes: [node], padding: 0.7, duration: 240, maxZoom: 1.4 });
+  }, [fitView, reactFlow, selectedNodeId]);
+  const autoLayout = useCallback(() => {
+    presentation.autoLayout();
+    window.setTimeout(fitVisible, 0);
+  }, [fitVisible, presentation]);
+  const resetLayout = useCallback(() => {
+    presentation.reset();
+    window.setTimeout(fitVisible, 0);
+  }, [fitVisible, presentation]);
 
   return (
-    <ReactFlow
-      nodes={nodes}
-      edges={edges}
-      nodeTypes={lineageNodeTypes}
-      fitView
-      fitViewOptions={fitOptions}
-      minZoom={0.2}
-      maxZoom={2.5}
-      nodesDraggable={false}
-      nodesConnectable={false}
-      elementsSelectable
-      onNodeClick={(_, node) => onNodeSelect(node.id)}
-      proOptions={{ hideAttribution: true }}
-    >
-      <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
-      <Controls className={CONTROLS_CLASS} showInteractive={false} />
-      {shouldShowGraphMiniMap(viewportInput) && (
-        <MiniMap
-          className={MINIMAP_CLASS}
-          style={{ background: MINIMAP_BG }}
-          maskColor={MINIMAP_MASK}
-          nodeColor={minimapNodeColor}
+    <div className="relative h-full">
+      <div className="absolute right-3 top-3 z-20">
+        <GraphInteractionToolbar
+          editing={presentation.editing}
+          hasSelection={Boolean(selectedNodeId)}
+          onFitVisible={fitVisible}
+          onFitSelection={fitSelection}
+          onAutoLayout={autoLayout}
+          onReset={resetLayout}
+          onToggleEditing={presentation.toggleEditing}
         />
-      )}
-    </ReactFlow>
+      </div>
+      <ReactFlow
+        key={presentation.storageKey}
+        nodes={presentation.nodes}
+        edges={edges}
+        nodeTypes={lineageNodeTypes}
+        fitView={!presentation.hasSavedState}
+        fitViewOptions={fitOptions}
+        minZoom={0.2}
+        maxZoom={2.5}
+        defaultViewport={presentation.viewport}
+        zoomOnScroll
+        zoomOnPinch
+        panOnDrag
+        preventScrolling
+        nodesDraggable={presentation.editing}
+        nodesConnectable={false}
+        nodesFocusable
+        edgesFocusable
+        elementsSelectable
+        onNodesChange={presentation.onNodesChange}
+        onNodeDragStop={presentation.onNodeDragStop}
+        onMoveEnd={presentation.onMoveEnd}
+        onNodeClick={(_, node) => onNodeSelect(node.id)}
+        proOptions={{ hideAttribution: true }}
+      >
+        <Background color={BACKGROUND_COLOR} gap={BACKGROUND_GAP} />
+        <Controls className={CONTROLS_CLASS} showInteractive={false} />
+        {shouldShowGraphMiniMap(viewportInput) && (
+          <MiniMap
+            className={MINIMAP_CLASS}
+            style={{ background: MINIMAP_BG }}
+            maskColor={MINIMAP_MASK}
+            nodeColor={minimapNodeColor}
+          />
+        )}
+      </ReactFlow>
+    </div>
   );
 }
 
@@ -162,6 +215,7 @@ export function SecurityGraphInvestigation({
   /** Notify parent when expand/impact actions advance the investigation step. */
   onStepHint?: ((step: "expand" | "impact" | "fix") => void) | undefined;
 }) {
+  const { session } = useAuthState();
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [drawerData, setDrawerData] = useState<LineageNodeData | null>(null);
   const [blastLoading, setBlastLoading] = useState(false);
@@ -207,6 +261,16 @@ export function SecurityGraphInvestigation({
       mode: (focusMode ? "context" : "lineage") as "context" | "lineage",
     }),
     [displayEdges.length, focusMode, layout.nodes.length, selectedNodeId],
+  );
+  const presentationScope = useMemo(
+    () => ({
+      tenantId: session?.tenant_id || "local",
+      subject: session?.subject || session?.auth_method || "local-viewer",
+      snapshotId: scanId || "unselected",
+      lens: "investigation",
+      scope: focusMode && attackPath ? attackPath.hops.join("=>") : "full-snapshot",
+    }),
+    [attackPath, focusMode, scanId, session?.auth_method, session?.subject, session?.tenant_id],
   );
 
   const selectedNode = useMemo(
@@ -355,6 +419,8 @@ export function SecurityGraphInvestigation({
               edges={displayEdges}
               viewportInput={viewportInput}
               onNodeSelect={setSelectedNodeId}
+              selectedNodeId={selectedNodeId}
+              presentationScope={presentationScope}
             />
           </ReactFlowProvider>
         )}

--- a/ui/e2e/lineage-graph-readability.spec.ts
+++ b/ui/e2e/lineage-graph-readability.spec.ts
@@ -270,3 +270,29 @@ for (const theme of ["dark", "light"] as const) {
     await captureGraphScreenshot(page, testInfo, theme);
   });
 }
+
+test("lineage graph controls zoom, move, persist, lock, fit, and auto-layout", async ({ page }) => {
+  await routeGraphPage(page);
+  await page.goto("/graph", { waitUntil: "domcontentloaded" });
+  await page.waitForURL((url) => url.pathname === "/graph" && url.searchParams.has("layers"));
+
+  const canvas = page.locator(".react-flow").last();
+  const node = canvas.locator(".react-flow__node").first();
+  await expect(node).toBeVisible();
+  const before = await node.boundingBox();
+  expect(before).not.toBeNull();
+
+  await page.getByRole("button", { name: "Edit layout" }).click();
+  await node.dragTo(canvas, { targetPosition: { x: 220, y: 220 } });
+  const saved = await page.evaluate(() =>
+    Object.keys(localStorage).some((key) => key.startsWith("agent-bom:graph-presentation:v1:")),
+  );
+  expect(saved).toBe(true);
+
+  await canvas.hover();
+  await page.mouse.wheel(0, -240);
+  await page.getByRole("button", { name: "Fit visible graph" }).click();
+  await page.getByRole("button", { name: "Auto-layout graph" }).click();
+  await page.getByRole("button", { name: "Lock layout" }).click();
+  await expect(page.getByRole("button", { name: "Edit layout" })).toBeVisible();
+});

--- a/ui/hooks/use-graph-presentation.ts
+++ b/ui/hooks/use-graph-presentation.ts
@@ -1,0 +1,195 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  applyNodeChanges,
+  type Node,
+  type NodeChange,
+  type OnNodeDrag,
+  type OnMoveEnd,
+} from "@xyflow/react";
+
+import {
+  applyGraphPresentation,
+  graphPositions,
+  graphPresentationStorageKey,
+  readGraphPresentation,
+  removeGraphPresentation,
+  writeGraphPresentation,
+  type GraphPresentationScope,
+  type GraphPresentationState,
+} from "@/lib/graph-presentation";
+
+const DEFAULT_VIEWPORT = { x: 0, y: 0, zoom: 1 };
+
+function browserStorage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+export function useGraphPresentation<T extends Node>({
+  nodes,
+  scope,
+  layout,
+  enabled = true,
+}: {
+  nodes: T[];
+  scope: GraphPresentationScope;
+  layout: string;
+  enabled?: boolean;
+}) {
+  const storageKey = useMemo(() => graphPresentationStorageKey(scope), [scope]);
+  const initialState = useMemo(
+    () => (enabled ? readGraphPresentation(browserStorage(), storageKey) : null),
+    [enabled, storageKey],
+  );
+  const [editing, setEditing] = useState(() => enabled && initialState?.locked === false);
+  const [hasSavedState, setHasSavedState] = useState(() => Boolean(enabled && initialState));
+  const accessibleNodes = useMemo(
+    () =>
+      nodes.map((node) => {
+        const data = node.data as { label?: unknown; nodeType?: unknown };
+        const label = typeof data.label === "string" ? data.label : node.id;
+        const kind = typeof data.nodeType === "string" ? `, ${data.nodeType}` : "";
+        return { ...node, ariaLabel: node.ariaLabel ?? `${label}${kind}` } as T;
+      }),
+    [nodes],
+  );
+  const [presentedNodes, setPresentedNodes] = useState<T[]>(() =>
+    applyGraphPresentation(accessibleNodes, initialState?.layout === layout ? initialState : null),
+  );
+  const [viewport, setViewport] = useState(initialState?.viewport ?? DEFAULT_VIEWPORT);
+  const nodesRef = useRef(presentedNodes);
+  const viewportRef = useRef(viewport);
+
+  useEffect(() => {
+    nodesRef.current = presentedNodes;
+  }, [presentedNodes]);
+  useEffect(() => {
+    viewportRef.current = viewport;
+  }, [viewport]);
+
+  useEffect(() => {
+    const stored = enabled ? readGraphPresentation(browserStorage(), storageKey) : null;
+    const compatible = stored?.layout === layout ? stored : null;
+    const nextNodes = applyGraphPresentation(accessibleNodes, compatible);
+    nodesRef.current = nextNodes;
+    setPresentedNodes(nextNodes);
+    const nextViewport = compatible?.viewport ?? DEFAULT_VIEWPORT;
+    viewportRef.current = nextViewport;
+    setViewport(nextViewport);
+    setEditing(enabled && compatible?.locked === false);
+    setHasSavedState(Boolean(enabled && compatible));
+  }, [accessibleNodes, enabled, layout, storageKey]);
+
+  const persist = useCallback(
+    (overrides: Partial<GraphPresentationState> = {}) => {
+      if (!enabled) return;
+      writeGraphPresentation(browserStorage(), storageKey, {
+        version: 1,
+        positions: graphPositions(nodesRef.current),
+        viewport: viewportRef.current,
+        layout,
+        locked: !editing,
+        ...overrides,
+      });
+      setHasSavedState(true);
+    },
+    [editing, enabled, layout, storageKey],
+  );
+
+  const onNodesChange = useCallback(
+    (changes: NodeChange<T>[]) => {
+      const allowed = editing
+        ? changes
+        : changes.filter((change) => change.type !== "position");
+      if (allowed.length === 0) return;
+      setPresentedNodes((current) => {
+        const next = applyNodeChanges(allowed, current) as T[];
+        nodesRef.current = next;
+        return next;
+      });
+    },
+    [editing],
+  );
+
+  const onNodeDragStop = useCallback<OnNodeDrag<T>>(
+    (_event, node) => {
+      if (!editing) return;
+      const next = nodesRef.current.map((current) =>
+        current.id === node.id ? ({ ...current, position: node.position } as T) : current,
+      );
+      nodesRef.current = next;
+      setPresentedNodes(next);
+      persist({ positions: graphPositions(next), locked: false });
+    },
+    [editing, persist],
+  );
+
+  const onMoveEnd = useCallback<OnMoveEnd>(
+    (_event, nextViewport) => {
+      viewportRef.current = nextViewport;
+      setViewport(nextViewport);
+      persist({ viewport: nextViewport });
+    },
+    [persist],
+  );
+
+  const toggleEditing = useCallback(() => {
+    setEditing((current) => {
+      const next = !current;
+      writeGraphPresentation(browserStorage(), storageKey, {
+        version: 1,
+        positions: graphPositions(nodesRef.current),
+        viewport: viewportRef.current,
+        layout,
+        locked: !next,
+      });
+      setHasSavedState(true);
+      return next;
+    });
+  }, [layout, storageKey]);
+
+  const reset = useCallback(() => {
+    removeGraphPresentation(browserStorage(), storageKey);
+    nodesRef.current = accessibleNodes;
+    setPresentedNodes(accessibleNodes);
+    viewportRef.current = DEFAULT_VIEWPORT;
+    setViewport(DEFAULT_VIEWPORT);
+    setEditing(false);
+    setHasSavedState(false);
+  }, [accessibleNodes, storageKey]);
+
+  const autoLayout = useCallback(() => {
+    nodesRef.current = accessibleNodes;
+    setPresentedNodes(accessibleNodes);
+    if (enabled) {
+      writeGraphPresentation(browserStorage(), storageKey, {
+        version: 1,
+        positions: {},
+        viewport: viewportRef.current,
+        layout,
+        locked: !editing,
+      });
+      setHasSavedState(true);
+    }
+  }, [accessibleNodes, editing, enabled, layout, storageKey]);
+
+  return {
+    storageKey,
+    nodes: presentedNodes,
+    editing,
+    hasSavedState,
+    viewport,
+    onNodesChange,
+    onNodeDragStop,
+    onMoveEnd,
+    toggleEditing,
+    reset,
+    autoLayout,
+  };
+}

--- a/ui/hooks/use-graph-presentation.ts
+++ b/ui/hooks/use-graph-presentation.ts
@@ -105,8 +105,10 @@ export function useGraphPresentation<T extends Node>({
   const onNodesChange = useCallback(
     (changes: NodeChange<T>[]) => {
       const allowed = editing
-        ? changes
-        : changes.filter((change) => change.type !== "position");
+        ? changes.filter((change) => change.type !== "remove")
+        : changes.filter(
+            (change) => change.type !== "position" && change.type !== "remove",
+          );
       if (allowed.length === 0) return;
       setPresentedNodes((current) => {
         const next = applyNodeChanges(allowed, current) as T[];

--- a/ui/hooks/use-graph-presentation.ts
+++ b/ui/hooks/use-graph-presentation.ts
@@ -13,7 +13,9 @@ import {
   applyGraphPresentation,
   graphPositions,
   graphPresentationStorageKey,
+  purgeGraphPresentationsForOwner,
   readGraphPresentation,
+  registerGraphPresentationKey,
   removeGraphPresentation,
   writeGraphPresentation,
   type GraphPresentationScope,
@@ -36,24 +38,31 @@ export function useGraphPresentation<T extends Node>({
   scope,
   layout,
   enabled = true,
+  ownerActive = true,
+  localMode = false,
 }: {
   nodes: T[];
   scope: GraphPresentationScope;
   layout: string;
   enabled?: boolean;
+  ownerActive?: boolean;
+  localMode?: boolean;
 }) {
+  const persistenceEnabled = enabled && ownerActive && (
+    localMode || (scope.tenantId !== "local" && scope.subject !== "local-viewer")
+  );
   const storageKey = useMemo(() => graphPresentationStorageKey(scope), [scope]);
   const initialState = useMemo(
-    () => (enabled ? readGraphPresentation(browserStorage(), storageKey) : null),
-    [enabled, storageKey],
+    () => (persistenceEnabled ? readGraphPresentation(browserStorage(), storageKey) : null),
+    [persistenceEnabled, storageKey],
   );
-  const [editing, setEditing] = useState(() => enabled && initialState?.locked === false);
-  const [hasSavedState, setHasSavedState] = useState(() => Boolean(enabled && initialState));
+  const [editing, setEditing] = useState(() => persistenceEnabled && initialState?.locked === false);
+  const [hasSavedState, setHasSavedState] = useState(() => Boolean(persistenceEnabled && initialState));
   const accessibleNodes = useMemo(
     () =>
       nodes.map((node) => {
         const data = node.data as { label?: unknown; nodeType?: unknown };
-        const label = typeof data.label === "string" ? data.label : node.id;
+        const label = typeof data.label === "string" ? data.label : "Graph node";
         const kind = typeof data.nodeType === "string" ? `, ${data.nodeType}` : "";
         return { ...node, ariaLabel: node.ariaLabel ?? `${label}${kind}` } as T;
       }),
@@ -65,6 +74,19 @@ export function useGraphPresentation<T extends Node>({
   const [viewport, setViewport] = useState(initialState?.viewport ?? DEFAULT_VIEWPORT);
   const nodesRef = useRef(presentedNodes);
   const viewportRef = useRef(viewport);
+  const ownerRef = useRef(`${scope.tenantId}\u0000${scope.subject}`);
+  const wasOwnerActiveRef = useRef(ownerActive);
+
+  useEffect(() => {
+    const owner = `${scope.tenantId}\u0000${scope.subject}`;
+    const ownerChanged = ownerRef.current !== owner;
+    if ((ownerChanged || (!ownerActive && wasOwnerActiveRef.current)) && wasOwnerActiveRef.current) {
+      const [previousTenant, previousSubject] = ownerRef.current.split("\u0000");
+      purgeGraphPresentationsForOwner(browserStorage(), previousTenant ?? "", previousSubject ?? "");
+    }
+    ownerRef.current = owner;
+    wasOwnerActiveRef.current = ownerActive;
+  }, [ownerActive, scope.subject, scope.tenantId, storageKey]);
 
   useEffect(() => {
     nodesRef.current = presentedNodes;
@@ -74,7 +96,7 @@ export function useGraphPresentation<T extends Node>({
   }, [viewport]);
 
   useEffect(() => {
-    const stored = enabled ? readGraphPresentation(browserStorage(), storageKey) : null;
+    const stored = persistenceEnabled ? readGraphPresentation(browserStorage(), storageKey) : null;
     const compatible = stored?.layout === layout ? stored : null;
     const nextNodes = applyGraphPresentation(accessibleNodes, compatible);
     nodesRef.current = nextNodes;
@@ -82,13 +104,14 @@ export function useGraphPresentation<T extends Node>({
     const nextViewport = compatible?.viewport ?? DEFAULT_VIEWPORT;
     viewportRef.current = nextViewport;
     setViewport(nextViewport);
-    setEditing(enabled && compatible?.locked === false);
-    setHasSavedState(Boolean(enabled && compatible));
-  }, [accessibleNodes, enabled, layout, storageKey]);
+    setEditing(persistenceEnabled && compatible?.locked === false);
+    setHasSavedState(Boolean(persistenceEnabled && compatible));
+  }, [accessibleNodes, layout, persistenceEnabled, storageKey]);
 
   const persist = useCallback(
     (overrides: Partial<GraphPresentationState> = {}) => {
-      if (!enabled) return;
+      if (!persistenceEnabled) return;
+      registerGraphPresentationKey(browserStorage(), scope, storageKey);
       writeGraphPresentation(browserStorage(), storageKey, {
         version: 1,
         positions: graphPositions(nodesRef.current),
@@ -99,11 +122,12 @@ export function useGraphPresentation<T extends Node>({
       });
       setHasSavedState(true);
     },
-    [editing, enabled, layout, storageKey],
+    [editing, layout, persistenceEnabled, scope, storageKey],
   );
 
   const onNodesChange = useCallback(
     (changes: NodeChange<T>[]) => {
+      if (!persistenceEnabled) return;
       const allowed = editing
         ? changes.filter((change) => change.type !== "remove")
         : changes.filter(
@@ -116,12 +140,12 @@ export function useGraphPresentation<T extends Node>({
         return next;
       });
     },
-    [editing],
+    [editing, persistenceEnabled],
   );
 
   const onNodeDragStop = useCallback<OnNodeDrag<T>>(
     (_event, node) => {
-      if (!editing) return;
+      if (!persistenceEnabled || !editing) return;
       const next = nodesRef.current.map((current) =>
         current.id === node.id ? ({ ...current, position: node.position } as T) : current,
       );
@@ -129,21 +153,24 @@ export function useGraphPresentation<T extends Node>({
       setPresentedNodes(next);
       persist({ positions: graphPositions(next), locked: false });
     },
-    [editing, persist],
+    [editing, persist, persistenceEnabled],
   );
 
   const onMoveEnd = useCallback<OnMoveEnd>(
     (_event, nextViewport) => {
+      if (!persistenceEnabled) return;
       viewportRef.current = nextViewport;
       setViewport(nextViewport);
       persist({ viewport: nextViewport });
     },
-    [persist],
+    [persist, persistenceEnabled],
   );
 
   const toggleEditing = useCallback(() => {
+    if (!persistenceEnabled) return;
     setEditing((current) => {
       const next = !current;
+      registerGraphPresentationKey(browserStorage(), scope, storageKey);
       writeGraphPresentation(browserStorage(), storageKey, {
         version: 1,
         positions: graphPositions(nodesRef.current),
@@ -154,9 +181,10 @@ export function useGraphPresentation<T extends Node>({
       setHasSavedState(true);
       return next;
     });
-  }, [layout, storageKey]);
+  }, [layout, persistenceEnabled, scope, storageKey]);
 
   const reset = useCallback(() => {
+    if (!persistenceEnabled) return;
     removeGraphPresentation(browserStorage(), storageKey);
     nodesRef.current = accessibleNodes;
     setPresentedNodes(accessibleNodes);
@@ -164,25 +192,26 @@ export function useGraphPresentation<T extends Node>({
     setViewport(DEFAULT_VIEWPORT);
     setEditing(false);
     setHasSavedState(false);
-  }, [accessibleNodes, storageKey]);
+  }, [accessibleNodes, persistenceEnabled, storageKey]);
 
   const autoLayout = useCallback(() => {
+    if (!persistenceEnabled) return;
     nodesRef.current = accessibleNodes;
     setPresentedNodes(accessibleNodes);
-    if (enabled) {
-      writeGraphPresentation(browserStorage(), storageKey, {
-        version: 1,
-        positions: {},
-        viewport: viewportRef.current,
-        layout,
-        locked: !editing,
-      });
-      setHasSavedState(true);
-    }
-  }, [accessibleNodes, editing, enabled, layout, storageKey]);
+    registerGraphPresentationKey(browserStorage(), scope, storageKey);
+    writeGraphPresentation(browserStorage(), storageKey, {
+      version: 1,
+      positions: {},
+      viewport: viewportRef.current,
+      layout,
+      locked: !editing,
+    });
+    setHasSavedState(true);
+  }, [accessibleNodes, editing, layout, persistenceEnabled, scope, storageKey]);
 
   return {
     storageKey,
+    enabled: persistenceEnabled,
     nodes: presentedNodes,
     editing,
     hasSavedState,

--- a/ui/lib/graph-presentation.ts
+++ b/ui/lib/graph-presentation.ts
@@ -46,6 +46,64 @@ export function graphPresentationStorageKey(scope: GraphPresentationScope): stri
   ]))}`;
 }
 
+export function graphNodeStorageKey(nodeId: string): string {
+  return `n:${stableHash(nodeId)}`;
+}
+
+export function graphNodeSetKey(nodes: Pick<Node, "id">[]): string {
+  return stableHash(nodes.map((node) => node.id).sort().join("\u0000"));
+}
+
+export function graphTopologyKey(
+  nodes: Pick<Node, "id">[],
+  edges: Array<Pick<Edge, "source" | "target" | "data">>,
+): string {
+  const nodePart = nodes.map((node) => node.id).sort();
+  const edgePart = edges.map((edge) => {
+    const relationship = (edge.data as { relationship?: unknown } | undefined)?.relationship;
+    return `${edge.source}\u0001${typeof relationship === "string" ? relationship : "relationship"}\u0001${edge.target}`;
+  }).sort();
+  return stableHash(JSON.stringify([nodePart, edgePart]));
+}
+
+function ownerRegistryKey(tenantId: string, subject: string): string {
+  return `${STORAGE_PREFIX}:owner:${stableHash(`${tenantId}\u0000${subject}`)}`;
+}
+
+export function registerGraphPresentationKey(
+  storage: StorageAdapter | null | undefined,
+  scope: Pick<GraphPresentationScope, "tenantId" | "subject">,
+  key: string,
+): void {
+  if (!storage) return;
+  const registryKey = ownerRegistryKey(scope.tenantId, scope.subject);
+  try {
+    const parsed = JSON.parse(storage.getItem(registryKey) ?? "[]");
+    const keys = Array.isArray(parsed) ? parsed.filter((item): item is string => typeof item === "string" && item.startsWith(STORAGE_PREFIX)) : [];
+    if (!keys.includes(key)) storage.setItem(registryKey, JSON.stringify([...keys, key]));
+  } catch {
+    try { storage.setItem(registryKey, JSON.stringify([key])); } catch { /* optional storage */ }
+  }
+}
+
+export function purgeGraphPresentationsForOwner(
+  storage: StorageAdapter | null | undefined,
+  tenantId: string,
+  subject: string,
+): void {
+  if (!storage) return;
+  const registryKey = ownerRegistryKey(tenantId, subject);
+  try {
+    const parsed = JSON.parse(storage.getItem(registryKey) ?? "[]");
+    if (Array.isArray(parsed)) {
+      for (const key of parsed) if (typeof key === "string" && key.startsWith(STORAGE_PREFIX)) storage.removeItem(key);
+    }
+    storage.removeItem(registryKey);
+  } catch {
+    try { storage.removeItem(registryKey); } catch { /* optional storage */ }
+  }
+}
+
 function finiteCoordinate(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) && Math.abs(value) <= MAX_COORDINATE
     ? value
@@ -73,7 +131,7 @@ function sanitizeState(value: unknown): GraphPresentationState | null {
   const positions: Record<string, GraphPosition> = {};
   if (candidate.positions && typeof candidate.positions === "object") {
     for (const [id, position] of Object.entries(candidate.positions)) {
-      if (!id || !position || typeof position !== "object") continue;
+      if (!/^n:[a-f0-9]{16}$/.test(id) || !position || typeof position !== "object") continue;
       const x = finiteCoordinate((position as Partial<GraphPosition>).x);
       const y = finiteCoordinate((position as Partial<GraphPosition>).y);
       if (x !== null && y !== null) positions[id] = { x, y };
@@ -134,7 +192,7 @@ export function applyGraphPresentation<T extends Node>(
 ): T[] {
   if (!state) return nodes;
   return nodes.map((node) => {
-    const position = state.positions[node.id];
+    const position = state.positions[graphNodeStorageKey(node.id)];
     return position ? { ...node, position } : node;
   });
 }
@@ -143,7 +201,7 @@ export function graphPositions(nodes: Node[]): Record<string, GraphPosition> {
   return Object.fromEntries(
     nodes
       .filter((node) => finiteCoordinate(node.position.x) !== null && finiteCoordinate(node.position.y) !== null)
-      .map((node) => [node.id, { x: node.position.x, y: node.position.y }]),
+      .map((node) => [graphNodeStorageKey(node.id), { x: node.position.x, y: node.position.y }]),
   );
 }
 

--- a/ui/lib/graph-presentation.ts
+++ b/ui/lib/graph-presentation.ts
@@ -1,0 +1,162 @@
+import type { Edge, Node, Viewport } from "@xyflow/react";
+
+export type GraphPresentationScope = {
+  tenantId: string;
+  subject: string;
+  snapshotId: string;
+  lens: string;
+  scope: string;
+};
+
+export type GraphPosition = { x: number; y: number };
+
+export type GraphPresentationState = {
+  version: 1;
+  positions: Record<string, GraphPosition>;
+  viewport: Viewport;
+  layout: string;
+  locked: boolean;
+};
+
+type StorageAdapter = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+const STORAGE_PREFIX = "agent-bom:graph-presentation:v1";
+const MAX_COORDINATE = 10_000_000;
+const MIN_ZOOM = 0.05;
+const MAX_ZOOM = 4;
+
+function stableHash(value: string): string {
+  let left = 0x811c9dc5;
+  let right = 0x9e3779b9;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    left = Math.imul(left ^ code, 0x01000193) >>> 0;
+    right = Math.imul(right ^ code, 0x85ebca6b) >>> 0;
+  }
+  return `${left.toString(16).padStart(8, "0")}${right.toString(16).padStart(8, "0")}`;
+}
+
+export function graphPresentationStorageKey(scope: GraphPresentationScope): string {
+  return `${STORAGE_PREFIX}:${stableHash(JSON.stringify([
+    scope.tenantId,
+    scope.subject,
+    scope.snapshotId,
+    scope.lens,
+    scope.scope,
+  ]))}`;
+}
+
+function finiteCoordinate(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) && Math.abs(value) <= MAX_COORDINATE
+    ? value
+    : null;
+}
+
+function sanitizeState(value: unknown): GraphPresentationState | null {
+  if (!value || typeof value !== "object") return null;
+  const candidate = value as Partial<GraphPresentationState>;
+  if (candidate.version !== 1 || typeof candidate.layout !== "string") return null;
+  const viewport = candidate.viewport as Partial<Viewport> | undefined;
+  const viewportX = finiteCoordinate(viewport?.x);
+  const viewportY = finiteCoordinate(viewport?.y);
+  const zoom = viewport?.zoom;
+  if (
+    viewportX === null ||
+    viewportY === null ||
+    typeof zoom !== "number" ||
+    !Number.isFinite(zoom) ||
+    zoom < MIN_ZOOM ||
+    zoom > MAX_ZOOM
+  ) {
+    return null;
+  }
+  const positions: Record<string, GraphPosition> = {};
+  if (candidate.positions && typeof candidate.positions === "object") {
+    for (const [id, position] of Object.entries(candidate.positions)) {
+      if (!id || !position || typeof position !== "object") continue;
+      const x = finiteCoordinate((position as Partial<GraphPosition>).x);
+      const y = finiteCoordinate((position as Partial<GraphPosition>).y);
+      if (x !== null && y !== null) positions[id] = { x, y };
+    }
+  }
+  return {
+    version: 1,
+    positions,
+    viewport: { x: viewportX, y: viewportY, zoom },
+    layout: candidate.layout.slice(0, 64),
+    locked: candidate.locked === true,
+  };
+}
+
+export function readGraphPresentation(
+  storage: StorageAdapter | null | undefined,
+  key: string,
+): GraphPresentationState | null {
+  if (!storage) return null;
+  try {
+    const raw = storage.getItem(key);
+    if (!raw) return null;
+    return sanitizeState(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+export function writeGraphPresentation(
+  storage: StorageAdapter | null | undefined,
+  key: string,
+  state: GraphPresentationState,
+): void {
+  if (!storage) return;
+  const sanitized = sanitizeState(state);
+  if (!sanitized) return;
+  try {
+    storage.setItem(key, JSON.stringify(sanitized));
+  } catch {
+    // Storage can be unavailable in private browsing or quota-constrained clients.
+  }
+}
+
+export function removeGraphPresentation(
+  storage: StorageAdapter | null | undefined,
+  key: string,
+): void {
+  try {
+    storage?.removeItem(key);
+  } catch {
+    // Presentation persistence is optional and must never block graph review.
+  }
+}
+
+export function applyGraphPresentation<T extends Node>(
+  nodes: T[],
+  state: GraphPresentationState | null,
+): T[] {
+  if (!state) return nodes;
+  return nodes.map((node) => {
+    const position = state.positions[node.id];
+    return position ? { ...node, position } : node;
+  });
+}
+
+export function graphPositions(nodes: Node[]): Record<string, GraphPosition> {
+  return Object.fromEntries(
+    nodes
+      .filter((node) => finiteCoordinate(node.position.x) !== null && finiteCoordinate(node.position.y) !== null)
+      .map((node) => [node.id, { x: node.position.x, y: node.position.y }]),
+  );
+}
+
+export function selectGraphSubgraph<T extends Node, E extends Edge>(
+  nodes: T[],
+  edges: E[],
+  selectedIds: Set<string> | null | undefined,
+): { nodes: T[]; edges: E[] } {
+  if (!selectedIds || selectedIds.size === 0) return { nodes, edges };
+  return {
+    nodes: nodes.filter((node) => selectedIds.has(node.id)),
+    edges: edges.filter(
+      (edge) => selectedIds.has(edge.source) && selectedIds.has(edge.target),
+    ),
+  };
+}

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -7,7 +7,7 @@ import type {
   LineageNodeData,
   LineageNodeType,
 } from "@/components/lineage-nodes";
-import type { Edge } from "@xyflow/react";
+import type { Edge, Node } from "@xyflow/react";
 import {
   GRAPH_EDGE_KIND_META,
   GRAPH_NODE_KIND_META,
@@ -18,11 +18,9 @@ import type { GraphChangeKind, GraphDiffResponse } from "@/lib/api-types";
 
 // ─── Shared Styling Constants ────────────────────────────────────────────────
 
-export const CONTROLS_CLASS =
-  "!bg-[var(--surface)]/90 !border-[var(--border-subtle)] !rounded-lg !backdrop-blur-sm [&>button]:!bg-[var(--surface-elevated)] [&>button]:!border-[var(--border-subtle)] [&>button]:!text-[var(--text-secondary)] [&>button:hover]:!bg-[var(--surface-muted)]";
+export const CONTROLS_CLASS = "graph-flow-controls";
 
-export const MINIMAP_CLASS =
-  "!bg-[var(--surface)]/90 !border-[var(--border-subtle)] !rounded-lg !backdrop-blur-sm";
+export const MINIMAP_CLASS = "graph-flow-minimap";
 // React Flow forwards `bgColor` into an inline CSS custom property that its
 // stylesheet resolves with `var()`, so a token reference here follows the
 // light/dark toggle without any runtime JS (was a hardcoded near-black #09090b
@@ -380,12 +378,7 @@ export function relationshipEdgeLabelText(
   relationship: string,
   metadata?: Record<string, unknown>,
 ): string {
-  if (relationship === "shares_server") {
-    return `shared: ${(metadata?.server as string) ?? ""}`.trim();
-  }
-  if (relationship === "shares_credential" || relationship === "shares_cred") {
-    return `shared: ${(metadata?.credential as string) ?? ""}`.trim();
-  }
+  void metadata;
   return relationshipLegendItem(relationship).label;
 }
 
@@ -519,6 +512,17 @@ function edgeRelationship(edge: Edge): string {
   return typeof relationship === "string" ? relationship : "";
 }
 
+export function graphNodeDisplayLabels(
+  nodes: Array<Pick<Node, "id" | "data">>,
+): ReadonlyMap<string, string> {
+  return new Map(nodes.map((node) => {
+    const data = node.data as { label?: unknown; name?: unknown; title?: unknown };
+    const label = [data.label, data.name, data.title]
+      .find((value): value is string => typeof value === "string" && value.trim().length > 0);
+    return [node.id, label ?? "graph node"];
+  }));
+}
+
 export function readableGraphEdges(
   edges: Edge[],
   activeNodeIds?: Set<string> | null,
@@ -530,6 +534,8 @@ export function readableGraphEdges(
     quietAnimation?: boolean;
     captureMode?: boolean;
     zoom?: number;
+    nodeLabels?: ReadonlyMap<string, string>;
+    preserveVisualStyle?: boolean;
   } = {},
 ): Edge[] {
   const {
@@ -540,6 +546,8 @@ export function readableGraphEdges(
     quietAnimation = true,
     captureMode = false,
     zoom = 1,
+    nodeLabels,
+    preserveVisualStyle = false,
   } = options;
 
   return edges.map((edge): Edge => {
@@ -557,16 +565,20 @@ export function readableGraphEdges(
     const captureInactiveOpacity = captureMode
       ? Math.max(inactiveOpacity, 0.18)
       : inactiveOpacity;
-    const opacity = activeNodeIds
+    const computedOpacity = activeNodeIds
       ? active
         ? activeOpacity
         : captureInactiveOpacity
       : highSignal
         ? captureHighSignalOpacity
         : captureBaseOpacity;
+    const opacity = preserveVisualStyle && typeof edge.style?.opacity === "number"
+      ? edge.style.opacity
+      : computedOpacity;
     const width = numericStrokeWidth(edge);
+    const safeSharedLabel = relationship.startsWith("shares_") || relationship === "shares_cred";
     const label =
-      edge.label ??
+      (safeSharedLabel ? undefined : edge.label) ??
       (relationship && (active || highSignal)
         ? relationshipEdgeLabelText(relationship, edge.data as Record<string, unknown>)
         : undefined);
@@ -578,10 +590,12 @@ export function readableGraphEdges(
       ...edge,
       label,
       ariaLabel: relationship
-        ? `${relationshipEdgeLabelText(relationship)} relationship from ${edge.source} to ${edge.target}`
-        : `Relationship from ${edge.source} to ${edge.target}`,
+        ? `${relationshipEdgeLabelText(relationship)} relationship from ${nodeLabels?.get(edge.source) ?? "source node"} to ${nodeLabels?.get(edge.target) ?? "target node"}`
+        : `Relationship from ${nodeLabels?.get(edge.source) ?? "source node"} to ${nodeLabels?.get(edge.target) ?? "target node"}`,
       ...labelPresentation,
-      animated: captureMode
+      animated: preserveVisualStyle && !captureMode
+        ? Boolean(edge.animated)
+        : captureMode
         ? false
         : quietAnimation
           ? Boolean(activeNodeIds && active && edge.animated)
@@ -589,7 +603,9 @@ export function readableGraphEdges(
       style: {
         ...edge.style,
         opacity,
-        strokeWidth: active
+        strokeWidth: preserveVisualStyle
+          ? width
+          : active
           ? Math.max(width, captureMode ? 3 : 2.6)
           : captureMode
             ? Math.max(Math.min(width, highSignal ? 2.2 : 1.6), 1.25)

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -410,8 +410,8 @@ export function relationshipEdgeLabelPresentation(options?: {
     },
     labelStyle: {
       fill: "#f4f4f5",
-      fontSize: 11,
-      fontWeight: 600,
+      fontSize: 12,
+      fontWeight: 650,
     },
   };
 }
@@ -561,9 +561,22 @@ export function readableGraphEdges(
         ? captureHighSignalOpacity
         : captureBaseOpacity;
     const width = numericStrokeWidth(edge);
+    const label =
+      edge.label ??
+      (relationship && (active || highSignal)
+        ? relationshipEdgeLabelText(relationship, edge.data as Record<string, unknown>)
+        : undefined);
+    const labelPresentation = label
+      ? relationshipEdgeLabelPresentation({ captureMode })
+      : {};
 
     return {
       ...edge,
+      label,
+      ariaLabel: relationship
+        ? `${relationshipEdgeLabelText(relationship)} relationship from ${edge.source} to ${edge.target}`
+        : `Relationship from ${edge.source} to ${edge.target}`,
+      ...labelPresentation,
       animated: captureMode
         ? false
         : quietAnimation

--- a/ui/lib/graph-utils.ts
+++ b/ui/lib/graph-utils.ts
@@ -391,6 +391,7 @@ export function relationshipEdgeLabelText(
 
 export function relationshipEdgeLabelPresentation(options?: {
   captureMode?: boolean;
+  zoom?: number;
 }): Pick<
   import("@xyflow/react").Edge,
   | "labelShowBg"
@@ -400,6 +401,7 @@ export function relationshipEdgeLabelPresentation(options?: {
   | "labelStyle"
 > {
   const captureMode = options?.captureMode ?? false;
+  const zoom = Math.max(0.2, Math.min(options?.zoom ?? 1, 2.5));
   return {
     labelShowBg: true,
     labelBgPadding: [8, 4],
@@ -410,7 +412,7 @@ export function relationshipEdgeLabelPresentation(options?: {
     },
     labelStyle: {
       fill: "#f4f4f5",
-      fontSize: 12,
+      fontSize: Math.max(10, Math.min(24, 12 / zoom)),
       fontWeight: 650,
     },
   };
@@ -527,6 +529,7 @@ export function readableGraphEdges(
     activeOpacity?: number;
     quietAnimation?: boolean;
     captureMode?: boolean;
+    zoom?: number;
   } = {},
 ): Edge[] {
   const {
@@ -536,6 +539,7 @@ export function readableGraphEdges(
     activeOpacity = 0.96,
     quietAnimation = true,
     captureMode = false,
+    zoom = 1,
   } = options;
 
   return edges.map((edge): Edge => {
@@ -567,7 +571,7 @@ export function readableGraphEdges(
         ? relationshipEdgeLabelText(relationship, edge.data as Record<string, unknown>)
         : undefined);
     const labelPresentation = label
-      ? relationshipEdgeLabelPresentation({ captureMode })
+      ? relationshipEdgeLabelPresentation({ captureMode, zoom })
       : {};
 
     return {

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -1,6 +1,6 @@
 import { defineConfig, devices } from "@playwright/test";
 
-const PORT = 3001;
+const PORT = Number(process.env.PLAYWRIGHT_PORT ?? "3001");
 const baseURL = `http://127.0.0.1:${PORT}`;
 const serverCommand =
   `if test -f .next/standalone/server.js; ` +

--- a/ui/tests/graph-chrome.test.tsx
+++ b/ui/tests/graph-chrome.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { FullscreenButton, GraphEvidenceExportButton, GraphLegend, GraphLegendDock } from "@/components/graph-chrome";
+import { FullscreenButton, GraphEvidenceExportButton, GraphInteractionToolbar, GraphLegend, GraphLegendDock } from "@/components/graph-chrome";
 import { api } from "@/lib/api";
 
 afterEach(() => {
@@ -89,6 +89,31 @@ describe("FullscreenButton", () => {
     render(<FullscreenButton />);
 
     expect(screen.getByRole("button", { name: /enter fullscreen/i })).toBeInTheDocument();
+  });
+});
+
+describe("GraphInteractionToolbar", () => {
+  it("exposes compact fit, reset, auto-layout, and edit-lock controls", () => {
+    const actions = {
+      onFitVisible: vi.fn(),
+      onFitSelection: vi.fn(),
+      onReset: vi.fn(),
+      onAutoLayout: vi.fn(),
+      onToggleEditing: vi.fn(),
+    };
+    render(<GraphInteractionToolbar editing={false} hasSelection {...actions} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /fit visible/i }));
+    fireEvent.click(screen.getByRole("button", { name: /fit selection/i }));
+    fireEvent.click(screen.getByRole("button", { name: /auto-layout/i }));
+    fireEvent.click(screen.getByRole("button", { name: /reset layout/i }));
+    fireEvent.click(screen.getByRole("button", { name: /edit layout/i }));
+
+    expect(actions.onFitVisible).toHaveBeenCalledOnce();
+    expect(actions.onFitSelection).toHaveBeenCalledOnce();
+    expect(actions.onAutoLayout).toHaveBeenCalledOnce();
+    expect(actions.onReset).toHaveBeenCalledOnce();
+    expect(actions.onToggleEditing).toHaveBeenCalledOnce();
   });
 });
 

--- a/ui/tests/graph-chrome.test.tsx
+++ b/ui/tests/graph-chrome.test.tsx
@@ -103,6 +103,8 @@ describe("GraphInteractionToolbar", () => {
     };
     render(<GraphInteractionToolbar editing={false} hasSelection {...actions} />);
 
+    expect(screen.getByRole("toolbar", { name: /graph layout controls/i })).toBeInTheDocument();
+
     fireEvent.click(screen.getByRole("button", { name: /fit visible/i }));
     fireEvent.click(screen.getByRole("button", { name: /fit selection/i }));
     fireEvent.click(screen.getByRole("button", { name: /auto-layout/i }));

--- a/ui/tests/graph-evidence-summary.test.tsx
+++ b/ui/tests/graph-evidence-summary.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GraphEvidenceSummary } from "@/components/graph-evidence-summary";
+
+describe("GraphEvidenceSummary", () => {
+  it("shows factual snapshot completeness, freshness, and provenance without a quality score", () => {
+    render(
+      <GraphEvidenceSummary
+        capturedAt="2026-07-24T20:00:00Z"
+        returnedNodes={93}
+        totalNodes={112}
+        evidencedEdges={7}
+        totalEdges={142}
+        completeness="truncated"
+      />,
+    );
+
+    expect(screen.getByText(/93 of 112 nodes/i)).toBeInTheDocument();
+    expect(screen.getByText(/7 of 142 relationships/i)).toBeInTheDocument();
+    expect(screen.getByText(/Captured/i)).toBeInTheDocument();
+    expect(screen.queryByText(/quality|score|usable/i)).not.toBeInTheDocument();
+  });
+
+  it("renders unavailable instead of fabricating zero when provenance is not reported", () => {
+    render(
+      <GraphEvidenceSummary
+        capturedAt={null}
+        returnedNodes={3}
+        totalNodes={3}
+        evidencedEdges={null}
+        totalEdges={null}
+        completeness="complete"
+      />,
+    );
+
+    expect(screen.getAllByText("Unavailable").length).toBeGreaterThanOrEqual(2);
+  });
+});

--- a/ui/tests/graph-presentation.test.ts
+++ b/ui/tests/graph-presentation.test.ts
@@ -3,8 +3,14 @@ import type { Edge, Node } from "@xyflow/react";
 
 import {
   applyGraphPresentation,
+  graphNodeSetKey,
+  graphNodeStorageKey,
+  graphPositions,
   graphPresentationStorageKey,
+  graphTopologyKey,
+  purgeGraphPresentationsForOwner,
   readGraphPresentation,
+  registerGraphPresentationKey,
   selectGraphSubgraph,
   writeGraphPresentation,
   type GraphPresentationState,
@@ -45,7 +51,7 @@ describe("graph presentation state", () => {
     };
     const state: GraphPresentationState = {
       version: 1,
-      positions: { a: { x: 42, y: 84 } },
+      positions: { [graphNodeStorageKey("resource-private")]: { x: 42, y: 84 } },
       viewport: { x: 1, y: 2, zoom: 1.4 },
       layout: "topology",
       locked: true,
@@ -54,13 +60,17 @@ describe("graph presentation state", () => {
     writeGraphPresentation(adapter, "key", state);
 
     expect(readGraphPresentation(adapter, "key")).toEqual(state);
+    expect(storage.get("key")).not.toContain("resource-private");
     expect(storage.get("key")).not.toContain("data");
   });
 
   it("applies saved positions without changing node data or graph relationships", () => {
     const presented = applyGraphPresentation(nodes, {
       version: 1,
-      positions: { a: { x: 44, y: 55 }, missing: { x: 1, y: 2 } },
+      positions: {
+        [graphNodeStorageKey("a")]: { x: 44, y: 55 },
+        [graphNodeStorageKey("missing")]: { x: 1, y: 2 },
+      },
       viewport: { x: 0, y: 0, zoom: 1 },
       layout: "topology",
       locked: false,
@@ -72,6 +82,42 @@ describe("graph presentation state", () => {
       { id: "a-b", source: "a", target: "b" },
       { id: "b-c", source: "b", target: "c" },
     ]);
+  });
+
+  it("stores only opaque node keys and invalidates the scope when the node set changes", () => {
+    const positions = graphPositions([
+      { id: "arn:private:resource", position: { x: 4, y: 8 }, data: { label: "Private resource" } },
+    ]);
+    expect(JSON.stringify(positions)).not.toContain("arn:private:resource");
+    expect(JSON.stringify(positions)).not.toContain("Private resource");
+    expect(Object.keys(positions)[0]).toMatch(/^n:[a-f0-9]{16}$/);
+    expect(graphNodeSetKey(nodes)).not.toBe(graphNodeSetKey(nodes.slice(0, 2)));
+    expect(graphTopologyKey(nodes, edges)).not.toBe(
+      graphTopologyKey(nodes, [{ ...edges[0]!, data: { relationship: "changed" } }, edges[1]!]),
+    );
+  });
+
+  it("tracks and purges every opaque layout key for an owner without storing owner identifiers", () => {
+    const storage = new Map<string, string>();
+    const adapter = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => { storage.set(key, value); },
+      removeItem: (key: string) => { storage.delete(key); },
+    };
+    const owner = { tenantId: "tenant-private", subject: "person@example.test" };
+    const first = graphPresentationStorageKey({ ...owner, snapshotId: "one", lens: "mesh", scope: "full" });
+    const second = graphPresentationStorageKey({ ...owner, snapshotId: "two", lens: "mesh", scope: "full" });
+    registerGraphPresentationKey(adapter, owner, first);
+    registerGraphPresentationKey(adapter, owner, second);
+    adapter.setItem(first, "layout-one");
+    adapter.setItem(second, "layout-two");
+
+    expect(JSON.stringify([...storage])).not.toContain(owner.tenantId);
+    expect(JSON.stringify([...storage])).not.toContain(owner.subject);
+    purgeGraphPresentationsForOwner(adapter, owner.tenantId, owner.subject);
+    expect(storage.has(first)).toBe(false);
+    expect(storage.has(second)).toBe(false);
+    expect(storage.size).toBe(0);
   });
 
   it("selects a focused subgraph before layout and removes unrelated whitespace", () => {

--- a/ui/tests/graph-presentation.test.ts
+++ b/ui/tests/graph-presentation.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+
+import {
+  applyGraphPresentation,
+  graphPresentationStorageKey,
+  readGraphPresentation,
+  selectGraphSubgraph,
+  writeGraphPresentation,
+  type GraphPresentationState,
+} from "@/lib/graph-presentation";
+
+const nodes: Node[] = [
+  { id: "a", position: { x: 0, y: 0 }, data: {} },
+  { id: "b", position: { x: 100, y: 0 }, data: {} },
+  { id: "c", position: { x: 900, y: 500 }, data: {} },
+];
+const edges: Edge[] = [
+  { id: "a-b", source: "a", target: "b" },
+  { id: "b-c", source: "b", target: "c" },
+];
+
+describe("graph presentation state", () => {
+  it("scopes browser-local state without exposing tenant, subject, or snapshot identifiers", () => {
+    const key = graphPresentationStorageKey({
+      tenantId: "tenant-private",
+      subject: "person@example.test",
+      snapshotId: "scan-private",
+      lens: "mesh",
+      scope: "account",
+    });
+
+    expect(key).toMatch(/^agent-bom:graph-presentation:v1:[a-f0-9]{16}$/);
+    expect(key).not.toContain("tenant-private");
+    expect(key).not.toContain("person@example.test");
+    expect(key).not.toContain("scan-private");
+  });
+
+  it("round-trips only finite node positions, viewport, layout, and lock state", () => {
+    const storage = new Map<string, string>();
+    const adapter = {
+      getItem: (key: string) => storage.get(key) ?? null,
+      setItem: (key: string, value: string) => storage.set(key, value),
+      removeItem: (key: string) => storage.delete(key),
+    };
+    const state: GraphPresentationState = {
+      version: 1,
+      positions: { a: { x: 42, y: 84 } },
+      viewport: { x: 1, y: 2, zoom: 1.4 },
+      layout: "topology",
+      locked: true,
+    };
+
+    writeGraphPresentation(adapter, "key", state);
+
+    expect(readGraphPresentation(adapter, "key")).toEqual(state);
+    expect(storage.get("key")).not.toContain("data");
+  });
+
+  it("applies saved positions without changing node data or graph relationships", () => {
+    const presented = applyGraphPresentation(nodes, {
+      version: 1,
+      positions: { a: { x: 44, y: 55 }, missing: { x: 1, y: 2 } },
+      viewport: { x: 0, y: 0, zoom: 1 },
+      layout: "topology",
+      locked: false,
+    });
+
+    expect(presented.find((node) => node.id === "a")?.position).toEqual({ x: 44, y: 55 });
+    expect(presented.find((node) => node.id === "b")?.position).toEqual({ x: 100, y: 0 });
+    expect(edges).toEqual([
+      { id: "a-b", source: "a", target: "b" },
+      { id: "b-c", source: "b", target: "c" },
+    ]);
+  });
+
+  it("selects a focused subgraph before layout and removes unrelated whitespace", () => {
+    const focused = selectGraphSubgraph(nodes, edges, new Set(["a", "b"]));
+
+    expect(focused.nodes.map((node) => node.id)).toEqual(["a", "b"]);
+    expect(focused.edges.map((edge) => edge.id)).toEqual(["a-b"]);
+  });
+});

--- a/ui/tests/graph-reactflow-surface-contract.test.ts
+++ b/ui/tests/graph-reactflow-surface-contract.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const source = (path: string) => readFileSync(join(process.cwd(), path), "utf8");
+
+describe("interactive React Flow surface contract", () => {
+  it.each([
+    "app/graph/graph-page-client.tsx",
+    "app/mesh/page.tsx",
+    "app/context/page.tsx",
+    "components/scan-mesh.tsx",
+    "components/attack-flow.tsx",
+    "components/security-graph-investigation.tsx",
+    "app/agents/page.tsx",
+  ])("keeps evidence topology immutable in %s", (path) => {
+    expect(source(path)).toContain("deleteKeyCode={null}");
+  });
+
+  it.each([
+    "app/context/page.tsx",
+    "components/scan-mesh.tsx",
+    "components/attack-flow.tsx",
+    "app/agents/page.tsx",
+  ])("persists personal node positions and viewport in %s", (path) => {
+    const content = source(path);
+    expect(content).toContain("useGraphPresentation");
+    expect(content).toContain("defaultViewport={presentation.viewport}");
+    expect(content).toContain("nodesDraggable=");
+    expect(content).toContain("presentation.editing");
+    expect(content).toContain("onNodesChange={presentation.onNodesChange}");
+    expect(content).toContain("onMoveEnd={presentation.onMoveEnd}");
+  });
+
+  it("keeps the investigation legend interactive", () => {
+    expect(source("components/security-graph-investigation.tsx")).toContain(
+      'className="pointer-events-auto absolute left-3 top-3',
+    );
+  });
+});

--- a/ui/tests/graph-reactflow-surface-contract.test.ts
+++ b/ui/tests/graph-reactflow-surface-contract.test.ts
@@ -37,4 +37,42 @@ describe("interactive React Flow surface contract", () => {
       'className="pointer-events-auto absolute left-3 top-3',
     );
   });
+
+  it.each([
+    "components/agent-topology.tsx",
+    "components/scan-pipeline.tsx",
+  ])("normalizes edge labels and accessibility text in %s", (path) => {
+    const content = source(path);
+    expect(content).toContain("readableGraphEdges");
+    expect(content).toContain("graphNodeDisplayLabels");
+    expect(content).toContain("preserveVisualStyle: true");
+  });
+
+  it.each([
+    "app/graph/graph-page-client.tsx",
+    "app/mesh/page.tsx",
+    "app/context/page.tsx",
+    "components/scan-mesh.tsx",
+    "components/attack-flow.tsx",
+    "app/agents/page.tsx",
+  ])("does not treat transient auth loading as logout in %s", (path) => {
+    const content = source(path);
+    expect(content).toContain("ownerActive: Boolean(session)");
+    expect(content).not.toContain("ownerActive: !authLoading");
+  });
+
+  it("passes a stable owner signal through the investigation flow", () => {
+    const content = source("components/security-graph-investigation.tsx");
+    expect(content).toContain("ownerActive={Boolean(session)}");
+    expect(content).toContain("ownerActive,");
+    expect(content).toContain('localMode={session?.recommended_ui_mode === "no_auth"}');
+  });
+
+  it.each([
+    "app/graph/graph-page-client.tsx",
+    "app/mesh/page.tsx",
+    "app/context/page.tsx",
+  ])("enables persistence only for an explicit no-auth local session in %s", (path) => {
+    expect(source(path)).toContain('localMode: session?.recommended_ui_mode === "no_auth"');
+  });
 });

--- a/ui/tests/graph-utils.test.ts
+++ b/ui/tests/graph-utils.test.ts
@@ -7,9 +7,16 @@ import {
   legendItemsForVisibleGraph,
   minimapNodeColor,
   NODE_COLOR_MAP,
+  relationshipEdgeLabelPresentation,
   relationshipLegendItem,
   readableGraphEdges,
 } from "@/lib/graph-utils";
+
+it("keeps relationship labels screen-readable across zoom levels", () => {
+  const distant = relationshipEdgeLabelPresentation({ zoom: 0.4 });
+  const close = relationshipEdgeLabelPresentation({ zoom: 1.6 });
+  expect(Number(distant.labelStyle?.fontSize)).toBeGreaterThan(Number(close.labelStyle?.fontSize));
+});
 
 describe("graph utility metadata", () => {
   it("uses generated schema metadata for production node legends", () => {

--- a/ui/tests/graph-utils.test.ts
+++ b/ui/tests/graph-utils.test.ts
@@ -101,6 +101,9 @@ describe("graph utility metadata", () => {
     expect(focused[0]!.style?.opacity).toBeLessThan(0.1);
     expect(focused[1]!.style?.opacity).toBeGreaterThan(0.9);
     expect(focused[1]!.style?.strokeWidth).toBeGreaterThanOrEqual(2.6);
+    expect(focused[1]!.label).toBe("Has CVE");
+    expect(focused[1]!.labelStyle).toMatchObject({ fontSize: 12 });
+    expect(focused[1]!.ariaLabel).toMatch(/relationship from b to c/i);
   });
 
   it("uses a stable non-animated edge profile for capture mode", () => {

--- a/ui/tests/graph-utils.test.ts
+++ b/ui/tests/graph-utils.test.ts
@@ -104,13 +104,46 @@ describe("graph utility metadata", () => {
     expect(edges[0]!.style?.opacity).toBeLessThan(edges[1]!.style?.opacity as number);
     expect(edges[0]!.style?.strokeWidth).toBeLessThanOrEqual(1.5);
 
-    const focused = readableGraphEdges(edges, new Set(["b", "c"]));
+    const focused = readableGraphEdges(edges, new Set(["b", "c"]), {
+      nodeLabels: new Map([["b", "Package"], ["c", "CVE-2026-0001"]]),
+    });
     expect(focused[0]!.style?.opacity).toBeLessThan(0.1);
     expect(focused[1]!.style?.opacity).toBeGreaterThan(0.9);
     expect(focused[1]!.style?.strokeWidth).toBeGreaterThanOrEqual(2.6);
     expect(focused[1]!.label).toBe("Has CVE");
     expect(focused[1]!.labelStyle).toMatchObject({ fontSize: 12 });
-    expect(focused[1]!.ariaLabel).toMatch(/relationship from b to c/i);
+    expect(focused[1]!.ariaLabel).toMatch(/relationship from Package to CVE-2026-0001/i);
+    expect(focused[1]!.ariaLabel).not.toMatch(/\bb\b|\bc\b/);
+  });
+
+  it("never exposes shared resource identifiers in labels or edge accessibility text", () => {
+    const [edge] = readableGraphEdges(
+      [{
+        id: "private-source/private-target",
+        source: "private-source",
+        target: "private-target",
+        data: { relationship: "shares_server", server: "arn:aws:private:server" },
+      }],
+      new Set(["private-source", "private-target"]),
+      { nodeLabels: new Map([["private-source", "Agent"], ["private-target", "Server"]]) },
+    );
+
+    expect(edge?.label).toBe("Shares Server");
+    expect(edge?.ariaLabel).toBe("Shares Server relationship from Agent to Server");
+    expect(String(edge?.label)).not.toContain("arn:aws:private:server");
+    expect(edge?.ariaLabel).not.toContain("arn:aws:private:server");
+    expect(edge?.ariaLabel).not.toContain("private-");
+  });
+
+  it("uses generic ARIA endpoints when display labels are unavailable", () => {
+    const [edge] = readableGraphEdges([{
+      id: "edge-private",
+      source: "arn:aws:private:source",
+      target: "arn:aws:private:target",
+      data: { relationship: "uses" },
+    }]);
+    expect(edge?.ariaLabel).toBe("Uses relationship from source node to target node");
+    expect(edge?.ariaLabel).not.toContain("arn:aws");
   });
 
   it("uses a stable non-animated edge profile for capture mode", () => {

--- a/ui/tests/lineage-filter.test.tsx
+++ b/ui/tests/lineage-filter.test.tsx
@@ -5,8 +5,11 @@ import {
   DEFAULT_FILTERS,
   FilterPanel,
   createAssetLifecycleDriftGraphFilters,
+  createCloudEstateGraphFilters,
+  createEnvironmentGraphFilters,
   createExpandedGraphFilters,
   createImmediateGraphFilters,
+  createRepositoryGraphFilters,
   graphScopeLabelForFilters,
   graphScopePresetForFilters,
   type FilterState,
@@ -26,6 +29,28 @@ describe("FilterPanel", () => {
     expect(DEFAULT_FILTERS.severity).toBeNull();
     expect(graphScopePresetForFilters(DEFAULT_FILTERS)).toBe("relevant");
     expect(graphScopeLabelForFilters(DEFAULT_FILTERS)).toBe("Relevant paths");
+  });
+
+  it("offers observed-data scopes for cloud estates, repositories, and environments", () => {
+    const cloud = createCloudEstateGraphFilters();
+    const repository = createRepositoryGraphFilters();
+    const environment = createEnvironmentGraphFilters();
+
+    expect(cloud.layers.account).toBe(true);
+    expect(cloud.layers.cloudResource).toBe(true);
+    expect(cloud.layers.sourceFile).toBe(false);
+    expect(graphScopePresetForFilters(cloud)).toBe("cloudEstate");
+
+    expect(repository.layers.directory).toBe(true);
+    expect(repository.layers.sourceFile).toBe(true);
+    expect(repository.layers.package).toBe(true);
+    expect(repository.layers.account).toBe(false);
+    expect(graphScopePresetForFilters(repository)).toBe("repository");
+
+    expect(environment.layers.environment).toBe(true);
+    expect(environment.layers.agent).toBe(true);
+    expect(environment.layers.server).toBe(true);
+    expect(graphScopePresetForFilters(environment)).toBe("environment");
   });
 
   it("names graph scope presets by operator workflow instead of raw depth", () => {

--- a/ui/tests/lineage-filter.test.tsx
+++ b/ui/tests/lineage-filter.test.tsx
@@ -10,6 +10,7 @@ import {
   createExpandedGraphFilters,
   createImmediateGraphFilters,
   createRepositoryGraphFilters,
+  GRAPH_SCOPE_DESCRIPTIONS,
   graphScopeLabelForFilters,
   graphScopePresetForFilters,
   type FilterState,
@@ -31,7 +32,7 @@ describe("FilterPanel", () => {
     expect(graphScopeLabelForFilters(DEFAULT_FILTERS)).toBe("Relevant paths");
   });
 
-  it("offers observed-data scopes for cloud estates, repositories, and environments", () => {
+  it("offers factual type-based scopes without claiming collection provenance", () => {
     const cloud = createCloudEstateGraphFilters();
     const repository = createRepositoryGraphFilters();
     const environment = createEnvironmentGraphFilters();
@@ -51,6 +52,10 @@ describe("FilterPanel", () => {
     expect(environment.layers.agent).toBe(true);
     expect(environment.layers.server).toBe(true);
     expect(graphScopePresetForFilters(environment)).toBe("environment");
+    for (const preset of ["cloudEstate", "repository", "environment"] as const) {
+      expect(GRAPH_SCOPE_DESCRIPTIONS[preset]).toMatch(/^Type-based view/);
+      expect(GRAPH_SCOPE_DESCRIPTIONS[preset]).not.toMatch(/observed/i);
+    }
   });
 
   it("names graph scope presets by operator workflow instead of raw depth", () => {

--- a/ui/tests/risk-campaign-command-center.test.tsx
+++ b/ui/tests/risk-campaign-command-center.test.tsx
@@ -152,6 +152,16 @@ describe("RiskCampaignCommandCenter", () => {
     expect(screen.queryByText(/all clear/i)).not.toBeInTheDocument();
   });
 
+  it("keeps the empty re-verification queue in a compact collapsed summary", async () => {
+    render(<RiskCampaignCommandCenter />);
+
+    await screen.findByText(response.campaigns[0]!.title);
+    const summary = screen.getByText(/Awaiting re-verification/i).closest("summary");
+    expect(summary).not.toBeNull();
+    expect(summary?.parentElement).not.toHaveAttribute("open");
+    expect(screen.getByText(/0 waiting/i)).toBeInTheDocument();
+  });
+
   it("pauses workflow and ticket actions for provisional membership", async () => {
     vi.mocked(api.listRiskCampaigns).mockResolvedValue({
       ...response,

--- a/ui/tests/scan-mesh-interactions.test.tsx
+++ b/ui/tests/scan-mesh-interactions.test.tsx
@@ -1,0 +1,91 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { useLayoutEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  autoLayout: vi.fn(),
+  fitView: vi.fn(),
+  reset: vi.fn(),
+}));
+
+vi.mock("@xyflow/react", () => ({
+  Background: () => null,
+  Controls: () => null,
+  MiniMap: () => null,
+  ReactFlow: ({ onInit }: { onInit?: (instance: unknown) => void }) => {
+    useLayoutEffect(() => {
+      onInit?.({ fitView: mocks.fitView, getNode: vi.fn() });
+    }, [onInit]);
+    return <div data-testid="react-flow" />;
+  },
+}));
+vi.mock("@/lib/use-graph-layout", () => ({
+  useGraphLayout: (_layout: string, nodes: unknown[], edges: unknown[]) => ({ nodes, edges }),
+}));
+vi.mock("@/lib/api", () => ({
+  api: { getScan: vi.fn().mockResolvedValue({ job_id: "scan-1", result: {}, created_at: "2026-07-25T00:00:00Z" }) },
+}));
+vi.mock("@/lib/mesh-graph", () => ({
+  buildMeshGraph: () => ({
+    nodes: [{ id: "agent", position: { x: 0, y: 0 }, data: { label: "Agent", nodeType: "agent" } }],
+    edges: [],
+    stats: {},
+  }),
+  getConnectedIds: () => null,
+}));
+vi.mock("@/hooks/use-graph-presentation", () => ({
+  useGraphPresentation: ({ nodes }: { nodes: unknown[] }) => ({
+    storageKey: "opaque",
+    enabled: true,
+    nodes,
+    editing: false,
+    hasSavedState: false,
+    viewport: { x: 0, y: 0, zoom: 1 },
+    autoLayout: mocks.autoLayout,
+    reset: mocks.reset,
+    toggleEditing: vi.fn(),
+    onNodesChange: vi.fn(),
+    onNodeDragStop: vi.fn(),
+    onMoveEnd: vi.fn(),
+  }),
+}));
+vi.mock("@/components/auth-provider", () => ({
+  useAuthState: () => ({
+    session: { tenant_id: "local", subject: null, auth_method: null, recommended_ui_mode: "no_auth" },
+    loading: false,
+  }),
+}));
+vi.mock("@/components/graph-chrome", () => ({
+  GraphLegend: () => null,
+  GraphInteractionToolbar: ({ onAutoLayout, onReset }: { onAutoLayout: () => void; onReset: () => void }) => (
+    <div>
+      <button onClick={onAutoLayout}>Auto layout</button>
+      <button onClick={onReset}>Reset layout</button>
+    </div>
+  ),
+}));
+vi.mock("@/components/mesh-stats", () => ({ MeshStats: () => null }));
+vi.mock("@/components/graph-entity-drawer", () => ({ GraphEntityDrawer: () => null }));
+
+import { ScanMeshView } from "@/components/scan-mesh";
+
+describe("ScanMesh presentation controls", () => {
+  beforeEach(() => {
+    mocks.autoLayout.mockClear();
+    mocks.fitView.mockClear();
+    mocks.reset.mockClear();
+  });
+
+  it("refits visible nodes after auto-layout and reset", async () => {
+    render(<ScanMeshView id="scan-1" />);
+    await waitFor(() => expect(screen.getByTestId("react-flow")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "Auto layout" }));
+    expect(mocks.autoLayout).toHaveBeenCalledOnce();
+    await waitFor(() => expect(mocks.fitView).toHaveBeenCalledOnce());
+
+    fireEvent.click(screen.getByRole("button", { name: "Reset layout" }));
+    expect(mocks.reset).toHaveBeenCalledOnce();
+    await waitFor(() => expect(mocks.fitView).toHaveBeenCalledTimes(2));
+  });
+});

--- a/ui/tests/use-graph-presentation.test.tsx
+++ b/ui/tests/use-graph-presentation.test.tsx
@@ -1,0 +1,83 @@
+import { act, renderHook } from "@testing-library/react";
+import type { Node } from "@xyflow/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { useGraphPresentation } from "@/hooks/use-graph-presentation";
+import {
+  graphPresentationStorageKey,
+  readGraphPresentation,
+  writeGraphPresentation,
+  type GraphPresentationScope,
+} from "@/lib/graph-presentation";
+
+const scope: GraphPresentationScope = {
+  tenantId: "tenant-test",
+  subject: "viewer-test",
+  snapshotId: "snapshot-test",
+  lens: "lineage",
+  scope: "repository",
+};
+
+const nodes: Node[] = [
+  { id: "package:a", position: { x: 0, y: 0 }, data: { label: "Package A" } },
+];
+
+describe("useGraphPresentation", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("restores a compatible personal viewport and node layout", () => {
+    writeGraphPresentation(
+      window.localStorage,
+      graphPresentationStorageKey(scope),
+      {
+        version: 1,
+        positions: { "package:a": { x: 120, y: 240 } },
+        viewport: { x: -20, y: 15, zoom: 1.4 },
+        layout: "dagre-lr",
+        locked: true,
+      },
+    );
+
+    const { result } = renderHook(() =>
+      useGraphPresentation({ nodes, scope, layout: "dagre-lr" }),
+    );
+
+    expect(result.current.hasSavedState).toBe(true);
+    expect(result.current.viewport).toEqual({ x: -20, y: 15, zoom: 1.4 });
+    expect(result.current.nodes[0]?.position).toEqual({ x: 120, y: 240 });
+    expect(result.current.nodes[0]?.ariaLabel).toBe("Package A");
+  });
+
+  it("blocks position changes while locked and persists them in edit mode", () => {
+    const { result } = renderHook(() =>
+      useGraphPresentation({ nodes, scope, layout: "dagre-lr" }),
+    );
+
+    act(() => {
+      result.current.onNodesChange([
+        { id: "package:a", type: "position", position: { x: 50, y: 80 } },
+      ]);
+    });
+    expect(result.current.nodes[0]?.position).toEqual({ x: 0, y: 0 });
+
+    act(() => result.current.toggleEditing());
+    act(() => {
+      result.current.onNodesChange([
+        { id: "package:a", type: "position", position: { x: 50, y: 80 } },
+      ]);
+      result.current.onNodeDragStop(
+        {} as never,
+        { ...result.current.nodes[0]!, position: { x: 50, y: 80 } },
+        [],
+      );
+    });
+
+    expect(result.current.nodes[0]?.position).toEqual({ x: 50, y: 80 });
+    expect(
+      readGraphPresentation(window.localStorage, graphPresentationStorageKey(scope)),
+    ).toMatchObject({
+      positions: { "package:a": { x: 50, y: 80 } },
+      locked: false,
+    });
+  });
+});

--- a/ui/tests/use-graph-presentation.test.tsx
+++ b/ui/tests/use-graph-presentation.test.tsx
@@ -80,4 +80,12 @@ describe("useGraphPresentation", () => {
       locked: false,
     });
   });
+
+  it("never removes evidence nodes from presentation state", () => {
+    const { result } = renderHook(() =>
+      useGraphPresentation({ nodes, scope, layout: "dagre-lr" }),
+    );
+    act(() => result.current.onNodesChange([{ id: "package:a", type: "remove" }]));
+    expect(result.current.nodes.map((node) => node.id)).toEqual(["package:a"]);
+  });
 });

--- a/ui/tests/use-graph-presentation.test.tsx
+++ b/ui/tests/use-graph-presentation.test.tsx
@@ -1,10 +1,11 @@
 import { act, renderHook } from "@testing-library/react";
 import type { Node } from "@xyflow/react";
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { useGraphPresentation } from "@/hooks/use-graph-presentation";
 import {
   graphPresentationStorageKey,
+  graphNodeStorageKey,
   readGraphPresentation,
   writeGraphPresentation,
   type GraphPresentationScope,
@@ -23,7 +24,20 @@ const nodes: Node[] = [
 ];
 
 describe("useGraphPresentation", () => {
-  beforeEach(() => window.localStorage.clear());
+  beforeEach(() => {
+    const values = new Map<string, string>();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        get length() { return values.size; },
+        clear: () => values.clear(),
+        getItem: (key: string) => values.get(key) ?? null,
+        key: (index: number) => [...values.keys()][index] ?? null,
+        removeItem: (key: string) => { values.delete(key); },
+        setItem: (key: string, value: string) => { values.set(key, value); },
+      } satisfies Storage,
+    });
+  });
 
   it("restores a compatible personal viewport and node layout", () => {
     writeGraphPresentation(
@@ -31,7 +45,7 @@ describe("useGraphPresentation", () => {
       graphPresentationStorageKey(scope),
       {
         version: 1,
-        positions: { "package:a": { x: 120, y: 240 } },
+        positions: { [graphNodeStorageKey("package:a")]: { x: 120, y: 240 } },
         viewport: { x: -20, y: 15, zoom: 1.4 },
         layout: "dagre-lr",
         locked: true,
@@ -46,6 +60,15 @@ describe("useGraphPresentation", () => {
     expect(result.current.viewport).toEqual({ x: -20, y: 15, zoom: 1.4 });
     expect(result.current.nodes[0]?.position).toEqual({ x: 120, y: 240 });
     expect(result.current.nodes[0]?.ariaLabel).toBe("Package A");
+  });
+
+  it("uses a generic accessibility fallback instead of a raw node identifier", () => {
+    const privateNodes: Node[] = [{ id: "arn:aws:private:resource", position: { x: 0, y: 0 }, data: {} }];
+    const { result } = renderHook(() =>
+      useGraphPresentation({ nodes: privateNodes, scope, layout: "dagre-lr" }),
+    );
+    expect(result.current.nodes[0]?.ariaLabel).toBe("Graph node");
+    expect(result.current.nodes[0]?.ariaLabel).not.toContain("arn:aws");
   });
 
   it("blocks position changes while locked and persists them in edit mode", () => {
@@ -76,7 +99,7 @@ describe("useGraphPresentation", () => {
     expect(
       readGraphPresentation(window.localStorage, graphPresentationStorageKey(scope)),
     ).toMatchObject({
-      positions: { "package:a": { x: 50, y: 80 } },
+      positions: { [graphNodeStorageKey("package:a")]: { x: 50, y: 80 } },
       locked: false,
     });
   });
@@ -87,5 +110,82 @@ describe("useGraphPresentation", () => {
     );
     act(() => result.current.onNodesChange([{ id: "package:a", type: "remove" }]));
     expect(result.current.nodes.map((node) => node.id)).toEqual(["package:a"]);
+  });
+
+  it("performs no storage mutations while persistence starts disabled", () => {
+    const setItem = vi.spyOn(window.localStorage, "setItem");
+    const removeItem = vi.spyOn(window.localStorage, "removeItem");
+    const { result } = renderHook(() =>
+      useGraphPresentation({ nodes, scope, layout: "dagre-lr", enabled: false }),
+    );
+    act(() => {
+      result.current.toggleEditing();
+      result.current.autoLayout();
+      result.current.reset();
+      result.current.onMoveEnd(null, { x: 1, y: 2, zoom: 1.2 });
+    });
+    expect(setItem).not.toHaveBeenCalled();
+    expect(removeItem).not.toHaveBeenCalled();
+    setItem.mockRestore();
+    removeItem.mockRestore();
+  });
+
+  it("does not persist unresolved auth placeholders unless the caller declares local mode", () => {
+    const localScope = { ...scope, tenantId: "local", subject: "local-viewer" };
+    const setItem = vi.spyOn(window.localStorage, "setItem");
+    const { result, rerender } = renderHook(
+      ({ localMode }) => useGraphPresentation({
+        nodes,
+        scope: localScope,
+        layout: "dagre-lr",
+        localMode,
+      }),
+      { initialProps: { localMode: false } },
+    );
+
+    act(() => result.current.toggleEditing());
+    expect(result.current.enabled).toBe(false);
+    expect(setItem).not.toHaveBeenCalled();
+
+    rerender({ localMode: true });
+    act(() => result.current.toggleEditing());
+    expect(result.current.enabled).toBe(true);
+    expect(setItem).toHaveBeenCalledTimes(2);
+    setItem.mockRestore();
+  });
+
+  it("preserves layouts during auth refresh, then purges them on logout and identity change", () => {
+    const { result, rerender } = renderHook(
+      ({ activeScope, enabled, ownerActive }) => useGraphPresentation({ nodes, scope: activeScope, layout: "dagre-lr", enabled, ownerActive }),
+      { initialProps: { activeScope: scope, enabled: true, ownerActive: true } },
+    );
+    act(() => result.current.toggleEditing());
+    const secondScope = { ...scope, snapshotId: "snapshot-two" };
+    rerender({ activeScope: secondScope, enabled: true, ownerActive: true });
+    act(() => result.current.toggleEditing());
+    expect(window.localStorage.getItem(graphPresentationStorageKey(scope))).not.toBeNull();
+    expect(window.localStorage.getItem(graphPresentationStorageKey(secondScope))).not.toBeNull();
+
+    // Auth refresh temporarily disables persistence while the same session is
+    // still present. This must not be interpreted as logout.
+    rerender({ activeScope: secondScope, enabled: false, ownerActive: true });
+    expect(window.localStorage.getItem(graphPresentationStorageKey(scope))).not.toBeNull();
+    expect(window.localStorage.getItem(graphPresentationStorageKey(secondScope))).not.toBeNull();
+
+    rerender({ activeScope: secondScope, enabled: true, ownerActive: true });
+    expect(window.localStorage.getItem(graphPresentationStorageKey(scope))).not.toBeNull();
+    expect(window.localStorage.getItem(graphPresentationStorageKey(secondScope))).not.toBeNull();
+
+    // The stable session signal becoming false is the actual logout boundary.
+    rerender({ activeScope: secondScope, enabled: false, ownerActive: false });
+    expect(window.localStorage.getItem(graphPresentationStorageKey(scope))).toBeNull();
+    expect(window.localStorage.getItem(graphPresentationStorageKey(secondScope))).toBeNull();
+
+    const nextScope = { ...scope, subject: "different-viewer" };
+    rerender({ activeScope: nextScope, enabled: true, ownerActive: true });
+    act(() => result.current.toggleEditing());
+    expect(window.localStorage.getItem(graphPresentationStorageKey(nextScope))).not.toBeNull();
+    rerender({ activeScope: scope, enabled: true, ownerActive: true });
+    expect(window.localStorage.getItem(graphPresentationStorageKey(nextScope))).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- simplify graph and remediation workspaces with compact controls, factual evidence summaries, type-based scope views, and expandable detail
- standardize React Flow interaction across supported small and medium graphs with pan, zoom, Fit, selection focus, Auto-layout, Edit/Lock dragging, and persistent personal layouts
- protect graph presentation state with opaque tenant/subject/topology-scoped storage, safe node and edge accessibility labels, renderer-aware controls, and logout cleanup

## Verification

- Node 22.22.2 / npm 10.9.7 toolchain verification
- focused Vitest: 9 files, 80 tests passed
- focused Playwright: 10 tests passed on an isolated port
- UI typecheck and ESLint passed
- production build passed: 49 routes
- bundle budget passed: 3613.3 / 3616.0 KiB total; 379.5 / 927.7 KiB largest chunk; 416.9 / 439.5 KiB shared runtime
- git diff --check passed
- independent privacy and behavior audit passed

## Notes

- React Flow remains the interactive renderer for bounded working sets; existing large-estate overview and WebGL paths remain intact.
- Cloud estate, Repository, and Environment scopes are explicitly described as type-based views unless provenance is available.
- Stored layout keys and payloads contain no raw tenant, subject, snapshot, repository path, cloud resource, or node identifiers.
- No live infrastructure, customer, reviewer, or session metadata is included.