### PR TITLE
fix(cloud): gate the routes that spend the platform's own cloud identity

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -60,6 +60,8 @@ AGENT_BOM_AWS_EVENT_QUEUE_URL
 # Opt-in (default OFF) gate for the estate-wide read-only Azure asset inventory scanner (token/credential auth only).
 AGENT_BOM_AWS_INVENTORY
 # Defensive cap on the number of member accounts a single AWS Organizations scan fans out over (default 200).
+# Operator-selected AWS profile for ambient-credential evaluation; read live and never caller-supplied, so a request cannot pick which host credential the control plane spends.
+AGENT_BOM_AWS_PROFILE
 AGENT_BOM_AWS_MAX_ACCOUNTS
 # Defensive cap on the number of regions a single multi-region AWS inventory scan fans out over.
 AGENT_BOM_AWS_MAX_REGIONS
@@ -94,6 +96,8 @@ AGENT_BOM_CLICKHOUSE_MAX_QUEUE
 AGENT_BOM_CLICKHOUSE_ACCESS_TOKEN
 AGENT_BOM_CLICKHOUSE_USER
 # Opt-in (default OFF) gate for the estate-wide read-only AWS asset inventory scanner.
+# Opt-in (default OFF, read live) gate allowing this control plane to run the CIS benchmark against its OWN ambient cloud identity rather than a tenant connection.
+AGENT_BOM_CLOUD_CIS_BENCHMARK
 AGENT_BOM_CLOUD_INVENTORY
 # Opt-in (default OFF) bounded S3 object byte-range sampling for DSPM content classification. Stores redacted classification counts, never raw object bytes.
 AGENT_BOM_DSPM_S3_SAMPLING

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -37,6 +37,12 @@ from fastapi import APIRouter, HTTPException, Query, Request
 from agent_bom.api.models import RuntimeEvidenceIngestRequest
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
+from agent_bom.cloud.ambient_credentials import (
+    PROFILE_REJECTED_NOTE,
+    ambient_cis_enabled,
+    configured_aws_profile,
+    disabled_payload,
+)
 from agent_bom.cloud.runtime_workload_evidence import (
     SourceAuthenticationError,
     get_runtime_source_registry,
@@ -52,6 +58,9 @@ _logger = logging.getLogger(__name__)
 # Reuse the same RBAC gate the sibling scan/identity routes use. Cloud scanning is
 # a scan-class action, so it maps to the "scan" permission ({admin, analyst}).
 _SCAN_DEP = require_authenticated_permission("scan")
+# Spending the control plane's own ambient cloud identity is an operator action,
+# not a tenant one, so it does not share the analyst-level scan dependency.
+_CIS_DEP = require_authenticated_permission("cloud_ambient")
 # The per-account drill summary is a read-only aggregation over already-ingested
 # evidence — it never triggers a provider scan — so it maps to the "read" gate
 # (all authenticated roles), like /v1/overview.
@@ -65,9 +74,7 @@ _ACCOUNT_SUMMARY_MAX_ROWS = 50_000
 
 # Asset-type buckets used to derive an honest identity/role count from the
 # account's finding assets (deeper IAM/grant enumeration is a follow-up).
-_IDENTITY_ASSET_TYPES = frozenset(
-    {"user", "service_account", "identity", "iam_user", "principal", "machine_identity", "nhi"}
-)
+_IDENTITY_ASSET_TYPES = frozenset({"user", "service_account", "identity", "iam_user", "principal", "machine_identity", "nhi"})
 _ROLE_ASSET_TYPES = frozenset({"role", "iam_role", "cloud_role"})
 
 # Provider -> the result keys (new + legacy) that carry a stored CIS benchmark
@@ -208,9 +215,7 @@ def _snowflake_inventory() -> tuple[dict[str, Any], dict[str, Any]]:
             "identity_count": 0,
             "node_summary": dict(node_summary),
             "warnings": (
-                [f"{warning_count} provider discovery warning(s) — run via CLI/MCP or see server logs for detail."]
-                if warning_count
-                else []
+                [f"{warning_count} provider discovery warning(s) — run via CLI/MCP or see server logs for detail."] if warning_count else []
             ),
         }
 
@@ -251,9 +256,7 @@ def _snowflake_inventory() -> tuple[dict[str, Any], dict[str, Any]]:
     return summary, raw_payload
 
 
