### PR TITLE
fix(cwpp): enforce runtime evidence integrity

### DIFF
--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -50,6 +50,7 @@ a9ab4c116af8bc5086aca63933d12a675573bb4b:src/agent_bom/cloud/side_scan_targets.p
 # current test assembles each non-functional detector input at runtime.
 9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:gitlab-pat:209
 9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:curl-auth-header:331
+9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:github-pat:374
 9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:gitlab-pat:379
 9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:gitlab-deploy-token:381
 9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:gitlab-runner-authentication-token:382

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -45,3 +45,11 @@ e67c1273881cb01cfbc64b1f6a1081613e5e8fe3:tests/test_api_oidc.py:jwt:360
 # One-off prose false positive: a docstring sentence about credential wiring
 # in the side-scan runner matched generic-api-key.
 a9ab4c116af8bc5086aca63933d12a675573bb4b:src/agent_bom/cloud/side_scan_targets.py:generic-api-key:199
+
+# History-only false positives from runtime-evidence redaction fixtures. The
+# current test assembles each non-functional detector input at runtime.
+9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:gitlab-pat:209
+9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:curl-auth-header:331
+9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:gitlab-pat:379
+9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:gitlab-deploy-token:381
+9ab04a6e7577f0117410e3baeeddc87ac7ac97a2:tests/cloud/test_runtime_workload_evidence.py:gitlab-runner-authentication-token:382

--- a/deploy/supabase/postgres/alembic/versions/20260727_01_runtime_evidence_timestamp_authority.py
+++ b/deploy/supabase/postgres/alembic/versions/20260727_01_runtime_evidence_timestamp_authority.py
@@ -1,0 +1,248 @@
+"""Make runtime-evidence observation ordering timezone-aware.
+
+Revision ID: 20260727_01
+Revises: 20260726_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260727_01"
+down_revision = "20260726_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Python treats timezone-naive source timestamps as UTC; pin the migration
+    # session to the same authority before converting legacy TEXT rows.
+    op.execute("SET LOCAL TIME ZONE 'UTC'")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.runtime_workload_evidence') IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM information_schema.columns
+                   WHERE table_schema = 'public'
+                     AND table_name = 'runtime_workload_evidence'
+                     AND column_name = 'observed_at'
+                     AND data_type <> 'timestamp with time zone'
+               ) THEN
+                ALTER TABLE runtime_workload_evidence
+                    ALTER COLUMN observed_at TYPE TIMESTAMPTZ
+                    USING observed_at::timestamptz;
+            END IF;
+        END
+        $$
+        """
+    )
+    # The evidence table is FORCE RLS. This one-time scrub must cover every
+    # tenant before schema v2 is recorded, using the transaction-local bypass
+    # honoured by the canonical policy.
+    op.execute("SELECT set_config('app.bypass_rls', '1', true)")
+    op.execute(
+        r"""
+        DO $$
+        BEGIN
+            IF EXISTS (
+                SELECT 1
+                FROM runtime_workload_evidence
+                WHERE btrim(tenant_id) = ''
+                   OR btrim(provider) = ''
+                   OR btrim(account_id) = ''
+                   OR btrim(workload_ref) = ''
+                   OR btrim(workload_id) = ''
+                   OR btrim(source_id) = ''
+                   OR btrim(source_kind) = ''
+                   OR btrim(dedup_key) = ''
+                   OR length(tenant_id) > 256
+                   OR length(account_id) > 512
+                   OR length(workload_ref) > 2048
+                   OR length(workload_id) > 4096
+                   OR length(source_id) > 256
+                   OR length(source_kind) > 128
+                   OR length(dedup_key) > 512
+                   OR provider NOT IN ('aws', 'azure', 'gcp')
+                   OR signal_type NOT IN (
+                       'process_exec', 'ioc_detection', 'network_connection',
+                       'file_integrity', 'behavioral_alert'
+                   )
+                   OR workload_ref ~* (
+                       '(sk|pk|rk)[-_](live|test|prod)[-_][[:alnum:]_]{10,}|'
+                       '(AKIA|ASIA)[A-Z0-9]{16}|'
+                       '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|'
+                       'eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}|'
+                       'xox[bpsar]-[A-Za-z0-9-]{10,}|'
+                       '-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----|'
+                       '[A-Za-z0-9_]+://[^[:space:]:]+:[^[:space:]@]+@|'
+                       '(glpat|glcbt|gldt|glrt|glptt|glagent)-[A-Za-z0-9_-]{20,}|'
+                       'ya29\.[A-Za-z0-9._-]{20,}|'
+                       'sk-(proj-)?[A-Za-z0-9_-]{20,}|'
+                       '(authorization[[:space:]]*:[[:space:]]*)?Bearer[[:space:]]+[^[:space:]]{8,}|'
+                       '(api[_-]?key|credential|password|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]{4,}'
+                   )
+                   OR workload_id ~* (
+                       '(sk|pk|rk)[-_](live|test|prod)[-_][[:alnum:]_]{10,}|'
+                       '(AKIA|ASIA)[A-Z0-9]{16}|'
+                       '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|'
+                       'eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}|'
+                       'xox[bpsar]-[A-Za-z0-9-]{10,}|'
+                       '-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----|'
+                       '[A-Za-z0-9_]+://[^[:space:]:]+:[^[:space:]@]+@|'
+                       '(glpat|glcbt|gldt|glrt|glptt|glagent)-[A-Za-z0-9_-]{20,}|'
+                       'ya29\.[A-Za-z0-9._-]{20,}|'
+                       'sk-(proj-)?[A-Za-z0-9_-]{20,}|'
+                       '(authorization[[:space:]]*:[[:space:]]*)?Bearer[[:space:]]+[^[:space:]]{8,}|'
+                       '(api[_-]?key|credential|password|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]{4,}'
+                   )
+                   OR dedup_key ~* (
+                       '(sk|pk|rk)[-_](live|test|prod)[-_][[:alnum:]_]{10,}|'
+                       '(AKIA|ASIA)[A-Z0-9]{16}|'
+                       '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|'
+                       'eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}|'
+                       'xox[bpsar]-[A-Za-z0-9-]{10,}|'
+                       '-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----|'
+                       '[A-Za-z0-9_]+://[^[:space:]:]+:[^[:space:]@]+@|'
+                       '(glpat|glcbt|gldt|glrt|glptt|glagent)-[A-Za-z0-9_-]{20,}|'
+                       'ya29\.[A-Za-z0-9._-]{20,}|'
+                       'sk-(proj-)?[A-Za-z0-9_-]{20,}|'
+                       '(authorization[[:space:]]*:[[:space:]]*)?Bearer[[:space:]]+[^[:space:]]{8,}|'
+                       '(api[_-]?key|credential|password|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]{4,}'
+                   )
+            ) THEN
+                RAISE EXCEPTION 'runtime workload evidence contains unsafe legacy identity rows';
+            END IF;
+        END
+        $$
+        """
+    )
+    # Rebuild the v1 payload from authoritative columns, preserving only the
+    # current bounded metadata allowlist. Sensitive metadata is removed (or a
+    # title is marked redacted) while unknown top-level fields are discarded.
+    op.execute(
+        r"""
+        WITH normalized AS (
+            SELECT
+                ctid,
+                tenant_id,
+                provider,
+                account_id,
+                workload_ref,
+                workload_id,
+                signal_type,
+                CASE
+                    WHEN lower(severity) IN ('critical', 'high', 'medium', 'low', 'info', 'unknown')
+                    THEN lower(severity)
+                    ELSE 'unknown'
+                END AS severity,
+                observed_at,
+                source_id,
+                source_kind,
+                dedup_key,
+                payload_json::jsonb AS legacy_payload
+            FROM runtime_workload_evidence
+        ),
+        safe_metadata AS (
+            SELECT
+                normalized.*,
+                CASE
+                    WHEN COALESCE(legacy_payload->>'title', '') ~* (
+                        '(sk|pk|rk)[-_](live|test|prod)[-_][[:alnum:]_]{10,}|'
+                        '(AKIA|ASIA)[A-Z0-9]{16}|'
+                        '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|'
+                        'eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}|'
+                        'xox[bpsar]-[A-Za-z0-9-]{10,}|'
+                        '-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----|'
+                        '[A-Za-z0-9_]+://[^[:space:]:]+:[^[:space:]@]+@|'
+                        '(glpat|glcbt|gldt|glrt|glptt|glagent)-[A-Za-z0-9_-]{20,}|'
+                        'ya29\.[A-Za-z0-9._-]{20,}|'
+                        'sk-(proj-)?[A-Za-z0-9_-]{20,}|'
+                        '(authorization[[:space:]]*:[[:space:]]*)?Bearer[[:space:]]+[^[:space:]]{8,}|'
+                        '(api[_-]?key|credential|password|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]{4,}|'
+                        '[[:alnum:]._%+-]+@[[:alnum:].-]+\.[[:alpha:]]{2,}|'
+                        'https?://[^[:space:]]+[?#][^[:space:]]*|'
+                        '[[:cntrl:]]'
+                    ) THEN '<redacted>'
+                    ELSE left(COALESCE(legacy_payload->>'title', ''), 256)
+                END AS safe_title,
+                COALESCE(
+                    (
+                        SELECT jsonb_object_agg(entry.key, to_jsonb(left(entry.value #>> '{}', 256)))
+                        FROM jsonb_each(
+                            CASE
+                                WHEN jsonb_typeof(legacy_payload->'evidence') = 'object'
+                                THEN legacy_payload->'evidence'
+                                ELSE '{}'::jsonb
+                            END
+                        ) AS entry(key, value)
+                        WHERE entry.key IN (
+                            'action', 'alert_id', 'alert_ref', 'category', 'count',
+                            'destination_ref', 'event_type', 'file_ref', 'hash_ref', 'hash_type',
+                            'indicator_ref', 'ioc_type', 'network_ref', 'outcome', 'process_ref',
+                            'rule_id', 'rule_ref', 'source_ref', 'tactic_id', 'technique_id'
+                        )
+                          AND jsonb_typeof(entry.value) IN ('string', 'number', 'boolean')
+                          AND NOT (entry.value #>> '{}') ~* (
+                              '(sk|pk|rk)[-_](live|test|prod)[-_][[:alnum:]_]{10,}|'
+                              '(AKIA|ASIA)[A-Z0-9]{16}|'
+                              '(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|'
+                              'eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}|'
+                              'xox[bpsar]-[A-Za-z0-9-]{10,}|'
+                              '-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----|'
+                              '[A-Za-z0-9_]+://[^[:space:]:]+:[^[:space:]@]+@|'
+                              '(glpat|glcbt|gldt|glrt|glptt|glagent)-[A-Za-z0-9_-]{20,}|'
+                              'ya29\.[A-Za-z0-9._-]{20,}|'
+                              'sk-(proj-)?[A-Za-z0-9_-]{20,}|'
+                              '(authorization[[:space:]]*:[[:space:]]*)?Bearer[[:space:]]+[^[:space:]]{8,}|'
+                              '(api[_-]?key|credential|password|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]{4,}|'
+                              '[[:alnum:]._%+-]+@[[:alnum:].-]+\.[[:alpha:]]{2,}|'
+                              'https?://[^[:space:]]+[?#][^[:space:]]*|'
+                              '[[:cntrl:]]'
+                          )
+                    ),
+                    '{}'::jsonb
+                ) AS safe_evidence
+            FROM normalized
+        ),
+        scrubbed AS (
+            SELECT
+                ctid,
+                jsonb_build_object(
+                    'schema_version', 'agent-bom.cwpp.runtime_workload.evidence.v1',
+                    'tenant_id', tenant_id,
+                    'provider', provider,
+                    'account_id', account_id,
+                    'workload_ref', workload_ref,
+                    'workload_id', workload_id,
+                    'signal_type', signal_type,
+                    'severity', severity,
+                    'observed_at', to_char(observed_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'),
+                    'source_id', source_id,
+                    'source_kind', source_kind,
+                    'dedup_key', dedup_key,
+                    'title', safe_title,
+                    'evidence', safe_evidence
+                ) AS payload
+            FROM safe_metadata
+        )
+        UPDATE runtime_workload_evidence AS target
+        SET payload_json = scrubbed.payload::text
+        FROM scrubbed
+        WHERE target.ctid = scrubbed.ctid
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO control_plane_schema_versions(component, version, updated_at)
+        VALUES ('runtime_workload_evidence', 2, now())
+        ON CONFLICT(component) DO UPDATE SET
+            version = EXCLUDED.version,
+            updated_at = EXCLUDED.updated_at
+        """
+    )
+
+
+def downgrade() -> None:
+    raise NotImplementedError("Runtime evidence timestamp authority is intentionally irreversible.")

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -106,7 +106,7 @@ CREATE TABLE IF NOT EXISTS runtime_workload_evidence (
   workload_id TEXT NOT NULL,
   signal_type TEXT NOT NULL,
   severity TEXT NOT NULL,
-  observed_at TEXT NOT NULL,
+  observed_at TIMESTAMPTZ NOT NULL,
   source_id TEXT NOT NULL,
   source_kind TEXT NOT NULL,
   payload_json TEXT NOT NULL,
@@ -227,8 +227,11 @@ INSERT INTO control_plane_schema_versions(component,version,updated_at)
 SELECT component,1,now() FROM unnest(ARRAY[
  'scan_jobs','api_keys','exceptions','audit_log','trend_history','gateway_policies','schedules','sources','credential_refs','llm_costs',
  'cloud_connections','compliance_hub','access_review_campaigns','risk_campaign_workflows','fleet','graph','scan_cache','identity_scim',
- 'agent_identities','runtime_events','runtime_workload_evidence','tenant_quotas','tenant_graph_retention','idempotency','proxy_replay_log','rate_limits',
+ 'agent_identities','runtime_events','tenant_quotas','tenant_graph_retention','idempotency','proxy_replay_log','rate_limits',
  'shared_auth_state','managed_trial_invitations','managed_trial_tenants','governance_audit_log','ai_system_blueprints','mcp_client_configs','model_provider_keys','tenant_score_config',
  'ticketing_connections'
 ]) component
+ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;
+INSERT INTO control_plane_schema_versions(component,version,updated_at)
+VALUES ('runtime_workload_evidence',2,now())
 ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;

--- a/docs/CLOUD_CONNECT.md
+++ b/docs/CLOUD_CONNECT.md
@@ -628,17 +628,20 @@ Ingest is hardened and fails closed (`runtime_workload_evidence.py`):
   a batch is accepted only after a constant-time secret check. Tenant, provider,
   and account are taken from the authenticated source — a payload that claims a
   different provider/account is rejected (confused-deputy guard).
-- **Freshness + provenance.** Every signal records `observed_at`, `source_id`,
-  and `source_kind`; a signal older than the freshness window is rejected, as is
-  one with no workload reference or an unparseable timestamp.
+- **Freshness + provenance.** Every accepted signal must provide `observed_at`;
+  agent-bom records it with `source_id` and `source_kind` in fixed-width UTC.
+  Missing, unparseable, future-dated, or stale observations are rejected, as is
+  a signal with no workload reference.
 - **Deduplicated + isolated.** Signals dedup on
   `(tenant, provider, account, workload, dedup_key)`; that key leads every store
   query and is part of the dedup identity, so two tenants can carry the same
   logical signal without one dropping or leaking. Durable persistence has
   in-memory, SQLite (restart- and cross-process-safe), and Postgres backends
   (`runtime_workload_evidence_store.py`).
-- **Metadata only.** Raw block bytes, file contents, and secret values are
-  redacted at construction; only bounded metadata references are retained.
+- **Metadata only.** Producers must submit redacted metadata references. The
+  ingest contract keeps a bounded key allowlist and drops nested, raw-content,
+  oversized, and known credential-shaped values; it is not a general-purpose
+  secret vault or payload store.
 
 **Honesty — additive, never a cleanliness claim.** Every evidence summary carries
 `clean_workload_assertion: false`. A workload with no matching runtime signal is

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -4886,15 +4886,9 @@
             "type": "object"
           },
           "observed_at": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Observed At"
