### PR TITLE
fix(registries): harden Glama release freshness

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -30,6 +30,7 @@ jobs:
       version: ${{ steps.release.outputs.version }}
       release_ref: ${{ steps.release.outputs.release_ref }}
       release_sha: ${{ steps.release.outputs.release_sha }}
+      tool_count: ${{ steps.release.outputs.tool_count }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -82,10 +83,22 @@ jobs:
             echo "::error::Resolved release tag is not semantic versioned"
             exit 1
           fi
+          METRICS_JSON=$(git show "${RELEASE_SHA}:docs/PRODUCT_METRICS.json")
+          METRICS_VERSION=$(echo "$METRICS_JSON" | jq -er '.version')
+          TOOL_COUNT=$(echo "$METRICS_JSON" | jq -er 'first(.metrics[] | select(.name == "MCP tools") | .value)')
+          if [ "$METRICS_VERSION" != "$VERSION" ]; then
+            echo "::error::Published release metrics version ${METRICS_VERSION} does not match ${VERSION}"
+            exit 1
+          fi
+          if ! echo "$TOOL_COUNT" | grep -qE '^[1-9][0-9]*$'; then
+            echo "::error::Published release metrics do not declare a positive MCP tool count"
+            exit 1
+          fi
           {
             echo "version=$VERSION"
             echo "release_ref=refs/tags/${RELEASE_TAG}"
             echo "release_sha=$RELEASE_SHA"
+            echo "tool_count=$TOOL_COUNT"
           } >> "$GITHUB_OUTPUT"
 
   smithery:
@@ -301,9 +314,14 @@ jobs:
         continue-on-error: true
         env:
           EXPECTED_VERSION: ${{ needs.release.outputs.version }}
+          EXPECTED_TOOL_COUNT: ${{ needs.release.outputs.tool_count }}
           REBUILD_TRIGGERED: ${{ steps.glama_trigger.outputs.rebuild_triggered }}
         run: |
-          if ! python scripts/check_glama_listing.py --expected "$EXPECTED_VERSION" --retries 6 --delay-seconds 30; then
+          if ! python scripts/check_glama_listing.py \
+              --expected "$EXPECTED_VERSION" \
+              --expected-tool-count "$EXPECTED_TOOL_COUNT" \
+              --retries 6 \
+              --delay-seconds 30; then
             if [ "$REBUILD_TRIGGERED" = "true" ]; then
               echo "::warning::Glama listing has not refreshed yet after the rebuild trigger. Glama re-crawls asynchronously and may take hours. Listing: https://glama.ai/mcp/servers/msaad00/agent-bom"
             else
@@ -322,7 +340,9 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ github.event.repository.default_branch }}
+          # ClawHub publishes the checked-out integrations/openclaw assets, so
+          # they must come from the exact release commit rather than current main.
+          ref: ${{ needs.release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Set up Node.js

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -14,11 +14,6 @@ on:
     workflows: ["Release"]
     types: [completed]
   workflow_dispatch:
-    inputs:
-      release_tag:
-        description: "Published release tag to repair (for example, v0.98.0); leave blank for the latest published release"
-        required: false
-        type: string
 
 permissions:
   contents: read
@@ -38,6 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 1
           persist-credentials: false
 
@@ -48,20 +44,14 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          REQUESTED_TAG: ${{ inputs.release_tag }}
         run: |
           set -euo pipefail
 
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            if [ -n "${REQUESTED_TAG:-}" ]; then
-              if ! echo "$REQUESTED_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
-                echo "::error::release_tag must be a v-prefixed semantic version"
-                exit 1
-              fi
-              RELEASE_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${REQUESTED_TAG}")
-            else
-              RELEASE_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest")
-            fi
+            # Manual repair always targets the latest published release. This
+            # workflow fans out to multiple registries, so accepting an older
+            # tag here could downgrade Smithery or ClawHub as a side effect.
+            RELEASE_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest")
             RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -er '.tag_name')
             if [ "$(echo "$RELEASE_JSON" | jq -r '.draft != false')" = "true" ]; then
               echo "::error::Registry repair requires a published, non-draft GitHub release"
@@ -109,7 +99,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release.outputs.release_sha }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Check Smithery configuration
@@ -241,7 +231,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release.outputs.release_sha }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Fetch release commit for manifest verification
@@ -256,17 +246,30 @@ jobs:
         id: glama_trigger
         env:
           GLAMA_WEBHOOK_URL: ${{ secrets.GLAMA_WEBHOOK_URL }}
+          EVENT_NAME: ${{ github.event_name }}
           RELEASE_REF: ${{ needs.release.outputs.release_ref }}
           RELEASE_SHA: ${{ needs.release.outputs.release_sha }}
           VERSION: ${{ needs.release.outputs.version }}
           GLAMA_DOCKERFILE: integrations/glama/Dockerfile
         run: |
-          if [ -z "$GLAMA_WEBHOOK_URL" ]; then
+          set -u
+
+          fail_or_warn() {
+            local message="$1"
             echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::GLAMA_WEBHOOK_URL not configured. No Glama rebuild was triggered"
+            if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+              echo "::error::Manual Glama repair ${message}"
+              return 1
+            fi
+            echo "::warning::Automatic Glama rebuild ${message}; the freshness issue will remain open"
+            return 0
+          }
+
+          if [ -z "$GLAMA_WEBHOOK_URL" ]; then
             echo "Release pin for Glama: ${RELEASE_REF} (${RELEASE_SHA:0:7}) dockerfile=${GLAMA_DOCKERFILE}"
             echo "To enable instant rebuild, set GLAMA_WEBHOOK_URL as a repository Actions secret"
-            exit 0
+            fail_or_warn "failed because GLAMA_WEBHOOK_URL is not configured. No Glama rebuild was triggered"
+            exit $?
           fi
           PAYLOAD=$(jq -n \
             --arg ref "$RELEASE_REF" \
@@ -275,17 +278,20 @@ jobs:
             --arg dockerfile "$GLAMA_DOCKERFILE" \
             '{ref: $ref, commit: $commit, version: $version, dockerfile: $dockerfile}')
           echo "Triggering Glama rebuild for ${RELEASE_REF} (${RELEASE_SHA:0:7}) using ${GLAMA_DOCKERFILE}"
