### PR TITLE
fix(docs): align README storefront contract

### DIFF
--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -76,7 +76,7 @@ def test_readme_places_persona_artwork_before_the_compact_role_table() -> None:
     """Public onboarding stays accessible while retaining visual workflow proof."""
     titles = [row[0] for row in _readme_persona_rows()]
     for title in (
-        "Local developers",
+        "Developers",
         "AppSec",
         "Security engineers",
         "Platform / SRE",

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -161,8 +161,8 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
         == 1
     )
     assert (
-        "Scan a repository, image, or cloud account for findings, an SBOM, and a graph of reachable impact — "
-        "locally or in a control plane you run."
+        "Scan repositories, images, and cloud accounts; centralize evidence across environments; "
+        "and enforce AI and MCP runtime policy in infrastructure you control."
     ) in hero
     assert "<b>15</b> package ecosystems" in hero
     assert "<b>16</b> compliance surfaces" in hero
@@ -175,10 +175,13 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert hero.index("how-it-works-dark.svg") > hero.index('href="https://demo.agent-bom.com"')
     assert "## How it works" not in readme
 
-    current_what_it_is = """`agent-bom` is an open local scanner and self-hosted control plane for software,
+    current_what_it_is = """`agent-bom` is an open scanner and self-hosted control plane for software,
 cloud, identity, AI-agent, and MCP evidence. One Finding + UnifiedGraph model
-powers CLI and CI artifacts, browser investigations, compliance evidence, and
-runtime policy without requiring a hosted account.
+powers CLI and CI artifacts, fleet and browser investigations, compliance
+evidence, and runtime policy.
+
+Use the scanner without an account, or deploy the shared control plane inside
+your own cloud, VPC, Kubernetes cluster, database, identity, and audit boundary.
 
 Graph provenance remains explicit: collected, inferred, static, and runtime
 relationships stay distinct, and unavailable evidence is never upgraded to


### PR DESCRIPTION
## Summary\n\n- align the README storefront and persona contracts with the merged scale-first copy\n- preserve exact-copy protection for self-hosted control-plane positioning and audience layout\n- unblock the full Python suite without weakening either guard\n\n## Verification\n\n- uv run pytest -q tests/test_doc_architecture_svgs.py tests/test_public_docs_cli_alignment.py (24 passed)\n- python scripts/check_public_docs_hygiene.py\n- python scripts/check_release_consistency.py\n- git diff --check\n- repository-wide stale-copy search for the superseded hero, local-first, persona, and hosted-account wording\n\n## Notes\n\nThis is a test-only follow-up to #4524. The full suite exposed two stale README assertions while validating #4523; no product copy was reverted.