### PR TITLE
fix(graph): scope credential identity to servers

### DIFF
--- a/src/agent_bom/a2a_auth_posture.py
+++ b/src/agent_bom/a2a_auth_posture.py
@@ -11,9 +11,8 @@ mint or exchange tokens, and never emits secret values. It inspects discovered
 agents, gateway/proxy policies, and delegation chains and flags four classes of
 weakness as unified :class:`~agent_bom.finding.Finding` objects:
 
-1. **Long-lived / shared credentials between agents** — one static token (or a
-   credential env var) feeding multiple agents, violating short-lived-token
-   policy.
+1. **Long-lived / shared credentials between agents** — one static token
+   explicitly mapped to multiple agents, violating short-lived-token policy.
 2. **Missing mutual auth** — an agent-to-agent or agent-to-MCP edge with no
    verified caller identity (``require_agent_identity`` off) or no
    ``bound_agents`` restriction (wildcard / unbounded delegation).
@@ -242,8 +241,12 @@ def _agent_asset(agent: Agent) -> Asset:
     return Asset(name=agent.name, asset_type="agent", identifier=agent.canonical_id, location=agent.config_path or None)
 
 
-def _detect_shared_credentials(agents: list[Agent], policies: list[A2APolicyView]) -> list[Finding]:
-    """Weakness 1: long-lived / shared credentials between agents."""
+def _detect_shared_credentials(_agents: list[Agent], policies: list[A2APolicyView]) -> list[Finding]:
+    """Weakness 1: credentials explicitly shared between agents.
+
+    Credential env-var names are intentionally excluded: a common name such as
+    ``GITHUB_TOKEN`` does not prove two agent processes resolve the same secret.
+    """
     findings: list[Finding] = []
 
     # 1a. One opaque gateway/proxy token mapped to multiple agent_ids.
