### PR TITLE
fix(graph): a filtered view of a truncated snapshot is still truncated

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1049,
+      "value": 1050,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1049 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1050 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -989,7 +989,7 @@ class UnifiedGraph:
 
         sub = self._subgraph(node_filter=node_filter, edge_filter=edge_filter)
         if not edge_scoped:
-            return sub
+            return self._inherit_completeness(sub)
 
         keep_ids = set(filters.include_ids)
         for edge in sub.edges:
@@ -1009,7 +1009,24 @@ class UnifiedGraph:
         for edge in sub.edges:
             if edge.source in pruned.nodes and edge.target in pruned.nodes:
                 pruned.add_edge(edge)
-        return pruned
+        return self._inherit_completeness(pruned)
+
+    def _inherit_completeness(self, view: "UnifiedGraph") -> "UnifiedGraph":
+        """Carry the source's truncation onto a derived view.
+
+        Truncation is a property of the SOURCE snapshot. Filtering cannot make
+        it untrue: nodes that were never loaded might have matched the filter,
+        and nobody can know whether they did. So the flag and reason propagate
+        unchanged, ``returned_nodes`` is recomputed for what this view actually
+        holds, and ``total_nodes`` stays the upstream total so ``omitted_nodes``
+        keeps meaning "how much of the estate we never saw".
+        """
+        view.completeness.truncated = self.completeness.truncated
+        view.completeness.node_budget = self.completeness.node_budget
+        view.completeness.reason = self.completeness.reason
+        view.completeness.total_nodes = self.completeness.total_nodes
+        view.completeness.returned_nodes = len(view.nodes)
+        return view
 
     def _subgraph(
         self,

--- a/tests/test_graph_filtered_view_completeness.py
+++ b/tests/test_graph_filtered_view_completeness.py
@@ -1,0 +1,70 @@
+"""A filtered view of a truncated graph is still truncated.
+
+`load_graph` bounds a large snapshot and records that on `completeness`.
+`filtered_view` then built a fresh UnifiedGraph copying scan_id, tenant_id,
+created_at and analysis_status — but NOT completeness — so the derived view
+reported `truncated=False` and `/v1/graph` answered "complete" over data it had
+already dropped nodes from.
+
+Truncation is a property of the SOURCE. Filtering cannot make it untrue: the
+nodes that were never loaded might have matched the filter, and nobody can know
+whether they did. The honest answer is "still truncated, and here is what this
+view actually contains".
+"""
+
+from __future__ import annotations
+
+from agent_bom.graph.container import GraphFilterOptions, UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+
+def _truncated_graph() -> UnifiedGraph:
+    """Six nodes upstream, three actually loaded — the shape load_graph produces."""
+    graph = UnifiedGraph(scan_id="s", tenant_id="t")
+    graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="a"))
+    graph.add_node(UnifiedNode(id="pkg:p", entity_type=EntityType.PACKAGE, label="p"))
+    graph.add_node(UnifiedNode(id="cve:c", entity_type=EntityType.VULNERABILITY, label="c", severity="critical"))
+    graph.add_edge(UnifiedEdge(source="agent:a", target="pkg:p", relationship=RelationshipType.USES))
+    graph.completeness.truncated = True
+    graph.completeness.node_budget = 3
+    graph.completeness.total_nodes = 6
+    graph.completeness.returned_nodes = 3
+    graph.completeness.reason = "node_budget"
+    return graph
+
+
+def test_entity_filter_preserves_the_truncation_fact():
+    view = _truncated_graph().filtered_view(GraphFilterOptions(entity_types={EntityType.AGENT}))
+    assert view.completeness.truncated is True, "a filtered view of truncated data is still truncated"
+    assert view.completeness.reason
+
+
+def test_relationship_scoped_filter_preserves_it_too():
+    """The edge-scoped branch builds a SECOND graph — it must carry it as well."""
+    view = _truncated_graph().filtered_view(GraphFilterOptions(relationship_types={RelationshipType.USES}))
+    assert view.completeness.truncated is True
+    assert view.completeness.reason
+
+
+def test_returned_count_reflects_this_view_not_the_source():
+    view = _truncated_graph().filtered_view(GraphFilterOptions(entity_types={EntityType.AGENT}))
+    assert view.completeness.returned_nodes == len(view.nodes)
+
+
+def test_upstream_total_is_preserved_so_omitted_stays_honest():
+    """total_nodes is what the SOURCE had; it must not be rewritten to the view size."""
+    view = _truncated_graph().filtered_view(GraphFilterOptions(entity_types={EntityType.AGENT}))
+    assert view.completeness.total_nodes == 6
+    assert view.completeness.omitted_nodes > 0
+
+
+def test_a_complete_graph_stays_complete_after_filtering():
+    """No false positives — filtering a whole snapshot must not claim truncation."""
+    graph = UnifiedGraph(scan_id="s", tenant_id="t")
+    graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="a"))
+    graph.add_node(UnifiedNode(id="pkg:p", entity_type=EntityType.PACKAGE, label="p"))
+
+    view = graph.filtered_view(GraphFilterOptions(entity_types={EntityType.AGENT}))
+    assert view.completeness.truncated is False


### PR DESCRIPTION
The honest-counts defect that has now survived two attempted fixes. Root-caused rather
than patched at the display layer.

## The defect

`load_graph` bounds a large snapshot and records that on `completeness`. `filtered_view`
then built a **fresh** `UnifiedGraph` copying `scan_id`, `tenant_id`, `created_at` and
`analysis_status` — but **not `completeness`**. So the derived view reported
`truncated=False`, and `/v1/graph` answered *"complete"* over data it had already dropped
nodes from.

Reproduced against the endpoint helper — a 6-node snapshot bounded to 3:

```
before:  {"status": "complete",   "complete": true,  "returned": 3, "total": 3}
after:   {"status": "truncated",  "complete": false, "returned": 3, "total": 6,
          "reason": "node_budget"}
```

## Why earlier attempts missed it

`filtered_view` has **two** construction paths. The entity/severity filter returns
`_subgraph(...)` directly; a relationship-scoped filter then builds a **second** graph to
prune dangling nodes. Fixing only the first leaves every `relationships=` /
`static_only` / `dynamic_only` query still lying — and those are exactly the queries that
reach this branch. Both now propagate, with a test pinning each.

## The reasoning, not just the plumbing

Truncation is a property of the **source**. Filtering cannot make it untrue: nodes that
were never loaded might have matched the filter, and nobody can know whether they did.

So the flag and reason propagate unchanged; `returned_nodes` is recomputed for what the
view actually holds; and `total_nodes` stays the **upstream** total, so `omitted_nodes`
keeps meaning *"how much of the estate we never saw"* rather than being quietly rewritten
to the view size — which would have made the numbers self-consistent and still wrong.

## No false positives

A complete snapshot still filters to a complete view. That test was green before the fix
and stays green, which is the guard against over-correcting into "everything is
truncated".

## Verified

- 5 new tests: 4 fail on `main`, the no-false-positive case passes throughout
- `pytest tests/ -k graph` → **1009 passed**, 35 skipped
- `ruff`, `mypy` clean
- container-level change only; no route signatures or response shapes altered, so no
  OpenAPI/SVG/manifest regeneration (metrics snapshot refreshed for the new test file)