### PR TITLE
test(overview): isolate the process-global caches /v1/overview reads

### DIFF
--- a/tests/test_overview.py
+++ b/tests/test_overview.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import JobStatus, _get_store, app, configure_api
@@ -12,6 +13,31 @@ from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_e
 
 _AUTH_HEADERS = proxy_headers(tenant="default")
 _ADMIN_HEADERS = proxy_headers(role="admin", tenant="default")
+
+
+@pytest.fixture(autouse=True)
+def _isolate_overview_process_globals():
+    """Drop every process-global the overview reads, before and after each test.
+
+    ``/v1/overview`` answers from more than the job store: ``hub_overview_cache``
+    holds a TTL-bounded per-tenant severity/KEV cache that any other test in the
+    same worker can populate for ``default``. ``_clear_jobs`` resets the job
+    store and the overview route's own cache but not that one, so a cached
+    ``{"critical": 3, ...}`` survived into these tests and the exec-headline
+    assertions read another test's data — the file passed alone and failed under
+    ``pytest-randomly`` + ``xdist`` depending on which files shared the worker.
+    """
+
+    from agent_bom.api import hub_overview_cache
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store
+
+    def _reset() -> None:
+        hub_overview_cache.reset_hub_overview_cache()
+        get_compliance_hub_store().clear("default")
+
+    _reset()
+    yield
+    _reset()
 
 
 def _recent_stamp() -> str:
@@ -456,9 +482,7 @@ def test_overview_vuln_tile_ok_when_only_low_severity() -> None:
     from agent_bom.api.compliance_hub_store import get_compliance_hub_store
 
     get_compliance_hub_store().clear("default")
-    _ingest_hub_findings(
-        [{"finding_id": "L-1", "severity": "low", "title": "cve", "vulnerability_id": "CVE-2025-low"}]
-    )
+    _ingest_hub_findings([{"finding_id": "L-1", "severity": "low", "title": "cve", "vulnerability_id": "CVE-2025-low"}])
     data = client_get_overview()
     vuln = data["domains"]["vuln"]
     assert vuln["metric"] > 0


### PR DESCRIPTION
Closes #4538.

## The failure

`CI/CD Pipeline` has been red on `main` intermittently — most recently at
`5c4a34a9b` and `1a75c1036` — with:

```
FAILED tests/test_overview.py::test_overview_coverage_lanes_overlap_for_repo_dependency_cve - assert 3 == 0
```

It moved between Python 3.11 and 3.13 across runs, which made it look flaky and
version-specific. It is neither.

## Root cause

`/v1/overview` answers from more than the job store. `hub_overview_cache` holds a
TTL-bounded, per-tenant severity/KEV cache. `_clear_jobs()` resets the job store
and the overview route's *own* cache — but never that one.

So whichever test in the same xdist worker populated the cache for the `default`
tenant first left its counts behind, and the exec-headline assertions
(`data["headline"]["critical"] == 0`) read another test's data. `pytest-randomly`
reshuffles order and xdist assigns files to workers differently every run, so
which Python version happened to lose was pure chance.

## Reproduced deterministically

Seeding the cache with `{"critical": 3, ...}` for `default` before the file makes
it fail every time — including the exact assertion CI reported:

```
FAILED tests/test_overview.py::test_overview_empty_shape - assert 3 == 0
FAILED tests/test_overview.py::test_overview_aggregates_findings - assert 4 == 1
FAILED tests/test_overview.py::test_overview_reads_compacted_scan_summary - assert 3 == 0
FAILED tests/test_overview.py::test_overview_counts_bulk_ingested_findings - assert 'D' == 'N/A'
4 failed, 24 passed
```

With the fixture, that same run is `28 passed`.

## Scope

I checked the five other test files that call `/v1/overview`
(`test_hosted_poc_smoke`, `test_demo_estate_bootstrap`, `test_findings_status_filter`,
`api/test_api_hardening`, `api/test_auth_harness_isolation`) against the same seeded
contamination. All pass — none assert on the cached severity — so this stays scoped
to one file rather than scattering speculative fixtures.

The fixture also clears the compliance hub store, which individual tests were each
clearing by hand, so isolation no longer depends on every future test remembering to.

## Verified

- deterministic repro red before, green after
- `pytest tests/test_overview.py` with CI's exact `--randomly-seed=664064825` → 27 passed
- `test_overview` + `test_read_path_compliance_hub` + `test_hub_overview_cache` + `test_findings_status_filter` → 68 passed, 1 skipped
- `ruff check` / `ruff format` clean, `make preflight` green
- one file changed, tests only