### PR TITLE
fix(graph): bound the investigation load and declare what it omits

### DIFF
--- a/docs/operations/ENV_VARS.md
+++ b/docs/operations/ENV_VARS.md
@@ -176,6 +176,7 @@ so they cannot regress silently, but they are not part of this reference.
 |---|---|---|---|
 | `AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH` | `bool` | `False` | — |
 | `AGENT_BOM_GRAPH_BACKEND` | `str` | `''` | SQLite is the local default. Postgres remains selected by AGENT_BOM_POSTGRES_URL. Neptune is experimental and requires explicit opt-in plus endpoint config. SQLite and Postgres remain the supported graph backends. |
+| `AGENT_BOM_GRAPH_INVESTIGATION_NODE_BUDGET` | `int` | `25000` | Ceiling on nodes materialized for one investigation read. The relationship / static / dynamic filters load a whole snapshot into memory; at 200k nodes that measured ~783 MB and 8.3s per request, and the read path permits several concurrentl |
 | `AGENT_BOM_NEPTUNE_ENDPOINT` | `str` | `''` | — |
 | `AGENT_BOM_NEPTUNE_TRAVERSAL_SOURCE` | `str` | `'g'` | — |
 

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -35,6 +35,7 @@ from agent_bom.graph import (
     technique_mappings_from_json,
 )
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
+from agent_bom.graph.container import apply_node_budget
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 
 # Only finding-like nodes (vulnerabilities, misconfigurations, drift) carry a
@@ -187,6 +188,7 @@ class GraphStoreProtocol(Protocol):
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
         relationship_types: frozenset[str] | None = None,
+        node_budget: int | None = None,
     ) -> UnifiedGraph: ...
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]: ...
@@ -1266,13 +1268,14 @@ class SQLiteGraphStore:
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
         relationship_types: frozenset[str] | None = None,
+        node_budget: int | None = None,
     ) -> UnifiedGraph:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         conn = self._open_ro_conn()
         if conn is None:
             return UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
         try:
-            return sqlite_graph_store.load_graph(
+            graph = sqlite_graph_store.load_graph(
                 conn,
                 tenant_id=tenant_id,
                 scan_id=scan_id,
@@ -1280,6 +1283,10 @@ class SQLiteGraphStore:
                 min_severity_rank=min_severity_rank,
                 relationship_types=relationship_types,
             )
+            # This backend has no query-side limit, so the cap is applied after
+            # the load. Memory is not saved, but the declared contract stays
+            # identical across backends.
+            return apply_node_budget(graph, node_budget)
         finally:
             conn.close()
 

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING, Any, Iterable, Mapping, NoReturn, Protocol, ca
 
 from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
+from agent_bom.graph.container import apply_node_budget
 
 if TYPE_CHECKING:
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
@@ -338,6 +339,7 @@ class NeptuneGraphStore:
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
         relationship_types: frozenset[str] | None = None,
+        node_budget: int | None = None,
     ) -> UnifiedGraph:
         tenant = tenant_id or "default"
         scan = scan_id or self.latest_snapshot_id(tenant_id=tenant)
@@ -365,7 +367,9 @@ class NeptuneGraphStore:
             edge = self._edge_from_record(row)
             if edge.source in graph.nodes and edge.target in graph.nodes:
                 graph.add_edge(edge)
-        return graph
+        # No query-side limit on this backend; cap after the load so the
+        # declared completeness contract matches every other store.
+        return apply_node_budget(graph, node_budget)
 
     def active_edges_at(self, at: str, *, tenant_id: str = "") -> list[dict[str, Any]]:
         rows = self._submit(

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -1029,7 +1029,17 @@ class PostgresGraphStore:
         entity_types: set[str] | None = None,
         min_severity_rank: int = 0,
         relationship_types: frozenset[str] | None = None,
+        node_budget: int | None = None,
     ) -> UnifiedGraph:
