### PR TITLE
fix(scan): match every vulnerable window and stop reading dates as SHAs

### DIFF
--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -151,9 +151,7 @@ def default_scan_options(
         offline=_scanners_patchable("offline_mode") if offline is None else offline,
         compliance_enabled=compliance_enabled,
         resolve_transitive=resolve_transitive,
-        prefer_local_db=(
-            prefer_local_db if prefer_local_db is not None else _scanners_patchable("prefer_local_db")
-        ),
+        prefer_local_db=(prefer_local_db if prefer_local_db is not None else _scanners_patchable("prefer_local_db")),
         demo_advisories=demo_advisories,
         project_dir=project_dir,
     )
@@ -467,6 +465,64 @@ def _version_matches_list(version: str, versions_list: list[str], ecosystem: str
     return False
 
 
+def _range_windows(events: list[dict]) -> list[tuple[str | None, str | None, str | None]]:
+    """Split OSV range ``events`` into ``(introduced, fixed, last_affected)`` windows.
+
+    A window opens on ``introduced`` and closes on ``fixed`` or
+    ``last_affected``; one left open at the end runs through latest. A range
+    with no ``introduced`` at all is vulnerable from 0.
+    """
+    windows: list[tuple[str | None, str | None, str | None]] = []
+    introduced: str | None = None
+    window_open = False
+    for event in events:
+        if "introduced" in event:
+            if window_open:
+                windows.append((introduced, None, None))
+            introduced = event["introduced"]
+            window_open = True
+        elif "fixed" in event:
+            windows.append((introduced, event["fixed"], None))
+            introduced, window_open = None, False
+        elif "last_affected" in event:
+            windows.append((introduced, None, event["last_affected"]))
+            introduced, window_open = None, False
+    if window_open:
+        windows.append((introduced, None, None))
+    if not windows:
+        windows.append((None, None, None))
+    return windows
+
+
+def _version_in_window(
+    version: str,
+    window: tuple[str | None, str | None, str | None],
+    ecosystem: str,
+) -> bool:
+    """Return whether *version* falls inside one vulnerable window."""
+    from agent_bom.version_utils import compare_version_order
+
+    introduced, fixed, last_affected = window
+
+    if introduced is not None and introduced != "0":
+        intro_cmp = compare_version_order(version, introduced, ecosystem)
+        # An uncomparable lower bound cannot rule the version out.
+        if intro_cmp is not None and intro_cmp < 0:
+            return False
+
+    if fixed is not None:
+        fixed_cmp = compare_version_order(version, fixed, ecosystem)
+        if fixed_cmp is not None and fixed_cmp >= 0:
+            return False
+
+    if last_affected is not None:
+        last_cmp = compare_version_order(version, last_affected, ecosystem)
+        if last_cmp is not None and last_cmp > 0:
+            return False
+
+    return True
+
+
 def _is_version_affected(
     vuln_data: dict,
     package_name: str,
@@ -530,27 +586,12 @@ def _is_version_affected(
                 continue
 
             events = rng.get("events", [])
-            # If range has fixed/last_affected but no introduced, assume introduced=0
-            has_introduced = any("introduced" in e for e in events)
-            is_affected = not has_introduced  # default: affected if no introduced
-            for event in events:
-                if "introduced" in event:
-                    intro = event["introduced"]
-                    if intro == "0":
-                        is_affected = True
-                    else:
-                        intro_cmp = compare_version_order(package_version, intro, ecosystem)
-                        is_affected = True if intro_cmp is None else intro_cmp >= 0
-                elif "fixed" in event:
-                    fixed_cmp = compare_version_order(package_version, event["fixed"], ecosystem)
-                    if fixed_cmp is not None and fixed_cmp >= 0:
-                        is_affected = False
-                elif "last_affected" in event:
-                    last_cmp = compare_version_order(package_version, event["last_affected"], ecosystem)
-                    if last_cmp is not None and last_cmp > 0:
-                        is_affected = False
-
-            if is_affected:
+            # A range may carry several vulnerable windows as alternating
+            # introduced/fixed events. Collect them first, then test each on its
+            # own: treating a later ``introduced`` as a reset of the running
+            # verdict discards an earlier window the version already matched.
+            windows = _range_windows(events)
+            if any(_version_in_window(package_version, window, ecosystem) for window in windows):
                 return True
 
     # If we found the package in affected but no range matched AND no version
@@ -1191,9 +1232,7 @@ async def scan_packages(
     # Query the local SQLite DB for packages not already covered by the
     # deterministic demo manifest. Packages covered by the DB skip OSV calls.
     local_db_targets = [p for p in scannable if _db_key(p) not in db_covered]
-    local_db_count, local_db_covered = (
-        _scanners_patchable("_scan_packages_local_db")(local_db_targets) if local_db_targets else (0, set())
-    )
+    local_db_count, local_db_covered = _scanners_patchable("_scan_packages_local_db")(local_db_targets) if local_db_targets else (0, set())
     local_count += local_db_count
     db_covered.update(local_db_covered)
     if local_count:

--- a/src/agent_bom/version_utils.py
+++ b/src/agent_bom/version_utils.py
@@ -199,7 +199,17 @@ def is_prerelease_version(version: str, ecosystem: str) -> bool:
 
 def _looks_like_commit_sha(version: str) -> bool:
     stripped = version.strip().lower().lstrip("v")
-    return bool(_HEXISH_RE.fullmatch(stripped))
+    if not _HEXISH_RE.fullmatch(stripped):
+        return False
+    if stripped.isdigit() and len(stripped) != 40:
+        # All-digit tokens are versions, not abbreviated SHAs. Date-stamped OS
+        # packages (ca-certificates 20230311, hwdata, tzdata) are common and
+        # every one of them would otherwise become uncomparable and fail closed
+        # — a missed CVE. An abbreviated SHA that happens to be all digits is
+        # possible but far rarer, and mistaking it for a version only costs an
+        # ordering comparison that a GIT-type range does not rely on.
+        return False
+    return True
 
 
 def _go_pseudo_timestamp(version: str) -> str | None:
@@ -593,9 +603,7 @@ _SEMVER_PRERELEASE_TAGS = frozenset(
 )
 
 
-_STRICT_SEMVER = re.compile(
-    r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
-)
+_STRICT_SEMVER = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$")
 
 
 def _compare_strict_semver(left: str, right: str) -> int | None:

--- a/tests/test_version_range_matching.py
+++ b/tests/test_version_range_matching.py
@@ -1,0 +1,109 @@
+"""Range matching must not lose vulnerable versions.
+
+Two independent defects, both silent false negatives:
+
+* A range that fixes several release branches encodes them as alternating
+  ``introduced``/``fixed`` events. Treating each ``introduced`` as a reset
+  discards an earlier window that already matched.
+* Date-style versions (``20230311``) are all-hex-digit strings, so the
+  abbreviated-commit-SHA heuristic claimed them. Comparison then returns
+  ``None`` and the bound fails closed — the package looks unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.db.lookup import _version_match_state
+from agent_bom.version_utils import _looks_like_commit_sha, compare_version_order, version_in_range
+
+
+def _osv_range(*events: dict) -> list[dict]:
+    return [{"type": "ECOSYSTEM", "events": list(events)}]
+
+
+# ── multi-window ranges ──────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("version", "expected"),
+    [
+        ("1.2", True),  # inside the first window — the regression case
+        ("1.7", False),  # between windows: fixed in 1.5, not yet reintroduced
+        ("2.2", True),  # inside the second window
+        ("2.5", False),  # fixed
+        ("0.9", False),  # before anything was introduced
+    ],
+)
+def test_multi_window_range_matches_every_window(version: str, expected: bool) -> None:
+    from agent_bom.scanners.package_scan import _is_version_affected
+
+    vuln = {
+        "affected": [
+            {
+                "package": {"ecosystem": "PyPI", "name": "widget"},
+                "ranges": _osv_range(
+                    {"introduced": "1.0"},
+                    {"fixed": "1.5"},
+                    {"introduced": "2.0"},
+                    {"fixed": "2.5"},
+                ),
+            }
+        ]
+    }
+
+    assert _is_version_affected(vuln, "widget", version, "PyPI") is expected
+
+
+def test_window_reopened_without_a_fix_stays_affected() -> None:
+    """A trailing ``introduced`` with no ``fixed`` is vulnerable through latest."""
+    from agent_bom.scanners.package_scan import _is_version_affected
+
+    vuln = {
+        "affected": [
+            {
+                "package": {"ecosystem": "PyPI", "name": "widget"},
+                "ranges": _osv_range({"introduced": "1.0"}, {"fixed": "1.5"}, {"introduced": "2.0"}),
+            }
+        ]
+    }
+
+    assert _is_version_affected(vuln, "widget", "3.0", "PyPI") is True
+    assert _is_version_affected(vuln, "widget", "1.7", "PyPI") is False
+
+
+# ── date versions vs commit SHAs ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("version", ["20230311", "20240226", "1234567"])
+def test_all_digit_tokens_are_versions_not_shas(version: str) -> None:
+    assert _looks_like_commit_sha(version) is False
+
+
+@pytest.mark.parametrize("sha", ["deadbeef", "a1b2c3d", "0" * 39 + "a", "f" * 40])
+def test_real_abbreviated_shas_are_still_detected(sha: str) -> None:
+    assert _looks_like_commit_sha(sha) is True
+
+
+def test_date_versioned_package_inside_range_is_affected() -> None:
+    """An apk date version below the fix must compare, not fail closed."""
+    assert compare_version_order("20230311", "20240226-r0", "apk") is not None
+    assert version_in_range("20230311", "0", "20240226-r0", None, "apk") is True
+
+
+def test_date_versioned_package_at_the_fix_is_clean() -> None:
+    assert version_in_range("20240226-r0", "0", "20240226-r0", None, "apk") is False
+
+
+def test_both_range_engines_agree_on_date_versions() -> None:
+    """``version_in_range`` and the DB lookup must not answer differently.
+
+    They are separate implementations reached by the live-OSV and local-DB
+    paths respectively; a scan and a cached lookup of the same package must
+    not disagree about whether it is vulnerable.
+    """
+    assert version_in_range("20230311", "0", "20240226-r0", None, "apk") is True
+    assert _version_match_state("20230311", "0", "20240226-r0", None, "apk") == "affected"
+
+    assert version_in_range("20240226-r0", "0", "20240226-r0", None, "apk") is False
+    assert _version_match_state("20240226-r0", "0", "20240226-r0", None, "apk") == "unaffected"


### PR DESCRIPTION
Two independent silent false negatives in range matching — the same failure mode #4473 fixed on the storage side, now on the comparison side.

## 1. Multi-window ranges lost every branch but the last

A range that fixes several release branches encodes them as alternating `introduced`/`fixed` events. The loop kept **one running verdict** and reassigned it on each `introduced`, so a later window overwrote an earlier one the version had already matched.

Events `[introduced 1.0, fixed 1.5, introduced 2.0, fixed 2.5]`:

| version | before | after | truth |
|---|---|---|---|
| 1.2 | **not affected** | affected | affected |
| 1.7 | not affected | not affected | not affected |
| 2.2 | affected | affected | affected |

Windows are now collected first (`_range_windows`) and each tested independently (`_version_in_window`), so the verdict is the OR of *complete* windows rather than whatever the last event happened to leave behind.

Worth noting: my first attempt OR-ed the running flag after every event, which flipped 1.7 and 2.5 to affected — a false **positive**. The parametrized cases covering versions *between* and *after* windows caught it. Both directions are tested.

## 2. Date versions were read as commit SHAs

`_looks_like_commit_sha` matched any 7–40 char hex string — which includes `20230311`. So:

```
compare_version_order("20230311", "20240226-r0", "apk")  → None
version_in_range("20230311", "0", "20240226-r0", None, "apk")  → False   # "not affected"
```

Every date-stamped OS package (`ca-certificates`, `hwdata`, `tzdata`, `publicsuffix`) became uncomparable and failed closed, hiding real CVEs. All-digit tokens are now treated as versions unless they are a full 40-char hash. A genuinely all-digit abbreviated SHA is possible but far rarer, and misreading one only costs an ordering comparison that GIT-type ranges don't rely on.

This is also where the **two range engines disagreed**: `version_utils.version_in_range` failed closed (`False`) while `db.lookup._version_match_state` returned `"unknown"` (conservatively included). Same input, opposite answers, depending on whether you hit the live-OSV path or the local DB. A test now pins them to the same verdict.

## Known residual — deliberately not changed

The two engines still differ on **genuinely** uncomparable bounds: one fails closed, the other reports `"unknown"`. Reconciling that is a policy choice with false-positive blast radius across every ecosystem, not a bug fix, so it is documented rather than altered silently. Worth a follow-up decision.

## Verified

- `tests/test_version_range_matching.py` — 16 tests, written first, confirmed red (6 failures across both defects)
- `test_local_vuln_db.py`, `test_osv_*`, `test_version_utils.py`, `test_db_sync_*` — 195 passed
- `pytest -k "version or osv or package_scan or reachab or cpe or vuln"` — **1146 passed**, 2 skipped
- All 9 preflight gates pass; `mypy` clean on both modules; `ruff check` + `format` clean