### PR TITLE
perf(control-plane): bound, de-duplicate, and honestly report the findings read path

### DIFF
--- a/scripts/env_var_allowlist.txt
+++ b/scripts/env_var_allowlist.txt
@@ -330,6 +330,12 @@ AGENT_BOM_OCI_MAX_LAYER_UNCOMPRESSED_BYTES
 AGENT_BOM_OFFLINE
 # TTL (seconds) for the per-tenant /v1/overview payload cache; read at call time so tests can vary it. 0 disables.
 AGENT_BOM_OVERVIEW_CACHE_TTL_SECONDS
+# How long a concurrent /v1/overview reader waits on the in-flight fold before recomputing itself; read at call time.
+AGENT_BOM_OVERVIEW_SINGLEFLIGHT_TIMEOUT_SECONDS
+# Rows one scope-filtered /v1/findings page walk may examine before it stops and reports a partial page; read at call time.
+AGENT_BOM_SCOPE_FILTER_SCAN_BUDGET
+# Wall-clock ceiling (seconds) for one scope-filtered /v1/findings page walk; read at call time.
+AGENT_BOM_SCOPE_FILTER_DEADLINE_SECONDS
 # TTL (seconds) for the hub-derived severity cache; read at call time so tests and operators can disable it with 0.
 AGENT_BOM_HUB_OVERVIEW_CACHE_TTL_SECONDS
 AGENT_BOM_SKIP_UPDATE_CHECK

--- a/src/agent_bom/api/compliance_hub_store.py
+++ b/src/agent_bom/api/compliance_hub_store.py
@@ -22,6 +22,7 @@ with ``ingested_at`` so future expiry / TTL work has a key.
 from __future__ import annotations
 
 import logging
+import os
 import sqlite3
 import threading
 import time
@@ -100,6 +101,33 @@ def scope_filter_batch_size(page_limit: int) -> int:
     return min(_SCOPE_FILTER_MAX_BATCH, max(_SCOPE_FILTER_MIN_BATCH, int(page_limit) + 1))
 
 
+def scope_filter_scan_budget() -> int:
+    """Rows one scope-filtered page walk may examine before it stops.
+
+    Operator-tunable so a deployment with a very sparse scope filter can trade
+    latency for completeness. Resolved per call (not bound at import) so the
+    knob applies without a restart and stays testable.
+    """
+    raw = os.environ.get("AGENT_BOM_SCOPE_FILTER_SCAN_BUDGET")
+    if raw is None:
+        return _SCOPE_FILTER_SCAN_BUDGET
+    try:
+        return max(1, int(raw))
+    except ValueError:
+        return _SCOPE_FILTER_SCAN_BUDGET
+
+
+def scope_filter_deadline_seconds() -> float:
+    """Wall-clock ceiling for one scope-filtered page walk."""
+    raw = os.environ.get("AGENT_BOM_SCOPE_FILTER_DEADLINE_SECONDS")
+    if raw is None:
+        return _SCOPE_FILTER_DEADLINE_SECONDS
+    try:
+        return max(0.001, float(raw))
+    except ValueError:
+        return _SCOPE_FILTER_DEADLINE_SECONDS
+
+
 # Lifecycle-status filter — a single source of truth shared by every read
 # surface (list_current_page + current_severity_breakdown, all backends) and the
 # route. ``status`` is a real, sargable column on ``hub_findings_current``
@@ -164,7 +192,7 @@ def collect_scope_filtered_page(
     start_cursor: str | None,
     sort: str,
     batch_size: int,
-    scan_budget: int = _SCOPE_FILTER_SCAN_BUDGET,
+    scan_budget: int | None = None,
     deadline_monotonic: float | None = None,
     metadata: dict[str, Any] | None = None,
 ) -> tuple[list[dict[str, Any]], str | None]:
@@ -180,7 +208,15 @@ def collect_scope_filtered_page(
 
     The loop applies ``predicate`` to each ``enriched_payload``, collecting
     matches until it holds ``page_limit + 1`` (enough to know a further page
-    exists) or the stream ends. ``next_cursor`` is derived from the LAST EMITTED
+    exists), the stream ends, or the walk exhausts its row budget / wall-clock
+    deadline. A bounded walk is NOT silent: ``metadata`` (when supplied) records
+    ``scanned_rows`` / ``scan_budget`` / ``truncated`` / ``reason`` so the caller
+    can label the page partial, and a resume cursor is still emitted so the rest
+    of the stream stays retrievable. ``metadata`` accumulates across calls, so a
+    caller that drives several walks for one response (the merged scan+bulk page)
+    can pass one dict and get the combined verdict.
+
+    ``next_cursor`` is derived from the LAST EMITTED
     match's ``current_row`` — never a discarded probe row — so the next page
     resumes strictly after it: 0 duplicates, 0 dropped rows across pages, and the
     filtered order matches the unfiltered keyset order restricted to the matching
@@ -189,12 +225,13 @@ def collect_scope_filtered_page(
     page_limit = max(0, int(page_limit))
     if page_limit == 0:
         return [], None
+    scan_budget = scope_filter_scan_budget() if scan_budget is None else max(1, int(scan_budget))
     matches: list[tuple[dict[str, Any], dict[str, Any]]] = []
     batch_cursor = start_cursor
     scanned_rows = 0
     bounded = False
     bound_reason = ""
-    deadline = deadline_monotonic or (time.monotonic() + _SCOPE_FILTER_DEADLINE_SECONDS)
+    deadline = deadline_monotonic or (time.monotonic() + scope_filter_deadline_seconds())
     last_scanned: dict[str, Any] | None = None
     while len(matches) <= page_limit:
         if scanned_rows >= scan_budget:
@@ -229,14 +266,11 @@ def collect_scope_filtered_page(
         if cursor_row is not None:
             next_cursor = cursor_from_current_row(cursor_row, sort=sort)
     if metadata is not None:
-        metadata.update(
-            {
-                "scanned_rows": scanned_rows,
-                "scan_budget": scan_budget,
-                "truncated": bounded,
-                "reason": bound_reason,
-            }
-        )
+        # Accumulate: one response may drive several walks (merged scan+bulk).
+        metadata["scanned_rows"] = int(metadata.get("scanned_rows") or 0) + scanned_rows
+        metadata["scan_budget"] = scan_budget
+        metadata["truncated"] = bool(metadata.get("truncated")) or bounded
+        metadata["reason"] = bound_reason or str(metadata.get("reason") or "")
     return payloads, next_cursor
 
 
@@ -570,6 +604,7 @@ class ComplianceHubStore(Protocol):
         since: str | None = None,
         scope: Mapping[str, str] | None = None,
         status: str | None = None,
+        scope_metadata: dict[str, Any] | None = None,
     ) -> FindingCursorPage:
         """Return a page from ``hub_findings_current`` with lifecycle fields merged.
 
@@ -588,6 +623,11 @@ class ComplianceHubStore(Protocol):
         the whole tenant. When ``scope`` is set the exact O(table) ``COUNT(*)`` is
         skipped and ``total`` is ``None`` (the route flags it approximate); when
         ``scope`` is falsy behavior is unchanged.
+
+        ``scope_metadata``, when supplied alongside ``scope``, is filled in place
+        with the scope walk's completeness (``scanned_rows`` / ``scan_budget`` /
+        ``truncated`` / ``reason``) so the caller can label a budget-bounded page
+        partial instead of presenting it as an honest empty result.
         """
         ...
 
@@ -1321,6 +1361,7 @@ class InMemoryComplianceHubStore:
         since: str | None = None,
         scope: Mapping[str, str] | None = None,
         status: str | None = None,
+        scope_metadata: dict[str, Any] | None = None,
     ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
 
@@ -1337,6 +1378,7 @@ class InMemoryComplianceHubStore:
                 since=since,
                 scope=scope,
                 status=status,
+                scope_metadata=scope_metadata,
             )
         with self._lock:
             rows = list(self._current.get(tenant_id, {}).values())
@@ -1386,6 +1428,7 @@ class InMemoryComplianceHubStore:
         since: str | None,
         scope: Mapping[str, str],
         status: str | None = None,