+        """Materialize a snapshot.
+
+        ``node_budget`` caps how many nodes are read. It defaults to unbounded
+        because callers that compute differences (snapshot diff, compare) are
+        only correct on a whole graph — a trimmed one reads as deletions that
+        never happened. Read paths that only display a graph pass a budget and
+        surface ``graph.completeness`` so a trimmed view is never mistaken for
+        a small one. When a budget applies, the highest-risk nodes are kept.
+        """
         tenant_id = normalize_graph_tenant_id(tenant_id)
         _assert_allowed_entity_types(entity_types)
         from agent_bom.graph import (
@@ -1040,6 +1050,7 @@ class PostgresGraphStore:
             UnifiedEdge,
             UnifiedGraph,
         )
+        from agent_bom.graph.container import GraphCompleteness, resolve_node_budget
 
         effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
         if not effective_scan_id:
@@ -1064,7 +1075,24 @@ class PostgresGraphStore:
                 placeholders = ",".join(["%s"] * len(entity_types))
                 query += f" AND entity_type IN ({placeholders})"
                 params.extend(sorted(entity_types))
-            query += " ORDER BY id"
+
+            budget = resolve_node_budget(node_budget)
+            total_nodes = 0
+            if budget is not None:
+                count_query = query.replace(
+                    "SELECT id, entity_type, label, category_uid, class_uid, type_uid, status, risk_score, severity, severity_id, "
+                    "first_seen, last_seen, attributes, compliance_tags, data_sources, dimensions ",
+                    "SELECT COUNT(*) ",
+                    1,
+                )
+                count_row = conn.execute(count_query, params).fetchone()
+                total_nodes = int(count_row[0]) if count_row else 0
+                # Risk-ranked so a trimmed view keeps what matters, not an
+                # arbitrary slice; id breaks ties so paging stays deterministic.
+                query += " ORDER BY risk_score DESC NULLS LAST, id LIMIT %s"
+                params.append(budget)
+            else:
+                query += " ORDER BY id"
 
             node_ids: set[str] = set()
             for row in conn.execute(query, params).fetchall():
@@ -1073,6 +1101,17 @@ class PostgresGraphStore:
                     continue
                 graph.add_node(self._node_from_row(row))
                 node_ids.add(row[0])
