### PR TITLE
fix(integrity): fail closed on missing and malformed evidence

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260729_03_partition_child_rls.py
+++ b/deploy/supabase/postgres/alembic/versions/20260729_03_partition_child_rls.py
@@ -1,0 +1,65 @@
+"""Force tenant RLS on every existing tenant-scoped partition child.
+
+Revision ID: 20260729_03
+Revises: 20260729_02
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260729_03"
+down_revision = "20260729_02"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $migration$
+        DECLARE
+            child_record RECORD;
+            tenant_column TEXT;
+        BEGIN
+            FOR child_record IN
+                SELECT parent.relname AS parent_name, child.relname AS child_name
+                FROM pg_inherits inh
+                JOIN pg_class parent ON parent.oid = inh.inhparent
+                JOIN pg_class child ON child.oid = inh.inhrelid
+                JOIN pg_namespace n ON n.oid = parent.relnamespace
+                WHERE n.nspname = current_schema()
+                  AND parent.relname IN ('audit_log', 'hub_findings_current_observations')
+            LOOP
+                tenant_column := CASE
+                    WHEN child_record.parent_name = 'audit_log' THEN 'team_id'
+                    ELSE 'tenant_id'
+                END;
+                EXECUTE format('ALTER TABLE %I ENABLE ROW LEVEL SECURITY', child_record.child_name);
+                EXECUTE format('ALTER TABLE %I FORCE ROW LEVEL SECURITY', child_record.child_name);
+                IF NOT EXISTS (
+                    SELECT 1 FROM pg_policies
+                    WHERE schemaname = current_schema()
+                      AND tablename = child_record.child_name
+                      AND policyname = child_record.child_name || '_tenant_isolation'
+                ) THEN
+                    EXECUTE format(
+                        'CREATE POLICY %I ON %I USING (public.abom_rls_bypass() OR %I = public.abom_current_tenant()) '
+                        'WITH CHECK (public.abom_rls_bypass() OR %I = public.abom_current_tenant())',
+                        child_record.child_name || '_tenant_isolation',
+                        child_record.child_name,
+                        tenant_column,
+                        tenant_column
+                    );
+                END IF;
+            END LOOP;
+        END
+        $migration$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Deliberately irreversible: removing tenant isolation from direct child
+    # tables would reopen a cross-tenant access path during rollback.
+    pass

--- a/sdks/shared/patterns.json
+++ b/sdks/shared/patterns.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "AWS Secret Key",
-      "pattern": "(?:aws_secret_access_key|secret_?key)\\s*[=:]\\s*[A-Za-z0-9/+=]{40}",
+      "pattern": "(['\\\"]?)(?:aws_secret_access_key|secret_?key)\\1\\s*[=:]\\s*(['\\\"]?)[A-Za-z0-9/+=]{40}\\2(?![A-Za-z0-9/+=])",
       "flags": "i"
     },
     {

--- a/sdks/shared/test-fixtures.json
+++ b/sdks/shared/test-fixtures.json
@@ -135,6 +135,20 @@
       "expected_message_contains": "AWS"
     },
     {
+      "name": "aws_secret_key_quoted_json",
+      "tool": "read_file",
+      "text": "\"AWS_SECRET_ACCESS_KEY\": \"Ab3dEf4gH5jKAb3dEf4gH5jKAb3dEf4gH5jKLm7N\"",
+      "expected_alert_count": 1,
+      "expected_severity": "critical",
+      "expected_message_contains": "AWS"
+    },
+    {
+      "name": "aws_secret_placeholder_no_alert",
+      "tool": "read_file",
+      "text": "AWS_SECRET_ACCESS_KEY='<set-me>'",
+      "expected_alert_count": 0
+    },
+    {
       "name": "github_token",
       "tool": "exec",
       "text": "token=ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij",

--- a/src/agent_bom/analytics_contract.py
+++ b/src/agent_bom/analytics_contract.py
@@ -264,11 +264,19 @@ def _cis_rows_for_cloud(cloud: str, benchmark: dict[str, Any], scan_id: str, mea
     from agent_bom.cloud.cis_remediation import fail_closed_remediation_payload
 
     rows: list[dict[str, Any]] = []
+    benchmark_version = str(benchmark.get("benchmark_version") or "")
     for check in benchmark.get("checks", []) or []:
         if not isinstance(check, dict):
             continue
         raw_remediation = check.get("remediation")
-        remediation = fail_closed_remediation_payload(raw_remediation)
+        remediation = fail_closed_remediation_payload(
+            raw_remediation,
+            cloud=cloud,
+            benchmark_version=benchmark_version,
+            check_id=str(check.get("check_id") or ""),
+            title=str(check.get("title") or ""),
+            cis_section=str(check.get("cis_section") or ""),
+        )
         priority = remediation.get("priority", check.get("priority", 0))
         try:
             priority_int = int(priority or 0)
@@ -279,6 +287,7 @@ def _cis_rows_for_cloud(cloud: str, benchmark: dict[str, Any], scan_id: str, mea
                 "scan_id": scan_id,
                 "measured_at": measured_at,
                 "cloud": cloud,
+                "benchmark_version": benchmark_version,
                 "check_id": str(check.get("check_id", "")),
                 "title": str(check.get("title", "")),
                 "status": str(check.get("status", "unknown")).lower() or "unknown",

--- a/src/agent_bom/api/audit_log.py
+++ b/src/agent_bom/api/audit_log.py
@@ -376,8 +376,10 @@ def _verify_audit_chain_with_checkpoint(
 ) -> tuple[int, int]:
     """Verify chain integrity and detect tail truncation via signed checkpoint."""
     verified, tampered = _verify_audit_chain(entries)
-    if checkpoint is None or not entries:
+    if checkpoint is None:
         return verified, tampered
+    if not entries:
+        return verified, tampered + (1 if checkpoint.entry_count > 0 else 0)
     if len(entries) != checkpoint.entry_count:
         return verified, tampered + 1
     if entries[-1].hmac_signature != checkpoint.head_signature:

--- a/src/agent_bom/api/clickhouse_store.py
+++ b/src/agent_bom/api/clickhouse_store.py
@@ -480,7 +480,14 @@ class ClickHouseAnalyticsStore:
         scan_id = check.get("scan_id", "")
         cloud = check.get("cloud", "")
         check_id = check.get("check_id", "")
-        remediation = fail_closed_remediation_payload(check.get("remediation"))
+        remediation = fail_closed_remediation_payload(
+            check.get("remediation"),
+            cloud=str(cloud),
+            benchmark_version=str(check.get("benchmark_version") or ""),
+            check_id=str(check_id),
+            title=str(check.get("title") or ""),
+            cis_section=str(check.get("cis_section") or ""),
+        )
         fix_cli = str(remediation.get("fix_cli") or "")
         fix_console = str(remediation.get("fix_console") or check.get("fix_console") or "")
         effort = str(remediation.get("effort") or "manual")

--- a/src/agent_bom/api/hub_observations_partition.py
+++ b/src/agent_bom/api/hub_observations_partition.py
@@ -51,17 +51,42 @@ def _create_observation_partition(conn: Any, year: int, month: int) -> None:
     of the Postgres catalog race would raise duplicate_table/duplicate_object ->
     500. Since the partition now exists either way, that is treated as success.
     """
+    savepoint = "agent_bom_observation_partition"
+    conn.execute(f"SAVEPOINT {savepoint}")
     try:
         conn.execute(create_observation_partition_ddl(year, month))
     except Exception as exc:  # noqa: BLE001 — narrowed by _is_duplicate_partition_error
+        # A caught Postgres DDL error still aborts the transaction. Recover the
+        # savepoint before inspecting the now-existing child or applying RLS.
+        conn.execute(f"ROLLBACK TO SAVEPOINT {savepoint}")
+        conn.execute(f"RELEASE SAVEPOINT {savepoint}")
         if _is_duplicate_partition_error(exc):
             logger.debug(
                 "observation partition y%dm%02d already created concurrently; treating as success",
                 year,
                 month,
             )
+            _ensure_observation_partition_rls(conn, partition_table_name(year, month))
             return
         raise
+    conn.execute(f"RELEASE SAVEPOINT {savepoint}")
+    _ensure_observation_partition_rls(conn, partition_table_name(year, month))
+
+
+def _ensure_observation_partition_rls(conn: Any, child: str) -> None:
+    """Apply forced tenant isolation directly to an observations child."""
+    from agent_bom.api.postgres_common import _ensure_tenant_rls
+
+    _ensure_tenant_rls(conn, child, "tenant_id")
+
+
+def ensure_observation_partition_children_rls(conn: Any) -> int:
+    """Idempotently backfill RLS on all existing observation partitions."""
+    children = list_observation_partition_names(conn)
+    for child in children:
+        if _PARTITION_NAME_RE.fullmatch(child):
+            _ensure_observation_partition_rls(conn, child)
+    return len(children)
 
 
 def partition_table_name(year: int, month: int) -> str:
@@ -169,6 +194,7 @@ def ensure_observation_partitions(
             (child,),
         ).fetchone()
         if exists:
+            _ensure_observation_partition_rls(conn, child)
             continue
         _create_observation_partition(conn, year, month)
         created += 1
@@ -342,13 +368,14 @@ def migrate_observations_to_partitioned(conn: Any) -> bool:
     cursor = date(min_month.year, min_month.month, 1)
     end_cursor = date(max_month.year, max_month.month, 1)
     while cursor <= end_cursor:
-        conn.execute(create_observation_partition_ddl(cursor.year, cursor.month))
+        _create_observation_partition(conn, cursor.year, cursor.month)
         if cursor.month == 12:
             cursor = date(cursor.year + 1, 1, 1)
         else:
             cursor = date(cursor.year, cursor.month + 1, 1)
 
     ensure_observation_partitions(conn, now=datetime.now(timezone.utc), months_ahead=2, months_behind=0)
