### PR TITLE
perf(gateway): make the activity feed durable and cursor-backed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1112,10 +1112,11 @@ jobs:
       )
     runs-on: ubuntu-latest
     # Version and dependency changes run the full suite under musl. The
-    # 0.98.0 release candidate reached the previous 25-minute ceiling while
-    # tests were still active, so keep a finite budget with enough Alpine
-    # headroom to finish and report an actual test result.
-    timeout-minutes: 35
+    # The 0.98.4 stabilization baseline completed the tests at 34m51s, then the
+    # previous 35-minute ceiling canceled action cleanup and falsely marked the
+    # passing job red. Keep a finite budget with cleanup and runner-variance
+    # headroom so CI reports the actual test result.
+    timeout-minutes: 45
     permissions:
       contents: read
     needs: [changes]

--- a/deploy/supabase/postgres/alembic/versions/20260729_02_gateway_activity_window_index.py
+++ b/deploy/supabase/postgres/alembic/versions/20260729_02_gateway_activity_window_index.py
@@ -15,6 +15,16 @@ depends_on = None
 
 
 def upgrade() -> None:
+    # A 0.98.2 deployment may have been stamped at the previous revision by
+    # the legacy bootstrap path without provisioning the optional runtime
+    # ledger.  Keep that supported forward-upgrade path non-destructive; the
+    # runtime bootstrap creates this same index when it creates the ledger.
+    relation = op.get_bind().exec_driver_sql(
+        "SELECT to_regclass('public.gateway_activity_events')"
+    ).scalar()
+    if relation is None:
+        return
+
     with op.get_context().autocommit_block():
         op.execute(
             "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gateway_activity_events_tenant_event_time "

--- a/deploy/supabase/postgres/alembic/versions/20260729_02_gateway_activity_window_index.py
+++ b/deploy/supabase/postgres/alembic/versions/20260729_02_gateway_activity_window_index.py
@@ -1,0 +1,30 @@
+"""Index exact gateway KPI windows by tenant and event time.
+
+Revision ID: 20260729_02
+Revises: 20260729_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260729_02"
+down_revision = "20260729_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gateway_activity_events_tenant_event_time "
+            "ON gateway_activity_events("
+            "tenant_id, event_timestamp, "
+            "((data::jsonb) ->> 'event_type'), ((data::jsonb) ->> 'reason_code')"
+            ")"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_gateway_activity_events_tenant_event_time")

--- a/deploy/supabase/postgres/runtime-schema.sql
+++ b/deploy/supabase/postgres/runtime-schema.sql
@@ -112,6 +112,7 @@ CREATE TABLE IF NOT EXISTS gateway_activity_events (tenant_id TEXT NOT NULL,even
 CREATE TABLE IF NOT EXISTS gateway_activity_sequences (tenant_id TEXT PRIMARY KEY,next_ordinal BIGINT NOT NULL CHECK(next_ordinal >= 1));
 CREATE TABLE IF NOT EXISTS gateway_activity_tombstones (tenant_id TEXT NOT NULL,event_id TEXT NOT NULL,event_digest TEXT NOT NULL,pruned_ordinal BIGINT NOT NULL,PRIMARY KEY(tenant_id,event_id));
 CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal ON gateway_activity_events(tenant_id,ingest_ordinal);
+CREATE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_event_time ON gateway_activity_events(tenant_id,event_timestamp,((data::jsonb)->>'event_type'),((data::jsonb)->>'reason_code'));
 CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal ON gateway_activity_tombstones(tenant_id,pruned_ordinal);
 CREATE TABLE IF NOT EXISTS runtime_workload_evidence (
   tenant_id TEXT NOT NULL,

--- a/docs/AGENT_CAPABILITY.md
+++ b/docs/AGENT_CAPABILITY.md
@@ -40,8 +40,8 @@ attack paths, compliance tags, and runtime audit chain.
 |---|---|---|
 | Local MCP proxy | `agent-bom proxy …` | stdio MCP on laptop or sidecar |
 | Shared gateway | `agent-bom gateway serve` / `/v1/gateway/*` | remote HTTP/SSE MCP traffic plane |
-| Gateway KPIs | `GET /v1/gateway/feed/kpis` | calls today, blocked, shadow AI, data filters |
-| Gateway feed | `GET /v1/gateway/feed` | per-agent tool-call authorization stream |
+| Gateway KPIs | `GET /v1/gateway/feed/kpis` | UTC-window calls, blocks, shadow AI, data filters, and exact/partial evidence state |
+| Gateway feed | `GET /v1/gateway/feed` | durable per-agent authorization stream with tenant-bound cursor resume |
 | Control plane UI | `/gateway?capture=1` | operator cockpit |
 
 ## Endpoints and resources

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -54,7 +54,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
 | `docs/openapi/v1.json` | paths | 321 |
-| `docs/openapi/v1.json` | component schemas | 121 |
+| `docs/openapi/v1.json` | component schemas | 124 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1053,
+      "value": 1054,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1053 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1054 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |

--- a/docs/design/MULTI_MCP_GATEWAY.md
+++ b/docs/design/MULTI_MCP_GATEWAY.md
@@ -89,10 +89,16 @@ bypass enforcement. Kubernetes intentionally exposes no equivalent bypass.
 Typed tool decisions carry a canonical client-profile ID and revision,
 separate role-blueprint ID and revision, managed identity/agent IDs, bound
 policy IDs, trace ID, and one stable event/decision ID. The control-plane audit
-ingest keeps these Tier-A fields in its bounded, tenant-scoped gateway feed;
+ingest stores these Tier-A fields in the bounded, tenant-scoped gateway
+activity ledger (shared Postgres for replicas, SQLite for a single node). Feed
+reads use server-owned ordinals and tenant-bound cursors; initial reads return
+the newest bounded backfill, while cursor reads resume forward without using
+caller timestamps for ordering. The response reports source, retention floor,
+and complete/partial state. The local ring/JSONL path is explicitly degraded;
+it cannot satisfy a durable cursor resume. KPI windows run from UTC midnight to
+the request time and report whether retained evidence makes the count exact;
 raw arguments, results, tokens, credential references, and unredacted previews
-are excluded. Durable cursor/backfill and multi-replica ordering remain a
-separate delivery stage and are not implied by this enforcement slice.
+are excluded.
 
 ### `upstreams.yaml`
 

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -3314,6 +3314,60 @@
         "title": "FleetAgentUpdate",
         "type": "object"
       },
+      "GatewayFeedCompletenessModel": {
+        "properties": {
+          "dedupe_window_events": {
+            "minimum": 0.0,
+            "title": "Dedupe Window Events",
+            "type": "integer"
+          },
+          "latest_ordinal": {
+            "minimum": 0.0,
+            "title": "Latest Ordinal",
+            "type": "integer"
+          },
+          "max_events_per_tenant": {
+            "minimum": 0.0,
+            "title": "Max Events Per Tenant",
+            "type": "integer"
+          },
+          "reasons": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Reasons",
+            "type": "array"
+          },
+          "retention_floor_ordinal": {
+            "minimum": 1.0,
+            "title": "Retention Floor Ordinal",
+            "type": "integer"
+          },
+          "server_ordered": {
+            "title": "Server Ordered",
+            "type": "boolean"
+          },
+          "status": {
+            "enum": [
+              "complete",
+              "partial"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "reasons",
+          "server_ordered",
+          "retention_floor_ordinal",
+          "latest_ordinal",
+          "max_events_per_tenant",
+          "dedupe_window_events"
+        ],
+        "title": "GatewayFeedCompletenessModel",
+        "type": "object"
+      },
       "GatewayFeedEventModel": {
         "properties": {
           "action_type": {
@@ -3385,6 +3439,18 @@
             "maxLength": 200,
             "title": "Identity Id",
             "type": "string"
+          },
+          "ingest_ordinal": {
+            "anyOf": [
+              {
+                "minimum": 1.0,
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ingest Ordinal"
           },
           "input_tokens": {
             "anyOf": [
@@ -3544,6 +3610,43 @@
         "title": "GatewayFeedHealthModel",
         "type": "object"
       },
+      "GatewayFeedKpiCompletenessModel": {
+        "properties": {
+          "latest_ordinal": {
+            "minimum": 0.0,
+            "title": "Latest Ordinal",
+            "type": "integer"
+          },
+          "reasons": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Reasons",
+            "type": "array"
+          },
+          "retention_floor_ordinal": {
+            "minimum": 1.0,
+            "title": "Retention Floor Ordinal",
+            "type": "integer"
+          },
+          "status": {
+            "enum": [
+              "complete",
+              "partial"
+            ],
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "reasons",
+          "retention_floor_ordinal",
+          "latest_ordinal"
+        ],
+        "title": "GatewayFeedKpiCompletenessModel",
+        "type": "object"
+      },
       "GatewayFeedKpisModel": {
         "properties": {
           "blocked_today": {
@@ -3553,6 +3656,9 @@
           "calls_today": {
             "title": "Calls Today",
             "type": "integer"
+          },
+          "completeness": {
+            "$ref": "#/components/schemas/GatewayFeedKpiCompletenessModel"
           },
           "data_filters_applied": {
             "title": "Data Filters Applied",
@@ -3577,6 +3683,14 @@
             "title": "Shadow Ai Blocked",
             "type": "integer"
           },
+          "source": {
+            "enum": [
+              "gateway_activity_ledger",
+              "degraded_single_process"
+            ],
+            "title": "Source",
+            "type": "string"
+          },
           "tenant_id": {
             "title": "Tenant Id",
             "type": "string"
@@ -3595,6 +3709,9 @@
               }
             ],
             "title": "Uptime Seconds"
+          },
+          "window": {
+            "$ref": "#/components/schemas/GatewayFeedWindowModel"
           }
         },
         "required": [
@@ -3607,6 +3724,9 @@
           "data_filters_applied",
           "tool_calls_authorized",
           "llm_calls",
+          "source",
+          "completeness",
+          "window",
           "health"
         ],
         "title": "GatewayFeedKpisModel",
@@ -3614,6 +3734,9 @@
       },
       "GatewayFeedResponseModel": {
         "properties": {
+          "completeness": {
+            "$ref": "#/components/schemas/GatewayFeedCompletenessModel"
+          },
           "count": {
             "title": "Count",
             "type": "integer"
@@ -3629,11 +3752,34 @@
             "title": "Generated At",
             "type": "string"
           },
+          "has_more": {
+            "title": "Has More",
+            "type": "boolean"
+          },
           "health": {
             "$ref": "#/components/schemas/GatewayFeedHealthModel"
           },
+          "next_cursor": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Cursor"
+          },
           "schema_version": {
             "title": "Schema Version",
+            "type": "string"
+          },
+          "source": {
+            "enum": [
+              "gateway_activity_ledger",
+              "degraded_single_process"
+            ],
+            "title": "Source",
             "type": "string"
           },
           "tenant_id": {
@@ -3647,9 +3793,42 @@
           "generated_at",
           "count",
           "events",
+          "next_cursor",
+          "has_more",
+          "source",
+          "completeness",
           "health"
         ],
         "title": "GatewayFeedResponseModel",
+        "type": "object"
+      },
+      "GatewayFeedWindowModel": {
+        "properties": {
+          "end": {
+            "title": "End",
+            "type": "string"
+          },
+          "exact": {
+            "title": "Exact",
+            "type": "boolean"
+          },
+          "start": {
+            "title": "Start",
+            "type": "string"
+          },
+          "timezone": {
+            "const": "UTC",
+            "title": "Timezone",
+            "type": "string"
+          }
+        },
+        "required": [
+          "start",
+          "end",
+          "timezone",
+          "exact"
+        ],
+        "title": "GatewayFeedWindowModel",
         "type": "object"
       },
       "GraphCompletenessResponse": {
@@ -17587,6 +17766,25 @@
               "minimum": 1,
               "title": "Limit",
               "type": "integer"
+            }
+          },
+          {
+            "description": "Opaque tenant-bound ledger cursor",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "maxLength": 1000,
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "description": "Opaque tenant-bound ledger cursor",
+              "title": "Cursor"
             }
           },
           {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -2266,6 +2266,48 @@ components:
           title: Tags
       title: FleetAgentUpdate
       type: object
+    GatewayFeedCompletenessModel:
+      properties:
+        dedupe_window_events:
+          minimum: 0.0
+          title: Dedupe Window Events
+          type: integer
+        latest_ordinal:
+          minimum: 0.0
+          title: Latest Ordinal
+          type: integer
+        max_events_per_tenant:
+          minimum: 0.0
+          title: Max Events Per Tenant
+          type: integer
+        reasons:
+          items:
+            type: string
+          title: Reasons
+          type: array
+        retention_floor_ordinal:
+          minimum: 1.0
+          title: Retention Floor Ordinal
+          type: integer
+        server_ordered:
+          title: Server Ordered
+          type: boolean
+        status:
+          enum:
+          - complete
+          - partial
+          title: Status
+          type: string
+      required:
+      - status
+      - reasons
+      - server_ordered
+      - retention_floor_ordinal
+      - latest_ordinal
+      - max_events_per_tenant
+      - dedupe_window_events
+      title: GatewayFeedCompletenessModel
+      type: object
     GatewayFeedEventModel:
       properties:
         action_type:
@@ -2320,6 +2362,12 @@ components:
           maxLength: 200
           title: Identity Id
           type: string
+        ingest_ordinal:
+          anyOf:
+          - minimum: 1.0
+            type: integer
+          - type: 'null'
+          title: Ingest Ordinal
         input_tokens:
           anyOf:
           - type: integer
@@ -2430,6 +2478,34 @@ components:
       - reason
       title: GatewayFeedHealthModel
       type: object
+    GatewayFeedKpiCompletenessModel:
+      properties:
+        latest_ordinal:
+          minimum: 0.0
+          title: Latest Ordinal
+          type: integer
+        reasons:
+          items:
+            type: string
+          title: Reasons
+          type: array
+        retention_floor_ordinal:
+          minimum: 1.0
+          title: Retention Floor Ordinal
+          type: integer
+        status:
+          enum:
+          - complete
+          - partial
+          title: Status
+          type: string
+      required:
+      - status
+      - reasons
+      - retention_floor_ordinal
+      - latest_ordinal
+      title: GatewayFeedKpiCompletenessModel
+      type: object
     GatewayFeedKpisModel:
       properties:
         blocked_today:
@@ -2438,6 +2514,8 @@ components:
         calls_today:
           title: Calls Today
           type: integer
+        completeness:
+          $ref: '#/components/schemas/GatewayFeedKpiCompletenessModel'
         data_filters_applied:
           title: Data Filters Applied
           type: integer
@@ -2455,6 +2533,12 @@ components:
         shadow_ai_blocked:
           title: Shadow Ai Blocked
           type: integer
+        source:
+          enum:
+          - gateway_activity_ledger
+          - degraded_single_process
+          title: Source
+          type: string
         tenant_id:
           title: Tenant Id
           type: string
@@ -2466,6 +2550,8 @@ components:
           - type: number
           - type: 'null'
           title: Uptime Seconds
+        window:
+          $ref: '#/components/schemas/GatewayFeedWindowModel'
       required:
       - schema_version
       - tenant_id
@@ -2476,11 +2562,16 @@ components:
       - data_filters_applied
       - tool_calls_authorized
       - llm_calls
+      - source
+      - completeness
+      - window
       - health
       title: GatewayFeedKpisModel
       type: object
     GatewayFeedResponseModel:
       properties:
+        completeness:
+          $ref: '#/components/schemas/GatewayFeedCompletenessModel'
         count:
           title: Count
           type: integer
@@ -2492,10 +2583,24 @@ components:
         generated_at:
           title: Generated At
           type: string
+        has_more:
+          title: Has More
+          type: boolean
         health:
           $ref: '#/components/schemas/GatewayFeedHealthModel'
+        next_cursor:
+          anyOf:
+          - type: string
+          - type: 'null'
+          title: Next Cursor
         schema_version:
           title: Schema Version
+          type: string
+        source:
+          enum:
+          - gateway_activity_ledger
+          - degraded_single_process
+          title: Source
           type: string
         tenant_id:
           title: Tenant Id
@@ -2506,8 +2611,34 @@ components:
       - generated_at
       - count
       - events
+      - next_cursor
+      - has_more
+      - source
+      - completeness
       - health
       title: GatewayFeedResponseModel
+      type: object
+    GatewayFeedWindowModel:
+      properties:
+        end:
+          title: End
+          type: string
+        exact:
+          title: Exact
+          type: boolean
+        start:
+          title: Start
+          type: string
+        timezone:
+          const: UTC
+          title: Timezone
+          type: string
+      required:
+      - start
+      - end
+      - timezone
+      - exact
+      title: GatewayFeedWindowModel
       type: object
     GraphCompletenessResponse:
       properties:
@@ -11708,6 +11839,17 @@ paths:
           minimum: 1
           title: Limit
           type: integer
+      - description: Opaque tenant-bound ledger cursor
+        in: query
+        name: cursor
+        required: false
+        schema:
+          anyOf:
+          - maxLength: 1000
+            type: string
+          - type: 'null'
+          description: Opaque tenant-bound ledger cursor
+          title: Cursor
       - in: header
         name: X-Agent-Bom-Role
         required: false

--- a/scripts/generate_agent_capability_manifest.py
+++ b/scripts/generate_agent_capability_manifest.py
@@ -115,8 +115,8 @@ attack paths, compliance tags, and runtime audit chain.
 |---|---|---|
 | Local MCP proxy | `agent-bom proxy …` | stdio MCP on laptop or sidecar |
 | Shared gateway | `agent-bom gateway serve` / `/v1/gateway/*` | remote HTTP/SSE MCP traffic plane |
-| Gateway KPIs | `GET /v1/gateway/feed/kpis` | calls today, blocked, shadow AI, data filters |
-| Gateway feed | `GET /v1/gateway/feed` | per-agent tool-call authorization stream |
+| Gateway KPIs | `GET /v1/gateway/feed/kpis` | UTC-window calls, blocks, shadow AI, data filters, and exact/partial evidence state |
+| Gateway feed | `GET /v1/gateway/feed` | durable per-agent authorization stream with tenant-bound cursor resume |
 | Control plane UI | `/gateway?capture=1` | operator cockpit |
 
 ## Endpoints and resources

--- a/src/agent_bom/api/gateway_activity_store.py
+++ b/src/agent_bom/api/gateway_activity_store.py
@@ -18,7 +18,7 @@ from collections import deque
 from dataclasses import asdict, dataclass, replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 from agent_bom.api.storage_schema import ensure_sqlite_schema_version
 from agent_bom.runtime.gateway_events import (
@@ -122,6 +122,13 @@ def ensure_sqlite_gateway_activity_schema(conn: sqlite3.Connection) -> None:
     conn.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal "
         "ON gateway_activity_events(tenant_id, ingest_ordinal)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_event_time "
+        "ON gateway_activity_events("
+        "tenant_id, event_timestamp, "
+        "json_extract(data, '$.event_type'), json_extract(data, '$.reason_code')"
+        ")"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal "
@@ -255,6 +262,42 @@ class GatewayActivityPage:
     dedupe_window_events: int
 
 
+@dataclass(frozen=True)
+class GatewayActivityWindowSummary:
+    tenant_id: str
+    start: str
+    end: str
+    tool_calls_authorized: int
+    blocked: int
+    shadow_blocked: int
+    data_filters: int
+    retention_floor_ordinal: int
+    latest_ordinal: int
+
+
+class GatewayActivityStore(Protocol):
+    """Shared contract for the tenant-scoped gateway activity ledger."""
+
+    max_events_per_tenant: int
+    max_tombstones_per_tenant: int
+
+    def init_schema(self) -> None: ...
+
+    def append_batch(self, records: list[GatewayActivityRecord]) -> GatewayActivityAppendResult: ...
+
+    def list_activity(
+        self,
+        tenant_id: str,
+        *,
+        cursor: str | None = None,
+        limit: int = 100,
+    ) -> GatewayActivityPage: ...
+
+    def encode_cursor(self, tenant_id: str, ordinal: int) -> str: ...
+
+    def summarize_window(self, tenant_id: str, *, start: str, end: str) -> GatewayActivityWindowSummary: ...
+
+
 def _required_text(value: object, field: str, *, max_len: int = 200) -> str:
     if not isinstance(value, str) or not value.strip():
         raise ValueError(f"gateway activity {field} is required")
@@ -324,6 +367,51 @@ def _validate_store_config(max_events_per_tenant: int, max_tombstones_per_tenant
         raise ValueError("gateway activity max_events_per_tenant must be at least 1")
     if isinstance(max_tombstones_per_tenant, bool) or max_tombstones_per_tenant < 1:
         raise ValueError("gateway activity max_tombstones_per_tenant must be at least 1")
+
+
+_SHADOW_REASON_MARKERS = (
+    "undeclared",
+    "shadow",
+    "unknown_agent",
+    "unknown agent",
+    "unregistered",
+    "unknown-agent",
+)
+
+
+def _is_shadow_reason(reason_code: str) -> bool:
+    normalized = reason_code.lower()
+    return any(marker in normalized for marker in _SHADOW_REASON_MARKERS)
+
+
+def _window_summary(
+    tenant_id: str,
+    *,
+    start: str,
+    end: str,
+    event_rows: list[tuple[str, str, int]],
+    floor: int,
+    latest: int,
+) -> GatewayActivityWindowSummary:
+    authorized = sum(count for event_type, _reason, count in event_rows if event_type in GATEWAY_ALLOWED_EVENT_TYPES)
+    blocked = sum(count for event_type, _reason, count in event_rows if event_type in GATEWAY_BLOCKED_EVENT_TYPES)
+    data_filters = sum(count for event_type, _reason, count in event_rows if event_type in GATEWAY_DATA_FILTER_EVENT_TYPES)
+    shadow_blocked = sum(
+        count
+        for event_type, reason, count in event_rows
+        if event_type in GATEWAY_BLOCKED_EVENT_TYPES and _is_shadow_reason(reason)
+    )
+    return GatewayActivityWindowSummary(
+        tenant_id=tenant_id,
+        start=start,
+        end=end,
+        tool_calls_authorized=authorized,
+        blocked=blocked,
+        shadow_blocked=shadow_blocked,
+        data_filters=data_filters,
+        retention_floor_ordinal=floor,
+        latest_ordinal=latest,
+    )
 
 
 def _digest_payload(record: GatewayActivityRecord) -> str:
@@ -561,6 +649,31 @@ class InMemoryGatewayActivityStore:
                 max_tombstones=self.max_tombstones_per_tenant,
             )
 
+    def summarize_window(self, tenant_id: str, *, start: str, end: str) -> GatewayActivityWindowSummary:
+        with self._lock:
+            rows = [
+                record
+                for (row_tenant, _), record in self._events.items()
+                if row_tenant == tenant_id and start <= record.event_timestamp <= end
+            ]
+            all_tenant_rows = [
+                record for (row_tenant, _), record in self._events.items() if row_tenant == tenant_id
+            ]
+            latest = self._next_ordinal.get(tenant_id, 1) - 1
+            floor = min((record.ingest_ordinal for record in all_tenant_rows), default=latest + 1)
+        grouped: dict[tuple[str, str], int] = {}
+        for record in rows:
+            key = (record.event_type, record.reason_code)
+            grouped[key] = grouped.get(key, 0) + 1
+        return _window_summary(
+            tenant_id,
+            start=start,
+            end=end,
+            event_rows=[(event_type, reason, count) for (event_type, reason), count in grouped.items()],
+            floor=floor,
+            latest=latest,
+        )
+
 
 class SQLiteGatewayActivityStore:
     def __init__(
@@ -763,6 +876,48 @@ class SQLiteGatewayActivityStore:
             max_tombstones=self.max_tombstones_per_tenant,
         )
 
+    def summarize_window(self, tenant_id: str, *, start: str, end: str) -> GatewayActivityWindowSummary:
+        rows = self._conn.execute(
+            """
+            WITH bounds AS (
+                SELECT
+                    COALESCE(
+                        (SELECT next_ordinal - 1 FROM gateway_activity_sequences WHERE tenant_id = ?),
+                        0
+                    ) AS latest,
+                    COALESCE(
+                        (SELECT MIN(ingest_ordinal) FROM gateway_activity_events WHERE tenant_id = ?),
+                        (SELECT next_ordinal FROM gateway_activity_sequences WHERE tenant_id = ?),
+                        1
+                    ) AS floor
+            ), grouped AS (
+                SELECT
+                    json_extract(data, '$.event_type') AS event_type,
+                    json_extract(data, '$.reason_code') AS reason_code,
+                    COUNT(*) AS event_count
+                FROM gateway_activity_events
+                WHERE tenant_id = ? AND event_timestamp >= ? AND event_timestamp <= ?
+                GROUP BY 1, 2
+            )
+            SELECT bounds.latest, bounds.floor, grouped.event_type, grouped.reason_code, grouped.event_count
+            FROM bounds LEFT JOIN grouped ON TRUE
+            """,
+            (tenant_id, tenant_id, tenant_id, tenant_id, start, end),
+        ).fetchall()
+        latest, floor = int(rows[0][0]), int(rows[0][1])
+        return _window_summary(
+            tenant_id,
+            start=start,
+            end=end,
+            event_rows=[
+                (str(event_type), str(reason), int(count))
+                for _, _, event_type, reason, count in rows
+                if event_type is not None and count is not None
+            ],
+            floor=floor,
+            latest=latest,
+        )
+
     def query_plan(self, tenant_id: str, *, after_ordinal: int, limit: int) -> str:
         rows = self._conn.execute(
             "EXPLAIN QUERY PLAN SELECT data FROM gateway_activity_events "
@@ -808,6 +963,47 @@ def _record_from_json(raw: str) -> GatewayActivityRecord:
     )
 
 
+_GATEWAY_ACTIVITY_STORE: GatewayActivityStore | None = None
+
+
+def get_gateway_activity_store() -> GatewayActivityStore:
+    """Return the process gateway ledger, durable by default.
+
+    The selection ladder matches the runtime observation store: shared
+    Postgres for replicas, SQLite for the default single-node deployment, and
+    memory only when the operator explicitly enables the ephemeral backend.
+    """
+
+    global _GATEWAY_ACTIVITY_STORE
+    if _GATEWAY_ACTIVITY_STORE is not None:
+        return _GATEWAY_ACTIVITY_STORE
+
+    from agent_bom.storage.factory import resolve_backend
+
+    selection = resolve_backend(mode="durable")
+    if selection.backend is BackendKind.POSTGRES:
+        from agent_bom.api.postgres_gateway_activity import PostgresGatewayActivityStore
+
+        store: GatewayActivityStore = PostgresGatewayActivityStore()
+    elif selection.backend is BackendKind.MEMORY:
+        store = InMemoryGatewayActivityStore()
+    else:
+        store = SQLiteGatewayActivityStore(selection.sqlite_path or "")
+    _GATEWAY_ACTIVITY_STORE = store
+    return store
+
+
+def set_gateway_activity_store(store: GatewayActivityStore | None) -> None:
+    """Override or reset the process gateway ledger (tests and embedding)."""
+
+    global _GATEWAY_ACTIVITY_STORE
+    _GATEWAY_ACTIVITY_STORE = store
+
+
+def reset_gateway_activity_store() -> None:
+    set_gateway_activity_store(None)
+
+
 __all__ = [
     "GatewayActivityAppendResult",
     "GatewayActivityConflictError",
@@ -815,11 +1011,16 @@ __all__ = [
     "GatewayActivityCursorExpiredError",
     "GatewayActivityPage",
     "GatewayActivityRecord",
+    "GatewayActivityStore",
+    "GatewayActivityWindowSummary",
     "GATEWAY_ACTIVITY_STORE_SCHEMA",
     "DEFAULT_MAX_TOMBSTONES_PER_TENANT",
     "MAX_ACTIVITY_BATCH_SIZE",
     "InMemoryGatewayActivityStore",
     "SQLiteGatewayActivityStore",
     "gateway_activity_record_from_event",
+    "get_gateway_activity_store",
+    "reset_gateway_activity_store",
+    "set_gateway_activity_store",
     "ensure_sqlite_gateway_activity_schema",
 ]

--- a/src/agent_bom/api/postgres_gateway_activity.py
+++ b/src/agent_bom/api/postgres_gateway_activity.py
@@ -16,11 +16,14 @@ from agent_bom.api.gateway_activity_store import (
     GatewayActivityCursorExpiredError,
     GatewayActivityPage,
     GatewayActivityRecord,
+    GatewayActivityWindowSummary,
     _decode_cursor,
+    _encode_cursor,
     _page,
     _prepare_batch,
     _record_from_json,
     _validate_store_config,
+    _window_summary,
 )
 from agent_bom.api.postgres_common import Connection, ConnectionPool, _ensure_tenant_rls, _get_pool, _tenant_connection
 from agent_bom.api.storage_schema import ensure_postgres_schema_version
@@ -37,6 +40,13 @@ def bootstrap_postgres_gateway_activity_schema(conn: Connection) -> None:
     conn.execute(
         "CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal "
         "ON gateway_activity_events(tenant_id, ingest_ordinal)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_event_time "
+        "ON gateway_activity_events("
+        "tenant_id, event_timestamp, "
+        "((data::jsonb) ->> 'event_type'), ((data::jsonb) ->> 'reason_code')"
+        ")"
     )
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal "
@@ -74,6 +84,10 @@ class PostgresGatewayActivityStore:
                 return
             bootstrap_postgres_gateway_activity_schema(conn)
             conn.commit()
+
+    @staticmethod
+    def encode_cursor(tenant_id: str, ordinal: int) -> str:
+        return _encode_cursor(tenant_id, ordinal)
 
     def append_batch(self, records: list[GatewayActivityRecord]) -> GatewayActivityAppendResult:
         tenant_id, prepared = _prepare_batch(records)
@@ -246,6 +260,49 @@ class PostgresGatewayActivityStore:
             latest=latest,
             max_events=self.max_events_per_tenant,
             max_tombstones=self.max_tombstones_per_tenant,
+        )
+
+    def summarize_window(self, tenant_id: str, *, start: str, end: str) -> GatewayActivityWindowSummary:
+        with _tenant_connection(self._pool) as conn:
+            rows = conn.execute(
+                """
+                WITH bounds AS (
+                    SELECT
+                        COALESCE(
+                            (SELECT next_ordinal - 1 FROM gateway_activity_sequences WHERE tenant_id = %s),
+                            0
+                        ) AS latest,
+                        COALESCE(
+                            (SELECT MIN(ingest_ordinal) FROM gateway_activity_events WHERE tenant_id = %s),
+                            (SELECT next_ordinal FROM gateway_activity_sequences WHERE tenant_id = %s),
+                            1
+                        ) AS floor
+                ), grouped AS (
+                    SELECT
+                        ((data::jsonb) ->> 'event_type') AS event_type,
+                        ((data::jsonb) ->> 'reason_code') AS reason_code,
+                        COUNT(*) AS event_count
+                    FROM gateway_activity_events
+                    WHERE tenant_id = %s AND event_timestamp >= %s AND event_timestamp <= %s
+                    GROUP BY 1, 2
+                )
+                SELECT bounds.latest, bounds.floor, grouped.event_type, grouped.reason_code, grouped.event_count
+                FROM bounds LEFT JOIN grouped ON TRUE
+                """,
+                (tenant_id, tenant_id, tenant_id, tenant_id, start, end),
+            ).fetchall()
+        latest, floor = int(rows[0][0]), int(rows[0][1])
+        return _window_summary(
+            tenant_id,
+            start=start,
+            end=end,
+            event_rows=[
+                (str(event_type), str(reason), int(count))
+                for _, _, event_type, reason, count in rows
+                if event_type is not None and count is not None
+            ],
+            floor=floor,
+            latest=latest,
         )
 
 

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -1,10 +1,12 @@
 """Gateway Live Feed — unified fleet event stream.
 
-A single normalized, time-ordered stream that fuses three runtime surfaces the
-platform already produces, with per-agent attribution:
+A single normalized, cursor-backed stream that projects the durable gateway
+activity ledger with per-agent attribution. Legacy proxy alerts and recent LLM
+cost observations remain an explicitly partial initial-page compatibility
+projection; cursor resume is ledger-only and server ordered.
 
-    * tool-call authorization decisions  (allowed / blocked)  — proxy alert ring
-      buffer + gateway audit events
+    * tool-call authorization decisions  (allowed / blocked)  — durable gateway
+      activity ledger
     * data-filter / DLP redaction events  (PII / credential masking applied to
       tool responses)                                         — proxy alert ring
       buffer (credential_leak / pii detectors)
@@ -12,9 +14,9 @@ platform already produces, with per-agent attribution:
       cost store (priced OTel GenAI spans)
 
 This module is read-only over those existing stores. It does NOT re-implement
-enforcement, DLP, audit, or streaming — it consumes the in-process proxy alert
-ring buffer (``agent_bom.api.routes.proxy``) and the cost store
-(``agent_bom.api.cost_store``) and projects a unified, redaction-safe feed.
+enforcement, DLP, audit, or streaming. Postgres/SQLite ledger data is primary;
+the in-process ring/JSONL path is labeled degraded and never satisfies a cursor
+resume when the ledger is unavailable.
 
 Endpoints:
     GET /v1/gateway/feed       normalized, time-ordered fused event list
@@ -25,8 +27,8 @@ All reads are RBAC-gated (``read`` permission), tenant-scoped, and
 redaction-safe: only metadata (timestamps, agent identifiers, tool/target
 names, action class, short non-secret detail strings) is returned. No raw
 arguments, raw responses, or credential values cross this surface — the source
-records are already sanitized by ``push_proxy_alert`` /
-``redact_for_persistence`` before they reach the ring buffer.
+records are projected through the ledger's strict metadata allowlist; degraded
+records are sanitized by ``push_proxy_alert`` / ``redact_for_persistence``.
 """
 
 from __future__ import annotations
@@ -35,9 +37,16 @@ from datetime import datetime, timezone
 from typing import Any, Literal, cast
 
 import anyio.to_thread
-from fastapi import APIRouter, Query, Request
+from fastapi import APIRouter, HTTPException, Query, Request
 from pydantic import BaseModel, Field
 
+from agent_bom.api.gateway_activity_store import (
+    GatewayActivityCursorError,
+    GatewayActivityCursorExpiredError,
+    GatewayActivityPage,
+    GatewayActivityWindowSummary,
+    get_gateway_activity_store,
+)
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.runtime.gateway_events import (
@@ -50,6 +59,10 @@ router = APIRouter()
 
 _FEED_SCHEMA_VERSION = "gateway.feed.v1"
 _FEED_STALE_AFTER_SECONDS = 120
+
+
+class GatewayFeedLedgerUnavailableError(RuntimeError):
+    """The shared ledger cannot satisfy a cursor-backed read."""
 
 
 class GatewayFeedHealthModel(BaseModel):
@@ -90,9 +103,34 @@ class GatewayFeedEventModel(BaseModel):
     tenant: str
     shadow: bool
     source: str
+    ingest_ordinal: int | None = Field(default=None, ge=1)
     input_tokens: int | None = None
     output_tokens: int | None = None
     cost_usd: float | None = None
+
+
+class GatewayFeedCompletenessModel(BaseModel):
+    status: Literal["complete", "partial"]
+    reasons: list[str]
+    server_ordered: bool
+    retention_floor_ordinal: int = Field(ge=1)
+    latest_ordinal: int = Field(ge=0)
+    max_events_per_tenant: int = Field(ge=0)
+    dedupe_window_events: int = Field(ge=0)
+
+
+class GatewayFeedKpiCompletenessModel(BaseModel):
+    status: Literal["complete", "partial"]
+    reasons: list[str]
+    retention_floor_ordinal: int = Field(ge=1)
+    latest_ordinal: int = Field(ge=0)
+
+
+class GatewayFeedWindowModel(BaseModel):
+    start: str
+    end: str
+    timezone: Literal["UTC"]
+    exact: bool
 
 
 class GatewayFeedResponseModel(BaseModel):
@@ -101,6 +139,10 @@ class GatewayFeedResponseModel(BaseModel):
     generated_at: str
     count: int
     events: list[GatewayFeedEventModel]
+    next_cursor: str | None
+    has_more: bool
+    source: Literal["gateway_activity_ledger", "degraded_single_process"]
+    completeness: GatewayFeedCompletenessModel
     health: GatewayFeedHealthModel
 
 
@@ -115,6 +157,9 @@ class GatewayFeedKpisModel(BaseModel):
     tool_calls_authorized: int
     llm_calls: int
     uptime_seconds: float | None = None
+    source: Literal["gateway_activity_ledger", "degraded_single_process"]
+    completeness: GatewayFeedKpiCompletenessModel
+    window: GatewayFeedWindowModel
     health: GatewayFeedHealthModel
 
 
@@ -124,6 +169,7 @@ ACTION_TOOL_CALL_AUTHORIZED = "tool_call_authorized"
 ACTION_TOOL_CALL_BLOCKED = "tool_call_blocked"
 ACTION_DATA_FILTER_APPLIED = "data_filter_applied"
 ACTION_LLM_CALL = "llm_call"
+_EVENT_TYPES = GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEWAY_DATA_FILTER_EVENT_TYPES
 
 # Block reasons that indicate a shadow / undeclared agent or shadow MCP server
 # rather than an ordinary policy block. ``undeclared`` is emitted by the proxy
@@ -224,6 +270,15 @@ def _sort_key(event: dict[str, Any]) -> str:
     timestamp sort last (oldest) by mapping to the empty string.
     """
     return str(event.get("ts") or "")
+
+
+def _feed_order_key(event: dict[str, Any]) -> tuple[int, int, str]:
+    """Prefer the server-owned ledger ordinal over caller timestamps."""
+
+    ordinal = event.get("ingest_ordinal")
+    if isinstance(ordinal, int) and not isinstance(ordinal, bool) and ordinal > 0:
+        return (1, ordinal, "")
+    return (0, 0, _sort_key(event))
 
 
 def _alert_agent(alert: dict[str, Any]) -> str:
@@ -439,7 +494,16 @@ def _normalize_alert_event(alert: dict[str, Any], tenant_id: str) -> dict[str, A
         "detail": detail,
         "tenant": tenant_id,
         "shadow": shadow,
-        "source": "proxy",
+        "source": (
+            "gateway_activity_ledger"
+            if str(alert.get("record_schema_version") or "").startswith("gateway.activity.record.")
+            else "proxy"
+        ),
+        "ingest_ordinal": (
+            int(alert["ingest_ordinal"])
+            if isinstance(alert.get("ingest_ordinal"), int) and int(alert["ingest_ordinal"]) > 0
+            else None
+        ),
     }
 
 
@@ -481,6 +545,7 @@ def _normalize_llm_event(record: Any, tenant_id: str) -> dict[str, Any]:
         "tenant": tenant_id,
         "shadow": False,
         "source": "observability",
+        "ingest_ordinal": None,
         "input_tokens": int(input_tokens),
         "output_tokens": int(output_tokens),
         "cost_usd": float(cost) if priced and isinstance(cost, int | float) else None,
@@ -510,7 +575,7 @@ def build_gateway_feed(
     for record in llm_records:
         events.append(_normalize_llm_event(record, tenant_id))
 
-    events.sort(key=_sort_key, reverse=True)
+    events.sort(key=_feed_order_key, reverse=True)
     bounded = events[:limit]
     return {
         "schema_version": _FEED_SCHEMA_VERSION,
@@ -542,10 +607,8 @@ def build_gateway_feed_kpis(
         * ``uptime_seconds``       — only emitted when the proxy reports it; never
                                      fabricated.
 
-    ``_today`` reflects the live in-process window the ring buffer retains (the
-    proxy alert deque + the day's cost records), not a wall-clock midnight cut —
-    the label matches the operator-facing "today" framing without overstating
-    retention.
+    The route applies a UTC-midnight-to-request-time window and reports whether
+    retention or supplemental source limits make the result partial.
     """
     authorized = 0
     blocked = 0
@@ -588,38 +651,134 @@ def _load_tenant_alerts(tenant_id: str) -> list[dict[str, Any]]:
     visibility and reads the configured audit log when the in-process buffer is
     empty. This module never mutates that buffer.
 
-    Synchronous by design — callers on the event loop must use
-    :func:`_load_tenant_alerts_async`.
+    Synchronous by design — route callers offload the complete evidence read.
     """
     from agent_bom.api.routes.proxy import _load_proxy_alerts
 
     return _load_proxy_alerts(tenant_id)
 
 
-async def _gather_feed_inputs_async(tenant_id: str, *, limit: int) -> tuple[list[dict[str, Any]], list[Any]]:
-    """Load every synchronous feed input off the event loop, in one hop.
+def _load_gateway_activity_page(
+    tenant_id: str,
+    *,
+    cursor: str | None,
+    limit: int,
+) -> tuple[GatewayActivityPage, bool]:
+    """Read a forward cursor page, using the newest bounded slice initially."""
 
-    Both the audit-log fallback and the cost-store read are blocking; offloading
-    only one still left the loop stalled for hundreds of milliseconds.
-    """
+    store = get_gateway_activity_store()
+    if cursor:
+        return store.list_activity(tenant_id, cursor=cursor, limit=limit), False
 
-    def _gather() -> tuple[list[dict[str, Any]], list[Any]]:
-        return _load_tenant_alerts(tenant_id), _load_tenant_llm_records(tenant_id, limit=limit)
+    bounds = store.list_activity(tenant_id, limit=1)
+    retained = max(0, bounds.latest_ordinal - bounds.retention_floor_ordinal + 1)
+    if retained <= limit:
+        return store.list_activity(tenant_id, limit=limit), False
+
+    after = bounds.latest_ordinal - limit
+    page = store.list_activity(
+        tenant_id,
+        cursor=store.encode_cursor(tenant_id, after),
+        limit=limit,
+    )
+    return page, True
+
+
+async def _gather_durable_feed_inputs_async(
+    tenant_id: str,
+    *,
+    cursor: str | None,
+    limit: int,
+) -> tuple[GatewayActivityPage, bool, list[dict[str, Any]], list[Any], bool, bool]:
+    """Read the ledger and compatibility sources without blocking the loop."""
+
+    def _load_llm() -> tuple[list[Any], bool]:
+        try:
+            return _load_tenant_llm_records(tenant_id, limit=limit), True
+        except Exception:  # noqa: BLE001 - optional evidence is reported partial
+            return [], False
+
+    def _gather() -> tuple[GatewayActivityPage, bool, list[dict[str, Any]], list[Any], bool, bool]:
+        try:
+            page, older_omitted = _load_gateway_activity_page(tenant_id, cursor=cursor, limit=limit)
+        except (GatewayActivityCursorError, GatewayActivityCursorExpiredError):
+            raise
+        except Exception as exc:  # noqa: BLE001 - caller receives sanitized state only
+            if cursor:
+                raise GatewayFeedLedgerUnavailableError from exc
+            page = GatewayActivityPage(
+                tenant_id=tenant_id,
+                events=[],
+                cursor=None,
+                next_cursor=None,
+                has_more=False,
+                retention_floor_ordinal=1,
+                latest_ordinal=0,
+                max_events_per_tenant=0,
+                dedupe_window_events=0,
+            )
+            older_omitted = False
+            llm_records, observability_available = _load_llm()
+            return (
+                page,
+                older_omitted,
+                _load_tenant_alerts(tenant_id),
+                llm_records,
+                False,
+                observability_available,
+            )
+        if cursor:
+            return page, older_omitted, [], [], True, True
+        # Legacy proxy-shaped events and cost spans have no ledger ordinal.
+        # Keep them only on the initial compatibility projection and never on
+        # cursor resumes, where replay-free server ordering is the contract.
+        alerts = _load_tenant_alerts(tenant_id)
+        ledger_ids = {str(event.get("event_id") or "") for event in page.events}
+        compatibility_alerts = [
+            alert
+            for alert in alerts
+            if str(alert.get("event_id") or "") not in ledger_ids
+            and (
+                str(alert.get("event_type") or "") not in _EVENT_TYPES
+                or not str(alert.get("event_id") or "")
+            )
+        ]
+        llm_records, observability_available = _load_llm()
+        return page, older_omitted, compatibility_alerts, llm_records, True, observability_available
 
     return await anyio.to_thread.run_sync(_gather)
 
 
-async def _load_tenant_alerts_async(tenant_id: str) -> list[dict[str, Any]]:
-    """Off-loop variant for async routes.
-
-    The audit-log fallback opens a JSONL file and parses up to _MAX_LOG_LINES
-    records, redacting each one. Called inline from an ``async def`` handler
-    that froze the entire process -- measured at several seconds on a large log,
-    stalling every other tenant's request and every background task, not just
-    this one. AGENT_BOM_LOG is a shipped deployment surface, so this is reachable
-    in a normal install.
-    """
-    return await anyio.to_thread.run_sync(_load_tenant_alerts, tenant_id)
+def _feed_completeness(
+    page: GatewayActivityPage,
+    *,
+    older_omitted: bool,
+    supplemental_event_count: int,
+    ledger_available: bool,
+    observability_available: bool,
+) -> dict[str, Any]:
+    partial_reasons: list[str] = []
+    if not ledger_available:
+        partial_reasons.append("ledger_unavailable")
+    if page.retention_floor_ordinal > 1:
+        partial_reasons.append("retention_floor_advanced")
+    if older_omitted:
+        partial_reasons.append("bounded_initial_backfill")
+    if page.has_more:
+        partial_reasons.append("page_limit")
+    if supplemental_event_count:
+        partial_reasons.append("supplemental_unordered_sources")
+    if not observability_available:
+        partial_reasons.append("observability_unavailable")
+    return {
+        "status": "partial" if partial_reasons else "complete",
+        "reasons": partial_reasons,
+        "server_ordered": ledger_available and supplemental_event_count == 0,
+        "retention_floor_ordinal": page.retention_floor_ordinal,
+        "latest_ordinal": page.latest_ordinal,
+        "max_events_per_tenant": page.max_events_per_tenant,
+        "dedupe_window_events": page.dedupe_window_events,
+    }
 
 
 def _load_tenant_uptime(tenant_id: str) -> float | None:
@@ -661,12 +820,77 @@ def _feed_health_from_metrics(metrics: dict[str, Any] | None) -> dict[str, Any]:
 
 def _load_tenant_llm_records(tenant_id: str, *, limit: int) -> list[Any]:
     """Read recent priced LLM cost records for the tenant (read-only)."""
-    try:
-        from agent_bom.api.cost_store import get_cost_store
+    from agent_bom.api.cost_store import get_cost_store
 
-        return list(get_cost_store().list_records(tenant_id, limit=limit))
-    except Exception:  # noqa: BLE001 — cost store is optional; feed degrades to proxy-only
-        return []
+    return list(get_cost_store().list_records(tenant_id, limit=limit))
+
+
+def _timestamp_in_window(value: object, *, start: datetime, end: datetime) -> bool:
+    parsed = _parse_iso_timestamp(str(value) if value else None)
+    return parsed is not None and start <= parsed <= end
+
+
+async def _gather_kpi_inputs_async(
+    tenant_id: str,
+    *,
+    start: datetime,
+    end: datetime,
+) -> tuple[list[dict[str, Any]], list[Any], GatewayActivityWindowSummary, int, bool, bool, bool]:
+    """Load UTC-window KPI evidence and completeness facts off-loop."""
+
+    def _gather() -> tuple[list[dict[str, Any]], list[Any], GatewayActivityWindowSummary, int, bool, bool, bool]:
+        try:
+            summary = get_gateway_activity_store().summarize_window(
+                tenant_id,
+                start=start.isoformat(),
+                end=end.isoformat(),
+            )
+            ledger_available = True
+        except Exception:  # noqa: BLE001 - degraded status is returned without exception text
+            ledger_available = False
+            summary = GatewayActivityWindowSummary(
+                tenant_id=tenant_id,
+                start=start.isoformat(),
+                end=end.isoformat(),
+                tool_calls_authorized=0,
+                blocked=0,
+                shadow_blocked=0,
+                data_filters=0,
+                retention_floor_ordinal=1,
+                latest_ordinal=0,
+            )
+        compatibility_alerts = [
+            alert
+            for alert in _load_tenant_alerts(tenant_id)
+            if (
+                str(alert.get("event_type") or "") not in _EVENT_TYPES
+                or not str(alert.get("event_id") or "")
+            )
+            and _timestamp_in_window(_alert_timestamp(alert), start=start, end=end)
+        ]
+        try:
+            raw_llm = _load_tenant_llm_records(tenant_id, limit=10_001)
+            observability_available = True
+        except Exception:  # noqa: BLE001 - optional evidence is reported partial
+            raw_llm = []
+            observability_available = False
+        llm_truncated = len(raw_llm) > 10_000
+        llm_records = [
+            record
+            for record in raw_llm[:10_000]
+            if _timestamp_in_window(getattr(record, "observed_at", None), start=start, end=end)
+        ]
+        return (
+            compatibility_alerts,
+            llm_records,
+            summary,
+            len(compatibility_alerts),
+            llm_truncated,
+            ledger_available,
+            observability_available,
+        )
+
+    return await anyio.to_thread.run_sync(_gather)
 
 
 @router.get(
@@ -678,6 +902,7 @@ def _load_tenant_llm_records(tenant_id: str, *, limit: int) -> list[Any]:
 async def gateway_feed(
     request: Request,
     limit: int = Query(default=100, ge=1, le=500, description="Max fused events to return (1-500)"),
+    cursor: str | None = Query(default=None, max_length=1000, description="Opaque tenant-bound ledger cursor"),
 ) -> dict[str, Any]:
     """Unified, time-ordered fleet event feed for the active tenant.
 
@@ -688,12 +913,53 @@ async def gateway_feed(
     no raw arguments, responses, or credential values are returned.
     """
     tenant_id = require_request_tenant_id(request)
-    alerts, llm_records = await _gather_feed_inputs_async(tenant_id, limit=limit)
+    # Direct unit calls invoke the handler without FastAPI resolving Query.
+    if not isinstance(cursor, str):
+        cursor = None
+    try:
+        (
+            page,
+            older_omitted,
+            compatibility_alerts,
+            llm_records,
+            ledger_available,
+            observability_available,
+        ) = await _gather_durable_feed_inputs_async(
+            tenant_id,
+            cursor=cursor,
+            limit=limit,
+        )
+    except GatewayActivityCursorExpiredError as exc:
+        raise HTTPException(
+            status_code=410,
+            detail={
+                "message": "Gateway activity cursor is older than retained history",
+                "retention_floor_ordinal": exc.retention_floor_ordinal,
+            },
+        ) from exc
+    except GatewayActivityCursorError as exc:
+        raise HTTPException(status_code=400, detail="Invalid gateway activity cursor") from exc
+    except GatewayFeedLedgerUnavailableError as exc:
+        raise HTTPException(status_code=503, detail="Gateway activity storage unavailable") from exc
     payload = build_gateway_feed(
         tenant_id=tenant_id,
-        alerts=alerts,
+        alerts=[*page.events, *compatibility_alerts],
         llm_records=llm_records,
         limit=limit,
+    )
+    payload["next_cursor"] = page.next_cursor
+    payload["has_more"] = page.has_more
+    payload["source"] = (
+        "gateway_activity_ledger"
+        if ledger_available and (page.latest_ordinal > 0 or not compatibility_alerts)
+        else "degraded_single_process"
+    )
+    payload["completeness"] = _feed_completeness(
+        page,
+        older_omitted=older_omitted,
+        supplemental_event_count=len(compatibility_alerts) + len(llm_records),
+        ledger_available=ledger_available,
+        observability_available=observability_available,
     )
     payload["health"] = _feed_health_from_metrics(await anyio.to_thread.run_sync(_load_tenant_transport_metrics, tenant_id))
     return payload
@@ -713,7 +979,21 @@ async def gateway_feed_kpis(request: Request) -> dict[str, Any]:
     ``uptime_seconds`` (only when the proxy reports it — never fabricated).
     """
     tenant_id = require_request_tenant_id(request)
-    alerts, llm_records = await _gather_feed_inputs_async(tenant_id, limit=10000)
+    window_end = datetime.now(timezone.utc)
+    window_start = window_end.replace(hour=0, minute=0, second=0, microsecond=0)
+    (
+        alerts,
+        llm_records,
+        summary,
+        compatibility_count,
+        llm_truncated,
+        ledger_available,
+        observability_available,
+    ) = await _gather_kpi_inputs_async(
+        tenant_id,
+        start=window_start,
+        end=window_end,
+    )
     uptime_seconds = await anyio.to_thread.run_sync(_load_tenant_uptime, tenant_id)
     payload = build_gateway_feed_kpis(
         tenant_id=tenant_id,
@@ -721,5 +1001,39 @@ async def gateway_feed_kpis(request: Request) -> dict[str, Any]:
         llm_records=llm_records,
         uptime_seconds=uptime_seconds,
     )
+    payload["tool_calls_authorized"] += summary.tool_calls_authorized
+    payload["blocked_today"] += summary.blocked
+    payload["shadow_ai_blocked"] += summary.shadow_blocked
+    payload["data_filters_applied"] += summary.data_filters
+    payload["calls_today"] += summary.tool_calls_authorized + summary.blocked
+    partial_reasons: list[str] = []
+    if not ledger_available:
+        partial_reasons.append("ledger_unavailable")
+    if summary.retention_floor_ordinal > 1:
+        partial_reasons.append("retention_floor_advanced")
+    if compatibility_count:
+        partial_reasons.append("legacy_unordered_sources")
+    if llm_truncated:
+        partial_reasons.append("observability_window_limit")
+    if not observability_available:
+        partial_reasons.append("observability_unavailable")
+    exact = not partial_reasons
+    payload["source"] = (
+        "gateway_activity_ledger"
+        if ledger_available and (summary.latest_ordinal > 0 or compatibility_count == 0)
+        else "degraded_single_process"
+    )
+    payload["completeness"] = {
+        "status": "complete" if exact else "partial",
+        "reasons": partial_reasons,
+        "retention_floor_ordinal": summary.retention_floor_ordinal,
+        "latest_ordinal": summary.latest_ordinal,
+    }
+    payload["window"] = {
+        "start": window_start.isoformat(),
+        "end": window_end.isoformat(),
+        "timezone": "UTC",
+        "exact": exact,
+    }
     payload["health"] = _feed_health_from_metrics(await anyio.to_thread.run_sync(_load_tenant_transport_metrics, tenant_id))
     return payload

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -24,6 +24,12 @@ from typing import TYPE_CHECKING, Any, cast
 import anyio.to_thread
 from fastapi import APIRouter, HTTPException, Query, Request, WebSocket
 
+from agent_bom.api.gateway_activity_store import (
+    GatewayActivityConflictError,
+    GatewayActivityRecord,
+    gateway_activity_record_from_event,
+    get_gateway_activity_store,
+)
 from agent_bom.api.idempotency_store import IdempotencyConflictError, idempotency_request_fingerprint
 from agent_bom.api.tenancy import require_request_tenant_id
 
@@ -33,6 +39,11 @@ if TYPE_CHECKING:
 from agent_bom.api.models import ProxyAuditIngestRequest
 from agent_bom.api.stores import _get_idempotency_store
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
+from agent_bom.runtime.gateway_events import (
+    GATEWAY_ALLOWED_EVENT_TYPES,
+    GATEWAY_BLOCKED_EVENT_TYPES,
+    GATEWAY_DATA_FILTER_EVENT_TYPES,
+)
 from agent_bom.security import sanitize_error, sanitize_sensitive_payload
 
 router = APIRouter()
@@ -40,9 +51,10 @@ ws_router = APIRouter()
 
 # ── In-process ring buffer for proxy alerts/metrics ──────────────────────────
 #
-# The proxy (when running in the same process, e.g. via the API) pushes
-# records here.  External proxy processes write to the JSONL audit log,
-# and these endpoints read it.
+# This ring remains a compatibility projection for legacy proxy alerts and
+# WebSocket hints. Canonical standalone-gateway decisions are acknowledged only
+# after the durable gateway activity ledger commits them; feed cursor reads do
+# not depend on this process-local deque.
 #
 # _proxy_alerts is a bounded deque (O(1) append/pop from both ends).
 # _proxy_alerts_total is a monotonic counter that never decrements —
@@ -149,6 +161,84 @@ def _alert_visible_to_tenant(alert: dict, tenant_id: str) -> bool:
     return alert_tenant == tenant_id
 
 
+_CANONICAL_GATEWAY_EVENT_TYPES = (
+    GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEWAY_DATA_FILTER_EVENT_TYPES
+)
+
+
+def _gateway_activity_record_from_alert(
+    alert: dict[str, Any],
+    *,
+    tenant_id: str,
+    source_id: str,
+    session_id: str,
+    received_at: datetime,
+    request_trace_id: str,
+) -> GatewayActivityRecord | None:
+    """Project one gateway-shaped alert onto the strict metadata-only ledger.
+
+    Historical audit envelopes contain extra proxy fields and some omit fields
+    that the standalone gateway now emits. Only canonical gateway event types
+    enter the durable ledger; the projection allowlists metadata and fills old
+    transport omissions from server-owned context. Raw arguments, prompts,
+    responses, previews, and free-text messages are never copied.
+    """
+
+    event_type = str(alert.get("event_type") or "")
+    event_id = str(alert.get("event_id") or "").strip()
+    if event_type not in _CANONICAL_GATEWAY_EVENT_TYPES or not event_id:
+        return None
+    expected_decision = "deny" if event_type in GATEWAY_BLOCKED_EVENT_TYPES else "allow"
+    agent_id = str(
+        alert.get("agent_id")
+        or alert.get("agent_name")
+        or alert.get("source_agent")
+        or source_id
+        or "unknown"
+    )
+    canonical: dict[str, Any] = {
+        "schema_version": "gateway.runtime.event.v1",
+        "event_id": event_id,
+        "decision_id": str(alert.get("decision_id") or event_id),
+        "event_type": event_type,
+        "event_timestamp": str(alert.get("event_timestamp") or received_at.isoformat()),
+        "agent_id": agent_id,
+        "upstream": str(alert.get("upstream") or alert.get("target") or "unknown"),
+        "tool": str(alert.get("tool") or alert.get("tool_name") or "unknown"),
+        "decision": str(alert.get("decision") or expected_decision),
+        "policy_source": str(alert.get("policy_source") or "legacy_proxy"),
+        "trace_id": str(alert.get("trace_id") or request_trace_id or event_id),
+    }
+    for field in (
+        "identity_id",
+        "profile_id",
+        "blueprint_id",
+        "reason_code",
+        "data_action",
+        "policy_id",
+        "evidence_id",
+    ):
+        value = alert.get(field)
+        if isinstance(value, str):
+            canonical[field] = value
+    for field in ("profile_revision", "blueprint_revision"):
+        value = alert.get(field)
+        if isinstance(value, int) and not isinstance(value, bool):
+            canonical[field] = value
+    policy_ids = alert.get("policy_ids")
+    if isinstance(policy_ids, list | tuple):
+        canonical["policy_ids"] = list(policy_ids)
+    if isinstance(alert.get("development_mode"), bool):
+        canonical["development_mode"] = alert["development_mode"]
+    return gateway_activity_record_from_event(
+        canonical,
+        tenant_id=tenant_id,
+        source_id=source_id,
+        session_id=session_id,
+        received_at=received_at,
+    )
+
+
 @router.post("/proxy/audit", tags=["proxy"])
 async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) -> dict:
     """Ingest alerts and summary from an external proxy process."""
@@ -181,8 +271,9 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
     from agent_bom.api.stores import _get_firewall_decision_store
 
     firewall_store = _get_firewall_decision_store()
-    duplicate_event_ids: list[str] = []
-    accepted_alerts: list[dict] = []
+    received_at = datetime.now(timezone.utc)
+    prepared_alerts: list[dict[str, Any]] = []
+    activity_records: list[GatewayActivityRecord] = []
     for alert in body.alerts:
         enriched = dict(alert)
         enriched.setdefault("source_id", source_id)
@@ -190,17 +281,59 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         enriched.setdefault("request_id", request_id)
         enriched.setdefault("trace_id", trace_id)
         enriched.setdefault("event_type", enriched.get("action") or enriched.get("type", "runtime_alert"))
-        # Force the server-authoritative tenant_id on the in-memory record so
-        # per-tenant posture queries (e.g. compliance has_proxy) scope correctly.
-        # The ring buffer is process-wide; never honor a client-supplied
-        # tenant_id here — setdefault would let a caller pre-tag another tenant
-        # and write a cross-tenant alert that surfaces in that tenant's reads.
         enriched["tenant_id"] = tenant_id
+        prepared_alerts.append(enriched)
+        try:
+            record = _gateway_activity_record_from_alert(
+                enriched,
+                tenant_id=tenant_id,
+                source_id=source_id,
+                session_id=session_id,
+                received_at=received_at,
+                request_trace_id=trace_id,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail="Invalid canonical gateway activity event") from exc
+        if record is not None:
+            activity_records.append(record)
+
+    durable_inserted_ids: set[str] = set()
+    durable_duplicate_ids: set[str] = set()
+    if activity_records:
+        try:
+            activity_result = await anyio.to_thread.run_sync(
+                partial(get_gateway_activity_store().append_batch, activity_records)
+            )
+        except GatewayActivityConflictError as exc:
+            raise HTTPException(
+                status_code=409,
+                detail="Gateway activity event conflicts with durable history",
+            ) from exc
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail="Invalid canonical gateway activity batch") from exc
+        except Exception as exc:  # noqa: BLE001 - storage failure is a safe 503
+            raise HTTPException(status_code=503, detail="Gateway activity storage unavailable") from exc
+        durable_inserted_ids.update(activity_result.inserted_event_ids)
+        durable_duplicate_ids.update(activity_result.duplicate_event_ids)
+
+    duplicate_event_ids: list[str] = []
+    accepted_alerts: list[dict] = []
+    consumed_durable_ids: set[str] = set()
+    for enriched in prepared_alerts:
         # dedupe by event_id so a buggy or hostile proxy
         # cannot replay credential_leak alerts and inflate per-detector
         # tallies. Empty event_id falls through to keep legacy callers working.
         event_id = str(enriched.get("event_id") or "")
-        if event_id and not _claim_audit_event(tenant_id, event_id):
+        canonical_gateway = str(enriched.get("event_type") or "") in _CANONICAL_GATEWAY_EVENT_TYPES and bool(event_id)
+        if canonical_gateway:
+            if event_id in durable_duplicate_ids or event_id in consumed_durable_ids:
+                duplicate_event_ids.append(event_id)
+                continue
+            if event_id not in durable_inserted_ids:
+                duplicate_event_ids.append(event_id)
+                continue
+            consumed_durable_ids.add(event_id)
+        elif event_id and not _claim_audit_event(tenant_id, event_id):
             duplicate_event_ids.append(event_id)
             continue
         accepted_alerts.append(enriched)
@@ -283,6 +416,8 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         "accepted_alert_count": accepted_count,
         "duplicate_alert_count": len(duplicate_event_ids),
         "duplicate_event_ids": duplicate_event_ids,
+        "durable_accepted_count": len(durable_inserted_ids),
+        "durable_duplicate_count": len(durable_duplicate_ids),
         "has_summary": body.summary is not None,
     }
     if body.idempotency_key:
@@ -315,32 +450,51 @@ def _get_configured_log_path() -> _Path | None:
     return path
 
 
-_MAX_LOG_LINES = 50_000  # Cap log parsing to prevent memory issues
+_MAX_LOG_LINES = 1_000
+_LOG_TAIL_BLOCK_BYTES = 64 * 1024
+
+
+def _read_newest_log_lines(path: _Path, *, limit: int) -> list[bytes]:
+    """Read at most the newest ``limit`` JSONL lines without scanning the file."""
+
+    if limit < 1:
+        return []
+    with open(path, "rb") as handle:
+        handle.seek(0, 2)
+        position = handle.tell()
+        chunks: list[bytes] = []
+        newline_count = 0
+        while position > 0 and newline_count <= limit:
+            block_size = min(_LOG_TAIL_BLOCK_BYTES, position)
+            position -= block_size
+            handle.seek(position)
+            chunk = handle.read(block_size)
+            chunks.append(chunk)
+            newline_count += chunk.count(b"\n")
+    data = b"".join(reversed(chunks))
+    return data.splitlines()[-limit:]
 
 
 def _read_alerts_from_log(path: _Path) -> list[dict]:
-    """Read runtime_alert records from a JSONL audit log."""
+    """Read the newest bounded runtime alerts from a JSONL audit log."""
     import json as _json
 
     alerts: list[dict] = []
     try:
-        with open(path) as f:
-            for i, raw_line in enumerate(f):
-                if i >= _MAX_LOG_LINES:
-                    break
-                line = raw_line.strip()
-                if not line:
-                    continue
-                try:
-                    record = _json.loads(line)
-                    if record.get("type") == "runtime_alert":
-                        sanitized = sanitize_sensitive_payload(record)
-                        if isinstance(sanitized, dict):
-                            safe = redact_for_persistence(sanitized, EvidenceTier.SAFE_TO_STORE)
-                            if isinstance(safe, dict):
-                                alerts.append(safe)
-                except (ValueError, KeyError):
-                    continue
+        for raw_line in _read_newest_log_lines(path, limit=_MAX_LOG_LINES):
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record = _json.loads(line)
+                if record.get("type") == "runtime_alert":
+                    sanitized = sanitize_sensitive_payload(record)
+                    if isinstance(sanitized, dict):
+                        safe = redact_for_persistence(sanitized, EvidenceTier.SAFE_TO_STORE)
+                        if isinstance(safe, dict):
+                            alerts.append(safe)
+            except (UnicodeDecodeError, ValueError, KeyError):
+                continue
     except OSError:
         pass
     return alerts

--- a/src/agent_bom/demo_estate/showcase_gateway.py
+++ b/src/agent_bom/demo_estate/showcase_gateway.py
@@ -21,9 +21,10 @@ Stores seeded (all the ones the gateway/proxy/runtime dashboards read):
       ``/v1/gateway/stats``.
 
 Events reuse the demo estate's real agent / server / tool names so the feed is
-consistent with the showcase graph. Everything is deterministic (a fixed time
-anchor, no wall-clock or randomness) and idempotent (re-running detects the
-demo marker and skips) so repeated bootstraps do not inflate the counters.
+consistent with the showcase graph. Event content and relative ordering are
+deterministic, while timestamps are anchored to the current UTC day so exact
+daily KPI windows remain truthful. Seeding is idempotent within that day, so
+repeated bootstraps do not inflate the counters.
 
 The event records are shaped exactly like alerts ingested through
 ``/v1/proxy/audit`` (they are pushed through ``push_proxy_alert``, which applies
@@ -47,19 +48,18 @@ _logger = logging.getLogger(__name__)
 # events are unmistakably demo data (never mixed with real ingested traffic).
 _DEMO_SOURCE_ID = "demo-estate-gateway"
 
-# Fixed time anchor — deterministic across runs (no Date.now / randomness). The
-# gateway KPI counters and feed are windowed by ring-buffer contents, not a
-# wall-clock midnight cut, so a fixed anchor still reads as recent activity.
-_ANCHOR = datetime(2026, 7, 6, 15, 30, 0, tzinfo=timezone.utc)
+def _event_time(anchor: datetime, minutes_ago: int) -> datetime:
+    """Return an event time inside the anchor's exact UTC-day KPI window."""
+    start_of_day = anchor.replace(hour=0, minute=0, second=0, microsecond=0)
+    return max(start_of_day, anchor - timedelta(minutes=minutes_ago))
 
 
-def _ts(minutes_ago: int) -> str:
-    """ISO-8601 timestamp ``minutes_ago`` before the fixed anchor."""
-    return (_ANCHOR - timedelta(minutes=minutes_ago)).isoformat()
+def _ts(anchor: datetime, minutes_ago: int) -> str:
+    return _event_time(anchor, minutes_ago).isoformat()
 
 
-def _epoch(minutes_ago: int) -> float:
-    return (_ANCHOR - timedelta(minutes=minutes_ago)).timestamp()
+def _epoch(anchor: datetime, minutes_ago: int) -> float:
+    return _event_time(anchor, minutes_ago).timestamp()
 
 
 # ── Curated feed ────────────────────────────────────────────────────────────
@@ -130,7 +130,7 @@ _FIREWALL_DECISIONS: tuple[tuple[int, str, str, str, dict[str, Any] | None], ...
 )
 
 
-def _proxy_metrics_summary(tenant_id: str) -> dict[str, Any]:
+def _proxy_metrics_summary(tenant_id: str, *, anchor: datetime) -> dict[str, Any]:
     """Believable traffic / uptime rollup for the proxy + runtime dashboards.
 
     Numbers are a curated day of activity — larger than the visible feed sample
@@ -166,8 +166,8 @@ def _proxy_metrics_summary(tenant_id: str) -> dict[str, Any]:
         "tenant_id": tenant_id,
         "source_id": _DEMO_SOURCE_ID,
         "session_id": "demo-estate",
-        "received_at": _ts(0),
-        "ts": _ts(0),
+        "received_at": _ts(anchor, 0),
+        "ts": _ts(anchor, 0),
         "uptime_seconds": 356_400.0,  # ~4.1 days
         "total_tool_calls": total_tool_calls,
         "total_blocked": total_blocked,
@@ -177,12 +177,14 @@ def _proxy_metrics_summary(tenant_id: str) -> dict[str, Any]:
     }
 
 
-def _tenant_has_demo_gateway_events(tenant_id: str) -> bool:
-    """True when this tenant's proxy alert buffer already holds the demo feed."""
+def _tenant_has_demo_gateway_events(tenant_id: str, *, anchor: datetime) -> bool:
+    """True when this tenant already holds the current UTC day's demo feed."""
     from agent_bom.api.routes.proxy import _load_proxy_alerts
 
+    day_prefix = anchor.date().isoformat()
     for alert in _load_proxy_alerts(tenant_id):
-        if str(alert.get("source_id") or "") == _DEMO_SOURCE_ID:
+        event_time = str(alert.get("timestamp") or alert.get("ts") or "")
+        if str(alert.get("source_id") or "") == _DEMO_SOURCE_ID and event_time.startswith(day_prefix):
             return True
     return False
 
@@ -192,15 +194,16 @@ def seed_showcase_gateway_events(*, tenant_id: str = SHOWCASE_TENANT) -> dict[st
     from agent_bom.api.routes.proxy import push_proxy_alert, push_proxy_metrics
     from agent_bom.api.stores import _get_firewall_decision_store
 
-    if _tenant_has_demo_gateway_events(tenant_id):
+    anchor = datetime.now(timezone.utc).replace(microsecond=0)
+    if _tenant_has_demo_gateway_events(tenant_id, anchor=anchor):
         return {"seeded": False, "reason": "already_present", "tenant_id": tenant_id}
 
     authorized = blocked = data_filters = shadow_blocked = 0
     for (minutes_ago, agent_name, tool_name, event_type, detector, decision, reason_code, severity) in _FEED_EVENTS:
         alert = {
-            "event_id": f"{_DEMO_SOURCE_ID}:{minutes_ago}:{tool_name}",
-            "ts": _ts(minutes_ago),
-            "timestamp": _ts(minutes_ago),
+            "event_id": f"{_DEMO_SOURCE_ID}:{anchor.date().isoformat()}:{minutes_ago}:{tool_name}",
+            "ts": _ts(anchor, minutes_ago),
+            "timestamp": _ts(anchor, minutes_ago),
             "tenant_id": tenant_id,
             "source_id": _DEMO_SOURCE_ID,
             "session_id": "demo-estate",
@@ -224,7 +227,7 @@ def seed_showcase_gateway_events(*, tenant_id: str = SHOWCASE_TENANT) -> dict[st
             if detector in {"undeclared_agent", "shadow_mcp"}:
                 shadow_blocked += 1
 
-    push_proxy_metrics(_proxy_metrics_summary(tenant_id))
+    push_proxy_metrics(_proxy_metrics_summary(tenant_id, anchor=anchor))
 
     firewall_store = _get_firewall_decision_store()
     for (minutes_ago, source_agent, target_agent, decision, matched_rule) in _FIREWALL_DECISIONS:
@@ -238,7 +241,7 @@ def seed_showcase_gateway_events(*, tenant_id: str = SHOWCASE_TENANT) -> dict[st
                 "effective_decision": decision,
                 "matched_rule": matched_rule,
                 "enforcement_mode": "enforce",
-                "timestamp": _epoch(minutes_ago),
+                "timestamp": _epoch(anchor, minutes_ago),
                 "tenant_id": tenant_id,
             },
         )

--- a/tests/api/test_api_gateway_feed.py
+++ b/tests/api/test_api_gateway_feed.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
+from datetime import datetime, timezone
 
 from starlette.testclient import TestClient
 
@@ -318,13 +319,14 @@ def test_typed_gateway_events_survive_audit_ingest_and_feed_without_payloads() -
     os.environ["AGENT_BOM_TRUST_PROXY_AUTH"] = "1"
     os.environ["AGENT_BOM_TRUST_PROXY_AUTH_SECRET"] = PROXY_SECRET
     tenant = "tenant-runtime"
+    now = datetime.now(timezone.utc).isoformat()
     leaked_secret = "sk-live-never-persist-this-value"
     typed_alerts = [
         {
             "event_id": "evt-allow",
             "decision_id": "evt-allow",
             "event_type": "gateway.tool_call.allowed",
-            "event_timestamp": "2026-07-28T01:02:03+00:00",
+            "event_timestamp": now,
             "agent_id": "agent-a",
             "identity_id": "identity-a",
             "profile_id": "client-profile-finance-prod",
@@ -484,12 +486,13 @@ def test_feed_http_is_tenant_scoped() -> None:
 
         configure_api(api_key=None)
         proxy_routes._proxy_alerts.clear()
+        now = datetime.now(timezone.utc).timestamp()
         # Use the realistic post-redaction shape: tier-A whitelist strips
         # free-text action/reason, so classification must ride on event_type /
         # decision (which survive the ring buffer).
         proxy_routes.push_proxy_alert(
             {
-                "ts": 10.0,
+                "ts": now,
                 "tenant_id": "tenant-x",
                 "agent_name": "x-agent",
                 "event_type": "gateway.policy_blocked",
@@ -500,7 +503,7 @@ def test_feed_http_is_tenant_scoped() -> None:
         )
         proxy_routes.push_proxy_alert(
             {
-                "ts": 11.0,
+                "ts": now,
                 "tenant_id": "tenant-y",
                 "agent_name": "y-agent",
                 "event_type": "gateway.policy_allowed",

--- a/tests/api/test_gateway_feed_durable.py
+++ b/tests/api/test_gateway_feed_durable.py
@@ -1,0 +1,277 @@
+"""Durable gateway feed contracts across API replica and restart boundaries."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.gateway_activity_store import (
+    InMemoryGatewayActivityStore,
+    set_gateway_activity_store,
+)
+from agent_bom.api.routes import gateway_feed as gateway_feed_routes
+from agent_bom.api.routes import proxy as proxy_routes
+from agent_bom.api.server import app, configure_api
+
+PROXY_SECRET = "durable-gateway-feed-secret-with-32-plus-bytes"
+
+
+def _headers(tenant_id: str, *, role: str = "viewer") -> dict[str, str]:
+    return {
+        "X-Agent-Bom-Role": role,
+        "X-Agent-Bom-Tenant-ID": tenant_id,
+        "X-Agent-Bom-Proxy-Secret": PROXY_SECRET,
+    }
+
+
+def _event(event_id: str, *, tool: str) -> dict[str, object]:
+    return {
+        "schema_version": "gateway.runtime.event.v1",
+        "event_id": event_id,
+        "decision_id": event_id,
+        "event_type": "gateway.tool_call.allowed",
+        "event_timestamp": datetime.now(timezone.utc).isoformat(),
+        "agent_id": "fleet-agent-1",
+        "upstream": "filesystem",
+        "tool": tool,
+        "decision": "allow",
+        "policy_source": "runtime_profile",
+        "trace_id": f"trace-{event_id}",
+    }
+
+
+def _blocked_event(event_id: str) -> dict[str, object]:
+    event = _event(event_id, tool="delete_all")
+    event.update(
+        {
+            "event_type": "gateway.tool_call.blocked",
+            "decision": "deny",
+            "reason_code": "unknown_agent",
+        }
+    )
+    return event
+
+
+@pytest.fixture(autouse=True)
+def _isolated_gateway_feed(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH", "1")
+    monkeypatch.setenv("AGENT_BOM_TRUST_PROXY_AUTH_SECRET", PROXY_SECRET)
+    configure_api(api_key=None)
+    proxy_routes._reset_proxy_runtime_for_tests()
+    set_gateway_activity_store(InMemoryGatewayActivityStore(max_events_per_tenant=20))
+    try:
+        yield
+    finally:
+        set_gateway_activity_store(None)
+        proxy_routes._reset_proxy_runtime_for_tests()
+        configure_api(api_key=None)
+
+
+def test_feed_survives_ring_loss_and_cursor_resumes_without_gaps() -> None:
+    client = TestClient(app)
+    tenant_id = "tenant-durable-feed"
+
+    first_ingest = client.post(
+        "/v1/proxy/audit",
+        headers=_headers(tenant_id, role="admin"),
+        json={
+            "source_id": "gateway-a",
+            "session_id": "session-a",
+            "alerts": [_event("evt-1", tool="read_file"), _event("evt-2", tool="list_files")],
+        },
+    )
+    assert first_ingest.status_code == 200, first_ingest.text
+    assert first_ingest.json()["durable_accepted_count"] == 2
+
+    # Simulate another API replica, or a process restart: the ring is gone but
+    # the shared ledger remains the authoritative feed source.
+    proxy_routes._reset_proxy_runtime_for_tests()
+    first_page = client.get(
+        "/v1/gateway/feed",
+        headers=_headers(tenant_id),
+        params={"limit": 10},
+    )
+    assert first_page.status_code == 200, first_page.text
+    first_body = first_page.json()
+    assert [event["event_id"] for event in first_body["events"]] == ["evt-2", "evt-1"]
+    assert first_body["source"] == "gateway_activity_ledger"
+    assert first_body["completeness"]["status"] == "complete"
+    assert first_body["next_cursor"]
+    assert first_body["has_more"] is False
+
+    second_ingest = client.post(
+        "/v1/proxy/audit",
+        headers=_headers(tenant_id, role="admin"),
+        json={
+            "source_id": "gateway-b",
+            "session_id": "session-b",
+            "alerts": [_event("evt-3", tool="stat")],
+        },
+    )
+    assert second_ingest.status_code == 200, second_ingest.text
+    proxy_routes._reset_proxy_runtime_for_tests()
+
+    resumed = client.get(
+        "/v1/gateway/feed",
+        headers=_headers(tenant_id),
+        params={"cursor": first_body["next_cursor"], "limit": 10},
+    )
+    assert resumed.status_code == 200, resumed.text
+    resumed_body = resumed.json()
+    assert [event["event_id"] for event in resumed_body["events"]] == ["evt-3"]
+    assert resumed_body["next_cursor"] != first_body["next_cursor"]
+
+    foreign = client.get(
+        "/v1/gateway/feed",
+        headers=_headers("tenant-other"),
+        params={"cursor": first_body["next_cursor"]},
+    )
+    assert foreign.status_code == 400
+
+
+def test_kpis_use_exact_utc_window_over_durable_events_after_ring_loss() -> None:
+    client = TestClient(app)
+    tenant_id = "tenant-durable-kpis"
+    ingest = client.post(
+        "/v1/proxy/audit",
+        headers=_headers(tenant_id, role="admin"),
+        json={
+            "source_id": "gateway-a",
+            "session_id": "session-a",
+            "alerts": [
+                _event("evt-allow", tool="read_file"),
+                _blocked_event("evt-block"),
+            ],
+        },
+    )
+    assert ingest.status_code == 200, ingest.text
+    proxy_routes._reset_proxy_runtime_for_tests()
+
+    response = client.get("/v1/gateway/feed/kpis", headers=_headers(tenant_id))
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["tool_calls_authorized"] == 1
+    assert body["blocked_today"] == 1
+    assert body["shadow_ai_blocked"] == 1
+    assert body["calls_today"] == 2
+    assert body["source"] == "gateway_activity_ledger"
+    assert body["completeness"]["status"] == "complete"
+    assert body["window"]["timezone"] == "UTC"
+    assert body["window"]["start"].endswith("+00:00")
+    assert body["window"]["end"].endswith("+00:00")
+    assert body["window"]["exact"] is True
+
+
+def test_retention_marks_initial_backfill_partial_and_expires_old_cursor() -> None:
+    store = InMemoryGatewayActivityStore(max_events_per_tenant=2)
+    set_gateway_activity_store(store)
+    client = TestClient(app)
+    tenant_id = "tenant-retained-feed"
+    stale_cursor = store.encode_cursor(tenant_id, 0)
+    ingest = client.post(
+        "/v1/proxy/audit",
+        headers=_headers(tenant_id, role="admin"),
+        json={
+            "source_id": "gateway-a",
+            "session_id": "session-a",
+            "alerts": [
+                _event("evt-1", tool="one"),
+                _event("evt-2", tool="two"),
+                _event("evt-3", tool="three"),
+            ],
+        },
+    )
+    assert ingest.status_code == 200, ingest.text
+    proxy_routes._reset_proxy_runtime_for_tests()
+
+    initial = client.get("/v1/gateway/feed", headers=_headers(tenant_id)).json()
+    assert [event["event_id"] for event in initial["events"]] == ["evt-3", "evt-2"]
+    assert initial["completeness"]["status"] == "partial"
+    assert "retention_floor_advanced" in initial["completeness"]["reasons"]
+
+    expired = client.get(
+        "/v1/gateway/feed",
+        headers=_headers(tenant_id),
+        params={"cursor": stale_cursor},
+    )
+    assert expired.status_code == 410
+    assert expired.json()["detail"]["retention_floor_ordinal"] == 2
+
+
+def test_store_outage_is_explicitly_degraded_and_cannot_resume_cursor() -> None:
+    class _UnavailableStore:
+        max_events_per_tenant = 50_000
+        max_tombstones_per_tenant = 100_000
+
+        def init_schema(self) -> None:
+            return None
+
+        def append_batch(self, records):
+            raise RuntimeError("database URL with secret must not escape")
+
+        def list_activity(self, tenant_id, *, cursor=None, limit=100):
+            raise RuntimeError("database URL with secret must not escape")
+
+        def encode_cursor(self, tenant_id, ordinal):
+            return "opaque"
+
+    set_gateway_activity_store(_UnavailableStore())
+    now = datetime.now(timezone.utc).timestamp()
+    proxy_routes.push_proxy_alert(
+        {
+            "ts": now,
+            "tenant_id": "tenant-degraded",
+            "agent_name": "legacy-agent",
+            "event_type": "gateway.policy_blocked",
+            "decision": "deny",
+            "tool_name": "exec",
+        }
+    )
+    client = TestClient(app, raise_server_exceptions=False)
+
+    initial = client.get("/v1/gateway/feed", headers=_headers("tenant-degraded"))
+
+    assert initial.status_code == 200, initial.text
+    body = initial.json()
+    assert body["source"] == "degraded_single_process"
+    assert body["completeness"]["status"] == "partial"
+    assert "ledger_unavailable" in body["completeness"]["reasons"]
+    assert [event["agent"] for event in body["events"]] == ["legacy-agent"]
+    assert "database URL" not in initial.text
+
+    kpis = client.get("/v1/gateway/feed/kpis", headers=_headers("tenant-degraded"))
+    assert kpis.status_code == 200, kpis.text
+    assert kpis.json()["source"] == "degraded_single_process"
+    assert "ledger_unavailable" in kpis.json()["completeness"]["reasons"]
+    assert kpis.json()["blocked_today"] == 1
+    assert "database URL" not in kpis.text
+
+    resumed = client.get(
+        "/v1/gateway/feed",
+        headers=_headers("tenant-degraded"),
+        params={"cursor": "opaque-cursor"},
+    )
+    assert resumed.status_code == 503
+    assert "database URL" not in resumed.text
+
+
+def test_observability_outage_marks_feed_and_kpis_partial(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _unavailable(_tenant_id: str, *, limit: int):
+        raise RuntimeError("cost store URL with secret must not escape")
+
+    monkeypatch.setattr(gateway_feed_routes, "_load_tenant_llm_records", _unavailable)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    feed = client.get("/v1/gateway/feed", headers=_headers("tenant-observability-outage"))
+    assert feed.status_code == 200, feed.text
+    assert "observability_unavailable" in feed.json()["completeness"]["reasons"]
+    assert "cost store URL" not in feed.text
+
+    kpis = client.get("/v1/gateway/feed/kpis", headers=_headers("tenant-observability-outage"))
+    assert kpis.status_code == 200, kpis.text
+    assert "observability_unavailable" in kpis.json()["completeness"]["reasons"]
+    assert kpis.json()["window"]["exact"] is False
+    assert "cost store URL" not in kpis.text

--- a/tests/api/test_gateway_feed_health.py
+++ b/tests/api/test_gateway_feed_health.py
@@ -204,5 +204,11 @@ def test_gateway_feed_openapi_declares_health_contract() -> None:
 
     response = schema["components"]["schemas"]["GatewayFeedResponseModel"]
     assert response["properties"]["events"]["items"]["$ref"].endswith("/GatewayFeedEventModel")
+    assert {"next_cursor", "has_more", "source", "completeness"} <= response["properties"].keys()
+    assert response["properties"]["completeness"]["$ref"].endswith("/GatewayFeedCompletenessModel")
     event = schema["components"]["schemas"]["GatewayFeedEventModel"]
-    assert {"input_tokens", "output_tokens", "cost_usd"} <= event["properties"].keys()
+    assert {"input_tokens", "output_tokens", "cost_usd", "ingest_ordinal"} <= event["properties"].keys()
+
+    kpis = schema["components"]["schemas"]["GatewayFeedKpisModel"]
+    assert {"source", "completeness", "window"} <= kpis["properties"].keys()
+    assert kpis["properties"]["window"]["$ref"].endswith("/GatewayFeedWindowModel")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -307,6 +307,12 @@ def _reset_durable_store_singletons() -> None:
     except Exception:
         pass
     try:
+        from agent_bom.api.gateway_activity_store import set_gateway_activity_store
+
+        set_gateway_activity_store(None)
+    except Exception:
+        pass
+    try:
         from agent_bom.api.cost_store import set_cost_store
 
         set_cost_store(None)

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -80,8 +80,8 @@ def test_test_job_timeout_leaves_margin_over_observed_worst_case() -> None:
 
 
 def test_alpine_full_suite_timeout_leaves_musl_headroom() -> None:
-    """Full-suite Alpine runs must outlive the observed 25-minute ceiling."""
-    assert _ci()["jobs"]["test-alpine"]["timeout-minutes"] == 35
+    """Full-suite Alpine runs must leave cleanup margin over the 34m51s baseline."""
+    assert _ci()["jobs"]["test-alpine"]["timeout-minutes"] == 45
 
 
 def test_pull_request_pytest_reports_slowest_tests() -> None:

--- a/tests/test_gateway_activity_ledger.py
+++ b/tests/test_gateway_activity_ledger.py
@@ -309,6 +309,14 @@ def test_sqlite_cursor_query_uses_tenant_ordinal_index(tmp_path) -> None:
     plan = store.query_plan("tenant-a", after_ordinal=10, limit=100)
     assert "idx_gateway_activity_events_tenant_ordinal" in plan
 
+    window_plan = store._conn.execute(
+        "EXPLAIN QUERY PLAN SELECT data FROM gateway_activity_events "
+        "WHERE tenant_id = ? AND event_timestamp >= ? AND event_timestamp <= ?",
+        ("tenant-a", "2026-07-28T00:00:00+00:00", "2026-07-28T23:59:59+00:00"),
+    ).fetchall()
+    rendered = " ".join(str(column) for row in window_plan for column in row)
+    assert "idx_gateway_activity_events_tenant_event_time" in rendered
+
 
 def test_sqlite_concurrent_writers_allocate_unique_ordinals(tmp_path) -> None:
     store = SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=20)
@@ -331,3 +339,71 @@ def test_sqlite_concurrent_writers_allocate_unique_ordinals(tmp_path) -> None:
     assert errors == []
     events = store.list_activity("tenant-a", limit=20).events
     assert [event["ingest_ordinal"] for event in events] == list(range(1, 9))
+
+
+def test_two_sqlite_api_replicas_share_one_gap_free_tenant_sequence(tmp_path) -> None:
+    path = str(tmp_path / "activity.db")
+    stores = [
+        SQLiteGatewayActivityStore(path, max_events_per_tenant=20),
+        SQLiteGatewayActivityStore(path, max_events_per_tenant=20),
+    ]
+    barrier = threading.Barrier(8)
+    errors: list[Exception] = []
+
+    def worker(index: int) -> None:
+        try:
+            barrier.wait()
+            stores[index % 2].append_batch([_record(f"replica-evt-{index}")])
+        except Exception as exc:  # noqa: BLE001
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert errors == []
+    page = stores[0].list_activity("tenant-a", limit=20)
+    assert [event["ingest_ordinal"] for event in page.events] == list(range(1, 9))
+    assert len({event["event_id"] for event in page.events}) == 8
+
+
+@pytest.mark.parametrize("store_kind", ["memory", "sqlite"])
+def test_window_summary_counts_canonical_events_without_materializing_payloads(store_kind: str, tmp_path) -> None:
+    store = (
+        InMemoryGatewayActivityStore(max_events_per_tenant=20)
+        if store_kind == "memory"
+        else SQLiteGatewayActivityStore(str(tmp_path / "activity.db"), max_events_per_tenant=20)
+    )
+    store.append_batch(
+        [
+            _record("allowed"),
+            _record(
+                "blocked",
+                event_type="gateway.tool_call.blocked",
+                decision="deny",
+                reason_code="unknown_agent",
+            ),
+            _record(
+                "redacted",
+                event_type="gateway.dlp.result_redacted",
+                decision="allow",
+                data_action="pii_redacted",
+            ),
+            _record("outside", timestamp="2026-07-27T11:59:00+00:00"),
+        ]
+    )
+
+    summary = store.summarize_window(
+        "tenant-a",
+        start="2026-07-28T00:00:00+00:00",
+        end="2026-07-28T23:59:59+00:00",
+    )
+
+    assert summary.tool_calls_authorized == 1
+    assert summary.blocked == 1
+    assert summary.shadow_blocked == 1
+    assert summary.data_filters == 1
+    assert summary.retention_floor_ordinal == 1
+    assert summary.latest_ordinal == 4

--- a/tests/test_gateway_feed_event_loop.py
+++ b/tests/test_gateway_feed_event_loop.py
@@ -37,6 +37,30 @@ def _write_log(path, lines: int) -> None:
             )
 
 
+def test_jsonl_fallback_reads_the_newest_bounded_records(tmp_path) -> None:
+    from agent_bom.api.routes.proxy import _read_alerts_from_log
+
+    log = tmp_path / "runtime.jsonl"
+    with open(log, "w") as handle:
+        for index in range(1_250):
+            handle.write(
+                json.dumps(
+                    {
+                        "type": "runtime_alert",
+                        "tenant_id": "default",
+                        "event_id": f"evt-{index}",
+                    }
+                )
+                + "\n"
+            )
+
+    alerts = _read_alerts_from_log(log)
+
+    assert len(alerts) == 1_000
+    assert alerts[0]["event_id"] == "evt-250"
+    assert alerts[-1]["event_id"] == "evt-1249"
+
+
 async def _max_stall_while(coro, *, tick: float = 0.001) -> tuple[object, float]:
     """Run *coro*, sampling how long the loop ever went without servicing a tick."""
     worst = 0.0

--- a/tests/test_postgres_gateway_activity.py
+++ b/tests/test_postgres_gateway_activity.py
@@ -172,3 +172,36 @@ def test_postgres_conflict_rolls_back_and_rls_hides_foreign_tenant() -> None:
     finally:
         reset_current_tenant(foreign_token)
         _cleanup(store, tenant_id)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_URL"),
+    reason="requires a migrated live PostgreSQL database",
+)
+def test_two_postgres_api_replicas_resume_one_shared_cursor_without_gaps() -> None:
+    first_replica = PostgresGatewayActivityStore(max_events_per_tenant=100)
+    second_replica = PostgresGatewayActivityStore(max_events_per_tenant=100)
+    tenant_id = f"gateway-replicas-{uuid.uuid4().hex}"
+    token = set_current_tenant(tenant_id)
+    try:
+        first_replica.append_batch([_record("evt-1", tenant_id), _record("evt-2", tenant_id)])
+        first_page = second_replica.list_activity(tenant_id, limit=2)
+        assert [event["event_id"] for event in first_page.events] == ["evt-1", "evt-2"]
+        assert first_page.next_cursor
+
+        second_replica.append_batch([_record("evt-3", tenant_id)])
+        resumed = first_replica.list_activity(tenant_id, cursor=first_page.next_cursor, limit=10)
+        assert [event["event_id"] for event in resumed.events] == ["evt-3"]
+        assert resumed.next_cursor != first_page.next_cursor
+
+        summary = second_replica.summarize_window(
+            tenant_id,
+            start="2000-01-01T00:00:00+00:00",
+            end="2099-12-31T23:59:59+00:00",
+        )
+        assert summary.tool_calls_authorized == 3
+        assert summary.retention_floor_ordinal == 1
+        assert summary.latest_ordinal == 3
+    finally:
+        reset_current_tenant(token)
+        _cleanup(first_replica, tenant_id)

--- a/tests/test_postgres_maintenance_pool.py
+++ b/tests/test_postgres_maintenance_pool.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 
@@ -226,7 +227,8 @@ def test_combined_preflight_preserves_explicit_single_tenant_superuser_acknowled
     monkeypatch.setattr(postgres_common, "ALLOW_SUPERUSER_DB", True)
     _install_pool_factory(monkeypatch, app_super=True)
 
-    postgres_common.preflight_rls_capable_role()
+    with caplog.at_level(logging.WARNING, logger=postgres_common.logger.name):
+        postgres_common.preflight_rls_capable_role()
 
     assert postgres_common._pool is not postgres_common._maintenance_pool
     assert any("disposable single-tenant/dev" in record.message for record in caplog.records)

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -24,6 +24,7 @@ RUNTIME_EVIDENCE_TIMESTAMP_AUTHORITY = VERSIONS_DIR / "20260727_01_runtime_evide
 MCP_PROFILE_BINDING_AUTHORITY = VERSIONS_DIR / "20260728_01_mcp_profile_binding_authority.py"
 GATEWAY_ACTIVITY_LEDGER = VERSIONS_DIR / "20260728_02_gateway_activity_ledger.py"
 TRUSTED_MAINTENANCE_RLS = VERSIONS_DIR / "20260728_03_trusted_maintenance_rls.py"
+GATEWAY_ACTIVITY_WINDOW_INDEX = VERSIONS_DIR / "20260729_02_gateway_activity_window_index.py"
 POSTGRES_MCP_CONFIG_STORE = Path(__file__).parent.parent / "src" / "agent_bom" / "api" / "postgres_mcp_config.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
@@ -372,6 +373,22 @@ def test_gateway_activity_ledger_migration_is_chained_durable_and_tenant_isolate
     assert "CREATE UNIQUE INDEX IF NOT EXISTS idx_gateway_activity_events_tenant_ordinal" in sql
     assert "CREATE INDEX IF NOT EXISTS idx_gateway_activity_tombstones_tenant_ordinal" in sql
     assert "VALUES ('runtime_events', 2, now())" in sql
+    assert "DROP TABLE" not in sql
+
+
+def test_gateway_activity_window_index_is_chained_and_matches_runtime_schema() -> None:
+    sql = GATEWAY_ACTIVITY_WINDOW_INDEX.read_text()
+    index_ddl = (
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_gateway_activity_events_tenant_event_time "
+        "ON gateway_activity_events(tenant_id, event_timestamp, "
+        "((data::jsonb) ->> 'event_type'), ((data::jsonb) ->> 'reason_code'))"
+    )
+    assert re.search(r'revision\s*=\s*"20260729_02"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260729_01"', sql)
+    assert _canonical_sql(index_ddl) in _canonical_sql(sql)
+    runtime_index_ddl = index_ddl.replace(" CONCURRENTLY", "")
+    assert _canonical_sql(runtime_index_ddl) in _canonical_sql(RUNTIME_SCHEMA_SQL.read_text())
+    assert "autocommit_block" in sql
     assert "DROP TABLE" not in sql
 
 

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -388,8 +388,42 @@ def test_gateway_activity_window_index_is_chained_and_matches_runtime_schema() -
     assert _canonical_sql(index_ddl) in _canonical_sql(sql)
     runtime_index_ddl = index_ddl.replace(" CONCURRENTLY", "")
     assert _canonical_sql(runtime_index_ddl) in _canonical_sql(RUNTIME_SCHEMA_SQL.read_text())
+    assert "SELECT to_regclass('public.gateway_activity_events')" in sql
     assert "autocommit_block" in sql
     assert "DROP TABLE" not in sql
+
+
+def test_gateway_activity_window_index_allows_legacy_schema_without_ledger(monkeypatch) -> None:
+    """A stamped 0.98.2 database may not have provisioned the optional ledger."""
+    monkeypatch.setitem(sys.modules, "alembic", SimpleNamespace(op=SimpleNamespace()))
+    migration = _load_module(GATEWAY_ACTIVITY_WINDOW_INDEX, "gateway_activity_window_index_legacy")
+    statements: list[str] = []
+
+    class _MissingRelationResult:
+        @staticmethod
+        def scalar():
+            return None
+
+    class _LegacyBind:
+        @staticmethod
+        def exec_driver_sql(statement: str):
+            statements.append(statement)
+            return _MissingRelationResult()
+
+    def _unexpected_context():
+        raise AssertionError("the concurrent index block must be skipped when the ledger is absent")
+
+    migration.op = SimpleNamespace(
+        get_bind=lambda: _LegacyBind(),
+        get_context=_unexpected_context,
+        execute=lambda _statement: (_ for _ in ()).throw(
+            AssertionError("no index DDL is valid without the ledger")
+        ),
+    )
+
+    migration.upgrade()
+
+    assert statements == ["SELECT to_regclass('public.gateway_activity_events')"]
 
 
 def test_trusted_maintenance_migration_is_forward_only_and_preserves_queue_rows() -> None:


### PR DESCRIPTION
## Summary

- make the Postgres/SQLite gateway activity ledger the primary feed source, with server-owned ordinals, tenant-bound cursor resume, bounded newest-first backfill, retention metadata, and explicit complete/partial evidence state
- commit canonical gateway events before acknowledging ingest, preserve the process ring and newest 1,000 JSONL records only as a degraded fallback, and return sanitized fail-closed storage errors
- calculate UTC-day KPIs with backend-native aggregation and a concurrent tenant/time/event-type index; unavailable ledger or observability evidence is reported as partial
- preserve the supported 0.98.2 partial-schema upgrade path when the optional gateway ledger was not provisioned
- anchor curated demo events to the current UTC day with date-scoped IDs so exact KPIs stay populated without durable-ledger dedupe conflicts
- raise the Alpine job timeout from 35 to 45 minutes after the suite passed at 34m51s but action cleanup was canceled by the old ceiling

## Verification

- `uv run pytest -q tests/test_demo_estate_bootstrap.py tests/test_product_metrics_snapshot.py tests/test_postgres_migrations.py tests/test_postgres_maintenance_pool.py` — 69 passed
- `uv run pytest -q tests/test_gateway_activity_ledger.py tests/test_postgres_gateway_activity.py tests/test_gateway_feed_event_loop.py tests/api/test_api_gateway_feed.py tests/api/test_gateway_feed_health.py tests/test_gateway_server.py` — 115 passed, 4 live-Postgres tests skipped locally
- original feature regression matrix across gateway, proxy, ingest, audit, schema, storage, and CI contracts — 279 passed, 4 live-Postgres tests skipped locally
- `make lint` — Ruff clean; MyPy clean across 813 source files
- `make preflight`
- `python scripts/check_exception_sanitization.py`
- `python scripts/check_public_docs_hygiene.py`
- `python scripts/check_workflow_timeouts.py`
- supported Node 24.15.0: toolchain verification, TypeScript, ESLint, 975 UI tests, and production build with 49 generated routes
- SQLite 50k-event HTTP KPI benchmark, 20 requests: p50 668 ms, p95 1.006 s, max 1.568 s; exact count 50,000

## Notes

- Canonical gateway ingest fails closed with a sanitized 503 when durable storage is unavailable. Initial legacy reads remain available only with `degraded_single_process` and partial completeness metadata; cursor resume requires the durable ledger.
- The Postgres index migration is additive and uses `CREATE INDEX CONCURRENTLY` when the gateway ledger exists. A legacy partial schema without the optional ledger advances safely; runtime bootstrap creates the same index when it provisions the ledger.
- CI remains responsible for the four live-Postgres replica/RLS cases that require `AGENT_BOM_POSTGRES_URL`.
- This is stabilization PR 2 and does not publish a release.

Progresses #4152.
