### PR TITLE
fix(ticketing): make Postgres schema migration-owned

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260726_01_ticketing_schema_authority.py
+++ b/deploy/supabase/postgres/alembic/versions/20260726_01_ticketing_schema_authority.py
@@ -1,0 +1,122 @@
+"""Make ticketing persistence migration-owned and tenant-isolated.
+
+Revision ID: 20260726_01
+Revises: 20260724_03
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260726_01"
+down_revision = "20260724_03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ticketing_connections (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            transport TEXT NOT NULL,
+            auth_method TEXT NOT NULL,
+            display_name TEXT NOT NULL,
+            endpoint TEXT NOT NULL DEFAULT '',
+            secret_encrypted TEXT NOT NULL DEFAULT '',
+            auth_params TEXT NOT NULL DEFAULT '{}',
+            status TEXT NOT NULL DEFAULT 'pending',
+            status_detail TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS ticket_links (
+            id TEXT PRIMARY KEY,
+            tenant_id TEXT NOT NULL,
+            connection_id TEXT NOT NULL,
+            dedupe_key TEXT NOT NULL,
+            provider TEXT NOT NULL,
+            status TEXT NOT NULL DEFAULT 'open',
+            external_id TEXT NOT NULL DEFAULT '',
+            key TEXT NOT NULL DEFAULT '',
+            url TEXT NOT NULL DEFAULT '',
+            created_at TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            UNIQUE (tenant_id, connection_id, dedupe_key)
+        )
+        """
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_ticketing_connections_tenant "
+        "ON ticketing_connections(tenant_id, created_at)"
+    )
+    op.execute("CREATE INDEX IF NOT EXISTS idx_ticket_links_tenant ON ticket_links(tenant_id, created_at)")
+    op.execute("ALTER TABLE ticketing_connections ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE ticketing_connections FORCE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE ticket_links ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE ticket_links FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = current_schema()
+              AND tablename = 'ticketing_connections'
+              AND policyname = 'ticketing_connections_tenant_isolation'
+          ) THEN
+            CREATE POLICY ticketing_connections_tenant_isolation ON ticketing_connections
+              USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+              WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+          END IF;
+        END $$
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = current_schema()
+              AND tablename = 'ticket_links'
+              AND policyname = 'ticket_links_tenant_isolation'
+          ) THEN
+            CREATE POLICY ticket_links_tenant_isolation ON ticket_links
+              USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+              WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+          END IF;
+        END $$
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+            GRANT SELECT, INSERT, UPDATE, DELETE ON ticketing_connections TO agent_bom_app;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON ticket_links TO agent_bom_app;
+          END IF;
+        END $$
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO control_plane_schema_versions(component, version, updated_at)
+        VALUES ('ticketing_connections', 1, now())
+        ON CONFLICT(component) DO UPDATE SET
+            version = EXCLUDED.version,
+            updated_at = EXCLUDED.updated_at
+        """
+    )
+
+
+def downgrade() -> None:
+    # Connections and ticket links are customer records. Preserve them on rollback.
+    pass

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -152,6 +152,10 @@ CREATE INDEX IF NOT EXISTS idx_dispatch_pending ON scan_dispatch_queue(status,cr
 CREATE TABLE IF NOT EXISTS cloud_connections (id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,provider TEXT NOT NULL,display_name TEXT NOT NULL,role_ref TEXT NOT NULL,external_id_encrypted TEXT NOT NULL DEFAULT '',regions TEXT NOT NULL DEFAULT '[]',status TEXT NOT NULL DEFAULT 'pending',status_detail TEXT NOT NULL DEFAULT '',created_at TEXT NOT NULL,updated_at TEXT NOT NULL,last_scan_at TEXT,last_scan_id TEXT,scan_interval_minutes INTEGER,auth_params TEXT NOT NULL DEFAULT '{}',last_event_at TEXT,inventory_scope TEXT NOT NULL DEFAULT 'account',scan_mode TEXT NOT NULL DEFAULT 'full',auto_scan_on_create BOOLEAN NOT NULL DEFAULT TRUE);
 CREATE INDEX IF NOT EXISTS idx_cloud_connections_tenant ON cloud_connections(tenant_id,created_at);
 CREATE INDEX IF NOT EXISTS idx_cloud_connections_schedulable ON cloud_connections(scan_interval_minutes,last_scan_at);
+CREATE TABLE IF NOT EXISTS ticketing_connections (id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,provider TEXT NOT NULL,transport TEXT NOT NULL,auth_method TEXT NOT NULL,display_name TEXT NOT NULL,endpoint TEXT NOT NULL DEFAULT '',secret_encrypted TEXT NOT NULL DEFAULT '',auth_params TEXT NOT NULL DEFAULT '{}',status TEXT NOT NULL DEFAULT 'pending',status_detail TEXT NOT NULL DEFAULT '',created_at TEXT NOT NULL,updated_at TEXT NOT NULL);
+CREATE INDEX IF NOT EXISTS idx_ticketing_connections_tenant ON ticketing_connections(tenant_id,created_at);
+CREATE TABLE IF NOT EXISTS ticket_links (id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,connection_id TEXT NOT NULL,dedupe_key TEXT NOT NULL,provider TEXT NOT NULL,status TEXT NOT NULL DEFAULT 'open',external_id TEXT NOT NULL DEFAULT '',key TEXT NOT NULL DEFAULT '',url TEXT NOT NULL DEFAULT '',created_at TEXT NOT NULL,updated_at TEXT NOT NULL,UNIQUE (tenant_id,connection_id,dedupe_key));
+CREATE INDEX IF NOT EXISTS idx_ticket_links_tenant ON ticket_links(tenant_id,created_at);
 CREATE TABLE IF NOT EXISTS control_plane_sources (source_id TEXT PRIMARY KEY,enabled INTEGER DEFAULT 1,tenant_id TEXT NOT NULL DEFAULT 'default',updated_at TEXT NOT NULL,data JSONB NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_control_plane_sources_tenant_updated ON control_plane_sources(tenant_id,updated_at DESC);
 CREATE TABLE IF NOT EXISTS credential_refs (credential_ref_id TEXT PRIMARY KEY,enabled INTEGER DEFAULT 1,tenant_id TEXT NOT NULL DEFAULT 'default',updated_at TEXT NOT NULL,data JSONB NOT NULL);
@@ -196,7 +200,7 @@ BEGIN
     'access_review_campaigns','access_review_items','agent_identities','agent_identity_jit_grants','agent_conditional_access_policies',
     'ai_system_blueprints','ai_system_blueprint_versions','runtime_observations','runtime_sessions','runtime_workload_evidence','scim_users','scim_groups',
     'idempotency_keys','proxy_replay_log','tenant_quota_overrides','tenant_graph_retention_overrides','tenant_score_config_overrides',
-    'mcp_client_configs','model_provider_keys','model_virtual_keys','risk_campaign_workflows','governance_audit_log','cloud_connections',
+    'mcp_client_configs','model_provider_keys','model_virtual_keys','risk_campaign_workflows','governance_audit_log','cloud_connections','ticketing_connections','ticket_links',
     'control_plane_sources','credential_refs','audit_chain_checkpoint','managed_trial_invitations','managed_trial_tenants','compliance_hub_findings','hub_findings_current',
     'hub_findings_current_observations','hub_cve_intel','hub_framework_refs'
   ] LOOP
@@ -224,6 +228,7 @@ SELECT component,1,now() FROM unnest(ARRAY[
  'scan_jobs','api_keys','exceptions','audit_log','trend_history','gateway_policies','schedules','sources','credential_refs','llm_costs',
  'cloud_connections','compliance_hub','access_review_campaigns','risk_campaign_workflows','fleet','graph','scan_cache','identity_scim',
  'agent_identities','runtime_events','runtime_workload_evidence','tenant_quotas','tenant_graph_retention','idempotency','proxy_replay_log','rate_limits',
- 'shared_auth_state','managed_trial_invitations','managed_trial_tenants','governance_audit_log','ai_system_blueprints','mcp_client_configs','model_provider_keys','tenant_score_config'
+ 'shared_auth_state','managed_trial_invitations','managed_trial_tenants','governance_audit_log','ai_system_blueprints','mcp_client_configs','model_provider_keys','tenant_score_config',
+ 'ticketing_connections'
 ]) component
 ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -49,6 +49,7 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     StorageSchemaComponent("gateway_policies", "sqlite/postgres", ("gateway_policies", "policy_audit_log")),
     StorageSchemaComponent("llm_costs", "sqlite/postgres", ("llm_costs", "llm_cost_budgets")),
     StorageSchemaComponent("cloud_connections", "sqlite/postgres", ("cloud_connections",)),
+    StorageSchemaComponent("ticketing_connections", "sqlite/postgres", ("ticketing_connections", "ticket_links")),
     StorageSchemaComponent("compliance_hub", "sqlite/postgres", ("compliance_hub_findings", "hub_findings_current")),
     StorageSchemaComponent("access_review_campaigns", "sqlite/postgres", ("access_review_campaigns", "access_review_items")),
     StorageSchemaComponent("risk_campaign_workflows", "sqlite/postgres", ("risk_campaign_workflows",)),

--- a/src/agent_bom/ticketing/postgres_store.py
+++ b/src/agent_bom/ticketing/postgres_store.py
@@ -41,7 +41,8 @@ class PostgresTicketingStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
-            ensure_postgres_schema_version(conn, "ticketing_connections")
+            if not ensure_postgres_schema_version(conn, "ticketing_connections"):
+                return
             conn.execute(
                 """
                 CREATE TABLE IF NOT EXISTS ticketing_connections (

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -75,6 +75,98 @@ def test_postgres_job_store_real_roundtrip_and_tenant_filter():
     assert any(item.job_id == job_id for item in results)
 
 
+def test_postgres_ticketing_store_real_dml_role_roundtrip_and_tenant_filter():
+    from agent_bom.api.postgres_common import _get_pool, reset_current_tenant, set_current_tenant
+    from agent_bom.ticketing.connection_store import TicketLink
+    from agent_bom.ticketing.models import TicketingConnectionRecord
+    from agent_bom.ticketing.postgres_store import PostgresTicketingStore
+
+    pool = _get_pool()
+    with pool.connection() as conn:
+        role = conn.execute(
+            "SELECT current_user, has_schema_privilege(current_user, current_schema(), 'CREATE')"
+        ).fetchone()
+    if role is None or role[1]:
+        pytest.skip("Ticketing DML contract requires the migration-provisioned application role")
+
+    suffix = uuid4().hex
+    tenant_id = f"ticketing-{suffix}"
+    other_tenant_id = f"ticketing-other-{suffix}"
+    connection_id = f"ticketing-connection-{suffix}"
+    ticket_id = f"ticket-link-{suffix}"
+    store = PostgresTicketingStore(pool=pool)
+    record = TicketingConnectionRecord(
+        id=connection_id,
+        tenant_id=tenant_id,
+        provider="jira",
+        transport="rest",
+        auth_method="token",
+        display_name="Postgres contract",
+        endpoint="https://tickets.example.invalid",
+        secret_encrypted="ciphertext",
+        auth_params={"user": "contract@example.invalid"},
+        status="active",
+        created_at="2026-07-26T00:00:00Z",
+        updated_at="2026-07-26T00:00:00Z",
+    )
+    link = TicketLink(
+        id=ticket_id,
+        tenant_id=tenant_id,
+        connection_id=connection_id,
+        dedupe_key=f"finding-{suffix}",
+        provider="jira",
+        created_at="2026-07-26T00:00:00Z",
+        updated_at="2026-07-26T00:00:00Z",
+    )
+
+    tenant_token = set_current_tenant(tenant_id)
+    try:
+        store.put_connection(record)
+        won, claimed = store.claim_ticket_link(link)
+        replay_won, replayed = store.claim_ticket_link(
+            TicketLink(**{**link.to_public_dict(), "id": f"ticket-link-replay-{suffix}"})
+        )
+        same_tenant = store.get_connection(tenant_id, connection_id)
+    finally:
+        reset_current_tenant(tenant_token)
+
+    other_token = set_current_tenant(other_tenant_id)
+    try:
+        other_tenant = store.get_connection(tenant_id, connection_id)
+        other_tenant_link = store.get_ticket_link(tenant_id, ticket_id)
+    finally:
+        reset_current_tenant(other_token)
+
+    try:
+        assert won is True
+        assert claimed.id == ticket_id
+        assert replay_won is False
+        assert replayed.id == ticket_id
+        assert same_tenant is not None
+        assert same_tenant.auth_params == {"user": "contract@example.invalid"}
+        assert other_tenant is None
+        assert other_tenant_link is None
+        with pool.connection() as conn:
+            marker = conn.execute(
+                "SELECT version FROM control_plane_schema_versions WHERE component = %s",
+                ("ticketing_connections",),
+            ).fetchone()
+            rls = conn.execute(
+                "SELECT relname, relrowsecurity, relforcerowsecurity FROM pg_class "
+                "WHERE oid IN ('public.ticketing_connections'::regclass, 'public.ticket_links'::regclass) "
+                "ORDER BY relname"
+            ).fetchall()
+        assert marker == (1,)
+        assert rls == [("ticket_links", True, True), ("ticketing_connections", True, True)]
+    finally:
+        cleanup_token = set_current_tenant(tenant_id)
+        try:
+            store.delete_ticket_link(tenant_id, ticket_id)
+            store.delete_connection(tenant_id, connection_id)
+        finally:
+            reset_current_tenant(cleanup_token)
+
+
 def test_postgres_invitation_provisions_team_and_key_atomically_under_new_tenant_rls():
     """An operator admin may provision a distinct tenant without an RLS or FK failure."""
     import psycopg

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -19,6 +19,7 @@ GRAPH_SNAPSHOT_JSON_PARITY = VERSIONS_DIR / "20260717_03_graph_snapshot_json_par
 RUNTIME_SCHEMA_AUTHORITY = VERSIONS_DIR / "20260718_01_runtime_schema_authority.py"
 CLOUD_CONNECTIONS_SCOPE_COLUMNS = VERSIONS_DIR / "20260724_02_cloud_connections_scope_columns.py"
 MANAGED_TRIAL_INVITATIONS = VERSIONS_DIR / "20260724_03_managed_trial_invitations.py"
+TICKETING_SCHEMA_AUTHORITY = VERSIONS_DIR / "20260726_01_ticketing_schema_authority.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
@@ -78,6 +79,23 @@ def test_managed_trial_invitation_migration_is_chained_and_secret_minimal() -> N
     assert "FORCE ROW LEVEL SECURITY" in sql
     assert "managed_trial_invitations_tenant_isolation" in sql
     assert "managed_trial_tenants_tenant_isolation" in sql
+
+
+def test_ticketing_schema_authority_migration_is_chained_and_tenant_isolated() -> None:
+    sql = TICKETING_SCHEMA_AUTHORITY.read_text()
+    assert re.search(r'revision\s*=\s*"20260726_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260724_03"', sql)
+    assert "CREATE TABLE IF NOT EXISTS ticketing_connections" in sql
+    assert "CREATE TABLE IF NOT EXISTS ticket_links" in sql
+    assert "UNIQUE (tenant_id, connection_id, dedupe_key)" in sql
+    assert "idx_ticketing_connections_tenant" in sql
+    assert "idx_ticket_links_tenant" in sql
+    for table in ("ticketing_connections", "ticket_links"):
+        assert f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY" in sql
+        assert f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY" in sql
+        assert f"{table}_tenant_isolation" in sql
+        assert f"GRANT SELECT, INSERT, UPDATE, DELETE ON {table} TO agent_bom_app" in sql
+    assert "VALUES ('ticketing_connections', 1, now())" in sql
 
 
 def test_baseline_migration_points_at_bootstrap_sql():

--- a/tests/test_postgres_schema_authority.py
+++ b/tests/test_postgres_schema_authority.py
@@ -6,7 +6,7 @@ import importlib
 import re
 from pathlib import Path
 
-from agent_bom.api.storage_schema import ensure_postgres_schema_version
+from agent_bom.api.storage_schema import CONTROL_PLANE_SCHEMA_COMPONENTS, ensure_postgres_schema_version
 from agent_bom.storage.base import StorageSchema, TableSchema
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -145,6 +145,23 @@ class _Connection:
         return _Result()
 
 
+class _Pool:
+    def __init__(self, connection: _Connection) -> None:
+        self._connection = connection
+
+    def connection(self):
+        connection = self._connection
+
+        class _Context:
+            def __enter__(self):
+                return connection
+
+            def __exit__(self, exc_type, exc, traceback):
+                return False
+
+        return _Context()
+
+
 def test_configured_postgres_schema_check_is_read_only(monkeypatch) -> None:
     monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app@postgres/agent_bom")
     connection = _Connection()
@@ -155,6 +172,28 @@ def test_configured_postgres_schema_check_is_read_only(monkeypatch) -> None:
     assert connection.statements == [
         "SELECT version FROM control_plane_schema_versions WHERE component = %s",
     ]
+
+
+def test_configured_ticketing_store_constructor_never_executes_ddl(monkeypatch) -> None:
+    from agent_bom.ticketing.postgres_store import PostgresTicketingStore
+
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app@postgres/agent_bom")
+    connection = _Connection()
+
+    PostgresTicketingStore(pool=_Pool(connection))
+
+    assert connection.statements == [
+        "SELECT version FROM control_plane_schema_versions WHERE component = %s",
+    ]
+
+
+def test_ticketing_tables_are_registered_as_one_schema_component() -> None:
+    ticketing = [component for component in CONTROL_PLANE_SCHEMA_COMPONENTS if component.component == "ticketing_connections"]
+
+    assert len(ticketing) == 1
+    assert ticketing[0].backend == "sqlite/postgres"
+    assert ticketing[0].tables == ("ticketing_connections", "ticket_links")
+    assert ticketing[0].tenant_scoped is True
 
 
 def test_legacy_postgres_db_setting_uses_the_same_read_only_contract(monkeypatch) -> None:
@@ -185,6 +224,7 @@ def test_every_postgres_store_guards_runtime_schema_ddl() -> None:
         for name in ("idempotency_store.py", "middleware.py", "proxy_replay_store.py", "shared_auth_state.py")
     )
     runtime_schema_files.append(ROOT / "src" / "agent_bom" / "cloud" / "runtime_workload_evidence_store.py")
