### PR TITLE
perf(gateway): stop the live feed freezing the whole control plane

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1048,
+      "value": 1049,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1048 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1049 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
+import anyio.to_thread
 from fastapi import APIRouter, Query, Request
 from pydantic import BaseModel, Field
 
@@ -586,10 +587,39 @@ def _load_tenant_alerts(tenant_id: str) -> list[dict[str, Any]]:
     Delegates to ``proxy._load_proxy_alerts`` which already enforces per-tenant
     visibility and reads the configured audit log when the in-process buffer is
     empty. This module never mutates that buffer.
+
+    Synchronous by design — callers on the event loop must use
+    :func:`_load_tenant_alerts_async`.
     """
     from agent_bom.api.routes.proxy import _load_proxy_alerts
 
     return _load_proxy_alerts(tenant_id)
+
+
+async def _gather_feed_inputs_async(tenant_id: str, *, limit: int) -> tuple[list[dict[str, Any]], list[Any]]:
+    """Load every synchronous feed input off the event loop, in one hop.
+
+    Both the audit-log fallback and the cost-store read are blocking; offloading
+    only one still left the loop stalled for hundreds of milliseconds.
+    """
+
+    def _gather() -> tuple[list[dict[str, Any]], list[Any]]:
+        return _load_tenant_alerts(tenant_id), _load_tenant_llm_records(tenant_id, limit=limit)
+
+    return await anyio.to_thread.run_sync(_gather)
+
+
+async def _load_tenant_alerts_async(tenant_id: str) -> list[dict[str, Any]]:
+    """Off-loop variant for async routes.
+
+    The audit-log fallback opens a JSONL file and parses up to _MAX_LOG_LINES
+    records, redacting each one. Called inline from an ``async def`` handler
+    that froze the entire process -- measured at several seconds on a large log,
+    stalling every other tenant's request and every background task, not just
+    this one. AGENT_BOM_LOG is a shipped deployment surface, so this is reachable
+    in a normal install.
+    """
+    return await anyio.to_thread.run_sync(_load_tenant_alerts, tenant_id)
 
 
 def _load_tenant_uptime(tenant_id: str) -> float | None:
@@ -658,15 +688,14 @@ async def gateway_feed(
     no raw arguments, responses, or credential values are returned.
     """
     tenant_id = require_request_tenant_id(request)
-    alerts = _load_tenant_alerts(tenant_id)
-    llm_records = _load_tenant_llm_records(tenant_id, limit=limit)
+    alerts, llm_records = await _gather_feed_inputs_async(tenant_id, limit=limit)
     payload = build_gateway_feed(
         tenant_id=tenant_id,
         alerts=alerts,
         llm_records=llm_records,
         limit=limit,
     )
-    payload["health"] = _feed_health_from_metrics(_load_tenant_transport_metrics(tenant_id))
+    payload["health"] = _feed_health_from_metrics(await anyio.to_thread.run_sync(_load_tenant_transport_metrics, tenant_id))
     return payload
 
 
