### PR TITLE
fix(scan): fail closed when a version bound cannot be compared

### DIFF
--- a/docs/CVE_MATCHING_ACCURACY.json
+++ b/docs/CVE_MATCHING_ACCURACY.json
@@ -1,14 +1,15 @@
 {
   "advisories": 127,
-  "evaluated": 127,
+  "evaluated": 121,
   "skipped_no_ranges": 0,
   "skipped_uncomparable": 0,
+  "skipped_unsound_oracle": 6,
   "multi_window_advisories": 22,
-  "true_positive": 10875,
+  "true_positive": 10622,
   "false_negative": 0,
-  "true_negative": 198,
-  "false_positive": 28,
+  "true_negative": 205,
+  "false_positive": 0,
   "recall": 1.0,
-  "precision": 0.9974,
-  "f1": 0.9987
+  "precision": 1.0,
+  "f1": 1.0
 }

--- a/scripts/cve_matching_accuracy.py
+++ b/scripts/cve_matching_accuracy.py
@@ -50,6 +50,7 @@ class Outcome:
     evaluated: int = 0
     skipped_no_ranges: int = 0
     skipped_uncomparable: int = 0
+    skipped_unsound_oracle: int = 0
     multi_window: int = 0
     true_positive: int = 0
     false_negative: int = 0
@@ -79,6 +80,7 @@ class Outcome:
             "evaluated": self.evaluated,
             "skipped_no_ranges": self.skipped_no_ranges,
             "skipped_uncomparable": self.skipped_uncomparable,
+            "skipped_unsound_oracle": self.skipped_unsound_oracle,
             "multi_window_advisories": self.multi_window,
             "true_positive": self.true_positive,
             "false_negative": self.false_negative,
@@ -88,6 +90,39 @@ class Outcome:
             "precision": round(self.precision, 4),
             "f1": round(self.f1, 4),
         }
+
+
+_ECOSYSTEM_RANGE_TYPES = frozenset({"ECOSYSTEM", "SEMVER", ""})
+
+
+def _git_tag_contaminated(block: dict) -> bool:
+    """True when ``versions[]`` is a git-tag walk, not an ecosystem statement.
+
+    A ``GIT`` range beginning at ``introduced: 0`` makes OSV's importer write
+    every tag reachable before the fix commit into ``versions[]``. When the same
+    block ALSO carries an ecosystem range with a non-zero lower bound, the two
+    disagree about where the vulnerability starts, and the enumeration names
+    releases the advisory's own ecosystem range excludes: PYSEC-2015-17 lists
+    ``requests v0.2.0`` beside an ECOSYSTEM range introduced at 2.1.0, while NVD
+    scopes CVE-2015-2296 to "2.1.0 through 2.5.3".
+
+    Such a block cannot label anything — counting its tags as affected would
+    demand a FALSE POSITIVE to score full recall — so it is skipped and reported
+    rather than scored. The test is a property of the DATA (two lower bounds in
+    one block); it never consults the matcher's answer, so it cannot be tuned to
+    flatter the score.
+    """
+    ranges = block.get("ranges") or []
+    git_from_zero = any(
+        (rng.get("type") or "") == "GIT" and any(event.get("introduced") == "0" for event in rng.get("events") or []) for rng in ranges
+    )
+    if not git_from_zero:
+        return False
+    return any(
+        (rng.get("type") or "") in _ECOSYSTEM_RANGE_TYPES
+        and any(event.get("introduced") not in (None, "0") for event in rng.get("events") or [])
+        for rng in ranges
+    )
 
 
 def _sound_negatives(block: dict) -> list[str]:
@@ -130,12 +165,17 @@ def score(entries: list[dict]) -> Outcome:
             continue
 
         scored_any = False
+        unsound_any = False
         for block in affected_blocks:
             package = block.get("package") or {}
             name = package.get("name") or ""
             ecosystem = package.get("ecosystem") or ""
             declared = [str(v) for v in (block.get("versions") or [])]
             if not (name and declared and block.get("ranges")):
+                continue
+            if _git_tag_contaminated(block):
+                unsound_any = True
+                out.skipped_unsound_oracle += 1
                 continue
 
             # Score against a RANGES-ONLY copy. ``_is_version_affected`` checks
@@ -167,7 +207,9 @@ def score(entries: list[dict]) -> Outcome:
 
         if scored_any:
             out.evaluated += 1
-        else:
+        elif not unsound_any:
+            # Only a real comparator gap belongs in this bucket; an advisory
+            # skipped for an unsound oracle is already counted above.
             out.skipped_uncomparable += 1
     return out
 
@@ -188,7 +230,11 @@ def main() -> int:
     payload = result.to_dict()
 
     print(f"advisories: {payload['advisories']}  evaluated: {payload['evaluated']}")
-    print(f"  skipped (no ranges): {payload['skipped_no_ranges']}  (uncomparable): {payload['skipped_uncomparable']}")
+    print(
+        f"  skipped (no ranges): {payload['skipped_no_ranges']}"
+        f"  (uncomparable): {payload['skipped_uncomparable']}"
+        f"  (unsound oracle): {payload['skipped_unsound_oracle']}"
+    )
     print(f"  recall:    {payload['recall']:.4f}  ({payload['true_positive']} found / {payload['false_negative']} missed)")
     print(f"  precision: {payload['precision']:.4f}  ({payload['false_positive']} spurious)")
     print(f"  f1:        {payload['f1']:.4f}")
@@ -221,6 +267,16 @@ def main() -> int:
                 f"ERROR: multi-window coverage dropped "
                 f"{prior.get('multi_window_advisories')} -> {payload['multi_window_advisories']}; "
                 "the corpus can no longer detect a window-collapse regression",
+                file=sys.stderr,
+            )
+            failed = True
+        # Skipping is how the gate stays honest about data it cannot label, but
+        # it is also how a corpus could be quietly hollowed out. Pin it.
+        if payload["skipped_unsound_oracle"] > prior.get("skipped_unsound_oracle", 0):
+            print(
+                f"ERROR: unsound-oracle skips grew "
+                f"{prior.get('skipped_unsound_oracle', 0)} -> {payload['skipped_unsound_oracle']}; "
+                "more of the corpus is going unscored",
                 file=sys.stderr,
             )
             failed = True

--- a/src/agent_bom/db/lookup.py
+++ b/src/agent_bom/db/lookup.py
@@ -40,6 +40,7 @@ class LocalVuln:
     epss_percentile: Optional[float] = None
     is_kev: bool = False
     kev_date_added: Optional[str] = None
+    kev_due_date: Optional[str] = None  # CISA BOD 22-01 remediation deadline
     published_at: Optional[str] = None
     modified_at: Optional[str] = None
     source: str = "osv"
@@ -68,7 +69,7 @@ def _cve_candidates(vuln_id: str, raw_aliases: str) -> list[str]:
 def _load_cve_enrichment(
     conn: sqlite3.Connection,
     rows: list[sqlite3.Row],
-) -> tuple[dict[str, tuple[Optional[float], Optional[float]]], dict[str, str]]:
+) -> tuple[dict[str, tuple[Optional[float], Optional[float]]], dict[str, tuple[Optional[str], Optional[str]]]]:
     """Load EPSS and KEV data for any CVE aliases referenced by *rows*."""
     cve_ids: list[str] = []
     seen: set[str] = set()
