### PR TITLE
feat(cost): attribute LLM spend and fuse it into the unified graph

### DIFF
--- a/src/agent_bom/api/cost_store.py
+++ b/src/agent_bom/api/cost_store.py
@@ -253,6 +253,79 @@ class CostStore(Protocol):
     ) -> CostBudget | None: ...
 
 
+def spend_rollup(store: Any, tenant_id: str, *, since: str | None = None) -> list[dict[str, Any]]:
+    """Aggregate spend by ``(agent, cost_center, provider)`` for one tenant.
+
+    Prefers a store-side ``spend_rollup`` (a SQL ``GROUP BY``, which stays
+    sargable on the ``idx_llm_costs_tenant_agent_observed`` index) and falls back
+    to aggregating in Python. The fallback deliberately does NOT use the default
+    ``list_records`` limit: that caps at 1000 rows ordered by recency, which
+    would silently drop a busy tenant's older spend from the total.
+    """
+    native = getattr(store, "spend_rollup", None)
+    if callable(native):
+        return list(native(tenant_id, since=since))
+
+    buckets: dict[tuple[str, str, str], dict[str, Any]] = {}
+    for record in store.list_records(tenant_id, limit=1_000_000):
+        if since is not None and record.observed_at < since:
+            continue
+        key = (record.agent, record.cost_center, record.provider)
+        bucket = buckets.setdefault(
+            key,
+            {"agent": record.agent, "cost_center": record.cost_center, "provider": record.provider, "calls": 0, "cost_usd": 0.0},
+        )
+        bucket["calls"] += 1
+        bucket["cost_usd"] += record.cost_usd
+    for bucket in buckets.values():
+        bucket["cost_usd"] = round(float(bucket["cost_usd"]), 6)
+    return sorted(buckets.values(), key=lambda b: (-float(b["cost_usd"]), str(b["agent"])))
+
+
+def graph_cost_rollup(
+    store: Any,
+    tenant_id: str,
+    *,
+    now: datetime | None = None,
+    window_days: int = 30,
+) -> list[dict[str, Any]]:
+    """Spend shaped for the graph cost overlay, split across the window boundary.
+
+    The overlay stamps both a windowed ``cost_usd_30d`` and an all-time
+    ``cost_usd`` per node, and decides which is which from each record's
+    ``observed_at``. So each group is emitted twice: once inside the window and
+    once as the out-of-window remainder. The two always reconcile to all-time
+    spend, which the tests assert directly.
+    """
+    ref = now or datetime.now(timezone.utc)
+    window_start = (ref - timedelta(days=window_days)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    before_window = (ref - timedelta(days=window_days + 1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    all_time = {(r["agent"], r["cost_center"], r["provider"]): r for r in spend_rollup(store, tenant_id)}
+    windowed = {(r["agent"], r["cost_center"], r["provider"]): r for r in spend_rollup(store, tenant_id, since=window_start)}
+
+    records: list[dict[str, Any]] = []
+    for key, total in all_time.items():
+        agent, cost_center, provider = key
+        recent = windowed.get(key)
+        if recent is not None and recent["cost_usd"]:
+            records.append({**recent, "observed_at": ref.strftime("%Y-%m-%dT%H:%M:%SZ")})
+        remainder = round(float(total["cost_usd"]) - float(recent["cost_usd"] if recent else 0.0), 6)
+        remainder_calls = int(total["calls"]) - int(recent["calls"] if recent else 0)
+        if remainder > 0 or remainder_calls > 0:
+            records.append(
+                {
+                    "agent": agent,
+                    "cost_center": cost_center,
+                    "provider": provider,
+                    "calls": remainder_calls,
+                    "cost_usd": remainder,
+                    "observed_at": before_window,
+                }
+            )
+    return records
+
+
 def _rollup_by_owner(records: list[LLMCostRecord], agent_owner: dict[str, str]) -> list[dict[str, Any]]:
     """Aggregate spend + tokens by the accountable owner governing each agent (#3909).
 
@@ -573,6 +646,25 @@ class SQLiteCostStore:
                 _decode_tags(r[12] if len(r) > 12 else None),
             )
             for r in rows
+        ]
+
+    def spend_rollup(self, tenant_id: str, *, since: str | None = None) -> list[dict[str, Any]]:
+        """GROUP BY in SQL so a busy tenant is never truncated or walked in Python."""
+        sql = "SELECT agent, cost_center, provider, COUNT(*), COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = ?"
+        params: list[Any] = [tenant_id]
+        if since is not None:
+            sql += " AND observed_at >= ?"
+            params.append(since)
+        sql += " GROUP BY agent, cost_center, provider ORDER BY SUM(cost_usd) DESC, agent"
+        return [
+            {
+                "agent": r[0] or "",
+                "cost_center": r[1] or "",
+                "provider": r[2] or "",
+                "calls": int(r[3]),
+                "cost_usd": round(float(r[4]), 6),
+            }
+            for r in self._conn.execute(sql, params).fetchall()
         ]
 
     def total_spend_by_cost_center(self, tenant_id: str, cost_center: str, *, since: str | None = None) -> float:

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -513,6 +513,21 @@ def _persist_graph_snapshot(
     tenant_id = job.tenant_id or "default"
     scan_id = report_json.get("scan_id") or job.job_id
 
+    # Fuse tenant LLM spend into the build so the graph cost overlay actually
+    # runs. The overlay has always existed but read report_json["llm_cost_records"],
+    # which nothing populated, so per-node cost_usd / subtree_cost_usd were never
+    # stamped. Shallow copy, never mutation: report_json is persisted elsewhere
+    # and must stay byte-identical. Best-effort, like the delta/webhook steps.
+    graph_input = report_json
+    try:
+        from agent_bom.api.cost_store import get_cost_store, graph_cost_rollup
+
+        cost_records = graph_cost_rollup(get_cost_store(), tenant_id)
+        if cost_records:
+            graph_input = {**report_json, "llm_cost_records": cost_records}
+    except Exception as exc:  # noqa: BLE001
+        _logger.debug("graph cost rollup skipped: %s", exc)
+
     # Store-backed producer (#4055/#4075): auto-on above the entity threshold
     # (or forced via AGENT_BOM_GRAPH_STORE_BACKED_BUILD). Builds into a per-build
     # store-backed container on a throwaway private SQLite workspace so peak RSS
@@ -529,7 +544,7 @@ def _persist_graph_snapshot(
         container_cm = contextlib.nullcontext(None)
 
     with container_cm as container:
-        graph = build_unified_graph_from_report(report_json, scan_id=scan_id, tenant_id=tenant_id, container=container)
+        graph = build_unified_graph_from_report(graph_input, scan_id=scan_id, tenant_id=tenant_id, container=container)
 
         # Stamp Finding.id onto vuln/misconfig nodes before persist so attack-path
         # finding_ids (and investigation deep-links) are not CVE-label-only.

--- a/src/agent_bom/api/postgres_cost.py
+++ b/src/agent_bom/api/postgres_cost.py
@@ -159,6 +159,31 @@ class PostgresCostStore:
             )
             conn.commit()
 
+    def spend_rollup(self, tenant_id: str, *, since: str | None = None) -> list[dict[str, Any]]:
+        """GROUP BY in SQL so a busy tenant is never truncated or walked in Python.
+
+        Sargable on idx_llm_costs_tenant_agent_observed: tenant_id leads and
+        observed_at bounds the scan.
+        """
+        sql = "SELECT agent, cost_center, provider, COUNT(*), COALESCE(SUM(cost_usd), 0.0) FROM llm_costs WHERE tenant_id = %s"
+        params: list[Any] = [tenant_id]
+        if since is not None:
+            sql += " AND observed_at >= %s"
+            params.append(since)
+        sql += " GROUP BY agent, cost_center, provider ORDER BY SUM(cost_usd) DESC, agent"
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(sql, params).fetchall()
+        return [
+            {
+                "agent": r[0] or "",
+                "cost_center": r[1] or "",
+                "provider": r[2] or "",
+                "calls": int(r[3]),
+                "cost_usd": round(float(r[4]), 6),
+            }
+            for r in rows
+        ]
+
     def list_records(self, tenant_id: str, *, limit: int = 1000) -> list[LLMCostRecord]:
         with _tenant_connection(self._pool) as conn:
             rows = conn.execute(

--- a/src/agent_bom/graph/cost_overlay.py
+++ b/src/agent_bom/graph/cost_overlay.py
@@ -79,6 +79,14 @@ def _record_tags(record: Any) -> dict[str, str]:
     return {}
 
 
+def _record_calls(record: Any) -> int:
+    """Call count for one record: an aggregate's own count, else a single call."""
+    calls = _record_field(record, "calls")
+    if isinstance(calls, bool) or not isinstance(calls, (int, float)):
+        return 1
+    return max(0, int(calls))
+
+
 def _node_match_keys(node: UnifiedNode) -> set[str]:
     """Lower-cased identifiers a cost record may name this node by.
 
@@ -180,7 +188,9 @@ def apply_cost_overlay(
         candidate_keys.discard("unknown")
         for key in candidate_keys:
             total_by_key[key] += cost_val
-            calls_by_key[key] += 1
+            # Aggregated rows carry their own call count; a raw LLMCostRecord has
+            # no ``calls`` field and falls back to one call per record.
+            calls_by_key[key] += _record_calls(record)
             if in_window:
                 window_by_key[key] += cost_val
 

--- a/src/agent_bom/otel_ingest.py
+++ b/src/agent_bom/otel_ingest.py
@@ -128,6 +128,10 @@ class LLMAPICall:
     output_tokens: int
     duration_ms: float
     status: str  # "ok" | "error"
+    # Calling agent, when the span says so. This is the join key that attributes
+    # spend to a graph node — without it every cost row buckets as "unknown".
+    # Defaulted and last so existing positional construction keeps working.
+    agent: str = ""
 
 
 @dataclass
@@ -299,6 +303,7 @@ def parse_ml_api_spans(trace_data: dict) -> list[LLMAPICall]:
     calls: list[LLMAPICall] = []
 
     for rs in trace_data.get("resourceSpans", []):
+        resource_attrs = rs.get("resource", {}).get("attributes", [])
         for ss in rs.get("scopeSpans", []):
             scope_name = ss.get("scope", {}).get("name", "")
             for span in ss.get("spans", []):
@@ -306,6 +311,15 @@ def parse_ml_api_spans(trace_data: dict) -> list[LLMAPICall]:
                     continue
 
                 attrs = span.get("attributes", [])
+                # Span-level attribution beats resource-level: one service can run
+                # several agents, so service.name is the fallback, not the answer.
+                agent = (
+                    _extract_attr(attrs, "gen_ai.agent.name")
+                    or _extract_attr(attrs, "agent.name")
+                    or _extract_attr(attrs, "gen_ai.agent.id")
+                    or _extract_attr(attrs, "agent.id")
+                    or _extract_attr(resource_attrs, "service.name")
+                )
 
                 # Provider: gen_ai.system (OTel convention) or infer from scope
                 provider = _extract_attr(attrs, "gen_ai.system")
@@ -371,6 +385,7 @@ def parse_ml_api_spans(trace_data: dict) -> list[LLMAPICall]:
                         output_tokens=output_tokens,
                         duration_ms=duration_ms,
                         status=status,
+                        agent=agent,
                     )
                 )
 

--- a/tests/test_finops_costs.py
+++ b/tests/test_finops_costs.py
@@ -470,3 +470,108 @@ def test_traces_ingest_without_agent_attribution_stays_unknown(client):
     assert client.post("/v1/traces", json=_ml_otlp_payload()).status_code == 200
     costs = client.get("/v1/observability/costs").json()
     assert [b["key"] for b in costs["by_agent"]] == ["unknown"]
+
+
+# ── Graph cost rollup (the aggregate the graph overlay joins on) ───────────────
+
+
+def _rollup_store():
+    from agent_bom.api.cost_store import LLMCostRecord
+
+    store = InMemoryCostStore()
+    for i, (agent, cost, observed) in enumerate(
+        [
+            ("checkout-agent", 10.0, "2026-07-20T00:00:00Z"),
+            ("checkout-agent", 5.0, "2026-07-25T00:00:00Z"),
+            ("billing-agent", 2.0, "2026-07-25T00:00:00Z"),
+            ("checkout-agent", 100.0, "2026-01-01T00:00:00Z"),  # outside a 30d window
+        ]
+    ):
+        store.record_cost(
+            LLMCostRecord(
+                tenant_id="default",
+                call_id=f"c{i}",
+                agent=agent,
+                session_id="s",
+                provider="openai",
+                model="gpt-4o",
+                input_tokens=1,
+                output_tokens=1,
+                cost_usd=cost,
+                priced=True,
+                observed_at=observed,
+                cost_center="ai-platform",
+            )
+        )
+    return store
+
+
+def test_spend_rollup_groups_by_agent_cost_center_provider():
+    from agent_bom.api.cost_store import spend_rollup
+
+    rows = spend_rollup(_rollup_store(), "default")
+    by_agent = {r["agent"]: r for r in rows}
+    assert by_agent["checkout-agent"]["cost_usd"] == 115.0
+    assert by_agent["checkout-agent"]["calls"] == 3
+    assert by_agent["billing-agent"]["cost_usd"] == 2.0
+    assert by_agent["checkout-agent"]["cost_center"] == "ai-platform"
+
+
+def test_spend_rollup_honours_the_since_bound():
+    from agent_bom.api.cost_store import spend_rollup
+
+    rows = spend_rollup(_rollup_store(), "default", since="2026-07-01T00:00:00Z")
+    by_agent = {r["agent"]: r for r in rows}
+    assert by_agent["checkout-agent"]["cost_usd"] == 15.0
+
+
+def test_graph_cost_rollup_splits_at_the_window_boundary():
+    """The two emitted buckets must reconcile to all-time spend, exactly."""
+    from datetime import datetime, timezone
+
+    from agent_bom.api.cost_store import graph_cost_rollup
+
+    store = _rollup_store()
+    now = datetime(2026, 7, 29, tzinfo=timezone.utc)
+    records = graph_cost_rollup(store, "default", now=now, window_days=30)
+
+    checkout = [r for r in records if r["agent"] == "checkout-agent"]
+    assert round(sum(r["cost_usd"] for r in checkout), 6) == store.total_spend("default", agent="checkout-agent")
+
+    in_window = [r for r in checkout if r["observed_at"] >= "2026-06-29"]
+    assert round(sum(r["cost_usd"] for r in in_window), 6) == 15.0
+
+
+def test_graph_cost_rollup_is_empty_when_no_spend():
+    from datetime import datetime, timezone
+
+    from agent_bom.api.cost_store import graph_cost_rollup
+
+    assert graph_cost_rollup(InMemoryCostStore(), "default", now=datetime(2026, 7, 29, tzinfo=timezone.utc)) == []
+
+
+def test_sqlite_spend_rollup_matches_the_python_fallback(tmp_path):
+    """SQL GROUP BY and the in-memory fallback must agree — backend parity."""
+    from agent_bom.api.cost_store import LLMCostRecord, SQLiteCostStore, spend_rollup
+
+    sqlite_store = SQLiteCostStore(str(tmp_path / "costs.db"))
+    memory_store = InMemoryCostStore()
+    for i, (agent, cost) in enumerate([("a", 3.0), ("a", 1.5), ("b", 2.0)]):
+        record = LLMCostRecord(
+            tenant_id="default",
+            call_id=f"c{i}",
+            agent=agent,
+            session_id="s",
+            provider="openai",
+            model="gpt-4o",
+            input_tokens=1,
+            output_tokens=1,
+            cost_usd=cost,
+            priced=True,
+            observed_at="2026-07-25T00:00:00Z",
+            cost_center="cc",
+        )
+        sqlite_store.record_cost(record)
+        memory_store.record_cost(record)
+
+    assert spend_rollup(sqlite_store, "default") == spend_rollup(memory_store, "default")

--- a/tests/test_finops_costs.py
+++ b/tests/test_finops_costs.py
@@ -445,3 +445,28 @@ def test_budget_enforcement_uses_rolling_window(monkeypatch):
     monkeypatch.setenv("AGENT_BOM_BUDGET_WINDOW_DAYS", "30")
     blocked, _b, spend = check_budget_enforcement(store, "t1", "")
     assert blocked is False and spend == 3.0
+
+
+def test_traces_ingest_attributes_cost_to_the_calling_agent(client):
+    """The join key that makes cost fusible with the graph.
+
+    LLMAPICall carried no agent field, so every OTLP-ingested cost row was
+    persisted with agent="" and rolled up as "unknown" — leaving the graph cost
+    overlay nothing to match on.
+    """
+    payload = _ml_otlp_payload()
+    payload["resourceSpans"][0]["scopeSpans"][0]["spans"][0]["attributes"].append(
+        {"key": "gen_ai.agent.name", "value": {"stringValue": "checkout-agent"}}
+    )
+    assert client.post("/v1/traces", json=payload).status_code == 200
+
+    costs = client.get("/v1/observability/costs").json()
+    assert [b["key"] for b in costs["by_agent"]] == ["checkout-agent"]
+    assert costs["by_agent"][0]["cost_usd"] == 12.5
+
+
+def test_traces_ingest_without_agent_attribution_stays_unknown(client):
+    """Absent attribution must stay honest, not be invented."""
+    assert client.post("/v1/traces", json=_ml_otlp_payload()).status_code == 200
+    costs = client.get("/v1/observability/costs").json()
+    assert [b["key"] for b in costs["by_agent"]] == ["unknown"]

--- a/tests/test_graph_cost_overlay.py
+++ b/tests/test_graph_cost_overlay.py
@@ -209,3 +209,138 @@ def test_builder_without_cost_records_leaves_no_cost_attrs():
     for node in graph.nodes.values():
         assert "cost_usd" not in node.attributes
         assert "subtree_cost_usd" not in node.attributes
+
+
+def test_aggregate_record_calls_field_is_honoured():
+    """An aggregated row stands for many calls, not one.
+
+    graph_cost_rollup emits one dict per (agent, cost_center, provider) group
+    carrying its own ``calls`` count; counting it as a single call would report
+    a fleet's spend as two calls.
+    """
+    graph = _org_account_agent_graph()
+    apply_cost_overlay(
+        graph,
+        [{"agent": "billing-bot", "cost_usd": 100.0, "calls": 42, "observed_at": "2026-06-20T00:00:00+00:00"}],
+        _NOW,
+    )
+    assert graph.get_node("agent:billing-bot").attributes["cost_calls"] == 42
+
+
+def test_raw_records_without_calls_field_count_as_one_each():
+    """A real LLMCostRecord has no ``calls`` field — it must not read as zero."""
+    graph = _org_account_agent_graph()
+    apply_cost_overlay(graph, [_record("billing-bot", 1.0), _record("billing-bot", 2.0, observed="2026-06-21T00:00:00+00:00")], _NOW)
+    assert graph.get_node("agent:billing-bot").attributes["cost_calls"] == 2
+
+
+# ── Pipeline fusion (the wiring that was missing) ──────────────────────────────
+#
+# apply_cost_overlay was reachable only from report_json["llm_cost_records"],
+# which no production path ever populated — so the overlay never ran on a real
+# scan and no node ever carried cost.
+
+
+def _seed_cost_store(agent: str, cost: float):
+    from agent_bom.api.cost_store import InMemoryCostStore, LLMCostRecord, set_cost_store
+
+    store = InMemoryCostStore()
+    store.record_cost(
+        LLMCostRecord(
+            tenant_id="default",
+            call_id="c1",
+            agent=agent,
+            session_id="s",
+            provider="openai",
+            model="gpt-4o",
+            input_tokens=10,
+            output_tokens=5,
+            cost_usd=cost,
+            priced=True,
+            observed_at=datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            cost_center="ai-platform",
+        )
+    )
+    set_cost_store(store)
+    return store
+
+
+def test_pipeline_injects_tenant_spend_without_mutating_the_report(monkeypatch):
+    """The wiring contract: records reach the build, report_json stays untouched.
+
+    Whether the overlay then stamps the nodes is the builder's job and is covered
+    above -- this pins the injection that was missing, and pins that report_json
+    (persisted elsewhere and expected byte-identical) is copied, never mutated.
+    """
+    from types import SimpleNamespace
+
+    from agent_bom.api import pipeline
+    from agent_bom.api.cost_store import set_cost_store
+
+    graph = _org_account_agent_graph()
+    _seed_cost_store("billing-bot", 77.0)
+    captured: dict[str, object] = {}
+
+    def _fake_build(report_json, scan_id, tenant_id, container=None):
+        captured["report_json"] = report_json
+        return graph
+
+    monkeypatch.setattr("agent_bom.graph.builder.build_unified_graph_from_report", _fake_build)
+    monkeypatch.setattr(
+        pipeline,
+        "_get_graph_store",
+        lambda: SimpleNamespace(save_graph_streaming=lambda **k: None, prior_delta_digest=lambda *a, **k: None),
+    )
+    try:
+        original = {"scan_id": "scan-1"}
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            pipeline._persist_graph_snapshot(SimpleNamespace(job_id="j1", tenant_id="default", progress=[]), original)
+
+        records = captured["report_json"]["llm_cost_records"]
+        assert any(r["agent"] == "billing-bot" for r in records)
+        assert "llm_cost_records" not in original, "report_json must never be mutated in place"
+    finally:
+        set_cost_store(None)
+
+
+def test_pipeline_leaves_the_report_alone_when_there_is_no_spend(monkeypatch):
+    from types import SimpleNamespace
+
+    from agent_bom.api import pipeline
+    from agent_bom.api.cost_store import InMemoryCostStore, set_cost_store
+
+    set_cost_store(InMemoryCostStore())
+    captured: dict[str, object] = {}
+
+    def _fake_build(report_json, scan_id, tenant_id, container=None):
+        captured["report_json"] = report_json
+        return _org_account_agent_graph()
+
+    monkeypatch.setattr("agent_bom.graph.builder.build_unified_graph_from_report", _fake_build)
+    monkeypatch.setattr(
+        pipeline,
+        "_get_graph_store",
+        lambda: SimpleNamespace(save_graph_streaming=lambda **k: None, prior_delta_digest=lambda *a, **k: None),
+    )
+    try:
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            pipeline._persist_graph_snapshot(SimpleNamespace(job_id="j1", tenant_id="default", progress=[]), {"scan_id": "s"})
+        assert "llm_cost_records" not in captured["report_json"]
+    finally:
+        set_cost_store(None)
+
+
+def test_builder_applies_injected_cost_records_to_agent_nodes():
+    """The other half: given the records, the builder must stamp the nodes."""
+    from agent_bom.graph.builder import _apply_cost_overlay
+
+    graph = _org_account_agent_graph()
+    _apply_cost_overlay(
+        graph,
+        {"llm_cost_records": [{"agent": "billing-bot", "cost_usd": 77.0, "calls": 3, "observed_at": _NOW.isoformat()}]},
+    )
+    assert graph.get_node("agent:billing-bot").attributes["cost_usd"] == 77.0

--- a/tests/test_otel_ingest.py
+++ b/tests/test_otel_ingest.py
@@ -494,3 +494,61 @@ def test_validate_otel_schema_rejects_non_list_resource_spans():
 
     with pytest.raises(ValueError, match="array"):
         validate_otel_schema({"resourceSpans": "not-a-list"})
+
+
+# ── Agent attribution (cost → graph join key) ─────────────────────────────────
+#
+# LLMCostRecord.agent was always "" for real OTLP ingest because LLMAPICall
+# carried no agent field, so every persisted cost row bucketed as "unknown" and
+# the graph cost overlay had nothing to join on.
+
+
+def _ml_span(attributes: list[dict]) -> dict:
+    return {
+        "traceId": "t1",
+        "spanId": "s1",
+        "parentSpanId": "",
+        "name": "chat gpt-4o",
+        "startTimeUnixNano": 1000000000,
+        "endTimeUnixNano": 1500000000,
+        "attributes": [{"key": "gen_ai.system", "value": {"stringValue": "openai"}}, *attributes],
+        "status": {},
+    }
+
+
+def _otlp_with_resource(spans: list[dict], resource_attributes: list[dict]) -> dict:
+    return {
+        "resourceSpans": [
+            {
+                "resource": {"attributes": resource_attributes},
+                "scopeSpans": [{"spans": spans}],
+            }
+        ]
+    }
+
+
+def test_ml_span_agent_read_from_gen_ai_agent_name():
+    calls = parse_ml_api_spans(_otlp_trace([_ml_span([{"key": "gen_ai.agent.name", "value": {"stringValue": "checkout-agent"}}])]))
+    assert len(calls) == 1
+    assert calls[0].agent == "checkout-agent"
+
+
+def test_ml_span_agent_falls_back_to_resource_service_name():
+    calls = parse_ml_api_spans(_otlp_with_resource([_ml_span([])], [{"key": "service.name", "value": {"stringValue": "billing-svc"}}]))
+    assert calls[0].agent == "billing-svc"
+
+
+def test_span_agent_attribute_beats_resource_service_name():
+    calls = parse_ml_api_spans(
+        _otlp_with_resource(
+            [_ml_span([{"key": "agent.name", "value": {"stringValue": "span-agent"}}])],
+            [{"key": "service.name", "value": {"stringValue": "resource-svc"}}],
+        )
+    )
+    assert calls[0].agent == "span-agent"
+
+
+def test_ml_span_agent_is_empty_when_absent():
+    """No attribution must stay empty rather than inventing one."""
+    calls = parse_ml_api_spans(_otlp_trace([_ml_span([])]))
+    assert calls[0].agent == ""


### PR DESCRIPTION
Makes agent spend real, end to end. Two commits, one vertical: attribution at
ingest, then fusion into the graph.

## The problem: dead on arrival, twice

`src/agent_bom/graph/cost_overlay.py` implements the entire cost overlay —
per-node `cost_usd` / `cost_usd_30d` / `cost_calls`, `subtree_cost_usd` rolled up
along CONTAINS, and a cost×risk fusion flagging nodes `expensive_and_exposed`.
It has 12 passing tests. **It has never run on a real scan.**

Two independent breaks:

1. **Nothing populated its input.** The overlay is reachable only from
   `report_json["llm_cost_records"]`, and no production path ever wrote that key.
2. **Its join key was always empty.** `LLMAPICall` carried no agent field, so
   `routes/observability.py` persisted every OTLP-ingested cost row with
   `agent=""` and `cost_store` rolled all of it up as `"unknown"`. Per-agent
   budgets and the anomaly z-score key on that same field, so they were equally
   blind — only the demo seeder, which sets `agent` explicitly, ever worked.

## The fix

**Attribution** — `parse_ml_api_spans` resolves the calling agent per span:
`gen_ai.agent.name` → `agent.name` → `gen_ai.agent.id` → `agent.id` → resource
`service.name`. Span-level beats resource-level, because one service can run
several agents — the same precedence `_allocation_for_spans` already uses for
cost centers. The resource attributes were already being parsed and thrown away.
Absent attribution stays `""` rather than being invented.

**Fusion** — `_persist_graph_snapshot` rolls up tenant spend and injects it into
the build. Shallow copy, never mutation: `report_json` is persisted elsewhere and
must stay byte-identical, and a test pins that. Best-effort like the delta and
webhook steps beside it, so a cost-store problem can never fail a scan.

**Scale** — `spend_rollup` is a SQL `GROUP BY` on both SQLite and Postgres,
sargable on the existing `idx_llm_costs_tenant_agent_observed`. The Python
fallback deliberately avoids the default `list_records` limit, which caps at 1000
rows by recency and would silently drop a busy tenant's older spend from its own
total. A parity test asserts SQL and in-memory agree.

**One overlay correction** — an aggregated row stands for many calls, so
`cost_calls` reads the row's own count. A raw `LLMCostRecord` has no `calls`
field and still counts as one, so the existing tests stay green byte-for-byte.

## Verified

- **317 passed** across cost / otel / pipeline / graph-builder suites
- both halves proven separately: the pipeline test pins *injection* and
  non-mutation; a builder test pins *application*. My first attempt asserted both
  through a mocked builder, which could never have applied the overlay — that was
  testing the wrong layer, so I split it.
- `graph_cost_rollup`'s two buckets are asserted to reconcile **exactly** to
  all-time spend, not assumed
- end-to-end through `/v1/traces` → `/v1/observability/costs`: spend now buckets
  under the named agent, and stays `unknown` when the span carries no attribution
- `ruff`, `mypy`, `make preflight` clean
- **no new routes or MCP tools** → no OpenAPI, schema, SVG, or capability-manifest
  regeneration

## Not in this PR

The graph header cost strip (the UI surface) and the Command Center / Trust Center
persona split. Both are UI work that would make this backend PR incoherent to
review; the node attributes this ships are what they'll read.