### PR TITLE
fix(api): reject malformed requests, degrade on unreadable manifests, and close tenant gaps

### DIFF
--- a/deploy/supabase/postgres/alembic/versions/20260730_02_teams_tenant_rls.py
+++ b/deploy/supabase/postgres/alembic/versions/20260730_02_teams_tenant_rls.py
@@ -1,0 +1,59 @@
+"""Force tenant RLS on the ``teams`` FK root.
+
+``teams`` was the only tenant-columned relation with ``relrowsecurity = f``,
+while ``agent_bom_app`` holds ``DELETE,INSERT,SELECT,UPDATE`` on it and every
+tenant table references it ``ON DELETE CASCADE``. An ordinary app-role session
+bound to one tenant could therefore enumerate all tenants and delete another
+tenant's root row, cascading its entire dataset away with no database backstop.
+
+The maintenance purge in ``api/tenant_lifecycle`` already runs inside
+``bypass_tenant_rls()`` + ``_maintenance_connection()``, so ``abom_rls_bypass()``
+keeps that path working.
+
+Revision ID: 20260730_02
+Revises: 20260730_01
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+revision = "20260730_02"
+down_revision = "20260730_01"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        DO $migration$
+        BEGIN
+            IF to_regclass('public.teams') IS NULL THEN
+                RETURN;
+            END IF;
+
+            ALTER TABLE teams ENABLE ROW LEVEL SECURITY;
+            ALTER TABLE teams FORCE ROW LEVEL SECURITY;
+
+            IF NOT EXISTS (
+                SELECT 1 FROM pg_policies
+                WHERE schemaname = current_schema()
+                  AND tablename = 'teams'
+                  AND policyname = 'teams_tenant_isolation'
+            ) THEN
+                CREATE POLICY teams_tenant_isolation ON teams
+                    USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
+                    WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
+            END IF;
+        END
+        $migration$;
+        """
+    )
+
+
+def downgrade() -> None:
+    # Deliberately irreversible, matching 20260729_03: removing tenant isolation
+    # from the FK root would reopen a cross-tenant destruction path during
+    # rollback.
+    pass

--- a/deploy/supabase/postgres/init.sql
+++ b/deploy/supabase/postgres/init.sql
@@ -847,6 +847,14 @@ AS $$
        AND pg_has_role(session_user, 'agent_bom_rls_maintenance', 'MEMBER')
 $$;
 
+-- teams is the FK root every tenant table references ON DELETE CASCADE, and
+-- agent_bom_app holds DML on it. Without RLS an app-role session bound to one
+-- tenant can enumerate every tenant and delete another tenant's root row,
+-- cascading that tenant's whole dataset away. The maintenance purge in
+-- api/tenant_lifecycle runs under the RLS-bypass role, so it is unaffected.
+ALTER TABLE teams ENABLE ROW LEVEL SECURITY;
+ALTER TABLE teams FORCE ROW LEVEL SECURITY;
+
 ALTER TABLE gateway_policies ENABLE ROW LEVEL SECURITY;
 ALTER TABLE gateway_policies FORCE ROW LEVEL SECURITY;
 
@@ -867,6 +875,21 @@ ALTER TABLE scan_jobs FORCE ROW LEVEL SECURITY;
 
 ALTER TABLE cis_benchmark_checks ENABLE ROW LEVEL SECURITY;
 ALTER TABLE cis_benchmark_checks FORCE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies
+        WHERE schemaname = 'public'
+          AND tablename = 'teams'
+          AND policyname = 'teams_tenant_isolation'
+    ) THEN
+        CREATE POLICY teams_tenant_isolation ON teams
+            USING (public.abom_rls_bypass() OR team_id = public.abom_current_tenant())
+            WITH CHECK (public.abom_rls_bypass() OR team_id = public.abom_current_tenant());
+    END IF;
+END
+$$;
 
 DO $$
 BEGIN

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1057,
+      "value": 1063,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1057 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1063 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 814 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/api/idempotency_store.py
+++ b/src/agent_bom/api/idempotency_store.py
@@ -57,6 +57,16 @@ class IdempotencyConflictError(RuntimeError):
     """Raised when a key is reused for a different request payload."""
 
 
