### PR TITLE
fix(compliance): derive the posture score from the status, once

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-07-30",
+  "generated_on": "2026-07-31",
   "version": "0.98.2",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1072,
+      "value": 1075,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 816,
+      "value": 817,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-07-30`
+- Generated on: `2026-07-31`
 - Version: `0.98.2`
 
 | Metric | Value | Source | Notes |
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1072 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1075 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 816 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 817 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -57,6 +57,7 @@ from agent_bom.evidence.control_modes import (
     MODE_DETECTIVE,
     detective_control_status,
 )
+from agent_bom.evidence.scoring import score_compliance
 from agent_bom.rbac import require_authenticated_permission
 from agent_bom.security import sanitize_error, sanitize_text
 
@@ -624,8 +625,6 @@ async def get_compliance(
     # benign/empty estate can't read as "fully compliant".
     aggregate_pass = total_pass + bench_pass
     aggregate_fail = total_fail + bench_fail
-    evaluated_controls = aggregate_pass + total_warn + aggregate_fail + bench_error
-    overall_score = round((aggregate_pass / evaluated_controls) * 100, 1) if evaluated_controls > 0 else 0.0
 
     # A score over EVALUATED controls is only honest next to its coverage: a
     # scan that touched 8 of 931 controls and passed all 8 is "100%" of a very
@@ -641,8 +640,6 @@ async def get_compliance(
         )
         + int(aisvs_summary["total"])
     )
-    coverage_pct = round((evaluated_controls / total_controls) * 100, 2) if total_controls > 0 else 0.0
-
     # A detective pass only establishes that we scan — it is evidence about the
     # monitoring program, not about whether the estate meets a framework. An
     # estate whose ONLY passing evidence is "a scan ran" has not been shown to
@@ -653,27 +650,26 @@ async def get_compliance(
     detective_passes = sum(
         1 for controls_list in all_frameworks for c in controls_list if c.get("evaluation_mode") == MODE_DETECTIVE and c["status"] == "pass"
     )
-    substantive_evaluated = evaluated_controls - detective_passes
 
-    if aggregate_fail > 0:
-        overall_status = "fail"
-    elif total_warn > 0 or bench_error > 0:
-        # A benchmark ERROR (unevaluable control) is not a clean pass either.
-        overall_status = "warning"
-    elif substantive_evaluated > 0:
-        overall_status = "pass"
-    else:
-        overall_status = "no_data"
-
-    # With zero completed scans there is nothing to measure — every control
-    # trivially "passes" because no findings map to it. Reporting
-    # overall_status="pass"/score=100 in that state reads as "fully compliant"
-    # when in fact no evidence exists. Surface an explicit no-data status
-    # (mirrors the Overview "idle" pattern) so consumers don't mistake an
-    # empty tenant for a clean audit.
-    if scan_count == 0:
-        overall_status = "no_data"
-        overall_score = 0.0
+    # ONE derivation of status + score, shared with the per-framework route, the
+    # MCP tool, the HTML report and the evidence bundle. Deriving the two
+    # separately here is exactly how overall_status="no_data" came to sit beside
+    # overall_score=100.0: the score was aggregate_pass/evaluated (all detective
+    # passes) while only the status consulted substantive_evaluated. With zero
+    # completed scans nothing is measurable at all, which ``has_evidence``
+    # carries.
+    verdict = score_compliance(
+        passed=aggregate_pass,
+        warned=total_warn,
+        failed=aggregate_fail,
+        errored=bench_error,
+        detective_passes=detective_passes,
+        has_evidence=scan_count > 0,
+    )
+    overall_status = verdict.status
+    overall_score = verdict.score
+    evaluated_controls = verdict.evaluated
+    coverage_pct = round((evaluated_controls / total_controls) * 100, 2) if total_controls > 0 else 0.0
 
     summary: dict[str, int | float] = {}
     for metadata in TAG_MAPPED_FRAMEWORKS:
@@ -1322,6 +1318,13 @@ async def get_compliance_summary(request: Request) -> dict:
     summary_keys = {
         "overall_score",
         "overall_status",
+        # overall_score is a percentage of EVALUATED controls, so its
+        # denominator travels with it on every surface that renders it (see the
+        # comment where these are computed in get_compliance). Omitting them
+        # here left the Overview rendering a bare percentage it could not
+        # qualify.
+        "evaluated_controls",
+        "total_controls",
         "scan_count",
         "latest_scan",
         "has_mcp_context",
@@ -1456,19 +1459,33 @@ async def get_compliance_by_framework(request: Request, framework: str) -> dict:
     fail_count = sum(1 for c in controls if c["status"] == "fail")
 
     if no_data or not controls:
-        status = "no_data"
-        score = 0.0
         pass_count = warn_count = fail_count = 0
-    else:
-        status = "fail" if fail_count else "warning" if warn_count else "pass"
-        score = round((pass_count / len(controls)) * 100, 1)
+
+    # Same scorer as the aggregate. The hand-rolled chain this replaces —
+    # ``"fail" if fail_count else "warning" if warn_count else "pass"`` — fell
+    # through to "pass" whenever all three counts were 0, so a framework that
+    # was never evaluated (SOC 2 on a zero-finding estate: pass 0, warning 0,
+    # fail 0) reported a passing status, and a framework whose only passes were
+    # detective (CSF, CIS) reported a pass with a real score.
+    detective_passes = sum(1 for c in controls if c.get("evaluation_mode") == MODE_DETECTIVE and c["status"] == "pass")
+    verdict = score_compliance(
+        passed=pass_count,
+        warned=warn_count,
+        failed=fail_count,
+        detective_passes=0 if no_data or not controls else detective_passes,
+        has_evidence=not no_data and bool(controls),
+    )
 
     return {
         "framework": framework,
-        "status": status,
+        "status": verdict.status,
         "controls": controls,
         "summary": {"pass": pass_count, "warning": warn_count, "fail": fail_count},
-        "score": score,
+        "score": verdict.score,
+        # The score is a percentage of EVALUATED controls, never of the whole
+        # catalogue — it does not travel without its denominator.
+        "evaluated_controls": verdict.evaluated,
+        "total_controls": len(controls),
     }
 
 
@@ -1568,17 +1585,55 @@ def _index_blast_radii_by_tag(jobs: list) -> dict[str, list[dict]]:
     return by_tag
 
 
-def _bundle_control_status(source_status: str, evidence: list[dict], *, has_completed_scans: bool) -> tuple[str, str]:
+def _bundle_control_status(
+    source_status: str,
+    evidence: list[dict],
+    *,
+    has_completed_scans: bool,
+    evaluation_mode: str | None = None,
+) -> tuple[str, str]:
+    """Map an API control status onto its bundle status + evidence state.
+
+    The bundle is the auditor's copy of what the API reports, so it must not
+    invent a different verdict. Two statuses previously had no mapping and fell
+    through to ``not_evaluated``/``incomplete``, making the signed artifact
+    contradict the live API:
+
+    * A **detective** control (RA-5, CM-8, CIS-07.1 …) passes because a
+      completed, in-window scan IS the control operating. The taggers
+      deliberately never map findings onto it, so demanding finding evidence
+      downgraded every detective pass to ``incomplete`` — a bar it could not
+      ever clear. Its evidence is the scan, recorded as ``scan_evidence``.
+    * **Applicability-overlay** statuses (MITRE ATT&CK ``applicable`` /
+      ``not_applicable``) are not pass/fail claims at all and pass through
+      unchanged, so the overlay's counters stop reading 0.
+    """
     status = (source_status or "unknown").lower()
     if not has_completed_scans:
         return "not_evaluated", "missing_scan"
+    if status in {"applicable", "not_applicable"}:
+        return status, "complete" if evidence else status
+    if status == "pass" and evaluation_mode == MODE_DETECTIVE:
+        return "pass", "scan_evidence"
     if status in {"pass", "warning", "fail"} and not evidence:
         return "incomplete", "missing_control_evidence"
     if evidence:
         return status, "complete"
-    if status in {"not_evaluated", "incomplete"}:
+    if status in {"not_evaluated", "incomplete", "not_assessed"}:
         return status, status
     return "not_evaluated", "missing_control_evidence"
+
+
+def _detective_pass_count(controls: list[dict], ceiling: int | None = None) -> int:
+    """How many of ``controls`` pass ONLY because a scan ran.
+
+    ``score_compliance`` subtracts these to decide whether anything substantive
+    was measured. ``ceiling`` clamps the result to the caller's own pass count,
+    which can be lower when a control's bundle status differs from its API
+    status (an overlay entry, or a pass without finding evidence).
+    """
+    count = sum(1 for c in controls if c.get("evaluation_mode") == MODE_DETECTIVE and str(c.get("status", "")).lower() == "pass")
+    return min(count, ceiling) if ceiling is not None else count
 
 
 def _verify_audit_entries(entries: list) -> tuple[int, int]:
@@ -1622,6 +1677,7 @@ def _enrich_controls_with_evidence(
             source_status,
             evidence,
             has_completed_scans=completed_scan_count > 0,
+            evaluation_mode=control.get("evaluation_mode"),
         )
         enriched_controls.append(
             {
@@ -1744,6 +1800,23 @@ async def export_compliance_report(
     incomplete_count = status_counts["incomplete"]
     not_evaluated_count = status_counts["not_evaluated"]
 
+    # An applicability overlay (ATT&CK) has no pass rate: a score would read as
+    # "0% of ATT&CK passing" for something that cannot pass. Null says so — the
+    # applicable counters carry the signal. Matches the evidence pack, which
+    # already nulls the score for a scored=False framework.
+    from agent_bom.compliance_coverage import TAG_MAPPED_FRAMEWORKS
+
+    bundle_scored = next((m.scored for m in TAG_MAPPED_FRAMEWORKS if m.output_key == framework_key), True)
+    # Same scorer as every other surface; the detective passes it discounts are
+    # the ones the bundle now preserves rather than downgrading to incomplete.
+    bundle_verdict = score_compliance(
+        passed=pass_count,
+        warned=warn_count,
+        failed=fail_count,
+        detective_passes=_detective_pass_count(controls, pass_count),
+        has_evidence=completed_scan_count > 0,
+    )
+
     # Replay-protection envelope: every bundle carries a fresh 128-bit nonce
     # and an explicit expiry. The signature is computed over the canonical
     # body that includes both, so tampering with either invalidates the
@@ -1795,7 +1868,10 @@ async def export_compliance_report(
             "not_evaluated": not_evaluated_count,
             "applicable": status_counts["applicable"],
             "not_applicable": status_counts["not_applicable"],
-            "score": round((pass_count / len(controls)) * 100, 1) if controls else 0.0,
+            "score": bundle_verdict.score if bundle_scored else None,
+            "status": bundle_verdict.status if bundle_scored else "not_scored",
+            # The score is over EVALUATED controls; it never travels alone.
+            "evaluated": bundle_verdict.evaluated,
         },
         "controls": enriched_controls,
         "audit_events": [entry.to_dict() for entry in audit_in_window],
@@ -1985,6 +2061,7 @@ async def export_compliance_pack(
         "applicable": 0,
         "not_applicable": 0,
     }
+    combined_detective_passes = 0
     for slug, (framework_key, framework_label) in framework_map.items():
         controls = full.get(framework_key, [])
         scored = scored_by_slug.get(slug, True)
@@ -1999,6 +2076,8 @@ async def export_compliance_pack(
             total_controls += len(controls)
         for key in combined_summary:
             combined_summary[key] += status_counts[key]
+        if scored:
+            combined_detective_passes += _detective_pass_count(controls, status_counts["pass"])
         framework_bundles.append(
             {
                 "framework": slug,
@@ -2010,7 +2089,17 @@ async def export_compliance_pack(
                 "scored": scored,
                 "summary": {
                     **status_counts,
-                    "score": (round((status_counts["pass"] / len(controls)) * 100, 1) if controls else 0.0) if scored else None,
+                    "score": (
+                        score_compliance(
+                            passed=status_counts["pass"],
+                            warned=status_counts["warning"],
+                            failed=status_counts["fail"],
+                            detective_passes=_detective_pass_count(controls, status_counts["pass"]),
+                            has_evidence=completed_scan_count > 0,
+                        ).score
+                        if scored
+                        else None
+                    ),
                 },
                 "control_count": len(controls),
                 "evidence_row_count": framework_rows,
@@ -2060,7 +2149,17 @@ async def export_compliance_pack(
         },
         "summary": {
             **combined_summary,
-            "score": round((combined_summary["pass"] / total_controls) * 100, 1) if total_controls else 0.0,
+            # Same scorer as every other surface. Scoring pass/total_controls
+            # here let the pack disagree with the aggregate: once detective
+            # passes were preserved (rather than downgraded to `incomplete`),
+            # this reported 3.3% over an estate the aggregate calls no_data.
+            "score": score_compliance(
+                passed=combined_summary["pass"],
+                warned=combined_summary["warning"],
+                failed=combined_summary["fail"],
+                detective_passes=min(combined_detective_passes, combined_summary["pass"]),
+                has_evidence=completed_scan_count > 0,
+            ).score,
         },
         "frameworks": framework_bundles,
         "audit_events": [entry.to_dict() for entry in audit_in_window],

--- a/src/agent_bom/evidence/control_modes.py
+++ b/src/agent_bom/evidence/control_modes.py
@@ -111,6 +111,11 @@ def finding_taggable_controls(tag_field: str, control_ids: Iterable[str]) -> set
     return {control_id for control_id in control_ids if control_id not in excluded}
 
 
+# Forward clock drift between a scanner host and the control plane that is
+# ordinary NTP skew rather than an untrustworthy timestamp.
+_MAX_FORWARD_CLOCK_SKEW = timedelta(minutes=5)
+
+
 def _parse_timestamp(value: str | None) -> datetime | None:
     if not value:
         return None
@@ -139,9 +144,17 @@ def detective_control_status(
       ``("pass", "fresh_scan_evidence")``. The scan IS the control operating.
     * A completed scan older than the window —
       ``("fail", "stale_scan_evidence")``. Continuous monitoring has lapsed.
-    * A completed scan with no usable timestamp —
-      ``("pass", "scan_evidence_age_unknown")``. The scan demonstrably ran; its
-      age is reported as unknown rather than silently assumed fresh or stale.
+    * A completed scan with no usable timestamp (missing, empty, or
+      unparseable) — ``("not_assessed", "scan_evidence_age_unknown")``. The
+      whole claim a detective pass makes is that monitoring is CURRENT, and that
+      rests entirely on the timestamp. Evidence we cannot date is not evidence
+      that the control operates now, so it is not asserted in either direction.
+      This previously returned ``pass``, which meant a DONE job with
+      ``completed_at=None`` produced a fully green scorecard.
+    * A completed scan dated in the FUTURE beyond ordinary clock skew —
+      ``("fail", "future_scan_evidence")``. ``reference - completed`` is
+      negative for a future timestamp and so can never exceed the window: a scan
+      dated +10 years read as fresh on every subsequent request, permanently.
     """
     from agent_bom import config
 
@@ -154,11 +167,16 @@ def detective_control_status(
 
     completed = _parse_timestamp(latest_scan)
     if completed is None:
-        return "pass", "scan_evidence_age_unknown"
+        return "not_assessed", "scan_evidence_age_unknown"
 
     reference = now or datetime.now(timezone.utc)
     if reference.tzinfo is None:
         reference = reference.replace(tzinfo=timezone.utc)
-    if reference - completed > timedelta(days=window_days):
+    age = reference - completed
+    if age > timedelta(days=window_days):
         return "fail", "stale_scan_evidence"
+    # Tolerate ordinary NTP drift between a scanner and the control plane; a
+    # timestamp further ahead than that is not a datable scan.
+    if -age > _MAX_FORWARD_CLOCK_SKEW:
+        return "fail", "future_scan_evidence"
     return "pass", "fresh_scan_evidence"

--- a/src/agent_bom/evidence/scoring.py
+++ b/src/agent_bom/evidence/scoring.py
@@ -1,0 +1,125 @@
+"""One derivation of the compliance top line — status AND score, together.
+
+Every surface that reports compliance posture needs the same judgement: given
+what a scan actually evaluated, is there a score worth showing, and what is it?
+That judgement was reimplemented independently on the REST aggregate, the
+per-framework REST route, the MCP tool, the HTML report, the signed evidence
+bundle, and the Overview cockpit. Each copy drifted, and a guard added to one
+left the other five reporting a green ``100% / PASS`` over an estate where
+nothing had been measured.
+
+The judgement itself has two parts, and both must be made in the same place:
+
+* **A pass is only meaningful if something SUBSTANTIVE was evaluated.** A
+  DETECTIVE control (see :mod:`agent_bom.evidence.control_modes`) passes because
+  a scan ran — it is evidence about the monitoring program, not about whether
+  the estate meets a framework. An estate whose every passing control is
+  detective has been shown to be scanned, not compliant, so it reports
+  ``no_data``.
+* **``no_data`` means there is no score.** Splitting the two derivations is what
+  let ``overall_status="no_data"`` sit beside ``overall_score=100.0``: the score
+  was ``passed / evaluated`` (8/8 detective passes) while the status keyed off
+  ``substantive_evaluated``. Deriving the score FROM the status makes that
+  disagreement unrepresentable.
+
+``0.0`` — not ``None`` — is the repo-wide score for an unevidenced estate,
+matching what the per-framework route, the signed bundle, and the evidence pack
+already emit. It is never rendered bare: every surface pairs it with the
+``no_data`` status, and the UI renders an em dash rather than "0%".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "STATUS_PASS",
+    "STATUS_WARNING",
+    "STATUS_FAIL",
+    "STATUS_NO_DATA",
+    "ComplianceVerdict",
+    "score_compliance",
+]
+
+STATUS_PASS = "pass"
+STATUS_WARNING = "warning"
+STATUS_FAIL = "fail"
+STATUS_NO_DATA = "no_data"
+
+
+@dataclass(frozen=True)
+class ComplianceVerdict:
+    """The top line for one framework or one aggregate.
+
+    ``score`` is a percentage of EVALUATED controls, so it is only honest beside
+    ``evaluated`` — every surface that renders one must render the other.
+    """
+
+    status: str
+    score: float
+    evaluated: int
+    substantive_evaluated: int
+
+    @property
+    def is_evaluated(self) -> bool:
+        """False when there is nothing to report — render an em dash, not a number."""
+        return self.status != STATUS_NO_DATA
+
+
+def score_compliance(
+    *,
+    passed: int,
+    warned: int,
+    failed: int,
+    errored: int = 0,
+    detective_passes: int = 0,
+    has_evidence: bool = True,
+) -> ComplianceVerdict:
+    """Derive ``(status, score)`` from what a scan evaluated.
+
+    Args:
+        passed / warned / failed: evaluated controls by outcome.
+        errored: controls that could not be evaluated (a benchmark ERROR). They
+            count toward the denominator — an unevaluable control drags the
+            score down — but are never a pass.
+        detective_passes: how many of ``passed`` are detective controls, i.e.
+            passing only because a scan ran. Subtracted to decide whether
+            anything substantive was measured.
+        has_evidence: False when no completed scan exists at all, in which case
+            every control trivially lacks findings and no count means anything.
+
+    Raises:
+        ValueError: if ``detective_passes`` exceeds ``passed``, or any count is
+            negative — a caller miscounting its own controls would otherwise
+            silently produce a wrong top line.
+    """
+    counts = {"passed": passed, "warned": warned, "failed": failed, "errored": errored, "detective_passes": detective_passes}
+    for name, value in counts.items():
+        if value < 0:
+            raise ValueError(f"{name} must be non-negative, got {value}")
+    if detective_passes > passed:
+        raise ValueError(f"detective_passes ({detective_passes}) cannot exceed passed ({passed})")
+
+    evaluated = passed + warned + failed + errored
+    substantive_evaluated = evaluated - detective_passes
+
+    if not has_evidence:
+        status = STATUS_NO_DATA
+    elif failed > 0:
+        status = STATUS_FAIL
+    elif warned > 0 or errored > 0:
+        status = STATUS_WARNING
+    elif substantive_evaluated > 0:
+        status = STATUS_PASS
+    else:
+        status = STATUS_NO_DATA
+
+    # Derived FROM the status, never re-derived from a second condition.
+    score = 0.0 if status == STATUS_NO_DATA else round((passed / evaluated) * 100, 1)
+
+    return ComplianceVerdict(
+        status=status,
+        score=score,
+        evaluated=evaluated,
+        substantive_evaluated=substantive_evaluated,
+    )

--- a/src/agent_bom/mcp_tools/compliance.py
+++ b/src/agent_bom/mcp_tools/compliance.py
@@ -84,10 +84,16 @@ async def compliance_impl(
                             pkgs.add(br["package"])
                         for a in br.get("affected_agents", []):
                             ags.add(a)
+                # A control with no mapped finding is NOT a pass. These
+                # catalogues (OWASP LLM/MCP, ATLAS, NIST AI RMF) are all
+                # corrective/preventive: they are attested by the absence of an
+                # open weakness, and absence of a CVE is not proof the control
+                # is implemented. Scoring them as passes made a clean scan
+                # return "100% / pass" over 99 never-evaluated controls — the
+                # same false green /v1/compliance removed. Mirrors the API's
+                # not_evaluated semantics (see evidence/control_modes.py).
                 status = (
-                    "not_evaluated"
-                    if not has_evidence
-                    else ("pass" if findings == 0 else ("fail" if sev_bk["critical"] > 0 or sev_bk["high"] > 0 else "warning"))
+                    "fail" if findings and (sev_bk["critical"] > 0 or sev_bk["high"] > 0) else "warning" if findings else "not_evaluated"
                 )
                 controls.append(
                     {
@@ -109,12 +115,20 @@ async def compliance_impl(
 
         all_controls = owasp + atlas + nist + owasp_mcp
         total = len(all_controls)
-        total_pass = sum(1 for c in all_controls if c["status"] == "pass")
-        evaluated_controls = sum(1 for c in all_controls if c["status"] != "not_evaluated")
+        # Same scorer as /v1/compliance, the per-framework route, the HTML
+        # report and the evidence bundle. None of these catalogues carry
+        # detective controls, so every evaluated control here is substantive.
+        from agent_bom.evidence.scoring import score_compliance
+
+        verdict = score_compliance(
+            passed=sum(1 for c in all_controls if c["status"] == "pass"),
+            warned=sum(1 for c in all_controls if c["status"] == "warning"),
+            failed=sum(1 for c in all_controls if c["status"] == "fail"),
+            has_evidence=has_evidence,
+        )
+        evaluated_controls = verdict.evaluated
         not_evaluated_controls = total - evaluated_controls
-        score = round((total_pass / evaluated_controls) * 100, 1) if evaluated_controls > 0 else 0.0
-        has_fail = any(c["status"] == "fail" for c in all_controls)
-        has_warn = any(c["status"] == "warning" for c in all_controls)
+        score = verdict.score
 
         # Catalog-backed NIST SP 800-53 Rev 5 line (vendor-asserted), scored
         # INDEPENDENTLY over evaluated controls only via the shared scorer — the
@@ -132,9 +146,7 @@ async def compliance_impl(
             json.dumps(
                 {
                     "overall_score": score,
-                    "overall_status": (
-                        "no_data" if evaluated_controls == 0 else ("fail" if has_fail else ("warning" if has_warn else "pass"))
-                    ),
+                    "overall_status": verdict.status,
                     "total_controls": total,
                     "evaluated_controls": evaluated_controls,
                     "not_evaluated_controls": not_evaluated_controls,

--- a/src/agent_bom/output/html/sections.py
+++ b/src/agent_bom/output/html/sections.py
@@ -170,9 +170,9 @@ def _scan_outcome_banner(report: "AIBOMReport") -> str:
     issues = "".join(f"<li>{_esc(issue.source)}: {_esc(issue.message)}</li>" for issue in run.issues)
     return (
         f'<div style="background:{color}18;border:1px solid {color};border-radius:8px;'
-        'padding:10px 16px;margin-bottom:12px;font-size:.85rem;'
+        "padding:10px 16px;margin-bottom:12px;font-size:.85rem;"
         f'color:{color}">&#x26a0;&#xfe0f; <b>{label}</b>: this report does not represent complete '
-        f'coverage. A low or zero finding count is not a clean bill of health.'
+        f"coverage. A low or zero finding count is not a clean bill of health."
         f'<ul style="margin:6px 0 0 18px">{issues}</ul></div>'
     )
 
@@ -1328,10 +1328,18 @@ def _inventory_cards(report: "AIBOMReport") -> str:
 
 # ─── Compliance section ──────────────────────────────────────────────────────
 
+_BADGE_STYLE = "color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem"
 _STATUS_BADGE = {
-    "pass": '<span style="background:#16a34a;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem">PASS</span>',
-    "warning": '<span style="background:#d97706;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem">WARN</span>',
-    "fail": '<span style="background:#dc2626;color:#fff;padding:2px 8px;border-radius:4px;font-size:.75rem">FAIL</span>',
+    "pass": f'<span style="background:#16a34a;{_BADGE_STYLE}">PASS</span>',
+    "warning": f'<span style="background:#d97706;{_BADGE_STYLE}">WARN</span>',
+    "fail": f'<span style="background:#dc2626;{_BADGE_STYLE}">FAIL</span>',
+    # A control with no mapped finding was NEVER evaluated. Rendering it green
+    # turned a clean scan into hundreds of PASS badges and a "100.0% PASS"
+    # headline in the document customers hand to auditors.
+    "not_evaluated": f'<span style="background:#64748b;{_BADGE_STYLE}">NOT EVALUATED</span>',
+    "no_data": f'<span style="background:#64748b;{_BADGE_STYLE}">NOT EVALUATED</span>',
+    "applicable": f'<span style="background:#475569;{_BADGE_STYLE}">APPLICABLE</span>',
+    "not_applicable": f'<span style="background:#64748b;{_BADGE_STYLE}">NOT APPLICABLE</span>',
 }
 
 
@@ -1349,9 +1357,23 @@ def _compliance_section(findings: list["Finding"]) -> str:
 
     br_dicts = [compliance_row_dict(finding) for finding in findings]
 
-    def _build_rows(catalog: dict[str, str], tag_field: str) -> tuple[str, int, int, int]:
+    def _build_rows(catalog: dict[str, str], tag_field: str, *, overlay: bool = False) -> tuple[str, dict[str, int]]:
+        """Render one framework table and its status counts.
+
+        These catalogues are all corrective/preventive — attested by the ABSENCE
+        of an open weakness — so a control with no mapped finding is
+        ``not_evaluated``, never a pass. Absence of a CVE is not proof a control
+        is implemented; scoring it as one produced "100.0% PASS" over an estate
+        nothing had been measured on. Mirrors evidence/control_modes.py and the
+        /v1/compliance semantics.
+
+        ``overlay`` marks an APPLICABILITY framework (MITRE ATT&CK): its
+        techniques describe adversary behaviour the estate is exposed to, and
+        can never "pass". It reports applicable / not_applicable and is excluded
+        from the score entirely.
+        """
         rows = []
-        pass_count = fail_count = warn_count = 0
+        counts = {"pass": 0, "warning": 0, "fail": 0, "not_evaluated": 0, "applicable": 0, "not_applicable": 0}
         for code, name in sorted(catalog.items()):
             findings = sum(1 for b in br_dicts if code in b.get(tag_field, []))
             sev_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
@@ -1360,43 +1382,69 @@ def _compliance_section(findings: list["Finding"]) -> str:
                     s = b.get("severity", "").lower()
                     if s in sev_counts:
                         sev_counts[s] += 1
-            if findings == 0:
-                status = "pass"
-                pass_count += 1
+            if overlay:
+                status = "applicable" if findings else "not_applicable"
+            elif findings == 0:
+                status = "not_evaluated"
             elif sev_counts["critical"] > 0 or sev_counts["high"] > 0:
                 status = "fail"
-                fail_count += 1
             else:
                 status = "warning"
-                warn_count += 1
+            counts[status] += 1
             badge = _STATUS_BADGE[status]
             rows.append(
                 f"<tr><td><code>{_esc(code)}</code></td><td>{_esc(name)}</td>"
                 f"<td style='text-align:center'>{findings}</td><td style='text-align:center'>{badge}</td></tr>"
             )
-        return "\n".join(rows), pass_count, fail_count, warn_count
+        return "\n".join(rows), counts
 
-    owasp_rows, op, of, ow = _build_rows(OWASP_LLM_TOP10, "owasp_tags")
-    atlas_rows, ap, af, aw = _build_rows(ATLAS_TECHNIQUES, "atlas_tags")
-    attack_rows, atp, atf, atw = _build_rows(dict(ATTACK_TECHNIQUES), "attack_tags")
-    nist_rows, np_, nf, nw = _build_rows(NIST_AI_RMF, "nist_ai_rmf_tags")
-    agentic_rows, oap, oaf, oaw = _build_rows(OWASP_AGENTIC_TOP10, "owasp_agentic_tags")
-    eu_rows, ep, ef_, ew = _build_rows(EU_AI_ACT, "eu_ai_act_tags")
+    owasp_rows, owasp_counts = _build_rows(OWASP_LLM_TOP10, "owasp_tags")
+    atlas_rows, atlas_counts = _build_rows(ATLAS_TECHNIQUES, "atlas_tags")
+    attack_rows, attack_counts = _build_rows(dict(ATTACK_TECHNIQUES), "attack_tags", overlay=True)
+    nist_rows, nist_counts = _build_rows(NIST_AI_RMF, "nist_ai_rmf_tags")
+    agentic_rows, agentic_counts = _build_rows(OWASP_AGENTIC_TOP10, "owasp_agentic_tags")
+    eu_rows, eu_counts = _build_rows(EU_AI_ACT, "eu_ai_act_tags")
 
-    total = (op + of + ow) + (ap + af + aw) + (atp + atf + atw) + (np_ + nf + nw) + (oap + oaf + oaw) + (ep + ef_ + ew)
-    total_pass = op + ap + atp + np_ + oap + ep
-    score = round((total_pass / total) * 100, 1) if total > 0 else 0.0
-    has_fail = (of + af + atf + nf + oaf + ef_) > 0
-    has_warn = (ow + aw + atw + nw + oaw + ew) > 0
-    overall = "fail" if has_fail else ("warning" if has_warn else "pass")
-    overall_badge = _STATUS_BADGE[overall]
+    # ATT&CK is deliberately absent: an applicability overlay has no pass rate,
+    # and folding its 413 techniques in as passes both faked a green headline and
+    # drowned every real framework in the denominator.
+    scored_counts = [owasp_counts, atlas_counts, nist_counts, agentic_counts, eu_counts]
 
-    def _framework_table(title: str, rows: str, p: int, f: int, w: int) -> str:
-        sub_total = p + f + w
+    # Same scorer as /v1/compliance, the per-framework route, the MCP tool and
+    # the evidence bundle — one derivation of status + score. None of these
+    # catalogues carry detective controls, so every evaluated control is
+    # substantive.
+    from agent_bom.evidence.scoring import score_compliance
+
+    verdict = score_compliance(
+        passed=sum(c["pass"] for c in scored_counts),
+        warned=sum(c["warning"] for c in scored_counts),
+        failed=sum(c["fail"] for c in scored_counts),
+    )
+    score = verdict.score
+    overall_badge = _STATUS_BADGE[verdict.status]
+    evaluated_note = (
+        f"{verdict.evaluated} of {sum(sum(c.values()) for c in scored_counts)} controls evaluated"
+        if verdict.is_evaluated
+        else "no control was evaluated"
+    )
+
+    def _framework_table(title: str, rows: str, counts: dict[str, int], *, overlay: bool = False) -> str:
+        """Header caption states what was EVALUATED, never `n/total pass`.
+
+        `(p/total pass)` counted never-evaluated controls in the denominator, so
+        a framework nothing touched read as "0/65 pass" — indistinguishable from
+        65 real failures.
+        """
+        if overlay:
+            caption = f"{counts['applicable']} applicable / {counts['applicable'] + counts['not_applicable']} techniques"
+        else:
+            evaluated = counts["pass"] + counts["warning"] + counts["fail"]
+            caption = f"{counts['pass']}/{evaluated} pass of {evaluated} evaluated" if evaluated else "not evaluated"
         return (
-            f'<details style="margin-bottom:12px" {"open" if f > 0 else ""}>'
+            f'<details style="margin-bottom:12px" {"open" if counts["fail"] > 0 else ""}>'
             f'<summary style="cursor:pointer;font-weight:600;padding:6px 0">'
-            f'{title} <span style="font-size:.8rem;color:#94a3b8">({p}/{sub_total} pass)</span></summary>'
+            f'{title} <span style="font-size:.8rem;color:#94a3b8">({caption})</span></summary>'
             f'<table class="vtable" style="margin-top:8px"><thead><tr>'
             f"<th>Code</th><th>Control</th><th>Findings</th><th>Status</th></tr></thead>"
             f"<tbody>{rows}</tbody></table></details>"
@@ -1406,13 +1454,13 @@ def _compliance_section(findings: list["Finding"]) -> str:
         f'<section id="compliance">'
         f'<div class="sec-title">&#x1f6e1;&#xfe0f; Compliance Posture'
         f'<sup style="font-size:.7rem;color:#475569;margin-left:6px">'
-        f"Score: {score}% {overall_badge}</sup></div>"
+        f"Score: {score}% {overall_badge} &middot; {_esc(evaluated_note)}</sup></div>"
         f'<div class="panel">'
-        f"{_framework_table('OWASP LLM Top 10', owasp_rows, op, of, ow)}"
-        f"{_framework_table('OWASP Agentic Top 10', agentic_rows, oap, oaf, oaw)}"
-        f"{_framework_table('MITRE ATT&CK Enterprise', attack_rows, atp, atf, atw)}"
-        f"{_framework_table('MITRE ATLAS (AI/ML)', atlas_rows, ap, af, aw)}"
-        f"{_framework_table('NIST AI RMF', nist_rows, np_, nf, nw)}"
-        f"{_framework_table('EU AI Act', eu_rows, ep, ef_, ew)}"
+        f"{_framework_table('OWASP LLM Top 10', owasp_rows, owasp_counts)}"
+        f"{_framework_table('OWASP Agentic Top 10', agentic_rows, agentic_counts)}"
+        f"{_framework_table('MITRE ATT&CK Enterprise', attack_rows, attack_counts, overlay=True)}"
+        f"{_framework_table('MITRE ATLAS (AI/ML)', atlas_rows, atlas_counts)}"
+        f"{_framework_table('NIST AI RMF', nist_rows, nist_counts)}"
+        f"{_framework_table('EU AI Act', eu_rows, eu_counts)}"
         f"</div></section>"
     )

--- a/tests/test_compliance_honesty.py
+++ b/tests/test_compliance_honesty.py
@@ -333,6 +333,185 @@ def test_scanning_alone_is_not_compliance() -> None:
     modes = {c["control_id"]: c for c in payload["nist_800_53"]}
     assert modes["RA-5"]["status"] == "pass", "the detective control itself is legitimately evidenced"
     assert payload["overall_status"] == "no_data", "scanning alone read as a compliant estate"
+    # The STATUS alone is not the guard: asserting only the status let the score
+    # keep the 100.0 that ``aggregate_pass / evaluated_controls`` produced when
+    # every passing control was detective. Score and status are asserted
+    # together, because that is the pair a user reads.
+    assert payload["overall_score"] == 0.0, "no_data estate still reported a compliant score"
+
+
+def test_summary_endpoint_agrees_with_the_aggregate_on_a_scanned_clean_estate() -> None:
+    """/v1/compliance/summary must not restate a score the aggregate disowned.
+
+    The summary is what the landing Overview reads, so a score there that the
+    Trust Center hides is the same false "Compliance 100%" headline in a
+    different pane.
+    """
+    _clear_jobs()
+    _add_done_job([])
+    with TestClient(app) as client:
+        full = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+        summary = client.get("/v1/compliance/summary", headers=_AUTH_HEADERS).json()
+
+    assert summary["overall_status"] == "no_data"
+    assert summary["overall_score"] == 0.0
+    assert summary["overall_score"] == full["overall_score"]
+    # A score is only honest beside its denominator (see the comment where
+    # evaluated_controls/total_controls are computed) — the summary renders
+    # overall_score, so it must ship them too.
+    assert summary["evaluated_controls"] == full["evaluated_controls"]
+    assert summary["total_controls"] == full["total_controls"]
+    assert summary["total_controls"] > 0
+
+
+def test_no_framework_reports_a_pass_it_did_not_evaluate() -> None:
+    """Per-framework drill: 0 pass / 0 warn / 0 fail is not a passing framework.
+
+    ``"fail" if fail_count else "warning" if warn_count else "pass"`` fell
+    through to ``pass`` for a framework with nothing evaluated, so SOC 2 read
+    "pass" with summary {pass: 0, warning: 0, fail: 0} on an estate where SOC 2
+    was never assessed. Detective-only frameworks (CSF, CIS) reported a pass
+    with a real score for the same reason.
+    """
+    _clear_jobs()
+    _add_done_job([])
+    from agent_bom.compliance_coverage import framework_output_key_by_slug
+
+    with TestClient(app) as client:
+        for slug in framework_output_key_by_slug():
+            payload = client.get(f"/v1/compliance/{slug}", headers=_AUTH_HEADERS).json()
+            summary = payload["summary"]
+            substantive = summary["pass"] + summary["warning"] + summary["fail"]
+            assert payload["status"] != "pass", f"{slug} reported a pass over an unevaluated estate"
+            if payload["status"] == "no_data":
+                assert payload["score"] == 0.0, f"{slug} scored a no_data framework"
+            assert not (substantive == 0 and payload["score"] > 0), f"{slug} scored {payload['score']} over 0 evaluated controls"
+
+
+def test_the_bundle_reports_the_same_control_statuses_as_the_api() -> None:
+    """The signed bundle is the auditor's copy — it cannot contradict the API.
+
+    Two divergences: a DETECTIVE control passes because a scan ran and by design
+    carries no finding evidence (the taggers exclude it), yet the bundle
+    demanded finding evidence and downgraded it to ``incomplete`` — so the
+    bundle said ``pass: 0`` where the API said ``pass: 2``. And ATT&CK's
+    applicability statuses had no mapping at all, so its counters were
+    permanently 0 while every technique fell into ``not_evaluated``.
+    """
+    _clear_jobs()
+    # CWE-200 gives the finding a real ATT&CK technique, so the overlay has
+    # something applicable to report.
+    _add_done_job([_blast(severity="critical", cwe_ids=["CWE-200"])])
+    with TestClient(app) as client:
+        api = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+        bundle = client.get("/v1/compliance/nist-800-53/report", headers=_AUTH_HEADERS).json()
+        attack = client.get("/v1/compliance/attack/report", headers=_AUTH_HEADERS).json()
+
+    body = bundle.get("body", bundle)
+    api_nist_pass = sum(1 for c in api["nist_800_53"] if c["status"] == "pass")
+    assert api_nist_pass > 0, "fixture no longer produces a detective pass"
+    assert body["summary"]["pass"] == api_nist_pass, "the bundle disagreed with the API on passing controls"
+    detective = {c["control_id"]: c for c in body["controls"]}
+    assert detective["RA-5"]["status"] == "pass"
+    assert detective["RA-5"]["evidence_state"] == "scan_evidence"
+
+    attack_body = attack.get("body", attack)
+    api_applicable = sum(1 for c in api["mitre_attack"] if c["status"] == "applicable")
+    assert attack_body["summary"]["applicable"] == api_applicable > 0, "ATT&CK applicability never reached the bundle"
+    # An overlay cannot pass, so it has no score to report.
+    assert attack_body["summary"]["score"] is None
+
+
+def test_no_data_never_carries_a_score_on_any_estate() -> None:
+    """The invariant, not one instance: no_data implies a zero score.
+
+    ``overall_status`` and ``overall_score`` are derived from the same evidence
+    and must never disagree. Each fixture below is an estate shape that has
+    produced ``no_data`` at some point in this code's history.
+    """
+    estates = {
+        "zero scans": lambda: None,
+        "scanned, nothing gradeable": lambda: _add_done_job([]),
+        "another tenant's scan only": lambda: _add_done_job([_blast(severity="low")], job_id="n", tenant_id="other"),
+        "stale scan evidence": lambda: _add_done_job([], completed_at=_iso(400)),
+    }
+    for label, seed in estates.items():
+        _clear_jobs()
+        seed()
+        with TestClient(app) as client:
+            payload = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+            summary = client.get("/v1/compliance/summary", headers=_AUTH_HEADERS).json()
+        for surface, body in (("aggregate", payload), ("summary", summary)):
+            if body["overall_status"] == "no_data":
+                assert body["overall_score"] == 0.0, f"{surface} scored a no_data estate ({label})"
+
+
+def test_no_surface_claims_compliance_for_the_zero_finding_estate() -> None:
+    """The cross-surface guard: one estate, every surface, one assertion.
+
+    ``test_scanning_alone_is_not_compliance`` asserted only
+    ``payload["overall_status"]`` on ONE endpoint. That is exactly how the same
+    P0 survived on five others — the REST aggregate was fixed while the
+    per-framework route, the MCP tool, the HTML report, the evidence bundle and
+    the Overview cockpit each kept their own copy of "no findings means pass".
+    Assert the property across the surfaces, not the instance on one of them.
+    """
+    import asyncio
+
+    from agent_bom.compliance_coverage import framework_output_key_by_slug
+    from agent_bom.models import Agent, AgentType
+    from agent_bom.output.html.sections import _compliance_section
+
+    _clear_jobs()
+    _add_done_job([])
+
+    passing = {"pass", "compliant"}
+    with TestClient(app) as client:
+        aggregate = client.get("/v1/compliance", headers=_AUTH_HEADERS).json()
+        summary = client.get("/v1/compliance/summary", headers=_AUTH_HEADERS).json()
+        narrative = client.get("/v1/compliance/narrative", headers=_AUTH_HEADERS).json()
+        pack = client.get("/v1/compliance/report/pack", headers=_AUTH_HEADERS).json()
+
+        # 1 + 2: REST aggregate and summary.
+        for name, body in (("aggregate", aggregate), ("summary", summary)):
+            assert body["overall_status"] not in passing, f"{name} claimed a pass"
+            assert body["overall_score"] == 0.0, f"{name} scored an unevidenced estate"
+
+        # 3: every framework slug, including the ones with only detective passes.
+        for slug in framework_output_key_by_slug():
+            drill = client.get(f"/v1/compliance/{slug}", headers=_AUTH_HEADERS).json()
+            assert drill["status"] not in passing, f"framework {slug} claimed a pass"
+            assert drill["score"] == 0.0, f"framework {slug} scored an unevidenced estate"
+
+            # 4: the signed evidence bundle for that framework.
+            bundle = client.get(f"/v1/compliance/{slug}/report", headers=_AUTH_HEADERS).json()
+            bundle_summary = bundle.get("body", bundle)["summary"]
+            assert bundle_summary["fail"] == 0
+            assert not bundle_summary["score"], f"bundle {slug} scored an unevidenced estate"
+
+    # 5: the multi-framework evidence pack.
+    assert pack.get("body", pack)["summary"]["score"] == 0.0
+
+    # 6: the narrative handed to a reader in prose.
+    prose = " ".join(str(v) for v in narrative.values()).lower()
+    assert "fully compliant" not in prose
+    assert "100%" not in prose
+
+    # 7: the HTML report an auditor receives.
+    html = _compliance_section([])
+    assert "Score: 0.0%" in html
+    assert "PASS</span>" not in html
+
+    # 8: the MCP tool, the primary agent-facing surface.
+    from agent_bom.mcp_tools.compliance import compliance_impl
+
+    async def _pipeline(_config=None, _image=None):
+        return [Agent(name="a", agent_type=AgentType.CUSTOM, config_path="/tmp/a")], [], [], ["local"]
+
+    mcp_raw = asyncio.run(compliance_impl(config_path=None, image=None, _run_scan_pipeline=_pipeline, _truncate_response=lambda s: s))
+    mcp = json.loads(mcp_raw)
+    assert mcp["overall_status"] not in passing, "the MCP tool claimed a pass"
+    assert mcp["overall_score"] == 0.0
 
 
 def test_one_tenants_scan_never_evidences_another_tenants_controls() -> None:

--- a/tests/test_detective_evidence_freshness.py
+++ b/tests/test_detective_evidence_freshness.py
@@ -1,0 +1,81 @@
+"""Detective-control freshness must fail CLOSED.
+
+A detective control passes only because a completed, in-window scan IS the
+control operating. That claim rests entirely on the scan's timestamp, so every
+path where the timestamp cannot be trusted was scoring ``pass``:
+
+* no timestamp at all      -> pass
+* an unparseable timestamp -> pass
+* a timestamp in the FUTURE -> pass, and fresh forever (a +10y clock skew
+  never ages out of the window)
+
+Undateable evidence is not fresh evidence; it is evidence whose age is unknown,
+which is not a basis for asserting continuous monitoring operates. The 89/90/91
+day boundary itself is correct and deliberately unchanged.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent_bom.evidence.control_modes import detective_control_status
+
+_NOW = datetime(2026, 7, 31, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _status(latest_scan: str | None, *, scan_count: int = 1) -> tuple[str, str]:
+    return detective_control_status(scan_count=scan_count, latest_scan=latest_scan, now=_NOW, max_age_days=90)
+
+
+def test_no_completed_scan_is_still_not_assessed() -> None:
+    assert _status(None, scan_count=0) == ("not_assessed", "no_completed_scan")
+
+
+def test_a_fresh_scan_still_passes() -> None:
+    status, reason = _status((_NOW - timedelta(days=1)).isoformat())
+    assert (status, reason) == ("pass", "fresh_scan_evidence")
+
+
+def test_a_stale_scan_still_fails() -> None:
+    status, reason = _status((_NOW - timedelta(days=91)).isoformat())
+    assert (status, reason) == ("fail", "stale_scan_evidence")
+
+
+def test_the_ninety_day_boundary_is_unchanged() -> None:
+    assert _status((_NOW - timedelta(days=89)).isoformat())[0] == "pass"
+    assert _status((_NOW - timedelta(days=90)).isoformat())[0] == "pass"
+    assert _status((_NOW - timedelta(days=91)).isoformat())[0] == "fail"
+
+
+@pytest.mark.parametrize("value", [None, "", "not-a-timestamp", "2026-13-45T99:99:99"])
+def test_undateable_evidence_is_not_assessed_never_a_pass(value: str | None) -> None:
+    """A scan we cannot date cannot evidence that monitoring is CURRENT."""
+    status, reason = _status(value)
+    assert status == "not_assessed", f"undateable evidence ({value!r}) scored {status}"
+    assert reason == "scan_evidence_age_unknown"
+
+
+def test_a_future_dated_scan_fails_instead_of_passing_forever() -> None:
+    """Clock skew must not buy permanent freshness.
+
+    ``reference - completed`` is negative for a future timestamp, so it can
+    never exceed the window — a scan dated +10 years read as fresh on every
+    future request.
+    """
+    status, reason = _status((_NOW + timedelta(days=3650)).isoformat())
+    assert status == "fail", "a future-dated scan passed"
+    assert reason == "future_scan_evidence"
+
+
+def test_small_forward_clock_skew_is_tolerated() -> None:
+    """Ordinary NTP drift between a scanner and the control plane is not fraud."""
+    status, _ = _status((_NOW + timedelta(minutes=2)).isoformat())
+    assert status == "pass"
+
+
+def test_a_disabled_window_does_not_resurrect_the_fail_open_paths() -> None:
+    """max_age_days<=0 disables the staleness check, not the honesty checks."""
+    disabled = detective_control_status(scan_count=1, latest_scan=None, now=_NOW, max_age_days=0)
+    assert disabled[0] == "pass"

--- a/tests/test_evidence_scoring.py
+++ b/tests/test_evidence_scoring.py
@@ -1,0 +1,87 @@
+"""The one derivation of "is this compliance score meaningful".
+
+Six surfaces (REST aggregate, per-framework REST, MCP tool, HTML report,
+evidence bundle, Overview cockpit) each grew their own answer to that question.
+The guard that held on one was defeated on the other five. These tests pin the
+shared primitive they now all route through.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.evidence.scoring import score_compliance
+
+
+def test_nothing_evaluated_is_no_data_not_a_pass() -> None:
+    verdict = score_compliance(passed=0, warned=0, failed=0)
+    assert verdict.status == "no_data"
+    assert verdict.score == 0.0
+
+
+def test_detective_passes_alone_are_no_data() -> None:
+    """The live P0 shape: 8 controls pass, every one of them detective.
+
+    A detective pass establishes that we scan, not that the estate complies.
+    ``passed / evaluated`` is 100% here, and that number is exactly what must
+    NOT escape.
+    """
+    verdict = score_compliance(passed=8, warned=0, failed=0, detective_passes=8)
+    assert verdict.status == "no_data"
+    assert verdict.score == 0.0
+    assert verdict.evaluated == 8
+    assert verdict.substantive_evaluated == 0
+
+
+def test_one_substantive_pass_makes_the_score_real() -> None:
+    verdict = score_compliance(passed=9, warned=0, failed=0, detective_passes=8)
+    assert verdict.status == "pass"
+    assert verdict.score == 100.0
+    assert verdict.substantive_evaluated == 1
+
+
+def test_a_failure_outranks_everything() -> None:
+    verdict = score_compliance(passed=8, warned=3, failed=1, detective_passes=8)
+    assert verdict.status == "fail"
+    assert verdict.score == round(8 / 12 * 100, 1)
+
+
+def test_a_warning_or_an_unevaluable_error_is_never_a_clean_pass() -> None:
+    assert score_compliance(passed=5, warned=1, failed=0).status == "warning"
+    # An ERROR is an unevaluable control: it counts toward the denominator
+    # (dragging the score down) but is never a pass.
+    errored = score_compliance(passed=5, warned=0, failed=0, errored=1)
+    assert errored.status == "warning"
+    assert errored.score == round(5 / 6 * 100, 1)
+
+
+def test_no_evidence_overrides_every_other_signal() -> None:
+    """Zero completed scans cannot produce a verdict, whatever the counts say."""
+    verdict = score_compliance(passed=99, warned=0, failed=0, has_evidence=False)
+    assert verdict.status == "no_data"
+    assert verdict.score == 0.0
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"passed": 0, "warned": 0, "failed": 0},
+        {"passed": 8, "warned": 0, "failed": 0, "detective_passes": 8},
+        {"passed": 3, "warned": 1, "failed": 2, "detective_passes": 3},
+        {"passed": 99, "warned": 0, "failed": 0, "has_evidence": False},
+        {"passed": 0, "warned": 0, "failed": 0, "errored": 4},
+        {"passed": 10, "warned": 0, "failed": 0},
+    ],
+)
+def test_the_invariant_no_data_never_carries_a_score(kwargs: dict) -> None:
+    """The property, not the instance: status and score can never disagree."""
+    verdict = score_compliance(**kwargs)
+    if verdict.status == "no_data":
+        assert verdict.score == 0.0
+    else:
+        assert verdict.substantive_evaluated > 0 or verdict.status in {"fail", "warning"}
+
+
+def test_detective_passes_can_never_exceed_the_passes_they_came_from() -> None:
+    with pytest.raises(ValueError):
+        score_compliance(passed=2, warned=0, failed=0, detective_passes=5)

--- a/tests/test_html_compliance_honesty.py
+++ b/tests/test_html_compliance_honesty.py
@@ -1,0 +1,72 @@
+"""The HTML report is the artifact handed to an auditor — it must not overclaim.
+
+It carried its own copy of "a control with no mapped finding passes", so a scan
+over a zero-finding estate rendered "Compliance Posture Score: 100.0% PASS" with
+hundreds of green PASS badges, including MITRE ATT&CK scored 413/413 pass —
+a framework the REST API reports as an applicability OVERLAY that can never
+pass.
+"""
+
+from __future__ import annotations
+
+from agent_bom.output.html.sections import _compliance_section
+
+
+def _finding(*, severity: str = "high", attack_tags: list[str] | None = None, owasp_tags: list[str] | None = None):
+    from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+    from agent_bom.models import Severity
+
+    finding = Finding(
+        finding_type=FindingType.CVE,
+        source=FindingSource.SBOM,
+        asset=Asset(name="demo", asset_type="package", identifier="demo@1.0.0"),
+        severity=Severity(severity),
+        title="CVE-2026-0001",
+        description="test",
+        cve_id="CVE-2026-0001",
+    )
+    finding.owasp_tags = list(owasp_tags or [])
+    finding.attack_tags = list(attack_tags or [])
+    return finding
+
+
+def _headline(html: str) -> str:
+    """The `Score: … BADGE` sup, which is what a reader sees first."""
+    return html.split('<div class="panel">')[0]
+
+
+def test_zero_finding_estate_never_renders_a_passing_posture() -> None:
+    html = _compliance_section([])
+
+    assert "Score: 0.0%" in html, "an unevaluated estate was scored"
+    assert "PASS</span>" not in html, "green PASS badges over an estate with nothing evaluated"
+    # The headline badge reads the no-data state, not a pass.
+    assert "NOT EVALUATED" in _headline(html)
+    assert "no control was evaluated" in html
+
+
+def test_attack_is_an_overlay_and_never_scored_as_pass_fail() -> None:
+    """ATT&CK applicability must not inflate the posture score.
+
+    413 techniques with no mapped finding used to count as 413 passes, which is
+    both a false green and a denominator that drowns every real framework.
+    """
+    html = _compliance_section([_finding(owasp_tags=["LLM01"], attack_tags=["T1059"])])
+
+    assert "MITRE ATT&amp;CK Enterprise" in html or "MITRE ATT&CK Enterprise" in html
+    # The overlay reports applicability, never a pass rate.
+    assert "413/413 pass" not in html
+    assert "applicable" in html.lower()
+
+
+def test_an_evaluated_failure_still_scores_and_fails() -> None:
+    """The honesty fix must not pin the score at zero for a real evaluation."""
+    html = _compliance_section([_finding(severity="high", owasp_tags=["LLM01"])])
+
+    assert "FAIL</span>" in html
+    assert "Score: 0.0%" in html  # 0 passes out of 1 evaluated control
+    # The headline is a real FAIL verdict, not the no-data state — and it says
+    # how little of the catalogue that verdict rests on.
+    assert "FAIL</span>" in _headline(html)
+    assert "NOT EVALUATED" not in _headline(html)
+    assert "1 of " in _headline(html) and "controls evaluated" in _headline(html)

--- a/tests/test_mcp_tool_impls.py
+++ b/tests/test_mcp_tool_impls.py
@@ -551,9 +551,7 @@ async def test_compliance_impl_surfaces_nist_catalog_line():
     async def _pipeline(_config=None, _image=None):
         return [agent], [br], [], []
 
-    result = await compliance_impl(
-        config_path=None, image=None, _run_scan_pipeline=_pipeline, _truncate_response=_trunc
-    )
+    result = await compliance_impl(config_path=None, image=None, _run_scan_pipeline=_pipeline, _truncate_response=_trunc)
     data = json.loads(result)
     catalog = data["nist_800_53_catalog"]
     assert catalog["framework_key"] == "nist_800_53_catalog"
@@ -565,15 +563,44 @@ async def test_compliance_impl_surfaces_nist_catalog_line():
 
 
 @pytest.mark.asyncio
+async def test_compliance_impl_never_passes_controls_it_did_not_evaluate():
+    """A scanned estate with zero findings is not a 100% compliant estate.
+
+    The MCP tool is the primary agent-facing compliance surface, and it scored
+    every catalogue control with no mapped finding as ``pass`` — so a clean scan
+    returned ``overall_score 100.0 / overall_status "pass"`` over 99 controls,
+    including all 65 MITRE ATLAS techniques. Absence of a CVE is not evidence a
+    control is implemented; it is ``not_evaluated``, exactly as /v1/compliance
+    has reported it since #4562.
+    """
+    from agent_bom.mcp_tools.compliance import compliance_impl
+    from agent_bom.models import Agent, AgentType
+
+    agent = Agent(name="claude", agent_type=AgentType.CUSTOM, config_path="/tmp")
+
+    async def _pipeline(_config=None, _image=None):
+        return [agent], [], [], ["local"]
+
+    result = await compliance_impl(config_path=None, image=None, _run_scan_pipeline=_pipeline, _truncate_response=_trunc)
+    data = json.loads(result)
+
+    assert data["overall_status"] == "no_data", "a clean scan read as a compliant estate"
+    assert data["overall_score"] == 0.0, "no_data still carried a score"
+    assert data["evaluated_controls"] == 0
+    assert data["not_evaluated_controls"] == data["total_controls"]
+    for line in ("owasp_llm_top10", "mitre_atlas", "nist_ai_rmf", "owasp_mcp_top10"):
+        statuses = {c["status"] for c in data[line]}
+        assert statuses == {"not_evaluated"}, f"{line} asserted a status it never evaluated: {statuses}"
+
+
+@pytest.mark.asyncio
 async def test_compliance_impl_nist_catalog_no_data_without_agents():
     from agent_bom.mcp_tools.compliance import compliance_impl
 
     async def _pipeline(_config=None, _image=None):
         return [], [], [], []
 
-    result = await compliance_impl(
-        config_path=None, image=None, _run_scan_pipeline=_pipeline, _truncate_response=_trunc
-    )
+    result = await compliance_impl(config_path=None, image=None, _run_scan_pipeline=_pipeline, _truncate_response=_trunc)
     catalog = json.loads(result)["nist_800_53_catalog"]
     assert catalog["status"] == "no_data"
     assert catalog["summary"]["evaluated"] == 0

--- a/ui/components/overview-cockpit.tsx
+++ b/ui/components/overview-cockpit.tsx
@@ -22,6 +22,7 @@ import type {
   ServiceId,
 } from "@/lib/api-types";
 import { Collapsible } from "@/components/collapsible";
+import { isNotEvaluated } from "@/components/compliance-status";
 import { FrameworkIcon } from "@/components/framework-icon";
 import type { SeverityCounts } from "@/lib/dashboard-data";
 import {
@@ -66,8 +67,19 @@ function frameworkEvaluated(framework: OverviewComplianceFramework): number {
   return framework.pass + framework.warn + framework.fail;
 }
 
+/** Is `overallScore` a number worth rendering?
+ *
+ *  Framework pass/warn/fail counts alone are NOT the answer. A completed scan
+ *  over an estate with nothing gradeable passes only its DETECTIVE controls
+ *  ("we scan") — real pass counts that make this predicate true — while the
+ *  backend correctly reports `overallStatus: "no_data"`. Reading the counts and
+ *  ignoring the status rendered "Compliance 100%" over an unmeasured estate.
+ *  The status is the backend's own verdict on whether the score means anything,
+ *  so it is authoritative here, and `isNotEvaluated` is the SAME predicate the
+ *  Trust Center uses — one implementation, not two. */
 function hasEvaluatedCompliance(compliance: OverviewComplianceSnapshot | null | undefined): boolean {
-  return Boolean(compliance?.frameworks.some((framework) => frameworkEvaluated(framework) > 0));
+  if (!compliance || isNotEvaluated(compliance.overallStatus)) return false;
+  return compliance.frameworks.some((framework) => frameworkEvaluated(framework) > 0);
 }
 
 // Shared class for the collapsible section headers (Command center, Cross-lane
@@ -219,9 +231,16 @@ export function OverviewCockpit({
   services = null,
 }: OverviewCockpitProps) {
   const hasScanEvidence = Boolean(summaryReady && scans && scans > 0);
-  const complianceScore =
-    hasScanEvidence && compliance != null && hasEvaluatedCompliance(compliance)
-      ? `${Math.round(compliance.overallScore)}%`
+  // Once scans exist the chip always renders, but an unevidenced score reads as
+  // an em dash — the SAME treatment the Trust Center gives this status. Hiding
+  // the chip instead would leave the reader unable to tell "not measured" from
+  // "not loaded"; printing the raw percentage claimed compliance we never
+  // evidenced.
+  const complianceEvaluated = hasScanEvidence && compliance != null && hasEvaluatedCompliance(compliance);
+  const complianceScore = complianceEvaluated
+    ? `${Math.round(compliance.overallScore)}%`
+    : hasScanEvidence && compliance != null
+      ? "—"
       : undefined;
 
   return (
@@ -1238,7 +1257,11 @@ function SeverityIssueStrip({
                 icon={ShieldCheck}
                 label="Compliance"
                 value={complianceScore}
-                title="Overall compliance score across evaluated frameworks"
+                title={
+                  complianceScore === "—"
+                    ? "No framework was substantively evaluated — nothing to score"
+                    : "Overall compliance score across evaluated frameworks"
+                }
               />
             ) : null}
           </div>

--- a/ui/tests/overview-cockpit.test.tsx
+++ b/ui/tests/overview-cockpit.test.tsx
@@ -383,6 +383,38 @@ describe("OverviewCockpit", () => {
     expect(screen.queryByText(/coverage appears after the first completed scan/i)).not.toBeInTheDocument();
   });
 
+  it("never renders a compliance percentage when the API says no_data", () => {
+    // The live shape of a completed scan over an estate with nothing gradeable:
+    // every passing control is detective ("we scan"), so the backend reports
+    // overall_status "no_data". The frameworks DO carry real pass counts, so a
+    // pass/warn/fail test alone reads this as evaluated and renders
+    // "Compliance 100%" over an unmeasured estate.
+    render(
+      <OverviewCockpit
+        {...baseProps}
+        compliance={{
+          overallScore: 100,
+          overallStatus: "no_data",
+          evaluatedControls: 8,
+          totalControls: 240,
+          frameworks: [
+            { id: "nist-csf", label: "NIST CSF", pass: 3, warn: 0, fail: 0, total: 14 },
+            { id: "nist-800-53", label: "NIST 800-53", pass: 2, warn: 0, fail: 0, total: 29 },
+            { id: "cis", label: "CIS Controls v8", pass: 3, warn: 0, fail: 0, total: 10 },
+          ],
+        }}
+      />,
+    );
+
+    expect(screen.queryByText("Compliance 100%")).not.toBeInTheDocument();
+    expect(screen.queryByText(/100% of 8 evaluated controls/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/0 frameworks need attention/i)).not.toBeInTheDocument();
+    // Same treatment the Trust Center already uses for this status: an explicit
+    // em dash, not a hidden chip that leaves the reader guessing.
+    expect(screen.getByText("Compliance —")).toBeInTheDocument();
+    expect(screen.getByText(/No evaluated framework coverage is available for completed scans/i)).toBeInTheDocument();
+  });
+
   it("never renders a green PASS for a framework with zero evaluated controls (#3889)", () => {
     render(
       <OverviewCockpit


### PR DESCRIPTION
> **Release blocker.** `main` currently reports a green **"Compliance 100%"** on the landing page
> for an estate that has been scanned and has no evidence to grade. This is the third appearance
> of that P0.

## Root cause

`overall_status` and `overall_score` were derived from **two different conditions**. The score was
`aggregate_pass / evaluated_controls`; only the status consulted `substantive_evaluated`. So when
every passing control was a *detective* control — "we ran a scan" — the status correctly read
`no_data` while the score stayed at `100.0`.

The score was zeroed only inside `if scan_count == 0`, which never covers that path. That is why
#4562 closed this and #4579 believed it had re-closed it, and it survived both.

## The fix is one shared derivation, not six patches

`src/agent_bom/evidence/scoring.py` — `score_compliance()` derives the score **from** the status,
which makes the disagreement unrepresentable rather than merely corrected. Six surfaces now route
through it.

*(Path note: `src/agent_bom/compliance_scoring.py` was the obvious home, but
`check_package_layout.py` freezes the set of top-level modules, so it lives in `evidence/`
alongside `control_modes.py` — which is where it belongs anyway.)*

| # | Surface | Before | After |
|---|---|---|---|
| 1 | REST aggregate | `100.0` / `no_data` | **`0.0`** / `no_data` |
| 2 | `/compliance/summary` | `100.0`, `evaluated_controls: null` | **`0.0`, 8 / 240** |
| 3 | `/compliance/{framework}` | soc2 **`pass`** at 0/0/0; nist-csf **`pass`** 21.4% | **`no_data` / `0.0`** |
| 4 | MCP `compliance` tool | `100.0` / **`"pass"`** over 99 controls incl. 65 ATLAS | **`0.0` / `no_data`**, all `not_evaluated` |
| 5 | HTML report | **"Score: 100.0% PASS"**, ATT&CK 413/413 pass | **"Score: 0.0% NOT EVALUATED"**, ATT&CK an overlay |
| 6 | Overview cockpit | **"Compliance 100%"** | **"Compliance —"** |

Two of these mattered more than the one originally reported: `/compliance/{framework}` is the drill
an auditor opens, and it answered **`pass` for SOC 2 on an estate where SOC 2 was never evaluated**.
The HTML report is the artifact customers hand to auditors.

## Fixed in passing, because the scorer exposed them

- The signed bundle reported `pass: 0` where the API said `pass: 2` — it demanded finding evidence
  from detective controls, which the taggers deliberately never tag. An unclearable bar.
- ATT&CK applicability never reached the bundle at all.
- The evidence pack would have drifted to `3.3` once detective passes were preserved — **the new
  cross-surface test caught that regression before it shipped.**

## Separate fail-open, same file

`evidence/control_modes.py:155-163` scored `pass` for a missing or unparseable scan timestamp, and
for **future-dated** scans — `reference - completed` goes negative, so a +10y clock skew read fresh
forever. Both now fail closed. The 90-day window and the `DETECTIVE_CONTROLS` taxonomy are
untouched; those remain the owner's call.

## Guards — the property, not the instance

The original guard, `test_scanning_alone_is_not_compliance`, asserted **status only, on one
endpoint**. That is precisely how five other surfaces stayed broken. Replaced with:

- score **and** status asserted together for the scanned-but-clean estate
- an invariant test: *for every fixture, `no_data` ⇒ score 0*
- a cross-surface test walking one estate through all eight surfaces
- a vitest case with `overallStatus: "no_data"` carrying the real live payload
- 13 scorer unit tests, 11 freshness tests

## Verification

`pytest` **2288 passed / 10 skipped** · `tests/api` **1115 passed** · `ruff check` clean · `mypy`
clean on 5 changed modules · `npm run typecheck` clean · `npx vitest run` **163 files / 979 tests** ·
all 5 drift gates OK.

## Notes

- **Deferred, flagged rather than silently widened:** the narrative (`compliance.py:1203`) says
  *"No completed scans available"* when `scan_count == 1`. Wrong text, but honest in direction, and
  outside this fix.
- `npm run build` was **not** run — its standalone step exhausted the disk earlier in this session.
  The UI change is a pure `.tsx` edit with no new route or dynamic param, but the export build is
  unverified rather than known-good.
