### PR TITLE
fix(cis): fail closed on stale remediation bindings

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1054,
+      "value": 1055,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1054 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1055 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |

--- a/docs/skills/cspm-aws-benchmark.md
+++ b/docs/skills/cspm-aws-benchmark.md
@@ -153,7 +153,7 @@ cis_benchmark(provider="aws", region="us-east-1")
   FINDING: Root account has access keys
   ──────────────────────────────────────
   WHY:     Root keys = unlimited blast radius. Compromised root = full account takeover.
-  FIX:     aws iam delete-access-key --user-name root --access-key-id AKIA...
+  FIX:     Sign in as the root user, open IAM > Security credentials, and delete the root access key.
   VERIFY:  agent-bom scan --aws --aws-cis-benchmark | grep "root_access_keys"
 ```
 

--- a/src/agent_bom/analytics_contract.py
+++ b/src/agent_bom/analytics_contract.py
@@ -261,12 +261,14 @@ def _build_cis_benchmark_checks(report: AIBOMReport, data: dict[str, Any], scan_
 
 
 def _cis_rows_for_cloud(cloud: str, benchmark: dict[str, Any], scan_id: str, measured_at: str) -> list[dict[str, Any]]:
+    from agent_bom.cloud.cis_remediation import fail_closed_remediation_payload
+
     rows: list[dict[str, Any]] = []
     for check in benchmark.get("checks", []) or []:
         if not isinstance(check, dict):
             continue
         raw_remediation = check.get("remediation")
-        remediation: dict[str, Any] = dict(raw_remediation) if isinstance(raw_remediation, dict) else {}
+        remediation = fail_closed_remediation_payload(raw_remediation)
         priority = remediation.get("priority", check.get("priority", 0))
         try:
             priority_int = int(priority or 0)
@@ -290,7 +292,7 @@ def _cis_rows_for_cloud(cloud: str, benchmark: dict[str, Any], scan_id: str, mea
                 "effort": str(remediation.get("effort") or ""),
                 "priority": priority_int,
                 "guardrails": [str(item) for item in remediation.get("guardrails", []) or []],
-                "requires_human_review": bool(remediation.get("requires_human_review", False)),
+                "requires_human_review": True,
             }
         )
     return rows

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -474,10 +474,13 @@ class ClickHouseAnalyticsStore:
         }
 
     def _cis_check_row(self, check: dict, *, tenant_id: str = "default") -> dict[str, Any]:
+        from agent_bom.cloud.cis_remediation import fail_closed_remediation_payload
+
         resolved_tenant = str(check.get("tenant_id") or tenant_id or "default")
         scan_id = check.get("scan_id", "")
         cloud = check.get("cloud", "")
         check_id = check.get("check_id", "")
+        remediation = fail_closed_remediation_payload(check.get("remediation"))
         return {
             "measured_at": _coerce_clickhouse_timestamp(check.get("measured_at")),
             "scan_id": scan_id,
@@ -492,13 +495,13 @@ class ClickHouseAnalyticsStore:
             "cis_section": check.get("cis_section", ""),
             "evidence": check.get("evidence", ""),
             "resource_ids": list(check.get("resource_ids", []) or []),
-            "remediation": json.dumps(check.get("remediation", {}) or {}, sort_keys=True),
-            "fix_cli": check.get("fix_cli", ""),
+            "remediation": json.dumps(remediation, sort_keys=True),
+            "fix_cli": "",
             "fix_console": check.get("fix_console", ""),
-            "effort": check.get("effort", ""),
+            "effort": "manual",
             "priority": int(check.get("priority", 0) or 0),
             "guardrails": list(check.get("guardrails", []) or []),
-            "requires_human_review": int(bool(check.get("requires_human_review", False))),
+            "requires_human_review": 1,
         }
 
     def record_audit_event(self, event: dict) -> None:

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -435,7 +435,12 @@ async def get_compliance(
 
     tenant_jobs = _tenant_jobs(request)
     if scan_id:
-        tenant_jobs = [job for job in tenant_jobs if job.job_id == scan_id or (job.result and str(job.result.get("scan_id") or "") == scan_id)]
+        matching_jobs = []
+        for job in tenant_jobs:
+            result_scan_id = str(job.result.get("scan_id") or "") if job.result else ""
+            if job.job_id == scan_id or result_scan_id == scan_id:
+                matching_jobs.append(job)
+        tenant_jobs = matching_jobs
 
     # Collect blast_radius entries from all completed scans
     all_blast: list[dict] = []

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -435,11 +435,7 @@ async def get_compliance(
 
     tenant_jobs = _tenant_jobs(request)
     if scan_id:
-        tenant_jobs = [
-            job
-            for job in tenant_jobs
-            if job.job_id == scan_id or (job.result and str(job.result.get("scan_id") or "") == scan_id)
-        ]
+        tenant_jobs = [job for job in tenant_jobs if job.job_id == scan_id or (job.result and str(job.result.get("scan_id") or "") == scan_id)]
 
     # Collect blast_radius entries from all completed scans
     all_blast: list[dict] = []
@@ -756,13 +752,21 @@ def _list_cis_benchmark_checks_impl(
 
 
 def _coerce_cis_row(row: dict[str, Any]) -> dict[str, Any]:
+    from agent_bom.cloud.cis_remediation import fail_closed_remediation_payload
+
     coerced = dict(row)
     remediation = coerced.get("remediation")
     if isinstance(remediation, str):
         try:
-            coerced["remediation"] = json.loads(remediation)
+            remediation = json.loads(remediation)
         except json.JSONDecodeError:
-            coerced["remediation"] = {}
+            remediation = {}
+    remediation = fail_closed_remediation_payload(remediation)
+    coerced["remediation"] = remediation
+    coerced["fix_cli"] = ""
+    coerced["fix_console"] = str(remediation.get("fix_console") or coerced.get("fix_console") or "")
+    coerced["effort"] = "manual"
+    coerced["requires_human_review"] = True
     return coerced
 
 

--- a/src/agent_bom/cloud/cis_remediation.py
+++ b/src/agent_bom/cloud/cis_remediation.py
@@ -22,8 +22,8 @@ null for ``fix_cli``):
 
 Population order (``build_remediation`` walks these in turn):
 
-    1. Hand-authored override keyed by (cloud, check_id) — takes precedence
-       for checks where the CLI form is unambiguous.
+    1. Hand-authored override keyed by exact cloud, benchmark version, check
+       ID, title, and section identity.
     2. Auto-derivation from the result's ``recommendation`` +
        ``severity`` + ``cis_section`` — produces a useful structured form
        even when no override exists.
@@ -31,15 +31,14 @@ Population order (``build_remediation`` walks these in turn):
        ``requires_human_review=True``, pointing the operator to the
        vendor docs.
 
-The overrides intentionally skew toward the highest-frequency checks
-(IAM root/MFA, CloudTrail/logging, storage encryption-at-rest, public
-bucket access) where a single command is both safe and well-documented
-by CIS. Other checks fall back to the auto-derived form rather than
-shipping commands that might break production.
+Overrides provide control-specific risk and console guidance. CLI mutations
+remain absent unless their exact identity is present in the separately reviewed
+allowlist; every other check falls back to manual advice.
 """
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Any
 
 # Guardrail principle tags. Kept explicit so the HTML / MCP output can
@@ -177,243 +176,202 @@ def _derived_why(title: str, recommendation: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Hand-authored overrides — only for checks where the CLI is safe and
-# unambiguous. Every entry below was cross-checked against CIS v3 (AWS /
-# Azure / GCP) or the Snowflake CIS benchmark. Commands intentionally use
-# placeholders (``<ARN>``, ``<RG>``, ``<PROJECT>``, etc.) so operators
-# must substitute before running — this is the human-in-loop surface.
+# Hand-authored overrides are bound to an exact benchmark identity. A check ID
+# is not stable across benchmark revisions, so matching only ``(cloud,
+# check_id)`` can attach a valid command to the wrong control. Unknown,
+# incomplete, and drifted identities deliberately fall back to manual advice.
 # ---------------------------------------------------------------------------
 
-_OVERRIDES: dict[tuple[str, str], dict[str, Any]] = {
+
+@dataclass(frozen=True, slots=True)
+class CISControlIdentity:
+    cloud: str
+    benchmark_version: str
+    check_id: str
+    title: str
+    cis_section: str
+
+
+@dataclass(frozen=True, slots=True)
+class CISRemediationOverride:
+    why: str
+    fix_console: str
+    guardrails: tuple[str, ...]
+    fix_cli: str | None = None
+    docs: str | None = None
+    effort: str = "manual"
+    requires_human_review: bool = True
+
+
+_OVERRIDES: dict[CISControlIdentity, CISRemediationOverride] = {
     # ── AWS ────────────────────────────────────────────────────────────
-    ("aws", "1.4"): {
-        "why": "Root account access keys allow full account takeover with no MFA and no per-user audit trail.",
-        "fix_cli": "aws iam delete-access-key --user-name root --access-key-id <ROOT_KEY_ID>",
-        "fix_console": "AWS Console → IAM → Security credentials (root) → Delete access key",
-        "effort": "low",
-        "guardrails": ["identity", "least-privilege", "priv-escalation", "zero-trust"],
-        "requires_human_review": True,
-    },
-    ("aws", "1.5"): {
-        "why": "Root user without MFA is a single-password path to full account compromise.",
-        "fix_cli": None,  # MFA enablement requires device enrollment — not a pure CLI fix
-        "fix_console": "AWS Console → IAM → Security credentials (root) → Assign MFA device",
-        "effort": "medium",
-        "guardrails": ["identity", "zero-trust", "priv-escalation", "human-in-loop"],
-        "requires_human_review": True,
-    },
-    ("aws", "1.6"): {
-        "why": "Root user without hardware MFA is still usable via phishing or SIM-swap.",
-        "fix_cli": None,
-        "fix_console": "AWS Console → IAM → Security credentials (root) → Assign hardware MFA device",
-        "effort": "medium",
-        "guardrails": ["identity", "zero-trust", "priv-escalation", "human-in-loop"],
-        "requires_human_review": True,
-    },
-    ("aws", "1.7"): {
-        "why": "Using the root user for daily operations bypasses least-privilege and audit boundaries.",
-        "fix_cli": None,
-        "fix_console": "AWS Console → IAM → Users → create admin user; stop using root for daily ops",
-        "effort": "medium",
-        "guardrails": ["identity", "least-privilege", "zero-trust"],
-        "requires_human_review": True,
-    },
-    ("aws", "1.8"): {
-        "why": "A weak password policy enables credential stuffing and brute-force against IAM users.",
-        "fix_cli": (
-            "aws iam update-account-password-policy --minimum-password-length 14 "
-            "--require-symbols --require-numbers --require-uppercase-characters "
-            "--require-lowercase-characters --allow-users-to-change-password "
-            "--max-password-age 90 --password-reuse-prevention 24"
-        ),
-        "fix_console": "AWS Console → IAM → Account settings → Password policy",
-        "effort": "low",
-        "guardrails": ["identity", "defense-in-depth"],
-        "requires_human_review": False,
-    },
-    ("aws", "1.14"): {
-        "why": "Access keys older than 90 days increase blast radius of leaked credentials.",
-        "fix_cli": "aws iam update-access-key --access-key-id <KEY_ID> --status Inactive --user-name <USER>",
-        "fix_console": "AWS Console → IAM → Users → <user> → Security credentials → Make inactive",
-        "effort": "low",
-        "guardrails": ["identity", "least-privilege", "human-in-loop"],
-        "requires_human_review": True,
-    },
-    ("aws", "2.1.1"): {
-        "why": "S3 bucket without Block Public Access can be made internet-reachable by any bucket policy edit.",
-        "fix_cli": (
-            "aws s3api put-public-access-block --bucket <BUCKET> "
-            "--public-access-block-configuration "
-            "BlockPublicAcls=true,IgnorePublicAcls=true,"
-            "BlockPublicPolicy=true,RestrictPublicBuckets=true"
-        ),
-        "fix_console": "AWS Console → S3 → <bucket> → Permissions → Block public access",
-        "effort": "low",
-        "guardrails": ["network-exposure", "defense-in-depth"],
-        "requires_human_review": True,
-    },
-    ("aws", "2.1.2"): {
-        "why": "Account-level Block Public Access is the backstop against any per-bucket misconfig.",
-        "fix_cli": (
-            "aws s3control put-public-access-block --account-id <ACCOUNT_ID> "
-            "--public-access-block-configuration "
-            "BlockPublicAcls=true,IgnorePublicAcls=true,"
-            "BlockPublicPolicy=true,RestrictPublicBuckets=true"
-        ),
-        "fix_console": "AWS Console → S3 → Block Public Access settings for this account",
-        "effort": "low",
-        "guardrails": ["network-exposure", "defense-in-depth"],
-        "requires_human_review": True,
-    },
-    ("aws", "3.1"): {
-        "why": "Without a multi-region CloudTrail, API activity can go unlogged in unused regions.",
-        "fix_cli": (
-            "aws cloudtrail create-trail --name org-trail --s3-bucket-name <LOG_BUCKET> "
-            "--is-multi-region-trail --include-global-service-events && "
-            "aws cloudtrail start-logging --name org-trail"
-        ),
-        "fix_console": "AWS Console → CloudTrail → Create trail → Apply trail to all regions",
-        "effort": "low",
-        "guardrails": ["logging-and-audit", "defense-in-depth"],
-        "requires_human_review": True,
-    },
-    ("aws", "3.2"): {
-        "why": "CloudTrail without log file validation cannot prove log integrity after the fact.",
-        "fix_cli": "aws cloudtrail update-trail --name <TRAIL> --enable-log-file-validation",
-        "fix_console": "AWS Console → CloudTrail → Trails → <trail> → Edit → Enable log file validation",
-        "effort": "low",
-        "guardrails": ["logging-and-audit", "defense-in-depth"],
-        "requires_human_review": False,
-    },
-    ("aws", "3.5"): {
-        "why": "CloudTrail KMS key rotation limits exposure if a key is ever compromised.",
-        "fix_cli": "aws kms enable-key-rotation --key-id <CLOUDTRAIL_KMS_KEY_ID>",
-        "fix_console": "AWS Console → KMS → Keys → <key> → Key rotation → Enable",
-        "effort": "low",
-        "guardrails": ["encryption", "secrets-handling"],
-        "requires_human_review": False,
-    },
+    CISControlIdentity("aws", "3.0", "1.4", "No root account access keys", "1 - Identity and Access Management"): CISRemediationOverride(
+        why="Root account access keys allow full account takeover with no MFA and no per-user audit trail.",
+        fix_console="AWS Console → IAM → Security credentials (root) → Delete access key",
+        guardrails=("identity", "least-privilege", "priv-escalation", "zero-trust"),
+    ),
+    CISControlIdentity("aws", "3.0", "1.5", "Root account MFA enabled", "1 - Identity and Access Management"): CISRemediationOverride(
+        why="Root user without MFA is a single-password path to full account compromise.",
+        fix_console="AWS Console → IAM → Security credentials (root) → Assign MFA device",
+        guardrails=("identity", "zero-trust", "priv-escalation", "human-in-loop"),
+    ),
+    CISControlIdentity("aws", "3.0", "1.6", "Hardware MFA for root account", "1 - Identity and Access Management"): CISRemediationOverride(
+        why="Root user without hardware MFA is still usable via phishing or SIM-swap.",
+        fix_console="AWS Console → IAM → Security credentials (root) → Assign hardware MFA device",
+        guardrails=("identity", "zero-trust", "priv-escalation", "human-in-loop"),
+    ),
+    CISControlIdentity(
+        "aws", "3.0", "1.7", "Root user not used for daily tasks", "1 - Identity and Access Management"
+    ): CISRemediationOverride(
+        why="Using the root user for daily operations bypasses least-privilege and audit boundaries.",
+        fix_console="AWS Console → IAM → Users → create admin user; stop using root for daily ops",
+        guardrails=("identity", "least-privilege", "zero-trust"),
+    ),
+    CISControlIdentity(
+        "aws", "3.0", "1.8", "IAM password policy minimum length >= 14", "1 - Identity and Access Management"
+    ): CISRemediationOverride(
+        why="A weak password policy enables credential stuffing and brute-force against IAM users.",
+        fix_console="AWS Console → IAM → Account settings → Password policy",
+        guardrails=("identity", "defense-in-depth"),
+    ),
+    CISControlIdentity(
+        "aws", "3.0", "1.14", "Access keys rotated within 90 days", "1 - Identity and Access Management"
+    ): CISRemediationOverride(
+        why="Access keys older than 90 days increase blast radius of leaked credentials.",
+        fix_console="AWS Console → IAM → Users → <user> → Security credentials → Make inactive",
+        guardrails=("identity", "least-privilege", "human-in-loop"),
+    ),
+    CISControlIdentity("aws", "3.0", "2.1.1", "S3 account-level public access block configured", "2 - Storage"): CISRemediationOverride(
+        why="Missing account-level Block Public Access permits bucket policies or ACLs to expose data publicly.",
+        fix_console="AWS Console → S3 → Block Public Access settings for this account",
+        guardrails=("network-exposure", "defense-in-depth"),
+    ),
+    CISControlIdentity("aws", "3.0", "2.1.2", "S3 bucket server-side encryption enabled", "2 - Storage"): CISRemediationOverride(
+        why="Buckets without default server-side encryption can persist new objects without encryption at rest.",
+        fix_console="AWS Console → S3 → <bucket> → Properties → Default encryption",
+        guardrails=("encryption", "defense-in-depth"),
+    ),
+    CISControlIdentity("aws", "3.0", "3.1", "CloudTrail enabled in all regions", "3 - Logging"): CISRemediationOverride(
+        why="Without a multi-region CloudTrail, API activity can go unlogged in unused regions.",
+        fix_console="AWS Console → CloudTrail → Create trail → Apply trail to all regions",
+        guardrails=("logging-and-audit", "defense-in-depth"),
+    ),
+    CISControlIdentity("aws", "3.0", "3.2", "CloudTrail log file validation enabled", "3 - Logging"): CISRemediationOverride(
+        why="CloudTrail without log file validation cannot prove log integrity after the fact.",
+        fix_console="AWS Console → CloudTrail → Trails → <trail> → Edit → Enable log file validation",
+        guardrails=("logging-and-audit", "defense-in-depth"),
+    ),
+    CISControlIdentity("aws", "3.0", "3.5", "CloudTrail records management events in all regions", "3 - Logging"): CISRemediationOverride(
+        why="Excluding management events from CloudTrail leaves control-plane changes unavailable for investigation.",
+        fix_console="AWS Console → CloudTrail → Trails → <trail> → Event selectors → Management events",
+        guardrails=("logging-and-audit", "defense-in-depth"),
+    ),
     # ── Azure ──────────────────────────────────────────────────────────
-    ("azure", "2.1.1"): {
-        "why": "Microsoft Defender for Servers off means hosts lack EDR-grade detection.",
-        "fix_cli": "az security pricing create --name VirtualMachines --tier Standard",
-        "fix_console": "Azure Portal → Microsoft Defender for Cloud → Environment settings → <subscription> → Defender plans",
-        "effort": "low",
-        "guardrails": ["defense-in-depth"],
-        "requires_human_review": True,
-    },
-    ("azure", "3.1"): {
-        "why": "Storage account without 'Secure transfer required' accepts plaintext HTTP traffic.",
-        "fix_cli": "az storage account update --name <SA_NAME> --resource-group <RG> --https-only true",
-        "fix_console": "Azure Portal → Storage accounts → <sa> → Configuration → Secure transfer required",
-        "effort": "low",
-        "guardrails": ["encryption", "network-exposure"],
-        "requires_human_review": False,
-    },
-    ("azure", "3.7"): {
-        "why": "Public blob access enables unauthenticated data read over the internet.",
-        "fix_cli": "az storage account update --name <SA_NAME> --resource-group <RG> --allow-blob-public-access false",
-        "fix_console": "Azure Portal → Storage accounts → <sa> → Configuration → Allow Blob public access: Disabled",
-        "effort": "low",
-        "guardrails": ["network-exposure", "defense-in-depth"],
-        "requires_human_review": True,
-    },
-    ("azure", "5.1.1"): {
-        "why": "Diagnostic settings off means control-plane activity is not centrally captured.",
-        "fix_cli": None,
-        "fix_console": "Azure Portal → Monitor → Activity log → Export activity logs → Add diagnostic setting",
-        "effort": "medium",
-        "guardrails": ["logging-and-audit", "defense-in-depth"],
-        "requires_human_review": True,
-    },
-    ("azure", "8.1"): {
-        "why": "Key Vault keys without expiration linger past their rotation window.",
-        "fix_cli": None,
-        "fix_console": "Azure Portal → Key vaults → <vault> → Keys → <key> → Set expiration",
-        "effort": "medium",
-        "guardrails": ["encryption", "secrets-handling", "human-in-loop"],
-        "requires_human_review": True,
-    },
+    CISControlIdentity(
+        "azure", "3.0", "3.1", "Secure transfer required on storage accounts", "3 - Storage Accounts"
+    ): CISRemediationOverride(
+        why="Storage accounts without secure transfer accept plaintext HTTP traffic.",
+        fix_console="Azure Portal → Storage accounts → <account> → Configuration → Secure transfer required",
+        guardrails=("encryption", "network-exposure"),
+    ),
+    CISControlIdentity("azure", "3.0", "3.7", "Blob containers set to private access", "3 - Storage Accounts"): CISRemediationOverride(
+        why="Public blob access enables unauthenticated data reads over the internet.",
+        fix_console="Azure Portal → Storage accounts → <account> → Containers → Change access level to Private",
+        guardrails=("network-exposure", "defense-in-depth"),
+    ),
+    CISControlIdentity(
+        "azure", "3.0", "5.1.1", "Diagnostic setting captures Activity Log", "5 - Logging and Monitoring"
+    ): CISRemediationOverride(
+        why="Missing diagnostic settings prevent centralized capture of control-plane activity.",
+        fix_console="Azure Portal → Monitor → Activity log → Export activity logs → Add diagnostic setting",
+        guardrails=("logging-and-audit", "defense-in-depth"),
+    ),
+    CISControlIdentity("azure", "3.0", "8.1", "Expiration date set on Key Vault keys", "8 - Key Vault"): CISRemediationOverride(
+        why="Key Vault keys without expiration can remain usable beyond their intended rotation window.",
+        fix_console="Azure Portal → Key vaults → <vault> → Keys → <key> → Set expiration",
+        guardrails=("encryption", "secrets-handling", "human-in-loop"),
+    ),
     # ── GCP ────────────────────────────────────────────────────────────
-    ("gcp", "1.4"): {
-        "why": "Service account keys are long-lived credentials; rotation and minimization reduce exposure.",
-        "fix_cli": "gcloud iam service-accounts keys delete <KEY_ID> --iam-account=<SA_EMAIL>",
-        "fix_console": "GCP Console → IAM & Admin → Service Accounts → <sa> → Keys",
-        "effort": "low",
-        "guardrails": ["identity", "least-privilege", "secrets-handling", "human-in-loop"],
-        "requires_human_review": True,
-    },
-    ("gcp", "2.1"): {
-        "why": "Without Cloud Audit Logs, sensitive API activity is not recoverable for investigations.",
-        "fix_cli": None,  # Requires full policy IAM bindings mutation — console-safer
-        "fix_console": "GCP Console → IAM & Admin → Audit Logs → Enable Data Read / Data Write / Admin Read for all services",
-        "effort": "medium",
-        "guardrails": ["logging-and-audit", "defense-in-depth"],
-        "requires_human_review": True,
-    },
-    ("gcp", "3.1"): {
-        "why": "Default VPC permits east-west traffic across legacy defaults that predate firewall best practices.",
-        "fix_cli": None,
-        "fix_console": "GCP Console → VPC network → Delete default network; create scoped VPCs per environment",
-        "effort": "high",
-        "guardrails": ["network-exposure", "segmentation", "zero-trust"],
-        "requires_human_review": True,
-    },
-    ("gcp", "5.1"): {
-        "why": "Storage buckets with uniform bucket-level access off still allow ACL-based public read.",
-        "fix_cli": "gcloud storage buckets update gs://<BUCKET> --uniform-bucket-level-access",
-        "fix_console": "GCP Console → Cloud Storage → <bucket> → Permissions → Uniform access control",
-        "effort": "low",
-        "guardrails": ["network-exposure", "defense-in-depth"],
-        "requires_human_review": False,
-    },
-    ("gcp", "5.2"): {
-        "why": "Buckets with public allUsers/allAuthenticatedUsers binding leak data over the internet.",
-        "fix_cli": "gsutil iam ch -d allUsers:objectViewer gs://<BUCKET> && gsutil iam ch -d allAuthenticatedUsers:objectViewer gs://<BUCKET>",
-        "fix_console": "GCP Console → Cloud Storage → <bucket> → Permissions → remove allUsers / allAuthenticatedUsers",
-        "effort": "low",
-        "guardrails": ["network-exposure", "least-privilege"],
-        "requires_human_review": True,
-    },
+    CISControlIdentity(
+        "gcp", "3.0", "1.4", "No user-managed service account keys", "1 - Identity and Access Management"
+    ): CISRemediationOverride(
+        why="User-managed service account keys are long-lived credentials that increase exposure when copied or leaked.",
+        fix_console="GCP Console → IAM & Admin → Service Accounts → <account> → Keys",
+        guardrails=("identity", "least-privilege", "secrets-handling", "human-in-loop"),
+    ),
+    CISControlIdentity("gcp", "3.0", "2.1", "Cloud Audit Logs configured for all services", "2 - Logging"): CISRemediationOverride(
+        why="Without Cloud Audit Logs, sensitive API activity is unavailable for investigations.",
+        fix_console="GCP Console → IAM & Admin → Audit Logs → Configure Data Read, Data Write, and Admin Read",
+        guardrails=("logging-and-audit", "defense-in-depth"),
+    ),
+    CISControlIdentity("gcp", "3.0", "3.1", "No default VPC network in the project", "3 - Networking"): CISRemediationOverride(
+        why="The default VPC carries broad legacy firewall defaults that weaken environment segmentation.",
+        fix_console="GCP Console → VPC network → Review default network and create scoped environment VPCs",
+        guardrails=("network-exposure", "segmentation", "zero-trust"),
+    ),
+    CISControlIdentity("gcp", "3.0", "5.1", "Cloud Storage buckets not publicly accessible", "5 - Cloud Storage"): CISRemediationOverride(
+        why="Public allUsers or allAuthenticatedUsers IAM bindings can expose bucket data to the internet.",
+        fix_console="GCP Console → Cloud Storage → <bucket> → Permissions → Review public principals",
+        guardrails=("network-exposure", "least-privilege"),
+    ),
+    CISControlIdentity("gcp", "3.0", "5.2", "Uniform bucket-level access enabled on buckets", "5 - Cloud Storage"): CISRemediationOverride(
+        why="Buckets without uniform access retain ACL-based authorization paths outside centralized IAM policy.",
+        fix_console="GCP Console → Cloud Storage → <bucket> → Permissions → Uniform access control",
+        guardrails=("identity", "least-privilege", "defense-in-depth"),
+    ),
     # ── Snowflake ──────────────────────────────────────────────────────
-    ("snowflake", "1.1"): {
-        "why": "SCIM / SSO disabled means identity lifecycle is not tied to the corporate IdP.",
-        "fix_cli": None,
-        "fix_console": "Snowsight → Admin → Security → SCIM / SSO integrations",
-        "effort": "high",
-        "guardrails": ["identity", "zero-trust", "human-in-loop"],
-        "requires_human_review": True,
-    },
-    ("snowflake", "1.2"): {
-        "why": "Users without MFA are a single-password path to tenant compromise.",
-        "fix_cli": "ALTER USER <USER> SET MINS_TO_BYPASS_MFA=0;  -- enforce MFA",
-        "fix_console": "Snowsight → Admin → Users & Roles → <user> → Require MFA",
-        "effort": "low",
-        "guardrails": ["identity", "zero-trust", "priv-escalation"],
-        "requires_human_review": True,
-    },
-    ("snowflake", "1.4"): {
-        "why": "ACCOUNTADMIN used for day-to-day operations breaks separation of duties.",
-        "fix_cli": None,
-        "fix_console": "Snowsight → Admin → Users & Roles → rotate admin role assignments",
-        "effort": "medium",
-        "guardrails": ["identity", "least-privilege", "priv-escalation"],
-        "requires_human_review": True,
-    },
-    ("snowflake", "2.1"): {
-        "why": "Network policies off means the account accepts traffic from any source IP.",
-        "fix_cli": "CREATE NETWORK POLICY corp_only ALLOWED_IP_LIST=('<CORP_CIDR>'); ALTER ACCOUNT SET NETWORK_POLICY=corp_only;",
-        "fix_console": "Snowsight → Admin → Security → Network policies",
-        "effort": "low",
-        "guardrails": ["network-exposure", "segmentation", "zero-trust"],
-        "requires_human_review": True,
-    },
+    CISControlIdentity(
+        "snowflake", "1.0", "1.1", "MFA enabled for password-auth users", "1 - Account and Authentication"
+    ): CISRemediationOverride(
+        why="Password-authenticated users without MFA remain exposed to single-factor account compromise.",
+        fix_console="Snowsight → Admin → Users & Roles → Review MFA enrollment and authentication policy",
+        guardrails=("identity", "zero-trust", "human-in-loop"),
+    ),
+    CISControlIdentity(
+        "snowflake", "1.0", "1.2", "Minimum password length 14 or greater", "1 - Account and Authentication"
+    ): CISRemediationOverride(
+        why="A password policy below 14 characters weakens resistance to password guessing and credential attacks.",
+        fix_console="Snowsight → Admin → Security → Password policies",
+        guardrails=("identity", "defense-in-depth", "human-in-loop"),
+    ),
+    CISControlIdentity(
+        "snowflake", "1.0", "1.4", "ACCOUNTADMIN granted to at most 2 users", "1 - Account and Authentication"
+    ): CISRemediationOverride(
+        why="Broad ACCOUNTADMIN assignment weakens separation of duties and expands privileged access.",
+        fix_console="Snowsight → Admin → Users & Roles → Review ACCOUNTADMIN grants",
+        guardrails=("identity", "least-privilege", "priv-escalation"),
+    ),
+    CISControlIdentity(
+        "snowflake", "1.0", "2.1", "Account-level network policies configured", "2 - Network Security"
+    ): CISRemediationOverride(
+        why="Without an account network policy, Snowflake access is not restricted to approved network locations.",
+        fix_console="Snowsight → Admin → Security → Network policies",
+        guardrails=("network-exposure", "segmentation", "zero-trust", "human-in-loop"),
+    ),
 }
+
+# PR 1 deliberately contains no verified commands. PR 2 may add an identity to
+# this set only with provider-doc evidence and exact command-contract tests.
+_VERIFIED_CLI_CONTROLS: frozenset[CISControlIdentity] = frozenset()
 
 
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
+
+
+def fail_closed_remediation_payload(value: Any) -> dict[str, Any]:
+    """Return a copy safe to expose while the verified CLI set is empty.
+
+    Historical scan jobs and analytics rows can contain commands written by an
+    older release. Canonicalizing at projection boundaries prevents those rows
+    from replaying stale mutations after an upgrade without rewriting evidence.
+    """
+    remediation = dict(value) if isinstance(value, dict) else {}
+    remediation["fix_cli"] = None
+    remediation["effort"] = "manual"
+    remediation["requires_human_review"] = True
+    return remediation
 
 
 def build_remediation(
@@ -424,6 +382,7 @@ def build_remediation(
     severity: str,
     recommendation: str,
     cis_section: str,
+    benchmark_version: str | None = None,
 ) -> dict[str, Any]:
     """Build a fully-populated remediation dict for a CIS check.
 
@@ -447,24 +406,33 @@ def build_remediation(
         "requires_human_review": True,
     }
 
-    override = _OVERRIDES.get((cloud, check_id))
+    identity = CISControlIdentity(
+        cloud=cloud,
+        benchmark_version=benchmark_version or "",
+        check_id=check_id,
+        title=title,
+        cis_section=cis_section,
+    )
+    override = _OVERRIDES.get(identity)
     if override:
-        # Overrides only need to provide the fields they want to set; the
-        # auto-derived values fill in the rest. This keeps override
-        # authoring terse while guaranteeing schema completeness.
-        merged = {**base, **override}
-        # Preserve priority from override if it set one explicitly; otherwise
-        # inherit severity-derived priority.
-        merged.setdefault("priority", priority)
-        # Preserve guardrails union if the override supplied its own list.
-        if "guardrails" not in override:
-            merged["guardrails"] = guardrails
+        fix_cli = override.fix_cli if identity in _VERIFIED_CLI_CONTROLS else None
+        merged = {
+            **base,
+            "why": override.why,
+            "fix_cli": fix_cli,
+            "fix_console": override.fix_console,
+            "effort": override.effort if fix_cli else "manual",
+            "guardrails": list(override.guardrails),
+            "requires_human_review": True,
+        }
+        if override.docs:
+            merged["docs"] = override.docs
         return merged
 
     return base
 
 
-def attach_remediation(result: Any, *, cloud: str) -> None:
+def attach_remediation(result: Any, *, cloud: str, benchmark_version: str | None = None) -> None:
     """Populate ``result.remediation`` in-place.
 
     Idempotent: calling twice produces the same dict. Safe to call on
@@ -478,10 +446,11 @@ def attach_remediation(result: Any, *, cloud: str) -> None:
         severity=result.severity,
         recommendation=result.recommendation,
         cis_section=result.cis_section,
+        benchmark_version=benchmark_version,
     )
 
 
 def attach_all(report: Any, *, cloud: str) -> None:
     """Attach remediation to every check in a CIS benchmark report."""
     for check in report.checks:
-        attach_remediation(check, cloud=cloud)
+        attach_remediation(check, cloud=cloud, benchmark_version=getattr(report, "benchmark_version", None))

--- a/src/agent_bom/demo_estate/showcase_cis.py
+++ b/src/agent_bom/demo_estate/showcase_cis.py
@@ -38,13 +38,13 @@ def _check(
 
 
 def _rem(
-    fix_cli: str,
+    fix_cli: str | None,
     fix_console: str,
     effort: str,
     priority: int,
     *,
     guardrails: list[str] | None = None,
-    requires_human_review: bool = False,
+    requires_human_review: bool = True,
 ) -> dict[str, Any]:
     return {
         "fix_cli": fix_cli,
@@ -61,7 +61,7 @@ _AWS_CHECKS: list[dict[str, Any]] = [
         "1.4", "Ensure no root user account access key exists", "pass", "high",
         "1 Identity and Access Management",
         "No access keys attached to the root account.", ["root"],
-        _rem("aws iam delete-access-key --user-name root", "IAM > Security credentials", "low", 3),
+        _rem(None, "IAM > Security credentials (root) > Delete access key", "manual", 3),
     ),
     _check(
         "1.12", "Ensure credentials unused for 45 days are disabled", "fail", "medium",

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -864,6 +864,7 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
         str(t) for t in (check.get("compliance_tags") or []) if str(t).strip()
     ]
     cis_section = sanitize_text(str(check.get("cis_section", "") or ""), max_len=200)
+    benchmark_version = sanitize_text(str(check.get("benchmark_version", "") or ""), max_len=40)
     status = str(check.get("status", "FAIL") or "FAIL").upper()
     if is_vendor_best_practice:
         finding_type = FindingType.CLOUD_BEST_PRACTICE_ERROR if status == "ERROR" else FindingType.CLOUD_BEST_PRACTICE_FAIL
@@ -912,8 +913,10 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
         evidence={
             "provider": provider,
             "check_id": check_id,
+            "control_title": title,
             "status": status,
             "cis_section": cis_section,
+            "benchmark_version": benchmark_version,
             "resource_ids": resource_ids,
             "benchmark": "Databricks Security Best Practices" if is_vendor_best_practice else "CIS",
         },

--- a/src/agent_bom/models.py
+++ b/src/agent_bom/models.py
@@ -1556,7 +1556,8 @@ class AIBOMReport:
                 continue
             for check in data.get("checks", []) or []:
                 if isinstance(check, dict) and str(check.get("status", "")).upper() in {"FAIL", "ERROR"}:
-                    findings.append(cloud_cis_check_to_finding(check, provider))
+                    check_with_version = {**check, "benchmark_version": data.get("benchmark_version")}
+                    findings.append(cloud_cis_check_to_finding(check_with_version, provider))
         return findings
 
     def cve_findings(self) -> "list[Finding]":

--- a/src/agent_bom/remediation.py
+++ b/src/agent_bom/remediation.py
@@ -285,16 +285,19 @@ def _build_cis_remediation(finding: "Finding") -> Remediation:
     evidence = finding.evidence or {}
     provider = _provider_from_finding(finding)
     check_id = str(evidence.get("check_id", "") or "")
+    control_title = str(evidence.get("control_title", "") or finding.title)
     cis_section = str(evidence.get("cis_section", "") or "")
+    benchmark_version = str(evidence.get("benchmark_version", "") or "") or None
     recommendation = finding.remediation_guidance or ""
 
     catalog = build_cis_catalog(
         cloud=provider,
         check_id=check_id,
-        title=finding.title,
+        title=control_title,
         severity=finding.effective_severity(),
         recommendation=recommendation,
         cis_section=cis_section,
+        benchmark_version=benchmark_version,
     )
 
     cli = catalog.get("fix_cli")

--- a/tests/test_cis_benchmark_analytics.py
+++ b/tests/test_cis_benchmark_analytics.py
@@ -44,12 +44,12 @@ def _cis_check(
         "evidence": "synthetic fixture",
         "resource_ids": [f"arn:{cloud}:resource:test"],
         "remediation": {"summary": "tighten config"},
-        "fix_cli": "noop",
+        "fix_cli": "",
         "fix_console": "see console",
-        "effort": "low",
+        "effort": "manual",
         "priority": priority,
         "guardrails": [],
-        "requires_human_review": False,
+        "requires_human_review": True,
         "measured_at": measured,
     }
 

--- a/tests/test_cis_remediation.py
+++ b/tests/test_cis_remediation.py
@@ -13,6 +13,7 @@ from agent_bom.cloud.aws_cis_benchmark import CheckStatus, CISCheckResult
 from agent_bom.cloud.cis_remediation import (
     _OVERRIDES,
     GUARDRAIL_TAGS,
+    attach_all,
     attach_remediation,
     build_remediation,
 )
@@ -62,16 +63,21 @@ def test_build_remediation_universal_fallback_has_schema():
 
 
 def test_all_overrides_validate_against_schema():
-    for (cloud, check_id), _override in _OVERRIDES.items():
+    for identity, override in _OVERRIDES.items():
         rem = build_remediation(
-            cloud=cloud,
-            check_id=check_id,
-            title="override test",
+            cloud=identity.cloud,
+            benchmark_version=identity.benchmark_version,
+            check_id=identity.check_id,
+            title=identity.title,
             severity="high",
             recommendation="",
-            cis_section="1 - Identity and Access Management",
+            cis_section=identity.cis_section,
         )
         _assert_schema(rem)
+        assert rem["why"] == override.why
+        assert rem["fix_cli"] is None
+        assert rem["effort"] == "manual"
+        assert rem["requires_human_review"] is True
 
 
 def test_priority_derives_from_severity():
@@ -96,31 +102,31 @@ def test_priority_derives_from_severity():
 def test_attach_remediation_is_idempotent():
     result = CISCheckResult(
         check_id="1.4",
-        title="Ensure no root user account access key exists",
+        title="No root account access keys",
         status=CheckStatus.FAIL,
         severity="high",
         recommendation="Remove root access keys.",
         cis_section="1 - Identity and Access Management",
     )
-    attach_remediation(result, cloud="aws")
+    attach_remediation(result, cloud="aws", benchmark_version="3.0")
     first = dict(result.remediation)
-    attach_remediation(result, cloud="aws")
+    attach_remediation(result, cloud="aws", benchmark_version="3.0")
     assert result.remediation == first
 
 
-def test_override_applies_when_check_id_matches():
+def test_override_applies_only_when_full_identity_matches():
     result = CISCheckResult(
         check_id="1.4",
-        title="Ensure no root user account access key exists",
+        title="No root account access keys",
         status=CheckStatus.FAIL,
         severity="high",
         recommendation="",
         cis_section="1 - Identity and Access Management",
     )
-    attach_remediation(result, cloud="aws")
-    # Hand-authored AWS 1.4 override has a concrete CLI.
-    assert result.remediation["fix_cli"] is not None
-    assert "delete-access-key" in result.remediation["fix_cli"]
+    attach_remediation(result, cloud="aws", benchmark_version="3.0")
+    assert result.remediation["fix_cli"] is None
+    assert result.remediation["effort"] == "manual"
+    assert result.remediation["requires_human_review"] is True
     assert "priv-escalation" in result.remediation["guardrails"]
 
 
@@ -162,3 +168,58 @@ def test_fallback_fix_console_non_empty_for_known_clouds(cloud):
         cis_section="1 - Identity and Access Management",
     )
     assert rem["fix_console"], f"expected console path for {cloud}"
+
+
+_AWS_ACCOUNT_PUBLIC_ACCESS = {
+    "cloud": "aws",
+    "check_id": "2.1.1",
+    "title": "S3 account-level public access block configured",
+    "severity": "high",
+    "recommendation": "Enable all four S3 public access block settings at the account level.",
+    "cis_section": "2 - Storage",
+}
+
+
+def test_matching_override_is_advisory_only_until_command_is_verified():
+    rem = build_remediation(**_AWS_ACCOUNT_PUBLIC_ACCESS, benchmark_version="3.0")
+
+    assert rem["fix_cli"] is None
+    assert rem["effort"] == "manual"
+    assert rem["requires_human_review"] is True
+    assert "account-level" in rem["why"].lower()
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [
+        {},
+        {"benchmark_version": "2.0"},
+        {"benchmark_version": "3.0", "title": "S3 bucket public access block configured"},
+        {"benchmark_version": "3.0", "cis_section": "2 - Different storage section"},
+    ],
+)
+def test_missing_or_drifted_control_identity_fails_closed(changes):
+    args = {**_AWS_ACCOUNT_PUBLIC_ACCESS, **changes}
+    rem = build_remediation(**args)
+
+    assert rem["fix_cli"] is None
+    assert rem["effort"] == "manual"
+    assert rem["requires_human_review"] is True
+    assert rem["why"] == f"Failure indicates: {args['title'].lower().rstrip('.')}."
+
+
+def test_attach_all_propagates_report_benchmark_version():
+    check = CISCheckResult(
+        check_id="2.1.1",
+        title="S3 account-level public access block configured",
+        status=CheckStatus.FAIL,
+        severity="high",
+        recommendation="Enable all four S3 public access block settings at the account level.",
+        cis_section="2 - Storage",
+    )
+    report = type("Report", (), {"benchmark_version": "3.0", "checks": [check]})()
+
+    attach_all(report, cloud="aws")
+
+    assert check.remediation["fix_cli"] is None
+    assert "account-level" in check.remediation["why"].lower()

--- a/tests/test_cis_remediation_catalog_contract.py
+++ b/tests/test_cis_remediation_catalog_contract.py
@@ -1,0 +1,84 @@
+"""Prevent CIS remediation overrides drifting away from live controls."""
+
+from __future__ import annotations
+
+import ast
+from collections import Counter
+from pathlib import Path
+
+from agent_bom.cloud.cis_remediation import (
+    _OVERRIDES,
+    _VERIFIED_CLI_CONTROLS,
+    CISControlIdentity,
+    CISRemediationOverride,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_CLOUD_MODULES = {
+    "aws": _REPO_ROOT / "src/agent_bom/cloud/aws_cis_benchmark.py",
+    "azure": _REPO_ROOT / "src/agent_bom/cloud/azure_cis_benchmark.py",
+    "gcp": _REPO_ROOT / "src/agent_bom/cloud/gcp_cis_benchmark.py",
+    "snowflake": _REPO_ROOT / "src/agent_bom/cloud/snowflake_cis_benchmark.py",
+}
+
+
+def _literal_string(node: ast.expr | None, constants: dict[str, str]) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.Name):
+        return constants.get(node.id)
+    return None
+
+
+def _catalog_identities(cloud: str, path: Path) -> list[CISControlIdentity]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    constants: dict[str, str] = {}
+    benchmark_version = ""
+
+    for node in tree.body:
+        if isinstance(node, ast.Assign) and len(node.targets) == 1 and isinstance(node.targets[0], ast.Name):
+            value = _literal_string(node.value, constants)
+            if value is not None:
+                constants[node.targets[0].id] = value
+        if isinstance(node, ast.ClassDef):
+            for child in node.body:
+                if isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name) and child.target.id == "benchmark_version":
+                    benchmark_version = _literal_string(child.value, constants) or ""
+
+    identities: list[CISControlIdentity] = []
+    for node in ast.walk(tree):
+        if not (isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "CISCheckResult"):
+            continue
+        keywords = {keyword.arg: keyword.value for keyword in node.keywords if keyword.arg}
+        check_id = _literal_string(keywords.get("check_id"), constants)
+        title = _literal_string(keywords.get("title"), constants)
+        cis_section = _literal_string(keywords.get("cis_section"), constants)
+        if check_id is not None and title is not None and cis_section is not None:
+            identities.append(
+                CISControlIdentity(
+                    cloud=cloud,
+                    benchmark_version=benchmark_version,
+                    check_id=check_id,
+                    title=title,
+                    cis_section=cis_section,
+                )
+            )
+    return identities
+
+
+def test_each_override_matches_exactly_one_live_catalog_control() -> None:
+    live = Counter(identity for cloud, path in _CLOUD_MODULES.items() for identity in _catalog_identities(cloud, path))
+
+    assert _OVERRIDES
+    for identity, override in _OVERRIDES.items():
+        assert isinstance(identity, CISControlIdentity)
+        assert isinstance(override, CISRemediationOverride)
+        assert live[identity] == 1, f"override is stale or ambiguous: {identity}"
+
+
+def test_pr1_has_no_verified_cli_mutations() -> None:
+    assert _VERIFIED_CLI_CONTROLS == frozenset()
+    for override in _OVERRIDES.values():
+        assert override.fix_cli is None
+        assert override.effort == "manual"
+        assert override.requires_human_review is True

--- a/tests/test_cis_remediation_surfaces.py
+++ b/tests/test_cis_remediation_surfaces.py
@@ -31,17 +31,17 @@ def _bundle_with_remediation(cloud: str = "aws") -> dict:
         "checks": [
             {
                 "check_id": "1.4",
-                "title": "Ensure no root user account access key exists",
+                "title": "No root account access keys",
                 "status": "fail",
                 "severity": "high",
                 "evidence": "Root access key present.",
                 "resource_ids": ["root"],
                 "recommendation": "Remove root access keys.",
                 "remediation": {
-                    "why": "Failure indicates: ensure no root user account access key exists.",
-                    "fix_cli": "aws iam delete-access-key --user-name root --access-key-id <ROOT_KEY_ID>",
+                    "why": "Root account access keys allow full account takeover with no per-user audit trail.",
+                    "fix_cli": None,
                     "fix_console": "AWS Console → IAM → Security credentials (root) → Delete access key",
-                    "effort": "low",
+                    "effort": "manual",
                     "priority": 1,
                     "docs": "https://example/docs",
                     "guardrails": ["identity", "least-privilege", "priv-escalation", "zero-trust"],
@@ -103,7 +103,7 @@ def test_cli_compact_cis_posture_renders_remediation():
     assert "Cloud Security Posture" in out
     assert "AWS" in out
     assert "1.4" in out  # check_id
-    assert "delete-access-key" in out  # fix_cli surfaced
+    assert "Security credentials" in out  # manual console path surfaced
     assert "priv-escalation" in out or "least-privilege" in out  # guardrails surfaced
     assert "review" in out  # requires_human_review flag shown
 
@@ -180,7 +180,7 @@ def test_html_cis_section_emits_remediation():
     assert 'id="cisbenchmarks"' in html
     assert "AWS" in html
     assert "1.4" in html
-    assert "delete-access-key" in html  # fix_cli
+    assert "Security credentials" in html  # manual console path
     assert "priv-escalation" in html or "least-privilege" in html
     assert "review" in html  # human-review flag rendered
 
@@ -240,10 +240,11 @@ def test_sarif_includes_cis_result_with_remediation_properties():
     assert len(cis_results) == 1
     props = cis_results[0].get("properties", {})
     # Structured remediation is preserved as a nested dict.
-    assert props["remediation"]["fix_cli"].startswith("aws iam delete-access-key")
+    assert props["remediation"]["fix_cli"] is None
     # Flat convenience keys are also present for SARIF consumers that
     # don't parse nested dicts.
-    assert props["fix_cli"].startswith("aws iam delete-access-key")
+    assert props["fix_cli"] is None
+    assert "Security credentials" in props["fix_console"]
     assert props["priority"] == 1
     assert "priv-escalation" in props["guardrails"]
     assert props["requires_human_review"] is True

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -359,8 +359,16 @@ class TestClickHouseAnalyticsStore:
                         "check_id": "1.5",
                         "status": "fail",
                         "priority": 1,
-                        "remediation": {"fix_console": "AWS Console", "priority": 1},
-                        "requires_human_review": True,
+                        "remediation": {
+                            "fix_cli": "aws kms enable-key-rotation --key-id <KMS_KEY_ID>",
+                            "fix_console": "AWS Console",
+                            "effort": "low",
+                            "priority": 1,
+                            "requires_human_review": False,
+                        },
+                        "fix_cli": "aws kms enable-key-rotation --key-id <KMS_KEY_ID>",
+                        "effort": "low",
+                        "requires_human_review": False,
                     }
                 ],
                 tenant_id="tenant-alpha",
@@ -370,7 +378,13 @@ class TestClickHouseAnalyticsStore:
         row = inserted["rows"][0]
         assert row["tenant_id"] == "tenant-alpha"
         assert row["priority"] == 1
-        assert json.loads(row["remediation"])["priority"] == 1
+        remediation = json.loads(row["remediation"])
+        assert remediation["priority"] == 1
+        assert remediation["fix_cli"] is None
+        assert remediation["effort"] == "manual"
+        assert remediation["requires_human_review"] is True
+        assert row["fix_cli"] == ""
+        assert row["effort"] == "manual"
         assert row["requires_human_review"] == 1
 
     def test_buffered_store_flushes_before_query(self):

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import JobStatus, _get_store, app
@@ -617,6 +619,66 @@ def test_cis_foundations_reconciles_with_cis_checks():
     assert scorecard["fail"] == tally["fail"]
     assert scorecard["error"] == tally["error"]
     _clear_jobs()
+
+
+def test_cis_checks_fail_closed_for_legacy_remediation_rows():
+    _clear_jobs()
+    _add_done_job(
+        [],
+        result_extra=_cis_benchmark_result(
+            [
+                {
+                    "check_id": "3.5",
+                    "title": "CloudTrail records management events in all regions",
+                    "status": "FAIL",
+                    "severity": "high",
+                    "remediation": {
+                        "fix_cli": "aws kms enable-key-rotation --key-id <KMS_KEY_ID>",
+                        "fix_console": "AWS Console → CloudTrail → Trails → Event selectors",
+                        "effort": "low",
+                        "requires_human_review": False,
+                    },
+                }
+            ]
+        ),
+    )
+
+    row = TestClient(app).get("/v1/cis/checks", headers=_AUTH_HEADERS).json()["checks"][0]
+    assert row["fix_cli"] == ""
+    assert row["effort"] == "manual"
+    assert row["requires_human_review"] is True
+    assert row["remediation"]["fix_cli"] is None
+    assert row["remediation"]["requires_human_review"] is True
+    assert "Event selectors" in row["fix_console"]
+    _clear_jobs()
+
+
+def test_persisted_cis_rows_are_canonicalized_fail_closed():
+    from agent_bom.api.routes.compliance import _coerce_cis_row
+
+    row = _coerce_cis_row(
+        {
+            "fix_cli": "aws kms enable-key-rotation --key-id <KMS_KEY_ID>",
+            "fix_console": "",
+            "effort": "low",
+            "requires_human_review": False,
+            "remediation": json.dumps(
+                {
+                    "fix_cli": "aws kms enable-key-rotation --key-id <KMS_KEY_ID>",
+                    "fix_console": "AWS Console → CloudTrail → Trails → Event selectors",
+                    "effort": "low",
+                    "requires_human_review": False,
+                }
+            ),
+        }
+    )
+
+    assert row["fix_cli"] == ""
+    assert row["effort"] == "manual"
+    assert row["requires_human_review"] is True
+    assert row["remediation"]["fix_cli"] is None
+    assert row["remediation"]["requires_human_review"] is True
+    assert "Event selectors" in row["fix_console"]
 
 
 # ─── PR3: NIST 800-53 catalog-backed scoring line ────────────────────────────

--- a/tests/test_compliance_report.py
+++ b/tests/test_compliance_report.py
@@ -272,7 +272,12 @@ def test_list_cis_checks_prefers_columnar_store():
     set_job_store(_ColumnarStore())
     body = asyncio.run(compliance_routes.list_cis_benchmark_checks(_request("tenant-alpha"), cloud="aws"))
     assert body["source"] == "columnar"
-    assert body["checks"][0]["remediation"] == {"priority": 1}
+    assert body["checks"][0]["remediation"] == {
+        "priority": 1,
+        "fix_cli": None,
+        "effort": "manual",
+        "requires_human_review": True,
+    }
 
 
 def _patched_get_compliance_returns(payload: dict):

--- a/tests/test_remediation_foundation.py
+++ b/tests/test_remediation_foundation.py
@@ -29,7 +29,7 @@ from agent_bom.remediation import (
 
 
 def _cis_finding() -> Finding:
-    """A CIS finding mirroring the AWS 2.1.1 (S3 public access) override."""
+    """A legacy CIS finding whose incomplete identity must fail closed."""
     return cloud_cis_check_to_finding(
         {
             "check_id": "2.1.1",
@@ -58,21 +58,20 @@ def test_build_remediation_cis_returns_fix_privilege_and_artifact() -> None:
     assert isinstance(rem.required_privilege, RequiredPrivilege)
     assert isinstance(rem.artifact, RemediationArtifact)
 
-    # fix carries the exact action from the CIS catalog override
-    assert rem.fix.cli is not None
-    assert "put-public-access-block" in rem.fix.cli
+    # A finding without benchmark provenance cannot receive a mutation.
+    assert rem.fix.cli is None
     assert rem.fix.console
     assert rem.fix.summary
 
-    # required_privilege names the least-privilege action to APPLY, not request
-    assert rem.required_privilege.actions == ["s3:PutBucketPublicAccessBlock"]
+    # Manual guidance does not invent an apply permission.
+    assert rem.required_privilege.actions == []
     assert "apply" in rem.required_privilege.description.lower()
-    assert "read-only" in rem.required_privilege.scope_note.lower()
+    assert "never requests" in rem.required_privilege.scope_note.lower()
 
     # artifact is a generated runbook (text only)
     assert rem.artifact.kind == "runbook"
-    assert "put-public-access-block" in rem.artifact.content
-    assert "s3:PutBucketPublicAccessBlock" in rem.artifact.content
+    assert "Console:" in rem.artifact.content
+    assert "Advisory only" in rem.artifact.content
 
 
 def test_cis_error_uses_review_guidance_not_control_fix() -> None:
@@ -94,6 +93,26 @@ def test_cis_error_uses_review_guidance_not_control_fix() -> None:
     assert "rerun" in remediation.fix.summary.lower()
 
 
+def test_versioned_cis_finding_uses_exact_advisory_metadata() -> None:
+    finding = cloud_cis_check_to_finding(
+        {
+            "check_id": "2.1.1",
+            "title": "S3 account-level public access block configured",
+            "status": "FAIL",
+            "severity": "high",
+            "recommendation": "Enable all four account-level settings.",
+            "cis_section": "2 - Storage",
+            "benchmark_version": "3.0",
+        },
+        provider="aws",
+    )
+
+    assert finding.remediation is not None
+    assert finding.remediation.fix.cli is None
+    assert "Block Public Access settings for this account" in (finding.remediation.fix.console or "")
+    assert "network-exposure" in finding.remediation.guardrails
+
+
 def test_advisory_flags_always_set() -> None:
     rem = build_remediation(_cis_finding())
     assert rem.applied is False
@@ -104,7 +123,8 @@ def test_cis_finding_populates_remediation_field() -> None:
     finding = _cis_finding()
     assert finding.remediation is not None
     assert finding.remediation.applied is False
-    assert finding.remediation.required_privilege.actions
+    assert finding.remediation.fix.cli is None
+    assert finding.remediation.required_privilege.actions == []
 
 
 # ---------------------------------------------------------------------------
@@ -207,8 +227,8 @@ def test_finding_to_dict_includes_remediation_when_present() -> None:
     rem = payload["remediation"]
     assert rem["applied"] is False
     assert rem["auto_remediation"] is False
-    assert rem["fix"]["cli"]
-    assert rem["required_privilege"]["actions"] == ["s3:PutBucketPublicAccessBlock"]
+    assert rem["fix"]["cli"] is None
+    assert rem["required_privilege"]["actions"] == []
     assert rem["artifact"]["kind"] == "runbook"
 
 

--- a/tests/test_sarif_advisory_text.py
+++ b/tests/test_sarif_advisory_text.py
@@ -121,9 +121,11 @@ def _report(*, cve_summary: str = _CVE_SUMMARY) -> AIBOMReport:
                 "resource_ids": ["arn:aws:iam::123456789012:root"],
                 "remediation": {
                     "docs": "https://docs.aws.amazon.com/iam",
-                    "fix_cli": "aws iam delete-access-key --user-name root",
-                    "effort": "low",
+                    "fix_cli": None,
+                    "fix_console": "AWS Console → IAM → Security credentials (root) → Delete access key",
+                    "effort": "manual",
                     "priority": 1,
+                    "requires_human_review": True,
                 },
             }
         ]
@@ -220,10 +222,10 @@ def test_cve_rule_help_carries_description_and_remediation(rules: dict[str, dict
     assert "https://osv.dev/vulnerability/CVE-2020-14343" in help_obj["markdown"]
 
 
-def test_cis_rule_help_carries_remediation_command(rules: dict[str, dict]) -> None:
+def test_cis_rule_help_carries_manual_remediation_guidance(rules: dict[str, dict]) -> None:
     help_obj = rules["cis/aws/1.4"]["help"]
     assert _CIS_RECOMMENDATION in help_obj["text"]
-    assert "aws iam delete-access-key --user-name root" in help_obj["text"]
+    assert "Security credentials" in help_obj["text"]
 
 
 def test_help_reference_link_cannot_be_broken_out_of() -> None:

--- a/ui/components/cis-benchmark-detail.tsx
+++ b/ui/components/cis-benchmark-detail.tsx
@@ -44,7 +44,7 @@ function normalizeCheck(check: CISBenchmarkCheck): CISBenchmarkCheck {
     resource_ids: Array.isArray(check.resource_ids) ? check.resource_ids : [],
     fix_cli: typeof check.fix_cli === "string" ? check.fix_cli : "",
     fix_console: typeof check.fix_console === "string" ? check.fix_console : "",
-    requires_human_review: Boolean(check.requires_human_review),
+    requires_human_review: check.requires_human_review !== false,
     priority: typeof check.priority === "number" ? check.priority : Number(check.priority) || 0,
     remediation: check.remediation ?? {},
   };
@@ -274,8 +274,9 @@ function FilterPills<T extends string | number>({
  * Cloud CIS benchmark drill-down. Fetches tenant-scoped checks from
  * `GET /v1/cis/checks`, then filters client-side by cloud, status, priority,
  * and guardrail so every fetched check participates in the guardrails filter.
- * Each failed check exposes a copy-pasteable `fix_cli` (with a human-review
- * warning when applicable) or a console path, plus a remediation docs link.
+ * Each failed check exposes a console path and remediation docs. A CLI command
+ * appears only for an explicitly verified control and always carries a review
+ * warning.
  */
 export function CISBenchmarkDetail() {
   const [checks, setChecks] = useState<CISBenchmarkCheck[] | null>(null);

--- a/ui/tests/cis-benchmark-detail.test.tsx
+++ b/ui/tests/cis-benchmark-detail.test.tsx
@@ -98,15 +98,18 @@ describe("CISBenchmarkDetail", () => {
     expect(screen.getByRole("button", { name: "Error" })).toBeInTheDocument();
   });
 
-  it("copies fix_cli and warns when the check requires human review", async () => {
+  it("copies a reviewed fix_cli and warns before use", async () => {
     apiMock.listCisBenchmarkChecks.mockResolvedValue({
       checks: [
         makeCheck({
-          check_id: "1.4",
-          title: "Eliminate root access keys",
-          fix_cli: "aws iam delete-access-key --user-name root",
+          check_id: "3.2",
+          title: "Enable CloudTrail log file validation",
+          fix_cli: "aws cloudtrail update-trail --name <TRAIL> --enable-log-file-validation",
           requires_human_review: true,
-          remediation: { fix_cli: "aws iam delete-access-key --user-name root", requires_human_review: true },
+          remediation: {
+            fix_cli: "aws cloudtrail update-trail --name <TRAIL> --enable-log-file-validation",
+            requires_human_review: true,
+          },
         }),
       ],
       count: 1,
@@ -114,14 +117,40 @@ describe("CISBenchmarkDetail", () => {
     });
     render(<CISBenchmarkDetail />);
 
-    await screen.findByText("Eliminate root access keys");
+    await screen.findByText("Enable CloudTrail log file validation");
     // Human-review badge is visible on a check that can break production.
     expect(screen.getByTestId("human-review-badge")).toBeInTheDocument();
 
     const copyButton = screen.getByRole("button", { name: /copy fix command/i });
     fireEvent.click(copyButton);
-    await waitFor(() => expect(writeText).toHaveBeenCalledWith("aws iam delete-access-key --user-name root"));
+    await waitFor(() =>
+      expect(writeText).toHaveBeenCalledWith(
+        "aws cloudtrail update-trail --name <TRAIL> --enable-log-file-validation",
+      ),
+    );
     expect(await screen.findByText(/review carefully before running/i)).toBeInTheDocument();
+  });
+
+  it("renders fail-closed remediation as manual guidance", async () => {
+    apiMock.listCisBenchmarkChecks.mockResolvedValue({
+      checks: [
+        makeCheck({
+          check_id: "1.4",
+          title: "No root account access keys",
+          fix_cli: "",
+          fix_console: "AWS Console → IAM → Security credentials (root) → Delete access key",
+          effort: "manual",
+          requires_human_review: true,
+        }),
+      ],
+      count: 1,
+      source: "scan_jobs",
+    });
+    render(<CISBenchmarkDetail />);
+
+    expect(await screen.findByText(/no copy-pasteable cli fix/i)).toBeInTheDocument();
+    expect(screen.getByText(/security credentials \(root\)/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /copy fix command/i })).not.toBeInTheDocument();
   });
 
   it("filters across all fetched checks by guardrail", async () => {


### PR DESCRIPTION
## Summary

- bind CIS remediation overrides to the exact provider, benchmark version, check ID, title, and section instead of reusing unstable check IDs
- remove all unverified CLI mutations, force manual human-reviewed guidance, and strip legacy commands from in-memory, Postgres/analytics, ClickHouse, API, demo, report, and UI projections
- add a source-catalog drift guard and correct the AWS, Azure, GCP, and Snowflake remediation metadata that had diverged from current controls

## Root cause

CIS remediation overrides were keyed only by `(cloud, check_id)`. Benchmark catalogs later reused several IDs for different controls, so structurally valid commands could be attached to the wrong finding. Persisted rows could also replay the stale commands after an upgrade.

## Verification

- TDD red state: 6 focused failures reproduced missing version/title/section checks and the stale AWS S3 command before implementation
- `uv run pytest -q <AWS/Azure/GCP/Snowflake CIS, remediation, persistence, API, SARIF, finding suites>` — 807 passed
- `uv run pytest -q tests/test_alert_dispatcher.py::test_webhook_channel_init` with network access — 1 passed (the unrestricted full-suite attempt otherwise stopped on sandbox DNS)
- `uv run ruff check src tests` — passed
- changed-file `uv run mypy ...` — passed for 8 source files
- `make preflight` — passed
- UI Node 24.18: toolchain check, TypeScript, 163 files / 976 tests, and production Next.js build — passed
- `uv run python scripts/check_public_docs_hygiene.py` — 813 files passed

## Notes

- no database migration or response-schema change
- historical evidence is not rewritten; commands are removed at projection boundaries
- full-project MyPy still reports the 12 existing cloud-SDK stub errors in unchanged files
- the verified CLI allowlist is intentionally empty for this PR; provider-verified restoration is a separate follow-up