### PR TITLE
feat(graph): surface spend and one-click containment on the canvas

### DIFF
--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -734,6 +734,44 @@ function GraphPageInner() {
   );
   const [blastRadius, setBlastRadius] = useState<BlastRadiusState | null>(null);
   const [loadingBlast, setLoadingBlast] = useState(false);
+  // Containment is a two-step action: the first click arms it, the second
+  // commits. Blocking every tool call for an agent is not a one-click gesture.
+  const [quarantine, setQuarantine] = useState<{
+    state: "idle" | "confirming" | "pending" | "done" | "error";
+    message: string;
+  }>({ state: "idle", message: "" });
+
+  const quarantineSelectedAgent = useCallback(
+    async (node: LineageNodeData | null) => {
+      const label = node?.label?.trim();
+      if (!label) return;
+      if (quarantine.state === "idle" || quarantine.state === "error") {
+        setQuarantine({
+          state: "confirming",
+          message: `Blocks every tool call from ${label} at the gateway. Release it from the fleet roster.`,
+        });
+        return;
+      }
+      if (quarantine.state !== "confirming") return;
+      setQuarantine({ state: "pending", message: "" });
+      try {
+        await quarantineAgentByLabel(label);
+        setQuarantine({ state: "done", message: `${label} is quarantined; every tool call is now denied.` });
+      } catch (e) {
+        setQuarantine({
+          state: "error",
+          message: e instanceof Error ? e.message : "Quarantine failed.",
+        });
+      }
+    },
+    [quarantine.state],
+  );
+
+  // Containment state belongs to one agent. Without this reset, opening a
+  // different node would show it already "quarantined".
+  useEffect(() => {
+    setQuarantine({ state: "idle", message: "" });
+  }, [selectedNodeId]);
   const [blastError, setBlastError] = useState<string | null>(null);
   const [rollupView, setRollupView] = useState<GraphRollupResponse | null>(null);
   const [rollupStack, setRollupStack] = useState<RollupBreadcrumb[]>(() => {
@@ -2449,6 +2487,22 @@ function GraphPageInner() {
                   label="paths"
                   accent="blue"
                 />
+                {/* Spend is opt-in by data: a tenant with no ingested LLM cost
+                    sees the header exactly as before rather than a $0 tile. */}
+                {flow.summary.costUsd30d > 0 && (
+                  <MetricCard
+                    value={flow.summary.costUsd30d}
+                    label="spend 30d"
+                    format="usd"
+                  />
+                )}
+                {flow.summary.expensiveExposed > 0 && (
+                  <MetricCard
+                    value={flow.summary.expensiveExposed}
+                    label="expensive & exposed"
+                    accent="red"
+                  />
+                )}
               </>
             )}
 
@@ -3366,6 +3420,9 @@ function GraphPageInner() {
               }}
               blastRadiusActive={blastRadius?.rootId === selectedNodeId}
               blastRadiusLoading={loadingBlast}
+              quarantineState={quarantine.state}
+              quarantineMessage={quarantine.message}
+              onQuarantine={() => void quarantineSelectedAgent(selectedNode)}
               onShowBlastRadius={
                 selectedNodeId
                   ? () =>
@@ -3384,14 +3441,34 @@ function GraphPageInner() {
   );
 }
 
