### PR TITLE
fix(cwpp): serialize runtime-evidence schema bootstrap across processes

### DIFF
--- a/src/agent_bom/cloud/runtime_workload_evidence_store.py
+++ b/src/agent_bom/cloud/runtime_workload_evidence_store.py
@@ -374,6 +374,14 @@ class PostgresRuntimeWorkloadEvidenceStore:
             reset_current_tenant(token)
 
     def _create_schema(self, conn: Connection) -> None:
+        # Serialize bootstrap DDL across processes. Every store construction runs
+        # this path, so replicas and workers starting together each issue
+        # CREATE INDEX / ALTER TABLE / DROP INDEX plus the v2 backfill UPDATE on
+        # the same relation. Those take conflicting relation-level locks and
+        # deadlock rather than queue — reproducible with concurrent writers
+        # against real Postgres. The advisory lock is transaction-scoped, so it
+        # releases on the commit below (or on rollback) with no cleanup path.
+        conn.execute("SELECT pg_advisory_xact_lock(hashtext(%s))", (f"agent_bom.schema.{self.table}",))
         conn.execute(
             f"""
             CREATE TABLE IF NOT EXISTS {self.table} (


### PR DESCRIPTION
Refs #4158 (stage 3 hardening).

## The defect

`PostgresRuntimeWorkloadEvidenceStore.__init__` calls `init_schema()` unconditionally,
and the explicit-DSN path runs the full bootstrap — `CREATE TABLE`, `CREATE INDEX`,
`ALTER TABLE`, `DROP INDEX`, plus the v2 backfill `UPDATE` — with no version guard and
no lock. Replicas and workers constructing the store concurrently take conflicting
relation-level locks on the same table and **deadlock instead of queueing**.

## Why it was invisible

`tests/cloud/test_runtime_workload_evidence_store.py::test_postgres_cross_process_writers_do_not_duplicate`
already covers exactly this. It is skipped whenever `AGENT_BOM_POSTGRES_URL` is unset —
which is every CI run — so the defect shipped behind a green suite.

Against a real Postgres 16 it fails **deterministically**, 3/3 runs:

```
psycopg.errors.DeadlockDetected: deadlock detected
DETAIL: Process 6515 waits for RowExclusiveLock on relation 49189; blocked by process 6514.
        Process 6514 waits for RowExclusiveLock on relation 49189; blocked by process 6515.
FAILED ...::test_postgres_cross_process_writers_do_not_duplicate - assert 1 == 0
```

Note the lock is on the **relation**, not a row — which is what points at concurrent DDL
rather than row contention. My first hypothesis was unordered row locks in `put_batch`;
sorting the batch changed nothing, because all three writers already insert identical keys
in identical order. That ruled it out and led to the bootstrap path.

## The fix

A transaction-scoped advisory lock keyed on the table name, taken before the bootstrap DDL.
Concurrent bootstraps queue instead of deadlocking. `pg_advisory_xact_lock` releases on
commit or rollback, so there is no cleanup path and no lock to leak.

## Verified

- against real Postgres 16: **4/4 runs green**, previously 1 failed on every run
- full `tests/cloud/` suite: 719 passed, 7 skipped
- `ruff` and `mypy` clean on the changed file

## Follow-up worth tracking separately

Only `postgres_campaign`, `postgres_graph`, and this store guard bootstrap DDL. The rest
reach it through `ensure_postgres_schema_version`, which performs no DDL once a deployment
URL is configured because Alembic owns migrations — so the exposure is the
explicit-DSN/development path, not a migrated deployment. That deserves a systematic pass,
not a blind patch across 24 files, so I did not widen this PR to cover it.