### PR TITLE
fix(release): close first-run and scale gates

### DIFF
--- a/.github/workflows/postgres-scale-evidence.yml
+++ b/.github/workflows/postgres-scale-evidence.yml
@@ -64,6 +64,9 @@ jobs:
           --health-retries 10
     env:
       AGENT_BOM_POSTGRES_URL: postgresql://agent_bom:agent_bom@localhost:5432/agent_bom
+      # The disposable service-container owner is intentionally a superuser;
+      # production and shared-database deployments must use a non-bypass role.
+      AGENT_BOM_ALLOW_SUPERUSER_DB: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:

--- a/.github/workflows/postgres-scale-evidence.yml
+++ b/.github/workflows/postgres-scale-evidence.yml
@@ -63,7 +63,8 @@ jobs:
           --health-timeout 5s
           --health-retries 10
     env:
-      AGENT_BOM_POSTGRES_URL: postgresql://agent_bom:agent_bom@localhost:5432/agent_bom
+      AGENT_BOM_POSTGRES_URL: postgresql://agent_bom_app:benchmark_app@localhost:5432/agent_bom
+      AGENT_BOM_POSTGRES_ADMIN_URL: postgresql://agent_bom:agent_bom@localhost:5432/agent_bom
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -82,7 +83,16 @@ jobs:
       - name: Migrate ephemeral Postgres schema
         env:
           ALEMBIC_DATABASE_URL: postgresql+psycopg://agent_bom:agent_bom@localhost:5432/agent_bom
-        run: alembic -c deploy/supabase/postgres/alembic.ini upgrade head
+        run: |
+          python - <<'PY'
+          import os
+
+          import psycopg
+
+          with psycopg.connect(os.environ["AGENT_BOM_POSTGRES_ADMIN_URL"], autocommit=True) as connection:
+              connection.execute("ALTER DATABASE agent_bom SET init.app_password = 'benchmark_app'")
+          PY
+          alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 
       - name: Smoke-test the harness
         run: scripts/run_postgres_scale_evidence.py --dry-run --output /tmp/dry.json

--- a/.github/workflows/postgres-scale-evidence.yml
+++ b/.github/workflows/postgres-scale-evidence.yml
@@ -64,9 +64,6 @@ jobs:
           --health-retries 10
     env:
       AGENT_BOM_POSTGRES_URL: postgresql://agent_bom:agent_bom@localhost:5432/agent_bom
-      # The disposable service-container owner is intentionally a superuser;
-      # production and shared-database deployments must use a non-bypass role.
-      AGENT_BOM_ALLOW_SUPERUSER_DB: "1"
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -81,6 +78,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -e ".[postgres,api]"
+
+      - name: Migrate ephemeral Postgres schema
+        env:
+          ALEMBIC_DATABASE_URL: postgresql+psycopg://agent_bom:agent_bom@localhost:5432/agent_bom
+        run: alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 
       - name: Smoke-test the harness
         run: scripts/run_postgres_scale_evidence.py --dry-run --output /tmp/dry.json

