### PR TITLE
fix(cli): stabilize demo agent identities

### DIFF
--- a/src/agent_bom/cli/_scan_runner.py
+++ b/src/agent_bom/cli/_scan_runner.py
@@ -65,6 +65,8 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
     if cfg.demo:
         from agent_bom.demo import DEMO_INVENTORY
 
+        for agent_data in DEMO_INVENTORY.get("agents", []):
+            agent_data.setdefault("config_path", f"~/.config/{agent_data.get('agent_type', 'agent')}/config.json")
         _demo_fd, _demo_path = tempfile.mkstemp(suffix=".json", prefix="agent-bom-demo-")
         with os.fdopen(_demo_fd, "w") as _df:
             json.dump(DEMO_INVENTORY, _df)
@@ -73,8 +75,6 @@ def run_default_scan(cfg: ScanConfig, con: "Console") -> ScanResult:
         compliance = True
         if not project:
             project = tempfile.mkdtemp(prefix="agent-bom-demo-dir-")
-        for agent_data in DEMO_INVENTORY.get("agents", []):
-            agent_data.setdefault("config_path", f"~/.config/{agent_data.get('agent_type', 'agent')}/config.json")
         iac_paths = (project,)
         if not cfg.quiet:
             con.print("\n[bold yellow]Demo mode[/bold yellow] — curated agent + MCP sample with known-vulnerable packages.\n")

--- a/src/agent_bom/cli/agents/_modes.py
+++ b/src/agent_bom/cli/agents/_modes.py
@@ -46,6 +46,8 @@ def apply_demo_mode(
 
     from agent_bom.demo import DEMO_INVENTORY
 
+    for agent_data in DEMO_INVENTORY.get("agents", []):
+        agent_data.setdefault("config_path", f"~/.config/{agent_data.get('agent_type', 'agent')}/config.json")
     fd, path = tempfile.mkstemp(suffix=".json", prefix="agent-bom-demo-")
     with os.fdopen(fd, "w") as out:
         json.dump(DEMO_INVENTORY, out)
@@ -55,8 +57,6 @@ def apply_demo_mode(
     compliance = True
     if not project:
         project = tempfile.mkdtemp(prefix="agent-bom-demo-dir-")
-    for agent_data in DEMO_INVENTORY.get("agents", []):
-        agent_data.setdefault("config_path", f"~/.config/{agent_data.get('agent_type', 'agent')}/config.json")
 
     # Disable IaC auto-detection: point iac_paths at the empty demo project so
     # the later "if not iac_paths" detection branch does not run.

--- a/tests/test_demo_inventory_accuracy.py
+++ b/tests/test_demo_inventory_accuracy.py
@@ -14,12 +14,19 @@ vulnerable ones (e.g. to show that not everything is on fire).
 
 from __future__ import annotations
 
+import copy
+import io
+import json
+from pathlib import Path
+
 import pytest
+from rich.console import Console
 
 from agent_bom.db.lookup import lookup_package
 from agent_bom.db.schema import init_db
 from agent_bom.demo import DEMO_INVENTORY
 from agent_bom.demo_advisories import seed_demo_advisories
+from agent_bom.scan_contract import ScanConfig
 
 # Packages that the demo intentionally ships at a known-clean version. Add
 # entries here only after manually confirming that the version genuinely
@@ -88,6 +95,75 @@ def test_demo_agents_keep_unique_identity_across_all_inventory_exports() -> None
     history_snapshot = _get_inventory_snapshot(report_json)
     assert len(history_snapshot["agents"]) == 5
     assert len({agent["id"] for agent in history_snapshot["agents"]}) == 5
+
+
+def _materialized_demo_agent_ids(inventory_path: str) -> list[str]:
+    from agent_bom.cli._common import _build_agents_from_inventory
+
+    payload = json.loads(Path(inventory_path).read_text())
+    return [agent.stable_id for agent in _build_agents_from_inventory(payload, inventory_path)]
+
+
+def test_scan_demo_agent_ids_are_stable_across_materializations(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """Random temporary inventory paths must not change demo agent identity."""
+    import agent_bom.demo as demo
+    from agent_bom.cli.agents._modes import apply_demo_mode
+
+    demo_inventory = copy.deepcopy(DEMO_INVENTORY)
+    monkeypatch.setattr(demo, "DEMO_INVENTORY", demo_inventory)
+
+    observed_ids: list[list[str]] = []
+    for _ in range(2):
+        _, inventory_path, _, _, _ = apply_demo_mode(
+            demo=True,
+            project=str(tmp_path),
+            inventory=None,
+            enrich=False,
+            compliance=False,
+            iac_paths=(),
+        )
+        assert inventory_path is not None
+        observed_ids.append(_materialized_demo_agent_ids(inventory_path))
+        Path(inventory_path).unlink()
+
+    assert observed_ids[0] == observed_ids[1]
+
+
+def test_default_scan_demo_agent_ids_are_stable_across_materializations(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """The shared SDK/remediation scan path must keep the same demo IDs."""
+    import agent_bom.demo as demo
+    from agent_bom.cli._scan_runner import run_default_scan
+
+    class CapturedDemoInventoryError(Exception):
+        pass
+
+    demo_inventory = copy.deepcopy(DEMO_INVENTORY)
+    monkeypatch.setattr(demo, "DEMO_INVENTORY", demo_inventory)
+
+    observed_ids: list[list[str]] = []
+
+    def capture_inventory(*args, **kwargs):  # noqa: ANN002, ANN003, ARG001
+        inventory_path = kwargs["inventory"]
+        observed_ids.append(_materialized_demo_agent_ids(inventory_path))
+        Path(inventory_path).unlink()
+        raise CapturedDemoInventoryError
+
+    monkeypatch.setattr("agent_bom.cli.agents._discovery.run_local_discovery", capture_inventory)
+
+    for _ in range(2):
+        with pytest.raises(CapturedDemoInventoryError):
+            run_default_scan(
+                ScanConfig(project=str(tmp_path), demo=True, quiet=True),
+                Console(file=io.StringIO()),
+            )
+
+    assert observed_ids[0] == observed_ids[1]
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

- assign deterministic demo config paths before materializing temporary inventory files
- keep canonical agent IDs stable across repeated `scan --demo` runs in both CLI scan paths
- add regressions for the primary CLI and shared SDK/remediation materializers

## Verification

- `uv run pytest -q tests/test_demo_inventory_accuracy.py -k stable_across_materializations` — 2 passed
- affected CLI suites — 152 passed
- `uv run ruff check src/agent_bom/cli/_scan_runner.py src/agent_bom/cli/agents/_modes.py tests/test_demo_inventory_accuracy.py`
- `git diff --check`
- two real `agent-bom scan --demo --offline` runs produced the same five stable IDs; both returned the expected findings exit code 1

## Notes

The regression tests were observed failing before the implementation: all five demo IDs changed because the random temporary inventory path became the canonical config-path fallback.