### PR TITLE
test(cloud): stop faked provider SDKs leaking between test files

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-07-28",
+  "generated_on": "2026-07-29",
   "version": "0.98.2",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1046,
+      "value": 1047,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-07-28`
+- Generated on: `2026-07-29`
 - Version: `0.98.2`
 
 | Metric | Value | Source | Notes |
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1046 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1047 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |

--- a/tests/cloud/test_cloud.py
+++ b/tests/cloud/test_cloud.py
@@ -34,11 +34,11 @@ _REPO_ROOT = _TESTS_ROOT.parent
 _CLOUD_FIXTURES = _TESTS_ROOT / "fixtures" / "cloud"
 
 # Provider SDKs that tests inject as mocks (or patch to None) in sys.modules.
-# The cloud submodules import these at module level, so reloading a submodule
-# while its SDK is mocked/absent rebinds the submodule against that transient
-# state. Left in place, that leaks into the next test on the same worker —
-# e.g. `_install_mock_snowflake()` uses setdefault and silently no-ops once a
-# prior mock persists, so discover() finds zero agents.
+# Reloading a cloud submodule while its SDK is mocked/absent rebinds that
+# submodule against the transient state, so it is restored per test here.
+# The sys.modules entries themselves are additionally snapshotted/restored for
+# every test by `reset_global_test_state` in tests/conftest.py, which is what
+# keeps a stub installed by ANOTHER file off this module's back.
 _MOCK_PROVIDER_SDK_MODULES = (
     "boto3",
     "botocore",
@@ -136,7 +136,11 @@ def _install_mock_boto3():
 
 
 def _install_mock_databricks():
-    """Install a mock databricks-sdk in sys.modules."""
+    """Install a mock databricks-sdk in sys.modules.
+
+    Assigns rather than ``setdefault``s: a stub another module leaked must not
+    win the import while the caller patches the object returned here.
+    """
     databricks = types.ModuleType("databricks")
     databricks_sdk = types.ModuleType("databricks.sdk")
     databricks_sdk_errors = types.ModuleType("databricks.sdk.errors")
@@ -149,15 +153,19 @@ def _install_mock_databricks():
     databricks_sdk.errors = databricks_sdk_errors
     databricks.sdk = databricks_sdk
 
-    sys.modules.setdefault("databricks", databricks)
-    sys.modules.setdefault("databricks.sdk", databricks_sdk)
-    sys.modules.setdefault("databricks.sdk.errors", databricks_sdk_errors)
+    sys.modules["databricks"] = databricks
+    sys.modules["databricks.sdk"] = databricks_sdk
+    sys.modules["databricks.sdk.errors"] = databricks_sdk_errors
 
     return databricks_sdk
 
 
 def _install_mock_snowflake():
-    """Install a mock snowflake-connector-python in sys.modules."""
+    """Install a mock snowflake-connector-python in sys.modules.
+
+    Assigns rather than ``setdefault``s: a stub another module leaked must not
+    win the import while the caller patches the object returned here.
+    """
     snowflake = types.ModuleType("snowflake")
     snowflake_connector = types.ModuleType("snowflake.connector")
     snowflake_connector_errors = types.ModuleType("snowflake.connector.errors")
@@ -170,9 +178,9 @@ def _install_mock_snowflake():
     snowflake_connector.errors = snowflake_connector_errors
     snowflake.connector = snowflake_connector
 
-    sys.modules.setdefault("snowflake", snowflake)
-    sys.modules.setdefault("snowflake.connector", snowflake_connector)
-    sys.modules.setdefault("snowflake.connector.errors", snowflake_connector_errors)
+    sys.modules["snowflake"] = snowflake
+    sys.modules["snowflake.connector"] = snowflake_connector
+    sys.modules["snowflake.connector.errors"] = snowflake_connector_errors
 
     return snowflake_connector
 
@@ -590,6 +598,46 @@ def test_snowflake_cortex_agents():
     assert len(cortex_agents) == 1
     assert cortex_agents[0].name == "cortex:my-search-service"
     assert "snowflake://" in cortex_agents[0].config_path
+
+
+def test_snowflake_mock_install_overrides_a_leaked_stub():
+    """A stub another test file leaked must not shadow this module's mock.
+
+    `_install_mock_snowflake()` has to be authoritative: whatever it returns must
+    be the object `agent_bom.cloud.snowflake` actually resolves `connect` from.
+    When it merely `setdefault`s, a foreign stub left in `sys.modules` wins the
+    import while the caller patches an orphan — and discovery silently yields
+    zero agents.
+    """
+    foreign = types.ModuleType("snowflake")
+    foreign_connector = types.ModuleType("snowflake.connector")
+    foreign_connector.connect = MagicMock(name="foreign-connect")
+    foreign.connector = foreign_connector
+    sys.modules["snowflake"] = foreign
+    sys.modules["snowflake.connector"] = foreign_connector
+
+    mock_sf = _install_mock_snowflake()
+
+    assert mock_sf is sys.modules["snowflake.connector"]
+    assert mock_sf is sys.modules["snowflake"].connector
+
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_cursor.description = [("name",), ("database_name",), ("schema_name",)]
+    mock_cursor.fetchall.side_effect = [
+        [("my-search-service", "MY_DB", "PUBLIC")],  # Cortex
+        [],  # Snowpark
+        [],  # Streamlit
+    ]
+
+    with patch.object(mock_sf, "connect", return_value=mock_conn):
+        importlib.reload(importlib.import_module("agent_bom.cloud.snowflake"))
+        from agent_bom.cloud.snowflake import discover
+
+        agents, _warnings = discover(account="myorg.us-east-1", user="test_user")
+
+    assert [a for a in agents if a.source == "snowflake-cortex"]
 
 
 def test_snowflake_snowpark_packages():

--- a/tests/cloud/test_snowflake_inventory_evaluation_failed.py
+++ b/tests/cloud/test_snowflake_inventory_evaluation_failed.py
@@ -15,6 +15,13 @@ from agent_bom.scanners.state import consume_coverage_warnings, reset_scan_warni
 
 
 def _install_mock_snowflake() -> types.ModuleType:
+    """Install a stub snowflake-connector-python and return the live connector.
+
+    Assigns rather than ``setdefault``s so the returned object is always the one
+    ``agent_bom.cloud.snowflake`` will import. ``reset_global_test_state`` in
+    ``tests/conftest.py`` drops these entries again after the test, so the stub
+    cannot shadow another module's mock later on the same xdist worker.
+    """
     snowflake = types.ModuleType("snowflake")
     snowflake_connector = types.ModuleType("snowflake.connector")
     snowflake_connector_errors = types.ModuleType("snowflake.connector.errors")
@@ -27,9 +34,9 @@ def _install_mock_snowflake() -> types.ModuleType:
     snowflake_connector.errors = snowflake_connector_errors
     snowflake.connector = snowflake_connector
 
-    sys.modules.setdefault("snowflake", snowflake)
-    sys.modules.setdefault("snowflake.connector", snowflake_connector)
-    sys.modules.setdefault("snowflake.connector.errors", snowflake_connector_errors)
+    sys.modules["snowflake"] = snowflake
+    sys.modules["snowflake.connector"] = snowflake_connector
+    sys.modules["snowflake.connector.errors"] = snowflake_connector_errors
     return snowflake_connector
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import logging
 import os
 import sys
 import tempfile
+import types
 from typing import Any
 
 import pytest
@@ -588,6 +589,46 @@ def _restore_scanner_globals(snapshot: list[tuple[Any, str, Any]]) -> None:
             pass
 
 
+# Optional provider SDKs that tests fake by writing synthetic modules straight
+# into `sys.modules`. Those entries outlive the test that wrote them, so under
+# `--dist worksteal` a stub from one file can already be installed when an
+# unrelated file starts — and a victim installer that `setdefault`s then no-ops,
+# patches an orphan module, and the code under test resolves the leaked stub.
+# Snapshot/restore the namespace so no test can hand one to the next.
+_STUB_SDK_ROOTS = (
+    "boto3",
+    "botocore",
+    "databricks",
+    "google",
+    "googleapiclient",
+    "snowflake",
+)
+
+
+def _is_stub_module(module: Any) -> bool:
+    """True for a hand-rolled test double, false for a genuinely imported package.
+
+    Real packages carry an import `__spec__`; `types.ModuleType(...)` doubles and
+    `MagicMock` stand-ins do not. Restoring only stubs keeps a real optional SDK
+    (installed in some CI images but not others) out of the blast radius.
+    """
+    return not isinstance(module, types.ModuleType) or getattr(module, "__spec__", None) is None
+
+
+def _snapshot_stub_sdk_modules() -> dict[str, Any]:
+    return {name: module for name, module in sys.modules.items() if name.split(".", 1)[0] in _STUB_SDK_ROOTS}
+
+
+def _restore_stub_sdk_modules(snapshot: dict[str, Any]) -> None:
+    for name in [name for name in sys.modules if name.split(".", 1)[0] in _STUB_SDK_ROOTS]:
+        current = sys.modules[name]
+        if name not in snapshot:
+            if _is_stub_module(current):
+                del sys.modules[name]
+        elif current is not snapshot[name] and _is_stub_module(current):
+            sys.modules[name] = snapshot[name]
+
+
 @pytest.fixture(autouse=True)
 def reset_global_test_state():
     """Reset process-global caches so test order does not affect outcomes."""
@@ -637,11 +678,18 @@ def reset_global_test_state():
     # binding + include_unfixed share the same set_*() global-mutation pattern.
     scanner_offline_snapshot = _snapshot_scanner_globals()
 
+    # Snapshot the faked provider-SDK entries in sys.modules (see
+    # _STUB_SDK_ROOTS). Taken AFTER module-scoped setup so a module-wide stub is
+    # preserved across that module's tests; anything a test body installs is
+    # reverted on teardown and cannot shadow the next test's own mock.
+    stub_sdk_modules_snapshot = _snapshot_stub_sdk_modules()
+
     yield
 
     # Drain first: stop any scan worker thread the test left running before we
     # restore globals it may still be mutating (scanner offline flags, stores).
     _drain_scan_executor()
+    _restore_stub_sdk_modules(stub_sdk_modules_snapshot)
     root_logger.handlers[:] = logging_handlers_snapshot
     root_logger.setLevel(logging_level_snapshot)
     _restore_scanner_globals(scanner_offline_snapshot)

--- a/tests/test_stub_sdk_module_isolation.py
+++ b/tests/test_stub_sdk_module_isolation.py
@@ -1,0 +1,95 @@
+"""Guard: hand-rolled provider-SDK stubs must not leak between tests.
+
+Several suites fake optional cloud SDKs (`snowflake`, `boto3`, `databricks`,
+`google`, ...) by writing synthetic modules straight into ``sys.modules``. Those
+entries outlive the test that wrote them, so under ``pytest-xdist --dist
+worksteal`` (plus ``pytest-randomly``) a stub from one file can be sitting in
+``sys.modules`` when an unrelated file starts. A victim installer that uses
+``setdefault`` then silently no-ops, patches an orphan module, and the code under
+test resolves the *leaked* stub instead — an intermittent, seed-dependent
+failure.
+
+``reset_global_test_state`` in ``tests/conftest.py`` restores the stub namespace
+around every test. These tests pin that contract down.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+
+from tests.conftest import _restore_stub_sdk_modules, _snapshot_stub_sdk_modules
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_snapshot_restore_drops_stubs_a_test_added():
+    snapshot = _snapshot_stub_sdk_modules()
+
+    stub = types.ModuleType("snowflake")
+    stub.connector = types.ModuleType("snowflake.connector")
+    sys.modules["snowflake"] = stub
+    sys.modules["snowflake.connector"] = stub.connector
+
+    _restore_stub_sdk_modules(snapshot)
+
+    assert "snowflake" not in sys.modules
+    assert "snowflake.connector" not in sys.modules
+
+
+def test_snapshot_restore_reinstates_a_stub_a_test_replaced():
+    original = types.ModuleType("databricks")
+    sys.modules["databricks"] = original
+    try:
+        snapshot = _snapshot_stub_sdk_modules()
+        sys.modules["databricks"] = types.ModuleType("databricks")
+
+        _restore_stub_sdk_modules(snapshot)
+
+        assert sys.modules["databricks"] is original
+    finally:
+        sys.modules.pop("databricks", None)
+
+
+def test_snapshot_restore_leaves_real_packages_alone():
+    """Only synthetic stubs are reverted; genuinely imported packages stay."""
+    snapshot = _snapshot_stub_sdk_modules()
+    import json as _real_module_probe  # noqa: F401
+
+    _restore_stub_sdk_modules(snapshot)
+
+    assert "json" in sys.modules
+    assert sys.modules["json"].__spec__ is not None
+
+
+def test_snowflake_cortex_discovery_survives_a_prior_stub_installer():
+    """The exact CI ordering that failed: leaker file first, victim test second.
+
+    ``tests/cloud/test_snowflake_inventory_evaluation_failed.py`` installs a stub
+    ``snowflake`` package; ``test_snowflake_cortex_agents`` then has to still see
+    its own mock. Run as a subprocess so the ordering is real rather than
+    simulated.
+    """
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "pytest",
+            "tests/cloud/test_snowflake_inventory_evaluation_failed.py",
+            "tests/cloud/test_cloud.py::test_snowflake_cortex_agents",
+            "-p",
+            "no:randomly",
+            "-p",
+            "no:cacheprovider",
+            "-q",
+            "--no-header",
+        ],
+        cwd=_REPO_ROOT,
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+    assert result.returncode == 0, f"stub leaked across files:\n{result.stdout}\n{result.stderr}"


### PR DESCRIPTION
Fixes the order-dependent failure that was red on #4549 and has been intermittently
failing `CI/CD Pipeline` on main:

```
FAILED tests/cloud/test_cloud.py::test_snowflake_cortex_agents - assert 0 == 1
```

## Deterministic repro

Fails on `main`, passes here — I verified both myself:

```
uv run --extra dev python -m pytest \
  tests/cloud/test_snowflake_inventory_evaluation_failed.py \
  tests/cloud/test_cloud.py::test_snowflake_cortex_agents -p no:randomly -q