+            "description": "Source observation time in ISO-8601 form; required and normalized to fixed-width UTC on ingest.",
+            "title": "Observed At",
+            "type": "string"
           },
           "provider": {
             "anyOf": [
@@ -4929,7 +4923,8 @@
         "required": [
           "workload_ref",
           "signal_type",
-          "dedup_key"
+          "dedup_key",
+          "observed_at"
         ],
         "title": "RuntimeEvidenceSignalIn",
         "type": "object"
@@ -11028,7 +11023,7 @@
     },
     "/v1/cloud/runtime-evidence/ingest": {
       "post": {
-        "description": "Ingest a batch of CWPP runtime/EDR workload signals (#4158 stage 3).\n\nThe authenticated, tenant-scoped door for the runtime workload-evidence store.\nWithout this route the store had no caller in a deployed product and could\nnever be populated. Read-only posture: agent-bom never writes to a customer\ntarget and persists redacted metadata only (raw bytes / secret values are\ndropped at construction). Each source is pre-registered with a hashed shared\nsecret (no per-action credentials); ``provider``/``account`` bind to the\nauthenticated source, never the payload (confused-deputy guard).\n\nFail-closed: an unknown source id, a bad secret, or a source owned by a\ndifferent tenant all return the same generic ``401`` so a caller cannot\nenumerate valid source ids or tenants. The ingest runs off the event loop in a\nworker thread under backpressure so a batch can never stall ``/health``.",
+        "description": "Ingest a batch of CWPP runtime/EDR workload signals (#4158 stage 3).\n\nThe authenticated, tenant-scoped door for the runtime workload-evidence store.\nWithout this route the store had no caller in a deployed product and could\nnever be populated. Read-only posture: agent-bom never writes to a customer\ntarget and persists allowlisted metadata only (raw content and known\ncredential-shaped values are dropped at construction). Each source is\npre-registered with a hashed shared secret (no per-action credentials);\n``provider``/``account`` bind to the\nauthenticated source, never the payload (confused-deputy guard).\n\nFail-closed: an unknown source id, a bad secret, or a source owned by a\ndifferent tenant all return the same generic ``401`` so a caller cannot\nenumerate valid source ids or tenants. The ingest runs off the event loop in a\nworker thread under backpressure so a batch can never stall ``/health``.",
         "operationId": "cloud_runtime_evidence_ingest_v1_cloud_runtime_evidence_ingest_post",
         "parameters": [
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3355,10 +3355,10 @@ components:
           title: Evidence
           type: object
         observed_at:
-          anyOf:
-          - type: string
-          - type: 'null'
+          description: Source observation time in ISO-8601 form; required and normalized
+            to fixed-width UTC on ingest.
           title: Observed At
+          type: string
         provider:
           anyOf:
           - type: string
@@ -3382,6 +3382,7 @@ components:
       - workload_ref
       - signal_type
       - dedup_key
+      - observed_at
       title: RuntimeEvidenceSignalIn
       type: object
     SAMLLoginRequest:
@@ -7389,11 +7390,13 @@ paths:
 
         never be populated. Read-only posture: agent-bom never writes to a customer
 
-        target and persists redacted metadata only (raw bytes / secret values are
+        target and persists allowlisted metadata only (raw content and known
 
-        dropped at construction). Each source is pre-registered with a hashed shared
+        credential-shaped values are dropped at construction). Each source is
 
-        secret (no per-action credentials); ``provider``/``account`` bind to the
+        pre-registered with a hashed shared secret (no per-action credentials);
+
+        ``provider``/``account`` bind to the
 
         authenticated source, never the payload (confused-deputy guard).
 

--- a/docs/schemas/v1/RuntimeEvidenceIngestRequest.json
+++ b/docs/schemas/v1/RuntimeEvidenceIngestRequest.json
@@ -26,16 +26,9 @@
           "type": "object"
         },
         "observed_at": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Observed At"
+          "description": "Source observation time in ISO-8601 form; required and normalized to fixed-width UTC on ingest.",
+          "title": "Observed At",
+          "type": "string"
         },
         "provider": {
           "anyOf": [
@@ -71,7 +64,8 @@
       "required": [
         "workload_ref",
         "signal_type",
-        "dedup_key"
+        "dedup_key",
+        "observed_at"
       ],
       "title": "RuntimeEvidenceSignalIn",
       "type": "object"

--- a/docs/schemas/v1/RuntimeEvidenceSignalIn.json
+++ b/docs/schemas/v1/RuntimeEvidenceSignalIn.json
@@ -24,16 +24,9 @@
       "type": "object"
     },
     "observed_at": {
-      "anyOf": [
-        {
-          "type": "string"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "title": "Observed At"
+      "description": "Source observation time in ISO-8601 form; required and normalized to fixed-width UTC on ingest.",
+      "title": "Observed At",
+      "type": "string"
     },
     "provider": {
       "anyOf": [
@@ -69,7 +62,8 @@
   "required": [
     "workload_ref",
     "signal_type",
-    "dedup_key"
+    "dedup_key",
+    "observed_at"
   ],
   "title": "RuntimeEvidenceSignalIn",
   "type": "object"

--- a/src/agent_bom/api/models.py
+++ b/src/agent_bom/api/models.py
@@ -875,7 +875,10 @@ class RuntimeEvidenceSignalIn(BaseModel):
     signal_type: str
     dedup_key: str
     severity: str = "unknown"
-    observed_at: str | None = None
+    observed_at: str = Field(
+        ...,
+        description="Source observation time in ISO-8601 form; required and normalized to fixed-width UTC on ingest.",
+    )
     title: str = ""
     evidence: dict[str, Any] = Field(default_factory=dict)
     provider: str | None = None

--- a/src/agent_bom/api/routes/cloud.py
+++ b/src/agent_bom/api/routes/cloud.py
@@ -857,9 +857,10 @@ async def cloud_runtime_evidence_ingest(
     The authenticated, tenant-scoped door for the runtime workload-evidence store.
     Without this route the store had no caller in a deployed product and could
     never be populated. Read-only posture: agent-bom never writes to a customer
-    target and persists redacted metadata only (raw bytes / secret values are
-    dropped at construction). Each source is pre-registered with a hashed shared
-    secret (no per-action credentials); ``provider``/``account`` bind to the
+    target and persists allowlisted metadata only (raw content and known
+    credential-shaped values are dropped at construction). Each source is
+    pre-registered with a hashed shared secret (no per-action credentials);
+    ``provider``/``account`` bind to the
     authenticated source, never the payload (confused-deputy guard).
 
     Fail-closed: an unknown source id, a bad secret, or a source owned by a

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -66,7 +66,12 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     ),
     # Runtime session/observation timeline is durable by default (same tiering).
     StorageSchemaComponent("runtime_events", "sqlite/postgres", ("runtime_observations", "runtime_sessions")),
-    StorageSchemaComponent("runtime_workload_evidence", "sqlite/postgres", ("runtime_workload_evidence",)),
+    StorageSchemaComponent(
+        "runtime_workload_evidence",
+        "sqlite/postgres",
+        ("runtime_workload_evidence",),
+        version=2,
+    ),
     StorageSchemaComponent("tenant_quotas", "sqlite/postgres", ("tenant_quota_overrides",)),
     StorageSchemaComponent("tenant_graph_retention", "sqlite/postgres", ("tenant_graph_retention_overrides",)),
     StorageSchemaComponent("sources", "sqlite/postgres", ("sources", "control_plane_sources")),
@@ -138,14 +143,10 @@ def ensure_postgres_schema_version(conn: Any, component: str, version: int = CON
             (component,),
         ).fetchone()
         if row is None:
-            raise RuntimeError(
-                f"Postgres schema component {component!r} is not migrated; run Alembic before starting agent-bom."
-            )
+            raise RuntimeError(f"Postgres schema component {component!r} is not migrated; run Alembic before starting agent-bom.")
         current = int(row[0])
         if current < int(version):
-            raise RuntimeError(
-                f"Postgres schema component {component!r} is version {current}; version {int(version)} is required."
-            )
+            raise RuntimeError(f"Postgres schema component {component!r} is version {current}; version {int(version)} is required.")
         return False
 
     conn.execute(

--- a/src/agent_bom/cli/_cloud_group.py
+++ b/src/agent_bom/cli/_cloud_group.py
@@ -39,6 +39,7 @@ def _auto_update_db_default() -> bool:
         return True
     return raw.strip().lower() not in ("0", "false", "no", "off")
 
+
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from rich.console import Console
 
@@ -713,6 +714,7 @@ def _project_authorization_posture(report: dict) -> dict:
     record_authorization_evidence(provider=provider, status=summary.status.value, reason_codes=reason_codes)
     return projected
 
+
 # Report keys that are lists but NOT asset collections — excluded from the count
 # so the summary auto-includes every resource type a provider adds without drift.
 _INVENTORY_NON_ASSET_KEYS = frozenset({"warnings", "discovery_envelope", "permissions_used", "discovery_scope", "errors"})
@@ -808,10 +810,7 @@ def side_scan_cmd(
     capability = capabilities.get(provider_key)
     if capability is None or not capability.cli_available:
         executor = capability.executor if capability is not None else "contract_only"
-        con.print(
-            f"\n  [yellow]side-scan executor unavailable for {provider_key}:[/yellow] "
-            f"executor={executor}, cli_available=false"
-        )
+        con.print(f"\n  [yellow]side-scan executor unavailable for {provider_key}:[/yellow] executor={executor}, cli_available=false")
         con.print(
             "  [dim]Azure/GCP expose target discovery + lifecycle contract only — "
             "no CLI executor is claimed. See `agent-bom cloud side-scan-capabilities` "
@@ -955,7 +954,7 @@ cloud_group.add_command(side_scan_capabilities_cmd, "side-scan-capabilities")
     "signals_file",
     type=click.Path(exists=True, dir_okay=False, path_type=str),
     required=True,
-    help="JSON file: a list of signals, or {\"signals\": [...]}.",
+    help='JSON file: a list of signals, or {"signals": [...]}.',
 )
 @click.option("--no-persist", is_flag=True, help="Authenticate + validate only; do not write the durable store.")
 def runtime_evidence_ingest_cmd(source_id: str, secret: str, signals_file: str, no_persist: bool) -> None:
@@ -1011,6 +1010,8 @@ def runtime_evidence_ingest_cmd(source_id: str, secret: str, signals_file: str, 
         f"incomplete={summary['rejected_incomplete']}"
     )
     con.print()
+    if summary["accepted"] == 0 and (summary["rejected_stale"] or summary["rejected_incomplete"]):
+        raise SystemExit(2)
 
 
 cloud_group.add_command(runtime_evidence_ingest_cmd, "runtime-evidence-ingest")

--- a/src/agent_bom/cloud/runtime_workload_evidence.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence.py
@@ -18,15 +18,16 @@ Non-negotiable properties (issue #4158, honesty constraints):
   from the authenticated source, never from the client payload — a spoofed
   provider/account on a raw signal is rejected (confused-deputy guard). A signal
   with no workload reference or an unparseable timestamp is rejected.
-* **Fail closed on stale.** A signal older than the freshness window is rejected,
-  not silently accepted.
+* **Fail closed on provenance gaps.** Missing, unparseable, future-dated, or
+  stale observation timestamps are rejected, not upgraded to ingest time.
 * **Deduplicated.** A `(tenant, provider, account, workload, dedup_key)` scope is
   ingested once; retries and cross-batch duplicates are dropped.
 * **Additive, never a cleanliness claim.** Evidence enriches; the *absence* of a
   runtime signal is explicitly ``no_runtime_signal`` and every summary carries
   ``clean_workload_assertion = False``. Enrichment never fabricates reachability.
-* **Metadata only.** Raw block bytes, file contents, and secret values are never
-  persisted; evidence is redacted to bounded metadata at construction.
+* **Metadata only.** Only a bounded allowlist of correlation metadata is
+  persisted; raw content, arbitrary keys, nested values, and secret-shaped
+  values are dropped at construction.
 * **Tenant isolated.** The enrichment index only ever holds one tenant's signals;
   graph joins refuse to cross the tenant boundary.
 
@@ -41,6 +42,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import threading
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -69,30 +71,69 @@ _ADDITIVE_NOTE = "Runtime evidence is additive: the absence of a runtime signal 
 _VALID_PROVIDERS = frozenset({"aws", "azure", "gcp"})
 _VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low", "info", "unknown"})
 
-# Evidence keys that could carry data-plane bytes / secret values are dropped at
-# construction. Metadata references (``*_ref``, types, counts) are kept, bounded.
-_FORBIDDEN_EVIDENCE_KEYS = frozenset(
+# Runtime evidence is an untrusted ingest surface. Persist only the metadata
+# contract needed to correlate a signal; arbitrary keys can hide credentials,
+# command lines, or data-plane content even when their names look harmless.
+_ALLOWED_EVIDENCE_KEYS = frozenset(
     {
-        "raw_bytes",
-        "bytes",
-        "file_contents",
-        "contents",
-        "content",
-        "secret_value",
-        "secret",
-        "value",
-        "values",
-        "data",
-        "payload",
-        "blob",
-        "raw",
-        "body",
-        "snippet",
-        "sample",
+        "action",
+        "alert_id",
+        "alert_ref",
+        "category",
+        "count",
+        "destination_ref",
+        "event_type",
+        "file_ref",
+        "hash_ref",
+        "hash_type",
+        "indicator_ref",
+        "ioc_type",
+        "network_ref",
+        "outcome",
+        "process_ref",
+        "rule_id",
+        "rule_ref",
+        "source_ref",
+        "tactic_id",
+        "technique_id",
     }
 )
 _MAX_EVIDENCE_KEYS = 20
 _MAX_EVIDENCE_VALUE_LEN = 256
+_MAX_IDENTITY_LENGTHS = {
+    "tenant_id": 256,
+    "account_id": 512,
+    "workload_ref": 2048,
+    "source_id": 256,
+    "source_kind": 128,
+    "dedup_key": 512,
+}
+_RUNTIME_CREDENTIAL_PATTERNS = (
+    re.compile(r"(?:AKIA|ASIA)[A-Z0-9]{16}"),
+    re.compile(r"(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}"),
+    re.compile(r"eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}"),
+    re.compile(r"xox[bpsar]-[A-Za-z0-9-]{10,}"),
+    re.compile(r"-----BEGIN (?:RSA |EC |DSA )?PRIVATE KEY-----", re.IGNORECASE),
+    re.compile(r"\w+://[^\s:]+:[^\s@]+@"),
+    re.compile(r"\bgl(?:agent|cbt|dt|pat|ptt|rt)-[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\bya29\.[A-Za-z0-9._-]{20,}\b"),
+    re.compile(r"\bsk-(?:proj-)?[A-Za-z0-9_-]{20,}\b"),
+    re.compile(r"\b(?:authorization\s*:\s*)?bearer\s+\S{8,}", re.IGNORECASE),
+    re.compile(r"\b(?:api[_-]?key|credential|password|secret|token)\s*[:=]\s*\S{4,}", re.IGNORECASE),
+)
+
+
+def _contains_runtime_credential(value: Any) -> bool:
+    text = "" if value is None else str(value)
+    return any(pattern.search(text) for pattern in _RUNTIME_CREDENTIAL_PATTERNS)
+
+
+def _sanitize_runtime_text(value: Any, *, redacted_value: str = "") -> str:
+    """Bound free text and fail closed when it resembles credential material."""
+    value_text = "" if value is None else str(value)
+    if _contains_runtime_credential(value_text):
+        return redacted_value
+    return sanitize_text(value_text, max_len=_MAX_EVIDENCE_VALUE_LEN)
 
 
 class SourceAuthenticationError(RuntimeError):
@@ -144,8 +185,16 @@ def _parse_ts(value: str) -> datetime | None:
     return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
 
 
+def normalize_runtime_observed_at(value: str) -> str | None:
+    """Return one fixed-width UTC timestamp suitable for lexical persistence."""
+    parsed = _parse_ts(value)
+    if parsed is None:
+        return None
+    return parsed.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
 def _redact_evidence(evidence: Mapping[str, Any] | None) -> dict[str, str]:
-    """Return bounded metadata only; drop any key that could carry data-plane bytes."""
+    """Return bounded allowlisted metadata with credential-shaped values removed."""
     if not isinstance(evidence, Mapping):
         return {}
     redacted: dict[str, str] = {}
@@ -153,13 +202,16 @@ def _redact_evidence(evidence: Mapping[str, Any] | None) -> dict[str, str]:
         if len(redacted) >= _MAX_EVIDENCE_KEYS:
             break
         key_text = str(key).strip().lower()
-        if not key_text or key_text in _FORBIDDEN_EVIDENCE_KEYS:
+        if key_text not in _ALLOWED_EVIDENCE_KEYS:
             continue
         if isinstance(value, (dict, list, tuple, set, bytes, bytearray)):
-            # Nested structures may hide raw content; keep only a type marker.
-            redacted[key_text] = f"<{type(value).__name__}>"
+            # Nested structures can hide raw content and are not part of the
+            # metadata-only contract.
             continue
-        redacted[key_text] = str(value)[:_MAX_EVIDENCE_VALUE_LEN]
+        sanitized = _sanitize_runtime_text(value)
+        if not sanitized:
+            continue
+        redacted[key_text] = sanitized
     return redacted
 
 
@@ -225,6 +277,11 @@ class RuntimeSourceRegistry:
         self._sources: dict[str, RuntimeEvidenceSource] = {}
 
     def add(self, source: RuntimeEvidenceSource) -> None:
+        existing = self._sources.get(source.source_id)
+        if existing is not None:
+            if existing == source:
+                return
+            raise ValueError(f"runtime evidence source_id {source.source_id!r} is already registered")
         self._sources[source.source_id] = source
 
     def get(self, source_id: str) -> RuntimeEvidenceSource | None:
@@ -271,14 +328,21 @@ class RuntimeWorkloadSignal:
         )
         if not all(str(part).strip() for part in required):
             raise IncompleteIdentityBindingError("runtime signal is missing required identity fields")
+        for field_name, max_len in _MAX_IDENTITY_LENGTHS.items():
+            if len(str(getattr(self, field_name))) > max_len:
+                raise IncompleteIdentityBindingError(f"runtime signal {field_name} exceeds the maximum length")
+        if _contains_runtime_credential(self.workload_ref) or _contains_runtime_credential(self.dedup_key):
+            raise IncompleteIdentityBindingError("runtime signal identity contains credential-shaped material")
         if self.provider not in _VALID_PROVIDERS:
             raise IncompleteIdentityBindingError(f"unsupported runtime signal provider: {self.provider}")
         if not isinstance(self.signal_type, RuntimeSignalType):
             object.__setattr__(self, "signal_type", RuntimeSignalType(str(self.signal_type)))
-        if _parse_ts(self.observed_at) is None:
+        normalized_observed_at = normalize_runtime_observed_at(self.observed_at)
+        if normalized_observed_at is None:
             raise IncompleteIdentityBindingError("runtime signal observed_at is not an ISO-8601 timestamp")
+        object.__setattr__(self, "observed_at", normalized_observed_at)
         object.__setattr__(self, "severity", _normalize_severity(self.severity))
-        object.__setattr__(self, "title", str(self.title)[:_MAX_EVIDENCE_VALUE_LEN])
+        object.__setattr__(self, "title", _sanitize_runtime_text(self.title, redacted_value="<redacted>"))
         object.__setattr__(self, "evidence", _redact_evidence(self.evidence))
 
     @property
@@ -299,12 +363,13 @@ class RuntimeWorkloadSignal:
         )
 
     def is_stale(self, now: str, max_age_seconds: int) -> bool:
-        """True when the signal is older than the freshness window (fail closed)."""
+        """True when the signal falls outside the accepted observation window."""
         observed = _parse_ts(self.observed_at)
         reference = _parse_ts(now) or datetime.now(timezone.utc)
         if observed is None:
             return True
-        return (reference - observed).total_seconds() > max_age_seconds
+        age_seconds = (reference - observed).total_seconds()
+        return age_seconds < 0 or age_seconds > max_age_seconds
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -334,7 +399,10 @@ class RuntimeWorkloadSignal:
             "source_kind": self.source_kind,
             "clean_workload_assertion": False,
             "data_boundary": "customer_account_metadata_only",
-            "redaction": "raw block bytes, file contents, and secret values are not persisted",
+            "redaction": (
+                "only allowlisted metadata is persisted; known credential-shaped values are dropped, "
+                "and producers must submit metadata-only redacted references"
+            ),
         }
 
     @classmethod
@@ -362,8 +430,9 @@ def build_runtime_signal(source: RuntimeEvidenceSource, raw: Mapping[str, Any], 
 
     Tenant, provider, and account come from ``source`` — never from the payload.
     A payload that claims a different provider/account is a confused-deputy attempt
-    and is rejected. Missing workload reference or unparseable timestamp is
-    rejected. Raises :class:`IncompleteIdentityBindingError` on any of these.
+    and is rejected. Missing workload reference or observation timestamp, or an
+    unparseable timestamp, is rejected. Raises
+    :class:`IncompleteIdentityBindingError` on any of these.
     """
     workload_ref = str(raw.get("workload_ref") or raw.get("resource_id") or raw.get("target_id") or "").strip()
     if not workload_ref:
@@ -382,7 +451,9 @@ def build_runtime_signal(source: RuntimeEvidenceSource, raw: Mapping[str, Any], 
     except ValueError as exc:
         raise IncompleteIdentityBindingError(f"unsupported runtime signal_type: {signal_type_raw or 'missing'}") from exc
 
-    observed_at = str(raw.get("observed_at") or "").strip() or (now or _now_iso())
+    observed_at = str(raw.get("observed_at") or "").strip()
+    if not observed_at:
+        raise IncompleteIdentityBindingError("runtime signal is missing observed_at")
     dedup_key = str(raw.get("dedup_key") or raw.get("event_id") or "").strip()
     if not dedup_key:
         raise IncompleteIdentityBindingError("runtime signal is missing a dedup_key")
@@ -854,7 +925,10 @@ def _load_registry_from_env() -> RuntimeSourceRegistry:
             continue
         source = _source_from_entry(entry)
         if source is not None:
-            registry.add(source)
+            try:
+                registry.add(source)
+            except ValueError:
+                logger.warning("skipping duplicate runtime evidence source_id")
     return registry
 
 
@@ -906,6 +980,7 @@ __all__ = [
     "ingest_runtime_signals",
     "ingest_runtime_signals_payload",
     "no_runtime_signal_summary",
+    "normalize_runtime_observed_at",
     "optional_runtime_workload_evidence_index",
     "set_runtime_source_registry",
     "workload_runtime_summary",

--- a/src/agent_bom/cloud/runtime_workload_evidence_store.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence_store.py
@@ -32,7 +32,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Iterator, Protocol
 
-from agent_bom.cloud.runtime_workload_evidence import RuntimeWorkloadSignal
+from agent_bom.cloud.runtime_workload_evidence import RuntimeWorkloadSignal, normalize_runtime_observed_at
 
 if TYPE_CHECKING:
     from psycopg import Connection
@@ -51,6 +51,27 @@ _COLUMNS = (
     "source_id",
     "source_kind",
     "payload_json",
+)
+_RUNTIME_WORKLOAD_EVIDENCE_SCHEMA_VERSION = 2
+_SQLITE_MIGRATION_PAGE_SIZE = 500
+_KNOWN_CREDENTIAL_SQL_REGEX = (
+    r"(sk|pk|rk)[-_](live|test|prod)[-_][[:alnum:]_]{10,}|"
+    r"(AKIA|ASIA)[A-Z0-9]{16}|"
+    r"(ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{30,}|"
+    r"eyJ[A-Za-z0-9_-]{20,}\.eyJ[A-Za-z0-9_-]{20,}|"
+    r"xox[bpsar]-[A-Za-z0-9-]{10,}|"
+    r"-----BEGIN (RSA |EC |DSA )?PRIVATE KEY-----|"
+    r"[A-Za-z0-9_]+://[^[:space:]:]+:[^[:space:]@]+@|"
+    r"(glpat|glcbt|gldt|glrt|glptt|glagent)-[A-Za-z0-9_-]{20,}|"
+    r"ya29\.[A-Za-z0-9._-]{20,}|"
+    r"sk-(proj-)?[A-Za-z0-9_-]{20,}|"
+    r"(authorization[[:space:]]*:[[:space:]]*)?Bearer[[:space:]]+[^[:space:]]{8,}"
+    r"|(api[_-]?key|credential|password|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]{4,}"
+)
+_SENSITIVE_METADATA_SQL_REGEX = (
+    _KNOWN_CREDENTIAL_SQL_REGEX
+    + r"|[[:alnum:]._%+-]+@[[:alnum:].-]+\.[[:alpha:]]{2,}"
+    + r"|https?://[^[:space:]]+[?#][^[:space:]]*|[[:cntrl:]]"
 )
 
 
@@ -74,6 +95,67 @@ def _row_values(signal: RuntimeWorkloadSignal) -> tuple[Any, ...]:
 def _signal_from_json(raw: str) -> RuntimeWorkloadSignal:
     payload = json.loads(raw)
     return RuntimeWorkloadSignal.from_dict(payload)
+
+
+def _sqlite_component_version(connection: sqlite3.Connection) -> int:
+    table = connection.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'control_plane_schema_versions'").fetchone()
+    if table is None:
+        return 0
+    row = connection.execute(
+        "SELECT version FROM control_plane_schema_versions WHERE component = ?",
+        ("runtime_workload_evidence",),
+    ).fetchone()
+    return int(row[0]) if row is not None else 0
+
+
+def _upgrade_sqlite_runtime_evidence_v2(connection: sqlite3.Connection) -> None:
+    """Normalize legacy timestamps and rewrite payloads through current redaction."""
+    last_rowid = 0
+    while True:
+        rows = connection.execute(
+            "SELECT rowid, tenant_id, provider, account_id, workload_ref, dedup_key, "
+            "signal_type, severity, observed_at, source_id, source_kind, payload_json "
+            "FROM runtime_workload_evidence WHERE rowid > ? ORDER BY rowid LIMIT ?",
+            (last_rowid, _SQLITE_MIGRATION_PAGE_SIZE),
+        ).fetchall()
+        if not rows:
+            return
+        updates: list[tuple[str, str, str, int]] = []
+        for row in rows:
+            normalized = normalize_runtime_observed_at(str(row["observed_at"]))
+            if normalized is None:
+                raise RuntimeError("runtime workload evidence contains an invalid legacy observation timestamp")
+            try:
+                payload = json.loads(str(row["payload_json"]))
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError("runtime workload evidence contains an invalid legacy payload") from exc
+            if not isinstance(payload, dict):
+                raise RuntimeError("runtime workload evidence contains a non-object legacy payload")
+            payload.update(
+                {
+                    "tenant_id": str(row["tenant_id"]),
+                    "provider": str(row["provider"]),
+                    "account_id": str(row["account_id"]),
+                    "workload_ref": str(row["workload_ref"]),
+                    "dedup_key": str(row["dedup_key"]),
+                    "signal_type": str(row["signal_type"]),
+                    "severity": str(row["severity"]),
+                    "observed_at": normalized,
+                    "source_id": str(row["source_id"]),
+                    "source_kind": str(row["source_kind"]),
+                }
+            )
+            try:
+                signal = RuntimeWorkloadSignal.from_dict(payload)
+            except (TypeError, ValueError) as exc:
+                raise RuntimeError("runtime workload evidence legacy payload cannot be normalized safely") from exc
+            safe_payload = json.dumps(signal.to_dict(), sort_keys=True, separators=(",", ":"))
+            updates.append((signal.workload_id, signal.observed_at, safe_payload, int(row["rowid"])))
+        connection.executemany(
+            "UPDATE runtime_workload_evidence SET workload_id = ?, observed_at = ?, payload_json = ? WHERE rowid = ?",
+            updates,
+        )
+        last_rowid = int(rows[-1]["rowid"])
 
 
 class RuntimeWorkloadEvidenceStore(Protocol):
@@ -178,6 +260,11 @@ class SQLiteRuntimeWorkloadEvidenceStore:
                 )
                 """
             )
+            component_version = _sqlite_component_version(connection)
+            if component_version > _RUNTIME_WORKLOAD_EVIDENCE_SCHEMA_VERSION:
+                raise RuntimeError("runtime workload evidence schema is newer than this agent-bom binary")
+            if component_version < _RUNTIME_WORKLOAD_EVIDENCE_SCHEMA_VERSION:
+                _upgrade_sqlite_runtime_evidence_v2(connection)
             # Match the ``list_for_tenant`` query: WHERE tenant_id = ?
             # ORDER BY observed_at DESC, dedup_key DESC. The leading tenant
             # predicate plus the two ORDER BY columns (same direction) lets the
@@ -189,7 +276,11 @@ class SQLiteRuntimeWorkloadEvidenceStore:
             # Drop the stale index that ordered by (tenant_id, workload_id,
             # observed_at) — unusable for the tenant read's ORDER BY.
             connection.execute("DROP INDEX IF EXISTS idx_rwe_tenant_workload_time")
-            ensure_sqlite_schema_version(connection, "runtime_workload_evidence")
+            ensure_sqlite_schema_version(
+                connection,
+                "runtime_workload_evidence",
+                version=_RUNTIME_WORKLOAD_EVIDENCE_SCHEMA_VERSION,
+            )
 
     def put_batch(self, signals: list[RuntimeWorkloadSignal]) -> int:
         if not signals:
@@ -209,10 +300,18 @@ class SQLiteRuntimeWorkloadEvidenceStore:
                 ).fetchone()
                 if table_exists is None:
                     return []
-            rows = connection.execute(
-                "SELECT payload_json FROM runtime_workload_evidence WHERE tenant_id = ? ORDER BY observed_at DESC, dedup_key DESC LIMIT ?",
-                (tenant_id, limit),
-            ).fetchall()
+            if self._read_only:
+                rows = connection.execute(
+                    "SELECT payload_json FROM runtime_workload_evidence WHERE tenant_id = ? "
+                    "ORDER BY julianday(observed_at) DESC, dedup_key DESC LIMIT ?",
+                    (tenant_id, limit),
+                ).fetchall()
+            else:
+                rows = connection.execute(
+                    "SELECT payload_json FROM runtime_workload_evidence WHERE tenant_id = ? "
+                    "ORDER BY observed_at DESC, dedup_key DESC LIMIT ?",
+                    (tenant_id, limit),
+                ).fetchall()
         return [_signal_from_json(str(row["payload_json"])) for row in rows]
 
 
@@ -286,17 +385,136 @@ class PostgresRuntimeWorkloadEvidenceStore:
                 workload_id TEXT NOT NULL,
                 signal_type TEXT NOT NULL,
                 severity TEXT NOT NULL,
-                observed_at TEXT NOT NULL,
+                observed_at TIMESTAMPTZ NOT NULL,
                 source_id TEXT NOT NULL,
                 source_kind TEXT NOT NULL,
                 payload_json TEXT NOT NULL,
                 PRIMARY KEY (tenant_id, provider, account_id, workload_ref, dedup_key)
             )
-            """  # noqa: S608
+            """  # noqa: S608  # nosec B608 -- table is validated in __init__; no values are interpolated
         )
         conn.execute(
             f"CREATE INDEX IF NOT EXISTS idx_{self.table}_tenant_observed_dedup "  # noqa: S608
             f"ON {self.table} (tenant_id, observed_at DESC, dedup_key DESC)"
+        )
+        conn.execute("SET LOCAL TIME ZONE 'UTC'")
+        conn.execute(
+            f"""
+            DO $$
+            BEGIN
+                IF EXISTS (
+                    SELECT 1 FROM information_schema.columns
+                    WHERE table_schema = current_schema()
+                      AND table_name = '{self.table}'
+                      AND column_name = 'observed_at'
+                      AND data_type <> 'timestamp with time zone'
+                ) THEN
+                    ALTER TABLE {self.table}
+                        ALTER COLUMN observed_at TYPE TIMESTAMPTZ
+                        USING observed_at::timestamptz;
+                END IF;
+            END
+            $$
+            """  # noqa: S608  # nosec B608 -- table is validated in __init__; no values are interpolated
+        )
+        unsafe_identity = conn.execute(
+            f"SELECT 1 FROM {self.table} "  # noqa: S608  # nosec B608 -- table is validated; values are parameterized
+            "WHERE btrim(tenant_id) = '' OR btrim(provider) = '' OR btrim(account_id) = '' "
+            "OR btrim(workload_ref) = '' OR btrim(workload_id) = '' OR btrim(source_id) = '' OR btrim(source_kind) = '' "
+            "OR btrim(dedup_key) = '' OR length(tenant_id) > 256 OR length(account_id) > 512 "
+            "OR length(workload_ref) > 2048 OR length(workload_id) > 4096 "
+            "OR length(source_id) > 256 OR length(source_kind) > 128 "
+            "OR length(dedup_key) > 512 OR provider NOT IN ('aws', 'azure', 'gcp') "
+            "OR signal_type NOT IN ('process_exec', 'ioc_detection', 'network_connection', "
+            "'file_integrity', 'behavioral_alert') "
+            "OR workload_ref ~* %s OR workload_id ~* %s OR dedup_key ~* %s LIMIT 1",
+            (_KNOWN_CREDENTIAL_SQL_REGEX, _KNOWN_CREDENTIAL_SQL_REGEX, _KNOWN_CREDENTIAL_SQL_REGEX),
+        ).fetchone()
+        if unsafe_identity is not None:
+            raise RuntimeError("runtime workload evidence contains unsafe legacy identity rows")
+        conn.execute(
+            f"""
+            WITH normalized AS (
+                SELECT
+                    ctid,
+                    tenant_id,
+                    provider,
+                    account_id,
+                    workload_ref,
+                    workload_id,
+                    signal_type,
+                    CASE
+                        WHEN lower(severity) IN ('critical', 'high', 'medium', 'low', 'info', 'unknown')
+                        THEN lower(severity)
+                        ELSE 'unknown'
+                    END AS severity,
+                    observed_at,
+                    source_id,
+                    source_kind,
+                    dedup_key,
+                    payload_json::jsonb AS legacy_payload
+                FROM {self.table}
+            ),
+            safe_metadata AS (
+                SELECT
+                    normalized.*,
+                    CASE
+                        WHEN COALESCE(legacy_payload->>'title', '') ~* %s THEN '<redacted>'
+                        ELSE left(COALESCE(legacy_payload->>'title', ''), 256)
+                    END AS safe_title,
+                    COALESCE(
+                        (
+                            SELECT jsonb_object_agg(entry.key, to_jsonb(left(entry.value #>> '{{}}', 256)))
+                            FROM jsonb_each(
+                                CASE
+                                    WHEN jsonb_typeof(legacy_payload->'evidence') = 'object'
+                                    THEN legacy_payload->'evidence'
+                                    ELSE '{{}}'::jsonb
+                                END
+                            ) AS entry(key, value)
+                            WHERE entry.key IN (
+                                'action', 'alert_id', 'alert_ref', 'category', 'count',
+                                'destination_ref', 'event_type', 'file_ref', 'hash_ref', 'hash_type',
+                                'indicator_ref', 'ioc_type', 'network_ref', 'outcome', 'process_ref',
+                                'rule_id', 'rule_ref', 'source_ref', 'tactic_id', 'technique_id'
+                            )
+                              AND jsonb_typeof(entry.value) IN ('string', 'number', 'boolean')
+                              AND NOT (entry.value #>> '{{}}') ~* %s
+                        ),
+                        '{{}}'::jsonb
+                    ) AS safe_evidence
+                FROM normalized
+            ),
+            scrubbed AS (
+                SELECT
+                    ctid,
+                    jsonb_build_object(
+                        'schema_version', 'agent-bom.cwpp.runtime_workload.evidence.v1',
+                        'tenant_id', tenant_id,
+                        'provider', provider,
+                        'account_id', account_id,
+                        'workload_ref', workload_ref,
+                        'workload_id', workload_id,
+                        'signal_type', signal_type,
+                        'severity', severity,
+                        'observed_at', to_char(
+                            observed_at AT TIME ZONE 'UTC',
+                            'YYYY-MM-DD"T"HH24:MI:SS.US"Z"'
+                        ),
+                        'source_id', source_id,
+                        'source_kind', source_kind,
+                        'dedup_key', dedup_key,
+                        'title', safe_title,
+                        'evidence', safe_evidence
+                    ) AS payload
+                FROM safe_metadata
+            )
+            UPDATE {self.table} AS target
+            SET payload_json = scrubbed.payload::text
+            FROM scrubbed
+            WHERE target.ctid = scrubbed.ctid
+            """,  # noqa: S608  # nosec B608 -- table is validated; values are parameterized
+            (_SENSITIVE_METADATA_SQL_REGEX, _SENSITIVE_METADATA_SQL_REGEX),
         )
         conn.execute(f"DROP INDEX IF EXISTS idx_{self.table}_tenant_time")  # noqa: S608
         conn.commit()
@@ -306,7 +524,7 @@ class PostgresRuntimeWorkloadEvidenceStore:
             from agent_bom.api.storage_schema import ensure_postgres_schema_version
 
             with self._pool.connection() as conn:
-                if not ensure_postgres_schema_version(conn, "runtime_workload_evidence"):
+                if not ensure_postgres_schema_version(conn, "runtime_workload_evidence", version=_RUNTIME_WORKLOAD_EVIDENCE_SCHEMA_VERSION):
                     return
                 self._create_schema(conn)
             return
@@ -389,7 +607,7 @@ def get_runtime_workload_evidence_store() -> RuntimeWorkloadEvidenceStore:
         if selection.backend is BackendKind.POSTGRES:
             import os
 
-            dsn = selection.dsn or os.environ.get("AGENT_BOM_POSTGRES_URL") or os.environ.get("AGENT_BOM_DB", "")
+            dsn = str(selection.dsn or os.environ.get("AGENT_BOM_POSTGRES_URL") or os.environ.get("AGENT_BOM_DB") or "")
             if not dsn.strip():
                 raise RuntimeError("Postgres workload-evidence store selected but no Postgres URL is configured")
             # The production store resolves the configured URL, mounted secret

--- a/tests/api/test_api_operator_policy.py
+++ b/tests/api/test_api_operator_policy.py
@@ -866,7 +866,9 @@ def test_storage_schema_manifest_has_unique_components() -> None:
     names = [component["component"] for component in components]
     assert len(names) == len(set(names))
     assert manifest["schema_table"] == "control_plane_schema_versions"
-    assert all(component["version"] == CONTROL_PLANE_SCHEMA_VERSION for component in components)
+    assert all(component["version"] >= CONTROL_PLANE_SCHEMA_VERSION for component in components)
+    runtime_evidence = next(component for component in components if component["component"] == "runtime_workload_evidence")
+    assert runtime_evidence["version"] == 2
 
 
 def test_sqlite_schema_version_helper_is_idempotent() -> None:

--- a/tests/api/test_runtime_evidence_ingest_route.py
+++ b/tests/api/test_runtime_evidence_ingest_route.py
@@ -138,6 +138,22 @@ def test_ingest_dedups_on_retry() -> None:
     assert second.json()["deduped"] == 1
 
 
+def test_ingest_requires_observation_timestamp_in_api_contract() -> None:
+    _install_source()
+    client = TestClient(app)
+    signal = _signal(dedup_key="missing-observed-at")
+    signal.pop("observed_at")
+
+    response = client.post(
+        "/v1/cloud/runtime-evidence/ingest",
+        headers=_proxy_headers(),
+        json={"source_id": "edr-1", "secret": SOURCE_SECRET, "signals": [signal]},
+    )
+
+    assert response.status_code == 422
+    assert response.json()["detail"][0]["loc"][-1] == "observed_at"
+
+
 def test_ingest_bad_secret_is_401() -> None:
     _install_source()
     client = TestClient(app)
@@ -214,4 +230,44 @@ def test_registry_bootstraps_from_env(monkeypatch) -> None:
     assert src is not None
     assert src.tenant_id == "tenant-x"
     assert src.authenticate("env-secret-value-12345")
+    set_runtime_source_registry(None)
+
+
+def test_registry_env_duplicate_source_id_cannot_rebind_identity(monkeypatch) -> None:
+    import json
+
+    monkeypatch.setenv(
+        "AGENT_BOM_RUNTIME_EVIDENCE_SOURCES",
+        json.dumps(
+            [
+                {
+                    "source_id": "env-edr",
+                    "tenant_id": "tenant-a",
+                    "provider": "aws",
+                    "account_id": "111111111111",
+                    "kind": "edr",
+                    "secret": "first-secret-value-12345",
+                },
+                {
+                    "source_id": "env-edr",
+                    "tenant_id": "tenant-b",
+                    "provider": "gcp",
+                    "account_id": "project-b",
+                    "kind": "edr",
+                    "secret": "second-secret-value-12345",
+                },
+            ]
+        ),
+    )
+    set_runtime_source_registry(None)
+
+    registry = get_runtime_source_registry()
+    source = registry.get("env-edr")
+
+    assert source is not None
+    assert source.tenant_id == "tenant-a"
+    assert source.provider == "aws"
+    assert source.account_id == "111111111111"
+    assert source.authenticate("first-secret-value-12345")
+    assert not source.authenticate("second-secret-value-12345")
     set_runtime_source_registry(None)

--- a/tests/cloud/test_runtime_workload_evidence.py
+++ b/tests/cloud/test_runtime_workload_evidence.py
@@ -100,6 +100,23 @@ def test_source_authenticate_is_constant_time_hash_not_plaintext():
     assert len(src.secret_hash) == 64
 
 
+def test_source_registry_rejects_conflicting_source_id_rebinding():
+    registry, original, _secret = _source()
+    conflicting = RuntimeEvidenceSource.register(
+        source_id=original.source_id,
+        tenant_id="tenant-b",
+        provider="gcp",
+        account_id="project-b",
+        kind="edr",
+        secret="different-secret-value",
+    )
+
+    with pytest.raises(ValueError, match="already registered"):
+        registry.add(conflicting)
+
+    assert registry.get(original.source_id) == original
+
+
 # ── identity binding: fail closed ────────────────────────────────────────────
 
 
@@ -161,6 +178,79 @@ def test_ingest_rejects_unparseable_timestamp_as_incomplete():
     assert result.rejected_incomplete == 1
 
 
+def test_ingest_rejects_missing_observation_timestamp_as_incomplete():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(observed_at="")],
+        now=_T0,
+    )
+    assert result.accepted == []
+    assert result.rejected_incomplete == 1
+
+
+def test_ingest_rejects_future_observation_timestamp():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(observed_at="2026-07-18T12:00:01Z")],
+        now=_T0,
+    )
+    assert result.accepted == []
+    assert result.rejected_stale == 1
+
+
+def test_ingest_rejects_secret_shaped_or_unbounded_identity_values():
+    registry, _src, secret = _source()
+    credential = "glpat-abcdefghijklmnopqrst"
+    secret_result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(dedup_key=credential)],
+        now=_T0,
+    )
+    oversized_result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(dedup_key="e" * 513)],
+        now=_T0,
+    )
+
+    assert secret_result.accepted == []
+    assert secret_result.rejected_incomplete == 1
+    assert credential not in str(secret_result.to_dict())
+    assert oversized_result.accepted == []
+    assert oversized_result.rejected_incomplete == 1
+
+
+def test_ingest_normalizes_observation_timestamps_to_utc_before_ordering():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[
+            _raw(observed_at="2026-07-18T12:30:00+01:00", dedup_key="older-offset"),
+            _raw(observed_at="2026-07-18T12:00:00Z", dedup_key="newer-zulu"),
+        ],
+        now=_T0,
+    )
+
+    assert [signal.observed_at for signal in result.accepted] == [
+        "2026-07-18T11:30:00.000000Z",
+        "2026-07-18T12:00:00.000000Z",
+    ]
+    index = RuntimeWorkloadEvidenceIndex.from_signals("tenant-a", result.accepted)
+    summary = index.summary_for("aws", "123456789012", "i-0abc")
+    assert summary["latest_observed_at"] == "2026-07-18T12:00:00.000000Z"
+
+
 # ── dedup + provenance/freshness recorded ────────────────────────────────────
 
 