@@ -684,14 +713,13 @@ async def gateway_feed_kpis(request: Request) -> dict[str, Any]:
     ``uptime_seconds`` (only when the proxy reports it — never fabricated).
     """
     tenant_id = require_request_tenant_id(request)
-    alerts = _load_tenant_alerts(tenant_id)
-    llm_records = _load_tenant_llm_records(tenant_id, limit=10000)
-    uptime_seconds = _load_tenant_uptime(tenant_id)
+    alerts, llm_records = await _gather_feed_inputs_async(tenant_id, limit=10000)
+    uptime_seconds = await anyio.to_thread.run_sync(_load_tenant_uptime, tenant_id)
     payload = build_gateway_feed_kpis(
         tenant_id=tenant_id,
         alerts=alerts,
         llm_records=llm_records,
         uptime_seconds=uptime_seconds,
     )
-    payload["health"] = _feed_health_from_metrics(_load_tenant_transport_metrics(tenant_id))
+    payload["health"] = _feed_health_from_metrics(await anyio.to_thread.run_sync(_load_tenant_transport_metrics, tenant_id))
     return payload

--- a/tests/test_gateway_feed_event_loop.py
+++ b/tests/test_gateway_feed_event_loop.py
@@ -1,0 +1,96 @@
+"""The gateway feed must not stall the event loop while it reads its audit log.
+
+`/v1/gateway/feed` and its KPI sibling answer from a JSONL audit log when the
+in-process ring buffer is empty. That read is synchronous — open, iterate up to
+_MAX_LOG_LINES, json.loads each line, redact each record — and it was called
+directly from `async def` handlers. On a large log the whole process stops:
+every other tenant's request, every health check, every background task.
+
+AGENT_BOM_LOG is a shipped deployment surface (deploy/docker-compose.runtime-example.yml),
+so this is reachable in a normal install, not a synthetic condition.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+
+import pytest
+
+
+def _write_log(path, lines: int) -> None:
+    with open(path, "w") as handle:
+        for i in range(lines):
+            handle.write(
+                json.dumps(
+                    {
+                        "type": "runtime_alert",
+                        "tenant_id": "default",
+                        "timestamp": "2026-07-29T00:00:00Z",
+                        "agent": f"agent-{i % 7}",
+                        "action": "blocked",
+                        "detail": "x" * 120,
+                    }
+                )
+                + "\n"
+            )
+
+
+async def _max_stall_while(coro, *, tick: float = 0.001) -> tuple[object, float]:
+    """Run *coro*, sampling how long the loop ever went without servicing a tick."""
+    worst = 0.0
+    stop = False
+
+    async def _heartbeat() -> None:
+        nonlocal worst
+        last = time.perf_counter()
+        while not stop:
+            await asyncio.sleep(tick)
+            now = time.perf_counter()
+            worst = max(worst, now - last)
+            last = now
+
+    beat = asyncio.create_task(_heartbeat())
+    # Let the heartbeat actually start before the work begins. Without this the
+    # task is merely scheduled, never runs, and a fully blocking call is
+    # measured as zero stall -- the instrument would exonerate the bug.
+    for _ in range(5):
+        await asyncio.sleep(tick)
+    try:
+        result = await coro
+    finally:
+        stop = True
+        await asyncio.sleep(0)
+        beat.cancel()
+    return result, worst
+
+
+@pytest.mark.parametrize("route", ["feed", "kpis"])
+def test_feed_routes_do_not_block_the_event_loop(tmp_path, monkeypatch, route):
+    from agent_bom.api.routes import gateway_feed as feed_mod
+    from agent_bom.api.routes import proxy as proxy_mod
+
+    log = tmp_path / "runtime.jsonl"
+    _write_log(log, 40_000)
+    monkeypatch.setenv("AGENT_BOM_LOG", str(log))
+    monkeypatch.setattr(proxy_mod, "_proxy_alerts", type(proxy_mod._proxy_alerts)(maxlen=1000))
+
+    class _Req:
+        state = type("S", (), {"tenant_id": "default"})()
+        headers: dict[str, str] = {}
+
+    handler = feed_mod.gateway_feed if route == "feed" else feed_mod.gateway_feed_kpis
+    call = handler(_Req(), limit=100) if route == "feed" else handler(_Req())
+
+    async def _drive():
+        return await _max_stall_while(call)
+
+    _result, worst_stall = asyncio.run(_drive())
+
+    # Before the fix this measured ~3.6 s: the whole process frozen, not merely
+    # a slow request. Off-loading brings it to ~0.19 s. The residue is GIL
+    # contention -- parsing 40k JSON lines is CPU-bound, so a worker thread
+    # interleaves with the loop rather than freeing it. Fully removing it needs
+    # the work bounded (pagination / a smaller cap), not more threading.
+    assert worst_stall < 0.35, f"event loop stalled {worst_stall * 1000:.0f} ms reading the audit log"


### PR DESCRIPTION
P0 from the main audit. The gateway live feed — the surface operators actually watch —
stalls the entire process while it reads its audit log.

## The defect

`/v1/gateway/feed` and `/v1/gateway/feed/kpis` answer from a JSONL audit log when the
in-process ring buffer is empty. That read is synchronous: open the file, iterate up to
`_MAX_LOG_LINES` (50,000), `json.loads` each line, redact each record. Both handlers
called it **inline from `async def`**.

While it runs nothing else on the loop runs — not another tenant's request, not a health
check, not a background task. `AGENT_BOM_LOG` is a shipped deployment surface
(`deploy/docker-compose.runtime-example.yml`), so this is a normal install.

## Measured

1 ms heartbeat, 40,000-line log:

| | worst event-loop stall |
|---|---|
| before | **~3,600 ms** |
| after | **~190 ms** |

Off-loading only the log read still left ~350 ms, because the up-to-10,000-row
cost-store read in the KPI path blocks too. Both are now gathered off-loop in one hop.

## What is still there, and why

**~190 ms is GIL contention, not I/O.** Parsing 40k JSON lines is CPU-bound, so a worker
thread *interleaves* with the loop rather than freeing it. Removing the rest needs the
work bounded — pagination or a smaller cap — not more threading. The test documents that
instead of implying the stall is gone.

## A note on the test, because it nearly fooled me

My first version **passed against the unfixed code**. The heartbeat task was created but
only *scheduled* — it never ran before the blocking call started, so a total process
freeze measured as zero stall. The instrument exonerated the bug.

It now runs several heartbeat ticks before the work begins, and fails on `main` with the
full 3.6 s. Second time this session that an instrument, not a diagnosis, was the thing
that was wrong — worth remembering when a perf test passes suspiciously easily.

## Verified

- fails on `main` at ~3.6 s for both routes, passes here at ~190 ms
- `pytest tests/ -k "gateway_feed or proxy or observability"` → **596 passed**, 8 skipped
- `ruff`, `mypy`, `make preflight` clean
- no route signatures or response shapes changed → no OpenAPI/SVG/manifest regeneration
  (metrics snapshot refreshed for the new test file)

## Follow-up worth tracking separately

Four sibling routes share the same unoffloaded `_read_alerts_from_log` call —
`/v1/proxy/status`, `/v1/runtime/production-index`, `/v1/proxy/alerts`, and the
trace-explorer path in `observability.py`. Same defect, same fix shape. Kept out of this
PR so the change stays reviewable; they deserve their own pass.