### PR TITLE
fix(release): harden demo and package evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint preflight preflight-fix docker-build docker-run scan clean build-ui analytics dev check-dupes clean-dupes secrets platform-up fullstack-up
+.PHONY: help install test lint preflight preflight-fix docker-build docker-run scan clean build-ui release-build publish-test publish analytics dev check-dupes clean-dupes secrets platform-up fullstack-up
 
 help:  ## Show this help message
 	@echo 'Usage: make [target]'
@@ -91,6 +91,11 @@ fullstack-up: secrets  ## Bring up the dev full-stack (API + UI + Postgres); gen
 build-ui:  ## Build Next.js dashboard and bundle into package
 	bash scripts/build-ui.sh
 
+release-build: build-ui  ## Build and verify release artifacts with the bundled dashboard
+	rm -rf dist/
+	uv build
+	uv run python scripts/verify_release_wheel.py dist
+
 check-dupes:  ## Detect Finder-style duplicate files (incl. untracked) in the working tree
 	python3 scripts/check_duplicate_artifacts.py --working-tree
 
@@ -105,12 +110,10 @@ clean:  ## Clean build artifacts
 	find . -type f -name '*.pyc' -delete
 	rm -f report.json ai-bom*.json *.cdx.json
 
-publish-test:  ## Publish to TestPyPI
-	python -m build
+publish-test: release-build  ## Publish verified artifacts to TestPyPI
 	twine upload --repository testpypi dist/*
 
-publish:  ## Publish to PyPI
-	python -m build
+publish: release-build  ## Publish verified artifacts to PyPI
 	twine upload dist/*
 
 version:  ## Show agent-bom version

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -27,8 +27,8 @@ signed release evidence.
 | Backend tests | `uv run pytest -q` | Python 3.11/3.13/3.14 CI must pass; local focused suites should cover changed areas. |
 | UI build | `cd ui && npm run typecheck && npm run lint && npm run build && npm run bundle:check && npm run test:run` | The dashboard builds, tests pass, and client JS stays under budget. |
 | Dashboard bundle | `make build-ui` | Runs the export build (`NEXT_EXPORT=1`) and copies it to `src/agent_bom/ui_dist` with CSP hashes. **Required before the package build** — the UI-build row above leaves nothing in `src/agent_bom/ui_dist`, and `ui_dist` is gitignored, so a `uv build` without this step produces a dashboard-less wheel and a dashboard-less image. |
-| Package build | `make build-ui && uv build --out-dir /tmp/agent-bom-build` | Wheel and sdist build from a clean tree. |
-| Packaged dashboard | `unzip -l /tmp/agent-bom-build/agent_bom-*.whl \| grep -c ui_dist` | Non-zero. Zero means the wheel ships no dashboard: `agent-bom serve` prints `Dashboard  Not bundled` and every UI route 404s. |
+| Package build | `make release-build` | Builds the dashboard, wheel, and sdist, then rejects any wheel missing the schemas, dashboard index, CSP manifest, or CSP script hashes. |
+| Packaged dashboard | `uv run python scripts/verify_release_wheel.py dist` | Every wheel passes the same dashboard and CSP contract used by the manual publish targets. |
 | PyPI smoke | `python -m venv /tmp/agent-bom-smoke && /tmp/agent-bom-smoke/bin/pip install agent-bom==<version> && /tmp/agent-bom-smoke/bin/agent-bom --version` | Published package installs in a fresh environment. |
 | Registry surface freshness (post-publish) | `PYTHONPATH=src python scripts/check_surface_freshness.py --out /tmp/agent-bom-surface-freshness.json` | PyPI, Docker, GHCR, Glama, and configured Smithery surfaces report the expected version and a non-empty inventory. Async rebuild acceptance is not release completion. |
 | Quickstart E2E | `agent-bom quickstart --run --offline --force --sample-dir /tmp/agent-bom-quickstart` | Generates a real report, graph, posture, and no coverage warnings. |

--- a/scripts/build-ui.sh
+++ b/scripts/build-ui.sh
@@ -12,6 +12,6 @@ NEXT_EXPORT=1 npm run build
 echo "Copying static output to package..."
 rm -rf "$ROOT_DIR/src/agent_bom/ui_dist"
 cp -r out "$ROOT_DIR/src/agent_bom/ui_dist"
-python "$ROOT_DIR/scripts/generate_ui_csp_hashes.py" "$ROOT_DIR/src/agent_bom/ui_dist"
+uv run python "$ROOT_DIR/scripts/generate_ui_csp_hashes.py" "$ROOT_DIR/src/agent_bom/ui_dist"
 
 echo "Dashboard bundled → src/agent_bom/ui_dist/"

--- a/scripts/verify_release_wheel.py
+++ b/scripts/verify_release_wheel.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Reject release wheels that omit required schemas or dashboard assets."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from zipfile import BadZipFile, ZipFile
+
+REQUIRED_FILES = (
+    "agent_bom/data/inventory.schema.json",
+    "agent_bom/data/mcp-intelligence.schema.json",
+    "agent_bom/ui_dist/index.html",
+    "agent_bom/ui_dist/csp-hashes.json",
+)
+CSP_MANIFEST = "agent_bom/ui_dist/csp-hashes.json"
+
+
+def verify_wheel(wheel_path: Path) -> None:
+    """Raise ``ValueError`` when a wheel lacks required release evidence."""
+    try:
+        with ZipFile(wheel_path) as archive:
+            members = set(archive.namelist())
+            missing = [path for path in REQUIRED_FILES if path not in members]
+            if missing:
+                raise ValueError(f"missing required file(s): {', '.join(missing)}")
+            manifest = json.loads(archive.read(CSP_MANIFEST))
+    except (BadZipFile, json.JSONDecodeError) as exc:
+        raise ValueError(f"invalid release wheel: {exc}") from exc
+
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("script_hashes"), list) or not manifest["script_hashes"]:
+        raise ValueError(f"{CSP_MANIFEST} must contain a non-empty script_hashes list")
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    dist_dir = Path(args[0]) if args else Path("dist")
+    wheels = sorted(dist_dir.glob("*.whl"))
+    if not wheels:
+        print(f"ERROR: no wheel found in {dist_dir}", file=sys.stderr)
+        return 1
+
+    for wheel in wheels:
+        try:
+            verify_wheel(wheel)
+        except (OSError, ValueError) as exc:
+            print(f"ERROR: {wheel.name}: {exc}", file=sys.stderr)
+            return 1
+        print(f"{wheel.name}: dashboard and CSP manifest verified")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -778,18 +778,21 @@ def scan(
     # attached to the report so the API/MCP can return it. Offline/airgapped
     # callers (``--offline`` or AGENT_BOM_VULN_DB_OFFLINE) never trigger a
     # network refresh — they use whatever cache exists.
-    from agent_bom.vuln_freshness import compute_freshness, should_refresh
+    from agent_bom.vuln_freshness import bundled_demo_freshness, compute_freshness, should_refresh
 
     _vuln_freshness = None
-    try:
-        _vuln_freshness = compute_freshness(offline=offline)
-    except Exception:
-        _vuln_freshness = None  # Never block a scan on a freshness probe failure
+    if demo:
+        _vuln_freshness = bundled_demo_freshness()
+    else:
+        try:
+            _vuln_freshness = compute_freshness(offline=offline)
+        except Exception:
+            _vuln_freshness = None  # Never block a scan on a freshness probe failure
 
     # Auto-refresh stale/missing DB if enabled (skip side-effect-light modes,
     # skip in offline mode). Never fail the scan on a refresh error — fall back
     # to live API or the existing cache.
-    if auto_update_db and not no_scan and not dry_run and not offline and _vuln_freshness is not None:
+    if auto_update_db and not demo and not no_scan and not dry_run and not offline and _vuln_freshness is not None:
         source_list = [s.strip() for s in db_sources.split(",")] if db_sources else None
         # Explicit --db-source always syncs; otherwise respect the age threshold
         # (idempotent: a fresh cache is not re-synced).

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -1084,6 +1084,9 @@ async def scan_packages(
     except Exception:  # noqa: BLE001
         pass
 
+    def _db_key(p: Package) -> str:
+        return f"{p.ecosystem.lower()}:{normalize_package_name(p.name, p.ecosystem)}@{p.version}"
+
     # ── Local version resolution (installed packages) ──────────────────────
     # Try resolving versions from locally installed packages FIRST.
     # This is more accurate than registry fallback because it reflects
@@ -1172,6 +1175,11 @@ async def scan_packages(
     elif still_unresolved and scan_offline:
         _logger.info("Offline mode: skipping registry version resolution for %d package(s)", len(still_unresolved))
 
+    # Capture the version-resolved direct demo inventory before optional online
+    # transitive expansion. Only this curated set is closed evidence; packages
+    # discovered outside it still require a real advisory lookup.
+    demo_inventory_keys = {_db_key(package) for package in packages} if scan_options.demo_advisories else set()
+
     # ── Transitive dependency resolution (npm / PyPI / Go) ───────────────────
     if scan_resolve_transitive and not scan_offline:
         transitive_ecosystems = {"npm", "pypi", "go"}
@@ -1216,9 +1224,6 @@ async def scan_packages(
     if not scannable:
         return 0
 
-    def _db_key(p: Package) -> str:
-        return f"{p.ecosystem.lower()}:{normalize_package_name(p.name, p.ecosystem)}@{p.version}"
-
     # ── Local DB lookup (fast, offline-capable) ───────────────────────────────
     # Demo mode uses bundled advisory rows first so published first-run evidence
     # is deterministic and does not depend on a user's ambient ~/.agent-bom DB.
@@ -1232,7 +1237,7 @@ async def scan_packages(
         # entries are intentionally clean or malicious without a CVE, so a
         # missing advisory row must not fall through to the user's ambient DB
         # (or OSV) and turn deterministic demo coverage into a partial scan.
-        db_covered.update(_db_key(package) for package in scannable)
+        db_covered.update(demo_inventory_keys)
 
     # Query the local SQLite DB for packages not already covered by the
     # deterministic demo manifest. Packages covered by the DB skip OSV calls.

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -1228,6 +1228,11 @@ async def scan_packages(
         demo_count, demo_covered = _scan_packages_demo_advisories(scannable)
         local_count += demo_count
         db_covered.update(demo_covered)
+        # The curated demo inventory is a closed, versioned evidence set. Some
+        # entries are intentionally clean or malicious without a CVE, so a
+        # missing advisory row must not fall through to the user's ambient DB
+        # (or OSV) and turn deterministic demo coverage into a partial scan.
+        db_covered.update(_db_key(package) for package in scannable)
 
     # Query the local SQLite DB for packages not already covered by the
     # deterministic demo manifest. Packages covered by the DB skip OSV calls.

--- a/src/agent_bom/vuln_freshness.py
+++ b/src/agent_bom/vuln_freshness.py
@@ -85,7 +85,8 @@ class VulnDataFreshness:
     Attributes:
         mode: ``"local"`` when a local cache is used, ``"live"`` when scanning
             falls back to the OSV/GHSA/NVD APIs, ``"offline"`` when network is
-            disabled and only the existing cache is consulted.
+            disabled and only the existing cache is consulted, or
+            ``"bundled-demo"`` for the versioned demo advisory set.
         sources: Human labels of the feeds in play (e.g. ``["OSV", "GHSA"]``).
         last_updated: ISO-8601 UTC timestamp of the oldest synced source, or
             ``None`` when there is no cache.
@@ -134,6 +135,9 @@ class VulnDataFreshness:
         "No local vulnerability DB found" warning, and reusable by any other
         text surface. Markup-free so it is safe for logs and JSON notes.
         """
+        if self.mode == "bundled-demo":
+            noun = "advisory" if self.record_count == 1 else "advisories"
+            return f"Vuln data: bundled demo advisory DB ({self.record_count} curated {noun})"
         sources = "+".join(self.sources) if self.sources else "OSV"
         if self.mode == "live":
             return f"Vuln data: {sources} live (no local cache — run `agent-bom db update` for faster offline scans)"
@@ -147,6 +151,19 @@ class VulnDataFreshness:
         if self.stale:
             return f"{base} — run `agent-bom db update` for daily freshness"
         return base
+
+
+def bundled_demo_freshness() -> VulnDataFreshness:
+    """Return truthful freshness metadata for the versioned demo evidence."""
+    from agent_bom.demo_advisories import DEMO_ADVISORIES
+
+    return VulnDataFreshness(
+        mode="bundled-demo",
+        sources=["DEMO"],
+        record_count=len(DEMO_ADVISORIES),
+        stale=False,
+        danger=False,
+    )
 
 
 def _humanize_age(age_hours: int | None) -> str:
@@ -316,7 +333,7 @@ def should_refresh(
     """
     if offline or offline_env():
         return False
-    if freshness.mode == "offline":
+    if freshness.mode in {"offline", "bundled-demo"}:
         return False
     # Missing cache (live mode) or stale local cache → refresh.
     if freshness.mode == "live":
@@ -370,7 +387,7 @@ def db_staleness(
     threshold = threshold_days if threshold_days is not None else db_stale_days_threshold()
     age = freshness.age_days
     if age is None:
-        if freshness.mode == "live":
+        if freshness.mode in {"live", "bundled-demo"}:
             return False, None
         return True, None
     return age >= threshold, age

--- a/tests/test_auto_update_db.py
+++ b/tests/test_auto_update_db.py
@@ -29,7 +29,7 @@ def _freshness(*, mode="local", stale=False, danger=False):
     )
 
 
-def test_auto_update_db_flag_triggers_sync_when_aging():
+def test_auto_update_db_flag_triggers_sync_when_aging(tmp_path):
     """When DB freshness misses the daily target, sync_db() must be called."""
     with (
         patch("agent_bom.vuln_freshness.compute_freshness", return_value=_freshness(stale=True)),
@@ -37,15 +37,28 @@ def test_auto_update_db_flag_triggers_sync_when_aging():
         patch("agent_bom.cli.agents.discover_all", return_value=[]),
         patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
     ):
-        result = _invoke("--auto-update-db", "--demo")
+        result = _invoke("--auto-update-db", str(tmp_path))
         assert mock_sync.call_count >= 1
         assert result.exit_code == 0
 
 
-def test_auto_update_db_skips_when_fresh():
+def test_auto_update_db_skips_when_fresh(tmp_path):
     """When DB freshness is inside the daily target, sync_db() must NOT be called."""
     with (
         patch("agent_bom.vuln_freshness.compute_freshness", return_value=_freshness(stale=False)),
+        patch("agent_bom.db.sync.sync_db") as mock_sync,
+        patch("agent_bom.cli.agents.discover_all", return_value=[]),
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
+    ):
+        result = _invoke("--auto-update-db", str(tmp_path))
+        mock_sync.assert_not_called()
+        assert result.exit_code == 0
+
+
+def test_demo_skips_db_refresh_when_ambient_cache_is_stale():
+    """The versioned demo evidence must not depend on an ambient DB refresh."""
+    with (
+        patch("agent_bom.vuln_freshness.compute_freshness", return_value=_freshness(stale=True)),
         patch("agent_bom.db.sync.sync_db") as mock_sync,
         patch("agent_bom.cli.agents.discover_all", return_value=[]),
         patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
@@ -68,7 +81,7 @@ def test_auto_update_db_opt_out():
         assert result.exit_code == 0
 
 
-def test_auto_update_db_on_by_default():
+def test_auto_update_db_on_by_default(tmp_path):
     """Default behavior: auto-update-db is ON, sync_db() called when stale (not with --no-scan)."""
     with (
         patch("agent_bom.vuln_freshness.compute_freshness", return_value=_freshness(stale=True)),
@@ -76,7 +89,7 @@ def test_auto_update_db_on_by_default():
         patch("agent_bom.cli.agents.discover_all", return_value=[]),
         patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
     ):
-        result = _invoke("--demo")
+        result = _invoke(str(tmp_path))
         assert mock_sync.call_count >= 1
         assert result.exit_code == 0
 
@@ -118,7 +131,7 @@ def test_dry_run_skips_db_refresh():
         assert result.exit_code == 0
 
 
-def test_auto_update_db_handles_sync_failure():
+def test_auto_update_db_handles_sync_failure(tmp_path):
     """When sync_db() raises, the scan should continue without crashing."""
     with (
         patch("agent_bom.vuln_freshness.compute_freshness", return_value=_freshness(mode="live", stale=False)),
@@ -126,6 +139,6 @@ def test_auto_update_db_handles_sync_failure():
         patch("agent_bom.cli.agents.discover_all", return_value=[]),
         patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
     ):
-        result = _invoke("--auto-update-db", "--demo")
+        result = _invoke("--auto-update-db", str(tmp_path))
         # Scan must not crash — exit code 0 (no findings)
         assert result.exit_code == 0

--- a/tests/test_cli_scan.py
+++ b/tests/test_cli_scan.py
@@ -1096,6 +1096,50 @@ def test_demo_scan_preserves_curated_inventory_without_registry_fallback(monkeyp
     assert "PARTIAL COVERAGE" not in result.output
 
 
+def test_demo_offline_with_missing_ambient_db_keeps_complete_bundled_evidence(monkeypatch, tmp_path):
+    """The advertised demo must not inherit partial coverage from an absent user DB."""
+    from agent_bom.db import schema
+    from agent_bom.demo_advisories import DEMO_ADVISORIES
+
+    output = tmp_path / "demo.json"
+    monkeypatch.setattr(schema, "DB_PATH", tmp_path / "missing" / "vulns.db")
+
+    result = _run(
+        [
+            "scan",
+            "--demo",
+            "--offline",
+            "--no-auto-update-db",
+            "--format",
+            "json",
+            "--output",
+            str(output),
+        ]
+    )
+
+    # Findings intentionally fail the demo scan; execution evidence is complete.
+    assert result.exit_code == 1, result.output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["scan_run"]["outcome"] == "complete"
+    assert payload["scan_run"]["issues"] == []
+    assert payload["warnings"] == []
+    assert payload["summary"]["coverage_warnings"] == []
+    assert payload["vuln_data_freshness"] == {
+        "mode": "bundled-demo",
+        "sources": ["DEMO"],
+        "last_updated": None,
+        "age_hours": None,
+        "age_days": None,
+        "record_count": len(DEMO_ADVISORIES),
+        "stale": False,
+        "danger": False,
+        "max_age_hours": 24,
+    }
+    assert "local vulnerability DB not found" not in result.output
+    assert "Offline coverage gap" not in result.output
+    assert "Vulnerability DB is stale" not in result.output
+
+
 def test_scan_format_sarif(tmp_path):
     """--format sarif should produce a SARIF file."""
     out = tmp_path / "results.sarif"

--- a/tests/test_console_reconciliation.py
+++ b/tests/test_console_reconciliation.py
@@ -40,18 +40,12 @@ def demo_json_report(tmp_path_factory) -> dict:
 
 
 def test_headline_counts_match_unified_stream(demo_console_output, demo_json_report):
-    """Whichever severity headline the console shows equals the unified stream.
-
-    With a local advisory DB the summary box prints CRIT/HIGH/MED counts;
-    without one (CI) it honestly shows PARTIAL COVERAGE and the labeled
-    all-categories Findings line is the reconciliation surface instead.
-    """
+    """The complete bundled-demo headline equals the unified findings stream."""
     by_sev = demo_json_report["finding_summary"]["by_severity"]
     match = re.search(r"CRIT\s+(\d+)\s+HIGH\s+(\d+)\s+MED\s+(\d+)", demo_console_output)
-    if match is None:
-        assert "PARTIAL COVERAGE" in demo_console_output, "summary box severity headline missing"
-        match = re.search(r"Findings — (\d+) critical · (\d+) high · (\d+) medium", demo_console_output)
-        assert match, "all-categories findings line missing"
+    assert match, "complete bundled-demo summary headline missing"
+    assert "PARTIAL COVERAGE" not in demo_console_output
+    assert demo_json_report["scan_run"]["outcome"] == "complete"
     assert int(match.group(1)) == by_sev["critical"]
     assert int(match.group(2)) == by_sev["high"]
     assert int(match.group(3)) == by_sev["medium"]

--- a/tests/test_dashboard_release_packaging.py
+++ b/tests/test_dashboard_release_packaging.py
@@ -12,8 +12,12 @@ doc language so the defect cannot silently return.
 
 from __future__ import annotations
 
+import json
+import subprocess
+import sys
 from pathlib import Path
 from typing import Any
+from zipfile import ZIP_DEFLATED, ZipFile
 
 import yaml
 
@@ -21,6 +25,7 @@ ROOT = Path(__file__).resolve().parent.parent
 RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 DASHBOARD_ARTIFACT = "dashboard-ui-dist"
 DASHBOARD_PATH = "src/agent_bom/ui_dist"
+WHEEL_VERIFIER = ROOT / "scripts" / "verify_release_wheel.py"
 
 
 def _release_jobs() -> dict[str, Any]:
@@ -138,10 +143,12 @@ def test_dockerfile_copies_the_package_source_that_carries_the_dashboard():
 
 
 def test_release_verification_bundles_the_dashboard_before_building_the_wheel():
-    """`uv build` alone yields a dashboard-less wheel; the doc must say so in order."""
+    """The release runbook must route package builds through the guarded target."""
     body = (ROOT / "docs" / "RELEASE_VERIFICATION.md").read_text(encoding="utf-8")
     assert "make build-ui" in body, "RELEASE_VERIFICATION.md never tells the release engineer to bundle the dashboard"
-    assert body.index("make build-ui") < body.index("uv build"), "the dashboard bundle step must precede the package build"
+    assert "make release-build" in body, "the release runbook bypasses the guarded package-build target"
+    assert body.index("make build-ui") < body.index("make release-build"), "the dashboard bundle contract must precede the package build"
+    assert "scripts/verify_release_wheel.py dist" in body, "the release runbook omits wheel dashboard verification"
     assert "ui_dist" in body, "the doc must name the artifact the bundle step produces"
 
 
@@ -151,3 +158,67 @@ def test_enterprise_deployment_states_what_each_artifact_bundles():
     assert "false. Verified above." not in body, "the guide still asserts a blanket claim the reader cannot verify"
     assert "The wheel bundles the dashboard" in body
     assert "agentbom/agent-bom" in body
+
+
+def _make_test_wheel(tmp_path: Path, *, include_index: bool = True, script_hashes: list[str] | None = None) -> Path:
+    wheel = tmp_path / "agent_bom-0.0.0-py3-none-any.whl"
+    with ZipFile(wheel, "w", compression=ZIP_DEFLATED) as archive:
+        archive.writestr("agent_bom/data/inventory.schema.json", "{}")
+        archive.writestr("agent_bom/data/mcp-intelligence.schema.json", "{}")
+        if include_index:
+            archive.writestr("agent_bom/ui_dist/index.html", "<!doctype html><title>agent-bom</title>")
+        archive.writestr(
+            "agent_bom/ui_dist/csp-hashes.json",
+            json.dumps({"script_hashes": ["sha256-test"] if script_hashes is None else script_hashes}),
+        )
+    return wheel
+
+
+def _verify_wheels(dist_dir: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(WHEEL_VERIFIER), str(dist_dir)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_release_wheel_verifier_accepts_dashboard_and_nonempty_csp_manifest(tmp_path):
+    wheel = _make_test_wheel(tmp_path)
+
+    result = _verify_wheels(tmp_path)
+
+    assert result.returncode == 0, result.stderr
+    assert wheel.name in result.stdout
+
+
+def test_release_wheel_verifier_rejects_a_dashboardless_wheel(tmp_path):
+    _make_test_wheel(tmp_path, include_index=False)
+
+    result = _verify_wheels(tmp_path)
+
+    assert result.returncode == 1
+    assert "agent_bom/ui_dist/index.html" in result.stderr
+
+
+def test_release_wheel_verifier_rejects_an_empty_csp_manifest(tmp_path):
+    _make_test_wheel(tmp_path, script_hashes=[])
+
+    result = _verify_wheels(tmp_path)
+
+    assert result.returncode == 1
+    assert "script_hashes" in result.stderr
+
+
+def test_manual_publish_targets_build_and_verify_dashboard_wheels_first():
+    body = (ROOT / "Makefile").read_text(encoding="utf-8")
+    build_ui = (ROOT / "scripts" / "build-ui.sh").read_text(encoding="utf-8")
+
+    assert "release-build: build-ui" in body
+    assert "uv build" in body
+    assert "uv run python scripts/verify_release_wheel.py dist" in body
+    assert "publish-test: release-build" in body
+    assert "publish: release-build" in body
+    assert "publish-test:\n\tuv build" not in body
+    assert "publish:\n\tuv build" not in body
+    assert 'uv run python "$ROOT_DIR/scripts/generate_ui_csp_hashes.py"' in build_ui

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -402,6 +402,36 @@ def test_scan_packages_demo_offline_uses_curated_advisories_without_local_db():
     mock_osv.assert_not_called()
 
 
+def test_scan_packages_demo_transitive_outside_curated_inventory_reaches_advisory_lookup():
+    """Demo closure must not silently cover packages discovered online."""
+    from agent_bom.scanners import ScanOptions, scan_packages
+
+    curated_direct = _make_pkg("semver", "7.5.2", "npm")
+    discovered_transitive = _make_pkg("left-pad", "1.3.0", "npm")
+
+    with (
+        patch(
+            "agent_bom.transitive.resolve_transitive_dependencies",
+            return_value=[discovered_transitive],
+        ),
+        patch("agent_bom.scanners._scan_packages_local_db", return_value=(0, set())) as mock_local_db,
+        patch("agent_bom.scanners.query_osv_batch", return_value={}) as mock_osv,
+    ):
+        asyncio.run(
+            scan_packages(
+                [curated_direct],
+                options=ScanOptions(resolve_transitive=True, demo_advisories=True),
+            )
+        )
+
+    local_targets = mock_local_db.call_args[0][0]
+    assert curated_direct not in local_targets
+    assert discovered_transitive in local_targets
+    osv_targets = mock_osv.call_args[0][0]
+    assert curated_direct not in osv_targets
+    assert discovered_transitive in osv_targets
+
+
 def test_scan_packages_offline_clean_pkg_in_covered_ecosystem_does_not_raise(monkeypatch):
     """A package with no DB rows whose ecosystem the DB covers is CLEAN, not a gap.
 

--- a/tests/test_local_db_scan.py
+++ b/tests/test_local_db_scan.py
@@ -379,6 +379,7 @@ def test_scan_packages_demo_offline_uses_curated_advisories_without_local_db():
     vulnerable_npm = _make_pkg("express", "4.17.1", "npm")
     vulnerable_pypi = _make_pkg("pillow", "9.0.0", "pypi")
     intentionally_clean = _make_pkg("semver", "7.5.2", "npm")
+    intentional_typosquat = _make_pkg("reqeusts", "2.99.0", "pypi")
 
     with (
         patch("agent_bom.scanners._scan_packages_local_db") as mock_local_db,
@@ -387,7 +388,7 @@ def test_scan_packages_demo_offline_uses_curated_advisories_without_local_db():
     ):
         count = asyncio.run(
             scan_packages(
-                [vulnerable_npm, vulnerable_pypi, intentionally_clean],
+                [vulnerable_npm, vulnerable_pypi, intentionally_clean, intentional_typosquat],
                 options=ScanOptions(offline=True, demo_advisories=True),
             )
         )
@@ -396,6 +397,7 @@ def test_scan_packages_demo_offline_uses_curated_advisories_without_local_db():
     assert vulnerable_npm.vulnerabilities
     assert vulnerable_pypi.vulnerabilities
     assert intentionally_clean.vulnerabilities == []
+    assert intentional_typosquat.vulnerabilities == []
     mock_local_db.assert_not_called()
     mock_osv.assert_not_called()
 

--- a/tests/test_vuln_freshness.py
+++ b/tests/test_vuln_freshness.py
@@ -12,7 +12,9 @@ from agent_bom.vuln_freshness import (
     DEFAULT_MAX_AGE_HOURS,
     STALE_DANGER_HOURS,
     VulnDataFreshness,
+    bundled_demo_freshness,
     compute_freshness,
+    db_staleness,
     max_age_hours,
     should_refresh,
 )
@@ -125,6 +127,24 @@ def test_to_dict_round_trip():
     assert d["age_hours"] == 49
     assert d["age_days"] == 2
     assert d["stale"] is True
+
+
+def test_bundled_demo_freshness_is_versioned_evidence_not_ambient_db_age():
+    """The deterministic demo reports its bundled source without inventing DB age."""
+    from agent_bom.demo_advisories import DEMO_ADVISORIES
+
+    fresh = bundled_demo_freshness()
+
+    assert fresh.mode == "bundled-demo"
+    assert fresh.sources == ["DEMO"]
+    assert fresh.record_count == len(DEMO_ADVISORIES)
+    assert fresh.last_updated is None
+    assert fresh.age_hours is None
+    assert fresh.stale is False
+    assert fresh.danger is False
+    assert fresh.summary_line() == f"Vuln data: bundled demo advisory DB ({len(DEMO_ADVISORIES)} curated advisories)"
+    assert should_refresh(fresh, offline=False) is False
+    assert db_staleness(fresh) == (False, None)
 
 
 # ── should_refresh ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- treat the curated demo inventory as a closed evidence set so a missing ambient vulnerability DB does not falsely downgrade offline demo coverage
- report truthful `bundled-demo` freshness metadata for the curated advisory snapshot
- make the manual release path build the dashboard and verify required wheel assets before publication

## Root cause

The demo path reused ambient-database freshness and coverage behavior intended for production scans, while the manual build path did not prove that exported dashboard and schema assets were present in the wheel.

## Impact

Fresh offline demo scans now remain complete and explain their bundled evidence source. Maintainer release builds fail before publication if the dashboard, schemas, CSP manifest, or script hashes are absent.

## Verification

- `uv run pytest -q tests/test_local_db_scan.py tests/test_vuln_freshness.py tests/test_dashboard_release_packaging.py` — 57 passed
- scanner/freshness/demo suite — 52 passed
- CLI/console suite — 123 passed
- dashboard/deployment suite — 63 passed
- packaging/CSP suite — 13 passed
- `make release-build`
- wheel verifier: 1,349 members, 520 dashboard files, schemas/index/CSP present, 116 nonempty script hashes
- Twine 6.2.0 wheel and sdist validation
- Ruff, shell syntax, public-doc hygiene, and `git diff --check`