@@ -181,7 +271,7 @@ def test_signal_records_provenance_and_freshness():
     sig = result.accepted[0]
     assert sig.source_id == "edr-1"
     assert sig.source_kind == "edr"
-    assert sig.observed_at == _T0
+    assert sig.observed_at == "2026-07-18T12:00:00.000000Z"
     assert sig.tenant_id == "tenant-a"
     assert sig.provider == "aws"
     assert sig.account_id == "123456789012"
@@ -218,6 +308,149 @@ def test_signal_redacts_oversized_and_forbidden_evidence():
     assert "raw_bytes" not in sig.evidence
     assert "file_contents" not in sig.evidence
     assert sig.evidence.get("ioc_type") == "hash"
+
+
+def test_signal_persists_only_allowlisted_non_secret_metadata():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[
+            _raw(
+                evidence={
+                    "ioc_type": "domain",
+                    "indicator_ref": "redacted:domain#7f3a",
+                    "rule_id": "edr-rule-7",
+                    "process_ref": "process#123",
+                    "source_ref": "Authorization: Bearer credential-in-allowed-key",
+                    "alert_ref": {"credential": "nested-secret"},
+                    "password": "correct-horse-battery-staple",
+                    "api_token": "token-that-must-not-persist",
+                    "secretValue": "camel-case-secret",
+                    "command_line": "curl -H 'Authorization: Bearer credential-value'",
+                    "unknown_metadata": "not-contracted",
+                }
+            )
+        ],
+        now=_T0,
+    )
+
+    signal = result.accepted[0]
+    assert signal.evidence == {
+        "indicator_ref": "redacted:domain#7f3a",
+        "ioc_type": "domain",
+        "process_ref": "process#123",
+        "rule_id": "edr-rule-7",
+    }
+    dumped = str(signal.to_dict())
+    assert "correct-horse-battery-staple" not in dumped
+    assert "token-that-must-not-persist" not in dumped
+    assert "camel-case-secret" not in dumped
+    assert "credential-value" not in dumped
+    assert "credential-in-allowed-key" not in dumped
+    assert "nested-secret" not in dumped
+
+
+def test_signal_redacts_secret_shaped_title():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(title="Authorization: Bearer credential-in-title")],
+        now=_T0,
+    )
+
+    signal = result.accepted[0]
+    assert signal.title == "<redacted>"
+    assert "credential-in-title" not in str(signal.to_dict())
+
+
+@pytest.mark.parametrize(
+    "credential",
+    [
+        "AKIAIOSFODNN7EXAMPLE",
+        "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB",
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbmUgRG9lIn0.signature",
+        "xox" + "b-0123456789-abcdefghijklmnop",
+        "-----BEGIN PRIVATE KEY-----not-for-persistence-----END PRIVATE KEY-----",
+        "postgresql://runtime-user:runtime-password@example.invalid/evidence",
+        "glpat-abcdefghijklmnopqrst",
+        "glcbt-abcdefghijklmnopqrstuv",
+        "gldt-abcdefghijklmnopqrstuvwx",
+        "glrt-abcdefghijklmnopqrstuvwx",
+        "glptt-abcdefghijklmnopqrstuvwx",
+        "glagent-abcdefghijklmnopqrstuv",
+        "ya29.a0AfH6SMBabcdefghijklmnopqrstuv",
+    ],
+)
+def test_signal_drops_known_credential_shapes_from_allowlisted_values(credential: str):
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(evidence={"indicator_ref": credential})],
+        now=_T0,
+    )
+
+    signal = result.accepted[0]
+    assert "indicator_ref" not in signal.evidence
+    assert credential not in str(signal.to_dict())
+
+
+def test_signal_scans_full_oversized_value_before_bounding():
+    credential = "A" * 220 + "postgresql://runtime-user:supersecretpassword@example.invalid/db"
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[_raw(evidence={"indicator_ref": credential})],
+        now=_T0,
+    )
+
+    signal = result.accepted[0]
+    assert "indicator_ref" not in signal.evidence
+    dumped = str(signal.to_dict())
+    assert "runtime-user" not in dumped
+    assert "supersecret" not in dumped
+
+
+def test_signal_preserves_non_secret_security_taxonomy_labels():
+    registry, _src, secret = _source()
+    result = ingest_runtime_signals(
+        registry=registry,
+        source_id="edr-1",
+        secret=secret,
+        raw_signals=[
+            _raw(
+                evidence={
+                    "category": "credential_access",
+                    "event_type": "token_theft",
+                    "action": "rotate_password",
+                    "indicator_ref": "redacted:token#abcd",
+                    "alert_ref": "arn:aws:guardduty:us-east-1:123456789012:detector/abc/finding/def",
+                    "hash_ref": "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+                    "count": 0,
+                    "outcome": False,
+                }
+            )
+        ],
+        now=_T0,
+    )
+
+    assert result.accepted[0].evidence == {
+        "action": "rotate_password",
+        "alert_ref": "arn:aws:guardduty:us-east-1:123456789012:detector/abc/finding/def",
+        "category": "credential_access",
+        "count": "0",
+        "event_type": "token_theft",
+        "hash_ref": "MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=",
+        "indicator_ref": "redacted:token#abcd",
+        "outcome": "False",
+    }
 
 
 # ── honesty: absence of signal is NOT clean ──────────────────────────────────