+    ensure_observation_partition_children_rls(conn)
 
     conn.execute(
         f"""
@@ -374,6 +401,7 @@ def run_hub_observations_retention(*, retention_days: int | None = None) -> int:
 
         with bypass_tenant_rls(audit=False), _maintenance_connection() as conn:
             ensure_observation_partitions(conn)
+            ensure_observation_partition_children_rls(conn)
             dropped = rollover_observation_partitions(conn, retention_days=days)
             conn.commit()
             return dropped

--- a/src/agent_bom/api/partition_maintenance.py
+++ b/src/agent_bom/api/partition_maintenance.py
@@ -135,6 +135,7 @@ class PartitionSpec:
     months_ahead: int = 2
     months_behind: int = 1
     partition_safe: bool = True
+    tenant_column: str = "tenant_id"
 
     def retention_days(self) -> int:
         """Resolve the retention window (env override → config default). ``<=0`` disables."""
@@ -163,6 +164,7 @@ DEFAULT_PARTITION_SPECS: tuple[PartitionSpec, ...] = (
         time_column="timestamp",
         retention_env="AGENT_BOM_AUDIT_LOG_RETENTION_DAYS",
         default_retention_days=0,
+        tenant_column="team_id",
     ),
 )
 
@@ -243,6 +245,50 @@ def list_partition_names(conn: Any, table: str) -> list[str]:
     return [str(row[0]) for row in rows]
 
 
+def _ensure_partition_tenant_rls(conn: Any, child: str, tenant_column: str) -> None:
+    """Apply the same forced tenant policy to a direct child partition."""
+    from agent_bom.api.postgres_common import _ensure_tenant_rls
+
+    _ensure_tenant_rls(conn, child, tenant_column)
+
+
+def ensure_partition_children_rls(conn: Any, spec: PartitionSpec) -> int:
+    """Idempotently backfill forced RLS on every existing child partition."""
+    children = list_partition_names(conn, spec.table)
+    for child in children:
+        if _partition_name_re(spec.table).fullmatch(child):
+            _ensure_partition_tenant_rls(conn, child, spec.tenant_column)
+    return len(children)
+
+
+def partition_children_missing_rls(conn: Any, table: str) -> list[str]:
+    """Return child partitions missing ENABLE/FORCE RLS or a tenant policy."""
+    rows = conn.execute(
+        """
+        SELECT child.relname
+        FROM pg_inherits inh
+        JOIN pg_class parent ON parent.oid = inh.inhparent
+        JOIN pg_class child ON child.oid = inh.inhrelid
+        JOIN pg_namespace n ON n.oid = parent.relnamespace
+        WHERE n.nspname = current_schema()
+          AND parent.relname = %s
+          AND (
+              NOT child.relrowsecurity
+              OR NOT child.relforcerowsecurity
+              OR NOT EXISTS (
+                  SELECT 1 FROM pg_policies p
+                  WHERE p.schemaname = n.nspname
+                    AND p.tablename = child.relname
+                    AND p.policyname = child.relname || '_tenant_isolation'
+              )
+          )
+        ORDER BY child.relname
+        """,
+        (table,),
+    ).fetchall()
+    return [str(row[0]) for row in rows]
+
+
 # ── DDL builders ─────────────────────────────────────────────────────────────
 
 
@@ -292,8 +338,10 @@ def ensure_partitions(
     for year, month in _iter_months(anchor, behind=spec.months_behind, ahead=spec.months_ahead):
         child = partition_table_name(spec.table, year, month)
         if child_partition_exists(conn, child):
+            _ensure_partition_tenant_rls(conn, child, spec.tenant_column)
             continue
         conn.execute(create_partition_ddl(spec.table, year, month))
+        _ensure_partition_tenant_rls(conn, child, spec.tenant_column)
         created += 1
     return created
 
@@ -340,6 +388,7 @@ def maintain_partitions(
 ) -> tuple[int, int]:
     """Ensure ahead + roll over expired for one spec. Returns ``(created, dropped)``."""
     created = ensure_partitions(conn, spec, now=now)
+    ensure_partition_children_rls(conn, spec)
     dropped = rollover_partitions(conn, spec, now=now)
     return created, dropped
 
@@ -387,7 +436,9 @@ def migrate_table_to_partitioned(
     cursor = date(min_month.year, min_month.month, 1)
     end_cursor = date(max_month.year, max_month.month, 1)
     while cursor <= end_cursor:
+        child = partition_table_name(spec.table, cursor.year, cursor.month)
         conn.execute(create_partition_ddl(spec.table, cursor.year, cursor.month))
+        _ensure_partition_tenant_rls(conn, child, spec.tenant_column)
         cursor = date(cursor.year + 1, 1, 1) if cursor.month == 12 else date(cursor.year, cursor.month + 1, 1)
 
     ensure_partitions(conn, spec, now=datetime.now(timezone.utc))

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -766,7 +766,14 @@ def _coerce_cis_row(row: dict[str, Any]) -> dict[str, Any]:
             remediation = json.loads(remediation)
         except json.JSONDecodeError:
             remediation = {}
-    remediation = fail_closed_remediation_payload(remediation)
+    remediation = fail_closed_remediation_payload(
+        remediation,
+        cloud=str(coerced.get("cloud") or ""),
+        benchmark_version=str(coerced.get("benchmark_version") or ""),
+        check_id=str(coerced.get("check_id") or ""),
+        title=str(coerced.get("title") or ""),
+        cis_section=str(coerced.get("cis_section") or ""),
+    )
     coerced["remediation"] = remediation
     coerced["fix_cli"] = str(remediation.get("fix_cli") or "")
     coerced["fix_console"] = str(remediation.get("fix_console") or coerced.get("fix_console") or "")
@@ -966,6 +973,7 @@ def _latest_report(request: Request) -> "AIBOMReport | None":
     We reconstruct a minimal report with only the fields the narrative generator
     reads (``blast_radii``, ``agents``, ``total_packages``, ``total_agents``).
     """
+    from agent_bom.compliance_coverage import blast_radius_tag_kwargs
     from agent_bom.models import (
         Agent,
         AgentType,
@@ -1029,18 +1037,9 @@ def _latest_report(request: Request) -> "AIBOMReport | None":
             exposed_credentials=bd.get("exposed_credentials", []),
             exposed_tools=[],
             risk_score=float(bd.get("risk_score") or 0),
-            owasp_tags=bd.get("owasp_tags", []),
-            atlas_tags=bd.get("atlas_tags", []),
-            nist_ai_rmf_tags=bd.get("nist_ai_rmf_tags", []),
-            owasp_mcp_tags=bd.get("owasp_mcp_tags", []),
-            owasp_agentic_tags=bd.get("owasp_agentic_tags", []),
-            eu_ai_act_tags=bd.get("eu_ai_act_tags", []),
-            nist_csf_tags=bd.get("nist_csf_tags", []),
-            iso_27001_tags=bd.get("iso_27001_tags", []),
-            soc2_tags=bd.get("soc2_tags", []),
-            cis_tags=bd.get("cis_tags", []),
-            cmmc_tags=bd.get("cmmc_tags", []),
         )
+        for tag_field, tags in blast_radius_tag_kwargs(bd).items():
+            setattr(br, tag_field, tags)
         blast_radii.append(br)
 
     # Pad agents list to match counts from scan summaries (narrative uses len(agents))
@@ -1426,6 +1425,8 @@ def _scan_request_payload(job: Any) -> dict:
 
 def _index_blast_radii_by_tag(jobs: list) -> dict[str, list[dict]]:
     """Build a flat tag → list[blast-radius] index across all completed scans."""
+    from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS
+
     by_tag: dict[str, list[dict]] = {}
     for job in jobs:
         if job.status != JobStatus.DONE or not job.result:
@@ -1442,22 +1443,7 @@ def _index_blast_radii_by_tag(jobs: list) -> dict[str, list[dict]]:
         }
         for br in job.result.get("blast_radius", []):
             br_with_scan = {**br, **scan_context}
