### PR TITLE
fix(gateway): make agent containment actually contain

### DIFF
--- a/src/agent_bom/api/agent_identity_store.py
+++ b/src/agent_bom/api/agent_identity_store.py
@@ -802,6 +802,39 @@ def revoke_identity(store: AgentIdentityStore, identity_id: str, *, tenant_id: s
     return identity
 
 
+def live_identity_for_agent(store: AgentIdentityStore, tenant_id: str, agent_id: str) -> AgentIdentity | None:
+    """Return one live identity for ``agent_id``, or ``None`` if every one is dead.
+
+    ``identity_for_token`` resolves by token hash, which only matches an
+    agent-bom-issued ``abi_`` token. A caller presenting a JWKS/OIDC JWT or an
+    opaque ``policy.agent_tokens`` mapping never reaches the identity store, so
+    the gateway needs an agent-keyed lookup to honour revocation for them too.
+    """
+    key = (agent_id or "").strip()
+    if not key:
+        return None
+    for identity in store.list(tenant_id, include_inactive=True, limit=200):
+        if (identity.agent_id or "").strip() == key and identity.is_live():
+            return identity
+    return None
+
+
+def agent_identity_revoked(store: AgentIdentityStore, tenant_id: str, agent_id: str) -> bool:
+    """Return True only when ``agent_id`` has identities and none are live.
+
+    An agent with no managed identity at all is *not* revoked — deployments that
+    never issued one must keep working. Rotation also leaves revoked rows behind,
+    so a single live identity is enough to keep the agent alive.
+    """
+    key = (agent_id or "").strip()
+    if not key:
+        return False
+    known = [i for i in store.list(tenant_id, include_inactive=True, limit=200) if (i.agent_id or "").strip() == key]
+    if not known:
+        return False
+    return not any(i.is_live() for i in known)
+
+
 def request_jit_grant(
     store: AgentIdentityStore,
     *,

--- a/src/agent_bom/api/routes/fleet.py
+++ b/src/agent_bom/api/routes/fleet.py
@@ -421,9 +421,7 @@ async def sync_fleet(request: Request, body: PushPayload | None = None) -> dict[
         matched_discovery: list[tuple[Any, FleetAgent | None]] = []
         for discovered_agent in discovered:
             discovered_type = (
-                discovered_agent.agent_type.value
-                if hasattr(discovered_agent.agent_type, "value")
-                else str(discovered_agent.agent_type)
+                discovered_agent.agent_type.value if hasattr(discovered_agent.agent_type, "value") else str(discovered_agent.agent_type)
             )
             match = match_discovered_fleet_agent(
                 existing_agents,
@@ -445,9 +443,7 @@ async def sync_fleet(request: Request, body: PushPayload | None = None) -> dict[
         ):
             for discovered_agent, existing in matched_discovery:
                 discovered_type = (
-                    discovered_agent.agent_type.value
-                    if hasattr(discovered_agent.agent_type, "value")
-                    else str(discovered_agent.agent_type)
+                    discovered_agent.agent_type.value if hasattr(discovered_agent.agent_type, "value") else str(discovered_agent.agent_type)
                 )
                 discovered_canonical_id = str(getattr(discovered_agent, "canonical_id", "") or "")
                 server_count, pkg_count, cred_count, vuln_count = _server_counts(discovered_agent)
@@ -467,9 +463,7 @@ async def sync_fleet(request: Request, body: PushPayload | None = None) -> dict[
                     existing.updated_at = now
                     existing.config_path = discovered_agent.config_path or ""
                     existing.source_id = str(getattr(discovered_agent, "source_id", "") or existing.source_id)
-                    existing.device_fingerprint = str(
-                        getattr(discovered_agent, "device_fingerprint", "") or existing.device_fingerprint
-                    )
+                    existing.device_fingerprint = str(getattr(discovered_agent, "device_fingerprint", "") or existing.device_fingerprint)
                     store.put(existing)
                     updated_count += 1
                 else:
@@ -543,6 +537,7 @@ async def update_fleet_state(request: Request, agent_id: str, body: StateUpdate)
     agent = store.get(agent_id, tenant_id=tenant_id)
     if agent is None:
         raise HTTPException(status_code=404, detail="Fleet agent not found")
+    was_quarantined = agent.lifecycle_state == FleetLifecycleState.QUARANTINED
     store.update_state(agent_id, new_state)
     log_action(
         "fleet.state_update",
@@ -551,7 +546,43 @@ async def update_fleet_state(request: Request, agent_id: str, body: StateUpdate)
         tenant_id=tenant_id,
         lifecycle_state=new_state.value,
     )
-    return {"agent_id": agent_id, "lifecycle_state": new_state.value}
+    result: dict[str, Any] = {"agent_id": agent_id, "lifecycle_state": new_state.value}
+
+    # Releasing an agent has to reverse containment, not just relabel it.
+    # Quarantine mints an enforce-mode deny-all policy; leaving the state
+    # without disabling it left the agent blocked forever on the control-plane
+    # policy path. Reuses _quarantine_policy_name so the two sides cannot drift.
+    if was_quarantined and new_state != FleetLifecycleState.QUARANTINED:
+        disabled = _disable_quarantine_policy(agent.name, tenant_id=tenant_id, actor=actor)
+        if disabled is not None:
+            result["gateway_policy"] = {"policy_id": disabled, "disabled": True}
+    return result
+
+
+def _disable_quarantine_policy(agent_name: str, *, tenant_id: str, actor: str) -> str | None:
+    """Disable the agent's quarantine deny policy; return its id when one was found."""
+    from agent_bom.api.audit_log import log_action
+
+    policy_store = _get_policy_store()
+    policy_name = _quarantine_policy_name(agent_name)
+    policy = next(
+        (p for p in policy_store.list_policies(tenant_id=tenant_id) if p.name == policy_name),
+        None,
+    )
+    if policy is None or not policy.enabled:
+        return None
+    policy.enabled = False
+    policy.updated_at = datetime.now(timezone.utc).isoformat()
+    policy_store.put_policy(policy)
+    log_action(
+        "gateway.policy_updated",
+        actor=actor,
+        resource=f"gateway-policy/{policy.policy_id}",
+        tenant_id=tenant_id,
+        origin="fleet_unquarantine",
+        enabled=False,
+    )
+    return str(policy.policy_id)
 
 
 @router.post("/fleet/{agent_id}/quarantine", tags=["fleet"], dependencies=[_dep("policy_write")])

--- a/src/agent_bom/cli/_gateway.py
+++ b/src/agent_bom/cli/_gateway.py
@@ -288,9 +288,13 @@ def init_policy_cmd(output_path: Path, mode: str, output_format: str, tenant_id:
     "--fleet-enforcement",
     type=click.Choice(["off", "warn", "enforce"]),
     envvar="AGENT_BOM_GATEWAY_FLEET_ENFORCEMENT",
-    default="off",
+    default="enforce",
     show_default=True,
-    help="Act on quarantined fleet agents: 'enforce' blocks every call from a quarantined agent, 'warn' audits it, 'off' stays advisory.",
+    help=(
+        "Act on quarantined fleet agents: 'enforce' blocks every call from a quarantined agent, "
+        "'warn' audits it, 'off' stays advisory. Defaults to 'enforce' so quarantine actually "
+        "contains on this relay; the check fails open if the fleet store is unreachable."
+    ),
 )
 @click.option(
     "--graph-reachability-report",

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -235,8 +235,15 @@ class GatewaySettings:
     # Fleet-state enforcement. An agent the operator has moved to the
     # QUARANTINED lifecycle state in the fleet roster can be fully blocked
     # ("enforce") or flagged ("warn") at the gateway — isolating a compromised
-    # or under-review agent without touching per-tool policy. Default "off".
-    fleet_enforcement_mode: str = "off"
+    # or under-review agent without touching per-tool policy.
+    #
+    # Defaults to "enforce": quarantine is an explicit operator action, and the
+    # minted deny GatewayPolicy only reaches the relay on the control-plane
+    # polling path (proxy.py), never on this one — so "off" made the documented
+    # one-click containment a no-op here. The check fails open on store error, so
+    # a fleet-store outage cannot become a fleet-wide outage. Opt out with
+    # ``--fleet-enforcement off`` / AGENT_BOM_GATEWAY_FLEET_ENFORCEMENT=off.
+    fleet_enforcement_mode: str = "enforce"
     # Fail-closed posture for the policy engine. "closed" (the secure default,
     # used when the env var is unset) makes a missing/unloadable policy or an
     # evaluation error DENY so a security-conscious operator never silently runs
@@ -354,6 +361,26 @@ def _agent_is_quarantined(tenant_id: str, source_agent: str) -> bool:
         if key in identifiers:
             return getattr(agent, "lifecycle_state", None) == FleetLifecycleState.QUARANTINED
     return False
+
+
+def _agent_identity_revoked(tenant_id: str, source_agent: str) -> tuple[bool, bool]:
+    """Return ``(revoked, lookup_unavailable)`` for a caller with no managed token.
+
+    ``identity_for_token`` only matches an agent-bom-issued ``abi_`` token, so a
+    JWKS/OIDC JWT or an opaque ``policy.agent_tokens`` caller previously bypassed
+    identity revocation entirely. Fail-open on store errors — the caller decides
+    whether its posture warrants failing closed — so an identity-store outage can
+    never become a fleet-wide outage.
+    """
+    if not source_agent or source_agent == ANONYMOUS:
+        return False, False
+    try:
+        from agent_bom.api.agent_identity_store import agent_identity_revoked, get_agent_identity_store
+
+        return agent_identity_revoked(get_agent_identity_store(), tenant_id, source_agent), False
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("gateway agent identity revocation check failed: %s", _sanitize_for_log(exc))
+        return False, True
 
 
 # Upper bound on open incidents fetched per drift enforcement check. When a
@@ -1203,6 +1230,40 @@ def build_control_plane_audit_sink(
     return _sink
 
 
+def _warn_on_quarantined_agents(settings: GatewaySettings) -> None:
+    """Name the agents that fleet enforcement will block, once, at boot.
+
+    ``fleet_enforcement_mode`` now defaults to ``enforce``. An operator upgrading
+    with a stale QUARANTINED row would otherwise discover the new behaviour as
+    unexplained traffic loss — especially likely because releasing an agent did
+    not disable its deny policy until this release. Best-effort and silent on
+    error: this is an advisory log, never a boot gate.
+    """
+    if settings.fleet_enforcement_mode != "enforce":
+        return
+    try:
+        from agent_bom.api.fleet_store import FleetLifecycleState
+        from agent_bom.api.stores import _get_fleet_store
+
+        # The relay resolves a tenant per request; at boot only the default
+        # tenant is knowable, which is the single-tenant self-host shape this
+        # warning exists for.
+        quarantined = [
+            (getattr(a, "name", "") or getattr(a, "agent_id", ""))
+            for a in _get_fleet_store().list_by_tenant("default")
+            if getattr(a, "lifecycle_state", None) == FleetLifecycleState.QUARANTINED
+        ]
+    except Exception:  # noqa: BLE001
+        return
+    if quarantined:
+        logger.warning(
+            "fleet enforcement is active: %d quarantined agent(s) will be blocked at this gateway: %s "
+            "(opt out with --fleet-enforcement off)",
+            len(quarantined),
+            ", ".join(sorted(_sanitize_for_log(name) for name in quarantined)[:20]),
+        )
+
+
 def create_gateway_app(settings: GatewaySettings) -> FastAPI:
     """Build the FastAPI app for `agent-bom gateway serve`.
 
@@ -1215,6 +1276,7 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
         require_visual_leak_runtime()
     _enforce_gateway_auth_posture(settings)
     _enforce_gateway_anonymous_agents_posture(settings)
+    _warn_on_quarantined_agents(settings)
     runtime_profile_mode = _validate_runtime_profile_posture(settings)
 
     managed_upstream_relay = GatewayUpstreamRelay(settings) if settings.upstream_caller is None else None
@@ -1753,6 +1815,21 @@ def create_gateway_app(settings: GatewaySettings) -> FastAPI:
             )
             if identity_token and identity_invalid_reason is None:
                 token_scopes = identity_token_scopes(identity_token)
+
+        # Revocation is agent-wide, so it is checked here — above the tool-call
+        # branch — rather than beside ``allowed_tools``. Stages that key off a
+        # resolved tool only run for ``tools/call``, which would leave a revoked
+        # caller free to run ``initialize`` / ``tools/list`` / ``resources/read``.
+        # It also has to precede the JIT-grant path, which can override a
+        # per-tool deny: a revoked identity must never be JIT-grantable.
+        if scoped_identity is None and identity_invalid_reason is None and source_agent != ANONYMOUS:
+            agent_revoked, revocation_lookup_unavailable = _agent_identity_revoked(tenant_id, source_agent)
+            if agent_revoked:
+                identity_invalid_reason = "agent identity revoked"
+            elif revocation_lookup_unavailable and (
+                current_policy.get("require_agent_identity") or not _gateway_allows_anonymous_agents(settings)
+            ):
+                identity_invalid_reason = "agent identity revocation status unavailable"
 
         identity_block_reason: str | None = None
         if identity_invalid_reason is not None:

--- a/tests/test_fleet_quarantine_gateway_deny.py
+++ b/tests/test_fleet_quarantine_gateway_deny.py
@@ -82,3 +82,49 @@ def test_quarantine_unknown_agent_is_404(client_with_agent):
     assert resp.status_code == 404
     # No policy created for a missing agent.
     assert policy_store.list_policies(tenant_id="default") == []
+
+
+def test_leaving_quarantine_disables_the_deny_policy(client_with_agent):
+    """Releasing an agent must reverse containment, not just relabel it.
+
+    ``PUT /state`` flipped the lifecycle row but left the enforce-mode
+    ``block_tools:["*"]`` policy bound to the agent forever, so a released agent
+    stayed blocked on the control-plane policy path.
+    """
+    client, fleet_store, policy_store = client_with_agent
+
+    client.post("/v1/fleet/agent-123/quarantine")
+    assert policy_store.list_policies(tenant_id="default")[0].enabled is True
+
+    resp = client.put("/v1/fleet/agent-123/state", json={"state": "approved"})
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["gateway_policy"]["disabled"] is True
+
+    policies = policy_store.list_policies(tenant_id="default")
+    assert len(policies) == 1, "releasing must reuse the same policy, never orphan a second one"
+    assert policies[0].enabled is False
+
+
+def test_requarantine_after_release_reuses_the_same_policy(client_with_agent):
+    """Idempotency has to survive the full quarantine → release → quarantine round trip."""
+    client, fleet_store, policy_store = client_with_agent
+
+    client.post("/v1/fleet/agent-123/quarantine")
+    first_id = policy_store.list_policies(tenant_id="default")[0].policy_id
+    client.put("/v1/fleet/agent-123/state", json={"state": "approved"})
+    client.post("/v1/fleet/agent-123/quarantine")
+
+    policies = policy_store.list_policies(tenant_id="default")
+    assert len(policies) == 1
+    assert policies[0].policy_id == first_id
+    assert policies[0].enabled is True
+
+
+def test_state_change_that_is_not_a_release_leaves_the_policy_alone(client_with_agent):
+    """Only a transition OUT of quarantine reverses containment."""
+    client, fleet_store, policy_store = client_with_agent
+
+    resp = client.put("/v1/fleet/agent-123/state", json={"state": "pending_review"})
+    assert resp.status_code == 200, resp.text
+    assert "gateway_policy" not in resp.json()
+    assert policy_store.list_policies(tenant_id="default") == []

--- a/tests/test_gateway_fleet_enforcement.py
+++ b/tests/test_gateway_fleet_enforcement.py
@@ -125,3 +125,168 @@ def test_fleet_store_failure_fails_open():
     client = TestClient(create_gateway_app(_settings("enforce")))
     resp = client.post("/mcp/filesystem", json=_call("token-a"))
     assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+# ── Identity revocation for non-managed callers (JWT / opaque tokens) ──────────
+#
+# The gateway resolves a managed (``abi_``) token through ``identity_for_token``,
+# which consults ``AgentIdentity.status`` on every call. A JWKS/OIDC JWT or an
+# opaque ``policy.agent_tokens`` mapping never touches the identity store, so the
+# agent's revocation was a runtime no-op for exactly the deployments most likely
+# to use a real IdP.
+
+
+def _identity(agent_id: str, status: str):
+    from agent_bom.api.agent_identity_store import AgentIdentity
+
+    return AgentIdentity(
+        identity_id=f"id-{agent_id}-{status}",
+        agent_id=agent_id,
+        tenant_id="default",
+        token_hash=f"hash-{agent_id}-{status}",
+        token_prefix="abi_test",
+        role="agent",
+        blueprint_id="",
+        status=status,
+        issued_at="2026-01-01T00:00:00Z",
+        expires_at="",
+    )
+
+
+def _seed_identities(*identities) -> None:
+    from agent_bom.api.agent_identity_store import InMemoryAgentIdentityStore, set_agent_identity_store
+
+    store = InMemoryAgentIdentityStore()
+    for identity in identities:
+        store.put(identity)
+    set_agent_identity_store(store)
+
+
+@pytest.fixture(autouse=True)
+def _reset_identity_store():
+    yield
+    from agent_bom.api.agent_identity_store import set_agent_identity_store
+
+    set_agent_identity_store(None)
+
+
+def test_opaque_caller_with_revoked_identity_is_denied():
+    """The bypass proof: an opaque-token caller whose identity was revoked."""
+    _seed_fleet()
+    _seed_identities(_identity("agent-b", "revoked"))
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert _is_blocked(resp), resp.text
+
+
+def test_opaque_caller_with_live_identity_is_allowed():
+    _seed_fleet()
+    _seed_identities(_identity("agent-b", "active"))
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+def test_caller_with_no_managed_identity_record_is_unaffected():
+    """Deployments that never issued a managed identity must not start failing."""
+    _seed_fleet()
+    _seed_identities()  # empty store
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+def test_agent_with_one_live_identity_among_revoked_is_allowed():
+    """Rotation leaves revoked rows behind; only an agent with NO live identity is dead."""
+    _seed_fleet()
+    _seed_identities(_identity("agent-b", "revoked"), _identity("agent-b", "active"))
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+def test_revocation_blocks_non_tool_methods():
+    """Pins the check ABOVE the tool-call branch.
+
+    ``allowed_tools`` and the JIT-grant path only run for ``tools/call``. If the
+    revocation check were placed there, a revoked caller could still run
+    ``tools/list``, ``initialize`` and ``resources/read``.
+    """
+    _seed_fleet()
+    _seed_identities(_identity("agent-b", "revoked"))
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post(
+        "/mcp/filesystem",
+        json={
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "tools/list",
+            "params": {"_meta": {"agent_identity": "token-b"}},
+        },
+    )
+    assert _is_blocked(resp), resp.text
+
+
+def test_identity_store_failure_fails_open_for_unsecured_posture():
+    """An identity-store outage must not become a fleet-wide outage.
+
+    Only the revocation lookup is broken here. Breaking the whole store would
+    also take out conditional access, which fails *closed* by design — that
+    would test the wrong subsystem.
+    """
+    from agent_bom.api.agent_identity_store import InMemoryAgentIdentityStore, set_agent_identity_store
+
+    class _RevocationLookupDown(InMemoryAgentIdentityStore):
+        def list(self, *a, **k):
+            raise RuntimeError("identity store down")
+
+    _seed_fleet()
+    set_agent_identity_store(_RevocationLookupDown())
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert resp.status_code == 200 and resp.json().get("result") == {"ok": True}
+
+
+def test_identity_store_failure_fails_closed_when_identity_is_required():
+    """Under a secured posture an unprovable revocation status must deny."""
+    from agent_bom.api.agent_identity_store import InMemoryAgentIdentityStore, set_agent_identity_store
+
+    class _RevocationLookupDown(InMemoryAgentIdentityStore):
+        def list(self, *a, **k):
+            raise RuntimeError("identity store down")
+
+    _seed_fleet()
+    set_agent_identity_store(_RevocationLookupDown())
+    settings = _settings("enforce")
+    settings.policy["require_agent_identity"] = True
+    client = TestClient(create_gateway_app(settings))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert _is_blocked(resp), resp.text
+
+
+def test_fleet_enforcement_defaults_to_enforce():
+    """Quarantine is an explicit operator action; 'off' made it a no-op."""
+    settings = GatewaySettings(registry=_registry(), policy={}, upstream_caller=_ok_caller)
+    assert settings.fleet_enforcement_mode == "enforce"
+
+
+def test_boot_warns_and_names_agents_that_enforcement_will_block(caplog):
+    """The default flip must not be a silent behaviour change on upgrade."""
+    import logging
+
+    _seed_fleet()
+    with caplog.at_level(logging.WARNING, logger="agent_bom.gateway_server"):
+        create_gateway_app(_settings("enforce"))
+    warnings = [r.getMessage() for r in caplog.records if "fleet enforcement is active" in r.getMessage()]
+    assert warnings, "operators must be told which agents will now be blocked"
+    assert "agent-a" in warnings[0]
+    assert "--fleet-enforcement off" in warnings[0]
+
+
+def test_boot_is_silent_when_enforcement_is_opted_out(caplog):
+    import logging
+
+    _seed_fleet()
+    with caplog.at_level(logging.WARNING, logger="agent_bom.gateway_server"):
+        create_gateway_app(_settings("off"))
+    assert not [r for r in caplog.records if "fleet enforcement is active" in r.getMessage()]


### PR DESCRIPTION
PR 1 of 4 from the graph-cockpit plan. Three defects that together made the
documented one-click kill switch a no-op in a default deployment.

## 1. Identity revocation was bypassable

The relay consults `AgentIdentity.status` only at token resolution
(`identity_for_token`), which matches an agent-bom-issued `abi_` token. A caller
presenting a **JWKS/OIDC JWT or an opaque `policy.agent_tokens` mapping never
reaches the identity store at all** — so revoking it was a runtime no-op, in
exactly the deployments most likely to front a real IdP.

`test_opaque_caller_with_revoked_identity_is_denied` **fails on `main`** — that's
the proof.

**Placement is the load-bearing decision.** The check goes above the tool-call
branch, not beside `allowed_tools`:
- revocation is agent-wide, and the per-tool stages only run for `tools/call` —
  placing it there leaves a revoked caller free to run `initialize`, `tools/list`,
  `resources/read`. `test_revocation_blocks_non_tool_methods` pins this and fails
  if the check is moved down.
- it must precede the JIT-grant path, which can override a per-tool deny. A revoked
  identity must never be JIT-grantable.

Deliberately conservative: an agent with **no** managed identity is not revoked, and
**one live identity among revoked rows keeps the agent alive** (rotation leaves
revoked rows behind). Deployments that never issued a managed identity see no change.

## 2. Releasing an agent did not release it

Quarantine mints an enforce-mode `block_tools:["*"]` policy, but `PUT /state` only
flipped the lifecycle row — a released agent stayed blocked **forever** on the
control-plane policy path. Leaving `QUARANTINED` now disables that policy, reusing
`_quarantine_policy_name` so the two sides cannot drift.

## 3. Fleet enforcement now defaults to `enforce`

The minted deny policy only reaches the relay on the control-plane polling path
(`proxy.py`), never on this one, and `control_plane_policies` is a **static
file-loaded list**. So with the old `"off"` default, quarantining an agent blocked
nothing here.

### This is the risky part, and it's deliberately de-risked
It changes behaviour for every existing deployment — and some tenants have stale
`QUARANTINED` rows *precisely because* defect 2 meant releasing never worked. So:
- **defect 2 is fixed before the default flips**, in that order. Never ship an
  enforcing switch whose off-position is broken.
- the gateway **names the quarantined agents it will block** in a boot warning,
  tested — an upgrade is not a silent behaviour change.
- the check already **fails open** on store error; pinned by a test, because a
  fleet-store outage must never become a fleet-wide outage.
- `--fleet-enforcement off` / `AGENT_BOM_GATEWAY_FLEET_ENFORCEMENT=off` makes
  rollback a config change, not a downgrade.

If you'd rather not take the behaviour change in this release, the flip is one line
plus one test and can be split out; defects 1 and 2 are strictly safety-increasing
with no upgrade exposure.

## Verified

- `pytest tests/ -k "gateway or fleet or identity"` → **894 passed, 15 skipped, 0 failures**
- both new bypass tests confirmed red on `main`
- one narrowed fixture worth noting: my first fail-open test broke the *whole*
  identity store, which also takes out conditional access — that fails closed by
  design. It now breaks only the revocation lookup, so it tests the right subsystem.
- `ruff`, `mypy`, `make preflight` clean
- **no new routes or MCP tools** → no OpenAPI, schema, SVG, or capability-manifest
  regeneration