### PR TITLE
feat(runtime): add durable gateway activity ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1043,7 +1043,7 @@ jobs:
             uv run alembic -c deploy/supabase/postgres/alembic.ini upgrade head
 
       - name: Run real Postgres storage contract
-        run: uv run pytest tests/test_postgres_integration.py -q --tb=short
+        run: uv run pytest tests/test_postgres_integration.py tests/test_postgres_gateway_activity.py -q --tb=short
 
   # 3b. Alpine/musl compatibility test
   # Runs the test suite inside an Alpine Linux container (musl libc) to catch

--- a/deploy/supabase/postgres/alembic/versions/20260728_02_gateway_activity_ledger.py
+++ b/deploy/supabase/postgres/alembic/versions/20260728_02_gateway_activity_ledger.py
@@ -1,0 +1,116 @@
+"""Add the tenant-scoped durable gateway activity ledger.
+
+Revision ID: 20260728_02
+Revises: 20260728_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260728_02"
+down_revision = "20260728_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS gateway_activity_events (
+            tenant_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            ingest_ordinal BIGINT NOT NULL,
+            event_timestamp TIMESTAMPTZ NOT NULL,
+            ingested_at TIMESTAMPTZ NOT NULL,
+            event_digest TEXT NOT NULL,
+            data TEXT NOT NULL,
+            PRIMARY KEY (tenant_id, event_id)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS gateway_activity_sequences (
+            tenant_id TEXT PRIMARY KEY,
+            next_ordinal BIGINT NOT NULL CHECK (next_ordinal >= 1)
+        )
+        """
+    )
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS gateway_activity_tombstones (
+            tenant_id TEXT NOT NULL,
+            event_id TEXT NOT NULL,
+            event_digest TEXT NOT NULL,
+            pruned_ordinal BIGINT NOT NULL,
+            PRIMARY KEY (tenant_id, event_id)
+        )
+        """
+    )
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal "
+        "ON gateway_activity_events(tenant_id, ingest_ordinal)"
+    )
+    op.execute(
+        "CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal "
+        "ON gateway_activity_tombstones(tenant_id, pruned_ordinal)"
+    )
+
+    op.execute("ALTER TABLE gateway_activity_events ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE gateway_activity_events FORCE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE gateway_activity_sequences ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE gateway_activity_sequences FORCE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE gateway_activity_tombstones ENABLE ROW LEVEL SECURITY")
+    op.execute("ALTER TABLE gateway_activity_tombstones FORCE ROW LEVEL SECURITY")
+
+    for table in (
+        "gateway_activity_events",
+        "gateway_activity_sequences",
+        "gateway_activity_tombstones",
+    ):
+        op.execute(
+            f"""
+            DO $$
+            BEGIN
+              IF NOT EXISTS (
+                SELECT 1 FROM pg_policies
+                WHERE schemaname = current_schema()
+                  AND tablename = '{table}'
+                  AND policyname = '{table}_tenant_isolation'
+              ) THEN
+                CREATE POLICY {table}_tenant_isolation ON {table}
+                  USING (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant())
+                  WITH CHECK (public.abom_rls_bypass() OR tenant_id = public.abom_current_tenant());
+              END IF;
+            END $$
+            """
+        )
+
+    op.execute(
+        """
+        DO $$
+        BEGIN
+          IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'agent_bom_app') THEN
+            GRANT SELECT, INSERT, UPDATE, DELETE ON gateway_activity_events TO agent_bom_app;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON gateway_activity_sequences TO agent_bom_app;
+            GRANT SELECT, INSERT, UPDATE, DELETE ON gateway_activity_tombstones TO agent_bom_app;
+          END IF;
+        END $$
+        """
+    )
+    op.execute(
+        """
+        INSERT INTO control_plane_schema_versions(component, version, updated_at)
+        VALUES ('runtime_events', 2, now())
+        ON CONFLICT(component) DO UPDATE SET
+            version = EXCLUDED.version,
+            updated_at = EXCLUDED.updated_at
+        """
+    )
+
+
+def downgrade() -> None:
+    # Gateway activity is governance evidence. Never destroy retained evidence
+    # or its replay tombstones automatically during a binary rollback.
+    raise NotImplementedError("Gateway activity ledger storage is additive and intentionally irreversible.")

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -97,6 +97,11 @@ CREATE TABLE IF NOT EXISTS runtime_observations (tenant_id TEXT NOT NULL, observ
 CREATE TABLE IF NOT EXISTS runtime_sessions (tenant_id TEXT NOT NULL, session_id TEXT NOT NULL, last_seen TEXT NOT NULL, data TEXT NOT NULL, PRIMARY KEY(tenant_id,session_id));
 CREATE INDEX IF NOT EXISTS idx_runtime_observations_tenant_session_time ON runtime_observations(tenant_id,session_id,observed_at DESC);
 CREATE INDEX IF NOT EXISTS idx_runtime_sessions_tenant_last_seen ON runtime_sessions(tenant_id,last_seen DESC);
+CREATE TABLE IF NOT EXISTS gateway_activity_events (tenant_id TEXT NOT NULL,event_id TEXT NOT NULL,ingest_ordinal BIGINT NOT NULL,event_timestamp TIMESTAMPTZ NOT NULL,ingested_at TIMESTAMPTZ NOT NULL,event_digest TEXT NOT NULL,data TEXT NOT NULL,PRIMARY KEY(tenant_id,event_id));
+CREATE TABLE IF NOT EXISTS gateway_activity_sequences (tenant_id TEXT PRIMARY KEY,next_ordinal BIGINT NOT NULL CHECK(next_ordinal >= 1));
+CREATE TABLE IF NOT EXISTS gateway_activity_tombstones (tenant_id TEXT NOT NULL,event_id TEXT NOT NULL,event_digest TEXT NOT NULL,pruned_ordinal BIGINT NOT NULL,PRIMARY KEY(tenant_id,event_id));
+CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal ON gateway_activity_events(tenant_id,ingest_ordinal);
+CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal ON gateway_activity_tombstones(tenant_id,pruned_ordinal);
 CREATE TABLE IF NOT EXISTS runtime_workload_evidence (
   tenant_id TEXT NOT NULL,
   provider TEXT NOT NULL,
@@ -200,7 +205,8 @@ DECLARE t TEXT;
 BEGIN
   FOREACH t IN ARRAY ARRAY[
     'access_review_campaigns','access_review_items','agent_identities','agent_identity_jit_grants','agent_conditional_access_policies',
-    'ai_system_blueprints','ai_system_blueprint_versions','runtime_observations','runtime_sessions','runtime_workload_evidence','scim_users','scim_groups',
+    'ai_system_blueprints','ai_system_blueprint_versions','runtime_observations','runtime_sessions','gateway_activity_events','gateway_activity_sequences',
+    'gateway_activity_tombstones','runtime_workload_evidence','scim_users','scim_groups',
     'idempotency_keys','proxy_replay_log','tenant_quota_overrides','tenant_graph_retention_overrides','tenant_score_config_overrides',
     'mcp_client_configs','model_provider_keys','model_virtual_keys','risk_campaign_workflows','governance_audit_log','cloud_connections','ticketing_connections','ticket_links',
     'control_plane_sources','credential_refs','audit_chain_checkpoint','managed_trial_invitations','managed_trial_tenants','compliance_hub_findings','hub_findings_current',
@@ -229,13 +235,16 @@ INSERT INTO control_plane_schema_versions(component,version,updated_at)
 SELECT component,1,now() FROM unnest(ARRAY[
  'scan_jobs','api_keys','exceptions','audit_log','trend_history','gateway_policies','schedules','sources','credential_refs','llm_costs',
  'cloud_connections','compliance_hub','access_review_campaigns','risk_campaign_workflows','fleet','graph','scan_cache','identity_scim',
- 'agent_identities','runtime_events','tenant_quotas','tenant_graph_retention','idempotency','proxy_replay_log','rate_limits',
+ 'agent_identities','tenant_quotas','tenant_graph_retention','idempotency','proxy_replay_log','rate_limits',
  'shared_auth_state','managed_trial_invitations','managed_trial_tenants','governance_audit_log','ai_system_blueprints','model_provider_keys','tenant_score_config',
  'ticketing_connections'
 ]) component
 ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;
 INSERT INTO control_plane_schema_versions(component,version,updated_at)
 VALUES ('runtime_workload_evidence',2,now())
+ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;
+INSERT INTO control_plane_schema_versions(component,version,updated_at)
+VALUES ('runtime_events',2,now())
 ON CONFLICT(component) DO UPDATE SET version=excluded.version,updated_at=excluded.updated_at;
 INSERT INTO control_plane_schema_versions(component,version,updated_at)
 VALUES ('mcp_client_configs',2,now())

--- a/src/agent_bom/api/gateway_activity_store.py
+++ b/src/agent_bom/api/gateway_activity_store.py
@@ -1,0 +1,825 @@
+"""Typed, append-only gateway activity ledger with tenant-safe cursors.
+
+This ledger is intentionally separate from the generic runtime session rollup:
+gateway activity needs conflict-aware replay, a server-owned ordering ordinal,
+and an explicit retention floor. Caller timestamps remain provenance only and
+never determine cursor or pruning order.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+import sqlite3
+import threading
+from collections import deque
+from dataclasses import asdict, dataclass, replace
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+from agent_bom.runtime.gateway_events import (
+    GATEWAY_ALLOWED_EVENT_TYPES,
+    GATEWAY_BLOCKED_EVENT_TYPES,
+    GATEWAY_DATA_FILTER_EVENT_TYPES,
+)
+from agent_bom.storage.base import BackendKind, StorageSchema, TableSchema
+
+GATEWAY_ACTIVITY_SCHEMA_VERSION = 1
+GATEWAY_ACTIVITY_STORAGE_VERSION = 2
+DEFAULT_MAX_EVENTS_PER_TENANT = 50_000
+DEFAULT_MAX_TOMBSTONES_PER_TENANT = 100_000
+MAX_ACTIVITY_PAGE_SIZE = 500
+MAX_ACTIVITY_BATCH_SIZE = 500
+MAX_EVENT_FUTURE_SKEW = timedelta(minutes=5)
+
+_SQLITE_EVENTS_DDL = """
+CREATE TABLE IF NOT EXISTS gateway_activity_events (
+    tenant_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    ingest_ordinal INTEGER NOT NULL,
+    event_timestamp TEXT NOT NULL,
+    ingested_at TEXT NOT NULL,
+    event_digest TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, event_id)
+)
+"""
+_POSTGRES_EVENTS_DDL = """
+CREATE TABLE IF NOT EXISTS gateway_activity_events (
+    tenant_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    ingest_ordinal BIGINT NOT NULL,
+    event_timestamp TIMESTAMPTZ NOT NULL,
+    ingested_at TIMESTAMPTZ NOT NULL,
+    event_digest TEXT NOT NULL,
+    data TEXT NOT NULL,
+    PRIMARY KEY (tenant_id, event_id)
+)
+"""
+_SQLITE_SEQUENCES_DDL = """
+CREATE TABLE IF NOT EXISTS gateway_activity_sequences (
+    tenant_id TEXT PRIMARY KEY,
+    next_ordinal INTEGER NOT NULL CHECK (next_ordinal >= 1)
+)
+"""
+_POSTGRES_SEQUENCES_DDL = """
+CREATE TABLE IF NOT EXISTS gateway_activity_sequences (
+    tenant_id TEXT PRIMARY KEY,
+    next_ordinal BIGINT NOT NULL CHECK (next_ordinal >= 1)
+)
+"""
+_SQLITE_TOMBSTONES_DDL = """
+CREATE TABLE IF NOT EXISTS gateway_activity_tombstones (
+    tenant_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    event_digest TEXT NOT NULL,
+    pruned_ordinal INTEGER NOT NULL,
+    PRIMARY KEY (tenant_id, event_id)
+)
+"""
+_POSTGRES_TOMBSTONES_DDL = """
+CREATE TABLE IF NOT EXISTS gateway_activity_tombstones (
+    tenant_id TEXT NOT NULL,
+    event_id TEXT NOT NULL,
+    event_digest TEXT NOT NULL,
+    pruned_ordinal BIGINT NOT NULL,
+    PRIMARY KEY (tenant_id, event_id)
+)
+"""
+
+GATEWAY_ACTIVITY_STORE_SCHEMA = StorageSchema(
+    component="runtime_events",
+    tables=(
+        TableSchema(
+            "gateway_activity_events",
+            ("tenant_id", "event_id", "ingest_ordinal", "event_timestamp", "ingested_at", "event_digest", "data"),
+            {BackendKind.SQLITE.value: _SQLITE_EVENTS_DDL, BackendKind.POSTGRES.value: _POSTGRES_EVENTS_DDL},
+        ),
+        TableSchema(
+            "gateway_activity_sequences",
+            ("tenant_id", "next_ordinal"),
+            {BackendKind.SQLITE.value: _SQLITE_SEQUENCES_DDL, BackendKind.POSTGRES.value: _POSTGRES_SEQUENCES_DDL},
+        ),
+        TableSchema(
+            "gateway_activity_tombstones",
+            ("tenant_id", "event_id", "event_digest", "pruned_ordinal"),
+            {BackendKind.SQLITE.value: _SQLITE_TOMBSTONES_DDL, BackendKind.POSTGRES.value: _POSTGRES_TOMBSTONES_DDL},
+        ),
+    ),
+)
+
+
+def ensure_sqlite_gateway_activity_schema(conn: sqlite3.Connection) -> None:
+    """Create the complete gateway portion of ``runtime_events`` schema v2."""
+
+    conn.execute(_SQLITE_EVENTS_DDL)
+    conn.execute(_SQLITE_SEQUENCES_DDL)
+    conn.execute(_SQLITE_TOMBSTONES_DDL)
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal "
+        "ON gateway_activity_events(tenant_id, ingest_ordinal)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal "
+        "ON gateway_activity_tombstones(tenant_id, pruned_ordinal)"
+    )
+    # The readiness marker is deliberately last: v2 means every ledger table
+    # and uniqueness guard above exists, regardless of which runtime store was
+    # constructed first.
+    ensure_sqlite_schema_version(conn, "runtime_events", version=GATEWAY_ACTIVITY_STORAGE_VERSION)
+
+_EVENT_TYPES = GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEWAY_DATA_FILTER_EVENT_TYPES
+_EXPECTED_DECISIONS = {
+    "gateway.tool_call.allowed": "allow",
+    "gateway.tool_call.blocked": "deny",
+    "gateway.dlp.arguments_redacted": "allow",
+    "gateway.dlp.result_redacted": "allow",
+    "gateway.dlp.result_blocked": "deny",
+    "gateway.visual.redacted": "allow",
+}
+_ALLOWED_EVENT_FIELDS = frozenset(
+    {
+        "schema_version",
+        "event_id",
+        "decision_id",
+        "event_type",
+        "event_timestamp",
+        "tenant_id",
+        "agent_id",
+        "identity_id",
+        "profile_id",
+        "profile_revision",
+        "blueprint_id",
+        "blueprint_revision",
+        "policy_ids",
+        "upstream",
+        "tool",
+        "decision",
+        "policy_source",
+        "reason_code",
+        "trace_id",
+        "data_action",
+        "policy_id",
+        "evidence_id",
+        "development_mode",
+    }
+)
+
+
+class GatewayActivityConflictError(ValueError):
+    """An event ID was replayed with different canonical metadata."""
+
+
+class GatewayActivityCursorError(ValueError):
+    """A cursor is malformed, foreign, unsupported, or ahead of the ledger."""
+
+
+class GatewayActivityCursorExpiredError(GatewayActivityCursorError):
+    """A cursor points below the retained tenant activity floor."""
+
+    def __init__(self, retention_floor_ordinal: int) -> None:
+        super().__init__("Gateway activity cursor is older than retained history")
+        self.retention_floor_ordinal = retention_floor_ordinal
+
+
+@dataclass(frozen=True)
+class GatewayActivityRecord:
+    tenant_id: str
+    event_id: str
+    decision_id: str
+    event_type: str
+    event_schema_version: str
+    event_timestamp: str
+    ingested_at: str
+    source_id: str
+    session_id: str
+    agent_id: str
+    upstream: str
+    tool: str
+    decision: str
+    policy_source: str
+    trace_id: str
+    identity_id: str = ""
+    profile_id: str = ""
+    profile_revision: int = 0
+    blueprint_id: str = ""
+    blueprint_revision: int = 0
+    policy_ids: tuple[str, ...] = ()
+    reason_code: str = ""
+    data_action: str = ""
+    policy_id: str = ""
+    evidence_id: str = ""
+    development_mode: bool = False
+    event_digest: str = ""
+    ingest_ordinal: int = 0
+    raw_payload_stored: bool = False
+    record_schema_version: str = "gateway.activity.record.v1"
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["policy_ids"] = list(self.policy_ids)
+        return payload
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), separators=(",", ":"), sort_keys=True)
+
+
+@dataclass(frozen=True)
+class GatewayActivityAppendResult:
+    inserted_event_ids: tuple[str, ...] = ()
+    duplicate_event_ids: tuple[str, ...] = ()
+
+    @property
+    def inserted_count(self) -> int:
+        return len(self.inserted_event_ids)
+
+    @property
+    def duplicate_count(self) -> int:
+        return len(self.duplicate_event_ids)
+
+
+@dataclass(frozen=True)
+class GatewayActivityPage:
+    tenant_id: str
+    events: list[dict[str, Any]]
+    cursor: str | None
+    next_cursor: str | None
+    has_more: bool
+    retention_floor_ordinal: int
+    latest_ordinal: int
+    max_events_per_tenant: int
+    dedupe_window_events: int
+
+
+def _required_text(value: object, field: str, *, max_len: int = 200) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"gateway activity {field} is required")
+    normalized = value.strip()
+    if len(normalized) > max_len:
+        raise ValueError(f"gateway activity {field} exceeds {max_len} characters")
+    return normalized
+
+
+def _optional_text(value: object, field: str, *, max_len: int = 200) -> str:
+    if value in (None, ""):
+        return ""
+    if not isinstance(value, str):
+        raise ValueError(f"gateway activity {field} must be text")
+    normalized = value.strip()
+    if len(normalized) > max_len:
+        raise ValueError(f"gateway activity {field} exceeds {max_len} characters")
+    return normalized
+
+
+def _revision(value: object, field: str) -> int:
+    if value in (None, ""):
+        return 0
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"gateway activity {field} must be a non-negative integer")
+    return value
+
+
+def _event_timestamp(value: object, *, received_at: datetime) -> str:
+    raw = _required_text(value, "event_timestamp", max_len=80)
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError("gateway activity event_timestamp is invalid") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError("gateway activity event_timestamp must include a timezone")
+    normalized_received_at = received_at.astimezone(timezone.utc)
+    normalized = parsed.astimezone(timezone.utc)
+    if normalized > normalized_received_at + MAX_EVENT_FUTURE_SKEW:
+        raise ValueError("gateway activity event_timestamp is too far in the future")
+    return normalized.isoformat()
+
+
+def _policy_ids(value: object) -> tuple[str, ...]:
+    if value in (None, ()):
+        return ()
+    if not isinstance(value, list | tuple) or len(value) > 200:
+        raise ValueError("gateway activity policy_ids must contain at most 200 items")
+    normalized: list[str] = []
+    for item in value:
+        policy_id = _required_text(item, "policy_ids item")
+        if policy_id not in normalized:
+            normalized.append(policy_id)
+    return tuple(normalized)
+
+
+def _development_mode(value: object) -> bool:
+    if value is None:
+        return False
+    if not isinstance(value, bool):
+        raise ValueError("gateway activity development_mode must be a boolean")
+    return value
+
+
+def _validate_store_config(max_events_per_tenant: int, max_tombstones_per_tenant: int) -> None:
+    if isinstance(max_events_per_tenant, bool) or max_events_per_tenant < 1:
+        raise ValueError("gateway activity max_events_per_tenant must be at least 1")
+    if isinstance(max_tombstones_per_tenant, bool) or max_tombstones_per_tenant < 1:
+        raise ValueError("gateway activity max_tombstones_per_tenant must be at least 1")
+
+
+def _digest_payload(record: GatewayActivityRecord) -> str:
+    payload = record.to_dict()
+    payload.pop("event_digest", None)
+    payload.pop("ingest_ordinal", None)
+    payload.pop("ingested_at", None)
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def gateway_activity_record_from_event(
+    event: dict[str, Any],
+    *,
+    tenant_id: str,
+    source_id: str,
+    session_id: str,
+    received_at: datetime | None = None,
+) -> GatewayActivityRecord:
+    """Validate one exact typed event and bind it to server-owned context."""
+
+    unexpected = sorted(set(event) - _ALLOWED_EVENT_FIELDS)
+    if unexpected:
+        raise ValueError(f"unexpected gateway activity field: {unexpected[0]}")
+    if event.get("schema_version") != "gateway.runtime.event.v1":
+        raise ValueError("gateway activity schema_version must be gateway.runtime.event.v1")
+    event_id = _required_text(event.get("event_id"), "event_id")
+    decision_id = _required_text(event.get("decision_id"), "decision_id")
+    if decision_id != event_id:
+        raise ValueError("gateway activity decision_id must equal event_id")
+    event_type = _required_text(event.get("event_type"), "event_type", max_len=120)
+    if event_type not in _EVENT_TYPES:
+        raise ValueError("gateway activity event_type is not canonical")
+    decision = _required_text(event.get("decision"), "decision", max_len=20)
+    if decision != _EXPECTED_DECISIONS[event_type]:
+        raise ValueError("gateway activity decision is inconsistent with event_type")
+    now = received_at or datetime.now(timezone.utc)
+    if now.tzinfo is None or now.utcoffset() is None:
+        raise ValueError("gateway activity received_at must include a timezone")
+    record = GatewayActivityRecord(
+        tenant_id=_required_text(tenant_id, "tenant_id"),
+        event_id=event_id,
+        decision_id=decision_id,
+        event_type=event_type,
+        event_schema_version="gateway.runtime.event.v1",
+        event_timestamp=_event_timestamp(event.get("event_timestamp"), received_at=now),
+        ingested_at=now.astimezone(timezone.utc).isoformat(),
+        source_id=_required_text(source_id, "source_id"),
+        session_id=_required_text(session_id, "session_id"),
+        agent_id=_required_text(event.get("agent_id"), "agent_id"),
+        identity_id=_optional_text(event.get("identity_id"), "identity_id"),
+        profile_id=_optional_text(event.get("profile_id"), "profile_id"),
+        profile_revision=_revision(event.get("profile_revision"), "profile_revision"),
+        blueprint_id=_optional_text(event.get("blueprint_id"), "blueprint_id"),
+        blueprint_revision=_revision(event.get("blueprint_revision"), "blueprint_revision"),
+        policy_ids=_policy_ids(event.get("policy_ids")),
+        upstream=_required_text(event.get("upstream"), "upstream"),
+        tool=_required_text(event.get("tool"), "tool"),
+        decision=decision,
+        policy_source=_required_text(event.get("policy_source"), "policy_source", max_len=120),
+        reason_code=_optional_text(event.get("reason_code"), "reason_code"),
+        trace_id=_required_text(event.get("trace_id"), "trace_id"),
+        data_action=_optional_text(event.get("data_action"), "data_action", max_len=80),
+        policy_id=_optional_text(event.get("policy_id"), "policy_id"),
+        evidence_id=_optional_text(event.get("evidence_id"), "evidence_id"),
+        development_mode=_development_mode(event.get("development_mode")),
+    )
+    return replace(record, event_digest=_digest_payload(record))
+
+
+def _prepare_batch(records: list[GatewayActivityRecord]) -> tuple[str, list[GatewayActivityRecord]]:
+    if not records:
+        return "", []
+    if len(records) > MAX_ACTIVITY_BATCH_SIZE:
+        raise ValueError(f"gateway activity batch exceeds {MAX_ACTIVITY_BATCH_SIZE} events")
+    tenants = {record.tenant_id for record in records}
+    if len(tenants) != 1:
+        raise ValueError("gateway activity batch must contain exactly one tenant")
+    by_id: dict[str, GatewayActivityRecord] = {}
+    for record in records:
+        if record.event_digest != _digest_payload(record):
+            raise ValueError(f"gateway activity event_digest is invalid: {record.event_id}")
+        existing = by_id.get(record.event_id)
+        if existing is not None and existing.event_digest != record.event_digest:
+            raise GatewayActivityConflictError(f"gateway activity event_id conflict: {record.event_id}")
+        by_id.setdefault(record.event_id, record)
+    return next(iter(tenants)), list(by_id.values())
+
+
+def _encode_cursor(tenant_id: str, ordinal: int) -> str:
+    payload = json.dumps(
+        {"ordinal": ordinal, "tenant_id": tenant_id, "v": GATEWAY_ACTIVITY_SCHEMA_VERSION},
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(payload).decode("ascii").rstrip("=")
+
+
+def _decode_cursor(cursor: str, tenant_id: str) -> int:
+    if not cursor or len(cursor) > 1000:
+        raise GatewayActivityCursorError("Invalid gateway activity cursor")
+    try:
+        padded = cursor + "=" * (-len(cursor) % 4)
+        payload = json.loads(base64.b64decode(padded, altchars=b"-_", validate=True))
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise GatewayActivityCursorError("Invalid gateway activity cursor") from exc
+    if not isinstance(payload, dict) or payload.get("v") != GATEWAY_ACTIVITY_SCHEMA_VERSION:
+        raise GatewayActivityCursorError("Invalid gateway activity cursor")
+    if payload.get("tenant_id") != tenant_id:
+        raise GatewayActivityCursorError("Invalid gateway activity cursor")
+    ordinal = payload.get("ordinal")
+    if isinstance(ordinal, bool) or not isinstance(ordinal, int) or ordinal < 0:
+        raise GatewayActivityCursorError("Invalid gateway activity cursor")
+    return ordinal
+
+
+def _page(
+    tenant_id: str,
+    records: list[GatewayActivityRecord],
+    *,
+    cursor: str | None,
+    limit: int,
+    floor: int,
+    latest: int,
+    max_events: int,
+    max_tombstones: int,
+) -> GatewayActivityPage:
+    bounded_limit = max(1, min(limit, MAX_ACTIVITY_PAGE_SIZE))
+    has_more = len(records) > bounded_limit
+    page_records = records[:bounded_limit]
+    next_cursor: str | None = (
+        _encode_cursor(tenant_id, page_records[-1].ingest_ordinal) if page_records else cursor
+    )
+    return GatewayActivityPage(
+        tenant_id=tenant_id,
+        events=[record.to_dict() for record in page_records],
+        cursor=cursor,
+        next_cursor=next_cursor,
+        has_more=has_more,
+        retention_floor_ordinal=floor,
+        latest_ordinal=latest,
+        max_events_per_tenant=max_events,
+        dedupe_window_events=max_events + max_tombstones,
+    )
+
+
+class InMemoryGatewayActivityStore:
+    def __init__(
+        self,
+        *,
+        max_events_per_tenant: int = DEFAULT_MAX_EVENTS_PER_TENANT,
+        max_tombstones_per_tenant: int = DEFAULT_MAX_TOMBSTONES_PER_TENANT,
+    ) -> None:
+        _validate_store_config(max_events_per_tenant, max_tombstones_per_tenant)
+        self.max_events_per_tenant = max_events_per_tenant
+        self.max_tombstones_per_tenant = max_tombstones_per_tenant
+        self._events: dict[tuple[str, str], GatewayActivityRecord] = {}
+        self._tombstones: dict[tuple[str, str], tuple[str, int]] = {}
+        self._tombstone_order: dict[str, deque[tuple[int, str]]] = {}
+        self._next_ordinal: dict[str, int] = {}
+        self._lock = threading.Lock()
+
+    def init_schema(self) -> None:
+        """Satisfy the shared store contract; memory has no external schema."""
+
+    @staticmethod
+    def encode_cursor(tenant_id: str, ordinal: int) -> str:
+        return _encode_cursor(tenant_id, ordinal)
+
+    def append_batch(self, records: list[GatewayActivityRecord]) -> GatewayActivityAppendResult:
+        tenant_id, prepared = _prepare_batch(records)
+        if not prepared:
+            return GatewayActivityAppendResult()
+        with self._lock:
+            duplicates: list[str] = []
+            new_records: list[GatewayActivityRecord] = []
+            for record in prepared:
+                key = (tenant_id, record.event_id)
+                existing = self._events.get(key)
+                tombstone = self._tombstones.get(key)
+                existing_digest = existing.event_digest if existing is not None else tombstone[0] if tombstone else None
+                if existing_digest is not None:
+                    if existing_digest != record.event_digest:
+                        raise GatewayActivityConflictError(f"gateway activity event_id conflict: {record.event_id}")
+                    duplicates.append(record.event_id)
+                else:
+                    new_records.append(record)
+            next_ordinal = self._next_ordinal.get(tenant_id, 1)
+            inserted: list[str] = []
+            for record in new_records:
+                stored = replace(record, ingest_ordinal=next_ordinal)
+                self._events[(tenant_id, record.event_id)] = stored
+                inserted.append(record.event_id)
+                next_ordinal += 1
+            self._next_ordinal[tenant_id] = next_ordinal
+            tenant_events = sorted(
+                (record for (row_tenant, _), record in self._events.items() if row_tenant == tenant_id),
+                key=lambda record: record.ingest_ordinal,
+            )
+            if self.max_events_per_tenant > 0:
+                for stale in tenant_events[: max(0, len(tenant_events) - self.max_events_per_tenant)]:
+                    self._events.pop((tenant_id, stale.event_id), None)
+                    self._tombstones[(tenant_id, stale.event_id)] = (stale.event_digest, stale.ingest_ordinal)
+                    self._tombstone_order.setdefault(tenant_id, deque()).append((stale.ingest_ordinal, stale.event_id))
+            tombstone_order = self._tombstone_order.setdefault(tenant_id, deque())
+            while len(tombstone_order) > self.max_tombstones_per_tenant:
+                ordinal, event_id = tombstone_order.popleft()
+                current = self._tombstones.get((tenant_id, event_id))
+                if current is not None and current[1] == ordinal:
+                    self._tombstones.pop((tenant_id, event_id), None)
+            return GatewayActivityAppendResult(tuple(inserted), tuple(duplicates))
+
+    def list_activity(self, tenant_id: str, *, cursor: str | None = None, limit: int = 100) -> GatewayActivityPage:
+        with self._lock:
+            latest = self._next_ordinal.get(tenant_id, 1) - 1
+            rows = sorted(
+                (record for (row_tenant, _), record in self._events.items() if row_tenant == tenant_id),
+                key=lambda record: record.ingest_ordinal,
+            )
+            floor = rows[0].ingest_ordinal if rows else latest + 1
+            after = _decode_cursor(cursor, tenant_id) if cursor else floor - 1
+            if after > latest:
+                raise GatewayActivityCursorError("Invalid gateway activity cursor")
+            if after < floor - 1:
+                raise GatewayActivityCursorExpiredError(floor)
+            selected = [record for record in rows if record.ingest_ordinal > after]
+            return _page(
+                tenant_id,
+                selected[: max(1, min(limit, MAX_ACTIVITY_PAGE_SIZE)) + 1],
+                cursor=cursor,
+                limit=limit,
+                floor=floor,
+                latest=latest,
+                max_events=self.max_events_per_tenant,
+                max_tombstones=self.max_tombstones_per_tenant,
+            )
+
+
+class SQLiteGatewayActivityStore:
+    def __init__(
+        self,
+        db_path: str,
+        *,
+        max_events_per_tenant: int = DEFAULT_MAX_EVENTS_PER_TENANT,
+        max_tombstones_per_tenant: int = DEFAULT_MAX_TOMBSTONES_PER_TENANT,
+    ) -> None:
+        _validate_store_config(max_events_per_tenant, max_tombstones_per_tenant)
+        self.db_path = str(Path(db_path))
+        self.max_events_per_tenant = max_events_per_tenant
+        self.max_tombstones_per_tenant = max_tombstones_per_tenant
+        self._local = threading.local()
+        self._init_schema()
+
+    def init_schema(self) -> None:
+        """Idempotently initialize the SQLite ledger schema."""
+
+        self._init_schema()
+
+    @property
+    def _conn(self) -> sqlite3.Connection:
+        if not hasattr(self._local, "conn") or self._local.conn is None:
+            self._local.conn = sqlite3.connect(self.db_path, check_same_thread=False)
+            self._local.conn.execute("PRAGMA journal_mode=WAL")
+        return self._local.conn
+
+    @staticmethod
+    def encode_cursor(tenant_id: str, ordinal: int) -> str:
+        return _encode_cursor(tenant_id, ordinal)
+
+    def _init_schema(self) -> None:
+        conn = self._conn
+        ensure_sqlite_gateway_activity_schema(conn)
+        conn.commit()
+
+    def append_batch(self, records: list[GatewayActivityRecord]) -> GatewayActivityAppendResult:
+        tenant_id, prepared = _prepare_batch(records)
+        if not prepared:
+            return GatewayActivityAppendResult()
+        conn = self._conn
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            conn.execute(
+                "INSERT INTO gateway_activity_sequences(tenant_id, next_ordinal) VALUES (?, 1) "
+                "ON CONFLICT(tenant_id) DO NOTHING",
+                (tenant_id,),
+            )
+            event_ids = [record.event_id for record in prepared]
+            placeholders = ",".join("?" for _ in event_ids)
+            active = dict(
+                conn.execute(
+                    f"SELECT event_id, event_digest FROM gateway_activity_events "  # nosec B608
+                    f"WHERE tenant_id = ? AND event_id IN ({placeholders})",
+                    (tenant_id, *event_ids),
+                ).fetchall()
+            )
+            tombstones = dict(
+                conn.execute(
+                    f"SELECT event_id, event_digest FROM gateway_activity_tombstones "  # nosec B608
+                    f"WHERE tenant_id = ? AND event_id IN ({placeholders})",
+                    (tenant_id, *event_ids),
+                ).fetchall()
+            )
+            duplicates: list[str] = []
+            new_records: list[GatewayActivityRecord] = []
+            for record in prepared:
+                digest = active.get(record.event_id) or tombstones.get(record.event_id)
+                if digest is not None:
+                    if digest != record.event_digest:
+                        raise GatewayActivityConflictError(f"gateway activity event_id conflict: {record.event_id}")
+                    duplicates.append(record.event_id)
+                else:
+                    new_records.append(record)
+            next_ordinal = int(
+                conn.execute(
+                    "SELECT next_ordinal FROM gateway_activity_sequences WHERE tenant_id = ?",
+                    (tenant_id,),
+                ).fetchone()[0]
+            )
+            stored_records = [replace(record, ingest_ordinal=next_ordinal + index) for index, record in enumerate(new_records)]
+            conn.executemany(
+                """
+                INSERT INTO gateway_activity_events
+                    (tenant_id,event_id,ingest_ordinal,event_timestamp,ingested_at,event_digest,data)
+                VALUES (?,?,?,?,?,?,?)
+                """,
+                [
+                    (
+                        record.tenant_id,
+                        record.event_id,
+                        record.ingest_ordinal,
+                        record.event_timestamp,
+                        record.ingested_at,
+                        record.event_digest,
+                        record.to_json(),
+                    )
+                    for record in stored_records
+                ],
+            )
+            conn.execute(
+                "UPDATE gateway_activity_sequences SET next_ordinal = ? WHERE tenant_id = ?",
+                (next_ordinal + len(stored_records), tenant_id),
+            )
+            if self.max_events_per_tenant > 0:
+                count = int(
+                    conn.execute(
+                        "SELECT COUNT(*) FROM gateway_activity_events WHERE tenant_id = ?",
+                        (tenant_id,),
+                    ).fetchone()[0]
+                )
+                excess = max(0, count - self.max_events_per_tenant)
+                stale = conn.execute(
+                    "SELECT event_id,event_digest,ingest_ordinal FROM gateway_activity_events "
+                    "WHERE tenant_id = ? ORDER BY ingest_ordinal ASC LIMIT ?",
+                    (tenant_id, excess),
+                ).fetchall()
+                if stale:
+                    conn.executemany(
+                        "INSERT INTO gateway_activity_tombstones(tenant_id,event_id,event_digest,pruned_ordinal) VALUES (?,?,?,?) "
+                        "ON CONFLICT(tenant_id,event_id) DO UPDATE SET "
+                        "event_digest=excluded.event_digest,pruned_ordinal=excluded.pruned_ordinal",
+                        [(tenant_id, event_id, digest, ordinal) for event_id, digest, ordinal in stale],
+                    )
+                    conn.executemany(
+                        "DELETE FROM gateway_activity_events WHERE tenant_id = ? AND event_id = ?",
+                        [(tenant_id, event_id) for event_id, _digest, _ordinal in stale],
+                    )
+                    tombstone_count = int(
+                        conn.execute(
+                            "SELECT COUNT(*) FROM gateway_activity_tombstones WHERE tenant_id = ?",
+                            (tenant_id,),
+                        ).fetchone()[0]
+                    )
+                    tombstone_excess = max(0, tombstone_count - self.max_tombstones_per_tenant)
+                    expired_ids = conn.execute(
+                        "SELECT event_id FROM gateway_activity_tombstones "
+                        "WHERE tenant_id = ? ORDER BY pruned_ordinal ASC LIMIT ?",
+                        (tenant_id, tombstone_excess),
+                    ).fetchall()
+                    conn.executemany(
+                        "DELETE FROM gateway_activity_tombstones WHERE tenant_id = ? AND event_id = ?",
+                        [(tenant_id, event_id) for (event_id,) in expired_ids],
+                    )
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        return GatewayActivityAppendResult(
+            tuple(record.event_id for record in stored_records),
+            tuple(duplicates),
+        )
+
+    def list_activity(self, tenant_id: str, *, cursor: str | None = None, limit: int = 100) -> GatewayActivityPage:
+        conn = self._conn
+        bounded_limit = max(1, min(limit, MAX_ACTIVITY_PAGE_SIZE))
+        requested_after = _decode_cursor(cursor, tenant_id) if cursor else None
+        rows = conn.execute(
+            """
+            WITH bounds AS (
+                SELECT
+                    COALESCE((SELECT next_ordinal - 1 FROM gateway_activity_sequences WHERE tenant_id = ?), 0) AS latest,
+                    COALESCE(
+                        (SELECT MIN(ingest_ordinal) FROM gateway_activity_events WHERE tenant_id = ?),
+                        (SELECT next_ordinal FROM gateway_activity_sequences WHERE tenant_id = ?),
+                        1
+                    ) AS floor
+            ), page AS (
+                SELECT data, ingest_ordinal
+                FROM gateway_activity_events, bounds
+                WHERE tenant_id = ?
+                  AND ingest_ordinal > COALESCE(?, bounds.floor - 1)
+                ORDER BY ingest_ordinal ASC
+                LIMIT ?
+            )
+            SELECT bounds.latest, bounds.floor, page.data
+            FROM bounds LEFT JOIN page ON 1 = 1
+            ORDER BY page.ingest_ordinal ASC
+            """,
+            (tenant_id, tenant_id, tenant_id, tenant_id, requested_after, bounded_limit + 1),
+        ).fetchall()
+        latest = int(rows[0][0])
+        floor = int(rows[0][1])
+        after = requested_after if requested_after is not None else floor - 1
+        if cursor:
+            if after > latest:
+                raise GatewayActivityCursorError("Invalid gateway activity cursor")
+            if after < floor - 1:
+                raise GatewayActivityCursorExpiredError(floor)
+        records = [_record_from_json(row[2]) for row in rows if row[2] is not None]
+        return _page(
+            tenant_id,
+            records,
+            cursor=cursor,
+            limit=bounded_limit,
+            floor=floor,
+            latest=latest,
+            max_events=self.max_events_per_tenant,
+            max_tombstones=self.max_tombstones_per_tenant,
+        )
+
+    def query_plan(self, tenant_id: str, *, after_ordinal: int, limit: int) -> str:
+        rows = self._conn.execute(
+            "EXPLAIN QUERY PLAN SELECT data FROM gateway_activity_events "
+            "WHERE tenant_id = ? AND ingest_ordinal > ? ORDER BY ingest_ordinal ASC LIMIT ?",
+            (tenant_id, after_ordinal, limit),
+        ).fetchall()
+        return " ".join(str(column) for row in rows for column in row)
+
+
+def _record_from_json(raw: str) -> GatewayActivityRecord:
+    payload = json.loads(raw)
+    return GatewayActivityRecord(
+        tenant_id=str(payload["tenant_id"]),
+        event_id=str(payload["event_id"]),
+        decision_id=str(payload["decision_id"]),
+        event_type=str(payload["event_type"]),
+        event_schema_version=str(payload["event_schema_version"]),
+        event_timestamp=str(payload["event_timestamp"]),
+        ingested_at=str(payload["ingested_at"]),
+        source_id=str(payload["source_id"]),
+        session_id=str(payload["session_id"]),
+        agent_id=str(payload["agent_id"]),
+        identity_id=str(payload.get("identity_id") or ""),
+        profile_id=str(payload.get("profile_id") or ""),
+        profile_revision=int(payload.get("profile_revision") or 0),
+        blueprint_id=str(payload.get("blueprint_id") or ""),
+        blueprint_revision=int(payload.get("blueprint_revision") or 0),
+        policy_ids=tuple(str(value) for value in payload.get("policy_ids") or []),
+        upstream=str(payload["upstream"]),
+        tool=str(payload["tool"]),
+        decision=str(payload["decision"]),
+        policy_source=str(payload["policy_source"]),
+        reason_code=str(payload.get("reason_code") or ""),
+        trace_id=str(payload["trace_id"]),
+        data_action=str(payload.get("data_action") or ""),
+        policy_id=str(payload.get("policy_id") or ""),
+        evidence_id=str(payload.get("evidence_id") or ""),
+        development_mode=bool(payload.get("development_mode", False)),
+        event_digest=str(payload["event_digest"]),
+        ingest_ordinal=int(payload["ingest_ordinal"]),
+        raw_payload_stored=False,
+        record_schema_version=str(payload.get("record_schema_version") or "gateway.activity.record.v1"),
+    )
+
+
+__all__ = [
+    "GatewayActivityAppendResult",
+    "GatewayActivityConflictError",
+    "GatewayActivityCursorError",
+    "GatewayActivityCursorExpiredError",
+    "GatewayActivityPage",
+    "GatewayActivityRecord",
+    "GATEWAY_ACTIVITY_STORE_SCHEMA",
+    "DEFAULT_MAX_TOMBSTONES_PER_TENANT",
+    "MAX_ACTIVITY_BATCH_SIZE",
+    "InMemoryGatewayActivityStore",
+    "SQLiteGatewayActivityStore",
+    "gateway_activity_record_from_event",
+    "ensure_sqlite_gateway_activity_schema",
+]

--- a/src/agent_bom/api/postgres_gateway_activity.py
+++ b/src/agent_bom/api/postgres_gateway_activity.py
@@ -1,0 +1,252 @@
+"""Shared-Postgres tier for the typed gateway activity ledger."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from agent_bom.api.gateway_activity_store import (
+    DEFAULT_MAX_EVENTS_PER_TENANT,
+    DEFAULT_MAX_TOMBSTONES_PER_TENANT,
+    GATEWAY_ACTIVITY_STORAGE_VERSION,
+    GATEWAY_ACTIVITY_STORE_SCHEMA,
+    MAX_ACTIVITY_PAGE_SIZE,
+    GatewayActivityAppendResult,
+    GatewayActivityConflictError,
+    GatewayActivityCursorError,
+    GatewayActivityCursorExpiredError,
+    GatewayActivityPage,
+    GatewayActivityRecord,
+    _decode_cursor,
+    _page,
+    _prepare_batch,
+    _record_from_json,
+    _validate_store_config,
+)
+from agent_bom.api.postgres_common import Connection, ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.storage_schema import ensure_postgres_schema_version
+from agent_bom.storage.base import BackendKind
+
+
+def bootstrap_postgres_gateway_activity_schema(conn: Connection) -> None:
+    """Create ledger tables for an explicitly non-authoritative dev/test pool."""
+
+    for table_schema in GATEWAY_ACTIVITY_STORE_SCHEMA.tables:
+        ddl = table_schema.ddl_for(BackendKind.POSTGRES)
+        if ddl:
+            conn.execute(ddl)
+    conn.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal "
+        "ON gateway_activity_events(tenant_id, ingest_ordinal)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal "
+        "ON gateway_activity_tombstones(tenant_id, pruned_ordinal)"
+    )
+    for table_name in (
+        "gateway_activity_events",
+        "gateway_activity_sequences",
+        "gateway_activity_tombstones",
+    ):
+        _ensure_tenant_rls(conn, table_name, "tenant_id")
+
+
+class PostgresGatewayActivityStore:
+    """Append-only, conflict-aware gateway activity shared by all replicas."""
+
+    def __init__(
+        self,
+        pool: ConnectionPool | None = None,
+        *,
+        max_events_per_tenant: int = DEFAULT_MAX_EVENTS_PER_TENANT,
+        max_tombstones_per_tenant: int = DEFAULT_MAX_TOMBSTONES_PER_TENANT,
+    ) -> None:
+        _validate_store_config(max_events_per_tenant, max_tombstones_per_tenant)
+        self._pool = pool or _get_pool()
+        self.max_events_per_tenant = max_events_per_tenant
+        self.max_tombstones_per_tenant = max_tombstones_per_tenant
+        self.init_schema()
+
+    def init_schema(self) -> None:
+        """Bootstrap isolated development pools or validate Alembic authority."""
+
+        with self._pool.connection() as conn:
+            if not ensure_postgres_schema_version(conn, "runtime_events", version=GATEWAY_ACTIVITY_STORAGE_VERSION):
+                return
+            bootstrap_postgres_gateway_activity_schema(conn)
+            conn.commit()
+
+    def append_batch(self, records: list[GatewayActivityRecord]) -> GatewayActivityAppendResult:
+        tenant_id, prepared = _prepare_batch(records)
+        if not prepared:
+            return GatewayActivityAppendResult()
+        with _tenant_connection(self._pool) as conn:
+            try:
+                conn.execute(
+                    "INSERT INTO gateway_activity_sequences(tenant_id, next_ordinal) VALUES (%s, 1) "
+                    "ON CONFLICT(tenant_id) DO NOTHING",
+                    (tenant_id,),
+                )
+                # This per-tenant row is the serialization point. It is locked
+                # before dedupe reads, so a concurrent commit is visible before
+                # this transaction decides whether an event is new.
+                sequence_row = conn.execute(
+                    "SELECT next_ordinal FROM gateway_activity_sequences "
+                    "WHERE tenant_id = %s FOR UPDATE",
+                    (tenant_id,),
+                ).fetchone()
+                if sequence_row is None:
+                    raise RuntimeError("Gateway activity sequence was not initialized")
+                next_ordinal = int(sequence_row[0])
+
+                event_ids = [record.event_id for record in prepared]
+                placeholders = ",".join("%s" for _ in event_ids)
+                active = dict(
+                    conn.execute(
+                        f"SELECT event_id, event_digest FROM gateway_activity_events "  # nosec B608
+                        f"WHERE tenant_id = %s AND event_id IN ({placeholders})",
+                        (tenant_id, *event_ids),
+                    ).fetchall()
+                )
+                tombstones = dict(
+                    conn.execute(
+                        f"SELECT event_id, event_digest FROM gateway_activity_tombstones "  # nosec B608
+                        f"WHERE tenant_id = %s AND event_id IN ({placeholders})",
+                        (tenant_id, *event_ids),
+                    ).fetchall()
+                )
+
+                duplicates: list[str] = []
+                new_records: list[GatewayActivityRecord] = []
+                for record in prepared:
+                    digest = active.get(record.event_id) or tombstones.get(record.event_id)
+                    if digest is None:
+                        new_records.append(record)
+                    elif digest == record.event_digest:
+                        duplicates.append(record.event_id)
+                    else:
+                        raise GatewayActivityConflictError(f"gateway activity event_id conflict: {record.event_id}")
+
+                stored_records = [replace(record, ingest_ordinal=next_ordinal + index) for index, record in enumerate(new_records)]
+                for record in stored_records:
+                    conn.execute(
+                        """
+                        INSERT INTO gateway_activity_events
+                            (tenant_id,event_id,ingest_ordinal,event_timestamp,ingested_at,event_digest,data)
+                        VALUES (%s,%s,%s,%s,%s,%s,%s)
+                        """,
+                        (
+                            record.tenant_id,
+                            record.event_id,
+                            record.ingest_ordinal,
+                            record.event_timestamp,
+                            record.ingested_at,
+                            record.event_digest,
+                            record.to_json(),
+                        ),
+                    )
+                conn.execute(
+                    "UPDATE gateway_activity_sequences SET next_ordinal = %s WHERE tenant_id = %s",
+                    (next_ordinal + len(stored_records), tenant_id),
+                )
+
+                if self.max_events_per_tenant > 0:
+                    stale = conn.execute(
+                        """
+                        SELECT event_id,event_digest,ingest_ordinal FROM gateway_activity_events
+                        WHERE tenant_id = %s
+                        ORDER BY ingest_ordinal DESC
+                        OFFSET %s
+                        """,
+                        (tenant_id, self.max_events_per_tenant),
+                    ).fetchall()
+                    if stale:
+                        for event_id, event_digest, ingest_ordinal in stale:
+                            conn.execute(
+                                """
+                                INSERT INTO gateway_activity_tombstones
+                                    (tenant_id,event_id,event_digest,pruned_ordinal)
+                                VALUES (%s,%s,%s,%s)
+                                ON CONFLICT(tenant_id,event_id) DO UPDATE SET
+                                    event_digest=EXCLUDED.event_digest,
+                                    pruned_ordinal=EXCLUDED.pruned_ordinal
+                                """,
+                                (tenant_id, event_id, event_digest, ingest_ordinal),
+                            )
+                            conn.execute(
+                                "DELETE FROM gateway_activity_events WHERE tenant_id = %s AND event_id = %s",
+                                (tenant_id, event_id),
+                            )
+                        stale_tombstones = conn.execute(
+                            """
+                            SELECT event_id FROM gateway_activity_tombstones
+                            WHERE tenant_id = %s
+                            ORDER BY pruned_ordinal DESC
+                            OFFSET %s
+                            """,
+                            (tenant_id, self.max_tombstones_per_tenant),
+                        ).fetchall()
+                        for (event_id,) in stale_tombstones:
+                            conn.execute(
+                                "DELETE FROM gateway_activity_tombstones WHERE tenant_id = %s AND event_id = %s",
+                                (tenant_id, event_id),
+                            )
+                conn.commit()
+            except Exception:
+                conn.rollback()
+                raise
+
+        return GatewayActivityAppendResult(
+            tuple(record.event_id for record in stored_records),
+            tuple(duplicates),
+        )
+
+    def list_activity(self, tenant_id: str, *, cursor: str | None = None, limit: int = 100) -> GatewayActivityPage:
+        bounded_limit = max(1, min(limit, MAX_ACTIVITY_PAGE_SIZE))
+        requested_after = _decode_cursor(cursor, tenant_id) if cursor else None
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                """
+                WITH bounds AS (
+                    SELECT
+                        COALESCE((SELECT next_ordinal - 1 FROM gateway_activity_sequences WHERE tenant_id = %s), 0) AS latest,
+                        COALESCE(
+                            (SELECT MIN(ingest_ordinal) FROM gateway_activity_events WHERE tenant_id = %s),
+                            (SELECT next_ordinal FROM gateway_activity_sequences WHERE tenant_id = %s),
+                            1
+                        ) AS floor
+                ), page AS (
+                    SELECT data, ingest_ordinal
+                    FROM gateway_activity_events, bounds
+                    WHERE tenant_id = %s
+                      AND ingest_ordinal > COALESCE(%s, bounds.floor - 1)
+                    ORDER BY ingest_ordinal ASC
+                    LIMIT %s
+                )
+                SELECT bounds.latest, bounds.floor, page.data
+                FROM bounds LEFT JOIN page ON TRUE
+                ORDER BY page.ingest_ordinal ASC NULLS LAST
+                """,
+                (tenant_id, tenant_id, tenant_id, tenant_id, requested_after, bounded_limit + 1),
+            ).fetchall()
+        latest = int(rows[0][0])
+        floor = int(rows[0][1])
+        after = requested_after if requested_after is not None else floor - 1
+        if cursor:
+            if after > latest:
+                raise GatewayActivityCursorError("Invalid gateway activity cursor")
+            if after < floor - 1:
+                raise GatewayActivityCursorExpiredError(floor)
+        records = [_record_from_json(row[2]) for row in rows if row[2] is not None]
+        return _page(
+            tenant_id,
+            records,
+            cursor=cursor,
+            limit=bounded_limit,
+            floor=floor,
+            latest=latest,
+            max_events=self.max_events_per_tenant,
+            max_tombstones=self.max_tombstones_per_tenant,
+        )
+
+
+__all__ = ["PostgresGatewayActivityStore", "bootstrap_postgres_gateway_activity_schema"]

--- a/src/agent_bom/api/postgres_runtime_event.py
+++ b/src/agent_bom/api/postgres_runtime_event.py
@@ -17,7 +17,9 @@ from __future__ import annotations
 import json
 
 from agent_bom.analytics_retention import prune_runtime_observations_for_tenant
+from agent_bom.api.gateway_activity_store import GATEWAY_ACTIVITY_STORAGE_VERSION
 from agent_bom.api.postgres_common import ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
+from agent_bom.api.postgres_gateway_activity import bootstrap_postgres_gateway_activity_schema
 from agent_bom.api.runtime_event_store import (
     _BATCH_LOOKUP_CHUNK,
     RuntimeObservationRecord,
@@ -44,7 +46,7 @@ class PostgresRuntimeEventStore:
 
     def _init_tables(self) -> None:
         with self._pool.connection() as conn:
-            if not ensure_postgres_schema_version(conn, "runtime_events"):
+            if not ensure_postgres_schema_version(conn, "runtime_events", version=GATEWAY_ACTIVITY_STORAGE_VERSION):
                 return
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS runtime_observations (
@@ -72,6 +74,7 @@ class PostgresRuntimeEventStore:
             conn.execute("CREATE INDEX IF NOT EXISTS idx_runtime_sessions_tenant_last_seen ON runtime_sessions(tenant_id, last_seen DESC)")
             _ensure_tenant_rls(conn, "runtime_observations", "tenant_id")
             _ensure_tenant_rls(conn, "runtime_sessions", "tenant_id")
+            bootstrap_postgres_gateway_activity_schema(conn)
             conn.commit()
 
     def put_observation(self, record: RuntimeObservationRecord) -> None:

--- a/src/agent_bom/api/runtime_event_store.py
+++ b/src/agent_bom/api/runtime_event_store.py
@@ -10,7 +10,7 @@ from dataclasses import asdict, dataclass, field
 from typing import Any, Protocol
 
 from agent_bom.analytics_retention import prune_runtime_observations_for_tenant
-from agent_bom.api.storage_schema import ensure_sqlite_schema_version
+from agent_bom.api.gateway_activity_store import ensure_sqlite_gateway_activity_schema
 from agent_bom.security import sanitize_sensitive_payload, sanitize_text
 
 RAW_RUNTIME_FIELDS = {
@@ -255,7 +255,6 @@ class SQLiteRuntimeEventStore:
         self._init_db()
 
     def _init_db(self) -> None:
-        ensure_sqlite_schema_version(self._conn, "runtime_events")
         self._conn.execute(
             """
             CREATE TABLE IF NOT EXISTS runtime_observations (
@@ -286,6 +285,7 @@ class SQLiteRuntimeEventStore:
         self._conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_runtime_sessions_tenant_last_seen ON runtime_sessions(tenant_id, last_seen DESC)"
         )
+        ensure_sqlite_gateway_activity_schema(self._conn)
         self._conn.commit()
 
     def put_observation(self, record: RuntimeObservationRecord) -> None:

--- a/src/agent_bom/api/storage_schema.py
+++ b/src/agent_bom/api/storage_schema.py
@@ -64,8 +64,21 @@ CONTROL_PLANE_SCHEMA_COMPONENTS: tuple[StorageSchemaComponent, ...] = (
         "sqlite/postgres",
         ("agent_identities", "agent_identity_jit_grants", "agent_conditional_access_policies"),
     ),
-    # Runtime session/observation timeline is durable by default (same tiering).
-    StorageSchemaComponent("runtime_events", "sqlite/postgres", ("runtime_observations", "runtime_sessions")),
+    # Runtime session/observation timeline and typed gateway ledger are durable
+    # by default (same tiering). Gateway activity adds server-owned ordinals and
+    # tombstones in v2 without changing the legacy observation contract.
+    StorageSchemaComponent(
+        "runtime_events",
+        "sqlite/postgres",
+        (
+            "runtime_observations",
+            "runtime_sessions",
+            "gateway_activity_events",
+            "gateway_activity_sequences",
+            "gateway_activity_tombstones",
+        ),
+        version=2,
+    ),
     StorageSchemaComponent(
         "runtime_workload_evidence",
         "sqlite/postgres",
@@ -119,7 +132,7 @@ def ensure_sqlite_schema_version(conn: Any, component: str, version: int = CONTR
         INSERT INTO control_plane_schema_versions (component, version, updated_at)
         VALUES (?, ?, ?)
         ON CONFLICT(component) DO UPDATE SET
-            version = excluded.version,
+            version = MAX(control_plane_schema_versions.version, excluded.version),
             updated_at = excluded.updated_at
         """,
         (component, int(version), _now_iso()),
@@ -163,7 +176,7 @@ def ensure_postgres_schema_version(conn: Any, component: str, version: int = CON
         INSERT INTO control_plane_schema_versions (component, version, updated_at)
         VALUES (%s, %s, now())
         ON CONFLICT (component) DO UPDATE SET
-            version = EXCLUDED.version,
+            version = GREATEST(control_plane_schema_versions.version, EXCLUDED.version),
             updated_at = EXCLUDED.updated_at
         """,
         (component, int(version)),

--- a/tests/test_gateway_activity_ledger.py
+++ b/tests/test_gateway_activity_ledger.py
@@ -1,0 +1,333 @@
+"""Canonical gateway activity ledger contracts for #4152."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from dataclasses import replace
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.api.gateway_activity_store import (
+    GATEWAY_ACTIVITY_STORE_SCHEMA,
+    MAX_ACTIVITY_BATCH_SIZE,
+    GatewayActivityConflictError,
+    GatewayActivityCursorError,
+    GatewayActivityCursorExpiredError,
+    InMemoryGatewayActivityStore,
+    SQLiteGatewayActivityStore,
+    gateway_activity_record_from_event,
+)
+from agent_bom.api.runtime_event_store import SQLiteRuntimeEventStore
+from agent_bom.storage.base import TenantScopedStore
+
+NOW = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+
+
+def test_store_schema_has_backend_parity_and_stores_conform(tmp_path) -> None:
+    assert GATEWAY_ACTIVITY_STORE_SCHEMA.drift_report() == {}
+    assert isinstance(InMemoryGatewayActivityStore(), TenantScopedStore)
+    assert isinstance(SQLiteGatewayActivityStore(str(tmp_path / "activity.db")), TenantScopedStore)
+
+
+def _event(event_id: str, *, timestamp: str = "2026-07-28T11:59:00+00:00", **overrides: object) -> dict[str, object]:
+    event: dict[str, object] = {
+        "schema_version": "gateway.runtime.event.v1",
+        "event_id": event_id,
+        "decision_id": event_id,
+        "event_type": "gateway.tool_call.allowed",
+        "event_timestamp": timestamp,
+        "tenant_id": "attacker-selected-tenant",
+        "agent_id": "agent-a",
+        "identity_id": "identity-a",
+        "profile_id": "profile-finance-prod",
+        "profile_revision": 3,
+        "blueprint_id": "finance",
+        "blueprint_revision": 1,
+        "policy_ids": ["policy-finance@7"],
+        "upstream": "filesystem",
+        "tool": "read_file",
+        "decision": "allow",
+        "policy_source": "runtime_profile",
+        "trace_id": f"trace-{event_id}",
+    }
+    event.update(overrides)
+    return event
+
+
+def _record(event_id: str, *, tenant_id: str = "tenant-a", **overrides: object):
+    return gateway_activity_record_from_event(
+        _event(event_id, **overrides),
+        tenant_id=tenant_id,
+        source_id="gateway-node-a",
+        session_id="session-a",
+        received_at=NOW,
+    )
+
+
+def test_mapping_is_strict_server_scoped_and_metadata_only() -> None:
+    event = _event("evt-1")
+    event["arguments"] = {"token": "sk-live-never-store"}
+    with pytest.raises(ValueError, match="unexpected gateway activity field"):
+        gateway_activity_record_from_event(
+            event,
+            tenant_id="tenant-a",
+            source_id="gateway-node-a",
+            session_id="session-a",
+            received_at=NOW,
+        )
+
+    record = _record("evt-1")
+    assert record.tenant_id == "tenant-a"
+    assert record.event_id == "evt-1"
+    assert record.decision_id == "evt-1"
+    assert record.event_schema_version == "gateway.runtime.event.v1"
+    assert record.record_schema_version == "gateway.activity.record.v1"
+    assert record.profile_id == "profile-finance-prod"
+    assert record.blueprint_id == "finance"
+    assert record.policy_ids == ("policy-finance@7",)
+    assert record.ingest_ordinal == 0
+    assert record.raw_payload_stored is False
+    assert "attacker-selected-tenant" not in record.to_json()
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"schema_version": "gateway.runtime.event.v0"}, "schema_version"),
+        ({"decision_id": "different"}, "decision_id"),
+        ({"decision": "deny"}, "decision"),
+        ({"event_timestamp": "2026-07-28T11:59:00"}, "timezone"),
+        ({"event_timestamp": "2026-07-28T12:06:00+00:00"}, "future"),
+        ({"event_type": "gateway.policy_allowed"}, "event_type"),
+        ({"development_mode": "false"}, "development_mode"),
+    ],
+)
+def test_mapping_rejects_invalid_or_inconsistent_events(overrides: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        _record("evt-invalid", **overrides)
+
+
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+def test_append_is_idempotent_conflict_aware_and_tenant_atomic(store_kind: str, tmp_path) -> None:
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=10)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=10)
+    )
+    first = _record("evt-1")
+    result = store.append_batch([first])
+    assert result.inserted_event_ids == ("evt-1",)
+    assert result.duplicate_event_ids == ()
+
+    replay = store.append_batch([first])
+    assert replay.inserted_event_ids == ()
+    assert replay.duplicate_event_ids == ("evt-1",)
+    with pytest.raises(GatewayActivityConflictError):
+        store.append_batch([_record("evt-1", tool="write_file")])
+
+    before = store.list_activity("tenant-a", limit=10)
+    with pytest.raises(ValueError, match="one tenant"):
+        store.append_batch([_record("evt-2"), _record("evt-3", tenant_id="tenant-b")])
+    after = store.list_activity("tenant-a", limit=10)
+    assert after.events == before.events
+
+
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+def test_append_rejects_tampered_digest(store_kind: str, tmp_path) -> None:
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=10)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=10)
+    )
+    with pytest.raises(ValueError, match="digest"):
+        store.append_batch([replace(_record("evt-tampered"), event_digest="0" * 64)])
+
+
+def test_store_rejects_unbounded_retention_configuration() -> None:
+    with pytest.raises(ValueError, match="max_events_per_tenant"):
+        InMemoryGatewayActivityStore(max_events_per_tenant=0)
+    with pytest.raises(ValueError, match="max_tombstones_per_tenant"):
+        InMemoryGatewayActivityStore(max_tombstones_per_tenant=0)
+
+
+def test_append_rejects_oversized_batch_atomically() -> None:
+    store = InMemoryGatewayActivityStore(max_events_per_tenant=MAX_ACTIVITY_BATCH_SIZE + 1)
+    records = [_record(f"evt-{index}") for index in range(MAX_ACTIVITY_BATCH_SIZE + 1)]
+    with pytest.raises(ValueError, match="batch"):
+        store.append_batch(records)
+    assert store.list_activity("tenant-a").events == []
+
+
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+def test_cursor_uses_server_ordinal_not_caller_timestamp(store_kind: str, tmp_path) -> None:
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=10)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=10)
+    )
+    store.append_batch([_record("evt-a", timestamp="2026-07-28T11:59:30+00:00")])
+    first = store.list_activity("tenant-a", limit=1)
+    assert [event["event_id"] for event in first.events] == ["evt-a"]
+    assert first.next_cursor
+
+    # Late evidence has an older observation timestamp but a newer server-owned
+    # ordinal. It must still appear after the issued cursor exactly once.
+    store.append_batch([_record("evt-late", timestamp="2026-07-28T11:58:00+00:00")])
+    resumed = store.list_activity("tenant-a", cursor=first.next_cursor, limit=10)
+    assert [event["event_id"] for event in resumed.events] == ["evt-late"]
+    assert resumed.events[0]["ingest_ordinal"] > first.events[0]["ingest_ordinal"]
+    assert store.list_activity("tenant-a", cursor=resumed.next_cursor, limit=10).events == []
+
+
+def test_cursor_rejects_malformed_foreign_and_future_values() -> None:
+    store = InMemoryGatewayActivityStore(max_events_per_tenant=10)
+    store.append_batch([_record("evt-1")])
+    cursor = store.list_activity("tenant-a", limit=1).next_cursor
+    assert cursor
+    with pytest.raises(GatewayActivityCursorError):
+        store.list_activity("tenant-a", cursor="not-a-cursor")
+    with pytest.raises(GatewayActivityCursorError):
+        store.list_activity("tenant-b", cursor=cursor)
+    with pytest.raises(GatewayActivityCursorError):
+        store.list_activity("tenant-a", cursor=store.encode_cursor("tenant-a", 999))
+
+
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+def test_retention_expires_old_cursor_and_tombstone_blocks_reinsert(store_kind: str, tmp_path) -> None:
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=2)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(
+            str(tmp_path / "activity.db"),
+            max_events_per_tenant=2,
+        )
+    )
+    store.append_batch([_record("evt-1"), _record("evt-2")])
+    stale_cursor = store.encode_cursor("tenant-a", 0)
+    store.append_batch([_record("evt-3")])
+
+    with pytest.raises(GatewayActivityCursorExpiredError) as exc_info:
+        store.list_activity("tenant-a", cursor=stale_cursor, limit=10)
+    assert exc_info.value.retention_floor_ordinal == 2
+    replay = store.append_batch([_record("evt-1")])
+    assert replay.inserted_event_ids == ()
+    assert replay.duplicate_event_ids == ("evt-1",)
+    with pytest.raises(GatewayActivityConflictError):
+        store.append_batch([_record("evt-1", tool="write_file")])
+
+    # Retention invalidates an explicit historical cursor, but a new reader has
+    # no historical claim and must begin at the current retained floor.
+    fresh = store.list_activity("tenant-a", limit=10)
+    assert [event["event_id"] for event in fresh.events] == ["evt-2", "evt-3"]
+
+
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+def test_pruned_event_id_remains_idempotent_without_expiry(store_kind: str, tmp_path) -> None:
+    path = str(tmp_path / "activity.db")
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=1)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(path, max_events_per_tenant=1)
+    )
+    original = _record("evt-1")
+    store.append_batch([original, _record("evt-2")])
+    if store_kind == "sqlite":
+        store = SQLiteGatewayActivityStore(path, max_events_per_tenant=1)
+    assert store.append_batch([original]).duplicate_event_ids == ("evt-1",)
+    with pytest.raises(GatewayActivityConflictError):
+        store.append_batch([_record("evt-1", tool="write_file")])
+
+
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+def test_dedupe_history_is_count_bounded_and_reports_window(store_kind: str, tmp_path) -> None:
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=1, max_tombstones_per_tenant=2)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(
+            str(tmp_path / "activity.db"),
+            max_events_per_tenant=1,
+            max_tombstones_per_tenant=2,
+        )
+    )
+    records = [_record(f"evt-{index}") for index in range(1, 5)]
+    store.append_batch(records)
+    page = store.list_activity("tenant-a")
+    assert page.dedupe_window_events == 3
+    assert [event["event_id"] for event in page.events] == ["evt-4"]
+    assert store.append_batch([records[1]]).duplicate_event_ids == ("evt-2",)
+
+    # evt-1 has aged beyond the explicit three-event dedupe window. The
+    # bounded ledger is intentionally at-least-once outside that window.
+    assert store.append_batch([records[0]]).inserted_event_ids == ("evt-1",)
+
+
+@pytest.mark.parametrize("first_store", ["runtime", "gateway"])
+def test_sqlite_runtime_v2_schema_converges_in_both_initialization_orders(tmp_path, first_store: str) -> None:
+    path = str(tmp_path / f"{first_store}.db")
+    constructors = {
+        "runtime": lambda: SQLiteRuntimeEventStore(path),
+        "gateway": lambda: SQLiteGatewayActivityStore(path),
+    }
+    constructors[first_store]()
+    constructors["gateway" if first_store == "runtime" else "runtime"]()
+
+    with sqlite3.connect(path) as connection:
+        marker = connection.execute(
+            "SELECT version FROM control_plane_schema_versions WHERE component = ?",
+            ("runtime_events",),
+        ).fetchone()
+        tables = {
+            row[0]
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name LIKE 'gateway_activity_%'"
+            )
+        }
+    assert marker == (2,)
+    assert tables == {
+        "gateway_activity_events",
+        "gateway_activity_sequences",
+        "gateway_activity_tombstones",
+    }
+
+
+def test_sqlite_restart_preserves_order_and_cursor(tmp_path) -> None:
+    path = str(tmp_path / "activity.db")
+    first_store = SQLiteGatewayActivityStore(path, max_events_per_tenant=10)
+    first_store.append_batch([_record("evt-1"), _record("evt-2")])
+    cursor = first_store.list_activity("tenant-a", limit=1).next_cursor
+    assert cursor
+
+    reopened = SQLiteGatewayActivityStore(path, max_events_per_tenant=10)
+    resumed = reopened.list_activity("tenant-a", cursor=cursor, limit=10)
+    assert [event["event_id"] for event in resumed.events] == ["evt-2"]
+
+
+def test_sqlite_cursor_query_uses_tenant_ordinal_index(tmp_path) -> None:
+    store = SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=10)
+    plan = store.query_plan("tenant-a", after_ordinal=10, limit=100)
+    assert "idx_gateway_activity_events_tenant_ordinal" in plan
+
+
+def test_sqlite_concurrent_writers_allocate_unique_ordinals(tmp_path) -> None:
+    store = SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=20)
+    barrier = threading.Barrier(8)
+    errors: list[Exception] = []
+
+    def worker(index: int) -> None:
+        try:
+            barrier.wait()
+            store.append_batch([_record(f"evt-{index}")])
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    events = store.list_activity("tenant-a", limit=20).events
+    assert [event["ingest_ordinal"] for event in events] == list(range(1, 9))

--- a/tests/test_postgres_gateway_activity.py
+++ b/tests/test_postgres_gateway_activity.py
@@ -1,0 +1,174 @@
+"""Postgres contracts for the durable gateway activity ledger."""
+
+from __future__ import annotations
+
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from agent_bom.api.gateway_activity_store import GatewayActivityConflictError, gateway_activity_record_from_event
+from agent_bom.api.postgres_common import _tenant_connection, reset_current_tenant, set_current_tenant
+from agent_bom.api.postgres_gateway_activity import PostgresGatewayActivityStore
+
+
+def _record(event_id: str, tenant_id: str, *, timestamp: str | None = None, tool: str = "read_file"):
+    return gateway_activity_record_from_event(
+        {
+            "schema_version": "gateway.runtime.event.v1",
+            "event_id": event_id,
+            "decision_id": event_id,
+            "event_type": "gateway.tool_call.allowed",
+            "event_timestamp": timestamp or datetime.now(timezone.utc).isoformat(),
+            "agent_id": "agent-a",
+            "upstream": "filesystem",
+            "tool": tool,
+            "decision": "allow",
+            "policy_source": "runtime_profile",
+            "trace_id": f"trace-{event_id}",
+        },
+        tenant_id=tenant_id,
+        source_id="gateway-node-a",
+        session_id="session-a",
+    )
+
+
+def _cleanup(store: PostgresGatewayActivityStore, tenant_id: str) -> None:
+    token = set_current_tenant(tenant_id)
+    try:
+        with _tenant_connection(store._pool) as conn:
+            conn.execute("DELETE FROM gateway_activity_events WHERE tenant_id = %s", (tenant_id,))
+            conn.execute("DELETE FROM gateway_activity_tombstones WHERE tenant_id = %s", (tenant_id,))
+            conn.execute("DELETE FROM gateway_activity_sequences WHERE tenant_id = %s", (tenant_id,))
+            conn.commit()
+    finally:
+        reset_current_tenant(token)
+
+
+def test_postgres_ledger_serializes_same_tenant_sequence_before_dedupe() -> None:
+    source = (
+        __import__("pathlib").Path(__file__).parents[1]
+        / "src"
+        / "agent_bom"
+        / "api"
+        / "postgres_gateway_activity.py"
+    ).read_text()
+    lock_position = source.index("FOR UPDATE")
+    active_lookup_position = source.index("SELECT event_id, event_digest FROM gateway_activity_events")
+    assert lock_position < active_lookup_position
+    assert "ON CONFLICT (tenant_id, event_id) DO NOTHING" not in source
+    assert 'ensure_postgres_schema_version(conn, "runtime_events", version=GATEWAY_ACTIVITY_STORAGE_VERSION)' in source
+
+    legacy_source = (
+        __import__("pathlib").Path(__file__).parents[1]
+        / "src"
+        / "agent_bom"
+        / "api"
+        / "postgres_runtime_event.py"
+    ).read_text()
+    assert 'ensure_postgres_schema_version(conn, "runtime_events", version=GATEWAY_ACTIVITY_STORAGE_VERSION)' in legacy_source
+    assert "bootstrap_postgres_gateway_activity_schema(conn)" in legacy_source
+
+
+@pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="requires a migrated live PostgreSQL database",
+)
+def test_postgres_concurrent_same_tenant_appends_get_unique_contiguous_ordinals() -> None:
+    store = PostgresGatewayActivityStore(max_events_per_tenant=100)
+    tenant_id = f"gateway-ledger-{uuid.uuid4().hex}"
+    barrier = threading.Barrier(8)
+    errors: list[Exception] = []
+
+    def worker(index: int) -> None:
+        token = set_current_tenant(tenant_id)
+        try:
+            barrier.wait()
+            result = store.append_batch([_record(f"evt-{index}", tenant_id)])
+            assert result.inserted_count == 1
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+        finally:
+            reset_current_tenant(token)
+
+    try:
+        threads = [threading.Thread(target=worker, args=(index,)) for index in range(8)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+
+        assert errors == []
+        token = set_current_tenant(tenant_id)
+        try:
+            page = store.list_activity(tenant_id, limit=20)
+        finally:
+            reset_current_tenant(token)
+        assert sorted(event["ingest_ordinal"] for event in page.events) == list(range(1, 9))
+        assert len({event["event_id"] for event in page.events}) == 8
+    finally:
+        _cleanup(store, tenant_id)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="requires a migrated live PostgreSQL database",
+)
+def test_postgres_concurrent_exact_replay_inserts_once() -> None:
+    store = PostgresGatewayActivityStore(max_events_per_tenant=100)
+    tenant_id = f"gateway-replay-{uuid.uuid4().hex}"
+    record = _record("evt-shared", tenant_id)
+    barrier = threading.Barrier(4)
+    results = []
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        token = set_current_tenant(tenant_id)
+        try:
+            barrier.wait()
+            results.append(store.append_batch([record]))
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+        finally:
+            reset_current_tenant(token)
+
+    try:
+        threads = [threading.Thread(target=worker) for _ in range(4)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        assert errors == []
+        assert sum(result.inserted_count for result in results) == 1
+        assert sum(result.duplicate_count for result in results) == 3
+    finally:
+        _cleanup(store, tenant_id)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="requires a migrated live PostgreSQL database",
+)
+def test_postgres_conflict_rolls_back_and_rls_hides_foreign_tenant() -> None:
+    store = PostgresGatewayActivityStore(max_events_per_tenant=100)
+    tenant_id = f"gateway-conflict-{uuid.uuid4().hex}"
+    foreign_tenant = f"gateway-foreign-{uuid.uuid4().hex}"
+    timestamp = datetime.now(timezone.utc).isoformat()
+    token = set_current_tenant(tenant_id)
+    try:
+        assert store.append_batch([_record("evt-shared", tenant_id, timestamp=timestamp)]).inserted_count == 1
+        with pytest.raises(GatewayActivityConflictError):
+            store.append_batch([_record("evt-shared", tenant_id, timestamp=timestamp, tool="write_file")])
+        assert store.append_batch([_record("evt-next", tenant_id)]).inserted_count == 1
+        assert [event["ingest_ordinal"] for event in store.list_activity(tenant_id).events] == [1, 2]
+    finally:
+        reset_current_tenant(token)
+
+    foreign_token = set_current_tenant(foreign_tenant)
+    try:
+        assert store.list_activity(tenant_id).events == []
+    finally:
+        reset_current_tenant(foreign_token)
+        _cleanup(store, tenant_id)

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -22,6 +22,7 @@ MANAGED_TRIAL_INVITATIONS = VERSIONS_DIR / "20260724_03_managed_trial_invitation
 TICKETING_SCHEMA_AUTHORITY = VERSIONS_DIR / "20260726_01_ticketing_schema_authority.py"
 RUNTIME_EVIDENCE_TIMESTAMP_AUTHORITY = VERSIONS_DIR / "20260727_01_runtime_evidence_timestamp_authority.py"
 MCP_PROFILE_BINDING_AUTHORITY = VERSIONS_DIR / "20260728_01_mcp_profile_binding_authority.py"
+GATEWAY_ACTIVITY_LEDGER = VERSIONS_DIR / "20260728_02_gateway_activity_ledger.py"
 POSTGRES_MCP_CONFIG_STORE = Path(__file__).parent.parent / "src" / "agent_bom" / "api" / "postgres_mcp_config.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
@@ -349,6 +350,26 @@ def test_cloud_connections_scope_columns_migration_is_idempotent_and_chained() -
         assert f"ALTER TABLE IF EXISTS cloud_connections {column_ddl}" in sql
     assert "VALUES ('cloud_connections', 1, now())" in sql
     assert "ON CONFLICT(component) DO UPDATE SET" in sql
+
+
+def test_gateway_activity_ledger_migration_is_chained_durable_and_tenant_isolated() -> None:
+    sql = GATEWAY_ACTIVITY_LEDGER.read_text()
+    assert re.search(r'revision\s*=\s*"20260728_02"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260728_01"', sql)
+    for table in (
+        "gateway_activity_events",
+        "gateway_activity_sequences",
+        "gateway_activity_tombstones",
+    ):
+        assert f"CREATE TABLE IF NOT EXISTS {table}" in sql
+        assert f"ALTER TABLE {table} ENABLE ROW LEVEL SECURITY" in sql
+        assert f"ALTER TABLE {table} FORCE ROW LEVEL SECURITY" in sql
+    assert "policyname = '{table}_tenant_isolation'" in sql
+    assert "CREATE POLICY {table}_tenant_isolation ON {table}" in sql
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal" in sql
+    assert "CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal" in sql
+    assert "VALUES ('runtime_events', 2, now())" in sql
+    assert "DROP TABLE" not in sql
 
 
 def test_hub_partition_migration_uses_the_psycopg_driver_connection(monkeypatch):

--- a/tests/test_postgres_schema_authority.py
+++ b/tests/test_postgres_schema_authority.py
@@ -174,6 +174,15 @@ def test_configured_postgres_schema_check_is_read_only(monkeypatch) -> None:
     ]
 
 
+def test_development_postgres_schema_marker_updates_are_monotonic(monkeypatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_POSTGRES_URL", raising=False)
+    monkeypatch.delenv("AGENT_BOM_DB", raising=False)
+    connection = _Connection()
+
+    assert ensure_postgres_schema_version(connection, "runtime_events", version=2) is True
+    assert any("GREATEST(control_plane_schema_versions.version, EXCLUDED.version)" in sql for sql in connection.statements)
+
+
 def test_configured_ticketing_store_constructor_never_executes_ddl(monkeypatch) -> None:
     from agent_bom.ticketing.postgres_store import PostgresTicketingStore
 
@@ -310,8 +319,23 @@ def test_migration_schema_uses_the_runtime_rls_contract_and_exact_dml_columns() 
         "model_provider_keys (provider_key_id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,provider TEXT NOT NULL,status TEXT NOT NULL",
         "model_virtual_keys (virtual_key_id TEXT PRIMARY KEY,tenant_id TEXT NOT NULL,provider_key_id TEXT NOT NULL",
         "scan_dispatch_queue (job_id TEXT PRIMARY KEY REFERENCES scan_jobs(job_id) ON DELETE CASCADE,tenant_id TEXT NOT NULL",
+        "gateway_activity_events (tenant_id TEXT NOT NULL,event_id TEXT NOT NULL,ingest_ordinal BIGINT NOT NULL",
+        "gateway_activity_sequences (tenant_id TEXT PRIMARY KEY,next_ordinal BIGINT NOT NULL",
+        "gateway_activity_tombstones (tenant_id TEXT NOT NULL,event_id TEXT NOT NULL,event_digest TEXT NOT NULL",
     ):
         assert required_fragment in sql
+
+
+def test_runtime_events_manifest_is_v2_and_includes_gateway_activity_tables() -> None:
+    component = next(item for item in CONTROL_PLANE_SCHEMA_COMPONENTS if item.component == "runtime_events")
+    assert component.version == 2
+    assert set(component.tables) == {
+        "runtime_observations",
+        "runtime_sessions",
+        "gateway_activity_events",
+        "gateway_activity_sequences",
+        "gateway_activity_tombstones",
+    }
 
 
 def test_declared_postgres_ddl_realises_every_logical_column() -> None:


### PR DESCRIPTION
## Summary

- add strict metadata-only gateway activity records with server-owned tenant context, ordinals, conflict-aware replay, and coherent tenant-bound cursor reads
- persist the store through memory, SQLite, and migration-authoritative Postgres with RLS, monotonic runtime schema v2, bounded active retention, and a separately bounded dedupe window
- run distinct-write, exact-replay, conflict rollback, and tenant-isolation cases in the real Postgres CI job

## Verification

- `uv run pytest -q tests/test_gateway_activity_ledger.py tests/test_postgres_gateway_activity.py tests/test_runtime_event_store.py tests/test_storage_foundation.py tests/test_durable_store_default.py tests/test_postgres_migrations.py tests/test_postgres_schema_authority.py tests/test_db_persistence_consistency.py` (113 passed, 3 skipped locally)
- `make lint`
- `make preflight`
- `actionlint .github/workflows/ci.yml`
- three independent read-only rereviews: no remaining P0/P1 findings

## Notes

- This is a store-only foundation. It does not replace the current feed, expose a REST/live stream, or claim WebSocket/SSE/KPI completion.
- Defaults retain 50,000 active events plus 100,000 digest-only replay tombstones per tenant. Replay inside the reported 150,000-event dedupe window is conflict-aware; behavior outside the bounded window is intentionally at-least-once.
- The three locally skipped tests require `AGENT_BOM_POSTGRES_URL`; this PR adds them to the credentialed Postgres Integration Contract job.
- Progresses #4152.