### PR TITLE
fix(control-plane): restore bounded result honesty

### DIFF
--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -1298,9 +1298,9 @@ class PostgresGraphStore:
         static_only: bool = False,
         dynamic_only: bool = False,
         limit: int = 25_001,
-    ) -> list[Sequence[Any]]:
+    ) -> tuple[list[Sequence[Any]], bool]:
         if not frontier:
-            return []
+            return [], False
         placeholders = ",".join("%s" for _ in frontier)
         where = [
             "tenant_id = %s",
@@ -1323,8 +1323,9 @@ class PostgresGraphStore:
             dynamic_placeholders = ",".join("%s" for _ in _DYNAMIC_RELATIONSHIP_VALUES)
             where.append(f"relationship IN ({dynamic_placeholders})")
             params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
-        params.append(max(1, int(limit)))
-        return cast(
+        bounded_limit = max(1, int(limit))
+        params.append(bounded_limit + 1)
+        rows = cast(
             "list[Sequence[Any]]",
             conn.execute(
                 f"""
@@ -1339,6 +1340,7 @@ class PostgresGraphStore:
                 params,
             ).fetchall(),
         )
+        return rows[:bounded_limit], len(rows) > bounded_limit
 
     def _walk_graph(
         self,
@@ -1414,7 +1416,7 @@ class PostgresGraphStore:
             index += 1
             if depth >= max_depth:
                 continue
-            rows = self._filtered_edge_rows(
+            rows, hit_limit = self._filtered_edge_rows(
                 conn,
                 tenant_id=tenant_id,
                 scan_id=effective_scan_id,
@@ -1425,6 +1427,8 @@ class PostgresGraphStore:
                 dynamic_only=dynamic_only,
                 limit=max_edges - edge_count + 1,
             )
+            if hit_limit:
+                truncated = True
             for row in rows:
                 edge = self._edge_from_row(row)
                 candidates: list[str] = []
@@ -1457,6 +1461,8 @@ class PostgresGraphStore:
                     parent_by_node.setdefault(neighbor, current)
                     discovery_order.append(neighbor)
                     queue.append((neighbor, depth + 1))
+            if hit_limit:
+                break
             if truncated and (
                 edge_count > max_edges
                 or (deadline_monotonic is not None and time.monotonic() >= deadline_monotonic)

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1850,7 +1850,7 @@ def _finding_facets_bounded(
     scanned_rows = 0
     truncated = False
     reason = ""
-    deadline = time.monotonic() + max(0.001, deadline_seconds)
+    deadline: float | None = None
     for row in iter_current_findings(
         tenant_id,
         severity=None,
@@ -1859,9 +1859,18 @@ def _finding_facets_bounded(
         scope=base_scope,
         status="all",
     ):
-        if scanned_rows >= scan_budget or time.monotonic() >= deadline:
+        if scanned_rows >= scan_budget:
             truncated = True
-            reason = "scan_budget" if scanned_rows >= scan_budget else "deadline"
+            reason = "scan_budget"
+            break
+        if deadline is None:
+            # Bound facet processing, not the backing iterator's time-to-first
+            # row. A slow cursor setup must not turn a non-empty tenant into a
+            # zero-count Findings response.
+            deadline = time.monotonic() + max(0.001, deadline_seconds)
+        elif time.monotonic() >= deadline:
+            truncated = True
+            reason = "deadline"
             break
         scanned_rows += 1
         finding_class = finding_class_for_row(row)
@@ -2599,7 +2608,7 @@ def _list_findings_impl(
     facets: dict[str, dict[str, int]] | None = None
     facet_completeness: dict[str, Any] | None = None
     if include_facets:
-        facets, total, facet_completeness = _finding_facets_bounded(
+        facets, facet_total, facet_completeness = _finding_facets_bounded(
             tenant_id,
             severity=severity,
             scan_id=scan_id,
@@ -2607,6 +2616,11 @@ def _list_findings_impl(
             scope=scope_filters,
             status=status_key,
         )
+        # A partial walk that could not process even one row is not evidence
+        # that the result set is empty. Preserve the list path's total instead
+        # of replacing it with a misleading zero.
+        if facet_completeness["status"] == "complete" or facet_completeness["scanned_rows"] > 0:
+            total = facet_total
         total_approximate = facet_completeness["status"] != "complete"
 
     try:

--- a/src/agent_bom/delivery.py
+++ b/src/agent_bom/delivery.py
@@ -193,13 +193,21 @@ Sender = Callable[[str, dict[str, str], bytes, float], "SendOutcome"]
 class SendOutcome:
     http_status: int | None
     error: str = ""
+    retryable: bool | None = None
 
     @property
     def is_success(self) -> bool:
         return self.http_status is not None and 200 <= self.http_status < 300
 
 
-def http_sender(url: str, headers: dict[str, str], body: bytes, timeout: float) -> SendOutcome:
+def http_sender(
+    url: str,
+    headers: dict[str, str],
+    body: bytes,
+    timeout: float,
+    *,
+    allow_private_networks: bool = False,
+) -> SendOutcome:
     """Default sender: one POST through the shared resilient sync client.
 
     The shared client already validates the URL (SSRF) and does connection-level
@@ -209,11 +217,20 @@ def http_sender(url: str, headers: dict[str, str], body: bytes, timeout: float) 
     from agent_bom.http_client import create_sync_client
     from agent_bom.security import SecurityError, validate_url
 
-    allow_private = os.environ.get("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "").strip().lower() in {"1", "true", "yes", "on"}
+    allow_private = allow_private_networks or os.environ.get("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
     try:
         validate_url(url, allowed_schemes=("https", "http") if allow_private else ("https",), allow_private=allow_private)
     except SecurityError as exc:
-        return SendOutcome(http_status=None, error=f"url rejected by outbound policy: {sanitize_error(exc)}")
+        return SendOutcome(
+            http_status=None,
+            error=f"url rejected by outbound policy: {sanitize_error(exc)}",
+            retryable=False,
+        )
     try:
         with create_sync_client(timeout=timeout) as client:
             resp = client.request("POST", url, content=body, headers=headers)
@@ -671,7 +688,16 @@ class DeliveryClient:
         for attempt in range(1, self.retry.max_attempts + 1):
             attempts_made = attempt
             headers = self._build_headers(destination, delivery, body, attempt)
-            outcome = self.sender(destination.url, headers, body, destination.timeout)
+            if self.sender is http_sender:
+                outcome = http_sender(
+                    destination.url,
+                    headers,
+                    body,
+                    destination.timeout,
+                    allow_private_networks=destination.allow_private_networks,
+                )
+            else:
+                outcome = self.sender(destination.url, headers, body, destination.timeout)
             attempt_now = self._now()
             last_http = outcome.http_status
             last_error = outcome.error
@@ -788,6 +814,8 @@ class DeliveryClient:
 
 
 def _is_retryable(outcome: SendOutcome) -> bool:
+    if outcome.retryable is not None:
+        return outcome.retryable
     if outcome.http_status is None:
         return True  # transport/connection error — retry
     if outcome.http_status in _RETRYABLE_STATUS:

--- a/src/agent_bom/siem/__init__.py
+++ b/src/agent_bom/siem/__init__.py
@@ -67,6 +67,7 @@ def _deliver_event(
         auth_token=auth_token,
         headers={"Content-Type": "application/json"},
         accepted_statuses=accepted_statuses,
+        allow_private_networks=config.allow_private_networks,
         timeout=10.0,
     )
     delivery = Delivery(
@@ -102,6 +103,7 @@ class SIEMConfig:
     source_type: str = "agent-bom"
     verify_ssl: bool = True
     event_format: str = "raw"
+    allow_private_networks: bool = False
 
 
 class SplunkHEC:
@@ -311,5 +313,7 @@ def create_from_env() -> SIEMConnector | None:
         url=os.environ.get("AGENT_BOM_SIEM_URL", ""),
         token=os.environ.get("AGENT_BOM_SIEM_TOKEN", ""),
         index=os.environ.get("AGENT_BOM_SIEM_INDEX", ""),
+        allow_private_networks=os.environ.get("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", "").strip().lower()
+        in {"1", "true", "yes", "on"},
     )
     return create_connector(siem_type, config)

--- a/tests/test_delivery_foundation.py
+++ b/tests/test_delivery_foundation.py
@@ -188,6 +188,67 @@ def test_auth_failure_is_permanent_no_retry_and_warned(tmp_path: Path) -> None:
     assert dead_letters[0]["attempt"] == 1
 
 
+def test_destination_policy_rejection_is_permanent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", raising=False)
+    clock = FakeClock()
+    client = DeliveryClient(
+        DeliveryStore(tmp_path / "policy-rejection.db"),
+        retry=RetryPolicy(max_attempts=4, initial_backoff=1.0),
+        now=clock.now,
+        sleep=clock.sleep,
+        rng=lambda: 0.0,
+    )
+    destination = Destination(destination_id="private-blocked", url="https://127.0.0.1:9200/events")
+    delivery = Delivery(destination_id=destination.destination_id, payload={"event": "blocked"})
+
+    result = client.deliver(destination, delivery)
+
+    assert result.status == "dead_letter"
+    assert result.attempts == 1
+    assert clock.slept == []
+
+
+def test_private_http_destination_approval_reaches_transport(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("AGENT_BOM_ALLOW_PRIVATE_EGRESS_URLS", raising=False)
+    clock = FakeClock()
+
+    class _Response:
+        status_code = 200
+
+    class _Client:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def request(self, *_args, **_kwargs):
+            return _Response()
+
+    monkeypatch.setattr("agent_bom.http_client.create_sync_client", lambda **_kwargs: _Client())
+    client = DeliveryClient(
+        DeliveryStore(tmp_path / "private-approved.db"),
+        retry=RetryPolicy(max_attempts=2, initial_backoff=1.0),
+        now=clock.now,
+        sleep=clock.sleep,
+        rng=lambda: 0.0,
+    )
+    destination = Destination(
+        destination_id="private-approved",
+        url="http://127.0.0.1:9200/events",
+        allow_private_networks=True,
+    )
+    delivery = Delivery(destination_id=destination.destination_id, payload={"event": "approved"})
+
+    result = client.deliver(destination, delivery)
+
+    assert result.delivered is True
+    assert result.attempts == 1
+    assert clock.slept == []
+
+
 @pytest.mark.parametrize(
     "kwargs",
     [

--- a/tests/test_findings_facets_export_contract.py
+++ b/tests/test_findings_facets_export_contract.py
@@ -234,6 +234,80 @@ def test_facet_walk_is_single_pass_and_marks_scan_budget_partial(monkeypatch: py
     }
 
 
+def test_facet_deadline_starts_after_the_first_row_is_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_bom.api.routes import scan as scan_routes
+
+    clock = {"now": 0.0}
+
+    def _rows(*_args, **_kwargs):
+        # Model a database cursor whose first row takes longer than the Python
+        # facet-processing budget to become available. Query latency must not
+        # turn a non-empty result set into a zero-count response.
+        clock["now"] = 2.0
+        yield {
+            "id": "finding-delayed",
+            "finding_type": "CVE",
+            "source": "SBOM",
+            "severity": "high",
+        }
+
+    monkeypatch.setattr("agent_bom.export.runner.iter_current_findings", _rows)
+    monkeypatch.setattr(scan_routes.time, "monotonic", lambda: clock["now"])
+
+    facets, total, metadata = scan_routes._finding_facets_bounded(
+        "tenant-delayed-facets",
+        severity=None,
+        scan_id=None,
+        since=None,
+        scope={},
+        status="open",
+        scan_budget=10,
+        deadline_seconds=1.0,
+    )
+
+    assert total == 1
+    assert facets["severity"]["high"] == 1
+    assert metadata["scanned_rows"] == 1
+    assert metadata["status"] == "complete"
+
+
+def test_partial_zero_row_facet_walk_preserves_the_list_total(monkeypatch: pytest.MonkeyPatch) -> None:
+    tenant = "default"
+    _seed_scan(tenant)
+    empty_facets = {
+        "finding_class": {},
+        "severity": {},
+        "status": {},
+        "domain": {},
+        "freshness": {},
+    }
+    monkeypatch.setattr(
+        "agent_bom.api.routes.scan._finding_facets_bounded",
+        lambda *_args, **_kwargs: (
+            empty_facets,
+            0,
+            {
+                "status": "partial",
+                "reason": "deadline",
+                "scanned_rows": 0,
+                "scan_budget": 50_000,
+                "deadline_ms": 1_500,
+            },
+        ),
+    )
+
+    response = TestClient(app).get(
+        "/v1/findings?include_facets=true&window_days=0",
+        headers=_headers(tenant),
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert len(body["findings"]) == 6
+    assert body["total"] == 6
+    assert body["total_approximate"] is True
+
+
 def test_async_export_uses_the_same_finding_predicates(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1736,6 +1736,69 @@ def test_graph_hot_paths_never_materialize_the_full_postgres_snapshot(mock_pool,
     assert "statement_timeout" in sql
 
 
+def test_filtered_edge_rows_reports_when_the_query_limit_omits_rows():
+    from agent_bom.api.postgres_store import PostgresGraphStore
+
+    rows = [(f"source:{index}", f"target:{index}") for index in range(3)]
+
+    class EdgeConnection:
+        def __init__(self):
+            self.params = None
+
+        def execute(self, _sql, params=None):
+            self.params = params
+            return MockCursor(rows)
+
+    conn = EdgeConnection()
+    store = object.__new__(PostgresGraphStore)
+
+    bounded_rows, hit_limit = store._filtered_edge_rows(
+        conn,
+        tenant_id="tenant-alpha",
+        scan_id="scan-limited",
+        frontier={"agent:a"},
+        limit=2,
+    )
+
+    assert bounded_rows == rows[:2]
+    assert hit_limit is True
+    assert conn.params[-1] == 3
+
+
+def test_graph_walk_marks_query_limit_omissions_truncated(monkeypatch):
+    from agent_bom.api.postgres_store import PostgresGraphStore
+
+    class WalkConnection:
+        def execute(self, sql, _params=None):
+            if "SELECT created_at FROM graph_snapshots" in sql:
+                return MockCursor([("2026-07-30T00:00:00+00:00",)])
+            if "SELECT id FROM graph_nodes" in sql:
+                return MockCursor([("agent:a",)])
+            raise AssertionError(sql)
+
+    store = object.__new__(PostgresGraphStore)
+    monkeypatch.setattr(store, "_filtered_edge_rows", lambda *_args, **_kwargs: ([], True))
+
+    result = store._walk_graph(
+        WalkConnection(),
+        tenant_id="tenant-alpha",
+        scan_id="scan-limited",
+        roots=["agent:a"],
+        direction="forward",
+        max_depth=4,
+        max_nodes=100,
+        max_edges=100,
+        deadline_monotonic=None,
+        traversable_only=False,
+        relationship_types=None,
+        static_only=False,
+        dynamic_only=False,
+        include_roots=True,
+    )
+
+    assert result[-1] is True
+
+
 def test_graph_store_save_graph_batches_postgres_writes(mock_pool, mock_maintenance_pool, monkeypatch):
     from agent_bom.api.postgres_store import PostgresGraphStore
     from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedGraph, UnifiedNode

--- a/tests/test_siem_push.py
+++ b/tests/test_siem_push.py
@@ -418,6 +418,34 @@ def test_siem_send_uses_governed_delivery_client(connector_type, config, sample_
     assert delivery.idempotency_key
 
 
+def test_siem_private_network_approval_reaches_governed_destination(sample_event):
+    config = SIEMConfig(
+        name="splunk",
+        url="http://127.0.0.1:8088",
+        token="splunk-token",
+        allow_private_networks=True,
+    )
+    captured: dict[str, object] = {}
+    client = MagicMock()
+
+    def _deliver(destination, delivery):
+        captured["destination"] = destination
+        return DeliveryResult(
+            idempotency_key=delivery.idempotency_key,
+            destination_id=destination.destination_id,
+            status="delivered",
+            http_status=200,
+            attempts=1,
+            delivered=True,
+        )
+
+    client.deliver.side_effect = _deliver
+    with patch("agent_bom.delivery.get_delivery_client", return_value=client):
+        assert SplunkHEC(config).send_event(sample_event) is True
+
+    assert captured["destination"].allow_private_networks is True
+
+
 def test_siem_delivery_failure_preserves_boolean_contract(splunk_config, sample_event):
     client = MagicMock()
     client.deliver.return_value = DeliveryResult(


### PR DESCRIPTION
## Summary

- start the findings facet-processing deadline after the first row is available and preserve the list-path total when a partial facet walk processes zero rows
- carry explicit private-network approval from SIEM configuration through the governed delivery destination, while treating outbound-policy rejection as permanent
- use a LIMIT+1 sentinel for Postgres graph edge reads and propagate omitted rows into graph-walk truncation metadata

## Verification

- `uv run pytest -q tests/test_findings_facets_export_contract.py tests/test_delivery_foundation.py tests/test_siem_push.py tests/test_postgres_store.py` (175 passed)
- `uv run pytest -q tests/test_graph_api.py tests/api/test_graph_scope_contract.py` (77 passed)
- `make lint` (Ruff clean; mypy clean across 814 source files)
- `make preflight` (OpenAPI, schemas, capability manifest, product surfaces, release consistency, env vars, SDK patterns, and SVG checks passed)
- `git diff --cached --check`

## Notes

The new focused tests were observed failing on `main` before the implementation: delayed facet setup returned a zero total, outbound policy rejection consumed all retry attempts, private SIEM approval did not reach transport, and graph query-limit omissions were not represented in walk completeness.