+
+            returned_nodes = len(node_ids)
+            if budget is None:
+                total_nodes = returned_nodes
+            graph.completeness = GraphCompleteness(
+                truncated=budget is not None and total_nodes > returned_nodes,
+                node_budget=budget,
+                total_nodes=total_nodes,
+                returned_nodes=returned_nodes,
+                reason="node_budget" if budget is not None and total_nodes > returned_nodes else "",
+            )
 
             edge_query = """
                 SELECT source_id, target_id, relationship, direction, weight, traversable,

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -44,6 +44,7 @@ from agent_bom.api.neptune_graph import NeptuneGraphStoreUnsupportedOperationErr
 from agent_bom.api.stores import _get_graph_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
+from agent_bom.config import GRAPH_INVESTIGATION_NODE_BUDGET
 from agent_bom.graph import (
     SEVERITY_RANK,
     AttackPath,
@@ -1435,6 +1436,7 @@ async def _load_graph_for_investigation(
     )
     return _enrich_loaded_graph_runtime_evidence(graph, tenant_id)
 
+
 async def _graph_compute_call(fn: Callable[..., _GraphCallResult], /, *args: Any, **kwargs: Any) -> _GraphCallResult:
     """Run CPU-heavy graph derivation and serialization off the event loop."""
     try:
@@ -1483,11 +1485,7 @@ def _ensure_attack_campaigns(graph: UnifiedGraph, paths: list[AttackPath] | None
         from agent_bom.graph.attack_path_fusion import _cluster_small_graph_campaigns, _is_crown_jewel
 
         candidate_paths = list(paths) if paths is not None else list(graph.attack_paths)
-        jewel_paths = [
-            path
-            for path in candidate_paths
-            if (node := graph.nodes.get(path.target)) is not None and _is_crown_jewel(node)
-        ]
+        jewel_paths = [path for path in candidate_paths if (node := graph.nodes.get(path.target)) is not None and _is_crown_jewel(node)]
         if jewel_paths:
             graph.attack_campaigns = _cluster_small_graph_campaigns(graph, jewel_paths)
             return
@@ -1527,11 +1525,15 @@ def _filtered_graph_response(graph: UnifiedGraph, *, offset: int, limit: int) ->
         "interaction_risks": interaction_risks,
         "stats": stats,
         "pagination": pagination,
+        # Two independent reasons a response can be partial: the page limit,
+        # and a snapshot that was already bounded at load time. The load-time
+        # cap is reported first because it is the wider omission — the page is
+        # a window onto whatever survived it.
         "completeness": graph_completeness(
             returned=len(paged_nodes),
-            total=len(all_nodes),
-            truncated=pagination["has_more"],
-            reason="node_page_limit" if pagination["has_more"] else "",
+            total=graph.completeness.total_nodes if graph.completeness.truncated else len(all_nodes),
+            truncated=graph.completeness.truncated or pagination["has_more"],
+            reason=("node_budget" if graph.completeness.truncated else "node_page_limit" if pagination["has_more"] else ""),
         ),
         "attack_path_pagination": {
             "total": len(matching_paths),
@@ -1695,11 +1697,7 @@ def _governance_graph_payload(
     for node in graph.nodes.values():
         if node.entity_type in governance_types:
             counts[node.entity_type.value] = counts.get(node.entity_type.value, 0) + 1
-    governance_truncated = (
-        len(nodes) < len(keep_ids)
-        or len(edges) < len(candidate_edges)
-        or len(attack_paths) < len(matching_paths)
-    )
+    governance_truncated = len(nodes) < len(keep_ids) or len(edges) < len(candidate_edges) or len(attack_paths) < len(matching_paths)
     return {
         "scan_id": graph.scan_id,
         "tenant_id": tenant_id,
@@ -1950,12 +1948,17 @@ async def get_graph(
         min_rank = SEVERITY_RANK.get(min_severity.lower(), 0)
 
     if relationships or static_only or dynamic_only:
+        # This branch materializes the whole snapshot. Bound it: at 200k nodes
+        # an uncapped load measured ~783 MB and 8.3s, and several of these can
+        # run concurrently. The budget keeps the highest-risk nodes and the
+        # response declares what was left out.
         graph = await _load_graph_for_investigation(
             graph_store,
             scan_id=requested_scan_id,
             tenant_id=tenant,
             entity_types=et_set,
             min_severity_rank=min_rank,
+            node_budget=GRAPH_INVESTIGATION_NODE_BUDGET,
         )
         rel_set = _parse_relationship_filter(relationships)
         filters = GraphFilterOptions(

--- a/src/agent_bom/config.py
+++ b/src/agent_bom/config.py
@@ -351,6 +351,14 @@ ANALYTICS_MAX_EVENTS = _int("AGENT_BOM_ANALYTICS_MAX_EVENTS", 50_000)
 # SQLite and Postgres remain the supported graph backends.
 
 GRAPH_BACKEND = _str("AGENT_BOM_GRAPH_BACKEND", "")
+
+# Ceiling on nodes materialized for one investigation read. The relationship /
+# static / dynamic filters load a whole snapshot into memory; at 200k nodes that
+# measured ~783 MB and 8.3s per request, and the read path permits several
+# concurrently. Highest-risk nodes are kept and the response declares what was
+# omitted, so a bounded view is never mistaken for a complete one. 0 disables
+# the cap — only safe on a control plane whose snapshots are known to be small.
+GRAPH_INVESTIGATION_NODE_BUDGET = _int("AGENT_BOM_GRAPH_INVESTIGATION_NODE_BUDGET", 25_000)
 EXPERIMENTAL_NEPTUNE_GRAPH = _bool("AGENT_BOM_EXPERIMENTAL_NEPTUNE_GRAPH", False)
 NEPTUNE_ENDPOINT = _str("AGENT_BOM_NEPTUNE_ENDPOINT", "")
 NEPTUNE_TRAVERSAL_SOURCE = _str("AGENT_BOM_NEPTUNE_TRAVERSAL_SOURCE", "g")

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -231,6 +231,88 @@ class InteractionRisk:
         )
 
 
+def resolve_node_budget(budget: int | None) -> int | None:
+    """Normalize a node budget; non-positive means unbounded.
+
+    Callers that need a whole graph to be correct — snapshot diff, compare,
+    anything computing removals — must be able to opt out, because a truncated
+    graph would read as deletions that never happened.
+    """
+    if budget is None or budget <= 0:
+        return None
+    return budget
+
+
+def apply_node_budget(graph: "UnifiedGraph", budget: int | None) -> "UnifiedGraph":
+    """Trim *graph* in place to the highest-risk ``budget`` nodes.
+
+    For backends that cannot push a limit into their query, this keeps the
+    bounded-and-declared contract uniform: the same completeness descriptor is
+    populated whether the cap was applied in SQL or afterwards. Edges whose
+    endpoints were dropped go too, so no edge dangles.
+    """
+    resolved = resolve_node_budget(budget)
+    total = len(graph.nodes)
+    if resolved is None or total <= resolved:
+        graph.completeness = GraphCompleteness(node_budget=resolved, total_nodes=total, returned_nodes=total)
+        return graph
+
+    ranked = sorted(graph.nodes.values(), key=lambda n: (-(n.risk_score or 0.0), n.id))
+    keep = {node.id for node in ranked[:resolved]}
+    graph.nodes = {node_id: node for node_id, node in graph.nodes.items() if node_id in keep}
+
+    surviving = [edge for edge in graph.edges if edge.source in keep and edge.target in keep]
+    graph.edges = []
+    graph.adjacency = defaultdict(list)
+    graph.reverse_adjacency = defaultdict(list)
+    graph._edge_keys = set()
+    for edge in surviving:
+        graph.add_edge(edge)
+    graph.completeness = GraphCompleteness(
+        truncated=True,
+        node_budget=resolved,
+        total_nodes=total,
+        returned_nodes=len(graph.nodes),
+        reason="node_budget",
+    )
+    return graph
+
+
+@dataclass(slots=True)
+class GraphCompleteness:
+    """Whether a loaded graph is the whole snapshot, and what was left out.
+
+    A bounded load is fine; a *silent* one is not. Without this a caller cannot
+    tell an empty blast radius from a trimmed one, which is the difference
+    between "nothing reaches this" and "we stopped looking".
+    """
+
+    truncated: bool = False
+    node_budget: int | None = None
+    total_nodes: int = 0
+    returned_nodes: int = 0
+    reason: str = ""
+
+    @property
+    def omitted_nodes(self) -> int:
+        return max(0, self.total_nodes - self.returned_nodes)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize through the shared graph-completeness contract.
+
+        The API already has one shape for "is this response exhaustive"; this
+        must not become a second one that clients have to branch on.
+        """
+        from agent_bom.graph.completeness import graph_completeness
+
+        return graph_completeness(
+            returned=self.returned_nodes,
+            total=self.total_nodes,
+            truncated=self.truncated,
+            reason=self.reason,
+        )
+
+
 @dataclass
 class UnifiedGraph:
     """The canonical graph structure for agent-bom.
@@ -258,6 +340,7 @@ class UnifiedGraph:
     scan_id: str = ""
     tenant_id: str = ""
     created_at: str = ""
+    completeness: "GraphCompleteness" = field(default_factory=lambda: GraphCompleteness())
 
     def __post_init__(self) -> None:
         if not self.created_at:

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -35,6 +35,7 @@ from agent_bom.graph import (
     UnifiedNode,
 )
 from agent_bom.graph.analysis import GraphAnalysisState, GraphAnalysisStatus
+from agent_bom.graph.container import apply_node_budget
 
 
 def _build_persisted_graph(db, scan_id="test-scan-001"):
@@ -1294,9 +1295,18 @@ class _RecordingGraphStore:
         self.calls.append(("prior_delta_digest", tenant_id, scan_id))
         return digest_from_graph(self.graph)
 
-    def load_graph(self, *, tenant_id: str = "", scan_id: str = "", entity_types=None, min_severity_rank: int = 0) -> UnifiedGraph:
+    def load_graph(
+        self,
+        *,
+        tenant_id: str = "",
+        scan_id: str = "",
+        entity_types=None,
+        min_severity_rank: int = 0,
+        relationship_types=None,
+        node_budget: int | None = None,
+    ) -> UnifiedGraph:
         self.calls.append(("load_graph", tenant_id, scan_id, entity_types, min_severity_rank))
-        return self.graph
+        return apply_node_budget(self.graph, node_budget)
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict:
         self.calls.append(("diff_snapshots", tenant_id, scan_id_old, scan_id_new))
@@ -1795,9 +1805,7 @@ class TestGraphStoreBackendSelection:
 
     def test_fix_first_graph_view_derives_paths_when_snapshot_has_topology_but_no_path_rows(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="server:a:fs", entity_type=EntityType.SERVER, label="mcp-fs"))
-        recording_graph_store.graph.add_node(
-            UnifiedNode(id="pkg:npm:form-data", entity_type=EntityType.PACKAGE, label="form-data")
-        )
+        recording_graph_store.graph.add_node(UnifiedNode(id="pkg:npm:form-data", entity_type=EntityType.PACKAGE, label="form-data"))
         recording_graph_store.graph.add_node(UnifiedNode(id="cred:aws", entity_type=EntityType.CREDENTIAL, label="AWS_SECRET_ACCESS_KEY"))
         recording_graph_store.graph.add_node(UnifiedNode(id="tool:shell", entity_type=EntityType.TOOL, label="run_shell"))
         recording_graph_store.graph.add_node(
@@ -1868,9 +1876,7 @@ class TestGraphStoreBackendSelection:
                 },
             )
         )
-        recording_graph_store.graph.add_edge(
-            UnifiedEdge(source="cloud:entry", target="ds:crown", relationship=RelationshipType.STORES)
-        )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="cloud:entry", target="ds:crown", relationship=RelationshipType.STORES))
         # Persist a jewel-terminating path (fusion does this at build time) but leave
         # attack_campaigns empty — matching store_backed.StoreBackedUnifiedGraph.
         recording_graph_store.graph.attack_paths.append(
@@ -1915,9 +1921,7 @@ class TestGraphStoreBackendSelection:
                 },
             )
         )
-        recording_graph_store.graph.add_edge(
-            UnifiedEdge(source="cloud:entry", target="ds:crown", relationship=RelationshipType.STORES)
-        )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="cloud:entry", target="ds:crown", relationship=RelationshipType.STORES))
         recording_graph_store.graph.attack_paths.append(
             AttackPath(
                 source="cloud:entry",
@@ -2895,9 +2899,7 @@ class TestGraphStoreBackendSelection:
     def test_graph_node_neighbors_returns_bounded_metadata(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
         recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
-        recording_graph_store.graph.add_node(
-            UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a", severity="high")
-        )
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a", severity="high"))
         recording_graph_store.graph.add_node(UnifiedNode(id="pkg:p", entity_type=EntityType.PACKAGE, label="pkg@1.0"))
         recording_graph_store.graph.add_edge(
             UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
@@ -2931,9 +2933,7 @@ class TestGraphStoreBackendSelection:
         recording_graph_store.graph.add_node(UnifiedNode(id="server:hub", entity_type=EntityType.SERVER, label="hub"))
         for index in range(5):
             neighbor_id = f"pkg:p{index}"
-            recording_graph_store.graph.add_node(
-                UnifiedNode(id=neighbor_id, entity_type=EntityType.PACKAGE, label=f"pkg-{index}")
-            )
+            recording_graph_store.graph.add_node(UnifiedNode(id=neighbor_id, entity_type=EntityType.PACKAGE, label=f"pkg-{index}"))
             recording_graph_store.graph.add_edge(
                 UnifiedEdge(source="server:hub", target=neighbor_id, relationship=RelationshipType.DEPENDS_ON)
             )
@@ -2956,12 +2956,8 @@ class TestGraphStoreBackendSelection:
         recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
         recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
         recording_graph_store.graph.add_node(UnifiedNode(id="pkg:p", entity_type=EntityType.PACKAGE, label="pkg@1.0"))
-        recording_graph_store.graph.add_edge(
-            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES)
-        )
-        recording_graph_store.graph.add_edge(
-            UnifiedEdge(source="server:s", target="pkg:p", relationship=RelationshipType.DEPENDS_ON)
-        )
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES))
+        recording_graph_store.graph.add_edge(UnifiedEdge(source="server:s", target="pkg:p", relationship=RelationshipType.DEPENDS_ON))
         client = TestClient(app)
 
         out_only = client.get("/v1/graph/node/server:s/neighbors", params={"direction": "out"}).json()

--- a/tests/test_graph_node_budget.py
+++ b/tests/test_graph_node_budget.py
@@ -1,0 +1,134 @@
+"""A bounded graph load must say so.
+
+Loading a whole snapshot into memory is what makes the investigation view fall
+over: 200k nodes measured at ~783 MB and 8.3s per request, and the read path
+allows several concurrent. Capping it is necessary, but a silently truncated
+graph is worse than a slow one — a user cannot tell an empty blast radius from
+a trimmed one. So the cap is paired with a declared completeness descriptor,
+and the nodes that survive are the highest-risk ones rather than an arbitrary
+page.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.graph import UnifiedGraph
+from agent_bom.graph.container import GraphCompleteness
+
+
+def test_a_graph_defaults_to_complete() -> None:
+    graph = UnifiedGraph(scan_id="s1", tenant_id="t1")
+
+    assert graph.completeness.truncated is False
+    assert graph.completeness.node_budget is None
+    assert graph.completeness.total_nodes == 0
+
+
+def test_completeness_records_what_was_omitted() -> None:
+    completeness = GraphCompleteness(truncated=True, node_budget=100, total_nodes=250, returned_nodes=100)
+
+    assert completeness.omitted_nodes == 150
+    assert completeness.truncated is True
+
+
+def test_completeness_serializes_through_the_shared_contract() -> None:
+    """One completeness shape for the whole graph API, not a second one."""
+    completeness = GraphCompleteness(truncated=True, node_budget=100, total_nodes=250, returned_nodes=100, reason="node_budget")
+
+    payload = completeness.to_dict()
+
+    assert payload["status"] == "truncated"
+    assert payload["complete"] is False
+    assert payload["truncated"] is True
+    assert payload["total"] == 250
+    assert payload["returned"] == 100
+    assert payload["reason"] == "node_budget"
+
+
+def test_untruncated_completeness_reports_no_omissions() -> None:
+    completeness = GraphCompleteness(total_nodes=42, returned_nodes=42)
+
+    assert completeness.omitted_nodes == 0
+    payload = completeness.to_dict()
+    assert payload["truncated"] is False
+    assert payload["status"] == "complete"
+
+
+@pytest.mark.parametrize("budget", [0, -1, None])
+def test_non_positive_budget_means_unbounded(budget: int | None) -> None:
+    """A caller that needs a whole graph (diff, compare) must be able to say so."""
+    from agent_bom.graph.container import resolve_node_budget
+
+    assert resolve_node_budget(budget) is None
+
+
+def test_positive_budget_is_honoured() -> None:
+    from agent_bom.graph.container import resolve_node_budget
+
+    assert resolve_node_budget(500) == 500
+
+
+def _graph_with(node_count: int) -> UnifiedGraph:
+    from agent_bom.graph import EntityType, UnifiedEdge, UnifiedNode
+    from agent_bom.graph.container import RelationshipType
+
+    graph = UnifiedGraph(scan_id="s", tenant_id="t")
+    for i in range(node_count):
+        graph.add_node(
+            UnifiedNode(
+                id=f"agent:a{i}",
+                entity_type=EntityType.AGENT,
+                label=f"a{i}",
+                risk_score=float(i),
+            )
+        )
+    for i in range(node_count - 1):
+        graph.add_edge(
+            UnifiedEdge(
+                source=f"agent:a{i}",
+                target=f"agent:a{i + 1}",
+                relationship=RelationshipType.USES,
+            )
+        )
+    return graph
+
+
+def test_budget_keeps_the_highest_risk_nodes() -> None:
+    from agent_bom.graph.container import apply_node_budget
+
+    graph = apply_node_budget(_graph_with(10), 3)
+
+    assert set(graph.nodes) == {"agent:a9", "agent:a8", "agent:a7"}
+    assert graph.completeness.truncated is True
+    assert graph.completeness.total_nodes == 10
+    assert graph.completeness.returned_nodes == 3
+    assert graph.completeness.omitted_nodes == 7
+
+
+def test_budget_drops_edges_whose_endpoints_went() -> None:
+    from agent_bom.graph.container import apply_node_budget
+
+    graph = apply_node_budget(_graph_with(10), 3)
+
+    node_ids = set(graph.nodes)
+    assert all(edge.source in node_ids and edge.target in node_ids for edge in graph.edges), "a dangling edge survived the trim"
+
+
+def test_graph_under_budget_is_untouched_and_marked_complete() -> None:
+    from agent_bom.graph.container import apply_node_budget
+
+    graph = apply_node_budget(_graph_with(4), 100)
+
+    assert len(graph.nodes) == 4
+    assert graph.completeness.truncated is False
+    assert graph.completeness.omitted_nodes == 0
+
+
+def test_unbounded_budget_never_trims() -> None:
+    from agent_bom.graph.container import apply_node_budget
+
+    graph = apply_node_budget(_graph_with(6), None)
+
+    assert len(graph.nodes) == 6
+    assert graph.completeness.truncated is False