--- a/docs/HOSTED_POC.md
+++ b/docs/HOSTED_POC.md
@@ -116,8 +116,16 @@ docker compose \
 ```
 
 The compose profile persists `/root/.agent-bom` in a named volume so the seeded
-demo graph survives container replacement. Replace it with real connected
-cloud scans as soon as the first account is connected.
+demo graph survives container replacement. Offline quickstart inventories and
+graphs the sample without package-CVE lookup; use the separate bundled demo
+scan for offline CVE proof:
+
+```bash
+agent-bom scan --demo --offline
+```
+
+Replace the sample with real connected cloud scans as soon as the first account
+is connected.
 
 Before opening the VM to testers, confirm the composed stack does not expose
 API/UI ports on all interfaces and does not mount the placeholder Postgres

--- a/docs/RELEASE_VERIFICATION.md
+++ b/docs/RELEASE_VERIFICATION.md
@@ -31,7 +31,7 @@ signed release evidence.
 | Packaged dashboard | `uv run python scripts/verify_release_wheel.py dist` | Every wheel passes the same dashboard and CSP contract used by the manual publish targets. |
 | PyPI smoke | `python -m venv /tmp/agent-bom-smoke && /tmp/agent-bom-smoke/bin/pip install agent-bom==<version> && /tmp/agent-bom-smoke/bin/agent-bom --version` | Published package installs in a fresh environment. |
 | Registry surface freshness (post-publish) | `PYTHONPATH=src python scripts/check_surface_freshness.py --out /tmp/agent-bom-surface-freshness.json` | PyPI, Docker, GHCR, Glama, and configured Smithery surfaces report the expected version and a non-empty inventory. Async rebuild acceptance is not release completion. |
-| Quickstart E2E | `agent-bom quickstart --run --offline --force --sample-dir /tmp/agent-bom-quickstart` | Generates a real report, graph, posture, and no coverage warnings. |
+| Quickstart E2E | `agent-bom quickstart --run --offline --force --sample-dir /tmp/agent-bom-quickstart` | Generates a real inventory report, graph, and posture with no coverage warnings; package-CVE lookup is skipped because a fresh install has no local database. Run `agent-bom scan --demo --offline` separately for bundled CVE proof. |
 | Hosted preflight | `python scripts/deploy/hosted_poc_preflight.py --write-secret` | Hosted compose has an HTTPS URL, no unauth mode, non-placeholder secrets, private API/UI binds, and safe CORS. |
 
 Do not publish a release as hosted-ready when any required line above is red.

--- a/scripts/run_postgres_scale_evidence.py
+++ b/scripts/run_postgres_scale_evidence.py
@@ -102,11 +102,10 @@ def _percentiles(values_ms: list[float]) -> dict[str, float]:
 
 def _synth_audit_entry(idx: int, tenant_id: str = "scale-evidence") -> dict[str, Any]:
     return {
-        "tenant_id": tenant_id,
         "actor": f"actor-{idx % 50}",
         "action": "scan.create" if idx % 3 else "scan.read",
         "resource": f"job-{idx}",
-        "metadata": {"source": "postgres-scale-evidence", "idx": idx},
+        "details": {"tenant_id": tenant_id, "source": "postgres-scale-evidence", "idx": idx},
         "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 
@@ -186,15 +185,15 @@ def _replica_worker(dsn: str, size: int, replica_idx: int, kinds: list[str]) -> 
     }
 
     if "audit" in kinds:
-        timings = _audit_append_iter(audit_log, size)
-        result["audit_append"] = _percentiles(timings)
+        audit_timings = _audit_append_iter(audit_log, size)
+        result["audit_append"] = _percentiles(audit_timings)
 
     sampled_ids: list[tuple[str, str]] = []
     if "job_put" in kinds:
         # Insert and remember a few ids for the read pass.
         from agent_bom.models import ScanJob, ScanRequest
 
-        timings: list[float] = []
+        job_timings: list[float] = []
         for i in range(size):
             tenant_id = f"r{replica_idx}-{i % 10}"
             job_id = str(uuid.uuid4())
@@ -208,10 +207,10 @@ def _replica_worker(dsn: str, size: int, replica_idx: int, kinds: list[str]) -> 
             )
             started = time.perf_counter()
             job_store.put(job)
-            timings.append((time.perf_counter() - started) * 1000)
+            job_timings.append((time.perf_counter() - started) * 1000)
             if i % max(1, size // 100) == 0:
                 sampled_ids.append((job_id, tenant_id))
-        result["job_put"] = _percentiles(timings)
+        result["job_put"] = _percentiles(job_timings)
 
     if "job_get" in kinds and sampled_ids:
         # Read 100 sampled jobs to measure RLS-bounded SELECT latency.

--- a/scripts/run_postgres_scale_evidence.py
+++ b/scripts/run_postgres_scale_evidence.py
@@ -139,9 +139,31 @@ def _job_put_iter(job_store, n: int, tenant_prefix: str = "t") -> list[float]:
             status="done",
         )
         started = time.perf_counter()
-        job_store.put(job)
+        _tenant_job_put(job_store, job)
         timings.append((time.perf_counter() - started) * 1000)
     return timings
+
+
+def _tenant_job_put(job_store, job) -> None:
+    """Write a job under the same tenant context installed by API middleware."""
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+
+    token = set_current_tenant(job.tenant_id)
+    try:
+        job_store.put(job)
+    finally:
+        reset_current_tenant(token)
+
+
+def _tenant_job_get(job_store, job_id: str, tenant_id: str):
+    """Read a job under its RLS-bound tenant context."""
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+
+    token = set_current_tenant(tenant_id)
+    try:
+        return job_store.get(job_id, tenant_id=tenant_id)
+    finally:
+        reset_current_tenant(token)
 
 
 def _job_get_iter(job_store, sample_ids: list[tuple[str, str]]) -> list[float]:
@@ -149,7 +171,7 @@ def _job_get_iter(job_store, sample_ids: list[tuple[str, str]]) -> list[float]:
     timings: list[float] = []
     for job_id, tenant_id in sample_ids:
         started = time.perf_counter()
-        job_store.get(job_id, tenant_id=tenant_id)
+        _tenant_job_get(job_store, job_id, tenant_id)
         timings.append((time.perf_counter() - started) * 1000)
     return timings
 
@@ -206,7 +228,7 @@ def _replica_worker(dsn: str, size: int, replica_idx: int, kinds: list[str]) -> 
                 status="done",
             )
             started = time.perf_counter()
-            job_store.put(job)
+            _tenant_job_put(job_store, job)
             job_timings.append((time.perf_counter() - started) * 1000)
             if i % max(1, size // 100) == 0:
                 sampled_ids.append((job_id, tenant_id))

--- a/scripts/run_postgres_scale_evidence.py
+++ b/scripts/run_postgres_scale_evidence.py
@@ -125,7 +125,7 @@ def _audit_append_iter(audit_log, n: int) -> list[float]:
 
 def _job_put_iter(job_store, n: int, tenant_prefix: str = "t") -> list[float]:
     """Insert n synthetic ScanJobs; return per-call ms."""
-    from agent_bom.models import ScanJob, ScanRequest
+    from agent_bom.api.models import ScanJob, ScanRequest
 
     timings: list[float] = []
     for i in range(n):
@@ -191,7 +191,7 @@ def _replica_worker(dsn: str, size: int, replica_idx: int, kinds: list[str]) -> 
     sampled_ids: list[tuple[str, str]] = []
     if "job_put" in kinds:
         # Insert and remember a few ids for the read pass.
-        from agent_bom.models import ScanJob, ScanRequest
+        from agent_bom.api.models import ScanJob, ScanRequest
 
         job_timings: list[float] = []
         for i in range(size):

--- a/src/agent_bom/cli/_quickstart.py
+++ b/src/agent_bom/cli/_quickstart.py
@@ -18,7 +18,11 @@ QUICKSTART_SCAN_TIMEOUT_SECONDS = 300
 
 @click.command("quickstart")
 @click.option("--dry-run", is_flag=True, help="Print the onboarding plan without writing files or starting services.")
-@click.option("--offline", is_flag=True, help="Show commands that avoid network enrichment and remote advisory calls.")
+@click.option(
+    "--offline",
+    is_flag=True,
+    help="Avoid network calls; with --run, inventory and graph the sample without package-CVE lookup.",
+)
 @click.option(
     "--sample-dir",
     type=click.Path(file_okay=False, path_type=Path),
@@ -156,7 +160,18 @@ def _run_quickstart(
         "-o",
         str(report_path),
     ]
-    scan_args.append("--offline" if offline else "--enrich")
+    if offline:
+        # A fresh install has no local vulnerability database. Keep the
+        # one-command onboarding deterministic and honest: inventory packages,
+        # analyze/persist the graph, and leave package-CVE proof to the bundled
+        # `scan --demo --offline` lane printed by the quickstart.
+        scan_args.extend(["--offline", "--no-scan"])
+        click.echo(
+            "[2/3] Offline first-run skips package-CVE lookup; "
+            "run `agent-bom scan --demo --offline` for bundled CVE proof."
+        )
+    else:
+        scan_args.append("--enrich")
     click.echo(f"[2/3] Scanning sample stack: {' '.join(scan_args[1:])}")
     result = subprocess.run(  # noqa: S603 - args built from validated inputs
         scan_args,

--- a/tests/test_quickstart.py
+++ b/tests/test_quickstart.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import subprocess
+import sys
 import tomllib
 from pathlib import Path
 
@@ -80,6 +82,7 @@ def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fak
     assert scan_args[1] == "agents"
     assert "--context-graph" in scan_args
     assert "--offline" in scan_args
+    assert "--no-scan" in scan_args
     assert "-o" in scan_args
     assert str(sample_dir / "agent-bom-report.json") in scan_args
     assert str(sample_dir / "inventory.json") in scan_args
@@ -95,6 +98,46 @@ def test_quickstart_run_scans_with_context_graph_and_seeds_policy(tmp_path, _fak
     # cockpit handoff must pass a flag that actually lets /v1/overview load on loopback
     assert "agent-bom serve --host 127.0.0.1 --port 8422 --allow-insecure-no-auth" in result.output
     assert "--api-key <key>" in result.output
+
+
+def test_quickstart_run_offline_succeeds_with_empty_vulnerability_db(tmp_path, monkeypatch):
+    """The advertised offline first run must work before `agent-bom db update`."""
+    sample_dir = tmp_path / "stack"
+    graph_db = tmp_path / "graph.db"
+    wrapper = tmp_path / "agent-bom"
+    wrapper.write_text(
+        f"#!{sys.executable}\n"
+        "from agent_bom.cli import main\n"
+        "main()\n"
+    )
+    wrapper.chmod(0o755)
+
+    monkeypatch.setattr("agent_bom.cli._quickstart._resolve_agent_bom", lambda: str(wrapper))
+    monkeypatch.setenv("AGENT_BOM_CONFIG", str(tmp_path / "no-profile.toml"))
+    monkeypatch.setenv("AGENT_BOM_DB", str(tmp_path / "control.db"))
+    monkeypatch.setenv("AGENT_BOM_DB_PATH", str(tmp_path / "empty-vulns.db"))
+    monkeypatch.setenv("AGENT_BOM_GRAPH_DB", str(graph_db))
+    monkeypatch.setenv("AGENT_BOM_LOCAL_ANALYTICS_DB", str(tmp_path / "analytics.db"))
+
+    result = CliRunner().invoke(
+        main,
+        ["quickstart", "--run", "--offline", "--force", "--sample-dir", str(sample_dir)],
+    )
+
+    assert result.exit_code == 0, result.output
+    report = json.loads((sample_dir / "agent-bom-report.json").read_text())
+    assert report["scan_run"]["outcome"] == "complete"
+    assert report["scan_run"]["issues"] == []
+    assert report["scan_run"]["warning_count"] == 0
+    assert report["coverage_warnings"] == []
+    assert report["summary"]["total_agents"] > 0
+    assert report["summary"]["total_packages"] > 0
+    assert report["summary"]["total_vulnerabilities"] == 0
+    assert (sample_dir / "gateway-baseline-policy.json").is_file()
+
+    with sqlite3.connect(graph_db) as connection:
+        assert connection.execute("SELECT COUNT(*) FROM graph_nodes").fetchone()[0] > 0
+        assert connection.execute("SELECT COUNT(*) FROM graph_edges").fetchone()[0] > 0
 
 
 def test_quickstart_run_no_gateway_policy_skips_file(tmp_path, _fake_scan):

--- a/tests/test_scale_evidence.py
+++ b/tests/test_scale_evidence.py
@@ -56,3 +56,10 @@ def test_postgres_scale_audit_payload_matches_runtime_contract() -> None:
     entry = AuditEntry(**module._synth_audit_entry(7, tenant_id="tenant-7"))
 
     assert entry.details == {"tenant_id": "tenant-7", "source": "postgres-scale-evidence", "idx": 7}
+
+
+def test_postgres_scale_job_models_use_api_contract() -> None:
+    script = Path("scripts/run_postgres_scale_evidence.py").read_text()
+
+    assert "from agent_bom.api.models import ScanJob, ScanRequest" in script
+    assert "from agent_bom.models import ScanJob, ScanRequest" not in script

--- a/tests/test_scale_evidence.py
+++ b/tests/test_scale_evidence.py
@@ -5,6 +5,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 
 def test_scale_evidence_scaffold_is_complete() -> None:
@@ -63,3 +64,37 @@ def test_postgres_scale_job_models_use_api_contract() -> None:
 
     assert "from agent_bom.api.models import ScanJob, ScanRequest" in script
     assert "from agent_bom.models import ScanJob, ScanRequest" not in script
+
+
+def test_postgres_scale_job_operations_install_and_reset_tenant(monkeypatch) -> None:
+    script = Path("scripts/run_postgres_scale_evidence.py")
+    spec = importlib.util.spec_from_file_location("run_postgres_scale_evidence", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    events: list[tuple[str, object]] = []
+
+    class Store:
+        def put(self, job) -> None:
+            events.append(("put", job.tenant_id))
+
+        def get(self, job_id: str, tenant_id: str):
+            events.append(("get", (job_id, tenant_id)))
+            return object()
+
+    monkeypatch.setattr("agent_bom.api.postgres_common.set_current_tenant", lambda tenant: events.append(("set", tenant)) or "token")
+    monkeypatch.setattr("agent_bom.api.postgres_common.reset_current_tenant", lambda token: events.append(("reset", token)))
+
+    store = Store()
+    module._tenant_job_put(store, SimpleNamespace(tenant_id="tenant-a"))
+    assert module._tenant_job_get(store, "job-a", "tenant-a") is not None
+
+    assert events == [
+        ("set", "tenant-a"),
+        ("put", "tenant-a"),
+        ("reset", "token"),
+        ("set", "tenant-a"),
+        ("get", ("job-a", "tenant-a")),
+        ("reset", "token"),
+    ]

--- a/tests/test_scale_evidence.py
+++ b/tests/test_scale_evidence.py
@@ -17,6 +17,14 @@ def test_scale_evidence_scaffold_is_complete() -> None:
     assert result.returncode == 0, result.stderr
 
 
+def test_postgres_scale_workflow_acknowledges_disposable_superuser() -> None:
+    """The ephemeral CI database must opt in without weakening production defaults."""
+    workflow = Path(".github/workflows/postgres-scale-evidence.yml").read_text()
+
+    assert 'AGENT_BOM_ALLOW_SUPERUSER_DB: "1"' in workflow
+    assert "disposable service-container owner" in workflow
+
+
 def test_postgres_scale_evidence_sets_current_postgres_url(monkeypatch) -> None:
     script = Path("scripts/run_postgres_scale_evidence.py")
     spec = importlib.util.spec_from_file_location("run_postgres_scale_evidence", script)

--- a/tests/test_scale_evidence.py
+++ b/tests/test_scale_evidence.py
@@ -17,12 +17,13 @@ def test_scale_evidence_scaffold_is_complete() -> None:
     assert result.returncode == 0, result.stderr
 
 
-def test_postgres_scale_workflow_acknowledges_disposable_superuser() -> None:
-    """The ephemeral CI database must opt in without weakening production defaults."""
+def test_postgres_scale_workflow_migrates_before_workload() -> None:
+    """Scale evidence must use the shipped schema and database-enforced RLS."""
     workflow = Path(".github/workflows/postgres-scale-evidence.yml").read_text()
 
-    assert 'AGENT_BOM_ALLOW_SUPERUSER_DB: "1"' in workflow
-    assert "disposable service-container owner" in workflow
+    assert "Migrate ephemeral Postgres schema" in workflow
+    assert "alembic -c deploy/supabase/postgres/alembic.ini upgrade head" in workflow
+    assert "AGENT_BOM_ALLOW_SUPERUSER_DB" not in workflow
 
 
 def test_postgres_scale_evidence_sets_current_postgres_url(monkeypatch) -> None:

--- a/tests/test_scale_evidence.py
+++ b/tests/test_scale_evidence.py
@@ -42,3 +42,17 @@ def test_postgres_scale_evidence_sets_current_postgres_url(monkeypatch) -> None:
 
     assert os.environ["AGENT_BOM_POSTGRES_URL"] == "postgresql://agent_bom:agent_bom@localhost:5432/agent_bom"
     assert os.environ["AGENT_BOM_POSTGRES_DSN"] == "postgresql://agent_bom:agent_bom@localhost:5432/agent_bom"
+
+
+def test_postgres_scale_audit_payload_matches_runtime_contract() -> None:
+    from agent_bom.api.audit_log import AuditEntry
+
+    script = Path("scripts/run_postgres_scale_evidence.py")
+    spec = importlib.util.spec_from_file_location("run_postgres_scale_evidence", script)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    entry = AuditEntry(**module._synth_audit_entry(7, tenant_id="tenant-7"))
+
+    assert entry.details == {"tenant_id": "tenant-7", "source": "postgres-scale-evidence", "idx": 7}

--- a/tests/test_scale_evidence.py
+++ b/tests/test_scale_evidence.py
@@ -23,6 +23,8 @@ def test_postgres_scale_workflow_migrates_before_workload() -> None:
 
     assert "Migrate ephemeral Postgres schema" in workflow
     assert "alembic -c deploy/supabase/postgres/alembic.ini upgrade head" in workflow
+    assert "AGENT_BOM_POSTGRES_URL: postgresql://agent_bom_app:" in workflow
+    assert "AGENT_BOM_POSTGRES_ADMIN_URL: postgresql://agent_bom:" in workflow
     assert "AGENT_BOM_ALLOW_SUPERUSER_DB" not in workflow
 
 


### PR DESCRIPTION
## Summary

- make the advertised fresh-install offline quickstart deterministic without requiring a pre-populated vulnerability database
- restore scheduled Postgres scale evidence with the shipped migration, a dedicated non-superuser app role, current audit/job contracts, and tenant-scoped operations
- document the separate bundled offline demo command for deterministic CVE proof

## Verification

- focused quickstart, scale, RLS, dashboard-packaging, and public-release tests passed
- canonical Python 3.11 `mypy src/ --ignore-missing-imports --disable-error-code import-untyped` passed (810 files)
- scale harness mypy, Ruff, actionlint, release preflight, and diff checks passed
- fresh Python 3.11 wheel install: offline quickstart exited 0, produced report/policy, and persisted 32 graph nodes / 43 edges with no warnings
- local disposable Postgres: migrated schema and two-replica audit/job_put/job_get workload passed under the non-superuser app role
- GitHub workflow run 30244693013: migration, clustered workload, summary, and evidence upload passed

## Notes

- The quickstart gap reproduces on published 0.98.1 and the pre-fix main branch.
- All smokes use local/synthetic evidence. No cloud account, Snowflake authentication, external credentials, or external service data were accessed.