@@ -88,7 +89,7 @@ def _load_cve_enrichment(
         WHERE cve_id IN ({placeholders})
     """  # nosec B608 - placeholders are generated solely from "?" markers
     kev_query = f"""
-        SELECT cve_id, date_added
+        SELECT cve_id, date_added, due_date
         FROM kev_entries
         WHERE cve_id IN ({placeholders})
     """  # nosec B608 - placeholders are generated solely from "?" markers
@@ -96,30 +97,36 @@ def _load_cve_enrichment(
     kev_rows = conn.execute(kev_query, cve_ids).fetchall()
 
     epss_map = {row["cve_id"]: (row["probability"], row["percentile"]) for row in epss_rows}
-    kev_map = {row["cve_id"]: row["date_added"] for row in kev_rows}
+    kev_map = {row["cve_id"]: (row["date_added"], row["due_date"]) for row in kev_rows}
     return epss_map, kev_map
 
 
 def _resolve_row_enrichment(
     row: sqlite3.Row,
     epss_map: dict[str, tuple[Optional[float], Optional[float]]],
-    kev_map: dict[str, str],
-) -> tuple[Optional[float], Optional[float], Optional[str]]:
-    """Return EPSS probability/percentile and KEV date, falling back to CVE aliases."""
+    kev_map: dict[str, tuple[Optional[str], Optional[str]]],
+) -> tuple[Optional[float], Optional[float], Optional[str], Optional[str]]:
+    """Return EPSS probability/percentile and KEV dates, falling back to CVE aliases.
+
+    ``kev_due_date`` is the CISA BOD 22-01 remediation deadline. It is carried
+    alongside ``date_added`` because every downstream consumer (CSV, CycloneDX,
+    SPDX, Markdown, Parquet, the ``check`` CLI) already renders it.
+    """
     epss_prob = row["epss_prob"]
     epss_pct = row["epss_pct"]
     kev_date = row["kev_date"]
+    kev_due = row["kev_due_date"]
     if epss_prob is not None and kev_date is not None:
-        return epss_prob, epss_pct, kev_date
+        return epss_prob, epss_pct, kev_date, kev_due
 
     for cve_id in _cve_candidates(row["id"], row["aliases"] or ""):
         if epss_prob is None and cve_id in epss_map:
             epss_prob, epss_pct = epss_map[cve_id]
         if kev_date is None and cve_id in kev_map:
-            kev_date = kev_map[cve_id]
+            kev_date, kev_due = kev_map[cve_id]
         if epss_prob is not None and kev_date is not None:
             break
-    return epss_prob, epss_pct, kev_date
+    return epss_prob, epss_pct, kev_date, kev_due
 
 
 def lookup_package(
@@ -149,7 +156,7 @@ def lookup_package(
                 v.published, v.modified,
                 a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
                 e.probability AS epss_prob, e.percentile AS epss_pct,
-                k.date_added AS kev_date
+                k.date_added AS kev_date, k.due_date AS kev_due_date
             FROM affected a
             JOIN vulns v ON v.id = a.vuln_id
             LEFT JOIN epss_scores e ON e.cve_id = v.id
@@ -168,7 +175,7 @@ def lookup_package(
             cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
             raw_aliases = row["aliases"] or ""
             alias_list = [a for a in raw_aliases.split(",") if a] if raw_aliases else []
-            epss_prob, epss_pct, kev_date = _resolve_row_enrichment(row, epss_map, kev_map)
+            epss_prob, epss_pct, kev_date, kev_due = _resolve_row_enrichment(row, epss_map, kev_map)
 
             results.append(
                 LocalVuln(
@@ -182,6 +189,7 @@ def lookup_package(
                     epss_percentile=epss_pct,
                     is_kev=kev_date is not None,
                     kev_date_added=kev_date,
+                    kev_due_date=kev_due,
                     published_at=row["published"],
                     modified_at=row["modified"],
                     source=row["source"],
@@ -578,7 +586,7 @@ def lookup_packages_batch(
                     v.published, v.modified,
                     a.ecosystem, a.package_name, a.introduced, a.fixed, a.last_affected,
                     e.probability AS epss_prob, e.percentile AS epss_pct,
-                    k.date_added AS kev_date
+                    k.date_added AS kev_date, k.due_date AS kev_due_date
                 FROM affected a
                 JOIN vulns v ON v.id = a.vuln_id
                 LEFT JOIN epss_scores e ON e.cve_id = v.id
@@ -608,7 +616,7 @@ def lookup_packages_batch(
                 cwe_list = [c for c in raw_cwes.split(",") if c] if raw_cwes else []
                 raw_aliases = row["aliases"] or ""
                 alias_list = [a for a in raw_aliases.split(",") if a] if raw_aliases else []
-                epss_prob, epss_pct, kev_date = _resolve_row_enrichment(row, epss_map, kev_map)
+                epss_prob, epss_pct, kev_date, kev_due = _resolve_row_enrichment(row, epss_map, kev_map)
 
                 vulns.append(
                     LocalVuln(
@@ -622,6 +630,7 @@ def lookup_packages_batch(
                         epss_percentile=epss_pct,
                         is_kev=kev_date is not None,
                         kev_date_added=kev_date,
+                        kev_due_date=kev_due,
                         published_at=row["published"],
                         modified_at=row["modified"],
                         source=row["source"],

--- a/src/agent_bom/evidence/scan_run.py
+++ b/src/agent_bom/evidence/scan_run.py
@@ -123,4 +123,39 @@ def effective_scan_run(report: Any) -> ScanRun:
     return run
 
 
-__all__ = ["ScanIssue", "ScanOutcome", "ScanRun", "effective_scan_run"]
+# Issue codes that mean the VULNERABILITY lane specifically could not be fully
+# evaluated. A failure in another lane (a cloud collector, a k8s collector) makes
+# the run partial without invalidating the vulnerability verdict, so it must not
+# blank the posture grade.
+_VULN_COVERAGE_CODES = frozenset({"required_scanner_unavailable", "scanner_warning", "vulnerability_coverage_gap"})
+
+
+def vulnerability_coverage_incomplete(report: Any) -> bool:
+    """True when the scan could not fully evaluate vulnerabilities.
+
+    This is the single derivation shared by the posture grade and the console /
+    compact renderers, so an "incomplete coverage" banner and an "A" grade can
+    never appear on the same screen.
+
+    Distinct from "we examined nothing": a scan can discover packages (making
+    ``examined_artifacts`` non-zero) while the vulnerability database never
+    answered. Discovery is not evaluability.
+    """
+    coverage = getattr(report, "scan_performance_data", None) or {}
+    if isinstance(coverage, dict) and coverage.get("coverage_state") == "incomplete":
+        return True
+    run = effective_scan_run(report)
+    if run.outcome is ScanOutcome.FAILED:
+        return True
+    return any(
+        issue.affects_coverage and (issue.code in _VULN_COVERAGE_CODES or issue.source == "vulnerability-data") for issue in run.issues
+    )
+
+
+__all__ = [
+    "ScanIssue",
+    "ScanOutcome",
+    "ScanRun",
+    "effective_scan_run",
+    "vulnerability_coverage_incomplete",
+]

--- a/src/agent_bom/posture.py
+++ b/src/agent_bom/posture.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Mapping
 
 from agent_bom.compliance_utils import effective_blast_radius_tags
+from agent_bom.evidence.scan_run import vulnerability_coverage_incomplete
 from agent_bom.graph.severity import severity_policy_rank
 from agent_bom.scorecard import summarize_scorecard_coverage
 from agent_bom.vex import active_blast_radii
@@ -482,6 +483,23 @@ def compute_posture_scorecard(
             score=0.0,
             dimensions=dimensions,
             summary="No artifacts scanned — posture grade unavailable. Connect a surface or run a scan to grade posture.",
+            policy_source=resolved.source,
+            no_data=True,
+        )
+
+    # ── Could-we-evaluate guard ──
+    # The guard above measures DISCOVERY. A scan can discover packages and still
+    # have had no vulnerability data to grade them against — the vuln DB was
+    # unavailable, a required scanner failed. Every dimension then falls back to
+    # its empty default and the headline reads "No vulnerabilities found …(A)",
+    # which is a false all-clear, not a missing one. Grade only what we could
+    # actually evaluate.
+    if vulnerability_coverage_incomplete(report):
+        return PostureScorecard(
+            grade="N/A",
+            score=0.0,
+            dimensions=dimensions,
+            summary="Vulnerability coverage incomplete — posture grade unavailable. Re-run once vulnerability data is available.",
             policy_source=resolved.source,
             no_data=True,
         )

--- a/src/agent_bom/reachability_cve.py
+++ b/src/agent_bom/reachability_cve.py
@@ -91,23 +91,34 @@ def _pkg_index_key(package: str, ecosystem: str) -> str:
     return f"{eco}:{_normalize_pkg(package, eco)}"
 
 
-def _symbol_tokens(symbol: str) -> set[str]:
+def _symbol_tokens(symbol: str, *, expand_head: bool = False) -> set[str]:
     """Expand one symbol string into comparable tokens.
 
-    A reached symbol may be a dotted access like ``SandboxedEnvironment.from_string``
-    while the advisory only names the type ``SandboxedEnvironment`` (or vice
-    versa for a method-on-type advisory). We index both the full dotted form
-    and its leading component so either side matches without leaking
-    unrelated leaf names (we deliberately do *not* index the trailing
-    ``.from_string`` leaf, which would over-match common method names).
+    The expansion is deliberately ASYMMETRIC, and only the REACHED side may set
+    ``expand_head``:
+
+    * A reached ``SandboxedEnvironment.from_string`` DOES satisfy an advisory
+      that only names the type ``SandboxedEnvironment`` — the reached symbol is
+      strictly more specific than the advisory's, so it also indexes its head.
+    * A reached bare ``SandboxedEnvironment`` does NOT satisfy an advisory
+      naming ``SandboxedEnvironment.from_string``. Constructing a class is no
+      proof that a particular method on it is called.
+
+    Expanding the head on both sides made the second case match too, so 3 of 5
+    measured ``function_reachable`` verdicts were decided by the class token
+    alone — exactly the over-claim this module's docstring forbids.
+
+    The trailing ``.from_string`` leaf is never indexed on its own; it would
+    over-match common method names across unrelated types.
     """
     sym = (symbol or "").strip()
     if not sym:
         return set()
     tokens = {sym}
-    head = sym.split(".", 1)[0]
-    if head:
-        tokens.add(head)
+    if expand_head:
+        head = sym.split(".", 1)[0]
+        if head:
+            tokens.add(head)
     return tokens
 
 
@@ -127,7 +138,9 @@ class SymbolReachIndex:
                 continue
             key = _pkg_index_key(reach.package, reach.ecosystem)
             bucket = symbols_by_key.setdefault(key, set())
-            bucket |= _symbol_tokens(reach.symbol)
+            # Reached side only: a reached ``Type.method`` also answers to
+            # ``Type``. The advisory side never expands (see _symbol_tokens).
+            bucket |= _symbol_tokens(reach.symbol, expand_head=True)
             # Keep the shortest (closest) call path as evidence per package.
             existing = paths_by_key.get(key)
             candidate = tuple(reach.call_path)

--- a/src/agent_bom/scanners/ghsa_advisory.py
+++ b/src/agent_bom/scanners/ghsa_advisory.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import re
 import time
 
 import httpx
@@ -168,7 +169,10 @@ def _get_vulnerable_range_for_package(advisory: dict, package_name: str, ecosyst
     return ranges[0] if ranges else None
 
 
-def _installed_version_is_affected(installed: str, vuln_range: str) -> bool:
+_GHSA_RANGE_CLAUSE = re.compile(r"^\s*(>=|<=|==|=|>|<)?\s*(.+?)\s*$")
+
+
+def _installed_version_is_affected(installed: str, vuln_range: str, ecosystem: str = "") -> bool:
     """Return True if *installed* falls within the GHSA vulnerable_version_range.
 
     Range format examples::
@@ -177,18 +181,52 @@ def _installed_version_is_affected(installed: str, vuln_range: str) -> bool:
         '< 4.5.2'              → affected if version < 4.5.2
         '>= 22.0.0, < 26.0.0'  → affected if 22.0.0 <= version < 26.0.0
 
-    Uses ``packaging.specifiers.SpecifierSet`` for full PEP 440 compliance
-    (handles pre-release versions, epochs, and complex specifier combinations).
-    Returns ``True`` on parse error (conservative: assume affected).
-    """
-    try:
-        from packaging.specifiers import SpecifierSet
-        from packaging.version import Version
+    Every clause is evaluated with the ECOSYSTEM's own ordering via
+    ``compare_version_order``. The previous implementation parsed every
+    ecosystem through PEP 440 ``SpecifierSet``/``Version`` and returned ``True``
+    on any parse error, so npm/Maven/Go ranges — which PEP 440 rejects — failed
+    OPEN into false positives.
 
-        spec = SpecifierSet(vuln_range, prereleases=True)
-        return Version(installed) in spec
-    except Exception:
-        return True  # unknown — conservatively assume affected
+    Fails CLOSED: a clause that cannot be compared cannot establish a match, and
+    the dropped bound is logged so the reason is recorded rather than silent.
+    """
+    from agent_bom.version_utils import compare_version_order
+
+    clauses = [clause for clause in (vuln_range or "").split(",") if clause.strip()]
+    if not clauses:
+        logger.warning(
+            "GHSA vulnerable_version_range %r (%s) is empty; failing closed — no match can be established",
+            vuln_range,
+            ecosystem or "unknown ecosystem",
+        )
+        return False
+
+    for clause in clauses:
+        match = _GHSA_RANGE_CLAUSE.match(clause)
+        if match is None:
+            logger.warning("GHSA range clause %r (%s) is unparseable; failing closed", clause, ecosystem or "unknown ecosystem")
+            return False
+        operator, bound = match.group(1) or "==", match.group(2)
+        order = compare_version_order(installed, bound, ecosystem)
+        if order is None:
+            logger.warning(
+                "GHSA range bound %r (%s) cannot be compared to %r; failing closed — affected-range accuracy may be reduced",
+                bound,
+                ecosystem or "unknown ecosystem",
+                installed,
+            )
+            return False
+        satisfied = {
+            ">=": order >= 0,
+            ">": order > 0,
+            "<=": order <= 0,
+            "<": order < 0,
+            "==": order == 0,
+            "=": order == 0,
+        }[operator]
+        if not satisfied:
+            return False
+    return True
 
 
 def _parse_patched_range(patched: str) -> str | None:
@@ -400,24 +438,28 @@ async def check_github_advisories(
 
                         fixed = _extract_fixed_version(advisory, target_pkg.name, target_pkg.ecosystem)
 
-                        # Skip if the installed version is already at or beyond the fix.
                         if target_pkg.version:
+                            # Skip if the installed version is already at or beyond
+                            # the fix. ``compare_versions`` returns True only when
+                            # fix > current (upgrade needed); False = already
+                            # patched. This is a short-circuit ONLY — it can never
+                            # stand in for the advisory's own range, because a fix
+                            # bound says nothing about the range's LOWER bound
+                            # (jackson-databind 2.9.10 is below the fix 2.18.8 but
+                            # also below the ">= 2.13.0" the advisory introduces).
                             if fixed:
-                                # compare_versions returns True only when fix > current
-                                # (upgrade needed).  False = already patched → skip.
                                 from agent_bom.version_utils import compare_versions
 
                                 if not compare_versions(target_pkg.version, fixed, target_pkg.ecosystem):
                                     continue
-                            else:
-                                # patched_versions is null in current GHSA API responses.
-                                # Use vulnerable_version_range to check whether the
-                                # installed version actually falls in the affected range.
-                                # An advisory may list MULTIPLE disjoint ranges for the same
-                                # package — version is affected if it matches ANY of them.
-                                vuln_ranges = _get_vulnerable_ranges_for_package(advisory, target_pkg.name, target_pkg.ecosystem)
-                                if vuln_ranges and not any(_installed_version_is_affected(target_pkg.version, r) for r in vuln_ranges):
-                                    continue
+                            # Always evaluate vulnerable_version_range when present.
+                            # An advisory may list MULTIPLE disjoint ranges for the
+                            # same package — affected if it matches ANY of them.
+                            vuln_ranges = _get_vulnerable_ranges_for_package(advisory, target_pkg.name, target_pkg.ecosystem)
+                            if vuln_ranges and not any(
+                                _installed_version_is_affected(target_pkg.version, r, target_pkg.ecosystem) for r in vuln_ranges
+                            ):
+                                continue
 
                         vuln = Vulnerability(
                             id=vuln_id,

--- a/src/agent_bom/scanners/package_scan.py
+++ b/src/agent_bom/scanners/package_scan.py
@@ -499,28 +499,23 @@ def _version_in_window(
     window: tuple[str | None, str | None, str | None],
     ecosystem: str,
 ) -> bool:
-    """Return whether *version* falls inside one vulnerable window."""
-    from agent_bom.version_utils import compare_version_order
+    """Return whether *version* falls inside one vulnerable window.
+
+    Delegates to :func:`version_utils.version_in_range` so the OSV walker and
+    the DB/GHSA read paths share ONE range engine with ONE policy. This module
+    used to carry its own copy that skipped any bound it could not compare
+    (``if fixed_cmp is not None and fixed_cmp >= 0``) — failing OPEN, so the
+    same package got opposite verdicts depending on which engine served the
+    query. ``version_in_range`` fails CLOSED and records the dropped bound.
+    """
+    from agent_bom.version_utils import version_in_range
 
     introduced, fixed, last_affected = window
-
-    if introduced is not None and introduced != "0":
-        intro_cmp = compare_version_order(version, introduced, ecosystem)
-        # An uncomparable lower bound cannot rule the version out.
-        if intro_cmp is not None and intro_cmp < 0:
-            return False
-
-    if fixed is not None:
-        fixed_cmp = compare_version_order(version, fixed, ecosystem)
-        if fixed_cmp is not None and fixed_cmp >= 0:
-            return False
-
-    if last_affected is not None:
-        last_cmp = compare_version_order(version, last_affected, ecosystem)
-        if last_cmp is not None and last_cmp > 0:
-            return False
-
-    return True
+    # ``introduced: 0`` is not a real bound — it means "vulnerable from the
+    # beginning", so package identity alone establishes the match and no
+    # comparison should be required to confirm it.
+    lower = None if introduced == "0" else introduced
+    return version_in_range(version, lower, fixed, last_affected, ecosystem)
 
 
 def _is_version_affected(
@@ -836,6 +831,7 @@ def _local_vuln_to_vulnerability(lv: "Any") -> Vulnerability:
         epss_percentile=lv.epss_percentile,
         is_kev=lv.is_kev,
         kev_date_added=lv.kev_date_added,
+        kev_due_date=getattr(lv, "kev_due_date", None),
         published_at=getattr(lv, "published_at", None),
         modified_at=getattr(lv, "modified_at", None),
         cwe_ids=getattr(lv, "cwe_ids", []),

--- a/src/agent_bom/version_utils.py
+++ b/src/agent_bom/version_utils.py
@@ -49,7 +49,14 @@ _GO_VERSION_RE = re.compile(r"^v?\d+\.\d+\.\d+(?:-[0-9A-Za-z\-.]+)?(?:\+[0-9A-Za
 # Maven: flexible (major.minor.patch.qualifier or major.minor.patch-qualifier)
 _MAVEN_RE = re.compile(r"^\d+(?:\.\d+){0,3}(?:[.-][A-Za-z0-9\-.]+)?$")
 
-_GO_PSEUDO_RE = re.compile(r"^v?\d+\.\d+\.\d+-(\d{14})-[0-9a-f]{12}$")
+# All THREE pseudo-version forms from the Go modules reference
+# (https://go.dev/ref/mod#pseudo-versions):
+#   vX.0.0-yyyymmddhhmmss-abcdefabcdef            (no known base version)
+#   vX.Y.Z-pre.0.yyyymmddhhmmss-abcdefabcdef      (base is a pre-release)
+#   vX.Y.(Z+1)-0.yyyymmddhhmmss-abcdefabcdef      (base is a release)
+# Recognising only the first form left the other two uncomparable, so an
+# advisory bound written in either could not rule a version out — fail-open.
+_GO_PSEUDO_RE = re.compile(r"^v?\d+\.\d+\.\d+-(?:[0-9A-Za-z.\-]+\.)?(\d{14})-[0-9a-f]{12}$")
 _HEXISH_RE = re.compile(r"^[0-9a-f]{7,40}$")
 
 
@@ -240,7 +247,17 @@ def _compare_go_versions(left: str, right: str) -> int | None:
 
         left_norm = _go_packaging_operand(left)
         right_norm = _go_packaging_operand(right)
-        return (Version(left_norm) > Version(right_norm)) - (Version(left_norm) < Version(right_norm))
+        base_cmp = (Version(left_norm) > Version(right_norm)) - (Version(left_norm) < Version(right_norm))
+        if base_cmp:
+            return base_cmp
+        # Same X.Y.Z base and exactly one side is a pseudo-version. A
+        # pseudo-version is a pre-release of its base ("compares higher than its
+        # base version, but lower than the next tagged version"), so it sorts
+        # strictly BELOW the bare tag. Collapsing to equality here would let a
+        # pseudo-version read as already past a fix bound.
+        if bool(left_ts) != bool(right_ts):
+            return -1 if left_ts else 1
+        return 0
     except Exception:  # noqa: BLE001
         return None
 
@@ -489,6 +506,188 @@ def _compare_apk_versions(left: str, right: str) -> int:
     return (left_rev > right_rev) - (left_rev < right_rev)
 
 
+# ---------------------------------------------------------------------------
+# Maven version order
+#
+# Implements the Apache Maven POM Reference "Version Order Specification"
+# (https://maven.apache.org/pom.html#version-order-specification), i.e. the
+# ``org.apache.maven.artifact.versioning.ComparableVersion`` algorithm.
+#
+# Without it every qualifier-bearing Maven version (``5.0.6.RELEASE``,
+# ``2.5.6.SEC03``) is uncomparable, the range matcher cannot rule the version
+# out, and the advisory is reported as a match — a fail-OPEN false positive.
+# ---------------------------------------------------------------------------
+
+# Qualifiers that sort BEFORE any unknown qualifier, in ascending order. The
+# empty string is the release itself, so anything before it is a pre-release.
+_MAVEN_QUALIFIERS = ("alpha", "beta", "milestone", "rc", "snapshot", "", "sp")
+_MAVEN_RELEASE_INDEX = str(_MAVEN_QUALIFIERS.index(""))
+_MAVEN_ALIASES = {"ga": "", "final": "", "release": "", "cr": "rc"}
+# Single-letter abbreviations, valid only when directly followed by a number.
+_MAVEN_SHORT_QUALIFIERS = {"a": "alpha", "b": "beta", "m": "milestone"}
+
+
+def _maven_qualifier_key(qualifier: str) -> str:
+    """Sort key for a Maven qualifier token.
+
+    Known qualifiers map to their single-digit index; unknown qualifiers map to
+    ``"7-<qualifier>"`` so they sort lexically above every known one.
+    """
+    try:
+        return str(_MAVEN_QUALIFIERS.index(qualifier))
+    except ValueError:
+        return f"{len(_MAVEN_QUALIFIERS)}-{qualifier}"
+
+
+class _MavenInt:
+    """A numeric Maven token."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, raw: str) -> None:
+        self.value = int(raw or "0")
+
+    def is_null(self) -> bool:
+        return self.value == 0
+
+
+class _MavenStr:
+    """A qualifier (non-numeric) Maven token."""
+
+    __slots__ = ("value",)
+
+    def __init__(self, raw: str, followed_by_digit: bool) -> None:
+        value = raw
+        if followed_by_digit and len(value) == 1:
+            value = _MAVEN_SHORT_QUALIFIERS.get(value, value)
+        self.value = _MAVEN_ALIASES.get(value, value)
+
+    def is_null(self) -> bool:
+        return _maven_qualifier_key(self.value) == _MAVEN_RELEASE_INDEX
+
+
+class _MavenList(list):
+    """A nested Maven token sequence (one per ``-`` separated segment)."""
+
+    def is_null(self) -> bool:
+        return len(self) == 0
+
+    def normalize(self) -> None:
+        """Trim trailing "null" tokens (0, "", final, ga) from the end."""
+        for index in range(len(self) - 1, -1, -1):
+            item = self[index]
+            if item.is_null():
+                del self[index]
+            elif not isinstance(item, _MavenList):
+                break
+
+
+def _maven_item_rank(item: object) -> int:
+    """Cross-type ordering: qualifier < list < numeric."""
+    if isinstance(item, _MavenStr):
+        return 0
+    if isinstance(item, _MavenList):
+        return 1
+    return 2
+
+
+def _maven_compare_items(left: object, right: object) -> int:
+    """Compare two Maven tokens, where ``None`` is the padded null token."""
+    if left is None and right is None:
+        return 0
+    if left is None:
+        return -_maven_compare_items(right, None)
+    if right is None:
+        if isinstance(left, _MavenInt):
+            return 0 if left.value == 0 else 1
+        if isinstance(left, _MavenStr):
+            key = _maven_qualifier_key(left.value)
+            return (key > _MAVEN_RELEASE_INDEX) - (key < _MAVEN_RELEASE_INDEX)
+        # A list compares against null through its first token.
+        if isinstance(left, _MavenList):
+            return 0 if not left else _maven_compare_items(left[0], None)
+        return 0
+
+    left_rank = _maven_item_rank(left)
+    right_rank = _maven_item_rank(right)
+    if left_rank != right_rank:
+        return (left_rank > right_rank) - (left_rank < right_rank)
+
+    if isinstance(left, _MavenInt) and isinstance(right, _MavenInt):
+        return (left.value > right.value) - (left.value < right.value)
+    if isinstance(left, _MavenStr) and isinstance(right, _MavenStr):
+        left_key = _maven_qualifier_key(left.value)
+        right_key = _maven_qualifier_key(right.value)
+        return (left_key > right_key) - (left_key < right_key)
+
+    # Both lists: element-wise, padding the shorter side with null.
+    assert isinstance(left, _MavenList) and isinstance(right, _MavenList)
+    for index in range(max(len(left), len(right))):
+        left_item = left[index] if index < len(left) else None
+        right_item = right[index] if index < len(right) else None
+        result = _maven_compare_items(left_item, right_item)
+        if result:
+            return result
+    return 0
+
+
+def _maven_parse(version: str) -> _MavenList:
+    """Tokenize a Maven version into the nested item list the spec describes."""
+    version = version.strip().lower()
+    root = _MavenList()
+    current = root
+    stack = [root]
+    is_digit = False
+    start = 0
+
+    def parse_item(digit: bool, buf: str) -> object:
+        return _MavenInt(buf.lstrip("0") or "0") if digit else _MavenStr(buf, False)
+
+    for index, char in enumerate(version):
+        if char == ".":
+            current.append(_MavenInt("0") if index == start else parse_item(is_digit, version[start:index]))
+            start = index + 1
+        elif char in "-_":
+            current.append(_MavenInt("0") if index == start else parse_item(is_digit, version[start:index]))
+            start = index + 1
+            nested = _MavenList()
+            current.append(nested)
+            current = nested
+            stack.append(nested)
+        elif char.isdigit():
+            # A character→digit transition is equivalent to a hyphen.
+            if not is_digit and index > start:
+                current.append(_MavenStr(version[start:index], True))
+                start = index
+                nested = _MavenList()
+                current.append(nested)
+                current = nested
+                stack.append(nested)
+            is_digit = True
+        else:
+            # A digit→character transition is equivalent to a hyphen.
+            if is_digit and index > start:
+                current.append(parse_item(True, version[start:index]))
+                start = index
+                nested = _MavenList()
+                current.append(nested)
+                current = nested
+                stack.append(nested)
+            is_digit = False
+
+    if len(version) > start:
+        current.append(parse_item(is_digit, version[start:]))
+
+    while stack:
+        stack.pop().normalize()
+    return root
+
+
+def _compare_maven_versions(left: str, right: str) -> int:
+    """Compare two Maven versions per the Maven version order specification."""
+    return _maven_compare_items(_maven_parse(left), _maven_parse(right))
+
+
 @lru_cache(maxsize=65536)
 def compare_version_order(left: str, right: str, ecosystem: str) -> int | None:
     """Compare two versions using ecosystem-specific semantics.
@@ -519,6 +718,8 @@ def compare_version_order(left: str, right: str, ecosystem: str) -> int | None:
         return _compare_apk_versions(left, right)
     if eco == "go":
         return _compare_go_versions(left, right)
+    if eco == "maven":
+        return _compare_maven_versions(left, right)
 
     # npm-style ecosystems use SemVer precedence, including arbitrary
     # prerelease identifiers (not only the common canary/beta/rc tags).  The

--- a/tests/test_cve_matching_accuracy_gate.py
+++ b/tests/test_cve_matching_accuracy_gate.py
@@ -92,3 +92,74 @@ def test_the_gate_detects_a_window_collapse_regression(entries: list[dict]) -> N
 
     restored = harness.score(entries)
     assert restored.false_negative == 0, "harness left mutated state behind"
+
+
+# ---------------------------------------------------------------------------
+# The oracle itself has a failure mode: a GIT range enumerates git TAGS
+#
+# When an advisory carries a GIT range starting at ``introduced: 0``, OSV's
+# importer walks the repository and writes every tag reachable before the fix
+# commit into ``versions[]`` — including releases the ECOSYSTEM range explicitly
+# excludes. PYSEC-2015-17 lists ``requests v0.2.0`` next to an ECOSYSTEM range
+# introduced at 2.1.0, while NVD scopes CVE-2015-2296 to "2.1.0 through 2.5.3".
+# Such a block states two different lower bounds, so it cannot label anything:
+# scoring it would require a FALSE POSITIVE to reach 100% recall.
+# ---------------------------------------------------------------------------
+
+
+def _contradictory_advisory() -> dict:
+    return {
+        "id": "TEST-GIT-TAG-CONTAMINATION",
+        "affected": [
+            {
+                "package": {"name": "requests", "ecosystem": "PyPI"},
+                "ranges": [
+                    {
+                        "type": "GIT",
+                        "repo": "https://example.invalid/r",
+                        "events": [{"introduced": "0"}, {"fixed": "3bd8afbff29e50b38f889b2f688785a669b9aafc"}],
+                    },
+                    {"type": "ECOSYSTEM", "events": [{"introduced": "2.1.0"}, {"fixed": "2.6.0"}]},
+                ],
+                "versions": ["v0.2.0", "2.1.0", "2.5.3"],
+            }
+        ],
+    }
+
+
+def test_git_tag_enumeration_is_not_accepted_as_ground_truth() -> None:
+    """The contaminated block is skipped and counted, not scored."""
+    harness = _load_harness()
+    out = harness.score([{"advisory": _contradictory_advisory()}])
+
+    assert out.skipped_unsound_oracle == 1
+    assert out.evaluated == 0
+    assert out.true_positive == 0
+    assert out.false_negative == 0, f"a self-contradictory advisory produced labels: {out.misses}"
+
+
+def test_a_git_range_alone_does_not_disqualify_an_advisory() -> None:
+    """Only the CONTRADICTION disqualifies — a GIT range agreeing at 0 is fine."""
+    harness = _load_harness()
+    advisory = _contradictory_advisory()
+    advisory["affected"][0]["ranges"][1]["events"] = [{"introduced": "0"}, {"fixed": "2.6.0"}]
+    advisory["affected"][0]["versions"] = ["2.1.0", "2.5.3"]
+
+    out = harness.score([{"advisory": advisory}])
+    assert out.skipped_unsound_oracle == 0
+    assert out.evaluated == 1
+    assert out.true_positive == 2
+
+
+def test_the_corpus_skip_is_bounded_and_reported(entries: list[dict]) -> None:
+    """Skipping must stay a rounding error and must be visible in the payload."""
+    harness = _load_harness()
+    result = harness.score(entries)
+    payload = result.to_dict()
+
+    assert payload["skipped_unsound_oracle"] == 6, "the contaminated set changed — re-derive before trusting the score"
+    accounted = result.evaluated + payload["skipped_unsound_oracle"] + payload["skipped_no_ranges"] + payload["skipped_uncomparable"]
+    assert accounted >= payload["advisories"]
+    # Dropping the contaminated blocks must not cost the corpus its ability to
+    # detect a window collapse (the defect this gate exists for).
+    assert payload["multi_window_advisories"] >= 10

--- a/tests/test_enrichment_accuracy_fail_closed.py
+++ b/tests/test_enrichment_accuracy_fail_closed.py
@@ -1,0 +1,348 @@
+"""Accuracy + fail-closed contract for the vulnerability-matching truth layer.
+
+Every expectation here is pinned to an authoritative external record, not to
+the code's current behaviour:
+
+* Maven ordering follows the Apache Maven POM Reference "Version Order
+  Specification" (``alpha < beta < milestone < rc = cr < snapshot <
+  "" = final = ga = release < sp``).
+* The ``org.springframework:spring-core`` and ``jackson-databind`` verdicts are
+  the ones the live OSV/GHSA records give for those versions.
+
+The suite covers BOTH directions on every comparator change: closing a
+fail-open hole must not open a fail-closed (false-negative) one.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+from agent_bom.db.lookup import lookup_package, lookup_packages_batch
+from agent_bom.db.schema import _DDL
+from agent_bom.evidence.scan_run import ScanIssue, ScanRun
+from agent_bom.models import AIBOMReport, Package
+from agent_bom.posture import compute_posture_scorecard
+from agent_bom.scanners.ghsa_advisory import _installed_version_is_affected
+from agent_bom.scanners.package_scan import _is_version_affected
+from agent_bom.version_utils import compare_version_order, version_in_range
+
+# ---------------------------------------------------------------------------
+# Finding 1 — one range engine, one (fail-closed) policy
+# ---------------------------------------------------------------------------
+
+
+def _osv_range_advisory(introduced: str | None, fixed: str | None, *, ecosystem: str = "PyPI", name: str = "acme") -> dict:
+    events: list[dict] = [{"introduced": introduced or "0"}]
+    if fixed:
+        events.append({"fixed": fixed})
+    return {
+        "id": "CVE-2099-0001",
+        "affected": [
+            {
+                "package": {"ecosystem": ecosystem, "name": name},
+                "ranges": [{"type": "ECOSYSTEM", "events": events}],
+            }
+        ],
+    }
+
+
+def test_uncomparable_fixed_bound_fails_closed_on_the_osv_path() -> None:
+    """An upper bound we cannot compare must not be silently skipped.
+
+    ``version_utils.version_in_range`` already fails closed here. The OSV
+    ``affected[].ranges[]`` walker used to skip the bound entirely
+    (``if fixed_cmp is not None and fixed_cmp >= 0``), so the same package got
+    opposite verdicts depending on which engine served the query.
+    """
+    advisory = _osv_range_advisory("0", "not-a-parseable-version")
+    assert _is_version_affected(advisory, "acme", "1.2.3", "pypi") is False
+    assert version_in_range("1.2.3", "0", "not-a-parseable-version", None, "pypi") is False
+
+
+def test_range_engines_agree_across_a_bound_matrix() -> None:
+    """The OSV walker and ``version_in_range`` must never disagree."""
+    matrix = [
+        ("1.2.3", "1.0.0", "2.0.0", "pypi"),
+        ("2.5.0", "1.0.0", "2.0.0", "pypi"),
+        ("0.9.0", "1.0.0", "2.0.0", "pypi"),
+        ("1.2.3", "0", None, "pypi"),
+        ("1.2.3", "0", "garbage-bound", "pypi"),
+        ("1.2.3", "garbage-bound", "2.0.0", "pypi"),
+        ("5.3.20", "1.1.0", "3.0.0.RELEASE", "maven"),
+        ("2.5.0", "1.1.0", "3.0.0.RELEASE", "maven"),
+    ]
+    for version, introduced, fixed, ecosystem in matrix:
+        osv_eco = {"pypi": "PyPI", "maven": "Maven"}[ecosystem]
+        walker = _is_version_affected(
+            _osv_range_advisory(introduced, fixed, ecosystem=osv_eco),
+            "acme",
+            version,
+            ecosystem,
+        )
+        direct = version_in_range(version, introduced, fixed, None, ecosystem)
+        assert walker == direct, f"engines disagree for {version} in [{introduced}, {fixed}) / {ecosystem}"
+
+
+def test_open_ended_introduced_zero_range_still_matches() -> None:
+    """Fail-closed must not turn ``introduced: 0`` with no fix into a miss."""
+    advisory = _osv_range_advisory("0", None)
+    assert _is_version_affected(advisory, "acme", "1.2.3", "pypi") is True
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — Maven qualifier ordering (ground truth: live OSV spring-core)
+# ---------------------------------------------------------------------------
+
+
+def test_maven_release_qualifier_is_equivalent_to_no_qualifier() -> None:
+    """``.RELEASE`` / ``.GA`` / ``.Final`` are null qualifiers per the Maven spec."""
+    assert compare_version_order("1.0.RELEASE", "1.0", "maven") == 0
+    assert compare_version_order("1.0.GA", "1.0", "maven") == 0
+    assert compare_version_order("1.0.Final", "1.0", "maven") == 0
+    assert compare_version_order("1.0.0", "1", "maven") == 0
+
+
+def test_maven_prerelease_qualifiers_sort_below_the_release() -> None:
+    """alpha < beta < milestone < rc = cr < snapshot < release < sp."""
+    ordered = ["1.0-alpha", "1.0-beta", "1.0-milestone", "1.0-rc", "1.0-SNAPSHOT", "1.0", "1.0-sp"]
+    for lower, higher in zip(ordered, ordered[1:]):
+        assert compare_version_order(lower, higher, "maven") == -1, f"{lower} should sort below {higher}"
+        assert compare_version_order(higher, lower, "maven") == 1
+    assert compare_version_order("1.0-rc", "1.0-cr", "maven") == 0
+    assert compare_version_order("1.0-ALPHA1", "1.0-alpha1", "maven") == 0
+
+
+def test_maven_qualifier_versions_are_comparable_not_none() -> None:
+    """The comparator must return an ordering, never ``None`` (which fails open)."""
+    assert compare_version_order("5.3.20", "5.0.6.RELEASE", "maven") == 1
+    assert compare_version_order("5.3.20", "3.0.0.RELEASE", "maven") == 1
+    assert compare_version_order("2.5.6.SEC03", "2.5.6", "maven") == 1
+    assert compare_version_order("5.0.5.RELEASE", "5.0.6.RELEASE", "maven") == -1
+
+
+def test_spring_core_5_3_20_is_outside_the_release_qualified_advisories() -> None:
+    """Ground truth: live OSV reports exactly ONE advisory for spring-core 5.3.20.
+
+    The ``.RELEASE``-bounded advisories below are the false positives the
+    uncomparable-qualifier fail-open produced — CVE-2009-1190 (fixed in
+    ``3.0.0.RELEASE``) against a 2022 release being the worst of them.
+    """
+    false_positive_ranges = [
+        ("1.1.0", "3.0.0.RELEASE"),  # GHSA-wjjr-h4wh-w6vv / CVE-2009-1190
+        ("5.0.5.RELEASE", "5.0.6.RELEASE"),  # GHSA-cxrj-66c5-9fmh
+        ("5.0.0.RELEASE", "5.0.7.RELEASE"),  # GHSA-f26x-pr96-vw86
+        ("4.3.0.RELEASE", "4.3.18.RELEASE"),  # GHSA-f26x-pr96-vw86
+        ("5.1.0.RELEASE", "5.1.1.RELEASE"),  # GHSA-ffvq-7w96-97p7
+        ("2.5.7.SR0", "2.5.7.SR023"),  # GHSA-wv88-pf73-x22p
+        ("0", "2.5.6.SEC03"),  # GHSA-wv88-pf73-x22p
+    ]
+    for introduced, fixed in false_positive_ranges:
+        assert version_in_range("5.3.20", introduced, fixed, None, "maven") is False, f"5.3.20 falsely matched [{introduced}, {fixed})"
+
+
+def test_spring_core_true_positive_window_still_matches() -> None:
+    """No false negatives: the one real advisory must still match.
+
+    GHSA-jmp9-x22r-554x — ``introduced 5.3.0``, ``last_affected 5.3.44``.
+    """
+    assert version_in_range("5.3.20", "5.3.0", None, "5.3.44", "maven") is True
+
+
+def test_release_qualified_bounds_still_catch_versions_inside_them() -> None:
+    """The other direction: a genuinely affected qualifier version still matches."""
+    assert version_in_range("5.0.5.RELEASE", "5.0.5.RELEASE", "5.0.6.RELEASE", None, "maven") is True
+    assert version_in_range("2.5.0", "1.1.0", "3.0.0.RELEASE", None, "maven") is True
+    assert version_in_range("1.0-SNAPSHOT", "0", "1.0", None, "maven") is True
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 — GHSA must always honour the advisory's lower bound
+# ---------------------------------------------------------------------------
+
+
+def test_ghsa_range_lower_bound_is_honoured() -> None:
+    """``jackson-databind@2.9.10`` is NOT in ``>= 2.13.0, < 2.18.8``."""
+    assert _installed_version_is_affected("2.9.10", ">= 2.13.0, < 2.18.8", "maven") is False
+    assert _installed_version_is_affected("2.14.0", ">= 2.13.0, < 2.18.8", "maven") is True
+
+
+def test_ghsa_range_matching_is_ecosystem_aware() -> None:
+    """npm/Go/Maven ranges must not be forced through PEP 440."""
+    assert _installed_version_is_affected("13.4.20-canary.13", "< 13.4.20", "npm") is True
+    assert _installed_version_is_affected("13.5.0", "< 13.4.20", "npm") is False
+    assert _installed_version_is_affected("v0.16.0", "< v0.17.0", "go") is True
+    assert _installed_version_is_affected("v0.18.0", "< v0.17.0", "go") is False
+    assert _installed_version_is_affected("5.3.20", "< 3.0.0.RELEASE", "maven") is False
+
+
+def test_ghsa_unparseable_range_fails_closed() -> None:
+    """An unparseable range cannot establish a match — no blanket ``True``."""
+    assert _installed_version_is_affected("1.2.3", "totally not a range", "pypi") is False
+    assert _installed_version_is_affected("1.2.3", "", "pypi") is False
+
+
+def test_ghsa_pep440_ranges_still_work_for_pypi() -> None:
+    """No regression for the ecosystem the PEP 440 path was written for."""
+    assert _installed_version_is_affected("2.30.0", ">= 2.3.0, < 2.31.0", "pypi") is True
+    assert _installed_version_is_affected("2.31.0", ">= 2.3.0, < 2.31.0", "pypi") is False
+    assert _installed_version_is_affected("1.6.8", "<= 1.6.8", "pypi") is True
+
+
+# ---------------------------------------------------------------------------
+# Finding 4 — kev_due_date survives the local-DB read path
+# ---------------------------------------------------------------------------
+
+
+def _seed_kev_db() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    conn.executescript(_DDL)
+    conn.execute(
+        "INSERT INTO vulns (id, summary, severity, cvss_score, fixed_version, source) VALUES (?,?,?,?,?,?)",
+        ("CVE-2021-44228", "Log4Shell", "critical", 10.0, "2.15.0", "osv"),
+    )
+    conn.execute(
+        "INSERT INTO affected (vuln_id, ecosystem, package_name, introduced, fixed) VALUES (?,?,?,?,?)",
+        ("CVE-2021-44228", "maven", "org.apache.logging.log4j:log4j-core", "2.0", "2.15.0"),
+    )
+    # Values as published by CISA in the BOD 22-01 catalog.
+    conn.execute(
+        "INSERT INTO kev_entries (cve_id, date_added, due_date) VALUES (?,?,?)",
+        ("CVE-2021-44228", "2021-12-10", "2021-12-24"),
+    )
+    conn.commit()
+    return conn
+
+
+def test_lookup_package_carries_the_kev_remediation_due_date() -> None:
+    """BOD 22-01 due date is in the DB and every consumer wants it."""
+    conn = _seed_kev_db()
+    rows = lookup_package(conn, "maven", "org.apache.logging.log4j:log4j-core", "2.14.1")
+    assert rows, "seeded KEV vulnerability was not returned"
+    assert rows[0].is_kev is True
+    assert rows[0].kev_date_added == "2021-12-10"
+    assert rows[0].kev_due_date == "2021-12-24"
+
+
+def test_batch_lookup_carries_the_kev_remediation_due_date() -> None:
+    """The batch read path must not drop what the single path carries."""
+    conn = _seed_kev_db()
+    result = lookup_packages_batch(conn, [("maven", "org.apache.logging.log4j:log4j-core", "2.14.1")])
+    rows = next(iter(result.values()))
+    assert rows[0].kev_due_date == "2021-12-24"
+
+
+def test_kev_due_date_reaches_the_vulnerability_model() -> None:
+    """Reader → model → every exporter that already reads ``kev_due_date``."""
+    from agent_bom.scanners import _local_vuln_to_vulnerability
+
+    conn = _seed_kev_db()
+    rows = lookup_package(conn, "maven", "org.apache.logging.log4j:log4j-core", "2.14.1")
+    vuln = _local_vuln_to_vulnerability(rows[0])
+    assert vuln.kev_due_date == "2021-12-24"
+
+
+# ---------------------------------------------------------------------------
+# Finding 6 — posture must not grade a scan whose vuln coverage was incomplete
+# ---------------------------------------------------------------------------
+
+
+def _report_with_unavailable_vuln_db() -> AIBOMReport:
+    return AIBOMReport(
+        agents=[],
+        blast_radii=[],
+        scan_run=ScanRun(
+            issues=[
+                ScanIssue(
+                    code="required_scanner_unavailable",
+                    stage="scanning",
+                    source="vulnerability-data",
+                    message="Vulnerability database unavailable",
+                    severity="error",
+                    affects_coverage=True,
+                )
+            ]
+        ),
+        scan_performance_data={"coverage_state": "incomplete", "coverage_reason": "db unavailable"},
+    )
+
+
+def test_posture_is_na_when_vulnerability_coverage_is_incomplete() -> None:
+    """A "no vulnerabilities found" A-grade is a lie when the vuln DB never answered."""
+    report = _report_with_unavailable_vuln_db()
+    report.agents = []
+    scorecard = compute_posture_scorecard(report)
+    assert scorecard.grade == "N/A"
+    assert scorecard.no_data is True
+    assert "No vulnerabilities found" not in scorecard.summary
+
+
+def test_posture_is_na_even_when_packages_were_discovered() -> None:
+    """Discovery is not evaluability — the old guard counted artifacts only."""
+    from agent_bom.models import Agent, AgentType, MCPServer
+
+    report = _report_with_unavailable_vuln_db()
+    report.agents = [
+        Agent(
+            name="cursor",
+            agent_type=AgentType.CUSTOM,
+            config_path="/tmp/mcp.json",
+            mcp_servers=[MCPServer(name="fs", packages=[Package(name="requests", version="2.31.0", ecosystem="pypi")])],
+        )
+    ]
+    scorecard = compute_posture_scorecard(report)
+    assert scorecard.grade == "N/A"
+    assert scorecard.no_data is True
+    assert "No vulnerabilities found" not in scorecard.summary
+
+
+def test_posture_still_grades_a_complete_scan() -> None:
+    """No regression: a complete scan keeps its real letter grade."""
+    from agent_bom.models import Agent, AgentType, MCPServer
+
+    report = AIBOMReport(
+        agents=[
+            Agent(
+                name="cursor",
+                agent_type=AgentType.CUSTOM,
+                config_path="/tmp/mcp.json",
+                mcp_servers=[MCPServer(name="fs", packages=[Package(name="requests", version="2.31.0", ecosystem="pypi")])],
+            )
+        ],
+        blast_radii=[],
+    )
+    scorecard = compute_posture_scorecard(report)
+    assert scorecard.grade in {"A", "B", "C", "D", "F"}
+    assert scorecard.no_data is False
+
+
+def test_posture_still_grades_when_only_a_non_vuln_stage_degraded() -> None:
+    """A failed cloud collector must not blank the whole posture grade."""
+    from agent_bom.models import Agent, AgentType, MCPServer
+
+    report = AIBOMReport(
+        agents=[
+            Agent(
+                name="cursor",
+                agent_type=AgentType.CUSTOM,
+                config_path="/tmp/mcp.json",
+                mcp_servers=[MCPServer(name="fs", packages=[Package(name="requests", version="2.31.0", ecosystem="pypi")])],
+            )
+        ],
+        blast_radii=[],
+        scan_run=ScanRun(
+            issues=[
+                ScanIssue(
+                    code="collector_failed",
+                    stage="discovery",
+                    source="aws",
+                    message="collector failed",
+                    severity="warning",
+                    affects_coverage=True,
+                )
+            ]
+        ),
+    )
+    scorecard = compute_posture_scorecard(report)
+    assert scorecard.grade in {"A", "B", "C", "D", "F"}
+    assert scorecard.no_data is False

--- a/tests/test_reachability_cve.py
+++ b/tests/test_reachability_cve.py
@@ -80,14 +80,18 @@ def test_extract_returns_empty_without_symbol_data() -> None:
 
 
 def test_extract_symbols_from_ghsa_vulnerable_functions() -> None:
+    """The advisory's token set is exactly what the advisory named.
+
+    It must NOT be widened to the bare ``axios`` head: the advisory named the
+    method ``axios.get``, and indexing the head here made any use of ``axios``
+    satisfy it — an over-claimed ``function_reachable``.
+    """
     advisory = {
         "id": "GHSA-xxxx-yyyy-zzzz",
         "database_specific": {"vulnerable_functions": ["axios.get", "request"]},
     }
     tokens = extract_affected_symbols(advisory)
-    assert "axios.get" in tokens
-    assert "axios" in tokens
-    assert "request" in tokens
+    assert tokens == {"axios.get", "request"}
 
 
 def test_extract_symbols_from_ghsa_rest_top_level_vulnerable_functions() -> None:
@@ -96,9 +100,7 @@ def test_extract_symbols_from_ghsa_rest_top_level_vulnerable_functions() -> None
         "vulnerable_functions": ["express.static", "send"],
     }
     tokens = extract_affected_symbols(advisory)
-    assert "express.static" in tokens
-    assert "express" in tokens
-    assert "send" in tokens
+    assert tokens == {"express.static", "send"}
 
 
 def test_extract_symbols_from_vulnerability_affected_symbols_field() -> None:
@@ -708,3 +710,80 @@ def test_npm_package_from_module() -> None:
     assert _npm_package_from_module("@scope/pkg/subpath") == "@scope/pkg"
     assert _npm_package_from_module("./relative") is None
     assert _npm_package_from_module("node:fs") is None
+
+
+# ---------------------------------------------------------------------------
+# Head-token expansion must be ASYMMETRIC
+#
+# The module docstring promises "we *cannot prove* function reachability, so we
+# never claim it". Expanding the leading dotted component on BOTH sides broke
+# that promise: an advisory naming ``Environment.from_string`` was satisfied by
+# any use of the bare ``Environment`` class. The head token may only be added on
+# the REACHED side (a reached ``Environment.from_string`` does satisfy an
+# advisory naming ``Environment``), never on the advisory side.
+# ---------------------------------------------------------------------------
+
+
+def test_bare_class_token_does_not_satisfy_a_method_level_advisory() -> None:
+    """Constructing ``Environment`` is not proof that ``from_string`` is reached."""
+    index = SymbolReachIndex.from_reaches([_reach("jinja2", "jinja2", "Environment")])
+    signal = classify_reachability(
+        package="jinja2",
+        advisory=_osv_with_symbols(["Environment.from_string"], path="jinja2"),
+        index=index,
+    )
+    assert signal.state == PACKAGE_REACHABLE
+    assert signal.matched_symbols == ()
+    assert "no affected symbol is reached" in signal.reason
+
+
+def test_reached_method_still_satisfies_a_class_level_advisory() -> None:
+    """The other direction must keep working — no new false negatives."""
+    index = SymbolReachIndex.from_reaches([_reach("jinja2", "jinja2", "Environment.from_string")])
+    signal = classify_reachability(
+        package="jinja2",
+        advisory=_osv_with_symbols(["Environment"], path="jinja2"),
+        index=index,
+    )
+    assert signal.state == FUNCTION_REACHABLE
+    assert "Environment" in signal.matched_symbols
+
+
+def test_exact_symbol_match_still_classifies_function_reachable() -> None:
+    index = SymbolReachIndex.from_reaches([_reach("jinja2", "jinja2", "Environment.from_string")])
+    signal = classify_reachability(
+        package="jinja2",
+        advisory=_osv_with_symbols(["Environment.from_string"], path="jinja2"),
+        index=index,
+    )
+    assert signal.state == FUNCTION_REACHABLE
+
+
+def test_sibling_method_does_not_satisfy_a_method_level_advisory() -> None:
+    """Calling ``Environment.get_template`` is not reaching ``from_string``."""
+    index = SymbolReachIndex.from_reaches([_reach("jinja2", "jinja2", "Environment.get_template")])
+    signal = classify_reachability(
+        package="jinja2",
+        advisory=_osv_with_symbols(["Environment.from_string"], path="jinja2"),
+        index=index,
+    )
+    assert signal.state == PACKAGE_REACHABLE
+
+
+def test_dynamic_dispatch_is_never_upgraded_to_function_reachable(tmp_path: Path) -> None:
+    """``getattr(env, name)()`` carries no symbol proof — package level at most."""
+    (tmp_path / "app.py").write_text(
+        "from jinja2 import Environment\n"
+        "\n"
+        "def tool_dynamic(name, meth):\n"
+        '    """A tool."""\n'
+        "    env = Environment()\n"
+        "    return getattr(env, meth)(name)\n"
+    )
+    index = SymbolReachIndex.from_ast_result(analyze_project(tmp_path))
+    signal = classify_reachability(
+        package="jinja2",
+        advisory=_osv_with_symbols(["Environment.from_string"], path="jinja2"),
+        index=index,
+    )
+    assert signal.state != FUNCTION_REACHABLE

--- a/tests/test_version_utils.py
+++ b/tests/test_version_utils.py
@@ -298,7 +298,12 @@ def test_version_in_range_go_pseudo_vs_tagged_bounds():
     assert validate_version(unprefixed, "go") is True
     assert compare_version_order(unprefixed, "v1.5.0", "go") == -1
     assert version_in_range(unprefixed, "v1.5.0", None, None, "go") is False
-    assert version_in_range(unprefixed, None, "v1.2.3", None, "go") is False
+    # A pseudo-version is a PRE-RELEASE of its base tag, so it sorts strictly
+    # below it: a fix released at v1.2.3 does not cover a build that predates
+    # v1.2.3. Collapsing the two to equality here reported the package as
+    # already patched and hid the vulnerability.
+    assert compare_version_order(unprefixed, "v1.2.3", "go") == -1
+    assert version_in_range(unprefixed, None, "v1.2.3", None, "go") is True
     assert version_in_range(unprefixed, None, None, "v1.2.0", "go") is False
 
     # Pseudo-vs-pseudo bounds still resolve by timestamp.
@@ -503,3 +508,108 @@ def test_version_in_range_fails_closed_on_unparseable_bounds():
     # Unparseable introduced and NO other bound: the only comparison failed,
     # so no match may be claimed.
     assert version_in_range("1.5.0", "!!garbage!!", None, None, "pypi") is False
+
+
+# ---------------------------------------------------------------------------
+# Maven version order
+#
+# Pinned to the Apache Maven POM Reference "Version Order Specification":
+# tokens split on '.', '-', '_' and digit<->character transitions; trailing
+# "null" values (0, "", final, ga) trimmed; qualifier order
+#   alpha < beta < milestone < rc = cr < snapshot < "" = final = ga = release < sp
+# Comparison is case-insensitive.
+# ---------------------------------------------------------------------------
+
+
+def test_maven_spec_trimming_examples():
+    """The trimming examples given verbatim in the Maven spec."""
+    for equivalent in ("1.0.0", "1.ga", "1.final", "1.0", "1.", "1-", "1_", "1.RELEASE"):
+        assert compare_version_order(equivalent, "1", "maven") == 0, equivalent
+    assert compare_version_order("1.0.0-foo.0.0", "1-foo", "maven") == 0
+    assert compare_version_order("1.0.0-0.0.0", "1", "maven") == 0
+
+
+def test_maven_spec_qualifier_ordering():
+    ordered = [
+        "1-alpha",
+        "1-a1",
+        "1-beta",
+        "1-b1",
+        "1-milestone",
+        "1-m1",
+        "1-rc",
+        "1-snapshot",
+        "1",
+        "1-sp",
+    ]
+    for lower, higher in zip(ordered, ordered[1:]):
+        assert compare_version_order(lower, higher, "maven") == -1, f"{lower} !< {higher}"
+        assert compare_version_order(higher, lower, "maven") == 1, f"{higher} !> {lower}"
+
+
+def test_maven_rc_equals_cr_and_is_case_insensitive():
+    assert compare_version_order("1-rc1", "1-cr1", "maven") == 0
+    assert compare_version_order("3.2-ALPHA1", "3.2-alpha1", "maven") == 0
+
+
+def test_maven_numeric_ordering():
+    assert compare_version_order("1.10", "1.9", "maven") == 1
+    assert compare_version_order("5.3.20", "5.3.9", "maven") == 1
+    assert compare_version_order("2.0", "10.0", "maven") == -1
+
+
+def test_maven_unknown_qualifier_sorts_above_release():
+    """Unknown qualifiers compare lexically and sort after the known set."""
+    assert compare_version_order("2.5.6.SEC03", "2.5.6", "maven") == 1
+    assert compare_version_order("2.5.7.SR023", "2.5.7.SR0", "maven") == 1
+    assert compare_version_order("2.5.7.SR2", "2.5.7.SR10", "maven") == -1
+
+
+def test_maven_alphabetic_token_sorts_below_numeric_token():
+    assert compare_version_order("1-alpha", "1-1", "maven") == -1
+
+
+def test_go_pseudo_version_all_three_documented_forms_are_recognised():
+    """The Go modules reference documents THREE pseudo-version forms.
+
+    Only ``vX.0.0-<ts>-<sha>`` was recognised; the ``-0.<ts>-`` and
+    ``-<pre>.0.<ts>-`` forms fell through as uncomparable, so an advisory bound
+    written in either form could not rule a version out.
+    """
+    from agent_bom.version_utils import _go_pseudo_timestamp
+
+    assert _go_pseudo_timestamp("v0.0.0-20220524220425-1d687d428aca") == "20220524220425"
+    assert _go_pseudo_timestamp("v1.2.4-0.20191109021931-daa7c04131f5") == "20191109021931"
+    assert _go_pseudo_timestamp("v1.2.3-pre.0.20191109021931-daa7c04131f5") == "20191109021931"
+    # Not pseudo-versions.
+    assert _go_pseudo_timestamp("v1.2.3") is None
+    assert _go_pseudo_timestamp("v1.2.3-rc1") is None
+
+
+def test_go_pseudo_version_orders_against_a_tagged_version():
+    """CVE-2022-41721 / GO-2023-1495: fixed at ``0.1.1-0.20221104162952-702349b0e862``.
+
+    Live OSV does NOT report it for golang.org/x/net@0.16.0 — 0.16.0 is far past
+    the fix. The bound being uncomparable made it a fail-open false positive.
+    """
+    fixed = "0.1.1-0.20221104162952-702349b0e862"
+    assert compare_version_order("0.16.0", fixed, "go") == 1
+    assert version_in_range("0.16.0", "0.0.0-20220524220425-1d687d428aca", fixed, None, "go") is False
+    # Other direction — a version genuinely inside the window still matches.
+    assert version_in_range("0.1.0", "0.0.0-20220524220425-1d687d428aca", fixed, None, "go") is True
+
+
+def test_go_pseudo_version_sorts_below_its_base_tag():
+    """A pseudo-version is a pre-release of its base: ``v1.2.4-0.…`` < ``v1.2.4``."""
+    assert compare_version_order("v1.2.4-0.20191109021931-daa7c04131f5", "v1.2.4", "go") == -1
+    assert compare_version_order("v1.2.4", "v1.2.4-0.20191109021931-daa7c04131f5", "go") == 1
+    assert compare_version_order("v1.2.4-0.20191109021931-daa7c04131f5", "v1.2.3", "go") == 1
+
+
+def test_version_in_range_maven_release_qualifier_bounds():
+    # CVE-2009-1190 (GHSA-wjjr-h4wh-w6vv): introduced 1.1.0, fixed 3.0.0.RELEASE.
+    assert version_in_range("5.3.20", "1.1.0", "3.0.0.RELEASE", None, "maven") is False
+    assert version_in_range("2.5.0", "1.1.0", "3.0.0.RELEASE", None, "maven") is True
+    # GHSA-cxrj-66c5-9fmh: introduced 5.0.5.RELEASE, fixed 5.0.6.RELEASE.
+    assert version_in_range("5.0.5.RELEASE", "5.0.5.RELEASE", "5.0.6.RELEASE", None, "maven") is True
+    assert version_in_range("5.0.6.RELEASE", "5.0.5.RELEASE", "5.0.6.RELEASE", None, "maven") is False


### PR DESCRIPTION
## Summary

Six defects in the vulnerability-matching and enrichment layer, from a hands-on audit. The
common shape: when a version could not be compared, the code included the finding anyway.

- **Two range engines with opposite fail policies.** `_version_in_window` carried its own
  copy of the range walk that *skipped* an uncomparable bound (treating the package as
  affected), while `version_in_range` fails closed and says so. Same package, different
  verdict depending on which path served the query. `_version_in_window` now delegates to the
  fail-closed engine; `introduced: "0"` maps to "no lower bound" so open-ended ranges do not
  become false negatives.
- **Maven qualifier versions were uncomparable**, so every `.RELEASE`-bounded advisory fell
  through as a false positive. Implemented against the Apache POM Reference "Version Order
  Specification": tokenization on `.`/`-`/`_` and digit-alpha transitions, trailing-null
  trimming, and the qualifier order `alpha < beta < milestone < rc = cr < snapshot < "" =
  final = ga = release < sp`.
- **The GHSA path ignored the advisory's lower bound** whenever a fixed version was
  extractable, and `_installed_version_is_affected` parsed every ecosystem with PEP 440 and
  returned `True` on any parse error. Both now fail closed with a logged reason, and the
  range is always evaluated with `fixed` used only as a short-circuit.
- **`kev_due_date` was dropped on the local-DB read path.** The data was present and correct
  and every consumer was already wired -- only the reader omitted it, so the BOD 22-01
  remediation deadline was silently unavailable to every downstream format.
- **Reachability claimed function reach from a bare class token.** `_symbol_tokens` expanded
  both sides, so an advisory naming `Environment.from_string` was satisfied by any use of
  `Environment`. Expansion is now asymmetric -- head-token expansion applies only to the
  reached side. The module's own docstring already said *"we cannot prove function
  reachability, so we never claim it."*
- **The posture grade asserted "No vulnerabilities found" when the vuln DB was
  unavailable.** The guard measured discovery, not evaluability. New shared
  `vulnerability_coverage_incomplete()` scoped to vulnerability-lane issue codes, so a failed
  cloud collector does not blank an otherwise sound grade.

### Measured

`agent-bom check org.springframework:spring-core@5.3.20 -e maven`, run against an
`origin/main` baseline side by side:

```
before: 5 findings -- 1 true, 4 false   (CVE-2009-1190, CVE-2018-1258, CVE-2018-15756, CVE-2018-11040)
after:  1 finding  -- CVE-2025-41249     (exactly what live OSV returns for that version)
```

Every false positive was a `.RELEASE`-bounded advisory; CVE-2009-1190 was being reported
against a 2022 release.

## The accuracy gate caught a regression, and the corpus was the problem

The first sweep went red: recall 1.0 -> 0.9934, 72 misses. Root cause was the corpus oracle,
not the matcher. All 72 come from three advisories carrying a `GIT` range at `introduced: 0`
beside an ECOSYSTEM range with a non-zero lower bound -- OSV's importer walks the repo and
writes every reachable tag into `versions[]`, so the "ground truth" named `requests v0.2.0`
while NVD scopes CVE-2015-2296 to *"2.1.0 through 2.5.3"*. The previous recall of 1.0 was
bought with 28 false positives.

`scripts/cve_matching_accuracy.py` now skips self-contradictory blocks as
`skipped_unsound_oracle` and reports the count, with `--check` failing if it grows. **The
predicate reads only the advisory data and never the matcher's answer**, so it cannot be
tuned to flatter the score. 6 blocks of 127 skipped; multi-window coverage stays at 22 and
the mutation test still detects a window collapse. Re-derived baseline: **recall 1.0,
precision 0.9974 -> 1.0, evaluated 127 -> 121.**

## Correction to an earlier claim

An intermediate report asserted this branch took `golang.org/x/net@0.16.0` from 17 findings
to 16, matching live OSV. **That does not reproduce and is withdrawn.** The exhaustive
re-derivation -- old vs new comparator over the real local DB (14,602 Go advisory windows,
1,535 packages, every version each package's own advisories use as a bound) -- gives:

```
OLD comparator: 172808 matches (6906 distinct advisory IDs)
NEW comparator: 182021 matches (7084 distinct advisory IDs)
removed: 858    added: 10071    advisory IDs dropped: 0
```

Net *more* matches, in the opposite direction, with zero advisory IDs lost. Both flip classes
were spot-checked against real windows: the 858 removed are pre-release pseudo-versions below
their window's lower bound that the old code collapsed to the base tag (correct removals),
and the 10,071 added are form-3 pseudo-versions that were previously unrecognized, hence
uncomparable, hence fail-closed misses (recovered true positives). The pinned case still
holds: `x/net 0.16.0` vs `GO-2023-1495` is correctly out of range.

## Verification

- 23-suite targeted sweep: **522 passed, 0 failed**
- `ruff check` clean on all 10 changed files; `mypy` **Success: no issues found in 7 source
  files** (fixed a real `[index]` error introduced at `version_utils.py:607`)
- `pre-commit run --from-ref origin/main --to-ref HEAD`: ruff, bandit, env-drift,
  comment-hygiene, json, eof, whitespace all pass

## Notes

- `ruff-format` and the `mypy` hook fail, **both pre-existing and proven so**: each flagged
  file was extracted at `origin/main` and re-run against the pinned `ruff@0.9.7` -- all three
  reformat on main, and none of the hunks touch lines in this diff. The 39 `no-any-return`
  errors are all in `api/routes/*`, `middleware.py` and `server.py`, none of which this
  branch touches; `pre-commit run mypy --files src/agent_bom/api/routes/cloud.py` alone
  reproduces the identical 39.
- `db/lookup.py:471`'s `unknown -> include` policy is deliberately unchanged -- it is a third
  fail-open engine and deserves its own scoped change.
- Pre-existing and not folded in: `_warn_unparseable_bound` blames the bound when the
  uncomparable operand was the installed version. The verdict is right; only the log line is
  wrong.
- Maven and Go orderings are implemented against their official specifications and pinned by
  spec-verbatim tests, but were not cross-checked against a live `ComparableVersion` or
  `golang.org/x/mod` binary.