+class IdempotencyPayloadError(ValueError):
+    """Raised when a request payload cannot be fingerprinted.
+
+    Pydantic's serializer aborts with ``ValueError: Circular reference detected
+    (depth exceeded)`` on a deeply nested body, and ``json.dumps`` can hit the
+    interpreter recursion limit on the same input. Both are caller-controlled,
+    so they must land as a 422 instead of escaping as an unhandled 500.
+    """
+
+
 class IdempotencyStore(Protocol):
     def get(
         self,
@@ -98,9 +108,17 @@ def _normalize_request_payload(value: Any) -> Any:
 
 
 def idempotency_request_fingerprint(payload: Any) -> str:
-    """Return a stable fingerprint for comparing idempotent write retries."""
-    normalized = _normalize_request_payload(payload or {})
-    encoded = json.dumps(normalized, sort_keys=True, separators=(",", ":"), default=str)
+    """Return a stable fingerprint for comparing idempotent write retries.
+
+    Raises:
+        IdempotencyPayloadError: when the caller's payload is too deeply nested
+            (or otherwise cyclic) to normalize. Callers surface this as 422.
+    """
+    try:
+        normalized = _normalize_request_payload(payload or {})
+        encoded = json.dumps(normalized, sort_keys=True, separators=(",", ":"), default=str)
+    except (ValueError, TypeError, RecursionError) as exc:
+        raise IdempotencyPayloadError("Request payload is too deeply nested to process") from exc
     return hashlib.sha256(encoded.encode("utf-8")).hexdigest()
 
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -1023,6 +1023,13 @@ async def run_resolver_chain(resolvers: Iterable[Callable[[], Awaitable[Resoluti
 # pages (``/overview``, ``/inventory``, ``/reports``, …) 401-ing on a cold
 # deep-link while non-existent routes stayed allowlisted. Empty means no
 # dashboard is mounted, so there is no SPA route to make public.
+#
+# BEHAVIOUR CHANGE: on a REST-only deployment (``serve --no-ui`` /
+# ``AGENT_BOM_NO_UI``, or a wheel built without ``ui_dist``) SPA paths now
+# answer 401 rather than 404. Nothing is being withheld — there is no SPA to
+# serve in that mode — and the previous 404 came from the router only after
+# auth had already waved the path through. Deliberate: it keeps the allowlist
+# honest instead of re-introducing a hardcoded fallback that would drift again.
 _DASHBOARD_SPA_ROUTES: frozenset[str] = frozenset()
 
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -44,7 +44,7 @@ from starlette.responses import JSONResponse, Response
 from starlette.types import ASGIApp, Message
 
 from agent_bom.api.dashboard_csp import dashboard_csp_header, describe_dashboard_csp_posture
-from agent_bom.security import sanitize_text
+from agent_bom.security import sanitize_error, sanitize_text
 
 _logger = logging.getLogger(__name__)
 _RATE_LIMIT_FINGERPRINT_FALLBACK = secrets.token_bytes(32)
@@ -2742,7 +2742,7 @@ def install_error_envelope(application: object) -> None:
         # this is a client error — not an unhandled 500 that poisons 5xx alerting.
         return _build_error_envelope(
             status_code=422,
-            detail=str(exc) or "Request payload could not be processed",
+            detail=sanitize_error(exc) or "Request payload could not be processed",
             correlation_id=_correlation_id(request),
         )
 

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -858,6 +858,17 @@ class TrustHeadersMiddleware(BaseHTTPMiddleware):
         trace_meta = make_request_trace(dict(request.headers))
         request_id = request.headers.get("x-request-id") or str(uuid.uuid4())
         request.state.request_id = request_id
+        # A percent-encoded NUL in a path parameter is decoded before routing and
+        # then handed to psycopg as a text value, which raises `DataError:
+        # PostgreSQL text fields cannot contain NUL (0x00) bytes` deep inside a
+        # store and surfaces as a bare 500. Reject the whole request here so the
+        # class is closed for every route rather than one path id at a time.
+        if "\x00" in request.url.path:
+            return _build_error_envelope(
+                status_code=400,
+                detail="Request path contains a NUL (0x00) byte",
+                correlation_id=request_id,
+            )
         request.state.trace_id = trace_meta["trace_id"]
         request.state.span_id = trace_meta["span_id"]
         request.state.parent_span_id = trace_meta["parent_span_id"]
@@ -1007,6 +1018,48 @@ async def run_resolver_chain(resolvers: Iterable[Callable[[], Awaitable[Resoluti
     return None
 
 
+# Public SPA routes, derived at startup from the dashboard files the server
+# actually ships. A hand-maintained list drifted from ``ui/app/`` and left real
+# pages (``/overview``, ``/inventory``, ``/reports``, …) 401-ing on a cold
+# deep-link while non-existent routes stayed allowlisted. Empty means no
+# dashboard is mounted, so there is no SPA route to make public.
+_DASHBOARD_SPA_ROUTES: frozenset[str] = frozenset()
+
+
+def dashboard_spa_routes_from_files(relative_paths: Iterable[str]) -> frozenset[str]:
+    """Derive the public SPA first-segment allowlist from exported file paths.
+
+    ``relative_paths`` are the dashboard-relative keys the SPA catch-all
+    resolves against (``overview/index.html``, ``findings.html``, …).
+    """
+    routes: set[str] = set()
+    for relative in relative_paths:
+        normalized = relative.strip("/")
+        if not normalized or normalized.startswith("_next"):
+            continue
+        first_segment, separator, _ = normalized.partition("/")
+        if separator:
+            routes.add(first_segment)
+        elif first_segment.lower().endswith(".html"):
+            routes.add(first_segment.rsplit(".", 1)[0])
+    if "index" in routes:
+        # ``index.html`` is the SPA shell: it backs both ``/`` and every
+        # client-side route the export did not pre-render as its own file.
+        routes.add("")
+    return frozenset(routes)
+
+
+def register_dashboard_spa_routes(relative_paths: Iterable[str]) -> None:
+    """Publish the SPA route allowlist discovered while mounting the dashboard."""
+    global _DASHBOARD_SPA_ROUTES  # noqa: PLW0603 — process-wide startup registry
+    _DASHBOARD_SPA_ROUTES = dashboard_spa_routes_from_files(relative_paths)
+
+
+def dashboard_spa_routes() -> frozenset[str]:
+    """Return the currently registered public SPA first-segment allowlist."""
+    return _DASHBOARD_SPA_ROUTES
+
+
 class APIKeyMiddleware(BaseHTTPMiddleware):
     """Optional API key authentication via Bearer token or X-API-Key header.
 
@@ -1084,40 +1137,7 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
             return True
         if path.startswith("/brand/"):
             return True
-        dashboard_routes = {
-            "",
-            "activity",
-            "agents",
-            "audit",
-            "compliance",
-            "context",
-            "dashboard",
-            "findings",
-            "connections",
-            "cost",
-            "drift",
-            "fleet",
-            "gateway",
-            "governance",
-            "graph",
-            "help",
-            "identity",
-            "index",
-            "insights",
-            "jobs",
-            "login",
-            "manifest",
-            "mesh",
-            "proxy",
-            "registry",
-            "remediation",
-            "scan",
-            "security-graph",
-            "settings",
-            "sources",
-            "traces",
-            "vulns",
-        }
+        dashboard_routes = _DASHBOARD_SPA_ROUTES
         normalized = path.strip("/")
         first_segment = normalized.split("/", 1)[0] if normalized else ""
         public_suffixes = (
@@ -1138,9 +1158,10 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
         )
         if path.lower().endswith(public_suffixes):
             return first_segment in dashboard_routes or ("/" not in normalized and normalized.rsplit(".", 1)[0] in dashboard_routes)
-        # Client-side dashboard routes are served by the SPA fallback. Keep
-        # this whitelist tight so arbitrary application routes cannot bypass
-        # OIDC/API-key/SCIM authentication just because they are GET requests.
+        # Client-side dashboard routes are served by the SPA fallback. The set
+        # is derived from the shipped dashboard files (see
+        # ``register_dashboard_spa_routes``) so it can neither drift from the
+        # real pages nor allowlist a route the SPA does not serve.
         return first_segment in dashboard_routes
 
     # Ordered route rules so narrower enterprise paths win over broad prefixes.
@@ -2572,21 +2593,43 @@ def _error_message_for(status_code: int, detail: object) -> str:
 
 
 def _json_safe_validation_errors(errors: Sequence[object]) -> list[dict[str, object]]:
-    """Make Pydantic validation errors JSON-serializable.
+    """Make Pydantic validation errors JSON-serializable and value-free.
 
-    ``model_validator`` failures embed a live ``ValueError`` in ``ctx['error']``;
-    serializing that verbatim blows up the 422 envelope and surfaces as 500.
+    Two failure modes are handled here:
+
+    * ``model_validator`` failures embed a live ``ValueError`` in
+      ``ctx['error']``, and a non-JSON request body (``text/plain``, form
+      encoding, or no ``Content-Type`` at all) makes Pydantic report the raw
+      ``bytes`` in ``input``. Serializing either verbatim raises *inside* the
+      validation handler, so the caller got a bare 500 with no ``error.code``
+      and no ``correlation_id`` — on every POST/PUT/PATCH.
+    * ``input`` reflected the submitted value back verbatim, so a
+      credential-shaped field ended up in CI logs, proxies, and error trackers.
+
+    Dropping ``input`` fixes both; ``jsonable_encoder`` is the backstop for any
+    remaining non-JSON value elsewhere in the error record.
     """
+    from fastapi.encoders import jsonable_encoder
+
     safe: list[dict[str, object]] = []
     for err in errors:
         if not isinstance(err, dict):
             safe.append({"error": str(err)})
             continue
-        item = dict(err)
+        item = {key: value for key, value in err.items() if key != "input"}
         ctx = item.get("ctx")
         if isinstance(ctx, dict):
             item["ctx"] = {key: str(value) if isinstance(value, BaseException) else value for key, value in ctx.items()}
-        safe.append(item)
+        try:
+            safe.append(cast(dict[str, object], jsonable_encoder(item)))
+        except Exception:  # noqa: BLE001 — the error envelope must never fail to serialize
+            safe.append(
+                {
+                    "type": str(item.get("type", "value_error")),
+                    "loc": [str(part) for part in cast(Sequence[object], item.get("loc") or ())],
+                    "msg": str(item.get("msg", "Validation error")),
+                }
+            )
     return safe
 
 
@@ -2626,6 +2669,8 @@ def install_error_envelope(application: object) -> None:
     from fastapi import HTTPException
     from fastapi.exceptions import RequestValidationError
     from starlette.exceptions import HTTPException as StarletteHTTPException
+
+    from agent_bom.api.idempotency_store import IdempotencyPayloadError
 
     def _correlation_id(request: StarletteRequest) -> str:
         return getattr(request.state, "request_id", "") or request.headers.get("x-request-id") or str(uuid.uuid4())
@@ -2667,6 +2712,16 @@ def install_error_envelope(application: object) -> None:
             correlation_id=_correlation_id(request),
         )
 
+    async def idempotency_payload_exception_handler(request: StarletteRequest, exc: Exception) -> JSONResponse:
+        # The payload that could not be fingerprinted is caller-controlled, so
+        # this is a client error — not an unhandled 500 that poisons 5xx alerting.
+        return _build_error_envelope(
+            status_code=422,
+            detail=str(exc) or "Request payload could not be processed",
+            correlation_id=_correlation_id(request),
+        )
+
     application.add_exception_handler(HTTPException, http_exception_handler)  # type: ignore[attr-defined]
     application.add_exception_handler(StarletteHTTPException, starlette_http_exception_handler)  # type: ignore[attr-defined]
     application.add_exception_handler(RequestValidationError, validation_exception_handler)  # type: ignore[attr-defined]
+    application.add_exception_handler(IdempotencyPayloadError, idempotency_payload_exception_handler)  # type: ignore[attr-defined]

--- a/src/agent_bom/api/middleware.py
+++ b/src/agent_bom/api/middleware.py
@@ -2026,7 +2026,14 @@ class APIKeyMiddleware(BaseHTTPMiddleware):
 
 
 DEFAULT_SCAN_RATE_LIMIT_RPM = 600
+# Anonymous / unidentified read budget. Kept where it was so raising the
+# authenticated budget below does not widen the pre-auth abuse surface.
 DEFAULT_READ_RATE_LIMIT_RPM = DEFAULT_SCAN_RATE_LIMIT_RPM * 5
+# Reads on a bucket we resolved to a tenant or API key. A cursor walk of a
+# large tenant is thousands of requests, so a connector or SIEM doing a full
+# sync through the public API was being 429'd partway through a legitimate
+# paginated read. Still bounded, and still under the coarse per-IP ceiling.
+DEFAULT_AUTHENTICATED_READ_RATE_LIMIT_RPM = DEFAULT_READ_RATE_LIMIT_RPM * 2
 MAX_RATE_LIMIT_RPM = 60_000
 # Coarse per-client-IP ceiling enforced OUTERMOST (before authentication) so an
 # unauthenticated flood is capped regardless of auth outcome. Deliberately much
@@ -2110,10 +2117,14 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         app: ASGIApp,
         scan_rpm: int = DEFAULT_SCAN_RATE_LIMIT_RPM,
         read_rpm: int = DEFAULT_READ_RATE_LIMIT_RPM,
+        authenticated_read_rpm: int = DEFAULT_AUTHENTICATED_READ_RATE_LIMIT_RPM,
     ):
         super().__init__(app)
         self._scan_rpm = _validate_rate_limit("scan_rpm", scan_rpm, max_rpm=MAX_RATE_LIMIT_RPM)
         self._read_rpm = _validate_rate_limit("read_rpm", read_rpm, max_rpm=MAX_RATE_LIMIT_RPM * 5)
+        self._authenticated_read_rpm = _validate_rate_limit(
+            "authenticated_read_rpm", authenticated_read_rpm, max_rpm=MAX_RATE_LIMIT_RPM * 10
+        )
         self._window = 60
         self._store = self._build_store()
 
@@ -2183,9 +2194,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         now = time.time()
 
         is_scan = self._is_write_rate_limited(request.url.path, request.method)
-        limit = self._scan_rpm if is_scan else self._read_rpm
-
         key = await self._bucket_key(request, is_scan)
+        if is_scan:
+            limit = self._scan_rpm
+        elif key.startswith("ip:"):
+            # No tenant and no API key resolved — the anonymous budget, which
+            # is deliberately tighter than the authenticated one below.
+            limit = self._read_rpm
+        else:
+            limit = self._authenticated_read_rpm
+
         hit_count, reset_at = await asyncio.to_thread(self._store.hit, key, now)
         remaining = max(0, limit - hit_count)
 

--- a/src/agent_bom/api/pipeline.py
+++ b/src/agent_bom/api/pipeline.py
@@ -35,6 +35,7 @@ from agent_bom.api.stores import (
     _job_lock,
     _jobs_put,
 )
+from agent_bom.api.tenant_worker import run_tenant_bound
 from agent_bom.config import API_SCAN_WORKER_RECYCLE_JOBS, API_SCAN_WORKERS
 from agent_bom.security import sanitize_error
 
@@ -142,14 +143,20 @@ def _observe_scan_future(done_future: Future | Any) -> None:
 
 
 def submit_scan_job(job: ScanJob) -> None:
-    """Submit a scan job to the bounded worker pool and observe completion."""
+    """Submit a scan job to the bounded worker pool and observe completion.
+
+    The worker thread carries no tenant contextvar of its own, so the binding
+    comes from the job — otherwise the pipeline's durable persistence
+    (``PostgresJobStore.put``) writes as the default tenant and against the RLS
+    ``WITH CHECK`` contract. Same requirement the claimed-job path documents.
+    """
     global _executor_active_jobs  # noqa: PLW0603
 
     with _executor_lock:
         executor = _executor_for_submission_locked()
         _executor_active_jobs += 1
         try:
-            future = executor.submit(_run_scan_sync, job)
+            future = executor.submit(run_tenant_bound, job.tenant_id or "default", _run_scan_sync, job)
         except Exception:
             _executor_active_jobs = max(0, _executor_active_jobs - 1)
             raise
@@ -164,6 +171,9 @@ def submit_scheduled_scan_job(loop: Any, job: ScanJob) -> None:
     ``loop.run_in_executor()`` separately, because API shutdown can close the
     pool between those operations. This helper keeps the lookup and submission
     under the same lifecycle lock used by HTTP-triggered scans.
+
+    Like ``submit_scan_job``, the worker runs bound to the job's tenant: the
+    scheduler runs outside any HTTP request, so nothing else would set it.
     """
 
     global _executor_active_jobs  # noqa: PLW0603
@@ -172,7 +182,7 @@ def submit_scheduled_scan_job(loop: Any, job: ScanJob) -> None:
         executor = _executor_for_submission_locked()
         _executor_active_jobs += 1
         try:
-            future = loop.run_in_executor(executor, _run_scan_sync, job)
+            future = loop.run_in_executor(executor, run_tenant_bound, job.tenant_id or "default", _run_scan_sync, job)
         except Exception:
             _executor_active_jobs = max(0, _executor_active_jobs - 1)
             raise

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -34,6 +34,7 @@ from agent_bom.api.middleware import (
     TrustHeadersMiddleware,
     global_ip_rate_limit_rpm,
     install_error_envelope,
+    register_dashboard_spa_routes,
 )
 
 # ─── Extracted modules ────────────────────────────────────────────────────────
@@ -1466,6 +1467,11 @@ def _mount_dashboard(application: FastAPI) -> None:
     _index_html = _validated_dashboard_file(ui_dist, "index.html")
     if _index_html is None:
         return
+
+    # Auth's public-SPA allowlist is derived from exactly the files the
+    # catch-all below can resolve, so a cold deep-link to a real page never
+    # 401s and a route the SPA does not serve is never allowlisted.
+    register_dashboard_spa_routes(_static_file_map)
 
     # SPA catch-all for client-side routing
     @application.api_route("/{path:path}", methods=["GET", "HEAD"], include_in_schema=False)

--- a/src/agent_bom/api/server.py
+++ b/src/agent_bom/api/server.py
@@ -855,7 +855,15 @@ def configure_api(
     # the front; this call order keeps the coarse per-IP limiter outermost
     # (capping unauthenticated floods before auth), then body-size, then auth
     # before the tenant-scoped rate limiter, which needs tenant/auth state.
-    _replace_middleware(RateLimitMiddleware, scan_rpm=_rate_limit_rpm, read_rpm=_rate_limit_rpm * 5)
+    # The authenticated read budget keeps the same 2x relationship to the
+    # anonymous one that the defaults have, so an operator override of
+    # rate_limit_rpm still controls both.
+    _replace_middleware(
+        RateLimitMiddleware,
+        scan_rpm=_rate_limit_rpm,
+        read_rpm=_rate_limit_rpm * 5,
+        authenticated_read_rpm=_rate_limit_rpm * 10,
+    )
     # Authentication can be optional; authorization cannot.  Keep the
     # principal resolver installed in pure no-auth mode so credential-less
     # callers receive the configured NO_AUTH_ROLE and traverse the same route

--- a/src/agent_bom/http_client.py
+++ b/src/agent_bom/http_client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import random
 import threading
 import time
@@ -124,6 +125,36 @@ def check_offline() -> None:
         raise OfflineModeError("Network request blocked: --offline mode is active")
 
 
+# The standard proxy environment variables httpx reads under ``trust_env``.
+_PROXY_ENV_VARS = (
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "ALL_PROXY",
+    "http_proxy",
+    "https_proxy",
+    "all_proxy",
+)
+
+
+def _env_proxy_configured() -> bool:
+    """True when the operator has pinned egress through a proxy.
+
+    httpx builds its environment proxy mounts only when ``transport`` is left
+    unset — ``allow_env_proxies = trust_env and transport is None`` in
+    ``httpx._client`` (0.28.1). Handing it our retrying transport therefore
+    emptied every proxy mount and traffic escaped the operator's proxy
+    silently, with no error and no way to tell: an egress-policy bypass that
+    fails open.
+
+    Egress policy outranks connection-level retries, so when a proxy is
+    configured the retrying transport stands down and httpx builds the env
+    mounts itself (including ``NO_PROXY`` exclusions, which are easy to get
+    subtly wrong by hand). ``request_with_retry`` / ``sync_request_with_retry``
+    still retry at the application level either way.
+    """
+    return any((os.environ.get(name) or "").strip() for name in _PROXY_ENV_VARS)
+
+
 def _sanitize_for_log(value: object) -> str:
     """Sanitize a value for safe inclusion in log messages.
 
@@ -198,7 +229,7 @@ def create_client(
 
     if timeout is None:
         timeout = HTTP_DEFAULT_TIMEOUT
-    transport = httpx.AsyncHTTPTransport(retries=2)
+    transport = None if _env_proxy_configured() else httpx.AsyncHTTPTransport(retries=2)
     return httpx.AsyncClient(
         timeout=timeout,
         transport=transport,
@@ -345,7 +376,7 @@ def create_sync_client(timeout: float | None = None, max_redirects: int = 0) -> 
 
     if timeout is None:
         timeout = HTTP_DEFAULT_TIMEOUT
-    transport = httpx.HTTPTransport(retries=2)
+    transport = None if _env_proxy_configured() else httpx.HTTPTransport(retries=2)
     return httpx.Client(
         timeout=timeout,
         transport=transport,

--- a/src/agent_bom/parsers/node_parsers.py
+++ b/src/agent_bom/parsers/node_parsers.py
@@ -211,16 +211,20 @@ def parse_npm_packages(directory: Path) -> list[Package]:
                         checksums=checksums,
                     )
                 )
-        except (json.JSONDecodeError, KeyError) as exc:
+        # OSError covers unreadable/oversize manifests (PermissionError and
+        # ManifestTooLargeError, which subclasses OSError); UnicodeDecodeError
+        # covers a binary/non-UTF8 manifest. Letting either escape aborted the
+        # whole scan with no artifact written, so one bad file in a repo could
+        # deny the scanner. Degrade with a named coverage warning instead.
+        except (json.JSONDecodeError, KeyError, OSError, UnicodeDecodeError) as exc:
             logger.debug("Failed to parse package-lock.json in %s: %s", directory, exc)
-            if isinstance(exc, json.JSONDecodeError):
-                from agent_bom.coverage import record_manifest_parse_warning
+            from agent_bom.coverage import record_manifest_parse_warning
 
-                record_manifest_parse_warning(
-                    ecosystem="npm",
-                    path=str(lock_file),
-                    detail=f"package-lock.json failed to parse ({exc}); npm dependencies were not scanned",
-                )
+            record_manifest_parse_warning(
+                ecosystem="npm",
+                path=str(lock_file),
+                detail=f"package-lock.json could not be read or parsed ({exc}); npm dependencies were not scanned",
+            )
 
     # Fallback to package.json only
     elif (directory / "package.json").exists():
@@ -267,16 +271,18 @@ def parse_npm_packages(directory: Path) -> list[Package]:
                             version_evidence=version_evidence,
                         )
                     )
-        except (json.JSONDecodeError, KeyError) as exc:
+        # Same graceful-degradation contract as the package-lock.json branch
+        # above: an unreadable, oversize, or non-UTF8 manifest is a coverage
+        # gap to report, never a scan-aborting exception.
+        except (json.JSONDecodeError, KeyError, OSError, UnicodeDecodeError) as exc:
             logger.debug("Failed to parse package.json in %s: %s", directory, exc)
-            if isinstance(exc, json.JSONDecodeError):
-                from agent_bom.coverage import record_manifest_parse_warning
+            from agent_bom.coverage import record_manifest_parse_warning
 
-                record_manifest_parse_warning(
-                    ecosystem="npm",
-                    path=str(directory / "package.json"),
-                    detail=f"package.json failed to parse ({exc}); npm dependencies were not scanned",
-                )
+            record_manifest_parse_warning(
+                ecosystem="npm",
+                path=str(directory / "package.json"),
+                detail=f"package.json could not be read or parsed ({exc}); npm dependencies were not scanned",
+            )
 
     return packages
 

--- a/tests/api/test_api_dashboard_deeplink_routes.py
+++ b/tests/api/test_api_dashboard_deeplink_routes.py
@@ -1,0 +1,135 @@
+"""Cold deep-links into the SPA must not 401.
+
+The public-route allowlist used to be a hand-maintained set that drifted from
+``ui/app/``: ``/overview`` (the header CTA and left-nav target), ``/inventory``,
+``/reports``, ``/runtime``, ``/threat-intel``, ``/self-posture``,
+``/blueprints``, ``/integrations`` and ``/accounts/*`` returned a raw JSON 401
+on a cold request, while ``/settings`` and ``/dashboard`` — which do not exist —
+returned 200. It only worked because landing on ``/`` first set the session
+cookie. The allowlist is now derived from the same shipped dashboard files the
+SPA catch-all resolves against.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.api import middleware as middleware_module
+from agent_bom.api.middleware import APIKeyMiddleware, dashboard_spa_routes_from_files
+
+UI_APP = Path(__file__).resolve().parents[2] / "ui" / "app"
+
+# Routes the audit proved were unreachable cold. Kept explicit so a regression
+# names the page that broke rather than a set difference.
+REGRESSION_ROUTES = (
+    "/overview",
+    "/inventory",
+    "/reports",
+    "/runtime",
+    "/threat-intel",
+    "/self-posture",
+    "/blueprints",
+    "/integrations",
+    "/accounts/aws-prod",
+)
+
+
+def _exported_relative_paths() -> list[str]:
+    """Approximate a Next.js static export of ``ui/app`` (one page per route)."""
+    paths = ["index.html", "404.html", "favicon.ico"]
+    for entry in sorted(UI_APP.iterdir()):
+        if entry.is_dir() and not entry.name.startswith(("_", "(")):
+            paths.append(f"{entry.name}/index.html")
+    return paths
+
+
+@pytest.fixture
+def _registered_spa_routes(monkeypatch):
+    monkeypatch.setattr(
+        middleware_module,
+        "_DASHBOARD_SPA_ROUTES",
+        dashboard_spa_routes_from_files(_exported_relative_paths()),
+    )
+
+
+def test_ui_app_route_directories_are_discovered() -> None:
+    routes = dashboard_spa_routes_from_files(_exported_relative_paths())
+    assert "" in routes
+    assert "overview" in routes
+    assert "findings" in routes
+
+
+def test_every_shipped_ui_route_is_reachable_on_a_cold_deep_link(_registered_spa_routes) -> None:
+    unreachable = [
+        entry.name
+        for entry in sorted(UI_APP.iterdir())
+        if entry.is_dir()
+        and not entry.name.startswith(("_", "("))
+        and not APIKeyMiddleware._is_dashboard_public_request(f"/{entry.name}", "GET")
+    ]
+    assert unreachable == []
+
+
+@pytest.mark.parametrize("path", REGRESSION_ROUTES)
+def test_audited_deep_links_are_public(path: str, _registered_spa_routes) -> None:
+    assert APIKeyMiddleware._is_dashboard_public_request(path, "GET") is True
+
+
+def test_root_and_index_stay_public(_registered_spa_routes) -> None:
+    assert APIKeyMiddleware._is_dashboard_public_request("/", "GET") is True
+    assert APIKeyMiddleware._is_dashboard_public_request("/index.html", "GET") is True
+
+
+def test_routes_that_do_not_exist_are_not_public(_registered_spa_routes) -> None:
+    """``/settings`` and ``/dashboard`` have no page; they must not be allowlisted."""
+    assert APIKeyMiddleware._is_dashboard_public_request("/settings", "GET") is False
+    assert APIKeyMiddleware._is_dashboard_public_request("/dashboard", "GET") is False
+
+
+def test_api_paths_are_never_treated_as_dashboard_routes(_registered_spa_routes) -> None:
+    assert APIKeyMiddleware._is_dashboard_public_request("/v1/findings", "GET") is False
+    assert APIKeyMiddleware._is_dashboard_public_request("/metrics", "GET") is False
+    assert APIKeyMiddleware._is_dashboard_public_request("/overview", "POST") is False
+
+
+def test_mounting_the_dashboard_registers_the_allowlist(tmp_path: Path, monkeypatch) -> None:
+    """The wiring, not just the derivation: mounting publishes the allowlist.
+
+    Mirrors a Next.js ``output: export`` layout (``trailingSlash`` is unset, so
+    a page becomes ``<route>.html`` and a dynamic segment becomes
+    ``<route>/<param>.html``).
+    """
+    from fastapi import FastAPI
+
+    from agent_bom.api import server as server_module
+
+    ui_dist = tmp_path / "ui_dist"
+    (ui_dist / "accounts").mkdir(parents=True)
+    (ui_dist / "_next" / "static").mkdir(parents=True)
+    (ui_dist / "index.html").write_text("<html></html>")
+    (ui_dist / "overview.html").write_text("<html></html>")
+    (ui_dist / "findings.html").write_text("<html></html>")
+    (ui_dist / "accounts" / "_.html").write_text("<html></html>")
+    (ui_dist / "_next" / "static" / "app.js").write_text("//")
+
+    monkeypatch.setattr(middleware_module, "_DASHBOARD_SPA_ROUTES", frozenset())
+    monkeypatch.setattr(server_module, "_dashboard_dist_dir", lambda: ui_dist)
+    monkeypatch.delenv("AGENT_BOM_NO_UI", raising=False)
+    server_module._mount_dashboard(FastAPI())
+
+    assert APIKeyMiddleware._is_dashboard_public_request("/overview", "GET") is True
+    assert APIKeyMiddleware._is_dashboard_public_request("/accounts/aws-prod", "GET") is True
+    assert APIKeyMiddleware._is_dashboard_public_request("/", "GET") is True
+    assert APIKeyMiddleware._is_dashboard_public_request("/settings", "GET") is False
+    assert APIKeyMiddleware._is_dashboard_public_request("/_next/static/app.js", "GET") is True
+
+
+def test_no_spa_mounted_means_no_public_spa_routes(monkeypatch) -> None:
+    """A REST-only deployment has no SPA to serve, so nothing is allowlisted."""
+    monkeypatch.setattr(middleware_module, "_DASHBOARD_SPA_ROUTES", frozenset())
+    assert APIKeyMiddleware._is_dashboard_public_request("/overview", "GET") is False
+    # Static asset routes that do not depend on the SPA stay public.
+    assert APIKeyMiddleware._is_dashboard_public_request("/favicon.ico", "GET") is True
+    assert APIKeyMiddleware._is_dashboard_public_request("/_next/static/x.js", "GET") is True

--- a/tests/api/test_api_error_envelope_robustness.py
+++ b/tests/api/test_api_error_envelope_robustness.py
@@ -108,3 +108,28 @@ def test_nul_byte_in_path_parameter_returns_400_envelope_not_500() -> None:
 def test_nul_byte_rejection_does_not_break_ordinary_paths() -> None:
     client = TestClient(app)
     assert client.get("/health").status_code == 200
+
+
+def test_idempotency_payload_error_detail_is_sanitized() -> None:
+    """The 422 body must never echo raw exception text (paths, URLs, secrets)."""
+    from fastapi import FastAPI
+
+    from agent_bom.api.idempotency_store import IdempotencyPayloadError
+    from agent_bom.api.middleware import install_error_envelope
+
+    leaky = FastAPI()
+    install_error_envelope(leaky)
+
+    @leaky.post("/boom")
+    async def _boom() -> None:
+        raise IdempotencyPayloadError(
+            "payload rejected at /srv/agent-bom/secrets/creds.json via https://internal.example/api token=SUPER_SECRET"
+        )
+
+    response = TestClient(leaky, raise_server_exceptions=False).post("/boom")
+    assert response.status_code == 422, response.text
+    error = _envelope(response)
+    assert "/srv/agent-bom/secrets/creds.json" not in response.text
+    assert "https://internal.example/api" not in response.text
+    assert "SUPER_SECRET" not in response.text
+    assert "<path>" in error["message"] or "<url>" in error["message"]

--- a/tests/api/test_api_error_envelope_robustness.py
+++ b/tests/api/test_api_error_envelope_robustness.py
@@ -1,0 +1,110 @@
+"""Client-caused malformed requests must be 4xx envelopes, never bare 500s.
+
+Every case here previously escaped as an unhandled exception: the caller got a
+bare ``500 Internal Server Error`` with no ``error.code`` and no
+``correlation_id``, and 5xx alerting was poisoned by client-caused errors.
+"""
+
+from __future__ import annotations
+
+import json
+
+from starlette.testclient import TestClient
+
+from agent_bom.api.server import app
+
+
+def _envelope(response) -> dict:
+    """Assert the v1 error envelope shape and return the ``error`` object."""
+    body = response.json()
+    assert "error" in body, body
+    error = body["error"]
+    assert isinstance(error.get("code"), str) and error["code"], body
+    assert isinstance(error.get("message"), str) and error["message"], body
+    assert isinstance(error.get("correlation_id"), str) and error["correlation_id"], body
+    return error
+
+
+def _deep_payload(depth: int = 400) -> dict:
+    root: dict = {}
+    cursor = root
+    for _ in range(depth):
+        cursor["a"] = {}
+        cursor = cursor["a"]
+    return root
+
+
+def test_non_json_content_type_returns_validation_envelope_not_500() -> None:
+    """A ``text/plain`` body makes Pydantic report raw ``bytes`` as ``input``."""
+    client = TestClient(app)
+    response = client.post(
+        "/v1/findings/bulk",
+        headers={"Content-Type": "text/plain"},
+        content=b'{"findings":[{"title":"x"}]}',
+    )
+    assert response.status_code == 422, response.text
+    _envelope(response)
+
+
+def test_form_encoded_body_returns_validation_envelope_not_500() -> None:
+    client = TestClient(app)
+    response = client.post(
+        "/v1/findings/bulk",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        content=b"findings=1",
+    )
+    assert response.status_code == 422, response.text
+    _envelope(response)
+
+
+def test_missing_content_type_returns_validation_envelope_not_500() -> None:
+    client = TestClient(app)
+    response = client.request(
+        "POST",
+        "/v1/findings/bulk",
+        headers={"Content-Type": ""},
+        content=b'{"findings":[{"title":"x"}]}',
+    )
+    assert response.status_code == 422, response.text
+    _envelope(response)
+
+
+def test_validation_errors_never_reflect_the_submitted_value() -> None:
+    """422 detail must not echo credential-shaped submitted values."""
+    client = TestClient(app)
+    response = client.post(
+        "/v1/exceptions",
+        json={"password": "hunter2-do-not-echo", "api_key": "abom_LEAKED_KEY_VALUE"},
+    )
+    assert response.status_code == 422, response.text
+    _envelope(response)
+    assert "hunter2-do-not-echo" not in response.text
+    assert "abom_LEAKED_KEY_VALUE" not in response.text
+    for item in response.json()["error"]["details"]:
+        assert "input" not in item, item
+
+
+def test_deeply_nested_body_returns_422_envelope_not_500() -> None:
+    """The idempotency fingerprint recurses; a 400-deep body must not 500."""
+    client = TestClient(app)
+    response = client.post(
+        "/v1/findings/bulk",
+        headers={"Content-Type": "application/json"},
+        content=json.dumps({"findings": [{"title": "x", "metadata": _deep_payload()}]}),
+    )
+    assert response.status_code == 422, response.text
+    _envelope(response)
+
+
+def test_nul_byte_in_path_parameter_returns_400_envelope_not_500() -> None:
+    """A NUL in a path id reaches psycopg as a text field and raises DataError."""
+    client = TestClient(app)
+    response = client.put("/v1/fleet/%00%01", json={"owner": "o"})
+    assert response.status_code == 400, response.text
+    error = _envelope(response)
+    assert "NUL" in error["message"] or "null byte" in error["message"].lower()
+
+
+def test_nul_byte_rejection_does_not_break_ordinary_paths() -> None:
+    client = TestClient(app)
+    assert client.get("/health").status_code == 200

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -767,9 +767,7 @@ def test_api_key_middleware_exempts_packaged_dashboard_assets(monkeypatch):
     monkeypatch.setattr(
         middleware_module,
         "_DASHBOARD_SPA_ROUTES",
-        middleware_module.dashboard_spa_routes_from_files(
-            ["index.html", "agents/index.html", "manifest/index.html", "vulns.html"]
-        ),
+        middleware_module.dashboard_spa_routes_from_files(["index.html", "agents/index.html", "manifest/index.html", "vulns.html"]),
     )
 
     async def dummy(request):
@@ -1734,7 +1732,9 @@ def test_rate_limit_middleware_scopes_api_keys_by_tenant():
     try:
         test_app = Starlette(routes=[Route("/v1/test", dummy)])
         test_app.add_middleware(APIKeyMiddleware, api_key="unused-static-key")
-        test_app.add_middleware(RateLimitMiddleware, scan_rpm=3, read_rpm=2)
+        # These reads resolve to a tenant bucket, so the authenticated budget is
+        # the one under test here; read_rpm covers anonymous callers only.
+        test_app.add_middleware(RateLimitMiddleware, scan_rpm=3, read_rpm=2, authenticated_read_rpm=2)
 
         client = TestClient(test_app)
         assert client.get("/v1/test", headers={"Authorization": f"Bearer {raw_alpha}"}).status_code == 200

--- a/tests/api/test_api_hardening.py
+++ b/tests/api/test_api_hardening.py
@@ -749,11 +749,28 @@ def test_configured_app_cors_preflight_survives_auth_and_rate_limit(monkeypatch)
             app.middleware_stack = app.build_middleware_stack()
 
 
-def test_api_key_middleware_exempts_packaged_dashboard_assets():
-    """Dashboard shell assets must load before browser auth/bootstrap completes."""
+def test_api_key_middleware_exempts_packaged_dashboard_assets(monkeypatch):
+    """Dashboard shell assets must load before browser auth/bootstrap completes.
+
+    The public-route set is derived from the dashboard files the server ships
+    (``register_dashboard_spa_routes``), so this fixes a representative export
+    rather than restating a hand-maintained list. ``/dashboard`` and
+    ``/settings``, which the old hardcoded list allowlisted even though no such
+    page exists, are asserted 401 here.
+    """
     from starlette.applications import Starlette
     from starlette.responses import JSONResponse as StarletteJSONResponse
     from starlette.routing import Route
+
+    from agent_bom.api import middleware as middleware_module
+
+    monkeypatch.setattr(
+        middleware_module,
+        "_DASHBOARD_SPA_ROUTES",
+        middleware_module.dashboard_spa_routes_from_files(
+            ["index.html", "agents/index.html", "manifest/index.html", "vulns.html"]
+        ),
+    )
 
     async def dummy(request):
         return StarletteJSONResponse({"ok": True})
@@ -776,11 +793,11 @@ def test_api_key_middleware_exempts_packaged_dashboard_assets():
     client = TestClient(test_app)
     assert client.get("/_next/static/app.js").status_code == 200
     assert client.get("/agents/index.html").status_code == 200
-    assert client.get("/dashboard").status_code == 200
     assert client.get("/manifest").status_code == 200
     assert client.get("/manifest/index.html").status_code == 200
-    assert client.get("/settings").status_code == 200
     assert client.get("/vulns.html").status_code == 200
+    assert client.get("/dashboard").status_code == 401
+    assert client.get("/settings").status_code == 401
     assert client.get("/admin.js").status_code == 401
     assert client.get("/v1/test.js").status_code == 401
 

--- a/tests/api/test_api_scan_worker_tenant_binding.py
+++ b/tests/api/test_api_scan_worker_tenant_binding.py
@@ -1,0 +1,75 @@
+"""Every scan worker thread runs bound to the submitting job's tenant.
+
+``submit_claimed_scan_job`` was already correct, but the HTTP-triggered and
+scheduler-triggered submissions handed ``_run_scan_sync`` straight to the pool,
+so the worker thread had no tenant contextvar and the pipeline's durable
+persistence (``PostgresJobStore.put``) wrote as the default tenant instead of
+the job's own — silently, and against the RLS ``WITH CHECK`` contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent_bom.api import pipeline as pipeline_module
+from agent_bom.api.models import ScanJob, ScanRequest
+from agent_bom.api.postgres_common import _current_tenant
+
+
+def _job(tenant_id: str) -> ScanJob:
+    return ScanJob(
+        job_id="job-1",
+        tenant_id=tenant_id,
+        created_at="2026-07-30T00:00:00Z",
+        request=ScanRequest(),
+    )
+
+
+@pytest.fixture
+def observed_tenants(monkeypatch) -> list[str]:
+    seen: list[str] = []
+
+    def _fake_run(job: ScanJob) -> None:
+        seen.append(_current_tenant.get())
+
+    monkeypatch.setattr(pipeline_module, "_run_scan_sync", _fake_run)
+    return seen
+
+
+def test_http_submitted_scan_runs_under_the_job_tenant(observed_tenants) -> None:
+    pipeline_module.submit_scan_job(_job("acme-corp"))
+    pipeline_module.shutdown_scan_executor(wait=True, cancel_futures=False)
+    assert observed_tenants == ["acme-corp"]
+
+
+def test_scheduled_scan_runs_under_the_job_tenant(observed_tenants) -> None:
+    async def _submit() -> None:
+        loop = asyncio.get_running_loop()
+        pipeline_module.submit_scheduled_scan_job(loop, _job("acme-corp"))
+
+    asyncio.run(_submit())
+    pipeline_module.shutdown_scan_executor(wait=True, cancel_futures=False)
+    assert observed_tenants == ["acme-corp"]
+
+
+def test_claimed_scan_still_runs_under_the_job_tenant(observed_tenants) -> None:
+    pipeline_module.submit_claimed_scan_job(_job("acme-corp"), lambda job_id: None)
+    pipeline_module.shutdown_scan_executor(wait=True, cancel_futures=False)
+    assert observed_tenants == ["acme-corp"]
+
+
+@pytest.mark.parametrize("tenant_id", ["", "   ", "default"])
+def test_unset_job_tenant_falls_back_to_default(observed_tenants, tenant_id) -> None:
+    pipeline_module.submit_scan_job(_job(tenant_id))
+    pipeline_module.shutdown_scan_executor(wait=True, cancel_futures=False)
+    assert observed_tenants == ["default"]
+
+
+def test_worker_tenant_does_not_leak_into_the_next_job(observed_tenants) -> None:
+    pipeline_module.submit_scan_job(_job("acme-corp"))
+    pipeline_module.shutdown_scan_executor(wait=True, cancel_futures=False)
+    pipeline_module.submit_scan_job(_job("other-corp"))
+    pipeline_module.shutdown_scan_executor(wait=True, cancel_futures=False)
+    assert observed_tenants == ["acme-corp", "other-corp"]

--- a/tests/test_http_client_proxy_env.py
+++ b/tests/test_http_client_proxy_env.py
@@ -1,0 +1,94 @@
+"""``HTTP(S)_PROXY`` must be honoured — a silently ignored proxy fails open.
+
+httpx only builds its environment proxy mounts when ``transport`` is left unset
+(``allow_env_proxies = trust_env and transport is None``, httpx 0.28.1
+``_client.py``). Passing our retrying transport therefore emptied every proxy
+mount, so an operator who believed egress was pinned through an inspecting
+proxy had no such control — disqualifying for a regulated self-host.
+"""
+
+from __future__ import annotations
+
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import httpx
+import pytest
+
+from agent_bom.http_client import create_client, create_sync_client
+
+PROXY_PORT = 8874
+PROXY_ENV_VARS = ("HTTP_PROXY", "HTTPS_PROXY", "ALL_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "all_proxy", "no_proxy")
+
+
+class _ProxyHandler(BaseHTTPRequestHandler):
+    """Answers any absolute-URI request with a marker status."""
+
+    protocol_version = "HTTP/1.1"
+
+    def do_GET(self) -> None:  # noqa: N802 — BaseHTTPRequestHandler contract
+        body = self.path.encode()
+        self.send_response(418)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, *args: object) -> None:
+        return
+
+
+@pytest.fixture
+def proxy_server(monkeypatch):
+    for name in PROXY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    server = ThreadingHTTPServer(("127.0.0.1", PROXY_PORT), _ProxyHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{PROXY_PORT}"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def test_sync_client_routes_through_the_configured_proxy(proxy_server, monkeypatch) -> None:
+    monkeypatch.setenv("HTTP_PROXY", proxy_server)
+
+    with create_sync_client(timeout=5) as client:
+        response = client.get("http://blocked.example/resource")
+
+    # The marker status can only come from the proxy: blocked.example does not
+    # resolve, so a direct connection could not have produced a response.
+    assert response.status_code == 418
+    assert response.text == "http://blocked.example/resource"
+
+
+@pytest.mark.asyncio
+async def test_async_client_routes_through_the_configured_proxy(proxy_server, monkeypatch) -> None:
+    monkeypatch.setenv("HTTP_PROXY", proxy_server)
+
+    async with create_client(timeout=5) as client:
+        response = await client.get("http://blocked.example/resource")
+
+    assert response.status_code == 418
+
+
+def test_no_proxy_exclusions_are_still_honoured(proxy_server, monkeypatch) -> None:
+    """A ``NO_PROXY`` host must bypass the proxy, not be forced through it."""
+    monkeypatch.setenv("HTTP_PROXY", proxy_server)
+    monkeypatch.setenv("NO_PROXY", "blocked.example")
+
+    with create_sync_client(timeout=5) as client:
+        with pytest.raises(httpx.ConnectError):
+            client.get("http://blocked.example/resource")
+
+
+def test_connection_retries_stay_enabled_without_a_proxy(monkeypatch) -> None:
+    """The retrying transport is only stood down when a proxy is configured."""
+    for name in PROXY_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+
+    with create_sync_client(timeout=5) as client:
+        assert isinstance(client._transport, httpx.HTTPTransport)
+        assert client._transport._pool._retries == 2

--- a/tests/test_node_manifest_read_failures.py
+++ b/tests/test_node_manifest_read_failures.py
@@ -1,0 +1,105 @@
+"""An unreadable or non-UTF8 npm manifest degrades; it never aborts the scan.
+
+``OSError``/``PermissionError`` (bounded reads in ``parsers/file_limits.py``)
+and ``UnicodeDecodeError`` (``errors="strict"``) escaped the npm parsers, so a
+single ``chmod 000`` manifest or one binary ``package.json`` killed the whole
+scan with no artifact written. The correct behaviour already existed one branch
+over for a corrupt lockfile: a named coverage warning plus a written report.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from agent_bom.parsers.node_parsers import parse_npm_packages
+from agent_bom.scanners import state as scanner_state
+
+
+@pytest.fixture(autouse=True)
+def _reset_coverage_warnings():
+    scanner_state.consume_coverage_warnings()
+    yield
+    scanner_state.consume_coverage_warnings()
+
+
+def _warning_paths() -> list[str]:
+    return [str(warning.get("release", "")) for warning in scanner_state.consume_coverage_warnings()]
+
+
+def _skip_if_root() -> None:
+    if os.geteuid() == 0:
+        pytest.skip("chmod 000 does not deny reads for root")
+
+
+def test_unreadable_package_lock_degrades_with_a_named_warning(tmp_path: Path) -> None:
+    _skip_if_root()
+    lock_file = tmp_path / "package-lock.json"
+    lock_file.write_text(json.dumps({"packages": {"node_modules/left-pad": {"version": "1.3.0"}}}))
+    lock_file.chmod(0o000)
+    try:
+        packages = parse_npm_packages(tmp_path)
+    finally:
+        lock_file.chmod(0o644)
+
+    assert packages == []
+    assert any("package-lock.json" in path for path in _warning_paths()), _warning_paths()
+
+
+def test_unreadable_package_json_degrades_with_a_named_warning(tmp_path: Path) -> None:
+    _skip_if_root()
+    manifest = tmp_path / "package.json"
+    manifest.write_text(json.dumps({"dependencies": {"left-pad": "1.3.0"}}))
+    manifest.chmod(0o000)
+    try:
+        packages = parse_npm_packages(tmp_path)
+    finally:
+        manifest.chmod(0o644)
+
+    assert packages == []
+    assert any("package.json" in path for path in _warning_paths()), _warning_paths()
+
+
+def test_non_utf8_package_json_degrades_with_a_named_warning(tmp_path: Path) -> None:
+    manifest = tmp_path / "package.json"
+    manifest.write_bytes(b'{"dependencies": {"left-pad": "\xa4\xa4"}}')
+
+    packages = parse_npm_packages(tmp_path)
+
+    assert packages == []
+    assert any("package.json" in path for path in _warning_paths()), _warning_paths()
+
+
+def test_non_utf8_package_lock_degrades_with_a_named_warning(tmp_path: Path) -> None:
+    lock_file = tmp_path / "package-lock.json"
+    lock_file.write_bytes(b'{"packages": {"node_modules/\xa4": {"version": "1.0.0"}}}')
+
+    packages = parse_npm_packages(tmp_path)
+
+    assert packages == []
+    assert any("package-lock.json" in path for path in _warning_paths()), _warning_paths()
+
+
+def test_oversize_package_json_degrades_with_a_named_warning(tmp_path: Path, monkeypatch) -> None:
+    """``ManifestTooLargeError`` subclasses ``OSError`` — same graceful path."""
+    monkeypatch.setenv("AGENT_BOM_MAX_MANIFEST_BYTES", "8")
+    manifest = tmp_path / "package.json"
+    manifest.write_text(json.dumps({"dependencies": {"left-pad": "1.3.0"}}))
+
+    packages = parse_npm_packages(tmp_path)
+
+    assert packages == []
+    assert any("package.json" in path for path in _warning_paths()), _warning_paths()
+
+
+def test_readable_manifest_still_parses(tmp_path: Path) -> None:
+    manifest = tmp_path / "package.json"
+    manifest.write_text(json.dumps({"dependencies": {"left-pad": "1.3.0"}}))
+
+    packages = parse_npm_packages(tmp_path)
+
+    assert [(pkg.name, pkg.version) for pkg in packages] == [("left-pad", "1.3.0")]
+    assert _warning_paths() == []

--- a/tests/test_postgres_integration.py
+++ b/tests/test_postgres_integration.py
@@ -261,7 +261,27 @@ def test_postgres_invitation_provisions_team_and_key_atomically_under_new_tenant
 
     from agent_bom.api.auth import Role, create_api_key
     from agent_bom.api.postgres_access import PostgresKeyStore
-    from agent_bom.api.postgres_common import _get_pool, reset_current_tenant, set_current_tenant
+    from agent_bom.api.postgres_common import (
+        _get_pool,
+        _tenant_connection,
+        reset_current_tenant,
+        set_current_tenant,
+    )
+
+    def _read_team(tenant_id: str, team_id: str) -> tuple | None:
+        """Read ``teams`` the way production does: on a tenant-bound session.
+
+        ``teams`` now FORCEs RLS, so a raw ``_get_pool().connection()`` never
+        runs ``_apply_tenant_session`` and reads as the ``'default'`` tenant —
+        it would report ``None`` for every tenant's root row and make these
+        assertions vacuous. Binding the session is what the policy is for.
+        """
+        token = set_current_tenant(tenant_id)
+        try:
+            with _tenant_connection(_get_pool()) as conn:
+                return conn.execute("SELECT team_id, name, slug FROM teams WHERE team_id = %s", (team_id,)).fetchone()
+        finally:
+            reset_current_tenant(token)
 
     suffix = uuid4().hex
     tenant_id = f"invite-{suffix}"
@@ -280,12 +300,14 @@ def test_postgres_invitation_provisions_team_and_key_atomically_under_new_tenant
         stored = store.get(api_key.key_id)
         assert stored is not None
         assert stored.tenant_id == tenant_id
-        with _get_pool().connection() as conn:
-            team = conn.execute("SELECT team_id, name, slug FROM teams WHERE team_id = %s", (tenant_id,)).fetchone()
     finally:
         reset_current_tenant(invited_token)
 
-    assert team == (tenant_id, "Example Organization", tenant_id)
+    assert _read_team(tenant_id, tenant_id) == (tenant_id, "Example Organization", tenant_id)
+
+    # The FK root is the cascade root for every tenant table, so no other
+    # tenant's app-role session may see (and therefore delete) it.
+    assert _read_team(f"operator-{suffix}", tenant_id) is None
 
     # Reusing an existing key id must fail closed and roll back the team row;
     # otherwise a partial invitation leaves an orphan tenant behind.
@@ -298,9 +320,76 @@ def test_postgres_invitation_provisions_team_and_key_atomically_under_new_tenant
     finally:
         reset_current_tenant(operator_token)
 
-    with _get_pool().connection() as conn:
-        rejected_team = conn.execute("SELECT team_id FROM teams WHERE team_id = %s", (rejected_tenant_id,)).fetchone()
-    assert rejected_team is None
+    assert _read_team(rejected_tenant_id, rejected_tenant_id) is None
+
+
+def test_postgres_teams_fk_root_is_tenant_isolated_but_still_purgeable_by_maintenance():
+    """``teams`` RLS must block a cross-tenant purge without breaking the real one.
+
+    ``teams`` is the FK root every tenant table references ``ON DELETE
+    CASCADE``, and ``agent_bom_app`` holds ``DELETE`` on it, so one tenant
+    reaching another tenant's root row destroys that tenant's whole dataset.
+    The isolation is only safe to ship if the legitimate purge in
+    ``tenant_lifecycle`` — ``bypass_tenant_rls()`` + ``_maintenance_connection()``
+    — still deletes the row; otherwise cleanup silently reports
+    ``tenant_root: 0`` and leaks orphan tenants forever.
+    """
+    from agent_bom.api.auth import Role, create_api_key
+    from agent_bom.api.postgres_access import PostgresKeyStore
+    from agent_bom.api.postgres_common import (
+        _get_pool,
+        _maintenance_connection,
+        _tenant_connection,
+        bypass_tenant_rls,
+        reset_current_tenant,
+        set_current_tenant,
+    )
+
+    suffix = uuid4().hex
+    victim = f"teams-victim-{suffix}"
+    attacker = f"teams-attacker-{suffix}"
+    _, victim_key = create_api_key("victim-owner", Role.ADMIN, tenant_id=victim)
+    store = PostgresKeyStore()
+    store.provision_tenant_key(victim_key, team_name="Victim Organization")
+
+    # An ordinary app-role session bound to another tenant can neither see nor
+    # delete the victim's root row, so the cascade cannot be triggered.
+    attacker_token = set_current_tenant(attacker)
+    try:
+        with _tenant_connection(_get_pool()) as conn:
+            assert conn.execute("SELECT team_id FROM teams WHERE team_id = %s", (victim,)).fetchone() is None
+            cursor = conn.execute("DELETE FROM teams WHERE team_id = %s", (victim,))
+            assert cursor.rowcount == 0
+            conn.commit()
+    finally:
+        reset_current_tenant(attacker_token)
+
+    victim_token = set_current_tenant(victim)
+    try:
+        with _tenant_connection(_get_pool()) as conn:
+            assert conn.execute("SELECT team_id FROM teams WHERE team_id = %s", (victim,)).fetchone() == (victim,)
+    finally:
+        reset_current_tenant(victim_token)
+
+    # The maintenance purge path still reaches the row.
+    purge_token = set_current_tenant(victim)
+    try:
+        with bypass_tenant_rls():
+            with _maintenance_connection() as conn:
+                assert conn.execute("SELECT public.abom_rls_bypass()").fetchone() == (True,)
+                conn.execute("DELETE FROM api_keys WHERE team_id = %s", (victim,))
+                cursor = conn.execute("DELETE FROM teams WHERE team_id = %s", (victim,))
+                assert cursor.rowcount == 1
+                conn.commit()
+    finally:
+        reset_current_tenant(purge_token)
+
+    verify_token = set_current_tenant(victim)
+    try:
+        with _tenant_connection(_get_pool()) as conn:
+            assert conn.execute("SELECT team_id FROM teams WHERE team_id = %s", (victim,)).fetchone() is None
+    finally:
+        reset_current_tenant(verify_token)
 
 
 def test_postgres_managed_trial_invitation_is_digest_only_email_bound_and_single_use():

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -27,6 +27,7 @@ TRUSTED_MAINTENANCE_RLS = VERSIONS_DIR / "20260728_03_trusted_maintenance_rls.py
 GATEWAY_ACTIVITY_WINDOW_INDEX = VERSIONS_DIR / "20260729_02_gateway_activity_window_index.py"
 PARTITION_CHILD_RLS = VERSIONS_DIR / "20260729_03_partition_child_rls.py"
 GRAPH_EDGE_SNAPSHOT_KEY_INDEX = VERSIONS_DIR / "20260730_01_graph_edge_snapshot_key_index.py"
+TEAMS_TENANT_RLS = VERSIONS_DIR / "20260730_02_teams_tenant_rls.py"
 POSTGRES_MCP_CONFIG_STORE = Path(__file__).parent.parent / "src" / "agent_bom" / "api" / "postgres_mcp_config.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
@@ -408,6 +409,40 @@ def test_partition_child_rls_is_chained_idempotent_and_irreversible() -> None:
     assert "CREATE POLICY" in sql
     assert "DROP POLICY" not in sql
     assert "DISABLE ROW LEVEL SECURITY" not in sql
+
+
+def test_teams_tenant_rls_is_chained_idempotent_and_irreversible() -> None:
+    """The FK root gets the same tenant-isolation contract as every other table.
+
+    Modelled on ``20260729_03_partition_child_rls``: idempotent (guarded
+    ``CREATE POLICY``), forward-only, and expressed with the shared
+    ``abom_rls_bypass()`` / ``abom_current_tenant()`` helpers so the
+    maintenance-role purge in ``tenant_lifecycle`` still works.
+    """
+    sql = TEAMS_TENANT_RLS.read_text()
+    assert re.search(r'revision\s*=\s*"20260730_02"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260730_01"', sql)
+    assert "ALTER TABLE teams ENABLE ROW LEVEL SECURITY" in sql
+    assert "ALTER TABLE teams FORCE ROW LEVEL SECURITY" in sql
+    assert "teams_tenant_isolation" in sql
+    assert "team_id = public.abom_current_tenant()" in sql
+    assert "public.abom_rls_bypass()" in sql
+    # Idempotent, and never weakens isolation on replay or rollback.
+    assert "IF NOT EXISTS" in sql
+    assert "DROP POLICY" not in sql
+    assert "DISABLE ROW LEVEL SECURITY" not in sql
+    assert "NO FORCE ROW LEVEL SECURITY" not in sql
+
+
+def test_teams_tenant_rls_is_the_alembic_head() -> None:
+    """Nothing may chain past the new revision without being noticed."""
+    revisions = {
+        path.name: re.search(r'down_revision\s*=\s*"([^"]+)"', path.read_text())
+        for path in VERSIONS_DIR.glob("*.py")
+        if path.name != "__init__.py"
+    }
+    parents = {match.group(1) for match in revisions.values() if match}
+    assert "20260730_02" not in parents
 
 
 def test_graph_edge_snapshot_key_index_is_chained_and_matches_bootstrap() -> None:

--- a/tests/test_postgres_schema_authority.py
+++ b/tests/test_postgres_schema_authority.py
@@ -306,6 +306,56 @@ def test_migration_schema_covers_every_runtime_postgres_table_and_component() ->
     assert migration_sql.rfind("INSERT INTO control_plane_schema_versions") > migration_sql.rfind("CREATE TABLE")
 
 
+def _rls_forced_tables(sql: str) -> set[str]:
+    return {name.lower() for name in re.findall(r"ALTER TABLE\s+([a-z_]+)\s+FORCE ROW LEVEL SECURITY", sql, re.IGNORECASE)}
+
+
+def _tenant_isolation_policied_tables(sql: str) -> set[str]:
+    return {name.lower() for name in re.findall(r"CREATE POLICY\s+([a-z_]+)_tenant_isolation", sql, re.IGNORECASE)}
+
+
+def _schema_authority_sql() -> str:
+    """Every DDL source a configured (migration-owned) deployment actually runs."""
+    sources = [POSTGRES_DIR / "init.sql", POSTGRES_DIR / "runtime-schema.sql"]
+    sources.extend(sorted((POSTGRES_DIR / "alembic" / "versions").glob("*.py")))
+    return "\n".join(_read_sql_source(path) for path in sources)
+
+
+def test_every_tenant_columned_relation_forces_row_level_security() -> None:
+    """No tenant-scoped table may ship without a DB-level isolation backstop.
+
+    ``teams`` was the one gap: it is the FK root that every tenant table
+    references ``ON DELETE CASCADE``, it carries ``team_id``, and
+    ``agent_bom_app`` holds ``DELETE,INSERT,SELECT,UPDATE`` on it — so an
+    ordinary app-role session bound to one tenant could enumerate every tenant
+    and ``DELETE FROM teams WHERE team_id = '<other>'``, cascading that
+    tenant's entire dataset away. The API layer 403s both paths, so this is
+    defense-in-depth, but ``tenant_lifecycle.delete_tenant_records`` runs that
+    exact DELETE with those exact credentials: one tenant-binding bug would
+    otherwise become total destruction of another tenant with no DB backstop.
+
+    This guard is deliberately derived, not a list, so the class cannot recur
+    when a new tenant-scoped table lands.
+    """
+    authority_sql = _schema_authority_sql()
+    baseline_tables = _columns_by_table(_read_sql_source(POSTGRES_DIR / "init.sql"))
+    tenant_tables = {table for table, columns in baseline_tables.items() if {"tenant_id", "team_id"} & columns}
+    assert tenant_tables, "no tenant-columned tables discovered — this guard would pass vacuously"
+
+    forced = _rls_forced_tables(authority_sql)
+    policied = _tenant_isolation_policied_tables(authority_sql)
+    assert sorted(tenant_tables - forced) == []
+    assert sorted(tenant_tables - policied) == []
+
+
+def test_teams_isolation_policy_is_keyed_on_team_id() -> None:
+    """The FK root's policy must compare ``team_id``, not a ``tenant_id`` column."""
+    sql = _read_sql_source(POSTGRES_DIR / "init.sql")
+    policy = sql.split("CREATE POLICY teams_tenant_isolation", 1)[1].split(";", 1)[0]
+    assert "team_id = public.abom_current_tenant()" in policy
+    assert policy.count("public.abom_rls_bypass()") == 2, policy
+
+
 def test_migration_schema_uses_the_runtime_rls_contract_and_exact_dml_columns() -> None:
     sql = (ROOT / "deploy" / "supabase" / "postgres" / "runtime-schema.sql").read_text()
 

--- a/tests/test_rate_limit_pagination_budget.py
+++ b/tests/test_rate_limit_pagination_budget.py
@@ -1,0 +1,105 @@
+"""A full-tenant cursor walk must not be 429'd by the default read budget.
+
+The default read budget was 5x the scan budget (3000 rpm) for every caller.
+A connector or SIEM doing a full sync of a large tenant through the public API
+walks the cursor thousands of times per minute and got cut off partway. The
+authenticated budget is now higher; the anonymous/flood caps are unchanged, so
+raising it does not widen the pre-auth abuse surface.
+"""
+
+from __future__ import annotations
+
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import JSONResponse as StarletteJSONResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from agent_bom.api.middleware import (
+    DEFAULT_AUTHENTICATED_READ_RATE_LIMIT_RPM,
+    DEFAULT_GLOBAL_IP_RATE_LIMIT_RPM,
+    DEFAULT_READ_RATE_LIMIT_RPM,
+    DEFAULT_SCAN_RATE_LIMIT_RPM,
+    RateLimitMiddleware,
+)
+
+# 500k rows at limit=500 is 1000 requests; a connector re-walking a couple of
+# large tenants in the same minute is the case that was getting cut off.
+FULL_SYNC_REQUESTS_PER_MINUTE = 5000
+
+
+def test_authenticated_read_budget_covers_a_full_tenant_cursor_walk() -> None:
+    assert DEFAULT_AUTHENTICATED_READ_RATE_LIMIT_RPM >= FULL_SYNC_REQUESTS_PER_MINUTE
+
+
+def test_anonymous_read_budget_is_unchanged() -> None:
+    """The pre-auth flood caps must not move when the authenticated one does."""
+    assert DEFAULT_READ_RATE_LIMIT_RPM == DEFAULT_SCAN_RATE_LIMIT_RPM * 5
+    assert DEFAULT_GLOBAL_IP_RATE_LIMIT_RPM == DEFAULT_READ_RATE_LIMIT_RPM * 4
+
+
+def test_write_budget_is_unchanged() -> None:
+    """Raising the read budget must not loosen the ingest/scan door."""
+    assert DEFAULT_SCAN_RATE_LIMIT_RPM == 600
+
+
+def test_authenticated_read_budget_stays_under_the_global_ip_ceiling() -> None:
+    """The coarse per-IP backstop must still bound a single source address."""
+    assert DEFAULT_AUTHENTICATED_READ_RATE_LIMIT_RPM < DEFAULT_GLOBAL_IP_RATE_LIMIT_RPM
+
+
+class _BindIdentity(BaseHTTPMiddleware):
+    """Stand in for APIKeyMiddleware: mark the request as tenant-authenticated."""
+
+    async def dispatch(self, request, call_next):
+        request.state.tenant_id = "acme-corp"
+        request.state.auth_method = "api_key"
+        return await call_next(request)
+
+
+def _app(*, authenticated: bool, scan_rpm: int = 10, read_rpm: int = 20, authenticated_read_rpm: int = 50):
+    async def dummy(request):
+        return StarletteJSONResponse({"ok": True})
+
+    app = Starlette(routes=[Route("/v1/findings", dummy), Route("/v1/scan", dummy, methods=["POST"])])
+    # add_middleware inserts outermost-last, so register the limiter first and
+    # the identity binder second: the binder must run before the limiter reads
+    # request.state.
+    app.add_middleware(
+        RateLimitMiddleware,
+        scan_rpm=scan_rpm,
+        read_rpm=read_rpm,
+        authenticated_read_rpm=authenticated_read_rpm,
+    )
+    if authenticated:
+        app.add_middleware(_BindIdentity)
+    return app
+
+
+def test_authenticated_reads_get_the_higher_budget() -> None:
+    client = TestClient(_app(authenticated=True))
+    response = client.get("/v1/findings")
+    assert response.status_code == 200
+    assert response.headers["x-ratelimit-limit"] == "50"
+
+
+def test_anonymous_reads_keep_the_lower_budget() -> None:
+    client = TestClient(_app(authenticated=False))
+    response = client.get("/v1/findings")
+    assert response.status_code == 200
+    assert response.headers["x-ratelimit-limit"] == "20"
+
+
+def test_authenticated_writes_still_use_the_scan_budget() -> None:
+    """The higher read budget must not leak into the ingest/scan door."""
+    client = TestClient(_app(authenticated=True))
+    response = client.post("/v1/scan")
+    assert response.status_code == 200
+    assert response.headers["x-ratelimit-limit"] == "10"
+
+
+def test_anonymous_flood_is_still_cut_off_at_the_lower_budget() -> None:
+    client = TestClient(_app(authenticated=False, read_rpm=3))
+    statuses = [client.get("/v1/findings").status_code for _ in range(6)]
+    assert 429 in statuses
+    assert statuses.index(429) == 3


### PR DESCRIPTION
## Summary

Ten defects from a hands-on audit, in two themes: requests that crashed instead of being
rejected, and tenant boundaries that were not enforced where the docs claim they are.

### Malformed requests returned 500 instead of a 4xx envelope

- Any non-JSON `Content-Type` on a body route returned a bare `500`. The validation handler
  itself raised `TypeError: Object of type bytes is not JSON serializable`, because the 422
  envelope sanitized `ctx` but not `input`. This affected every POST/PUT/PATCH, gave the
  caller no `error.code` and no `correlation_id`, and poisoned 5xx alerting with
  client-caused errors.
- The same `input` field reflected the submitted body verbatim, including credential-shaped
  keys. Dropping `input` closes both.
- A deeply nested body 500'd on `ValueError: Circular reference detected` inside idempotency
  fingerprinting. Now a typed `IdempotencyPayloadError` mapped to 422 -- which closes all
  six call sites, not just the reported one.
- A NUL byte in a path parameter 500'd via `psycopg.DataError`. Now rejected at the edge, so
  the class is closed for every route rather than one path id.

### The scanner aborted instead of degrading

One unreadable file or one non-UTF8 `package.json` killed the whole scan and wrote no
artifact -- `OSError`/`PermissionError`/`UnicodeDecodeError` escaped both npm parse branches,
while the sibling corrupt-lockfile path already degraded correctly with a named warning.
Both branches now route through the same warning path.

### Tenant boundaries

- **`teams` had no RLS**, and it is the FK cascade root for findings, api_keys, agents,
  exceptions, job_queue and policy_results. An ordinary app-role session could enumerate
  every tenant and delete another tenant's row, taking its entire dataset with it. The API
  layer 403s both paths, so this was defence-in-depth -- but `tenant_lifecycle` issues that
  exact DELETE with those credentials, so one binding bug would have been unrecoverable.
- **HTTP- and scheduler-triggered scans ran as tenant `default`.** The claimed-job path was
  already bound; these two were not, so durable persistence wrote under the wrong tenant.
  This must land with the RLS change: `postgres_job_store.put` provisions the teams row from
  `job.tenant_id` and now has to satisfy the new `WITH CHECK`.
- Nine real app routes returned raw JSON 401 on a cold deep-link, including `/overview` --
  the page the header CTA and left nav both point at -- while `/settings` and `/dashboard`,
  which do not exist, returned 200. The SPA allowlist was hand-maintained and had drifted;
  it is now derived from the same static file map the catch-all resolves against.
- **`HTTP(S)_PROXY` was silently ignored**, so an operator who believed egress was pinned
  through an inspecting proxy had no such control, failing open.
- The default read rate limit 429'd a legitimate full-tenant cursor walk partway through.
  Authenticated reads now get their own budget; anonymous, per-IP and scan limits unchanged.

## Verification

- `pytest`: **1278 passed, 2 skipped, 0 failed** across `tests/api` plus 13 named suites
- every fix verified red before green
- `ruff check` clean on all changed files; `ruff format --check` clean on every file touched
- `mypy`: `Success: no issues found in 6 source files`

## Notes for review

- **The `teams` RLS migration is unverified against a live database.** Postgres was
  unavailable. The DDL mirrors `20260729_03_partition_child_rls` and the existing `init.sql`
  policy blocks, and the `ALTER TABLE … ENABLE/FORCE ROW LEVEL SECURITY`-inside-`DO` idiom
  already ships and runs live in `init.sql`. All three `INSERT INTO teams` sites were
  confirmed to run bound to the tenant they insert, so they satisfy the new `WITH CHECK`.
  It still needs a real fresh-install and upgrade-from-head replay before release.
- **Behaviour change:** on REST-only deployments (no packaged UI) SPA paths now 401 rather
  than 404, because nothing is mounted to serve them. Deliberate -- the alternative is the
  hardcoded fallback that drifted in the first place. Recorded in `4a2c10a34`.
- The audit's suggested proxy fix does not work on the pinned version: httpx removed
  `proxies=` in 0.28 and this repo pins 0.28.1. Real mechanism, confirmed in the pinned
  source: `allow_env_proxies = trust_env and transport is None`, so passing any explicit
  transport drops every env proxy mount. Fixed by standing the retrying transport down when
  a proxy is configured, which also preserves `NO_PROXY` handling.
- **Pre-existing gap found while verifying, not fixed here:** `report["coverage_warnings"]`
  is `[]` in the written artifact even though the warning is logged and the scan degrades
  correctly. `consume_coverage_warnings()` is drained in two places and whoever runs first
  wins. Confirmed identical on the corrupt-JSON path that already worked, so it is not a
  regression -- but it is an honesty gap in a shipped artifact and deserves its own issue.
