### PR TITLE
fix(evidence): preserve runtime and graph projections

### DIFF
--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -366,6 +366,12 @@ def _redact_finding(payload: dict[str, Any]) -> dict[str, Any]:
         for key, value in safe_finding_response_payload(payload).items()
         if value is not None
     }
+    # The public finding contract uses an empty list for assessed-or-unknown
+    # agent reachability, but persisting that default in every ledger row adds
+    # no evidence and defeats reference-table compaction at scale. Non-empty
+    # observed agent ids remain durable.
+    if not clean.get("graph_reachable_from_agents"):
+        clean.pop("graph_reachable_from_agents", None)
     # Classification is derived deterministically from the stored finding on
     # every read. Keeping it in each ledger row wastes space and can drift from
     # the canonical classifier after an upgrade.

--- a/src/agent_bom/api/finding_reachability.py
+++ b/src/agent_bom/api/finding_reachability.py
@@ -1,0 +1,194 @@
+"""Bounded projection of persisted graph paths onto finding-list rows.
+
+The graph store is the durable source for ranked ExposurePaths. Findings are a
+separate current-state projection, so this module joins only the current page
+to a bounded path window and leaves unassessed rows unknown instead of
+inventing ``False`` evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Mapping
+
+if TYPE_CHECKING:
+    from agent_bom.api.graph_store import GraphStoreProtocol
+    from agent_bom.graph.container import AttackPath
+
+
+MAX_FINDING_REACHABILITY_PATHS = 1000
+
+
+@dataclass(frozen=True, slots=True)
+class FindingReachabilityProjection:
+    rows: list[dict[str, Any]]
+    truncated: bool
+
+
+@dataclass(slots=True)
+class _ReachabilityEvidence:
+    min_hops: int
+    agents: set[str]
+
+
+def _text(value: object) -> str:
+    return str(value).strip() if isinstance(value, str) else ""
+
+
+def _vulnerability_id(value: object) -> str:
+    normalized = _text(value)
+    if not normalized:
+        return ""
+    lowered = normalized.lower()
+    for prefix in ("vuln:", "finding:"):
+        if lowered.startswith(prefix):
+            normalized = normalized[len(prefix) :]
+            break
+    return normalized.upper()
+
+
+def _row_vulnerability_ids(row: Mapping[str, Any]) -> set[str]:
+    values: list[object] = [row.get("cve_id"), row.get("vulnerability_id")]
+    for key in ("cve_ids", "advisory_ids", "aliases", "advisory_aliases"):
+        collection = row.get(key)
+        if isinstance(collection, list):
+            values.extend(collection)
+    return {identifier for value in values if (identifier := _vulnerability_id(value))}
+
+
+def _path_vulnerability_ids(path: AttackPath) -> set[str]:
+    values: list[object] = list(path.vuln_ids)
+    values.append(path.target)
+    values.extend(path.hops)
+    return {
+        identifier
+        for value in values
+        if (identifier := _vulnerability_id(value)).startswith(("CVE-", "GHSA-", "MAL-"))
+    }
+
+
+def _row_node_ids(row: Mapping[str, Any]) -> set[str]:
+    return {node_id for key in ("node_id", "finding_node_id") if (node_id := _text(row.get(key)))}
+
+
+def _row_finding_ids(row: Mapping[str, Any]) -> set[str]:
+    return {finding_id for key in ("id", "canonical_id") if (finding_id := _text(row.get(key)))}
+
+
+def _path_matches_row(path: AttackPath, row: Mapping[str, Any]) -> bool:
+    finding_ids = _row_finding_ids(row)
+    if finding_ids.intersection(path.finding_ids):
+        return True
+
+    if not _row_vulnerability_ids(row).intersection(_path_vulnerability_ids(path)):
+        return False
+
+    # When the finding carries graph FKs, require one on the path. This avoids
+    # marking every asset-specific occurrence of a shared CVE reachable because
+    # a different package/server occurrence has a path.
+    row_nodes = _row_node_ids(row)
+    if not row_nodes:
+        return True
+    return bool(row_nodes.intersection({path.source, path.target, *path.hops}))
+
+
+def _path_hop_distance(path: AttackPath, row: Mapping[str, Any]) -> int:
+    hops = list(path.hops)
+    if not hops:
+        return 0
+    try:
+        source_index = hops.index(path.source)
+    except ValueError:
+        source_index = 0
+
+    row_nodes = _row_node_ids(row)
+    matching_indexes = [index for index, node_id in enumerate(hops) if node_id in row_nodes]
+    if matching_indexes:
+        forward = [index - source_index for index in matching_indexes if index >= source_index]
+        if forward:
+            return min(forward)
+    try:
+        target_index = hops.index(path.target)
+    except ValueError:
+        target_index = len(hops) - 1
+    return max(0, target_index - source_index)
+
+
+def _reaching_agents(path: AttackPath) -> set[str]:
+    agents = {node_id for node_id in (path.source, *path.hops) if node_id.startswith("agent:")}
+    return agents
+
+
+def project_persisted_graph_reachability(
+    rows: list[dict[str, Any]],
+    *,
+    graph_store: GraphStoreProtocol,
+    tenant_id: str,
+    scan_id: str | None,
+    path_limit: int = MAX_FINDING_REACHABILITY_PATHS,
+) -> FindingReachabilityProjection:
+    """Project one bounded, tenant-scoped path read onto a findings page.
+
+    A missing match is not proof of unreachability, particularly when the path
+    window is truncated, so non-overlapping rows retain their prior value and
+    otherwise remain ``None``.
+    """
+
+    projected = [dict(row) for row in rows]
+    for row in projected:
+        row.setdefault("graph_reachable", None)
+        row.setdefault("graph_min_hop_distance", None)
+        row.setdefault("graph_reachable_from_agents", [])
+    if not projected or not any(_row_vulnerability_ids(row) or _row_finding_ids(row) for row in projected):
+        return FindingReachabilityProjection(projected, truncated=False)
+
+    bounded_limit = max(1, min(int(path_limit), MAX_FINDING_REACHABILITY_PATHS))
+    _effective_scan_id, _created_at, paths, total = graph_store.attack_paths(
+        tenant_id=tenant_id,
+        scan_id=scan_id or "",
+        offset=0,
+        limit=bounded_limit,
+    )
+
+    paths_by_finding: dict[str, list[AttackPath]] = {}
+    paths_by_vulnerability: dict[str, list[AttackPath]] = {}
+    for path in paths:
+        for finding_id in set(path.finding_ids):
+            paths_by_finding.setdefault(finding_id, []).append(path)
+        for vulnerability_id in _path_vulnerability_ids(path):
+            paths_by_vulnerability.setdefault(vulnerability_id, []).append(path)
+
+    evidence_by_row: dict[int, _ReachabilityEvidence] = {}
+    for index, row in enumerate(projected):
+        candidates: dict[int, AttackPath] = {}
+        for finding_id in _row_finding_ids(row):
+            candidates.update((id(path), path) for path in paths_by_finding.get(finding_id, ()))
+        for vulnerability_id in _row_vulnerability_ids(row):
+            candidates.update((id(path), path) for path in paths_by_vulnerability.get(vulnerability_id, ()))
+        for path in candidates.values():
+            if not _path_matches_row(path, row):
+                continue
+            distance = _path_hop_distance(path, row)
+            evidence = evidence_by_row.get(index)
+            if evidence is None:
+                evidence = _ReachabilityEvidence(min_hops=distance, agents=set())
+                evidence_by_row[index] = evidence
+            else:
+                evidence.min_hops = min(evidence.min_hops, distance)
+            evidence.agents.update(_reaching_agents(path))
+
+    for index, evidence in evidence_by_row.items():
+        row = projected[index]
+        prior_distance = row.get("graph_min_hop_distance")
+        row["graph_reachable"] = True
+        row["graph_min_hop_distance"] = (
+            min(prior_distance, evidence.min_hops)
+            if isinstance(prior_distance, int) and not isinstance(prior_distance, bool) and prior_distance >= 0
+            else evidence.min_hops
+        )
+        prior_agents = row.get("graph_reachable_from_agents")
+        if isinstance(prior_agents, list):
+            evidence.agents.update(_text(value) for value in prior_agents if _text(value))
+        row["graph_reachable_from_agents"] = sorted(evidence.agents)
+
+    return FindingReachabilityProjection(projected, truncated=total > len(paths))

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -48,6 +48,7 @@ from werkzeug.security import safe_join
 from agent_bom.api import job_status_count_cache
 from agent_bom.api.finding_list_envelope import HUB_LIST_OFFSET_CEILING as _HUB_LIST_OFFSET_CEILING
 from agent_bom.api.finding_list_envelope import finding_list_envelope
+from agent_bom.api.finding_reachability import project_persisted_graph_reachability
 from agent_bom.api.hub_ingest import hub_ingest_store_writes, hub_store_call
 from agent_bom.api.idempotency_store import (
     IdempotencyConflictError,
@@ -69,6 +70,7 @@ from agent_bom.api.pipeline import _now, request_scan_cancellation, submit_scan_
 from agent_bom.api.scan_batches import child_request_for_target, refresh_batch_parent, scan_request_targets
 from agent_bom.api.scan_job_reconciliation import reconcile_scan_jobs_active
 from agent_bom.api.stores import (
+    _get_graph_store,
     _get_idempotency_store,
     _get_store,
     _job_lock,
@@ -2573,6 +2575,23 @@ def _list_findings_impl(
             status=status_key,
         )
         total_approximate = False
+
+    try:
+        reachability = project_persisted_graph_reachability(
+            page_rows,
+            graph_store=_get_graph_store(),
+            tenant_id=tenant_id,
+            scan_id=scan_id,
+        )
+        page_rows = reachability.rows
+        if reachability.truncated:
+            warnings.append(
+                "Graph reachability projection is bounded to the highest-risk 1000 persisted paths; "
+                "unmatched findings remain unassessed."
+            )
+    except Exception as exc:  # noqa: BLE001 — optional evidence must not fail the findings list
+        _logger.warning("Finding graph reachability projection skipped: %s", sanitize_error(exc))
+        warnings.append("Graph reachability evidence is unavailable for this page; unmatched findings remain unassessed.")
 
     page = _redact_finding_page(page_rows)
     envelope = finding_list_envelope(

--- a/src/agent_bom/evidence/policy.py
+++ b/src/agent_bom/evidence/policy.py
@@ -14,6 +14,7 @@ The acceptance contract from issue #2261:
 
 from __future__ import annotations
 
+import math
 import os
 from datetime import datetime, timedelta, timezone
 from enum import Enum
@@ -274,6 +275,58 @@ TIER_A_FIELDS: frozenset[str] = frozenset(
         "fleet_id",
         "exception_id",
         "alert_id",
+        # Runtime proxy summary metrics. These are bounded, non-content
+        # counters and posture values consumed by audit replay and operator
+        # status surfaces. Aggregate maps are additionally constrained by
+        # TIER_A_COUNT_MAP_FIELDS and _redact_count_map below.
+        "uptime_seconds",
+        "total_tool_calls",
+        "total_blocked",
+        "calls_by_tool",
+        "blocked_by_reason",
+        "latency",
+        "min_ms",
+        "max_ms",
+        "avg_ms",
+        "p50_ms",
+        "p95_ms",
+        "messages_client_to_server",
+        "messages_server_to_client",
+        "replay_rejections",
+        "relay_errors",
+        "last_decision",
+        "audit_buffer_bytes",
+        "audit_spillover_bytes",
+        "audit_dlq_bytes",
+        "policy_fetch_failures",
+        "audit_push_failures",
+        "audit_push_backoff_seconds",
+        "audit_circuit_open",
+        "runtime_alerts",
+        "runtime_alerts_by_severity",
+        "runtime_alerts_by_detector",
+        "blocked_runtime_alerts",
+        "latest_runtime_alert_at",
+        # Safe runtime isolation posture. Image references, warning text,
+        # mount paths, users, and other free-text fields intentionally remain
+        # replay-only and are dropped from these retained containers.
+        "execution_posture",
+        "sandbox_evidence",
+        "mode",
+        "enabled",
+        "runtime",
+        "image_pinned",
+        "image_pin_policy",
+        "network",
+        "egress_policy",
+        "cpus",
+        "memory",
+        "pids_limit",
+        "tmpfs_size",
+        "timeout_seconds",
+        "read_only_rootfs",
+        "drop_capabilities",
+        "no_new_privileges",
     }
 )
 
@@ -282,8 +335,15 @@ TIER_A_COUNT_MAP_FIELDS: frozenset[str] = frozenset(
         "class_counts",
         "severity_counts",
         "signal_types",
+        "calls_by_tool",
+        "blocked_by_reason",
+        "runtime_alerts_by_severity",
+        "runtime_alerts_by_detector",
     }
 )
+
+_TIER_A_COUNT_MAP_MAX_ENTRIES = 256
+_TIER_A_COUNT_MAP_MAX_KEY_CHARS = 96
 
 # Explicit replay-only set — present so the redactor can short-circuit and
 # so static auditors can see the list. Anything *not* in TIER_A_FIELDS is
@@ -383,12 +443,21 @@ def _redact_count_map(value: Any) -> dict[str, int | float]:
     """Preserve non-content aggregate count maps with arbitrary bucket keys."""
     if not isinstance(value, dict):
         return {}
-    out: dict[str, int | float] = {}
+    aggregated: dict[str, int | float] = {}
     for key, count in value.items():
         if isinstance(count, bool) or not isinstance(count, (int, float)):
             continue
-        out[str(key)[:96]] = count
-    return out
+        if not math.isfinite(float(count)):
+            continue
+        bounded_key = mask_email(str(key)).replace("\r", "").replace("\n", "")[:_TIER_A_COUNT_MAP_MAX_KEY_CHARS]
+        if not bounded_key:
+            continue
+        aggregated[bounded_key] = aggregated.get(bounded_key, 0) + count
+
+    # Stable ordering makes truncation deterministic across processes and
+    # retains the highest-volume buckets when cardinality is unexpectedly high.
+    ordered = sorted(aggregated.items(), key=lambda item: (-float(item[1]), item[0]))
+    return dict(ordered[:_TIER_A_COUNT_MAP_MAX_ENTRIES])
 
 
 # ─── Replay-only TTL helpers ────────────────────────────────────────────────

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -421,6 +421,8 @@ _CANONICAL_NULLABLE_FINDING_FIELDS: tuple[str, ...] = (
     "provenance",
     "owner",
     "sla_due_at",
+    "graph_reachable",
+    "graph_min_hop_distance",
 )
 
 _FINDING_RESPONSE_TIMESTAMPS = (
@@ -559,6 +561,21 @@ def safe_finding_response_payload(row: Mapping[str, Any]) -> dict[str, Any]:
             payload["epss_score"] = score
     if isinstance(row.get("is_kev"), bool):
         payload["is_kev"] = row["is_kev"]
+
+    graph_reachable = row.get("graph_reachable")
+    payload["graph_reachable"] = graph_reachable if isinstance(graph_reachable, bool) else None
+    graph_distance = row.get("graph_min_hop_distance")
+    payload["graph_min_hop_distance"] = (
+        graph_distance
+        if isinstance(graph_distance, int) and not isinstance(graph_distance, bool) and 0 <= graph_distance <= 10_000
+        else None
+    )
+    graph_agents = row.get("graph_reachable_from_agents")
+    payload["graph_reachable_from_agents"] = [
+        agent_id
+        for value in (graph_agents[:100] if isinstance(graph_agents, list) else [])
+        if (agent_id := _safe_optional_text(value, max_len=512)) is not None
+    ]
 
     remediation_versions = row.get("remediation_versions")
     if not isinstance(remediation_versions, list):

--- a/tests/api/test_api_scan_findings_wiring.py
+++ b/tests/api/test_api_scan_findings_wiring.py
@@ -14,12 +14,17 @@ import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api import stores as api_stores
+from agent_bom.api.finding_reachability import (
+    MAX_FINDING_REACHABILITY_PATHS,
+    project_persisted_graph_reachability,
+)
 from agent_bom.api.graph_store import SQLiteGraphStore
 from agent_bom.api.models import JobStatus
 from agent_bom.api.pipeline import _now, _persist_graph_snapshot
 from agent_bom.api.server import _jobs, app, set_job_store
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.api.stores import set_graph_store
+from agent_bom.graph import AttackPath
 from agent_bom.models import (
     Agent,
     AgentType,
@@ -35,6 +40,7 @@ from agent_bom.models import (
 from agent_bom.output import to_json
 
 KNOWN_CVE = "CVE-2026-9999"
+NON_OVERLAP_CVE = "CVE-2026-0000"
 
 
 def _report_with_known_vuln() -> dict:
@@ -74,7 +80,36 @@ def _report_with_known_vuln() -> dict:
         risk_score=9.0,
         owasp_tags=["LLM05"],
     )
-    return to_json(AIBOMReport(agents=[agent], blast_radii=[blast]))
+    report = to_json(AIBOMReport(agents=[agent], blast_radii=[blast]))
+    report["findings"].append(
+        {
+            "schema_version": "1",
+            "id": "finding-without-a-persisted-path",
+            "canonical_id": "finding-without-a-persisted-path",
+            "finding_type": "CVE",
+            "finding_category": "vulnerability",
+            "source": "MCP_SCAN",
+            "severity": "medium",
+            "effective_severity": "medium",
+            "title": f"{NON_OVERLAP_CVE}: standalone-lib@1.0.0",
+            "description": "Static finding without graph path evidence",
+            "cve_id": NON_OVERLAP_CVE,
+            "vulnerability_id": NON_OVERLAP_CVE,
+            "node_id": "pkg:pypi:standalone-lib@1.0.0",
+            "finding_node_id": f"vuln:{NON_OVERLAP_CVE}",
+            "asset": {
+                "name": "standalone-lib",
+                "asset_type": "package",
+                "stable_id": "standalone-lib",
+            },
+            "affected_agents": [],
+            "affected_servers": [],
+            "exposed_credentials": [],
+            "exposed_tools": [],
+            "evidence": {},
+        }
+    )
+    return report
 
 
 @pytest.fixture
@@ -92,7 +127,8 @@ def wired_client(tmp_path, monkeypatch):
     _jobs.clear()
 
     original_graph_store = api_stores._graph_store
-    set_graph_store(SQLiteGraphStore(tmp_path / "graph.db"))
+    graph_store = SQLiteGraphStore(tmp_path / "graph.db")
+    set_graph_store(graph_store)
 
     report_json = _report_with_known_vuln()
 
@@ -102,6 +138,14 @@ def wired_client(tmp_path, monkeypatch):
         job.completed_at = _now()
         store.put(job)
         _persist_graph_snapshot(job, report_json)
+        # The production demo estate persists its ranked ExposurePaths. This
+        # fixture materializes the same evidence so /v1/findings can prove its
+        # read-side projection from the graph store rather than re-deriving it.
+        from agent_bom.api.routes.graph import _derived_attack_paths
+
+        graph = graph_store.load_graph(tenant_id="default")
+        graph.attack_paths = _derived_attack_paths(graph)
+        graph_store.save_graph(graph)
 
     monkeypatch.setattr("agent_bom.api.routes.scan.submit_scan_job", _complete_synchronously)
 
@@ -122,7 +166,8 @@ def test_scan_vuln_flows_to_findings_and_attack_paths(wired_client):
 
     findings = wired_client.get("/v1/findings")
     assert findings.status_code == 200
-    finding_vulns = {row.get("vulnerability_id") for row in findings.json()["findings"]}
+    finding_rows = findings.json()["findings"]
+    finding_vulns = {row.get("vulnerability_id") for row in finding_rows}
     assert KNOWN_CVE in finding_vulns, f"known vuln missing from findings: {finding_vulns}"
 
     attack_paths = wired_client.get("/v1/graph/attack-paths")
@@ -131,6 +176,79 @@ def test_scan_vuln_flows_to_findings_and_attack_paths(wired_client):
     assert paths, "expected at least one derived attack path for the known vuln"
     path_vuln_ids = {vid for path in paths for vid in (path.get("vuln_ids") or [])}
     assert KNOWN_CVE in path_vuln_ids, f"known vuln missing from attack paths: {path_vuln_ids}"
+
+    matching_paths = [path for path in paths if KNOWN_CVE in (path.get("vuln_ids") or [])]
+    expected_min_hops = min(len(path["hops"]) - 1 for path in matching_paths)
+    reachable = next(row for row in finding_rows if row.get("vulnerability_id") == KNOWN_CVE)
+    assert reachable["graph_reachable"] is True
+    assert reachable["graph_min_hop_distance"] == expected_min_hops
+    assert reachable["graph_reachable_from_agents"] == ["agent:demo-agent"]
+
+    unassessed = next(row for row in finding_rows if row.get("vulnerability_id") == NON_OVERLAP_CVE)
+    assert unassessed["graph_reachable"] is None
+    assert unassessed["graph_min_hop_distance"] is None
+    assert unassessed["graph_reachable_from_agents"] == []
+
+
+def test_findings_reachability_projection_is_tenant_scoped_and_bounded():
+    class RecordingGraphStore:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, object]] = []
+
+        def attack_paths(self, **kwargs):
+            self.calls.append(kwargs)
+            path = AttackPath(
+                source="agent:reachable",
+                target=f"vuln:{KNOWN_CVE}",
+                hops=["agent:reachable", "server:demo", f"vuln:{KNOWN_CVE}"],
+                vuln_ids=[KNOWN_CVE],
+            )
+            return "scan-alpha", "2026-07-27T00:00:00Z", [path], MAX_FINDING_REACHABILITY_PATHS + 1
+
+    store = RecordingGraphStore()
+    result = project_persisted_graph_reachability(
+        [
+            {"id": "reachable", "cve_id": KNOWN_CVE, "finding_node_id": f"vuln:{KNOWN_CVE}"},
+            {"id": "unassessed", "cve_id": NON_OVERLAP_CVE},
+        ],
+        graph_store=store,  # type: ignore[arg-type]
+        tenant_id="tenant-alpha",
+        scan_id="scan-alpha",
+        path_limit=50_000,
+    )
+
+    assert store.calls == [
+        {
+            "tenant_id": "tenant-alpha",
+            "scan_id": "scan-alpha",
+            "offset": 0,
+            "limit": MAX_FINDING_REACHABILITY_PATHS,
+        }
+    ]
+    assert result.truncated is True
+    assert result.rows[0]["graph_reachable"] is True
+    assert result.rows[0]["graph_min_hop_distance"] == 2
+    assert result.rows[0]["graph_reachable_from_agents"] == ["agent:reachable"]
+    assert result.rows[1]["graph_reachable"] is None
+
+
+def test_findings_read_survives_unavailable_graph_backend(wired_client, monkeypatch):
+    class UnavailableGraphStore:
+        def attack_paths(self, **_kwargs):
+            raise NotImplementedError("graph backend unavailable at secret://internal-host")
+
+    monkeypatch.setattr("agent_bom.api.routes.scan._get_graph_store", lambda: UnavailableGraphStore())
+
+    create = wired_client.post("/v1/scan", json={})
+    assert create.status_code == 202
+    response = wired_client.get("/v1/findings")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["findings"]
+    assert any("Graph reachability evidence is unavailable" in warning for warning in payload["warnings"])
+    assert "secret://internal-host" not in response.text
+    assert all(row["graph_reachable"] is None for row in payload["findings"])
 
 
 def test_findings_read_sheds_with_429_when_backpressure_opens(wired_client, monkeypatch):

--- a/tests/test_evidence_policy.py
+++ b/tests/test_evidence_policy.py
@@ -229,6 +229,29 @@ def test_redact_preserves_tier_a_fields():
     assert redacted["class_counts"] == {"2004": 1, "4001": 1}
 
 
+def test_tier_a_count_maps_are_deterministic_bounded_and_numeric_only():
+    """Aggregate maps stay useful without becoming unbounded content channels."""
+    expected_limit = 256
+    buckets: dict[str, object] = {
+        f"tool-{index:03d}-{'x' * 120}": index + 1
+        for index in range(expected_limit + 20)
+    }
+    buckets["reject-bool"] = True
+    buckets["reject-string"] = "7"
+
+    redacted = redact_for_persistence(
+        {"calls_by_tool": buckets},
+        EvidenceTier.SAFE_TO_STORE,
+    )["calls_by_tool"]
+
+    assert len(redacted) == expected_limit
+    assert all(len(key) <= 96 for key in redacted)
+    assert all(isinstance(value, int | float) and not isinstance(value, bool) for value in redacted.values())
+    assert "reject-bool" not in redacted
+    assert "reject-string" not in redacted
+    assert list(redacted) == sorted(redacted, key=lambda key: (-redacted[key], key))
+
+
 def test_redact_for_replay_only_keeps_everything():
     redacted = redact_for_persistence(SYNTHETIC_PAYLOAD, EvidenceTier.REPLAY_ONLY)
     assert set(redacted) == set(SYNTHETIC_PAYLOAD)

--- a/tests/test_hub_reference_normalization.py
+++ b/tests/test_hub_reference_normalization.py
@@ -89,6 +89,7 @@ def test_hub_list_returns_hydrated_user_visible_fields(store_factory: str, tmp_p
         stored = json.loads(row[0])
         assert stored.get("intel_ref") == "CVE-2026-3513"
         assert "summary" not in stored
+        assert "graph_reachable_from_agents" not in stored
 
 
 def test_reference_normalization_reduces_ledger_bytes_at_scale(tmp_path) -> None:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -124,6 +124,100 @@ def test_write_audit_record_drops_nested_replay_only_fields_before_write():
     assert payload["event_relationships"]["resources"][0] == {"type": "file", "id": "resource-1"}
 
 
+def test_write_audit_record_preserves_proxy_summary_metrics():
+    """Durable proxy summaries must keep the non-content metrics operators consume."""
+    metrics = ProxyMetrics()
+    metrics.record_call("read_file")
+    metrics.record_blocked("policy")
+    metrics.record_latency(12.5)
+    metrics.total_messages_client_to_server = 3
+    metrics.total_messages_server_to_client = 2
+    buf = io.StringIO()
+
+    payload = write_audit_record(buf, metrics.summary())
+
+    assert payload["total_tool_calls"] == 1
+    assert payload["total_blocked"] == 1
+    assert payload["calls_by_tool"] == {"read_file": 1}
+    assert payload["blocked_by_reason"] == {"policy": 1}
+    assert payload["latency"] == {
+        "min_ms": 12.5,
+        "max_ms": 12.5,
+        "avg_ms": 12.5,
+        "p50_ms": 12.5,
+        "p95_ms": 12.5,
+        "count": 1,
+    }
+    assert payload["messages_client_to_server"] == 3
+    assert payload["messages_server_to_client"] == 2
+
+
+def test_write_audit_record_preserves_safe_execution_posture_only():
+    """Isolation proof survives while images, mounts, users, and free text do not."""
+    buf = io.StringIO()
+
+    payload = write_audit_record(
+        buf,
+        {
+            "type": "mcp_execution_posture",
+            "execution_posture": {
+                "mode": "container_isolated",
+                "sandbox_evidence": {
+                    "enabled": True,
+                    "runtime": "docker",
+                    "image": "registry.example/private/server@sha256:abc",
+                    "image_pinned": True,
+                    "image_pin_policy": "enforce",
+                    "image_pin_warning": "private registry warning",
+                    "network": "none",
+                    "egress_policy": "deny",
+                    "cpus": "1.0",
+                    "memory": "512m",
+                    "pids_limit": 128,
+                    "tmpfs_size": "64m",
+                    "timeout_seconds": 300,
+                    "read_only_rootfs": True,
+                    "drop_capabilities": True,
+                    "no_new_privileges": True,
+                    "user": "customer-runtime-user",
+                    "mounts": [
+                        {
+                            "source": "/Users/alice/private-workspace",
+                            "target": "/workspace",
+                            "readonly": True,
+                        }
+                    ],
+                },
+            },
+        },
+    )
+
+    assert payload["execution_posture"] == {
+        "mode": "container_isolated",
+        "sandbox_evidence": {
+            "enabled": True,
+            "runtime": "docker",
+            "image_pinned": True,
+            "image_pin_policy": "enforce",
+            "network": "none",
+            "egress_policy": "deny",
+            "cpus": "1.0",
+            "memory": "512m",
+            "pids_limit": 128,
+            "tmpfs_size": "64m",
+            "timeout_seconds": 300,
+            "read_only_rootfs": True,
+            "drop_capabilities": True,
+            "no_new_privileges": True,
+        },
+    }
+    encoded = json.dumps(payload)
+    assert "registry.example" not in encoded
+    assert "private registry warning" not in encoded
+    assert "customer-runtime-user" not in encoded
+    assert "/Users/alice" not in encoded
+
+
 @pytest.mark.asyncio
 async def test_read_bounded_line_discards_oversized_line_and_resyncs():
     reader = asyncio.StreamReader(limit=32)

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -183,8 +183,9 @@ function collectUnifiedFindings(findings: UnifiedFinding[]): EnrichedVuln[] {
             },
           ]
         : [],
-      graph_reachable: null,
-      graph_min_hop_distance: null,
+      graph_reachable: finding.graph_reachable ?? null,
+      graph_min_hop_distance: finding.graph_min_hop_distance ?? null,
+      graph_reachable_from_agents: finding.graph_reachable_from_agents ?? [],
       lifecycle_status: finding.status ?? undefined,
       first_seen: finding.first_seen ?? undefined,
       last_seen: finding.last_seen ?? undefined,

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1088,6 +1088,10 @@ export interface UnifiedFinding {
   affected_agents?: string[] | undefined;
   exposed_credentials?: string[] | undefined;
   exposed_tools?: string[] | undefined;
+  /** Persisted graph path evidence for this asset-specific finding. */
+  graph_reachable?: boolean | null | undefined;
+  graph_min_hop_distance?: number | null | undefined;
+  graph_reachable_from_agents?: string[] | undefined;
   scan_id?: string | undefined;
   scan_sources?: string[] | undefined;
   status?: string | undefined;

--- a/ui/lib/findings-view.ts
+++ b/ui/lib/findings-view.ts
@@ -29,6 +29,7 @@ export interface EnrichedVuln extends Vulnerability {
   remediation_items: RemediationSummary[];
   graph_reachable?: boolean | null | undefined;
   graph_min_hop_distance?: number | null | undefined;
+  graph_reachable_from_agents?: string[] | undefined;
   effective_reach_score?: number | undefined;
   effective_reach_band?: string | undefined;
   framework_tags?: string[] | undefined;

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -336,6 +336,45 @@ describe("FindingsPage", () => {
     expect(screen.queryByRole("columnheader", { name: "Control mapping" })).not.toBeInTheDocument();
   });
 
+  it("renders persisted graph reachability without inventing evidence for non-overlapping findings", async () => {
+    apiMock.listFindings.mockResolvedValue({
+      schema_version: "v1",
+      findings: [
+        {
+          ...canonicalFinding,
+          graph_reachable: true,
+          graph_min_hop_distance: 2,
+          graph_reachable_from_agents: ["agent:developer-copilot"],
+        },
+        {
+          ...canonicalFinding,
+          id: "finding-without-a-path",
+          cve_id: "CVE-2026-5678",
+          title: "Static finding without graph evidence",
+          graph_reachable: null,
+          graph_min_hop_distance: null,
+          graph_reachable_from_agents: [],
+        },
+      ],
+      total: 2,
+      facets: {
+        finding_class: { vulnerability: 2, misconfiguration: 0, secret: 0, identity: 0, unclassified: 0 },
+        severity: { critical: 2, high: 0, medium: 0, low: 0, info: 0, unknown: 0 },
+        status: { open: 2, resolved: 0 },
+        domain: { cspm: 0, vuln: 2, aspm: 0, dspm: 0, aispm: 0 },
+        freshness: { last_24_hours: 0, last_7_days: 0, last_30_days: 0, older: 0, unavailable: 2 },
+      },
+    });
+
+    render(<FindingsPage />);
+
+    expect(await screen.findByText("CVE-2026-1234")).toBeInTheDocument();
+    const summary = screen.getByTestId("findings-workspace-summary");
+    expect(within(summary).getByText("1 reachable")).toBeInTheDocument();
+    expect(within(summary).getByText("1 assessed on this page")).toBeInTheDocument();
+    expect(screen.getByText("Reachable · 2 hops")).toBeInTheDocument();
+  });
+
   it("gives Compliance distinct columns, actions, and an evidence-first drawer", async () => {
     navigationState.query = "lens=trust";
     apiMock.listFindings.mockResolvedValue({


### PR DESCRIPTION
## Summary

- retain bounded proxy counters, count maps, latency, and safe execution-posture fields in signed durable audit records while continuing to redact paths, users, mounts, images, and free text
- project persisted attack-path evidence onto matching findings with tenant/scan scoping, a 1,000-path bound, minimum hop distance, and reaching agents
- preserve `null` reachability for genuinely unassessed findings and return sanitized warnings when graph evidence is unavailable or truncated

## Root cause

Tier-A evidence redaction removed documented non-content runtime summary fields, so valid audit chains replayed false-zero totals and could not prove isolation posture. Separately, the Findings UI hardcoded graph reachability to `null` even when persisted exposure paths proved the same CVE/agent relationship.

## Impact

Runtime operators and SOC reviewers receive truthful signed activity/isolation evidence. SecOps and remediation operators see the same reachability evidence in Findings that is already present in Investigation, without unbounded graph reads or false certainty.

## Verification

- TDD red: exact failures for missing `total_tool_calls`, `execution_posture`, `calls_by_tool`, and graph reachability rendered as unavailable
- combined focused verification: 120 passed
- runtime/proxy suites: 157 passed
- evidence and audit replay suites: 93 passed
- runtime/security pack: 28 passed
- affected findings/API/graph suites: 60 passed
- UI suite: 160 files, 950 tests
- UI typecheck, ESLint, 49-page production build
- bundle budget: 3601.3 / 3616 KiB
- `make preflight`
- Ruff, mypy, exception-sanitization guard, and `git diff --check`
- live audit replay: 1 call, 1 block, full latency/maps, 3 verified / 0 tampered