+        scope_metadata: dict[str, Any] | None = None,
     ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
         from agent_bom.finding_scope import row_matches_scope
@@ -1418,6 +1461,7 @@ class InMemoryComplianceHubStore:
             start_cursor=cursor,
             sort=sort,
             batch_size=scope_filter_batch_size(page_limit),
+            metadata=scope_metadata,
         )
         return payloads, None, next_cursor
 
@@ -1951,7 +1995,11 @@ class SQLiteComplianceHubStore:
                 )
             )
         existing_ids = self._existing_finding_ids(tenant_id, finding_ids)
-        new_rows = sum(1 for row in rows if str(row[1]) not in existing_ids)
+        # Count DISTINCT ids: ``ON CONFLICT … DO UPDATE`` collapses ids repeated
+        # WITHIN the batch into one row, so counting per-row overstated the
+        # tenant total permanently (the cached total then disagreed with
+        # ``COUNT(*)`` forever).
+        new_rows = len({str(row[1]) for row in rows} - existing_ids)
         # Idempotent ingest: a repeat of the same (tenant_id, finding_id)
         # refreshes the stored payload/metadata in place and keeps the original
         # ``ordinal`` (ingest order) instead of appending a duplicate row.
@@ -2337,6 +2385,7 @@ class SQLiteComplianceHubStore:
         since: str | None = None,
         scope: Mapping[str, str] | None = None,
         status: str | None = None,
+        scope_metadata: dict[str, Any] | None = None,
     ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
 
@@ -2392,6 +2441,7 @@ class SQLiteComplianceHubStore:
                 limit=limit,
                 cursor=cursor,
                 scope=scope,
+                scope_metadata=scope_metadata,
             )
         if cursor:
             keyset_sql, keyset_params = sqlite_keyset_clause(normalized_sort, cursor)
@@ -2453,6 +2503,7 @@ class SQLiteComplianceHubStore:
         limit: int,
         cursor: str | None,
         scope: Mapping[str, str],
+        scope_metadata: dict[str, Any] | None = None,
     ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
         from agent_bom.finding_scope import row_matches_scope
@@ -2497,6 +2548,7 @@ class SQLiteComplianceHubStore:
             start_cursor=cursor,
             sort=normalized_sort,
             batch_size=scope_filter_batch_size(page_limit),
+            metadata=scope_metadata,
         )
         return payloads, None, next_cursor
 

--- a/src/agent_bom/api/postgres_compliance_hub.py
+++ b/src/agent_bom/api/postgres_compliance_hub.py
@@ -658,7 +658,11 @@ class PostgresComplianceHubStore:
             finding_id = str(payload.get("id") or f"hub-{now}-{id(original)}")
             rows_to_insert.append((finding_id, frameworks_csv, payload))
         existing_ids = self._existing_finding_ids(conn, tenant_id, [row[0] for row in rows_to_insert])
-        new_rows = sum(1 for finding_id, _, _ in rows_to_insert if finding_id not in existing_ids)
+        # Count DISTINCT ids: ``ON CONFLICT … DO UPDATE`` collapses ids repeated
+        # WITHIN the batch into one row, so counting per-row overstated the
+        # tenant total permanently (the cached total then disagreed with
+        # ``COUNT(*)`` forever).
+        new_rows = len({finding_id for finding_id, _, _ in rows_to_insert} - existing_ids)
         # Idempotent ingest: a resend of the same (tenant_id, finding_id) refreshes
         # payload/metadata and keeps the original ``ordinal`` (the BIGSERIAL default
         # only advances on genuine inserts). Batched via ``executemany`` (psycopg
@@ -1243,6 +1247,7 @@ class PostgresComplianceHubStore:
         since: str | None = None,
         scope: Mapping[str, str] | None = None,
         status: str | None = None,
+        scope_metadata: dict[str, Any] | None = None,
     ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
 
@@ -1296,6 +1301,7 @@ class PostgresComplianceHubStore:
                 limit=limit,
                 cursor=cursor,
                 scope=scope,
+                scope_metadata=scope_metadata,
             )
         if cursor:
             keyset_sql, keyset_params = postgres_keyset_clause(normalized_sort, cursor)
@@ -1357,6 +1363,7 @@ class PostgresComplianceHubStore:
         limit: int,
         cursor: str | None,
         scope: Mapping[str, str],
+        scope_metadata: dict[str, Any] | None = None,
     ) -> FindingCursorPage:
         from agent_bom.api.finding_lifecycle import enriched_finding_payload
         from agent_bom.finding_scope import row_matches_scope
@@ -1403,6 +1410,7 @@ class PostgresComplianceHubStore:
                 start_cursor=cursor,
                 sort=normalized_sort,
                 batch_size=scope_filter_batch_size(page_limit),
+                metadata=scope_metadata,
             )
         return payloads, None, next_cursor
 

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -38,6 +38,7 @@ import logging
 import os
 import threading
 import time
+from dataclasses import dataclass, field
 from typing import Any, cast
 from urllib.parse import urlencode
 
@@ -64,6 +65,25 @@ _logger = logging.getLogger(__name__)
 _OVERVIEW_CACHE_TTL_SECONDS_DEFAULT = 15.0
 _overview_cache: dict[str, tuple[float, str, dict[str, Any]]] = {}
 _overview_cache_lock = threading.Lock()
+
+# Single-flight. The cache alone is a plain read-compute-write, so every reader
+# that arrives while the fold is running misses and folds the estate itself: a
+# 2.4s solo read measured 29.2s at 8 concurrent readers, and during ingest the
+# fingerprint invalidates continuously so the cache is permanently cold. One
+# in-flight computation per tenant; the rest wait on its Event and reuse the
+# result. A leader that fails or overruns never strands a follower — the
+# follower recomputes rather than serving a missing payload.
+_OVERVIEW_SINGLEFLIGHT_TIMEOUT_SECONDS = 30.0
+
+
+@dataclass
+class _OverviewFlight:
+    fingerprint: str
+    event: threading.Event = field(default_factory=threading.Event)
+    payload: dict[str, Any] | None = None
+
+
+_overview_inflight: dict[str, _OverviewFlight] = {}
 
 
 def _overview_cache_ttl() -> float:
@@ -123,6 +143,19 @@ def _reset_overview_cache() -> None:
     """Test hook: drop all cached overview payloads."""
     with _overview_cache_lock:
         _overview_cache.clear()
+        for flight in _overview_inflight.values():
+            flight.event.set()
+        _overview_inflight.clear()
+
+
+def _overview_singleflight_timeout() -> float:
+    raw = os.environ.get("AGENT_BOM_OVERVIEW_SINGLEFLIGHT_TIMEOUT_SECONDS")
+    if raw is None:
+        return _OVERVIEW_SINGLEFLIGHT_TIMEOUT_SECONDS
+    try:
+        return max(0.0, float(raw))
+    except ValueError:
+        return _OVERVIEW_SINGLEFLIGHT_TIMEOUT_SECONDS
 
 
 _SEVERITY_KEYS = ("critical", "high", "medium", "low")