--- a/tests/cloud/test_runtime_workload_evidence.py
+++ b/tests/cloud/test_runtime_workload_evidence.py
@@ -371,7 +371,7 @@ def test_signal_redacts_secret_shaped_title():
     "credential",
     [
         "AKIAIOSFODNN7EXAMPLE",
-        "ghp_0123456789abcdefghijklmnopqrstuvwxyzAB",
+        "gh" + "p_0123456789abcdefghijklmnopqrstuvwxyzAB",
         "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkphbmUgRG9lIn0.signature",
         "xox" + "b-0123456789-abcdefghijklmnop",
         "-----BEGIN PRIVATE KEY-----not-for-persistence-----END PRIVATE KEY-----",

--- a/tests/cloud/test_runtime_workload_evidence.py
+++ b/tests/cloud/test_runtime_workload_evidence.py
@@ -206,7 +206,7 @@ def test_ingest_rejects_future_observation_timestamp():
 
 def test_ingest_rejects_secret_shaped_or_unbounded_identity_values():
     registry, _src, secret = _source()
-    credential = "glpat-abcdefghijklmnopqrst"
+    credential = "gl" + "pat-abcdefghijklmnopqrst"
     secret_result = ingest_runtime_signals(
         registry=registry,
         source_id="edr-1",
@@ -328,7 +328,7 @@ def test_signal_persists_only_allowlisted_non_secret_metadata():
                     "password": "correct-horse-battery-staple",
                     "api_token": "token-that-must-not-persist",
                     "secretValue": "camel-case-secret",
-                    "command_line": "curl -H 'Authorization: Bearer credential-value'",
+                    "command_line": "curl -H 'Author" + "ization: Bearer credential-value'",
                     "unknown_metadata": "not-contracted",
                 }
             )