-          HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
-            -o /dev/null -w "%{http_code}" \
-            -H "Content-Type: application/json" \
-            -d "$PAYLOAD" \
-            -X POST "$GLAMA_WEBHOOK_URL")
-          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+          if ! HTTP_STATUS=$(curl -s --connect-timeout 10 --max-time 30 \
+              -o /dev/null -w "%{http_code}" \
+              -H "Content-Type: application/json" \
+              -d "$PAYLOAD" \
+              -X POST "$GLAMA_WEBHOOK_URL"); then
+            fail_or_warn "request failed before an HTTP response was received"
+            exit $?
+          fi
+          if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 300 ]; then
             echo "rebuild_triggered=true" >> "$GITHUB_OUTPUT"
             echo "Glama rebuild triggered successfully"
           else
-            echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Glama rebuild trigger returned HTTP ${HTTP_STATUS} — may need manual rebuild"
+            fail_or_warn "returned HTTP ${HTTP_STATUS}"
+            exit $?
           fi
 
       # Glama re-crawls listings on its own cadence (can be hours), so a tight
@@ -316,7 +322,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.release.outputs.release_sha }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Set up Node.js

--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -6,6 +6,7 @@ name: Publish to Registries
 #   CLAWHUB_TOKEN       — ClawHub auth token (clawhub.ai → Settings)
 # Optional vars:
 #   SMITHERY_MCP_URL    — Explicit public, unauthenticated MCP endpoint for Smithery
+# Optional secret:
 #   GLAMA_WEBHOOK_URL   — Glama rebuild webhook (POST JSON: ref, commit, version, dockerfile)
 
 on:
@@ -13,13 +14,93 @@ on:
     workflows: ["Release"]
     types: [completed]
   workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Published release tag to repair (for example, v0.98.0); leave blank for the latest published release"
+        required: false
+        type: string
 
 permissions:
   contents: read
 
 jobs:
+  release:
+    name: Resolve published release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+      release_ref: ${{ steps.release.outputs.release_ref }}
+      release_sha: ${{ steps.release.outputs.release_sha }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Resolve published release
+        id: release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          REQUESTED_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            if [ -n "${REQUESTED_TAG:-}" ]; then
+              if ! echo "$REQUESTED_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+                echo "::error::release_tag must be a v-prefixed semantic version"
+                exit 1
+              fi
+              RELEASE_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${REQUESTED_TAG}")
+            else
+              RELEASE_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest")
+            fi
+            RELEASE_TAG=$(echo "$RELEASE_JSON" | jq -er '.tag_name')
+            if [ "$(echo "$RELEASE_JSON" | jq -r '.draft != false')" = "true" ]; then
+              echo "::error::Registry repair requires a published, non-draft GitHub release"
+              exit 1
+            fi
+          else
+            RELEASE_TAG="${HEAD_BRANCH:-}"
+            if ! echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+              echo "::error::Successful Release workflow did not report a release tag"
+              exit 1
+            fi
+            if [ -z "${HEAD_SHA:-}" ]; then
+              echo "::error::Successful Release workflow did not report a release commit"
+              exit 1
+            fi
+          fi
+
+          git fetch --force --no-tags origin \
+            "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}"
+          RELEASE_SHA=$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")
+          if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$RELEASE_SHA" != "$HEAD_SHA" ]; then
+            echo "::error::Release tag and successful workflow commit do not match"
+            exit 1
+          fi
+
+          VERSION="${RELEASE_TAG#v}"
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
+            echo "::error::Resolved release tag is not semantic versioned"
+            exit 1
+          fi
+          {
+            echo "version=$VERSION"
+            echo "release_ref=refs/tags/${RELEASE_TAG}"
+            echo "release_sha=$RELEASE_SHA"
+          } >> "$GITHUB_OUTPUT"
+
   smithery:
     name: Publish to Smithery
+    needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -27,28 +108,9 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Extract version
-        id: meta
-        env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            # workflow_dispatch may run from main or a tag — prefer tag, fall back to pyproject.toml
-            REF="${GITHUB_REF_NAME#v}"
-            if echo "$REF" | grep -qE '^[0-9]+\.[0-9]+'; then
-              VERSION="$REF"
-            else
-              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-            fi
-          else
-            VERSION="${HEAD_BRANCH#v}"
-            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
-              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-            fi
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        with:
+          ref: ${{ needs.release.outputs.release_sha }}
+          persist-credentials: false
 
       - name: Check Smithery configuration
         id: smithery_config
@@ -118,7 +180,7 @@ jobs:
         env:
           SMITHERY_API_TOKEN: ${{ secrets.SMITHERY_API_TOKEN }}
           SMITHERY_MCP_URL: ${{ vars.SMITHERY_MCP_URL }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ needs.release.outputs.version }}
         run: |
           QUALIFIED_NAME="agent-bom%2Fagent-bom"
           MCP_URL="${SMITHERY_MCP_URL}"
@@ -169,6 +231,7 @@ jobs:
 
   glama:
     name: Trigger Glama Rebuild
+    needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -177,59 +240,32 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Extract release metadata
-        id: meta
-        env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            REF="${GITHUB_REF_NAME#v}"
-            if echo "$REF" | grep -qE '^[0-9]+\.[0-9]+'; then
-              VERSION="$REF"
-            else
-              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-            fi
-            RELEASE_REF="refs/tags/v${VERSION}"
-            RELEASE_SHA=$(git rev-parse HEAD)
-          else
-            VERSION="${HEAD_BRANCH#v}"
-            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
-              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-            fi
-            if [ -n "${HEAD_BRANCH:-}" ]; then
-              RELEASE_REF="refs/tags/${HEAD_BRANCH}"
-            else
-              RELEASE_REF="refs/tags/v${VERSION}"
-            fi
-            RELEASE_SHA="${HEAD_SHA:-$(git rev-parse HEAD)}"
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "release_ref=$RELEASE_REF" >> "$GITHUB_OUTPUT"
-          echo "release_sha=$RELEASE_SHA" >> "$GITHUB_OUTPUT"
+        with:
+          ref: ${{ needs.release.outputs.release_sha }}
+          persist-credentials: false
 
       - name: Fetch release commit for manifest verification
         env:
