### PR TITLE
fix(cis): restrict root remediation to break-glass use

### DIFF
--- a/docs/skills/cspm-aws-benchmark.md
+++ b/docs/skills/cspm-aws-benchmark.md
@@ -153,7 +153,8 @@ cis_benchmark(provider="aws", region="us-east-1")
   FINDING: Root account has access keys
   ──────────────────────────────────────
   WHY:     Root keys = unlimited blast radius. Compromised root = full account takeover.
-  FIX:     Sign in as the root user, open IAM > Security credentials, and delete the root access key.
+  FIX:     Prefer AWS Organizations root access management for member accounts. Otherwise, use an approved
+           break-glass root session, delete the key under IAM > Security credentials, and sign out immediately.
   VERIFY:  agent-bom scan --aws --aws-cis-benchmark | grep "root_access_keys"
 ```
 

--- a/src/agent_bom/cloud/cis_remediation.py
+++ b/src/agent_bom/cloud/cis_remediation.py
@@ -207,7 +207,11 @@ _OVERRIDES: dict[CISControlIdentity, CISRemediationOverride] = {
     # ── AWS ────────────────────────────────────────────────────────────
     CISControlIdentity("aws", "3.0", "1.4", "No root account access keys", "1 - Identity and Access Management"): CISRemediationOverride(
         why="Root account access keys allow full account takeover with no MFA and no per-user audit trail.",
-        fix_console="AWS Console → IAM → Security credentials (root) → Delete access key",
+        fix_console=(
+            "AWS Organizations → Root access management (preferred for member accounts), or an approved "
+            "break-glass root session → IAM → Security credentials → Delete access key → sign out immediately"
+        ),
+        docs="https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user_manage_delete-key.html",
         guardrails=("identity", "least-privilege", "priv-escalation", "zero-trust"),
     ),
     CISControlIdentity("aws", "3.0", "1.5", "Root account MFA enabled", "1 - Identity and Access Management"): CISRemediationOverride(

--- a/tests/test_cis_remediation.py
+++ b/tests/test_cis_remediation.py
@@ -7,6 +7,8 @@ validated against the same schema.
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from agent_bom.cloud.aws_cis_benchmark import CheckStatus, CISCheckResult
@@ -128,6 +130,36 @@ def test_override_applies_only_when_full_identity_matches():
     assert result.remediation["effort"] == "manual"
     assert result.remediation["requires_human_review"] is True
     assert "priv-escalation" in result.remediation["guardrails"]
+
+
+def test_aws_root_access_key_guidance_is_break_glass_only():
+    rem = build_remediation(
+        cloud="aws",
+        benchmark_version="3.0",
+        check_id="1.4",
+        title="No root account access keys",
+        severity="high",
+        recommendation="Remove root access keys.",
+        cis_section="1 - Identity and Access Management",
+    )
+
+    guidance = rem["fix_console"].lower()
+    assert "aws organizations" in guidance
+    assert "break-glass" in guidance
+    assert "sign out immediately" in guidance
+    assert rem["fix_cli"] is None
+    assert rem["requires_human_review"] is True
+    assert rem["docs"] == "https://docs.aws.amazon.com/IAM/latest/UserGuide/id_root-user_manage_delete-key.html"
+
+
+def test_aws_root_access_key_playbook_does_not_normalize_root_login():
+    playbook = (Path(__file__).parents[1] / "docs/skills/cspm-aws-benchmark.md").read_text(encoding="utf-8")
+    root_key_guidance = playbook.split("FINDING: Root account has access keys", 1)[1].split("```", 1)[0]
+
+    assert "Sign in as the root user" not in root_key_guidance
+    assert "AWS Organizations" in root_key_guidance
+    assert "break-glass" in root_key_guidance
+    assert "sign out immediately" in root_key_guidance
 
 
 def test_guardrails_inferred_from_iam_section():


### PR DESCRIPTION
## Summary

- prefer AWS Organizations root access management for member-account root-key removal
- restrict direct root access guidance to an approved break-glass session with immediate sign-out
- bind CIS 1.4 to the specific AWS root-key deletion documentation and prevent unsafe wording from returning

## Verification

- `uv run pytest -q tests/test_cis_remediation.py tests/test_cis_remediation_catalog_contract.py tests/test_cis_remediation_surfaces.py` (31 passed)
- `uv run ruff check src/agent_bom/cloud/cis_remediation.py tests/test_cis_remediation.py`
- `uv run mypy src/agent_bom/cloud/cis_remediation.py`
- `uv run python scripts/check_public_docs_hygiene.py`
- `git diff --check`
- repository search confirms no `--user-name root` command remains

## Notes

- Root cause: the manual CIS 1.4 console guidance named a root session without distinguishing centralized organization handling from tightly controlled break-glass access.
- Remediation remains advisory: `fix_cli` is null and human review is required.
- No database or wire-schema change.
