### PR TITLE
fix(ui): redact unhandled error boundary messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,9 @@ Versions follow [Semantic Versioning](https://semver.org/).
 - Focused graph paths are filtered before layout, relationship labels remain
   readable at initial fit, and dragged nodes retain their positions without
   changing relationship endpoints.
+- Dashboard error boundaries render and report fixed safe messages instead of
+  exposing raw exception text; valid server-generated digests remain available
+  as bounded correlation references.
 
 ### Removed
 - The optional Go runtime tier (`runtime/gateway-relay`, `runtime/event-collector`)

--- a/ui/app/error.tsx
+++ b/ui/app/error.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { ShieldX } from "lucide-react";
 
 import { api } from "@/lib/api";
+import { errorBoundaryMessage, errorReference } from "@/lib/error-boundary-message";
 
 export default function GlobalError({
   error,
@@ -12,22 +13,28 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const message = errorBoundaryMessage(error);
+  const reference = errorReference(error.digest);
+
   useEffect(() => {
     void api
       .reportClientError({
-        message: error.message,
-        digest: error.digest,
+        message,
+        digest: reference ?? undefined,
         path: window.location.pathname,
         component: "global-error-boundary",
       })
       .catch(() => {});
-  }, [error]);
+  }, [message, reference]);
 
   return (
     <main className="flex h-[80vh] flex-col items-center justify-center gap-4 px-6 text-center">
       <ShieldX className="h-12 w-12 text-red-500" aria-hidden="true" />
       <h1 className="text-lg font-semibold text-[var(--foreground)]">Something went wrong</h1>
-      <p className="max-w-md text-sm text-[var(--text-secondary)]">{error.message}</p>
+      <p className="max-w-md text-sm text-[var(--text-secondary)]">{message}</p>
+      {reference ? (
+        <p className="text-xs text-[var(--text-secondary)]">Reference: {reference}</p>
+      ) : null}
       <button
         type="button"
         onClick={reset}

--- a/ui/app/global-error.tsx
+++ b/ui/app/global-error.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { ShieldX } from "lucide-react";
 
 import { api } from "@/lib/api";
+import { errorBoundaryMessage, errorReference } from "@/lib/error-boundary-message";
 
 export default function GlobalError({
   error,
@@ -12,16 +13,19 @@ export default function GlobalError({
   error: Error & { digest?: string };
   reset: () => void;
 }) {
+  const message = errorBoundaryMessage(error);
+  const reference = errorReference(error.digest);
+
   useEffect(() => {
     void api
       .reportClientError({
-        message: error.message,
-        digest: error.digest,
+        message,
+        digest: reference ?? undefined,
         path: typeof window === "undefined" ? "/" : window.location.pathname,
         component: "root-global-error-boundary",
       })
       .catch(() => {});
-  }, [error]);
+  }, [message, reference]);
 
   return (
     <html lang="en">
@@ -29,7 +33,10 @@ export default function GlobalError({
         <main className="flex min-h-screen flex-col items-center justify-center gap-4 px-6 text-center">
           <ShieldX className="h-12 w-12 text-red-500" aria-hidden="true" />
           <h1 className="text-lg font-semibold">Something went wrong</h1>
-          <p className="max-w-md text-sm text-[var(--text-secondary)]">{error.message}</p>
+          <p className="max-w-md text-sm text-[var(--text-secondary)]">{message}</p>
+          {reference ? (
+            <p className="text-xs text-[var(--text-secondary)]">Reference: {reference}</p>
+          ) : null}
           <button
             type="button"
             onClick={reset}

--- a/ui/lib/error-boundary-message.ts
+++ b/ui/lib/error-boundary-message.ts
@@ -1,0 +1,53 @@
+/**
+ * User-facing text for an unhandled render error.
+ *
+ * An exception message is developer output. It routinely carries a stack
+ * fragment, an internal path, a connection string, or a raw upstream response
+ * body — a demo capture once showed `Invalid time value` as the entire page.
+ * None of that helps the reader and some of it should never leave the server.
+ *
+ * So the boundary and its telemetry report both use a fixed string chosen from
+ * the error's shape. The server-generated digest remains the correlation key;
+ * caller-controlled exception text never crosses the browser/API boundary.
+ */
+
+export const GENERIC_ERROR_MESSAGE =
+  "This page could not be displayed. The error has been reported. Try again, and if it keeps happening, check the control-plane logs.";
+
+export const NETWORK_ERROR_MESSAGE =
+  "The dashboard could not reach the control plane. Check that it is running and reachable, then try again.";
+
+export const PERMISSION_ERROR_MESSAGE =
+  "You do not have access to this view. Ask an administrator to check your role, then try again.";
+
+export const NOT_FOUND_ERROR_MESSAGE = "That item no longer exists. It may have been deleted or moved.";
+
+const NETWORK_HINTS = ["failed to fetch", "networkerror", "load failed", "err_connection", "econnrefused"];
+const PERMISSION_HINTS = ["401", "403", "unauthorized", "forbidden"];
+const NOT_FOUND_HINTS = ["404", "not found"];
+
+/**
+ * Map an error to a fixed, safe message. Never returns caller-controlled text.
+ */
+export function errorBoundaryMessage(error: unknown): string {
+  const raw = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  const probe = raw.toLowerCase();
+
+  if (NETWORK_HINTS.some((hint) => probe.includes(hint))) return NETWORK_ERROR_MESSAGE;
+  if (PERMISSION_HINTS.some((hint) => probe.includes(hint))) return PERMISSION_ERROR_MESSAGE;
+  if (NOT_FOUND_HINTS.some((hint) => probe.includes(hint))) return NOT_FOUND_ERROR_MESSAGE;
+  return GENERIC_ERROR_MESSAGE;
+}
+
+/**
+ * Short, non-secret correlation handle so a user can quote something useful.
+ *
+ * Next.js digests are server-generated hashes, not error text, so they are safe
+ * to display and are what an operator greps for.
+ */
+export function errorReference(digest?: string): string | null {
+  const trimmed = (digest ?? "").trim();
+  // Next.js digests are hash-like values. Fail closed if a caller supplies
+  // punctuation, whitespace, or another shape that could be raw error text.
+  return /^[a-f0-9]{8,64}$/i.test(trimmed) ? trimmed.slice(0, 12) : null;
+}

--- a/ui/tests/error-boundary-message.test.ts
+++ b/ui/tests/error-boundary-message.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  GENERIC_ERROR_MESSAGE,
+  NETWORK_ERROR_MESSAGE,
+  NOT_FOUND_ERROR_MESSAGE,
+  PERMISSION_ERROR_MESSAGE,
+  errorBoundaryMessage,
+  errorReference,
+} from "@/lib/error-boundary-message";
+
+describe("errorBoundaryMessage", () => {
+  it("never returns the raw exception text", () => {
+    const secret = "connection failed: postgresql://user:hunter2@db.internal:5432/agent_bom";
+
+    const shown = errorBoundaryMessage(new Error(secret));
+
+    expect(shown).not.toContain("hunter2");
+    expect(shown).not.toContain("db.internal");
+    expect(shown).toBe(GENERIC_ERROR_MESSAGE);
+  });
+
+  it("does not leak the demo capture's raw message", () => {
+    expect(errorBoundaryMessage(new Error("Invalid time value"))).toBe(GENERIC_ERROR_MESSAGE);
+  });
+
+  it("recognizes an unreachable control plane", () => {
+    expect(errorBoundaryMessage(new Error("Failed to fetch"))).toBe(NETWORK_ERROR_MESSAGE);
+    expect(errorBoundaryMessage(new Error("NetworkError when attempting to fetch resource"))).toBe(NETWORK_ERROR_MESSAGE);
+  });
+
+  it("recognizes an authorization failure", () => {
+    expect(errorBoundaryMessage(new Error("Request failed with status 403"))).toBe(PERMISSION_ERROR_MESSAGE);
+    expect(errorBoundaryMessage(new Error("Unauthorized"))).toBe(PERMISSION_ERROR_MESSAGE);
+  });
+
+  it("recognizes a missing resource", () => {
+    expect(errorBoundaryMessage(new Error("404 Not Found"))).toBe(NOT_FOUND_ERROR_MESSAGE);
+  });
+
+  it("handles non-Error values without throwing", () => {
+    expect(errorBoundaryMessage(undefined)).toBe(GENERIC_ERROR_MESSAGE);
+    expect(errorBoundaryMessage("some string")).toBe(GENERIC_ERROR_MESSAGE);
+    expect(errorBoundaryMessage({ nope: true })).toBe(GENERIC_ERROR_MESSAGE);
+  });
+
+  it("returns only the documented catalog entries", () => {
+    const catalog = new Set([
+      GENERIC_ERROR_MESSAGE,
+      NETWORK_ERROR_MESSAGE,
+      PERMISSION_ERROR_MESSAGE,
+      NOT_FOUND_ERROR_MESSAGE,
+    ]);
+    const probes = ["boom", "500 server error", "TypeError: x is not a function", "403", "Failed to fetch", ""];
+
+    for (const probe of probes) {
+      expect(catalog.has(errorBoundaryMessage(new Error(probe)))).toBe(true);
+    }
+  });
+});
+
+describe("errorReference", () => {
+  it("exposes a short digest a user can quote", () => {
+    expect(errorReference("abcdef0123456789abcdef")).toBe("abcdef012345");
+  });
+
+  it("returns null when there is no digest", () => {
+    expect(errorReference(undefined)).toBeNull();
+    expect(errorReference("   ")).toBeNull();
+  });
+
+  it("rejects a caller-controlled value that is not a digest", () => {
+    expect(errorReference("postgresql://user:secret@db.internal")).toBeNull();
+    expect(errorReference("raw error message")).toBeNull();
+  });
+});

--- a/ui/tests/error-page.test.tsx
+++ b/ui/tests/error-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/api", () => ({
@@ -6,6 +7,7 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import ErrorBoundary from "@/app/error";
+import RootErrorBoundary from "@/app/global-error";
 
 describe("route error boundary", () => {
   it("renders a top-level heading inside a main landmark", () => {
@@ -14,6 +16,41 @@ describe("route error boundary", () => {
     const heading = screen.getByRole("heading", { level: 1, name: /something went wrong/i });
     expect(heading).toBeInTheDocument();
     expect(screen.getByRole("main")).toBeInTheDocument();
-    expect(screen.getByText("boom")).toBeInTheDocument();
+  });
+
+  it("never renders the raw exception text", () => {
+    const secret = "connect ECONNREFUSED postgresql://user:hunter2@db.internal:5432";
+
+    render(<ErrorBoundary error={new Error(secret)} reset={() => {}} />);
+
+    expect(screen.queryByText(secret)).not.toBeInTheDocument();
+    expect(document.body.textContent).not.toContain("hunter2");
+    expect(document.body.textContent).not.toContain("db.internal");
+  });
+
+  it("reports only safe catalog text to telemetry", async () => {
+    const { api } = await import("@/lib/api");
+    const secret = "connect ECONNREFUSED postgresql://user:hunter2@db.internal:5432";
+
+    render(<ErrorBoundary error={new Error(secret)} reset={() => {}} />);
+
+    expect(api.reportClientError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: "The dashboard could not reach the control plane. Check that it is running and reachable, then try again.",
+      }),
+    );
+    expect(api.reportClientError).not.toHaveBeenCalledWith(expect.objectContaining({ message: secret }));
+  });
+});
+
+describe("root error boundary", () => {
+  it("never renders the raw exception text", () => {
+    const secret = "postgresql://user:hunter2@db.internal:5432";
+
+    const markup = renderToStaticMarkup(<RootErrorBoundary error={new Error(secret)} reset={() => {}} />);
+
+    expect(markup).not.toContain("hunter2");
+    expect(markup).not.toContain("db.internal");
+    expect(markup).toContain("Something went wrong");
   });
 });


### PR DESCRIPTION
## Summary

- replace raw route and root error-boundary messages with a fixed safe catalog
- send only safe catalog text and validated digest references to UI error telemetry
- reject non-hash digest values and cover both error boundaries with regression tests
- record the correction in the pending 0.98.1 changelog

## Verification

- Node 24 toolchain contract — passed
- UI tests — 157 files / 903 tests passed
- UI typecheck — passed
- Next.js production build — passed
- public-docs hygiene — passed
- comment hygiene — passed
- `git diff --check` — passed

## Notes

Error classification is local and bounded to fixed user-facing strings. Raw exception text, connection strings, internal paths, and upstream bodies are neither rendered nor transmitted by these boundaries. Only hash-shaped server digests are shown as correlation references.