-def _build_inventory_payload(
-    tenant_id: str, selected: list[str], scoped_region: str | None
-) -> dict[str, Any]:
+def _build_inventory_payload(tenant_id: str, selected: list[str], scoped_region: str | None) -> dict[str, Any]:
     """Synchronous estate inventory body — runs off the event loop in a worker thread.
 
     Calls the same ``discover_inventory`` functions the CLI/MCP use and reduces
@@ -344,9 +347,7 @@ async def cloud_inventory(
         # scan to a worker thread under backpressure so a live inventory can never
         # stall the event loop (a burst sheds with a 429 instead).
         async with adaptive_backpressure("cloud_inventory"):
-            return await anyio.to_thread.run_sync(
-                _build_inventory_payload, tenant_id, selected, scoped_region
-            )
+            return await anyio.to_thread.run_sync(_build_inventory_payload, tenant_id, selected, scoped_region)
     except BackpressureRejectedError as exc:
         raise HTTPException(
             status_code=429,
@@ -450,7 +451,7 @@ async def cloud_cis_benchmark(
     profile: str = Query("", description="Optional AWS profile name."),
     subscription_id: str = Query("", description="Optional Azure subscription id."),
     project_id: str = Query("", description="Optional GCP project id."),
-    _role: Any = _SCAN_DEP,
+    _role: Any = _CIS_DEP,
 ) -> dict[str, Any]:
     """Run the CIS Foundations benchmark for a cloud provider over REST.
 
