### PR TITLE
fix(graph): make topology and completeness contracts honest

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-07-27",
+  "generated_on": "2026-07-28",
   "version": "0.98.2",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1038,
+      "value": 1045,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 810,
+      "value": 813,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },
@@ -60,7 +60,7 @@
       "name": "Compliance surfaces",
       "value": 16,
       "source": "src/agent_bom/compliance_coverage.py",
-      "notes": "14 tag-mapped frameworks plus the OWASP AISVS benchmark surface."
+      "notes": "15 tag-mapped frameworks plus the OWASP AISVS benchmark surface."
     },
     {
       "name": "Proxy inline detectors",

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-07-27`
+- Generated on: `2026-07-28`
 - Version: `0.98.2`
 
 | Metric | Value | Source | Notes |
@@ -14,12 +14,12 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1038 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1045 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 810 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
-| Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 14 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
+| Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |
 | Runtime protection engine detectors | 11 | `src/agent_bom/runtime/protection.py` | Broader protection engine used outside the lighter proxy-only path. |
 

--- a/scripts/product_metrics_snapshot.py
+++ b/scripts/product_metrics_snapshot.py
@@ -92,10 +92,6 @@ def _count_compliance_frameworks() -> int:
     return 0
 
 
-def _count_compliance_surfaces() -> int:
-    return _count_compliance_frameworks() + 1
-
-
 def _count_proxy_inline_detectors() -> int:
     content = (ROOT / "src" / "agent_bom" / "proxy.py").read_text()
     detector_block = re.search(
@@ -123,6 +119,7 @@ def _current_version() -> str:
 
 
 def build_snapshot() -> dict[str, object]:
+    compliance_framework_count = _count_compliance_frameworks()
     return {
         "generated_on": str(date.today()),
         "version": _current_version(),
@@ -183,9 +180,9 @@ def build_snapshot() -> dict[str, object]:
             },
             {
                 "name": "Compliance surfaces",
-                "value": _count_compliance_surfaces(),
+                "value": compliance_framework_count + 1,
                 "source": "src/agent_bom/compliance_coverage.py",
-                "notes": "14 tag-mapped frameworks plus the OWASP AISVS benchmark surface.",
+                "notes": f"{compliance_framework_count} tag-mapped frameworks plus the OWASP AISVS benchmark surface.",
             },
             {
                 "name": "Proxy inline detectors",

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -2876,7 +2876,7 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
         ).to_dict(),
         "completeness": graph_completeness(
             returned=len(filtered_graph.nodes),
-            total=filtered_graph.stats().get("node_count", len(filtered_graph.nodes)),
+            total=None if truncated else filtered_graph.stats().get("node_count", len(filtered_graph.nodes)),
             truncated=truncated,
             reason="traversal_budget" if truncated else "",
         ),

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2682,6 +2682,36 @@ class TestGraphStoreBackendSelection:
         assert any(call[0] == "traverse_subgraph" for call in recording_graph_store.calls)
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
 
+    def test_graph_query_traversal_budget_does_not_fabricate_exhaustive_total(self, recording_graph_store):
+        recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
+        recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="server:s", entity_type=EntityType.SERVER, label="server-s"))
+        recording_graph_store.graph.add_node(UnifiedNode(id="tool:t", entity_type=EntityType.TOOL, label="tool-t"))
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="agent:a", target="server:s", relationship=RelationshipType.USES, traversable=True)
+        )
+        recording_graph_store.graph.add_edge(
+            UnifiedEdge(source="server:s", target="tool:t", relationship=RelationshipType.PROVIDES_TOOL, traversable=True)
+        )
+        client = TestClient(app)
+
+        response = client.post(
+            "/v1/graph/query",
+            json={"roots": ["agent:a"], "max_depth": 3, "max_nodes": 2},
+        )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["truncated"] is True
+        assert body["completeness"] == {
+            "status": "truncated",
+            "complete": False,
+            "sampled": False,
+            "truncated": True,
+            "returned": 2,
+            "reason": "traversal_budget",
+        }
+
     def test_graph_query_keeps_attack_path_with_filtered_intermediate_hop(self, recording_graph_store):
         recording_graph_store.graph = UnifiedGraph(scan_id="store-scan", tenant_id="default")
         recording_graph_store.graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="agent-a"))

--- a/tests/test_product_metrics_snapshot.py
+++ b/tests/test_product_metrics_snapshot.py
@@ -1,0 +1,46 @@
+"""Contract tests for the generated product-metrics snapshot."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+from types import ModuleType
+from typing import cast
+
+from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "product_metrics_snapshot.py"
+METRICS_JSON = ROOT / "docs" / "PRODUCT_METRICS.json"
+METRICS_MARKDOWN = ROOT / "docs" / "PRODUCT_METRICS.md"
+
+
+def _load_metrics_script() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("product_metrics_snapshot", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_compliance_metric_uses_the_canonical_framework_count() -> None:
+    module = _load_metrics_script()
+    snapshot = module.build_snapshot()
+    metrics = cast(list[dict[str, object]], snapshot["metrics"])
+    compliance = next(metric for metric in metrics if metric["name"] == "Compliance surfaces")
+    tag_mapped_count = len(TAG_MAPPED_FRAMEWORKS)
+
+    assert tag_mapped_count == 15
+    assert compliance["value"] == tag_mapped_count + 1 == 16
+    assert compliance["notes"] == f"{tag_mapped_count} tag-mapped frameworks plus the OWASP AISVS benchmark surface."
+
+    checked_in = json.loads(METRICS_JSON.read_text(encoding="utf-8"))
+    assert checked_in["version"] == snapshot["version"]
+    assert checked_in["metrics"] == snapshot["metrics"]
+    checked_in_compliance = next(metric for metric in checked_in["metrics"] if metric["name"] == "Compliance surfaces")
+    assert checked_in_compliance == compliance
+    assert (
+        f"| Compliance surfaces | {compliance['value']} | `src/agent_bom/compliance_coverage.py` | {compliance['notes']} |"
+        in METRICS_MARKDOWN.read_text(encoding="utf-8")
+    )

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -470,7 +470,12 @@ body {
 .attack-flow-swatch { @apply h-2.5 w-2.5 rounded border-2; }
 .attack-flow-loading { @apply flex h-[80vh] items-center justify-center text-[var(--text-secondary)]; }
 .attack-flow-error { @apply flex h-[80vh] flex-col items-center justify-center gap-3 text-[var(--text-secondary)]; }
-.graph-page-header { @apply border-b border-[var(--border-subtle)] bg-[radial-gradient(circle_at_top_left,rgba(14,165,233,0.10),transparent_24%),linear-gradient(180deg,rgba(24,24,27,0.96),rgba(9,9,11,0.96))] px-4 py-3; }
+.graph-page-header {
+  @apply border-b border-[var(--border-subtle)] px-4 py-3;
+  background-image:
+    radial-gradient(circle at top left, rgba(14, 165, 233, 0.10), transparent 24%),
+    linear-gradient(180deg, var(--surface-panel), var(--background));
+}
 .graph-page-select { @apply rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-3 py-2 text-sm text-[var(--text-secondary)] focus:border-sky-600 focus:outline-none; }
 .graph-page-search { @apply min-w-[260px] flex-1 rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/90 px-3 py-2 text-sm text-[var(--text-secondary)] placeholder:text-[var(--text-tertiary)] focus:border-sky-600 focus:outline-none; }
 .graph-page-action { @apply rounded-xl border border-[var(--border-subtle)] bg-[var(--surface)]/80 px-3 py-2 text-sm text-[var(--text-secondary)] transition hover:border-[var(--border-strong)] hover:text-[var(--foreground)] disabled:cursor-not-allowed disabled:opacity-40; }
@@ -487,7 +492,7 @@ body {
 .graph-chip-rose { @apply rounded-lg border border-rose-400/30 bg-rose-950/60 px-2.5 py-1 text-rose-100 transition hover:border-rose-300; }
 .graph-chip-violet { @apply rounded-lg border border-violet-400/30 bg-violet-950/60 px-2.5 py-1 text-violet-100 transition hover:border-violet-300; }
 .graph-chip-emerald { @apply rounded-lg border border-emerald-400/30 bg-emerald-950/60 px-2.5 py-1 text-emerald-100 transition hover:border-emerald-300; }
-.graph-chip-emerald-truncate { @apply max-w-[12rem] truncate rounded border border-emerald-400/20 bg-emerald-950/50 px-2 py-0.5 transition hover:border-emerald-300; }
+.graph-chip-emerald-truncate { @apply max-w-[12rem] truncate rounded border border-emerald-500/30 bg-emerald-50 px-2 py-0.5 text-emerald-900 transition hover:border-emerald-500 dark:bg-emerald-950/50 dark:text-emerald-100; }
 .graph-chip-elevated { @apply rounded-lg border border-[var(--border-subtle)] bg-[var(--surface-elevated)]/80 px-2 py-1 text-[11px] text-[var(--text-secondary)]; }
 .graph-drawer-summary { @apply flex cursor-pointer list-none flex-wrap items-center justify-between gap-3 px-3 py-2; }
 .graph-drawer-summary::-webkit-details-marker { display: none; }

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -70,10 +70,13 @@ import {
   isClusterPillNode,
 } from "@/lib/sibling-aggregator";
 import {
-  EntityType,
   RelationshipType,
   type UnifiedNode,
 } from "@/lib/graph-schema";
+import {
+  entityTypesForLayers,
+  lineageNodeTypeForEntity,
+} from "@/lib/graph-entity-mapping";
 import {
   attackPathKey,
   decodeGraphInvestigationParams,
@@ -132,9 +135,11 @@ import {
   shouldVirtualizeReactFlowNodes,
 } from "@/lib/graph-renderer-switch";
 import {
+  graphRollupCanvasMode,
   graphRollupEligible,
   parseGraphRollupUrlPreference,
   parseRollupNodeParam,
+  rollupDismissedForPreference,
   rollupViewHasContainers,
 } from "@/lib/graph-rollup-default";
 import {
@@ -318,36 +323,6 @@ function addNeighbor(
   }
 }
 
-const LAYER_ENTITY_TYPES: Array<[LineageNodeType, EntityType]> = [
-  ["provider", EntityType.PROVIDER],
-  ["agent", EntityType.AGENT],
-  ["user", EntityType.USER],
-  ["group", EntityType.GROUP],
-  ["serviceAccount", EntityType.SERVICE_ACCOUNT],
-  ["environment", EntityType.ENVIRONMENT],
-  ["fleet", EntityType.FLEET],
-  ["cluster", EntityType.CLUSTER],
-  ["server", EntityType.SERVER],
-  ["package", EntityType.PACKAGE],
-  ["model", EntityType.MODEL],
-  ["framework", EntityType.FRAMEWORK],
-  ["dataset", EntityType.DATASET],
-  ["container", EntityType.CONTAINER],
-  ["cloudResource", EntityType.CLOUD_RESOURCE],
-  ["vulnerability", EntityType.VULNERABILITY],
-  ["misconfiguration", EntityType.MISCONFIGURATION],
-  ["credential", EntityType.CREDENTIAL],
-  ["tool", EntityType.TOOL],
-  ["managedIdentity", EntityType.MANAGED_IDENTITY],
-  ["accessGrant", EntityType.ACCESS_GRANT],
-  ["accessPolicy", EntityType.ACCESS_POLICY],
-  ["driftIncident", EntityType.DRIFT_INCIDENT],
-  ["dataStore", EntityType.DATA_STORE],
-  ["directory", EntityType.DIRECTORY],
-  ["sourceFile", EntityType.SOURCE_FILE],
-  ["configFile", EntityType.CONFIG_FILE],
-];
-
 const RELATIONSHIP_SCOPE_MAP: Record<
   FilterState["relationshipScope"],
   RelationshipType[] | undefined
@@ -404,12 +379,6 @@ const RELATIONSHIP_SCOPE_MAP: Record<
   ],
 };
 
-function entityTypesForLayers(filters: FilterState): EntityType[] {
-  return LAYER_ENTITY_TYPES.filter(([layer]) => filters.layers[layer]).map(
-    ([, entityType]) => entityType,
-  );
-}
-
 function emptyGraphResponse(scanId: string): UnifiedGraphResponse {
   return {
     scan_id: scanId,
@@ -441,10 +410,7 @@ function emptyGraphResponse(scanId: string): UnifiedGraphResponse {
 }
 
 function lineageTypeForEntity(entityType: string): LineageNodeType {
-  return (
-    LAYER_ENTITY_TYPES.find(([, current]) => current === entityType)?.[0] ??
-    "server"
-  );
+  return lineageNodeTypeForEntity(entityType) ?? "server";
 }
 
 function stringAttribute(
@@ -644,9 +610,17 @@ type InvestigationMode = {
   edgeCount: number;
 };
 
-function queryResponseToGraphResponse(
+export function queryResponseToGraphResponse(
   response: GraphQueryResponse,
 ): UnifiedGraphResponse {
+  const completeness = response.completeness ?? {
+    status: response.truncated ? "truncated" : "complete",
+    complete: !response.truncated,
+    sampled: false,
+    truncated: response.truncated,
+    returned: response.nodes.length,
+    ...(response.truncated ? { reason: "traversal_budget" } : { total: response.nodes.length }),
+  };
   return {
     scan_id: response.scan_id,
     tenant_id: response.tenant_id,
@@ -656,13 +630,20 @@ function queryResponseToGraphResponse(
     attack_paths: response.attack_paths,
     interaction_risks: response.interaction_risks,
     stats: response.stats,
+    completeness,
     pagination: {
-      total: response.nodes.length,
+      total: completeness.total ?? response.nodes.length,
       offset: 0,
       limit: response.nodes.length,
-      has_more: false,
+      has_more: response.truncated,
     },
   };
+}
+
+/** Return only an exhaustive total; truncated traversals intentionally have none. */
+export function knownGraphTotal(response: UnifiedGraphResponse): number | null {
+  if (response.completeness) return response.completeness.total ?? null;
+  return response.pagination.total;
 }
 
 /**
@@ -769,6 +750,7 @@ function GraphPageInner() {
   );
   const [loadingRollup, setLoadingRollup] = useState(false);
   const [rollupError, setRollupError] = useState<string | null>(null);
+  const [rollupUnavailable, setRollupUnavailable] = useState(false);
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [pinnedFocusId, setPinnedFocusId] = useState<string | null>(null);
   const [expandedClusterIds, setExpandedClusterIds] = useState<Set<string>>(
@@ -824,8 +806,7 @@ function GraphPageInner() {
   useEffect(() => {
     const preference = parseGraphRollupUrlPreference(searchParams);
     rollupPreferenceRef.current = preference;
-    if (preference === "force") setRollupDismissed(false);
-    if (preference === "off") setRollupDismissed(true);
+    setRollupDismissed(rollupDismissedForPreference(preference));
   }, [searchParams]);
   const firstScanSelectionRef = useRef(true);
   // Last URL the filter→URL sync effect wrote, used to break an infinite
@@ -860,8 +841,8 @@ function GraphPageInner() {
   }, []);
 
   const serverEntityTypes = useMemo(
-    () => entityTypesForLayers(filters),
-    [filters],
+    () => entityTypesForLayers(filters.layers),
+    [filters.layers],
   );
 
   const serverRelationships = useMemo(
@@ -899,8 +880,11 @@ function GraphPageInner() {
     setReachabilityError(null);
     setRollupView(null);
     setRollupStack([]);
-    setRollupDismissed(false);
+    setRollupDismissed(
+      rollupDismissedForPreference(rollupPreferenceRef.current),
+    );
     setRollupError(null);
+    setRollupUnavailable(false);
     if (firstScanSelectionRef.current) {
       firstScanSelectionRef.current = false;
       if (seededFromUrlRef.current) {
@@ -1171,6 +1155,7 @@ function GraphPageInner() {
     hasSelectedScan: Boolean(selectedScanId),
     rollupPreference: rollupPreferenceRef.current,
     rollupDismissed,
+    estateNodeCount,
     investigationMode: Boolean(investigationMode),
     selectedAttackPath: Boolean(selectedAttackPath),
     reachabilityActive: Boolean(reachabilitySummary),
@@ -1178,8 +1163,17 @@ function GraphPageInner() {
     attackPathCount: attackPaths.length,
   });
 
-  const rollupNavigationActive =
-    rollupEligible && !rollupDismissed && rollupView !== null;
+  const rollupCanvasMode = graphRollupCanvasMode({
+    eligible: rollupEligible,
+    dismissed: rollupDismissed,
+    hasView: rollupView !== null,
+    unavailable: rollupUnavailable,
+    failed: rollupError !== null,
+  });
+  const rollupNavigationActive = rollupCanvasMode === "active";
+  const rollupCanvasPending = rollupCanvasMode === "loading";
+  const rollupCanvasOwnsPresentation =
+    rollupNavigationActive || rollupCanvasPending;
 
   useEffect(() => {
     if (!selectedScanId || !rollupEligible || rollupDismissed) {
@@ -1189,6 +1183,7 @@ function GraphPageInner() {
     let cancelled = false;
     setLoadingRollup(true);
     setRollupError(null);
+    setRollupUnavailable(false);
     const drillNode = rollupStack.at(-1)?.id;
 
     api
@@ -1205,18 +1200,20 @@ function GraphPageInner() {
             result.children,
           )
         ) {
-          setRollupDismissed(true);
           setRollupView(null);
+          setRollupUnavailable(true);
           setRollupError(null);
           return;
         }
         setRollupView(result);
+        setRollupUnavailable(false);
         setRollupError(null);
       })
       .catch((e) => {
         if (cancelled) return;
         setRollupError(e.message);
         setRollupView(null);
+        setRollupUnavailable(false);
       })
       .finally(() => {
         if (!cancelled) setLoadingRollup(false);
@@ -1249,6 +1246,16 @@ function GraphPageInner() {
           null | ReturnType<typeof buildUnifiedFlowGraph>["summary"],
       };
     }
+    if (rollupCanvasPending) {
+      return {
+        nodes: [],
+        edges: [],
+        agentNames: [],
+        legend: [],
+        summary: null as
+          null | ReturnType<typeof buildUnifiedFlowGraph>["summary"],
+      };
+    }
     if (!mergedGraphData) {
       return {
         nodes: [],
@@ -1264,6 +1271,7 @@ function GraphPageInner() {
     mergedGraphData,
     filters,
     rollupNavigationActive,
+    rollupCanvasPending,
     rollupView,
   ]);
 
@@ -2007,6 +2015,7 @@ function GraphPageInner() {
       ).length ?? null,
     [graphData],
   );
+  const graphTotal = graphData ? knownGraphTotal(graphData) : null;
 
   const hasContextualGraph = useMemo(
     () =>
@@ -2508,7 +2517,7 @@ function GraphPageInner() {
               label="Severity"
               value={filters.severity ? `${filters.severity}+` : "all"}
             />
-            {sourceNodeCount > 0 && (
+            {sourceNodeCount > 0 && !rollupCanvasOwnsPresentation && (
               <span
                 data-testid="graph-compression-summary"
                 className="graph-chip-neutral"
@@ -2612,6 +2621,7 @@ function GraphPageInner() {
                 breadcrumbs={rollupStack}
                 loading={loadingRollup}
                 error={rollupError}
+                unavailable={rollupUnavailable}
                 active={rollupNavigationActive}
                 onDismiss={dismissRollup}
                 onReset={resetRollupToRoot}
@@ -2660,16 +2670,23 @@ function GraphPageInner() {
         <div className="mt-3 flex flex-wrap items-center gap-4 text-[11px] text-[var(--text-tertiary)]">
           {activeSnapshot && (
             <>
-              <span>{activeSnapshot.node_count} nodes</span>
-              <span>{activeSnapshot.edge_count} edges</span>
+              {!rollupCanvasOwnsPresentation && (
+                <>
+                  <span>{activeSnapshot.node_count} nodes in snapshot</span>
+                  <span>{activeSnapshot.edge_count} edges</span>
+                </>
+              )}
               <span>
                 captured {new Date(activeSnapshot.created_at).toLocaleString()}
               </span>
             </>
           )}
-          {graphData && graphData.pagination.total > 0 && (
+          {graphData &&
+            !rollupCanvasOwnsPresentation &&
+            graphTotal !== null &&
+            graphTotal > 0 && (
             <span>
-              {graphData.pagination.total.toLocaleString()} nodes in graph
+              {graphTotal.toLocaleString()} nodes in graph
             </span>
           )}
         </div>
@@ -2678,7 +2695,12 @@ function GraphPageInner() {
           <GraphEvidenceSummary
             capturedAt={activeSnapshot?.created_at ?? null}
             returnedNodes={graphData?.completeness?.returned ?? graphData?.nodes.length ?? null}
-            totalNodes={graphData?.completeness?.total ?? graphData?.pagination.total ?? null}
+            totalNodes={
+              graphData?.completeness
+                ? (graphData.completeness.total ?? null)
+                : (graphData?.pagination.total ?? null)
+            }
+            snapshotTotalNodes={activeSnapshot?.node_count ?? null}
             evidencedEdges={relationshipEvidenceCount}
             totalEdges={graphData?.edges.length ?? null}
             completeness={
@@ -2689,6 +2711,9 @@ function GraphPageInner() {
                   ? "complete"
                   : null)
             }
+            completenessReason={graphData?.completeness?.reason ?? null}
+            showCompleteness={!rollupCanvasOwnsPresentation}
+            showRelationships={!rollupCanvasOwnsPresentation}
           />
         </div>
 
@@ -3199,6 +3224,11 @@ function GraphPageInner() {
               detail={graphPanelError.detail}
               suggestions={graphPanelError.suggestions}
             />
+          ) : rollupCanvasPending ? (
+            <GraphPanelSkeleton
+              title="Loading scope navigation"
+              detail="Collapsing the containment hierarchy before rendering aggregate navigation cards."
+            />
           ) : displayNodes.length === 0 ? (
             <GraphEmptyState
               title="No nodes match the current graph scope"
@@ -3302,21 +3332,25 @@ function GraphPageInner() {
           {graphTruncated && (
             <div className="mt-2 border-t border-[var(--border-subtle)]/80 px-1 pt-2">
               <GraphCompletenessBanner
-                completeness={{
-                  status: "truncated",
-                  truncated: true,
-                  complete: false,
-                  sampled: false,
-                  returned: displayNodes.length,
-                  total: graphData?.pagination.total ?? GRAPH_FULL_FETCH_LIMIT,
-                  reason: `Interactive render budget is ${GRAPH_FULL_FETCH_LIMIT.toLocaleString()} nodes. Dense neighborhoods are aggregated — filter or focus rather than treating this canvas as the full estate.`,
-                }}
+                completeness={
+                  graphData?.completeness ?? {
+                    status: "truncated",
+                    truncated: true,
+                    complete: false,
+                    sampled: false,
+                    returned: displayNodes.length,
+                    reason: `Interactive render budget is ${GRAPH_FULL_FETCH_LIMIT.toLocaleString()} nodes. Dense neighborhoods are aggregated — filter or focus rather than treating this canvas as the full estate.`,
+                  }
+                }
                 visibleCount={displayNodes.length}
-                omittedCount={Math.max(
-                  0,
-                  (graphData?.pagination.total ?? displayNodes.length) -
-                    displayNodes.length,
-                )}
+                omittedCount={
+                  graphData?.completeness?.total == null
+                    ? undefined
+                    : Math.max(
+                        0,
+                        graphData.completeness.total - displayNodes.length,
+                      )
+                }
               />
             </div>
           )}
@@ -3586,6 +3620,7 @@ function RollupNavigationPanel({
   breadcrumbs,
   loading,
   error,
+  unavailable,
   active,
   onDismiss,
   onReset,
@@ -3596,6 +3631,7 @@ function RollupNavigationPanel({
   breadcrumbs: RollupBreadcrumb[];
   loading: boolean;
   error: string | null;
+  unavailable: boolean;
   active: boolean;
   onDismiss: () => void;
   onReset: () => void;
@@ -3607,30 +3643,37 @@ function RollupNavigationPanel({
       : (summary?.top_level?.length ?? 0);
 
   return (
-    <div className="mt-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-100">
+    <div className="mt-3 rounded-2xl border border-emerald-500/30 bg-emerald-500/10 p-3 text-xs text-emerald-900 dark:text-emerald-100">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex items-start gap-2">
-          <Layers className="mt-0.5 h-4 w-4 text-emerald-300" />
+          <Layers className="mt-0.5 h-4 w-4 text-emerald-700 dark:text-emerald-300" />
           <div>
-            <p className="text-[10px] uppercase tracking-[0.24em] text-emerald-300">
-              Scope roll-up
+            <p className="text-[10px] uppercase tracking-[0.24em] text-emerald-700 dark:text-emerald-300">
+              Scope navigation
             </p>
-            <p className="mt-1 text-sm font-medium text-emerald-50">
+            <p className="mt-1 text-sm font-medium text-emerald-950 dark:text-emerald-50">
               {active
                 ? `${visibleCount} container${visibleCount === 1 ? "" : "s"} at this level · ${estateNodeCount} nodes in snapshot`
+                : unavailable
+                  ? `Roll-up unavailable · ${estateNodeCount} nodes in snapshot`
                 : `Loading CONTAINS roll-up · ${estateNodeCount} nodes in snapshot`}
             </p>
             {active && (
-              <p className="mt-1 text-[11px] text-emerald-200/80">
-                Click a container with descendants to drill down one CONTAINS
-                level. Severity filters apply to rolled-up aggregates.
+              <p className="mt-1 text-[11px] text-emerald-800 dark:text-emerald-200/80">
+                Aggregate cards help navigate scope; they are not rendered
+                relationship evidence. Open node view for the real topology.
               </p>
             )}
             {error && (
-              <p className="mt-1 text-[11px] text-amber-200">{error}</p>
+              <p className="mt-1 text-[11px] text-amber-800 dark:text-amber-200">{error}</p>
+            )}
+            {unavailable && (
+              <p className="mt-1 text-[11px] text-emerald-800 dark:text-emerald-200/80">
+                No containment scope is available; showing the real topology.
+              </p>
             )}
             {loading && (
-              <p className="mt-1 flex items-center gap-1 text-[11px] text-emerald-200">
+              <p className="mt-1 flex items-center gap-1 text-[11px] text-emerald-800 dark:text-emerald-200">
                 <Loader2 className="h-3 w-3 animate-spin" />
                 Collapsing containment hierarchy
               </p>
@@ -3649,12 +3692,12 @@ function RollupNavigationPanel({
       {breadcrumbs.length > 0 && (
         <nav
           aria-label="Roll-up breadcrumb"
-          className="mt-3 flex flex-wrap items-center gap-1 text-[11px] text-emerald-100"
+          className="mt-3 flex flex-wrap items-center gap-1 text-[11px] text-emerald-900 dark:text-emerald-100"
         >
           <button
             type="button"
             onClick={onReset}
-            className="rounded border border-emerald-400/20 bg-emerald-950/50 px-2 py-0.5 transition hover:border-emerald-300"
+            className="rounded border border-emerald-500/30 bg-emerald-50 px-2 py-0.5 text-emerald-900 transition hover:border-emerald-500 dark:bg-emerald-950/50 dark:text-emerald-100"
           >
             Estate root
           </button>

--- a/ui/components/graph-completeness-banner.tsx
+++ b/ui/components/graph-completeness-banner.tsx
@@ -11,8 +11,8 @@ export type GraphCompletenessLike = {
   truncated?: boolean;
   sampled?: boolean;
   returned?: number;
-  total?: number;
-  reason?: string;
+  total?: number | undefined;
+  reason?: string | undefined;
 };
 
 export function GraphCompletenessBanner({

--- a/ui/components/graph-evidence-summary.tsx
+++ b/ui/components/graph-evidence-summary.tsx
@@ -11,38 +11,81 @@ function capturedLabel(value: string | null): string {
   return Number.isNaN(date.getTime()) ? "Unavailable" : date.toLocaleString();
 }
 
+function completenessLabel(
+  returned: number | null,
+  scopeTotal: number | null,
+  snapshotTotal: number | null,
+  status: string | null,
+): string {
+  if (returned === null) return "Unavailable";
+  if (status === "truncated" || status === "sampled") {
+    return snapshotTotal === null
+      ? `${returned.toLocaleString()} nodes returned`
+      : `${returned.toLocaleString()} nodes returned · ${snapshotTotal.toLocaleString()} nodes in snapshot`;
+  }
+  const denominator = snapshotTotal ?? scopeTotal;
+  return denominator === null
+    ? `${returned.toLocaleString()} nodes in current scope`
+    : `${returned.toLocaleString()} of ${denominator.toLocaleString()} nodes in current scope`;
+}
+
+function completenessDetail(status: string | null, reason: string | null): string {
+  if (status === "complete") return "Complete for current scope";
+  const value = reason || status;
+  if (!value) return "Unavailable";
+  const normalized = value.replaceAll("_", " ");
+  return normalized.charAt(0).toUpperCase() + normalized.slice(1);
+}
+
 export function GraphEvidenceSummary({
   capturedAt,
   returnedNodes,
   totalNodes,
+  snapshotTotalNodes,
   evidencedEdges,
   totalEdges,
   completeness,
+  completenessReason = null,
+  showCompleteness = true,
+  showRelationships = true,
 }: {
   capturedAt: string | null;
   returnedNodes: number | null;
   totalNodes: number | null;
+  snapshotTotalNodes: number | null;
   evidencedEdges: number | null;
   totalEdges: number | null;
   completeness: string | null;
+  completenessReason?: string | null;
+  showCompleteness?: boolean;
+  showRelationships?: boolean;
 }) {
-  const items = [
+  const items: Array<{ label: string; value: string; detail?: string }> = [
     {
       label: "Snapshot freshness",
       value: capturedLabel(capturedAt),
-      detail: capturedAt ? "Captured" : undefined,
+      ...(capturedAt ? { detail: "Captured" } : {}),
     },
-    {
+  ];
+  if (showCompleteness) {
+    items.push({
       label: "Completeness",
-      value: countLabel(returnedNodes, totalNodes, "nodes"),
-      detail: completeness ? completeness.replaceAll("_", " ") : "Unavailable",
-    },
-    {
+      value: completenessLabel(
+        returnedNodes,
+        totalNodes,
+        snapshotTotalNodes,
+        completeness,
+      ),
+      detail: completenessDetail(completeness, completenessReason),
+    });
+  }
+  if (showRelationships) {
+    items.push({
       label: "Relationship provenance",
       value: countLabel(evidencedEdges, totalEdges, "relationships"),
       detail: evidencedEdges === null ? "Evidence metadata not reported" : "with evidence metadata",
-    },
-  ];
+    });
+  }
 
   return (
     <section aria-label="Graph evidence status" className="graph-evidence-summary">

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -147,7 +147,11 @@ function buildCockpitGraph(nodeCount = 5) {
   };
 }
 
-async function routeCockpit(page: Page, snapshotNodeCount?: number) {
+async function routeCockpit(
+  page: Page,
+  snapshotNodeCount?: number,
+  options: { emptyRollup?: boolean; rollupDelayMs?: number } = {},
+) {
   const graph = buildCockpitGraph(snapshotNodeCount);
 
   await page.route("**/health", async (route) => {
@@ -260,6 +264,9 @@ async function routeCockpit(page: Page, snapshotNodeCount?: number) {
     await route.fulfill({ contentType: "application/json", body: JSON.stringify(graph) });
   });
   await page.route("**/v1/graph/rollup?**", async (route) => {
+    if (options.rollupDelayMs) {
+      await new Promise((resolve) => setTimeout(resolve, options.rollupDelayMs));
+    }
     await route.fulfill({
       contentType: "application/json",
       body: JSON.stringify({
@@ -268,7 +275,7 @@ async function routeCockpit(page: Page, snapshotNodeCount?: number) {
         created_at: createdAt,
         mode: "rollup",
         filters: {},
-        top_level: [
+        top_level: options.emptyRollup ? [] : [
           {
             id: "account:production",
             label: "Production account",
@@ -310,7 +317,12 @@ async function routeCockpit(page: Page, snapshotNodeCount?: number) {
             },
           },
         ],
-        summary: { total_nodes: 1241, total_edges: 4, top_level_count: 2, container_count: 2 },
+        summary: {
+          total_nodes: snapshotNodeCount ?? 1241,
+          total_edges: graph.edges.length,
+          top_level_count: options.emptyRollup ? 0 : 2,
+          container_count: options.emptyRollup ? 0 : 2,
+        },
       }),
     });
   });
@@ -423,7 +435,9 @@ test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ pa
   await expect(page).toHaveURL(/scan=scan-cockpit-fixture/);
   await expect(page).toHaveURL(/rollup=1/);
   await rollupRequest;
-  await expect(page.getByText("Scope roll-up")).toBeVisible();
+  await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
+  await expect(page.getByText(/not rendered relationship evidence/i)).toBeVisible();
+  await expect(page.getByTestId("graph-compression-summary")).toHaveCount(0);
   await expect(page.getByText(/2 containers at this level.*1241 nodes in snapshot/)).toBeVisible();
   const cards = page.locator('[data-rollup-container="true"]');
   await expect(cards).toHaveCount(2);
@@ -437,3 +451,54 @@ test(`large estates lead with non-overlapping clusters in ${theme}`, async ({ pa
   await expect(page).toHaveURL(/rollup=0/);
 });
 }
+
+test("36-node snapshots default to real topology and forced roll-up stays edge-free", async ({ page }) => {
+  await routeCockpit(page, 36);
+
+  await page.goto(`/graph?scan=${scanId}`);
+  await page.waitForLoadState("networkidle");
+  await expect(page.getByText("Scope navigation", { exact: true })).toHaveCount(0);
+  expect(await page.locator(".react-flow__edge").count()).toBeGreaterThan(0);
+
+  await page.goto(`/graph?scan=${scanId}&rollup=1`);
+  await page.waitForLoadState("networkidle");
+  await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
+  await expect(page.locator('[data-rollup-container="true"]')).toHaveCount(2);
+  await expect(page.locator(".react-flow__edge")).toHaveCount(0);
+  await expect(page.getByTestId("graph-compression-summary")).toHaveCount(0);
+});
+
+test("200-node snapshots default to roll-up and explicit raw topology persists", async ({ page }) => {
+  await routeCockpit(page, 200);
+
+  await page.goto(`/graph?scan=${scanId}`);
+  await page.waitForLoadState("networkidle");
+  await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
+  await expect(page.getByText(/200 nodes in snapshot/i)).toBeVisible();
+
+  await page.goto(`/graph?scan=${scanId}&rollup=0`);
+  await page.waitForLoadState("networkidle");
+  await expect(page).toHaveURL(/rollup=0/);
+  await expect(page.getByText("Scope navigation", { exact: true })).toHaveCount(0);
+  expect(await page.locator(".react-flow__edge").count()).toBeGreaterThan(0);
+});
+
+test("empty forced roll-up preserves operator preference and falls back to real topology", async ({ page }) => {
+  await routeCockpit(page, 36, { emptyRollup: true });
+
+  await page.goto(`/graph?scan=${scanId}&rollup=1`);
+  await page.waitForLoadState("networkidle");
+  await expect(page).toHaveURL(/rollup=1/);
+  await expect(page.getByText(/Roll-up unavailable/i)).toBeVisible();
+  expect(await page.locator(".react-flow__edge").count()).toBeGreaterThan(0);
+});
+
+test("eligible roll-up shows a loading surface without raw-topology counts", async ({ page }) => {
+  await routeCockpit(page, 200, { rollupDelayMs: 750 });
+
+  await page.goto(`/graph?scan=${scanId}`);
+  await expect(page.getByText("Loading scope navigation")).toBeVisible();
+  await expect(page.getByTestId("graph-compression-summary")).toHaveCount(0);
+  await expect(page.locator(".react-flow__edge")).toHaveCount(0);
+  await expect(page.getByText("Scope navigation", { exact: true })).toBeVisible();
+});

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -422,6 +422,7 @@ export interface GraphQueryResponse extends UnifiedGraphData {
   missing_roots: string[];
   depth_by_node: Record<string, number>;
   filters: Record<string, unknown>;
+  completeness: GraphCompleteness;
 }
 
 export interface GraphImpactResponse {

--- a/ui/lib/filter-algebra.ts
+++ b/ui/lib/filter-algebra.ts
@@ -29,6 +29,7 @@ import {
 } from "@/lib/graph-schema";
 import type { UnifiedGraphResponse } from "@/lib/api-types";
 import type { ChangeKind } from "@/lib/graph-utils";
+import { lineageNodeTypeForEntity } from "@/lib/graph-entity-mapping";
 
 // ───────────────────────────────────────────────────────────────────────
 // Public types
@@ -49,59 +50,6 @@ export interface AppliedFilterResult {
   nodes: UnifiedNode[];
   edges: UnifiedEdge[];
   validValues: FilterValidValues;
-}
-
-// ───────────────────────────────────────────────────────────────────────
-// Layer ↔ entity-type map (mirror of graph-page-client.tsx LAYER_ENTITY_TYPES)
-// Kept local so the algebra has no React dependency.
-// ───────────────────────────────────────────────────────────────────────
-
-const LAYER_TO_ENTITY: Record<LineageNodeType, EntityType | string> = {
-  provider: EntityType.PROVIDER,
-  agent: EntityType.AGENT,
-  org: EntityType.ORG,
-  account: EntityType.ACCOUNT,
-  user: EntityType.USER,
-  group: EntityType.GROUP,
-  role: EntityType.ROLE,
-  policy: EntityType.POLICY,
-  serviceAccount: EntityType.SERVICE_ACCOUNT,
-  servicePrincipal: EntityType.SERVICE_PRINCIPAL,
-  federatedIdentity: EntityType.FEDERATED_IDENTITY,
-  environment: EntityType.ENVIRONMENT,
-  fleet: EntityType.FLEET,
-  cluster: EntityType.CLUSTER,
-  server: EntityType.SERVER,
-  // sharedServer is a UI-only refinement of SERVER — treat as server for
-  // entity-type membership.
-  sharedServer: EntityType.SERVER,
-  package: EntityType.PACKAGE,
-  model: EntityType.MODEL,
-  framework: EntityType.FRAMEWORK,
-  dataset: EntityType.DATASET,
-  container: EntityType.CONTAINER,
-  cloudResource: EntityType.CLOUD_RESOURCE,
-  vulnerability: EntityType.VULNERABILITY,
-  misconfiguration: EntityType.MISCONFIGURATION,
-  credential: EntityType.CREDENTIAL,
-  tool: EntityType.TOOL,
-  managedIdentity: EntityType.MANAGED_IDENTITY,
-  accessGrant: EntityType.ACCESS_GRANT,
-  accessPolicy: EntityType.ACCESS_POLICY,
-  driftIncident: EntityType.DRIFT_INCIDENT,
-  dataStore: EntityType.DATA_STORE,
-  directory: EntityType.DIRECTORY,
-  sourceFile: EntityType.SOURCE_FILE,
-  configFile: EntityType.CONFIG_FILE,
-};
-
-const ENTITY_TO_LAYER: Map<string, LineageNodeType> = new Map();
-for (const [layer, entity] of Object.entries(LAYER_TO_ENTITY)) {
-  // First write wins — sharedServer collides with server, but server is
-  // listed first in the iteration order above so this is safe.
-  if (!ENTITY_TO_LAYER.has(String(entity))) {
-    ENTITY_TO_LAYER.set(String(entity), layer as LineageNodeType);
-  }
 }
 
 const RELATIONSHIP_SCOPE_MAP: Record<
@@ -195,7 +143,7 @@ function layerPasses(
   node: UnifiedNode,
   layers: Record<LineageNodeType, boolean>,
 ): boolean {
-  const layer = ENTITY_TO_LAYER.get(String(node.entity_type));
+  const layer = lineageNodeTypeForEntity(node.entity_type);
   if (!layer) return true; // unmapped entity types pass through
   return Boolean(layers[layer]);
 }
@@ -531,7 +479,7 @@ export function computeValidValues(
   });
   const layers = new Set<LineageNodeType>();
   for (const n of layerSurvivors) {
-    const layer = ENTITY_TO_LAYER.get(String(n.entity_type));
+    const layer = lineageNodeTypeForEntity(n.entity_type);
     if (layer) layers.add(layer);
   }
 
@@ -748,7 +696,3 @@ export function decodeFiltersFromParams(
 
   return patch;
 }
-
-// Re-export for callers that want the layer→entity map without importing
-// from graph-page-client (which is "use client").
-export { LAYER_TO_ENTITY, ENTITY_TO_LAYER };

--- a/ui/lib/graph-entity-mapping.ts
+++ b/ui/lib/graph-entity-mapping.ts
@@ -1,0 +1,79 @@
+import type { LineageNodeType } from "@/lib/entity-icons";
+import { EntityType } from "@/lib/graph-schema";
+
+/**
+ * Canonical bridge between public graph layers, API entity filters, and
+ * lineage renderers. A layer may intentionally own more than one backend
+ * entity type (for example applications use the existing container visual).
+ */
+export const GRAPH_LAYER_ENTITY_TYPES: Record<
+  LineageNodeType,
+  readonly EntityType[]
+> = {
+  provider: [EntityType.PROVIDER],
+  agent: [EntityType.AGENT],
+  org: [EntityType.ORG],
+  account: [EntityType.ACCOUNT],
+  user: [EntityType.USER],
+  group: [EntityType.GROUP],
+  role: [EntityType.ROLE],
+  policy: [EntityType.POLICY],
+  serviceAccount: [EntityType.SERVICE_ACCOUNT],
+  servicePrincipal: [EntityType.SERVICE_PRINCIPAL],
+  federatedIdentity: [EntityType.FEDERATED_IDENTITY],
+  environment: [EntityType.ENVIRONMENT],
+  fleet: [EntityType.FLEET],
+  cluster: [EntityType.CLUSTER],
+  server: [EntityType.SERVER],
+  sharedServer: [EntityType.SERVER],
+  package: [EntityType.PACKAGE],
+  model: [EntityType.MODEL],
+  framework: [EntityType.FRAMEWORK],
+  dataset: [EntityType.DATASET],
+  container: [EntityType.CONTAINER, EntityType.APPLICATION],
+  cloudResource: [EntityType.CLOUD_RESOURCE],
+  vulnerability: [EntityType.VULNERABILITY],
+  misconfiguration: [EntityType.MISCONFIGURATION],
+  credential: [EntityType.CREDENTIAL],
+  tool: [EntityType.TOOL],
+  managedIdentity: [EntityType.MANAGED_IDENTITY],
+  accessGrant: [EntityType.ACCESS_GRANT],
+  accessPolicy: [EntityType.ACCESS_POLICY],
+  driftIncident: [EntityType.DRIFT_INCIDENT],
+  dataStore: [EntityType.DATA_STORE],
+  directory: [EntityType.DIRECTORY],
+  sourceFile: [EntityType.SOURCE_FILE],
+  configFile: [EntityType.CONFIG_FILE],
+};
+
+const ENTITY_TO_LINEAGE_NODE_TYPE = new Map<string, LineageNodeType>();
+for (const [layer, entityTypes] of Object.entries(GRAPH_LAYER_ENTITY_TYPES)) {
+  for (const entityType of entityTypes) {
+    // First write wins: sharedServer refines SERVER in the UI, while the
+    // canonical topology renderer remains server. Applications are owned by
+    // the container layer and therefore map to its existing renderer.
+    if (!ENTITY_TO_LINEAGE_NODE_TYPE.has(entityType)) {
+      ENTITY_TO_LINEAGE_NODE_TYPE.set(entityType, layer as LineageNodeType);
+    }
+  }
+}
+
+export function entityTypesForLayers(
+  layers: Record<LineageNodeType, boolean>,
+): EntityType[] {
+  const requested = new Set<EntityType>();
+  for (const [layer, enabled] of Object.entries(layers)) {
+    if (!enabled) continue;
+    for (const entityType of
+      GRAPH_LAYER_ENTITY_TYPES[layer as LineageNodeType]) {
+      requested.add(entityType);
+    }
+  }
+  return [...requested];
+}
+
+export function lineageNodeTypeForEntity(
+  entityType: EntityType | string,
+): LineageNodeType | null {
+  return ENTITY_TO_LINEAGE_NODE_TYPE.get(String(entityType)) ?? null;
+}

--- a/ui/lib/graph-rollup-default.ts
+++ b/ui/lib/graph-rollup-default.ts
@@ -1,9 +1,10 @@
 /**
- * Estate roll-up is the default graph entry when a snapshot is loaded.
- * Operators opt out with `?rollup=0` or "Show full graph".
+ * Estate roll-up is the default graph entry for snapshots at the scale
+ * threshold. Smaller snapshots lead with their real relationship topology.
  */
 
 export type GraphRollupUrlPreference = "default" | "force" | "off";
+export type GraphRollupCanvasMode = "raw" | "loading" | "active";
 
 export function parseGraphRollupUrlPreference(
   params: URLSearchParams | { get(name: string): string | null },
@@ -12,6 +13,27 @@ export function parseGraphRollupUrlPreference(
   if (rollup === "0" || rollup === "false") return "off";
   if (rollup === "1" || rollup === "true") return "force";
   return "default";
+}
+
+/** Only an explicit URL/operator opt-out dismisses roll-up navigation. */
+export function rollupDismissedForPreference(
+  preference: GraphRollupUrlPreference,
+): boolean {
+  return preference === "off";
+}
+
+/** Keep raw topology off-canvas while an eligible roll-up request is pending. */
+export function graphRollupCanvasMode(input: {
+  eligible: boolean;
+  dismissed: boolean;
+  hasView: boolean;
+  unavailable: boolean;
+  failed: boolean;
+}): GraphRollupCanvasMode {
+  if (!input.eligible || input.dismissed) return "raw";
+  if (input.hasView) return "active";
+  if (input.unavailable || input.failed) return "raw";
+  return "loading";
 }
 
 /** Drill-down container id persisted in shareable graph URLs. */
@@ -26,13 +48,16 @@ export interface GraphRollupEligibilityInput {
   hasSelectedScan: boolean;
   rollupPreference: GraphRollupUrlPreference;
   rollupDismissed: boolean;
+  estateNodeCount: number;
   investigationMode: boolean;
   selectedAttackPath: boolean;
   reachabilityActive: boolean;
   blastRadiusActive: boolean;
-  /** When ranked attack paths exist, prefer path-focused canvas over roll-up. */
+  /** Retained for call-site compatibility; availability alone does not select a path. */
   attackPathCount?: number;
 }
+
+export const DEFAULT_GRAPH_ROLLUP_NODE_THRESHOLD = 200;
 
 /** Whether the graph should fetch and prefer the CONTAINS roll-up view. */
 export function graphRollupEligible(input: GraphRollupEligibilityInput): boolean {
@@ -44,11 +69,10 @@ export function graphRollupEligible(input: GraphRollupEligibilityInput): boolean
   if (input.selectedAttackPath) return false;
   if (input.reachabilityActive) return false;
   if (input.blastRadiusActive) return false;
-  // An explicit `?rollup=1` is an operator decision. It must win over the
-  // automatic attack-path-count default, but not the detail overlays above.
+  // An explicit `?rollup=1` is an operator decision, but detail overlays above
+  // still require their focused node set.
   if (input.rollupPreference === "force") return true;
-  if ((input.attackPathCount ?? 0) > 0) return false;
-  return true;
+  return input.estateNodeCount >= DEFAULT_GRAPH_ROLLUP_NODE_THRESHOLD;
 }
 
 export function rollupViewHasContainers(

--- a/ui/lib/graph-rollup-view.ts
+++ b/ui/lib/graph-rollup-view.ts
@@ -2,43 +2,7 @@ import type { Edge, Node } from "@xyflow/react";
 
 import type { LineageNodeData, LineageNodeType } from "@/components/lineage-nodes";
 import type { GraphRollupContainer } from "@/lib/api-types";
-
-const ROLLUP_ENTITY_TO_NODE_TYPE: Record<string, LineageNodeType> = {
-  provider: "provider",
-  org: "org",
-  account: "account",
-  user: "user",
-  group: "group",
-  role: "role",
-  policy: "policy",
-  service_account: "serviceAccount",
-  service_principal: "servicePrincipal",
-  federated_identity: "federatedIdentity",
-  environment: "environment",
-  fleet: "fleet",
-  cluster: "cluster",
-  application: "container",
-  server: "server",
-  package: "package",
-  tool: "tool",
-  credential: "credential",
-  vulnerability: "vulnerability",
-  misconfiguration: "misconfiguration",
-  model: "model",
-  framework: "framework",
-  dataset: "dataset",
-  container: "container",
-  cloud_resource: "cloudResource",
-  managed_identity: "managedIdentity",
-  access_grant: "accessGrant",
-  access_policy: "accessPolicy",
-  drift_incident: "driftIncident",
-  data_store: "dataStore",
-  directory: "directory",
-  source_file: "sourceFile",
-  config_file: "configFile",
-  agent: "agent",
-};
+import { lineageNodeTypeForEntity } from "@/lib/graph-entity-mapping";
 
 const FLOW_NODE_TYPES: Record<LineageNodeType, string> = {
   provider: "providerNode",
@@ -86,7 +50,7 @@ const NODE_WIDTH = NODE_CARD_MAX_WIDTH + NODE_COLUMN_GAP;
 const NODE_HEIGHT = 112;
 
 export function rollupEntityToNodeType(entityType: string): LineageNodeType {
-  return ROLLUP_ENTITY_TO_NODE_TYPE[entityType] ?? "cloudResource";
+  return lineageNodeTypeForEntity(entityType) ?? "cloudResource";
 }
 
 export function rollupContainerSubtitle(container: GraphRollupContainer): string {

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -17,6 +17,7 @@ import {
 } from "@/lib/effective-reach";
 import { relationshipLegendItem, type LegendItem } from "@/lib/graph-utils";
 import { displayContextDescription } from "@/lib/context-graph";
+import { lineageNodeTypeForEntity } from "@/lib/graph-entity-mapping";
 import {
   EntityType,
   type UnifiedEdge,
@@ -65,51 +66,6 @@ export interface UnifiedGraphFlowResult {
   summary: UnifiedGraphFlowSummary;
 }
 
-const ENTITY_TO_NODE_TYPE: Partial<
-  Record<EntityType | string, LineageNodeType>
-> = {
-  [EntityType.PROVIDER]: "provider",
-  [EntityType.AGENT]: "agent",
-  [EntityType.ORG]: "org",
-  [EntityType.ACCOUNT]: "account",
-  [EntityType.USER]: "user",
-  [EntityType.GROUP]: "group",
-  [EntityType.ROLE]: "role",
-  [EntityType.POLICY]: "policy",
-  [EntityType.SERVICE_ACCOUNT]: "serviceAccount",
-  [EntityType.SERVICE_PRINCIPAL]: "servicePrincipal",
-  [EntityType.FEDERATED_IDENTITY]: "federatedIdentity",
-  [EntityType.ENVIRONMENT]: "environment",
-  [EntityType.FLEET]: "fleet",
-  [EntityType.CLUSTER]: "cluster",
-  [EntityType.SERVER]: "server",
-  [EntityType.PACKAGE]: "package",
-  [EntityType.TOOL]: "tool",
-  [EntityType.CREDENTIAL]: "credential",
-  [EntityType.VULNERABILITY]: "vulnerability",
-  [EntityType.MISCONFIGURATION]: "misconfiguration",
-  [EntityType.MODEL]: "model",
-  [EntityType.FRAMEWORK]: "framework",
-  [EntityType.DATASET]: "dataset",
-  [EntityType.CONTAINER]: "container",
-  [EntityType.CLOUD_RESOURCE]: "cloudResource",
-  // Agent-identity governance + cloud-CNAPP nodes get distinct render types
-  // (own color/label/badge) reusing the closest component renderer, so an
-  // investigator can tell a managed identity from a service account, a drift
-  // incident from a misconfiguration, and a data store from a cloud resource.
-  [EntityType.MANAGED_IDENTITY]: "managedIdentity",
-  [EntityType.ACCESS_GRANT]: "accessGrant",
-  [EntityType.ACCESS_POLICY]: "accessPolicy",
-  [EntityType.DRIFT_INCIDENT]: "driftIncident",
-  [EntityType.DATA_STORE]: "dataStore",
-  // Repository folder/file-structure nodes (CODE layer) so a repo / project
-  // scan renders its directory tree, manifest files, and file → dependency →
-  // vuln paths.
-  [EntityType.DIRECTORY]: "directory",
-  [EntityType.SOURCE_FILE]: "sourceFile",
-  [EntityType.CONFIG_FILE]: "configFile",
-};
-
 const FLOW_NODE_TYPES: Record<LineageNodeType, string> = {
   provider: "providerNode",
   agent: "agentNode",
@@ -146,6 +102,12 @@ const FLOW_NODE_TYPES: Record<LineageNodeType, string> = {
   sourceFile: "packageNode",
   configFile: "packageNode",
 };
+
+/** Resolve an API entity to the renderer registered by the graph canvas. */
+export function flowRendererTypeForEntity(entityType: EntityType | string): string | null {
+  const nodeType = lineageNodeTypeForEntity(entityType);
+  return nodeType ? FLOW_NODE_TYPES[nodeType] : null;
+}
 
 const NODE_LABELS: Record<LineageNodeType, string> = {
   provider: "Provider",
@@ -319,7 +281,7 @@ export function buildUnifiedFlowGraph(
     if (!nodeType || !filters.layers[nodeType]) continue;
     nodes.push({
       id: node.id,
-      type: FLOW_NODE_TYPES[nodeType],
+      type: flowRendererTypeForEntity(node.entity_type) ?? FLOW_NODE_TYPES[nodeType],
       position: { x: 0, y: 0 },
       data: toLineageData(node, nodeType, outgoing, incoming, nodeById),
       ...(isCriticalNode(node) ? { className: "node-critical-pulse" } : {}),
@@ -961,7 +923,7 @@ function legendShapeForNodeType(
 }
 
 function mapNodeType(node: UnifiedNode): LineageNodeType | null {
-  return ENTITY_TO_NODE_TYPE[String(node.entity_type)] ?? null;
+  return lineageNodeTypeForEntity(node.entity_type);
 }
 
 function stringAttr(node: UnifiedNode, key: string): string {

--- a/ui/tests/graph-completeness-banner.test.tsx
+++ b/ui/tests/graph-completeness-banner.test.tsx
@@ -38,4 +38,25 @@ describe("GraphCompletenessBanner", () => {
     await user.click(screen.getByRole("button", { name: /Load more/i }));
     expect(onLoadMore).toHaveBeenCalled();
   });
+
+  it("does not invent an exhaustive total for traversal-budget truncation", () => {
+    render(
+      <GraphCompletenessBanner
+        completeness={{
+          status: "truncated",
+          complete: false,
+          truncated: true,
+          sampled: false,
+          returned: 2,
+          reason: "traversal_budget",
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId("graph-completeness-banner")).toHaveTextContent(
+      "Showing 2 items",
+    );
+    expect(screen.getByText("traversal_budget")).toBeInTheDocument();
+    expect(screen.queryByText(/2 of 2/i)).not.toBeInTheDocument();
+  });
 });

--- a/ui/tests/graph-entity-mapping.test.ts
+++ b/ui/tests/graph-entity-mapping.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import { EXPANDED_LAYER_DEFAULTS } from "@/components/lineage-filter";
+import {
+  GRAPH_LAYER_ENTITY_TYPES,
+  entityTypesForLayers,
+  lineageNodeTypeForEntity,
+} from "@/lib/graph-entity-mapping";
+import { EntityType } from "@/lib/graph-schema";
+import { flowRendererTypeForEntity } from "@/lib/unified-graph-flow";
+import { lineageNodeTypesAdaptive } from "@/components/lineage-nodes";
+
+describe("canonical graph entity mapping", () => {
+  it("gives every enabled public layer a supported API entity type", () => {
+    for (const [layer, enabled] of Object.entries(EXPANDED_LAYER_DEFAULTS)) {
+      if (!enabled) continue;
+      expect(GRAPH_LAYER_ENTITY_TYPES[layer as keyof typeof GRAPH_LAYER_ENTITY_TYPES]).not.toHaveLength(0);
+    }
+  });
+
+  it("requests every identity and estate type and can render every request", () => {
+    const requested = entityTypesForLayers(EXPANDED_LAYER_DEFAULTS);
+    expect(requested).toEqual(
+      expect.arrayContaining([
+        EntityType.ORG,
+        EntityType.ACCOUNT,
+        EntityType.ROLE,
+        EntityType.POLICY,
+        EntityType.SERVICE_PRINCIPAL,
+        EntityType.FEDERATED_IDENTITY,
+        EntityType.APPLICATION,
+      ]),
+    );
+    expect(new Set(requested).size).toBe(requested.length);
+    for (const entityType of requested) {
+      expect(lineageNodeTypeForEntity(entityType)).not.toBeNull();
+      const renderer = flowRendererTypeForEntity(entityType);
+      expect(renderer).not.toBeNull();
+      expect(renderer && renderer in lineageNodeTypesAdaptive).toBe(true);
+    }
+  });
+
+  it("uses the existing container visual for applications and canonical server visual for aliases", () => {
+    expect(lineageNodeTypeForEntity(EntityType.APPLICATION)).toBe("container");
+    expect(lineageNodeTypeForEntity(EntityType.SERVER)).toBe("server");
+  });
+});

--- a/ui/tests/graph-evidence-summary.test.tsx
+++ b/ui/tests/graph-evidence-summary.test.tsx
@@ -8,15 +8,17 @@ describe("GraphEvidenceSummary", () => {
     render(
       <GraphEvidenceSummary
         capturedAt="2026-07-24T20:00:00Z"
-        returnedNodes={93}
-        totalNodes={112}
+        returnedNodes={34}
+        totalNodes={34}
+        snapshotTotalNodes={36}
         evidencedEdges={7}
         totalEdges={142}
-        completeness="truncated"
+        completeness="complete"
       />,
     );
 
-    expect(screen.getByText(/93 of 112 nodes/i)).toBeInTheDocument();
+    expect(screen.getByText(/34 of 36 nodes in current scope/i)).toBeInTheDocument();
+    expect(screen.getByText(/Complete for current scope/i)).toBeInTheDocument();
     expect(screen.getByText(/7 of 142 relationships/i)).toBeInTheDocument();
     expect(screen.getByText(/Captured/i)).toBeInTheDocument();
     expect(screen.queryByText(/quality|score|usable/i)).not.toBeInTheDocument();
@@ -28,6 +30,7 @@ describe("GraphEvidenceSummary", () => {
         capturedAt={null}
         returnedNodes={3}
         totalNodes={3}
+        snapshotTotalNodes={null}
         evidencedEdges={null}
         totalEdges={null}
         completeness="complete"
@@ -35,5 +38,44 @@ describe("GraphEvidenceSummary", () => {
     );
 
     expect(screen.getAllByText("Unavailable").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("does not present a truncated traversal as an exhaustive N of N total", () => {
+    render(
+      <GraphEvidenceSummary
+        capturedAt="2026-07-24T20:00:00Z"
+        returnedNodes={2}
+        totalNodes={null}
+        snapshotTotalNodes={36}
+        evidencedEdges={1}
+        totalEdges={1}
+        completeness="truncated"
+        completenessReason="traversal_budget"
+      />,
+    );
+
+    expect(screen.getByText(/2 nodes returned.*36 nodes in snapshot/i)).toBeInTheDocument();
+    expect(screen.getByText(/Traversal budget/i)).toBeInTheDocument();
+    expect(screen.queryByText(/2 of 2 nodes/i)).not.toBeInTheDocument();
+  });
+
+  it("hides topology counts when the canvas is roll-up navigation", () => {
+    render(
+      <GraphEvidenceSummary
+        capturedAt="2026-07-24T20:00:00Z"
+        returnedNodes={36}
+        totalNodes={36}
+        snapshotTotalNodes={36}
+        evidencedEdges={4}
+        totalEdges={4}
+        completeness="complete"
+        showCompleteness={false}
+        showRelationships={false}
+      />,
+    );
+
+    expect(screen.getByText(/Captured/i)).toBeInTheDocument();
+    expect(screen.queryByText(/nodes in current scope/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/relationships/i)).not.toBeInTheDocument();
   });
 });

--- a/ui/tests/graph-query-adapter.test.ts
+++ b/ui/tests/graph-query-adapter.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  knownGraphTotal,
+  queryResponseToGraphResponse,
+} from "@/app/graph/graph-page-client";
+import type { GraphQueryResponse } from "@/lib/api-types";
+
+describe("graph query response adapter", () => {
+  it("preserves traversal completeness without inventing an exhaustive total", () => {
+    const response: GraphQueryResponse = {
+      scan_id: "scan-query",
+      tenant_id: "default",
+      created_at: "2026-07-28T00:00:00Z",
+      nodes: [],
+      edges: [],
+      attack_paths: [],
+      interaction_risks: [],
+      stats: {
+        total_nodes: 0,
+        total_edges: 0,
+        node_types: {},
+        severity_counts: {},
+        relationship_types: {},
+        attack_path_count: 0,
+        interaction_risk_count: 0,
+        max_attack_path_risk: 0,
+        highest_interaction_risk: 0,
+      },
+      roots: ["agent:root"],
+      direction: "both",
+      max_depth: 2,
+      max_nodes: 2,
+      max_edges: 10,
+      timeout_ms: 2500,
+      budget: { max_nodes: 2 },
+      truncated: true,
+      missing_roots: [],
+      depth_by_node: {},
+      filters: {},
+      completeness: {
+        status: "truncated",
+        complete: false,
+        sampled: false,
+        truncated: true,
+        returned: 2,
+        reason: "traversal_budget",
+      },
+    };
+
+    const adapted = queryResponseToGraphResponse(response);
+
+    expect(adapted.completeness).toEqual(response.completeness);
+    expect(adapted.completeness?.total).toBeUndefined();
+    expect(adapted.pagination.has_more).toBe(true);
+    expect(knownGraphTotal(adapted)).toBeNull();
+  });
+});

--- a/ui/tests/graph-rollup-default.test.ts
+++ b/ui/tests/graph-rollup-default.test.ts
@@ -1,14 +1,16 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  graphRollupCanvasMode,
   graphRollupEligible,
   parseGraphRollupUrlPreference,
   parseRollupNodeParam,
+  rollupDismissedForPreference,
   rollupViewHasContainers,
 } from "@/lib/graph-rollup-default";
 
 describe("parseGraphRollupUrlPreference", () => {
-  it("defaults to roll-up unless explicitly opted out", () => {
+  it("parses default, forced, and explicitly disabled preferences", () => {
     expect(parseGraphRollupUrlPreference(new URLSearchParams())).toBe("default");
     expect(parseGraphRollupUrlPreference(new URLSearchParams("rollup=1"))).toBe(
       "force",
@@ -30,18 +32,27 @@ describe("graphRollupEligible", () => {
     hasSelectedScan: true,
     rollupPreference: "default" as const,
     rollupDismissed: false,
+    estateNodeCount: 36,
     investigationMode: false,
     selectedAttackPath: false,
     reachabilityActive: false,
     blastRadiusActive: false,
   };
 
-  it("enables roll-up for any snapshot size when not in investigation overlays", () => {
-    expect(graphRollupEligible(base)).toBe(true);
+  it("defaults to real topology below 200 nodes and roll-up at 200 or more", () => {
+    expect(graphRollupEligible(base)).toBe(false);
+    expect(graphRollupEligible({ ...base, estateNodeCount: 199 })).toBe(false);
+    expect(graphRollupEligible({ ...base, estateNodeCount: 200 })).toBe(true);
   });
 
-  it("skips roll-up when ranked attack paths are available", () => {
-    expect(graphRollupEligible({ ...base, attackPathCount: 3 })).toBe(false);
+  it("does not let ranked-path availability override the estate threshold", () => {
+    expect(
+      graphRollupEligible({
+        ...base,
+        estateNodeCount: 200,
+        attackPathCount: 3,
+      }),
+    ).toBe(true);
   });
 
   it("honors an explicit rollup=1 preference even when attack paths exist", () => {
@@ -50,6 +61,7 @@ describe("graphRollupEligible", () => {
         hasSelectedScan: true,
         rollupPreference: "force",
         rollupDismissed: false,
+        estateNodeCount: 36,
         investigationMode: false,
         selectedAttackPath: false,
         reachabilityActive: false,
@@ -70,6 +82,7 @@ describe("graphRollupEligible", () => {
         hasSelectedScan: true,
         rollupPreference: "force",
         rollupDismissed: false,
+        estateNodeCount: 36,
         investigationMode: false,
         selectedAttackPath: false,
         reachabilityActive: false,
@@ -97,6 +110,53 @@ describe("graphRollupEligible", () => {
     expect(graphRollupEligible({ ...base, blastRadiusActive: true })).toBe(
       false,
     );
+  });
+});
+
+describe("roll-up presentation state", () => {
+  it("derives dismissal only from an explicit operator opt-out", () => {
+    expect(rollupDismissedForPreference("off")).toBe(true);
+    expect(rollupDismissedForPreference("force")).toBe(false);
+    expect(rollupDismissedForPreference("default")).toBe(false);
+  });
+
+  it("withholds raw topology while an eligible roll-up is loading", () => {
+    expect(
+      graphRollupCanvasMode({
+        eligible: true,
+        dismissed: false,
+        hasView: false,
+        unavailable: false,
+        failed: false,
+      }),
+    ).toBe("loading");
+    expect(
+      graphRollupCanvasMode({
+        eligible: true,
+        dismissed: false,
+        hasView: true,
+        unavailable: false,
+        failed: false,
+      }),
+    ).toBe("active");
+    expect(
+      graphRollupCanvasMode({
+        eligible: true,
+        dismissed: false,
+        hasView: false,
+        unavailable: true,
+        failed: false,
+      }),
+    ).toBe("raw");
+    expect(
+      graphRollupCanvasMode({
+        eligible: true,
+        dismissed: false,
+        hasView: false,
+        unavailable: false,
+        failed: false,
+      }),
+    ).toBe("loading");
   });
 });
 

--- a/ui/tests/light-theme-token-guard.test.ts
+++ b/ui/tests/light-theme-token-guard.test.ts
@@ -36,6 +36,25 @@ function walk(dir: string): string[] {
 }
 
 describe("light theme token guard", () => {
+  it("keeps the graph page header on semantic surfaces in both themes", () => {
+    const css = readFileSync(path.join(UI_ROOT, "app/globals.css"), "utf8");
+    const header = css.match(/\.graph-page-header\s*\{([^}]+)\}/)?.[1] ?? "";
+    expect(header).toContain("var(--surface-panel)");
+    expect(header).toContain("var(--background)");
+    expect(header).not.toMatch(/rgba\(24,24,27|rgba\(9,9,11/);
+
+    const graphPage = readFileSync(
+      path.join(UI_ROOT, "app/graph/graph-page-client.tsx"),
+      "utf8",
+    );
+    expect(graphPage).toContain(
+      "text-emerald-950 dark:text-emerald-50",
+    );
+    expect(graphPage).toContain(
+      "text-emerald-800 dark:text-emerald-200/80",
+    );
+  });
+
   it("keeps shared graph chrome and filters on theme tokens instead of dark-only panels", () => {
     const violations = GUARDED_GRAPH_SURFACES.flatMap((file) => {
       const source = readFileSync(path.join(UI_ROOT, file), "utf8");

--- a/ui/tests/unified-graph-flow.test.ts
+++ b/ui/tests/unified-graph-flow.test.ts
@@ -107,4 +107,47 @@ describe("buildUnifiedFlowGraph", () => {
       evidenceMode: "static",
     });
   });
+
+  it("retains application entities through the existing container renderer", () => {
+    const graph: UnifiedGraphData = {
+      scan_id: "scan-application",
+      tenant_id: "default",
+      created_at: createdAt,
+      nodes: [
+        node("agent:checkout", EntityType.AGENT, "Checkout Agent"),
+        node("application:checkout", EntityType.APPLICATION, "Checkout"),
+      ],
+      edges: [
+        edge(
+          "agent:checkout",
+          "application:checkout",
+          RelationshipType.USES,
+        ),
+      ],
+      attack_paths: [],
+      interaction_risks: [],
+      stats: {
+        total_nodes: 2,
+        total_edges: 1,
+        node_types: { agent: 1, application: 1 },
+        severity_counts: {},
+        relationship_types: {},
+        attack_path_count: 0,
+        interaction_risk_count: 0,
+        max_attack_path_risk: 0,
+        highest_interaction_risk: 0,
+      },
+    };
+    const filters = createFocusedGraphFilters();
+    filters.layers.container = true;
+
+    const flow = buildUnifiedFlowGraph(graph, filters);
+
+    expect(flow.nodes).toHaveLength(2);
+    expect(flow.nodes.find((entry) => entry.id === "application:checkout")).toMatchObject({
+      id: "application:checkout",
+      type: "containerNode",
+      data: { nodeType: "container", entityType: "application" },
+    });
+  });
 });


### PR DESCRIPTION
Summary

- default to relationship topology below 200 nodes and scope navigation at 200+, while preserving explicit roll-up on/off and keeping roll-up edges empty
- centralize layer-to-entity mappings, restore identity/estate/application entities, and verify every requested entity resolves to a registered renderer
- preserve traversal completeness without fabricated totals, separate current-scope and snapshot counts, and derive the 16-surface metrics note from 15 mapped frameworks plus AISVS
- preserve forced roll-up across empty responses, withhold raw topology while roll-up loads, and remove competing topology/provenance counts from roll-up presentation

Verification

- uv run pytest -q tests/test_graph_api.py tests/test_product_metrics_snapshot.py tests/test_compliance_coverage.py (69 passed)
- uv run ruff check src/agent_bom/api/routes/graph.py tests/test_graph_api.py scripts/product_metrics_snapshot.py tests/test_product_metrics_snapshot.py
- uv run mypy src/agent_bom/api/routes/graph.py
- make preflight
- npm run typecheck; npm run lint; npm test -- --run (965 passed); npm run build
- npx playwright test e2e/security-graph-cockpit.spec.ts (11 passed; dark, light, mobile, 36-node, 200-node, empty and delayed roll-up)
- UI Docker image build and live HTTP smoke
- three independent read-only rereviews: no remaining P0/P1/P2 findings

Notes

- Roll-up cards are navigation aggregates and never claim rendered relationship evidence.
- Truncated traversal reports reason=traversal_budget and intentionally omits an exhaustive total.