+/** Resolve a graph agent label to its fleet id, then contain it at the gateway.
+ *
+ * The graph knows an agent by label; quarantine is keyed by fleet id, so this
+ * bridges the two through the existing fleet list. An agent that is not in the
+ * roster cannot be contained — say so plainly rather than failing silently.
+ */
+async function quarantineAgentByLabel(label: string): Promise<string> {
+  const roster = await api.listFleet({ search: label, include_quarantined: true });
+  const match = roster.agents.find(
+    (agent) => (agent.name || "").trim().toLowerCase() === label.trim().toLowerCase(),
+  );
+  if (!match) {
+    throw new Error(`"${label}" is not registered in the fleet roster, so it cannot be quarantined.`);
+  }
+  await api.quarantineFleetAgent(match.agent_id);
+  return match.agent_id;
+}
+
 function MetricCard({
   value,
   label,
   accent = "zinc",
+  format = "count",
 }: {
   value: number;
   label: string;
   accent?: "zinc" | "red" | "orange" | "blue";
+  format?: "count" | "usd";
 }) {
   const accentClass =
     accent === "red"
@@ -3402,9 +3479,18 @@ function MetricCard({
           ? "border-sky-500/20 bg-sky-500/10 text-sky-700 dark:text-sky-200"
           : "border-[var(--border-subtle)] bg-[var(--surface)]/80 text-[var(--text-secondary)]";
 
+  const rendered =
+    format === "usd"
+      ? value.toLocaleString(undefined, {
+          style: "currency",
+          currency: "USD",
+          maximumFractionDigits: value < 100 ? 2 : 0,
+        })
+      : value.toLocaleString();
+
   return (
     <div className={`rounded-xl border px-3 py-1.5 text-xs ${accentClass}`}>
-      <span className="font-mono text-[var(--foreground)]">{value}</span> {label}
+      <span className="font-mono text-[var(--foreground)]">{rendered}</span> {label}
     </div>
   );
 }

--- a/ui/components/graph-entity-drawer.tsx
+++ b/ui/components/graph-entity-drawer.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { ArrowRight, Loader2, Network, Radar } from "lucide-react";
+import { ArrowRight, Loader2, Network, Radar, ShieldAlert } from "lucide-react";
 
 import { LineageDetailPanel } from "@/components/lineage-detail";
 import type { LineageNodeData } from "@/components/lineage-nodes";
@@ -31,6 +31,9 @@ export function GraphEntityDrawer({
   blastRadiusLoading = false,
   onExpandNeighbors,
   onShowImpact,
+  onQuarantine,
+  quarantineState = "idle",
+  quarantineMessage = "",
   remediationHref,
   enrich = true,
 }: {
@@ -43,6 +46,10 @@ export function GraphEntityDrawer({
   blastRadiusLoading?: boolean;
   onExpandNeighbors?: (() => void) | undefined;
   onShowImpact?: (() => void) | undefined;
+  /** Contain this agent at the gateway. Agent nodes only; drawer stays presentational. */
+  onQuarantine?: (() => void) | undefined;
+  quarantineState?: "idle" | "confirming" | "pending" | "done" | "error";
+  quarantineMessage?: string;
   remediationHref?: string | undefined;
   /** When true and scanId is set, refresh node detail from /v1/graph/node. */
   enrich?: boolean;
@@ -156,6 +163,33 @@ export function GraphEntityDrawer({
               Impact
             </button>
           ) : null}
+        </div>
+      )}
+      {onQuarantine && enriched.nodeType === "agent" && (
+        <div className="space-y-1.5 border-t border-[color:var(--border-subtle)] pt-2">
+          <button
+            type="button"
+            onClick={onQuarantine}
+            disabled={quarantineState === "pending" || quarantineState === "done"}
+            data-testid="graph-quarantine-agent"
+            className="inline-flex w-full items-center justify-center gap-1.5 rounded-lg border border-red-500/40 bg-red-500/10 px-2 py-2 text-[11px] font-medium text-red-700 transition hover:border-red-500/60 disabled:opacity-60 dark:text-red-200"
+          >
+            <ShieldAlert className="h-3.5 w-3.5" />
+            {quarantineState === "confirming"
+              ? "Confirm — block every tool call"
+              : quarantineState === "pending"
+                ? "Quarantining…"
+                : quarantineState === "done"
+                  ? "Quarantined"
+                  : "Quarantine agent"}
+          </button>
+          {quarantineMessage && (
+            <p
+              className={`text-[10px] ${quarantineState === "error" ? "text-red-600 dark:text-red-300" : "text-[color:var(--text-tertiary)]"}`}
+            >
+              {quarantineMessage}
+            </p>
+          )}
         </div>
       )}
     </div>

--- a/ui/lib/unified-graph-flow.ts
+++ b/ui/lib/unified-graph-flow.ts
@@ -42,6 +42,19 @@ export interface UnifiedGraphFlowSummary {
   critical: number;
   attackPaths: number;
   runtimeEdges: number;
+  /** Rolling 30-day spend across the nodes currently visible, in USD. */
+  costUsd30d: number;
+  /** Visible nodes the cost overlay flagged as both high-cost and high-risk. */
+  expensiveExposed: number;
+}
+
+/** Read a numeric node attribute, ignoring absent or non-numeric values.
+ *
+ * Node attributes are an untyped bag written by backend overlays, so a string
+ * or null must degrade to 0 rather than propagate NaN into the header.
+ */
+function numericAttribute(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
 }
 
 function safeGraphConnection(value: string): string {
@@ -700,6 +713,17 @@ function buildSummary(
       RUNTIME_RELATIONSHIPS.has(String(edge.relationship)),
   ).length;
 
+  // Spend is summed over the visible nodes only, so the header reconciles with
+  // what is actually on the canvas rather than reporting an estate-wide figure
+  // beside a filtered graph.
+  const costUsd30d = nodes.reduce(
+    (total, node) => total + numericAttribute(node.data.attributes?.cost_usd_30d),
+    0,
+  );
+  const expensiveExposed = nodes.filter(
+    (node) => node.data.attributes?.cost_risk_priority === "expensive_and_exposed",
+  ).length;
+
   return {
     agents: nodes.filter((node) => node.data.nodeType === "agent").length,
     servers: nodes.filter((node) => node.data.nodeType === "server").length,
@@ -707,6 +731,8 @@ function buildSummary(
     critical,
     attackPaths: graph.attack_paths.length,
     runtimeEdges,
+    costUsd30d: Math.round(costUsd30d * 1e6) / 1e6,
+    expensiveExposed,
   };
 }
 

--- a/ui/tests/graph-quarantine-action.test.tsx
+++ b/ui/tests/graph-quarantine-action.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { GraphEntityDrawer } from "@/components/graph-entity-drawer";
+import type { LineageNodeData } from "@/components/lineage-nodes";
+
+function node(nodeType: string, label = "checkout-agent"): LineageNodeData {
+  return { label, nodeType, severity: "none" } as unknown as LineageNodeData;
+}
+
+const noop = () => {};
+
+describe("graph quarantine action", () => {
+  it("offers containment on an agent node", () => {
+    render(
+      <GraphEntityDrawer data={node("agent")} onClose={noop} enrich={false} onQuarantine={noop} />,
+    );
+    expect(screen.getByTestId("graph-quarantine-agent")).toHaveTextContent("Quarantine agent");
+  });
+
+  it("is not offered on non-agent nodes", () => {
+    render(
+      <GraphEntityDrawer data={node("package", "left-pad")} onClose={noop} enrich={false} onQuarantine={noop} />,
+    );
+    expect(screen.queryByTestId("graph-quarantine-agent")).toBeNull();
+  });
+
+  it("is absent entirely when no handler is supplied", () => {
+    render(<GraphEntityDrawer data={node("agent")} onClose={noop} enrich={false} />);
+    expect(screen.queryByTestId("graph-quarantine-agent")).toBeNull();
+  });
+
+  it("requires a second confirming click before it commits", () => {
+    const onQuarantine = vi.fn();
+    render(
+      <GraphEntityDrawer
+        data={node("agent")}
+        onClose={noop}
+        enrich={false}
+        onQuarantine={onQuarantine}
+        quarantineState="confirming"
+        quarantineMessage="Blocks every tool call"
+      />,
+    );
+    expect(screen.getByTestId("graph-quarantine-agent")).toHaveTextContent("Confirm");
+    expect(screen.getByText(/Blocks every tool call/)).toBeTruthy();
+  });
+
+  it("disables the control while pending and once done", () => {
+    const { rerender } = render(
+      <GraphEntityDrawer
+        data={node("agent")}
+        onClose={noop}
+        enrich={false}
+        onQuarantine={noop}
+        quarantineState="pending"
+      />,
+    );
+    expect(screen.getByTestId("graph-quarantine-agent")).toBeDisabled();
+
+    rerender(
+      <GraphEntityDrawer
+        data={node("agent")}
+        onClose={noop}
+        enrich={false}
+        onQuarantine={noop}
+        quarantineState="done"
+      />,
+    );
+    expect(screen.getByTestId("graph-quarantine-agent")).toBeDisabled();
+  });
+
+  it("surfaces a failure instead of silently doing nothing", () => {
+    render(
+      <GraphEntityDrawer
+        data={node("agent")}
+        onClose={noop}
+        enrich={false}
+        onQuarantine={noop}
+        quarantineState="error"
+        quarantineMessage='"checkout-agent" is not registered in the fleet roster, so it cannot be quarantined.'
+      />,
+    );
+    expect(screen.getByText(/not registered in the fleet roster/)).toBeTruthy();
+  });
+});

--- a/ui/tests/unified-graph-flow.test.ts
+++ b/ui/tests/unified-graph-flow.test.ts
@@ -151,3 +151,66 @@ describe("buildUnifiedFlowGraph", () => {
     });
   });
 });
+
+describe("cost summary", () => {
+  function costGraph(attrs: Record<string, unknown>[]): UnifiedGraphData {
+    const nodes = attrs.map((a, i) => ({
+      ...node(`agent:a${i}`, EntityType.AGENT, `agent-${i}`),
+      attributes: a as Record<string, never>,
+    }));
+    return {
+      scan_id: "scan-cost",
+      tenant_id: "default",
+      created_at: createdAt,
+      nodes,
+      edges: [],
+      attack_paths: [],
+      interaction_risks: [],
+      stats: {
+        total_nodes: nodes.length,
+        total_edges: 0,
+        node_types: {},
+        severity_counts: {},
+        relationship_types: {},
+        attack_path_count: 0,
+        interaction_risk_count: 0,
+        max_attack_path_risk: 0,
+        highest_interaction_risk: 0,
+        analysis_status: {},
+      },
+    } as unknown as UnifiedGraphData;
+  }
+
+  it("sums windowed spend across visible nodes", () => {
+    const flow = buildUnifiedFlowGraph(
+      costGraph([{ cost_usd_30d: 12.5 }, { cost_usd_30d: 7.25 }, {}]),
+      createFocusedGraphFilters(""),
+    );
+    expect(flow.summary.costUsd30d).toBeCloseTo(19.75, 5);
+  });
+
+  it("counts nodes that are both expensive and exposed", () => {
+    const flow = buildUnifiedFlowGraph(
+      costGraph([
+        { cost_usd_30d: 500, cost_risk_priority: "expensive_and_exposed" },
+        { cost_usd_30d: 10 },
+      ]),
+      createFocusedGraphFilters(""),
+    );
+    expect(flow.summary.expensiveExposed).toBe(1);
+  });
+
+  it("reports zero when no node carries cost, so the strip stays hidden", () => {
+    const flow = buildUnifiedFlowGraph(costGraph([{}, {}]), createFocusedGraphFilters(""));
+    expect(flow.summary.costUsd30d).toBe(0);
+    expect(flow.summary.expensiveExposed).toBe(0);
+  });
+
+  it("ignores a non-numeric cost attribute rather than rendering NaN", () => {
+    const flow = buildUnifiedFlowGraph(
+      costGraph([{ cost_usd_30d: "not-a-number" }, { cost_usd_30d: 5 }]),
+      createFocusedGraphFilters(""),
+    );
+    expect(flow.summary.costUsd30d).toBe(5);
+  });
+});


### PR DESCRIPTION
Two capabilities that already exist in the backend but had no operator surface.

## Spend on the canvas

The cost overlay stamps `cost_usd_30d` and `cost_risk_priority` onto nodes
(#4545). The graph header never read them.

It now sums windowed spend across the **visible** nodes — so the figure
reconciles with what is actually on the canvas, rather than reporting an
estate-wide number beside a filtered graph — and counts the nodes the overlay
flagged as both high-cost and high-risk.

Both tiles are **opt-in by data**: a tenant with no ingested LLM cost sees the
header exactly as before, not a `$0` tile. A non-numeric attribute degrades to
`0` rather than rendering `NaN`, because node attributes are an untyped bag
written by backend overlays.

## One-click containment

Quarantining an agent was API-only. The entity drawer now offers it on agent
nodes, resolving the graph label to a fleet id through the existing roster and
calling the existing quarantine route — **no new API surface**.

Deliberately two-step: the first click arms, the second commits. Blocking every
tool call for an agent is not a one-click gesture. An agent missing from the
fleet roster reports that plainly rather than failing silently, and the armed
state resets when the selected node changes, so a different agent can never
inherit it.

Pairs with #4544, which made that quarantine actually enforce at the gateway.

## Verified

- **37 vitest** across the flow summary, the drawer control, and the existing
  React Flow surface contract
- `npm run typecheck` and `npm run lint` clean
- **no new routes** → no OpenAPI, schema, SVG, or capability-manifest regeneration

## Ordering note

The cost tiles read attributes produced by #4545, which is still open. This PR is
safe to merge in either order — the tiles are conditional on the data being
present, so before #4545 lands they simply don't render.

## Deferred

Agent-group cluster pills and the inline snapshot/version control from the same
plan. Both are self-contained and better reviewed on their own than bolted onto
this.