### PR TITLE
fix(exports): keep optional enrichment read-only

### DIFF
--- a/src/agent_bom/api/durable_store.py
+++ b/src/agent_bom/api/durable_store.py
@@ -48,14 +48,16 @@ def state_dir() -> Path:
     return Path(os.environ.get("AGENT_BOM_STATE_DIR", Path.home() / ".agent-bom"))
 
 
-def default_state_db_path() -> str:
+def default_state_db_path(*, create_parent: bool = True) -> str:
     """Return the durable SQLite path used when no backend is configured.
 
-    Creates the parent directory if needed so first-run boot does not fail on a
-    missing ``~/.agent-bom`` directory.
+    Creates the parent directory by default so first-run boot does not fail on
+    a missing ``~/.agent-bom`` directory. Read-only callers can pass
+    ``create_parent=False`` to resolve the path without mutating the filesystem.
     """
     directory = state_dir()
-    directory.mkdir(parents=True, exist_ok=True)
+    if create_parent:
+        directory.mkdir(parents=True, exist_ok=True)
     return str(directory / DEFAULT_STATE_DB_FILENAME)
 
 
@@ -84,7 +86,7 @@ def postgres_configured() -> bool:
     return bool(db) and _is_postgres_url(db)
 
 
-def sqlite_path() -> str:
+def sqlite_path(*, create_parent: bool = True) -> str:
     """Return the SQLite path for the durable default backend.
 
     Uses ``AGENT_BOM_DB`` when it points at a file path; otherwise the durable
@@ -93,7 +95,7 @@ def sqlite_path() -> str:
     db = os.environ.get("AGENT_BOM_DB", "")
     if db and not _is_postgres_url(db):
         return db
-    return default_state_db_path()
+    return default_state_db_path(create_parent=create_parent)
 
 
 def select_backend() -> str:

--- a/src/agent_bom/cloud/runtime_workload_evidence.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence.py
@@ -708,9 +708,11 @@ def optional_runtime_workload_evidence_index(
     try:
         active_store = store
         if active_store is None:
-            from agent_bom.cloud.runtime_workload_evidence_store import get_runtime_workload_evidence_store
+            from agent_bom.cloud.runtime_workload_evidence_store import get_optional_runtime_workload_evidence_store
 
-            active_store = get_runtime_workload_evidence_store()
+            active_store = get_optional_runtime_workload_evidence_store()
+        if active_store is None:
+            return None
         index = RuntimeWorkloadEvidenceIndex.from_store(active_store, active_tenant)
         return None if index.is_empty() else index
     except Exception as exc:  # noqa: BLE001 - enrichment is explicitly optional

--- a/src/agent_bom/cloud/runtime_workload_evidence_store.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence_store.py
@@ -130,14 +130,28 @@ class InMemoryRuntimeWorkloadEvidenceStore:
 class SQLiteRuntimeWorkloadEvidenceStore:
     """Node-local, restart-safe, cross-process-safe SQLite backend."""
 
-    def __init__(self, path: str | Path) -> None:
+    def __init__(self, path: str | Path, *, read_only: bool = False) -> None:
         self._path = str(path)
-        self.init_schema()
+        self._read_only = read_only
+        if read_only:
+            # Validate access without running migrations or creating SQLite
+            # sidecar files. Optional export enrichment must be a pure read.
+            with self._connect():
+                pass
+        else:
+            self.init_schema()
 
     def _connect(self) -> sqlite3.Connection:
-        connection = sqlite3.connect(self._path, timeout=30)
+        if self._read_only:
+            uri = f"{Path(self._path).resolve().as_uri()}?mode=ro"
+            connection = sqlite3.connect(uri, timeout=30, uri=True)
+        else:
+            connection = sqlite3.connect(self._path, timeout=30)
         connection.row_factory = sqlite3.Row
-        connection.execute("PRAGMA journal_mode=WAL")
+        if self._read_only:
+            connection.execute("PRAGMA query_only=ON")
+        else:
+            connection.execute("PRAGMA journal_mode=WAL")
         connection.execute("PRAGMA busy_timeout=30000")
         return connection
 
@@ -189,6 +203,12 @@ class SQLiteRuntimeWorkloadEvidenceStore:
 
     def list_for_tenant(self, tenant_id: str, *, limit: int = 5000) -> list[RuntimeWorkloadSignal]:
         with self._connect() as connection:
+            if self._read_only:
+                table_exists = connection.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'runtime_workload_evidence'"
+                ).fetchone()
+                if table_exists is None:
+                    return []
             rows = connection.execute(
                 "SELECT payload_json FROM runtime_workload_evidence WHERE tenant_id = ? ORDER BY observed_at DESC, dedup_key DESC LIMIT ?",
                 (tenant_id, limit),
@@ -383,6 +403,37 @@ def get_runtime_workload_evidence_store() -> RuntimeWorkloadEvidenceStore:
         return _default_store
 
 
+def get_optional_runtime_workload_evidence_store() -> RuntimeWorkloadEvidenceStore | None:
+    """Return a non-mutating store for optional export enrichment.
+
+    An explicitly initialized or injected store is reused. For the default
+    SQLite tier, a missing or unreadable database means there is no optional
+    evidence: do not create the state directory, database, schema, WAL, or SHM
+    files merely to render a scan report. Durable ingest continues to use
+    :func:`get_runtime_workload_evidence_store` and remains fail-closed.
+    """
+    with _default_lock:
+        if _default_store is not None:
+            return _default_store
+
+    from agent_bom.api import durable_store
+
+    backend = durable_store.select_backend()
+    if backend != "sqlite":
+        return get_runtime_workload_evidence_store()
+
+    path = durable_store.sqlite_path(create_parent=False)
+    if path == ":memory:" or not Path(path).is_file():
+        return None
+    try:
+        return SQLiteRuntimeWorkloadEvidenceStore(path, read_only=True)
+    except (OSError, sqlite3.Error):
+        # Optional enrichment treats an inaccessible local evidence database as
+        # absent. Corrupt/query failures still surface from list_for_tenant and
+        # are sanitized by the caller's existing warning path.
+        return None
+
+
 def set_runtime_workload_evidence_store(store: RuntimeWorkloadEvidenceStore | None) -> None:
     global _default_store
     with _default_lock:
@@ -398,6 +449,7 @@ __all__ = [
     "PostgresRuntimeWorkloadEvidenceStore",
     "RuntimeWorkloadEvidenceStore",
     "SQLiteRuntimeWorkloadEvidenceStore",
+    "get_optional_runtime_workload_evidence_store",
     "get_runtime_workload_evidence_store",
     "reset_runtime_workload_evidence_store",
     "set_runtime_workload_evidence_store",

--- a/tests/test_workload_runtime_evidence_exports.py
+++ b/tests/test_workload_runtime_evidence_exports.py
@@ -3,20 +3,24 @@
 from __future__ import annotations
 
 import logging
+import sqlite3
 from datetime import datetime, timezone
 
 from agent_bom.cloud.runtime_workload_evidence import (
     STATE_HAS_IOC,
     STATE_NO_SIGNAL,
     RuntimeEvidenceSource,
+    RuntimeSignalType,
     RuntimeSourceRegistry,
     RuntimeWorkloadEvidenceIndex,
+    RuntimeWorkloadSignal,
     attach_workload_runtime_evidence_to_finding_model,
     ingest_runtime_signals,
     no_runtime_signal_summary,
 )
 from agent_bom.cloud.runtime_workload_evidence_store import (
     InMemoryRuntimeWorkloadEvidenceStore,
+    SQLiteRuntimeWorkloadEvidenceStore,
     set_runtime_workload_evidence_store,
 )
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
@@ -53,6 +57,50 @@ def _workload_finding(*, with_ioc_summary: bool = False) -> Finding:
             "note": "Runtime evidence is additive and never a clean-workload claim.",
         }
     return finding
+
+
+def _configure_default_store(monkeypatch, state_dir, *, tenant_id: str | None = None, ephemeral: bool = False) -> None:
+    monkeypatch.setenv("AGENT_BOM_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    if tenant_id is None:
+        monkeypatch.delenv("AGENT_BOM_TENANT_ID", raising=False)
+    else:
+        monkeypatch.setenv("AGENT_BOM_TENANT_ID", tenant_id)
+    if ephemeral:
+        monkeypatch.setenv("AGENT_BOM_EPHEMERAL_STORE", "1")
+    else:
+        monkeypatch.delenv("AGENT_BOM_EPHEMERAL_STORE", raising=False)
+    set_runtime_workload_evidence_store(None)
+
+
+def _seed_ioc(db_path, *, tenant_id: str, dedup_key: str) -> None:
+    writer = SQLiteRuntimeWorkloadEvidenceStore(db_path)
+    assert (
+        writer.put_batch(
+            [
+                RuntimeWorkloadSignal(
+                    tenant_id=tenant_id,
+                    provider="aws",
+                    account_id="123456789012",
+                    workload_ref="i-0abc",
+                    signal_type=RuntimeSignalType.IOC_DETECTION,
+                    severity="high",
+                    observed_at="2026-07-26T12:00:00Z",
+                    source_id="edr-1",
+                    source_kind="edr",
+                    dedup_key=dedup_key,
+                    title="known IOC",
+                )
+            ]
+        )
+        == 1
+    )
+
+
+def _export(finding: Finding) -> dict:
+    report = AIBOMReport(generated_at=datetime.now(timezone.utc), tool_version="0.0.0", findings=[finding])
+    return to_json(report)
 
 
 def test_json_sarif_html_carry_preattached_workload_runtime_evidence() -> None:
@@ -149,6 +197,94 @@ def test_optional_enrichment_failure_does_not_suppress_core_findings(caplog) -> 
         assert "secret-value" not in caplog.text
     finally:
         evidence_logger.propagate = prev_propagate
+        set_runtime_workload_evidence_store(None)
+
+
+def test_optional_enrichment_does_not_create_missing_default_sqlite(monkeypatch, tmp_path, caplog) -> None:
+    state_dir = tmp_path / "missing-state"
+    _configure_default_store(monkeypatch, state_dir)
+
+    evidence_logger = logging.getLogger("agent_bom.cloud.runtime_workload_evidence")
+    previous_propagate = evidence_logger.propagate
+    evidence_logger.propagate = True
+    caplog.set_level(logging.WARNING, logger="agent_bom.cloud.runtime_workload_evidence")
+    try:
+        finding = _workload_finding()
+        payload = _export(finding)
+
+        assert any(row["id"] == finding.id for row in payload["findings"])
+        assert not state_dir.exists()
+        assert "optional runtime workload evidence enrichment unavailable" not in caplog.text
+    finally:
+        evidence_logger.propagate = previous_propagate
+        set_runtime_workload_evidence_store(None)
+
+
+def test_optional_enrichment_reads_existing_read_only_sqlite(monkeypatch, tmp_path, caplog) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "control-plane.db"
+    _seed_ioc(db_path, tenant_id="tenant-read-only", dedup_key="evt-read-only")
+    _configure_default_store(monkeypatch, state_dir, tenant_id="tenant-read-only")
+
+    db_path.chmod(0o444)
+    state_dir.chmod(0o555)
+    try:
+        finding = _workload_finding()
+        payload = _export(finding)
+
+        exported = next(row for row in payload["findings"] if row["id"] == finding.id)
+        assert exported["workload_runtime_evidence"]["state"] == STATE_HAS_IOC
+        assert "optional runtime workload evidence enrichment unavailable" not in caplog.text
+    finally:
+        state_dir.chmod(0o755)
+        db_path.chmod(0o644)
+        set_runtime_workload_evidence_store(None)
+
+
+def test_optional_enrichment_skips_unreadable_default_sqlite_quietly(monkeypatch, tmp_path, caplog) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "control-plane.db"
+    SQLiteRuntimeWorkloadEvidenceStore(db_path)
+    _configure_default_store(monkeypatch, state_dir)
+
+    original_connect = SQLiteRuntimeWorkloadEvidenceStore._connect
+
+    def deny_read_only_open(store):
+        if store._read_only:  # noqa: SLF001 - targeted failure injection
+            raise sqlite3.OperationalError("unable to open database file")
+        return original_connect(store)
+
+    monkeypatch.setattr(SQLiteRuntimeWorkloadEvidenceStore, "_connect", deny_read_only_open)
+    evidence_logger = logging.getLogger("agent_bom.cloud.runtime_workload_evidence")
+    previous_propagate = evidence_logger.propagate
+    evidence_logger.propagate = True
+    caplog.set_level(logging.WARNING, logger="agent_bom.cloud.runtime_workload_evidence")
+    try:
+        finding = _workload_finding()
+        payload = _export(finding)
+
+        assert any(row["id"] == finding.id for row in payload["findings"])
+        assert "optional runtime workload evidence enrichment unavailable" not in caplog.text
+    finally:
+        evidence_logger.propagate = previous_propagate
+        set_runtime_workload_evidence_store(None)
+
+
+def test_optional_enrichment_ephemeral_opt_out_ignores_stale_default_sqlite(monkeypatch, tmp_path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    db_path = state_dir / "control-plane.db"
+    _seed_ioc(db_path, tenant_id="tenant-ephemeral", dedup_key="evt-stale")
+    _configure_default_store(monkeypatch, state_dir, tenant_id="tenant-ephemeral", ephemeral=True)
+    try:
+        finding = _workload_finding()
+        payload = _export(finding)
+
+        exported = next(row for row in payload["findings"] if row["id"] == finding.id)
+        assert "workload_runtime_evidence" not in exported
+    finally:
         set_runtime_workload_evidence_store(None)
 
 


### PR DESCRIPTION
## Summary

- resolve optional runtime-evidence SQLite paths without creating state directories or databases
- read existing optional evidence through SQLite read-only/query-only connections
- preserve durable ingest, explicit ephemeral mode, and Postgres behavior
- cover missing, read-only, inaccessible, and stale-ephemeral storage cases

## Verification

- affected export/storage suites — 25 passed, 3 skipped
- broader focused persistence suites — 27 passed, 3 skipped
- storage foundation — 23 passed
- Ruff and mypy passed for all changed source files
- exception-sanitization guard passed
- `git diff --check`
- hands-on `agent-bom scan --demo --offline --format json` with a 0555 state directory produced 5 agents and 25 findings, left the directory empty, and emitted no runtime-evidence database warning

## Notes

The regression tests were observed failing before implementation: a missing state directory was created by an export read, and a read-only database emitted a warning and lost optional enrichment. Optional inaccessible local evidence now degrades quietly; durable ingest remains fail-closed.