### PR TITLE
fix(ci): make MCP server tests hermetic instead of registry-dependent

### DIFF
--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -5,7 +5,7 @@ import json
 import re
 import sys
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -18,6 +18,25 @@ pytest.importorskip("mcp", reason="mcp SDK not installed — pip install 'agent-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _no_registry_network():
+    """Keep this module hermetic — no test here may reach a package registry.
+
+    The ``check`` tool confirms a pinned version actually exists before calling
+    it clean, which is a live npm/PyPI lookup. Tests that only mocked the
+    scanner still made that request, so their result depended on CI egress:
+    a blocked or rate-limited runner turned "clean" into "unknown" and failed
+    the build on one Python version while the others passed.
+
+    The real published/unpublished semantics are covered deliberately in
+    ``tests/test_mcp_check_version_existence.py``, which mocks this same
+    function both ways. Here it is pinned to "published" so these tests
+    exercise the scanner path they are actually about.
+    """
+    with patch("agent_bom.mcp_tools.scanning._version_published", new=AsyncMock(return_value=True)):
+        yield
 
 
 def _run(coro):
@@ -122,9 +141,7 @@ def test_static_operator_token_authorizes_every_registered_write_family():
     assert operator_access is not None
     server_root = Path(__file__).resolve().parents[1] / "src" / "agent_bom"
     required_scopes = {
-        match
-        for path in server_root.glob("mcp_server_*.py")
-        for match in re.findall(r'required_scope="([^"]+)"', path.read_text())
+        match for path in server_root.glob("mcp_server_*.py") for match in re.findall(r'required_scope="([^"]+)"', path.read_text())
     }
     assert required_scopes == {"findings:write", "identity:write", "shield:write", "ticketing:write"}
     for required_scope in required_scopes:


### PR DESCRIPTION
Closes #4546 (`ci-regression`, `release-blocker`).

## Not a Python 3.14 bug, and not flake

`CI/CD Pipeline` has been red on main with:

```
FAILED tests/test_mcp_server.py::test_check_scoped_npm_package - AssertionError: assert 'unknown' == 'clean'
```

on **Python 3.14 only**, while 3.11 and 3.13 passed the same commit.

The `check` tool confirms a pinned version actually exists in the npm/PyPI registry
before it will call the package clean — a deliberate guard so a typo'd or hallucinated
pin cannot read as safe. **That is a live HTTP request.** These tests mocked the
scanner but not the registry lookup, so the result depended on the runner's egress: a
blocked, rate-limited, or slow registry turns `clean` into `unknown`. Whichever job
loses the race fails, which is exactly why it moved between Python versions.

## Proven, not assumed

I instrumented the call — the test genuinely reaches the npm registry (322 ms,
`published=True` locally). Then I simulated a runner whose lookup fails:

```
# before this PR, registry lookup failing
FAILED tests/test_mcp_server.py::test_check_clean_package        - assert 'unknown' == 'clean'
FAILED tests/test_mcp_server.py::test_check_scoped_npm_package   - assert 'unknown' == 'clean'
2 failed, 85 passed

# with this PR, same conditions
87 passed
```

That reproduces **the exact CI assertion**, and surfaces a **second** test with the
same latent dependency that CI hadn't hit yet.

Worth noting: my first attempt to prove this by blocking `socket.socket.connect`
showed both versions passing — httpx's async path doesn't go through that hook. The
socket blocker was the flawed instrument, not the diagnosis; the spy settled it.

## The fix

An autouse fixture pins the lookup to "published" for this module, so no test here can
reach a registry.

**It hides no behaviour.** The real published/unpublished semantics stay covered where
they belong — `tests/test_mcp_check_version_existence.py` mocks the same function both
ways and still passes (3/3).

## Why this matters beyond the red build

We're a public OSS repo people self-host. A contributor who is offline, behind a
corporate proxy, or in an air-gapped environment could not run this suite green — the
failure would look like their change broke something.

## Verified

- 87 passed in the module, both with and without a simulated registry outage
- `pytest tests/ -k mcp` → **777 passed**, 9 skipped
- `ruff` clean
- test-only change; no backend, middleware, API, or UI surface touched, so no OpenAPI,
  schema, SVG, or capability-manifest regeneration