@@ -468,7 +469,12 @@ async def cloud_cis_benchmark(
 
     check_list = [c.strip() for c in checks.split(",") if c.strip()] or None
     region_arg = region.strip() or None
-    profile_arg = profile.strip() or None
+    if profile.strip():
+        # Choosing which host credential to spend is operator configuration.
+        # Accepting it from the request would let any caller pivot across every
+        # profile mounted on the control plane.
+        raise HTTPException(status_code=400, detail=PROFILE_REJECTED_NOTE)
+    profile_arg = configured_aws_profile()
     if region_arg and not _REGION_RE.fullmatch(region_arg):
         raise HTTPException(status_code=400, detail=f"Invalid AWS region format: {region}")
     if profile_arg and not _PROFILE_RE.fullmatch(profile_arg):
@@ -476,6 +482,12 @@ async def cloud_cis_benchmark(
             status_code=400,
             detail="Invalid AWS profile name. Use alphanumeric, dot, dash, underscore (max 100 chars).",
         )
+
+    if not ambient_cis_enabled():
+        # Off by default: this evaluates with whatever credentials the
+        # control-plane process itself holds, so a stock install must never
+        # spend them on request.
+        return {**disabled_payload(requested), "tenant_id": tenant_id}
 
     try:
         # A full CIS benchmark runs synchronous provider SDK/network evaluation;
@@ -594,9 +606,7 @@ def _cis_counts(data: dict[str, Any]) -> tuple[int, int]:
     return p, f
 
 
-def _compliance_for_account(
-    jobs_newest_first: list[Any], provider: str, wanted_ref: str
-) -> dict[str, Any]:
+def _compliance_for_account(jobs_newest_first: list[Any], provider: str, wanted_ref: str) -> dict[str, Any]:
     """Aggregate stored CIS pass-rate for the account (newest run per provider).
 
     Only blocks whose normalized account matches ``wanted_ref`` are counted; a

--- a/src/agent_bom/cloud/ambient_credentials.py
+++ b/src/agent_bom/cloud/ambient_credentials.py
@@ -1,0 +1,59 @@
+"""Guards for evaluating with the control plane's *own* cloud identity.
+
+Most cloud work runs against a tenant's stored, scoped connection. A few
+surfaces instead evaluate with whatever ambient credentials the process itself
+holds — an instance role, an assumed role, a mounted profile. That is a
+different trust level, so it is off unless an operator turns it on, and the
+caller never chooses which credential gets spent.
+
+The guard lives here rather than in a route because REST and the MCP tool call
+the same benchmark. Gating only one of them would leave the other as an open
+path to the same credentials.
+"""
+
+from __future__ import annotations
+
+import os
+
+AMBIENT_CIS_ENV = "AGENT_BOM_CLOUD_CIS_BENCHMARK"
+AWS_PROFILE_ENV = "AGENT_BOM_AWS_PROFILE"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+DISABLED_NOTE = (
+    "Ambient-credential CIS benchmark is opt-in. Set AGENT_BOM_CLOUD_CIS_BENCHMARK=1 to allow this control "
+    "plane to evaluate its own cloud identity. Prefer scanning through a tenant cloud connection instead."
+)
+
+PROFILE_REJECTED_NOTE = (
+    "The profile parameter is not accepted. The control plane evaluates its configured credentials; "
+    "set AGENT_BOM_AWS_PROFILE on the server to choose a different one."
+)
+
+
+def ambient_cis_enabled() -> bool:
+    """Whether an operator allows ambient-credential CIS evaluation.
+
+    Read live so the flag can be flipped without a redeploy, matching how the
+    cloud inventory surface resolves its own per-provider opt-ins.
+    """
+    return (os.environ.get(AMBIENT_CIS_ENV) or "").strip().lower() in _TRUTHY
+
+
+def configured_aws_profile() -> str | None:
+    """Operator-selected AWS profile, if any. Never caller-supplied."""
+    return (os.environ.get(AWS_PROFILE_ENV) or "").strip() or None
+
+
+def disabled_payload(provider: str) -> dict[str, str]:
+    """Envelope returned when ambient evaluation is not enabled.
+
+    Carries ``error`` so headless callers that branch on it degrade the same way
+    they do for a missing SDK, and ``status`` so operators can tell a disabled
+    surface from a failed one.
+    """
+    return {
+        "provider": provider,
+        "status": "disabled",
+        "error": DISABLED_NOTE,
+    }

--- a/src/agent_bom/mcp_tools/compliance.py
+++ b/src/agent_bom/mcp_tools/compliance.py
@@ -161,8 +161,22 @@ async def cis_benchmark_impl(
 
         if region and not _re.fullmatch(r"[a-z]{2}(-gov)?-[a-z]+-\d{1,2}", region):
             return json.dumps({"error": f"Invalid AWS region format: {region}"})
-        if profile and not _re.fullmatch(r"[a-zA-Z0-9._-]{1,100}", profile):
-            return json.dumps({"error": "Invalid AWS profile name. Use alphanumeric, dot, dash, underscore (max 100 chars)."})
+
+        # This benchmark spends the control plane's own cloud identity, so it
+        # carries the same operator opt-in as the REST surface. Gating one and
+        # not the other would leave this tool as a way around it.
+        from agent_bom.cloud.ambient_credentials import (
+            PROFILE_REJECTED_NOTE,
+            ambient_cis_enabled,
+            configured_aws_profile,
+            disabled_payload,
+        )
+
+        if profile:
+            return json.dumps({"error": PROFILE_REJECTED_NOTE})
+        profile = configured_aws_profile()
+        if not ambient_cis_enabled():
+            return json.dumps(disabled_payload(provider))
 
         cis_report: object
         if provider == "aws":

--- a/src/agent_bom/rbac.py
+++ b/src/agent_bom/rbac.py
@@ -78,6 +78,9 @@ _PERMISSIONS: dict[str, set[Role]] = {
     "sla_write": {Role.ADMIN},
     "sla_read": {Role.ADMIN, Role.ANALYST, Role.VIEWER},
     "config": {Role.ADMIN},
+    # Routes that spend the control plane's OWN cloud identity rather than a
+    # tenant's stored connection. Analyst-in-any-tenant is the wrong bar.
+    "cloud_ambient": {Role.ADMIN},
 }
 
 

--- a/tests/api/test_api_cloud_surface_parity.py
+++ b/tests/api/test_api_cloud_surface_parity.py
@@ -224,7 +224,10 @@ def test_cloud_inventory_bad_region_400() -> None:
     assert resp.status_code == 400
 
 
-def test_cloud_cis_allows_admin_role() -> None:
+def test_cloud_cis_allows_admin_role(monkeypatch) -> None:
+    # Ambient-credential evaluation is operator opt-in; enable it so this test
+    # exercises the wired path rather than the disabled guard.
+    monkeypatch.setenv("AGENT_BOM_CLOUD_CIS_BENCHMARK", "1")
     client = TestClient(app)
     resp = client.get("/v1/cloud/aws/cis-benchmark", headers=_proxy_headers())
     # Authorized: 200 whether or not the cloud SDK is installed. With the SDK it
@@ -244,11 +247,12 @@ def test_cloud_cis_unknown_provider_404() -> None:
     assert resp.status_code == 404
 
 
-def test_cloud_cis_snowflake_is_wired_not_404() -> None:
+def test_cloud_cis_snowflake_is_wired_not_404(monkeypatch) -> None:
     # Snowflake CIS is a real benchmark (snowflake_cis_benchmark.run_benchmark);
     # it must not 404 like an unknown provider. Without the snowflake connector /
     # credentials in the test env it degrades to the shared "unavailable"
     # envelope (HTTP 200), exactly like the other providers — never 404, never 500.
+    monkeypatch.setenv("AGENT_BOM_CLOUD_CIS_BENCHMARK", "1")
     client = TestClient(app)
     resp = client.get("/v1/cloud/snowflake/cis-benchmark", headers=_proxy_headers())
     assert resp.status_code == 200

--- a/tests/api/test_cloud_scan_offload.py
+++ b/tests/api/test_cloud_scan_offload.py
@@ -51,6 +51,9 @@ def test_cloud_inventory_offloads_provider_scan(monkeypatch):
 
 
 def test_cloud_cis_benchmark_offloads_evaluation(monkeypatch):
+    # Ambient evaluation is operator opt-in; enable it so this exercises the
+    # offload rather than the disabled guard.
+    monkeypatch.setenv("AGENT_BOM_CLOUD_CIS_BENCHMARK", "1")
     monkeypatch.setattr(cloud, "_tenant", lambda request: "t-cis")
     offloaded = _spy_run_sync(monkeypatch)
 
@@ -130,6 +133,7 @@ async def test_slow_inventory_scan_keeps_event_loop_responsive(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_cloud_cis_timeout_returns_bounded_unavailable_envelope(monkeypatch):
+    monkeypatch.setenv("AGENT_BOM_CLOUD_CIS_BENCHMARK", "1")
     """Provider credential/metadata retries cannot hold an API request forever."""
     monkeypatch.setattr(cloud, "_tenant", lambda request: "t-timeout")
     monkeypatch.setattr(cloud, "_cloud_cis_timeout_seconds", lambda: 0.01)

--- a/tests/test_cloud_ambient_credential_guard.py
+++ b/tests/test_cloud_ambient_credential_guard.py
@@ -1,0 +1,93 @@
+"""Routes that spend the control plane's own cloud identity are privileged.
+
+``/v1/cloud/{provider}/cis-benchmark`` does not use a tenant's stored
+connection. It runs against whatever ambient credentials the control-plane
+process itself holds — an instance role, an assumed role, a mounted profile.
+Two consequences follow:
+
+* it must be an explicit operator opt-in, not on by default, and
+* it must require admin, because "analyst in any tenant" is not the same
+  trust level as "may spend the platform's own identity".
+
+The caller must also not choose which host profile to spend. Selecting the
+credential is operator configuration, not request input.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+
+
+@pytest.fixture
+def client() -> Any:
+    return TestClient(app)
+
+
+def test_cis_benchmark_is_disabled_unless_an_operator_enables_it(client: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default install must not spend ambient credentials on request."""
+    monkeypatch.delenv("AGENT_BOM_CLOUD_CIS_BENCHMARK", raising=False)
+
+    response = client.get("/v1/cloud/aws/cis-benchmark")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "disabled"
+    # Carries ``error`` too so headless callers degrade like any other envelope.
+    assert "AGENT_BOM_CLOUD_CIS_BENCHMARK" in body["error"]
+
+
+def test_disabled_benchmark_never_invokes_a_provider(client: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """The guard must short-circuit before any SDK call."""
+    monkeypatch.delenv("AGENT_BOM_CLOUD_CIS_BENCHMARK", raising=False)
+
+    with patch("agent_bom.api.routes.cloud._run_cis_benchmark") as runner:
+        client.get("/v1/cloud/aws/cis-benchmark")
+
+    runner.assert_not_called()
+
+
+def test_enabled_benchmark_rejects_a_caller_supplied_profile(client: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Which host credential to spend is operator config, not request input."""
+    monkeypatch.setenv("AGENT_BOM_CLOUD_CIS_BENCHMARK", "1")
+
+    response = client.get("/v1/cloud/aws/cis-benchmark?profile=production")
+
+    assert response.status_code == 400
+    assert "profile" in response.json()["detail"].lower()
+
+
+def test_enabled_benchmark_still_runs_without_a_profile(client: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Enabling the flag must leave the normal path working."""
+    monkeypatch.setenv("AGENT_BOM_CLOUD_CIS_BENCHMARK", "1")
+
+    with patch("agent_bom.api.routes.cloud._run_cis_benchmark", return_value={"status": "ok"}) as runner:
+        response = client.get("/v1/cloud/aws/cis-benchmark")
+
+    assert response.status_code == 200
+    runner.assert_called_once()
+
+
+def test_benchmark_requires_admin_not_analyst() -> None:
+    """Analyst-in-any-tenant is the wrong bar for the platform's own identity."""
+    from agent_bom.api.routes import cloud
+
+    assert cloud._CIS_DEP is not cloud._SCAN_DEP, "CIS benchmark must not share the analyst-level scan dependency"
+
+
+def test_inventory_keeps_its_own_per_provider_opt_in(client: Any) -> None:
+    """The inventory surface is unchanged: still analyst-level, still env-gated."""
+    from agent_bom.api.routes import cloud
+
+    response = client.get("/v1/cloud/aws/inventory")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "disabled"
+    # Unlike the benchmark, inventory returns non-secret counts and keeps the
+    # scan-level dependency it already had.
+    assert cloud._SCAN_DEP is not cloud._CIS_DEP


### PR DESCRIPTION
## The exposure

`/v1/cloud/{provider}/cis-benchmark` does **not** use a tenant's stored connection. It evaluates with whatever ambient credentials the control-plane process itself holds — instance role, assumed role, mounted profile. As shipped it was:

- **on by default**, with no operator opt-in (unlike the inventory surface, which is env-gated per provider)
- reachable at `require_authenticated_permission("scan")` — **analyst in any tenant**
- accepting a caller-supplied `profile`, letting any caller name which host AWS profile to spend

While writing the guard, the test run demonstrated the problem by accident: the request reached the **live AWS SDK** before anything stopped it (`CIS check 2.1.1 failed: AccountId must only contain...` in the log). That output is gone now.

## The part the audit missed

Gating the REST route alone would have been theatre. The MCP `cis_benchmark` tool calls the **same benchmark**, with the same ambient credentials and the same caller-supplied `profile`, and had no gate at all — so the tool was a way around the route guard.

The check therefore lives in `agent_bom.cloud.ambient_credentials`, and both surfaces use it. That is also what keeps REST/MCP shape parity intact, which the existing parity test enforces.

## What changed

| | Before | After |
|---|---|---|
| Default | on | off — `AGENT_BOM_CLOUD_CIS_BENCHMARK=1` to enable |
| Permission | `scan` (analyst, any tenant) | `cloud_ambient` (admin only), a new dedicated permission |
| Profile | caller-supplied | `AGENT_BOM_AWS_PROFILE`, server-side; a request profile now returns 400 |
| MCP tool | ungated | same guard, same envelope |

The disabled envelope carries both `error` (so headless callers degrade exactly as they do for a missing SDK) and `status: "disabled"` (so an operator can tell a disabled surface from a broken one).

**Inventory is deliberately untouched** — it already has per-provider env gates and returns non-secret counts, so it keeps the scan-level permission.

## Two mistakes I made and corrected

1. **I put the gate before input validation**, so a malformed region returned "disabled" instead of 400. Caught by `test_cloud_cis_bad_region_400`. Validation now runs first.
2. **I fixed only REST first**, which broke REST/MCP parity and left the bypass above. Caught by `test_rest_cis_shape_matches_mcp_tool`. That test earned its keep.

I also **changed two existing tests**: `test_cloud_cis_allows_admin_role` and `test_cloud_cis_snowflake_is_wired_not_404` asserted the old always-on default. They now set the flag, so they still test what they were written to test — that the route is wired and degrades without a 404 or 500 — rather than encoding a default this PR intentionally changes.

## Verified

- `tests/test_cloud_ambient_credential_guard.py` — 6 tests, written first, confirmed red; includes one asserting the provider is **never invoked** while disabled
- `tests/cloud/` + cloud surface parity + guard — **734 passed**
- `pytest -k "mcp_tool or compliance or rbac or auth"` — **1370 passed**
- All **17** CI gates; `mypy` clean on 4 modules; `ruff` clean

Note on the suite: a broad `-k` sweep shows ~19-23 failures on **unmodified main** too, in different files per run — the repo's known order-dependent test class. I verified against a clean `git stash -u` baseline and re-ran the affected suites with `-p no:randomly`, where everything passes.