### PR TITLE
feat(runtime): add canonical client profile foundation

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260728_01_mcp_profile_binding_authority.py
+++ b/deploy/supabase/postgres/alembic/versions/20260728_01_mcp_profile_binding_authority.py
@@ -1,0 +1,136 @@
+"""Make managed-identity profile bindings migration-owned and unambiguous.
+
+Revision ID: 20260728_01
+Revises: 20260727_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260728_01"
+down_revision = "20260727_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Legacy distribution-only configurations remain deliberately unbound.
+    # New profile-aware writers persist the lookup fields beside the JSON
+    # document so tenant/identity resolution is indexed and enforceable by the
+    # database rather than a capped presentation-list scan.
+    op.execute("ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS identity_id TEXT")
+    op.execute("ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS issuer TEXT NOT NULL DEFAULT ''")
+    op.execute("ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS environment TEXT NOT NULL DEFAULT ''")
+    op.execute("ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS status TEXT")
+    op.execute("ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS revision INTEGER")
+    op.execute("ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS updated_at TEXT")
+    op.execute(
+        """
+        UPDATE mcp_client_configs
+        SET identity_id = COALESCE(identity_id, ''),
+            status = COALESCE(status, CASE WHEN revoked THEN 'revoked' ELSE 'active' END),
+            revision = COALESCE(revision, 1),
+            updated_at = COALESCE(updated_at, created_at)
+        WHERE status IS NULL OR revision IS NULL OR updated_at IS NULL
+        """
+    )
+    op.execute("ALTER TABLE mcp_client_configs ALTER COLUMN identity_id SET DEFAULT ''")
+    op.execute("ALTER TABLE mcp_client_configs ALTER COLUMN identity_id SET NOT NULL")
+    op.execute("ALTER TABLE mcp_client_configs ALTER COLUMN status SET DEFAULT 'active'")
+    op.execute("ALTER TABLE mcp_client_configs ALTER COLUMN status SET NOT NULL")
+    op.execute("ALTER TABLE mcp_client_configs ALTER COLUMN revision SET DEFAULT 1")
+    op.execute("ALTER TABLE mcp_client_configs ALTER COLUMN revision SET NOT NULL")
+    op.execute(
+        "ALTER TABLE mcp_client_configs ALTER COLUMN updated_at "
+        "SET DEFAULT to_char(now() AT TIME ZONE 'UTC','YYYY-MM-DD\"T\"HH24:MI:SS\"Z\"')"
+    )
+    op.execute("ALTER TABLE mcp_client_configs ALTER COLUMN updated_at SET NOT NULL")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conrelid = 'mcp_client_configs'::regclass
+              AND conname = 'mcp_client_configs_status_valid'
+          ) THEN
+            ALTER TABLE mcp_client_configs
+              ADD CONSTRAINT mcp_client_configs_status_valid
+              CHECK (status IN ('active', 'disabled', 'revoked'));
+          END IF;
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_constraint
+            WHERE conrelid = 'mcp_client_configs'::regclass
+              AND conname = 'mcp_client_configs_revision_positive'
+          ) THEN
+            ALTER TABLE mcp_client_configs
+              ADD CONSTRAINT mcp_client_configs_revision_positive
+              CHECK (revision >= 1);
+          END IF;
+        END $$
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_client_configs_active_identity
+        ON mcp_client_configs (tenant_id, identity_id)
+        WHERE identity_id IS NOT NULL AND btrim(identity_id) <> '' AND status = 'active' AND revoked = FALSE
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_identity_history
+        ON mcp_client_configs (tenant_id, identity_id, updated_at DESC)
+        WHERE identity_id IS NOT NULL AND btrim(identity_id) <> ''
+        """
+    )
+
+    # Reassert the existing security contract after widening the table. ALTER
+    # TABLE preserves RLS and grants in Postgres; these idempotent statements
+    # also repair pre-authority development databases before recording v2.
+    op.execute("ALTER TABLE mcp_client_configs ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE mcp_client_configs FORCE ROW LEVEL SECURITY")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_policies
+            WHERE schemaname = current_schema()
+              AND tablename = 'mcp_client_configs'
+              AND policyname = 'mcp_client_configs_tenant_isolation'
+          ) THEN
+            CREATE POLICY mcp_client_configs_tenant_isolation ON mcp_client_configs
+              USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+              WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+          END IF;
+        END $$
+        """
+    )
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+            GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_client_configs TO agent_bom_app;
+          END IF;
+        END $$
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO control_plane_schema_versions(component, version, updated_at)
+        VALUES ('mcp_client_configs', 2, now())
+        ON CONFLICT(component) DO UPDATE SET
+            version = EXCLUDED.version,
+            updated_at = EXCLUDED.updated_at
+        """
+    )
+
+
+def downgrade() -> None:
+    # Profile bindings and revisions are customer governance records. Keep the
+    # additive columns and uniqueness contract on rollback rather than destroy
+    # them or make an older process accept ambiguous live bindings.
+    raise NotImplementedError("MCP profile binding authority is additive and intentionally irreversible.")

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -131,8 +131,10 @@ CREATE TABLE IF NOT EXISTS tenant_quota_overrides (tenant_id TEXT PRIMARY KEY,up
 CREATE TABLE IF NOT EXISTS tenant_graph_retention_overrides (tenant_id TEXT PRIMARY KEY,updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS"Z"'),retention_days INTEGER NOT NULL);
 CREATE TABLE IF NOT EXISTS tenant_score_config_overrides (tenant_id TEXT PRIMARY KEY,updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS"Z"'),data TEXT NOT NULL);
 
-CREATE TABLE IF NOT EXISTS mcp_client_configs (config_id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,name TEXT NOT NULL,profile_id TEXT NOT NULL,created_at TEXT NOT NULL,revoked BOOLEAN NOT NULL DEFAULT FALSE,data TEXT NOT NULL);
+CREATE TABLE IF NOT EXISTS mcp_client_configs (config_id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,name TEXT NOT NULL,profile_id TEXT NOT NULL,created_at TEXT NOT NULL,revoked BOOLEAN NOT NULL DEFAULT FALSE,data TEXT NOT NULL,identity_id TEXT NOT NULL DEFAULT '',issuer TEXT NOT NULL DEFAULT '',environment TEXT NOT NULL DEFAULT '',status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','disabled','revoked')),revision INTEGER NOT NULL DEFAULT 1 CHECK(revision >= 1),updated_at TEXT NOT NULL DEFAULT to_char(now() AT TIME ZONE 'UTC','YYYY-MM-DD"T"HH24:MI:SS"Z"'));
 CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_tenant ON mcp_client_configs(tenant_id,created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_client_configs_active_identity ON mcp_client_configs (tenant_id, identity_id) WHERE identity_id IS NOT NULL AND btrim(identity_id) <> '' AND status = 'active' AND revoked = FALSE;
+CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_identity_history ON mcp_client_configs (tenant_id, identity_id, updated_at DESC) WHERE identity_id IS NOT NULL AND btrim(identity_id) <> '';
 CREATE TABLE IF NOT EXISTS model_provider_keys (provider_key_id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,provider TEXT NOT NULL,status TEXT NOT NULL,created_at TEXT NOT NULL,data TEXT NOT NULL);
 CREATE TABLE IF NOT EXISTS model_virtual_keys (virtual_key_id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,provider_key_id TEXT NOT NULL,token_hash TEXT NOT NULL UNIQUE,status TEXT NOT NULL,issued_at TEXT NOT NULL,data TEXT NOT NULL);
 CREATE INDEX IF NOT EXISTS idx_model_provider_keys_tenant ON model_provider_keys(tenant_id,created_at);
@@ -228,10 +230,13 @@ SELECT component,1,now() FROM unnest(ARRAY[
  'scan_jobs','api_keys','exceptions','audit_log','trend_history','gateway_policies','schedules','sources','credential_refs','llm_costs',
  'cloud_connections','compliance_hub','access_review_campaigns','risk_campaign_workflows','fleet','graph','scan_cache','identity_scim',
  'agent_identities','runtime_events','tenant_quotas','tenant_graph_retention','idempotency','proxy_replay_log','rate_limits',
- 'shared_auth_state','managed_trial_invitations','managed_trial_tenants','governance_audit_log','ai_system_blueprints','mcp_client_configs','model_provider_keys','tenant_score_config',
+ 'shared_auth_state','managed_trial_invitations','managed_trial_tenants','governance_audit_log','ai_system_blueprints','model_provider_keys','tenant_score_config',
  'ticketing_connections'
 ]) component
 ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;
 INSERT INTO control_plane_schema_versions(component,version,updated_at)
 VALUES ('runtime_workload_evidence',2,now())
+ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;
+INSERT INTO control_plane_schema_versions(component,version,updated_at)
+VALUES ('mcp_client_configs',2,now())
 ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -17,7 +17,7 @@ attack paths, compliance tags, and runtime audit chain.
 | Area | Shipped today |
 |---|---|
 | MCP security tools | 77 tools, 6 resources, 8 workflow prompts |
-| REST API | 379 operations across 44 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
+| REST API | 380 operations across 44 route modules (+ 2 WebSocket routes) — see `docs/openapi/v1.json` |
 | Package / SCA | 15 ecosystems, SARIF, CycloneDX, SPDX, HTML |
 | Graph / blast radius | UnifiedGraph, attack paths, hop counts, remediation handoff |
 | Runtime proxy | stdio/local MCP inline enforcement (7 detectors) |

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -54,7 +54,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
 | `docs/openapi/v1.json` | paths | 321 |
-| `docs/openapi/v1.json` | component schemas | 119 |
+| `docs/openapi/v1.json` | component schemas | 121 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -55,7 +55,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (321 paths / 379 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (321 paths / 380 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/docs/START_HERE.md
+++ b/docs/START_HERE.md
@@ -47,7 +47,7 @@ docker compose -f deploy/docker-compose.pilot.yml up -d
 
 - Deployment chooser (Docker / Helm / EKS / Postgres):
   [`../site-docs/deployment/overview.md`](../site-docs/deployment/overview.md)
-- API contract (379 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
+- API contract (380 operations): [`../docs/openapi/v1.json`](openapi/v1.json)
 - Enterprise auth, tenancy, RBAC: [`ENTERPRISE_DEPLOYMENT.md`](ENTERPRISE_DEPLOYMENT.md),
   [`PERMISSIONS.md`](PERMISSIONS.md)
 - Runtime proxy/gateway enforcement: [`MCP_SERVER.md`](MCP_SERVER.md) and the

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -83,7 +83,7 @@
 <rect x="488" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
 <text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">379 ops</text>
+<text x="526" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">380 ops</text>
 <rect x="706" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
 <text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Gateway</text>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -83,7 +83,7 @@
 <rect x="488" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
 <text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">379 ops</text>
+<text x="526" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">380 ops</text>
 <rect x="706" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
 <text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Gateway</text>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -86,6 +86,6 @@
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
 <text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">379 API ops · 77 MCP tools · SARIF</text>
+<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">380 API ops · 77 MCP tools · SARIF</text>
 <rect x="24" y="196" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -86,6 +86,6 @@
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
 <text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">379 API ops · 77 MCP tools · SARIF</text>
+<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">380 API ops · 77 MCP tools · SARIF</text>
 <rect x="24" y="196" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -4187,6 +4187,180 @@
         "title": "ManagedTrialOIDCStartRequest",
         "type": "object"
       },
+      "McpConfigAssignmentCreate": {
+        "additionalProperties": false,
+        "description": "Strict, secret-free client-profile assignment request.",
+        "properties": {
+          "allowed_tools": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Allowed Tools",
+            "type": "array"
+          },
+          "connection_ids": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Connection Ids",
+            "type": "array"
+          },
+          "connector_ids": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "minItems": 1,
+            "title": "Connector Ids",
+            "type": "array"
+          },
+          "environment": {
+            "default": "",
+            "maxLength": 120,
+            "title": "Environment",
+            "type": "string"
+          },
+          "expires_at": {
+            "default": "",
+            "maxLength": 80,
+            "title": "Expires At",
+            "type": "string"
+          },
+          "identity_id": {
+            "default": "",
+            "maxLength": 200,
+            "title": "Identity Id",
+            "type": "string"
+          },
+          "issuer": {
+            "default": "",
+            "maxLength": 500,
+            "title": "Issuer",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "policy_ids": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Policy Ids",
+            "type": "array"
+          },
+          "profile_id": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Profile Id",
+            "type": "string"
+          },
+          "required_scopes": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Required Scopes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "name",
+          "profile_id",
+          "connector_ids"
+        ],
+        "title": "McpConfigAssignmentCreate",
+        "type": "object"
+      },
+      "McpConfigAssignmentUpdate": {
+        "additionalProperties": false,
+        "description": "Full profile replacement guarded by an optimistic revision.",
+        "properties": {
+          "allowed_tools": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Allowed Tools",
+            "type": "array"
+          },
+          "connection_ids": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Connection Ids",
+            "type": "array"
+          },
+          "connector_ids": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "minItems": 1,
+            "title": "Connector Ids",
+            "type": "array"
+          },
+          "environment": {
+            "default": "",
+            "maxLength": 120,
+            "title": "Environment",
+            "type": "string"
+          },
+          "expected_revision": {
+            "minimum": 1.0,
+            "title": "Expected Revision",
+            "type": "integer"
+          },
+          "expires_at": {
+            "default": "",
+            "maxLength": 80,
+            "title": "Expires At",
+            "type": "string"
+          },
+          "name": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          },
+          "policy_ids": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Policy Ids",
+            "type": "array"
+          },
+          "profile_id": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Profile Id",
+            "type": "string"
+          },
+          "required_scopes": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 200,
+            "title": "Required Scopes",
+            "type": "array"
+          }
+        },
+        "required": [
+          "expected_revision",
+          "name",
+          "profile_id",
+          "connector_ids"
+        ],
+        "title": "McpConfigAssignmentUpdate",
+        "type": "object"
+      },
       "ModelFilesRequest": {
         "additionalProperties": false,
         "description": "Request body for POST /v1/scan/model-files.",
@@ -25271,9 +25445,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "additionalProperties": true,
-                "title": "Body",
-                "type": "object"
+                "$ref": "#/components/schemas/McpConfigAssignmentCreate"
               }
             }
           },