### PR DESCRIPTION
## The P0

`/v1/graph` falls back to materializing an entire snapshot whenever `relationships`, `static_only`, or `dynamic_only` is set — and the UI wires that to a runtime-mode toggle. Measured on live Postgres at 200k nodes: **8.28s and +783 MB RSS per request**, with the read path admitting several concurrently. One click could put the control plane into memory pressure.

## Bounded — and declared

`load_graph` now accepts a node budget, applied to the investigation read path (`AGENT_BOM_GRAPH_INVESTIGATION_NODE_BUDGET`, default 25,000, `0` disables).

**The default is unbounded**, deliberately. Callers that compute differences — snapshot diff, compare — are only correct on a whole graph; a trimmed one reads as deletions that never happened. Only display paths opt in. That also keeps this change additive for the four other `load_graph` call sites the audit never examined.

Bounding *silently* would be the worse bug. A trimmed blast radius is indistinguishable from an empty one, and "nothing reaches this" is the opposite conclusion from "we stopped looking." So the response reports the truncation, and the retained nodes are the **highest-risk** ones rather than an arbitrary page.

## One completeness contract, not two

First pass added a `completeness` key to the graph response. Ruff's `F601` caught it as a **duplicate dictionary key** — the graph API already has a `graph_completeness()` contract used at nine call sites. I'd have silently shadowed an existing client-facing field with a differently-shaped one.