+    runtime_schema_files.append(ROOT / "src" / "agent_bom" / "ticketing" / "postgres_store.py")
     for path in sorted(runtime_schema_files):
         for line_number, line in enumerate(path.read_text().splitlines(), start=1):
             if "ensure_postgres_schema_version(" not in line or line.lstrip().startswith("def "):
@@ -231,6 +271,7 @@ def test_migration_schema_covers_every_runtime_postgres_table_and_component() ->
         )
     )
     runtime_paths.append(ROOT / "src" / "agent_bom" / "cloud" / "runtime_workload_evidence_store.py")
+    runtime_paths.append(ROOT / "src" / "agent_bom" / "ticketing" / "postgres_store.py")
     runtime_source = "\n".join(path.read_text() for path in runtime_paths)
     migration_sql = (ROOT / "deploy" / "supabase" / "postgres" / "runtime-schema.sql").read_text()
     baseline_sql = (ROOT / "deploy" / "supabase" / "postgres" / "init.sql").read_text()


### PR DESCRIPTION
## Summary

- add migration-owned PostgreSQL ticketing tables, indexes, schema marker, DML grants, and forced tenant RLS
- stop ticketing request paths from attempting DDL when PostgreSQL is configured as migration-owned
- include ticketing in schema-authority drift checks and a real DML-only tenant-isolation/idempotency contract

## Verification

- ticketing, migration, and schema-authority tests — 66 passed
- PostgreSQL 16 DML-only integration contract — 14 passed, 1 skipped
- risk campaign tests — 62 passed
- previous-head Alembic upgrade and idempotent rerun — passed
- `make preflight` — passed
- `make lint` — passed
- `git diff --check origin/main...HEAD` — passed

## Notes

The migration is additive and preserves customer ticketing records on downgrade. Runtime schema initialization remains available only for legacy bootstrap mode; configured migration-owned PostgreSQL is read-only with respect to schema creation. All test identities and endpoints are synthetic.