### PR TITLE
fix(readme): restore the storefront contract the badge row broke

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@
 
 <p align="center">
   <a href="#quick-start"><b>Quick start</b></a> ·
-  <a href="https://demo.agent-bom.com"><b>Live demo</b></a> ·
-  <a href="https://msaad00.github.io/agent-bom/">Docs</a>
+  <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
+  <a href="https://demo.agent-bom.com">Live demo</a>
 </p>
 
 ## What it is
@@ -157,8 +157,8 @@ real identity, TLS, PostgreSQL, encryption, and audit keys before exposing it.
 | EKS | [Terraform module](deploy/terraform/platform-eks) |
 | Air-gapped | [Image bundle guide](site-docs/deployment/airgapped-image-bundle.md) |
 
-> Pins target `v0.99.0`, the version this tree builds. Until that release is
-> published, use the version shown on the PyPI badge above.
+> Examples target `v0.99.0`; confirm release availability before copying an
+> exact pin. Otherwise, use the latest version shown on PyPI.
 
 [Deployment overview](site-docs/deployment/overview.md) ·
 [Enterprise configuration](docs/ENTERPRISE.md) ·
@@ -173,7 +173,7 @@ real identity, TLS, PostgreSQL, encryption, and audit keys before exposing it.
 | Cloud evidence | `agent-bom connect aws` | Stored connection reference; run scans from the control plane |
 | Runtime gateway | `agent-bom gateway serve --from-control-plane http://127.0.0.1:8422 --bind 127.0.0.1:8090` | Allow, warn, and block audit events |
 | Agent interface | `agent-bom mcp server` | 77 MCP tools, 6 resources, and 8 workflow prompts |
-| Agent distribution | [Smithery](integrations/smithery.yaml) · [Glama](glama.json) · [MCP registry](integrations/mcp-registry) · [Docker MCP](integrations/docker-mcp-registry) | Registry-specific installation metadata |
+| Agent distribution | [Smithery manifest](integrations/smithery.yaml) · [Glama](glama.json) · [MCP registry](integrations/mcp-registry) · [Docker MCP](integrations/docker-mcp-registry) | Registry-specific installation metadata |
 
 The CLI, Docker, API, Helm chart, MCP server, gateway, and SDK are distribution
 surfaces of the same product. EKS remains a deployment profile; Snowflake and
@@ -192,7 +192,7 @@ dependencies.
 | Kubernetes | `helm install agent-bom oci://ghcr.io/msaad00/charts/agent-bom` |
 | GitHub Action | [`msaad00/agent-bom`](action.yml) |
 | MCP server | `pip install 'agent-bom[mcp-server]' && agent-bom mcp server` |
-| MCP registries | [Smithery](integrations/smithery.yaml) · [Glama](glama.json) · [MCP registry](integrations/mcp-registry) · [Docker MCP](integrations/docker-mcp-registry) |
+| MCP registries | [Smithery manifest](integrations/smithery.yaml) · [Glama](glama.json) · [MCP registry](integrations/mcp-registry) · [Docker MCP](integrations/docker-mcp-registry) |
 | SDKs | [Python](sdks/python) · [TypeScript](sdks/typescript) · [Go](sdks/go) |
 
 </details>

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -139,7 +139,11 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert positions == sorted(positions)
 
     hero = readme[: positions[0]]
-    assert hero.count("img.shields.io/") <= 2
+    # The storefront carries a single badge row of build/version/adoption/trust
+    # signals. It is capped so the row cannot grow into a wall, but not held to
+    # two: license, Docker pulls, and the OpenSSF score are the evidence a
+    # first-time reader uses to judge a security tool.
+    assert hero.count("img.shields.io/") <= 8
     assert '<a href="#quick-start"><b>Quick start</b></a>' in hero
     assert '<a href="https://msaad00.github.io/agent-bom/">Docs</a>' in hero
     assert '<a href="https://demo.agent-bom.com">Live demo</a>' in hero


### PR DESCRIPTION
**Main is red.** #4480 merged with three failing assertions in `tests/test_public_docs_cli_alignment.py`. My mistake: I opened that PR and never waited for its CI before it was reviewed and merged.

## Two of the three were honesty guards, not style

This is the part that matters:

| Assertion | What my edit did |
|---|---|
| `"Smithery manifest" in readme` | I shortened the link text to "Smithery" — which quietly turns "we ship a manifest" into "we are listed in the live catalog". The test exists precisely to stop that overclaim. |
| `"confirm release availability before copying an" in readme` | I rewrote the note and dropped the hedge, while the gap it hedges (tree builds `v0.99.0`, PyPI serves `v0.98.0`) still exists. |

Both restored verbatim. The hero nav order and exact link markup are also asserted, so those are restored rather than reordered.

## The badge cap is changed on purpose

`assert hero.count("img.shields.io/") <= 2` was not an accident in the 0.98.0 release prep — it was a deliberate, test-enforced "concise storefront" decision, and I read the badge reduction as a regression without checking for a test that owned it.

Raised to **8**, with the rationale recorded in the test: capping the row stops it becoming a wall, but two was too tight — license, Docker pulls, and the OpenSSF score are the evidence a first-time reader uses to judge a security tool. Everything else the contract enforces — section order, the two-command first run, the collapsibles, the provenance wording — is untouched and still passing.

If you would rather keep the two-badge storefront, say so and I will revert the badge row instead; this PR is the version that matches what you asked for.

## Verified

- `tests/test_public_docs_cli_alignment.py` — **12 passed** (was 3 failing on main)
- `pytest -k "public_docs or readme or storefront or release_consistency"` — **31 passed**, 1 skipped
- `check_release_consistency`, `check_public_docs_hygiene`, `check_product_surface_contract` all pass