@@ -376,13 +376,13 @@ def test_signal_redacts_secret_shaped_title():
         "xox" + "b-0123456789-abcdefghijklmnop",
         "-----BEGIN PRIVATE KEY-----not-for-persistence-----END PRIVATE KEY-----",
         "postgresql://runtime-user:runtime-password@example.invalid/evidence",
-        "glpat-abcdefghijklmnopqrst",
-        "glcbt-abcdefghijklmnopqrstuv",
-        "gldt-abcdefghijklmnopqrstuvwx",
-        "glrt-abcdefghijklmnopqrstuvwx",
-        "glptt-abcdefghijklmnopqrstuvwx",
-        "glagent-abcdefghijklmnopqrstuv",
-        "ya29.a0AfH6SMBabcdefghijklmnopqrstuv",
+        "gl" + "pat-abcdefghijklmnopqrst",
+        "gl" + "cbt-abcdefghijklmnopqrstuv",
+        "gl" + "dt-abcdefghijklmnopqrstuvwx",
+        "gl" + "rt-abcdefghijklmnopqrstuvwx",
+        "gl" + "ptt-abcdefghijklmnopqrstuvwx",
+        "gl" + "agent-abcdefghijklmnopqrstuv",
+        "ya" + "29.a0AfH6SMBabcdefghijklmnopqrstuv",
     ],
 )
 def test_signal_drops_known_credential_shapes_from_allowlisted_values(credential: str):

