### PR TITLE
fix(gateway): stop identity revocation failing open on a large roster

### DIFF
--- a/src/agent_bom/api/agent_identity_store.py
+++ b/src/agent_bom/api/agent_identity_store.py
@@ -802,6 +802,26 @@ def revoke_identity(store: AgentIdentityStore, identity_id: str, *, tenant_id: s
     return identity
 
 
+# Upper bound on identities fetched per revocation check. ``store.list`` returns
+# the most recently issued identities, so a smaller window would silently drop an
+# older revoked identity and read as "this agent was never issued one". When the
+# cap is actually hit we cannot rule out an identity in the untraversed tail, so
+# the lookup reports ``unavailable`` — an honest partial signal the caller can
+# fail closed on — rather than a confident "not revoked". Mirrors
+# ``_DRIFT_INCIDENT_LOOKUP_CAP`` in the gateway.
+_IDENTITY_LOOKUP_CAP = 5000
+
+
+def identities_for_agent(store: AgentIdentityStore, tenant_id: str, agent_id: str) -> tuple[list[AgentIdentity], bool]:
+    """Return ``(identities_for_agent, lookup_was_capped)`` for one tenant."""
+    key = (agent_id or "").strip()
+    if not key:
+        return [], False
+    rows = store.list(tenant_id, include_inactive=True, limit=_IDENTITY_LOOKUP_CAP)
+    capped = len(rows) >= _IDENTITY_LOOKUP_CAP
+    return [i for i in rows if (i.agent_id or "").strip() == key], capped
+
+
 def live_identity_for_agent(store: AgentIdentityStore, tenant_id: str, agent_id: str) -> AgentIdentity | None:
     """Return one live identity for ``agent_id``, or ``None`` if every one is dead.
 
@@ -810,29 +830,28 @@ def live_identity_for_agent(store: AgentIdentityStore, tenant_id: str, agent_id:
     opaque ``policy.agent_tokens`` mapping never reaches the identity store, so
     the gateway needs an agent-keyed lookup to honour revocation for them too.
     """
-    key = (agent_id or "").strip()
-    if not key:
-        return None
-    for identity in store.list(tenant_id, include_inactive=True, limit=200):
-        if (identity.agent_id or "").strip() == key and identity.is_live():
+    identities, _capped = identities_for_agent(store, tenant_id, agent_id)
+    for identity in identities:
+        if identity.is_live():
             return identity
     return None
 
 
-def agent_identity_revoked(store: AgentIdentityStore, tenant_id: str, agent_id: str) -> bool:
-    """Return True only when ``agent_id`` has identities and none are live.
+def agent_identity_revoked(store: AgentIdentityStore, tenant_id: str, agent_id: str) -> tuple[bool, bool]:
+    """Return ``(revoked, lookup_incomplete)`` for ``agent_id`` in one tenant.
 
     An agent with no managed identity at all is *not* revoked — deployments that
     never issued one must keep working. Rotation also leaves revoked rows behind,
     so a single live identity is enough to keep the agent alive.
+
+    ``lookup_incomplete`` is True when the roster hit the lookup cap and this
+    agent had no matching identity: absence is then unproven, not evidence of
+    absence, and the caller must not read it as "authorized".
     """
-    key = (agent_id or "").strip()
-    if not key:
-        return False
-    known = [i for i in store.list(tenant_id, include_inactive=True, limit=200) if (i.agent_id or "").strip() == key]
-    if not known:
-        return False
-    return not any(i.is_live() for i in known)
+    identities, capped = identities_for_agent(store, tenant_id, agent_id)
+    if not identities:
+        return False, capped
+    return not any(i.is_live() for i in identities), False
 
 
 def request_jit_grant(

--- a/src/agent_bom/gateway_server.py
+++ b/src/agent_bom/gateway_server.py
@@ -377,7 +377,11 @@ def _agent_identity_revoked(tenant_id: str, source_agent: str) -> tuple[bool, bo
     try:
         from agent_bom.api.agent_identity_store import agent_identity_revoked, get_agent_identity_store
 
-        return agent_identity_revoked(get_agent_identity_store(), tenant_id, source_agent), False
+        # The store returns its own "lookup incomplete" signal when the roster
+        # exceeded the scan cap: absence of a matching identity is then unproven
+        # and must not be read as "authorized".
+        revoked, lookup_incomplete = agent_identity_revoked(get_agent_identity_store(), tenant_id, source_agent)
+        return revoked, lookup_incomplete
     except Exception as exc:  # noqa: BLE001
         logger.warning("gateway agent identity revocation check failed: %s", _sanitize_for_log(exc))
         return False, True

--- a/tests/test_gateway_fleet_enforcement.py
+++ b/tests/test_gateway_fleet_enforcement.py
@@ -290,3 +290,69 @@ def test_boot_is_silent_when_enforcement_is_opted_out(caplog):
     with caplog.at_level(logging.WARNING, logger="agent_bom.gateway_server"):
         create_gateway_app(_settings("off"))
     assert not [r for r in caplog.records if "fleet enforcement is active" in r.getMessage()]
+
+
+def test_revocation_is_not_defeated_by_a_large_identity_roster():
+    """The lookup must not silently fail open once a tenant grows.
+
+    store.list() returns the N most recently issued identities. A revoked
+    agent whose identity is older than that window fell out of the result,
+    the helper saw "no identities for this agent", and concluded "not
+    revoked" — reporting no degradation, so the fail-closed branch never
+    fired either.
+    """
+    from agent_bom.api.agent_identity_store import agent_identity_revoked, get_agent_identity_store
+
+    _seed_fleet()
+    # The revoked identity is the OLDEST, so any recency-capped window drops it.
+    identities = [_identity("agent-b", "revoked")]
+    identities[0].issued_at = "2020-01-01T00:00:00Z"
+    for i in range(500):
+        filler = _identity(f"filler-{i}", "active")
+        filler.identity_id = f"filler-id-{i}"
+        filler.token_hash = f"filler-hash-{i}"
+        filler.issued_at = "2026-01-01T00:00:00Z"
+        identities.append(filler)
+    _seed_identities(*identities)
+
+    assert agent_identity_revoked(get_agent_identity_store(), "default", "agent-b") == (True, False)
+
+    client = TestClient(create_gateway_app(_settings("enforce")))
+    resp = client.post("/mcp/filesystem", json=_call("token-b"))
+    assert _is_blocked(resp), "a revoked agent must stay blocked regardless of roster size"
+
+
+def test_unknown_agent_in_a_capped_roster_reports_the_lookup_as_incomplete():
+    """Absence past the scan cap is unproven, not evidence of absence.
+
+    With a roster larger than the cap and no matching identity, the helper must
+    say so rather than returning a confident "not revoked" — otherwise the
+    caller's fail-closed branch can never fire.
+    """
+    from agent_bom.api import agent_identity_store as store_mod
+    from agent_bom.api.agent_identity_store import agent_identity_revoked, get_agent_identity_store
+
+    original_cap = store_mod._IDENTITY_LOOKUP_CAP
+    store_mod._IDENTITY_LOOKUP_CAP = 10
+    try:
+        fillers = []
+        for i in range(20):
+            filler = _identity(f"filler-{i}", "active")
+            filler.identity_id = f"filler-id-{i}"
+            filler.token_hash = f"filler-hash-{i}"
+            fillers.append(filler)
+        _seed_identities(*fillers)
+
+        revoked, incomplete = agent_identity_revoked(get_agent_identity_store(), "default", "agent-zzz")
+        assert revoked is False
+        assert incomplete is True, "a capped lookup must not read as a clean negative"
+    finally:
+        store_mod._IDENTITY_LOOKUP_CAP = original_cap
+
+
+def test_small_roster_reports_a_clean_negative():
+    """Below the cap, absence IS proven — this must not start failing closed."""
+    from agent_bom.api.agent_identity_store import agent_identity_revoked, get_agent_identity_store
+
+    _seed_identities(_identity("agent-b", "active"))
+    assert agent_identity_revoked(get_agent_identity_store(), "default", "agent-zzz") == (False, False)


### PR DESCRIPTION
**Regression in my own #4544.** Found by an audit of current main, reproduced, fixed.

## The defect

The revocation check added in #4544 called `store.list(tenant_id, include_inactive=True, limit=200)`.
That returns the **200 most recently issued** identities (`ORDER BY issued_at DESC LIMIT ?`).

A revoked agent whose identity is older than that window falls out of the result.
The helper sees no identities for that agent and concludes *"this agent never had a
managed identity, so it is not revoked."*

Worse than a missed block: it **also reported no degradation**, so the caller's
fail-closed branch for an unavailable lookup never fired either. The relay treated a
revoked agent as fully authorized and said nothing about it.

Any tenant past 200 issued identities — rotation alone gets you there — silently lost
the containment guarantee #4544 was written to provide.

## Repro (fails on `main`)

`test_revocation_is_not_defeated_by_a_large_identity_roster`: a 501-identity roster
whose revoked entry is the **oldest**. On `main` the relay lets the call through; with
this fix it blocks.

## The fix

The lookup scans to an explicit cap and, when that cap is **actually hit and no
identity matched**, reports the lookup as *incomplete* rather than returning a
confident negative. Absence past the cap is unproven, not evidence of absence.

This mirrors `_DRIFT_INCIDENT_LOOKUP_CAP` twelve lines away in `gateway_server.py`,
which already treats a hit cap as an "honest partial signal" — revocation was the
outlier that just lied.

**Below the cap nothing changes.** Absence is still proven and still reads as a clean
negative, so deployments that never issued a managed identity keep working — pinned by
`test_small_roster_reports_a_clean_negative`.

## Verified

- the large-roster repro fails on `main`, passes here
- `test_unknown_agent_in_a_capped_roster_reports_the_lookup_as_incomplete` pins the
  honest-partial-signal behaviour by temporarily lowering the cap
- `pytest tests/ -k "gateway or fleet or identity"` → **897 passed**, 15 skipped
- `ruff` and `mypy` clean

## Note on the contract change

`agent_identity_revoked` now returns `(revoked, lookup_incomplete)` instead of a bare
bool. `live_identity_for_agent` still has no callers, so the only consumer is the
gateway helper updated here.