### PR TITLE
fix(ci): remove privileged untrusted checkout

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -35,7 +35,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.repository.default_branch }}
-          fetch-depth: 1
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Resolve published release
@@ -45,6 +45,9 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RUN_EVENT: ${{ github.event.workflow_run.event }}
+          RUN_REPOSITORY: ${{ github.event.workflow_run.repository.full_name }}
         run: |
           set -euo pipefail
 
@@ -59,6 +62,10 @@ jobs:
               exit 1
             fi
           else
+            if [ "$RUN_EVENT" != "push" ] || [ "$RUN_REPOSITORY" != "$GITHUB_REPOSITORY" ]; then
+              echo "::error::Release workflow must be a same-repository tag push"
+              exit 1
+            fi
             RELEASE_TAG="${HEAD_BRANCH:-}"
             if ! echo "$RELEASE_TAG" | grep -qE '^v[0-9]+\.[0-9]+\.[0-9]+([.-][0-9A-Za-z.-]+)?$'; then
               echo "::error::Successful Release workflow did not report a release tag"
@@ -75,6 +82,12 @@ jobs:
           RELEASE_SHA=$(git rev-list -n 1 "refs/tags/${RELEASE_TAG}")
           if [ "$EVENT_NAME" != "workflow_dispatch" ] && [ "$RELEASE_SHA" != "$HEAD_SHA" ]; then
             echo "::error::Release tag and successful workflow commit do not match"
+            exit 1
+          fi
+          git fetch --no-tags origin \
+            "refs/heads/${DEFAULT_BRANCH}:refs/remotes/origin/${DEFAULT_BRANCH}"
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" "origin/$DEFAULT_BRANCH"; then
+            echo "::error::Published release commit is not reachable from the trusted default branch"
             exit 1
           fi
 
@@ -340,9 +353,10 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          # ClawHub publishes the checked-out integrations/openclaw assets, so
-          # they must come from the exact release commit rather than current main.
-          ref: ${{ needs.release.outputs.release_sha }}
+          # Keep privileged workflow code on the trusted default branch. Exact
+          # release assets are exported as inert regular files below; the
+          # workflow never checks out or executes the release tree.
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
 
       - name: Set up Node.js
@@ -362,6 +376,34 @@ jobs:
           fi
           echo "enabled=true" >> "$GITHUB_OUTPUT"
 
+      - name: Stage exact release ClawHub assets
+        if: steps.clawhub_config.outputs.enabled == 'true'
+        env:
+          RELEASE_SHA: ${{ needs.release.outputs.release_sha }}
+          CLAWHUB_RELEASE_ROOT: ${{ runner.temp }}/clawhub-release
+        run: |
+          set -euo pipefail
+          git fetch --no-tags --depth=1 origin "$RELEASE_SHA"
+
+          # A privileged workflow must not check out or execute a data-derived
+          # release tree. Export only the curated OpenClaw subtree, and reject
+          # symlinks, submodules, and executable files before extraction.
+          INVALID_ENTRIES=$(git ls-tree -r "$RELEASE_SHA" -- integrations/openclaw |
+            awk '$1 != "100644" { print }')
+          if [ -n "$INVALID_ENTRIES" ]; then
+            echo "::error::Only regular, non-executable release assets may be published to ClawHub"
+            printf '%s\n' "$INVALID_ENTRIES"
+            exit 1
+          fi
+
+          mkdir -p "$CLAWHUB_RELEASE_ROOT"
+          git archive --format=tar "$RELEASE_SHA" -- integrations/openclaw |
+            tar -xf - --directory "$CLAWHUB_RELEASE_ROOT" --no-same-owner --no-same-permissions
+          if find "$CLAWHUB_RELEASE_ROOT" -type l -print -quit | grep -q .; then
+            echo "::error::ClawHub release staging produced a symbolic link"
+            exit 1
+          fi
+
       - name: Install ClawHub CLI
         if: steps.clawhub_config.outputs.enabled == 'true'
         run: |
@@ -377,6 +419,7 @@ jobs:
         env:
           CLAWHUB_TOKEN: ${{ secrets.CLAWHUB_TOKEN }}
           VERSION: ${{ needs.release.outputs.version }}
+          CLAWHUB_RELEASE_ROOT: ${{ runner.temp }}/clawhub-release
         run: |
           echo "Publishing agent-bom v${VERSION} to ClawHub..."
           clawhub login --token "$CLAWHUB_TOKEN" --no-browser
@@ -433,13 +476,13 @@ jobs:
 
           # Curated, focused skills only. Do not publish the oversized omnibus root
           # skill to ClawHub — keep the marketplace surface small and guardrailed.
