### PR TITLE
fix(graph): bound Postgres edge reconciliation

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260730_01_graph_edge_snapshot_key_index.py
+++ b/deploy/supabase/postgres/alembic/versions/20260730_01_graph_edge_snapshot_key_index.py
@@ -1,0 +1,37 @@
+"""Index complete edge identities within a tenant snapshot.
+
+The reconciliation path joins consecutive snapshots by the three edge identity
+columns while tenant and scan RLS predicates remain active.  The historical
+primary key starts with the identity columns, and the existing tenant/scan
+indexes cover only one endpoint, so neither gives the planner one exact lookup
+path for the full predicate.
+
+Revision ID: 20260730_01
+Revises: 20260729_03
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260730_01"
+down_revision = "20260729_03"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    relation = op.get_bind().exec_driver_sql("SELECT to_regclass('public.graph_edges')").scalar()
+    if relation is None:
+        return
+
+    with op.get_context().autocommit_block():
+        op.execute(
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pg_graph_edges_snapshot_key "
+            "ON graph_edges(tenant_id, scan_id, source_id, target_id, relationship)"
+        )
+
+
+def downgrade() -> None:
+    with op.get_context().autocommit_block():
+        op.execute("DROP INDEX CONCURRENTLY IF EXISTS idx_pg_graph_edges_snapshot_key")

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -454,6 +454,8 @@ CREATE TABLE IF NOT EXISTS graph_edges (
 
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan ON graph_edges(tenant_id, scan_id);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source ON graph_edges(tenant_id, scan_id, source_id);
+CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_snapshot_key
+    ON graph_edges(tenant_id, scan_id, source_id, target_id, relationship);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_target ON graph_edges(tenant_id, scan_id, target_id);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_valid ON graph_edges(tenant_id, valid_from, valid_to);
 CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source_traversable

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -785,6 +785,7 @@ class PostgresGraphStore:
                         edge.activity_id,
                         scan,
                         tenant,
+                        previous_scan,
                     )
 
             def attack_path_rows() -> Iterator[tuple[Any, ...]]:
@@ -826,7 +827,44 @@ class PostgresGraphStore:
                     traversable, first_seen, last_seen, valid_from, valid_to,
                     confidence, provenance, source_scan_id, source_run_id,
                     evidence, activity_id, scan_id, tenant_id
-                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                )
+                SELECT
+                    incoming.source_id,
+                    incoming.target_id,
+                    incoming.relationship,
+                    incoming.direction,
+                    incoming.weight,
+                    incoming.traversable,
+                    COALESCE(NULLIF(previous.first_seen, ''), incoming.first_seen),
+                    incoming.last_seen,
+                    COALESCE(
+                        NULLIF(previous.valid_from, ''),
+                        NULLIF(previous.first_seen, ''),
+                        incoming.valid_from
+                    ),
+                    incoming.valid_to,
+                    incoming.confidence,
+                    incoming.provenance,
+                    incoming.source_scan_id,
+                    incoming.source_run_id,
+                    incoming.evidence,
+                    incoming.activity_id,
+                    incoming.scan_id,
+                    incoming.tenant_id
+                FROM (
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                ) AS incoming (
+                    source_id, target_id, relationship, direction, weight,
+                    traversable, first_seen, last_seen, valid_from, valid_to,
+                    confidence, provenance, source_scan_id, source_run_id,
+                    evidence, activity_id, scan_id, tenant_id
+                )
+                LEFT JOIN graph_edges AS previous
+                  ON previous.tenant_id = incoming.tenant_id
+                 AND previous.scan_id = %s
+                 AND previous.source_id = incoming.source_id
+                 AND previous.target_id = incoming.target_id
+                 AND previous.relationship = incoming.relationship
                 ON CONFLICT (source_id, target_id, relationship, scan_id, tenant_id) DO UPDATE SET
                     direction = EXCLUDED.direction,
                     weight = EXCLUDED.weight,
@@ -846,35 +884,10 @@ class PostgresGraphStore:
                 batch_size=batch_size,
             )
             if previous_scan:
-                # Preserve temporal continuity and retire missing prior edges
-                # inside Postgres. Materialize each bounded snapshot slice once:
-                # a direct graph_edges self-join made Postgres repeatedly rescan
-                # the table and hit the statement timeout on modest second
-                # snapshots, while loading the prior snapshot into Python would
-                # restore O(previous-edge-count) application memory.
-                conn.execute(
-                    """
-                    WITH previous_edges AS MATERIALIZED (
-                        SELECT source_id, target_id, relationship, first_seen, valid_from
-                        FROM graph_edges
-                        WHERE tenant_id = %s AND scan_id = %s
-                    )
-                    UPDATE graph_edges AS current
-                    SET first_seen = COALESCE(NULLIF(previous.first_seen, ''), current.first_seen),
-                        valid_from = COALESCE(
-                            NULLIF(previous.valid_from, ''),
-                            NULLIF(previous.first_seen, ''),
-                            current.valid_from
-                        )
-                    FROM previous_edges AS previous
-                    WHERE current.source_id = previous.source_id
-                      AND current.target_id = previous.target_id
-                      AND current.relationship = previous.relationship
-                      AND current.scan_id = %s
-                      AND current.tenant_id = %s
-                    """,
-                    (tenant, previous_scan, scan, tenant),
-                )
+                # Continuity is resolved while each bounded insert batch is
+                # written, avoiding a second full-snapshot UPDATE. Compute only
+                # the missing prior-edge set here so retired edges can be closed
+                # without materializing the snapshot in application memory.
                 conn.execute(
                     """
                     WITH current_edge_keys AS MATERIALIZED (

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -318,6 +318,10 @@ class PostgresGraphStore:
             )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan ON graph_edges(tenant_id, scan_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_source ON graph_edges(tenant_id, scan_id, source_id)")
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_snapshot_key "
+                "ON graph_edges(tenant_id, scan_id, source_id, target_id, relationship)"
+            )
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_scan_target ON graph_edges(tenant_id, scan_id, target_id)")
             conn.execute("CREATE INDEX IF NOT EXISTS idx_pg_graph_edges_valid ON graph_edges(tenant_id, valid_from, valid_to)")
             conn.execute(

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -843,10 +843,18 @@ class PostgresGraphStore:
             )
             if previous_scan:
                 # Preserve temporal continuity and retire missing prior edges