@@ -277,31 +280,6 @@ def _detect_shared_credentials(agents: list[Agent], policies: list[A2APolicyView
                     },
                     remediation="Issue a unique short-lived credential per agent; never map one static token to many agents.",
                     risk_score=7.5,
-                    weakness="shared_credentials",
-                )
-            )
-
-    # 1b. The same credential env-var name feeding multiple agents' servers.
-    cred_to_agents: dict[str, set[str]] = defaultdict(set)
-    for agent in agents:
-        for server in agent.mcp_servers:
-            for cred in server.credential_names:
-                cred_to_agents[cred].add(agent.name)
-    for cred, agent_names in sorted(cred_to_agents.items()):
-        if len(agent_names) >= A2A_AUTH_SHARED_TOKEN_MIN_AGENTS:
-            findings.append(
-                _finding(
-                    title="Shared credential referenced across multiple agents",
-                    description=(
-                        f"Credential env var {cred!r} is referenced by {len(agent_names)} agents "
-                        f"({', '.join(sorted(agent_names))}). A credential shared across agents cannot be "
-                        "rotated or revoked per agent and widens the blast radius of any single compromise."
-                    ),
-                    severity="medium",
-                    asset=Asset(name=cred, asset_type="agent", identifier=f"a2a:shared-cred:{cred}"),
-                    evidence={"credential_ref": cred, "agents": sorted(agent_names), "agent_count": len(agent_names)},
-                    remediation="Scope each credential to a single agent identity and rotate on a short interval.",
-                    risk_score=5.5,
                     weakness="shared_credentials",
                 )
             )

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -2125,10 +2125,9 @@ def scan(
                 con.print(f"  [red]⚠[/red] Findings — {_u_str} [dim](all finding categories)[/dim]")
 
     # ── Context graph: lateral movement analysis ────────────────────
-    # Build whenever requested — credential pivots / SHARES_CREDENTIAL lateral
-    # edges exist independent of any CVE, so gating on blast_radii hid the
-    # credential lateral graph for vuln-free estates (the case credential-risk
-    # ranking already surfaces without a CVE).
+    # Build whenever requested — credential exposure and tool-reach edges exist
+    # independent of any CVE, so gating on blast_radii would hide the credential
+    # graph for vulnerability-free estates.
     if context_graph_flag:
         from agent_bom.context_graph import (
             build_context_graph,

--- a/src/agent_bom/context_graph.py
+++ b/src/agent_bom/context_graph.py
@@ -171,9 +171,8 @@ def build_context_graph(
     """
     graph = ContextGraph()
 
-    # Track which agents use which server names / credential names
+    # Track which agents use which server names.
     server_to_agents: dict[str, list[str]] = defaultdict(list)
-    cred_to_agents: dict[str, list[str]] = defaultdict(list)
 
     # ── Build agent → server → credential / tool nodes & edges ────────
     for agent_dict in agents_data:
@@ -246,26 +245,24 @@ def build_context_graph(
             # Credentials. The serialized scan contract surfaces credential env
             # var names via ``credential_env_vars`` (the canonical builder writes
             # them there and leaves ``env`` empty/redacted in output), so reading
-            # only ``env`` produced zero credential nodes — and zero
-            # SHARES_CREDENTIAL lateral edges — on real scan JSON. Read both:
-            # the explicit credential list plus any credential-looking inline env
-            # keys, deduped.
+            # only ``env`` produced zero credential nodes on real scan JSON. Read
+            # both the explicit credential list and any credential-looking inline
+            # env keys, deduped within this server.
             cred_keys = list(srv_dict.get("credential_env_vars", []))
             cred_keys += [k for k in srv_dict.get("env", {}) if _is_credential_key(k)]
             for env_key in dict.fromkeys(cred_keys):
-                cred_id = f"cred:{env_key}"
-                if cred_id not in graph.nodes:
-                    graph.add_node(
-                        GraphNode(
-                            id=cred_id,
-                            kind=NodeKind.CREDENTIAL,
-                            label=env_key,
-                            metadata={"servers": []},
-                        )
+                # The report carries only a credential env-var name, not proof
+                # that two servers resolve it to the same secret.  Keep each
+                # credential slot server-scoped and fail closed on correlation.
+                cred_id = f"cred:{srv_id}:{env_key}"
+                graph.add_node(
+                    GraphNode(
+                        id=cred_id,
+                        kind=NodeKind.CREDENTIAL,
+                        label=env_key,
+                        metadata={"server": srv_id, "servers": [srv_id]},
                     )
-                # Track which servers expose this credential
-                if srv_id not in graph.nodes[cred_id].metadata["servers"]:
-                    graph.nodes[cred_id].metadata["servers"].append(srv_id)
+                )
                 graph.add_edge(
                     GraphEdge(
                         source=srv_id,
@@ -274,7 +271,6 @@ def build_context_graph(
                         weight=2.0,
                     )
                 )
-                cred_to_agents[env_key].append(agent_name)
 
             # Tools
             for tool_dict in srv_dict.get("tools", []):
@@ -395,54 +391,6 @@ def build_context_graph(
                                 kind=EdgeKind.SHARES_SERVER,
                                 weight=3.0,
                                 metadata={"server": _srv_name},
-                            )
-                        )
-
-    # ── Shared credential edges ──────────────────────────────────────
-    # Deduplication is now handled by ContextGraph.add_edge() in O(1).
-    for _cred_name, agent_names in cred_to_agents.items():
-        unique = sorted(set(agent_names))
-        if len(unique) >= 2:
-            metadata: dict[str, object] = {"credential": _cred_name}
-            if len(unique) > _MAX_PAIRWISE_SHARED_AGENTS:
-                # The canonical credential node already connects all of its
-                # servers.  Add one linear agent→credential edge per member;
-                # reverse adjacency lets BFS discover the other agents without
-                # materializing every pair.
-                cred_id = f"cred:{_cred_name}"
-                if cred_id in graph.nodes:
-                    graph.nodes[cred_id].metadata.update(
-                        {
-                            "shared_group": True,
-                            "shared_agent_count": len(unique),
-                            "shared_agents": unique,
-                        }
-                    )
-                metadata = {
-                    **metadata,
-                    "shared_group": True,
-                    "shared_agent_count": len(unique),
-                }
-                for agent_name in unique:
-                    graph.add_edge(
-                        GraphEdge(
-                            source=f"agent:{agent_name}",
-                            target=cred_id,
-                            kind=EdgeKind.SHARES_CREDENTIAL,
-                            weight=4.0,
-                            metadata=metadata,
-                        )
-                    )
-            else:
-                for i, a1 in enumerate(unique):
-                    for a2 in unique[i + 1 :]:
-                        graph.add_edge(
-                            GraphEdge(
-                                source=f"agent:{a1}",
-                                target=f"agent:{a2}",
-                                kind=EdgeKind.SHARES_CREDENTIAL,
-                                weight=4.0,
-                                metadata=metadata,
                             )
                         )
 

--- a/src/agent_bom/graph/builder.py
+++ b/src/agent_bom/graph/builder.py
@@ -87,7 +87,6 @@ def build_unified_graph_from_report(
 
     # Track shared resources for lateral movement edges
     server_to_agents: dict[str, list[str]] = defaultdict(list)
-    cred_to_agents: dict[str, list[str]] = defaultdict(list)
     # Track server/package indexes for vuln edges
     pkg_key_to_servers: dict[str, list[str]] = defaultdict(list)
     package_name_to_ids: dict[str, list[str]] = defaultdict(list)
@@ -355,7 +354,11 @@ def build_unified_graph_from_report(
                 if isinstance(env_dict, dict):
                     env_keys = [k for k in env_dict if _is_credential_key(k)]
             for env_key in env_keys:
-                cred_id = f"cred:{env_key}"
+                # An env-var name identifies a credential slot on this server,
+                # not the underlying secret.  Scoping the node prevents common
+                # names such as GITHUB_TOKEN from merging unrelated credentials
+                # and fabricating cross-agent blast radius.
+                cred_id = f"cred:{srv_id}:{env_key}"
                 graph.add_node(
                     UnifiedNode(
                         id=cred_id,
@@ -363,7 +366,8 @@ def build_unified_graph_from_report(
                         label=env_key,
                         attributes={
                             "canonical_id": canonical_graph_node_id(EntityType.CREDENTIAL.value, cred_id),
-                            "source_ids": source_ids(env_key=env_key),
+                            "source_ids": source_ids(env_key=env_key, server_id=srv_id),
+                            "server": srv_id,
                             "servers": [srv_id],
                         },
                         data_sources=[data_source_tag],
@@ -377,7 +381,6 @@ def build_unified_graph_from_report(
                         weight=2.0,
                     )
                 )
-                cred_to_agents[env_key].append(agent_id)
                 for tool_id in tool_ids:
                     graph.add_edge(
                         UnifiedEdge(
@@ -523,23 +526,6 @@ def build_unified_graph_from_report(
                             direction="bidirectional",
                             weight=3.0,
                             evidence={"server": srv_name},
-                        )
-                    )
-
-    # ── Shared credential edges (agent ↔ agent) ─────────────────────
-    for cred_name, agent_names in cred_to_agents.items():
-        unique = sorted(set(agent_names))
-        if len(unique) >= 2:
-            for i, a1 in enumerate(unique):
-                for a2 in unique[i + 1 :]:
-                    graph.add_edge(
-                        UnifiedEdge(
-                            source=a1,
-                            target=a2,
-                            relationship=RelationshipType.SHARES_CRED,
-                            direction="bidirectional",
-                            weight=4.0,
-                            evidence={"credential": cred_name},
                         )
                     )
 

--- a/src/agent_bom/output/graph_export.py
+++ b/src/agent_bom/output/graph_export.py
@@ -203,7 +203,10 @@ def build_graph_from_scan_data(data: dict[str, Any]) -> DepGraph:
                 tool_ids.append((tool_name, tool_id))
 
             for cred_name in _credential_names_from_server(server):
-                cred_id = f"cred:{cred_name}"
+                # Env-var names are credential slots, not globally identifying
+                # secret material.  Scope them to the server to prevent the
+                # export from inventing cross-server reachability.
+                cred_id = f"cred:{srv_id}:{cred_name}"
                 graph.add_node(cred_id, cred_name, "credential", attributes={"server": srv_id})
                 graph.add_edge(srv_id, cred_id, "exposes_cred")
                 for tool_name, tool_id in tool_ids:

--- a/tests/_graph_helpers.py
+++ b/tests/_graph_helpers.py
@@ -43,13 +43,12 @@ def load_self_scan_fixture() -> dict[str, Any]:
 
 
 def synthetic_inventory() -> dict[str, Any]:
-    """Tiny deterministic inventory: 3 agents, 5 packages, 2 CVEs, 2 credentials.
+    """Tiny inventory: 3 agents, 5 packages, 2 CVEs, 3 credential slots.
 
     Designed to exercise every ``EdgeKind`` produced by the builder:
 
     - USES, PROVIDES, EXPOSES, VULNERABLE_TO
     - SHARES_SERVER (agents A & B both use ``filesystem``)
-    - SHARES_CREDENTIAL (agents A & B both expose ``GITHUB_TOKEN``)
     - ATTACHED_TO (agent A has a cloud_principal in metadata)
     """
     return {
@@ -169,7 +168,7 @@ def expected_inventory_sets(inv: dict[str, Any]) -> dict[str, set[str]]:
     agents: set[str] = set()
     servers: set[str] = set()  # ``server:<agent>:<name>``
     tools: set[str] = set()  # ``tool:server:<agent>:<server>:<name>``
-    credentials: set[str] = set()  # ``cred:<env_key>``
+    credentials: set[str] = set()  # ``cred:<server_id>:<env_key>``
     iam_roles: set[str] = set()  # ``iam_role:<principal_id>``
     vulnerabilities: set[str] = set()  # ``vuln:<id>``
 
@@ -193,7 +192,7 @@ def expected_inventory_sets(inv: dict[str, Any]) -> dict[str, set[str]]:
             servers.add(srv_id)
             for env_key in srv.get("env") or {}:
                 if is_credential_key(env_key):
-                    credentials.add(f"cred:{env_key}")
+                    credentials.add(f"cred:{srv_id}:{env_key}")
             for tool in srv.get("tools", []) or []:
                 t_name = tool.get("name", "")
                 if t_name:

--- a/tests/test_a2a_auth_posture.py
+++ b/tests/test_a2a_auth_posture.py
@@ -49,17 +49,14 @@ def test_shared_static_token_across_agents_flagged() -> None:
     assert "static-token-xyz" not in str(f.to_dict())
 
 
-def test_shared_credential_env_var_across_agents_flagged() -> None:
+def test_shared_credential_env_var_name_across_agents_is_not_flagged() -> None:
     server_a = MCPServer(name="db", env={"SHARED_API_TOKEN": "x"})
     server_b = MCPServer(name="db2", env={"SHARED_API_TOKEN": "y"})
     findings = evaluate_a2a_auth_posture(
         [_agent("a", servers=[server_a]), _agent("b", servers=[server_b])],
     )
     shared = [f for f in findings if f.evidence.get("credential_ref") == "SHARED_API_TOKEN"]
-    assert shared
-    assert set(shared[0].evidence["agents"]) == {"a", "b"}
-    # Secret value must not leak.
-    assert '"x"' not in str(shared[0].to_dict())
+    assert shared == []
 
 
 # ── Weakness 2: missing mutual auth ──────────────────────────────────────────

--- a/tests/test_context_graph.py
+++ b/tests/test_context_graph.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from agent_bom.context_graph import (
     ContextGraph,
     EdgeKind,
+    GraphEdge,
+    GraphNode,
     NodeKind,
     build_context_graph,
     collect_lateral_paths,
@@ -106,10 +108,11 @@ class TestBuildGraph:
     def test_credential_nodes(self):
         agents = [_agent(servers=[_server(env={"GITHUB_TOKEN": "xxx", "PATH": "/usr/bin"})])]
         graph = build_context_graph(agents, [])
-        assert "cred:GITHUB_TOKEN" in graph.nodes
-        assert graph.nodes["cred:GITHUB_TOKEN"].kind == NodeKind.CREDENTIAL
+        credential_id = "cred:server:agent-a:filesystem:GITHUB_TOKEN"
+        assert credential_id in graph.nodes
+        assert graph.nodes[credential_id].kind == NodeKind.CREDENTIAL
         # PATH should not be a credential
-        assert "cred:PATH" not in graph.nodes
+        assert "cred:server:agent-a:filesystem:PATH" not in graph.nodes
         exposes = [e for e in graph.edges if e.kind == EdgeKind.EXPOSES]
         assert len(exposes) == 1
 
@@ -124,16 +127,30 @@ class TestBuildGraph:
             "credential_env_vars": ["AWS_SECRET_ACCESS_KEY", "GITHUB_TOKEN"],
         }
         graph = build_context_graph([_agent(servers=[server])], [])
-        assert "cred:AWS_SECRET_ACCESS_KEY" in graph.nodes
-        assert "cred:GITHUB_TOKEN" in graph.nodes
-        assert graph.nodes["cred:AWS_SECRET_ACCESS_KEY"].kind == NodeKind.CREDENTIAL
+        aws_credential_id = "cred:server:agent-a:aws-ops:AWS_SECRET_ACCESS_KEY"
+        github_credential_id = "cred:server:agent-a:aws-ops:GITHUB_TOKEN"
+        assert aws_credential_id in graph.nodes
+        assert github_credential_id in graph.nodes
+        assert graph.nodes[aws_credential_id].kind == NodeKind.CREDENTIAL
         exposes = [e for e in graph.edges if e.kind == EdgeKind.EXPOSES]
         assert len(exposes) == 2
 
-    def test_shares_credential_edge_from_credential_env_vars(self):
-        # Two agents whose servers expose the same credential (surfaced via
-        # credential_env_vars) must yield a SHARES_CREDENTIAL lateral edge —
-        # previously lost because no credential nodes were built from output JSON.
+    def test_same_env_var_name_does_not_merge_credential_slots(self):
+        agents = [
+            _agent(name="a1", servers=[{**_server(name="s1"), "credential_env_vars": ["DATABASE_URL"]}]),
+            _agent(name="a2", servers=[{**_server(name="s2"), "credential_env_vars": ["DATABASE_URL"]}]),
+        ]
+
+        graph = build_context_graph(agents, [])
+
+        credential_ids = {node.id for node in graph.nodes.values() if node.kind == NodeKind.CREDENTIAL}
+        assert credential_ids == {
+            "cred:server:a1:s1:DATABASE_URL",
+            "cred:server:a2:s2:DATABASE_URL",
+        }
+        assert not any(edge.kind == EdgeKind.SHARES_CREDENTIAL for edge in graph.edges)
+
+    def test_credential_env_var_names_do_not_imply_sharing(self):
         def _cred_server(name):
             return {**_server(name=name), "env": {}, "credential_env_vars": ["DATABASE_URL"]}
 
@@ -143,7 +160,7 @@ class TestBuildGraph:
         ]
         graph = build_context_graph(agents, [])
         shares = [e for e in graph.edges if e.kind == EdgeKind.SHARES_CREDENTIAL]
-        assert len(shares) >= 1
+        assert shares == []
 
     def test_tool_nodes_with_capability(self):
         agents = [_agent(servers=[_server(tools=[_tool("execute_code", "Run arbitrary code")])])]
@@ -201,17 +218,16 @@ class TestBuildGraph:
         assert len(shares) == 1
         assert set([shares[0].source, shares[0].target]) == {"agent:agent-a", "agent:agent-b"}
 
-    def test_shared_credential_detection(self):
+    def test_different_values_under_same_env_name_are_not_correlated(self):
         agents = [
             _agent(name="agent-a", servers=[_server(env={"API_KEY": "xxx"})]),
             _agent(name="agent-b", servers=[_server(env={"API_KEY": "yyy"})]),
         ]
         graph = build_context_graph(agents, [])
         shares = [e for e in graph.edges if e.kind == EdgeKind.SHARES_CREDENTIAL]
-        assert len(shares) == 1
-        assert shares[0].metadata["credential"] == "API_KEY"
+        assert shares == []
 
-    def test_large_shared_groups_use_bounded_edges(self):
+    def test_large_same_name_credential_groups_do_not_fabricate_edges(self):
         def _shared_server(name):
             return {
                 **_server(name=name),
@@ -229,15 +245,16 @@ class TestBuildGraph:
         cred_shares = [e for e in graph.edges if e.kind == EdgeKind.SHARES_CREDENTIAL]
         # The old pairwise implementation emitted 4,950 edges per resource.
         assert len(server_shares) == 100
-        assert len(cred_shares) == 100
+        assert cred_shares == []
         assert "shared-server:shared-srv" in graph.nodes
-        assert graph.nodes["cred:SHARED_TOKEN"].metadata["shared_agent_count"] == 100
-        assert all("shared_agents" not in edge.metadata for edge in server_shares + cred_shares)
+        credential_nodes = [node for node in graph.nodes.values() if node.kind == NodeKind.CREDENTIAL]
+        assert len(credential_nodes) == 100
+        assert all("shared_agents" not in edge.metadata for edge in server_shares)
 
         risks = compute_interaction_risks(graph)
         patterns = {risk.pattern for risk in risks}
         assert "shared_server" in patterns
-        assert "shared_credential" in patterns
+        assert "shared_credential" not in patterns
 
 
 # ---------------------------------------------------------------------------
@@ -363,11 +380,17 @@ class TestLateralPaths:
 
 class TestInteractionRisks:
     def test_shared_credential_pattern(self):
-        agents = [
-            _agent(name="agent-a", servers=[_server(env={"DB_PASSWORD": "x"})]),
-            _agent(name="agent-b", servers=[_server(env={"DB_PASSWORD": "y"})]),
-        ]
-        graph = build_context_graph(agents, [])
+        graph = ContextGraph()
+        graph.add_node(GraphNode(id="agent:agent-a", kind=NodeKind.AGENT, label="agent-a"))
+        graph.add_node(GraphNode(id="agent:agent-b", kind=NodeKind.AGENT, label="agent-b"))
+        graph.add_edge(
+            GraphEdge(
+                source="agent:agent-a",
+                target="agent:agent-b",
+                kind=EdgeKind.SHARES_CREDENTIAL,
+                metadata={"credential": "DB_PASSWORD", "correlation": "explicit"},
+            )
+        )
         risks = compute_interaction_risks(graph)
         cred_risks = [r for r in risks if r.pattern == "shared_credential"]
         assert len(cred_risks) == 1
@@ -415,11 +438,17 @@ class TestInteractionRisks:
         assert len(risks) == 0
 
     def test_owasp_tag_assignment(self):
-        agents = [
-            _agent(name="agent-a", servers=[_server(env={"TOKEN": "x"})]),
-            _agent(name="agent-b", servers=[_server(env={"TOKEN": "y"})]),
-        ]
-        graph = build_context_graph(agents, [])
+        graph = ContextGraph()
+        graph.add_node(GraphNode(id="agent:agent-a", kind=NodeKind.AGENT, label="agent-a"))
+        graph.add_node(GraphNode(id="agent:agent-b", kind=NodeKind.AGENT, label="agent-b"))
+        graph.add_edge(
+            GraphEdge(
+                source="agent:agent-a",
+                target="agent:agent-b",
+                kind=EdgeKind.SHARES_CREDENTIAL,
+                metadata={"credential": "TOKEN", "correlation": "explicit"},
+            )
+        )
         risks = compute_interaction_risks(graph)
         cred_risks = [r for r in risks if r.pattern == "shared_credential"]
         assert cred_risks[0].owasp_agentic_tag == "ASI07"

--- a/tests/test_graph_builder.py
+++ b/tests/test_graph_builder.py
@@ -554,9 +554,21 @@ class TestBuildUnifiedGraphFromReport:
         assert "GITHUB_TOKEN" in labels
         assert "OPENAI_API_KEY" in labels
 
+    def test_same_env_var_name_does_not_merge_credential_slots(self):
+        report = _minimal_report()
+
+        g = build_unified_graph_from_report(report)
+
+        github_creds = {node.id for node in g.nodes_by_type(EntityType.CREDENTIAL) if node.label == "GITHUB_TOKEN"}
+        assert github_creds == {
+            "cred:server:claude-desktop:mcp-fs:GITHUB_TOKEN",
+            "cred:server:cursor:mcp-fs:GITHUB_TOKEN",
+        }
+        assert not any(edge.relationship == RelationshipType.SHARES_CRED for edge in g.edges)
+
     def test_credential_to_tool_reaches_edges(self):
         g = build_unified_graph_from_report(_minimal_report())
-        github_cred_id = "cred:GITHUB_TOKEN"
+        github_cred_id = "cred:server:claude-desktop:mcp-fs:GITHUB_TOKEN"
         read_tool_id = "tool:server:claude-desktop:mcp-fs:read_file"
         write_tool_id = "tool:server:claude-desktop:mcp-fs:write_file"
 
@@ -578,9 +590,11 @@ class TestBuildUnifiedGraphFromReport:
 
         g = build_unified_graph_from_report(report)
 
-        assert g.has_edge("cred:GITHUB_TOKEN", "tool:server:cursor:mcp-fs:delete_repo")
+        cursor_cred_id = "cred:server:cursor:mcp-fs:GITHUB_TOKEN"
+        claude_cred_id = "cred:server:claude-desktop:mcp-fs:OPENAI_API_KEY"
+        assert g.has_edge(cursor_cred_id, "tool:server:cursor:mcp-fs:delete_repo")
         assert not any(
-            edge.source == "cred:OPENAI_API_KEY"
+            edge.source == claude_cred_id
             and edge.target == "tool:server:cursor:mcp-fs:delete_repo"
             and edge.relationship == RelationshipType.REACHES_TOOL
             for edge in g.edges
@@ -718,11 +732,9 @@ class TestBuildUnifiedGraphFromReport:
         g = build_unified_graph_from_report(report)
         assert g.has_edge("server:claude-desktop:mcp-fs", "vuln:CVE-2024-1234")
 
-    def test_shared_credential_edge(self):
+    def test_same_env_var_name_does_not_create_shared_credential_edge(self):
         g = build_unified_graph_from_report(_minimal_report())
-        # Both agents expose GITHUB_TOKEN
-        has_share = any(e.relationship == RelationshipType.SHARES_CRED for e in g.edges)
-        assert has_share
+        assert not any(e.relationship == RelationshipType.SHARES_CRED for e in g.edges)
 
     def test_compliance_tags_on_vuln(self):
         g = build_unified_graph_from_report(_minimal_report())

--- a/tests/test_graph_edge_counts.py
+++ b/tests/test_graph_edge_counts.py
@@ -106,7 +106,6 @@ class TestSyntheticEdgeCounts:
             "provides",
             "vulnerable_to",
             "shares_server",
-            "shares_credential",
             "attached_to",
         }
         missing = required - set(counts.keys())
@@ -117,11 +116,9 @@ class TestSyntheticEdgeCounts:
         # agent-a and agent-b both use ``filesystem`` → exactly one SHARES_SERVER edge.
         assert counts["shares_server"] == 1
 
-    def test_synthetic_shares_credential_count(self, graph) -> None:
+    def test_synthetic_does_not_infer_shared_credentials_from_env_names(self, graph) -> None:
         counts = edge_counts_by_kind(graph)
-        # GITHUB_TOKEN is exposed by both agent-a and agent-b → exactly one
-        # SHARES_CREDENTIAL edge.
-        assert counts["shares_credential"] == 1
+        assert "shares_credential" not in counts
 
     def test_synthetic_attached_to_count(self, graph) -> None:
         counts = edge_counts_by_kind(graph)

--- a/tests/test_graph_export.py
+++ b/tests/test_graph_export.py
@@ -194,7 +194,7 @@ def test_credential_to_tool_reaches_edges_export_with_evidence():
         payload = to_json(graph)
         edge = next(edge for edge in payload["edges"] if edge["kind"] == "reaches_tool" and edge["target"].endswith("/delete_repo"))
 
-        assert edge["source"] == "cred:GITHUB_TOKEN"
+        assert edge["source"] == "cred:server:a/github:GITHUB_TOKEN"
         assert edge["evidence"]["mapping_method"] == "server_scope_conservative"
         assert edge["evidence"]["confidence"] == "medium"
         assert "|reaches_tool|" in to_mermaid(graph)
@@ -204,8 +204,34 @@ def test_credential_to_tool_reaches_edges_export_with_evidence():
         os.unlink(path)
 
 
+def test_same_env_var_name_stays_scoped_to_each_exported_server():
+    data = _make_scan_json(
+        [
+            _agent("a", [_server("github", tools=[{"name": "create_issue"}], credential_env_vars=["GITHUB_TOKEN"])]),
+            _agent("b", [_server("github", tools=[{"name": "delete_repo"}], credential_env_vars=["GITHUB_TOKEN"])]),
+        ]
+    )
+    path = _write_scan(data)
+    try:
+        graph = load_graph_from_scan(path)
+    finally:
+        os.unlink(path)
+
+    credential_ids = {node.id for node in graph.nodes if node.kind == "credential"}
+    assert credential_ids == {
+        "cred:server:a/github:GITHUB_TOKEN",
+        "cred:server:b/github:GITHUB_TOKEN",
+    }
+    for edge in graph.edges:
+        if edge.kind != "reaches_tool":
+            continue
+        credential = next(node for node in graph.nodes if node.id == edge.source)
+        tool = next(node for node in graph.nodes if node.id == edge.target)
+        assert credential.attributes["server"] == tool.attributes["server"]
+
+
 def test_redacted_report_keeps_distinct_credential_nodes_and_no_phantom_edges():
-    """Regression: credential env-var NAMES are identifiers, not secret values.
+    """Regression: credential slots retain names without becoming global IDs.
 
     The report-write path (``to_redacted_json`` → ``sanitize_sensitive_payload``)
     must not collapse distinct credential names into one ``***REDACTED***`` label.
@@ -263,10 +289,10 @@ def test_redacted_report_keeps_distinct_credential_nodes_and_no_phantom_edges():
     cred_nodes = {node.id for node in graph.nodes if node.kind == "credential"}
     # (a) each distinct credential stays its own node — no collapse to one label.
     assert cred_nodes == {
-        "cred:OPENAI_API_KEY",
-        "cred:VECTOR_DB_TOKEN",
-        "cred:BROWSER_SESSION_TOKEN",
-        "cred:ANTHROPIC_API_KEY",
+        "cred:server:agent-a/openai-srv:OPENAI_API_KEY",
+        "cred:server:agent-a/vector-srv:VECTOR_DB_TOKEN",
+        "cred:server:agent-b/browser-srv:BROWSER_SESSION_TOKEN",
+        "cred:server:agent-b/anthropic-srv:ANTHROPIC_API_KEY",
     }
     assert "cred:***REDACTED***" not in cred_nodes
 

--- a/tests/test_graph_roundtrip.py
+++ b/tests/test_graph_roundtrip.py
@@ -7,7 +7,7 @@ during the build step).
 Two fixtures:
 
 1. A tiny synthetic inventory (3 agents, 5 packages on servers, 2 CVEs,
-   2 credentials, 1 cloud principal) — exercises every ``EdgeKind`` /
+   2 credential names across 3 server-scoped slots, 1 cloud principal) — exercises every ``EdgeKind`` /
    ``NodeKind`` the builder produces.
 2. The trimmed agent-bom self-scan at
    ``tests/fixtures/agent_bom_self_scan_inventory.json`` — exercises a
@@ -66,7 +66,11 @@ class TestRoundTripSynthetic:
         inv = synthetic_inventory()
         graph = build_graph_from_inventory(inv)
         projected = project_graph_to_inventory_sets(graph)
-        assert {"cred:GITHUB_TOKEN", "cred:GH_TOKEN"} <= projected["credentials"]
+        assert {
+            "cred:server:agent-a:filesystem:GITHUB_TOKEN",
+            "cred:server:agent-b:filesystem:GITHUB_TOKEN",
+            "cred:server:agent-c:github:GH_TOKEN",
+        } <= projected["credentials"]
 
     def test_synthetic_vulnerabilities_present(self) -> None:
         inv = synthetic_inventory()


### PR DESCRIPTION
## Summary

- scope credential nodes to their owning server across the unified graph, context graph, and standalone graph export
- stop inferring shared-credential edges and A2A findings from common environment-variable names while preserving findings for explicitly shared gateway tokens
- add regression coverage for duplicate credential names, cross-server tool reachability, graph round trips, and interaction-risk semantics

## Verification

- `uv run pytest -q tests/test_graph_builder.py tests/test_context_graph.py tests/test_graph_export.py tests/test_a2a_auth_posture.py tests/test_graph_roundtrip.py tests/test_graph_edge_counts.py tests/test_graph_api.py tests/test_graph_schema.py tests/test_graph_wave1.py tests/test_graph_wave23.py tests/test_graph_attack_path_e2e.py tests/test_toxic_findings.py tests/test_graph_reachability_runtime.py tests/test_mcp_auth_posture.py` — 435 passed
- `uv run ruff check src/agent_bom/a2a_auth_posture.py src/agent_bom/cli/agents/scan_cmd.py src/agent_bom/context_graph.py src/agent_bom/graph/builder.py src/agent_bom/output/graph_export.py tests/_graph_helpers.py tests/test_a2a_auth_posture.py tests/test_context_graph.py tests/test_graph_builder.py tests/test_graph_edge_counts.py tests/test_graph_export.py tests/test_graph_roundtrip.py`
- `uv run mypy src/agent_bom/graph/builder.py src/agent_bom/context_graph.py src/agent_bom/output/graph_export.py src/agent_bom/a2a_auth_posture.py`
- `uv run agent-bom scan --demo --offline --format json --output /private/tmp/agent-bom-credential-identity-scan.json` — completed with the expected finding exit code
- `uv run agent-bom graph /private/tmp/agent-bom-credential-identity-scan.json --format json --output /private/tmp/agent-bom-credential-identity-graph.json` — exported 89 nodes and 133 edges

## Notes

An environment-variable name identifies a credential slot, not secret material. Shared-credential relationships now require explicit correlation evidence instead of matching names such as `DATABASE_URL` or `GITHUB_TOKEN`.
