### PR TITLE
fix(models): surface malicious artifacts as findings

### DIFF
--- a/src/agent_bom/cli/agents/_post.py
+++ b/src/agent_bom/cli/agents/_post.py
@@ -387,8 +387,9 @@ def compute_exit_code(
             for finding in report.to_findings():
                 if getattr(finding, "is_malicious", False):
                     if not quiet:
-                        reason = finding.malicious_reason or "known malicious package"
-                        con.print(f"\n  [red]Exiting with code 1: malicious package {finding.asset.name} ({reason})[/red]")
+                        asset_kind = "package" if finding.asset.asset_type == "package" else finding.asset.asset_type.replace("_", " ")
+                        reason = finding.malicious_reason or f"known malicious {asset_kind}"
+                        con.print(f"\n  [red]Exiting with code 1: malicious {asset_kind} {finding.asset.name} ({reason})[/red]")
                     exit_code = 1
                     break
             if exit_code == 0:

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2270,7 +2270,13 @@ def scan(
             con.print("  [cyan]>[/cyan] Auto-detected model files in project — scanning...")
 
     if not skill_only and model_dirs:
-        from agent_bom.model_files import check_sigstore_signature, scan_model_files, scan_model_manifests, verify_model_hash
+        from agent_bom.model_files import (
+            check_sigstore_signature,
+            model_file_findings,
+            scan_model_files,
+            scan_model_manifests,
+            verify_model_hash,
+        )
 
         for mdir in model_dirs:
             con.print(f"  [cyan]>[/cyan] Scanning for model files in {mdir}...")
@@ -2288,6 +2294,10 @@ def scan(
                     mf["signature_path"] = sig_result["signature_path"]
                     mf["security_flags"].extend(sig_result["security_flags"])
             report.model_files.extend(mf_results)
+            _existing_finding_ids = {finding.id for finding in report.findings}
+            report.findings.extend(
+                finding for finding in model_file_findings(mf_results) if finding.id not in _existing_finding_ids
+            )
             report.model_manifests.extend(manifest_results)
             for w in mf_warnings:
                 con.print(f"  [yellow]⚠[/yellow] {w}")

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -55,6 +55,7 @@ class FindingType(str, Enum):
     MCP_BLOCKLIST = "MCP_BLOCKLIST"  # Curated malicious/suspicious MCP server match
     COMBINATION = "COMBINATION"  # Toxic combination — multiple signals chained into one exploitable path
     MALICIOUS_PACKAGE = "MALICIOUS_PACKAGE"  # Known-malicious / typosquat package with no CVE row
+    MALICIOUS_MODEL = "MALICIOUS_MODEL"  # Content-confirmed executable payload in a model artifact
     CIEM_OVER_PRIVILEGE = "CIEM_OVER_PRIVILEGE"  # Cloud identity granted permissions it never uses (right-sizing)
     SENSITIVE_DATA = "SENSITIVE_DATA"  # Content-confirmed sensitive data at rest (DSPM object/database sampling)
 
@@ -77,6 +78,7 @@ class FindingSource(str, Enum):
     SECRET_SCAN = "SECRET_SCAN"  # hardcoded secret / PII scanner
     GRAPH_ANALYSIS = "GRAPH_ANALYSIS"  # graph-level correlation (toxic combinations, attack-path fusion)
     DSPM = "DSPM"  # data security posture content classifier (S3/GCS/Azure Blob/database sampling)
+    MODEL_SCAN = "MODEL_SCAN"  # static model-artifact safety scanner
 
 
 @dataclass(frozen=True)

--- a/src/agent_bom/finding_scope.py
+++ b/src/agent_bom/finding_scope.py
@@ -72,7 +72,7 @@ FINDING_SEVERITY_FILTERS: tuple[FindingSeverityFilter, ...] = (
     "unknown",
 )
 
-_VULNERABILITY_TYPES = {"CVE", "MALICIOUS_PACKAGE", "SAST"}
+_VULNERABILITY_TYPES = {"CVE", "MALICIOUS_PACKAGE", "MALICIOUS_MODEL", "SAST"}
 _MISCONFIGURATION_TYPES = {
     "CIS_FAIL",
     "CIS_ERROR",
@@ -328,7 +328,7 @@ def security_lenses_for(
     )
 
     # Vulnerability-management lens.
-    if finding_type in (FindingType.CVE, FindingType.MALICIOUS_PACKAGE, FindingType.LICENSE):
+    if finding_type in (FindingType.CVE, FindingType.MALICIOUS_PACKAGE, FindingType.MALICIOUS_MODEL, FindingType.LICENSE):
         lenses.add("vuln")
     if not is_code_or_secret and source in (
         FindingSource.CONTAINER,

--- a/src/agent_bom/framework_mapping.py
+++ b/src/agent_bom/framework_mapping.py
@@ -308,6 +308,7 @@ _SOURCE_BASELINE: dict[FindingSource, tuple[str, ...]] = {
         FRAMEWORK_CIS,
         FRAMEWORK_SOC2,
     ),
+    FindingSource.MODEL_SCAN: _AI_FRAMEWORKS,
     FindingSource.EXTERNAL: _EXTERNAL_BASELINE,
 }
 
@@ -320,6 +321,7 @@ _ASSET_TYPE_ADDITIONS: dict[str, tuple[str, ...]] = {
     "tool": _AI_FRAMEWORKS,
     "skill": _AI_FRAMEWORKS,
     "container": _CONTAINER_FRAMEWORKS,
+    "model_file": _AI_FRAMEWORKS,
     "cloud_resource": _CLOUD_POSTURE_FRAMEWORKS,
     "iac_resource": (FRAMEWORK_CIS, FRAMEWORK_NIST_800_53, FRAMEWORK_FEDRAMP),
 }
@@ -332,6 +334,7 @@ _FINDING_TYPE_ADDITIONS: dict[FindingType, tuple[str, ...]] = {
     FindingType.LICENSE: (FRAMEWORK_NIST_CSF, FRAMEWORK_SOC2),
     FindingType.INJECTION: _AI_FRAMEWORKS,
     FindingType.EXFILTRATION: _AI_FRAMEWORKS + (FRAMEWORK_SOC2,),
+    FindingType.MALICIOUS_MODEL: _AI_FRAMEWORKS,
     FindingType.CIS_FAIL: (FRAMEWORK_CIS,),
     FindingType.CIS_ERROR: (FRAMEWORK_CIS,),
     FindingType.CLOUD_BEST_PRACTICE_FAIL: (),

--- a/src/agent_bom/model_files.py
+++ b/src/agent_bom/model_files.py
@@ -12,9 +12,13 @@ import logging
 import os
 import tempfile
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from agent_bom.floating_refs import classify_model_revision, is_hex_digest
 from agent_bom.model_pickle_scan import PICKLE_BEARING_EXTENSIONS, scan_pickle_file_flags
+
+if TYPE_CHECKING:
+    from agent_bom.finding import Finding
 
 logger = logging.getLogger(__name__)
 
@@ -290,6 +294,82 @@ def scan_model_files(
         results_by_path[path_str] = entry
 
     return results, warnings
+
+
+def model_file_findings(model_files: list[dict]) -> list["Finding"]:
+    """Convert content-confirmed malicious model flags to unified findings.
+
+    Extension-only warnings such as ``PICKLE_DESERIALIZATION`` describe an
+    unsafe format, not a proven malicious payload, and intentionally remain
+    inventory metadata. Only ``MALICIOUS_PICKLE`` flags emitted by bounded
+    static opcode disassembly are promoted to fail-closed findings.
+    """
+    from agent_bom.compliance_hub import apply_hub_classification
+    from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+    from agent_bom.security import sanitize_text
+
+    findings: list[Finding] = []
+    seen_ids: set[str] = set()
+    for model_file in model_files:
+        if not isinstance(model_file, dict):
+            continue
+        path = sanitize_text(model_file.get("path", "") or "", max_len=1000)
+        filename = sanitize_text(model_file.get("filename", "") or Path(path).name or "model artifact", max_len=255)
+        for raw_flag in model_file.get("security_flags", []) or []:
+            if not isinstance(raw_flag, dict) or raw_flag.get("type") != "MALICIOUS_PICKLE":
+                continue
+            description = sanitize_text(
+                raw_flag.get("description", "") or "Static pickle analysis found an executable payload.",
+                max_len=2000,
+            )
+            dangerous_imports = [
+                sanitize_text(value, max_len=200)
+                for value in raw_flag.get("dangerous_imports", []) or []
+                if isinstance(value, str)
+            ][:32]
+            code_exec_opcodes = [
+                sanitize_text(value, max_len=80)
+                for value in raw_flag.get("code_exec_opcodes", []) or []
+                if isinstance(value, str)
+            ][:32]
+            finding = apply_hub_classification(
+                Finding(
+                    finding_type=FindingType.MALICIOUS_MODEL,
+                    source=FindingSource.MODEL_SCAN,
+                    asset=Asset(
+                        name=filename,
+                        asset_type="model_file",
+                        identifier=path or filename,
+                        location=path or None,
+                    ),
+                    severity=str(raw_flag.get("severity") or "critical"),
+                    title=f"Malicious model payload: {filename}",
+                    description=description,
+                    cwe_ids=["CWE-502"],
+                    is_malicious=True,
+                    malicious_reason="Content-confirmed executable pickle payload",
+                    remediation_guidance=(
+                        "Quarantine the artifact, verify its publisher and digest, and replace it with a trusted "
+                        "safetensors or ONNX artifact. Do not deserialize the flagged file."
+                    ),
+                    is_actionable=True,
+                    risk_score=10.0,
+                    evidence={
+                        "detector": "pickletools-static-disassembly",
+                        "detection_type": "MALICIOUS_PICKLE",
+                        "format": sanitize_text(model_file.get("format", "") or "", max_len=120),
+                        "extension": sanitize_text(model_file.get("extension", "") or "", max_len=40),
+                        "size_bytes": model_file.get("size_bytes") if isinstance(model_file.get("size_bytes"), int) else None,
+                        "dangerous_imports": dangerous_imports,
+                        "code_exec_opcodes": code_exec_opcodes,
+                        "deserialized": False,
+                    },
+                )
+            )
+            if finding.id not in seen_ids:
+                findings.append(finding)
+                seen_ids.add(finding.id)
+    return findings
 
 
 def scan_model_manifests(

--- a/tests/test_model_pickle_scan.py
+++ b/tests/test_model_pickle_scan.py
@@ -11,13 +11,17 @@ embedded ``__reduce__``. The scanner under test never deserializes either.
 from __future__ import annotations
 
 import io
+import json
 import pickle
 import zipfile
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from click.testing import CliRunner
 
 from agent_bom import model_pickle_scan
+from agent_bom.cli import main
 from agent_bom.model_files import scan_model_files
 from agent_bom.model_pickle_scan import scan_pickle_file, scan_pickle_file_flags
 
@@ -211,6 +215,109 @@ def test_wired_into_scan_model_files(tmp_path: Path):
     crit = [f for f in flags if f["type"] == "MALICIOUS_PICKLE"][0]
     assert crit["severity"] == "CRITICAL"
     assert any("MALICIOUS_PICKLE" in w for w in warnings)
+
+
+def test_malicious_pickle_becomes_canonical_finding(tmp_path: Path):
+    """Content-confirmed malicious models must enter the unified finding stream."""
+    from agent_bom.finding import FindingSource, FindingType
+    from agent_bom.model_files import model_file_findings
+
+    model = tmp_path / "model.pkl"
+    model.write_bytes(_malicious_bytes())
+    results, _ = scan_model_files(tmp_path)
+
+    findings = model_file_findings(results)
+
+    assert len(findings) == 1
+    finding = findings[0]
+    assert finding.finding_type is FindingType.MALICIOUS_MODEL
+    assert finding.source is FindingSource.MODEL_SCAN
+    assert finding.severity == "critical"
+    assert finding.asset.asset_type == "model_file"
+    assert finding.asset.location == str(model)
+    assert finding.is_malicious is True
+    assert finding.is_actionable is True
+    assert finding.cwe_ids == ["CWE-502"]
+    assert finding.evidence["detector"] == "pickletools-static-disassembly"
+    assert finding.security_domain == "aispm"
+    assert finding.applicable_frameworks
+    assert "echo pwned" not in json.dumps(finding.to_dict())
+    assert model_file_findings(results)[0].id == finding.id
+
+
+def test_unsafe_but_benign_pickle_does_not_become_malicious_finding(tmp_path: Path):
+    """The extension-only pickle warning is not a content-confirmed malicious result."""
+    from agent_bom.model_files import model_file_findings
+
+    (tmp_path / "benign.pkl").write_bytes(pickle.dumps([1, 2, 3]))
+    results, _ = scan_model_files(tmp_path)
+
+    assert model_file_findings(results) == []
+
+
+def test_scan_cli_gates_on_malicious_model_finding(tmp_path: Path):
+    """A malicious model must be visible in JSON and fail the normal CI severity gate."""
+    model = tmp_path / "model.pkl"
+    model.write_bytes(_malicious_bytes())
+    output = tmp_path / "report.json"
+
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=[]),
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+    ):
+        result = CliRunner().invoke(
+            main,
+            [
+                "scan",
+                "--model-files",
+                str(tmp_path),
+                "--no-discover",
+                "--no-scan",
+                "--no-auto-update-db",
+                "--fail-on-severity",
+                "critical",
+                "--format",
+                "json",
+                "--output",
+                str(output),
+            ],
+            catch_exceptions=False,
+        )
+
+    assert result.exit_code == 1
+    assert "found critical finding (MALICIOUS_MODEL)" in result.output
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    finding = next(item for item in payload["findings"] if item["finding_type"] == "MALICIOUS_MODEL")
+    assert finding["severity"] == "critical"
+    assert finding["asset"]["name"] == model.name
+    assert finding["evidence"]["deserialized"] is False
+
+    default_gate_output = tmp_path / "default-gate.json"
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=[]),
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+    ):
+        default_gate = CliRunner().invoke(
+            main,
+            [
+                "scan",
+                "--model-files",
+                str(tmp_path),
+                "--no-discover",
+                "--no-scan",
+                "--no-auto-update-db",
+                "--format",
+                "json",
+                "--output",
+                str(default_gate_output),
+            ],
+            catch_exceptions=False,
+        )
+
+    assert default_gate.exit_code == 1
+    assert "malicious model file model.pkl" in default_gate.output
 
 
 def test_wired_benign_pickle_only_extension_flag(tmp_path: Path):


### PR DESCRIPTION
## Summary

- promote content-confirmed `MALICIOUS_PICKLE` model detections into the canonical finding stream as `MALICIOUS_MODEL`
- classify model findings under AISPM with stable model-file identity, CWE-502, actionable remediation, and static-analysis evidence
- preserve extension-only pickle warnings as inventory metadata so benign pickle files are not mislabeled as malicious
- route malicious model findings through JSON/SARIF-compatible unified outputs and fail-closed CLI severity/malicious-artifact gates

## Root cause

The model-file scanner attached malicious pickle detections only to `model_files[].security_flags`. The scan command never adapted those flags into `report.findings`, so unified outputs and CI exit gates could not observe them.

## Verification

- `uv run pytest -q tests/test_model_pickle_scan.py tests/test_finding.py tests/test_finding_scope.py tests/test_compliance_hub.py tests/test_two_tier_severity.py tests/test_output_formats.py tests/test_sarif_schema_2_1_0.py` — 214 passed
- targeted adapter and CLI gate regression tests — 3 passed
- `make lint`
- `make preflight`
- real offline CLI smoke with a safely serialized malicious pickle fixture: emitted one critical `MALICIOUS_MODEL` finding with `deserialized: false` and exited 1 at `--fail-on-severity critical`

## Notes

The scanner continues to use bounded `pickletools` opcode disassembly and never deserializes the model artifact.