@@ -1014,7 +1047,9 @@ def _build_overview(request: Request) -> dict[str, Any]:
     Serves a cached payload when the tenant's job-metadata fingerprint is
     unchanged within the TTL, so repeated landing-page reads don't refold the
     whole estate (#3963 follow-up). Cache misses (new/changed scan data or an
-    expired entry) recompute and refresh the cache.
+    expired entry) recompute and refresh the cache — but only ONCE per tenant
+    per fingerprint: concurrent misses join the in-flight fold instead of
+    stampeding it.
     """
     tenant_id = _tenant_id(request)
     jobs = _get_store().list_all(tenant_id=tenant_id)
@@ -1025,9 +1060,33 @@ def _build_overview(request: Request) -> dict[str, Any]:
     if cached is not None:
         return cached
 
-    payload = _compose_overview(request, tenant_id, jobs, hub_severity)
-    _overview_cache_put(tenant_id, fingerprint, payload)
-    return payload
+    with _overview_cache_lock:
+        flight = _overview_inflight.get(tenant_id)
+        leader = flight is None or flight.fingerprint != fingerprint
+        if leader:
+            flight = _OverviewFlight(fingerprint=fingerprint)
+            _overview_inflight[tenant_id] = flight
+
+    assert flight is not None  # nosec B101 — narrowing; set on both branches
+    if not leader:
+        if flight.event.wait(timeout=_overview_singleflight_timeout()) and flight.payload is not None:
+            return flight.payload
+        # The leader failed or overran its budget. Recompute rather than serve
+        # nothing — correctness beats de-duplication.
+        payload = _compose_overview(request, tenant_id, jobs, hub_severity)
+        _overview_cache_put(tenant_id, fingerprint, payload)
+        return payload
+
+    try:
+        payload = _compose_overview(request, tenant_id, jobs, hub_severity)
+        _overview_cache_put(tenant_id, fingerprint, payload)
+        flight.payload = payload
+        return payload
+    finally:
+        with _overview_cache_lock:
+            if _overview_inflight.get(tenant_id) is flight:
+                del _overview_inflight[tenant_id]
+        flight.event.set()
 
 
 def _compose_overview(request: Request, tenant_id: str, jobs: list[Any], hub_severity: dict[str, int]) -> dict[str, Any]:

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -2065,6 +2065,7 @@ def _merged_scan_bulk_page(
     since: str | None = None,
     scope: Mapping[str, str] | None = None,
     status: str | None = None,
+    scope_metadata: dict[str, Any] | None = None,
 ) -> MergedScanBulkPage:
     """Merge pre-sorted scan findings with bulk hub pages without O(table) work.
 
