### PR TITLE
fix(audit): stop one tenant's policy audit entry discarding another's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1317,6 +1317,12 @@ jobs:
               raise SystemExit(f"wheel is missing required package data: {', '.join(missing)}")
           PY
 
+      - name: Smoke clean unlocked wheel MCP protocol
+        run: |
+          python -m venv "$RUNNER_TEMP/agent-bom-wheel-smoke"
+          "$RUNNER_TEMP/agent-bom-wheel-smoke/bin/pip" install --disable-pip-version-check dist/*.whl
+          "$RUNNER_TEMP/agent-bom-wheel-smoke/bin/python" scripts/smoke_mcp_wheel.py
+
       - name: Upload package
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -262,6 +262,12 @@ jobs:
               raise SystemExit("wheel dashboard CSP hash manifest has no script hashes; packaged UI would fall back to unsafe-inline")
           PY
 
+      - name: Smoke clean unlocked wheel MCP protocol
+        run: |
+          python -m venv "$RUNNER_TEMP/agent-bom-wheel-smoke"
+          "$RUNNER_TEMP/agent-bom-wheel-smoke/bin/pip" install --disable-pip-version-check dist/*.whl
+          "$RUNNER_TEMP/agent-bom-wheel-smoke/bin/python" scripts/smoke_mcp_wheel.py
+
       - name: Upload dist artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/deploy/supabase/postgres/alembic.ini
+++ b/deploy/supabase/postgres/alembic.ini
@@ -1,6 +1,7 @@
 [alembic]
 script_location = deploy/supabase/postgres/alembic
 prepend_sys_path = .
+path_separator = os
 sqlalchemy.url =
 
 [loggers]

--- a/deploy/supabase/postgres/alembic/versions/20260729_01_policy_audit_tenant_scoped_index.py
+++ b/deploy/supabase/postgres/alembic/versions/20260729_01_policy_audit_tenant_scoped_index.py
@@ -28,14 +28,43 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # A pre-existing duplicate across tenants is impossible: the old index made
-    # it unrepresentable. So the tenant-scoped index can be built directly.
-    op.execute("DROP INDEX IF EXISTS uq_policy_audit_log_entry")
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(team_id, entry_id)")
+    # policy_audit_log is created by init.sql or lazily by the policy store, so
+    # a database migrating forward from an older revision may not have it yet —
+    # the legacy upgrade contract starts from a fixture that has only scan_jobs
+    # and scan_dispatch_queue. Rebuild the index only when the table is actually
+    # present; the runtime store creates the tenant-scoped index itself on first
+    # use, and init.sql ships it for fresh bootstraps.
+    #
+    # A pre-existing duplicate across tenants is impossible — the old index made
+    # it unrepresentable — so the new index can be built without deduping first.
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.policy_audit_log') IS NOT NULL THEN
+                DROP INDEX IF EXISTS uq_policy_audit_log_entry;
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry
+                    ON policy_audit_log(team_id, entry_id);
+            END IF;
+        END
+        $$;
+        """
+    )
 
 
 def downgrade() -> None:
     # Narrowing back can fail if two tenants have since written the same
     # entry_id — which is exactly the data this migration exists to preserve.
-    op.execute("DROP INDEX IF EXISTS uq_policy_audit_log_entry")
-    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(entry_id)")
+    op.execute(
+        """
+        DO $$
+        BEGIN
+            IF to_regclass('public.policy_audit_log') IS NOT NULL THEN
+                DROP INDEX IF EXISTS uq_policy_audit_log_entry;
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry
+                    ON policy_audit_log(entry_id);
+            END IF;
+        END
+        $$;
+        """
+    )

--- a/deploy/supabase/postgres/alembic/versions/20260729_01_policy_audit_tenant_scoped_index.py
+++ b/deploy/supabase/postgres/alembic/versions/20260729_01_policy_audit_tenant_scoped_index.py
@@ -1,0 +1,41 @@
+"""Scope the policy audit uniqueness index by tenant.
+
+``policy_audit_log`` carried ``UNIQUE (entry_id)`` with no tenant column, and the
+writer used ``ON CONFLICT (entry_id) DO NOTHING``. Two tenants writing the same
+logical ``entry_id`` collapsed to one row: the second write reported success and
+silently vanished. Unique indexes are enforced below RLS, so FORCE ROW LEVEL
+SECURITY does not protect against this.
+
+An audit log that drops entries without erroring is worse than one that fails
+loudly. The governance chain already scopes its equivalent index by tenant
+(``uq_governance_audit_tenant_action``); this brings the policy chain in line.
+
+Rebuilding the index cannot merge rows that were already lost — those writes
+never landed. It only stops further loss.
+
+Revision ID: 20260729_01
+Revises: 20260728_03
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260729_01"
+down_revision = "20260728_03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # A pre-existing duplicate across tenants is impossible: the old index made
+    # it unrepresentable. So the tenant-scoped index can be built directly.
+    op.execute("DROP INDEX IF EXISTS uq_policy_audit_log_entry")
+    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(team_id, entry_id)")
+
+
+def downgrade() -> None:
+    # Narrowing back can fail if two tenants have since written the same
+    # entry_id — which is exactly the data this migration exists to preserve.
+    op.execute("DROP INDEX IF EXISTS uq_policy_audit_log_entry")
+    op.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(entry_id)")

--- a/deploy/supabase/postgres/alembic/versions/20260729_01_policy_audit_tenant_scoped_index.py
+++ b/deploy/supabase/postgres/alembic/versions/20260729_01_policy_audit_tenant_scoped_index.py
@@ -1,17 +1,17 @@
-"""Scope the policy audit uniqueness index by tenant.
+"""Make policy-audit deduplication tenant-safe without breaking old replicas.
 
-``policy_audit_log`` carried ``UNIQUE (entry_id)`` with no tenant column, and the
-writer used ``ON CONFLICT (entry_id) DO NOTHING``. Two tenants writing the same
-logical ``entry_id`` collapsed to one row: the second write reported success and
-silently vanished. Unique indexes are enforced below RLS, so FORCE ROW LEVEL
-SECURITY does not protect against this.
+Old application versions insert with ``ON CONFLICT (entry_id) DO NOTHING``.
+Changing the unique index to ``(team_id, entry_id)`` would make those replicas
+error during a rolling deployment because their conflict target no longer has a
+matching unique index.  Instead, ``entry_id`` becomes an injective
+tenant-derived physical key while ``logical_entry_id`` and the JSON payload
+retain the caller-visible ID.  A database trigger applies the mapping for both
+old and new application versions.
 
-An audit log that drops entries without erroring is worse than one that fails
-loudly. The governance chain already scopes its equivalent index by tenant
-(``uq_governance_audit_tenant_action``); this brings the policy chain in line.
-
-Rebuilding the index cannot merge rows that were already lost — those writes
-never landed. It only stops further loss.
+The migration takes an ACCESS EXCLUSIVE lock while it rewrites the small policy
+audit ledger, so no insert can land between the backfill and index rebuild.  It
+cannot recover rows discarded by the previous global index; it prevents future
+loss.
 
 Revision ID: 20260729_01
 Revises: 20260728_03
@@ -28,43 +28,102 @@ depends_on = None
 
 
 def upgrade() -> None:
-    # policy_audit_log is created by init.sql or lazily by the policy store, so
-    # a database migrating forward from an older revision may not have it yet —
-    # the legacy upgrade contract starts from a fixture that has only scan_jobs
-    # and scan_dispatch_queue. Rebuild the index only when the table is actually
-    # present; the runtime store creates the tenant-scoped index itself on first
-    # use, and init.sql ships it for fresh bootstraps.
-    #
-    # A pre-existing duplicate across tenants is impossible — the old index made
-    # it unrepresentable — so the new index can be built without deduping first.
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.abom_policy_audit_key(
+            tenant_id TEXT,
+            logical_id TEXT
+        ) RETURNS TEXT
+        LANGUAGE SQL
+        IMMUTABLE
+        STRICT
+        PARALLEL SAFE
+        AS $$
+            SELECT octet_length(tenant_id)::TEXT || ':' || tenant_id || ':' || logical_id
+        $$
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.abom_policy_audit_set_key()
+        RETURNS TRIGGER
+        LANGUAGE plpgsql
+        AS $$
+        BEGIN
+            NEW.logical_entry_id := COALESCE(NEW.logical_entry_id, NEW.entry_id);
+            IF NEW.logical_entry_id IS NOT NULL THEN
+                NEW.entry_id := public.abom_policy_audit_key(NEW.team_id, NEW.logical_entry_id);
+            END IF;
+            RETURN NEW;
+        END
+        $$
+        """
+    )
     op.execute(
         """
         DO $$
+        DECLARE
+            had_rls BOOLEAN;
+            had_force_rls BOOLEAN;
         BEGIN
             IF to_regclass('public.policy_audit_log') IS NOT NULL THEN
+                LOCK TABLE policy_audit_log IN ACCESS EXCLUSIVE MODE;
+
+                SELECT relrowsecurity, relforcerowsecurity
+                  INTO had_rls, had_force_rls
+                  FROM pg_class
+                 WHERE oid = 'public.policy_audit_log'::regclass;
+
+                -- The migration owner must see every tenant while rewriting
+                -- the physical key. The table lock prevents runtime access,
+                -- and the prior RLS posture is restored before commit.
+                IF had_rls THEN
+                    ALTER TABLE policy_audit_log DISABLE ROW LEVEL SECURITY;
+                END IF;
+
+                ALTER TABLE policy_audit_log
+                    ADD COLUMN IF NOT EXISTS logical_entry_id TEXT;
+
+                DROP TRIGGER IF EXISTS policy_audit_set_key ON policy_audit_log;
+                CREATE TRIGGER policy_audit_set_key
+                    BEFORE INSERT OR UPDATE OF team_id, entry_id, logical_entry_id
+                    ON policy_audit_log
+                    FOR EACH ROW
+                    EXECUTE FUNCTION public.abom_policy_audit_set_key();
+
                 DROP INDEX IF EXISTS uq_policy_audit_log_entry;
-                CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry
-                    ON policy_audit_log(team_id, entry_id);
+                UPDATE policy_audit_log
+                   SET logical_entry_id = COALESCE(logical_entry_id, entry_id),
+                       entry_id = public.abom_policy_audit_key(
+                           team_id,
+                           COALESCE(logical_entry_id, entry_id)
+                       )
+                 WHERE entry_id IS NOT NULL;
+                CREATE UNIQUE INDEX uq_policy_audit_log_entry
+                    ON policy_audit_log(entry_id);
+                COMMENT ON INDEX uq_policy_audit_log_entry IS
+                    'agent-bom policy audit tenant key v2';
+
+                COMMENT ON COLUMN policy_audit_log.entry_id IS
+                    'Tenant-derived physical dedupe key; use logical_entry_id or data->>entry_id externally';
+                COMMENT ON COLUMN policy_audit_log.logical_entry_id IS
+                    'Caller-visible policy audit entry ID preserved across tenant-safe deduplication';
+
+                IF had_rls THEN
+                    ALTER TABLE policy_audit_log ENABLE ROW LEVEL SECURITY;
+                END IF;
+                IF had_force_rls THEN
+                    ALTER TABLE policy_audit_log FORCE ROW LEVEL SECURITY;
+                END IF;
             END IF;
         END
-        $$;
+        $$
         """
     )
 
 
 def downgrade() -> None:
-    # Narrowing back can fail if two tenants have since written the same
-    # entry_id — which is exactly the data this migration exists to preserve.
-    op.execute(
-        """
-        DO $$
-        BEGIN
-            IF to_regclass('public.policy_audit_log') IS NOT NULL THEN
-                DROP INDEX IF EXISTS uq_policy_audit_log_entry;
-                CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry
-                    ON policy_audit_log(entry_id);
-            END IF;
-        END
-        $$;
-        """
+    raise NotImplementedError(
+        "Policy-audit tenant deduplication is forward-only: an application rollback is compatible, "
+        "but the database migration cannot be reversed after cross-tenant logical IDs are accepted."
     )

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -216,7 +216,10 @@ DO $$ BEGIN
 END $$;
 
 CREATE INDEX IF NOT EXISTS idx_audit_ts ON policy_audit_log(ts DESC);
-CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(entry_id);
+-- Tenant-scoped: a bare UNIQUE(entry_id) let one tenant's audit row discard
+-- another's, because unique indexes are enforced below RLS. Matches the
+-- governance chain's uq_governance_audit_tenant_action.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(team_id, entry_id);
 CREATE INDEX IF NOT EXISTS idx_gateway_policies_team ON gateway_policies(team_id);
 CREATE INDEX IF NOT EXISTS idx_policy_audit_log_team_ts ON policy_audit_log(team_id, ts DESC);
 

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -197,15 +197,45 @@ CREATE TABLE IF NOT EXISTS gateway_policies (
 );
 
 CREATE TABLE IF NOT EXISTS policy_audit_log (
-    id       SERIAL PRIMARY KEY,
-    entry_id TEXT,                    -- mirrors SQLite PRIMARY KEY; dedup key for idempotent re-ingestion
-    ts       TEXT NOT NULL,
-    team_id  TEXT NOT NULL DEFAULT 'default',
-    data     JSONB NOT NULL
+    id               SERIAL PRIMARY KEY,
+    entry_id         TEXT, -- tenant-derived physical key; old replicas conflict on this column
+    logical_entry_id TEXT, -- caller-visible ID, also retained in data->>'entry_id'
+    ts               TEXT NOT NULL,
+    team_id          TEXT NOT NULL DEFAULT 'default',
+    data             JSONB NOT NULL
 );
 
--- Idempotent: add entry_id to existing policy_audit_log tables that predate
--- the dedup key (matches the application bootstrap in api/postgres_policy.py).
+-- Old application replicas use ON CONFLICT(entry_id), so that unique target
+-- must remain present throughout rolling deploys. A trigger rewrites the
+-- caller-visible ID into a tenant-derived physical key before conflict checking.
+CREATE OR REPLACE FUNCTION public.abom_policy_audit_key(
+    tenant_id TEXT,
+    logical_id TEXT
+) RETURNS TEXT
+LANGUAGE SQL
+IMMUTABLE
+STRICT
+PARALLEL SAFE
+AS $$
+    SELECT octet_length(tenant_id)::TEXT || ':' || tenant_id || ':' || logical_id
+$$;
+
+CREATE OR REPLACE FUNCTION public.abom_policy_audit_set_key()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+    NEW.logical_entry_id := COALESCE(NEW.logical_entry_id, NEW.entry_id);
+    IF NEW.logical_entry_id IS NOT NULL THEN
+        NEW.entry_id := public.abom_policy_audit_key(NEW.team_id, NEW.logical_entry_id);
+    END IF;
+    RETURN NEW;
+END
+$$;
+
+-- Idempotently reconcile a legacy bootstrap. The table lock and temporary RLS
+-- disable are transactional; previous RLS state is restored before the block
+-- commits, and no runtime insert can race the physical-key rewrite.
 DO $$ BEGIN
     IF NOT EXISTS (
         SELECT 1 FROM information_schema.columns
@@ -215,11 +245,53 @@ DO $$ BEGIN
     END IF;
 END $$;
 
+DO $$
+DECLARE
+    had_rls BOOLEAN;
+    had_force_rls BOOLEAN;
+BEGIN
+    LOCK TABLE policy_audit_log IN ACCESS EXCLUSIVE MODE;
+    SELECT relrowsecurity, relforcerowsecurity
+      INTO had_rls, had_force_rls
+      FROM pg_class
+     WHERE oid = 'public.policy_audit_log'::regclass;
+
+    IF had_rls THEN
+        ALTER TABLE policy_audit_log DISABLE ROW LEVEL SECURITY;
+    END IF;
+
+    ALTER TABLE policy_audit_log
+        ADD COLUMN IF NOT EXISTS logical_entry_id TEXT;
+    DROP TRIGGER IF EXISTS policy_audit_set_key ON policy_audit_log;
+    CREATE TRIGGER policy_audit_set_key
+        BEFORE INSERT OR UPDATE OF team_id, entry_id, logical_entry_id
+        ON policy_audit_log
+        FOR EACH ROW
+        EXECUTE FUNCTION public.abom_policy_audit_set_key();
+
+    DROP INDEX IF EXISTS uq_policy_audit_log_entry;
+    UPDATE policy_audit_log
+       SET logical_entry_id = COALESCE(logical_entry_id, entry_id),
+           entry_id = public.abom_policy_audit_key(
+               team_id,
+               COALESCE(logical_entry_id, entry_id)
+           )
+     WHERE entry_id IS NOT NULL;
+    CREATE UNIQUE INDEX uq_policy_audit_log_entry
+        ON policy_audit_log(entry_id);
+    COMMENT ON INDEX uq_policy_audit_log_entry IS
+        'agent-bom policy audit tenant key v2';
+
+    IF had_rls THEN
+        ALTER TABLE policy_audit_log ENABLE ROW LEVEL SECURITY;
+    END IF;
+    IF had_force_rls THEN
+        ALTER TABLE policy_audit_log FORCE ROW LEVEL SECURITY;
+    END IF;
+END
+$$;
+
 CREATE INDEX IF NOT EXISTS idx_audit_ts ON policy_audit_log(ts DESC);
--- Tenant-scoped: a bare UNIQUE(entry_id) let one tenant's audit row discard
--- another's, because unique indexes are enforced below RLS. Matches the
--- governance chain's uq_governance_audit_tenant_action.
-CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(team_id, entry_id);
 CREATE INDEX IF NOT EXISTS idx_gateway_policies_team ON gateway_policies(team_id);
 CREATE INDEX IF NOT EXISTS idx_policy_audit_log_team_ts ON policy_audit_log(team_id, ts DESC);
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1050,
+      "value": 1053,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1050 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1053 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,12 +249,16 @@ dev = [
     "pytest-xdist>=3.5",  # Parallel test execution (-n auto) — cuts CI test wall time
     "pytest-randomly>=3.15",  # Randomize test order to surface order-dependence early
     # API-layer test modules (tests/test_api_*, TestClient) fail to COLLECT
-    # without these. httpx is already a core dep (powers TestClient); fastapi +
-    # starlette live in the [api] extra, so a dev-only env can't import the API
-    # app under test. Pin them into [dev] so the full suite collects locally
-    # without needing `[dev,api]`. (#1969)
+    # without these. httpx remains a core runtime dependency; Starlette 1.x
+    # TestClient uses its successor package, httpx2, and warns on the legacy
+    # fallback. Keep Starlette's documented TestClient contract explicit in the
+    # dev environment so test imports stay warning-free. fastapi + starlette
+    # live in the [api] extra, so a dev-only env can't import the API app under
+    # test. Pin them into [dev] so the full suite collects locally without
+    # needing `[dev,api]`. (#1969)
     "fastapi>=0.115,!=0.136.3",
     "starlette>=0.40",
+    "httpx2>=2.0.0",
 ]
 dev-all = [
     "agent-bom[dev]",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -249,16 +249,14 @@ dev = [
     "pytest-xdist>=3.5",  # Parallel test execution (-n auto) — cuts CI test wall time
     "pytest-randomly>=3.15",  # Randomize test order to surface order-dependence early
     # API-layer test modules (tests/test_api_*, TestClient) fail to COLLECT
-    # without these. httpx remains a core runtime dependency; Starlette 1.x
-    # TestClient uses its successor package, httpx2, and warns on the legacy
-    # fallback. Keep Starlette's documented TestClient contract explicit in the
-    # dev environment so test imports stay warning-free. fastapi + starlette
-    # live in the [api] extra, so a dev-only env can't import the API app under
-    # test. Pin them into [dev] so the full suite collects locally without
-    # needing `[dev,api]`. (#1969)
+    # without these. Keep Starlette on its patched 1.x line but do not install
+    # its optional TestClient transport until that package passes our
+    # supply-chain gate; tests use Starlette's governed httpx fallback instead.
+    # fastapi + starlette live in the [api] extra, so a dev-only env can't import
+    # the API app under test. Pin them into [dev] so the full suite collects
+    # locally without needing `[dev,api]`. (#1969)
     "fastapi>=0.115,!=0.136.3",
-    "starlette>=0.40",
-    "httpx2>=2.0.0",
+    "starlette>=1.3.1,<2",
 ]
 dev-all = [
     "agent-bom[dev]",
@@ -330,6 +328,13 @@ pythonpath = ["src"]
 # `--randomly-seed=N` to replay the exact order. To force deterministic order
 # for a one-off local run, pass `-p no:randomly`.
 addopts = ""
+# Starlette 1.x recommends an optional TestClient transport that our own
+# supply-chain scanner currently blocks. Keep the patched framework and its
+# supported httpx fallback while silencing only this exact upstream migration
+# warning; all other deprecations remain visible.
+filterwarnings = [
+    "ignore:Using `httpx` with `starlette\\.testclient` is deprecated; install `httpx2` instead\\.:DeprecationWarning",
+]
 markers = [
     "network: tests that require network access (OSV API)",
     "slow: slow tests (e.g. large-scale perf benchmarks) — opt-in only",

--- a/scripts/smoke_mcp_wheel.py
+++ b/scripts/smoke_mcp_wheel.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+"""Exercise MCP initialize and tools/list from an installed release wheel.
+
+Run this script with the Python interpreter from a clean environment containing
+only an unlocked ``pip install dist/agent_bom-*.whl``.  It deliberately imports
+the advertised server entry point before starting a real stdio MCP client
+session, catching dependency-major drift that metadata-only wheel checks miss.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+EXPECTED_TOOL_COUNT = 77
+
+
+async def _smoke() -> dict[str, object]:
+    importlib.import_module("agent_bom.mcp_server")
+
+    from mcp import ClientSession, StdioServerParameters
+    from mcp.client.stdio import stdio_client
+
+    child_env = dict(os.environ)
+    child_env["AGENT_BOM_SKIP_UPDATE_CHECK"] = "1"
+    executable = Path(sys.executable).with_name("agent-bom")
+    if not executable.is_file():
+        raise RuntimeError(f"installed agent-bom console script is missing: {executable}")
+    server = StdioServerParameters(
+        command=str(executable),
+        args=["mcp", "server"],
+        env=child_env,
+    )
+    async with stdio_client(server) as (read_stream, write_stream):
+        async with ClientSession(read_stream, write_stream) as session:
+            initialized = await session.initialize()
+            listed = await session.list_tools()
+
+    tool_names = [tool.name for tool in listed.tools]
+    if len(tool_names) != EXPECTED_TOOL_COUNT:
+        raise RuntimeError(f"MCP tools/list returned {len(tool_names)} tools; expected {EXPECTED_TOOL_COUNT}")
+    if len(set(tool_names)) != len(tool_names):
+        raise RuntimeError("MCP tools/list returned duplicate tool names")
+
+    return {
+        "protocol_version": initialized.protocolVersion,
+        "server_name": initialized.serverInfo.name,
+        "server_version": initialized.serverInfo.version,
+        "tool_count": len(tool_names),
+    }
+
+
+def main() -> int:
+    try:
+        evidence = asyncio.run(asyncio.wait_for(_smoke(), timeout=90))
+    except Exception as exc:
+        print(f"MCP wheel smoke failed: {type(exc).__name__}: {exc}", file=sys.stderr)
+        traceback.print_exc()
+        return 1
+    print(json.dumps(evidence, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/agent_bom/api/postgres_common.py
+++ b/src/agent_bom/api/postgres_common.py
@@ -354,6 +354,7 @@ def _get_pool() -> ConnectionPool:
                 max_size=max_size,
                 kwargs=kwargs,
                 connection_class=iam_auth_connection_class,
+                open=True,
             )
         else:
             _pool = psycopg_pool.ConnectionPool(
@@ -361,6 +362,7 @@ def _get_pool() -> ConnectionPool:
                 min_size=min_size,
                 max_size=max_size,
                 kwargs=kwargs,
+                open=True,
             )
     _guard_rls_capable_role(_pool)
     return _pool
@@ -454,6 +456,7 @@ def _get_maintenance_pool() -> ConnectionPool:
             min_size=1,
             max_size=max_size,
             kwargs=kwargs,
+            open=True,
         )
         try:
             _guard_maintenance_role_separation(_get_pool(), _maintenance_pool)

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -60,6 +60,7 @@ class PostgresPolicyStore:
                 CREATE TABLE IF NOT EXISTS policy_audit_log (
                     id SERIAL PRIMARY KEY,
                     entry_id TEXT,
+                    logical_entry_id TEXT,
                     ts TEXT NOT NULL,
                     team_id TEXT NOT NULL DEFAULT 'default',
                     data JSONB NOT NULL
@@ -88,10 +89,104 @@ class PostgresPolicyStore:
                     ) THEN
                         ALTER TABLE policy_audit_log ADD COLUMN entry_id TEXT;
                     END IF;
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'policy_audit_log' AND column_name = 'logical_entry_id'
+                    ) THEN
+                        ALTER TABLE policy_audit_log ADD COLUMN logical_entry_id TEXT;
+                    END IF;
                 END
                 $$;
             """)
-            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(team_id, entry_id)")
+            conn.execute("""
+                CREATE OR REPLACE FUNCTION public.abom_policy_audit_key(
+                    tenant_id TEXT,
+                    logical_id TEXT
+                ) RETURNS TEXT
+                LANGUAGE SQL
+                IMMUTABLE
+                STRICT
+                PARALLEL SAFE
+                AS $$
+                    SELECT octet_length(tenant_id)::TEXT || ':' || tenant_id || ':' || logical_id
+                $$
+            """)
+            conn.execute("""
+                CREATE OR REPLACE FUNCTION public.abom_policy_audit_set_key()
+                RETURNS TRIGGER
+                LANGUAGE plpgsql
+                AS $$
+                BEGIN
+                    NEW.logical_entry_id := COALESCE(NEW.logical_entry_id, NEW.entry_id);
+                    IF NEW.logical_entry_id IS NOT NULL THEN
+                        NEW.entry_id := public.abom_policy_audit_key(NEW.team_id, NEW.logical_entry_id);
+                    END IF;
+                    RETURN NEW;
+                END
+                $$
+            """)
+            conn.execute("""
+                DO $$
+                DECLARE
+                    had_rls BOOLEAN;
+                    had_force_rls BOOLEAN;
+                    physical_key_ready BOOLEAN;
+                BEGIN
+                    SELECT COALESCE(
+                        obj_description(to_regclass('public.uq_policy_audit_log_entry'), 'pg_class') =
+                            'agent-bom policy audit tenant key v2',
+                        FALSE
+                    )
+                      INTO physical_key_ready
+                    ;
+
+                    IF NOT COALESCE(physical_key_ready, FALSE) THEN
+                        LOCK TABLE policy_audit_log IN ACCESS EXCLUSIVE MODE;
+                        SELECT relrowsecurity, relforcerowsecurity
+                          INTO had_rls, had_force_rls
+                          FROM pg_class
+                         WHERE oid = 'public.policy_audit_log'::regclass;
+
+                        IF had_rls THEN
+                            ALTER TABLE policy_audit_log DISABLE ROW LEVEL SECURITY;
+                        END IF;
+
+                        DROP INDEX IF EXISTS uq_policy_audit_log_entry;
+                        UPDATE policy_audit_log
+                           SET logical_entry_id = COALESCE(logical_entry_id, entry_id),
+                               entry_id = public.abom_policy_audit_key(
+                                   team_id,
+                                   COALESCE(logical_entry_id, entry_id)
+                               )
+                         WHERE entry_id IS NOT NULL;
+                        CREATE UNIQUE INDEX uq_policy_audit_log_entry
+                            ON policy_audit_log(entry_id);
+                        COMMENT ON INDEX uq_policy_audit_log_entry IS
+                            'agent-bom policy audit tenant key v2';
+
+                        IF had_rls THEN
+                            ALTER TABLE policy_audit_log ENABLE ROW LEVEL SECURITY;
+                        END IF;
+                        IF had_force_rls THEN
+                            ALTER TABLE policy_audit_log FORCE ROW LEVEL SECURITY;
+                        END IF;
+                    END IF;
+
+                    IF NOT EXISTS (
+                        SELECT 1 FROM pg_trigger
+                         WHERE tgrelid = 'public.policy_audit_log'::regclass
+                           AND tgname = 'policy_audit_set_key'
+                           AND NOT tgisinternal
+                    ) THEN
+                        CREATE TRIGGER policy_audit_set_key
+                            BEFORE INSERT OR UPDATE OF team_id, entry_id, logical_entry_id
+                            ON policy_audit_log
+                            FOR EACH ROW
+                            EXECUTE FUNCTION public.abom_policy_audit_set_key();
+                    END IF;
+                END
+                $$;
+            """)
             conn.execute("CREATE INDEX IF NOT EXISTS idx_gateway_policies_team ON gateway_policies(team_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_audit_log_team_ts ON policy_audit_log(team_id, ts DESC)")
             _ensure_tenant_rls(conn, "gateway_policies", "team_id")
@@ -181,13 +276,14 @@ class PostgresPolicyStore:
         entry_id = getattr(entry, "entry_id", None)
         with _tenant_connection(self._pool) as conn:
             if entry_id:
-                # entry_id carries the dedup key (mirrors the SQLite PRIMARY
-                # KEY); ON CONFLICT keeps re-ingestion idempotent.
+                # Old and new replicas intentionally retain this conflict target.
+                # The database trigger maps the logical entry ID to a
+                # tenant-derived physical key before uniqueness is evaluated.
                 conn.execute(
                     """
                     INSERT INTO policy_audit_log (entry_id, ts, team_id, data)
                     VALUES (%s, %s, %s, %s)
-                    ON CONFLICT (team_id, entry_id) DO NOTHING
+                    ON CONFLICT (entry_id) DO NOTHING
                     """,
                     (entry_id, ts, team_id, data),
                 )

--- a/src/agent_bom/api/postgres_policy.py
+++ b/src/agent_bom/api/postgres_policy.py
@@ -91,7 +91,7 @@ class PostgresPolicyStore:
                 END
                 $$;
             """)
-            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(entry_id)")
+            conn.execute("CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry ON policy_audit_log(team_id, entry_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_gateway_policies_team ON gateway_policies(team_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_policy_audit_log_team_ts ON policy_audit_log(team_id, ts DESC)")
             _ensure_tenant_rls(conn, "gateway_policies", "team_id")
@@ -187,7 +187,7 @@ class PostgresPolicyStore:
                     """
                     INSERT INTO policy_audit_log (entry_id, ts, team_id, data)
                     VALUES (%s, %s, %s, %s)
-                    ON CONFLICT (entry_id) DO NOTHING
+                    ON CONFLICT (team_id, entry_id) DO NOTHING
                     """,
                     (entry_id, ts, team_id, data),
                 )

--- a/tests/test_db_persistence_consistency.py
+++ b/tests/test_db_persistence_consistency.py
@@ -46,12 +46,13 @@ class _FakePolicyConnection:
     def execute(self, sql, params=None):
         s = " ".join(sql.lower().split())
         params = tuple(params or ())
-        audit = self._state["audit"]  # entry_id -> (entry_id, ts, team_id, data)
+        audit = self._state["audit"]  # physical key -> (physical key, ts, team_id, data)
         anon = self._state["anon"]  # rows inserted without an entry_id
 
         if s.startswith("insert into policy_audit_log") and "entry_id" in s:
             entry_id, ts, team_id, data = params
-            audit.setdefault(entry_id, (entry_id, ts, team_id, data))  # ON CONFLICT DO NOTHING
+            physical_key = f"{len(team_id.encode('utf-8'))}:{team_id}:{entry_id}"
+            audit.setdefault(physical_key, (physical_key, ts, team_id, data))  # trigger + ON CONFLICT
             return _FakeCursor()
         if s.startswith("insert into policy_audit_log"):
             anon.append(("__anon__", *params))  # (ts, team_id, data)
@@ -200,7 +201,7 @@ def test_pg_policy_audit_idempotent_no_duplicate(monkeypatch):
     rows = store.list_audit_entries(tenant_id="acme")
     assert len(rows) == 1
     assert rows[0].timestamp == ts
-    assert pool._state["audit"]["e1"][1] == ts  # stored ts == caller ts
+    assert pool._state["audit"]["4:acme:e1"][1] == ts  # stored ts == caller ts
 
 
 def test_pg_policy_audit_persists_caller_timestamp(monkeypatch):
@@ -208,7 +209,22 @@ def test_pg_policy_audit_persists_caller_timestamp(monkeypatch):
     store, pool = _pg_policy_store(monkeypatch)
     ts = "2020-01-01T12:00:00+00:00"  # in the past — cannot be insert time
     store.put_audit_entry(_audit_entry("e1", ts))
-    assert pool._state["audit"]["e1"][1] == ts
+    assert pool._state["audit"]["4:acme:e1"][1] == ts
+
+
+def test_pg_policy_audit_same_logical_id_isolated_by_tenant(monkeypatch):
+    """A retry dedupes within one tenant without discarding another's row."""
+    store, pool = _pg_policy_store(monkeypatch)
+    first = _audit_entry("shared", "2026-07-29T00:00:00+00:00")
+    second = first.model_copy(update={"tenant_id": "globex"})
+
+    store.put_audit_entry(first)
+    store.put_audit_entry(first)
+    store.put_audit_entry(second)
+
+    assert [row.entry_id for row in store.list_audit_entries(tenant_id="acme")] == ["shared"]
+    assert [row.entry_id for row in store.list_audit_entries(tenant_id="globex")] == ["shared"]
+    assert len(pool._state["audit"]) == 2
 
 
 def test_pg_policy_audit_filters_before_limit(monkeypatch):

--- a/tests/test_graph_edge_counts.py
+++ b/tests/test_graph_edge_counts.py
@@ -94,7 +94,8 @@ class TestSyntheticEdgeCounts:
     """Exact-count assertions on the synthetic fixture (no corpus drift here)."""
 
     @pytest.fixture(scope="class")
-    def graph(self):
+    @classmethod
+    def graph(cls):
         return build_graph_from_inventory(synthetic_inventory())
 
     def test_synthetic_emits_all_expected_edge_kinds(self, graph) -> None:

--- a/tests/test_graph_roundtrip.py
+++ b/tests/test_graph_roundtrip.py
@@ -79,7 +79,8 @@ class TestRoundTripSelfScan:
     """Larger real-world fixture — guards against parser regressions."""
 
     @pytest.fixture(scope="class")
-    def inventory(self) -> dict:
+    @classmethod
+    def inventory(cls) -> dict:
         return load_self_scan_fixture()
 
     def test_self_scan_round_trip_subset(self, inventory: dict) -> None:

--- a/tests/test_mcp_wheel_smoke.py
+++ b/tests/test_mcp_wheel_smoke.py
@@ -1,0 +1,26 @@
+"""Release gates must exercise MCP from an unlocked wheel install."""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SMOKE = ROOT / "scripts/smoke_mcp_wheel.py"
+
+
+def test_mcp_wheel_smoke_is_real_jsonrpc_and_syntax_valid() -> None:
+    body = SMOKE.read_text(encoding="utf-8")
+    ast.parse(body)
+    assert 'importlib.import_module("agent_bom.mcp_server")' in body
+    assert "session.initialize()" in body
+    assert "session.list_tools()" in body
+    assert "EXPECTED_TOOL_COUNT = 77" in body
+
+
+def test_ci_and_release_use_a_clean_unlocked_wheel_install() -> None:
+    for workflow in (".github/workflows/ci.yml", ".github/workflows/release.yml"):
+        body = (ROOT / workflow).read_text(encoding="utf-8")
+        assert "python -m venv" in body
+        assert 'bin/pip" install --disable-pip-version-check dist/*.whl' in body
+        assert "scripts/smoke_mcp_wheel.py" in body

--- a/tests/test_policy_audit_migration_live.py
+++ b/tests/test_policy_audit_migration_live.py
@@ -1,0 +1,118 @@
+"""Live Postgres contract for the policy-audit rolling migration."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_ADMIN_URL"),
+    reason="AGENT_BOM_POSTGRES_ADMIN_URL is required for the live policy-audit migration contract",
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+ALEMBIC_DIR = REPO_ROOT / "deploy" / "supabase" / "postgres"
+
+
+def _with_database(url: str, database: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, f"/{database}", parts.query, parts.fragment))
+
+
+def _sqlalchemy_url(url: str) -> str:
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg://", 1)
+    return url
+
+
+def test_legacy_rows_backfill_and_old_writer_remains_compatible(monkeypatch) -> None:
+    """Upgrade an old global-key table, then write with the old SQL contract."""
+    import psycopg
+    from alembic import command
+    from alembic.config import Config
+    from psycopg import sql
+
+    admin_url = os.environ["AGENT_BOM_POSTGRES_ADMIN_URL"]
+    database = f"abom_policy_migration_{uuid4().hex[:12]}"
+    database_url = _with_database(admin_url, database)
+
+    with psycopg.connect(admin_url, autocommit=True) as conn:
+        conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database)))
+    try:
+        with psycopg.connect(database_url) as conn:
+            conn.execute(
+                """
+                CREATE TABLE policy_audit_log (
+                    id SERIAL PRIMARY KEY,
+                    entry_id TEXT,
+                    ts TEXT NOT NULL,
+                    team_id TEXT NOT NULL DEFAULT 'default',
+                    data JSONB NOT NULL
+                )
+                """
+            )
+            conn.execute("CREATE UNIQUE INDEX uq_policy_audit_log_entry ON policy_audit_log(entry_id)")
+            conn.execute("ALTER TABLE policy_audit_log ENABLE ROW LEVEL SECURITY")
+            conn.execute("ALTER TABLE policy_audit_log FORCE ROW LEVEL SECURITY")
+            conn.execute(
+                "INSERT INTO policy_audit_log (entry_id, ts, team_id, data) VALUES (%s, %s, %s, %s)",
+                ("shared", "2026-07-28T00:00:00Z", "tenant-a", json.dumps({"entry_id": "shared"})),
+            )
+
+        cfg = Config(str(ALEMBIC_DIR / "alembic.ini"))
+        cfg.set_main_option("script_location", str(ALEMBIC_DIR / "alembic"))
+        monkeypatch.setenv("ALEMBIC_DATABASE_URL", _sqlalchemy_url(database_url))
+        command.stamp(cfg, "20260728_03")
+        command.upgrade(cfg, "head")
+
+        with psycopg.connect(database_url) as conn:
+            # This is the exact SQL shape used by pre-migration replicas.
+            old_insert = """
+                INSERT INTO policy_audit_log (entry_id, ts, team_id, data)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (entry_id) DO NOTHING
+            """
+            conn.execute(
+                old_insert,
+                ("shared", "2026-07-29T00:00:00Z", "tenant-a", json.dumps({"entry_id": "shared"})),
+            )
+            conn.execute(
+                old_insert,
+                ("shared", "2026-07-29T00:00:01Z", "tenant-b", json.dumps({"entry_id": "shared"})),
+            )
+
+            rows = conn.execute(
+                """
+                SELECT entry_id, logical_entry_id, team_id, data ->> 'entry_id'
+                  FROM policy_audit_log
+                 WHERE logical_entry_id = 'shared'
+                 ORDER BY team_id
+                """
+            ).fetchall()
+            indexdef = conn.execute(
+                "SELECT indexdef FROM pg_indexes WHERE indexname = 'uq_policy_audit_log_entry'"
+            ).fetchone()
+            rls = conn.execute(
+                """
+                SELECT relrowsecurity, relforcerowsecurity
+                  FROM pg_class
+                 WHERE oid = 'public.policy_audit_log'::regclass
+                """
+            ).fetchone()
+
+        assert [(row[1], row[2], row[3]) for row in rows] == [
+            ("shared", "tenant-a", "shared"),
+            ("shared", "tenant-b", "shared"),
+        ]
+        assert rows[0][0] != rows[1][0]
+        assert indexdef is not None and "(entry_id)" in indexdef[0]
+        assert "team_id, entry_id" not in indexdef[0]
+        assert rls == (True, True)
+    finally:
+        with psycopg.connect(admin_url, autocommit=True) as conn:
+            conn.execute(sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(sql.Identifier(database)))

--- a/tests/test_policy_audit_tenant_isolation.py
+++ b/tests/test_policy_audit_tenant_isolation.py
@@ -1,0 +1,53 @@
+"""A tenant's policy audit record must never be discarded by another tenant's.
+
+``policy_audit_log`` carried ``UNIQUE (entry_id)`` with no tenant column, and the
+writer used ``ON CONFLICT (entry_id) DO NOTHING``. Two tenants writing the same
+logical ``entry_id`` therefore collapsed to one row: the second write returned
+success and vanished. Unique indexes are enforced *below* RLS, so FORCE ROW
+LEVEL SECURITY does not help here.
+
+An audit log that silently drops entries is worse than one that errors — the
+sibling governance chain already learned this and scopes its index by tenant
+(``uq_governance_audit_tenant_action``).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(rel: str) -> str:
+    return (ROOT / rel).read_text(encoding="utf-8")
+
+
+def test_bootstrap_index_is_tenant_scoped() -> None:
+    sql = _read("deploy/supabase/postgres/init.sql")
+    match = re.search(r"CREATE UNIQUE INDEX[^;]*uq_policy_audit_log_entry[^;]*;", sql)
+    assert match, "the policy audit uniqueness index is gone entirely"
+    index = match.group(0)
+    assert "team_id" in index, f"tenant-less uniqueness lets one tenant discard another's audit row: {index}"
+
+
+def test_runtime_index_matches_the_bootstrap() -> None:
+    store = _read("src/agent_bom/api/postgres_policy.py")
+    match = re.search(r"CREATE UNIQUE INDEX[^\"']*uq_policy_audit_log_entry[^\"']*", store)
+    assert match, "the store no longer creates the uniqueness index"
+    assert "team_id" in match.group(0), "the store's index drifted from init.sql"
+
+
+def test_conflict_target_includes_the_tenant() -> None:
+    store = _read("src/agent_bom/api/postgres_policy.py")
+    assert "ON CONFLICT (entry_id) DO NOTHING" not in store, "a tenant-less conflict target silently drops another tenant's audit entry"
+    assert re.search(r"ON CONFLICT \(\s*team_id\s*,\s*entry_id\s*\)", store), (
+        "the insert must dedupe within a tenant, not across the estate"
+    )
+
+
+def test_a_migration_rebuilds_the_index_for_existing_deployments() -> None:
+    """A deployed database keeps the old index until Alembic replaces it."""
+    versions = ROOT / "deploy" / "supabase" / "postgres" / "alembic" / "versions"
+    hits = [p for p in versions.glob("*.py") if "uq_policy_audit_log_entry" in p.read_text(encoding="utf-8")]
+    assert hits, "no migration rebuilds the tenant-scoped index for already-migrated databases"

--- a/tests/test_policy_audit_tenant_isolation.py
+++ b/tests/test_policy_audit_tenant_isolation.py
@@ -1,14 +1,12 @@
-"""A tenant's policy audit record must never be discarded by another tenant's.
+"""Policy audit deduplication must be tenant-safe and rollout-compatible.
 
-``policy_audit_log`` carried ``UNIQUE (entry_id)`` with no tenant column, and the
-writer used ``ON CONFLICT (entry_id) DO NOTHING``. Two tenants writing the same
-logical ``entry_id`` therefore collapsed to one row: the second write returned
-success and vanished. Unique indexes are enforced *below* RLS, so FORCE ROW
-LEVEL SECURITY does not help here.
-
-An audit log that silently drops entries is worse than one that errors — the
-sibling governance chain already learned this and scopes its index by tenant
-(``uq_governance_audit_tenant_action``).
+The pre-fix schema used ``UNIQUE (entry_id)`` and old application replicas use
+``ON CONFLICT (entry_id) DO NOTHING``.  Replacing that index with a composite
+one fixes new replicas but makes every old replica fail during a rolling
+deployment.  The compatible contract keeps the legacy conflict target while a
+database trigger maps the logical ID to an injective tenant-derived physical
+key.  The logical ID remains in the signed JSON payload and in a dedicated
+column for operators.
 """
 
 from __future__ import annotations
@@ -17,37 +15,62 @@ import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
+MIGRATION = ROOT / "deploy/supabase/postgres/alembic/versions/20260729_01_policy_audit_tenant_scoped_index.py"
 
 
 def _read(rel: str) -> str:
     return (ROOT / rel).read_text(encoding="utf-8")
 
 
-def test_bootstrap_index_is_tenant_scoped() -> None:
-    sql = _read("deploy/supabase/postgres/init.sql")
+def _policy_index(sql: str) -> str:
     match = re.search(r"CREATE UNIQUE INDEX[^;]*uq_policy_audit_log_entry[^;]*;", sql)
-    assert match, "the policy audit uniqueness index is gone entirely"
-    index = match.group(0)
-    assert "team_id" in index, f"tenant-less uniqueness lets one tenant discard another's audit row: {index}"
+    assert match, "the policy audit deduplication index is missing"
+    return match.group(0)
 
 
-def test_runtime_index_matches_the_bootstrap() -> None:
+def test_bootstrap_keeps_the_legacy_conflict_target_with_a_physical_key_trigger() -> None:
+    sql = _read("deploy/supabase/postgres/init.sql")
+    index = _policy_index(sql)
+
+    assert re.search(r"ON\s+policy_audit_log\s*\(\s*entry_id\s*\)", index)
+    assert "logical_entry_id TEXT" in sql
+    assert "abom_policy_audit_key" in sql
+    assert "abom_policy_audit_set_key" in sql
+    assert "BEFORE INSERT OR UPDATE" in sql
+
+
+def test_runtime_bootstrap_matches_the_rolling_deployment_contract() -> None:
     store = _read("src/agent_bom/api/postgres_policy.py")
-    match = re.search(r"CREATE UNIQUE INDEX[^\"']*uq_policy_audit_log_entry[^\"']*", store)
-    assert match, "the store no longer creates the uniqueness index"
-    assert "team_id" in match.group(0), "the store's index drifted from init.sql"
+    index = _policy_index(store)
+
+    assert re.search(r"ON\s+policy_audit_log\s*\(\s*entry_id\s*\)", index)
+    assert "logical_entry_id TEXT" in store
+    assert "abom_policy_audit_key" in store
+    assert "abom_policy_audit_set_key" in store
 
 
-def test_conflict_target_includes_the_tenant() -> None:
+def test_writer_remains_compatible_with_old_and_new_database_shapes() -> None:
     store = _read("src/agent_bom/api/postgres_policy.py")
-    assert "ON CONFLICT (entry_id) DO NOTHING" not in store, "a tenant-less conflict target silently drops another tenant's audit entry"
-    assert re.search(r"ON CONFLICT \(\s*team_id\s*,\s*entry_id\s*\)", store), (
-        "the insert must dedupe within a tenant, not across the estate"
-    )
+
+    assert "ON CONFLICT (entry_id) DO NOTHING" in store
+    assert "ON CONFLICT (team_id, entry_id)" not in store
 
 
-def test_a_migration_rebuilds_the_index_for_existing_deployments() -> None:
-    """A deployed database keeps the old index until Alembic replaces it."""
-    versions = ROOT / "deploy" / "supabase" / "postgres" / "alembic" / "versions"
-    hits = [p for p in versions.glob("*.py") if "uq_policy_audit_log_entry" in p.read_text(encoding="utf-8")]
-    assert hits, "no migration rebuilds the tenant-scoped index for already-migrated databases"
+def test_migration_backfills_physical_keys_before_restoring_uniqueness() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert re.search(r'revision\s*=\s*"20260729_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260728_03"', sql)
+    assert "ADD COLUMN IF NOT EXISTS logical_entry_id TEXT" in sql
+    assert "abom_policy_audit_key" in sql
+    assert "abom_policy_audit_set_key" in sql
+    assert "UPDATE policy_audit_log" in sql
+    assert sql.index("DROP INDEX IF EXISTS uq_policy_audit_log_entry") < sql.index("UPDATE policy_audit_log")
+    assert sql.index("UPDATE policy_audit_log") < sql.rindex("CREATE UNIQUE INDEX uq_policy_audit_log_entry")
+
+
+def test_migration_is_forward_only_after_cross_tenant_duplicates_are_accepted() -> None:
+    sql = MIGRATION.read_text(encoding="utf-8")
+
+    assert "raise NotImplementedError" in sql
+    assert "CREATE UNIQUE INDEX IF NOT EXISTS uq_policy_audit_log_entry" not in sql.split("def downgrade", 1)[1]

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -611,6 +611,180 @@ def test_postgres_audit_log_real_roundtrip_and_schema_marker():
     assert row[0] == CONTROL_PLANE_SCHEMA_VERSION
 
 
+def test_policy_audit_dedup_is_tenant_safe_and_old_replica_compatible():
+    """The database trigger preserves the legacy conflict target during rollout."""
+    from agent_bom.api.policy_store import PolicyAuditEntry
+    from agent_bom.api.postgres_common import _tenant_connection, reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_policy import PostgresPolicyStore
+
+    store = PostgresPolicyStore()
+    suffix = uuid4().hex
+    logical_id = f"shared-{suffix}"
+    tenant_a = f"policy-a-{suffix}"
+    tenant_b = f"policy-b-{suffix}"
+
+    def _entry(tenant_id: str) -> PolicyAuditEntry:
+        return PolicyAuditEntry(
+            entry_id=logical_id,
+            policy_id="rollout-policy",
+            policy_name="rollout compatibility",
+            rule_id="r1",
+            agent_name="agent-a",
+            tool_name="shell",
+            action_taken="blocked",
+            reason="test",
+            timestamp="2026-07-29T00:00:00+00:00",
+            tenant_id=tenant_id,
+        )
+
+    physical_keys: list[str] = []
+    for tenant_id in (tenant_a, tenant_b):
+        entry = _entry(tenant_id)
+        token = set_current_tenant(tenant_id)
+        try:
+            store.put_audit_entry(entry)
+            store.put_audit_entry(entry)  # same-tenant retry still dedupes
+            rows = store.list_audit_entries(tenant_id=tenant_id)
+            with _tenant_connection(store._pool) as conn:
+                stored = conn.execute(
+                    """
+                    SELECT entry_id, logical_entry_id, data ->> 'entry_id'
+                      FROM policy_audit_log
+                     WHERE logical_entry_id = %s
+                    """,
+                    (logical_id,),
+                ).fetchall()
+        finally:
+            reset_current_tenant(token)
+
+        assert [row.entry_id for row in rows if row.entry_id == logical_id] == [logical_id]
+        assert len(stored) == 1
+        assert stored[0][1:] == (logical_id, logical_id)
+        physical_keys.append(stored[0][0])
+
+    assert physical_keys[0] != physical_keys[1]
+
+
+# Bare unique indexes on tenant tables need an explicit identity contract. Most
+# are server-issued opaque/global IDs, database surrogates, security-token
+# digests, or the globally unique team slug. policy_audit_log is the one
+# compatibility exception: its trigger turns the bare entry_id column into a
+# tenant-derived physical key so old ON CONFLICT(entry_id) writers remain valid.
+_AUDITED_GLOBAL_TENANT_INDEXES = {
+    # Server-issued or globally canonical opaque identifiers.
+    ("agent_conditional_access_policies", "agent_conditional_access_policies_pkey"),
+    ("agent_identities", "agent_identities_pkey"),
+    ("agent_identity_jit_grants", "agent_identity_jit_grants_pkey"),
+    ("agents", "agents_pkey"),
+    ("api_keys", "api_keys_pkey"),
+    ("audit_log", "audit_log_pkey"),
+    ("cloud_connections", "cloud_connections_pkey"),
+    ("control_plane_sources", "control_plane_sources_pkey"),
+    ("credential_refs", "credential_refs_pkey"),
+    ("exceptions", "exceptions_pkey"),
+    ("findings", "findings_pkey"),
+    ("fleet_agents", "fleet_agents_pkey"),
+    ("gateway_policies", "gateway_policies_pkey"),
+    ("job_queue", "job_queue_pkey"),
+    ("managed_trial_invitations", "managed_trial_invitations_pkey"),
+    ("mcp_client_configs", "mcp_client_configs_pkey"),
+    ("model_provider_keys", "model_provider_keys_pkey"),
+    ("model_virtual_keys", "model_virtual_keys_pkey"),
+    ("policy_results", "policy_results_pkey"),
+    ("proxy_replay_log", "proxy_replay_log_pkey"),
+    ("scan_dispatch_queue", "scan_dispatch_queue_pkey"),
+    ("scan_jobs", "scan_jobs_pkey"),
+    ("scan_schedules", "scan_schedules_pkey"),
+    ("ticket_links", "ticket_links_pkey"),
+    ("ticketing_connections", "ticketing_connections_pkey"),
+    # Database-generated surrogate sequence keys; tenant uniqueness is carried
+    # by a separate logical index where the table has a logical dedupe key.
+    ("cis_benchmark_checks", "cis_benchmark_checks_pkey"),
+    ("governance_audit_log", "governance_audit_log_pkey"),
+    ("policy_audit_log", "policy_audit_log_pkey"),
+    ("trend_history", "trend_history_pkey"),
+    # Credential/token digests are intentionally globally unique so the same
+    # bearer secret can never authenticate as two principals or invitations.
+    ("agent_identities", "agent_identities_token_hash_key"),
+    ("managed_trial_invitations", "managed_trial_invitations_token_digest_key"),
+    ("model_virtual_keys", "model_virtual_keys_token_hash_key"),
+    # Team slugs are the global routing namespace.
+    ("teams", "teams_slug_key"),
+    # Rolling-deployment-compatible tenant-derived physical key, asserted below.
+    ("policy_audit_log", "uq_policy_audit_log_entry"),
+}
+
+
+def test_every_tenant_table_global_unique_index_has_an_audited_contract():
+    """Fail CI when a tenant table gains a bare unique key without review."""
+    from agent_bom.api.postgres_common import _get_pool
+
+    with _get_pool().connection() as conn:
+        rows = conn.execute(
+            """
+            WITH tenant_tables AS (
+                SELECT c.oid,
+                       c.relname,
+                       array_agg(a.attname ORDER BY a.attname)
+                           FILTER (WHERE a.attname IN ('tenant_id', 'team_id')) AS tenant_cols
+                  FROM pg_class c
+                  JOIN pg_namespace n ON n.oid = c.relnamespace
+                  JOIN pg_attribute a
+                    ON a.attrelid = c.oid
+                   AND a.attnum > 0
+                   AND NOT a.attisdropped
+                 WHERE n.nspname = 'public'
+                   AND c.relkind IN ('r', 'p')
+                 GROUP BY c.oid, c.relname
+                HAVING bool_or(a.attname IN ('tenant_id', 'team_id'))
+            ), unique_indexes AS (
+                SELECT tables.relname AS table_name,
+                       tables.tenant_cols,
+                       index_class.relname AS index_name,
+                       array_agg(attribute.attname ORDER BY key.ordinality)
+                           FILTER (WHERE attribute.attname IS NOT NULL) AS index_cols
+                  FROM tenant_tables tables
+                  JOIN pg_index index_meta
+                    ON index_meta.indrelid = tables.oid
+                   AND index_meta.indisunique
+                  JOIN pg_class index_class ON index_class.oid = index_meta.indexrelid
+                  LEFT JOIN LATERAL unnest(index_meta.indkey)
+                       WITH ORDINALITY AS key(attnum, ordinality) ON TRUE
+                  LEFT JOIN pg_attribute attribute
+                    ON attribute.attrelid = tables.oid
+                   AND attribute.attnum = key.attnum
+                 GROUP BY tables.relname, tables.tenant_cols, index_class.relname
+            )
+            SELECT table_name, index_name
+              FROM unique_indexes
+             WHERE NOT (index_cols && tenant_cols)
+             ORDER BY table_name, index_name
+            """
+        ).fetchall()
+        policy_key = conn.execute(
+            """
+            SELECT indexdef,
+                   obj_description(to_regclass('public.uq_policy_audit_log_entry'), 'pg_class'),
+                   EXISTS (
+                       SELECT 1 FROM pg_trigger
+                        WHERE tgrelid = 'public.policy_audit_log'::regclass
+                          AND tgname = 'policy_audit_set_key'
+                          AND NOT tgisinternal
+                   )
+              FROM pg_indexes
+             WHERE schemaname = 'public'
+               AND indexname = 'uq_policy_audit_log_entry'
+            """
+        ).fetchone()
+
+    actual = {(str(table), str(index)) for table, index in rows}
+    assert actual == _AUDITED_GLOBAL_TENANT_INDEXES
+    assert policy_key is not None
+    assert "(entry_id)" in policy_key[0] and "team_id, entry_id" not in policy_key[0]
+    assert policy_key[1] == "agent-bom policy audit tenant key v2"
+    assert policy_key[2] is True
+
+
 def test_postgres_scan_jobs_rls_schema_is_locked_down():
     # Schema-level guard for #1815: assert the structural RLS guarantees on
     # scan_jobs so a future migration cannot quietly relax them. This catches

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1198,11 +1198,12 @@ def test_get_pool_uses_tuned_pool_sizes_and_connect_timeout(monkeypatch):
     captured: dict[str, object] = {}
 
     class CapturePool:
-        def __init__(self, conninfo, min_size, max_size, kwargs=None):
+        def __init__(self, conninfo, min_size, max_size, kwargs=None, open=None):
             captured["url"] = conninfo
             captured["min_size"] = min_size
             captured["max_size"] = max_size
             captured["kwargs"] = kwargs or {}
+            captured["open"] = open
 
     reset = postgres_common.reset_pool
     reset()
@@ -1237,6 +1238,7 @@ def test_get_pool_uses_tuned_pool_sizes_and_connect_timeout(monkeypatch):
             "min_size": 7,
             "max_size": 21,
             "kwargs": {"connect_timeout": 9},
+            "open": True,
         }
     finally:
         reset()

--- a/tests/test_stub_sdk_module_isolation.py
+++ b/tests/test_stub_sdk_module_isolation.py
@@ -25,18 +25,16 @@ from tests.conftest import _restore_stub_sdk_modules, _snapshot_stub_sdk_modules
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
-def test_snapshot_restore_drops_stubs_a_test_added():
+def test_snapshot_restore_drops_stub_modules_a_test_added():
+    """The contract is independent of whether a real provider SDK is installed."""
     snapshot = _snapshot_stub_sdk_modules()
 
-    stub = types.ModuleType("snowflake")
-    stub.connector = types.ModuleType("snowflake.connector")
-    sys.modules["snowflake"] = stub
-    sys.modules["snowflake.connector"] = stub.connector
+    stub_name = "snowflake.__agent_bom_test_stub__"
+    sys.modules[stub_name] = types.ModuleType(stub_name)
 
     _restore_stub_sdk_modules(snapshot)
 
-    assert "snowflake" not in sys.modules
-    assert "snowflake.connector" not in sys.modules
+    assert stub_name not in sys.modules
 
 
 def test_snapshot_restore_reinstates_a_stub_a_test_replaced():

--- a/uv.lock
+++ b/uv.lock
@@ -262,6 +262,7 @@ databricks = [
 dev = [
     { name = "bandit" },
     { name = "fastapi" },
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -279,6 +280,7 @@ dev-all = [
     { name = "alembic" },
     { name = "bandit" },
     { name = "fastapi" },
+    { name = "httpx2" },
     { name = "mypy" },
     { name = "networkx" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -489,6 +491,7 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'gcp'", specifier = ">=2.10" },
     { name = "httpcore", specifier = ">=1.0.9,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
+    { name = "httpx2", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.20" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.0" },
@@ -2778,6 +2781,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "h11" },
+    { name = "truststore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
+]
+
+[[package]]
 name = "httplib2"
 version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2854,6 +2870,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
+]
+
+[[package]]
+name = "httpx2"
+version = "2.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "httpcore2" },
+    { name = "idna" },
+    { name = "truststore" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -6032,6 +6064,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/84/da0e5038228fa34dfd77c5026b173ed035d2a3ba31f1077590c013de2bff/tqdm-4.69.1.tar.gz", hash = "sha256:2be21080a0ce17e902c2f1baeb6a74bf551b67bbdfa4bc0109fad471d0b4cb0d", size = 793046, upload-time = "2026-07-24T14:22:02.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/50/5817619a0fca56aff06383dbfde7ae017b3ca383915b3f1e4713164273cf/tqdm-4.69.1-py3-none-any.whl", hash = "sha256:0a654b96f7a2660cceb615b56f307ec2bef96c515409014a429a561981ab52b4", size = 675452, upload-time = "2026-07-24T14:22:00.048Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,6 @@ databricks = [
 dev = [
     { name = "bandit" },
     { name = "fastapi" },
-    { name = "httpx2" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -280,7 +279,6 @@ dev-all = [
     { name = "alembic" },
     { name = "bandit" },
     { name = "fastapi" },
-    { name = "httpx2" },
     { name = "mypy" },
     { name = "networkx" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
@@ -491,7 +489,6 @@ requires-dist = [
     { name = "google-cloud-storage", marker = "extra == 'gcp'", specifier = ">=2.10" },
     { name = "httpcore", specifier = ">=1.0.9,<2" },
     { name = "httpx", specifier = ">=0.28.1" },
-    { name = "httpx2", marker = "extra == 'dev'", specifier = ">=2.0.0" },
     { name = "huggingface-hub", marker = "extra == 'huggingface'", specifier = ">=0.20" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.0" },
@@ -541,7 +538,7 @@ requires-dist = [
     { name = "snowflake-connector-python", marker = "extra == 'snowflake'", specifier = ">=3.6" },
     { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=2.0" },
     { name = "sse-starlette", marker = "extra == 'api'", specifier = ">=2.1" },
-    { name = "starlette", marker = "extra == 'dev'", specifier = ">=0.40" },
+    { name = "starlette", marker = "extra == 'dev'", specifier = ">=1.3.1,<2" },
     { name = "streamlit", marker = "extra == 'dashboard'", specifier = ">=1.55.0" },
     { name = "toml", specifier = ">=0.10" },
     { name = "tornado", specifier = ">=6.5.7" },
@@ -2781,19 +2778,6 @@ wheels = [
 ]
 
 [[package]]
-name = "httpcore2"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "h11" },
-    { name = "truststore" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/39/a8/20ed1ed79cbc2ecdf5301c0968ab7c85547212e2a7bd126ddd2d986e206e/httpcore2-2.9.1.tar.gz", hash = "sha256:4d8acbf8b306f48c9d6046591fd5ba4037d1b1b1000d140fc2c3eab1e9a0c0e2", size = 67089, upload-time = "2026-07-24T09:21:03.867Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/fb/46c52b781975c335a2bcf1072c7bbc007cbdc8d674217f5ee1daba2c848b/httpcore2-2.9.1-py3-none-any.whl", hash = "sha256:6182472379e855fe4221246a2bb7ecede403bc61c6798062ae1787d051ccde26", size = 82809, upload-time = "2026-07-24T09:21:01.178Z" },
-]
-
-[[package]]
 name = "httplib2"
 version = "0.32.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2870,22 +2854,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0f/4c/751061ffa58615a32c31b2d82e8482be8dd4a89154f003147acee90f2be9/httpx_sse-0.4.3.tar.gz", hash = "sha256:9b1ed0127459a66014aec3c56bebd93da3c1bc8bb6618c8082039a44889a755d", size = 15943, upload-time = "2025-10-10T21:48:22.271Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/fd/6668e5aec43ab844de6fc74927e155a3b37bf40d7c3790e49fc0406b6578/httpx_sse-0.4.3-py3-none-any.whl", hash = "sha256:0ac1c9fe3c0afad2e0ebb25a934a59f4c7823b60792691f779fad2c5568830fc", size = 8960, upload-time = "2025-10-10T21:48:21.158Z" },
-]
-
-[[package]]
-name = "httpx2"
-version = "2.9.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "httpcore2" },
-    { name = "idna" },
-    { name = "truststore" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/14/38128fbafd7e0ed41d874df6c9a653d47c2d111cfe59e2b4ac95161b4abd/httpx2-2.9.1.tar.gz", hash = "sha256:1932a768737e3666291582833da748cc4e563c337cf96706fccc04fa6e58764a", size = 95458, upload-time = "2026-07-24T09:21:04.972Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/b8/cfd91c4ab9134d386d48f0b6ac662ff3d4be6efdee59ee1c67ebc3c0487c/httpx2-2.9.1-py3-none-any.whl", hash = "sha256:1820fe14a9ab1107bfeff39259987429450b070ec0ff38cc87eb0d8c97fdc71a", size = 91191, upload-time = "2026-07-24T09:21:02.6Z" },
 ]
 
 [[package]]
@@ -6064,15 +6032,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/84/da0e5038228fa34dfd77c5026b173ed035d2a3ba31f1077590c013de2bff/tqdm-4.69.1.tar.gz", hash = "sha256:2be21080a0ce17e902c2f1baeb6a74bf551b67bbdfa4bc0109fad471d0b4cb0d", size = 793046, upload-time = "2026-07-24T14:22:02.08Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/50/5817619a0fca56aff06383dbfde7ae017b3ca383915b3f1e4713164273cf/tqdm-4.69.1-py3-none-any.whl", hash = "sha256:0a654b96f7a2660cceb615b56f307ec2bef96c515409014a429a561981ab52b4", size = 675452, upload-time = "2026-07-24T14:22:00.048Z" },
-]
-
-[[package]]
-name = "truststore"
-version = "0.10.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Makes policy-audit deduplication tenant-safe without changing the logical audit-event schema or breaking replicas that still execute `ON CONFLICT (entry_id)`.
- Stores a tenant-derived, length-prefixed physical key in `entry_id`, preserves the caller's value in `logical_entry_id`, and restores RLS / FORCE RLS state after the atomic migration.
- Adds a live catalog guard for every global unique key on tenant-scoped tables and a dedicated marker/trigger contract for policy-audit storage.
- Adds an unlocked clean-wheel MCP protocol smoke: import, JSON-RPC initialize, and `tools/list` with the expected 77 unique tools.
- Removes the current TestClient, fixture, connection-pool, and Alembic path-parsing deprecation warnings.

## Rollout and rollback

- Old and new application replicas remain compatible because `entry_id` stays uniquely indexed and the legacy conflict target remains valid.
- Application rollback is supported.
- Database downgrade is deliberately prohibited after this migration; accepting the same logical ID in multiple tenants makes a destructive downgrade unsafe.
- Rows discarded before this fix cannot be recovered because they were never stored.

## Verification

- `uv run pytest -q` — **16,881 passed, 187 skipped** on the isolated stabilization branch.
- Post-rebase graph/foundation overlap suite — **128 passed** on current main including #4555 and #4557.
- Live PostgreSQL 16 full migration chain and focused proof — **3 passed**, warning-free:
  - legacy writer SQL remains compatible;
  - same logical ID persists for two tenants;
  - same-tenant retry deduplicates;
  - RLS / FORCE RLS state is restored;
  - every tenant-table global unique index has an audited contract.
- Clean Python 3.13 wheel install with ordinary unlocked pip resolved MCP 1.29.0; JSON-RPC negotiated protocol 2025-11-25 and returned 77 tools.
- `uv run ruff check src tests scripts/smoke_mcp_wheel.py` — green.
- `uv run mypy src/agent_bom` — green across 813 source files.
- `make preflight` — OpenAPI, 57 schemas, product surface, release consistency, environment reference, SDK patterns, and SVG gates green.
- `git diff --check` — green.

## Notes

This branch is rebased on current `main` through the gateway-feed fix #4555 and graph-completeness fix #4557. No v0.98.4 tag or publication is performed by this PR.