-            for tag_field in (
-                "owasp_tags",
-                "owasp_mcp_tags",
-                "atlas_tags",
-                "nist_ai_rmf_tags",
-                "nist_csf_tags",
-                "iso_27001_tags",
-                "soc2_tags",
-                "cmmc_tags",
-                "fedramp_tags",
-                "owasp_agentic_tags",
-                "eu_ai_act_tags",
-                "cis_tags",
-                "nist_800_53_tags",
-                "pci_dss_tags",
-            ):
+            for tag_field in COMPLIANCE_TAG_FIELDS:
                 for tag in br.get(tag_field, []) or []:
                     by_tag.setdefault(tag, []).append(br_with_scan)
     return by_tag

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1097,10 +1097,12 @@ def _redact_scan_result_for_response(result: dict[str, Any] | None) -> dict[str,
     """Drop replay-only fields from top-level scan findings before API return."""
     if not isinstance(result, dict):
         return result
+    from agent_bom.cloud.cis_remediation import fail_closed_cis_result
+
+    redacted = cast(dict[str, Any], fail_closed_cis_result(result))
     findings = result.get("findings")
     if not isinstance(findings, list):
-        return result
-    redacted = dict(result)
+        return redacted
     redacted["findings"] = redact_for_persistence(findings, EvidenceTier.SAFE_TO_STORE)
     return redacted
 

--- a/src/agent_bom/cli/agents/_context.py
+++ b/src/agent_bom/cli/agents/_context.py
@@ -48,6 +48,10 @@ class ScanContext:
     cloud_provider_failures: list = field(default_factory=list)
     cloud_provider_successes: list = field(default_factory=list)
     cloud_provider_warnings: list = field(default_factory=list)
+    # Runtime evidence for vulnerability-enrichment sources. Active CI gates
+    # consume this snapshot so an unavailable KEV feed cannot look like zero
+    # known-exploited findings.
+    enrichment_posture: dict = field(default_factory=dict)
     # per-step timing breakdown (step_name → seconds)
     step_timings: dict = field(default_factory=dict)
     # internal references used for AI enrichment

--- a/src/agent_bom/cli/agents/_post.py
+++ b/src/agent_bom/cli/agents/_post.py
@@ -415,6 +415,20 @@ def compute_exit_code(
                     f"finding(s) found (use --enrich if not already)[/red bold]"
                 )
             exit_code = 1
+        else:
+            sources = ctx.enrichment_posture.get("sources", []) if isinstance(ctx.enrichment_posture, dict) else []
+            kev_source = next(
+                (source for source in sources if isinstance(source, dict) and source.get("source") == "cisa_kev"),
+                None,
+            )
+            kev_status = str(kev_source.get("status") if kev_source else "unknown")
+            if kev_status != "ok":
+                if not quiet:
+                    con.print(
+                        "\n  [red bold]Exiting with code 1: CISA KEV evidence is unavailable or stale; "
+                        "--fail-on-kev cannot prove a clean result[/red bold]"
+                    )
+                exit_code = 1
 
     if fail_if_ai_risk and _active_blast_radii:
         ai_findings = [br for br in _active_blast_radii if br.ai_risk_context and br.exposed_credentials]

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2957,6 +2957,9 @@ def scan(
     )
 
     # Step 9: Exit code
+    from agent_bom.enrichment_posture import describe_enrichment_posture
+
+    ctx.enrichment_posture = describe_enrichment_posture()
     exit_code = compute_exit_code(
         ctx,
         fail_on_severity=fail_on_severity,

--- a/src/agent_bom/cloud/cis_remediation.py
+++ b/src/agent_bom/cloud/cis_remediation.py
@@ -403,31 +403,39 @@ _VERIFIED_CLI_CONTROLS: frozenset[CISControlIdentity] = frozenset(
     }
 )
 
-_VERIFIED_CLI_BY_COMMAND: dict[str, CISRemediationOverride] = {
-    override.fix_cli: override
-    for identity, override in _OVERRIDES.items()
-    if identity in _VERIFIED_CLI_CONTROLS and override.fix_cli is not None
-}
-
-
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
 
-def fail_closed_remediation_payload(value: Any) -> dict[str, Any]:
+def fail_closed_remediation_payload(
+    value: Any,
+    *,
+    cloud: str | None = None,
+    benchmark_version: str | None = None,
+    check_id: str | None = None,
+    title: str | None = None,
+    cis_section: str | None = None,
+) -> dict[str, Any]:
     """Return a copy containing only an exact provider-verified command.
 
     Historical scan jobs and analytics rows can contain commands written by an
-    older release. Exact command allowlisting at projection boundaries prevents
-    those rows from replaying stale mutations after an upgrade without rewriting
-    evidence. Current command metadata is canonicalized from the reviewed
-    override; commands are never executed by this module.
+    older release. Projection boundaries must provide the complete benchmark
+    identity: command text alone is not an identity and can otherwise be replayed
+    onto a different control. Missing, stale, or drifted metadata therefore
+    falls back to manual guidance. Commands are never executed by this module.
     """
     remediation = dict(value) if isinstance(value, dict) else {}
     command = remediation.get("fix_cli")
-    verified = _VERIFIED_CLI_BY_COMMAND.get(command) if isinstance(command, str) else None
-    if verified is None:
+    identity = CISControlIdentity(
+        cloud=cloud or "",
+        benchmark_version=benchmark_version or "",
+        check_id=check_id or "",
+        title=title or "",
+        cis_section=cis_section or "",
+    )
+    verified = _OVERRIDES.get(identity) if identity in _VERIFIED_CLI_CONTROLS else None
+    if verified is None or not isinstance(command, str) or command != verified.fix_cli:
         remediation["fix_cli"] = None
         remediation["effort"] = "manual"
     else:
@@ -437,6 +445,66 @@ def fail_closed_remediation_payload(value: Any) -> dict[str, Any]:
             remediation["docs"] = verified.docs
     remediation["requires_human_review"] = True
     return remediation
+
+
+def fail_closed_check_remediation(
+    check: Any,
+    *,
+    cloud: str,
+    benchmark_version: str | None,
+) -> dict[str, Any]:
+    """Validate one serialized check's remediation against its full identity."""
+    item = check if isinstance(check, dict) else {}
+    return fail_closed_remediation_payload(
+        item.get("remediation"),
+        cloud=cloud,
+        benchmark_version=benchmark_version,
+        check_id=str(item.get("check_id") or ""),
+        title=str(item.get("title") or ""),
+        cis_section=str(item.get("cis_section") or ""),
+    )
+
+
+def fail_closed_cis_bundle(value: Any, *, cloud: str) -> Any:
+    """Copy a CIS bundle and identity-validate every projected remediation."""
+    if not isinstance(value, dict):
+        return value
+    bundle = dict(value)
+    benchmark_version = str(bundle.get("benchmark_version") or "")
+    checks: list[Any] = []
+    for raw_check in bundle.get("checks", []) or []:
+        if not isinstance(raw_check, dict):
+            checks.append(raw_check)
+            continue
+        check = dict(raw_check)
+        check["remediation"] = fail_closed_check_remediation(
+            check,
+            cloud=cloud,
+            benchmark_version=benchmark_version,
+        )
+        checks.append(check)
+    bundle["checks"] = checks
+    return bundle
+
+
+_CIS_RESULT_KEYS: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("aws", ("cis_benchmark", "cis_benchmark_data")),
+    ("azure", ("azure_cis_benchmark", "azure_cis_benchmark_data")),
+    ("gcp", ("gcp_cis_benchmark", "gcp_cis_benchmark_data")),
+    ("snowflake", ("snowflake_cis_benchmark", "snowflake_cis_benchmark_data")),
+)
+
+
+def fail_closed_cis_result(value: Any) -> Any:
+    """Copy a serialized report and validate every known CIS side bundle."""
+    if not isinstance(value, dict):
+        return value
+    result = dict(value)
+    for cloud, keys in _CIS_RESULT_KEYS:
+        for key in keys:
+            if key in result:
+                result[key] = fail_closed_cis_bundle(result[key], cloud=cloud)
+    return result
 
 
 def build_remediation(

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -275,6 +275,20 @@ TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
     ),
 )
 
