### PR TITLE
fix(cis): restore provider-verified remediation commands

### DIFF
--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -481,6 +481,10 @@ class ClickHouseAnalyticsStore:
         cloud = check.get("cloud", "")
         check_id = check.get("check_id", "")
         remediation = fail_closed_remediation_payload(check.get("remediation"))
+        fix_cli = str(remediation.get("fix_cli") or "")
+        fix_console = str(remediation.get("fix_console") or check.get("fix_console") or "")
+        effort = str(remediation.get("effort") or "manual")
+        guardrails = list(remediation.get("guardrails") or check.get("guardrails") or [])
         return {
             "measured_at": _coerce_clickhouse_timestamp(check.get("measured_at")),
             "scan_id": scan_id,
@@ -496,11 +500,11 @@ class ClickHouseAnalyticsStore:
             "evidence": check.get("evidence", ""),
             "resource_ids": list(check.get("resource_ids", []) or []),
             "remediation": json.dumps(remediation, sort_keys=True),
-            "fix_cli": "",
-            "fix_console": check.get("fix_console", ""),
-            "effort": "manual",
+            "fix_cli": fix_cli,
+            "fix_console": fix_console,
+            "effort": effort,
             "priority": int(check.get("priority", 0) or 0),
-            "guardrails": list(check.get("guardrails", []) or []),
+            "guardrails": guardrails,
             "requires_human_review": 1,
         }
 

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -768,9 +768,9 @@ def _coerce_cis_row(row: dict[str, Any]) -> dict[str, Any]:
             remediation = {}
     remediation = fail_closed_remediation_payload(remediation)
     coerced["remediation"] = remediation
-    coerced["fix_cli"] = ""
+    coerced["fix_cli"] = str(remediation.get("fix_cli") or "")
     coerced["fix_console"] = str(remediation.get("fix_console") or coerced.get("fix_console") or "")
-    coerced["effort"] = "manual"
+    coerced["effort"] = str(remediation.get("effort") or "manual")
     coerced["requires_human_review"] = True
     return coerced
 