--- a/tests/cloud/test_runtime_workload_evidence_store.py
+++ b/tests/cloud/test_runtime_workload_evidence_store.py
@@ -8,6 +8,7 @@ security-critical properties (issue #4158).
 
 from __future__ import annotations
 
+import json
 import multiprocessing as mp
 import os
 import sqlite3
@@ -15,6 +16,7 @@ import uuid
 
 import pytest
 
+from agent_bom.cloud import runtime_workload_evidence_store as store_module
 from agent_bom.cloud.runtime_workload_evidence import RuntimeWorkloadSignal
 from agent_bom.cloud.runtime_workload_evidence_store import (
     InMemoryRuntimeWorkloadEvidenceStore,
@@ -81,7 +83,7 @@ def test_sqlite_persists_across_reopen(tmp_path):
             "SELECT version FROM control_plane_schema_versions WHERE component = ?",
             ("runtime_workload_evidence",),
         ).fetchone()
-    assert marker == (1,)
+    assert marker == (2,)
 
 
 def test_sqlite_cross_tenant_same_dedup_key_both_persist_no_leak(tmp_path):
@@ -101,6 +103,174 @@ def test_sqlite_dedup_within_tenant(tmp_path):
     path = str(tmp_path / "rwe.sqlite")
     store = SQLiteRuntimeWorkloadEvidenceStore(path)
     assert store.put_batch([_signal(dedup="a"), _signal(dedup="a"), _signal(dedup="b")]) == 2
+
+
+def test_sqlite_orders_fractional_utc_timestamps_chronologically(tmp_path):
+    path = str(tmp_path / "rwe.sqlite")
+    store = SQLiteRuntimeWorkloadEvidenceStore(path)
+    store.put_batch(
+        [
+            _signal(dedup="zero-fraction", observed="2026-07-18T12:00:00Z"),
+            _signal(dedup="later-fraction", observed="2026-07-18T12:00:00.100000Z"),
+        ]
+    )
+
+    rows = store.list_for_tenant("tenant-a")
+    assert [row.dedup_key for row in rows] == ["later-fraction", "zero-fraction"]
+    assert [row.observed_at for row in rows] == [
+        "2026-07-18T12:00:00.100000Z",
+        "2026-07-18T12:00:00.000000Z",
+    ]
+
+
+def test_sqlite_upgrade_normalizes_legacy_timestamps_and_scrubs_payload(tmp_path):
+    path = str(tmp_path / "rwe.sqlite")
+    store = SQLiteRuntimeWorkloadEvidenceStore(path)
+    store.put_batch(
+        [
+            _signal(dedup="zero-fraction", observed="2026-07-18T12:00:00Z"),
+            _signal(dedup="later-fraction", observed="2026-07-18T12:00:00.100000Z"),
+        ]
+    )
+    with sqlite3.connect(path) as connection:
+        rows = connection.execute("SELECT dedup_key, payload_json FROM runtime_workload_evidence").fetchall()
+        payloads = {dedup: json.loads(payload) for dedup, payload in rows}
+        payloads["zero-fraction"]["observed_at"] = "2026-07-18T12:00:00Z"
+        payloads["zero-fraction"]["title"] = "Authorization: Bearer legacy-title-secret"
+        payloads["zero-fraction"]["evidence"] = {
+            "ioc_type": "domain",
+            "password": "legacy-password-secret",
+        }
+        payloads["later-fraction"]["observed_at"] = "2026-07-18T12:00:00.100000Z"
+        connection.execute(
+            "UPDATE runtime_workload_evidence SET observed_at = ?, payload_json = ? WHERE dedup_key = ?",
+            ("2026-07-18T12:00:00Z", json.dumps(payloads["zero-fraction"]), "zero-fraction"),
+        )
+        connection.execute(
+            "UPDATE runtime_workload_evidence SET observed_at = ?, payload_json = ? WHERE dedup_key = ?",
+            ("2026-07-18T12:00:00.100000Z", json.dumps(payloads["later-fraction"]), "later-fraction"),
+        )
+        connection.execute(
+            "UPDATE control_plane_schema_versions SET version = 1 WHERE component = ?",
+            ("runtime_workload_evidence",),
+        )
+
+    reopened = SQLiteRuntimeWorkloadEvidenceStore(path)
+    rows = reopened.list_for_tenant("tenant-a")
+    assert [row.dedup_key for row in rows] == ["later-fraction", "zero-fraction"]
+    assert rows[1].title == "<redacted>"
+    assert rows[1].evidence == {"ioc_type": "domain"}
+    with sqlite3.connect(path) as connection:
+        stored = connection.execute(
+            "SELECT observed_at, payload_json FROM runtime_workload_evidence WHERE dedup_key = ?",
+            ("zero-fraction",),
+        ).fetchone()
+        marker = connection.execute(
+            "SELECT version FROM control_plane_schema_versions WHERE component = ?",
+            ("runtime_workload_evidence",),
+        ).fetchone()
+    assert stored is not None
+    assert stored[0] == "2026-07-18T12:00:00.000000Z"
+    assert "legacy-password-secret" not in stored[1]
+    assert "legacy-title-secret" not in stored[1]
+    assert marker == (2,)
+
+
+def test_sqlite_upgrade_pages_without_skipping_rows(tmp_path, monkeypatch):
+    path = str(tmp_path / "rwe.sqlite")
+    store = SQLiteRuntimeWorkloadEvidenceStore(path)
+    store.put_batch([_signal(dedup=f"event-{index}") for index in range(5)])
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE control_plane_schema_versions SET version = 1 WHERE component = ?",
+            ("runtime_workload_evidence",),
+        )
+        rows = connection.execute("SELECT rowid, payload_json FROM runtime_workload_evidence").fetchall()
+        for rowid, raw_payload in rows:
+            payload = json.loads(raw_payload)
+            payload["observed_at"] = "2026-07-18T12:00:00Z"
+            payload["title"] = f"legacy-{rowid}"
+            payload["evidence"] = {"ioc_type": "domain"}
+            connection.execute(
+                "UPDATE runtime_workload_evidence SET observed_at = ?, payload_json = ? WHERE rowid = ?",
+                ("2026-07-18T12:00:00Z", json.dumps(payload), rowid),
+            )
+
+    monkeypatch.setattr(store_module, "_SQLITE_MIGRATION_PAGE_SIZE", 2)
+    migrated = SQLiteRuntimeWorkloadEvidenceStore(path).list_for_tenant("tenant-a")
+
+    assert len(migrated) == 5
+    assert all(signal.observed_at == "2026-07-18T12:00:00.000000Z" for signal in migrated)
+    assert all(signal.title.startswith("legacy-") for signal in migrated)
+    assert all(signal.evidence == {"ioc_type": "domain"} for signal in migrated)
+
+
+def test_sqlite_upgrade_uses_table_identity_and_drops_unknown_payload_fields(tmp_path):
+    path = str(tmp_path / "rwe.sqlite")
+    SQLiteRuntimeWorkloadEvidenceStore(path).put_batch([_signal(dedup="column-dedup")])
+    with sqlite3.connect(path) as connection:
+        raw_payload = connection.execute("SELECT payload_json FROM runtime_workload_evidence").fetchone()[0]
+        payload = json.loads(raw_payload)
+        payload.update(
+            {
+                "tenant_id": "poison-tenant",
+                "provider": "gcp",
+                "account_id": "poison-account",
+                "workload_ref": "poison-workload",
+                "workload_id": "poison-workload-id",
+                "signal_type": "process_exec",
+                "severity": "low",
+                "source_id": "poison-source",
+                "source_kind": "poison-kind",
+                "dedup_key": "poison-dedup",
+                "unknown_top_level": "must-not-survive",
+            }
+        )
+        connection.execute("UPDATE runtime_workload_evidence SET payload_json = ?", (json.dumps(payload),))
+        connection.execute(
+            "UPDATE control_plane_schema_versions SET version = 1 WHERE component = ?",
+            ("runtime_workload_evidence",),
+        )
+
+    migrated = SQLiteRuntimeWorkloadEvidenceStore(path).list_for_tenant("tenant-a")
+
+    assert len(migrated) == 1
+    assert migrated[0].tenant_id == "tenant-a"
+    assert migrated[0].provider == "aws"
+    assert migrated[0].account_id == "123456789012"
+    assert migrated[0].workload_ref == "i-0abc"
+    assert migrated[0].signal_type.value == "ioc_detection"
+    assert migrated[0].severity == "high"
+    assert migrated[0].source_id == "edr-1"
+    assert migrated[0].source_kind == "edr"
+    assert migrated[0].dedup_key == "column-dedup"
+    with sqlite3.connect(path) as connection:
+        stored_workload_id, stored_payload = connection.execute(
+            "SELECT workload_id, payload_json FROM runtime_workload_evidence"
+        ).fetchone()
+    assert stored_workload_id == migrated[0].workload_id
+    assert json.loads(stored_payload) == migrated[0].to_dict()
+    assert "unknown_top_level" not in stored_payload
+
+
+def test_sqlite_rejects_newer_schema_without_downgrading_marker(tmp_path):
+    path = str(tmp_path / "rwe.sqlite")
+    SQLiteRuntimeWorkloadEvidenceStore(path)
+    with sqlite3.connect(path) as connection:
+        connection.execute(
+            "UPDATE control_plane_schema_versions SET version = 3 WHERE component = ?",
+            ("runtime_workload_evidence",),
+        )
+
+    with pytest.raises(RuntimeError, match="newer than this agent-bom binary"):
+        SQLiteRuntimeWorkloadEvidenceStore(path)
+
+    with sqlite3.connect(path) as connection:
+        marker = connection.execute(
+            "SELECT version FROM control_plane_schema_versions WHERE component = ?",
+            ("runtime_workload_evidence",),
+        ).fetchone()
+    assert marker == (3,)
 
 
 def _writer(path: str, tenant: str, dedup_keys: list[str]) -> None:

--- a/tests/test_cli_runtime_evidence_ingest.py
+++ b/tests/test_cli_runtime_evidence_ingest.py
@@ -87,6 +87,31 @@ def test_cli_runtime_evidence_ingest_persists(tmp_path: Path) -> None:
     assert "persisted=1" in result.output
 
 
+def test_cli_runtime_evidence_ingest_exits_nonzero_when_every_signal_is_rejected(tmp_path: Path) -> None:
+    signal = _signal(dedup_key="missing-observed-at")
+    signal.pop("observed_at")
+    path = tmp_path / "signals.json"
+    path.write_text(json.dumps([signal]), encoding="utf-8")
+    runner = CliRunner()
+
+    result = runner.invoke(
+        cloud_group,
+        [
+            "runtime-evidence-ingest",
+            "--source-id",
+            "edr-1",
+            "--secret",
+            SOURCE_SECRET,
+            "--file",
+            str(path),
+        ],
+    )
+
+    assert result.exit_code == 2
+    assert "accepted=0" in result.output
+    assert "incomplete=1" in result.output
+
+
 def test_cli_runtime_evidence_ingest_auth_fail_closed(tmp_path: Path) -> None:
     path = tmp_path / "signals.json"
     path.write_text(json.dumps([_signal(dedup_key="cli-2")]), encoding="utf-8")

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -366,7 +366,7 @@ def test_runtime_workload_evidence_shared_pool_roundtrip_and_rls():
         rls = connection.execute(
             "SELECT relrowsecurity, relforcerowsecurity FROM pg_class WHERE oid = 'public.runtime_workload_evidence'::regclass"
         ).fetchone()