+# One authoritative inventory for every framework-tag field carried by both
+# BlastRadius and Finding. Reconstructors and exporters must consume this
+# registry instead of maintaining partial literal tuples that silently drift.
+COMPLIANCE_TAG_FIELDS: tuple[str, ...] = tuple(metadata.tag_field for metadata in TAG_MAPPED_FRAMEWORKS)
+
+
+def blast_radius_tag_kwargs(payload: Mapping[str, object]) -> dict[str, list[str]]:
+    """Return normalized BlastRadius tag kwargs from a serialized payload."""
+    normalized: dict[str, list[str]] = {}
+    for field in COMPLIANCE_TAG_FIELDS:
+        raw = payload.get(field)
+        normalized[field] = [str(tag) for tag in raw] if isinstance(raw, (list, tuple, set)) else []
+    return normalized
+
 # Canonical hyphenated slugs (``TAG_MAPPED_FRAMEWORKS``) vs legacy ingest aliases.
 FRAMEWORK_SLUG_ALIASES: dict[str, str] = {
     "mitre-attack": "attack",

--- a/src/agent_bom/mcp_server.py
+++ b/src/agent_bom/mcp_server.py
@@ -1037,7 +1037,7 @@ def create_mcp_server(*, host: str = "127.0.0.1", port: int = 8000, bearer_token
             image: Docker image reference to scan (e.g. "nginx:1.25").
 
         Returns:
-            JSON with overall_score (0-100), overall_status (pass/warning/fail),
+            JSON with overall_score (0-100), overall_status (pass/warning/fail/no_data),
             and per-control details for OWASP LLM Top 10 (10 controls),
             OWASP MCP Top 10 (10 controls), MITRE ATLAS (13 techniques),
             and NIST AI RMF (14 subcategories). Plus a nist_800_53_catalog line:

--- a/src/agent_bom/mcp_tools/compliance.py
+++ b/src/agent_bom/mcp_tools/compliance.py
@@ -50,7 +50,8 @@ async def compliance_impl(
         from agent_bom.owasp import OWASP_LLM_TOP10
         from agent_bom.owasp_mcp import OWASP_MCP_TOP10
 
-        agents, blast_radii, _warnings, _srcs = await _run_scan_pipeline(config_path, image)
+        agents, blast_radii, _warnings, scan_sources = await _run_scan_pipeline(config_path, image)
+        has_evidence = bool(agents or blast_radii or scan_sources)
 
         # Convert BlastRadius objects to dicts for aggregation
         br_dicts = []
@@ -83,7 +84,11 @@ async def compliance_impl(
                             pkgs.add(br["package"])
                         for a in br.get("affected_agents", []):
                             ags.add(a)
-                status = "pass" if findings == 0 else ("fail" if sev_bk["critical"] > 0 or sev_bk["high"] > 0 else "warning")
+                status = (
+                    "not_evaluated"
+                    if not has_evidence
+                    else ("pass" if findings == 0 else ("fail" if sev_bk["critical"] > 0 or sev_bk["high"] > 0 else "warning"))
+                )
                 controls.append(
                     {
                         id_key: code,
@@ -105,7 +110,9 @@ async def compliance_impl(
         all_controls = owasp + atlas + nist + owasp_mcp
         total = len(all_controls)
         total_pass = sum(1 for c in all_controls if c["status"] == "pass")
-        score = round((total_pass / total) * 100, 1) if total > 0 else 100.0
+        evaluated_controls = sum(1 for c in all_controls if c["status"] != "not_evaluated")
+        not_evaluated_controls = total - evaluated_controls
+        score = round((total_pass / evaluated_controls) * 100, 1) if evaluated_controls > 0 else 0.0
         has_fail = any(c["status"] == "fail" for c in all_controls)
         has_warn = any(c["status"] == "warning" for c in all_controls)
 
@@ -119,14 +126,18 @@ async def compliance_impl(
         # estate reads no_data, never a false pass.
         from agent_bom.compliance_nist_catalog import build_nist_800_53_catalog_line
 
-        nist_800_53_catalog = build_nist_800_53_catalog_line(br_dicts, {}, 1 if agents else 0)
+        nist_800_53_catalog = build_nist_800_53_catalog_line(br_dicts, {}, 1 if has_evidence else 0)
 
         return _truncate_response(
             json.dumps(
                 {
                     "overall_score": score,
-                    "overall_status": "fail" if has_fail else ("warning" if has_warn else "pass"),
+                    "overall_status": (
+                        "no_data" if evaluated_controls == 0 else ("fail" if has_fail else ("warning" if has_warn else "pass"))
+                    ),
                     "total_controls": total,
+                    "evaluated_controls": evaluated_controls,
+                    "not_evaluated_controls": not_evaluated_controls,
                     "owasp_llm_top10": owasp,
                     "mitre_atlas": atlas,
                     "nist_ai_rmf": nist,

--- a/src/agent_bom/mcp_tools/graph.py
+++ b/src/agent_bom/mcp_tools/graph.py
@@ -266,8 +266,8 @@ async def deploy_decision_impl(
 
     matched_paths = [path for path in payload.get("paths", []) if _candidate_matches_path(candidate_value, path)]
     matched_paths = matched_paths[:limit]
-    max_risk = max((float(path.get("riskScore", 0.0) or 0.0) for path in matched_paths), default=0.0)
-    decision = _decision_for_risk(max_risk, warn_risk=warn_risk, block_risk=block_risk)
+    max_risk = max((float(path.get("riskScore", 0.0) or 0.0) for path in matched_paths), default=None)
+    decision = _decision_for_risk(max_risk, warn_risk=warn_risk, block_risk=block_risk) if max_risk is not None else "warn"
     reasons: list[str] = []
     if matched_paths:
         top = matched_paths[0]
@@ -276,7 +276,7 @@ async def deploy_decision_impl(
         if findings:
             reasons.append(f"Matched findings: {', '.join(findings[:5])}.")
     else:
-        reasons.append("No matching exposure paths were found for the candidate in the selected graph snapshot.")
+        reasons.append("No matching exposure path evidence was found for the candidate; this is not an approval to deploy.")
 
     encoded = json.dumps(
         {
@@ -287,11 +287,15 @@ async def deploy_decision_impl(
             "candidate": {"value": candidate_value},
             "decision": decision,
             "maxRisk": max_risk,
+            "evidenceStatus": "evaluated" if matched_paths else "not_evaluated",
             "thresholds": {"warnRisk": warn_risk, "blockRisk": block_risk},
             "reasons": reasons,
             "matchedPathCount": len(matched_paths),
             "matchedPaths": matched_paths,
-            "provenance": {"source": "mcp_should_i_deploy", "basis": "exposure_paths"},
+            "provenance": {
+                "source": "mcp_should_i_deploy",
+                "basis": "exposure_paths" if matched_paths else "no_matching_exposure_path_evidence",
+            },
         },
         indent=2,
         default=str,

--- a/src/agent_bom/output/compact.py
+++ b/src/agent_bom/output/compact.py
@@ -128,6 +128,8 @@ def _agent_display_name(agent) -> str:
 
 def _iter_cis_bundles(report: AIBOMReport):
     """Yield (cloud, bundle_dict) for every populated CIS benchmark bundle."""
+    from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
+
     bundles = [
         ("aws", getattr(report, "cis_benchmark_data", None)),
         ("azure", getattr(report, "azure_cis_benchmark_data", None)),
@@ -136,7 +138,7 @@ def _iter_cis_bundles(report: AIBOMReport):
     ]
     for cloud, bundle in bundles:
         if bundle and bundle.get("checks"):
-            yield cloud, bundle
+            yield cloud, fail_closed_cis_bundle(bundle, cloud=cloud)
 
 
 # ─── Compact Output (default mode) ───────────────────────────────────────────

--- a/src/agent_bom/output/compliance_narrative.py
+++ b/src/agent_bom/output/compliance_narrative.py
@@ -32,7 +32,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from agent_bom.models import AIBOMReport
 
-from agent_bom.compliance_coverage import FRAMEWORK_SLUG_ALIASES, normalize_framework_slug
+from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS, FRAMEWORK_SLUG_ALIASES, normalize_framework_slug
 
 # ─── Catalogue lookups ────────────────────────────────────────────────────────
 # Imported lazily where needed to keep top-level import cost low.
@@ -696,21 +696,7 @@ def generate_compliance_narrative(
                 "affected_agents": [a.name for a in br.affected_agents],
                 "affected_servers": [s.name for s in br.affected_servers],
                 "exposed_credentials": br.exposed_credentials,
-                "owasp_tags": br.owasp_tags,
-                "atlas_tags": br.atlas_tags,
-                "nist_ai_rmf_tags": br.nist_ai_rmf_tags,
-                "owasp_mcp_tags": br.owasp_mcp_tags,
-                "owasp_agentic_tags": br.owasp_agentic_tags,
-                "eu_ai_act_tags": br.eu_ai_act_tags,
-                "nist_csf_tags": br.nist_csf_tags,
-                "iso_27001_tags": br.iso_27001_tags,
-                "soc2_tags": br.soc2_tags,
-                "cis_tags": br.cis_tags,
-                "cmmc_tags": br.cmmc_tags,
-                "attack_tags": getattr(br, "attack_tags", []),
-                "nist_800_53_tags": getattr(br, "nist_800_53_tags", []),
-                "fedramp_tags": getattr(br, "fedramp_tags", []),
-                "pci_dss_tags": getattr(br, "pci_dss_tags", []),
+                **{field: list(getattr(br, field, []) or []) for field in COMPLIANCE_TAG_FIELDS},
             }
         )
 

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -1686,9 +1686,15 @@ def print_cis_findings(report: AIBOMReport, *, show_passed: bool = False) -> Non
     Ordering is deterministic so the same report renders identically
     across runs. Emits nothing when no CIS data is present.
     """
+    from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
+
     con = _console()
     raw_bundles = [(cloud, label, getattr(report, attr, None)) for cloud, label, attr in _CIS_CLOUD_BUNDLES]
-    bundles = [(c, lbl, b) for c, lbl, b in raw_bundles if b and b.get("checks")]
+    bundles = [
+        (c, lbl, fail_closed_cis_bundle(b, cloud=c) if c in {"aws", "azure", "gcp", "snowflake"} else b)
+        for c, lbl, b in raw_bundles
+        if b and b.get("checks")
+    ]
     if not bundles:
         return
 

--- a/src/agent_bom/output/cyclonedx_fmt.py
+++ b/src/agent_bom/output/cyclonedx_fmt.py
@@ -278,11 +278,11 @@ def _build_model_card(provenance: dict) -> dict:
     considerations: dict = {}
     risk_flags = provenance.get("risk_flags", [])
     if risk_flags:
-        considerations["technicalLimitations"] = [{"description": f"Risk flag: {flag}"} for flag in risk_flags]
+        considerations["technicalLimitations"] = [f"Risk flag: {flag}" for flag in risk_flags]
     safe_format = provenance.get("is_safe_format", True)
     if not safe_format:
         considerations.setdefault("technicalLimitations", []).append(
-            {"description": "Model uses unsafe serialization format (pickle/pt) — arbitrary code execution on load"}
+            "Model uses unsafe serialization format (pickle/pt) — arbitrary code execution on load"
         )
     if considerations:
         card["considerations"] = considerations
@@ -353,7 +353,7 @@ def _build_model_file_component(model_file: dict, comp_id: int) -> tuple[dict, s
         )
         # Also add to considerations in modelCard
         component.setdefault("modelCard", {}).setdefault("considerations", {}).setdefault("technicalLimitations", []).append(
-            {"description": flag.get("description", "")}
+            str(flag.get("description", ""))
         )
 
     return component, ref
@@ -467,7 +467,7 @@ def _build_training_component(run: dict, comp_id: int) -> tuple[dict, str]:
     # considerations — security flags
     for flag in run.get("security_flags", []):
         model_card.setdefault("considerations", {}).setdefault("technicalLimitations", []).append(
-            {"description": flag.get("description", "")}
+            str(flag.get("description", ""))
         )
 
     if model_card:

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS
 from agent_bom.finding import Finding, FindingType, blast_radius_to_finding
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 
@@ -288,12 +289,7 @@ def compliance_row_dict(finding: Finding) -> dict[str, Any]:
     """Framework table row payload from a unified CVE finding."""
     return {
         "severity": severity_value(finding),
-        "owasp_tags": list(finding.owasp_tags),
-        "atlas_tags": list(finding.atlas_tags),
-        "attack_tags": list(finding.attack_tags),
-        "nist_ai_rmf_tags": list(finding.nist_ai_rmf_tags),
-        "owasp_agentic_tags": list(finding.owasp_agentic_tags),
-        "eu_ai_act_tags": list(finding.eu_ai_act_tags),
+        **{field: list(getattr(finding, field, []) or []) for field in COMPLIANCE_TAG_FIELDS},
     }
 
 
@@ -307,11 +303,5 @@ def topology_vuln_dict(finding: Finding) -> dict[str, Any]:
         "risk_score": finding.risk_score,
         "cvss_score": finding.cvss_score or 0,
         "fix_version": finding.fixed_version or "",
-        "owasp_tags": list(finding.owasp_tags),
-        "atlas_tags": list(finding.atlas_tags),
-        "attack_tags": list(finding.attack_tags),
-        "nist_ai_rmf_tags": list(finding.nist_ai_rmf_tags),
-        "owasp_mcp_tags": list(finding.owasp_mcp_tags),
-        "owasp_agentic_tags": list(finding.owasp_agentic_tags),
-        "eu_ai_act_tags": list(finding.eu_ai_act_tags),
+        **{field: list(getattr(finding, field, []) or []) for field in COMPLIANCE_TAG_FIELDS},
     }

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -623,9 +623,9 @@ def to_graphml(graph: DepGraph) -> str:
     """
     lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
-        '<graphml xmlns="http://graphml.graphstruct.org/graphml"',
+        '<graphml xmlns="http://graphml.graphdrawing.org/xmlns"',
         '         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"',
-        '         xsi:schemaLocation="http://graphml.graphstruct.org/graphml http://graphml.graphstruct.org/xmlns/1.1/graphml.xsd">',
+        '         xsi:schemaLocation="http://graphml.graphdrawing.org/xmlns http://graphml.graphdrawing.org/xmlns/1.0/graphml.xsd">',
         "  <!-- AIBOM graph exported by agent-bom -->",
     ]
 

--- a/src/agent_bom/output/html/sections.py
+++ b/src/agent_bom/output/html/sections.py
@@ -835,11 +835,15 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
             priority = 3
         return (severity_worst_first_rank(c.get("severity")), priority, str(c.get("check_id") or ""))
 
+    from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
+
     panels: list[str] = []
     for idx, (cloud_key, (label, attr)) in enumerate(_CIS_CLOUD_LABELS.items()):
         bundle = getattr(report, attr, None)
         if not bundle:
             continue
+        if cloud_key in {"aws", "azure", "gcp", "snowflake"}:
+            bundle = fail_closed_cis_bundle(bundle, cloud=cloud_key)
         checks = bundle.get("checks") or []
         if not checks:
             continue

--- a/src/agent_bom/output/json_fmt.py
+++ b/src/agent_bom/output/json_fmt.py
@@ -1337,10 +1337,14 @@ def to_json(report: AIBOMReport) -> dict:
         result["cloud_audit_trail"] = report.cloud_audit_trail_data
 
     if report.cis_benchmark_data:
-        result["cis_benchmark"] = report.cis_benchmark_data
+        from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
+
+        result["cis_benchmark"] = fail_closed_cis_bundle(report.cis_benchmark_data, cloud="aws")
 
     if report.snowflake_cis_benchmark_data:
-        result["snowflake_cis_benchmark"] = report.snowflake_cis_benchmark_data
+        from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
+
+        result["snowflake_cis_benchmark"] = fail_closed_cis_bundle(report.snowflake_cis_benchmark_data, cloud="snowflake")
     if report.snowflake_object_graph_data:
         result["snowflake_object_graph"] = report.snowflake_object_graph_data
     if report.snowflake_login_anomalies_data:
@@ -1363,10 +1367,14 @@ def to_json(report: AIBOMReport) -> dict:
         result["snowflake_activity"] = report.snowflake_activity_data
 
     if report.azure_cis_benchmark_data:
-        result["azure_cis_benchmark"] = report.azure_cis_benchmark_data
+        from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
+
+        result["azure_cis_benchmark"] = fail_closed_cis_bundle(report.azure_cis_benchmark_data, cloud="azure")
 
     if report.gcp_cis_benchmark_data:
-        result["gcp_cis_benchmark"] = report.gcp_cis_benchmark_data
+        from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
+
+        result["gcp_cis_benchmark"] = fail_closed_cis_bundle(report.gcp_cis_benchmark_data, cloud="gcp")
 
     if report.databricks_security_data:
         # Canonical vendor-best-practice key; Databricks has no official CIS

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -12,6 +12,7 @@ from agent_bom.asset_provenance import (
     agent_discovery_provenance,
     sanitize_discovery_provenance,
 )
+from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS
 from agent_bom.evidence import EvidenceTier, redact_for_persistence
 from agent_bom.exploitability import exploitability_tags, parse_cvss_vector_signals
 from agent_bom.finding import Finding, FindingType
@@ -385,25 +386,6 @@ _DEDICATED_CIS_BENCHMARKS: tuple[tuple[str, str], ...] = (
 )
 _DEDICATED_CIS_PROVIDERS = frozenset(provider for provider, _ in _DEDICATED_CIS_BENCHMARKS)
 
-_FRAMEWORK_TAG_FIELDS: tuple[str, ...] = (
-    "owasp_tags",
-    "atlas_tags",
-    "attack_tags",
-    "nist_ai_rmf_tags",
-    "owasp_mcp_tags",
-    "owasp_agentic_tags",
-    "eu_ai_act_tags",
-    "nist_csf_tags",
-    "iso_27001_tags",
-    "soc2_tags",
-    "cis_tags",
-    "cmmc_tags",
-    "nist_800_53_tags",
-    "fedramp_tags",
-    "pci_dss_tags",
-)
-
-
 def _finding_artifact_uri(report: AIBOMReport, finding: Finding) -> str:
     """Resolve a SARIF artifact URI from unified finding + report agent inventory."""
     ecosystem = package_ecosystem(finding) or None
@@ -450,7 +432,7 @@ def _server_discovery_provenance_from_report(report: AIBOMReport, server_names: 
 
 def _framework_tag_properties(finding: Finding) -> dict[str, list[str]]:
     props: dict[str, list[str]] = {}
-    for field in _FRAMEWORK_TAG_FIELDS:
+    for field in COMPLIANCE_TAG_FIELDS:
         value = getattr(finding, field, [])
         if value:
             props[field] = list(value)
@@ -966,10 +948,13 @@ def to_sarif(
     # and downstream SARIF consumers can surface fix guidance per finding.
     cis_sev_map = {"critical": "error", "high": "error", "medium": "warning", "low": "note", "info": "none"}
     cis_sev_score = {"critical": "9.0", "high": "7.0", "medium": "4.0", "low": "1.0", "info": "0.0"}
+    from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
+
     for cloud_key, data_attr in _DEDICATED_CIS_BENCHMARKS:
         bundle = getattr(report, data_attr, None)
         if not bundle:
             continue
+        bundle = fail_closed_cis_bundle(bundle, cloud=cloud_key)
         for check in bundle.get("checks", []):
             if check.get("status") != "fail":
                 continue

--- a/src/agent_bom/proxy_scanner.py
+++ b/src/agent_bom/proxy_scanner.py
@@ -137,7 +137,10 @@ _GATEWAY_SECRET_PATTERNS: list[tuple[re.Pattern, str, str]] = [
         # AWS secret access key value (40-char base64) — REQUIRE the label. A
         # bare 40-char base64 string collides with git SHAs, hashes, etc., so it
         # is only flagged when explicitly named ``aws_secret_access_key``.
-        re.compile(r"(?i)aws_secret_access_key\s*[:=]\s*['\"]?[A-Za-z0-9/+]{40}"),
+        re.compile(
+            r"(?i)(?P<aws_label_quote>['\"]?)aws_secret_access_key(?P=aws_label_quote)\s*[:=]\s*"
+            r"(?P<aws_value_quote>['\"]?)[A-Za-z0-9/+=]{40}(?P=aws_value_quote)(?![A-Za-z0-9/+=])"
+        ),
         "aws_secret_access_key",
         "critical",
     ),
@@ -214,7 +217,11 @@ _UNICODE_CONTROL_CHARS = {
 def _normalize_detector_text(text: str) -> str:
     """Normalize detector input so invisible Unicode controls cannot split patterns."""
     normalized = unicodedata.normalize("NFKC", text)
-    return "".join(ch for ch in normalized if ch not in _UNICODE_CONTROL_CHARS)
+    normalized = "".join(ch for ch in normalized if ch not in _UNICODE_CONTROL_CHARS)
+    # Tool responses are commonly JSON-serialized before DLP inspection, so
+    # quoted keys/values arrive as \"key\": \"value\". Normalize quote escapes
+    # for detection only; the original response is never rewritten or logged.
+    return normalized.replace('\\"', '"').replace("\\'", "'")
 
 
 def _redact_excerpt(match_text: str, max_len: int = 12) -> str:

--- a/src/agent_bom/runtime/patterns.py
+++ b/src/agent_bom/runtime/patterns.py
@@ -13,7 +13,14 @@ import re
 # Each pattern: (name, compiled regex)
 CREDENTIAL_PATTERNS: list[tuple[str, re.Pattern]] = [
     ("AWS Access Key", re.compile(r"AKIA[0-9A-Z]{16}")),
-    ("AWS Secret Key", re.compile(r"(?:aws_secret_access_key|secret_?key)\s*[=:]\s*[A-Za-z0-9/+=]{40}", re.IGNORECASE)),
+    (
+        "AWS Secret Key",
+        re.compile(
+            r"(['\"]?)(?:aws_secret_access_key|secret_?key)\1\s*[=:]\s*"
+            r"(['\"]?)[A-Za-z0-9/+=]{40}\2(?![A-Za-z0-9/+=])",
+            re.IGNORECASE,
+        ),
+    ),
     ("GitHub Token", re.compile(r"gh[pousr]_[A-Za-z0-9_]{36,}")),
     ("GitLab Token", re.compile(r"glpat-[A-Za-z0-9\-_]{20,}")),
     ("OpenAI API Key", re.compile(r"sk-(?:proj-)?[A-Za-z0-9\-_]{20,}")),

--- a/src/agent_bom/version_utils.py
+++ b/src/agent_bom/version_utils.py
@@ -44,12 +44,12 @@ _PEP440_RE = re.compile(
 )
 
 # Go: v-prefix semver or vX.Y.Z-pre
-_GO_VERSION_RE = re.compile(r"^v\d+\.\d+\.\d+(?:-[0-9A-Za-z\-.]+)?(?:\+[0-9A-Za-z\-.]+)?$")
+_GO_VERSION_RE = re.compile(r"^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z\-.]+)?(?:\+[0-9A-Za-z\-.]+)?$")
 
 # Maven: flexible (major.minor.patch.qualifier or major.minor.patch-qualifier)
 _MAVEN_RE = re.compile(r"^\d+(?:\.\d+){0,3}(?:[.-][A-Za-z0-9\-.]+)?$")
 
-_GO_PSEUDO_RE = re.compile(r"^v\d+\.\d+\.\d+-(\d{14})-[0-9a-f]{12}$")
+_GO_PSEUDO_RE = re.compile(r"^v?\d+\.\d+\.\d+-(\d{14})-[0-9a-f]{12}$")
 _HEXISH_RE = re.compile(r"^[0-9a-f]{7,40}$")
 
 

--- a/tests/test_audit_chain.py
+++ b/tests/test_audit_chain.py
@@ -57,6 +57,27 @@ def test_chain_hash_head_deletion_detected_with_checkpoint():
     assert tampered == 1
 
 
+def test_chain_hash_full_wipe_detected_with_checkpoint():
+    log = InMemoryAuditLog()
+    log.append(AuditEntry(action="scan", actor="test", resource="pkg-a"))
+    log._entries.clear()
+
+    assert log.verify_integrity() == (0, 1)
+
+
+def test_new_empty_chain_without_checkpoint_is_not_tampered():
+    assert InMemoryAuditLog().verify_integrity() == (0, 0)
+
+
+def test_sqlite_full_wipe_detected_with_checkpoint(tmp_path):
+    log = SQLiteAuditLog(str(tmp_path / "audit-wipe.db"))
+    log.append(AuditEntry(action="scan", actor="test", resource="pkg-a"))
+    log._conn.execute("DELETE FROM audit_log")
+    log._conn.commit()
+
+    assert log.verify_integrity() == (0, 1)
+
+
 def test_sqlite_audit_hydrates_last_signature_after_restart(tmp_path):
     db = str(tmp_path / "audit.db")
     first = SQLiteAuditLog(db)

--- a/tests/test_audit_checkpoint_backfill_4294.py
+++ b/tests/test_audit_checkpoint_backfill_4294.py
@@ -247,3 +247,21 @@ def test_postgres_append_seed_uses_true_count_for_legacy_tenant() -> None:
         assert store.verify_integrity(tenant_id=tenant) == (n + 1, 0)
     finally:
         _current_tenant.reset(token)
+
+
+@_REQUIRES_PG
+def test_postgres_full_ledger_wipe_with_checkpoint_is_tampered() -> None:
+    from agent_bom.api.postgres_common import _current_tenant, set_current_tenant
+    from agent_bom.api.postgres_store import PostgresAuditLog
+
+    store = PostgresAuditLog()
+    tenant = f"tenant-wipe-{uuid.uuid4().hex[:12]}"
+    token = set_current_tenant(tenant)
+    try:
+        _pg_build_chain(store, tenant, 2)
+        _pg_exec("DELETE FROM audit_log WHERE team_id = %s", (tenant,))
+
+        assert store.verify_integrity(tenant_id=tenant) == (0, 1)
+    finally:
+        _pg_exec("DELETE FROM audit_chain_checkpoint WHERE tenant_id = %s", (tenant,))
+        _current_tenant.reset(token)

--- a/tests/test_audit_queue_fixes.py
+++ b/tests/test_audit_queue_fixes.py
@@ -114,6 +114,41 @@ def test_scan_exits_one_on_malicious_package_by_default() -> None:
     assert code == 1
 
 
+def test_fail_on_kev_fails_closed_when_catalog_evidence_is_unavailable() -> None:
+    from io import StringIO
+
+    from rich.console import Console
+
+    from agent_bom.cli.agents._context import ScanContext
+    from agent_bom.cli.agents._post import compute_exit_code
+
+    blast_radius = _malicious_blast_radius()
+    blast_radius.package.is_malicious = False
+    blast_radius.package.malicious_reason = None
+    blast_radius.vulnerability.id = "CVE-2021-44228"
+    blast_radius.vulnerability.is_kev = False
+    ctx = ScanContext(
+        con=Console(file=StringIO(), force_terminal=False),
+        blast_radii=[blast_radius],
+        enrichment_posture={
+            "sources": [{"source": "cisa_kev", "status": "degraded"}],
+        },
+    )
+
+    code = compute_exit_code(
+        ctx,
+        fail_on_severity=None,
+        warn_on_severity=None,
+        fail_on_kev=True,
+        fail_if_ai_risk=False,
+        push_url=None,
+        push_api_key=None,
+        quiet=True,
+    )
+
+    assert code == 1
+
+
 def test_forward_fixed_version_rejects_downgrade() -> None:
     assert _forward_fixed_version("0.2.1", "1.2.0", "npm") is None
     assert _forward_fixed_version("1.2.3", "1.2.0", "npm") == "1.2.3"

--- a/tests/test_cis_remediation_surfaces.py
+++ b/tests/test_cis_remediation_surfaces.py
@@ -13,7 +13,9 @@ from rich.console import Console
 from agent_bom.cloud.cis_remediation import build_remediation
 from agent_bom.models import AIBOMReport
 from agent_bom.output import print_compact_cis_posture
+from agent_bom.output.console_render import print_cis_findings
 from agent_bom.output.html import _cis_benchmark_section
+from agent_bom.output.json_fmt import to_json
 from agent_bom.output.sarif import to_sarif
 
 
@@ -171,6 +173,43 @@ def test_provider_verified_command_reaches_cli_html_and_sarif():
     assert props["fix_cli"] == command
     assert props["remediation"]["fix_cli"] == command
     assert props["requires_human_review"] is True
+
+
+def test_verified_command_cannot_replay_on_a_different_control_or_surface():
+    report, command = _report_with_verified_aws_cis()
+    check = report.cis_benchmark_data["checks"][0]
+    check.update(
+        {
+            "check_id": "3.1",
+            "title": "CloudTrail enabled in all regions",
+            "cis_section": "3 - Logging",
+        }
+    )
+
+    import agent_bom.output as output_mod
+
+    for renderer in (print_compact_cis_posture, print_cis_findings):
+        buf = StringIO()
+        original = output_mod.console
+        output_mod.console = Console(file=buf, force_terminal=False, width=240)
+        try:
+            renderer(report)
+        finally:
+            output_mod.console = original
+        assert command not in buf.getvalue()
+
+    assert command not in _cis_benchmark_section(report)
+    serialized = to_json(report)
+    assert serialized["cis_benchmark"]["checks"][0]["remediation"]["fix_cli"] is None
+    sarif = to_sarif(report)
+    result = next(item for item in sarif["runs"][0]["results"] if item["ruleId"] == "cis/aws/3.1")
+    assert result["properties"]["fix_cli"] is None
+
+    from agent_bom.api.routes.scan import _redact_scan_result_for_response
+
+    api_result = _redact_scan_result_for_response({"cis_benchmark": report.cis_benchmark_data})
+    assert api_result is not None
+    assert api_result["cis_benchmark"]["checks"][0]["remediation"]["fix_cli"] is None
 
 
 def test_cli_compact_cis_posture_silent_without_cis_data():

--- a/tests/test_cli_cloud_scan.py
+++ b/tests/test_cli_cloud_scan.py
@@ -398,7 +398,10 @@ class TestGroupedCisRendererRouting:
         # Failed checks carry evidence + fix lines.
         assert "evidence:" in out and "fix:" in out
         assert "arn:aws:iam::1:root" in out
-        assert "aws iam delete-access-key" in out
+        # A command without the complete version-bound control identity must
+        # fail closed to the manual recommendation on every render surface.
+        assert "aws iam delete-access-key" not in out
+        assert "Delete root access keys." in out
         # Passes are collapsed into a count, not listed individually.
         assert "2 passed" in out
         assert "--show-passed" in out

--- a/tests/test_clickhouse.py
+++ b/tests/test_clickhouse.py
@@ -408,7 +408,10 @@ class TestClickHouseAnalyticsStore:
                     {
                         "scan_id": "scan-verified",
                         "cloud": "aws",
+                        "benchmark_version": "3.0",
                         "check_id": "3.2",
+                        "title": "CloudTrail log file validation enabled",
+                        "cis_section": "3 - Logging",
                         "status": "fail",
                         "priority": 2,
                         "remediation": {

--- a/tests/test_compliance.py
+++ b/tests/test_compliance.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import json
+from dataclasses import fields
+from types import SimpleNamespace
 
 from starlette.testclient import TestClient
 
 from agent_bom.api.server import JobStatus, _get_store, app
 from agent_bom.api.store import InMemoryJobStore
 from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.models import BlastRadius
 from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
 
 _AUTH_HEADERS = proxy_headers(tenant="default")
@@ -55,6 +59,59 @@ def _add_done_job(
     if result_extra:
         job.result.update(result_extra)
     _get_store().put(job)
+
+
+def test_compliance_tag_registry_covers_every_blast_radius_tag_field() -> None:
+    from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS
+    from agent_bom.output.finding_views import compliance_row_dict
+
+    model_fields = {item.name for item in fields(BlastRadius) if item.name.endswith("_tags")}
+    finding_fields = {
+        item.name for item in fields(Finding) if item.name.endswith("_tags") and item.name != "compliance_tags"
+    }
+    assert set(COMPLIANCE_TAG_FIELDS) == model_fields
+    assert set(COMPLIANCE_TAG_FIELDS) == finding_fields
+    row = compliance_row_dict(
+        Finding(
+            finding_type=FindingType.CVE,
+            source=FindingSource.SBOM,
+            asset=Asset(name="pkg", asset_type="package"),
+            severity="low",
+            title="test",
+        )
+    )
+    assert set(COMPLIANCE_TAG_FIELDS).issubset(row)
+
+
+def test_narrative_and_evidence_index_preserve_all_framework_tags(monkeypatch) -> None:
+    from agent_bom.api.routes import compliance as route
+    from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS
+
+    blast = {
+        "vulnerability_id": "CVE-2026-TAGS",
+        "package": "demo@1.0.0",
+        "severity": "high",
+        **{field: [f"tag:{field}"] for field in COMPLIANCE_TAG_FIELDS},
+    }
+    job = SimpleNamespace(
+        status=JobStatus.DONE,
+        job_id="scan-tags",
+        result={"blast_radius": [blast], "summary": {"total_agents": 1, "total_packages": 1}},
+        request={},
+        created_at="2026-07-29T00:00:00Z",
+        completed_at="2026-07-29T00:01:00Z",
+    )
+    monkeypatch.setattr(route, "_tenant_jobs", lambda _request: [job])
+
+    report = route._latest_report(object())
+    assert report is not None
+    rebuilt = report.blast_radii[0]
+    for field in COMPLIANCE_TAG_FIELDS:
+        assert getattr(rebuilt, field) == [f"tag:{field}"]
+
+    index = route._index_blast_radii_by_tag([job])
+    for field in COMPLIANCE_TAG_FIELDS:
+        assert f"tag:{field}" in index
 
 
 # ─── Tests ───────────────────────────────────────────────────────────────────
@@ -463,7 +520,7 @@ def _cis_benchmark_result(checks: list[dict], *, cloud_key: str = "cis_benchmark
     (``cis_benchmark`` for AWS, ``azure_cis_benchmark`` for Azure, etc.) —
     the exact keys /v1/cis/checks reads via build_cis_benchmark_check_rows.
     """
-    return {"scan_id": "cis-scan", cloud_key: {"checks": checks}}
+    return {"scan_id": "cis-scan", cloud_key: {"benchmark_version": "3.0", "checks": checks}}
 
 
 def test_compliance_surfaces_cis_foundations_benchmark_line():
@@ -663,6 +720,7 @@ def test_cis_checks_preserve_exact_provider_verified_remediation():
                 {
                     "check_id": "3.1",
                     "title": "Secure transfer required on storage accounts",
+                    "cis_section": "3 - Storage Accounts",
                     "status": "FAIL",
                     "severity": "high",
                     "remediation": {
@@ -721,6 +779,11 @@ def test_persisted_cis_rows_preserve_only_exact_verified_command():
     command = "gcloud storage buckets update gs://<BUCKET_NAME> --uniform-bucket-level-access"
     row = _coerce_cis_row(
         {
+            "cloud": "gcp",
+            "benchmark_version": "3.0",
+            "check_id": "5.2",
+            "title": "Uniform bucket-level access enabled on buckets",
+            "cis_section": "5 - Cloud Storage",
             "fix_cli": "stale top-level command",
             "effort": "manual",
             "requires_human_review": False,

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -16,6 +16,7 @@ Tests cover:
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import tempfile
@@ -710,6 +711,7 @@ def test_to_graphml_basic_structure():
         assert "<node" in gml
         assert "<edge" in gml
         assert 'key="kind"' in gml
+        assert 'xmlns="http://graphml.graphdrawing.org/xmlns"' in gml
     finally:
         os.unlink(path)
 
@@ -734,6 +736,20 @@ def test_to_graphml_empty_graph():
     gml = to_graphml(g)
     assert "<graphml" in gml
     assert "<node" not in gml
+
+
+def test_to_graphml_round_trips_through_networkx_with_escaped_labels():
+    nx = pytest.importorskip("networkx")
+    graph = DepGraph()
+    graph.add_node("node<&\"", "Agent <prod> & ops", "agent")
+    graph.add_node("target", "Target", "server")
+    graph.add_edge("node<&\"", "target", "uses_server")
+
+    parsed = nx.read_graphml(io.BytesIO(to_graphml(graph).encode("utf-8")))
+
+    assert parsed.is_directed()
+    assert set(parsed.nodes) == {"node<&\"", "target"}
+    assert parsed.nodes["node<&\""]["label"] == "Agent <prod> & ops"
 
 
 # ── to_cypher ──────────────────────────────────────────────────────────────

--- a/tests/test_hub_observations_partition.py
+++ b/tests/test_hub_observations_partition.py
@@ -63,17 +63,24 @@ def test_partition_is_expired_uses_partition_end() -> None:
     )
 
 
-def test_ensure_observation_partitions_creates_missing_children() -> None:
+def test_ensure_observation_partitions_creates_missing_children(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.api.hub_observations_partition._ensure_observation_partition_rls", lambda *_args: None)
     conn = MagicMock()
     conn.execute.side_effect = [
         MagicMock(fetchone=MagicMock(return_value=("p",))),  # is_observations_partitioned
         MagicMock(fetchone=MagicMock(return_value=None)),  # y2026m06 missing
-        MagicMock(),
+        MagicMock(),  # savepoint
+        MagicMock(),  # create
+        MagicMock(),  # release savepoint
         MagicMock(fetchone=MagicMock(return_value=("child",))),  # y2026m07 exists
         MagicMock(fetchone=MagicMock(return_value=None)),  # y2026m08 missing
-        MagicMock(),
+        MagicMock(),  # savepoint
+        MagicMock(),  # create
+        MagicMock(),  # release savepoint
         MagicMock(fetchone=MagicMock(return_value=None)),  # y2026m09 missing
-        MagicMock(),
+        MagicMock(),  # savepoint
+        MagicMock(),  # create
+        MagicMock(),  # release savepoint
     ]
 
     created = ensure_observation_partitions(
@@ -87,6 +94,64 @@ def test_ensure_observation_partitions_creates_missing_children() -> None:
     executed = [str(call.args[0]).strip() for call in conn.execute.call_args_list]
     assert any("CREATE TABLE IF NOT EXISTS hub_findings_current_observations_y2026m06" in sql for sql in executed)
     assert any("CREATE TABLE IF NOT EXISTS hub_findings_current_observations_y2026m08" in sql for sql in executed)
+
+
+def test_ensure_observation_partitions_enforces_rls_on_existing_and_new_children(monkeypatch) -> None:
+    protected: list[str] = []
+    monkeypatch.setattr(
+        "agent_bom.api.hub_observations_partition._ensure_observation_partition_rls",
+        lambda _conn, child: protected.append(child),
+    )
+    conn = MagicMock()
+    conn.execute.side_effect = [
+        MagicMock(fetchone=MagicMock(return_value=("p",))),
+        MagicMock(fetchone=MagicMock(return_value=("child",))),
+        MagicMock(fetchone=MagicMock(return_value=None)),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(),
+        MagicMock(fetchone=MagicMock(return_value=("child",))),
+        MagicMock(fetchone=MagicMock(return_value=("child",))),
+    ]
+
+    ensure_observation_partitions(conn, now=datetime(2026, 7, 5, tzinfo=timezone.utc))
+
+    assert protected == [
+        "hub_findings_current_observations_y2026m06",
+        "hub_findings_current_observations_y2026m07",
+        "hub_findings_current_observations_y2026m08",
+        "hub_findings_current_observations_y2026m09",
+    ]
+
+
+def test_concurrent_partition_creation_recovers_transaction_before_rls(monkeypatch) -> None:
+    from agent_bom.api import hub_observations_partition as partitions
+
+    protected: list[str] = []
+    monkeypatch.setattr(partitions, "_ensure_observation_partition_rls", lambda _conn, child: protected.append(child))
+
+    class DuplicatePartitionError(Exception):
+        sqlstate = "42P07"
+
+    class RecordingConnection:
+        def __init__(self) -> None:
+            self.statements: list[str] = []
+
+        def execute(self, sql: str):
+            self.statements.append(sql.strip())
+            if "CREATE TABLE IF NOT EXISTS" in sql:
+                raise DuplicatePartitionError("already exists")
+            return MagicMock()
+
+    conn = RecordingConnection()
+    partitions._create_observation_partition(conn, 2026, 7)
+
+    assert conn.statements[0] == "SAVEPOINT agent_bom_observation_partition"
+    assert conn.statements[-2:] == [
+        "ROLLBACK TO SAVEPOINT agent_bom_observation_partition",
+        "RELEASE SAVEPOINT agent_bom_observation_partition",
+    ]
+    assert protected == ["hub_findings_current_observations_y2026m07"]
 
 
 def test_ensure_observation_partitions_noop_when_not_partitioned() -> None:
@@ -132,7 +197,9 @@ def test_rollover_disabled_when_retention_non_positive() -> None:
     conn.execute.assert_not_called()
 
 
-def test_migrate_observations_to_partitioned_renames_and_copies() -> None:
+def test_migrate_observations_to_partitioned_renames_and_copies(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.api.hub_observations_partition._ensure_observation_partition_rls", lambda *_args: None)
+    monkeypatch.setattr("agent_bom.api.hub_observations_partition.ensure_observation_partition_children_rls", lambda *_args: 0)
     conn = MagicMock()
     fetchone_queue = [
         (1,),  # observations_table_exists

--- a/tests/test_interop_schema_conformance.py
+++ b/tests/test_interop_schema_conformance.py
@@ -170,6 +170,42 @@ def test_cyclonedx_conforms_to_1_7_schema(report: AIBOMReport) -> None:
     )
 
 
+def test_cyclonedx_model_limitations_are_schema_valid_strings() -> None:
+    report = AIBOMReport(
+        model_provenance=[{"model": "org/model", "risk_flags": ["unsigned"], "is_safe_format": False}],
+        model_files=[
+            {
+                "filename": "unsafe.pkl",
+                "format": "pickle",
+                "security_flags": [{"type": "MALICIOUS_PICKLE", "severity": "CRITICAL", "description": "Unsafe opcode"}],
+            }
+        ],
+        training_pipelines={
+            "runs": [
+                {
+                    "name": "train",
+                    "security_flags": [{"type": "UNPINNED_INPUT", "description": "Input is not pinned"}],
+                }
+            ]
+        },
+    )
+    cdx = to_cyclonedx(report)
+    _assert_schema_valid(
+        "CycloneDX 1.7 model limitations",
+        "cyclonedx-1.7.schema.json",
+        Draft7Validator,
+        cdx,
+        registry=_cyclonedx_registry(),
+    )
+    limitations = [
+        item
+        for component in cdx.get("components", [])
+        for item in component.get("modelCard", {}).get("considerations", {}).get("technicalLimitations", [])
+    ]
+    assert limitations
+    assert all(isinstance(item, str) for item in limitations)
+
+
 def _shared_server_cyclonedx_report() -> AIBOMReport:
     """Demo-equivalent overlap: repeated agent/server discovery and a package
     without a package URL must still produce one strict-valid BOM graph."""

--- a/tests/test_mcp_exposure_paths.py
+++ b/tests/test_mcp_exposure_paths.py
@@ -123,12 +123,15 @@ async def test_deploy_decision_blocks_high_risk_candidate():
 
 
 @pytest.mark.asyncio
-async def test_deploy_decision_allows_without_matching_paths():
+async def test_deploy_decision_does_not_approve_without_matching_evidence():
     response = await deploy_decision_impl(candidate="safe-service", _get_graph_store=lambda: _GraphStore())
     payload = json.loads(response)
 
-    assert payload["decision"] == "allow"
+    assert payload["decision"] == "warn"
+    assert payload["maxRisk"] is None
+    assert payload["evidenceStatus"] == "not_evaluated"
     assert payload["matchedPathCount"] == 0
+    assert "not an approval" in payload["reasons"][0]
 
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -802,17 +802,20 @@ def test_cli_mcp_server_transport_options():
 
 @patch("agent_bom.mcp_server._run_scan_pipeline")
 def test_compliance_no_agents(mock_pipeline):
-    """Compliance with no agents should return 100% score."""
+    """Compliance with no evidence must be unevaluated, never a clean pass."""
     mock_pipeline.return_value = ([], [], [], [])
     from agent_bom.mcp_server import create_mcp_server
 
     server = create_mcp_server()
     result = _call_tool(server, "compliance", {})
-    assert result["overall_score"] == 100.0
-    assert result["overall_status"] == "pass"
+    assert result["overall_score"] == 0.0
+    assert result["overall_status"] == "no_data"
+    assert result["evaluated_controls"] == 0
+    assert result["not_evaluated_controls"] == result["total_controls"]
     assert len(result["owasp_llm_top10"]) == 10
     assert len(result["mitre_atlas"]) >= 50
     assert len(result["nist_ai_rmf"]) == 14
+    assert all(control["status"] == "not_evaluated" for control in result["owasp_llm_top10"])
 
 
 @patch("agent_bom.mcp_server._run_scan_pipeline")

--- a/tests/test_partition_maintenance.py
+++ b/tests/test_partition_maintenance.py
@@ -18,6 +18,7 @@ from agent_bom.api.partition_maintenance import (
     maintain_partitions,
     migrate_table_to_partitioned,
     month_range_bounds,
+    partition_children_missing_rls,
     partition_end_date,
     partition_is_expired,
     partition_table_name,
@@ -33,6 +34,7 @@ _AUDIT = PartitionSpec(
     time_column="timestamp",
     retention_env="AGENT_BOM_AUDIT_LOG_RETENTION_DAYS",
     default_retention_days=0,
+    tenant_column="team_id",
 )
 
 
@@ -104,7 +106,8 @@ def test_partitioned_parent_ddl_requires_time_key_in_pk() -> None:
 # ── Ensure-ahead ─────────────────────────────────────────────────────────────
 
 
-def test_ensure_partitions_creates_missing_children() -> None:
+def test_ensure_partitions_creates_missing_children(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.api.partition_maintenance._ensure_partition_tenant_rls", lambda *_args: None)
     conn = MagicMock()
     conn.execute.side_effect = [
         MagicMock(fetchone=MagicMock(return_value=("p",))),  # is_partitioned
@@ -121,6 +124,32 @@ def test_ensure_partitions_creates_missing_children() -> None:
     executed = [str(call.args[0]) for call in conn.execute.call_args_list]
     assert any("audit_log_y2026m06 PARTITION OF audit_log" in sql for sql in executed)
     assert any("audit_log_y2026m08 PARTITION OF audit_log" in sql for sql in executed)
+
+
+def test_ensure_partitions_enforces_rls_on_existing_and_new_children(monkeypatch) -> None:
+    protected: list[tuple[str, str]] = []
+    monkeypatch.setattr(
+        "agent_bom.api.partition_maintenance._ensure_partition_tenant_rls",
+        lambda _conn, child, tenant_column: protected.append((child, tenant_column)),
+    )
+    conn = MagicMock()
+    conn.execute.side_effect = [
+        MagicMock(fetchone=MagicMock(return_value=("p",))),
+        MagicMock(fetchone=MagicMock(return_value=("child",))),
+        MagicMock(fetchone=MagicMock(return_value=None)),
+        MagicMock(),
+        MagicMock(fetchone=MagicMock(return_value=("child",))),
+        MagicMock(fetchone=MagicMock(return_value=("child",))),
+    ]
+
+    ensure_partitions(conn, _AUDIT, now=datetime(2026, 7, 5, tzinfo=timezone.utc))
+
+    assert protected == [
+        ("audit_log_y2026m06", "team_id"),
+        ("audit_log_y2026m07", "team_id"),
+        ("audit_log_y2026m08", "team_id"),
+        ("audit_log_y2026m09", "team_id"),
+    ]
 
 
 def test_ensure_partitions_noop_when_not_partitioned() -> None:
@@ -196,10 +225,22 @@ def test_list_partition_names_returns_children() -> None:
     assert list_partition_names(conn, "audit_log") == ["audit_log_y2026m06", "audit_log_y2026m07"]
 
 
+def test_partition_rls_guard_returns_only_catalog_gaps() -> None:
+    conn = MagicMock()
+    conn.execute.return_value.fetchall.return_value = [("audit_log_y2026m05",)]
+
+    assert partition_children_missing_rls(conn, "audit_log") == ["audit_log_y2026m05"]
+    sql = str(conn.execute.call_args.args[0])
+    assert "relrowsecurity" in sql
+    assert "relforcerowsecurity" in sql
+    assert "pg_policies" in sql
+
+
 # ── Migration (opt-in) ───────────────────────────────────────────────────────
 
 
-def test_migrate_table_renames_copies_and_drops() -> None:
+def test_migrate_table_renames_copies_and_drops(monkeypatch) -> None:
+    monkeypatch.setattr("agent_bom.api.partition_maintenance._ensure_partition_tenant_rls", lambda *_args: None)
     conn = MagicMock()
     fetchone_queue = [
         (1,),  # table_exists

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -25,6 +25,7 @@ MCP_PROFILE_BINDING_AUTHORITY = VERSIONS_DIR / "20260728_01_mcp_profile_binding_
 GATEWAY_ACTIVITY_LEDGER = VERSIONS_DIR / "20260728_02_gateway_activity_ledger.py"
 TRUSTED_MAINTENANCE_RLS = VERSIONS_DIR / "20260728_03_trusted_maintenance_rls.py"
 GATEWAY_ACTIVITY_WINDOW_INDEX = VERSIONS_DIR / "20260729_02_gateway_activity_window_index.py"
+PARTITION_CHILD_RLS = VERSIONS_DIR / "20260729_03_partition_child_rls.py"
 POSTGRES_MCP_CONFIG_STORE = Path(__file__).parent.parent / "src" / "agent_bom" / "api" / "postgres_mcp_config.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
@@ -391,6 +392,21 @@ def test_gateway_activity_window_index_is_chained_and_matches_runtime_schema() -
     assert "SELECT to_regclass('public.gateway_activity_events')" in sql
     assert "autocommit_block" in sql
     assert "DROP TABLE" not in sql
+
+
+def test_partition_child_rls_is_chained_idempotent_and_irreversible() -> None:
+    sql = PARTITION_CHILD_RLS.read_text()
+    assert re.search(r'revision\s*=\s*"20260729_03"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260729_02"', sql)
+    assert "pg_inherits" in sql
+    assert "audit_log" in sql
+    assert "hub_findings_current_observations" in sql
+    assert "ENABLE ROW LEVEL SECURITY" in sql
+    assert "FORCE ROW LEVEL SECURITY" in sql
+    assert "IF NOT EXISTS" in sql
+    assert "CREATE POLICY" in sql
+    assert "DROP POLICY" not in sql
+    assert "DISABLE ROW LEVEL SECURITY" not in sql
 
 
 def test_gateway_activity_window_index_allows_legacy_schema_without_ledger(monkeypatch) -> None:

--- a/tests/test_proxy_scanner.py
+++ b/tests/test_proxy_scanner.py
@@ -218,10 +218,24 @@ _MODERN_SECRET_CASES = [
     ("bearer_opaque", _sample("Authorization: ", "Bearer ", _token_body(24))),
     ("aws_secret_lower", _sample("aws_", "secret_", "access_", "key=", _token_body(40, "Ab3dEf4gH5jK/Lm7N"))),
     ("aws_secret_upper", _sample("AWS_", "SECRET_", "ACCESS_", "KEY = ", _token_body(40, "Ab3dEf4gH5jK/Lm7N"))),
+    ("aws_secret_single_quoted", _sample("aws_secret_access_key='", _token_body(40, "Ab3dEf4gH5jK/Lm7N"), "'")),
+    ("aws_secret_double_quoted_json", _sample('"AWS_SECRET_ACCESS_KEY": "', _token_body(40, "Ab3dEf4gH5jK/Lm7N"), '"')),
     ("client_secret_embedded", _sample("client_", "secret=", _token_body(28))),
     ("secret_key_embedded", _sample("my_", "secret_", "key: ", _token_body(24))),
     ("access_token_embedded", _sample("access_", "token=", _token_body(28))),
 ]
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "aws_secret_access_key='short'",
+        '"AWS_SECRET_ACCESS_KEY": "<set-me>"',
+        "aws_secret_access_key=EXAMPLE_AWS_SECRET_ACCESS_KEY_VALUE",
+    ],
+)
+def test_aws_secret_pattern_ignores_short_and_placeholder_values(text):
+    assert not [result for result in scan_content(text, _cfg()) if result.rule_id == "aws_secret_access_key"]
 
 
 class TestModernSecretFormats:

--- a/tests/test_report_ux.py
+++ b/tests/test_report_ux.py
@@ -112,9 +112,11 @@ def test_terminal_each_failed_has_evidence_and_recommendation():
     out = _render(_report_large())
     assert "evidence:" in out
     assert "fix:" in out
-    # A resource id (evidence) and a fix command both surface.
+    # Evidence and truthful manual guidance both surface.  The synthetic
+    # command has no verified CIS identity and must therefore fail closed.
     assert "arn:res:0" in out
-    assert "aws fix-0" in out
+    assert "aws fix-0" not in out
+    assert "Remediate c0." in out
 
 
 def test_terminal_header_has_verdict_and_pass_rate():
@@ -166,7 +168,8 @@ def test_html_per_finding_evidence_and_remediation():
     html = _cis_benchmark_section(_report_large())
     assert "Evidence" in html  # column header
     assert "arn:res:0" in html  # resource id evidence rendered
-    assert "aws fix-0" in html  # remediation command rendered
+    assert "aws fix-0" not in html  # unverified command fails closed
+    assert "Remediate c0." in html  # manual guidance remains available
 
 
 def test_html_rows_carry_severity_for_filtering():

--- a/tests/test_version_accuracy.py
+++ b/tests/test_version_accuracy.py
@@ -60,11 +60,11 @@ class TestValidateVersion:
 
     def test_go_valid(self):
         assert validate_version("v1.9.1", "go") is True
+        assert validate_version("1.9.1", "go") is True
         assert validate_version("v0.1.0", "go") is True
         assert validate_version("v1.0.0-rc.1", "go") is True
 
     def test_go_invalid(self):
-        assert validate_version("1.9.1", "go") is False  # Missing v prefix
         assert validate_version("latest", "go") is False
 
     def test_cargo_valid(self):

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -43,8 +43,8 @@ def test_validate_version_go_valid():
     assert validate_version("v1.2.3", "go") is True
 
 
-def test_validate_version_go_invalid():
-    assert validate_version("1.2.3", "go") is False  # Go requires v prefix
+def test_validate_version_go_accepts_parser_normalized_form():
+    assert validate_version("1.2.3", "go") is True
 
 
 def test_validate_version_maven_valid():
@@ -291,6 +291,15 @@ def test_version_in_range_go_pseudo_vs_tagged_bounds():
     assert version_in_range(older, "v1.0.0", None, None, "go") is True
     assert version_in_range(newer, None, "v2.0.0", None, "go") is True
     assert version_in_range(newer, "v1.0.0", "v2.0.0", None, "go") is True
+
+    # Package parsers commonly normalize away the leading v. Internal Go
+    # comparison must preserve identical semantics for that canonical form.
+    unprefixed = older.removeprefix("v")
+    assert validate_version(unprefixed, "go") is True
+    assert compare_version_order(unprefixed, "v1.5.0", "go") == -1
+    assert version_in_range(unprefixed, "v1.5.0", None, None, "go") is False
+    assert version_in_range(unprefixed, None, "v1.2.3", None, "go") is False
+    assert version_in_range(unprefixed, None, None, "v1.2.0", "go") is False
 
     # Pseudo-vs-pseudo bounds still resolve by timestamp.
     assert (

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -51,7 +51,7 @@ export type OverviewComplianceFramework = {
 
 export type OverviewComplianceSnapshot = {
   overallScore: number;
-  overallStatus: "pass" | "warning" | "fail";
+  overallStatus: "pass" | "warning" | "fail" | "no_data";
   frameworks: OverviewComplianceFramework[];
 };
 

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2244,7 +2244,7 @@ export interface NistCatalogDrill extends NistCatalogLine {
 
 export interface ComplianceResponse {
   overall_score: number;
-  overall_status: "pass" | "warning" | "fail";
+  overall_status: "pass" | "warning" | "fail" | "no_data";
   scan_count: number;
   latest_scan: string | null;
   has_mcp_context?: boolean | undefined;


### PR DESCRIPTION
## Summary

- fail closed when compliance, deployment, KEV, audit-ledger, or CIS remediation evidence is missing, stale, or bound to the wrong identity
- preserve every supported compliance framework tag through reconstruction and exports; correct Go, AWS-secret, CycloneDX, and GraphML evidence handling
- enable and force tenant RLS on new and existing Postgres partition children, including hub-observation partitions, with an idempotent backfill migration

## Verification

- `uv run pytest -q ...` across the affected integrity, compliance, CIS, graph, partition, output, MCP, CLI, and migration suites (`666 passed, 4 skipped`)
- `make lint` (Ruff clean; MyPy clean across 813 source files)
- `make preflight`
- UI toolchain verification with Node 22.22.2, `npm run typecheck`, and `npm test -- --run` (`976 passed`)
- TypeScript SDK tests (`52 passed`)

## Notes

- The four focused skips require a live Postgres DSN; CI remains responsible for the live database contract.
- A full sandboxed Python run reached `16,998 passed`; the remaining failures required blocked loopback sockets, home-directory writes, or live DNS/network access. The one in-scope Go-version assertion found by that run was corrected and is covered above.
- The RLS migration is idempotent and fail-closed. Its downgrade is intentionally non-destructive.
- CIS remediation remains advisory and human-reviewed. Historical rows without a complete provider/version/check/title/section identity render manual guidance.