Corrected: the node-budget truncation now flows through that existing contract, and `GraphCompleteness.to_dict()` delegates to it. Clients keep one shape to branch on. Where both a load-time cap and a page limit apply, the cap is reported as the reason — it's the wider omission, and the page is a window onto whatever survived it.

## Backends

`node_budget` is on the store protocol and all three implementations. Postgres pushes it into SQL with `ORDER BY risk_score DESC` + `LIMIT`, which is where the memory is actually saved. SQLite and Neptune cap after loading — no memory win there, but the declared contract is identical whichever store is configured, and edges whose endpoints were dropped go with them so nothing dangles.

Note for reviewers: this widens the `GraphStore` protocol signature. All in-repo implementations and the test double are updated; an out-of-tree backend implementing the protocol would need the parameter added.

## Verified

- `tests/test_graph_node_budget.py` — 12 tests, written first, confirmed red; covers highest-risk retention, dangling-edge removal, under-budget no-op, and unbounded opt-out
- `pytest -k graph` — **994 passed**, 15 skipped
- All **17** CI gates run locally (9 preflight + 8 security-scan), `mypy` clean on all five modules, `ruff` clean
- `docs/operations/ENV_VARS.md` regenerated for the new knob

## Deferred, with reason

Pushing the relationship filters into SQL so this path reuses the paged loader is **not** in scope. `apply_governance_overlay` runs on the full node set before `filtered_view` prunes, and `_derived_attack_paths` builds adjacency over all edges — so the pushdown changes what a filtered view may omit. That's a product decision about path completeness, not a refactor. This PR's declared-truncation contract is what makes that decision safe to take later.