-          _publish_skill "integrations/openclaw/scan"       "agent-bom-scan"       true  "agent-bom scan"
-          _publish_skill "integrations/openclaw/compliance" "agent-bom-compliance" false "agent-bom compliance"
-          _publish_skill "integrations/openclaw/registry"   "agent-bom-registry"   false "agent-bom registry"
-          _publish_skill "integrations/openclaw/runtime"    "agent-bom-runtime"    false "agent-bom runtime"
-          _publish_skill "integrations/openclaw/discover-aws" "agent-bom-discover-aws" false "agent-bom discover aws"
-          _publish_skill "integrations/openclaw/discover-azure" "agent-bom-discover-azure" false "agent-bom discover azure"
-          _publish_skill "integrations/openclaw/discover-gcp" "agent-bom-discover-gcp" false "agent-bom discover gcp"
-          _publish_skill "integrations/openclaw/discover-snowflake" "agent-bom-discover-snowflake" false "agent-bom discover snowflake"
-          _publish_skill "integrations/openclaw/ingest" "agent-bom-ingest" false "agent-bom ingest"
-          _publish_skill "integrations/openclaw/vulnerability-intel" "agent-bom-vulnerability-intel" false "agent-bom vulnerability intel"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/scan"       "agent-bom-scan"       true  "agent-bom scan"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/compliance" "agent-bom-compliance" false "agent-bom compliance"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/registry"   "agent-bom-registry"   false "agent-bom registry"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/runtime"    "agent-bom-runtime"    false "agent-bom runtime"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/discover-aws" "agent-bom-discover-aws" false "agent-bom discover aws"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/discover-azure" "agent-bom-discover-azure" false "agent-bom discover azure"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/discover-gcp" "agent-bom-discover-gcp" false "agent-bom discover gcp"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/discover-snowflake" "agent-bom-discover-snowflake" false "agent-bom discover snowflake"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/ingest" "agent-bom-ingest" false "agent-bom ingest"
+          _publish_skill "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/vulnerability-intel" "agent-bom-vulnerability-intel" false "agent-bom vulnerability intel"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -591,9 +591,21 @@ def test_publish_registries_workflow_validates_smithery_best_effort_and_curated_
     assert '_publish_skill "integrations/openclaw" "agent-bom"' not in workflow
     assert 'git fetch --no-tags --depth=1 origin "$RELEASE_SHA"' in workflow
     assert 'check_glama_listing.py --verify-manifest --git-ref "${{ needs.release.outputs.release_sha }}"' in workflow
-    assert workflow.count("ref: ${{ needs.release.outputs.release_sha }}") == 1
-    assert workflow.count("ref: ${{ github.event.repository.default_branch }}") == 3
+    # Privileged workflow_run jobs may never check out a data-derived ref. The
+    # ClawHub job stages regular-file assets from the verified release object
+    # without executing or checking out that tree.
+    assert "ref: ${{ needs.release.outputs.release_sha }}" not in workflow
+    assert workflow.count("ref: ${{ github.event.repository.default_branch }}") == 4
     assert workflow.count("persist-credentials: false") == 4
+    assert "Stage exact release ClawHub assets" in workflow
+    assert 'git ls-tree -r "$RELEASE_SHA" -- integrations/openclaw' in workflow
+    assert 'git archive --format=tar "$RELEASE_SHA" -- integrations/openclaw' in workflow
+    assert "Only regular, non-executable release assets may be published to ClawHub" in workflow
+    assert "${CLAWHUB_RELEASE_ROOT}/integrations/openclaw/scan" in workflow
+    assert "RUN_EVENT: ${{ github.event.workflow_run.event }}" in workflow
+    assert "RUN_REPOSITORY: ${{ github.event.workflow_run.repository.full_name }}" in workflow
+    assert 'git merge-base --is-ancestor "$RELEASE_SHA" "origin/$DEFAULT_BRANCH"' in workflow
+    assert "Release workflow must be a same-repository tag push" in workflow
     assert "workflow_run.head_sha || github.ref" not in workflow
     assert "actions: read" in workflow
     assert "jq -n" in workflow
@@ -625,7 +637,8 @@ def test_publish_registries_uses_release_metrics_for_glama_and_clawhub_assets():
     assert 'select(.name == "MCP tools")' in workflow
     assert "EXPECTED_TOOL_COUNT: ${{ needs.release.outputs.tool_count }}" in workflow
     assert '--expected-tool-count "$EXPECTED_TOOL_COUNT"' in workflow
-    assert workflow.count("ref: ${{ needs.release.outputs.release_sha }}") == 1
+    assert "ref: ${{ needs.release.outputs.release_sha }}" not in workflow
+    assert 'git archive --format=tar "$RELEASE_SHA" -- integrations/openclaw' in workflow
 
 
 def test_glama_rebuild_webhook_is_secret_and_missing_secret_is_honest():


### PR DESCRIPTION
## Summary

- require automatic registry publication to originate from a same-repository tag push whose release commit is reachable from the trusted default branch
- keep the privileged ClawHub job checked out on the default branch and export only regular `integrations/openclaw` files from the verified release commit
- reject executable, symlink, and submodule entries before publishing exact-release assets

## Root cause

The privileged `workflow_run` job passed a computed release SHA to `actions/checkout` before using `CLAWHUB_TOKEN`. The release resolver compared the tag SHA with the completed Release workflow SHA, but it did not establish default-branch ancestry and the dynamic checkout remained a CodeQL critical sink.

Addresses CodeQL alert [#1839](https://github.com/msaad00/agent-bom/security/code-scanning/1839).

## Verification

- `uv run --no-cache pytest -q tests/test_deployment.py` — 56 passed
- `make preflight`
- `actionlint .github/workflows/publish-registries.yml`
- `python scripts/lint_release_workflow.py .github/workflows/publish-registries.yml`
- `python scripts/check_workflow_timeouts.py`
- exact `v0.98.2` archive smoke — 18 regular assets exported; no symbolic links
- independent read-only security review — no blockers

## Notes

- No registry publish, cloud credential, or customer data-plane action was performed.
- CodeQL on this PR is the authoritative regression check for the removed untrusted-checkout dataflow.