@@ -2099,6 +2100,10 @@ def _merged_scan_bulk_page(
         extra_kwargs["status"] = status
     if scope:
         extra_kwargs["scope"] = dict(scope)
+        if scope_metadata is not None:
+            # One dict across every refill: ``collect_scope_filtered_page``
+            # accumulates, so the merged page reports the combined walk.
+            extra_kwargs["scope_metadata"] = scope_metadata
 
     def _refill_bulk() -> bool:
         nonlocal bulk_buf, bulk_i, fetch_cursor, bulk_exhausted
@@ -2459,6 +2464,11 @@ def _list_findings_impl(
     # a single SQL predicate). This keeps the fast keyset path — a scoped page
     # never materializes the whole tenant and ``next_cursor`` is emitted — while
     # ``total`` is honestly approximate (no O(table) COUNT under a scope filter).
+    # Completeness of the store-internal scope walk. The walk is bounded by a
+    # row budget + wall-clock deadline, so a sparse filter can return an empty
+    # page with a resume cursor; that must be labelled partial, never presented
+    # as an honest "no results".
+    scope_metadata: dict[str, Any] = {}
     if scope_filters and has_current_page and callable(bulk_list):
         scope_arg = dict(scope_filters)
         if use_merged:
@@ -2478,6 +2488,7 @@ def _list_findings_impl(
                 since=window_since,
                 scope=scope_arg,
                 status=status_key,
+                scope_metadata=scope_metadata,
             )
             page_rows = merged.rows
             next_cursor = _encode_merged_next(merged)
@@ -2495,6 +2506,7 @@ def _list_findings_impl(
                 since=window_since,
                 scope=scope_arg,
                 status=status_key,
+                scope_metadata=scope_metadata,
             )
             page_rows = bulk_result[0]
             next_cursor = bulk_result[2] if len(bulk_result) > 2 else None
@@ -2640,6 +2652,22 @@ def _list_findings_impl(
         _logger.warning("Finding graph reachability projection skipped: %s", sanitize_error(exc))
         warnings.append("Graph reachability evidence is unavailable for this page; unmatched findings remain unassessed.")
 
+    scope_completeness: dict[str, Any] | None = None
+    if scope_filters and scope_metadata:
+        scope_truncated = bool(scope_metadata.get("truncated"))
+        scope_completeness = {
+            "status": "partial" if scope_truncated else "complete",
+            "reason": str(scope_metadata.get("reason") or ""),
+            "scanned_rows": int(scope_metadata.get("scanned_rows") or 0),
+            "scan_budget": int(scope_metadata.get("scan_budget") or 0),
+        }
+        if scope_truncated:
+            warnings.append(
+                "Scope filter matching stopped after "
+                f"{scope_completeness['scanned_rows']} scanned rows ({scope_completeness['reason']}); "
+                "this page is partial — continue with next_cursor for the rest."
+            )
+
     page = _redact_finding_page(page_rows)
     envelope = finding_list_envelope(
         findings=page,
@@ -2664,6 +2692,8 @@ def _list_findings_impl(
     # Echo the applied read-window so clients label counts honestly as
     # "last Nd" rather than "all" (#4009).
     envelope["window"] = time_window.window_metadata(resolved_window)
+    if scope_completeness is not None:
+        envelope["scope_completeness"] = scope_completeness
     if facets is not None:
         envelope["facets"] = facets
         envelope["facets_approximate"] = bool(facet_completeness and facet_completeness["status"] != "complete")

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -108,6 +108,8 @@ except ImportError as exc:  # pragma: no cover
     raise ImportError(_api_extra_import_error_message(exc)) from exc
 
 if TYPE_CHECKING:
+    import datetime as _datetime
+
     from fastapi.responses import HTMLResponse
 
 # ─── App ──────────────────────────────────────────────────────────────────────
@@ -1044,142 +1046,167 @@ async def _cleanup_loop() -> None:
     """
     while True:
         await asyncio.sleep(60)
-        store = _get_store()
-        store.cleanup_expired(_JOB_TTL_SECONDS)
-        # Public demo self-heal: if AGENT_BOM_DEMO_ESTATE is on and the curated
-        # scan job is missing/empty (TTL wipe, partial boot, operator reset),
-        # reseed without waiting for a container restart. Cheap no-op when a
-        # usable demo job is already present.
-        try:
-            from agent_bom.demo_estate.bootstrap import (
-                demo_estate_enabled,
-                maybe_bootstrap_demo_estate,
+        await _cleanup_tick()
+
+
+async def _cleanup_tick() -> None:
+    """One maintenance pass: TTL purges, partition retention, job reconcile.
+
+    EVERY work item is synchronous store/DB work and is offloaded to a worker
+    thread. Left inline it ran on the event loop once a minute; on Postgres at
+    volume the partition DDL alone freezes the whole control plane for the
+    duration of the tick. Each hook stays fail-open so a backend hiccup skips
+    one item instead of killing the loop.
+    """
+    store = _get_store()
+    await asyncio.to_thread(store.cleanup_expired, _JOB_TTL_SECONDS)
+    # Public demo self-heal: if AGENT_BOM_DEMO_ESTATE is on and the curated
+    # scan job is missing/empty (TTL wipe, partial boot, operator reset),
+    # reseed without waiting for a container restart. Cheap no-op when a
+    # usable demo job is already present.
+    try:
+        from agent_bom.demo_estate.bootstrap import (
+            demo_estate_enabled,
+            maybe_bootstrap_demo_estate,
+        )
+
+        if demo_estate_enabled():
+            await asyncio.to_thread(maybe_bootstrap_demo_estate)
+    except Exception:  # noqa: BLE001
+        _logger.warning("demo estate cleanup-loop reseed skipped", exc_info=True)
+    # Tier-B replay-log TTL purge (#2261). Wrapped so a backend hiccup
+    # never takes down the whole cleanup loop.
+    try:
+        from agent_bom.api.proxy_replay_store import get_proxy_replay_store
+
+        removed = await asyncio.to_thread(lambda: get_proxy_replay_store().cleanup_expired())
+        if removed:
+            _logger.info("proxy_replay_log cleanup removed %d expired rows", removed)
+    except Exception:  # noqa: BLE001
+        _logger.debug("proxy_replay_log cleanup skipped", exc_info=True)
+    # Hub observations partition retention (#3463). Postgres-only; no-op on
+    # SQLite and legacy unpartitioned tables. Fail-open like other cleanup
+    # hooks so a backend hiccup never stops the loop.
+    try:
+        from agent_bom.api.hub_observations_partition import run_hub_observations_retention
+
+        dropped_partitions = await asyncio.to_thread(run_hub_observations_retention)
+        if dropped_partitions:
+            _logger.info(
+                "hub_findings_current_observations retention dropped %d partition(s)",
+                dropped_partitions,
             )
+    except Exception:  # noqa: BLE001
+        _logger.debug("hub observations retention skipped", exc_info=True)
+    # Generic partition maintenance for the other append-only tables (#3463):
+    # ensure next partitions exist and roll over expired ones. Postgres-only;
+    # a strict no-op on SQLite and on any table an operator has not converted
+    # to declarative partitioning. Fail-open like the hooks above.
+    try:
+        from agent_bom.api.partition_maintenance import run_partition_retention
 
-            if demo_estate_enabled():
-                await asyncio.to_thread(maybe_bootstrap_demo_estate)
-        except Exception:  # noqa: BLE001
-            _logger.warning("demo estate cleanup-loop reseed skipped", exc_info=True)
-        # Tier-B replay-log TTL purge (#2261). Wrapped so a backend hiccup
-        # never takes down the whole cleanup loop.
-        try:
-            from agent_bom.api.proxy_replay_store import get_proxy_replay_store
+        partition_results = await asyncio.to_thread(run_partition_retention)
+        for table, (partitions_created, partitions_dropped) in partition_results.items():
+            _logger.info(
+                "%s partition maintenance: %d created, %d dropped",
+                table,
+                partitions_created,
+                partitions_dropped,
+            )
+    except Exception:  # noqa: BLE001
+        _logger.debug("partition maintenance skipped", exc_info=True)
+    # NHI lifecycle enforcement (#nhi): expire lingering JIT grants, opt-in
+    # dormant-identity deprovision, advisory token rotation-due flagging.
+    # Backend-agnostic and fail-open — a store error logs and is skipped so
+    # the loop survives. Timestamp injected for deterministic, replica-safe
+    # transitions.
+    try:
+        from datetime import datetime as _dt
+        from datetime import timezone as _tz
 
-            removed = get_proxy_replay_store().cleanup_expired()
-            if removed:
-                _logger.info("proxy_replay_log cleanup removed %d expired rows", removed)
-        except Exception:  # noqa: BLE001
-            _logger.debug("proxy_replay_log cleanup skipped", exc_info=True)
-        # Hub observations partition retention (#3463). Postgres-only; no-op on
-        # SQLite and legacy unpartitioned tables. Fail-open like other cleanup
-        # hooks so a backend hiccup never stops the loop.
-        try:
-            from agent_bom.api.hub_observations_partition import run_hub_observations_retention
+        from agent_bom.api.agent_identity_store import get_agent_identity_store, run_nhi_lifecycle_cleanup
+        from agent_bom.api.governance_audit_log import get_governance_audit_log
 
-            dropped_partitions = run_hub_observations_retention()
-            if dropped_partitions:
-                _logger.info(
-                    "hub_findings_current_observations retention dropped %d partition(s)",
-                    dropped_partitions,
-                )
-        except Exception:  # noqa: BLE001
-            _logger.debug("hub observations retention skipped", exc_info=True)
-        # Generic partition maintenance for the other append-only tables (#3463):
-        # ensure next partitions exist and roll over expired ones. Postgres-only;
-        # a strict no-op on SQLite and on any table an operator has not converted
-        # to declarative partitioning. Fail-open like the hooks above.
-        try:
-            from agent_bom.api.partition_maintenance import run_partition_retention
-
-            partition_results = run_partition_retention()
-            for table, (partitions_created, partitions_dropped) in partition_results.items():
-                _logger.info(
-                    "%s partition maintenance: %d created, %d dropped",
-                    table,
-                    partitions_created,
-                    partitions_dropped,
-                )
-        except Exception:  # noqa: BLE001
-            _logger.debug("partition maintenance skipped", exc_info=True)
-        # NHI lifecycle enforcement (#nhi): expire lingering JIT grants, opt-in
-        # dormant-identity deprovision, advisory token rotation-due flagging.
-        # Backend-agnostic and fail-open — a store error logs and is skipped so
-        # the loop survives. Timestamp injected for deterministic, replica-safe
-        # transitions.
-        try:
-            from datetime import datetime as _dt
-            from datetime import timezone as _tz
-
-            from agent_bom.api.agent_identity_store import get_agent_identity_store, run_nhi_lifecycle_cleanup
-            from agent_bom.api.governance_audit_log import get_governance_audit_log
-
-            nhi_now = _dt.now(_tz.utc)
-            nhi_result = run_nhi_lifecycle_cleanup(
+        nhi_now = _dt.now(_tz.utc)
+        nhi_result = await asyncio.to_thread(
+            lambda: run_nhi_lifecycle_cleanup(
                 get_agent_identity_store(),
                 now=nhi_now,
                 audit_log=get_governance_audit_log(),
             )
-            grants = nhi_result.get("grants", {})
-            dormant = nhi_result.get("dormant", {})
-            rotation = nhi_result.get("rotation", {})
-            acted = grants.get("expired", 0) + grants.get("pruned", 0) + dormant.get("revoked", 0) + rotation.get("flagged", 0)
-            if acted:
+        )
+        grants = nhi_result.get("grants", {})
+        dormant = nhi_result.get("dormant", {})
+        rotation = nhi_result.get("rotation", {})
+        acted = grants.get("expired", 0) + grants.get("pruned", 0) + dormant.get("revoked", 0) + rotation.get("flagged", 0)
+        if acted:
+            _logger.info(
+                "nhi lifecycle cleanup: %d grants expired, %d denied pruned, %d dormant revoked, %d rotation-due",
+                grants.get("expired", 0),
+                grants.get("pruned", 0),
+                dormant.get("revoked", 0),
+                rotation.get("flagged", 0),
+            )
+    except Exception:  # noqa: BLE001 — cleanup must never crash the loop
+        _logger.warning(
+            "nhi lifecycle cleanup skipped this tick; check the agent-identity store and governance audit-log backend connectivity",
+            exc_info=True,
+        )
+    # Managed-trial lifecycle: access is revoked at expiry, while data is
+    # deleted only after the configured grace period. This hook is opt-in
+    # and never runs in ordinary self-hosted deployments.
+    try:
+        from agent_bom.api.managed_trial import managed_trial_enabled
+
+        if managed_trial_enabled():
+            from agent_bom.api.tenant_lifecycle import run_managed_trial_lifecycle_tick
+
+            lifecycle_result = await asyncio.to_thread(run_managed_trial_lifecycle_tick)
+            if lifecycle_result["expired"] or lifecycle_result["deleted"]:
                 _logger.info(
-                    "nhi lifecycle cleanup: %d grants expired, %d denied pruned, %d dormant revoked, %d rotation-due",
-                    grants.get("expired", 0),
-                    grants.get("pruned", 0),
-                    dormant.get("revoked", 0),
-                    rotation.get("flagged", 0),
+                    "managed-trial lifecycle: %d expired, %d deleted",
+                    lifecycle_result["expired"],
+                    lifecycle_result["deleted"],
                 )
-        except Exception:  # noqa: BLE001 — cleanup must never crash the loop
-            _logger.warning(
-                "nhi lifecycle cleanup skipped this tick; check the agent-identity store and governance audit-log backend connectivity",
-                exc_info=True,
-            )
-        # Managed-trial lifecycle: access is revoked at expiry, while data is
-        # deleted only after the configured grace period. This hook is opt-in
-        # and never runs in ordinary self-hosted deployments.
-        try:
-            from agent_bom.api.managed_trial import managed_trial_enabled
+    except Exception:  # noqa: BLE001 — lifecycle cleanup remains retryable
+        _logger.warning(
+            "managed-trial lifecycle cleanup skipped this tick; check the lifecycle and tenant stores",
+            exc_info=True,
+        )
+    # Unstick jobs that have been RUNNING for too long
+    try:
+        from datetime import datetime, timezone
 
-            if managed_trial_enabled():
-                from agent_bom.api.tenant_lifecycle import run_managed_trial_lifecycle_tick
+        from agent_bom.api.scan_job_reconciliation import fail_stale_active_scan_jobs, reconcile_scan_jobs_active
 
-                lifecycle_result = await asyncio.to_thread(run_managed_trial_lifecycle_tick)
-                if lifecycle_result["expired"] or lifecycle_result["deleted"]:
-                    _logger.info(
-                        "managed-trial lifecycle: %d expired, %d deleted",
-                        lifecycle_result["expired"],
-                        lifecycle_result["deleted"],
-                    )
-        except Exception:  # noqa: BLE001 — lifecycle cleanup remains retryable
-            _logger.warning(
-                "managed-trial lifecycle cleanup skipped this tick; check the lifecycle and tenant stores",
-                exc_info=True,
-            )
-        # Unstick jobs that have been RUNNING for too long
-        try:
-            from datetime import datetime, timezone
+        now = datetime.now(timezone.utc)
+        await asyncio.to_thread(_fail_stuck_running_jobs, store, now)
+        await asyncio.to_thread(fail_stale_active_scan_jobs, store, timeout_seconds=_STUCK_JOB_TIMEOUT, now=now)
+        await asyncio.to_thread(reconcile_scan_jobs_active, store)
+    except Exception:  # noqa: BLE001
+        pass
 
-            from agent_bom.api.scan_job_reconciliation import fail_stale_active_scan_jobs, reconcile_scan_jobs_active
 
-            now = datetime.now(timezone.utc)
-            with _jobs_lock:
-                for job in list(_jobs.values()):
-                    if job.status == JobStatus.RUNNING and job.created_at:
-                        try:
-                            job_created = datetime.fromisoformat(job.created_at.replace("Z", "+00:00"))
-                            if (now - job_created).total_seconds() > _STUCK_JOB_TIMEOUT:
-                                job.status = JobStatus.FAILED
-                                job.error = "Timed out (stuck in RUNNING state)"
-                                job.completed_at = now.isoformat()
-                                store.put(job)
-                        except (ValueError, TypeError):
-                            pass
-            fail_stale_active_scan_jobs(store, timeout_seconds=_STUCK_JOB_TIMEOUT, now=now)
-            reconcile_scan_jobs_active(store)
-        except Exception:  # noqa: BLE001
-            pass
+def _fail_stuck_running_jobs(store: Any, now: _datetime.datetime) -> None:
+    """Mark in-process jobs stuck in RUNNING past the timeout as FAILED.
+
+    Synchronous by design — ``store.put`` is a DB write, so the caller runs
+    this in a worker thread.
+    """
+    from datetime import datetime
+
+    with _jobs_lock:
+        for job in list(_jobs.values()):
+            if job.status == JobStatus.RUNNING and job.created_at:
+                try:
+                    job_created = datetime.fromisoformat(job.created_at.replace("Z", "+00:00"))
+                except (ValueError, TypeError):
+                    continue
+                if (now - job_created).total_seconds() > _STUCK_JOB_TIMEOUT:
+                    job.status = JobStatus.FAILED
+                    job.error = "Timed out (stuck in RUNNING state)"
+                    job.completed_at = now.isoformat()
+                    store.put(job)
 
 
 # ─── Meta Routes ─────────────────────────────────────────────────────────────

--- a/src/agent_bom/backpressure.py
+++ b/src/agent_bom/backpressure.py
@@ -140,6 +140,23 @@ _DEFAULT_P99_THRESHOLD_MS: dict[str, int] = {"graph": 12_000, "findings": 12_000
 _GENERIC_P99_THRESHOLD_MS = 2500
 
 
+def _default_concurrency() -> int:
+    """Default concurrency ceiling: the process's worker-thread capacity.
+
+    Read handlers offload their synchronous store work to the AnyIO worker
+    pool, so that pool — not a magic number — is what the process can actually
+    serve in parallel. A hardcoded 8 shed 92% of reads at 50 concurrent clients
+    (4 successful reads/sec) while 20 worker threads sat idle: backpressure was
+    firing at single-analyst load rather than at overload. Deriving it from
+    ``WORKER_THREAD_LIMIT`` keeps the two from drifting; the per-path
+    ``AGENT_BOM_BACKPRESSURE_<PATH>_CONCURRENCY`` override still wins, and the
+    shedding behaviour past the ceiling is unchanged.
+    """
+    from agent_bom.config import WORKER_THREAD_LIMIT
+
+    return max(1, int(WORKER_THREAD_LIMIT))
+
+
 def _percentile(values: list[float], percentile: float) -> float:
     if not values:
         return 0.0
@@ -178,7 +195,7 @@ def _controller_for(path: str) -> BackpressureController:
             return controller
         controller = BackpressureController(
             path=path,
-            max_concurrency=_env_int(_path_env_key(path, "CONCURRENCY"), 8, minimum=1, maximum=1024),
+            max_concurrency=_env_int(_path_env_key(path, "CONCURRENCY"), _default_concurrency(), minimum=1, maximum=1024),
             p99_threshold_ms=float(
                 _env_int(
                     _path_env_key(path, "P99_MS"),

--- a/tests/api/test_findings_contract_envelope.py
+++ b/tests/api/test_findings_contract_envelope.py
@@ -47,9 +47,17 @@ def _client(tenant: str = "tenant-alpha", role: str = "admin") -> TestClient:
 
 
 def _assert_canonical_envelope(body: dict) -> None:
-    # ``total_approximate`` and the default-read-window echo ``window`` (#4009)
-    # are optional extras; every other key is fixed.
-    keys = set(body) - {"total_approximate", "window", "facets", "facets_approximate", "facet_metadata"}
+    # ``total_approximate``, the default-read-window echo ``window`` (#4009) and
+    # ``scope_completeness`` (only under a scope filter) are optional extras;
+    # every other key is fixed.
+    keys = set(body) - {
+        "total_approximate",
+        "window",
+        "facets",
+        "facets_approximate",
+        "facet_metadata",
+        "scope_completeness",
+    }
     assert keys == set(FINDING_LIST_ENVELOPE_KEYS), sorted(keys ^ set(FINDING_LIST_ENVELOPE_KEYS))
     assert isinstance(body["findings"], list)
     assert body["count"] == len(body["findings"])

--- a/tests/test_findings_scope_filter_keyset.py
+++ b/tests/test_findings_scope_filter_keyset.py
@@ -512,3 +512,149 @@ def test_postgres_list_current_page_scoped_no_dup_no_drop(monkeypatch) -> None:
     first_sql, first_params = conn.select_calls[0]
     assert "effective_reach_score <" not in first_sql  # first batch: no keyset
     assert int(first_params[-1]) == 201  # scope_filter_batch_size(17)=200 -> fetch 201
+
+
+# --------------------------------------------------------------------------- #
+# Truncation honesty: a scope walk that stops on its budget must SAY so, all
+# the way out to the response envelope. A sparse filter otherwise returns an
+# empty page with a "more" cursor and no partial signal.
+# --------------------------------------------------------------------------- #
+
+
+def _no_match_findings(count: int = 400) -> list[dict]:
+    return [
+        {
+            "id": f"nomatch-{idx:04d}",
+            "title": f"Finding {idx}",
+            "severity": "high",
+            "effective_reach_score": float(count - idx),
+            "provider": "gcp",
+            "account_ref": "gcp:acct-0",
+            "environment": "dev",
+            "security_domain": "cspm",
+            "origin": "bulk_ingest",
+            "source": "test",
+            "batch_id": "batch-scope-budget",
+        }
+        for idx in range(count)
+    ]
+
+
+def _seed_memory_bulk(findings: list[dict]) -> InMemoryComplianceHubStore:
+    store = InMemoryComplianceHubStore()
+    store.add("default", findings)
+    store.upsert_current_batch(
+        "default",
+        findings,
+        observed_at="2026-07-18T00:00:00Z",
+        batch_id="batch-scope-budget",
+        source="test",
+    )
+    set_compliance_hub_store(store)
+    set_job_store(InMemoryJobStore())
+    return store
+
+
+def test_memory_store_reports_scope_walk_truncation(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SCOPE_FILTER_SCAN_BUDGET", "25")
+    store = _seed_memory_bulk(_no_match_findings())
+
+    metadata: dict = {}
+    rows, total, next_cursor = store.list_current_page(
+        "default",
+        limit=20,
+        origin="bulk_ingest",
+        include_total=False,
+        scope={"provider": "aws"},
+        scope_metadata=metadata,
+    )
+
+    assert rows == []
+    assert total is None
+    assert next_cursor, "a budget-bounded walk must hand back a resume cursor"
+    assert metadata["truncated"] is True
+    assert metadata["reason"] == "scan_budget"
+    assert metadata["scanned_rows"] == 25
+    assert metadata["scan_budget"] == 25
+
+
+def test_sqlite_store_reports_scope_walk_truncation(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SCOPE_FILTER_SCAN_BUDGET", "25")
+    store = _seed_sqlite_bulk(_no_match_findings())
+
+    metadata: dict = {}
+    rows, _total, next_cursor = store.list_current_page(
+        "default",
+        limit=20,
+        origin="bulk_ingest",
+        include_total=False,
+        scope={"provider": "aws"},
+        scope_metadata=metadata,
+    )
+
+    assert rows == []
+    assert next_cursor
+    assert metadata["truncated"] is True
+    assert metadata["scanned_rows"] == 25
+
+
+def test_scope_walk_completes_reports_complete(monkeypatch) -> None:
+    """A walk that finishes inside its budget must NOT be flagged partial."""
+    monkeypatch.setenv("AGENT_BOM_SCOPE_FILTER_SCAN_BUDGET", "5000")
+    store = _seed_memory_bulk(_bulk_findings())
+
+    metadata: dict = {}
+    rows, _total, _next_cursor = store.list_current_page(
+        "default",
+        limit=500,
+        origin="bulk_ingest",
+        include_total=False,
+        scope={"provider": "aws"},
+        scope_metadata=metadata,
+    )
+
+    assert len(rows) == 150
+    assert metadata["truncated"] is False
+
+
+def test_findings_envelope_flags_a_bounded_scope_walk(monkeypatch) -> None:
+    """GET /v1/findings must surface the partial walk, not a silent empty page."""
+    monkeypatch.setenv("AGENT_BOM_SCOPE_FILTER_SCAN_BUDGET", "25")
+    _seed_sqlite_bulk(_no_match_findings())
+    client = TestClient(app)
+
+    resp = client.get("/v1/findings?provider=aws&limit=20&include_facets=false", headers=_AUTH)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert body["findings"] == []
+    completeness = body["scope_completeness"]
+    assert completeness["status"] == "partial"
+    assert completeness["reason"] == "scan_budget"
+    assert completeness["scanned_rows"] == 25
+    assert completeness["scan_budget"] == 25
+    assert body["total_approximate"] is True
+    assert any("scope filter" in warning.lower() for warning in body["warnings"]), body["warnings"]
+
+
+def test_findings_envelope_marks_a_complete_scope_walk(monkeypatch) -> None:
+    monkeypatch.setenv("AGENT_BOM_SCOPE_FILTER_SCAN_BUDGET", "5000")
+    _seed_sqlite_bulk(_bulk_findings())
+    client = TestClient(app)
+
+    resp = client.get("/v1/findings?provider=aws&limit=25&include_facets=false", headers=_AUTH)
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+
+    assert len(body["findings"]) == 25
+    assert body["scope_completeness"]["status"] == "complete"
+    assert not [warning for warning in body["warnings"] if "scope filter" in warning.lower()]
+
+
+def test_findings_envelope_omits_scope_completeness_without_a_scope_filter() -> None:
+    _seed_sqlite_bulk(_bulk_findings())
+    client = TestClient(app)
+
+    resp = client.get("/v1/findings?limit=5&include_facets=false", headers=_AUTH)
+    assert resp.status_code == 200, resp.text
+    assert "scope_completeness" not in resp.json()

--- a/tests/test_read_path_scale_hardening.py
+++ b/tests/test_read_path_scale_hardening.py
@@ -1,0 +1,317 @@
+"""Scale/read-path hardening: honest counts, bounded scope walks, no stampede.
+
+Each test encodes a property the audit found violated at volume:
+
+* ledger ingest counts must not double-count intra-batch duplicates that the
+  ``ON CONFLICT`` upsert collapses into a single row;
+* a scope-filtered page that stopped on its scan budget must say so in the
+  response envelope instead of looking like an honest empty result;
+* concurrent ``/v1/overview`` misses must share one fold (single-flight), not
+  stampede the O(estate) composition once per reader;
+* the ``findings`` backpressure controller must admit as many concurrent
+  readers as there are worker threads, not a hardcoded 8;
+* the retention/maintenance tick must not run store work on the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+import pytest
+
+from agent_bom.api.compliance_hub_store import SQLiteComplianceHubStore
+
+
+def _finding(finding_id: str, **extra: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "id": finding_id,
+        "source": "external-agent",
+        "origin": "bulk_ingest",
+        "severity": "high",
+        "cvss_score": 7.5,
+    }
+    payload.update(extra)
+    return payload
+
+
+# --------------------------------------------------------------------------- #
+# Ledger ingest count honesty (intra-batch duplicates)
+# --------------------------------------------------------------------------- #
+
+
+def test_ledger_ingest_count_dedupes_within_the_batch(tmp_path) -> None:
+    """Three findings sharing one canonical id land as ONE row; the cached
+    tenant total must agree with ``COUNT(*)`` rather than counting all three."""
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "tenant-dupes"
+
+    reported = store.add(tenant, [_finding("dup-1"), _finding("dup-1"), _finding("dup-1")])
+
+    assert store.count(tenant) == 1
+    assert reported == 1
+
+
+def test_ledger_ingest_count_mixes_new_and_duplicate_rows(tmp_path) -> None:
+    store = SQLiteComplianceHubStore(str(tmp_path / "hub.db"))
+    tenant = "tenant-mixed"
+
+    store.add(tenant, [_finding("a")])
+    # ``a`` already exists (DB dupe); ``b`` appears twice (intra-batch dupe).
+    reported = store.add(tenant, [_finding("a"), _finding("b"), _finding("b"), _finding("c")])
+
+    assert store.count(tenant) == 3
+    assert reported == 3
+
+
+# --------------------------------------------------------------------------- #
+# Backpressure: read concurrency tracks worker-thread capacity
+# --------------------------------------------------------------------------- #
+
+
+def test_findings_backpressure_defaults_to_worker_thread_capacity(monkeypatch) -> None:
+    from agent_bom import backpressure
+    from agent_bom.config import WORKER_THREAD_LIMIT
+
+    monkeypatch.delenv("AGENT_BOM_BACKPRESSURE_FINDINGS_CONCURRENCY", raising=False)
+    backpressure.reset_backpressure_for_tests()
+    try:
+        controller = backpressure._controller_for("findings")
+        assert controller.max_concurrency == WORKER_THREAD_LIMIT
+        assert controller.max_concurrency > 8
+    finally:
+        backpressure.reset_backpressure_for_tests()
+
+
+def test_backpressure_concurrency_stays_env_overridable(monkeypatch) -> None:
+    from agent_bom import backpressure
+
+    monkeypatch.setenv("AGENT_BOM_BACKPRESSURE_FINDINGS_CONCURRENCY", "3")
+    backpressure.reset_backpressure_for_tests()
+    try:
+        assert backpressure._controller_for("findings").max_concurrency == 3
+    finally:
+        backpressure.reset_backpressure_for_tests()
+
+
+def test_backpressure_still_sheds_beyond_the_limit() -> None:
+    """The shedding behaviour is unchanged — only the default ceiling moved."""
+    from agent_bom.backpressure import BackpressureController, BackpressureRejectedError
+
+    controller = BackpressureController(
+        path="findings",
+        max_concurrency=2,
+        p99_threshold_ms=10_000,
+        cooldown_seconds=1,
+        min_samples=100,
+    )
+    controller.try_enter()
+    controller.try_enter()
+    with pytest.raises(BackpressureRejectedError):
+        controller.try_enter()
+
+
+# --------------------------------------------------------------------------- #
+# /v1/overview single-flight (cache stampede)
+# --------------------------------------------------------------------------- #
+
+
+class _FakeJobStore:
+    def __init__(self, jobs: list[Any]) -> None:
+        self._jobs = jobs
+
+    def list_all(self, tenant_id: str) -> list[Any]:
+        return list(self._jobs)
+
+
+def _await_until(predicate, timeout: float = 10.0) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.005)
+    return False
+
+
+def test_overview_concurrent_misses_share_one_fold(monkeypatch) -> None:
+    """8 concurrent cold readers must fold the estate ONCE.
+
+    The barrier is structural, not a timing assertion: every reader is held
+    until all 8 have missed the cache, so a stampeding implementation is
+    guaranteed to record 8 folds and a single-flight one exactly 1.
+    """
+    from agent_bom.api.routes import overview
+
+    overview._reset_overview_cache()
+    monkeypatch.setattr(overview, "_tenant_id", lambda request: "acme")
+    monkeypatch.delenv("AGENT_BOM_OVERVIEW_CACHE_TTL_SECONDS", raising=False)
+    monkeypatch.setattr(overview, "_get_store", lambda: _FakeJobStore([]))
+    monkeypatch.setattr(overview, "_hub_severity_snapshot", lambda request: {"critical": 1})
+
+    readers = 8
+    arrived = threading.Semaphore(0)
+    release = threading.Event()
+    folds = {"n": 0}
+    folds_lock = threading.Lock()
+
+    real_cache_get = overview._overview_cache_get
+
+    def _counting_cache_get(tenant_id: str, fingerprint: str):
+        result = real_cache_get(tenant_id, fingerprint)
+        arrived.release()
+        return result
+
+    monkeypatch.setattr(overview, "_overview_cache_get", _counting_cache_get)
+
+    def _slow_compose(request, tenant_id, jobs, hub_severity):
+        with folds_lock:
+            folds["n"] += 1
+        assert release.wait(timeout=10)
+        return {"schema_version": "overview.v1", "tenant_id": tenant_id}
+
+    monkeypatch.setattr(overview, "_compose_overview", _slow_compose)
+
+    results: list[Any] = [None] * readers
+    errors: list[BaseException] = []
+
+    def _reader(index: int) -> None:
+        try:
+            results[index] = overview._build_overview(object())
+        except BaseException as exc:  # noqa: BLE001 — surfaced by the assertion below
+            errors.append(exc)
+
+    threads = [threading.Thread(target=_reader, args=(i,)) for i in range(readers)]
+    for thread in threads:
+        thread.start()
+    try:
+        for _ in range(readers):
+            assert arrived.acquire(timeout=10), "readers did not all reach the cache probe"
+    finally:
+        release.set()
+    for thread in threads:
+        thread.join(timeout=15)
+
+    overview._reset_overview_cache()
+    assert not errors
+    assert all(thread.is_alive() is False for thread in threads)
+    assert folds["n"] == 1
+    assert all(result == {"schema_version": "overview.v1", "tenant_id": "acme"} for result in results)
+
+
+def test_overview_singleflight_follower_recomputes_when_leader_fails(monkeypatch) -> None:
+    """A failed leader must not poison followers with a missing payload."""
+    from agent_bom.api.routes import overview
+
+    overview._reset_overview_cache()
+    monkeypatch.setattr(overview, "_tenant_id", lambda request: "acme")
+    monkeypatch.setattr(overview, "_get_store", lambda: _FakeJobStore([]))
+    monkeypatch.setattr(overview, "_hub_severity_snapshot", lambda request: {"critical": 1})
+
+    calls = {"n": 0}
+
+    def _flaky_compose(request, tenant_id, jobs, hub_severity):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("cold fold exploded")
+        return {"schema_version": "overview.v1", "tenant_id": tenant_id}
+
+    monkeypatch.setattr(overview, "_compose_overview", _flaky_compose)
+
+    with pytest.raises(RuntimeError):
+        overview._build_overview(object())
+    # The in-flight slot must be released so the next reader is not stranded.
+    assert overview._build_overview(object()) == {"schema_version": "overview.v1", "tenant_id": "acme"}
+    overview._reset_overview_cache()
+
+
+# --------------------------------------------------------------------------- #
+# Retention/maintenance tick runs off the event loop
+# --------------------------------------------------------------------------- #
+
+
+def test_cleanup_tick_runs_store_work_off_the_event_loop(monkeypatch) -> None:
+    """Every blocking work item in the maintenance tick must be offloaded.
+
+    The tick records the thread it ran on; none may equal the event-loop
+    thread, otherwise a 60s partition-DDL tick freezes the control plane.
+    """
+    from agent_bom.api import server
+
+    seen: dict[str, int] = {}
+
+    class _RecordingStore:
+        def cleanup_expired(self, ttl_seconds: int) -> int:
+            seen["cleanup_expired"] = threading.get_ident()
+            return 0
+
+        def put(self, job: Any) -> None:  # pragma: no cover - not exercised here
+            pass
+
+    monkeypatch.setattr(server, "_get_store", lambda: _RecordingStore())
+
+    class _RecordingReplayStore:
+        def cleanup_expired(self) -> int:
+            seen["replay_cleanup"] = threading.get_ident()
+            return 0
+
+    monkeypatch.setattr(
+        "agent_bom.api.proxy_replay_store.get_proxy_replay_store",
+        lambda: _RecordingReplayStore(),
+    )
+
+    def _hub_retention() -> int:
+        seen["hub_observations_retention"] = threading.get_ident()
+        return 0
+
+    monkeypatch.setattr(
+        "agent_bom.api.hub_observations_partition.run_hub_observations_retention",
+        _hub_retention,
+    )
+
+    def _partition_retention() -> dict[str, tuple[int, int]]:
+        seen["partition_retention"] = threading.get_ident()
+        return {}
+
+    monkeypatch.setattr("agent_bom.api.partition_maintenance.run_partition_retention", _partition_retention)
+
+    def _nhi_cleanup(store: Any, *, now: Any, audit_log: Any) -> dict[str, Any]:
+        seen["nhi_lifecycle"] = threading.get_ident()
+        return {"grants": {}, "dormant": {}, "rotation": {}}
+
+    monkeypatch.setattr("agent_bom.api.agent_identity_store.run_nhi_lifecycle_cleanup", _nhi_cleanup)
+    monkeypatch.setattr("agent_bom.api.agent_identity_store.get_agent_identity_store", lambda: object())
+    monkeypatch.setattr("agent_bom.api.governance_audit_log.get_governance_audit_log", lambda: object())
+
+    def _fail_stale(store: Any, *, timeout_seconds: int, now: Any) -> int:
+        seen["fail_stale_active_scan_jobs"] = threading.get_ident()
+        return 0
+
+    def _reconcile(store: Any) -> int:
+        seen["reconcile_scan_jobs_active"] = threading.get_ident()
+        return 0
+
+    monkeypatch.setattr("agent_bom.api.scan_job_reconciliation.fail_stale_active_scan_jobs", _fail_stale)
+    monkeypatch.setattr("agent_bom.api.scan_job_reconciliation.reconcile_scan_jobs_active", _reconcile)
+    monkeypatch.setattr("agent_bom.demo_estate.bootstrap.demo_estate_enabled", lambda: False)
+    monkeypatch.setattr("agent_bom.api.managed_trial.managed_trial_enabled", lambda: False)
+
+    async def _run() -> int:
+        await server._cleanup_tick()
+        return threading.get_ident()
+
+    loop_thread_id = asyncio.run(_run())
+
+    expected = {
+        "cleanup_expired",
+        "replay_cleanup",
+        "hub_observations_retention",
+        "partition_retention",
+        "nhi_lifecycle",
+        "fail_stale_active_scan_jobs",
+        "reconcile_scan_jobs_active",
+    }
+    assert expected <= set(seen), f"maintenance work item never ran: {sorted(expected - set(seen))}"
+    on_loop = sorted(name for name, ident in seen.items() if ident == loop_thread_id)
+    assert on_loop == [], f"maintenance work ran on the event loop: {on_loop}"

--- a/ui/app/findings/page.tsx
+++ b/ui/app/findings/page.tsx
@@ -11,7 +11,7 @@ import {
   type FindingTriageJustification,
   type ReadWindow,
 } from "@/lib/api";
-import type { FindingFacets } from "@/lib/api-types";
+import type { FindingFacets, ScopeCompleteness } from "@/lib/api-types";
 import { ApiOfflineState } from "@/components/api-offline-state";
 import { FindingDrawer } from "@/components/finding-drawer";
 import { FindingsQueueTable } from "@/components/findings-queue";
@@ -311,6 +311,7 @@ function FindingsPage() {
   const [findingsTotalApproximate, setFindingsTotalApproximate] = useState(false);
   const [findingFacets, setFindingFacets] = useState<FindingFacets | null>(null);
   const [findingFacetsApproximate, setFindingFacetsApproximate] = useState(false);
+  const [scopeCompleteness, setScopeCompleteness] = useState<ScopeCompleteness | null>(null);
   const [hasMoreFindings, setHasMoreFindings] = useState(false);
   const [nextFindingsCursor, setNextFindingsCursor] = useState("");
   const [pageCursors, setPageCursors] = useState<string[]>([""]);
@@ -554,6 +555,7 @@ function FindingsPage() {
         setFindingsTotalApproximate(Boolean(response.total_approximate));
         setFindingFacets(response.facets ?? null);
         setFindingFacetsApproximate(Boolean(response.facets_approximate));
+        setScopeCompleteness(response.scope_completeness ?? null);
         setHasMoreFindings(Boolean(response.has_more || response.next_cursor));
         setNextFindingsCursor(response.next_cursor ?? "");
       } catch (e: unknown) {
@@ -772,7 +774,20 @@ function FindingsPage() {
         />
       )}
 
-      {!loading && !error && vulns.length === 0 && (
+      {/* A scope walk that stopped on its row budget is NOT evidence of an empty
+          estate. Say so, and never let the "No findings found" empty state stand
+          in for a partial page. */}
+      {!loading && !error && scopeCompleteness?.status === "partial" && (
+        <div
+          data-testid="findings-scope-partial"
+          className="rounded-md border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] px-3 py-2 text-xs text-[color:var(--text-secondary)]"
+        >
+          Partial results — filter matching stopped after {scopeCompleteness.scanned_rows.toLocaleString()} scanned rows
+          to keep the read fast. Page through with Next for the rest, or narrow the filters.
+        </div>
+      )}
+
+      {!loading && !error && vulns.length === 0 && scopeCompleteness?.status !== "partial" && (
         <PageEmptyState
           title="No findings found"
           detail="Run a scan or connect a cloud account to populate CVE, cloud posture, graph, and remediation evidence."

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -1149,6 +1149,20 @@ export interface FindingListEnvelope<T> {
       missing_or_invalid: "unavailable";
     };
   } | undefined;
+  /**
+   * Completeness of the server-side scope walk. Present only when a scope
+   * filter (`provider` / `account` / `environment` / `domain` / `q`) is
+   * applied. `partial` means the walk hit its row budget or deadline: the page
+   * is a prefix, not the whole matching set — continue with `next_cursor`.
+   */
+  scope_completeness?: ScopeCompleteness | undefined;
+}
+
+export interface ScopeCompleteness {
+  status: "complete" | "partial";
+  reason: string;
+  scanned_rows: number;
+  scan_budget: number;
 }
 
 export interface FindingFacets {

--- a/ui/tests/findings-page.test.tsx
+++ b/ui/tests/findings-page.test.tsx
@@ -336,6 +336,38 @@ describe("FindingsPage", () => {
     expect(screen.queryByRole("columnheader", { name: "Control mapping" })).not.toBeInTheDocument();
   });
 
+  it("labels a budget-bounded scope walk partial instead of showing a silent empty page", async () => {
+    apiMock.listFindings.mockResolvedValue({
+      schema_version: "v1",
+      findings: [],
+      total: null,
+      total_approximate: true,
+      has_more: true,
+      next_cursor: "cursor-next",
+      scope_completeness: { status: "partial", reason: "scan_budget", scanned_rows: 20000, scan_budget: 20000 },
+    });
+
+    render(<FindingsPage />);
+
+    const notice = await screen.findByTestId("findings-scope-partial");
+    expect(notice).toHaveTextContent(/Partial results/i);
+    expect(notice).toHaveTextContent("20,000");
+  });
+
+  it("shows no partial-results notice when the scope walk completed", async () => {
+    apiMock.listFindings.mockResolvedValue({
+      schema_version: "v1",
+      findings: [canonicalFinding],
+      total: 1,
+      scope_completeness: { status: "complete", reason: "", scanned_rows: 300, scan_budget: 20000 },
+    });
+
+    render(<FindingsPage />);
+
+    expect(await screen.findByText("CVE-2026-1234")).toBeInTheDocument();
+    expect(screen.queryByTestId("findings-scope-partial")).not.toBeInTheDocument();
+  });
+
   it("renders persisted graph reachability without inventing evidence for non-overlapping findings", async () => {
     apiMock.listFindings.mockResolvedValue({
       schema_version: "v1",


### PR DESCRIPTION
## Summary

Read-path hardening from a hands-on audit. Five defects that each made the control plane
either report a wrong number or fall over under ordinary analyst load.

- **Bounded scope walks now say they were bounded.** PR #4566 added the scan budget and
  deadline to `collect_scope_filtered_page`, but all three `list_current_page` callers
  discarded the truncation metadata, so a sparse filter returned an empty page with a
  "more" cursor and no partial signal at all. The metadata is now plumbed through the
  Protocol and every backend, surfaced as `scope_completeness` plus an explicit warning,
  and accumulated across refills rather than overwritten by the last one.
- **`/v1/overview` no longer stampedes.** The cache was a plain read-compute-write with no
  in-flight de-duplication; 8 concurrent readers each computed the full fold. Now
  single-flight per tenant. Measured 8 folds -> 1.
- **Read concurrency is no longer pinned at 8.** The `findings` controller's ceiling was a
  literal 8 regardless of hardware, which shed ~92% of reads at 50 clients. It now derives
  from `WORKER_THREAD_LIMIT` (default 20), matching the worker pool the reads actually run
  on. Env override and shedding behaviour unchanged.
- **Bulk ingest counts distinct rows.** `new_rows` counted each row against the DB but never
  deduped within the batch, while `ON CONFLICT DO UPDATE` collapsed intra-batch duplicates
  and the cached tenant total advanced by the inflated count. Posting 3 rows sharing a
  canonical id reported 3 ingested while 1 landed.
- **The retention tick runs off the event loop.** Six of eight work items in `_cleanup_loop`
  ran inline, including Postgres partition DDL, which would freeze the control plane every
  60 seconds at volume.

The scan-budget/deadline bounds are now resolved per call so operators can tune them
without a restart.

## Full-stack alignment

`scope_completeness` is a new response field, threaded through `ui/lib/api-types.ts` and
rendered in `ui/app/findings/page.tsx` as a partial-results notice. The findings page also
stops showing "No findings found" when the walk was partial -- that empty state was the
user-visible face of this bug.

## Verification

- targeted `pytest`: 90 passed (read-scale, facets export contract, scope-filter keyset,
  envelope contract, backpressure, overview, overview cache, new hardening module);
  hub/server suites 182 passed, 1 skipped
- every new guard verified red before green
- `ruff check` clean on all 9 changed Python files
- `mypy src/`: 12 errors, all pre-existing cloud-SDK stub mismatches in files not in this diff
- preflight drift gates: OpenAPI OK, v1 schemas OK, product surface passed, env-var reference OK
- UI: lint clean, typecheck clean, `vitest` 978 passed across 163 files

## Notes

- **Postgres changes are verified by symmetry only.** The local PG instance was unavailable.
  Both PG edits mirror the SQLite path exactly and the PG scope path is exercised by the
  existing fake-connection test against the real store class. The distinct-id count assumes
  `executemany` + `ON CONFLICT DO UPDATE` collapses intra-batch duplicates on PG as on
  SQLite; that is the one assumption not reproduced empirically.
- Raising the concurrency default lets more reads through, so the 12s p99 cooldown now
  carries more of the shedding load. Intended, but worth watching under real load.
- `ruff format --check` flags 3 files, all in lines this branch never touched; `make lint`
  runs `ruff check` + `mypy` only, and main is not format-clean either. Left alone rather
  than sweeping unrelated reformatting in.
