### PR TITLE
fix(ui): preserve evidence in operator views

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -54,7 +54,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
 | `docs/openapi/v1.json` | paths | 321 |
-| `docs/openapi/v1.json` | component schemas | 118 |
+| `docs/openapi/v1.json` | component schemas | 119 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -3314,6 +3314,128 @@
         "title": "FleetAgentUpdate",
         "type": "object"
       },
+      "GatewayFeedEventModel": {
+        "properties": {
+          "action_type": {
+            "enum": [
+              "tool_call_authorized",
+              "tool_call_blocked",
+              "data_filter_applied",
+              "llm_call"
+            ],
+            "title": "Action Type",
+            "type": "string"
+          },
+          "agent": {
+            "title": "Agent",
+            "type": "string"
+          },
+          "cost_usd": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Cost Usd"
+          },
+          "data_action": {
+            "title": "Data Action",
+            "type": "string"
+          },
+          "decision": {
+            "title": "Decision",
+            "type": "string"
+          },
+          "detail": {
+            "title": "Detail",
+            "type": "string"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "input_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Input Tokens"
+          },
+          "output_tokens": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Output Tokens"
+          },
+          "policy_source": {
+            "title": "Policy Source",
+            "type": "string"
+          },
+          "profile_id": {
+            "title": "Profile Id",
+            "type": "string"
+          },
+          "shadow": {
+            "title": "Shadow",
+            "type": "boolean"
+          },
+          "source": {
+            "title": "Source",
+            "type": "string"
+          },
+          "target": {
+            "title": "Target",
+            "type": "string"
+          },
+          "tenant": {
+            "title": "Tenant",
+            "type": "string"
+          },
+          "trace_id": {
+            "title": "Trace Id",
+            "type": "string"
+          },
+          "ts": {
+            "title": "Ts",
+            "type": "string"
+          },
+          "upstream": {
+            "title": "Upstream",
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_id",
+          "ts",
+          "agent",
+          "profile_id",
+          "action_type",
+          "target",
+          "upstream",
+          "decision",
+          "data_action",
+          "policy_source",
+          "trace_id",
+          "detail",
+          "tenant",
+          "shadow",
+          "source"
+        ],
+        "title": "GatewayFeedEventModel",
+        "type": "object"
+      },
       "GatewayFeedHealthModel": {
         "properties": {
           "age_seconds": {
@@ -3448,8 +3570,7 @@
           },
           "events": {
             "items": {
-              "additionalProperties": true,
-              "type": "object"
+              "$ref": "#/components/schemas/GatewayFeedEventModel"
             },
             "title": "Events",
             "type": "array"

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2266,6 +2266,91 @@ components:
           title: Tags
       title: FleetAgentUpdate
       type: object
+    GatewayFeedEventModel:
+      properties:
+        action_type:
+          enum:
+          - tool_call_authorized
+          - tool_call_blocked
+          - data_filter_applied
+          - llm_call
+          title: Action Type
+          type: string
+        agent:
+          title: Agent
+          type: string
+        cost_usd:
+          anyOf:
+          - type: number
+          - type: 'null'
+          title: Cost Usd
+        data_action:
+          title: Data Action
+          type: string
+        decision:
+          title: Decision
+          type: string
+        detail:
+          title: Detail
+          type: string
+        event_id:
+          title: Event Id
+          type: string
+        input_tokens:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Input Tokens
+        output_tokens:
+          anyOf:
+          - type: integer
+          - type: 'null'
+          title: Output Tokens
+        policy_source:
+          title: Policy Source
+          type: string
+        profile_id:
+          title: Profile Id
+          type: string
+        shadow:
+          title: Shadow
+          type: boolean
+        source:
+          title: Source
+          type: string
+        target:
+          title: Target
+          type: string
+        tenant:
+          title: Tenant
+          type: string
+        trace_id:
+          title: Trace Id
+          type: string
+        ts:
+          title: Ts
+          type: string
+        upstream:
+          title: Upstream
+          type: string
+      required:
+      - event_id
+      - ts
+      - agent
+      - profile_id
+      - action_type
+      - target
+      - upstream
+      - decision
+      - data_action
+      - policy_source
+      - trace_id
+      - detail
+      - tenant
+      - shadow
+      - source
+      title: GatewayFeedEventModel
+      type: object
     GatewayFeedHealthModel:
       properties:
         age_seconds:
@@ -2360,8 +2445,7 @@ components:
           type: integer
         events:
           items:
-            additionalProperties: true
-            type: object
+            $ref: '#/components/schemas/GatewayFeedEventModel'
           title: Events
           type: array
         generated_at:

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -60,12 +60,38 @@ class GatewayFeedHealthModel(BaseModel):
     reason: str
 
 
+class GatewayFeedEventModel(BaseModel):
+    event_id: str
+    ts: str
+    agent: str
+    profile_id: str
+    action_type: Literal[
+        "tool_call_authorized",
+        "tool_call_blocked",
+        "data_filter_applied",
+        "llm_call",
+    ]
+    target: str
+    upstream: str
+    decision: str
+    data_action: str
+    policy_source: str
+    trace_id: str
+    detail: str
+    tenant: str
+    shadow: bool
+    source: str
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    cost_usd: float | None = None
+
+
 class GatewayFeedResponseModel(BaseModel):
     schema_version: str
     tenant_id: str
     generated_at: str
     count: int
-    events: list[dict[str, Any]]
+    events: list[GatewayFeedEventModel]
     health: GatewayFeedHealthModel
 
 
@@ -400,6 +426,9 @@ def _normalize_llm_event(record: Any, tenant_id: str) -> dict[str, Any]:
         "tenant": tenant_id,
         "shadow": False,
         "source": "observability",
+        "input_tokens": int(input_tokens),
+        "output_tokens": int(output_tokens),
+        "cost_usd": float(cost) if priced and isinstance(cost, int | float) else None,
     }
 
 

--- a/tests/api/test_api_gateway_feed.py
+++ b/tests/api/test_api_gateway_feed.py
@@ -112,6 +112,11 @@ def test_feed_fuses_all_three_sources_and_orders_newest_first() -> None:
     assert timestamps == sorted(timestamps, reverse=True)
     assert feed["events"][0]["action_type"] == ACTION_LLM_CALL
 
+    llm_event = feed["events"][0]
+    assert llm_event["input_tokens"] == 10
+    assert llm_event["output_tokens"] == 5
+    assert llm_event["cost_usd"] == 0.0012
+
 
 def test_feed_per_agent_attribution_present_on_every_event() -> None:
     alerts = [_authorized_alert(agent="alpha"), _blocked_alert(agent="beta"), _dlp_alert(agent="gamma")]

--- a/tests/api/test_gateway_feed_health.py
+++ b/tests/api/test_gateway_feed_health.py
@@ -201,3 +201,8 @@ def test_gateway_feed_openapi_declares_health_contract() -> None:
         "reason",
     ]
     assert health["properties"]["state"]["enum"] == ["live", "stale", "unavailable", "sample"]
+
+    response = schema["components"]["schemas"]["GatewayFeedResponseModel"]
+    assert response["properties"]["events"]["items"]["$ref"].endswith("/GatewayFeedEventModel")
+    event = schema["components"]["schemas"]["GatewayFeedEventModel"]
+    assert {"input_tokens", "output_tokens", "cost_usd"} <= event["properties"].keys()

--- a/ui/app/page.tsx
+++ b/ui/app/page.tsx
@@ -63,6 +63,7 @@ export default function Dashboard() {
   const [posture, setPosture] = useState<PostureResponse | null>(null);
   const [overview, setOverview] = useState<OverviewResponse | null>(null);
   const [compliance, setCompliance] = useState<ComplianceResponse | null>(null);
+  const [postureOverviewLoading, setPostureOverviewLoading] = useState(true);
   // Local display-format override; falls back to the persisted per-tenant
   // config carried on the overview posture. Toggling persists via the API (#3940).
   const [scoreFormatOverride, setScoreFormatOverride] = useState<PostureScoreFormat | null>(null);
@@ -72,9 +73,24 @@ export default function Dashboard() {
 
   // Fetch posture grade + cross-domain overview (folded into the header scorecard)
   useEffect(() => {
-    api.getPosture().then(setPosture).catch(() => {});
-    api.getOverview().then(setOverview).catch(() => {});
-    api.getCompliance().then(setCompliance).catch(() => {});
+    let cancelled = false;
+    void Promise.allSettled([api.getPosture(), api.getOverview()]).then(
+      ([postureResult, overviewResult]) => {
+        if (cancelled) return;
+        if (postureResult.status === "fulfilled") setPosture(postureResult.value);
+        if (overviewResult.status === "fulfilled") setOverview(overviewResult.value);
+        setPostureOverviewLoading(false);
+      },
+    );
+    void api.getCompliance().then(
+      (value) => {
+        if (!cancelled) setCompliance(value);
+      },
+      () => {},
+    );
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {
@@ -385,6 +401,7 @@ export default function Dashboard() {
       />
 
       <OverviewCockpit
+        loading={postureOverviewLoading}
         grade={postureGrade}
         score={postureScore}
         scoreFormat={scoreFormat}

--- a/ui/components/activity-event-stream.tsx
+++ b/ui/components/activity-event-stream.tsx
@@ -43,8 +43,9 @@ function gatewayDecision(event: GatewayFeedEvent): string | null {
 }
 
 function normalizeGatewayEvent(event: GatewayFeedEvent, index: number): ActivityEvent {
+  const costUsd = finiteMeasurement(event.cost_usd);
   return {
-    id: event.event_id ?? `${event.ts}-${event.agent}-${event.target}-${index}`,
+    id: event.event_id?.trim() || `${event.ts}-${event.agent}-${event.target}-${index}`,
     source: "Gateway",
     timestamp: event.ts,
     actor: event.agent || "Unavailable",
@@ -53,9 +54,9 @@ function normalizeGatewayEvent(event: GatewayFeedEvent, index: number): Activity
     decision: gatewayDecision(event),
     policy: event.policy_source?.trim() || null,
     latencyMs: null,
-    inputTokens: null,
-    outputTokens: null,
-    cost: null,
+    inputTokens: finiteMeasurement(event.input_tokens),
+    outputTokens: finiteMeasurement(event.output_tokens),
+    cost: costUsd === null ? null : `$${costUsd.toFixed(4)}`,
     traceId: event.trace_id?.trim() || null,
     provenance: event.source?.trim() || null,
     detail: event.detail?.trim() || null,
@@ -63,8 +64,8 @@ function normalizeGatewayEvent(event: GatewayFeedEvent, index: number): Activity
   };
 }
 
-function finiteMeasurement(value: number): number | null {
-  return Number.isFinite(value) && value >= 0 ? value : null;
+function finiteMeasurement(value: number | null | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : null;
 }
 
 function normalizeObservabilityEvent(event: ObservabilityEvent): ActivityEvent {

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -145,6 +145,8 @@ function derivePostureBlurb({
 }
 
 export interface OverviewCockpitProps {
+  /** True until the posture and cross-domain overview requests settle. */
+  loading?: boolean | undefined;
   grade: string;
   score?: number | undefined;
   /** Display-only score presentation. Defaults to a percentage. */
@@ -186,6 +188,7 @@ export interface OverviewCockpitProps {
 }
 
 export function OverviewCockpit({
+  loading = false,
   grade,
   score,
   scoreFormat = "percent",
@@ -227,7 +230,7 @@ export function OverviewCockpit({
           subtitle="Posture and open issues across every lane — one exec read."
           defaultOpen
         >
-          <FreshnessStatus latestScan={latestScan} scans={scans} />
+          <FreshnessStatus latestScan={latestScan} scans={scans} loading={loading} />
 
           {/* 1 — Posture headline + open issues by severity.
               Posture track is capped (minmax) so a long summary can't grow it
@@ -235,6 +238,7 @@ export function OverviewCockpit({
               unreadable sliver. */}
           <div className="mt-1 grid gap-5 lg:grid-cols-[minmax(0,20rem)_minmax(0,1fr)] lg:items-start">
             <PostureHero
+              loading={loading}
               grade={grade}
               score={score}
               scoreFormat={scoreFormat}
@@ -290,11 +294,15 @@ export function OverviewCockpit({
 function FreshnessStatus({
   latestScan,
   scans,
+  loading,
 }: {
   latestScan: string | null;
   scans: number | null;
+  loading: boolean;
 }) {
-  const label = latestScan
+  const label = loading
+    ? "Loading scan evidence"
+    : latestScan
     ? "Last successful scan"
     : scans === 0
       ? "No completed scan evidence"
@@ -313,7 +321,11 @@ function FreshnessStatus({
         />
         <span className="text-xs font-semibold text-[color:var(--foreground)]">{label}</span>
       </div>
-      {latestScan ? (
+      {loading ? (
+        <span className="text-[11px] text-[color:var(--text-tertiary)]">
+          Refreshing current evidence.
+        </span>
+      ) : latestScan ? (
         <time className="text-xs font-medium tabular-nums text-[color:var(--text-secondary)]">
           {latestScan}
         </time>
@@ -982,6 +994,7 @@ function ScoreFormatToggle({
 }
 
 function PostureHero({
+  loading,
   grade,
   score,
   scoreFormat = "percent",
@@ -991,6 +1004,7 @@ function PostureHero({
   high,
   cves,
 }: {
+  loading: boolean;
   grade: string;
   score?: number | undefined;
   scoreFormat?: PostureScoreFormat | undefined;
@@ -1010,13 +1024,21 @@ function PostureHero({
         : "border-red-500/40 bg-red-500/10 text-red-400";
   const graded = typeof score === "number" && !ungraded;
   const scoreDisplay = graded ? formatPostureScore(score, grade, scoreFormat) : null;
-  const blurb = derivePostureBlurb({ summary, critical, high, cves, graded });
+  const blurb = loading
+    ? "Refreshing the current posture and evidence summary."
+    : derivePostureBlurb({ summary, critical, high, cves, graded });
 
   return (
     <div className="flex items-center gap-4">
       <div
         className={`flex h-16 w-16 shrink-0 flex-col items-center justify-center rounded-2xl border ${badgeTone}`}
-        title={graded ? `Grade ${grade}${scoreDisplay ? ` · ${scoreDisplay}` : ""}` : "Awaiting scan"}
+        title={
+          loading
+            ? "Loading posture"
+            : graded
+              ? `Grade ${grade}${scoreDisplay ? ` · ${scoreDisplay}` : ""}`
+              : "Awaiting scan"
+        }
       >
         <span className="text-3xl font-bold leading-none">{grade}</span>
         {graded && scoreFormat !== "grade" && scoreDisplay ? (
@@ -1033,7 +1055,9 @@ function PostureHero({
           ) : null}
         </div>
         <p className="mt-1 flex items-baseline gap-2 text-lg font-semibold text-[color:var(--foreground)]">
-          {graded ? (
+          {loading ? (
+            "Loading posture…"
+          ) : graded ? (
             <>
               {/* Always show BOTH the letter grade and the %/points, whatever the
                   chosen primary format, so the number is never ambiguous. */}

--- a/ui/components/ranked-path-list.tsx
+++ b/ui/components/ranked-path-list.tsx
@@ -21,6 +21,17 @@ export interface RankedPathRow {
   environmentTags?: string[] | undefined;
 }
 
+function displayPathTitle(row: RankedPathRow): string {
+  const title = row.title.trim();
+  const cve = row.cve?.trim();
+  if (!cve) return title;
+
+  const startsWithCve =
+    title.slice(0, cve.length).toLowerCase() === cve.toLowerCase() &&
+    (title.length === cve.length || !/[a-z0-9]/i.test(title.charAt(cve.length)));
+  return startsWithCve ? title : `${cve} · ${title}`;
+}
+
 /**
  * Compact, scannable list of ranked exposure paths. One row per path — the
  * DAG for the active row renders once in the command-center panel above, not
@@ -50,6 +61,7 @@ export function RankedPathList({
     >
       {rows.map((row) => {
         const active = row.selectionKey === selectedKey;
+        const displayTitle = displayPathTitle(row);
         return (
           <button
             key={row.key}
@@ -73,9 +85,11 @@ export function RankedPathList({
               {row.rank === 1 ? "#1 fix first" : `#${row.rank}`}
             </span>
             <span className="min-w-0 flex-1">
-              <span className="block break-words text-sm font-medium leading-snug text-[color:var(--foreground)]">
-                {row.cve ? `${row.cve} · ` : ""}
-                {row.title}
+              <span
+                className="line-clamp-2 break-normal text-sm font-medium leading-snug text-[color:var(--foreground)]"
+                title={displayTitle}
+              >
+                {displayTitle}
               </span>
               <span className="mt-0.5 block text-[11px] text-[color:var(--text-tertiary)]">
                 {pathSpanLabel(row.nodeCount)} · {row.agents} agent{row.agents === 1 ? "" : "s"}

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2556,6 +2556,9 @@ export interface GatewayFeedEvent {
   tenant: string;
   shadow: boolean;
   source: string;
+  input_tokens?: number | null;
+  output_tokens?: number | null;
+  cost_usd?: number | null;
 }
 
 export type GatewayFeedHealthState = "live" | "stale" | "unavailable" | "sample";

--- a/ui/tests/activity-event-stream.test.tsx
+++ b/ui/tests/activity-event-stream.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { ActivityEventStream } from "@/components/activity-event-stream";
@@ -79,6 +79,92 @@ describe("ActivityEventStream", () => {
     expect(screen.getByText("runtime-policy")).toBeInTheDocument();
     expect(screen.getByText("trace-gateway")).toBeInTheDocument();
     expect(screen.getAllByText("Unavailable").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("shows structured token and cost evidence for an LLM gateway event", async () => {
+    apiMock.getGatewayFeed.mockResolvedValue({
+      events: [
+        {
+          event_id: "llm-1",
+          ts: "2026-07-26T17:00:00Z",
+          agent: "review-agent",
+          action_type: "llm_call",
+          target: "openai/gpt-5",
+          decision: "allow",
+          policy_source: "observability",
+          trace_id: "trace-llm",
+          detail: "$4.8200 · 140400 tokens",
+          tenant: "synthetic",
+          shadow: false,
+          source: "observability",
+          input_tokens: 100_000,
+          output_tokens: 40_400,
+          cost_usd: 4.82,
+        },
+      ],
+      health: {
+        state: "live",
+        live: true,
+        heartbeat_at: "2026-07-26T17:00:01Z",
+        age_seconds: 1,
+        stale_after_seconds: 120,
+        reason: "recent_transport_heartbeat",
+      },
+    });
+
+    render(<ActivityEventStream observabilityEvents={[]} />);
+    await waitFor(() =>
+      expect(screen.getByText("review-agent → openai/gpt-5")).toBeInTheDocument(),
+    );
+    fireEvent.click(screen.getByText("review-agent → openai/gpt-5"));
+
+    const drawer = screen.getByRole("dialog", { name: "Activity event details" });
+    expect(within(drawer).getByText("140,400 total")).toBeInTheDocument();
+    expect(within(drawer).getByText("$4.8200")).toBeInTheDocument();
+  });
+
+  it("falls back to a stable row key when normalized events have blank IDs", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    apiMock.getGatewayFeed.mockResolvedValue({
+      events: [
+        {
+          event_id: "",
+          ts: "2026-07-26T17:00:00Z",
+          agent: "agent-a",
+          action_type: "llm_call",
+          target: "openai/gpt-5",
+          detail: "10 tokens",
+          tenant: "synthetic",
+          shadow: false,
+          source: "observability",
+        },
+        {
+          event_id: "",
+          ts: "2026-07-26T16:59:00Z",
+          agent: "agent-b",
+          action_type: "llm_call",
+          target: "anthropic/claude",
+          detail: "20 tokens",
+          tenant: "synthetic",
+          shadow: false,
+          source: "observability",
+        },
+      ],
+      health: {
+        state: "sample",
+        live: false,
+        heartbeat_at: null,
+        age_seconds: null,
+        stale_after_seconds: 120,
+        reason: "synthetic_sample",
+      },
+    });
+
+    render(<ActivityEventStream observabilityEvents={[]} />);
+    await waitFor(() => expect(screen.getByText("agent-b → anthropic/claude")).toBeInTheDocument());
+
+    expect(consoleError.mock.calls.flat().join(" ")).not.toMatch(/same key/i);
+    consoleError.mockRestore();
   });
 
   it("never labels stale retained events as live", async () => {

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -258,6 +258,25 @@ describe("OverviewCockpit", () => {
     expect(screen.getByText(/Connect a surface or run a scan to grade posture/i)).toBeInTheDocument();
   });
 
+  it("labels posture and freshness as loading before the overview hydrates", () => {
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        grade="—"
+        score={undefined}
+        scans={null}
+        latestScan={null}
+        summaryReady={false}
+        loading
+      />,
+    );
+
+    expect(screen.getByTestId("overview-freshness")).toHaveTextContent("Loading scan evidence");
+    expect(screen.getByText("Loading posture…")).toBeInTheDocument();
+    expect(screen.queryByText("Awaiting scan")).not.toBeInTheDocument();
+    expect(screen.queryByText("Last successful scan unavailable")).not.toBeInTheDocument();
+  });
+
   it("never asserts 'no vulnerabilities' while open CVEs are present", () => {
     // Backend posture summary is derived from only the latest single scan, so it
     // can read "No vulnerabilities found" even when the estate rollup shows open

--- a/ui/tests/ranked-path-list.test.tsx
+++ b/ui/tests/ranked-path-list.test.tsx
@@ -69,12 +69,34 @@ describe("RankedPathList", () => {
     expect(within(active[0]!).getByText("#2")).toBeInTheDocument();
   });
 
-  it("uses a stacked mobile hierarchy without truncating the path title", () => {
+  it("bounds long path titles while preserving their full value in a tooltip", () => {
     render(<RankedPathList rows={rows} selectedKey="k1" onSelect={vi.fn()} />);
 
     const title = screen.getByText(/CVE-2026-0002/);
-    expect(title).toHaveClass("break-words");
-    expect(title).not.toHaveClass("truncate");
+    expect(title).toHaveClass("line-clamp-2", "break-normal");
+    expect(title).not.toHaveClass("break-words");
+    expect(title).toHaveAttribute("title", "CVE-2026-0002 · Agent → Database → werkzeug");
     expect(title.closest("button")).toHaveClass("grid");
+  });
+
+  it("does not repeat a CVE prefix already present in the path title", () => {
+    render(
+      <RankedPathList
+        rows={[
+          {
+            ...rows[0]!,
+            title: "CVE-2026-0002 via Agent → Database → werkzeug",
+          },
+        ]}
+        selectedKey="k1"
+        onSelect={vi.fn()}
+      />,
+    );
+
+    const title = screen.getByText("CVE-2026-0002 via Agent → Database → werkzeug");
+    expect(title).toHaveAttribute(
+      "title",
+      "CVE-2026-0002 via Agent → Database → werkzeug",
+    );
   });
 });


### PR DESCRIPTION
## Summary

- expose typed gateway LLM token and cost evidence through the API contract and activity drawer
- distinguish loading posture from an empty or unavailable estate, without letting compliance delay posture hydration
- stabilize blank activity-event keys and keep ranked graph-path labels readable without repeating CVE prefixes
- regenerate the checked-in OpenAPI contract and data-model inventory

## Verification

- `UV_CACHE_DIR=/private/tmp/codex-uv-cache uv run pytest -q tests/api/test_api_gateway_feed.py tests/api/test_gateway_feed_health.py` (24 passed)
- `UV_CACHE_DIR=/private/tmp/codex-uv-cache uv run ruff check src/agent_bom/api/routes/gateway_feed.py tests/api/test_api_gateway_feed.py tests/api/test_gateway_feed_health.py`
- `npm test -- --run tests/activity-event-stream.test.tsx tests/overview-cockpit.test.tsx tests/ranked-path-list.test.tsx` (30 passed)
- full UI suite (160 files, 948 tests)
- `npm run typecheck`
- `npm run build` (49 pages)
- production bundle budget check (3601.1 / 3616 KiB; budget unchanged)
- `make preflight`
- `git diff --check`
- browser review of Activity event details and ranked graph paths with non-empty graph data (112 nodes, 142 edges, 26 ranked paths)

## Notes

- Regression tests were observed failing before the implementation for missing structured measurements, false empty-state copy, duplicate blank-ID keys, unbounded path labels, and repeated CVE prefixes.
- The existing bundle ceiling was not increased.