-                # inside Postgres. Loading the prior snapshot into a Python dict
-                # + set made this streamed writer O(previous-edge-count) memory.
+                # inside Postgres. Materialize each bounded snapshot slice once:
+                # a direct graph_edges self-join made Postgres repeatedly rescan
+                # the table and hit the statement timeout on modest second
+                # snapshots, while loading the prior snapshot into Python would
+                # restore O(previous-edge-count) application memory.
                 conn.execute(
                     """
+                    WITH previous_edges AS MATERIALIZED (
+                        SELECT source_id, target_id, relationship, first_seen, valid_from
+                        FROM graph_edges
+                        WHERE tenant_id = %s AND scan_id = %s
+                    )
                     UPDATE graph_edges AS current
                     SET first_seen = COALESCE(NULLIF(previous.first_seen, ''), current.first_seen),
                         valid_from = COALESCE(
@@ -854,35 +862,41 @@ class PostgresGraphStore:
                             NULLIF(previous.first_seen, ''),
                             current.valid_from
                         )
-                    FROM graph_edges AS previous
+                    FROM previous_edges AS previous
                     WHERE current.source_id = previous.source_id
                       AND current.target_id = previous.target_id
                       AND current.relationship = previous.relationship
                       AND current.scan_id = %s
                       AND current.tenant_id = %s
-                      AND previous.scan_id = %s
-                      AND previous.tenant_id = %s
                     """,
-                    (scan, tenant, previous_scan, tenant),
+                    (tenant, previous_scan, scan, tenant),
                 )
                 conn.execute(
                     """
+                    WITH current_edge_keys AS MATERIALIZED (
+                        SELECT source_id, target_id, relationship
+                        FROM graph_edges
+                        WHERE tenant_id = %s AND scan_id = %s
+                    ),
+                    retired_edge_keys AS MATERIALIZED (
+                        SELECT source_id, target_id, relationship
+                        FROM graph_edges
+                        WHERE tenant_id = %s AND scan_id = %s
+                        EXCEPT
+                        SELECT source_id, target_id, relationship
+                        FROM current_edge_keys AS current
+                    )
                     UPDATE graph_edges AS previous
                     SET valid_to = COALESCE(previous.valid_to, %s),
                         activity_id = CASE WHEN previous.activity_id = 1 THEN 3 ELSE previous.activity_id END
+                    FROM retired_edge_keys AS retired
                     WHERE previous.tenant_id = %s
                       AND previous.scan_id = %s
-                      AND NOT EXISTS (
-                            SELECT 1
-                            FROM graph_edges AS current
-                            WHERE current.source_id = previous.source_id
-                              AND current.target_id = previous.target_id
-                              AND current.relationship = previous.relationship
-                              AND current.scan_id = %s
-                              AND current.tenant_id = %s
-                      )
+                      AND previous.source_id = retired.source_id
+                      AND previous.target_id = retired.target_id
+                      AND previous.relationship = retired.relationship
                     """,
-                    (now, tenant, previous_scan, scan, tenant),
+                    (tenant, scan, tenant, previous_scan, now, tenant, previous_scan),
                 )
             _execute_many_batched(
                 conn,

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -847,7 +847,7 @@ class PostgresGraphStore:
                     incoming.provenance,
                     incoming.source_scan_id,
                     incoming.source_run_id,
-                    incoming.evidence,
+                    incoming.evidence::jsonb,
                     incoming.activity_id,
                     incoming.scan_id,
                     incoming.tenant_id

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -2389,17 +2389,32 @@ class PostgresGraphStore:
                     [tenant_id, effective_scan_id, *params, *params],
                 ).fetchone()
                 total_edges = int((total_edges_row[0] if total_edges_row else 0) or 0)