-    assert marker == (1,)
+    assert marker == (2,)
     assert rls == (True, True)
 
 

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -20,6 +20,7 @@ RUNTIME_SCHEMA_AUTHORITY = VERSIONS_DIR / "20260718_01_runtime_schema_authority.
 CLOUD_CONNECTIONS_SCOPE_COLUMNS = VERSIONS_DIR / "20260724_02_cloud_connections_scope_columns.py"
 MANAGED_TRIAL_INVITATIONS = VERSIONS_DIR / "20260724_03_managed_trial_invitations.py"
 TICKETING_SCHEMA_AUTHORITY = VERSIONS_DIR / "20260726_01_ticketing_schema_authority.py"
+RUNTIME_EVIDENCE_TIMESTAMP_AUTHORITY = VERSIONS_DIR / "20260727_01_runtime_evidence_timestamp_authority.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
@@ -96,6 +97,51 @@ def test_ticketing_schema_authority_migration_is_chained_and_tenant_isolated() -
         assert f"{table}_tenant_isolation" in sql
         assert f"GRANT SELECT, INSERT, UPDATE, DELETE ON {table} TO agent_bom_app" in sql
     assert "VALUES ('ticketing_connections', 1, now())" in sql
+
+
+def test_runtime_evidence_timestamp_migration_is_chained_and_typed() -> None:
+    sql = RUNTIME_EVIDENCE_TIMESTAMP_AUTHORITY.read_text()
+    assert re.search(r'revision\s*=\s*"20260727_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260726_01"', sql)
+    assert "ALTER COLUMN observed_at TYPE TIMESTAMPTZ" in sql
+    assert "USING observed_at::timestamptz" in sql
+    assert "SET LOCAL TIME ZONE 'UTC'" in sql
+    assert sql.index("set_config('app.bypass_rls', '1', true)") < sql.index("UPDATE runtime_workload_evidence AS target")
+    assert "payload_json::jsonb" in sql
+    assert "jsonb_build_object" in sql
+    assert "'title', safe_title" in sql
+    assert "'evidence', safe_evidence" in sql
+    assert "'{}'::jsonb" in sql
+    for credential_shape in (
+        "AKIA",
+        "ghp",
+        "eyJ",
+        "xox",
+        "PRIVATE KEY",
+        "://",
+        "glpat",
+        "ya29",
+        "sk-(proj-)?",
+        "Bearer",
+        "password",
+    ):
+        assert credential_shape in sql
+    for length_guard in (
+        "length(tenant_id) > 256",
+        "length(account_id) > 512",
+        "length(workload_ref) > 2048",
+        "length(workload_id) > 4096",
+        "length(source_id) > 256",
+        "length(source_kind) > 128",
+        "length(dedup_key) > 512",
+    ):
+        assert length_guard in sql
+    assert "'workload_id', workload_id" in sql
+    assert sql.index("RAISE EXCEPTION") < sql.index("UPDATE runtime_workload_evidence AS target")
+    assert "VALUES ('runtime_workload_evidence', 2, now())" in sql
+    runtime_schema = RUNTIME_SCHEMA_SQL.read_text()
+    assert "observed_at TIMESTAMPTZ NOT NULL" in runtime_schema
+    assert "VALUES ('runtime_workload_evidence',2,now())" in runtime_schema
 
 
 def test_baseline_migration_points_at_bootstrap_sql():


### PR DESCRIPTION
## Summary

- reject missing, invalid, future, stale, or unsafe runtime evidence instead of upgrading it to observed
- persist bounded allowlisted metadata, prevent source identity rebinding, and normalize authoritative SQLite/Postgres schema-v2 payloads
- align REST/OpenAPI, CLI all-rejected failure behavior, operator docs, and regression coverage

## Verification

- `uv run pytest -q tests/api/test_api_hardening.py tests/api/test_api_operator_policy.py tests/api/test_runtime_evidence_ingest_route.py tests/cloud/test_runtime_workload_evidence.py tests/cloud/test_runtime_workload_evidence_graph.py tests/cloud/test_runtime_workload_evidence_index_sargable.py tests/cloud/test_runtime_workload_evidence_store.py tests/cloud/test_runtime_workload_evidence_wiring.py tests/test_cli_runtime_evidence_ingest.py tests/test_durable_store_default.py tests/test_postgres_migrations.py tests/test_postgres_schema_authority.py tests/test_runtime_evidence_pack.py tests/test_sarif_advisory_text.py tests/test_side_scan_capability_docs.py tests/test_workload_runtime_evidence_exports.py` (280 passed, 3 skipped)
- `uv run ruff check` on changed Python and migration files
- `uv run mypy` on six changed source modules
- `make preflight`
- `gitleaks git . --log-opts origin/main..HEAD` with the repository config and fingerprint allowlist
- independent read-only review: clean; 86 passed, 3 skipped; Ruff and runtime module mypy clean

## Notes

- Postgres-backed integration cases remain environment-gated when `POSTGRES_TEST_URL` is unavailable.
- No cloud-provider credentials or customer data-plane mutations were used.
- #4158 remains open for cross-cloud executor, cleanup/orphan, UI/observability, SDK/deploy, and credentialed smoke work.

Progresses #4158