--- a/src/agent_bom/cloud/cis_remediation.py
+++ b/src/agent_bom/cloud/cis_remediation.py
@@ -247,13 +247,29 @@ _OVERRIDES: dict[CISControlIdentity, CISRemediationOverride] = {
     ),
     CISControlIdentity("aws", "3.0", "2.1.1", "S3 account-level public access block configured", "2 - Storage"): CISRemediationOverride(
         why="Missing account-level Block Public Access permits bucket policies or ACLs to expose data publicly.",
+        fix_cli=(
+            "aws s3control put-public-access-block --account-id <ACCOUNT_ID> "
+            "--public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,"
+            "BlockPublicPolicy=true,RestrictPublicBuckets=true"
+        ),
         fix_console="AWS Console → S3 → Block Public Access settings for this account",
+        docs="https://docs.aws.amazon.com/cli/latest/reference/s3control/put-public-access-block.html",
         guardrails=("network-exposure", "defense-in-depth"),
+        effort="low",
+        requires_human_review=True,
     ),
     CISControlIdentity("aws", "3.0", "2.1.2", "S3 bucket server-side encryption enabled", "2 - Storage"): CISRemediationOverride(
         why="Buckets without default server-side encryption can persist new objects without encryption at rest.",
+        fix_cli=(
+            "aws s3api put-bucket-encryption --bucket <BUCKET_NAME> "
+            "--server-side-encryption-configuration "
+            '\'{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}\''
+        ),
         fix_console="AWS Console → S3 → <bucket> → Properties → Default encryption",
+        docs="https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-encryption.html",
         guardrails=("encryption", "defense-in-depth"),
+        effort="low",
+        requires_human_review=True,
     ),
     CISControlIdentity("aws", "3.0", "3.1", "CloudTrail enabled in all regions", "3 - Logging"): CISRemediationOverride(
         why="Without a multi-region CloudTrail, API activity can go unlogged in unused regions.",
@@ -262,8 +278,12 @@ _OVERRIDES: dict[CISControlIdentity, CISRemediationOverride] = {
     ),
     CISControlIdentity("aws", "3.0", "3.2", "CloudTrail log file validation enabled", "3 - Logging"): CISRemediationOverride(
         why="CloudTrail without log file validation cannot prove log integrity after the fact.",
+        fix_cli="aws cloudtrail update-trail --name <TRAIL_NAME_OR_ARN> --enable-log-file-validation",
         fix_console="AWS Console → CloudTrail → Trails → <trail> → Edit → Enable log file validation",
+        docs="https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/update-trail.html",
         guardrails=("logging-and-audit", "defense-in-depth"),
+        effort="low",
+        requires_human_review=True,
     ),
     CISControlIdentity("aws", "3.0", "3.5", "CloudTrail records management events in all regions", "3 - Logging"): CISRemediationOverride(
         why="Excluding management events from CloudTrail leaves control-plane changes unavailable for investigation.",
@@ -275,13 +295,24 @@ _OVERRIDES: dict[CISControlIdentity, CISRemediationOverride] = {
         "azure", "3.0", "3.1", "Secure transfer required on storage accounts", "3 - Storage Accounts"
     ): CISRemediationOverride(
         why="Storage accounts without secure transfer accept plaintext HTTP traffic.",
+        fix_cli=("az storage account update --name <STORAGE_ACCOUNT_NAME> --resource-group <RESOURCE_GROUP_NAME> --https-only true"),
         fix_console="Azure Portal → Storage accounts → <account> → Configuration → Secure transfer required",
+        docs="https://learn.microsoft.com/azure/storage/common/storage-require-secure-transfer",
         guardrails=("encryption", "network-exposure"),
+        effort="low",
+        requires_human_review=True,
     ),
     CISControlIdentity("azure", "3.0", "3.7", "Blob containers set to private access", "3 - Storage Accounts"): CISRemediationOverride(
         why="Public blob access enables unauthenticated data reads over the internet.",
+        fix_cli=(
+            "az storage account update --name <STORAGE_ACCOUNT_NAME> "
+            "--resource-group <RESOURCE_GROUP_NAME> --allow-blob-public-access false"
+        ),
         fix_console="Azure Portal → Storage accounts → <account> → Containers → Change access level to Private",
+        docs="https://learn.microsoft.com/azure/storage/blobs/anonymous-read-access-configure",
         guardrails=("network-exposure", "defense-in-depth"),
+        effort="low",
+        requires_human_review=True,
     ),
     CISControlIdentity(
         "azure", "3.0", "5.1.1", "Diagnostic setting captures Activity Log", "5 - Logging and Monitoring"
@@ -320,8 +351,12 @@ _OVERRIDES: dict[CISControlIdentity, CISRemediationOverride] = {
     ),
     CISControlIdentity("gcp", "3.0", "5.2", "Uniform bucket-level access enabled on buckets", "5 - Cloud Storage"): CISRemediationOverride(
         why="Buckets without uniform access retain ACL-based authorization paths outside centralized IAM policy.",
+        fix_cli="gcloud storage buckets update gs://<BUCKET_NAME> --uniform-bucket-level-access",
         fix_console="GCP Console → Cloud Storage → <bucket> → Permissions → Uniform access control",
+        docs="https://cloud.google.com/storage/docs/using-uniform-bucket-level-access",
         guardrails=("identity", "least-privilege", "defense-in-depth"),
+        effort="low",
+        requires_human_review=True,
     ),
     # ── Snowflake ──────────────────────────────────────────────────────
     CISControlIdentity(
@@ -354,9 +389,25 @@ _OVERRIDES: dict[CISControlIdentity, CISRemediationOverride] = {
     ),
 }
 
-# PR 1 deliberately contains no verified commands. PR 2 may add an identity to
-# this set only with provider-doc evidence and exact command-contract tests.
-_VERIFIED_CLI_CONTROLS: frozenset[CISControlIdentity] = frozenset()
+# Commands are advisory strings only; agent-bom never executes them. A command
+# is exposed only when the complete benchmark identity matches this reviewed
+# set, and every entry retains an explicit placeholder and human approval.
+_VERIFIED_CLI_CONTROLS: frozenset[CISControlIdentity] = frozenset(
+    {
+        CISControlIdentity("aws", "3.0", "2.1.1", "S3 account-level public access block configured", "2 - Storage"),
+        CISControlIdentity("aws", "3.0", "2.1.2", "S3 bucket server-side encryption enabled", "2 - Storage"),
+        CISControlIdentity("aws", "3.0", "3.2", "CloudTrail log file validation enabled", "3 - Logging"),
+        CISControlIdentity("azure", "3.0", "3.1", "Secure transfer required on storage accounts", "3 - Storage Accounts"),
+        CISControlIdentity("azure", "3.0", "3.7", "Blob containers set to private access", "3 - Storage Accounts"),
+        CISControlIdentity("gcp", "3.0", "5.2", "Uniform bucket-level access enabled on buckets", "5 - Cloud Storage"),
+    }
+)
+
+_VERIFIED_CLI_BY_COMMAND: dict[str, CISRemediationOverride] = {
+    override.fix_cli: override
+    for identity, override in _OVERRIDES.items()
+    if identity in _VERIFIED_CLI_CONTROLS and override.fix_cli is not None
+}
 
 
 # ---------------------------------------------------------------------------
@@ -365,15 +416,25 @@ _VERIFIED_CLI_CONTROLS: frozenset[CISControlIdentity] = frozenset()
 
 
 def fail_closed_remediation_payload(value: Any) -> dict[str, Any]:
-    """Return a copy safe to expose while the verified CLI set is empty.
+    """Return a copy containing only an exact provider-verified command.
 
     Historical scan jobs and analytics rows can contain commands written by an
-    older release. Canonicalizing at projection boundaries prevents those rows
-    from replaying stale mutations after an upgrade without rewriting evidence.
+    older release. Exact command allowlisting at projection boundaries prevents
+    those rows from replaying stale mutations after an upgrade without rewriting
+    evidence. Current command metadata is canonicalized from the reviewed
+    override; commands are never executed by this module.
     """
     remediation = dict(value) if isinstance(value, dict) else {}
-    remediation["fix_cli"] = None
-    remediation["effort"] = "manual"
+    command = remediation.get("fix_cli")
+    verified = _VERIFIED_CLI_BY_COMMAND.get(command) if isinstance(command, str) else None
+    if verified is None:
+        remediation["fix_cli"] = None
+        remediation["effort"] = "manual"
+    else:
+        remediation["fix_cli"] = command
+        remediation["effort"] = verified.effort
+        if verified.docs:
+            remediation["docs"] = verified.docs
     remediation["requires_human_review"] = True
     return remediation
 

--- a/tests/test_cis_remediation.py
+++ b/tests/test_cis_remediation.py
@@ -14,6 +14,7 @@ import pytest
 from agent_bom.cloud.aws_cis_benchmark import CheckStatus, CISCheckResult
 from agent_bom.cloud.cis_remediation import (
     _OVERRIDES,
+    _VERIFIED_CLI_CONTROLS,
     GUARDRAIL_TAGS,
     attach_all,
     attach_remediation,
@@ -77,8 +78,12 @@ def test_all_overrides_validate_against_schema():
         )
         _assert_schema(rem)
         assert rem["why"] == override.why
-        assert rem["fix_cli"] is None
-        assert rem["effort"] == "manual"
+        if identity in _VERIFIED_CLI_CONTROLS:
+            assert rem["fix_cli"] == override.fix_cli
+            assert rem["effort"] == override.effort
+        else:
+            assert rem["fix_cli"] is None
+            assert rem["effort"] == "manual"
         assert rem["requires_human_review"] is True
 
 
@@ -212,11 +217,12 @@ _AWS_ACCOUNT_PUBLIC_ACCESS = {
 }
 
 
-def test_matching_override_is_advisory_only_until_command_is_verified():
+def test_matching_verified_override_exposes_advisory_command():
     rem = build_remediation(**_AWS_ACCOUNT_PUBLIC_ACCESS, benchmark_version="3.0")
 
-    assert rem["fix_cli"] is None
-    assert rem["effort"] == "manual"
+    assert rem["fix_cli"].startswith("aws s3control put-public-access-block")
+    assert "<ACCOUNT_ID>" in rem["fix_cli"]
+    assert rem["effort"] == "low"
     assert rem["requires_human_review"] is True
     assert "account-level" in rem["why"].lower()
 
@@ -253,5 +259,6 @@ def test_attach_all_propagates_report_benchmark_version():
 
     attach_all(report, cloud="aws")
 
-    assert check.remediation["fix_cli"] is None
+    assert check.remediation["fix_cli"].startswith("aws s3control put-public-access-block")
+    assert check.remediation["requires_human_review"] is True
     assert "account-level" in check.remediation["why"].lower()

--- a/tests/test_cis_remediation_catalog_contract.py
+++ b/tests/test_cis_remediation_catalog_contract.py
@@ -11,6 +11,7 @@ from agent_bom.cloud.cis_remediation import (
     _VERIFIED_CLI_CONTROLS,
     CISControlIdentity,
     CISRemediationOverride,
+    build_remediation,
 )
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -76,9 +77,77 @@ def test_each_override_matches_exactly_one_live_catalog_control() -> None:
         assert live[identity] == 1, f"override is stale or ambiguous: {identity}"
 
 
-def test_pr1_has_no_verified_cli_mutations() -> None:
-    assert _VERIFIED_CLI_CONTROLS == frozenset()
-    for override in _OVERRIDES.values():
-        assert override.fix_cli is None
-        assert override.effort == "manual"
+_VERIFIED_EXPECTATIONS = {
+    CISControlIdentity("aws", "3.0", "2.1.1", "S3 account-level public access block configured", "2 - Storage"): (
+        "aws s3control put-public-access-block --account-id <ACCOUNT_ID> "
+        "--public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,"
+        "BlockPublicPolicy=true,RestrictPublicBuckets=true",
+        "https://docs.aws.amazon.com/cli/latest/reference/s3control/put-public-access-block.html",
+    ),
+    CISControlIdentity("aws", "3.0", "2.1.2", "S3 bucket server-side encryption enabled", "2 - Storage"): (
+        "aws s3api put-bucket-encryption --bucket <BUCKET_NAME> "
+        "--server-side-encryption-configuration "
+        '\'{"Rules":[{"ApplyServerSideEncryptionByDefault":{"SSEAlgorithm":"AES256"}}]}\'',
+        "https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-encryption.html",
+    ),
+    CISControlIdentity("aws", "3.0", "3.2", "CloudTrail log file validation enabled", "3 - Logging"): (
+        "aws cloudtrail update-trail --name <TRAIL_NAME_OR_ARN> --enable-log-file-validation",
+        "https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/update-trail.html",
+    ),
+    CISControlIdentity("azure", "3.0", "3.1", "Secure transfer required on storage accounts", "3 - Storage Accounts"): (
+        "az storage account update --name <STORAGE_ACCOUNT_NAME> --resource-group <RESOURCE_GROUP_NAME> --https-only true",
+        "https://learn.microsoft.com/azure/storage/common/storage-require-secure-transfer",
+    ),
+    CISControlIdentity("azure", "3.0", "3.7", "Blob containers set to private access", "3 - Storage Accounts"): (
+        "az storage account update --name <STORAGE_ACCOUNT_NAME> --resource-group <RESOURCE_GROUP_NAME> --allow-blob-public-access false",
+        "https://learn.microsoft.com/azure/storage/blobs/anonymous-read-access-configure",
+    ),
+    CISControlIdentity("gcp", "3.0", "5.2", "Uniform bucket-level access enabled on buckets", "5 - Cloud Storage"): (
+        "gcloud storage buckets update gs://<BUCKET_NAME> --uniform-bucket-level-access",
+        "https://cloud.google.com/storage/docs/using-uniform-bucket-level-access",
+    ),
+}
+
+
+def test_only_provider_verified_cli_mutations_are_enabled() -> None:
+    assert _VERIFIED_CLI_CONTROLS == frozenset(_VERIFIED_EXPECTATIONS)
+
+    for identity, (expected_command, expected_docs) in _VERIFIED_EXPECTATIONS.items():
+        override = _OVERRIDES[identity]
+        assert override.fix_cli == expected_command
+        assert override.docs == expected_docs
+        assert override.effort == "low"
         assert override.requires_human_review is True
+
+        remediation = build_remediation(
+            cloud=identity.cloud,
+            benchmark_version=identity.benchmark_version,
+            check_id=identity.check_id,
+            title=identity.title,
+            severity="high",
+            recommendation="",
+            cis_section=identity.cis_section,
+        )
+        assert remediation["fix_cli"] == expected_command
+        assert remediation["docs"] == expected_docs
+        assert remediation["effort"] == "low"
+        assert remediation["requires_human_review"] is True
+
+
+def test_every_exposed_cis_command_is_placeholder_bound_and_allowlisted() -> None:
+    for identity in _OVERRIDES:
+        remediation = build_remediation(
+            cloud=identity.cloud,
+            benchmark_version=identity.benchmark_version,
+            check_id=identity.check_id,
+            title=identity.title,
+            severity="high",
+            recommendation="",
+            cis_section=identity.cis_section,
+        )
+        command = remediation["fix_cli"]
+        if command is None:
+            continue
+        assert identity in _VERIFIED_EXPECTATIONS
+        assert "<" in command and ">" in command
+        assert remediation["requires_human_review"] is True

--- a/tests/test_cis_remediation_surfaces.py
+++ b/tests/test_cis_remediation_surfaces.py
@@ -10,6 +10,7 @@ from io import StringIO
 
 from rich.console import Console
 
+from agent_bom.cloud.cis_remediation import build_remediation
 from agent_bom.models import AIBOMReport
 from agent_bom.output import print_compact_cis_posture
 from agent_bom.output.html import _cis_benchmark_section
@@ -40,7 +41,10 @@ def _bundle_with_remediation(cloud: str = "aws") -> dict:
                 "remediation": {
                     "why": "Root account access keys allow full account takeover with no per-user audit trail.",
                     "fix_cli": None,
-                    "fix_console": "AWS Console → IAM → Security credentials (root) → Delete access key",
+                    "fix_console": (
+                        "AWS Organizations → Root access management, or approved break-glass root session → "
+                        "IAM → Security credentials → Delete access key → sign out immediately"
+                    ),
                     "effort": "manual",
                     "priority": 1,
                     "docs": "https://example/docs",
@@ -81,6 +85,36 @@ def _report_with_aws_cis() -> AIBOMReport:
     return report
 
 
+def _report_with_verified_aws_cis() -> tuple[AIBOMReport, str]:
+    command = "aws cloudtrail update-trail --name <TRAIL_NAME_OR_ARN> --enable-log-file-validation"
+    bundle = _bundle_with_remediation("aws")
+    check = bundle["checks"][0]
+    check.update(
+        {
+            "check_id": "3.2",
+            "title": "CloudTrail log file validation enabled",
+            "status": "fail",
+            "severity": "medium",
+            "evidence": "Trail has log file validation disabled.",
+            "resource_ids": ["arn:aws:cloudtrail:us-east-1:123456789012:trail/audit"],
+            "recommendation": "Enable log file validation on all CloudTrail trails.",
+            "cis_section": "3 - Logging",
+            "remediation": build_remediation(
+                cloud="aws",
+                benchmark_version="3.0",
+                check_id="3.2",
+                title="CloudTrail log file validation enabled",
+                severity="medium",
+                recommendation="Enable log file validation on all CloudTrail trails.",
+                cis_section="3 - Logging",
+            ),
+        }
+    )
+    report = AIBOMReport(tool_version="0.98.2")
+    report.cis_benchmark_data = bundle
+    return report, command
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────
 
 
@@ -106,6 +140,37 @@ def test_cli_compact_cis_posture_renders_remediation():
     assert "Security credentials" in out  # manual console path surfaced
     assert "priv-escalation" in out or "least-privilege" in out  # guardrails surfaced
     assert "review" in out  # requires_human_review flag shown
+
+
+def test_provider_verified_command_reaches_cli_html_and_sarif():
+    report, command = _report_with_verified_aws_cis()
+    buf = StringIO()
+    con = Console(file=buf, force_terminal=False, width=240)
+
+    import agent_bom.output as output_mod
+
+    original = output_mod.console
+    output_mod.console = con
+    try:
+        print_compact_cis_posture(report)
+    finally:
+        output_mod.console = original
+
+    cli = buf.getvalue()
+    assert "update-trail" in cli
+    assert "<TRAIL_NAME_OR_ARN>" in cli
+    assert "review" in cli.lower()
+
+    html = _cis_benchmark_section(report)
+    assert "update-trail" in html
+    assert "&lt;TRAIL_NAME_OR_ARN&gt;" in html
+
+    sarif = to_sarif(report)
+    result = next(item for item in sarif["runs"][0]["results"] if item["ruleId"] == "cis/aws/3.2")
+    props = result["properties"]
+    assert props["fix_cli"] == command
+    assert props["remediation"]["fix_cli"] == command
+    assert props["requires_human_review"] is True
 
 
 def test_cli_compact_cis_posture_silent_without_cis_data():

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -387,6 +387,54 @@ class TestClickHouseAnalyticsStore:
         assert row["effort"] == "manual"
         assert row["requires_human_review"] == 1
 
+    def test_record_cis_benchmark_checks_preserves_verified_remediation(self):
+        from agent_bom.api.clickhouse_store import ClickHouseAnalyticsStore
+
+        inserted = {}
+        command = "aws cloudtrail update-trail --name <TRAIL_NAME_OR_ARN> --enable-log-file-validation"
+
+        class _Client:
+            def ensure_tables(self):
+                return None
+
+            def insert_json(self, table, rows):
+                inserted["table"] = table
+                inserted["rows"] = rows
+
+        with patch("agent_bom.cloud.clickhouse.ClickHouseClient", return_value=_Client()):
+            store = ClickHouseAnalyticsStore(url="http://localhost:8123")
+            store.record_cis_benchmark_checks(
+                [
+                    {
+                        "scan_id": "scan-verified",
+                        "cloud": "aws",
+                        "check_id": "3.2",
+                        "status": "fail",
+                        "priority": 2,
+                        "remediation": {
+                            "fix_cli": command,
+                            "fix_console": "AWS Console → CloudTrail → Trails",
+                            "effort": "high",
+                            "docs": "https://untrusted.example/old-doc",
+                            "guardrails": ["logging-and-audit"],
+                            "requires_human_review": False,
+                        },
+                    }
+                ],
+                tenant_id="tenant-alpha",
+            )
+
+        assert inserted["table"] == "cis_benchmark_checks"
+        row = inserted["rows"][0]
+        remediation = json.loads(row["remediation"])
+        assert remediation["fix_cli"] == command
+        assert remediation["effort"] == "low"
+        assert remediation["docs"] == "https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/update-trail.html"
+        assert remediation["requires_human_review"] is True
+        assert row["fix_cli"] == command
+        assert row["effort"] == "low"
+        assert row["requires_human_review"] == 1
+
     def test_buffered_store_flushes_before_query(self):
         from agent_bom.api.clickhouse_store import BufferedAnalyticsStore, ClickHouseAnalyticsStore
 

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -653,6 +653,40 @@ def test_cis_checks_fail_closed_for_legacy_remediation_rows():
     _clear_jobs()
 
 
+def test_cis_checks_preserve_exact_provider_verified_remediation():
+    command = "az storage account update --name <STORAGE_ACCOUNT_NAME> --resource-group <RESOURCE_GROUP_NAME> --https-only true"
+    _clear_jobs()
+    _add_done_job(
+        [],
+        result_extra=_cis_benchmark_result(
+            [
+                {
+                    "check_id": "3.1",
+                    "title": "Secure transfer required on storage accounts",
+                    "status": "FAIL",
+                    "severity": "high",
+                    "remediation": {
+                        "fix_cli": command,
+                        "fix_console": "Azure Portal → Storage accounts → Configuration",
+                        "effort": "low",
+                        "docs": "https://untrusted.example/old-doc",
+                        "requires_human_review": False,
+                    },
+                }
+            ],
+            cloud_key="azure_cis_benchmark",
+        ),
+    )
+
+    row = TestClient(app).get("/v1/cis/checks", headers=_AUTH_HEADERS).json()["checks"][0]
+    assert row["fix_cli"] == command
+    assert row["effort"] == "low"
+    assert row["requires_human_review"] is True
+    assert row["remediation"]["fix_cli"] == command
+    assert row["remediation"]["docs"] == ("https://learn.microsoft.com/azure/storage/common/storage-require-secure-transfer")
+    _clear_jobs()
+
+
 def test_persisted_cis_rows_are_canonicalized_fail_closed():
     from agent_bom.api.routes.compliance import _coerce_cis_row
 
@@ -679,6 +713,33 @@ def test_persisted_cis_rows_are_canonicalized_fail_closed():
     assert row["remediation"]["fix_cli"] is None
     assert row["remediation"]["requires_human_review"] is True
     assert "Event selectors" in row["fix_console"]
+
+
+def test_persisted_cis_rows_preserve_only_exact_verified_command():
+    from agent_bom.api.routes.compliance import _coerce_cis_row
+
+    command = "gcloud storage buckets update gs://<BUCKET_NAME> --uniform-bucket-level-access"
+    row = _coerce_cis_row(
+        {
+            "fix_cli": "stale top-level command",
+            "effort": "manual",
+            "requires_human_review": False,
+            "remediation": json.dumps(
+                {
+                    "fix_cli": command,
+                    "fix_console": "GCP Console → Cloud Storage → Permissions",
+                    "effort": "high",
+                    "docs": "https://untrusted.example/old-doc",
+                    "requires_human_review": False,
+                }
+            ),
+        }
+    )
+
+    assert row["fix_cli"] == command
+    assert row["effort"] == "low"
+    assert row["requires_human_review"] is True
+    assert row["remediation"]["docs"] == ("https://cloud.google.com/storage/docs/using-uniform-bucket-level-access")
 
 
 # ─── PR3: NIST 800-53 catalog-backed scoring line ────────────────────────────

--- a/tests/test_remediation_foundation.py
+++ b/tests/test_remediation_foundation.py
@@ -108,7 +108,13 @@ def test_versioned_cis_finding_uses_exact_advisory_metadata() -> None:
     )
 
     assert finding.remediation is not None
-    assert finding.remediation.fix.cli is None
+    assert finding.remediation.fix.cli == (
+        "aws s3control put-public-access-block --account-id <ACCOUNT_ID> "
+        "--public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,"
+        "BlockPublicPolicy=true,RestrictPublicBuckets=true"
+    )
+    assert finding.remediation.fix.requires_human_review is True
+    assert finding.remediation.fix.docs == ("https://docs.aws.amazon.com/cli/latest/reference/s3control/put-public-access-block.html")
     assert "Block Public Access settings for this account" in (finding.remediation.fix.console or "")
     assert "network-exposure" in finding.remediation.guardrails
 

--- a/ui/tests/cis-benchmark-detail.test.tsx
+++ b/ui/tests/cis-benchmark-detail.test.tsx
@@ -104,10 +104,10 @@ describe("CISBenchmarkDetail", () => {
         makeCheck({
           check_id: "3.2",
           title: "Enable CloudTrail log file validation",
-          fix_cli: "aws cloudtrail update-trail --name <TRAIL> --enable-log-file-validation",
+          fix_cli: "aws cloudtrail update-trail --name <TRAIL_NAME_OR_ARN> --enable-log-file-validation",
           requires_human_review: true,
           remediation: {
-            fix_cli: "aws cloudtrail update-trail --name <TRAIL> --enable-log-file-validation",
+            fix_cli: "aws cloudtrail update-trail --name <TRAIL_NAME_OR_ARN> --enable-log-file-validation",
             requires_human_review: true,
           },
         }),
@@ -125,7 +125,7 @@ describe("CISBenchmarkDetail", () => {
     fireEvent.click(copyButton);
     await waitFor(() =>
       expect(writeText).toHaveBeenCalledWith(
-        "aws cloudtrail update-trail --name <TRAIL> --enable-log-file-validation",
+        "aws cloudtrail update-trail --name <TRAIL_NAME_OR_ARN> --enable-log-file-validation",
       ),
     );
     expect(await screen.findByText(/review carefully before running/i)).toBeInTheDocument();
@@ -138,7 +138,7 @@ describe("CISBenchmarkDetail", () => {
           check_id: "1.4",
           title: "No root account access keys",
           fix_cli: "",
-          fix_console: "AWS Console → IAM → Security credentials (root) → Delete access key",
+          fix_console: "AWS Organizations → Root access management, or approved break-glass root session → sign out immediately",
           effort: "manual",
           requires_human_review: true,
         }),
@@ -149,7 +149,7 @@ describe("CISBenchmarkDetail", () => {
     render(<CISBenchmarkDetail />);
 
     expect(await screen.findByText(/no copy-pasteable cli fix/i)).toBeInTheDocument();
-    expect(screen.getByText(/security credentials \(root\)/i)).toBeInTheDocument();
+    expect(screen.getByText(/approved break-glass root session/i)).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /copy fix command/i })).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

- restore advisory CLI guidance for exactly six CIS 3.0 controls: AWS 2.1.1, 2.1.2, and 3.2; Azure 3.1 and 3.7; GCP 5.2
- bind every command to the complete provider/version/check/title/section identity, an explicit placeholder, and control-specific vendor documentation
- preserve exact reviewed commands through CLI, HTML, SARIF, API, ClickHouse, and dashboard projections while stripping legacy or altered commands
- require human review for every command; agent-bom does not execute remediation

## Verification

- `uv run pytest -q tests/test_cis_remediation.py tests/test_cis_remediation_catalog_contract.py tests/test_cis_remediation_surfaces.py tests/test_cis_benchmark_analytics.py tests/test_compliance.py tests/test_compliance_report.py tests/test_remediation_foundation.py tests/test_sarif_advisory_text.py tests/test_clickhouse.py` (175 passed)
- `uv run ruff check ...` and `uv run ruff format --check ...`
- `uv run mypy src/agent_bom/cloud/cis_remediation.py src/agent_bom/api/routes/compliance.py src/agent_bom/api/clickhouse_store.py`
- `make preflight`
- `npm run typecheck`
- `npm test -- --run tests/cis-benchmark-detail.test.tsx` (9 passed)
- UI ESLint passed; toolchain contract passed with Node 24.15.0 and npm 10.9.7

## Notes

- AWS syntax: https://docs.aws.amazon.com/cli/latest/reference/s3control/put-public-access-block.html, https://docs.aws.amazon.com/cli/latest/reference/s3api/put-bucket-encryption.html, https://docs.aws.amazon.com/cli/latest/reference/cloudtrail/update-trail.html
- Azure syntax: https://learn.microsoft.com/azure/storage/common/storage-require-secure-transfer, https://learn.microsoft.com/azure/storage/blobs/anonymous-read-access-configure
- GCP syntax and migration caveat: https://cloud.google.com/storage/docs/using-uniform-bucket-level-access
- Account policy overrides, anonymous-client compatibility, ACL migration, encryption selection, and rollback remain operator review responsibilities.
- Root operations, credential mutation, password and authentication policies, event-selector replacement, public-IAM removal, and Snowflake network policies remain manual.
- No database migration or wire-schema change.