```

## Mechanism

None of these cloud SDKs are actually installed, so every `sys.modules` entry is a stub.
`tests/cloud/test_snowflake_inventory_evaluation_failed.py` installs its own stub
`snowflake*` modules with **no teardown**, leaving them for the rest of the worker.

When it ran first, `test_cloud.py::_install_mock_snowflake` used
`sys.modules.setdefault(...)` — which **no-ops** — yet still returned its own freshly
built module. The test then patched `connect` on that orphan while
`agent_bom.cloud.snowflake` resolved `connect` from the *leaked* stub, so `discover()`
got a bare `MagicMock` cursor and produced zero cortex agents.

Only `--dist worksteal` + `pytest-randomly` decided whether the leaker ran first, which
is exactly why it looked like flake and moved between Python versions.

Two notes on how this was found, because they matter for the next person:
- A plain `pytest_runtest_teardown` leak detector fires **before** fixture finalization
  and falsely flags every `monkeypatch.setitem` user. The first pass was misleading for
  that reason; `pytest_runtest_logfinish` gives the true picture.
- `test_cloud.py` already had an `_isolate_cloud_provider_imports` fixture, but it's
  teardown-only and module-scoped — it cannot defend against a stub a *sibling file*
  installed before the module was even imported.

## Fix — root cause, and the whole class

1. Stub installers **assign** instead of `setdefault`, so the returned object is always
   the one under import (`_install_mock_snowflake`, `_install_mock_databricks`, and the
   installer in the contaminating file).
2. `reset_global_test_state` in `tests/conftest.py` snapshots and restores the faked
   provider-SDK namespace around **every** test, so no file can hand a stub to the next.
   It reverts only synthetic doubles (`__spec__ is None`, or non-`ModuleType` such as
   `MagicMock`) and leaves a genuinely-installed optional SDK alone — which matters
   because CI images differ by extras.

The same defect existed for `google.*` / `googleapiclient.*` in
`test_cloud.py::test_gcp_missing_project`, `test_gcp_cis_benchmark.py`, and
`test_cis_denied_read_coverage.py`. All fixed. Leak detector: **6 leaks → 0**.

## Verified

- `tests/cloud/` green at seeds 1, 7, 42, 1337, 20260729 (720 passed each)
- `pytest tests/ -k "snowflake or cloud"` → 1546 passed
- full suite CI-style (`-n 4 --dist worksteal`) at two seeds → **16846 passed, 0 failed**
- `make preflight` passed, `ruff check` clean

## Note for review

The new test file bumped the checked-in test-file count, so
`tests/test_product_metrics_snapshot.py` went red until `docs/PRODUCT_METRICS.{json,md}`
were regenerated — that regeneration is in the commit. Any PR adding a test file needs it.