### PR TITLE
fix(mcp): pin the MCP SDK to the major that ships our entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,10 @@ dependencies = [
     "jsonschema>=4.0",
     # MCP is a first-class advertised entry point (`uvx agent-bom mcp server`)
     # and must work from the base package used by the official registry.
-    "mcp>=1.26",
+    # Bounded to the major we import: we use `mcp.server.fastmcp`, which mcp
+    # 2.0.0 removed. An unbounded floor resolved straight to 2.x on a fresh
+    # install and left `agent-bom mcp server` unable to start.
+    "mcp>=1.26,<2",
     # Transitive dep pins — fix known CVEs flagged by OpenSSF/OSV
     "jinja2>=3.1.6",  # GHSA-cpwx-vrp4-4pq7, GHSA-gmj6-6f8f-6699 (sandbox breakout)
     "werkzeug>=3.1.8",  # GHSA-29vq-49wr-vm6x, GHSA-2g68-c3qc-8985, GHSA-87hc-h4r5-73f7, GHSA-f9vj-2wh5-fj8j, GHSA-hgf8-39gv-g3f2, GHSA-hrfv-mqp8-q5rw, GHSA-px8h-6qxv-m22q, GHSA-q34m-jh98-gwm2, GHSA-xg9f-g7g7-2323

--- a/src/agent_bom/mcp_server_runtime.py
+++ b/src/agent_bom/mcp_server_runtime.py
@@ -670,7 +670,30 @@ def get_registry_data_raw(registry_raw_cache: str | None, registry_path: Path) -
 
 
 def check_mcp_sdk() -> None:
+    """Verify the MCP SDK is present AND exposes the entry point we build on.
+
+    Checking only ``import mcp`` was not enough: mcp 2.x removed
+    ``mcp.server.fastmcp``, so the import succeeded while the server could not
+    start, and the user was told to install a package they already had.
+    """
     try:
         import mcp  # noqa: F401
     except ImportError:
         raise ImportError("mcp SDK is required for the MCP server. Install with: pip install 'agent-bom[mcp-server]'") from None
+
+    try:
+        import mcp.server.fastmcp  # noqa: F401
+    except ImportError:
+        installed = ""
+        try:
+            from importlib.metadata import version
+
+            installed = f" (found {version('mcp')})"
+        except Exception:  # noqa: BLE001 - diagnostics only; never mask the real error
+            installed = ""
+        raise ImportError(
+            f"The installed mcp SDK is incompatible{installed}: it does not provide "
+            "'mcp.server.fastmcp', which agent-bom's MCP server is built on. mcp 2.x "
+            "removed that module. Install a supported release with: "
+            "pip install 'mcp<2'  (agent-bom pins mcp>=1.26,<2)"
+        ) from None

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -122,9 +122,7 @@ def test_static_operator_token_authorizes_every_registered_write_family():
     assert operator_access is not None
     server_root = Path(__file__).resolve().parents[1] / "src" / "agent_bom"
     required_scopes = {
-        match
-        for path in server_root.glob("mcp_server_*.py")
-        for match in re.findall(r'required_scope="([^"]+)"', path.read_text())
+        match for path in server_root.glob("mcp_server_*.py") for match in re.findall(r'required_scope="([^"]+)"', path.read_text())
     }
     assert required_scopes == {"findings:write", "identity:write", "shield:write", "ticketing:write"}
     for required_scope in required_scopes:
@@ -1530,3 +1528,40 @@ def test_safe_path_traversal():
 
     with pytest.raises(ValueError, match="outside home directory"):
         _safe_path("/etc/passwd")
+
+
+def test_sdk_check_names_an_incompatible_major_distinctly():
+    """An installed-but-incompatible SDK must not read as "not installed".
+
+    ``check_mcp_sdk`` only did ``import mcp``, which succeeds on mcp 2.x — the
+    major that removed ``mcp.server.fastmcp``. Users got "install
+    agent-bom[mcp-server]", the exact command they had just run, for a problem
+    that installing more could never fix.
+    """
+    import builtins
+
+    from agent_bom.mcp_server_runtime import check_mcp_sdk
+
+    real_import = builtins.__import__
+
+    def _fastmcp_missing(name, *args, **kwargs):
+        if name == "mcp.server.fastmcp" or name.startswith("mcp.server.fastmcp."):
+            raise ModuleNotFoundError("No module named 'mcp.server.fastmcp'")
+        return real_import(name, *args, **kwargs)
+
+    with patch.object(builtins, "__import__", _fastmcp_missing):
+        with pytest.raises(ImportError) as excinfo:
+            check_mcp_sdk()
+
+    message = str(excinfo.value)
+    assert "incompatible" in message.lower(), message
+    assert "<2" in message or "2.x" in message, message
+
+
+def test_sdk_check_still_reports_a_genuinely_missing_sdk():
+    """The absent-SDK message must survive — it is the common case."""
+    from agent_bom.mcp_server_runtime import check_mcp_sdk
+
+    with patch.dict(sys.modules, {"mcp": None}):
+        with pytest.raises(ImportError, match="mcp SDK is required"):
+            check_mcp_sdk()

--- a/tests/test_public_release_contracts.py
+++ b/tests/test_public_release_contracts.py
@@ -22,6 +22,20 @@ def test_base_install_contains_advertised_mcp_runtime() -> None:
     assert any(item.startswith("mcp>=") for item in dependencies)
 
 
+def test_mcp_dependency_is_bounded_to_the_supported_major() -> None:
+    """An unbounded ``mcp>=`` resolves to a major that removed our entry point.
+
+    We import ``mcp.server.fastmcp``. mcp 2.0.0 deleted that module, so an
+    unbounded floor silently installed an SDK where ``agent-bom mcp server``
+    cannot start — and the failure told the user to run the very command they
+    had just run. The advertised MCP surface must not depend on the resolver
+    happening to pick an older major.
+    """
+    project = tomllib.loads(_read("pyproject.toml"))["project"]
+    spec = next(item for item in project["dependencies"] if str(item).lower().startswith("mcp>="))
+    assert "<2" in str(spec).replace(" ", ""), f"{spec!r} is unbounded; pin the supported major so a fresh install cannot pull mcp 2.x"
+
+
 def test_public_mcp_counts_match_server_card() -> None:
     count = len(_SERVER_CARD_TOOLS)
     expected = {

--- a/uv.lock
+++ b/uv.lock
@@ -493,7 +493,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.0" },
     { name = "litellm", marker = "extra == 'ai-enrich'", specifier = ">=1.83.14" },
-    { name = "mcp", specifier = ">=1.26" },
+    { name = "mcp", specifier = ">=1.26,<2" },
     { name = "mkdocs-material", marker = "extra == 'docs'", specifier = ">=9.5" },
     { name = "mkdocstrings", extras = ["python"], marker = "extra == 'docs'", specifier = ">=0.24" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.0" },
@@ -5440,7 +5440,7 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -5521,7 +5521,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a7/25/c2700dfaf6442b4effaa91af24ebce5dc9d31bb4a69706313aae70d72cd0/scipy-1.18.0.tar.gz", hash = "sha256:67b2ad2ad54c72ca6d04975a9b2df8c3638c34ddd5b28738e94fc2b57929d378", size = 30774447, upload-time = "2026-06-19T15:01:43.456Z" }
 wheels = [


### PR DESCRIPTION
**Shipped-release blocker.** `agent-bom mcp server` is dead on any fresh install today.

## The defect

The base package declared an unbounded `mcp>=1.26`. pip now resolves that to
**mcp 2.0.0, which removed `mcp.server.fastmcp`** — the module our server is built on.

Verified independently rather than taken on report:

```
$ pip install "mcp==2.0.0"
$ python -c "import mcp.server.fastmcp"
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

This takes out the advertised MCP surface and every registry listing — Smithery, Glama,
the MCP registry, Docker MCP — for anyone installing now. The 77/6/8 counts were never
wrong; the SDK simply couldn't load.

## Two fixes, because there were two problems

**1. The pin.** `mcp>=1.26,<2`. A fresh venv install from source now resolves
**mcp 1.29.0**, imports `fastmcp`, and registers all **77 tools**.

**2. The diagnosis, which is why this wasn't self-serviceable.** `check_mcp_sdk` only
did `import mcp` — which **succeeds** on 2.x. So the user was told:

> `ERROR: MCP SDK required. Install with: pip install 'agent-bom[mcp-server]'`

…the exact command they had just run, for a problem that installing more could never
fix. It now checks the module we actually import, and when the SDK is present but
incompatible it names the installed version and explains that mcp 2.x removed the
module.

## Guard

A release-contract test pins the upper bound. This class of failure only appears once
the ecosystem publishes a new major — long after the change that made us vulnerable —
so it needs a gate, not vigilance.

## Verified

- fresh venv install → mcp 1.29.0, `fastmcp` present, 77 tools registered
- `mcp==2.0.0` → `mcp.server.fastmcp` missing, confirming the cause
- **97 passed** across the MCP and release-contract suites
- `ruff`, `mypy`, `make preflight` clean; `uv.lock` refreshed
- no route or MCP-tool count change → no OpenAPI, schema, SVG, or manifest regeneration