### PR TITLE
fix(runtime): bind tenant work and bound hot paths

### DIFF
--- a/docs/OCSF_BOUNDARY.md
+++ b/docs/OCSF_BOUNDARY.md
@@ -88,7 +88,8 @@ inflating trend queries (#3484).
 
 ## Why keep OCSF at all
 
-AWS Security Lake, Google Chronicle, and Microsoft Sentinel all
-standardize on OCSF. Dropping it eliminates a real enterprise-buyer
-checkbox for ~130 lines of optional code. Keeping it as an opt-in
-peripheral costs effectively zero and preserves integration upside.
+AWS Security Lake stores supported and custom-source security events in OCSF,
+and Google Security Operations can ingest OCSF JSON through its OCSF parser.
+Other SIEM paths remain connector-specific. Keeping OCSF as an optional
+projection preserves those interoperability paths without making it an
+internal dependency or implying that every destination standardizes on it.

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-07-29",
+  "generated_on": "2026-07-30",
   "version": "0.98.2",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1055,
+      "value": 1056,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 813,
+      "value": 814,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-07-29`
+- Generated on: `2026-07-30`
 - Version: `0.98.2`
 
 | Metric | Value | Source | Notes |
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1055 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1056 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 814 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import logging
 import sqlite3
 import threading
+import time
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, Protocol
 
@@ -90,6 +91,8 @@ _REACH_SORT_KEY = "__reach_sort__"
 # cursor until it has ``page_limit + 1`` matches or the stream is exhausted.
 _SCOPE_FILTER_MIN_BATCH = 200
 _SCOPE_FILTER_MAX_BATCH = 1000
+_SCOPE_FILTER_SCAN_BUDGET = 20_000
+_SCOPE_FILTER_DEADLINE_SECONDS = 1.5
 
 
 def scope_filter_batch_size(page_limit: int) -> int:
@@ -161,6 +164,9 @@ def collect_scope_filtered_page(
     start_cursor: str | None,
     sort: str,
     batch_size: int,
+    scan_budget: int = _SCOPE_FILTER_SCAN_BUDGET,
+    deadline_monotonic: float | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> tuple[list[dict[str, Any]], str | None]:
     """Collect one scope-filtered keyset page without materializing the table.
 
@@ -185,22 +191,52 @@ def collect_scope_filtered_page(
         return [], None
     matches: list[tuple[dict[str, Any], dict[str, Any]]] = []
     batch_cursor = start_cursor
+    scanned_rows = 0
+    bounded = False
+    bound_reason = ""
+    deadline = deadline_monotonic or (time.monotonic() + _SCOPE_FILTER_DEADLINE_SECONDS)
+    last_scanned: dict[str, Any] | None = None
     while len(matches) <= page_limit:
-        items, batch_next = fetch_batch(batch_cursor, batch_size)
+        if scanned_rows >= scan_budget:
+            bounded = True
+            bound_reason = "scan_budget"
+            break
+        if time.monotonic() >= deadline:
+            bounded = True
+            bound_reason = "deadline"
+            break
+        items, batch_next = fetch_batch(batch_cursor, min(batch_size, scan_budget - scanned_rows))
         for current_row, enriched in items:
+            if scanned_rows >= scan_budget or time.monotonic() >= deadline:
+                bounded = True
+                bound_reason = "scan_budget" if scanned_rows >= scan_budget else "deadline"
+                break
+            scanned_rows += 1
+            last_scanned = current_row
             if predicate(enriched):
                 matches.append((current_row, enriched))
                 if len(matches) > page_limit:
                     break
-        if len(matches) > page_limit or batch_next is None:
+        if bounded or len(matches) > page_limit or batch_next is None:
             break
         batch_cursor = batch_next
-    has_more = len(matches) > page_limit
+    has_more = len(matches) > page_limit or bounded
     emitted = matches[:page_limit]
     payloads = [enriched for (_current, enriched) in emitted]
     next_cursor = None
-    if has_more and emitted:
-        next_cursor = cursor_from_current_row(emitted[-1][0], sort=sort)
+    if has_more:
+        cursor_row = emitted[-1][0] if emitted else last_scanned
+        if cursor_row is not None:
+            next_cursor = cursor_from_current_row(cursor_row, sort=sort)
+    if metadata is not None:
+        metadata.update(
+            {
+                "scanned_rows": scanned_rows,
+                "scan_budget": scan_budget,
+                "truncated": bounded,
+                "reason": bound_reason,
+            }
+        )
     return payloads, next_cursor
 
 

--- a/src/agent_bom/api/export_scheduler.py
+++ b/src/agent_bom/api/export_scheduler.py
@@ -37,6 +37,7 @@ from agent_bom.api.export_schedule_store import (
     get_export_schedule_store,
 )
 from agent_bom.api.scheduler import parse_cron_next
+from agent_bom.api.tenant_worker import run_tenant_bound
 from agent_bom.export.destinations import ExportPublicationIndeterminateError, ExportResult
 from agent_bom.export.runner import run_findings_export
 
@@ -168,7 +169,15 @@ async def run_due_exports_once(
 
     async def _guarded(schedule: ExportSchedule) -> None:
         async with semaphore:
-            await asyncio.to_thread(execute_export, schedule, store, destination_store, now)
+            await asyncio.to_thread(
+                run_tenant_bound,
+                schedule.tenant_id,
+                execute_export,
+                schedule,
+                store,
+                destination_store,
+                now,
+            )
 
     await asyncio.gather(*(_guarded(schedule) for schedule in claimed))
     return len(claimed)

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -282,6 +282,42 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _record_graph_persistence(
+    job: ScanJob,
+    *,
+    status: str,
+    scan_id: str | None = None,
+    nodes: int | None = None,
+    edges: int | None = None,
+    lock: threading.Lock | None = None,
+) -> None:
+    """Expose graph persistence truth without leaking backend exceptions."""
+
+    def _record() -> None:
+        if not isinstance(job.result, dict):
+            return
+        current = job.result.get("graph_persistence")
+        # Delivery or post-persist bookkeeping can fail after the snapshot has
+        # committed. Never overwrite durable evidence with a false failure.
+        if status == "failed" and isinstance(current, dict) and current.get("status") == "persisted":
+            return
+        evidence: dict[str, Any] = {
+            "status": status,
+            "scan_id": scan_id or job.job_id,
+        }
+        if nodes is not None:
+            evidence["nodes"] = nodes
+        if edges is not None:
+            evidence["edges"] = edges
+        job.result["graph_persistence"] = evidence
+
+    if lock is None:
+        _record()
+    else:
+        with lock:
+            _record()
+
+
 def iter_pipeline_dag_event_records(
     progress_lines: Iterable[str],
     *,
@@ -607,6 +643,14 @@ def _persist_graph_snapshot(
 
         node_count = counts.get("nodes", len(graph.nodes))
         edge_count = counts.get("edges", len(graph.edges))
+        _record_graph_persistence(
+            job,
+            status="persisted",
+            scan_id=scan_id,
+            nodes=node_count,
+            edges=edge_count,
+            lock=lock,
+        )
         alerts = compute_delta_alerts_from_digest(prior_digest, graph)
         delivery = dispatch_delta_alerts(alerts, product_version=__version__, tenant_id=tenant_id) if alerts else None
         _logger.info(
@@ -1348,9 +1392,10 @@ def _run_scan_sync(job: ScanJob) -> None:
                         pipeline.update_step("output", "Persisting unified graph...")
                         _persist_graph_snapshot(job, report_json, lock=lock)
                     except Exception as graph_exc:  # noqa: BLE001
-                        _logger.warning("Unified graph persistence failed: %s", graph_exc)
+                        _logger.warning("Unified graph persistence failed: %s", sanitize_error(graph_exc, generic=True))
+                        _record_graph_persistence(job, status="failed", lock=lock)
                         with lock:
-                            job.progress.append(f"Graph persistence skipped: {sanitize_error(graph_exc)}")
+                            job.progress.append("Graph persistence failed; scan evidence remains available")
                 pipeline.complete_step("output", "Report ready")
                 return
 
@@ -1638,9 +1683,10 @@ def _run_scan_sync(job: ScanJob) -> None:
                 pipeline.update_step("output", "Persisting unified graph...")
                 _persist_graph_snapshot(job, report_json, lock=lock)
             except Exception as graph_exc:  # noqa: BLE001
-                _logger.warning("Unified graph persistence failed: %s", graph_exc)
+                _logger.warning("Unified graph persistence failed: %s", sanitize_error(graph_exc, generic=True))
+                _record_graph_persistence(job, status="failed", lock=lock)
                 with lock:
-                    job.progress.append(f"Graph persistence skipped: {sanitize_error(graph_exc)}")
+                    job.progress.append("Graph persistence failed; scan evidence remains available")
 
             try:
                 from agent_bom.asset_tracker import AssetTracker

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -294,9 +294,10 @@ def _record_graph_persistence(
     """Expose graph persistence truth without leaking backend exceptions."""
 
     def _record() -> None:
-        if not isinstance(job.result, dict):
+        result = getattr(job, "result", None)
+        if not isinstance(result, dict):
             return
-        current = job.result.get("graph_persistence")
+        current = result.get("graph_persistence")
         # Delivery or post-persist bookkeeping can fail after the snapshot has
         # committed. Never overwrite durable evidence with a false failure.
         if status == "failed" and isinstance(current, dict) and current.get("status") == "persisted":
@@ -309,7 +310,7 @@ def _record_graph_persistence(
             evidence["nodes"] = nodes
         if edges is not None:
             evidence["edges"] = edges
-        job.result["graph_persistence"] = evidence
+        result["graph_persistence"] = evidence
 
     if lock is None:
         _record()

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from agent_bom.graph.delta_digest import PriorSnapshotDigest
 
 from agent_bom.api.graph_store import (
+    _DYNAMIC_RELATIONSHIP_VALUES,
     MAX_NODE_PAGE_OFFSET,
     _escape_like_query,
     _node_search_text,
@@ -1239,6 +1240,242 @@ class PostgresGraphStore:
             ).fetchall()
         return [self._node_from_row(row) for row in rows]
 
+    @staticmethod
+    def _edge_from_row(row: Sequence[Any]) -> Any:
+        from agent_bom.graph import RelationshipType, UnifiedEdge
+
+        return UnifiedEdge(
+            source=row[0],
+            target=row[1],
+            relationship=RelationshipType(row[2]),
+            direction=row[3],
+            weight=row[4],
+            traversable=bool(row[5]),
+            first_seen=row[6],
+            last_seen=row[7],
+            valid_from=row[8] or row[6],
+            valid_to=row[9],
+            confidence=row[10],
+            provenance=_decode_json_object(row[11], field="edge provenance"),
+            source_scan_id=row[12] or row[16],
+            source_run_id=row[13] or "",
+            evidence=_decode_json_object(row[14], field="edge evidence"),
+            activity_id=row[15],
+        )
+
+    @staticmethod
+    def _reverse_edge(edge: Any) -> Any:
+        from agent_bom.graph import UnifiedEdge
+
+        return UnifiedEdge(
+            source=edge.target,
+            target=edge.source,
+            relationship=edge.relationship,
+            direction=edge.direction,
+            weight=edge.weight,
+            traversable=edge.traversable,
+            first_seen=edge.first_seen,
+            last_seen=edge.last_seen,
+            valid_from=edge.valid_from,
+            valid_to=edge.valid_to,
+            confidence=edge.confidence,
+            provenance=edge.provenance,
+            source_scan_id=edge.source_scan_id,
+            source_run_id=edge.source_run_id,
+            evidence=edge.evidence,
+            activity_id=edge.activity_id,
+        )
+
+    def _filtered_edge_rows(
+        self,
+        conn: Any,
+        *,
+        tenant_id: str,
+        scan_id: str,
+        frontier: set[str],
+        traversable_only: bool = False,
+        relationship_types: set[RelationshipType] | None = None,
+        static_only: bool = False,
+        dynamic_only: bool = False,
+        limit: int = 25_001,
+    ) -> list[Sequence[Any]]:
+        if not frontier:
+            return []
+        placeholders = ",".join("%s" for _ in frontier)
+        where = [
+            "tenant_id = %s",
+            "scan_id = %s",
+            f"(source_id IN ({placeholders}) OR target_id IN ({placeholders}))",
+        ]
+        params: list[Any] = [tenant_id, scan_id, *sorted(frontier), *sorted(frontier)]
+        if traversable_only:
+            where.append("traversable = 1")
+        if relationship_types:
+            values = sorted(rel.value if hasattr(rel, "value") else str(rel) for rel in relationship_types)
+            rel_placeholders = ",".join("%s" for _ in values)
+            where.append(f"relationship IN ({rel_placeholders})")
+            params.extend(values)
+        if static_only:
+            dynamic_placeholders = ",".join("%s" for _ in _DYNAMIC_RELATIONSHIP_VALUES)
+            where.append(f"relationship NOT IN ({dynamic_placeholders})")
+            params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
+        if dynamic_only:
+            dynamic_placeholders = ",".join("%s" for _ in _DYNAMIC_RELATIONSHIP_VALUES)
+            where.append(f"relationship IN ({dynamic_placeholders})")
+            params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
+        params.append(max(1, int(limit)))
+        return cast(
+            "list[Sequence[Any]]",
+            conn.execute(
+                f"""
+                SELECT source_id, target_id, relationship, direction, weight, traversable,
+                       first_seen, last_seen, valid_from, valid_to, confidence, provenance,
+                       source_scan_id, source_run_id, evidence, activity_id, scan_id
+                FROM graph_edges
+                WHERE {" AND ".join(where)}
+                ORDER BY source_id, target_id, relationship
+                LIMIT %s
+                """,  # nosec B608 - clauses and placeholders are generated internally
+                params,
+            ).fetchall(),
+        )
+
+    def _walk_graph(
+        self,
+        conn: Any,
+        *,
+        tenant_id: str,
+        scan_id: str,
+        roots: list[str],
+        direction: str,
+        max_depth: int,
+        max_nodes: int,
+        max_edges: int,
+        deadline_monotonic: float | None,
+        traversable_only: bool,
+        relationship_types: set[RelationshipType] | None,
+        static_only: bool,
+        dynamic_only: bool,
+        include_roots: bool,
+    ) -> tuple[str, str, set[str], dict[str, int], dict[tuple[str, str, str], Any], dict[str, str], list[str], bool]:
+        tenant_id = normalize_graph_tenant_id(tenant_id)
+        effective_scan_id = scan_id
+        if not effective_scan_id:
+            latest = conn.execute(
+                """
+                SELECT scan_id
+                FROM graph_snapshots
+                WHERE tenant_id = %s
+                ORDER BY created_at DESC, scan_id DESC
+                LIMIT 1
+                """,
+                (tenant_id,),
+            ).fetchone()
+            effective_scan_id = str(latest[0]) if latest else ""
+        if not effective_scan_id:
+            return scan_id, "", set(), {}, {}, {}, [], False
+        snapshot = conn.execute(
+            "SELECT created_at FROM graph_snapshots WHERE tenant_id = %s AND scan_id = %s",
+            (tenant_id, effective_scan_id),
+        ).fetchone()
+        placeholders = ",".join("%s" for _ in roots)
+        existing_roots: set[str] = set()
+        if roots:
+            existing_roots = {
+                str(row[0])
+                for row in conn.execute(
+                    f"SELECT id FROM graph_nodes WHERE tenant_id = %s AND scan_id = %s AND id IN ({placeholders})",  # nosec B608
+                    [tenant_id, effective_scan_id, *roots],
+                ).fetchall()
+            }
+
+        visited: set[str] = set()
+        depth_by_node: dict[str, int] = {}
+        traversed_edges: dict[tuple[str, str, str], Any] = {}
+        parent_by_node: dict[str, str] = {}
+        discovery_order: list[str] = []
+        queue: list[tuple[str, int]] = []
+        for root in roots:
+            if root not in existing_roots:
+                continue
+            queue.append((root, 0))
+            depth_by_node[root] = 0
+            if include_roots:
+                visited.add(root)
+
+        truncated = False
+        edge_count = 0
+        index = 0
+        while index < len(queue):
+            if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
+                truncated = True
+                break
+            current, depth = queue[index]
+            index += 1
+            if depth >= max_depth:
+                continue
+            rows = self._filtered_edge_rows(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=effective_scan_id,
+                frontier={current},
+                traversable_only=traversable_only,
+                relationship_types=relationship_types,
+                static_only=static_only,
+                dynamic_only=dynamic_only,
+                limit=max_edges - edge_count + 1,
+            )
+            for row in rows:
+                edge = self._edge_from_row(row)
+                candidates: list[str] = []
+                if direction in {"forward", "both"}:
+                    if edge.source == current:
+                        candidates.append(edge.target)
+                    elif edge.is_bidirectional and edge.target == current:
+                        candidates.append(edge.source)
+                if direction in {"reverse", "both"}:
+                    if edge.target == current:
+                        candidates.append(edge.source)
+                    elif edge.is_bidirectional and edge.source == current:
+                        candidates.append(edge.target)
+                if not candidates:
+                    continue
+                edge_count += 1
+                if edge_count > max_edges:
+                    truncated = True
+                    break
+                relationship = edge.relationship.value if hasattr(edge.relationship, "value") else str(edge.relationship)
+                traversed_edges.setdefault((edge.source, edge.target, relationship), edge)
+                for neighbor in candidates:
+                    if neighbor in visited:
+                        continue
+                    if len(visited) >= max_nodes:
+                        truncated = True
+                        continue
+                    visited.add(neighbor)
+                    depth_by_node[neighbor] = depth + 1
+                    parent_by_node.setdefault(neighbor, current)
+                    discovery_order.append(neighbor)
+                    queue.append((neighbor, depth + 1))
+            if truncated and (
+                edge_count > max_edges
+                or (deadline_monotonic is not None and time.monotonic() >= deadline_monotonic)
+            ):
+                break
+
+        if include_roots:
+            visited.update(existing_roots)
+        return (
+            effective_scan_id,
+            str(snapshot[0]) if snapshot else "",
+            visited,
+            depth_by_node,
+            traversed_edges,
+            parent_by_node,
+            discovery_order,
+            truncated,
+        )
+
     def bfs_paths(
         self,
         *,
@@ -1249,17 +1486,40 @@ class PostgresGraphStore:
         traversable_only: bool = True,
     ) -> tuple[list[list[str]], set[str]]:
         tenant_id = normalize_graph_tenant_id(tenant_id)
-        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
-        if not graph.has_node(source):
+        timeout_ms = _graph_search_timeout_ms()
+        deadline = time.monotonic() + (timeout_ms / 1000) if timeout_ms else None
+        with _tenant_connection(self._pool) as conn:
+            _apply_graph_search_timeout(conn)
+            _, _, visited, _, _, parents, order, _ = self._walk_graph(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=scan_id,
+                roots=[source],
+                direction="forward",
+                max_depth=max_depth,
+                max_nodes=5000,
+                max_edges=25_000,
+                deadline_monotonic=deadline,
+                traversable_only=traversable_only,
+                relationship_types=None,
+                static_only=False,
+                dynamic_only=False,
+                include_roots=True,
+            )
+        if source not in visited:
             return [], set()
-        paths = graph.bfs(source, max_depth=max_depth, traversable_only=traversable_only)
-        reachable = graph.reachable_from(
-            source,
-            max_depth=max_depth,
-            traversable_only=traversable_only,
-            include_source=False,
-        )
-        return paths, reachable
+        paths: list[list[str]] = []
+        for node_id in order:
+            path = [node_id]
+            current = node_id
+            while current in parents:
+                current = parents[current]
+                path.append(current)
+            path.reverse()
+            if path and path[0] == source:
+                paths.append(path)
+        visited.discard(source)
+        return paths, visited
 
     def impact_of(
         self,
@@ -1270,10 +1530,42 @@ class PostgresGraphStore:
         max_depth: int = 4,
     ) -> dict[str, Any] | None:
         tenant_id = normalize_graph_tenant_id(tenant_id)
-        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
-        if not graph.has_node(node_id):
+        timeout_ms = _graph_search_timeout_ms()
+        deadline = time.monotonic() + (timeout_ms / 1000) if timeout_ms else None
+        with _tenant_connection(self._pool) as conn:
+            _apply_graph_search_timeout(conn)
+            effective_scan_id, _, visited, depths, _, _, _, truncated = self._walk_graph(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=scan_id,
+                roots=[node_id],
+                direction="reverse",
+                max_depth=max_depth,
+                max_nodes=5000,
+                max_edges=25_000,
+                deadline_monotonic=deadline,
+                traversable_only=False,
+                relationship_types=None,
+                static_only=False,
+                dynamic_only=False,
+                include_roots=True,
+            )
+        if node_id not in visited:
             return None
-        return graph.impact_of(node_id, max_depth=max_depth)
+        affected = sorted(visited - {node_id})
+        rows = self.nodes_by_ids(tenant_id=tenant_id, scan_id=effective_scan_id, node_ids=set(affected))
+        by_type: dict[str, int] = {}
+        for node in rows:
+            entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else str(node.entity_type)
+            by_type[entity_type] = by_type.get(entity_type, 0) + 1
+        return {
+            "node_id": node_id,
+            "affected_nodes": affected,
+            "affected_by_type": by_type,
+            "affected_count": len(affected),
+            "max_depth_reached": max((depths.get(value, 0) for value in affected), default=0),
+            "completeness": "partial" if truncated else "complete",
+        }
 
     def traverse_subgraph(
         self,
@@ -1293,20 +1585,37 @@ class PostgresGraphStore:
         include_roots: bool = True,
     ) -> tuple[Any, dict[str, int], bool]:
         tenant_id = normalize_graph_tenant_id(tenant_id)
-        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
-        return graph.traverse_subgraph(
-            roots,
-            direction=direction,
-            max_depth=max_depth,
-            max_nodes=max_nodes,
-            max_edges=max_edges,
-            deadline_monotonic=deadline_monotonic,
-            traversable_only=traversable_only,
-            relationship_types=relationship_types,
-            static_only=static_only,
-            dynamic_only=dynamic_only,
-            include_roots=include_roots,
-        )
+        timeout_ms = _graph_search_timeout_ms()
+        query_deadline = time.monotonic() + (timeout_ms / 1000) if timeout_ms else None
+        if deadline_monotonic is not None:
+            query_deadline = min(query_deadline, deadline_monotonic) if query_deadline is not None else deadline_monotonic
+        with _tenant_connection(self._pool) as conn:
+            _apply_graph_search_timeout(conn)
+            effective_scan_id, created_at, visited, depths, edges, _, _, truncated = self._walk_graph(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=scan_id,
+                roots=roots,
+                direction=direction,
+                max_depth=max_depth,
+                max_nodes=max_nodes,
+                max_edges=max_edges,
+                deadline_monotonic=query_deadline,
+                traversable_only=traversable_only,
+                relationship_types=relationship_types,
+                static_only=static_only,
+                dynamic_only=dynamic_only,
+                include_roots=include_roots,
+            )
+        from agent_bom.graph import UnifiedGraph
+
+        graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=created_at)
+        for node in self.nodes_by_ids(tenant_id=tenant_id, scan_id=effective_scan_id, node_ids=visited):
+            graph.add_node(node)
+        for edge in edges.values():
+            if edge.source in graph.nodes and edge.target in graph.nodes:
+                graph.add_edge(edge)
+        return graph, depths, truncated
 
     def attack_paths_for_sources(
         self,
@@ -1417,17 +1726,57 @@ class PostgresGraphStore:
         node_id: str,
     ) -> dict[str, Any] | None:
         tenant_id = normalize_graph_tenant_id(tenant_id)
-        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
-        node = graph.get_node(node_id)
-        if not node:
+        effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
+        if not effective_scan_id:
             return None
+        nodes = self.nodes_by_ids(tenant_id=tenant_id, scan_id=effective_scan_id, node_ids={node_id})
+        if not nodes:
+            return None
+        with _tenant_connection(self._pool) as conn:
+            _apply_graph_search_timeout(conn)
+            rows = conn.execute(
+                """
+                SELECT source_id, target_id, relationship, direction, weight, traversable,
+                       first_seen, last_seen, valid_from, valid_to, confidence, provenance,
+                       source_scan_id, source_run_id, evidence, activity_id, scan_id
+                FROM graph_edges
+                WHERE tenant_id = %s AND scan_id = %s AND (source_id = %s OR target_id = %s)
+                ORDER BY source_id, target_id, relationship
+                LIMIT 10001
+                """,
+                (tenant_id, effective_scan_id, node_id, node_id),
+            ).fetchall()
+        truncated = len(rows) > 10_000
+        edges_out: list[Any] = []
+        edges_in: list[Any] = []
+        neighbors: list[str] = []
+        sources: list[str] = []
+        for row in rows[:10_000]:
+            edge = self._edge_from_row(row)
+            if edge.source == node_id:
+                edges_out.append(edge)
+                neighbors.append(edge.target)
+                if edge.is_bidirectional:
+                    edges_in.append(self._reverse_edge(edge))
+                    sources.append(edge.target)
+            if edge.target == node_id:
+                edges_in.append(edge)
+                sources.append(edge.source)
+                if edge.is_bidirectional:
+                    edges_out.append(self._reverse_edge(edge))
+                    neighbors.append(edge.source)
         return {
-            "node": node,
-            "edges_out": graph.edges_from(node_id),
-            "edges_in": graph.edges_to(node_id),
-            "neighbors": graph.neighbors(node_id),
-            "sources": graph.sources_of(node_id),
-            "impact": graph.impact_of(node_id),
+            "node": nodes[0],
+            "edges_out": edges_out,
+            "edges_in": edges_in,
+            "neighbors": neighbors,
+            "sources": sources,
+            "impact": self.impact_of(tenant_id=tenant_id, scan_id=effective_scan_id, node_id=node_id),
+            "completeness": {
+                "status": "partial" if truncated else "complete",
+                "reason": "edge_budget" if truncated else "",
+                "edge_budget": 10_000,
+            },
         }
 
     def compliance_summary(
@@ -1440,7 +1789,35 @@ class PostgresGraphStore:
         tenant_id = normalize_graph_tenant_id(tenant_id)
         from collections import defaultdict
 
-        graph = self.load_graph(tenant_id=tenant_id, scan_id=scan_id)
+        effective_scan_id = scan_id or self.latest_snapshot_id(tenant_id=tenant_id)
+        if not effective_scan_id:
+            return {
+                "scan_id": scan_id,
+                "framework_count": 0,
+                "total_tagged_findings": 0,
+                "frameworks": {},
+                "completeness": {
+                    "status": "complete",
+                    "reason": "",
+                    "node_budget": 50_000,
+                },
+            }
+        compliance_node_budget = 50_000
+        with _tenant_connection(self._pool) as conn:
+            _apply_graph_search_timeout(conn)
+            rows = conn.execute(
+                """
+                SELECT id, entity_type, severity, compliance_tags
+                FROM graph_nodes
+                WHERE tenant_id = %s AND scan_id = %s
+                  AND compliance_tags IS NOT NULL
+                  AND compliance_tags <> '[]'
+                ORDER BY id
+                LIMIT %s
+                """,
+                (tenant_id, effective_scan_id, compliance_node_budget + 1),
+            ).fetchall()
+        truncated = len(rows) > compliance_node_budget
         framework_stats: dict[str, dict[str, Any]] = defaultdict(
             lambda: {
                 "total_findings": 0,
@@ -1451,21 +1828,22 @@ class PostgresGraphStore:
             }
         )
 
-        for node in graph.nodes.values():
-            if not node.compliance_tags:
+        for row in rows[:compliance_node_budget]:
+            tags = _decode_json_array(row[3], field="node compliance tags")
+            if not tags:
                 continue
-            for tag in node.compliance_tags:
+            for tag_value in tags:
+                tag = str(tag_value)
                 prefix = tag.split("-")[0].upper() if "-" in tag else tag.upper()
                 if framework and framework.upper() != prefix:
                     continue
                 stats = framework_stats[prefix]
                 stats["total_findings"] += 1
-                stats["by_severity"][node.severity or "unknown"] += 1
-                entity_type = node.entity_type.value if hasattr(node.entity_type, "value") else node.entity_type
-                stats["by_entity_type"][entity_type] += 1
+                stats["by_severity"][row[2] or "unknown"] += 1
+                stats["by_entity_type"][str(row[1])] += 1
                 stats["tags"].add(tag)
-                if node.id not in stats["node_ids"]:
-                    stats["node_ids"].append(node.id)
+                if row[0] not in stats["node_ids"]:
+                    stats["node_ids"].append(row[0])
 
         frameworks: dict[str, Any] = {}
         for name, stats in sorted(framework_stats.items()):
@@ -1479,10 +1857,15 @@ class PostgresGraphStore:
             }
 
         return {
-            "scan_id": graph.scan_id,
+            "scan_id": effective_scan_id,
             "framework_count": len(frameworks),
             "total_tagged_findings": sum(stats["total_findings"] for stats in frameworks.values()),
             "frameworks": frameworks,
+            "completeness": {
+                "status": "partial" if truncated else "complete",
+                "reason": "node_budget" if truncated else "",
+                "node_budget": compliance_node_budget,
+            },
         }
 
     def diff_snapshots(self, scan_id_old: str, scan_id_new: str, *, tenant_id: str = "") -> dict[str, Any]:

--- a/src/agent_bom/api/report_worker.py
+++ b/src/agent_bom/api/report_worker.py
@@ -14,6 +14,7 @@ from agent_bom.api.models import JobStatus, ReportJob
 from agent_bom.api.pipeline import get_executor
 from agent_bom.api.report_artifact_store import publish_report_artifact
 from agent_bom.api.report_job_store import get_report_job_store
+from agent_bom.api.tenant_worker import submit_tenant_bound
 from agent_bom.security import sanitize_error, sanitize_text
 
 _logger = logging.getLogger(__name__)
@@ -36,7 +37,7 @@ def _artifact_path(tenant_id: str, job_id: str) -> Path:
 
 def submit_report_job(job_id: str, tenant_id: str) -> None:
     """Queue a report export on the shared scan worker pool."""
-    get_executor().submit(_run_report_job_sync, job_id, tenant_id)
+    submit_tenant_bound(get_executor(), tenant_id, _run_report_job_sync, job_id, tenant_id)
 
 
 def _run_report_job_sync(job_id: str, tenant_id: str) -> None:

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -24,6 +24,7 @@ from agent_bom.api.models import JobStatus
 from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store, _get_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, package_version_provenance
+from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import (
     sanitize_command_args,
@@ -492,12 +493,19 @@ async def list_agents(
         if not refresh and cached is not None and now - cached[0] <= _AGENTS_RESPONSE_CACHE_TTL_SECONDS:
             return deepcopy(cached[1])
 
-        response = _build_agents_response(tenant_id)
+        async with adaptive_backpressure("discovery"):
+            response = await anyio.to_thread.run_sync(_build_agents_response, tenant_id)
         _agents_response_cache[tenant_id] = (now, deepcopy(response))
         return response
+    except BackpressureRejectedError as exc:
+        raise HTTPException(
+            status_code=429,
+            detail=exc.to_dict(),
+            headers={"Retry-After": str(exc.retry_after_seconds)},
+        ) from exc
     except Exception as exc:  # noqa: BLE001
-        _logger.exception("Agent discovery failed")
-        raise HTTPException(status_code=500, detail=sanitize_error(exc)) from exc
+        _logger.warning("Agent discovery failed: %s", sanitize_error(exc, generic=True))
+        raise HTTPException(status_code=500, detail=sanitize_error(exc, generic=True)) from exc
 
 
 @router.get("/discovery/providers", tags=["discovery"])

--- a/src/agent_bom/api/routes/exports.py
+++ b/src/agent_bom/api/routes/exports.py
@@ -36,6 +36,7 @@ from agent_bom.api.export_destination_store import (
 )
 from agent_bom.api.export_schedule_store import ExportSchedule, get_export_schedule_store
 from agent_bom.api.tenancy import require_request_tenant_id
+from agent_bom.api.tenant_worker import submit_tenant_bound
 from agent_bom.export.destinations import SUPPORTED_EXPORT_KINDS, ExportPublicationIndeterminateError
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.security import sanitize_error
@@ -167,7 +168,7 @@ async def run_export_destination(request: Request, destination_id: str, _role: A
     from agent_bom.api.pipeline import get_executor
 
     run_id = uuid.uuid4().hex
-    get_executor().submit(_run_export_sync, tenant_id, destination_id, run_id)
+    submit_tenant_bound(get_executor(), tenant_id, _run_export_sync, tenant_id, destination_id, run_id)
     log_action(
         "export_destination.run", actor=_actor(request), resource=f"export-destination/{destination_id}", tenant_id=tenant_id, run_id=run_id
     )

--- a/src/agent_bom/api/routes/gateway_feed.py
+++ b/src/agent_bom/api/routes/gateway_feed.py
@@ -741,6 +741,7 @@ async def _gather_durable_feed_inputs_async(
             and (
                 str(alert.get("event_type") or "") not in _EVENT_TYPES
                 or not str(alert.get("event_id") or "")
+                or alert.get("gateway_activity_durable") is False
             )
         ]
         llm_records, observability_available = _load_llm()
@@ -863,8 +864,10 @@ async def _gather_kpi_inputs_async(
             alert
             for alert in _load_tenant_alerts(tenant_id)
             if (
-                str(alert.get("event_type") or "") not in _EVENT_TYPES
+                not ledger_available
+                or str(alert.get("event_type") or "") not in _EVENT_TYPES
                 or not str(alert.get("event_id") or "")
+                or alert.get("gateway_activity_durable") is False
             )
             and _timestamp_in_window(_alert_timestamp(alert), start=start, end=end)
         ]

--- a/src/agent_bom/api/routes/intel.py
+++ b/src/agent_bom/api/routes/intel.py
@@ -40,8 +40,12 @@ class IntelDailyBriefRequest(BaseModel):
 async def get_intel_sources() -> dict[str, Any]:
     """Return canonical threat-intel source and feed-run metadata."""
 
-    result: dict[str, Any] = list_intel_sources()
-    return result
+    try:
+        async with adaptive_backpressure("intel"):
+            result: dict[str, Any] = await anyio.to_thread.run_sync(list_intel_sources)
+            return result
+    except BackpressureRejectedError as exc:
+        raise _backpressure_429(exc) from exc
 
 
 def _backpressure_429(exc: BackpressureRejectedError) -> HTTPException:

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -177,16 +177,24 @@ def _gateway_activity_record_from_alert(
 ) -> GatewayActivityRecord | None:
     """Project one gateway-shaped alert onto the strict metadata-only ledger.
 
-    Historical audit envelopes contain extra proxy fields and some omit fields
-    that the standalone gateway now emits. Only canonical gateway event types
-    enter the durable ledger; the projection allowlists metadata and fills old
-    transport omissions from server-owned context. Raw arguments, prompts,
-    responses, previews, and free-text messages are never copied.
+    Historical audit envelopes contain extra proxy fields and may omit the
+    event timestamp emitted by the standalone gateway. Only canonical gateway
+    events with caller-observed time enter the durable ledger; inventing an
+    ingestion timestamp would change the event digest on every retry. Older
+    timestamp-free records remain an explicitly degraded ring-buffer event.
     """
 
     event_type = str(alert.get("event_type") or "")
     event_id = str(alert.get("event_id") or "").strip()
     if event_type not in _CANONICAL_GATEWAY_EVENT_TYPES or not event_id:
+        return None
+    event_timestamp = alert.get("event_timestamp") or alert.get("timestamp")
+    if isinstance(event_timestamp, int | float) and not isinstance(event_timestamp, bool):
+        try:
+            event_timestamp = datetime.fromtimestamp(float(event_timestamp), tz=timezone.utc).isoformat()
+        except (OverflowError, OSError, ValueError):
+            return None
+    if not isinstance(event_timestamp, str) or not event_timestamp.strip():
         return None
     expected_decision = "deny" if event_type in GATEWAY_BLOCKED_EVENT_TYPES else "allow"
     agent_id = str(
@@ -201,7 +209,7 @@ def _gateway_activity_record_from_alert(
         "event_id": event_id,
         "decision_id": str(alert.get("decision_id") or event_id),
         "event_type": event_type,
-        "event_timestamp": str(alert.get("event_timestamp") or received_at.isoformat()),
+        "event_timestamp": event_timestamp,
         "agent_id": agent_id,
         "upstream": str(alert.get("upstream") or alert.get("target") or "unknown"),
         "tool": str(alert.get("tool") or alert.get("tool_name") or "unknown"),
@@ -237,6 +245,30 @@ def _gateway_activity_record_from_alert(
         session_id=session_id,
         received_at=received_at,
     )
+
+
+def _append_gateway_activity_resilient(
+    records: list[GatewayActivityRecord],
+) -> tuple[set[str], set[str], set[str]]:
+    """Append a batch, isolating conflicting IDs without losing valid peers."""
+
+    store = get_gateway_activity_store()
+    try:
+        result = store.append_batch(records)
+        return set(result.inserted_event_ids), set(result.duplicate_event_ids), set()
+    except GatewayActivityConflictError:
+        inserted: set[str] = set()
+        duplicates: set[str] = set()
+        conflicts: set[str] = set()
+        for record in records:
+            try:
+                result = store.append_batch([record])
+            except GatewayActivityConflictError:
+                conflicts.add(record.event_id)
+                continue
+            inserted.update(result.inserted_event_ids)
+            duplicates.update(result.duplicate_event_ids)
+        return inserted, duplicates, conflicts
 
 
 @router.post("/proxy/audit", tags=["proxy"])
@@ -280,6 +312,9 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         enriched.setdefault("session_id", session_id)
         enriched.setdefault("request_id", request_id)
         enriched.setdefault("trace_id", trace_id)
+        # Receipt time is transport metadata owned by this API process. Never
+        # accept a caller-supplied future value into degraded feed ordering.
+        enriched["received_at"] = received_at.isoformat()
         enriched.setdefault("event_type", enriched.get("action") or enriched.get("type", "runtime_alert"))
         enriched["tenant_id"] = tenant_id
         prepared_alerts.append(enriched)
@@ -296,25 +331,24 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
             raise HTTPException(status_code=422, detail="Invalid canonical gateway activity event") from exc
         if record is not None:
             activity_records.append(record)
+    activity_candidate_ids = {record.event_id for record in activity_records}
 
     durable_inserted_ids: set[str] = set()
     durable_duplicate_ids: set[str] = set()
+    durable_conflict_ids: set[str] = set()
     if activity_records:
         try:
-            activity_result = await anyio.to_thread.run_sync(
-                partial(get_gateway_activity_store().append_batch, activity_records)
+            inserted_ids, duplicate_ids, conflict_ids = await anyio.to_thread.run_sync(
+                _append_gateway_activity_resilient,
+                activity_records,
             )
-        except GatewayActivityConflictError as exc:
-            raise HTTPException(
-                status_code=409,
-                detail="Gateway activity event conflicts with durable history",
-            ) from exc
         except ValueError as exc:
             raise HTTPException(status_code=422, detail="Invalid canonical gateway activity batch") from exc
         except Exception as exc:  # noqa: BLE001 - storage failure is a safe 503
             raise HTTPException(status_code=503, detail="Gateway activity storage unavailable") from exc
-        durable_inserted_ids.update(activity_result.inserted_event_ids)
-        durable_duplicate_ids.update(activity_result.duplicate_event_ids)
+        durable_inserted_ids.update(inserted_ids)
+        durable_duplicate_ids.update(duplicate_ids)
+        durable_conflict_ids.update(conflict_ids)
 
     duplicate_event_ids: list[str] = []
     accepted_alerts: list[dict] = []
@@ -324,8 +358,10 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         # cannot replay credential_leak alerts and inflate per-detector
         # tallies. Empty event_id falls through to keep legacy callers working.
         event_id = str(enriched.get("event_id") or "")
-        canonical_gateway = str(enriched.get("event_type") or "") in _CANONICAL_GATEWAY_EVENT_TYPES and bool(event_id)
+        canonical_gateway = event_id in activity_candidate_ids
         if canonical_gateway:
+            if event_id in durable_conflict_ids:
+                continue
             if event_id in durable_duplicate_ids or event_id in consumed_durable_ids:
                 duplicate_event_ids.append(event_id)
                 continue
@@ -333,9 +369,12 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
                 duplicate_event_ids.append(event_id)
                 continue
             consumed_durable_ids.add(event_id)
+            enriched["gateway_activity_durable"] = True
         elif event_id and not _claim_audit_event(tenant_id, event_id):
             duplicate_event_ids.append(event_id)
             continue
+        elif str(enriched.get("event_type") or "") in _CANONICAL_GATEWAY_EVENT_TYPES:
+            enriched["gateway_activity_durable"] = False
         accepted_alerts.append(enriched)
         push_proxy_alert(enriched)
         # Tally inter-agent firewall decisions for the runtime-tab dashboard
@@ -418,6 +457,8 @@ async def ingest_proxy_audit(request: Request, body: ProxyAuditIngestRequest) ->
         "duplicate_event_ids": duplicate_event_ids,
         "durable_accepted_count": len(durable_inserted_ids),
         "durable_duplicate_count": len(durable_duplicate_ids),
+        "durable_conflict_count": len(durable_conflict_ids),
+        "durable_conflict_event_ids": sorted(durable_conflict_ids),
         "has_summary": body.summary is not None,
     }
     if body.idempotency_key:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1762,6 +1762,8 @@ _DEFAULT_FINDING_STATUS = "open"
 _ALLOWED_FINDING_SEVERITIES = FINDING_SEVERITY_FILTERS
 
 _FRESHNESS_BUCKETS = ("last_24_hours", "last_7_days", "last_30_days", "older", "unavailable")
+_FACET_SCAN_BUDGET = 50_000
+_FACET_DEADLINE_SECONDS = 1.5
 
 
 def _freshness_bucket(row: Mapping[str, Any], *, now: datetime | None = None) -> str:
@@ -1795,12 +1797,36 @@ def _finding_facets(
     scope: Mapping[str, str],
     status: str,
 ) -> tuple[dict[str, dict[str, int]], int]:
-    """Compute exact, self-excluding facets from the canonical finding stream.
+    facets, total, _metadata = _finding_facets_bounded(
+        tenant_id,
+        severity=severity,
+        scan_id=scan_id,
+        since=since,
+        scope=scope,
+        status=status,
+    )
+    return facets, total
 
-    This is intentionally opt-in at the route: each dimension needs its own
-    bounded keyset walk so selecting one value does not erase alternative values
-    in that dimension. The same iterator and predicates power async export.
+
+def _finding_facets_bounded(
+    tenant_id: str,
+    *,
+    severity: str | None,
+    scan_id: str | None,
+    since: str | None,
+    scope: Mapping[str, str],
+    status: str,
+    scan_budget: int = _FACET_SCAN_BUDGET,
+    deadline_seconds: float = _FACET_DEADLINE_SECONDS,
+) -> tuple[dict[str, dict[str, int]], int, dict[str, Any]]:
+    """Compute self-excluding facets in one bounded canonical-stream pass.
+
+    A row is tested against every dimension's self-excluding predicate while it
+    is resident, avoiding four full tenant walks. When the row/deadline budget
+    is reached the counts remain useful lower-bound evidence and are explicitly
+    marked approximate by the caller.
     """
+    from agent_bom.api.compliance_hub_store import status_matches
     from agent_bom.export.runner import iter_current_findings
     from agent_bom.finding_scope import FINDING_CLASSES, SECURITY_DOMAINS, finding_class_for_row, lenses_for_row
 
@@ -1813,69 +1839,73 @@ def _finding_facets(
     freshness_counts: dict[str, int] = {key: 0 for key in _FRESHNESS_BUCKETS}
 
     class_scope = dict(scope)
-    active_class = class_scope.pop("finding_class", None)
+    class_scope.pop("finding_class", None)
+    domain_scope = dict(scope)
+    domain_scope.pop("domain", None)
+    full_scope = dict(scope)
+    base_scope = dict(full_scope)
+    base_scope.pop("finding_class", None)
+    base_scope.pop("domain", None)
     total = 0
-    for row in iter_current_findings(
-        tenant_id,
-        severity=severity,
-        since=since,
-        scan_id=scan_id,
-        scope=class_scope,
-        status=status,
-    ):
-        finding_class = finding_class_for_row(row)
-        class_counts[finding_class] += 1
-        if active_class is None or finding_class == active_class:
-            total += 1
-            freshness_counts[_freshness_bucket(row)] += 1
-
+    scanned_rows = 0
+    truncated = False
+    reason = ""
+    deadline = time.monotonic() + max(0.001, deadline_seconds)
     for row in iter_current_findings(
         tenant_id,
         severity=None,
         since=since,
         scan_id=scan_id,
-        scope=scope,
-        status=status,
-    ):
-        value = str(row.get("severity") or "unknown").strip().lower()
-        if value == "informational":
-            value = "info"
-        if value not in severity_counts:
-            value = "unknown"
-        severity_counts[value] += 1
-
-    for row in iter_current_findings(
-        tenant_id,
-        severity=severity,
-        since=since,
-        scan_id=scan_id,
-        scope=scope,
+        scope=base_scope,
         status="all",
     ):
-        value = "resolved" if str(row.get("status") or "").strip().lower() == "resolved" else "open"
-        status_counts[value] += 1
+        if scanned_rows >= scan_budget or time.monotonic() >= deadline:
+            truncated = True
+            reason = "scan_budget" if scanned_rows >= scan_budget else "deadline"
+            break
+        scanned_rows += 1
+        finding_class = finding_class_for_row(row)
+        row_severity = str(row.get("severity") or "unknown").strip().lower()
+        if row_severity == "informational":
+            row_severity = "info"
+        if row_severity not in severity_counts:
+            row_severity = "unknown"
+        severity_matches = severity is None or row_severity == severity.lower()
+        status_matches_active = status_matches(row, status)
+        full_scope_matches = _row_matches_scope(row, full_scope)
 
-    domain_scope = dict(scope)
-    domain_scope.pop("domain", None)
-    for row in iter_current_findings(
-        tenant_id,
-        severity=severity,
-        since=since,
-        scan_id=scan_id,
-        scope=domain_scope,
-        status=status,
-    ):
-        for value in lenses_for_row(row):
-            if value in domain_counts:
-                domain_counts[value] += 1
+        if severity_matches and status_matches_active and _row_matches_scope(row, class_scope):
+            class_counts[finding_class] += 1
+        if status_matches_active and full_scope_matches:
+            severity_counts[row_severity] += 1
+        if severity_matches and full_scope_matches:
+            row_status = "resolved" if str(row.get("status") or "").strip().lower() == "resolved" else "open"
+            status_counts[row_status] += 1
+        if severity_matches and status_matches_active and _row_matches_scope(row, domain_scope):
+            for value in lenses_for_row(row):
+                if value in domain_counts:
+                    domain_counts[value] += 1
+        if severity_matches and status_matches_active and full_scope_matches:
+            total += 1
+            freshness_counts[_freshness_bucket(row)] += 1
 
-    return {
-        "finding_class": class_counts,
-        "severity": severity_counts,
-        "status": status_counts,
-        "domain": domain_counts,
-        "freshness": freshness_counts,
-    }, total
+    return (
+        {
+            "finding_class": class_counts,
+            "severity": severity_counts,
+            "status": status_counts,
+            "domain": domain_counts,
+            "freshness": freshness_counts,
+        },
+        total,
+        {
+            "status": "partial" if truncated else "complete",
+            "reason": reason,
+            "scanned_rows": scanned_rows,
+            "scan_budget": scan_budget,
+            "deadline_ms": int(deadline_seconds * 1000),
+        },
+    )
 
 
 def _canonical_scope_filters(
@@ -2567,8 +2597,9 @@ def _list_findings_impl(
             next_cursor = encode_merged_scan_cursor(sort=sort_key, scan_index=end, bulk_cursor="")
 
     facets: dict[str, dict[str, int]] | None = None
+    facet_completeness: dict[str, Any] | None = None
     if include_facets:
-        facets, total = _finding_facets(
+        facets, total, facet_completeness = _finding_facets_bounded(
             tenant_id,
             severity=severity,
             scan_id=scan_id,
@@ -2576,7 +2607,7 @@ def _list_findings_impl(
             scope=scope_filters,
             status=status_key,
         )
-        total_approximate = False
+        total_approximate = facet_completeness["status"] != "complete"
 
     try:
         reachability = project_persisted_graph_reachability(
@@ -2621,13 +2652,14 @@ def _list_findings_impl(
     envelope["window"] = time_window.window_metadata(resolved_window)
     if facets is not None:
         envelope["facets"] = facets
-        envelope["facets_approximate"] = False
+        envelope["facets_approximate"] = bool(facet_completeness and facet_completeness["status"] != "complete")
         envelope["facet_metadata"] = {
             "freshness": {
                 "basis": ["last_observed", "last_seen"],
                 "thresholds_hours": [24, 168, 720],
                 "missing_or_invalid": "unavailable",
-            }
+            },
+            "completeness": facet_completeness,
         }
     return envelope
 

--- a/src/agent_bom/api/tenant_worker.py
+++ b/src/agent_bom/api/tenant_worker.py
@@ -1,0 +1,44 @@
+"""Tenant-safe execution helpers for background and pooled work."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from concurrent.futures import Executor, Future
+from typing import ParamSpec, TypeVar
+
+from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+
+P = ParamSpec("P")
+R = TypeVar("R")
+
+
+def run_tenant_bound(
+    tenant_id: str,
+    function: Callable[P, R],
+    /,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> R:
+    """Run one callable under ``tenant_id`` and always restore prior context."""
+
+    token = set_current_tenant(tenant_id)
+    try:
+        return function(*args, **kwargs)
+    finally:
+        reset_current_tenant(token)
+
+
+def submit_tenant_bound(
+    executor: Executor,
+    tenant_id: str,
+    function: Callable[P, R],
+    /,
+    *args: P.args,
+    **kwargs: P.kwargs,
+) -> Future[R]:
+    """Submit work whose worker thread is explicitly tenant-bound."""
+
+    return executor.submit(run_tenant_bound, tenant_id, function, *args, **kwargs)
+
+
+__all__ = ["run_tenant_bound", "submit_tenant_bound"]

--- a/src/agent_bom/delivery.py
+++ b/src/agent_bom/delivery.py
@@ -104,6 +104,7 @@ class Destination:
     auth_token: str = ""
     auth_header: str = "Authorization"
     headers: dict[str, str] = field(default_factory=dict)
+    accepted_statuses: frozenset[int] = field(default_factory=frozenset)
     allow_private_networks: bool = False
     timeout: float = 30.0
 
@@ -115,6 +116,8 @@ class Destination:
         scheme = self.auth_scheme.strip().lower()
         if scheme and scheme not in {"bearer", "token", "header"}:
             raise DeliveryError(f"unsupported auth_scheme: {self.auth_scheme!r}")
+        if any(isinstance(status, bool) or not isinstance(status, int) or not 200 <= status < 300 for status in self.accepted_statuses):
+            raise DeliveryError("accepted_statuses must contain only HTTP 2xx integers")
 
     @property
     def secret_fingerprint(self) -> str:
@@ -137,14 +140,14 @@ class Delivery:
     """
 
     destination_id: str
-    payload: dict[str, Any]
+    payload: dict[str, Any] | list[dict[str, Any]]
     event_type: str = "delivery"
     idempotency_key: str = ""
     created_at: float = field(default_factory=_wall_now)
 
     def __post_init__(self) -> None:
         clean = sanitize_sensitive_payload(self.payload)
-        if not isinstance(clean, dict):
+        if not isinstance(clean, dict | list):
             clean = {"value": clean}
         object.__setattr__(self, "payload", clean)
         if not self.idempotency_key:
@@ -473,7 +476,7 @@ def default_delivery_store_path() -> Path:
 _PREVIEW_MAX = 512
 
 
-def redacted_preview(payload: dict[str, Any]) -> str:
+def redacted_preview(payload: dict[str, Any] | list[dict[str, Any]]) -> str:
     """A short, secret-free preview of a payload for the audit log."""
     safe = sanitize_sensitive_payload(payload)
     text = _canonical_json(safe)
@@ -673,7 +676,10 @@ class DeliveryClient:
             last_http = outcome.http_status
             last_error = outcome.error
 
-            if outcome.is_success:
+            accepted = outcome.is_success and (
+                not destination.accepted_statuses or outcome.http_status in destination.accepted_statuses
+            )
+            if accepted:
                 self.store.log_attempt(
                     idempotency_key=key,
                     destination_id=destination.destination_id,

--- a/src/agent_bom/evidence/policy.py
+++ b/src/agent_bom/evidence/policy.py
@@ -67,6 +67,7 @@ TIER_A_FIELDS: frozenset[str] = frozenset(
         "decision_id",
         "event_type",
         "event_timestamp",
+        "gateway_activity_durable",
         "data_action",
         # Host / network identifiers
         "hostname",
@@ -99,6 +100,7 @@ TIER_A_FIELDS: frozenset[str] = frozenset(
         "first_seen",
         "last_seen",
         "ingested_at",
+        "received_at",
         "not_after",
         "captured_at",
         # Status / response codes (no body)

--- a/src/agent_bom/siem/__init__.py
+++ b/src/agent_bom/siem/__init__.py
@@ -12,6 +12,7 @@ in the _CONNECTORS dict for dynamic dispatch.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -21,6 +22,65 @@ from datetime import datetime, timezone
 from typing import Any, Protocol
 
 logger = logging.getLogger(__name__)
+
+
+def _delivery_identity(kind: str, url: str, index: str) -> str:
+    material = json.dumps([kind, url, index], separators=(",", ":"), ensure_ascii=True)
+    return f"siem-{kind}-{hashlib.sha256(material.encode('utf-8')).hexdigest()[:16]}"
+
+
+def _event_identity(kind: str, destination_id: str, event: dict[str, Any]) -> str:
+    material = json.dumps(
+        {"destination_id": destination_id, "event": event, "kind": kind},
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+        ensure_ascii=True,
+    )
+    return hashlib.sha256(material.encode("utf-8")).hexdigest()
+
+
+def _deliver_event(
+    *,
+    kind: str,
+    config: "SIEMConfig",
+    url: str,
+    payload: dict[str, Any] | list[dict[str, Any]],
+    source_event: dict[str, Any],
+    auth_scheme: str,
+    auth_header: str,
+    auth_token: str,
+    accepted_statuses: frozenset[int],
+) -> bool:
+    """Send one SIEM payload through the governed delivery foundation."""
+
+    from agent_bom.delivery import Delivery, Destination, get_delivery_client
+    from agent_bom.security import sanitize_error, sanitize_text
+
+    destination_id = _delivery_identity(kind, url, config.index)
+    destination = Destination(
+        destination_id=destination_id,
+        url=url,
+        kind=f"siem.{kind}",
+        auth_scheme=auth_scheme,
+        auth_header=auth_header,
+        auth_token=auth_token,
+        headers={"Content-Type": "application/json"},
+        accepted_statuses=accepted_statuses,
+        timeout=10.0,
+    )
+    delivery = Delivery(
+        destination_id=destination_id,
+        payload=payload,
+        event_type=f"siem.{kind}",
+        idempotency_key=_event_identity(kind, destination_id, source_event),
+    )
+    try:
+        return get_delivery_client().deliver(destination, delivery).delivered
+    except Exception as exc:  # noqa: BLE001 - preserve connector boolean contract
+        safe = sanitize_error(exc, generic=True)
+        logger.warning("SIEM delivery setup failed for %s: %s", kind, sanitize_text(safe))
+        return False
 
 
 class SIEMConnector(Protocol):
@@ -52,8 +112,6 @@ class SplunkHEC:
         self.url = config.url.rstrip("/")
 
     def send_event(self, event: dict) -> bool:
-        import httpx
-
         payload = {
             "event": event,
             "sourcetype": self.config.source_type,
@@ -62,18 +120,17 @@ class SplunkHEC:
         if self.config.index:
             payload["index"] = self.config.index
 
-        try:
-            resp = httpx.post(
-                f"{self.url}/services/collector/event",
-                json=payload,
-                headers={"Authorization": f"Splunk {self.config.token}"},
-                verify=self.config.verify_ssl,
-                timeout=10,
-            )
-            return resp.status_code == 200
-        except Exception:
-            logger.exception("Splunk HEC send failed")
-            return False
+        return _deliver_event(
+            kind="splunk",
+            config=self.config,
+            url=f"{self.url}/services/collector/event",
+            payload=payload,
+            source_event=event,
+            auth_scheme="header",
+            auth_header="Authorization",
+            auth_token=f"Splunk {self.config.token}",
+            accepted_statuses=frozenset({200}),
+        )
 
     def send_batch(self, events: list[dict]) -> int:
         return sum(1 for e in events if self.send_event(e))
@@ -101,8 +158,6 @@ class DatadogLogs:
         self.url = config.url or "https://http-intake.logs.datadoghq.com"
 
     def send_event(self, event: dict) -> bool:
-        import httpx
-
         payload = {
             "ddsource": "agent-bom",
             "ddtags": f"source:agent-bom,type:{event.get('type', 'scan_alert')}",
@@ -110,20 +165,17 @@ class DatadogLogs:
             "message": json.dumps(event),
         }
 
-        try:
-            resp = httpx.post(
-                f"{self.url}/api/v2/logs",
-                json=[payload],
-                headers={
-                    "DD-API-KEY": self.config.token,
-                    "Content-Type": "application/json",
-                },
-                timeout=10,
-            )
-            return resp.status_code in (200, 202)
-        except Exception:
-            logger.exception("Datadog send failed")
-            return False
+        return _deliver_event(
+            kind="datadog",
+            config=self.config,
+            url=f"{self.url}/api/v2/logs",
+            payload=[payload],
+            source_event=event,
+            auth_scheme="header",
+            auth_header="DD-API-KEY",
+            auth_token=self.config.token,
+            accepted_statuses=frozenset({200, 202}),
+        )
 
     def send_batch(self, events: list[dict]) -> int:
         return sum(1 for e in events if self.send_event(e))
@@ -151,29 +203,22 @@ class ElasticsearchConnector:
         self.index = config.index or "agent-bom-alerts"
 
     def send_event(self, event: dict) -> bool:
-        import httpx
-
         doc = {
             **event,
             "@timestamp": datetime.now(timezone.utc).isoformat(),
             "source": "agent-bom",
         }
-        headers: dict[str, str] = {"Content-Type": "application/json"}
-        if self.config.token:
-            headers["Authorization"] = f"Bearer {self.config.token}"
-
-        try:
-            resp = httpx.post(
-                f"{self.url}/{self.index}/_doc",
-                json=doc,
-                headers=headers,
-                verify=self.config.verify_ssl,
-                timeout=10,
-            )
-            return resp.status_code in (200, 201)
-        except Exception:
-            logger.exception("Elasticsearch send failed")
-            return False
+        return _deliver_event(
+            kind="elasticsearch",
+            config=self.config,
+            url=f"{self.url}/{self.index}/_doc",
+            payload=doc,
+            source_event=event,
+            auth_scheme="bearer" if self.config.token else "",
+            auth_header="Authorization",
+            auth_token=self.config.token,
+            accepted_statuses=frozenset({200, 201}),
+        )
 
     def send_batch(self, events: list[dict]) -> int:
         return sum(1 for e in events if self.send_event(e))

--- a/tests/api/test_gateway_feed_durable.py
+++ b/tests/api/test_gateway_feed_durable.py
@@ -258,6 +258,34 @@ def test_store_outage_is_explicitly_degraded_and_cannot_resume_cursor() -> None:
     assert "database URL" not in resumed.text
 
 
+def test_store_outage_counts_canonical_ring_events_as_partial_evidence() -> None:
+    class _UnavailableStore:
+        max_events_per_tenant = 50_000
+        max_tombstones_per_tenant = 100_000
+
+        def summarize_window(self, tenant_id, *, start, end):
+            raise RuntimeError("database URL with secret must not escape")
+
+    set_gateway_activity_store(_UnavailableStore())
+    tenant_id = "tenant-canonical-outage"
+    event = _blocked_event("evt-blocked-during-outage")
+    event["tenant_id"] = tenant_id
+    event["gateway_activity_durable"] = False
+    proxy_routes.push_proxy_alert(event)
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.get("/v1/gateway/feed/kpis", headers=_headers(tenant_id))
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["blocked_today"] == 1
+    assert body["calls_today"] == 1
+    assert body["source"] == "degraded_single_process"
+    assert body["completeness"]["status"] == "partial"
+    assert "ledger_unavailable" in body["completeness"]["reasons"]
+    assert body["window"]["exact"] is False
+
+
 def test_observability_outage_marks_feed_and_kpis_partial(monkeypatch: pytest.MonkeyPatch) -> None:
     def _unavailable(_tenant_id: str, *, limit: int):
         raise RuntimeError("cost store URL with secret must not escape")
@@ -275,3 +303,56 @@ def test_observability_outage_marks_feed_and_kpis_partial(monkeypatch: pytest.Mo
     assert "observability_unavailable" in kpis.json()["completeness"]["reasons"]
     assert kpis.json()["window"]["exact"] is False
     assert "cost store URL" not in kpis.text
+
+
+def test_missing_timestamp_replay_is_degraded_not_a_durable_conflict() -> None:
+    client = TestClient(app)
+    tenant_id = "tenant-missing-timestamp"
+    event = _blocked_event("evt-no-timestamp")
+    event.pop("event_timestamp")
+    payload = {
+        "source_id": "legacy-gateway",
+        "session_id": "session-a",
+        "alerts": [event],
+    }
+
+    first = client.post("/v1/proxy/audit", headers=_headers(tenant_id, role="admin"), json=payload)
+    replay = client.post("/v1/proxy/audit", headers=_headers(tenant_id, role="admin"), json=payload)
+
+    assert first.status_code == 200, first.text
+    assert first.json()["durable_accepted_count"] == 0
+    assert replay.status_code == 200, replay.text
+    assert replay.json()["duplicate_event_ids"] == ["evt-no-timestamp"]
+    feed = client.get("/v1/gateway/feed", headers=_headers(tenant_id)).json()
+    assert [row["event_id"] for row in feed["events"]] == ["evt-no-timestamp"]
+    assert feed["source"] == "degraded_single_process"
+    assert feed["completeness"]["status"] == "partial"
+
+
+def test_one_durable_conflict_does_not_discard_valid_batch_members() -> None:
+    client = TestClient(app)
+    tenant_id = "tenant-partial-conflict"
+    initial = client.post(
+        "/v1/proxy/audit",
+        headers=_headers(tenant_id, role="admin"),
+        json={"source_id": "gateway-a", "alerts": [_event("evt-conflict", tool="read_file")]},
+    )
+    assert initial.status_code == 200, initial.text
+
+    conflicting = _event("evt-conflict", tool="write_file")
+    valid = [_event(f"evt-valid-{index}", tool=f"tool-{index}") for index in range(5)]
+    batch = client.post(
+        "/v1/proxy/audit",
+        headers=_headers(tenant_id, role="admin"),
+        json={"source_id": "gateway-b", "alerts": [conflicting, *valid]},
+    )
+
+    assert batch.status_code == 200, batch.text
+    body = batch.json()
+    assert body["durable_accepted_count"] == 5
+    assert body["durable_conflict_count"] == 1
+    assert body["durable_conflict_event_ids"] == ["evt-conflict"]
+    feed = client.get("/v1/gateway/feed", headers=_headers(tenant_id), params={"limit": 20}).json()
+    by_id = {row["event_id"]: row for row in feed["events"]}
+    assert set(by_id) == {"evt-conflict", *(f"evt-valid-{index}" for index in range(5))}
+    assert by_id["evt-conflict"]["target"] == "read_file"

--- a/tests/api/test_route_event_loop_guard.py
+++ b/tests/api/test_route_event_loop_guard.py
@@ -40,6 +40,12 @@ BLOCKING_MODULE_ROOTS = {"requests", "urllib", "socket", "httpx"}
 # Exact dotted callables that block.
 BLOCKING_DOTTED = {"time.sleep"}
 
+# Imported functions whose implementation is known to perform blocking IO.
+BLOCKING_IMPORTED_CALLS = {"agent_bom.intel_lookup.list_intel_sources"}
+
+# Heavy sync helpers defined in the route module itself.
+BLOCKING_LOCAL_CALLS = {"_build_agents_response"}
+
 # Any ``<obj>.health_check()`` is a sync connector probe (SIEM, ticketing, …).
 BLOCKING_ATTR_CALLS = {"health_check"}
 
@@ -73,9 +79,29 @@ def _callable_name(node: ast.AST) -> str:
     return ""
 
 
+def _import_aliases(tree: ast.Module) -> dict[str, str]:
+    aliases: dict[str, str] = {}
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module:
+            for alias in node.names:
+                if alias.name != "*":
+                    aliases[alias.asname or alias.name] = f"{node.module}.{alias.name}"
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                aliases[alias.asname or alias.name.split(".", 1)[0]] = alias.name
+    return aliases
+
+
+def _resolve_dotted(dotted: str, aliases: dict[str, str]) -> str:
+    root, separator, remainder = dotted.partition(".")
+    resolved_root = aliases.get(root, root)
+    return f"{resolved_root}.{remainder}" if separator else resolved_root
+
+
 class _BlockingCallFinder(ast.NodeVisitor):
-    def __init__(self) -> None:
+    def __init__(self, aliases: dict[str, str]) -> None:
         self.violations: list[tuple[int, str]] = []
+        self.aliases = aliases
 
     # Nested sync defs are the offload bodies handed to to_thread — worker-thread code.
     def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
@@ -87,11 +113,14 @@ class _BlockingCallFinder(ast.NodeVisitor):
     def visit_Call(self, node: ast.Call) -> None:
         func = node.func
         dotted = _dotted(func)
-        root = dotted.split(".", 1)[0]
+        resolved = _resolve_dotted(dotted, self.aliases)
+        root = resolved.split(".", 1)[0]
         if root in BLOCKING_MODULE_ROOTS:
-            self.violations.append((node.lineno, dotted))
-        if dotted in BLOCKING_DOTTED:
-            self.violations.append((node.lineno, dotted))
+            self.violations.append((node.lineno, resolved))
+        if resolved in BLOCKING_DOTTED or resolved in BLOCKING_IMPORTED_CALLS:
+            self.violations.append((node.lineno, resolved))
+        if isinstance(func, ast.Name) and func.id in BLOCKING_LOCAL_CALLS:
+            self.violations.append((node.lineno, func.id))
         if isinstance(func, ast.Attribute):
             if func.attr in BLOCKING_ATTR_CALLS:
                 self.violations.append((node.lineno, f"{dotted}()"))
@@ -116,8 +145,9 @@ def test_async_route_handlers_never_call_blocking_work_on_the_loop():
     violations: list[str] = []
     for path in sorted(ROUTES_DIR.glob("*.py")):
         tree = ast.parse(path.read_text(encoding="utf-8"))
+        aliases = _import_aliases(tree)
         for handler in _iter_route_handlers(tree):
-            finder = _BlockingCallFinder()
+            finder = _BlockingCallFinder(aliases)
             for stmt in handler.body:
                 finder.visit(stmt)
             violations.extend(f"{path.name}:{lineno} {handler.name}: {what}" for lineno, what in finder.violations)
@@ -125,6 +155,22 @@ def test_async_route_handlers_never_call_blocking_work_on_the_loop():
         "Blocking call(s) running directly on the event loop in async route handlers "
         "(offload via anyio.to_thread.run_sync / asyncio.to_thread):\n" + "\n".join(violations)
     )
+
+
+def test_imported_blocking_callable_alias_is_detected() -> None:
+    tree = ast.parse(
+        """
+from agent_bom.intel_lookup import list_intel_sources as sources
+
+async def handler():
+    return sources()
+"""
+    )
+    handler = next(node for node in tree.body if isinstance(node, ast.AsyncFunctionDef))
+    finder = _BlockingCallFinder(_import_aliases(tree))
+    for statement in handler.body:
+        finder.visit(statement)
+    assert finder.violations == [(5, "agent_bom.intel_lookup.list_intel_sources")]
 
 
 async def _trivial() -> str:
@@ -162,3 +208,47 @@ async def test_slow_siem_health_check_keeps_event_loop_responsive(monkeypatch):
 
     result = await task
     assert result == {"siem_type": "splunk", "healthy": True}
+
+
+@pytest.mark.asyncio
+async def test_slow_intel_source_listing_keeps_event_loop_responsive(monkeypatch):
+    from agent_bom.api.routes import intel
+
+    block_seconds = 0.5
+
+    def _slow_sources() -> dict[str, object]:
+        time.sleep(block_seconds)
+        return {"sources": []}
+
+    monkeypatch.setattr(intel, "list_intel_sources", _slow_sources)
+    task = asyncio.create_task(intel.get_intel_sources())
+    await asyncio.sleep(0.05)
+    assert not task.done(), "source listing should still be in flight"
+
+    started = asyncio.get_running_loop().time()
+    assert await asyncio.wait_for(_trivial(), timeout=0.15) == "responsive"
+    assert asyncio.get_running_loop().time() - started < block_seconds / 2
+    assert await task == {"sources": []}
+
+
+@pytest.mark.asyncio
+async def test_slow_agent_discovery_keeps_event_loop_responsive(monkeypatch):
+    from agent_bom.api.routes import discovery
+
+    block_seconds = 0.5
+
+    def _slow_agents(_tenant_id: str) -> dict[str, object]:
+        time.sleep(block_seconds)
+        return {"agents": [], "count": 0}
+
+    discovery._clear_agents_response_cache_for_tests()
+    monkeypatch.setattr(discovery, "_tenant_id", lambda _request: "tenant-agents")
+    monkeypatch.setattr(discovery, "_build_agents_response", _slow_agents)
+    task = asyncio.create_task(discovery.list_agents(SimpleNamespace(), refresh=True))
+    await asyncio.sleep(0.05)
+    assert not task.done(), "agent discovery should still be in flight"
+
+    started = asyncio.get_running_loop().time()
+    assert await asyncio.wait_for(_trivial(), timeout=0.15) == "responsive"
+    assert asyncio.get_running_loop().time() - started < block_seconds / 2
+    assert await task == {"agents": [], "count": 0}

--- a/tests/test_enterprise_gaps.py
+++ b/tests/test_enterprise_gaps.py
@@ -536,6 +536,29 @@ class TestTrendAnalysis:
 class TestSIEMConnectors:
     """Test SIEM integrations."""
 
+    @pytest.fixture(autouse=True)
+    def _governed_delivery_client(self, tmp_path):
+        from agent_bom.delivery import DeliveryClient, DeliveryStore, RetryPolicy, SendOutcome, set_delivery_client
+
+        def _sender(url, headers, body, timeout):
+            import httpx
+
+            try:
+                response = httpx.post(url, json=json.loads(body), headers=headers, timeout=timeout)
+                return SendOutcome(http_status=response.status_code)
+            except Exception:
+                return SendOutcome(http_status=None, error="transport failure")
+
+        set_delivery_client(
+            DeliveryClient(
+                DeliveryStore(tmp_path / "delivery.db"),
+                sender=_sender,
+                retry=RetryPolicy(max_attempts=1),
+            )
+        )
+        yield
+        set_delivery_client(None)
+
     def test_list_connectors(self):
         from agent_bom.siem import list_connectors
 

--- a/tests/test_export_scheduler.py
+++ b/tests/test_export_scheduler.py
@@ -18,6 +18,7 @@ from agent_bom.api.export_destination_store import (
 )
 from agent_bom.api.export_schedule_store import ExportSchedule, InMemoryExportScheduleStore
 from agent_bom.api.export_scheduler import claim_due_schedules, run_due_exports_once
+from agent_bom.api.postgres_common import _current_tenant
 from agent_bom.export.destinations import ExportPublicationIndeterminateError
 
 
@@ -118,6 +119,7 @@ def test_run_due_exports_streams_to_destination_using_stored_secret(monkeypatch)
 
     def fake_run(**kwargs):
         captured.update(kwargs)
+        captured["context_tenant"] = _current_tenant.get()
         from agent_bom.export.destinations import ExportResult
 
         return ExportResult(kind="clickhouse", destination_uri="clickhouse://agent_bom/findings_feed", row_count=7)
@@ -137,6 +139,7 @@ def test_run_due_exports_streams_to_destination_using_stored_secret(monkeypatch)
     assert decrypted == ["enc-token"]
     assert captured["secret"] == "plain-token"
     assert captured["tenant_id"] == "tenant-a"
+    assert captured["context_tenant"] == "tenant-a"
     assert captured["kind"] == "clickhouse"
 
     # Schedule run metadata + destination status persisted.

--- a/tests/test_findings_facets_export_contract.py
+++ b/tests/test_findings_facets_export_contract.py
@@ -193,6 +193,47 @@ def test_facets_exclude_only_their_own_active_dimension() -> None:
     assert body["facets"]["domain"]["aspm"] == 1
 
 
+def test_facet_walk_is_single_pass_and_marks_scan_budget_partial(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.api.routes.scan import _finding_facets_bounded
+
+    calls = 0
+
+    def _rows(*_args, **_kwargs):
+        nonlocal calls
+        calls += 1
+        for index in range(10):
+            yield {
+                "id": f"finding-{index}",
+                "finding_type": "CVE",
+                "source": "SBOM",
+                "severity": "high",
+            }
+
+    monkeypatch.setattr("agent_bom.export.runner.iter_current_findings", _rows)
+
+    facets, total, metadata = _finding_facets_bounded(
+        "tenant-bounded-facets",
+        severity=None,
+        scan_id=None,
+        since=None,
+        scope={},
+        status="open",
+        scan_budget=3,
+        deadline_seconds=60,
+    )
+
+    assert calls == 1
+    assert total == 3
+    assert facets["severity"]["high"] == 3
+    assert metadata == {
+        "status": "partial",
+        "reason": "scan_budget",
+        "scanned_rows": 3,
+        "scan_budget": 3,
+        "deadline_ms": 60_000,
+    }
+
+
 def test_async_export_uses_the_same_finding_predicates(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_findings_scope_filter_keyset.py
+++ b/tests/test_findings_scope_filter_keyset.py
@@ -340,6 +340,44 @@ def test_collect_scope_filtered_page_helper_no_dup_no_drop() -> None:
     assert len(seen) == len(set(seen))
 
 
+def test_collect_scope_filtered_page_stops_at_scan_budget_with_resume_cursor() -> None:
+    rows = [
+        {
+            "canonical_id": f"c{idx:03d}",
+            "effective_reach_score": float(100 - idx),
+            "last_seen": "2026-07-18T00:00:00Z",
+            "payload": {"id": f"r{idx:03d}"},
+        }
+        for idx in range(20)
+    ]
+
+    def fetch(_cursor, limit):
+        window = rows[:limit]
+        return [(row, row["payload"]) for row in window], cursor_from_current_row(window[-1], sort="effective_reach")
+
+    metadata: dict[str, object] = {}
+    payloads, next_cursor = collect_scope_filtered_page(
+        fetch,
+        predicate=lambda _payload: False,
+        page_limit=5,
+        start_cursor=None,
+        sort="effective_reach",
+        batch_size=10,
+        scan_budget=3,
+        deadline_monotonic=float("inf"),
+        metadata=metadata,
+    )
+
+    assert payloads == []
+    assert next_cursor is not None
+    assert metadata == {
+        "scanned_rows": 3,
+        "scan_budget": 3,
+        "truncated": True,
+        "reason": "scan_budget",
+    }
+
+
 # --------------------------------------------------------------------------- #
 # Focused Postgres backend coverage (no live DB): a fake connection returns
 # fixture current-rows in keyset order, honoring the keyset WHERE + LIMIT the

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -2227,7 +2227,7 @@ class TestGraphStoreBackendSelection:
             lambda token: tenant_context.append(("reset", token)),
         )
 
-        job = SimpleNamespace(job_id="job-123", tenant_id="default", progress=[])
+        job = SimpleNamespace(job_id="job-123", tenant_id="default", progress=[], result={})
         _persist_graph_snapshot(job, {"scan_id": "job-123"})
 
         # Write path now streams node/edge iterables into the store instead of
@@ -2238,6 +2238,26 @@ class TestGraphStoreBackendSelection:
         assert not any(call[0] == "load_graph" for call in recording_graph_store.calls)
         assert ("prior_delta_digest", "default", "store-scan") in recording_graph_store.calls
         assert tenant_context == [("set", "default"), ("reset", "tenant-token")]
+        assert job.result["graph_persistence"] == {
+            "status": "persisted",
+            "scan_id": "job-123",
+            "nodes": 1,
+            "edges": 0,
+        }
+
+    def test_graph_persistence_failure_is_visible_without_backend_details(self):
+        from agent_bom.api.pipeline import _record_graph_persistence
+
+        job = SimpleNamespace(job_id="job-failed", result={})
+
+        _record_graph_persistence(job, status="failed")
+
+        assert job.result == {
+            "graph_persistence": {
+                "status": "failed",
+                "scan_id": "job-failed",
+            }
+        }
 
     def test_graph_search_uses_store_native_query(self, recording_graph_store):
         recording_graph_store.graph.add_node(UnifiedNode(id="server:a", entity_type=EntityType.SERVER, label="agent-a server"))

--- a/tests/test_graph_persist_memory_bound.py
+++ b/tests/test_graph_persist_memory_bound.py
@@ -90,8 +90,10 @@ def test_digest_peak_is_small_fraction_of_full_load_and_stays_bounded(tmp_path: 
     # adjacency — only an id set + agent refs. Measured ~0.07; guard well clear.
     assert ratio_small < 0.4, f"digest/full peak ratio too high at N=2000: {ratio_small:.3f}"
     assert ratio_large < 0.4, f"digest/full peak ratio too high at N=8000: {ratio_large:.3f}"
-    # The advantage must not erode as the prior snapshot grows 4x.
-    assert ratio_large <= ratio_small * 1.5, f"digest advantage eroded with scale: {ratio_small:.3f} -> {ratio_large:.3f}"
+    # A 4x snapshot may grow the compact id digest proportionally, but must not
+    # cross into super-linear allocation. Comparing two tiny ratios directly is
+    # allocator-noisy on hosted runners, so pin the actual growth instead.
+    assert large_digest <= small_digest * 5, f"digest allocation grew super-linearly: {small_digest} -> {large_digest}"
 
 
 def test_production_persist_path_does_not_materialise_full_prior_graph(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_graph_scale_quickwins.py
+++ b/tests/test_graph_scale_quickwins.py
@@ -42,6 +42,43 @@ def _small_graph(scan_id: str = "scale-scan") -> UnifiedGraph:
     return g
 
 
+@pytest.mark.parametrize("edge_count", [10_000, 50_000])
+def test_two_large_sqlite_snapshots_persist_without_silent_second_write_loss(tmp_path, edge_count):
+    """Keep a permanent reproduction for the reported ~7k-edge second-write loss."""
+    store = SQLiteGraphStore(tmp_path / f"sequential-{edge_count}.db")
+    node_count = 225
+    graph = UnifiedGraph(scan_id="large-first", tenant_id="tenant-scale")
+    for index in range(node_count):
+        graph.add_node(UnifiedNode(id=f"agent:{index}", entity_type=EntityType.AGENT, label=f"Agent {index}"))
+    created = 0
+    for source in range(node_count):
+        for target in range(node_count):
+            if source == target:
+                continue
+            graph.add_edge(
+                UnifiedEdge(
+                    source=f"agent:{source}",
+                    target=f"agent:{target}",
+                    relationship=RelationshipType.DELEGATED_TO,
+                )
+            )
+            created += 1
+            if created == edge_count:
+                break
+        if created == edge_count:
+            break
+
+    store.save_graph(graph)
+    graph.scan_id = "large-second"
+    store.save_graph(graph)
+
+    first = store.snapshot_stats(tenant_id="tenant-scale", scan_id="large-first")
+    second = store.snapshot_stats(tenant_id="tenant-scale", scan_id="large-second")
+    assert first["total_edges"] == edge_count
+    assert second["total_edges"] == edge_count
+    assert second["total_nodes"] == node_count
+
+
 # ── FIX 1: snapshot_stats reads the materialised snapshot counts ──────────────
 
 

--- a/tests/test_ocsf_boundary.py
+++ b/tests/test_ocsf_boundary.py
@@ -17,7 +17,7 @@ If this test fails, either:
 
 from __future__ import annotations
 
-import re
+import ast
 from pathlib import Path
 
 _REPO_ROOT = Path(__file__).resolve().parent.parent
@@ -38,10 +38,55 @@ _ALLOWED_OCSF_CONSUMERS = {
     "output/ocsf.py",
 }
 
-_OCSF_EMISSION_IMPORT = re.compile(
-    r"from\s+agent_bom\.(siem\.ocsf|output\.ocsf)\s+import"
-    r"|import\s+agent_bom\.(siem\.ocsf|output\.ocsf)"
-)
+_OCSF_EMISSION_MODULES = {"agent_bom.output.ocsf", "agent_bom.siem.ocsf"}
+
+
+def _package_for(relative_path: str) -> list[str]:
+    parent = Path(relative_path).parent
+    return ["agent_bom", *(() if str(parent) == "." else parent.parts)]
+
+
+def _resolve_from_import(node: ast.ImportFrom, relative_path: str) -> str:
+    if node.level == 0:
+        return node.module or ""
+    package = _package_for(relative_path)
+    keep = max(0, len(package) - (node.level - 1))
+    base = package[:keep]
+    if node.module:
+        base.extend(node.module.split("."))
+    return ".".join(base)
+
+
+def _literal_module_name(call: ast.Call) -> str | None:
+    if not call.args or not isinstance(call.args[0], ast.Constant) or not isinstance(call.args[0].value, str):
+        return None
+    if isinstance(call.func, ast.Name) and call.func.id in {"__import__", "import_module"}:
+        return call.args[0].value
+    if isinstance(call.func, ast.Attribute) and call.func.attr == "import_module":
+        return call.args[0].value
+    return None
+
+
+def _ocsf_imports(source: str, relative_path: str) -> list[tuple[int, str]]:
+    offenders: list[tuple[int, str]] = []
+    for node in ast.walk(ast.parse(source)):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in _OCSF_EMISSION_MODULES:
+                    offenders.append((node.lineno, alias.name))
+        elif isinstance(node, ast.ImportFrom):
+            base = _resolve_from_import(node, relative_path)
+            if base in _OCSF_EMISSION_MODULES:
+                offenders.append((node.lineno, base))
+            for alias in node.names:
+                imported = f"{base}.{alias.name}" if base else alias.name
+                if imported in _OCSF_EMISSION_MODULES:
+                    offenders.append((node.lineno, imported))
+        elif isinstance(node, ast.Call):
+            imported = _literal_module_name(node)
+            if imported in _OCSF_EMISSION_MODULES:
+                offenders.append((node.lineno, imported))
+    return sorted(set(offenders))
 
 
 def test_no_core_module_imports_ocsf_emission_layer():
@@ -50,13 +95,26 @@ def test_no_core_module_imports_ocsf_emission_layer():
         rel = path.relative_to(_SRC_ROOT).as_posix()
         if rel in _ALLOWED_OCSF_CONSUMERS:
             continue
-        text = path.read_text(encoding="utf-8")
-        if _OCSF_EMISSION_IMPORT.search(text):
-            offenders.append(rel)
+        source = path.read_text(encoding="utf-8")
+        offenders.extend(f"{rel}:{line} ({module})" for line, module in _ocsf_imports(source, rel))
     assert not offenders, (
         "OCSF boundary violation — these core modules import the "
         "OCSF emission layer. See docs/OCSF_BOUNDARY.md:\n  - " + "\n  - ".join(sorted(offenders))
     )
+
+
+def test_ocsf_boundary_guard_covers_import_shapes() -> None:
+    cases = {
+        "import agent_bom.siem.ocsf": "agent_bom.siem.ocsf",
+        "from agent_bom.siem.ocsf import to_ocsf_batch": "agent_bom.siem.ocsf",
+        "from agent_bom.siem import ocsf": "agent_bom.siem.ocsf",
+        "from ..siem import ocsf": "agent_bom.siem.ocsf",
+        'import_module("agent_bom.output.ocsf")': "agent_bom.output.ocsf",
+        'importlib.import_module("agent_bom.siem.ocsf")': "agent_bom.siem.ocsf",
+        '__import__("agent_bom.output.ocsf")': "agent_bom.output.ocsf",
+    }
+    for source, expected in cases.items():
+        assert _ocsf_imports(source, "api/example.py") == [(1, expected)]
 
 
 def test_graph_ocsf_map_is_thin_mapping_only():

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1710,6 +1710,32 @@ def test_graph_store_nodes_by_ids_uses_node_table(mock_pool, mock_maintenance_po
     assert "id IN" in select_sql
 
 
+def test_graph_hot_paths_never_materialize_the_full_postgres_snapshot(mock_pool, mock_maintenance_pool, monkeypatch):
+    from agent_bom.api.postgres_store import PostgresGraphStore
+    from agent_bom.graph import EntityType, UnifiedGraph, UnifiedNode
+
+    store = PostgresGraphStore(pool=mock_pool, maintenance_pool=mock_maintenance_pool)
+    graph = UnifiedGraph(scan_id="scan-hot-path", tenant_id="tenant-alpha")
+    graph.add_node(UnifiedNode(id="agent:a", entity_type=EntityType.AGENT, label="Agent A"))
+    store.save_graph(graph)
+
+    def _fail_load_graph(**_kwargs):
+        raise AssertionError("Postgres graph hot paths must use bounded table queries")
+
+    monkeypatch.setattr(store, "load_graph", _fail_load_graph)
+
+    store.bfs_paths(tenant_id="tenant-alpha", scan_id="scan-hot-path", source="agent:a")
+    store.impact_of(tenant_id="tenant-alpha", scan_id="scan-hot-path", node_id="agent:a")
+    store.traverse_subgraph(tenant_id="tenant-alpha", scan_id="scan-hot-path", roots=["agent:a"])
+    store.node_context(tenant_id="tenant-alpha", scan_id="scan-hot-path", node_id="agent:a")
+    store.compliance_summary(tenant_id="tenant-alpha", scan_id="scan-hot-path")
+
+    sql = "\n".join(statement for statement, _params in mock_pool._conn.executed)
+    assert "FROM graph_edges" in sql
+    assert "FROM graph_nodes" in sql
+    assert "statement_timeout" in sql
+
+
 def test_graph_store_save_graph_batches_postgres_writes(mock_pool, mock_maintenance_pool, monkeypatch):
     from agent_bom.api.postgres_store import PostgresGraphStore
     from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -170,9 +170,6 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert '<a href="#quick-start"><b>Quick start</b></a>' in hero
     assert '<a href="https://msaad00.github.io/agent-bom/">Docs</a>' in hero
     assert '<a href="https://demo.agent-bom.com">Live demo</a>' in hero
-    assert hero.count("how-it-works-dark.svg") == 1
-    assert hero.count("how-it-works-light.svg") == 1
-    assert hero.index("how-it-works-dark.svg") > hero.index('href="https://demo.agent-bom.com"')
     assert "## How it works" not in readme
 
     current_what_it_is = """`agent-bom` is an open scanner and self-hosted control plane for software,
@@ -205,9 +202,8 @@ observed."""
     assert "| AppSec |" in readme
     assert "| GRC / audit |" in readme
 
-    # The workflow and persona proof stay directly visible. Architecture and
-    # product screenshots remain collapsible, with the gallery open by default.
-    assert readme.count("how-it-works-dark.svg") == 1
+    # Persona proof stays directly visible. Architecture and product
+    # screenshots remain collapsible, with the gallery open by default.
     assert readme.count("architecture-dark.svg") == 1
     assert "<summary><b>Audience workflow map</b></summary>" not in readme
     assert "<summary><b>Control-plane architecture</b></summary>" in readme

--- a/tests/test_siem_push.py
+++ b/tests/test_siem_push.py
@@ -11,10 +11,19 @@ Tests cover:
 
 from __future__ import annotations
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from agent_bom.delivery import (
+    DeliveryClient,
+    DeliveryResult,
+    DeliveryStore,
+    RetryPolicy,
+    SendOutcome,
+    set_delivery_client,
+)
 from agent_bom.siem import (
     DatadogLogs,
     ElasticsearchConnector,
@@ -28,6 +37,33 @@ from agent_bom.siem import (
 )
 
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _governed_delivery_client(tmp_path):
+    def _sender(url, headers, body, timeout):
+        import httpx
+
+        try:
+            response = httpx.post(
+                url,
+                json=json.loads(body),
+                headers=headers,
+                timeout=timeout,
+            )
+            return SendOutcome(http_status=response.status_code)
+        except Exception:
+            return SendOutcome(http_status=None, error="transport failure")
+
+    set_delivery_client(
+        DeliveryClient(
+            DeliveryStore(tmp_path / "delivery.db"),
+            sender=_sender,
+            retry=RetryPolicy(max_attempts=1),
+        )
+    )
+    yield
+    set_delivery_client(None)
 
 
 @pytest.fixture()
@@ -337,3 +373,60 @@ def test_siem_config_custom_values():
     assert config.token == "tok"
     assert config.index == "idx"
     assert config.verify_ssl is False
+
+
+@pytest.mark.parametrize(
+    ("connector_type", "config"),
+    [
+        (SplunkHEC, SIEMConfig(name="splunk", url="https://splunk.test:8088", token="splunk-token", index="main")),
+        (DatadogLogs, SIEMConfig(name="datadog", url="https://logs.datadog.test", token="dd-token")),
+        (
+            ElasticsearchConnector,
+            SIEMConfig(name="elasticsearch", url="https://elastic.test:9200", token="es-token", index="findings"),
+        ),
+    ],
+)
+def test_siem_send_uses_governed_delivery_client(connector_type, config, sample_event):
+    captured: dict[str, object] = {}
+    client = MagicMock()
+
+    def _deliver(destination, delivery):
+        captured["destination"] = destination
+        captured["delivery"] = delivery
+        return DeliveryResult(
+            idempotency_key=delivery.idempotency_key,
+            destination_id=destination.destination_id,
+            status="delivered",
+            http_status=200,
+            attempts=1,
+            delivered=True,
+        )
+
+    client.deliver.side_effect = _deliver
+    with (
+        patch("agent_bom.delivery.get_delivery_client", return_value=client),
+        patch("httpx.post", side_effect=AssertionError("raw SIEM POST bypassed DeliveryClient")),
+    ):
+        assert connector_type(config).send_event(sample_event) is True
+
+    destination = captured["destination"]
+    delivery = captured["delivery"]
+    assert destination.kind.startswith("siem.")
+    assert destination.auth_token
+    assert config.token not in destination.destination_id
+    assert delivery.destination_id == destination.destination_id
+    assert delivery.idempotency_key
+
+
+def test_siem_delivery_failure_preserves_boolean_contract(splunk_config, sample_event):
+    client = MagicMock()
+    client.deliver.return_value = DeliveryResult(
+        idempotency_key="delivery-key",
+        destination_id="siem-splunk",
+        status="dead_letter",
+        attempts=3,
+        delivered=False,
+        warning="sanitized failure",
+    )
+    with patch("agent_bom.delivery.get_delivery_client", return_value=client):
+        assert SplunkHEC(splunk_config).send_event(sample_event) is False

--- a/tests/test_tenant_worker.py
+++ b/tests/test_tenant_worker.py
@@ -1,0 +1,79 @@
+"""Tenant context must cross every background-worker boundary."""
+
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent_bom.api.postgres_common import _current_tenant
+from agent_bom.api.tenant_worker import run_tenant_bound, submit_tenant_bound
+
+
+def test_run_tenant_bound_sets_and_restores_context() -> None:
+    token = _current_tenant.set("outer-tenant")
+    try:
+        observed = run_tenant_bound("worker-tenant", _current_tenant.get)
+        assert observed == "worker-tenant"
+        assert _current_tenant.get() == "outer-tenant"
+    finally:
+        _current_tenant.reset(token)
+
+
+def test_run_tenant_bound_restores_context_after_failure() -> None:
+    token = _current_tenant.set("outer-tenant")
+
+    def _fail() -> None:
+        assert _current_tenant.get() == "worker-tenant"
+        raise RuntimeError("expected failure")
+
+    try:
+        with pytest.raises(RuntimeError, match="expected failure"):
+            run_tenant_bound("worker-tenant", _fail)
+        assert _current_tenant.get() == "outer-tenant"
+    finally:
+        _current_tenant.reset(token)
+
+
+def test_submit_tenant_bound_does_not_inherit_or_leak_pool_context() -> None:
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first = submit_tenant_bound(executor, "tenant-a", _current_tenant.get)
+        second = executor.submit(_current_tenant.get)
+
+        assert first.result(timeout=2) == "tenant-a"
+        assert second.result(timeout=2) == "default"
+
+
+def test_report_submission_runs_with_explicit_tenant(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.api import report_worker
+
+    observed: list[str] = []
+
+    class _ImmediateExecutor:
+        def submit(self, function: Any, /, *args: Any, **kwargs: Any) -> None:
+            function(*args, **kwargs)
+
+    monkeypatch.setattr(report_worker, "get_executor", _ImmediateExecutor)
+    monkeypatch.setattr(
+        report_worker,
+        "_run_report_job_sync",
+        lambda _job_id, _tenant_id: observed.append(_current_tenant.get()),
+    )
+
+    report_worker.submit_report_job("job-1", "tenant-report")
+
+    assert observed == ["tenant-report"]
+    assert _current_tenant.get() == "default"
+
+
+def test_background_export_submit_sites_use_tenant_wrapper() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    for relative_path in (
+        "src/agent_bom/api/report_worker.py",
+        "src/agent_bom/api/routes/exports.py",
+    ):
+        source = (repo_root / relative_path).read_text(encoding="utf-8")
+        assert "submit_tenant_bound(" in source
+        assert "get_executor().submit(" not in source

--- a/ui/e2e/large-graph-overview.spec.ts
+++ b/ui/e2e/large-graph-overview.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page, type TestInfo } from "@playwright/test";
+import { expect, test, type Locator, type Page, type TestInfo } from "@playwright/test";
 
 const scanId = "scan-large-overview";
 const createdAt = "2026-05-08T16:00:00Z";
@@ -311,6 +311,18 @@ async function expectSigmaCanvases(page: Page) {
   expect(canvasSummary.drawable).toBeGreaterThan(0);
 }
 
+async function captureRenderedRegion(page: Page, region: Locator, path: string) {
+  const box = await region.boundingBox();
+  expect(box).not.toBeNull();
+  if (!box) return;
+  await page.screenshot({
+    path,
+    animations: "disabled",
+    clip: box,
+    timeout: 15_000,
+  });
+}
+
 test("large graph overview renders above threshold", async ({ page }, testInfo: TestInfo) => {
   test.setTimeout(60_000);
   const failedGraphResponses: string[] = [];
@@ -330,10 +342,13 @@ test("large graph overview renders above threshold", async ({ page }, testInfo: 
   await expect(page.getByText(/Draw budget:/)).toBeVisible();
   await expect(page.getByText("Pan, zoom, search, filter, and select nodes for evidence.")).toBeVisible();
   await expectCanvasHasPixels(page);
-  await page.screenshot({ path: testInfo.outputPath("large-graph-overview.png"), fullPage: true });
-
   await expect(page.getByRole("button", { name: "Search", exact: true })).toBeEnabled({ timeout: 15_000 });
   expect(failedGraphResponses).toEqual([]);
+  await captureRenderedRegion(
+    page,
+    page.getByTestId("large-graph-overview"),
+    testInfo.outputPath("large-graph-overview.png"),
+  );
 });
 
 test("sigma webgl overview renders when explicitly requested", async ({ page }, testInfo: TestInfo) => {
@@ -349,5 +364,5 @@ test("sigma webgl overview renders when explicitly requested", async ({ page }, 
   await expect(sigma.getByText("WebGL graph overview")).toBeVisible();
   await expect(sigma.getByText(/Sigma\.js renderer for broad estate scans/)).toBeVisible();
   await expectSigmaCanvases(page);
-  await page.screenshot({ path: testInfo.outputPath("sigma-webgl-overview.png"), fullPage: true });
+  await captureRenderedRegion(page, sigma, testInfo.outputPath("sigma-webgl-overview.png"));
 });


### PR DESCRIPTION
## Summary

- bind asynchronous reports and exports to tenant context, and offload blocking API work through bounded execution
- govern SIEM delivery and the OCSF boundary while preserving connector payload and return contracts
- make gateway retry/outage evidence truthful, bound Postgres graph and finding hot paths, and expose persistence/completeness status
- stabilize large-graph browser evidence capture without weakening functional assertions

## Verification

- affected Python regression gate: 455 passed, 1 skipped
- Ruff on changed Python sources and tests
- MyPy on all changed Python modules
- `make preflight`
- public documentation hygiene and exception-sanitization guards
- UI toolchain verification, typecheck, lint, 976 unit tests, and production build
- focused large-graph Playwright gate: 2 passed

## Notes

- a local full-suite run reached 2,367 passed and 10 skipped with no failures before an unrelated online advisory lookup blocked the run; the complete immutable-SHA suite remains a CI requirement
- graph persistence remains fail-safe and reports a sanitized degraded state rather than silently claiming success