@@ -25397,6 +25569,107 @@
           }
         },
         "summary": "Get Mcp Config Assignment",
+        "tags": [
+          "mcp-config"
+        ]
+      },
+      "put": {
+        "description": "Replace a profile contract atomically when the expected revision matches.",
+        "operationId": "update_mcp_config_assignment_v1_mcp_config_assignments__config_id__put",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "config_id",
+            "required": true,
+            "schema": {
+              "title": "Config Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Role",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Role"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Tenant-ID",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Tenant-Id"
+            }
+          },
+          {
+            "in": "header",
+            "name": "X-Agent-Bom-Proxy-Secret",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "X-Agent-Bom-Proxy-Secret"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/McpConfigAssignmentUpdate"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "title": "Response Update Mcp Config Assignment V1 Mcp Config Assignments  Config Id  Put",
+                  "type": "object"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Update Mcp Config Assignment",
         "tags": [
           "mcp-config"
         ]

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2896,6 +2896,143 @@ components:
       - token
       title: ManagedTrialOIDCStartRequest
       type: object
+    McpConfigAssignmentCreate:
+      additionalProperties: false
+      description: Strict, secret-free client-profile assignment request.
+      properties:
+        allowed_tools:
+          items:
+            type: string
+          maxItems: 200
+          title: Allowed Tools
+          type: array
+        connection_ids:
+          items:
+            type: string
+          maxItems: 200
+          title: Connection Ids
+          type: array
+        connector_ids:
+          items:
+            type: string
+          maxItems: 200
+          minItems: 1
+          title: Connector Ids
+          type: array
+        environment:
+          default: ''
+          maxLength: 120
+          title: Environment
+          type: string
+        expires_at:
+          default: ''
+          maxLength: 80
+          title: Expires At
+          type: string
+        identity_id:
+          default: ''
+          maxLength: 200
+          title: Identity Id
+          type: string
+        issuer:
+          default: ''
+          maxLength: 500
+          title: Issuer
+          type: string
+        name:
+          maxLength: 200
+          minLength: 1
+          title: Name
+          type: string
+        policy_ids:
+          items:
+            type: string
+          maxItems: 200
+          title: Policy Ids
+          type: array
+        profile_id:
+          maxLength: 200
+          minLength: 1
+          title: Profile Id
+          type: string
+        required_scopes:
+          items:
+            type: string
+          maxItems: 200
+          title: Required Scopes
+          type: array
+      required:
+      - name
+      - profile_id
+      - connector_ids
+      title: McpConfigAssignmentCreate
+      type: object
+    McpConfigAssignmentUpdate:
+      additionalProperties: false
+      description: Full profile replacement guarded by an optimistic revision.
+      properties:
+        allowed_tools:
+          items:
+            type: string
+          maxItems: 200
+          title: Allowed Tools
+          type: array
+        connection_ids:
+          items:
+            type: string
+          maxItems: 200
+          title: Connection Ids
+          type: array
+        connector_ids:
+          items:
+            type: string
+          maxItems: 200
+          minItems: 1
+          title: Connector Ids
+          type: array
+        environment:
+          default: ''
+          maxLength: 120
+          title: Environment
+          type: string
+        expected_revision:
+          minimum: 1.0
+          title: Expected Revision
+          type: integer
+        expires_at:
+          default: ''
+          maxLength: 80
+          title: Expires At
+          type: string
+        name:
+          maxLength: 200
+          minLength: 1
+          title: Name
+          type: string
+        policy_ids:
+          items:
+            type: string
+          maxItems: 200
+          title: Policy Ids
+          type: array
+        profile_id:
+          maxLength: 200
+          minLength: 1
+          title: Profile Id
+          type: string
+        required_scopes:
+          items:
+            type: string
+          maxItems: 200
+          title: Required Scopes
+          type: array
+      required:
+      - expected_revision
+      - name
+      - profile_id
+      - connector_ids
+      title: McpConfigAssignmentUpdate
+      type: object
     ModelFilesRequest:
       additionalProperties: false
       description: Request body for POST /v1/scan/model-files.
@@ -16589,9 +16726,7 @@ paths:
         content:
           application/json:
             schema:
-              additionalProperties: true
-              title: Body
-              type: object
+              $ref: '#/components/schemas/McpConfigAssignmentCreate'
         required: true
       responses:
         '201':
@@ -16664,6 +16799,66 @@ paths:
                 $ref: '#/components/schemas/HTTPValidationError'
           description: Validation Error
       summary: Get Mcp Config Assignment
+      tags:
+      - mcp-config
+    put:
+      description: Replace a profile contract atomically when the expected revision
+        matches.
+      operationId: update_mcp_config_assignment_v1_mcp_config_assignments__config_id__put
+      parameters:
+      - in: path
+        name: config_id
+        required: true
+        schema:
+          title: Config Id
+          type: string
+      - in: header
+        name: X-Agent-Bom-Role
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Role
+      - in: header
+        name: X-Agent-Bom-Tenant-ID
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Tenant-Id
+      - in: header
+        name: X-Agent-Bom-Proxy-Secret
+        required: false
+        schema:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: X-Agent-Bom-Proxy-Secret
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/McpConfigAssignmentUpdate'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                additionalProperties: true
+                title: Response Update Mcp Config Assignment V1 Mcp Config Assignments  Config
+                  Id  Put
+                type: object
+          description: Successful Response
+        '422':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
+          description: Validation Error
+      summary: Update Mcp Config Assignment
       tags:
       - mcp-config
   /v1/mcp-config/assignments/{config_id}/revoke:

--- a/src/agent_bom/api/mcp_config_store.py
+++ b/src/agent_bom/api/mcp_config_store.py
@@ -30,7 +30,8 @@ import json
 import secrets
 import sqlite3
 import threading
-from dataclasses import asdict, dataclass, field
+from copy import deepcopy
+from dataclasses import asdict, dataclass, field, replace
 from datetime import datetime, timezone
 from typing import Any, Protocol
 
@@ -39,6 +40,18 @@ from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _bounded_identity_history_limit(limit: int) -> int:
+    return max(1, min(int(limit), 1_000))
+
+
+class McpConfigConflictError(ValueError):
+    """The requested assignment would violate a profile-binding invariant."""
+
+
+class McpConfigRevisionConflictError(McpConfigConflictError):
+    """The assignment changed after the caller read it."""
 
 
 @dataclass
@@ -61,15 +74,66 @@ class McpClientConfigAssignment:
     created_by: str = ""
     updated_at: str = ""
     revoked: bool = False
+    # Optional canonical runtime binding. Empty keeps pre-#4152 assignments
+    # distribution-only; a non-empty identity is unique per tenant while live.
+    identity_id: str = ""
+    issuer: str = ""
+    environment: str = ""
+    allowed_tools: list[str] = field(default_factory=list)
+    required_scopes: list[str] = field(default_factory=list)
+    policy_ids: list[str] = field(default_factory=list)
+    owner: str = ""
+    status: str = "active"
+    revision: int = 1
+    expires_at: str = ""
 
     def to_public_dict(self) -> dict[str, Any]:
         return asdict(self)
+
+
+def _assignment_from_storage_row(row: Any) -> McpClientConfigAssignment:
+    """Decode JSON while treating indexed lifecycle columns as authoritative."""
+
+    payload = json.loads(row[0])
+    payload.update(
+        {
+            "config_id": str(row[1]),
+            "tenant_id": str(row[2]),
+            "identity_id": str(row[3] or ""),
+            "issuer": str(row[4] or ""),
+            "environment": str(row[5] or ""),
+            "status": str(row[6] or "active"),
+            "revision": max(1, int(row[7] or 1)),
+            "updated_at": str(row[8] or payload.get("created_at", "")),
+            "revoked": bool(row[9]),
+        }
+    )
+    return McpClientConfigAssignment(**payload)
 
 
 class McpConfigStore(Protocol):
     def put(self, assignment: McpClientConfigAssignment) -> None: ...
 
     def get(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None: ...
+
+    def get_active_for_identity(self, tenant_id: str, identity_id: str) -> McpClientConfigAssignment | None: ...
+
+    def list_for_identity(
+        self,
+        tenant_id: str,
+        identity_id: str,
+        *,
+        limit: int = 200,
+    ) -> builtins.list[McpClientConfigAssignment]: ...
+
+    def compare_and_swap(
+        self,
+        assignment: McpClientConfigAssignment,
+        *,
+        expected_revision: int,
+    ) -> McpClientConfigAssignment: ...
+
+    def revoke(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None: ...
 
     def list_for_tenant(
         self, tenant_id: str, *, include_revoked: bool = False, limit: int = 200
@@ -79,31 +143,131 @@ class McpConfigStore(Protocol):
 class InMemoryMcpConfigStore:
     def __init__(self) -> None:
         self._rows: dict[str, McpClientConfigAssignment] = {}
+        self._active_by_identity: dict[tuple[str, str], str] = {}
+        self._by_identity: dict[tuple[str, str], set[str]] = {}
         self._lock = threading.Lock()
 
     def put(self, assignment: McpClientConfigAssignment) -> None:
         with self._lock:
-            self._rows[assignment.config_id] = assignment
+            existing = self._rows.get(assignment.config_id)
+            if existing is not None:
+                raise McpConfigConflictError("MCP client profile already exists; use compare-and-swap to update it")
+            stored = deepcopy(assignment)
+            self._assert_identity_available(stored)
+            if existing is not None:
+                self._remove_active_index(existing)
+            self._rows[stored.config_id] = stored
+            if stored.identity_id:
+                self._by_identity.setdefault((stored.tenant_id, stored.identity_id), set()).add(stored.config_id)
+            self._add_active_index(stored)
+
+    @staticmethod
+    def _is_active_binding(assignment: McpClientConfigAssignment) -> bool:
+        return bool(assignment.identity_id and not assignment.revoked and assignment.status == "active")
+
+    def _assert_identity_available(self, assignment: McpClientConfigAssignment) -> None:
+        if not self._is_active_binding(assignment):
+            return
+        key = (assignment.tenant_id, assignment.identity_id)
+        current = self._active_by_identity.get(key)
+        if current is not None and current != assignment.config_id:
+            raise McpConfigConflictError("The managed identity already has an active client profile")
+
+    def _remove_active_index(self, assignment: McpClientConfigAssignment) -> None:
+        if not assignment.identity_id:
+            return
+        key = (assignment.tenant_id, assignment.identity_id)
+        if self._active_by_identity.get(key) == assignment.config_id:
+            self._active_by_identity.pop(key, None)
+
+    def _add_active_index(self, assignment: McpClientConfigAssignment) -> None:
+        if self._is_active_binding(assignment):
+            self._active_by_identity[(assignment.tenant_id, assignment.identity_id)] = assignment.config_id
 
     def get(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
         with self._lock:
             row = self._rows.get(config_id)
             if row is None or row.tenant_id != tenant_id:
                 return None
-            return row
+            return deepcopy(row)
+
+    def get_active_for_identity(self, tenant_id: str, identity_id: str) -> McpClientConfigAssignment | None:
+        if not identity_id:
+            return None
+        with self._lock:
+            config_id = self._active_by_identity.get((tenant_id, identity_id))
+            row = self._rows.get(config_id) if config_id is not None else None
+            return deepcopy(row) if row is not None else None
+
+    def list_for_identity(
+        self,
+        tenant_id: str,
+        identity_id: str,
+        *,
+        limit: int = 200,
+    ) -> builtins.list[McpClientConfigAssignment]:
+        if not identity_id:
+            return []
+        with self._lock:
+            rows = [self._rows[config_id] for config_id in self._by_identity.get((tenant_id, identity_id), set())]
+            return deepcopy(
+                sorted(rows, key=lambda row: (row.updated_at or row.created_at, row.config_id), reverse=True)[
+                    : _bounded_identity_history_limit(limit)
+                ]
+            )
+
+    def compare_and_swap(
+        self,
+        assignment: McpClientConfigAssignment,
+        *,
+        expected_revision: int,
+    ) -> McpClientConfigAssignment:
+        with self._lock:
+            current = self._rows.get(assignment.config_id)
+            if current is None or current.tenant_id != assignment.tenant_id:
+                raise McpConfigRevisionConflictError("MCP client profile no longer exists")
+            if current.revision != expected_revision:
+                raise McpConfigRevisionConflictError("MCP client profile revision is stale")
+            if current.identity_id != assignment.identity_id:
+                raise McpConfigConflictError("A canonical profile binding cannot be rebound to another identity")
+            candidate = deepcopy(replace(assignment, revision=expected_revision + 1))
+            self._assert_identity_available(candidate)
+            self._remove_active_index(current)
+            self._rows[candidate.config_id] = candidate
+            self._add_active_index(candidate)
+            return deepcopy(candidate)
+
+    def revoke(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
+        with self._lock:
+            current = self._rows.get(config_id)
+            if current is None or current.tenant_id != tenant_id:
+                return None
+            if current.revoked:
+                return deepcopy(current)
+            revoked = replace(
+                current,
+                revoked=True,
+                status="revoked",
+                revision=current.revision + 1,
+                updated_at=_now_iso(),
+            )
+            self._remove_active_index(current)
+            self._rows[config_id] = revoked
+            return deepcopy(revoked)
 
     def list_for_tenant(
         self, tenant_id: str, *, include_revoked: bool = False, limit: int = 200
     ) -> builtins.list[McpClientConfigAssignment]:
         with self._lock:
             rows = [r for r in self._rows.values() if r.tenant_id == tenant_id and (include_revoked or not r.revoked)]
-            return sorted(rows, key=lambda r: r.created_at, reverse=True)[:limit]
+            return deepcopy(sorted(rows, key=lambda r: r.created_at, reverse=True)[:limit])
 
 
 class SQLiteMcpConfigStore:
     def __init__(self, db_path: str = "agent_bom.db") -> None:
         self._db_path = db_path
         self._local = threading.local()
+        self._write_lock = threading.Lock()
         self._init_db()
 
     @property
@@ -115,7 +279,7 @@ class SQLiteMcpConfigStore:
         return conn
 
     def _init_db(self) -> None:
-        ensure_sqlite_schema_version(self._conn, "mcp_client_configs")
+        ensure_sqlite_schema_version(self._conn, "mcp_client_configs", version=2)
         self._conn.execute(
             """
             CREATE TABLE IF NOT EXISTS mcp_client_configs (
@@ -123,50 +287,227 @@ class SQLiteMcpConfigStore:
                 tenant_id  TEXT NOT NULL,
                 name       TEXT NOT NULL,
                 profile_id TEXT NOT NULL,
+                identity_id TEXT NOT NULL DEFAULT '',
+                issuer TEXT NOT NULL DEFAULT '',
+                environment TEXT NOT NULL DEFAULT '',
+                status TEXT NOT NULL DEFAULT 'active',
+                revision INTEGER NOT NULL DEFAULT 1,
                 created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL DEFAULT '',
                 revoked    INTEGER NOT NULL DEFAULT 0,
                 data       TEXT NOT NULL
             )
             """
         )
+        columns = {str(row[1]) for row in self._conn.execute("PRAGMA table_info(mcp_client_configs)").fetchall()}
+        had_status = "status" in columns
+        had_updated_at = "updated_at" in columns
+        for column, ddl in (
+            ("identity_id", "TEXT NOT NULL DEFAULT ''"),
+            ("issuer", "TEXT NOT NULL DEFAULT ''"),
+            ("environment", "TEXT NOT NULL DEFAULT ''"),
+            ("status", "TEXT NOT NULL DEFAULT 'active'"),
+            ("revision", "INTEGER NOT NULL DEFAULT 1"),
+            ("updated_at", "TEXT NOT NULL DEFAULT ''"),
+        ):
+            if column not in columns:
+                self._conn.execute(f"ALTER TABLE mcp_client_configs ADD COLUMN {column} {ddl}")  # noqa: S608
+        if not had_status:
+            self._conn.execute("UPDATE mcp_client_configs SET status = CASE WHEN revoked = 1 THEN 'revoked' ELSE 'active' END")
+        if not had_updated_at:
+            self._conn.execute("UPDATE mcp_client_configs SET updated_at = created_at WHERE updated_at = ''")
         self._conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_tenant ON mcp_client_configs(tenant_id, created_at)")
-        self._conn.commit()
-
-    def put(self, assignment: McpClientConfigAssignment) -> None:
         self._conn.execute(
-            "INSERT OR REPLACE INTO mcp_client_configs "
-            "(config_id, tenant_id, name, profile_id, created_at, revoked, data) VALUES (?, ?, ?, ?, ?, ?, ?)",
-            (
-                assignment.config_id,
-                assignment.tenant_id,
-                assignment.name,
-                assignment.profile_id,
-                assignment.created_at,
-                1 if assignment.revoked else 0,
-                json.dumps(asdict(assignment), sort_keys=True),
-            ),
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_client_configs_active_identity "
+            "ON mcp_client_configs(tenant_id, identity_id) "
+            "WHERE identity_id <> '' AND revoked = 0 AND status = 'active'"
+        )
+        self._conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_identity_history "
+            "ON mcp_client_configs(tenant_id, identity_id, updated_at DESC) WHERE identity_id <> ''"
         )
         self._conn.commit()
 
+    def put(self, assignment: McpClientConfigAssignment) -> None:
+        with self._write_lock:
+            existing = self._conn.execute(
+                "SELECT tenant_id, identity_id FROM mcp_client_configs WHERE config_id = ?", (assignment.config_id,)
+            ).fetchone()
+            if existing is not None:
+                raise McpConfigConflictError("MCP client profile already exists; use compare-and-swap to update it")
+            try:
+                self._conn.execute(
+                    "INSERT INTO mcp_client_configs "
+                    "(config_id, tenant_id, name, profile_id, identity_id, issuer, environment, status, revision, "
+                    "created_at, updated_at, revoked, data) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    self._values(assignment),
+                )
+                self._conn.commit()
+            except sqlite3.IntegrityError as exc:
+                self._conn.rollback()
+                raise McpConfigConflictError("The managed identity already has an active client profile") from exc
+
+    @staticmethod
+    def _values(assignment: McpClientConfigAssignment) -> tuple[Any, ...]:
+        return (
+            assignment.config_id,
+            assignment.tenant_id,
+            assignment.name,
+            assignment.profile_id,
+            assignment.identity_id,
+            assignment.issuer,
+            assignment.environment,
+            assignment.status,
+            int(assignment.revision),
+            assignment.created_at,
+            assignment.updated_at,
+            1 if assignment.revoked else 0,
+            json.dumps(asdict(assignment), sort_keys=True),
+        )
+
     def get(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
         row = self._conn.execute(
-            "SELECT data FROM mcp_client_configs WHERE config_id = ? AND tenant_id = ?", (config_id, tenant_id)
+            "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+            "FROM mcp_client_configs WHERE config_id = ? AND tenant_id = ?",
+            (config_id, tenant_id),
         ).fetchone()
-        return McpClientConfigAssignment(**json.loads(row[0])) if row else None
+        return _assignment_from_storage_row(row) if row else None
+
+    def get_active_for_identity(self, tenant_id: str, identity_id: str) -> McpClientConfigAssignment | None:
+        if not identity_id:
+            return None
+        row = self._conn.execute(
+            "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+            "FROM mcp_client_configs "
+            "WHERE tenant_id = ? AND identity_id = ? AND identity_id <> '' "
+            "AND revoked = 0 AND status = 'active'",
+            (tenant_id, identity_id),
+        ).fetchone()
+        return _assignment_from_storage_row(row) if row else None
+
+    def list_for_identity(
+        self,
+        tenant_id: str,
+        identity_id: str,
+        *,
+        limit: int = 200,
+    ) -> builtins.list[McpClientConfigAssignment]:
+        if not identity_id:
+            return []
+        rows = self._conn.execute(
+            "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+            "FROM mcp_client_configs WHERE tenant_id = ? AND identity_id = ? AND identity_id <> '' "
+            "ORDER BY updated_at DESC, config_id DESC LIMIT ?",
+            (tenant_id, identity_id, _bounded_identity_history_limit(limit)),
+        ).fetchall()
+        return [_assignment_from_storage_row(row) for row in rows]
+
+    def compare_and_swap(
+        self,
+        assignment: McpClientConfigAssignment,
+        *,
+        expected_revision: int,
+    ) -> McpClientConfigAssignment:
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT identity_id, revision FROM mcp_client_configs WHERE config_id = ? AND tenant_id = ?",
+                    (assignment.config_id, assignment.tenant_id),
+                ).fetchone()
+                if row is None or int(row[1]) != expected_revision:
+                    raise McpConfigRevisionConflictError("MCP client profile revision is stale")
+                if str(row[0]) != assignment.identity_id:
+                    raise McpConfigConflictError("A canonical profile binding cannot be rebound to another identity")
+                candidate = replace(assignment, revision=expected_revision + 1)
+                cursor = self._conn.execute(
+                    "UPDATE mcp_client_configs SET name=?, profile_id=?, issuer=?, environment=?, status=?, "
+                    "revision=?, updated_at=?, revoked=?, data=? "
+                    "WHERE config_id=? AND tenant_id=? AND revision=?",
+                    (
+                        candidate.name,
+                        candidate.profile_id,
+                        candidate.issuer,
+                        candidate.environment,
+                        candidate.status,
+                        candidate.revision,
+                        candidate.updated_at,
+                        1 if candidate.revoked else 0,
+                        json.dumps(asdict(candidate), sort_keys=True),
+                        candidate.config_id,
+                        candidate.tenant_id,
+                        expected_revision,
+                    ),
+                )
+                if cursor.rowcount != 1:
+                    raise McpConfigRevisionConflictError("MCP client profile revision is stale")
+                self._conn.commit()
+                return candidate
+            except sqlite3.IntegrityError as exc:
+                self._conn.rollback()
+                raise McpConfigConflictError("The managed identity already has an active client profile") from exc
+            except Exception:
+                self._conn.rollback()
+                raise
+
+    def revoke(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
+        with self._write_lock:
+            self._conn.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._conn.execute(
+                    "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                    "FROM mcp_client_configs WHERE config_id = ? AND tenant_id = ?",
+                    (config_id, tenant_id),
+                ).fetchone()
+                if row is None:
+                    self._conn.rollback()
+                    return None
+                current = _assignment_from_storage_row(row)
+                if current.revoked:
+                    self._conn.commit()
+                    return current
+                revoked = replace(
+                    current,
+                    revoked=True,
+                    status="revoked",
+                    revision=current.revision + 1,
+                    updated_at=_now_iso(),
+                )
+                self._conn.execute(
+                    "UPDATE mcp_client_configs SET status=?, revision=?, updated_at=?, revoked=1, data=? "
+                    "WHERE config_id=? AND tenant_id=? AND revision=?",
+                    (
+                        revoked.status,
+                        revoked.revision,
+                        revoked.updated_at,
+                        json.dumps(asdict(revoked), sort_keys=True),
+                        config_id,
+                        tenant_id,
+                        current.revision,
+                    ),
+                )
+                self._conn.commit()
+                return revoked
+            except Exception:
+                self._conn.rollback()
+                raise
 
     def list_for_tenant(
         self, tenant_id: str, *, include_revoked: bool = False, limit: int = 200
     ) -> builtins.list[McpClientConfigAssignment]:
         if include_revoked:
             rows = self._conn.execute(
-                "SELECT data FROM mcp_client_configs WHERE tenant_id = ? ORDER BY created_at DESC LIMIT ?", (tenant_id, limit)
+                "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                "FROM mcp_client_configs WHERE tenant_id = ? ORDER BY created_at DESC LIMIT ?",
+                (tenant_id, limit),
             ).fetchall()
         else:
             rows = self._conn.execute(
-                "SELECT data FROM mcp_client_configs WHERE tenant_id = ? AND revoked = 0 ORDER BY created_at DESC LIMIT ?",
+                "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                "FROM mcp_client_configs WHERE tenant_id = ? AND revoked = 0 ORDER BY created_at DESC LIMIT ?",
                 (tenant_id, limit),
             ).fetchall()
-        return [McpClientConfigAssignment(**json.loads(r[0])) for r in rows]
+        return [_assignment_from_storage_row(row) for row in rows]
 
 
 # ── Composition (reference-only served document) ─────────────────────────────────
@@ -262,6 +603,14 @@ def create_assignment(
     connector_ids: list[str],
     connection_ids: list[str] | None = None,
     created_by: str = "",
+    identity_id: str = "",
+    issuer: str = "",
+    environment: str = "",
+    allowed_tools: list[str] | None = None,
+    required_scopes: list[str] | None = None,
+    policy_ids: list[str] | None = None,
+    owner: str = "",
+    expires_at: str = "",
 ) -> McpClientConfigAssignment:
     """Create and persist a tenant-scoped MCP-client-config assignment."""
     now = _now_iso()
@@ -276,19 +625,23 @@ def create_assignment(
         created_by=created_by[:200],
         updated_at=now,
         revoked=False,
+        identity_id=identity_id.strip()[:200],
+        issuer=issuer.strip()[:500],
+        environment=environment.strip()[:120],
+        allowed_tools=list(dict.fromkeys(allowed_tools or [])),
+        required_scopes=list(dict.fromkeys(required_scopes or [])),
+        policy_ids=list(dict.fromkeys(policy_ids or [])),
+        owner=owner.strip()[:200],
+        status="active",
+        revision=1,
+        expires_at=expires_at,
     )
     store.put(assignment)
     return assignment
 
 
 def revoke_assignment(store: McpConfigStore, *, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
-    assignment = store.get(tenant_id, config_id)
-    if assignment is None:
-        return None
-    assignment.revoked = True
-    assignment.updated_at = _now_iso()
-    store.put(assignment)
-    return assignment
+    return store.revoke(tenant_id, config_id)
 
 
 _MCP_CONFIG_STORE: McpConfigStore | None = None

--- a/src/agent_bom/api/postgres_mcp_config.py
+++ b/src/agent_bom/api/postgres_mcp_config.py
@@ -11,9 +11,16 @@ from __future__ import annotations
 
 import builtins
 import json
-from dataclasses import asdict
+from dataclasses import asdict, replace
 
-from agent_bom.api.mcp_config_store import McpClientConfigAssignment
+from agent_bom.api.mcp_config_store import (
+    McpClientConfigAssignment,
+    McpConfigConflictError,
+    McpConfigRevisionConflictError,
+    _assignment_from_storage_row,
+    _bounded_identity_history_limit,
+    _now_iso,
+)
 from agent_bom.api.postgres_common import (
     ConnectionPool,
     _ensure_tenant_rls,
@@ -32,7 +39,7 @@ class PostgresMcpConfigStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
-            if not ensure_postgres_schema_version(conn, "mcp_client_configs"):
+            if not ensure_postgres_schema_version(conn, "mcp_client_configs", version=2):
                 return
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS mcp_client_configs (
@@ -40,45 +47,204 @@ class PostgresMcpConfigStore:
                     tenant_id  TEXT NOT NULL,
                     name       TEXT NOT NULL,
                     profile_id TEXT NOT NULL,
+                    identity_id TEXT NOT NULL DEFAULT '',
+                    issuer TEXT NOT NULL DEFAULT '',
+                    environment TEXT NOT NULL DEFAULT '',
+                    status TEXT NOT NULL DEFAULT 'active',
+                    revision INTEGER NOT NULL DEFAULT 1,
                     created_at TEXT NOT NULL,
+                    updated_at TEXT NOT NULL DEFAULT '',
                     revoked    BOOLEAN NOT NULL DEFAULT FALSE,
                     data       TEXT NOT NULL
                 )
             """)
+            for ddl in (
+                "ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS identity_id TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS issuer TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS environment TEXT NOT NULL DEFAULT ''",
+                "ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS status TEXT NOT NULL DEFAULT 'active'",
+                "ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS revision INTEGER NOT NULL DEFAULT 1",
+                "ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS updated_at TEXT NOT NULL DEFAULT ''",
+            ):
+                conn.execute(ddl)
+            conn.execute("UPDATE mcp_client_configs SET identity_id = COALESCE(identity_id, '')")
+            conn.execute("ALTER TABLE mcp_client_configs ALTER COLUMN identity_id SET DEFAULT ''")
+            conn.execute("ALTER TABLE mcp_client_configs ALTER COLUMN identity_id SET NOT NULL")
+            conn.execute("UPDATE mcp_client_configs SET status = 'revoked' WHERE revoked = TRUE AND status = 'active'")
+            conn.execute("UPDATE mcp_client_configs SET updated_at = created_at WHERE updated_at = ''")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_tenant ON mcp_client_configs(tenant_id, created_at)")
+            conn.execute(
+                "CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_client_configs_active_identity "
+                "ON mcp_client_configs(tenant_id, identity_id) "
+                "WHERE btrim(identity_id) <> '' AND revoked = FALSE AND status = 'active'"
+            )
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mcp_client_configs_identity_history "
+                "ON mcp_client_configs(tenant_id, identity_id, updated_at DESC) WHERE btrim(identity_id) <> ''"
+            )
             _ensure_tenant_rls(conn, "mcp_client_configs", "tenant_id")
             conn.commit()
 
     def put(self, assignment: McpClientConfigAssignment) -> None:
         with _tenant_connection(self._pool) as conn:
-            conn.execute(
-                """
-                INSERT INTO mcp_client_configs (config_id, tenant_id, name, profile_id, created_at, revoked, data)
-                VALUES (%s, %s, %s, %s, %s, %s, %s)
-                ON CONFLICT (config_id) DO UPDATE SET
-                    name = EXCLUDED.name,
-                    profile_id = EXCLUDED.profile_id,
-                    revoked = EXCLUDED.revoked,
-                    data = EXCLUDED.data
-                """,
-                (
-                    assignment.config_id,
-                    assignment.tenant_id,
-                    assignment.name,
-                    assignment.profile_id,
-                    assignment.created_at,
-                    bool(assignment.revoked),
-                    json.dumps(asdict(assignment), sort_keys=True),
-                ),
-            )
-            conn.commit()
+            try:
+                conn.execute(
+                    """
+                    INSERT INTO mcp_client_configs (
+                        config_id, tenant_id, name, profile_id, identity_id, issuer,
+                        environment, status, revision, created_at, updated_at, revoked, data
+                    )
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    """,
+                    self._values(assignment),
+                )
+                conn.commit()
+            except Exception as exc:
+                conn.rollback()
+                if exc.__class__.__name__ == "UniqueViolation":
+                    raise McpConfigConflictError("MCP client profile conflicts with an existing assignment") from exc
+                raise
+
+    @staticmethod
+    def _values(assignment: McpClientConfigAssignment) -> tuple[object, ...]:
+        return (
+            assignment.config_id,
+            assignment.tenant_id,
+            assignment.name,
+            assignment.profile_id,
+            assignment.identity_id,
+            assignment.issuer,
+            assignment.environment,
+            assignment.status,
+            int(assignment.revision),
+            assignment.created_at,
+            assignment.updated_at,
+            bool(assignment.revoked),
+            json.dumps(asdict(assignment), sort_keys=True),
+        )
 
     def get(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
         with _tenant_connection(self._pool) as conn:
             row = conn.execute(
-                "SELECT data FROM mcp_client_configs WHERE config_id = %s AND tenant_id = %s", (config_id, tenant_id)
+                "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                "FROM mcp_client_configs WHERE config_id = %s AND tenant_id = %s",
+                (config_id, tenant_id),
             ).fetchone()
-        return McpClientConfigAssignment(**json.loads(row[0])) if row else None
+        return _assignment_from_storage_row(row) if row else None
+
+    def get_active_for_identity(self, tenant_id: str, identity_id: str) -> McpClientConfigAssignment | None:
+        if not identity_id:
+            return None
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                "FROM mcp_client_configs "
+                "WHERE tenant_id = %s AND identity_id = %s AND btrim(identity_id) <> '' "
+                "AND revoked = FALSE AND status = 'active'",
+                (tenant_id, identity_id),
+            ).fetchone()
+        return _assignment_from_storage_row(row) if row else None
+
+    def list_for_identity(
+        self,
+        tenant_id: str,
+        identity_id: str,
+        *,
+        limit: int = 200,
+    ) -> builtins.list[McpClientConfigAssignment]:
+        if not identity_id:
+            return []
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                "FROM mcp_client_configs WHERE tenant_id = %s AND identity_id = %s AND btrim(identity_id) <> '' "
+                "ORDER BY updated_at DESC, config_id DESC LIMIT %s",
+                (tenant_id, identity_id, _bounded_identity_history_limit(limit)),
+            ).fetchall()
+        return [_assignment_from_storage_row(row) for row in rows]
+
+    def compare_and_swap(
+        self,
+        assignment: McpClientConfigAssignment,
+        *,
+        expected_revision: int,
+    ) -> McpClientConfigAssignment:
+        candidate = replace(assignment, revision=expected_revision + 1)
+        with _tenant_connection(self._pool) as conn:
+            try:
+                row = conn.execute(
+                    """
+                    UPDATE mcp_client_configs SET
+                        name = %s, profile_id = %s, issuer = %s, environment = %s,
+                        status = %s, revision = %s, updated_at = %s, revoked = %s, data = %s
+                    WHERE config_id = %s AND tenant_id = %s AND identity_id = %s AND revision = %s
+                    RETURNING data
+                    """,
+                    (
+                        candidate.name,
+                        candidate.profile_id,
+                        candidate.issuer,
+                        candidate.environment,
+                        candidate.status,
+                        candidate.revision,
+                        candidate.updated_at,
+                        bool(candidate.revoked),
+                        json.dumps(asdict(candidate), sort_keys=True),
+                        candidate.config_id,
+                        candidate.tenant_id,
+                        candidate.identity_id,
+                        expected_revision,
+                    ),
+                ).fetchone()
+                if row is None:
+                    raise McpConfigRevisionConflictError("MCP client profile revision is stale")
+                conn.commit()
+                return McpClientConfigAssignment(**json.loads(row[0]))
+            except Exception as exc:
+                conn.rollback()
+                if exc.__class__.__name__ == "UniqueViolation":
+                    raise McpConfigConflictError("The managed identity already has an active client profile") from exc
+                raise
+
+    def revoke(self, tenant_id: str, config_id: str) -> McpClientConfigAssignment | None:
+        with _tenant_connection(self._pool) as conn:
+            row = conn.execute(
+                "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                "FROM mcp_client_configs WHERE config_id = %s AND tenant_id = %s FOR UPDATE",
+                (config_id, tenant_id),
+            ).fetchone()
+            if row is None:
+                conn.rollback()
+                return None
+            current = _assignment_from_storage_row(row)
+            if current.revoked:
+                conn.commit()
+                return current
+            revoked = replace(
+                current,
+                revoked=True,
+                status="revoked",
+                revision=current.revision + 1,
+                updated_at=_now_iso(),
+            )
+            updated = conn.execute(
+                "UPDATE mcp_client_configs SET status = %s, revision = %s, updated_at = %s, "
+                "revoked = TRUE, data = %s WHERE config_id = %s AND tenant_id = %s AND revision = %s RETURNING data",
+                (
+                    revoked.status,
+                    revoked.revision,
+                    revoked.updated_at,
+                    json.dumps(asdict(revoked), sort_keys=True),
+                    config_id,
+                    tenant_id,
+                    current.revision,
+                ),
+            ).fetchone()
+            if updated is None:
+                conn.rollback()
+                raise McpConfigRevisionConflictError("MCP client profile revision is stale")
+            conn.commit()
+            return McpClientConfigAssignment(**json.loads(updated[0]))
 
     def list_for_tenant(
         self, tenant_id: str, *, include_revoked: bool = False, limit: int = 200
@@ -86,12 +252,14 @@ class PostgresMcpConfigStore:
         with _tenant_connection(self._pool) as conn:
             if include_revoked:
                 rows = conn.execute(
-                    "SELECT data FROM mcp_client_configs WHERE tenant_id = %s ORDER BY created_at DESC LIMIT %s",
+                    "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                    "FROM mcp_client_configs WHERE tenant_id = %s ORDER BY created_at DESC LIMIT %s",
                     (tenant_id, limit),
                 ).fetchall()
             else:
                 rows = conn.execute(
-                    "SELECT data FROM mcp_client_configs WHERE tenant_id = %s AND revoked = FALSE ORDER BY created_at DESC LIMIT %s",
+                    "SELECT data, config_id, tenant_id, identity_id, issuer, environment, status, revision, updated_at, revoked "
+                    "FROM mcp_client_configs WHERE tenant_id = %s AND revoked = FALSE ORDER BY created_at DESC LIMIT %s",
                     (tenant_id, limit),
                 ).fetchall()
-        return [McpClientConfigAssignment(**json.loads(r[0])) for r in rows]
+        return [_assignment_from_storage_row(row) for row in rows]

--- a/src/agent_bom/api/routes/mcp_config.py
+++ b/src/agent_bom/api/routes/mcp_config.py
@@ -18,13 +18,19 @@ RBAC-gated and tenant-scoped; a cross-tenant fetch is a 404.
 
 from __future__ import annotations
 
-from typing import Any, cast
+from dataclasses import replace
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING, Any, cast
 
 from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from agent_bom.api.audit_log import log_action
 from agent_bom.api.mcp_config_store import (
     McpClientConfigAssignment,
+    McpConfigConflictError,
+    McpConfigRevisionConflictError,
+    _now_iso,
     build_served_mcp_config,
     create_assignment,
     get_mcp_config_store,
@@ -35,7 +41,87 @@ from agent_bom.api.versioning import API_V1_PREFIX
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.runtime_blueprints import runtime_role_blueprint
 
+if TYPE_CHECKING:
+    from agent_bom.api.agent_identity_store import AgentIdentity
+
 router = APIRouter(tags=["mcp-config"])
+
+
+def _normalize_string_list(values: list[str]) -> list[str]:
+    normalized: list[str] = []
+    for value in values:
+        item = str(value).strip()
+        if not item:
+            continue
+        if len(item) > 200:
+            raise ValueError("list items must be at most 200 characters")
+        if item not in normalized:
+            normalized.append(item)
+    return normalized
+
+
+def _normalize_expiry_value(value: str) -> str:
+    if not value:
+        return ""
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("expires_at must include a timezone")
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+class McpConfigAssignmentCreate(BaseModel):
+    """Strict, secret-free client-profile assignment request."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    name: str = Field(min_length=1, max_length=200)
+    profile_id: str = Field(min_length=1, max_length=200)
+    connector_ids: list[str] = Field(min_length=1, max_length=200)
+    connection_ids: list[str] = Field(default_factory=list, max_length=200)
+    identity_id: str = Field(default="", max_length=200)
+    issuer: str = Field(default="", max_length=500)
+    environment: str = Field(default="", max_length=120)
+    allowed_tools: list[str] = Field(default_factory=list, max_length=200)
+    required_scopes: list[str] = Field(default_factory=list, max_length=200)
+    policy_ids: list[str] = Field(default_factory=list, max_length=200)
+    expires_at: str = Field(default="", max_length=80)
+
+    @field_validator("connector_ids", "connection_ids", "allowed_tools", "required_scopes", "policy_ids")
+    @classmethod
+    def _normalize_list(cls, values: list[str]) -> list[str]:
+        return _normalize_string_list(values)
+
+    @field_validator("expires_at")
+    @classmethod
+    def _normalize_expiry(cls, value: str) -> str:
+        return _normalize_expiry_value(value)
+
+
+class McpConfigAssignmentUpdate(BaseModel):
+    """Full profile replacement guarded by an optimistic revision."""
+
+    model_config = ConfigDict(extra="forbid", str_strip_whitespace=True)
+
+    expected_revision: int = Field(ge=1)
+    name: str = Field(min_length=1, max_length=200)
+    profile_id: str = Field(min_length=1, max_length=200)
+    connector_ids: list[str] = Field(min_length=1, max_length=200)
+    connection_ids: list[str] = Field(default_factory=list, max_length=200)
+    environment: str = Field(default="", max_length=120)
+    allowed_tools: list[str] = Field(default_factory=list, max_length=200)
+    required_scopes: list[str] = Field(default_factory=list, max_length=200)
+    policy_ids: list[str] = Field(default_factory=list, max_length=200)
+    expires_at: str = Field(default="", max_length=80)
+
+    @field_validator("connector_ids", "connection_ids", "allowed_tools", "required_scopes", "policy_ids")
+    @classmethod
+    def _normalize_list(cls, values: list[str]) -> list[str]:
+        return _normalize_string_list(values)
+
+    @field_validator("expires_at")
+    @classmethod
+    def _normalize_expiry(cls, value: str) -> str:
+        return _normalize_expiry_value(value)
 
 
 def _dep(permission: str) -> Any:
@@ -81,49 +167,143 @@ def _config_url(config_id: str) -> str:
     return f"{API_V1_PREFIX}/mcp-config/{config_id}/mcp.json"
 
 
-@router.post("/mcp-config/assignments", status_code=201, dependencies=[_dep("config")])
-async def create_mcp_config_assignment(request: Request, body: dict) -> dict[str, object]:
-    """Assign a profile + connectors, yielding one distributable read-only config URL."""
-    tenant_id = _tenant(request)
-    name = str(body.get("name", "") or "").strip()
-    if not name:
-        raise HTTPException(status_code=400, detail="'name' is required")
-    profile_id = str(body.get("profile_id", "") or "").strip()
-    if not profile_id:
-        raise HTTPException(status_code=400, detail="'profile_id' is required")
+def _validate_references(*, tenant_id: str, profile_id: str, connector_ids: list[str], connection_ids: list[str]) -> None:
     if runtime_role_blueprint(profile_id) is None:
         raise HTTPException(status_code=400, detail="Unknown profile_id")
-
-    connector_ids = _str_list(body, "connector_ids")
-    if not connector_ids:
-        raise HTTPException(status_code=400, detail="'connector_ids' must list at least one connector")
-    known = {str(e.get("id")) for e in _registry()}
-    unknown = [c for c in connector_ids if c not in known]
-    if unknown:
+    known = {str(entry.get("id")) for entry in _registry()}
+    if any(connector_id not in known for connector_id in connector_ids):
         raise HTTPException(status_code=400, detail="One or more connector_ids are not in the registry")
-
-    connection_ids = _str_list(body, "connection_ids")
     if connection_ids:
-        owned = {str(c.get("id")) for c in _tenant_connections(tenant_id)}
-        if any(cid not in owned for cid in connection_ids):
+        owned = {str(connection.get("id")) for connection in _tenant_connections(tenant_id)}
+        if any(connection_id not in owned for connection_id in connection_ids):
             raise HTTPException(status_code=404, detail="One or more connection_ids are not available for this tenant")
 
-    assignment = create_assignment(
-        get_mcp_config_store(),
+
+def _bound_identity(*, tenant_id: str, identity_id: str, profile_id: str) -> AgentIdentity | None:
+    if not identity_id:
+        return None
+    from agent_bom.api.agent_identity_store import get_agent_identity_store
+
+    identity = get_agent_identity_store().get(identity_id, tenant_id=tenant_id)
+    if identity is None:
+        raise HTTPException(status_code=404, detail="Managed identity not found")
+    expected_blueprint = identity.blueprint_id.strip().lower().replace("-", "_")
+    requested_blueprint = profile_id.strip().lower().replace("-", "_")
+    if expected_blueprint != requested_blueprint:
+        raise HTTPException(status_code=400, detail="Managed identity blueprint does not match profile_id")
+    return identity
+
+
+@router.post("/mcp-config/assignments", status_code=201, dependencies=[_dep("config")])
+async def create_mcp_config_assignment(request: Request, body: McpConfigAssignmentCreate) -> dict[str, object]:
+    """Assign a profile + connectors, yielding one distributable read-only config URL."""
+    tenant_id = _tenant(request)
+    _validate_references(
         tenant_id=tenant_id,
-        name=name,
-        profile_id=profile_id,
-        connector_ids=connector_ids,
-        connection_ids=connection_ids,
-        created_by=_actor(request),
+        profile_id=body.profile_id,
+        connector_ids=body.connector_ids,
+        connection_ids=body.connection_ids,
     )
+    identity = _bound_identity(tenant_id=tenant_id, identity_id=body.identity_id, profile_id=body.profile_id)
+    if identity is not None:
+        if body.issuer not in ("", "agent-bom"):
+            raise HTTPException(status_code=400, detail="Managed identities use the agent-bom issuer")
+        if not body.environment:
+            raise HTTPException(status_code=400, detail="environment is required for a managed identity binding")
+    elif any((body.issuer, body.environment, body.allowed_tools, body.required_scopes, body.policy_ids, body.expires_at)):
+        raise HTTPException(status_code=400, detail="Runtime profile constraints require identity_id")
+
+    try:
+        assignment = create_assignment(
+            get_mcp_config_store(),
+            tenant_id=tenant_id,
+            name=body.name,
+            profile_id=body.profile_id,
+            connector_ids=body.connector_ids,
+            connection_ids=body.connection_ids,
+            created_by=_actor(request),
+            identity_id=body.identity_id,
+            issuer="agent-bom" if identity is not None else "",
+            environment=body.environment,
+            allowed_tools=body.allowed_tools,
+            required_scopes=body.required_scopes,
+            policy_ids=body.policy_ids,
+            owner=(identity.owner if identity is not None else "") or _actor(request),
+            expires_at=body.expires_at,
+        )
+    except McpConfigConflictError as exc:
+        raise HTTPException(status_code=409, detail="Managed identity already has an active client profile") from exc
     log_action(
         "mcp_config.assignment_created",
         actor=_actor(request),
         resource=f"mcp-config/{assignment.config_id}",
         tenant_id=tenant_id,
-        profile_id=profile_id,
-        connector_count=len(connector_ids),
+        profile_id=body.profile_id,
+        identity_id=body.identity_id,
+        connector_count=len(body.connector_ids),
+    )
+    return {
+        "schema_version": "mcp.client.config.v1",
+        "assignment": assignment.to_public_dict(),
+        "config_url": _config_url(assignment.config_id),
+    }
+
+
+@router.put("/mcp-config/assignments/{config_id}", dependencies=[_dep("config")])
+async def update_mcp_config_assignment(
+    request: Request,
+    config_id: str,
+    body: McpConfigAssignmentUpdate,
+) -> dict[str, object]:
+    """Replace a profile contract atomically when the expected revision matches."""
+    current = _assignment_for_tenant(request, config_id)
+    if current.revoked:
+        raise HTTPException(status_code=409, detail="Revoked MCP-client-config assignments cannot be updated")
+    # Reject a stale caller before validating replacement details. The store
+    # repeats this check atomically, closing the race after this fast path.
+    if current.revision != body.expected_revision:
+        raise HTTPException(status_code=409, detail="MCP-client-config assignment revision is stale")
+    tenant_id = _tenant(request)
+    _validate_references(
+        tenant_id=tenant_id,
+        profile_id=body.profile_id,
+        connector_ids=body.connector_ids,
+        connection_ids=body.connection_ids,
+    )
+    identity = _bound_identity(tenant_id=tenant_id, identity_id=current.identity_id, profile_id=body.profile_id)
+    if identity is not None and not body.environment:
+        raise HTTPException(status_code=400, detail="environment is required for a managed identity binding")
+    if identity is None and any(
+        (body.environment, body.allowed_tools, body.required_scopes, body.policy_ids, body.expires_at)
+    ):
+        raise HTTPException(status_code=400, detail="Runtime profile constraints require identity_id")
+    candidate = replace(
+        current,
+        name=body.name,
+        profile_id=body.profile_id,
+        connector_ids=body.connector_ids,
+        connection_ids=body.connection_ids,
+        environment=body.environment,
+        allowed_tools=body.allowed_tools,
+        required_scopes=body.required_scopes,
+        policy_ids=body.policy_ids,
+        expires_at=body.expires_at,
+        updated_at=_now_iso(),
+    )
+    try:
+        assignment = get_mcp_config_store().compare_and_swap(candidate, expected_revision=body.expected_revision)
+    except McpConfigRevisionConflictError as exc:
+        raise HTTPException(status_code=409, detail="MCP-client-config assignment revision is stale") from exc
+    except McpConfigConflictError as exc:
+        raise HTTPException(status_code=409, detail="MCP-client-config assignment conflicts with an active binding") from exc
+    log_action(
+        "mcp_config.assignment_updated",
+        actor=_actor(request),
+        resource=f"mcp-config/{assignment.config_id}",
+        tenant_id=tenant_id,
+        profile_id=assignment.profile_id,
+        identity_id=assignment.identity_id,
+        revision=assignment.revision,
     )
     return {
         "schema_version": "mcp.client.config.v1",

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -86,7 +86,7 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
     StorageSchemaComponent("governance_audit_log", "sqlite/postgres", ("governance_audit_log",)),
     StorageSchemaComponent("credential_refs", "sqlite/postgres", ("credential_refs",)),
     StorageSchemaComponent("ai_system_blueprints", "sqlite/postgres", ("ai_system_blueprints", "ai_system_blueprint_versions")),
-    StorageSchemaComponent("mcp_client_configs", "sqlite/postgres", ("mcp_client_configs",)),
+    StorageSchemaComponent("mcp_client_configs", "sqlite/postgres", ("mcp_client_configs",), version=2),
     StorageSchemaComponent("model_provider_keys", "sqlite/postgres", ("model_provider_keys", "model_virtual_keys")),
     StorageSchemaComponent("tenant_score_config", "sqlite/postgres", ("tenant_score_config_overrides",)),
     StorageSchemaComponent(

--- a/src/agent_bom/runtime/profile_resolution.py
+++ b/src/agent_bom/runtime/profile_resolution.py
@@ -1,0 +1,227 @@
+"""Canonical, fail-closed managed client-profile resolution.
+
+This joins the existing managed identity, MCP client-config assignment, and
+runtime role blueprint. Legacy unbound assignments remain distributable, but
+cannot be upgraded into observed runtime authorization.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from agent_bom.api.agent_identity_store import AgentIdentity
+from agent_bom.api.mcp_config_store import McpClientConfigAssignment, McpConfigStore
+from agent_bom.runtime_blueprints import runtime_role_blueprint
+
+PROFILE_SCHEMA_VERSION = "runtime.client.profile.v1"
+
+
+class ProfileResolutionCode(str, Enum):
+    RESOLVED = "resolved"
+    IDENTITY_INACTIVE = "identity_inactive"
+    TENANT_MISMATCH = "tenant_mismatch"
+    PROFILE_NOT_FOUND = "profile_not_found"
+    PROFILE_REVOKED = "profile_revoked"
+    PROFILE_DISABLED = "profile_disabled"
+    PROFILE_EXPIRED = "profile_expired"
+    PROFILE_INCOMPLETE = "profile_incomplete"
+    BLUEPRINT_UNKNOWN = "blueprint_unknown"
+    BLUEPRINT_MISMATCH = "blueprint_mismatch"
+    ISSUER_MISMATCH = "issuer_mismatch"
+    ENVIRONMENT_MISMATCH = "environment_mismatch"
+    INSUFFICIENT_SCOPE = "insufficient_scope"
+    TOOL_CONSTRAINT_CONFLICT = "tool_constraint_conflict"
+
+
+@dataclass(frozen=True)
+class ResolvedRuntimeProfile:
+    """Secret-free authorization view for a single managed identity."""
+
+    client_profile_id: str
+    tenant_id: str
+    revision: int
+    blueprint_id: str
+    blueprint_revision: int
+    identity_id: str
+    agent_id: str
+    issuer: str
+    environment: str
+    allowed_upstreams: tuple[str, ...]
+    allowed_tools: tuple[str, ...]
+    required_scopes: tuple[str, ...]
+    policy_ids: tuple[str, ...]
+    credential_references: tuple[str, ...]
+    owner: str
+    status: str
+    expires_at: str
+    schema_version: str = PROFILE_SCHEMA_VERSION
+
+    def allows_upstream(self, upstream: str) -> bool:
+        return "*" in self.allowed_upstreams or upstream in self.allowed_upstreams
+
+    def allows_tool(self, tool: str) -> bool:
+        return not self.allowed_tools or "*" in self.allowed_tools or tool in self.allowed_tools
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class ProfileResolution:
+    code: ProfileResolutionCode
+    profile: ResolvedRuntimeProfile | None = None
+
+    @property
+    def resolved(self) -> bool:
+        return self.code is ProfileResolutionCode.RESOLVED and self.profile is not None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": PROFILE_SCHEMA_VERSION,
+            "code": self.code.value,
+            "resolved": self.resolved,
+            "profile": self.profile.to_dict() if self.profile is not None else None,
+        }
+
+
+def _normalized(values: list[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value.strip() for value in values if value.strip()))
+
+
+def _intersect_constraints(identity_values: list[str], profile_values: list[str]) -> tuple[str, ...] | None:
+    identity = _normalized(identity_values)
+    profile = _normalized(profile_values)
+    if not identity:
+        return profile
+    if not profile:
+        return identity
+    if "*" in identity:
+        return profile
+    if "*" in profile:
+        return identity
+    intersection = tuple(value for value in identity if value in set(profile))
+    # Empty normally means unrestricted in the established identity contract;
+    # preserve that meaning by representing disjoint non-empty constraints as
+    # an explicit resolution denial instead of an empty allowlist.
+    return intersection or None
+
+
+def _expired(value: str, *, at: datetime) -> bool:
+    if not value:
+        return False
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        return True
+    return parsed <= at
+
+
+def _deny(code: ProfileResolutionCode) -> ProfileResolution:
+    return ProfileResolution(code=code)
+
+
+def _inactive_code(rows: list[McpClientConfigAssignment]) -> ProfileResolutionCode:
+    if len(rows) == 1:
+        if rows[0].revoked or rows[0].status == "revoked":
+            return ProfileResolutionCode.PROFILE_REVOKED
+        if rows[0].status != "active":
+            return ProfileResolutionCode.PROFILE_DISABLED
+    return ProfileResolutionCode.PROFILE_NOT_FOUND
+
+
+def resolve_runtime_profile(
+    assignment_store: McpConfigStore,
+    *,
+    identity: AgentIdentity,
+    tenant_id: str,
+    issuer: str,
+    environment: str,
+    granted_scopes: set[str] | frozenset[str],
+    at: datetime | None = None,
+) -> ProfileResolution:
+    """Resolve one managed identity to its unique live, versioned profile."""
+
+    now = at or datetime.now(timezone.utc)
+    if now.tzinfo is None or now.utcoffset() is None:
+        return _deny(ProfileResolutionCode.IDENTITY_INACTIVE)
+    if identity.tenant_id != tenant_id:
+        return _deny(ProfileResolutionCode.TENANT_MISMATCH)
+    try:
+        identity_live = identity.is_live(at=now)
+    except (TypeError, ValueError):
+        # Legacy or externally restored identities can contain malformed or
+        # timezone-naive expiry values. Resolution is an authorization seam,
+        # so invalid lifecycle evidence is a denial rather than a runtime 500.
+        identity_live = False
+    if not identity_live:
+        return _deny(ProfileResolutionCode.IDENTITY_INACTIVE)
+
+    assignment = assignment_store.get_active_for_identity(tenant_id, identity.identity_id)
+    if assignment is None:
+        return _deny(_inactive_code(assignment_store.list_for_identity(tenant_id, identity.identity_id, limit=2)))
+    if assignment.revoked:
+        return _deny(ProfileResolutionCode.PROFILE_REVOKED)
+    if assignment.status != "active":
+        return _deny(ProfileResolutionCode.PROFILE_DISABLED)
+    if _expired(assignment.expires_at, at=now):
+        return _deny(ProfileResolutionCode.PROFILE_EXPIRED)
+    if not assignment.issuer or not assignment.environment:
+        return _deny(ProfileResolutionCode.PROFILE_INCOMPLETE)
+
+    blueprint = runtime_role_blueprint(assignment.profile_id)
+    if blueprint is None:
+        return _deny(ProfileResolutionCode.BLUEPRINT_UNKNOWN)
+    blueprint_id = str(blueprint["blueprint_id"])
+    identity_blueprint = identity.blueprint_id.strip().lower().replace("-", "_")
+    if identity_blueprint != blueprint_id:
+        return _deny(ProfileResolutionCode.BLUEPRINT_MISMATCH)
+    if assignment.issuer != issuer:
+        return _deny(ProfileResolutionCode.ISSUER_MISMATCH)
+    if assignment.environment != environment:
+        return _deny(ProfileResolutionCode.ENVIRONMENT_MISMATCH)
+
+    required_scopes = _normalized(assignment.required_scopes)
+    if not set(required_scopes).issubset(granted_scopes):
+        return _deny(ProfileResolutionCode.INSUFFICIENT_SCOPE)
+    allowed_tools = _intersect_constraints(identity.allowed_tools, assignment.allowed_tools)
+    if allowed_tools is None:
+        return _deny(ProfileResolutionCode.TOOL_CONSTRAINT_CONFLICT)
+
+    raw_blueprint_revision = blueprint.get("revision")
+    blueprint_revision = raw_blueprint_revision if isinstance(raw_blueprint_revision, int) else 1
+    return ProfileResolution(
+        code=ProfileResolutionCode.RESOLVED,
+        profile=ResolvedRuntimeProfile(
+            client_profile_id=assignment.config_id,
+            tenant_id=tenant_id,
+            revision=max(1, int(assignment.revision)),
+            blueprint_id=blueprint_id,
+            blueprint_revision=max(1, blueprint_revision),
+            identity_id=identity.identity_id,
+            agent_id=identity.agent_id,
+            issuer=assignment.issuer,
+            environment=assignment.environment,
+            allowed_upstreams=_normalized(assignment.connector_ids),
+            allowed_tools=allowed_tools,
+            required_scopes=required_scopes,
+            policy_ids=_normalized(assignment.policy_ids),
+            credential_references=tuple(f"connection:{value}" for value in _normalized(assignment.connection_ids)),
+            owner=assignment.owner or identity.owner,
+            status=assignment.status,
+            expires_at=assignment.expires_at,
+        ),
+    )
+
+
+__all__ = [
+    "PROFILE_SCHEMA_VERSION",
+    "ProfileResolution",
+    "ProfileResolutionCode",
+    "ResolvedRuntimeProfile",
+    "resolve_runtime_profile",
+]

--- a/src/agent_bom/runtime_blueprints.py
+++ b/src/agent_bom/runtime_blueprints.py
@@ -20,6 +20,7 @@ class RuntimeRoleBlueprint:
     default_decision: str
     retention_mode: str
     evidence_required: tuple[str, ...]
+    revision: int = 1
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)

--- a/tests/test_mcp_config_profile_binding.py
+++ b/tests/test_mcp_config_profile_binding.py
@@ -1,0 +1,479 @@
+"""Durable canonical managed-identity to MCP profile bindings (#4152)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.agent_identity_store import (
+    InMemoryAgentIdentityStore,
+    issue_identity,
+    set_agent_identity_store,
+)
+from agent_bom.api.mcp_config_store import (
+    InMemoryMcpConfigStore,
+    McpConfigConflictError,
+    SQLiteMcpConfigStore,
+    _bounded_identity_history_limit,
+    create_assignment,
+    revoke_assignment,
+    set_mcp_config_store,
+)
+
+
+class _FakeCursor:
+    def __init__(self, row=None) -> None:
+        self._row = row
+
+    def fetchone(self):
+        return self._row
+
+
+class _FakePostgresConnection:
+    def __init__(self) -> None:
+        self.statements: list[str] = []
+        self.commits = 0
+
+    def execute(self, sql, params=None):
+        self.statements.append(str(sql))
+        return _FakeCursor()
+
+    def commit(self) -> None:
+        self.commits += 1
+
+
+class _FakePostgresPool:
+    def __init__(self, connection: _FakePostgresConnection) -> None:
+        self._connection = connection
+
+    @contextmanager
+    def connection(self):
+        yield self._connection
+
+
+@pytest.fixture(params=["memory", "sqlite"])
+def profile_store(request: pytest.FixtureRequest, tmp_path: Path):
+    if request.param == "sqlite":
+        return SQLiteMcpConfigStore(str(tmp_path / "profiles.db"))
+    return InMemoryMcpConfigStore()
+
+
+def test_exact_active_binding_is_tenant_scoped_unique_and_not_list_limited(profile_store) -> None:
+    bound = create_assignment(
+        profile_store,
+        tenant_id="tenant-a",
+        name="canonical",
+        profile_id="finance",
+        connector_ids=["snowflake"],
+        identity_id="identity-a",
+        issuer="agent-bom",
+        environment="prod",
+    )
+    # A resolver must not depend on the tenant-list presentation limit. Put the
+    # canonical row behind more than the API's maximum 1,000 returned rows.
+    for index in range(1001):
+        create_assignment(
+            profile_store,
+            tenant_id="tenant-a",
+            name=f"distractor-{index}",
+            profile_id="developer",
+            connector_ids=["filesystem"],
+        )
+    create_assignment(
+        profile_store,
+        tenant_id="tenant-b",
+        name="foreign",
+        profile_id="finance",
+        connector_ids=["snowflake"],
+        identity_id="identity-a",
+        issuer="agent-bom",
+        environment="prod",
+    )
+
+    resolved = profile_store.get_active_for_identity("tenant-a", "identity-a")
+    assert resolved is not None
+    assert resolved.config_id == bound.config_id
+    assert profile_store.get_active_for_identity("tenant-c", "identity-a") is None
+
+    with pytest.raises(McpConfigConflictError):
+        create_assignment(
+            profile_store,
+            tenant_id="tenant-a",
+            name="ambiguous",
+            profile_id="finance",
+            connector_ids=["snowflake"],
+            identity_id="identity-a",
+            issuer="agent-bom",
+            environment="prod",
+        )
+
+
+def test_revoke_is_atomic_versioned_and_releases_the_identity_binding(profile_store) -> None:
+    assignment = create_assignment(
+        profile_store,
+        tenant_id="tenant-a",
+        name="canonical",
+        profile_id="developer",
+        connector_ids=["filesystem"],
+        identity_id="identity-a",
+        issuer="agent-bom",
+        environment="prod",
+    )
+    assert assignment.revision == 1
+
+    revoked = revoke_assignment(profile_store, tenant_id="tenant-a", config_id=assignment.config_id)
+    assert revoked is not None
+    assert revoked.revoked is True
+    assert revoked.status == "revoked"
+    assert revoked.revision == 2
+    # Idempotent retries do not create phantom revisions.
+    retried = revoke_assignment(profile_store, tenant_id="tenant-a", config_id=assignment.config_id)
+    assert retried is not None
+    assert retried.revision == 2
+    assert profile_store.get_active_for_identity("tenant-a", "identity-a") is None
+
+    replacement = create_assignment(
+        profile_store,
+        tenant_id="tenant-a",
+        name="replacement",
+        profile_id="developer",
+        connector_ids=["filesystem"],
+        identity_id="identity-a",
+        issuer="agent-bom",
+        environment="prod",
+    )
+    assert replacement.revision == 1
+    assert profile_store.get_active_for_identity("tenant-a", "identity-a").config_id == replacement.config_id
+    bounded_history = profile_store.list_for_identity("tenant-a", "identity-a", limit=1)
+    assert [row.config_id for row in bounded_history] == [replacement.config_id]
+
+
+def test_put_cannot_rebind_a_distribution_assignment_to_an_identity(profile_store) -> None:
+    assignment = create_assignment(
+        profile_store,
+        tenant_id="tenant-a",
+        name="distribution-only",
+        profile_id="developer",
+        connector_ids=["filesystem"],
+    )
+
+    with pytest.raises(McpConfigConflictError):
+        profile_store.put(
+            replace(
+                assignment,
+                identity_id="identity-a",
+                issuer="agent-bom",
+                environment="prod",
+            )
+        )
+
+    assert profile_store.get_active_for_identity("tenant-a", "identity-a") is None
+    assert profile_store.get("tenant-a", assignment.config_id).identity_id == ""
+
+
+def test_put_cannot_move_an_assignment_between_tenants(profile_store) -> None:
+    assignment = create_assignment(
+        profile_store,
+        tenant_id="tenant-a",
+        name="canonical",
+        profile_id="developer",
+        connector_ids=["filesystem"],
+        identity_id="identity-a",
+        issuer="agent-bom",
+        environment="prod",
+    )
+
+    with pytest.raises(McpConfigConflictError):
+        profile_store.put(replace(assignment, tenant_id="tenant-b"))
+
+    assert profile_store.get("tenant-b", assignment.config_id) is None
+    assert profile_store.get_active_for_identity("tenant-a", "identity-a") is not None
+
+
+def test_put_is_insert_only_and_cannot_roll_back_a_revision(profile_store) -> None:
+    assignment = create_assignment(
+        profile_store,
+        tenant_id="tenant-a",
+        name="canonical",
+        profile_id="developer",
+        connector_ids=["filesystem"],
+        identity_id="identity-a",
+        issuer="agent-bom",
+        environment="prod",
+    )
+    updated = profile_store.compare_and_swap(
+        replace(assignment, name="revision-two"),
+        expected_revision=1,
+    )
+    assert updated.revision == 2
+
+    with pytest.raises(McpConfigConflictError):
+        profile_store.put(assignment)
+
+    readback = profile_store.get("tenant-a", assignment.config_id)
+    assert readback is not None
+    assert readback.revision == 2
+    assert readback.name == "revision-two"
+
+
+def test_memory_store_does_not_expose_mutable_assignment_state() -> None:
+    store = InMemoryMcpConfigStore()
+    assignment = create_assignment(
+        store,
+        tenant_id="tenant-a",
+        name="canonical",
+        profile_id="developer",
+        connector_ids=["filesystem"],
+        identity_id="identity-a",
+        issuer="agent-bom",
+        environment="prod",
+    )
+
+    assignment.identity_id = "identity-b"
+    assignment.connector_ids.append("snowflake")
+    readback = store.get("tenant-a", assignment.config_id)
+    assert readback is not None
+    readback.identity_id = "identity-c"
+    readback.connector_ids.append("github")
+
+    resolved = store.get_active_for_identity("tenant-a", "identity-a")
+    assert resolved is not None
+    assert resolved.identity_id == "identity-a"
+    assert resolved.connector_ids == ["filesystem"]
+    assert store.get_active_for_identity("tenant-a", "identity-b") is None
+    assert store.get_active_for_identity("tenant-a", "identity-c") is None
+
+
+def test_sqlite_v1_upgrade_overlays_authoritative_profile_columns(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy-profiles.db"
+    conn = sqlite3.connect(db_path)
+    legacy = {
+        "config_id": "legacy-revoked",
+        "tenant_id": "tenant-a",
+        "name": "legacy",
+        "profile_id": "developer",
+        "connector_ids": ["filesystem"],
+        "connection_ids": [],
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "created_by": "operator",
+        "revoked": True,
+    }
+    conn.execute(
+        "CREATE TABLE mcp_client_configs (config_id TEXT PRIMARY KEY, tenant_id TEXT NOT NULL, "
+        "name TEXT NOT NULL, profile_id TEXT NOT NULL, created_at TEXT NOT NULL, "
+        "revoked INTEGER NOT NULL DEFAULT 0, data TEXT NOT NULL)"
+    )
+    conn.execute(
+        "INSERT INTO mcp_client_configs "
+        "(config_id, tenant_id, name, profile_id, created_at, revoked, data) VALUES (?, ?, ?, ?, ?, ?, ?)",
+        (
+            legacy["config_id"],
+            legacy["tenant_id"],
+            legacy["name"],
+            legacy["profile_id"],
+            legacy["created_at"],
+            1,
+            json.dumps(legacy),
+        ),
+    )
+    conn.commit()
+    conn.close()
+
+    store = SQLiteMcpConfigStore(str(db_path))
+    upgraded = store.get("tenant-a", "legacy-revoked")
+    assert upgraded is not None
+    assert upgraded.identity_id == ""
+    assert upgraded.status == "revoked"
+    assert upgraded.revision == 1
+    assert upgraded.updated_at == legacy["created_at"]
+    assert store.revoke("tenant-a", "legacy-revoked").status == "revoked"
+
+
+def test_sqlite_identity_queries_use_partial_indexes(tmp_path: Path) -> None:
+    store = SQLiteMcpConfigStore(str(tmp_path / "profile-indexes.db"))
+    active_plan = store._conn.execute(
+        "EXPLAIN QUERY PLAN SELECT data FROM mcp_client_configs "
+        "WHERE tenant_id = ? AND identity_id = ? AND identity_id <> '' "
+        "AND revoked = 0 AND status = 'active'",
+        ("tenant-a", "identity-a"),
+    ).fetchall()
+    history_plan = store._conn.execute(
+        "EXPLAIN QUERY PLAN SELECT data FROM mcp_client_configs "
+        "WHERE tenant_id = ? AND identity_id = ? AND identity_id <> '' "
+        "ORDER BY updated_at DESC, config_id DESC LIMIT ?",
+        ("tenant-a", "identity-a", 2),
+    ).fetchall()
+
+    assert "idx_mcp_client_configs_active_identity" in " ".join(str(row[3]) for row in active_plan)
+    assert "idx_mcp_client_configs_identity_history" in " ".join(str(row[3]) for row in history_plan)
+
+
+def test_identity_history_limit_is_bounded() -> None:
+    assert _bounded_identity_history_limit(0) == 1
+    assert _bounded_identity_history_limit(2) == 2
+    assert _bounded_identity_history_limit(100_000) == 1_000
+
+
+def test_postgres_development_bootstrap_upgrades_v1_before_identity_indexes(monkeypatch) -> None:
+    import agent_bom.api.postgres_mcp_config as postgres_module
+
+    connection = _FakePostgresConnection()
+    monkeypatch.setattr(postgres_module, "ensure_postgres_schema_version", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(postgres_module, "_ensure_tenant_rls", lambda *_args, **_kwargs: None)
+
+    postgres_module.PostgresMcpConfigStore(_FakePostgresPool(connection))
+
+    sql = "\n".join(connection.statements)
+    assert sql.index("ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS identity_id") < sql.index(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_client_configs_active_identity"
+    )
+    assert "UPDATE mcp_client_configs SET identity_id = COALESCE(identity_id, '')" in sql
+    assert "ALTER TABLE mcp_client_configs ALTER COLUMN identity_id SET NOT NULL" in sql
+    assert connection.commits == 1
+
+
+@pytest.fixture()
+def bound_client() -> Iterator[tuple[TestClient, InMemoryAgentIdentityStore]]:
+    config_store = InMemoryMcpConfigStore()
+    identity_store = InMemoryAgentIdentityStore()
+    set_mcp_config_store(config_store)
+    set_agent_identity_store(identity_store)
+    from agent_bom.api.server import app
+
+    try:
+        yield TestClient(app), identity_store
+    finally:
+        set_agent_identity_store(None)
+        set_mcp_config_store(None)
+
+
+def _first_connector_id(client: TestClient) -> str:
+    servers = client.get("/v1/registry").json()["servers"]
+    assert servers
+    return str(servers[0]["id"])
+
+
+def test_bound_profile_api_uses_tenant_identity_and_compare_and_swap(bound_client) -> None:
+    client, identities = bound_client
+    identity, _token = issue_identity(
+        identities,
+        agent_id="agent-a",
+        tenant_id="default",
+        blueprint_id="developer",
+        owner="platform-security",
+    )
+    connector_id = _first_connector_id(client)
+    created = client.post(
+        "/v1/mcp-config/assignments",
+        json={
+            "name": "developer-prod",
+            "profile_id": "developer",
+            "connector_ids": [connector_id],
+            "identity_id": identity.identity_id,
+            "issuer": "agent-bom",
+            "environment": "prod",
+            "allowed_tools": ["read_file"],
+            "policy_ids": ["policy-developer"],
+        },
+    )
+    assert created.status_code == 201, created.text
+    assignment = created.json()["assignment"]
+    assert assignment["identity_id"] == identity.identity_id
+    assert assignment["owner"] == "platform-security"
+    assert assignment["revision"] == 1
+    assert "token_hash" not in created.text
+
+    updated = client.put(
+        f"/v1/mcp-config/assignments/{assignment['config_id']}",
+        json={
+            "expected_revision": 1,
+            "name": "developer-prod-v2",
+            "profile_id": "developer",
+            "connector_ids": [connector_id],
+            "environment": "prod",
+            "allowed_tools": ["read_file", "list_directory"],
+            "policy_ids": ["policy-developer-v2"],
+        },
+    )
+    assert updated.status_code == 200, updated.text
+    assert updated.json()["assignment"]["revision"] == 2
+    assert updated.json()["assignment"]["allowed_tools"] == ["read_file", "list_directory"]
+
+    stale = client.put(
+        f"/v1/mcp-config/assignments/{assignment['config_id']}",
+        json={
+            "expected_revision": 1,
+            "name": "stale",
+            "profile_id": "finance",
+            "connector_ids": [connector_id],
+            "environment": "dev",
+        },
+    )
+    assert stale.status_code == 409
+    readback = client.get(f"/v1/mcp-config/assignments/{assignment['config_id']}").json()["assignment"]
+    assert readback["revision"] == 2
+    assert readback["name"] == "developer-prod-v2"
+    assert readback["profile_id"] == "developer"
+    assert readback["environment"] == "prod"
+
+
+def test_bound_profile_api_hides_foreign_identity(bound_client) -> None:
+    client, identities = bound_client
+    foreign, _token = issue_identity(
+        identities,
+        agent_id="foreign-agent",
+        tenant_id="foreign-tenant",
+        blueprint_id="developer",
+    )
+    response = client.post(
+        "/v1/mcp-config/assignments",
+        json={
+            "name": "foreign",
+            "profile_id": "developer",
+            "connector_ids": [_first_connector_id(client)],
+            "identity_id": foreign.identity_id,
+            "issuer": "agent-bom",
+            "environment": "prod",
+        },
+    )
+    assert response.status_code == 404
+
+
+def test_unbound_profile_update_rejects_runtime_constraints(bound_client) -> None:
+    client, _identities = bound_client
+    connector_id = _first_connector_id(client)
+    created = client.post(
+        "/v1/mcp-config/assignments",
+        json={
+            "name": "distribution-only",
+            "profile_id": "developer",
+            "connector_ids": [connector_id],
+        },
+    )
+    assert created.status_code == 201, created.text
+    assignment = created.json()["assignment"]
+
+    response = client.put(
+        f"/v1/mcp-config/assignments/{assignment['config_id']}",
+        json={
+            "expected_revision": 1,
+            "name": "invalid-runtime-metadata",
+            "profile_id": "developer",
+            "connector_ids": [connector_id],
+            "environment": "prod",
+            "allowed_tools": ["read_file"],
+        },
+    )
+
+    assert response.status_code == 400
+    readback = client.get(f"/v1/mcp-config/assignments/{assignment['config_id']}").json()["assignment"]
+    assert readback["revision"] == 1
+    assert readback["environment"] == ""
+    assert readback["allowed_tools"] == []

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -21,6 +21,8 @@ CLOUD_CONNECTIONS_SCOPE_COLUMNS = VERSIONS_DIR / "20260724_02_cloud_connections_
 MANAGED_TRIAL_INVITATIONS = VERSIONS_DIR / "20260724_03_managed_trial_invitations.py"
 TICKETING_SCHEMA_AUTHORITY = VERSIONS_DIR / "20260726_01_ticketing_schema_authority.py"
 RUNTIME_EVIDENCE_TIMESTAMP_AUTHORITY = VERSIONS_DIR / "20260727_01_runtime_evidence_timestamp_authority.py"
+MCP_PROFILE_BINDING_AUTHORITY = VERSIONS_DIR / "20260728_01_mcp_profile_binding_authority.py"
+POSTGRES_MCP_CONFIG_STORE = Path(__file__).parent.parent / "src" / "agent_bom" / "api" / "postgres_mcp_config.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
 BOOTSTRAP = ALEMBIC_DIR / "bootstrap.py"
@@ -142,6 +144,52 @@ def test_runtime_evidence_timestamp_migration_is_chained_and_typed() -> None:
     runtime_schema = RUNTIME_SCHEMA_SQL.read_text()
     assert "observed_at TIMESTAMPTZ NOT NULL" in runtime_schema
     assert "VALUES ('runtime_workload_evidence',2,now())" in runtime_schema
+
+
+def test_mcp_profile_binding_migration_is_chained_unique_and_tenant_isolated() -> None:
+    sql = MCP_PROFILE_BINDING_AUTHORITY.read_text()
+    assert re.search(r'revision\s*=\s*"20260728_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260727_01"', sql)
+    for column in ("identity_id", "issuer", "environment", "status", "revision", "updated_at"):
+        assert f"ADD COLUMN IF NOT EXISTS {column}" in sql
+    assert "UPDATE mcp_client_configs" in sql
+    assert "WHEN revoked THEN 'revoked'" in sql
+    assert "idx_mcp_client_configs_active_identity" in sql
+    assert "idx_mcp_client_configs_identity_history" in sql
+    assert "ON mcp_client_configs (tenant_id, identity_id)" in sql
+    assert "btrim(identity_id) <> ''" in sql
+    assert "WHERE identity_id IS NOT NULL AND btrim(identity_id) <> '' AND status = 'active' AND revoked = FALSE" in sql
+    assert "identity_id = COALESCE(identity_id, '')" in sql
+    assert "ALTER COLUMN identity_id SET DEFAULT ''" in sql
+    assert "ALTER COLUMN identity_id SET NOT NULL" in sql
+    assert "raise NotImplementedError" in sql
+    assert "identity_id = COALESCE(identity_id, '')" in sql
+    assert "ALTER COLUMN identity_id SET DEFAULT ''" in sql
+    assert "ALTER COLUMN identity_id SET NOT NULL" in sql
+    assert "ALTER TABLE mcp_client_configs ENABLE ROW LEVEL SECURITY" in sql
+    assert "ALTER TABLE mcp_client_configs FORCE ROW LEVEL SECURITY" in sql
+    assert "mcp_client_configs_tenant_isolation" in sql
+    assert "GRANT SELECT, INSERT, UPDATE, DELETE ON mcp_client_configs TO agent_bom_app" in sql
+    assert "VALUES ('mcp_client_configs', 2, now())" in sql
+
+    runtime_schema = RUNTIME_SCHEMA_SQL.read_text()
+    for column in ("identity_id", "issuer", "environment", "status", "revision", "updated_at"):
+        assert column in runtime_schema
+    assert "idx_mcp_client_configs_active_identity" in runtime_schema
+    assert "idx_mcp_client_configs_identity_history" in runtime_schema
+    assert "identity_id TEXT NOT NULL DEFAULT ''" in runtime_schema
+    assert "VALUES ('mcp_client_configs',2,now())" in runtime_schema
+
+
+def test_development_postgres_profile_bootstrap_upgrades_v1_before_indexes() -> None:
+    source = POSTGRES_MCP_CONFIG_STORE.read_text()
+    alter = source.index("ALTER TABLE mcp_client_configs ADD COLUMN IF NOT EXISTS identity_id")
+    active_index = source.index("CREATE UNIQUE INDEX IF NOT EXISTS idx_mcp_client_configs_active_identity")
+    assert alter < active_index
+    assert "UPDATE mcp_client_configs SET identity_id = COALESCE(identity_id, '')" in source
+    assert "ALTER TABLE mcp_client_configs ALTER COLUMN identity_id SET NOT NULL" in source
+    assert source.count("btrim(identity_id) <> ''") >= 4
+    assert "ON CONFLICT (config_id) DO UPDATE" not in source
 
 
 def test_baseline_migration_points_at_bootstrap_sql():

--- a/tests/test_postgres_schema_authority.py
+++ b/tests/test_postgres_schema_authority.py
@@ -196,6 +196,16 @@ def test_ticketing_tables_are_registered_as_one_schema_component() -> None:
     assert ticketing[0].tenant_scoped is True
 
 
+def test_mcp_profile_bindings_require_schema_version_two() -> None:
+    components = [component for component in CONTROL_PLANE_SCHEMA_COMPONENTS if component.component == "mcp_client_configs"]
+
+    assert len(components) == 1
+    assert components[0].backend == "sqlite/postgres"
+    assert components[0].tables == ("mcp_client_configs",)
+    assert components[0].tenant_scoped is True
+    assert components[0].version == 2
+
+
 def test_legacy_postgres_db_setting_uses_the_same_read_only_contract(monkeypatch) -> None:
     monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
     monkeypatch.setenv("AGENT_BOM_DB", "postgresql://agent_bom_app@postgres/agent_bom")

--- a/tests/test_runtime_profile_resolution.py
+++ b/tests/test_runtime_profile_resolution.py
@@ -1,0 +1,206 @@
+"""Canonical managed-identity to client-profile resolution foundation (#4152)."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+
+import pytest
+
+from agent_bom.api.agent_identity_store import AgentIdentity
+from agent_bom.api.mcp_config_store import InMemoryMcpConfigStore, McpClientConfigAssignment
+from agent_bom.runtime.profile_resolution import ProfileResolutionCode, resolve_runtime_profile
+
+
+def _identity(**overrides: object) -> AgentIdentity:
+    values: dict[str, object] = {
+        "identity_id": "identity-a",
+        "agent_id": "agent-a",
+        "tenant_id": "tenant-a",
+        "token_hash": "must-never-leave-the-identity-store",
+        "token_prefix": "public",
+        "role": "finance-agent",
+        "blueprint_id": "finance",
+        "status": "active",
+        "issued_at": "2026-01-01T00:00:00+00:00",
+        "expires_at": "2030-01-01T00:00:00+00:00",
+        "allowed_tools": ["read_file", "run_report"],
+        "owner": "finance-platform",
+    }
+    values.update(overrides)
+    return AgentIdentity(**values)  # type: ignore[arg-type]
+
+
+def _assignment(**overrides: object) -> McpClientConfigAssignment:
+    values: dict[str, object] = {
+        "config_id": "client-profile-finance-prod",
+        "tenant_id": "tenant-a",
+        "name": "Finance production client",
+        "profile_id": "finance",
+        "identity_id": "identity-a",
+        "connector_ids": ["filesystem", "snowflake"],
+        "connection_ids": ["snowflake-prod"],
+        "issuer": "agent-bom",
+        "environment": "prod",
+        "allowed_tools": ["read_file"],
+        "required_scopes": ["tools:read"],
+        "policy_ids": ["policy-finance"],
+        "owner": "finance-security",
+        "status": "active",
+        "revision": 3,
+        "expires_at": "2030-01-01T00:00:00+00:00",
+        "created_at": "2026-01-01T00:00:00+00:00",
+        "updated_at": "2026-07-17T00:00:00+00:00",
+    }
+    values.update(overrides)
+    return McpClientConfigAssignment(**values)  # type: ignore[arg-type]
+
+
+def _store(assignment: McpClientConfigAssignment | None = None) -> InMemoryMcpConfigStore:
+    store = InMemoryMcpConfigStore()
+    if assignment is not None:
+        store.put(assignment)
+    return store
+
+
+def test_resolves_versioned_secret_free_profile_contract() -> None:
+    result = resolve_runtime_profile(
+        _store(_assignment()),
+        identity=_identity(),
+        tenant_id="tenant-a",
+        issuer="agent-bom",
+        environment="prod",
+        granted_scopes={"tools:read", "openid"},
+    )
+
+    assert result.code is ProfileResolutionCode.RESOLVED
+    assert result.profile is not None
+    assert result.profile.schema_version == "runtime.client.profile.v1"
+    assert result.profile.client_profile_id == "client-profile-finance-prod"
+    assert result.profile.blueprint_id == "finance"
+    assert result.profile.revision == 3
+    assert result.profile.allowed_upstreams == ("filesystem", "snowflake")
+    assert result.profile.allowed_tools == ("read_file",)
+    assert result.profile.credential_references == ("connection:snowflake-prod",)
+    assert result.profile.owner == "finance-security"
+    serialized = repr(result.to_dict())
+    assert "must-never-leave-the-identity-store" not in serialized
+    assert "token_hash" not in serialized
+
+
+@pytest.mark.parametrize(
+    ("assignment", "code"),
+    [
+        (_assignment(revoked=True), ProfileResolutionCode.PROFILE_REVOKED),
+        (_assignment(status="disabled"), ProfileResolutionCode.PROFILE_DISABLED),
+        (_assignment(expires_at="2020-01-01T00:00:00+00:00"), ProfileResolutionCode.PROFILE_EXPIRED),
+        (_assignment(profile_id="unknown-role"), ProfileResolutionCode.BLUEPRINT_UNKNOWN),
+    ],
+)
+def test_non_live_or_unknown_profile_fails_closed(
+    assignment: McpClientConfigAssignment,
+    code: ProfileResolutionCode,
+) -> None:
+    result = resolve_runtime_profile(
+        _store(assignment),
+        identity=_identity(blueprint_id=assignment.profile_id),
+        tenant_id="tenant-a",
+        issuer="agent-bom",
+        environment="prod",
+        granted_scopes={"tools:read"},
+    )
+    assert result.code is code
+    assert result.profile is None
+
+
+@pytest.mark.parametrize(
+    ("assignment", "kwargs", "code"),
+    [
+        (_assignment(), {"tenant_id": "tenant-b"}, ProfileResolutionCode.TENANT_MISMATCH),
+        (_assignment(), {"issuer": "foreign"}, ProfileResolutionCode.ISSUER_MISMATCH),
+        (_assignment(), {"environment": "dev"}, ProfileResolutionCode.ENVIRONMENT_MISMATCH),
+        (_assignment(), {"granted_scopes": set()}, ProfileResolutionCode.INSUFFICIENT_SCOPE),
+        (_assignment(issuer=""), {}, ProfileResolutionCode.PROFILE_INCOMPLETE),
+        (_assignment(environment=""), {}, ProfileResolutionCode.PROFILE_INCOMPLETE),
+    ],
+)
+def test_request_context_cannot_escape_binding(
+    assignment: McpClientConfigAssignment,
+    kwargs: dict[str, object],
+    code: ProfileResolutionCode,
+) -> None:
+    call: dict[str, object] = {
+        "identity": _identity(),
+        "tenant_id": "tenant-a",
+        "issuer": "agent-bom",
+        "environment": "prod",
+        "granted_scopes": {"tools:read"},
+    }
+    call.update(kwargs)
+    result = resolve_runtime_profile(_store(assignment), **call)  # type: ignore[arg-type]
+    assert result.code is code
+    assert result.profile is None
+
+
+def test_disjoint_identity_and_profile_tool_constraints_deny_all() -> None:
+    result = resolve_runtime_profile(
+        _store(_assignment(allowed_tools=["write_file"])),
+        identity=_identity(allowed_tools=["read_file"]),
+        tenant_id="tenant-a",
+        issuer="agent-bom",
+        environment="prod",
+        granted_scopes={"tools:read"},
+    )
+    assert result.code is ProfileResolutionCode.TOOL_CONSTRAINT_CONFLICT
+    assert result.profile is None
+
+
+def test_missing_binding_and_inactive_identity_fail_closed() -> None:
+    missing = resolve_runtime_profile(
+        _store(),
+        identity=_identity(),
+        tenant_id="tenant-a",
+        issuer="agent-bom",
+        environment="prod",
+        granted_scopes={"tools:read"},
+    )
+    assert missing.code is ProfileResolutionCode.PROFILE_NOT_FOUND
+
+    inactive = resolve_runtime_profile(
+        _store(_assignment()),
+        identity=replace(_identity(), status="revoked"),
+        tenant_id="tenant-a",
+        issuer="agent-bom",
+        environment="prod",
+        granted_scopes={"tools:read"},
+    )
+    assert inactive.code is ProfileResolutionCode.IDENTITY_INACTIVE
+
+
+def test_naive_identity_expiry_fails_closed_without_raising() -> None:
+    result = resolve_runtime_profile(
+        _store(_assignment()),
+        identity=_identity(expires_at="2030-01-01T00:00:00"),
+        tenant_id="tenant-a",
+        issuer="agent-bom",
+        environment="prod",
+        granted_scopes={"tools:read"},
+    )
+
+    assert result.code is ProfileResolutionCode.IDENTITY_INACTIVE
+    assert result.profile is None
+
+
+def test_naive_resolution_clock_fails_closed_without_raising() -> None:
+    result = resolve_runtime_profile(
+        _store(_assignment()),
+        identity=_identity(expires_at=""),
+        tenant_id="tenant-a",
+        issuer="agent-bom",
+        environment="prod",
+        granted_scopes={"tools:read"},
+        at=datetime(2026, 7, 28),
+    )
+
+    assert result.code is ProfileResolutionCode.IDENTITY_INACTIVE
+    assert result.profile is None

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -3851,6 +3851,16 @@ export interface McpClientConfigAssignment {
   created_by: string;
   updated_at: string;
   revoked: boolean;
+  identity_id: string;
+  issuer: string;
+  environment: string;
+  allowed_tools: string[];
+  required_scopes: string[];
+  policy_ids: string[];
+  owner: string;
+  status: "active" | "disabled" | "revoked";
+  revision: number;
+  expires_at: string;
   config_url?: string;
 }
 


### PR DESCRIPTION
## Summary

- reconcile managed identities, MCP client-config assignments, and runtime role blueprints into one versioned, tenant-scoped client-profile relation
- add strict create/update contracts, immutable identity bindings, optimistic revision updates, idempotent revocation, and fail-closed profile resolution
- keep SQLite and Postgres schema authority aligned, including safe v1 upgrades, exact indexed identity lookup, bounded history, and generated OpenAPI/UI contract updates

## Why

The runtime gateway already has identity and blueprint primitives, but it cannot yet resolve one durable sanctioned client profile before routing. This foundation closes the data-contract and persistence gaps without adding a parallel profile silo or claiming that in-path gateway enforcement is complete.

The review also found and fixed legacy-upgrade and concurrency defects before publication: nullable Postgres identities, stale JSON lifecycle fields, mutable in-memory indexes, CAS bypass through upsert, non-sargable partial-index queries, and timezone-naive lifecycle crashes.

## Verification

- `uv run pytest -q tests/test_mcp_config_profile_binding.py tests/test_runtime_profile_resolution.py tests/test_mcp_config_distribution.py tests/test_governance_audit_actor.py tests/api/test_api_agent_detail.py tests/test_postgres_migrations.py tests/test_postgres_schema_authority.py tests/test_durable_store_default.py tests/test_runtime_blueprints.py` — 100 passed
- `make lint` — Ruff clean; mypy clean across 811 source files
- `make preflight` — OpenAPI, schemas, capability manifest, product surfaces, release consistency, env references, SDK patterns, and documentation SVGs aligned
- Node 24.15.0 / npm 10.9.7: `npm run verify:toolchain`, `npm run typecheck`, and `npm test -- --run` — 160 files / 954 tests passed
- independent security, persistence, and public-contract rereviews — no remaining P0/P1 findings

## Notes

- `POSTGRES_TEST_URL` was not available locally, so credentialed Postgres execution remains CI/environment-gated; migration/schema authority and a fake-pool bootstrap contract are covered locally.
- This PR establishes the profile relation and resolver only. Gateway decision-point enforcement, typed durable activity, operator surfaces, and HA/deployment proof remain follow-up slices.
- No cloud-provider credentials or customer data-plane mutations were used.

Progresses #4152