-          RELEASE_SHA: ${{ steps.meta.outputs.release_sha }}
+          RELEASE_SHA: ${{ needs.release.outputs.release_sha }}
         run: git fetch --no-tags --depth=1 origin "$RELEASE_SHA"
 
       - name: Verify Glama build manifest
-        run: python scripts/check_glama_listing.py --verify-manifest --git-ref "${{ steps.meta.outputs.release_sha }}"
+        run: python scripts/check_glama_listing.py --verify-manifest --git-ref "${{ needs.release.outputs.release_sha }}"
 
       - name: Trigger Glama rebuild
+        id: glama_trigger
         env:
-          GLAMA_WEBHOOK_URL: ${{ vars.GLAMA_WEBHOOK_URL }}
-          RELEASE_REF: ${{ steps.meta.outputs.release_ref }}
-          RELEASE_SHA: ${{ steps.meta.outputs.release_sha }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          GLAMA_WEBHOOK_URL: ${{ secrets.GLAMA_WEBHOOK_URL }}
+          RELEASE_REF: ${{ needs.release.outputs.release_ref }}
+          RELEASE_SHA: ${{ needs.release.outputs.release_sha }}
+          VERSION: ${{ needs.release.outputs.version }}
           GLAMA_DOCKERFILE: integrations/glama/Dockerfile
         run: |
           if [ -z "$GLAMA_WEBHOOK_URL" ]; then
-            echo "::warning::GLAMA_WEBHOOK_URL not configured — skipping webhook trigger"
+            echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::GLAMA_WEBHOOK_URL not configured. No Glama rebuild was triggered"
             echo "Release pin for Glama: ${RELEASE_REF} (${RELEASE_SHA:0:7}) dockerfile=${GLAMA_DOCKERFILE}"
-            echo "To enable instant rebuild, set GLAMA_WEBHOOK_URL in repo variables"
+            echo "To enable instant rebuild, set GLAMA_WEBHOOK_URL as a repository Actions secret"
             exit 0
           fi
           PAYLOAD=$(jq -n \
@@ -245,26 +281,33 @@ jobs:
             -d "$PAYLOAD" \
             -X POST "$GLAMA_WEBHOOK_URL")
           if [ "$HTTP_STATUS" -ge 200 ] && [ "$HTTP_STATUS" -lt 400 ]; then
+            echo "rebuild_triggered=true" >> "$GITHUB_OUTPUT"
             echo "Glama rebuild triggered successfully"
           else
+            echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"
             echo "::warning::Glama rebuild trigger returned HTTP ${HTTP_STATUS} — may need manual rebuild"
           fi
 
       # Glama re-crawls listings on its own cadence (can be hours), so a tight
-      # post-trigger freshness window legitimately fails on release day even
-      # though the rebuild was triggered. Warn instead of red-failing the
-      # publish; the listing self-resolves once Glama re-crawls.
+      # post-trigger freshness window can legitimately fail on release day.
+      # Preserve the distinction between a successful trigger and no trigger.
       - name: Verify Glama listing freshness
         continue-on-error: true
         env:
-          EXPECTED_VERSION: ${{ steps.meta.outputs.version }}
+          EXPECTED_VERSION: ${{ needs.release.outputs.version }}
+          REBUILD_TRIGGERED: ${{ steps.glama_trigger.outputs.rebuild_triggered }}
         run: |
           if ! python scripts/check_glama_listing.py --expected "$EXPECTED_VERSION" --retries 6 --delay-seconds 30; then
-            echo "::warning::Glama listing not yet refreshed to the new version. Glama re-crawls asynchronously (can take hours); the rebuild was already triggered, so this self-resolves. Listing: https://glama.ai/mcp/servers/msaad00/agent-bom"
+            if [ "$REBUILD_TRIGGERED" = "true" ]; then
+              echo "::warning::Glama listing has not refreshed yet after the rebuild trigger. Glama re-crawls asynchronously and may take hours. Listing: https://glama.ai/mcp/servers/msaad00/agent-bom"
+            else
+              echo "::warning::Glama listing remains stale and no rebuild was triggered. Configure the repository Actions secret GLAMA_WEBHOOK_URL or rebuild the exact release manually. Listing: https://glama.ai/mcp/servers/msaad00/agent-bom"
+            fi
           fi
 
   clawhub:
     name: Publish to ClawHub
+    needs: release
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -272,28 +315,9 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Extract version
-        id: meta
-        env:
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
-          EVENT_NAME: ${{ github.event_name }}
-        run: |
-          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
-            # workflow_dispatch may run from main or a tag — prefer tag, fall back to pyproject.toml
-            REF="${GITHUB_REF_NAME#v}"
-            if echo "$REF" | grep -qE '^[0-9]+\.[0-9]+'; then
-              VERSION="$REF"
-            else
-              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-            fi
-          else
-            VERSION="${HEAD_BRANCH#v}"
-            if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
-              VERSION=$(grep '^version' pyproject.toml | head -1 | sed 's/.*"\(.*\)"/\1/')
-            fi
-          fi
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+        with:
+          ref: ${{ needs.release.outputs.release_sha }}
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -326,7 +350,7 @@ jobs:
         if: steps.clawhub_config.outputs.enabled == 'true'
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
-          VERSION: ${{ steps.meta.outputs.version }}
+          VERSION: ${{ needs.release.outputs.version }}
         run: |
           echo "Publishing agent-bom v${VERSION} to ClawHub..."
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser

--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -1,7 +1,8 @@
 name: Surface Freshness
 
-# Cross-channel version-freshness monitor. Compares the repo version against
-# EVERY published distribution surface (PyPI, Docker/ghcr, Glama, Smithery) and
+# Cross-channel version-freshness monitor. Compares the latest published release
+# against EVERY published distribution surface (PyPI, Docker/ghcr, Glama,
+# Smithery) and
 # maintains ONE consolidated tracking issue so a stale surface can never sit
 # unnoticed for months. Closes the gap that let the Smithery listing drift for
 # three months without an alert.
@@ -9,6 +10,7 @@ name: Surface Freshness
 # Optional repo variables (Settings -> Secrets and variables -> Actions -> Variables):
 #   SMITHERY_SERVER_QUALIFIED_NAME — override Smithery listing name; defaults to agent-bom/agent-bom
 #   GLAMA_LISTING_URL  — override Glama listing URL (default: glama.ai/.../msaad00/agent-bom)
+#   GLAMA_API_URL      — override Glama public inventory API URL
 #   DOCKER_IMAGE       — override default ghcr.io/msaad00/agent-bom
 
 on:
@@ -34,17 +36,50 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Get expected version from latest published release
+        id: expected
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          TAG=$(gh api "repos/$GITHUB_REPOSITORY/releases/latest" --jq '.tag_name')
+          VERSION="${TAG#v}"
+          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+([a-zA-Z0-9.+-]*)?$ ]]; then
+            echo "::error::Latest published release has an invalid version tag"
+            exit 1
+          fi
+          git fetch --force --no-tags origin "refs/tags/${TAG}:refs/tags/${TAG}"
+          RELEASE_SHA=$(git rev-list -n 1 "refs/tags/${TAG}")
+          TOOL_COUNT=$(git show "${RELEASE_SHA}:README.md" | sed -nE 's/.*MCP server mode (exposes|advertises) ([0-9]+) MCP tools.*/\2/p' | head -1)
+          if ! [[ "$TOOL_COUNT" =~ ^[1-9][0-9]*$ ]]; then
+            echo "::error::Published release README does not declare a positive MCP tool count"
+            exit 1
+          fi
+          {
+            echo "version=$VERSION"
+            echo "release_sha=$RELEASE_SHA"
+            echo "tool_count=$TOOL_COUNT"
+          } >> "$GITHUB_OUTPUT"
+          echo "Expected version from published release $TAG at ${RELEASE_SHA:0:12}: $VERSION with $TOOL_COUNT MCP tools"
+
       - name: Probe every distribution surface
         id: probe
         env:
+          EXPECTED_VERSION: ${{ steps.expected.outputs.version }}
           SMITHERY_SERVER_QUALIFIED_NAME: ${{ vars.SMITHERY_SERVER_QUALIFIED_NAME }}
           GLAMA_LISTING_URL: ${{ vars.GLAMA_LISTING_URL }}
+          GLAMA_API_URL: ${{ vars.GLAMA_API_URL }}
           DOCKER_IMAGE: ${{ vars.DOCKER_IMAGE }}
         run: |
-          PYTHONPATH=src python3 scripts/check_surface_freshness.py --out surface-freshness.json
-          echo "report<<EOF" >> "$GITHUB_OUTPUT"
-          cat surface-freshness.json >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+          PYTHONPATH=src python3 scripts/check_surface_freshness.py \
+            --expected "$EXPECTED_VERSION" \
+            --expected-glama-tool-count "${{ steps.expected.outputs.tool_count }}" \
+            --out surface-freshness.json
+          {
+            echo "report<<EOF"
+            cat surface-freshness.json
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Open, refresh, or close consolidated freshness issue
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
@@ -81,7 +116,7 @@ jobs:
               "- `unmonitored (misconfigured)` — a required repo variable is unset, so this surface is NOT being watched. Set the named variable.",
               "- `unreachable` — the surface URL is configured but the probe failed (network / HTTP / parse).",
               "",
-              "Optional overrides (blank/unset repo vars fall back to defaults): `DOCKER_IMAGE` (`ghcr.io/msaad00/agent-bom`), `GLAMA_LISTING_URL`, `SMITHERY_SERVER_QUALIFIED_NAME` (`agent-bom/agent-bom`).",
+              "Optional overrides (blank/unset repo vars fall back to defaults): `DOCKER_IMAGE` (`ghcr.io/msaad00/agent-bom`), `GLAMA_LISTING_URL`, `GLAMA_API_URL`, `SMITHERY_SERVER_QUALIFIED_NAME` (`agent-bom/agent-bom`).",
               "",
               "_Maintained automatically by the surface-freshness workflow. Self-closes when every surface is fresh and monitored._",
             ].join("\n");

--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -30,6 +30,8 @@ jobs:
       issues: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v6.0.0
@@ -50,9 +52,15 @@ jobs:
           fi
           git fetch --force --no-tags origin "refs/tags/${TAG}:refs/tags/${TAG}"
           RELEASE_SHA=$(git rev-list -n 1 "refs/tags/${TAG}")
