### PR TITLE
docs(readme): restore the MCP tool-count sentence Glama reads

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ real identity, TLS, PostgreSQL, encryption, and audit keys before exposing it.
 | Agent interface | `agent-bom mcp server` | 77 MCP tools, 6 resources, and 8 workflow prompts |
 | Agent distribution | [Smithery manifest](integrations/smithery.yaml) · [Glama](glama.json) · [MCP registry](integrations/mcp-registry) · [Docker MCP](integrations/docker-mcp-registry) | Registry-specific installation metadata |
 
+MCP server mode exposes 77 MCP tools, 6 resources, and 8 workflow prompts, all
+read-first: discovery and analysis never mutate a scanned target.
+
 The CLI, Docker, API, Helm chart, MCP server, gateway, and SDK are distribution
 surfaces of the same product. EKS remains a deployment profile; Snowflake and
 Snowpark remain connector/runtime integrations rather than hosted-core


### PR DESCRIPTION
Repo half of the fix for the Glama surface in #4472.

## What was wrong

`scripts/check_glama_listing.py` requires the README to state the MCP surface counts, matching `MCP server mode (exposes|advertises) N MCP tools`. Running it locally failed before reaching the network:

```
README.md MCP tool count sentence not found
```

`git log -S` shows the sentence was dropped by **#4475** (0.98.0 release prep). It was present at `8a8680f91~1` and gone after.

That absence has a real external consequence, not just a red check: **Glama's crawler reads that sentence to populate the catalog entry.** With it missing, the public listing still advertises `18 tools for CVE scanning` from an old release, while `glama.json` has said 77 for months. So the repo has been under-representing the product on a public catalog since that release prep.

Restored next to the distribution table, with the read-first framing that matches the rest of the section.

## What this does not fix

The check probes the live listing, and that only refreshes when Glama re-crawls. Fetching it right now still returns:

```
missing token: 'v0.98.1'
missing token: 'MCP server mode exposes|advertises 77 MCP tools'
stale pattern still present: 18 tools for CVE scanning
```

So **#4472 stays open after this merges**, and that is correct — the check is reporting a true fact about an external surface. A release tag is what normally triggers their re-crawl, so shipping 0.98.1 is the action that closes it. I would rather leave the issue honestly red than silence a check that is telling the truth.

## Verified

- `check_glama_listing.py` now clears the README stage and fails only on live-listing content
- `check_release_consistency`, `check_public_docs_hygiene`, `check_product_surface_contract`, `check_comment_hygiene` — all pass
- `tests/test_public_docs_cli_alignment.py` — 12 passed