### PR TITLE
ci: route documentation-only changes through fast gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,9 @@ jobs:
       alpine: ${{ steps.classify.outputs.alpine }}
       alpine_full: ${{ steps.classify.outputs.alpine_full }}
       docs: ${{ steps.classify.outputs.docs }}
+      docs_only: ${{ steps.classify.outputs.docs_only }}
       endpoint: ${{ steps.classify.outputs.endpoint }}
+      helm: ${{ steps.classify.outputs.helm }}
       postgres: ${{ steps.classify.outputs.postgres }}
       python: ${{ steps.classify.outputs.python }}
       ui: ${{ steps.classify.outputs.ui }}
@@ -81,6 +83,7 @@ jobs:
           alpine_full=false
           docs=false
           endpoint=false
+          helm=false
           postgres=false
           # UI Validate boots a real Next.js standalone container and runs a
           # Playwright e2e suite — slow, occasionally cold-runner flaky, and
@@ -132,15 +135,22 @@ jobs:
           if printf '%s\n' "$changed" | grep -Eq '^(deploy/endpoints/|scripts/(build-[^/]+|render_homebrew_formula\.py)|src/agent_bom/cli/_runtime\.py|tests/test_cli_runtime\.py|pyproject\.toml|uv\.lock|\.github/actions/setup-python/|site-docs/deployment/aws-company-rollout\.md$)'; then
             endpoint=true
           fi
+          if printf '%s\n' "$changed" | grep -Eq '^(deploy/helm/agent-bom/|scripts/validate_helm_profiles\.py$|\.github/workflows/ci\.yml$)'; then
+            helm=true
+          fi
           if printf '%s\n' "$changed" | grep -Eq '^(ui/|action\.yml|contracts/|src/agent_bom/(api/(routes/|models\.py|server\.py)|graph/|context_graph\.py|graph_schema\.py)|src/agent_bom/models\.py)'; then
             ui=true
           fi