-            rel_rows = conn.execute(
-                f"""
-                SELECT relationship, COUNT(*)
-                FROM graph_edges
-                WHERE tenant_id = %s AND scan_id = %s
-                  AND source_id IN (SELECT id FROM graph_nodes WHERE {where_sql})
-                  AND target_id IN (SELECT id FROM graph_nodes WHERE {where_sql})
-                GROUP BY relationship
-                """,  # nosec B608 - where_sql is built from static clause fragments
-                [tenant_id, effective_scan_id, *params, *params],
-            ).fetchall()
+            if not filters_active:
+                # Persisted snapshots already validate their topology while
+                # writing. Avoid two redundant graph_nodes membership scans on
+                # the common unfiltered stats path; the snapshot-key index can
+                # serve this bounded edge aggregation directly.
+                rel_rows = conn.execute(
+                    """
+                    SELECT relationship, COUNT(*)
+                    FROM graph_edges
+                    WHERE tenant_id = %s AND scan_id = %s
+                    GROUP BY relationship
+                    """,
+                    (tenant_id, effective_scan_id),
+                ).fetchall()
+            else:
+                rel_rows = conn.execute(
+                    f"""
+                    SELECT relationship, COUNT(*)
+                    FROM graph_edges
+                    WHERE tenant_id = %s AND scan_id = %s
+                      AND source_id IN (SELECT id FROM graph_nodes WHERE {where_sql})
+                      AND target_id IN (SELECT id FROM graph_nodes WHERE {where_sql})
+                    GROUP BY relationship
+                    """,  # nosec B608 - where_sql is built from static clause fragments
+                    [tenant_id, effective_scan_id, *params, *params],
+                ).fetchall()
             attack_row = conn.execute(
                 "SELECT COUNT(*), COALESCE(MAX(composite_risk), 0.0) FROM attack_paths WHERE tenant_id = %s AND scan_id = %s",
                 (tenant_id, effective_scan_id),

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -297,10 +297,43 @@ def test_prior_edges_reconcile_in_postgres_without_python_materialization(monkey
         edges=iter([edge]),
     )
 
-    continuity_at = next(i for i, sql in enumerate(conn.sql_calls) if sql.startswith("update graph_edges as current"))
-    retirement_at = next(i for i, sql in enumerate(conn.sql_calls) if sql.startswith("update graph_edges as previous"))
-    assert conn.sql_params[continuity_at] == ("current-scan", "tenant-a", "prior-scan", "tenant-a")
-    assert conn.sql_params[retirement_at][1:] == ("tenant-a", "prior-scan", "current-scan", "tenant-a")
+    continuity_at = next(i for i, sql in enumerate(conn.sql_calls) if "update graph_edges as current" in sql)
+    retirement_at = next(i for i, sql in enumerate(conn.sql_calls) if "update graph_edges as previous" in sql)
+    assert conn.sql_params[continuity_at] == ("tenant-a", "prior-scan", "current-scan", "tenant-a")
+    assert conn.sql_params[retirement_at][:4] == ("tenant-a", "current-scan", "tenant-a", "prior-scan")
+    assert conn.sql_params[retirement_at][5:] == ("tenant-a", "prior-scan")
+
+
+def test_prior_edge_reconciliation_materializes_each_snapshot_before_updates(monkeypatch):
+    class _PreviousSnapshotConn(_RecordingConn):
+        def execute(self, sql, params=None):
+            low = " ".join(sql.strip().lower().split())
+            if low.startswith("select scan_id, created_at") and "from graph_snapshots" in low:
+                self.sql_calls.append(low)
+                self.sql_params.append(tuple(params) if params is not None else None)
+                return _FakeCursor([("prior-scan", "2026-07-18T00:00:00Z")])
+            return super().execute(sql, params)
+
+    conn = _PreviousSnapshotConn()
+    store = _make_store(conn, monkeypatch)
+    edge = UnifiedEdge(source="agent:1", target="pkg:1", relationship=RelationshipType.DEPENDS_ON)
+
+    store.save_graph_streaming(
+        scan_id="current-scan",
+        tenant_id="tenant-a",
+        nodes=_nodes(1),
+        edges=iter([edge]),
+    )
+
+    continuity_sql = next(sql for sql in conn.sql_calls if "update graph_edges as current" in sql)
+    retirement_sql = next(sql for sql in conn.sql_calls if "update graph_edges as previous" in sql)
+    assert continuity_sql.startswith("with previous_edges as materialized")
+    assert "from previous_edges as previous" in continuity_sql
+    assert "from graph_edges as previous" not in continuity_sql
+    assert retirement_sql.startswith("with current_edge_keys as materialized")
+    assert "from current_edge_keys as current" in retirement_sql
+    assert "except select source_id, target_id, relationship from current_edge_keys as current" in retirement_sql
+    assert "from graph_edges as current" not in retirement_sql
 
 
 @pytest.mark.parametrize(
@@ -555,7 +588,7 @@ def test_retired_edge_update_records_ocsf_close_activity(monkeypatch):
             low = " ".join(sql.strip().lower().split())
             if low.startswith("select scan_id, created_at from graph_snapshots"):
                 return _FakeCursor([("scan-old", "2026-07-16T00:00:00Z")])
-            if low.startswith("update graph_edges as previous"):
+            if "update graph_edges as previous" in low:
                 self.retirement_sql = low
             return super().execute(sql, params)
 

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -334,6 +334,7 @@ def test_prior_edge_continuity_is_resolved_during_insert_before_retirement(monke
     retirement_sql = next(sql for sql in conn.sql_calls if "update graph_edges as previous" in sql)
     assert continuity_sql.startswith("insert into graph_edges")
     assert "coalesce(nullif(previous.first_seen, ''), incoming.first_seen)" in continuity_sql
+    assert "incoming.evidence::jsonb" in continuity_sql
     assert "left join graph_edges as previous" in continuity_sql
     assert "previous.scan_id = %s" in continuity_sql
     assert "update graph_edges as current" not in continuity_sql

--- a/tests/test_postgres_graph_streaming.py
+++ b/tests/test_postgres_graph_streaming.py
@@ -40,6 +40,7 @@ class _RecordingConn:
         self.node_rows: list[tuple] = []
         self.search_rows: list[tuple] = []
         self.edge_rows: list[tuple] = []
+        self.edge_sql: str | None = None
         self.snapshot_params: tuple | None = None
         self.executemany_calls: list[str] = []
         self.committed = 0
@@ -80,6 +81,7 @@ class _RecordingConn:
             self.executemany_calls.append("graph_node_search")
             self.search_rows.extend(rows)
         elif low.startswith("insert into graph_edges"):
+            self.edge_sql = low
             self.edge_rows.extend(rows)
         return _FakeCursor(rows)
 
@@ -297,14 +299,16 @@ def test_prior_edges_reconcile_in_postgres_without_python_materialization(monkey
         edges=iter([edge]),
     )
 
-    continuity_at = next(i for i, sql in enumerate(conn.sql_calls) if "update graph_edges as current" in sql)
     retirement_at = next(i for i, sql in enumerate(conn.sql_calls) if "update graph_edges as previous" in sql)
-    assert conn.sql_params[continuity_at] == ("tenant-a", "prior-scan", "current-scan", "tenant-a")
+    assert conn.edge_sql is not None
+    assert "left join graph_edges as previous" in conn.edge_sql
+    assert conn.edge_rows[0][-1] == "prior-scan"
+    assert not any("update graph_edges as current" in sql for sql in conn.sql_calls)
     assert conn.sql_params[retirement_at][:4] == ("tenant-a", "current-scan", "tenant-a", "prior-scan")
     assert conn.sql_params[retirement_at][5:] == ("tenant-a", "prior-scan")
 
 
-def test_prior_edge_reconciliation_materializes_each_snapshot_before_updates(monkeypatch):
+def test_prior_edge_continuity_is_resolved_during_insert_before_retirement(monkeypatch):
     class _PreviousSnapshotConn(_RecordingConn):
         def execute(self, sql, params=None):
             low = " ".join(sql.strip().lower().split())
@@ -325,11 +329,14 @@ def test_prior_edge_reconciliation_materializes_each_snapshot_before_updates(mon
         edges=iter([edge]),
     )
 
-    continuity_sql = next(sql for sql in conn.sql_calls if "update graph_edges as current" in sql)
+    assert conn.edge_sql is not None
+    continuity_sql = conn.edge_sql
     retirement_sql = next(sql for sql in conn.sql_calls if "update graph_edges as previous" in sql)
-    assert continuity_sql.startswith("with previous_edges as materialized")
-    assert "from previous_edges as previous" in continuity_sql
-    assert "from graph_edges as previous" not in continuity_sql
+    assert continuity_sql.startswith("insert into graph_edges")
+    assert "coalesce(nullif(previous.first_seen, ''), incoming.first_seen)" in continuity_sql
+    assert "left join graph_edges as previous" in continuity_sql
+    assert "previous.scan_id = %s" in continuity_sql
+    assert "update graph_edges as current" not in continuity_sql
     assert retirement_sql.startswith("with current_edge_keys as materialized")
     assert "from current_edge_keys as current" in retirement_sql
     assert "except select source_id, target_id, relationship from current_edge_keys as current" in retirement_sql

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -833,6 +833,61 @@ def test_postgres_scan_jobs_rls_schema_is_locked_down():
     )
 
 
+def test_postgres_second_large_graph_snapshot_reconciles_within_statement_timeout(monkeypatch):
+    """A 7k-edge second persist completes under the production timeout contract."""
+    from agent_bom.api import postgres_common
+    from agent_bom.api.postgres_common import reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_graph import PostgresGraphStore
+    from agent_bom.graph import EntityType, RelationshipType, UnifiedEdge, UnifiedNode
+
+    edge_count = 7_000
+    suffix = uuid4().hex
+    tenant_id = f"graph-reconcile-{suffix}"
+    prior_scan = f"prior-{suffix}"
+    current_scan = f"current-{suffix}"
+
+    def nodes():
+        for index in range(edge_count + 1):
+            yield UnifiedNode(id=f"node:{index}", entity_type=EntityType.AGENT, label=f"Node {index}")
+
+    def edges():
+        for index in range(edge_count):
+            yield UnifiedEdge(
+                source=f"node:{index}",
+                target=f"node:{index + 1}",
+                relationship=RelationshipType.DEPENDS_ON,
+            )
+
+    # Keep the live regression tighter than the production 15s default while
+    # leaving ample room for CI variance. The timeout is applied when the pool
+    # checks out each connection.
+    monkeypatch.setattr(postgres_common, "POSTGRES_STATEMENT_TIMEOUT_MS", 5_000)
+    postgres_common.reset_pool()
+    store = PostgresGraphStore()
+    token = set_current_tenant(tenant_id)
+    try:
+        store.save_graph_streaming(
+            scan_id=prior_scan,
+            tenant_id=tenant_id,
+            nodes=nodes(),
+            edges=edges(),
+            created_at="2026-07-30T00:00:00Z",
+        )
+        persisted = store.save_graph_streaming(
+            scan_id=current_scan,
+            tenant_id=tenant_id,
+            nodes=nodes(),
+            edges=edges(),
+            created_at="2026-07-30T00:01:00Z",
+        )
+        stats = store.snapshot_stats(tenant_id=tenant_id, scan_id=current_scan)
+        assert persisted["edge_count"] == edge_count
+        assert stats["total_edges"] == edge_count
+    finally:
+        store.delete_tenant(tenant_id=tenant_id)
+        reset_current_tenant(token)
+
+
 def test_postgres_graph_build_workspace_rls_schema_is_locked_down():
     """Structural RLS guard for graph_build_workspace_* staging tables."""
     from agent_bom.api.postgres_common import _get_pool

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -881,7 +881,7 @@ def test_postgres_second_large_graph_snapshot_reconciles_within_statement_timeou
             created_at="2026-07-30T00:01:00Z",
         )
         stats = store.snapshot_stats(tenant_id=tenant_id, scan_id=current_scan)
-        assert persisted["edge_count"] == edge_count
+        assert persisted["edges"] == edge_count
         assert stats["total_edges"] == edge_count
     finally:
         store.delete_tenant(tenant_id=tenant_id)

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -26,6 +26,7 @@ GATEWAY_ACTIVITY_LEDGER = VERSIONS_DIR / "20260728_02_gateway_activity_ledger.py
 TRUSTED_MAINTENANCE_RLS = VERSIONS_DIR / "20260728_03_trusted_maintenance_rls.py"
 GATEWAY_ACTIVITY_WINDOW_INDEX = VERSIONS_DIR / "20260729_02_gateway_activity_window_index.py"
 PARTITION_CHILD_RLS = VERSIONS_DIR / "20260729_03_partition_child_rls.py"
+GRAPH_EDGE_SNAPSHOT_KEY_INDEX = VERSIONS_DIR / "20260730_01_graph_edge_snapshot_key_index.py"
 POSTGRES_MCP_CONFIG_STORE = Path(__file__).parent.parent / "src" / "agent_bom" / "api" / "postgres_mcp_config.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
@@ -407,6 +408,22 @@ def test_partition_child_rls_is_chained_idempotent_and_irreversible() -> None:
     assert "CREATE POLICY" in sql
     assert "DROP POLICY" not in sql
     assert "DISABLE ROW LEVEL SECURITY" not in sql
+
+
+def test_graph_edge_snapshot_key_index_is_chained_and_matches_bootstrap() -> None:
+    sql = GRAPH_EDGE_SNAPSHOT_KEY_INDEX.read_text()
+    index_ddl = (
+        "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_pg_graph_edges_snapshot_key "
+        "ON graph_edges(tenant_id, scan_id, source_id, target_id, relationship)"
+    )
+    assert re.search(r'revision\s*=\s*"20260730_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260729_03"', sql)
+    assert _canonical_sql(index_ddl) in _canonical_sql(sql)
+    bootstrap_index_ddl = index_ddl.replace(" CONCURRENTLY", "")
+    assert _canonical_sql(bootstrap_index_ddl) in _canonical_sql((POSTGRES_DIR / "init.sql").read_text())
+    assert "SELECT to_regclass('public.graph_edges')" in sql
+    assert "autocommit_block" in sql
+    assert "DROP TABLE" not in sql
 
 
 def test_gateway_activity_window_index_allows_legacy_schema_without_ledger(monkeypatch) -> None:

--- a/tests/test_postgres_schema.py
+++ b/tests/test_postgres_schema.py
@@ -647,6 +647,7 @@ def test_graph_hot_path_indexes_exist():
     for index_name in (
         "idx_pg_graph_nodes_scan_id_cover",
         "idx_pg_graph_edges_scan_source_traversable",
+        "idx_pg_graph_edges_snapshot_key",
         "idx_pg_attack_paths_source_risk",
         "idx_pg_graph_node_search_trgm",
         "idx_pg_graph_node_search_lower_trgm",

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1569,6 +1569,7 @@ def test_graph_store_init_adds_query_indexes(mock_pool, mock_maintenance_pool):
     assert any("idx_pg_graph_nodes_scan_order" in sql for sql, _ in mock_pool._conn.executed)
     assert any("idx_pg_graph_nodes_scan_id_cover" in sql for sql, _ in mock_pool._conn.executed)
     assert any("idx_pg_graph_edges_scan_source" in sql for sql, _ in mock_pool._conn.executed)
+    assert any("idx_pg_graph_edges_snapshot_key" in sql for sql, _ in mock_pool._conn.executed)
     assert any("idx_pg_graph_edges_scan_target" in sql for sql, _ in mock_pool._conn.executed)
     assert any("idx_pg_graph_edges_scan_source_traversable" in sql for sql, _ in mock_pool._conn.executed)
     assert any("idx_pg_attack_paths_scan_risk" in sql for sql, _ in mock_pool._conn.executed)

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1578,6 +1578,30 @@ def test_graph_store_init_adds_query_indexes(mock_pool, mock_maintenance_pool):
     assert any("idx_pg_graph_node_search_lower_trgm" in sql for sql, _ in mock_pool._conn.executed)
 
 
+def test_graph_snapshot_stats_uses_bounded_unfiltered_edge_aggregation():
+    from agent_bom.api.postgres_store import PostgresGraphStore
+
+    class SnapshotStatsConnection(MockConnection):
+        def execute(self, sql, params=None):
+            if "coalesce(max" in sql.lower():
+                self.executed.append((sql, params))
+                return MockCursor([(0, 0.0)])
+            return super().execute(sql, params)
+
+    pool = MockPool()
+    pool._conn = SnapshotStatsConnection()
+    store = PostgresGraphStore(pool=pool, maintenance_pool=pool)
+    store.snapshot_stats(tenant_id="tenant-a", scan_id="scan-a")
+
+    relationship_sql = next(
+        " ".join(sql.strip().lower().split())
+        for sql, _ in pool._conn.executed
+        if "group by relationship" in sql.lower()
+    )
+    assert "from graph_edges" in relationship_sql
+    assert "from graph_nodes" not in relationship_sql
+
+
 def test_graph_store_init_tolerates_restricted_pg_trgm_extension():
     from agent_bom.api.postgres_store import PostgresGraphStore
 


### PR DESCRIPTION
## Summary

- preserve temporal continuity during each bounded edge insert instead of rewriting the complete current snapshot afterward
- replace the correlated retirement anti-scan with a materialized `EXCEPT` key set
- add a tenant/snapshot/full-edge-key index through application bootstrap, `init.sql`, and an online Alembic migration
- add query-shape coverage and a live 7,000-edge second-snapshot regression under a 5-second Postgres statement timeout

## Verification

- `uv run ruff check src/agent_bom/api/postgres_graph.py deploy/supabase/postgres/alembic/versions/20260730_01_graph_edge_snapshot_key_index.py tests/test_postgres_migrations.py tests/test_postgres_schema.py tests/test_postgres_store.py tests/test_postgres_graph_streaming.py tests/test_postgres_integration.py`
- `uv run pytest -q tests/test_postgres_migrations.py tests/test_postgres_schema.py tests/test_postgres_store.py tests/test_postgres_graph_streaming.py tests/test_postgres_integration.py::test_postgres_second_large_graph_snapshot_reconciles_within_statement_timeout` (`200 passed, 1 skipped`; the live Postgres regression runs in CI)
- `uv run pytest -q tests/test_graph_persist_memory_bound.py tests/test_graph_persist_pipeline_scale_bound.py tests/test_graph_store_streamed_persistence.py tests/test_graph_api.py` (`85 passed`)
- `uv run mypy src/agent_bom/api/postgres_graph.py`
- `make preflight`
- `git diff --check`

## Notes

- no API contract changes
- migration creates the additive index concurrently and remains safe when `graph_edges` is absent
- edge history remains application-memory bounded; no prior snapshot dictionary or set is materialized in Python
- the live scale assertion is delegated to CI's PostgreSQL 16 service because no local Postgres service was available