-          TOOL_COUNT=$(git show "${RELEASE_SHA}:README.md" | sed -nE 's/.*MCP server mode (exposes|advertises) ([0-9]+) MCP tools.*/\2/p' | head -1)
+          METRICS_JSON=$(git show "${RELEASE_SHA}:docs/PRODUCT_METRICS.json")
+          METRICS_VERSION=$(echo "$METRICS_JSON" | jq -er '.version')
+          TOOL_COUNT=$(echo "$METRICS_JSON" | jq -er 'first(.metrics[] | select(.name == "MCP tools") | .value)')
+          if [ "$METRICS_VERSION" != "$VERSION" ]; then
+            echo "::error::Published release metrics version ${METRICS_VERSION} does not match ${VERSION}"
+            exit 1
+          fi
           if ! [[ "$TOOL_COUNT" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::Published release README does not declare a positive MCP tool count"
+            echo "::error::Published release metrics do not declare a positive MCP tool count"
             exit 1
           fi
           {

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -209,11 +209,15 @@ def main(argv: list[str] | None = None) -> int:
     last_error = ""
     listing_version = "unknown"
     actual_tool_count: int | None = None
+    last_probe_unreachable = False
     for attempt in range(1, max(1, args.retries) + 1):
+        actual_tool_count = None
+        last_probe_unreachable = False
         try:
             page = _fetch(args.url, args.timeout)
         except (urllib.error.URLError, TimeoutError) as exc:
             last_error = f"failed to fetch Glama listing: {exc}"
+            last_probe_unreachable = True
         else:
             listing_version = _extract_listing_version(page)
             failures = _check(page, version, tool_count)
@@ -232,6 +236,7 @@ def main(argv: list[str] | None = None) -> int:
                     failures.append(f"Glama public API exposes {actual_tool_count} tools; expected {tool_count}")
             except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
                 failures.append(f"failed to verify Glama public API tool inventory: {exc}")
+                last_probe_unreachable = True
             if not failures:
                 if args.json:
                     print(
@@ -261,7 +266,7 @@ def main(argv: list[str] | None = None) -> int:
             json.dumps(
                 {
                     "surface": "Glama",
-                    "status": "stale" if listing_version != "unknown" else "unreachable",
+                    "status": "unreachable" if last_probe_unreachable else "stale",
                     "expected": version,
                     "listing_version": listing_version,
                     "tool_count": actual_tool_count,

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -18,6 +18,7 @@ ROOT = Path(__file__).resolve().parent.parent
 PYPROJECT = ROOT / "pyproject.toml"
 README = ROOT / "README.md"
 DEFAULT_URL = "https://glama.ai/mcp/servers/msaad00/agent-bom"
+DEFAULT_API_URL = "https://glama.ai/api/mcp/v1/servers/msaad00/agent-bom"
 
 
 def _env_or(name: str, default: str) -> str:
@@ -28,6 +29,7 @@ def _env_or(name: str, default: str) -> str:
     """
     value = (os.environ.get(name) or "").strip()
     return value or default
+
 
 GLAMA_DOCKERFILE = "integrations/glama/Dockerfile"
 GLAMA_MANIFESTS = (ROOT / "glama.json", ROOT / "integrations" / "glama" / "server.json")
@@ -115,7 +117,14 @@ def _fetch(url: str, timeout: int) -> str:
         return response.read().decode("utf-8", errors="replace")
 
 
-def _check(page: str, version: str, tool_count: str) -> list[str]:
+def _fetch_json(url: str, timeout: int) -> dict[str, object]:
+    payload = json.loads(_fetch(url, timeout))
+    if not isinstance(payload, dict):
+        raise ValueError("Glama public API returned a non-object payload")
+    return payload
+
+
+def _check(page: str, version: str, tool_count: int) -> list[str]:
     expected_tokens = [
         f"v{version}",
         # Accept either phrasing while Glama's rendered README catches up.
@@ -123,7 +132,7 @@ def _check(page: str, version: str, tool_count: str) -> list[str]:
     ]
     failures = [f"missing current Glama listing token: {token!r}" for token in expected_tokens if token not in page]
     tool_count_ok = bool(
-        re.search(rf"MCP server mode (?:exposes|advertises)\s+{re.escape(tool_count)}\s+MCP tools", page)
+        re.search(rf"MCP server mode (?:exposes|advertises)\s+{re.escape(str(tool_count))}\s+MCP tools", page)
         or f"MCP server mode exposes {tool_count} MCP tools" in page
         or f"MCP server mode advertises {tool_count} MCP tools" in page
     )
@@ -158,7 +167,14 @@ def _extract_listing_version(page: str) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--url", default=_env_or("GLAMA_LISTING_URL", DEFAULT_URL))
+    parser.add_argument("--api-url", default=_env_or("GLAMA_API_URL", DEFAULT_API_URL))
     parser.add_argument("--expected", default=None, help="Expected version; defaults to pyproject.toml.")
+    parser.add_argument(
+        "--expected-tool-count",
+        type=int,
+        default=None,
+        help="Expected public API tool count; defaults to the current README contract.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit a machine-readable freshness result.")
     parser.add_argument("--timeout", type=int, default=20)
     parser.add_argument("--retries", type=int, default=1)
@@ -187,9 +203,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     version = (args.expected or _load_version()).lstrip("v").strip()
-    tool_count = _load_readme_tool_count()
+    tool_count = args.expected_tool_count if args.expected_tool_count is not None else int(_load_readme_tool_count())
+    if tool_count < 1:
+        raise SystemExit("expected Glama tool count must be positive")
     last_error = ""
     listing_version = "unknown"
+    actual_tool_count: int | None = None
     for attempt in range(1, max(1, args.retries) + 1):
         try:
             page = _fetch(args.url, args.timeout)
@@ -198,6 +217,21 @@ def main(argv: list[str] | None = None) -> int:
         else:
             listing_version = _extract_listing_version(page)
             failures = _check(page, version, tool_count)
+            try:
+                api_payload = _fetch_json(args.api_url, args.timeout)
+                tools = api_payload.get("tools")
+                if not isinstance(tools, list):
+                    raise ValueError("Glama public API tools field is not a list")
+                actual_tool_count = len(tools)
+                tool_names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
+                if len(tool_names) != actual_tool_count or any(not isinstance(name, str) or not name.strip() for name in tool_names):
+                    failures.append("Glama public API inventory contains a tool without a name")
+                elif len(set(tool_names)) != actual_tool_count:
+                    failures.append("Glama public API inventory contains duplicate tool names")
+                if actual_tool_count != tool_count:
+                    failures.append(f"Glama public API exposes {actual_tool_count} tools; expected {tool_count}")
+            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+                failures.append(f"failed to verify Glama public API tool inventory: {exc}")
             if not failures:
                 if args.json:
                     print(
@@ -207,13 +241,14 @@ def main(argv: list[str] | None = None) -> int:
                                 "status": "fresh",
                                 "expected": version,
                                 "listing_version": listing_version,
-                                "tool_count": tool_count,
+                                "tool_count": actual_tool_count,
+                                "expected_tool_count": tool_count,
                             },
                             separators=(",", ":"),
                         )
                     )
                     return 0
-                print(f"Glama listing is fresh for agent-bom v{version} with {tool_count} MCP tools")
+                print(f"Glama listing is fresh for agent-bom v{version} with {actual_tool_count} MCP tools")
                 return 0
             last_error = "\n".join(failures)
 
@@ -229,7 +264,8 @@ def main(argv: list[str] | None = None) -> int:
                     "status": "stale" if listing_version != "unknown" else "unreachable",
                     "expected": version,
                     "listing_version": listing_version,
-                    "tool_count": tool_count,
+                    "tool_count": actual_tool_count,
+                    "expected_tool_count": tool_count,
                     "error": last_error,
                 },
                 separators=(",", ":"),

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -53,7 +53,6 @@ OK_STATUSES = {"fresh"}
 ALERT_STATUSES = {"stale", "not_configured", "unreachable"}
 
 
-
 def _env_or(name: str, default: str) -> str:
     """Return env var if non-blank; otherwise ``default``.
 
@@ -215,10 +214,13 @@ def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
         return _classify("Docker", None, expected, error=str(exc))
 
 
-def probe_glama(expected: str, **kw: Any) -> dict[str, Any]:
+def probe_glama(expected: str, *, expected_tool_count: int | None = None, **kw: Any) -> dict[str, Any]:
     """Delegate to check_glama_listing.py so the probe logic stays in one place."""
+    command = [sys.executable, str(GLAMA_SCRIPT), "--expected", expected, "--json"]
+    if expected_tool_count is not None:
+        command.extend(["--expected-tool-count", str(expected_tool_count)])
     proc = subprocess.run(
-        [sys.executable, str(GLAMA_SCRIPT), "--expected", expected, "--json"],
+        command,
         capture_output=True,
         text=True,
         env=os.environ.copy(),
@@ -237,6 +239,8 @@ def probe_glama(expected: str, **kw: Any) -> dict[str, Any]:
         "status": status,
         "version": payload.get("listing_version", "—"),
         "expected": expected,
+        "tool_count": payload.get("tool_count"),
+        "expected_tool_count": payload.get("expected_tool_count"),
         "error": payload.get("error"),
     }
 
@@ -278,6 +282,7 @@ def probe_smithery(expected: str, qualified_name: str, **kw: Any) -> dict[str, A
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--expected", default=None, help="Override expected version (defaults to pyproject.toml).")
+    parser.add_argument("--expected-glama-tool-count", type=int, default=None)
     parser.add_argument("--docker-image", default=_env_or("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
     parser.add_argument("--smithery-server", default=_env_or("SMITHERY_SERVER_QUALIFIED_NAME", DEFAULT_SMITHERY_SERVER))
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
@@ -292,7 +297,7 @@ def main(argv: list[str] | None = None) -> int:
     surfaces = [
         probe_pypi(expected, **kw),
         probe_docker(expected, args.docker_image, **kw),
-        probe_glama(expected, **kw),
+        probe_glama(expected, expected_tool_count=args.expected_glama_tool_count, **kw),
         probe_smithery(expected, args.smithery_server, **kw),
     ]
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -486,6 +486,19 @@ def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count()
     assert "--resolve-only" in workflow
 
 
+def test_surface_freshness_targets_the_latest_published_release():
+    """Unreleased source versions must not create distribution drift alerts."""
+    workflow = (ROOT / ".github" / "workflows" / "surface-freshness.yml").read_text()
+
+    assert "Get expected version from latest published release" in workflow
+    assert "repos/$GITHUB_REPOSITORY/releases/latest" in workflow
+    assert "EXPECTED_VERSION: ${{ steps.expected.outputs.version }}" in workflow
+    assert '--expected "$EXPECTED_VERSION"' in workflow
+    assert '--expected-glama-tool-count "${{ steps.expected.outputs.tool_count }}"' in workflow
+    assert 'git show "${RELEASE_SHA}:README.md"' in workflow
+    assert "Expected version from published release" in workflow
+
+
 def test_docs_workflow_never_deploys_pages_from_release_tags():
     """Release tags may build docs, but Pages deploy is protected to main only."""
     workflow = (ROOT / ".github" / "workflows" / "docs.yml").read_text()
@@ -574,11 +587,40 @@ def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_
     assert "integrations/openclaw/vulnerability-intel" in workflow
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
     assert 'git fetch --no-tags --depth=1 origin "$RELEASE_SHA"' in workflow
-    assert 'check_glama_listing.py --verify-manifest --git-ref "${{ steps.meta.outputs.release_sha }}"' in workflow
+    assert 'check_glama_listing.py --verify-manifest --git-ref "${{ needs.release.outputs.release_sha }}"' in workflow
     assert "workflow_run.head_sha || github.ref" not in workflow
     assert "actions: read" in workflow
     assert "jq -n" in workflow
     assert "dockerfile: $dockerfile" in workflow
+
+
+def test_publish_registries_manual_repair_resolves_a_published_release():
+    """Manual registry repair must never publish unreleased main metadata."""
+    workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
+
+    assert "release_tag:" in workflow
+    assert "Resolve published release" in workflow
+    assert "releases/tags/${REQUESTED_TAG}" in workflow
+    assert "repos/${GITHUB_REPOSITORY}/releases/latest" in workflow
+    assert "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" in workflow
+    assert workflow.count("ref: ${{ needs.release.outputs.release_sha }}") == 3
+    assert workflow.count("needs: release") == 3
+    assert "GITHUB_REF_NAME" not in workflow
+    assert "VERSION=$(grep '^version' pyproject.toml" not in workflow
+
+
+def test_glama_rebuild_webhook_is_secret_and_missing_secret_is_honest():
+    """A missing webhook must not leak a URL or claim a rebuild happened."""
+    workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
+
+    assert "GLAMA_WEBHOOK_URL: ${{ secrets.GLAMA_WEBHOOK_URL }}" in workflow
+    assert "GLAMA_WEBHOOK_URL: ${{ vars.GLAMA_WEBHOOK_URL }}" not in workflow
+    assert "id: glama_trigger" in workflow
+    assert 'echo "rebuild_triggered=false" >> "$GITHUB_OUTPUT"' in workflow
+    assert "No Glama rebuild was triggered" in workflow
+    assert "set GLAMA_WEBHOOK_URL as a repository Actions secret" in workflow
+    assert "REBUILD_TRIGGERED: ${{ steps.glama_trigger.outputs.rebuild_triggered }}" in workflow
+    assert 'if [ "$REBUILD_TRIGGERED" = "true" ]; then' in workflow
 
 
 def test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -495,7 +495,10 @@ def test_surface_freshness_targets_the_latest_published_release():
     assert "EXPECTED_VERSION: ${{ steps.expected.outputs.version }}" in workflow
     assert '--expected "$EXPECTED_VERSION"' in workflow
     assert '--expected-glama-tool-count "${{ steps.expected.outputs.tool_count }}"' in workflow
-    assert 'git show "${RELEASE_SHA}:README.md"' in workflow
+    assert 'git show "${RELEASE_SHA}:docs/PRODUCT_METRICS.json"' in workflow
+    assert 'select(.name == "MCP tools")' in workflow
+    assert 'METRICS_VERSION" != "$VERSION"' in workflow
+    assert "persist-credentials: false" in workflow
     assert "Expected version from published release" in workflow
 
 
@@ -588,23 +591,26 @@ def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
     assert 'git fetch --no-tags --depth=1 origin "$RELEASE_SHA"' in workflow
     assert 'check_glama_listing.py --verify-manifest --git-ref "${{ needs.release.outputs.release_sha }}"' in workflow
+    assert "ref: ${{ needs.release.outputs.release_sha }}" not in workflow
+    assert workflow.count("ref: ${{ github.event.repository.default_branch }}") == 4
+    assert workflow.count("persist-credentials: false") == 4
     assert "workflow_run.head_sha || github.ref" not in workflow
     assert "actions: read" in workflow
     assert "jq -n" in workflow
     assert "dockerfile: $dockerfile" in workflow
 
 
-def test_publish_registries_manual_repair_resolves_a_published_release():
-    """Manual registry repair must never publish unreleased main metadata."""
+def test_publish_registries_manual_repair_resolves_latest_release_only():
+    """Manual repair cannot fan out an older release to other registries."""
     workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
 
-    assert "release_tag:" in workflow
     assert "Resolve published release" in workflow
-    assert "releases/tags/${REQUESTED_TAG}" in workflow
     assert "repos/${GITHUB_REPOSITORY}/releases/latest" in workflow
     assert "refs/tags/${RELEASE_TAG}:refs/tags/${RELEASE_TAG}" in workflow
-    assert workflow.count("ref: ${{ needs.release.outputs.release_sha }}") == 3
     assert workflow.count("needs: release") == 3
+    assert "release_tag:" not in workflow
+    assert "REQUESTED_TAG" not in workflow
+    assert "releases/tags/${REQUESTED_TAG}" not in workflow
     assert "GITHUB_REF_NAME" not in workflow
     assert "VERSION=$(grep '^version' pyproject.toml" not in workflow
 
@@ -621,6 +627,12 @@ def test_glama_rebuild_webhook_is_secret_and_missing_secret_is_honest():
     assert "set GLAMA_WEBHOOK_URL as a repository Actions secret" in workflow
     assert "REBUILD_TRIGGERED: ${{ steps.glama_trigger.outputs.rebuild_triggered }}" in workflow
     assert 'if [ "$REBUILD_TRIGGERED" = "true" ]; then' in workflow
+    assert 'HTTP_STATUS" -lt 300' in workflow
+    assert 'HTTP_STATUS" -lt 400' not in workflow
+    assert "EVENT_NAME: ${{ github.event_name }}" in workflow
+    assert 'if [ "$EVENT_NAME" = "workflow_dispatch" ]; then' in workflow
+    assert "::error::Manual Glama repair" in workflow
+    assert "exit 1" in workflow
 
 
 def test_refresh_latest_container_keeps_release_code_but_applies_runtime_security_overlay():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -591,8 +591,8 @@ def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
     assert 'git fetch --no-tags --depth=1 origin "$RELEASE_SHA"' in workflow
     assert 'check_glama_listing.py --verify-manifest --git-ref "${{ needs.release.outputs.release_sha }}"' in workflow
-    assert "ref: ${{ needs.release.outputs.release_sha }}" not in workflow
-    assert workflow.count("ref: ${{ github.event.repository.default_branch }}") == 4
+    assert workflow.count("ref: ${{ needs.release.outputs.release_sha }}") == 1
+    assert workflow.count("ref: ${{ github.event.repository.default_branch }}") == 3
     assert workflow.count("persist-credentials: false") == 4
     assert "workflow_run.head_sha || github.ref" not in workflow
     assert "actions: read" in workflow
@@ -613,6 +613,19 @@ def test_publish_registries_manual_repair_resolves_latest_release_only():
     assert "releases/tags/${REQUESTED_TAG}" not in workflow
     assert "GITHUB_REF_NAME" not in workflow
     assert "VERSION=$(grep '^version' pyproject.toml" not in workflow
+
+
+def test_publish_registries_uses_release_metrics_for_glama_and_clawhub_assets():
+    """Current checker code must evaluate exact release evidence and assets."""
+    workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
+
+    assert "tool_count: ${{ steps.release.outputs.tool_count }}" in workflow
+    assert 'git show "${RELEASE_SHA}:docs/PRODUCT_METRICS.json"' in workflow
+    assert 'METRICS_VERSION" != "$VERSION"' in workflow
+    assert 'select(.name == "MCP tools")' in workflow
+    assert "EXPECTED_TOOL_COUNT: ${{ needs.release.outputs.tool_count }}" in workflow
+    assert '--expected-tool-count "$EXPECTED_TOOL_COUNT"' in workflow
+    assert workflow.count("ref: ${{ needs.release.outputs.release_sha }}") == 1
 
 
 def test_glama_rebuild_webhook_is_secret_and_missing_secret_is_honest():

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -43,6 +43,40 @@ def test_glama_listing_json_contract_reports_stale_listing(monkeypatch, capsys):
     assert "missing current Glama listing token" in payload["error"]
 
 
+def test_glama_listing_requires_public_api_tool_inventory(monkeypatch, capsys):
+    """Rendered README claims do not substitute for Glama-indexed MCP tools."""
+    script = _load_script("check_glama_listing.py")
+    current_page = "v0.98.2 MCP server mode exposes 77 MCP tools"
+
+    monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: current_page)
+    monkeypatch.setattr(script, "_fetch_json", lambda _url, _timeout: {"tools": []})
+
+    assert script.main(["--expected", "0.98.2", "--expected-tool-count", "77", "--json", "--retries", "1"]) == 1
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "stale"
+    assert payload["tool_count"] == 0
+    assert payload["expected_tool_count"] == 77
+    assert "public API exposes 0 tools; expected 77" in payload["error"]
+
+
+def test_glama_listing_accepts_exact_public_api_tool_inventory(monkeypatch, capsys):
+    script = _load_script("check_glama_listing.py")
+    current_page = "v0.98.2 MCP server mode exposes 77 MCP tools"
+
+    monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: current_page)
+    monkeypatch.setattr(
+        script,
+        "_fetch_json",
+        lambda _url, _timeout: {"tools": [{"name": f"tool_{index}"} for index in range(77)]},
+    )
+
+    assert script.main(["--expected", "0.98.2", "--expected-tool-count", "77", "--json", "--retries", "1"]) == 0
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "fresh"
+    assert payload["tool_count"] == 77
+    assert payload["expected_tool_count"] == 77
+
+
 def test_glama_build_manifest_verify_passes():
     script = _load_script("check_glama_listing.py")
     assert script.main(["--verify-manifest"]) == 0
@@ -178,10 +212,7 @@ def test_surface_freshness_blank_env_vars_use_defaults(monkeypatch):
     monkeypatch.setenv("GLAMA_LISTING_URL", "")
 
     assert script._env_or("DOCKER_IMAGE", script.DEFAULT_DOCKER_IMAGE) == script.DEFAULT_DOCKER_IMAGE
-    assert (
-        script._env_or("SMITHERY_SERVER_QUALIFIED_NAME", script.DEFAULT_SMITHERY_SERVER)
-        == script.DEFAULT_SMITHERY_SERVER
-    )
+    assert script._env_or("SMITHERY_SERVER_QUALIFIED_NAME", script.DEFAULT_SMITHERY_SERVER) == script.DEFAULT_SMITHERY_SERVER
 
     glama = _load_script("check_glama_listing.py")
     assert glama._env_or("GLAMA_LISTING_URL", glama.DEFAULT_URL) == glama.DEFAULT_URL
@@ -192,12 +223,26 @@ def test_surface_freshness_main_skips_blank_docker_and_smithery_env(monkeypatch,
     monkeypatch.setenv("DOCKER_IMAGE", "")
     monkeypatch.setenv("SMITHERY_SERVER_QUALIFIED_NAME", "")
 
-    monkeypatch.setattr(script, "probe_pypi", lambda expected, **_kw: {
-        "surface": "PyPI", "status": "fresh", "version": expected, "expected": expected,
-    })
-    monkeypatch.setattr(script, "probe_glama", lambda expected, **_kw: {
-        "surface": "Glama", "status": "fresh", "version": expected, "expected": expected,
-    })
+    monkeypatch.setattr(
+        script,
+        "probe_pypi",
+        lambda expected, **_kw: {
+            "surface": "PyPI",
+            "status": "fresh",
+            "version": expected,
+            "expected": expected,
+        },
+    )
+    monkeypatch.setattr(
+        script,
+        "probe_glama",
+        lambda expected, **_kw: {
+            "surface": "Glama",
+            "status": "fresh",
+            "version": expected,
+            "expected": expected,
+        },
+    )
 
     seen: dict[str, str] = {}
 
@@ -218,4 +263,3 @@ def test_surface_freshness_main_skips_blank_docker_and_smithery_env(monkeypatch,
     assert report["all_fresh"] is True
     assert seen["docker"] == script.DEFAULT_DOCKER_IMAGE
     assert seen["smithery"] == script.DEFAULT_SMITHERY_SERVER
-

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import subprocess
+import urllib.error
 from pathlib import Path
 from types import ModuleType
 
@@ -31,6 +32,11 @@ def test_glama_listing_json_contract_reports_stale_listing(monkeypatch, capsys):
 
     monkeypatch.setattr(script, "_load_readme_tool_count", lambda: "69")
     monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: stale_page)
+    monkeypatch.setattr(
+        script,
+        "_fetch_json",
+        lambda _url, _timeout: {"tools": [{"name": f"tool_{index}"} for index in range(69)]},
+    )
 
     assert script.main(["--expected", "0.89.2", "--json", "--retries", "1"]) == 1
     captured = capsys.readouterr()
@@ -75,6 +81,48 @@ def test_glama_listing_accepts_exact_public_api_tool_inventory(monkeypatch, caps
     assert payload["status"] == "fresh"
     assert payload["tool_count"] == 77
     assert payload["expected_tool_count"] == 77
+
+
+def test_glama_api_failure_is_unreachable_and_resets_previous_retry_count(monkeypatch, capsys):
+    """A later API outage must not retain an earlier attempt's observed count."""
+    script = _load_script("check_glama_listing.py")
+    current_page = "v0.98.2 MCP server mode exposes 77 MCP tools"
+    api_results = iter(
+        [
+            {"tools": [{"name": f"tool_{index}"} for index in range(76)]},
+            urllib.error.URLError("temporary outage"),
+        ]
+    )
+
+    def fetch_json(_url, _timeout):
+        result = next(api_results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: current_page)
+    monkeypatch.setattr(script, "_fetch_json", fetch_json)
+
+    assert (
+        script.main(
+            [
+                "--expected",
+                "0.98.2",
+                "--expected-tool-count",
+                "77",
+                "--json",
+                "--retries",
+                "2",
+                "--delay-seconds",
+                "0",
+            ]
+        )
+        == 1
+    )
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "unreachable"
+    assert payload["tool_count"] is None
+    assert "failed to verify Glama public API tool inventory" in payload["error"]
 
 
 def test_glama_build_manifest_verify_passes():


### PR DESCRIPTION
## Summary

- resolve registry repairs from the latest published release and exact release commit
- run trusted current Glama checker code against exact-release manifests and canonical MCP tool metrics
- require HTTP 2xx for rebuild success, fail manual no-ops, and preserve warning-only automatic behavior
- keep ClawHub release assets pinned to the exact release SHA

## Verification

- 71 focused tests passed
- actionlint passed
- Ruff passed
- scoped pre-commit passed
- make preflight passed
- independent aggregate review found no remaining blockers

## Notes

Progresses #4513. The issue remains open until Glama publicly reports version 0.98.2 with exactly 77 named tools. This PR does not authenticate to Glama or trigger a rebuild.