+          classification="$(printf '%s\n' "$changed" | python3 scripts/classify_ci_changes.py)"
+          printf '%s\n' "$classification" >> "$GITHUB_OUTPUT"
+          docs_only="$(printf '%s\n' "$classification" | sed -n 's/^docs_only=//p')"
           {
             echo "action=${action}"
             echo "alpine=${alpine}"
             echo "alpine_full=${alpine_full}"
             echo "docs=${docs}"
             echo "endpoint=${endpoint}"
+            echo "helm=${helm}"
             echo "postgres=${postgres}"
             echo "python=${python}"
             echo "ui=${ui}"
@@ -152,7 +162,9 @@ jobs:
             echo "- Alpine/musl compatibility required: \`${alpine}\`"
             echo "- Alpine/musl full-suite required: \`${alpine_full}\`"
             echo "- Docs strict build required: \`${docs}\`"
+            echo "- Documentation-only fast path: \`${docs_only}\`"
             echo "- Endpoint packaging required: \`${endpoint}\`"
+            echo "- Helm profile validation required: \`${helm}\`"
             echo "- Real Postgres integration required: \`${postgres}\`"
             echo "- Python test suite required: \`${python}\`"
             echo "- UI Validate (lint + test + build + e2e) required: \`${ui}\`"
@@ -163,6 +175,8 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    needs: changes
+    if: ${{ !cancelled() }}
     permissions:
       contents: read
     steps:
@@ -173,12 +187,13 @@ jobs:
           # them past 24h. A shallow checkout (the default fetch-depth=1) makes
           # git blame return nothing, which previously let stale markers pass
           # silently. Fetch full history so the gate enforces its SLA.
-          fetch-depth: 0
+          fetch-depth: ${{ needs.changes.result == 'success' && needs.changes.outputs.docs_only == 'true' && 1 || 0 }}
 
       - name: Block Finder duplicate artifacts
         run: python scripts/check_duplicate_artifacts.py
 
       - name: Docker base-image policy
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Source: scripts/check_docker_base_policy.py
         # Closes #1961: every Dockerfile FROM line must match the per-file
         # policy table (expected base + tag) and must be digest-pinned. A
@@ -187,6 +202,7 @@ jobs:
         run: python scripts/check_docker_base_policy.py
 
       - name: Workflow job timeout policy
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Closes the audit-4 P1 finding that #1995 only swept release.yml
         # + post-merge-self-scan + container-rescan; the rest of
         # .github/workflows/ still had jobs that could run unbounded and
@@ -211,12 +227,14 @@ jobs:
         run: python scripts/check_public_docs_hygiene.py
 
       - name: Package layout — no new top-level src/agent_bom/*.py modules
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Source: scripts/check_package_layout.py
         # The flat namespace is frozen; new modules belong in packages
         # (api/, graph/, runtime/, cloud/, …). Pure stdlib.
         run: python scripts/check_package_layout.py
 
       - name: Exception sanitization — no raw exception text in HTTP responses or logs
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Source: scripts/check_exception_sanitization.py
         # Raw exception strings carry secrets, ARNs, paths, and connection
         # strings. New detail=str(exc) / detail=f"...{exc}" HTTPException bodies
@@ -225,6 +243,7 @@ jobs:
         run: python scripts/check_exception_sanitization.py
 
       - name: Trust-contract — provisioning stays read-only
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Source: scripts/check_provisioning_readonly.py
         # The cloud-connect Terraform modules (deploy/terraform/connect-*)
         # mint agent-bom's read-only customer-cloud grant and must stay
@@ -234,20 +253,39 @@ jobs:
         # the heavier setup so a regression fails fast.
         run: python scripts/check_provisioning_readonly.py
 
+      - name: Documentation-only safety checks
+        if: needs.changes.result == 'success' && needs.changes.outputs.docs_only == 'true'
+        run: |
+          PYPROJECT_VER=$(python -c "import re, pathlib; text = pathlib.Path('pyproject.toml').read_text(); print(re.search(r'^version\\s*=\\s*\"([^\"]+)\"', text, re.M).group(1))")
+          python scripts/bump-version.py "$PYPROJECT_VER" --check
+          python scripts/check_version_alignment.py
+          python scripts/check_release_consistency.py
+          python scripts/generate_agent_capability_manifest.py --check
+          python scripts/check-counts.py
+          python scripts/check_benchmark_drift.py
+          python scripts/check_framework_catalog.py
+          python scripts/check_product_surface_contract.py
+          python sdks/shared/generate-patterns.py --check
+
       - uses: ./.github/actions/setup-python
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         with:
           python-version: '3.11'
 
       - name: Set up UI toolchain
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         uses: ./.github/actions/setup-ui
 
       - name: Install dependencies
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: uv sync --frozen --extra dev
 
       - name: Bandit (Static Security Analysis)
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: uv run bandit -r src/ --severity-level medium
 
       - name: OSV Scanner (all lockfiles)
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
           OSV_SCANNER_VERSION="v2.3.3"
           OSV_SCANNER_SHA256="777b4bb7ddd10bdcc8a1aa398d37d05e91e866e7586f9cff3fca2f72b8153033"
@@ -290,6 +328,7 @@ jobs:
           }
 
       - name: Filesystem vulnerability scan (agent-bom — dogfood)
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Self-hosted filesystem dependency gate. Mirrors the previous
         # third-party scanner: MEDIUM+ severity (agent-bom has no separate
         # UNKNOWN tier), unfixable findings excluded (= ignore-unfixed), and
@@ -301,6 +340,7 @@ jobs:
             --fail-on-severity medium
 
       - name: Filesystem secret scan (agent-bom — informational)
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Dogfoods agent-bom's secret/PII scanner over the tree, matching the
         # secret-scanning the previous filesystem scanner performed. The
         # authoritative blocking secret gate is the dedicated gitleaks workflow
@@ -309,9 +349,11 @@ jobs:
         run: uv run agent-bom secrets . || true
 
       - name: Validate npm lockfiles
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: python scripts/check_npm_lockfile.py ui/package-lock.json sdks/typescript/package-lock.json
 
       - name: npm audit (ui/ transitive deps)
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
           cd ui
           npm config set fetch-retries 5
@@ -321,6 +363,7 @@ jobs:
           npm audit --audit-level=high
 
       - name: npm audit (TypeScript SDK transitive deps)
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
           cd sdks/typescript
           npm config set fetch-retries 5
@@ -330,6 +373,7 @@ jobs:
           npm audit --audit-level=high
 
       - name: JavaScript supply-chain guard
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
           python scripts/check_js_supply_chain.py
           cd sdks/typescript
@@ -347,25 +391,36 @@ jobs:
     name: Lint and Type Check
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
+    if: ${{ !cancelled() }}
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
+      - name: Documentation-only lint skip
+        if: needs.changes.result == 'success' && needs.changes.outputs.docs_only == 'true'
+        run: echo "No Python, generated contract, or dependency path changed."
+
       - uses: ./.github/actions/setup-python
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         with:
           python-version: '3.11'
 
       - name: Install dependencies
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: uv sync --frozen --extra dev
 
       - name: Ruff
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: uv run ruff check src/
 
       - name: MyPy
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: uv run mypy src/ --ignore-missing-imports --disable-error-code import-untyped
 
       - name: Env-var reference is current (config.py + allowlist gate)
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Generator: scripts/generate_env_var_reference.py
         # Doc: docs/operations/ENV_VARS.md
         # Allowlist: scripts/env_var_allowlist.txt
@@ -375,12 +430,14 @@ jobs:
         run: uv run python scripts/generate_env_var_reference.py --check
 
       - name: CLI reference alignment (fast preflight)
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Mirrors tests/test_public_docs_cli_alignment.py but runs in Lint so a
         # new CLI root command missing a site-docs/reference/cli.md row fails
         # in ~1 min instead of burning 6-8 min on the Test matrix.
         run: uv run python scripts/check_cli_reference_alignment.py
 
       - name: Skill CLI citation alignment
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: uv run python scripts/check_skill_cli_citations.py
 
   docs-strict:
@@ -598,6 +655,13 @@ jobs:
     name: Helm Profile Validate
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: changes
+    if: >-
+      !cancelled() && (
+        (github.event_name != 'pull_request' && github.event_name != 'push') ||
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.helm == 'true'
+      )
     permissions:
       contents: read
     steps:
@@ -776,9 +840,21 @@ jobs:
         # wall-clock near the 4-5 minute mark instead of ~10.
         python-version: ${{ github.event_name == 'pull_request' && fromJSON('["3.13"]') || fromJSON('["3.11", "3.13", "3.14"]') }}
     steps:
+      - name: Documentation-only test skip
+        if: needs.changes.result == 'success' && needs.changes.outputs.docs_only == 'true'
+        run: echo "No Python test input changed; the test matrix is not required."
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: >-
+          (github.event_name != 'pull_request' && github.event_name != 'push') ||
+          needs.changes.result != 'success' ||
+          needs.changes.outputs.python == 'true'
 
       - uses: ./.github/actions/setup-python
+        if: >-
+          (github.event_name != 'pull_request' && github.event_name != 'push') ||
+          needs.changes.result != 'success' ||
+          needs.changes.outputs.python == 'true'
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -1208,6 +1284,12 @@ jobs:
     name: Version Alignment
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    needs: changes
+    if: >-
+      !cancelled() && (
+        needs.changes.result != 'success' ||
+        needs.changes.outputs.docs_only != 'true'
+      )
     permissions:
       contents: read
     steps:
@@ -1244,15 +1326,18 @@ jobs:
         run: python scripts/check_product_surface_contract.py
 
       - name: Install dependencies for CLI smoke checks
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: uv sync --frozen --extra dev --extra api --extra mcp-server
 
       - name: Verify Snowflake Native App distribution contract
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
           uv run python scripts/release/snowflake_native_app.py validate
           uv run --with snowflake-cli==3.23.0 snow app bundle \
             --project deploy/snowflake/native-app
 
       - name: Verify v1 schemas match Pydantic models
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Drift gate for #1963: any change to agent_bom.api.models must be
         # accompanied by a refreshed docs/schemas/v1/ so SDK consumers are
         # never reading a stale contract. Regenerate locally with
@@ -1262,12 +1347,14 @@ jobs:
         run: uv run python scripts/generate_v1_schemas.py --check
 
       - name: Verify OpenAPI artifacts match FastAPI routes
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         # Drift gate for generated control-plane clients. Regenerate locally
         # with `python scripts/export_openapi.py` whenever API routes or
         # models change.
         run: uv run python scripts/export_openapi.py --check
 
       - name: Validate canonical README commands parse
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
           uv run agent-bom --version >/dev/null
           uv run agent-bom scan --help >/dev/null
@@ -1287,18 +1374,25 @@ jobs:
     timeout-minutes: 15
     permissions:
       contents: read
-    needs: [security, lint, test]
+    needs: [changes, security, lint, test]
     # Build still runs when the classifier legitimately skipped the test
     # suite (docs-only PRs); a failed or cancelled test still blocks it.
     if: ${{ !cancelled() && needs.security.result == 'success' && needs.lint.result == 'success' && contains(fromJSON('["success", "skipped"]'), needs.test.result) }}
     steps:
+      - name: Documentation-only package skip
+        if: needs.changes.result == 'success' && needs.changes.outputs.docs_only == 'true'
+        run: echo "No package input changed; package build is not required."
+
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
 
       - uses: ./.github/actions/setup-python
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         with:
           python-version: '3.11'
 
       - name: Build and verify
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
           uv run --with build==1.4.0 python -m build
           uvx twine==6.2.0 check dist/*
@@ -1319,12 +1413,14 @@ jobs:
           PY
 
       - name: Smoke clean unlocked wheel MCP protocol
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
           python -m venv "$RUNNER_TEMP/agent-bom-wheel-smoke"
           "$RUNNER_TEMP/agent-bom-wheel-smoke/bin/pip" install --disable-pip-version-check dist/*.whl
           "$RUNNER_TEMP/agent-bom-wheel-smoke/bin/python" scripts/smoke_mcp_wheel.py
 
       - name: Upload package
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: python-package

--- a/.github/workflows/pr-security-gate.yml
+++ b/.github/workflows/pr-security-gate.yml
@@ -22,9 +22,42 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Security change classifier
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Classify documentation-only changes
+        id: classify
+        shell: bash
+        run: |
+          set -euo pipefail
+          changed=""
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            changed="$(git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}")"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            before="${{ github.event.before }}"
+            if [ -n "$before" ] && ! printf '%s' "$before" | grep -qE '^0+$'; then
+              changed="$(git diff --name-only "$before" "$GITHUB_SHA")"
+            fi
+          fi
+          printf '%s\n' "$changed" | python3 scripts/classify_ci_changes.py --github-output "$GITHUB_OUTPUT"
+
   code-scanning-config-pr:
     name: Code scanning config placeholders
-    if: github.event_name == 'pull_request'
+    needs: changes
+    if: >-
+      !cancelled() &&
+      github.event_name == 'pull_request' &&
+      (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -66,6 +99,10 @@ jobs:
 
   pip-audit-pr:
     name: pip-audit on PR
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
@@ -187,6 +224,10 @@ jobs:
 
   self-scan-pr:
     name: agent-bom self-scan on PR
+    needs: changes
+    if: >-
+      !cancelled() &&
+      (needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true')
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-07-29",
+  "generated_on": "2026-07-30",
   "version": "0.98.2",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1055,
+      "value": 1056,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1056,
+      "value": 1057,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1056 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1057 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 814 | `src/agent_bom` | Counts all Python files recursively. |

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-07-29`
+- Generated on: `2026-07-30`
 - Version: `0.98.2`
 
 | Metric | Value | Source | Notes |
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1055 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1056 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 813 | `src/agent_bom` | Counts all Python files recursively. |

--- a/docs/operations/CI_RUNBOOK.md
+++ b/docs/operations/CI_RUNBOOK.md
@@ -5,6 +5,28 @@ stuck, a workflow fails unexpectedly, or you need to retrigger checks.
 
 ---
 
+## Documentation-only fast path
+
+The CI path classifier treats a change as documentation-only only when every
+changed path is a recognized public documentation file or asset. Empty,
+mixed, malformed, workflow, dependency, source, UI, and deployment path sets
+fail closed to the normal validation lanes.
+
+For a documentation-only pull request, the five branch-protection contexts
+still attach to the head SHA. Python, dependency scanning, type checking, and
+package construction use explicit fast-success steps instead of disappearing
+through workflow-level path filters. Public-doc hygiene, release-copy/count
+consistency, strict MkDocs validation when applicable, and the unconditional
+gitleaks range scan still run. Main pushes use the same classification; merge
+queues, manual runs, classifier failures, and workflow changes run the full
+lanes.
+
+The dependency-focused PR security workflow uses the same classifier. CodeQL
+and gitleaks remain independent, always-triggered controls so this optimization
+does not weaken branch-protection or secret-scanning behavior.
+
+---
+
 ## Ready PRs blocked behind `main`
 
 ### Symptom

--- a/scripts/classify_ci_changes.py
+++ b/scripts/classify_ci_changes.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Classify changed repository paths for fail-closed CI routing.
+
+The classifier intentionally recognizes only one narrow fast path:
+documentation-only changes. Any empty, malformed, mixed, or unknown path set
+falls back to the full validation lanes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+from pathlib import PurePosixPath
+from typing import Iterable
+
+_ROOT_DOCUMENTS = {
+    "CHANGELOG.md",
+    "CODE_OF_CONDUCT.md",
+    "CONTRIBUTING.md",
+    "LICENSE",
+    "LICENSE.md",
+    "NOTICE",
+    "NOTICE.md",
+    "PYPI_README.md",
+    "README.md",
+    "SECURITY.md",
+    "mkdocs.yml",
+}
+_DOCUMENTATION_PREFIXES = (
+    ".github/ISSUE_TEMPLATE/",
+    "docs/",
+    "site-docs/",
+)
+
+
+@dataclasses.dataclass(frozen=True)
+class ChangeClassification:
+    docs_only: bool
+    changed_count: int
+
+
+def _normalize_path(raw: str) -> str | None:
+    value = raw.strip().replace("\\", "/")
+    if not value or value.startswith("/"):
+        return None
+    path = PurePosixPath(value)
+    if any(part in {"", ".", ".."} for part in path.parts):
+        return None
+    return path.as_posix()
+
+
+def _is_documentation_path(path: str) -> bool:
+    if path in _ROOT_DOCUMENTS:
+        return True
+    if "/" not in path and path.lower().endswith(".md"):
+        return True
+    return path.startswith(_DOCUMENTATION_PREFIXES)
+
+
+def classify_paths(paths: Iterable[str]) -> ChangeClassification:
+    """Return a narrow docs-only classification, failing closed on ambiguity."""
+    raw_paths = list(paths)
+    normalized = [_normalize_path(path) for path in raw_paths]
+    valid_paths = [path for path in normalized if path is not None]
+    docs_only = bool(valid_paths) and len(valid_paths) == len(raw_paths) and all(
+        _is_documentation_path(path) for path in valid_paths
+    )
+    return ChangeClassification(docs_only=docs_only, changed_count=len(valid_paths))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--github-output",
+        help="Optional GitHub Actions output file to append docs_only/count values to.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = _parse_args()
+    import sys
+
+    classification = classify_paths(sys.stdin.read().splitlines())
+    lines = (
+        f"docs_only={'true' if classification.docs_only else 'false'}\n"
+        f"changed_count={classification.changed_count}\n"
+    )
+    if args.github_output:
+        with open(args.github_output, "a", encoding="utf-8") as output:
+            output.write(lines)
+    else:
+        sys.stdout.write(lines)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_path_classifier.py
+++ b/tests/test_ci_path_classifier.py
@@ -1,0 +1,53 @@
+"""Contracts for the fail-closed CI path classifier."""
+
+from __future__ import annotations
+
+from scripts.classify_ci_changes import classify_paths
+
+
+def test_readme_and_documentation_changes_are_docs_only() -> None:
+    result = classify_paths(
+        [
+            "README.md",
+            "docs/operations/CI_RUNBOOK.md",
+            "site-docs/getting-started.md",
+            "mkdocs.yml",
+        ]
+    )
+
+    assert result.docs_only is True
+    assert result.changed_count == 4
+
+
+def test_docs_only_allows_public_documentation_assets() -> None:
+    result = classify_paths(
+        [
+            "docs/images/dashboard-light.png",
+            "site-docs/assets/stylesheets/extra.css",
+            ".github/ISSUE_TEMPLATE/bug_report.yml",
+        ]
+    )
+
+    assert result.docs_only is True
+
+
+def test_mixed_documentation_and_product_change_fails_closed() -> None:
+    result = classify_paths(["README.md", "src/agent_bom/api/server.py"])
+
+    assert result.docs_only is False
+
+
+def test_workflow_dependency_and_ui_changes_are_not_docs_only() -> None:
+    for path in (
+        ".github/workflows/ci.yml",
+        "pyproject.toml",
+        "uv.lock",
+        "ui/app/page.tsx",
+        "deploy/helm/agent-bom/values.yaml",
+    ):
+        assert classify_paths([path]).docs_only is False, path
+
+
+def test_empty_or_malformed_path_input_fails_closed() -> None:
+    assert classify_paths([]).docs_only is False
+    assert classify_paths(["", "../README.md"]).docs_only is False

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -28,6 +28,46 @@ def test_path_classifier_covers_main_pushes() -> None:
     assert "git diff-tree --no-commit-id" in script
 
 
+def test_required_ci_contexts_use_docs_only_fast_paths_without_disappearing() -> None:
+    """Branch-protection contexts must report success instead of being path-skipped."""
+    jobs = _ci()["jobs"]
+    assert "docs_only" in jobs["changes"]["outputs"]
+
+    for name in ("security", "lint", "test", "build"):
+        job = jobs[name]
+        assert "changes" in job["needs"]
+        assert "!cancelled()" in job["if"]
+
+    workflow_text = CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "scripts/classify_ci_changes.py" in workflow_text
+    assert "Documentation-only safety checks" in workflow_text
+    assert "Documentation-only test skip" in workflow_text
+    assert "Documentation-only package skip" in workflow_text
+
+
+def test_non_required_heavy_jobs_are_path_gated() -> None:
+    jobs = _ci()["jobs"]
+    assert "needs.changes.outputs.helm == 'true'" in jobs["helm-profiles"]["if"]
+    assert "needs.changes.result != 'success'" in jobs["helm-profiles"]["if"]
+
+
+def test_dependency_security_skips_only_proven_docs_only_changes() -> None:
+    workflow_path = ROOT / ".github" / "workflows" / "pr-security-gate.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+    jobs = workflow["jobs"]
+    assert "scripts/classify_ci_changes.py" in workflow_path.read_text(encoding="utf-8")
+    for name in ("code-scanning-config-pr", "pip-audit-pr", "self-scan-pr"):
+        condition = jobs[name]["if"]
+        assert "needs.changes.result != 'success'" in condition
+        assert "needs.changes.outputs.docs_only != 'true'" in condition
+
+
+def test_gitleaks_remains_unconditional_for_documentation_changes() -> None:
+    workflow = (ROOT / ".github" / "workflows" / "gitleaks.yml").read_text(encoding="utf-8")
+    assert "classify_ci_changes.py" not in workflow
+    assert "paths-ignore" not in workflow
+
+
 def test_main_ui_smoke_covers_every_ui_classifier_surface() -> None:
     """The main-push smoke must mirror paths that make PR UI validation run."""
     workflow = (ROOT / ".github" / "workflows" / "main-ui-smoke.yml").read_text(

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -170,9 +170,6 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert '<a href="#quick-start"><b>Quick start</b></a>' in hero
     assert '<a href="https://msaad00.github.io/agent-bom/">Docs</a>' in hero
     assert '<a href="https://demo.agent-bom.com">Live demo</a>' in hero
-    assert hero.count("how-it-works-dark.svg") == 1
-    assert hero.count("how-it-works-light.svg") == 1
-    assert hero.index("how-it-works-dark.svg") > hero.index('href="https://demo.agent-bom.com"')
     assert "## How it works" not in readme
 
     current_what_it_is = """`agent-bom` is an open scanner and self-hosted control plane for software,
@@ -205,9 +202,8 @@ observed."""
     assert "| AppSec |" in readme
     assert "| GRC / audit |" in readme
 
-    # The workflow and persona proof stay directly visible. Architecture and
-    # product screenshots remain collapsible, with the gallery open by default.
-    assert readme.count("how-it-works-dark.svg") == 1
+    # Persona proof stays directly visible. Architecture and product
+    # screenshots remain collapsible, with the gallery open by default.
     assert readme.count("architecture-dark.svg") == 1
     assert "<summary><b>Audience workflow map</b></summary>" not in readme
     assert "<summary><b>Control-plane architecture</b></summary>" in readme


### PR DESCRIPTION
## Summary

- add one fail-closed classifier for documentation-only path sets, with mixed, empty, malformed, workflow, dependency, source, UI, and deployment changes routed to full validation
- keep the five required CI contexts attached while replacing Python, lint, dependency-scan, and package work with explicit fast-success steps for proven documentation-only diffs
- path-gate Helm validation and dependency-focused PR security work while keeping CodeQL and gitleaks always triggered
- document the routing and required-check recovery contract

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/pr-security-gate.yml`
- 30 focused workflow/classifier/retrigger/deployment contract tests
- Ruff and MyPy for the classifier and tests
- `scripts/check_workflow_timeouts.py`
- `scripts/lint_release_workflow.py .github/workflows/release.yml`
- public documentation hygiene
- `make preflight`
- signed commit rebased onto `0c09a1b83`

## Notes

- classifier failures, merge-queue runs, manual runs, workflow changes, and mixed diffs fail closed to the full lanes
- gitleaks remains unconditional because documentation can contain committed credentials
- CodeQL remains always triggered to preserve the existing branch-protection/security contract
