### PR TITLE
fix(hub): stop compliance ingest breaking on a date certain

### DIFF
--- a/deploy/supabase/postgres/alembic/env.py
+++ b/deploy/supabase/postgres/alembic/env.py
@@ -6,7 +6,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
-from deploy.supabase.postgres.compose_migrate import _normalize_sqlalchemy_url
+from deploy.supabase.postgres.compose_migrate import _normalize_sqlalchemy_url, top_up_observation_partition_runway
 
 config = context.config
 
@@ -79,6 +79,10 @@ def run_migrations_online() -> None:
 
         with context.begin_transaction():
             context.run_migrations()
+            # Partition provisioning is migration-owned (the runtime roles are
+            # DML-only), so the runway has to be topped up by every deploy —
+            # not fixed once by a single revision that never runs again.
+            top_up_observation_partition_runway(connection)
 
 
 if context.is_offline_mode():

--- a/deploy/supabase/postgres/alembic/versions/20260731_01_observation_partition_runway.py
+++ b/deploy/supabase/postgres/alembic/versions/20260731_01_observation_partition_runway.py
@@ -1,0 +1,54 @@
+"""Extend the hub observations partition runway to a full year.
+
+``20260705_01`` provisioned only a ``behind=1 / ahead=2`` window at migration
+time, so a head database carried roughly three months of runway. Nothing at
+runtime can extend it: ``init.sql`` grants ``agent_bom_app`` USAGE but revokes
+CREATE on schema ``public``, ``agent_bom_maintenance`` is equally DML-only, and
+the children are owned by the migration role. Once the last provisioned month
+elapsed, every current-dated hub ingest failed permanently with HTTP 500.
+
+This tops the runway up to at least 12 months ahead. The same helper also runs
+after every ``alembic upgrade`` (see ``alembic/env.py``) so each deploy tops the
+runway up instead of it being fixed once.
+
+Each new child gets ``ENABLE``/``FORCE ROW LEVEL SECURITY`` plus the tenant
+isolation policy — partition children do not inherit them, and skipping that
+would reopen the cross-tenant hole ``20260729_03`` closed.
+
+Revision ID: 20260731_01
+Revises: 20260730_02
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from alembic import op
+
+revision = "20260731_01"
+down_revision = "20260730_02"
+branch_labels = None
+depends_on = None
+
+_REPO_ROOT = Path(__file__).resolve().parents[5]
+_SRC = _REPO_ROOT / "src"
+if str(_SRC) not in sys.path:
+    sys.path.insert(0, str(_SRC))
+
+from agent_bom.api.hub_observations_partition import (  # noqa: E402
+    provision_observation_partition_runway,
+)
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    # The shared helper uses psycopg's ``execute(sql, tuple)`` contract; unwrap
+    # the DBAPI connection while retaining Alembic's transaction (as 20260705_01).
+    provision_observation_partition_runway(bind.connection.driver_connection)
+
+
+def downgrade() -> None:
+    # Deliberately irreversible: dropping provisioned future partitions would
+    # discard ingested observations and re-create the ingest cliff.
+    pass

--- a/deploy/supabase/postgres/compose_migrate.py
+++ b/deploy/supabase/postgres/compose_migrate.py
@@ -22,6 +22,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from typing import Any
 from urllib.parse import quote, unquote, urlsplit, urlunsplit
 
 BASELINE_REVISION = "20260416_01"
@@ -36,6 +37,29 @@ def _normalize_sqlalchemy_url(url: str) -> str:
         if url.startswith(prefix):
             return "postgresql+psycopg://" + url[len(prefix) :]
     return url
+
+
+def top_up_observation_partition_runway(connection: Any) -> int:
+    """Extend the hub observations partition runway; run after every upgrade.
+
+    ``hub_findings_current_observations`` is monthly RANGE-partitioned and both
+    runtime roles are DML-only (``init.sql`` revokes CREATE on schema
+    ``public``), so only the migration owner can create a child. Provisioning a
+    fixed window once would simply move the ingest cliff, so every Alembic
+    upgrade tops the runway back up to a full year ahead.
+
+    Deliberately not swallowed: a migration owner that cannot provision must
+    fail the deploy loudly rather than ship a database that will stop accepting
+    current-dated ingest on a date certain.
+    """
+    src = Path(__file__).resolve().parents[3] / "src"
+    if src.is_dir() and str(src) not in sys.path:
+        sys.path.insert(0, str(src))
+    from agent_bom.api.hub_observations_partition import provision_observation_partition_runway
+
+    # The shared helper speaks psycopg's ``execute(sql, tuple)`` contract, so
+    # unwrap the DBAPI connection while retaining Alembic's transaction.
+    return provision_observation_partition_runway(connection.connection.driver_connection)
 
 
 def _repo_root() -> Path:

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1077,
+      "value": 1079,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1077 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1079 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 817 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/api/hub_observations_partition.py
+++ b/src/agent_bom/api/hub_observations_partition.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import re
+import time
 from calendar import monthrange
 from datetime import date, datetime, timedelta, timezone
 from typing import Any
@@ -26,6 +27,27 @@ logger = logging.getLogger(__name__)
 
 OBSERVATIONS_TABLE = "hub_findings_current_observations"
 _PARTITION_NAME_RE = re.compile(r"^hub_findings_current_observations_y(\d{4})m(\d{2})$")
+
+# How far ahead the migration owner provisions child partitions. Partition DDL
+# is deliberately migration-owned: ``agent_bom_app`` is DML-only (init.sql
+# revokes CREATE on schema ``public``) and ``agent_bom_maintenance`` is too, so
+# no runtime code path can create a child. The runway must therefore outlast a
+# long gap between deploys — a year of not upgrading must not break ingest.
+OBSERVATION_PARTITION_RUNWAY_MONTHS = 12
+
+# Alert an operator once the remaining runway drops below this many months, so
+# a silent cliff becomes months of actionable warning.
+OBSERVATION_PARTITION_RUNWAY_ALERT_MONTHS = 3
+
+# The cleanup loop ticks every 60s; re-emit the same runway alert at most hourly
+# so the warning stays visible without drowning the log.
+_RUNWAY_ALERT_MIN_INTERVAL_SECONDS = 3600.0
+_runway_alert_state: tuple[str, float] | None = None
+
+
+def _utc_now() -> datetime:
+    """Single clock seam so runway guards can freeze time instead of drifting."""
+    return datetime.now(timezone.utc)
 
 
 # SQLSTATEs raised when a concurrent worker already created the child partition
@@ -179,7 +201,7 @@ def ensure_observation_partitions(
     """Create missing monthly child partitions around *now*. Returns partitions created."""
     if not is_observations_partitioned(conn):
         return 0
-    anchor = (now or datetime.now(timezone.utc)).date()
+    anchor = (now or _utc_now()).date()
     created = 0
     for year, month in _iter_months(anchor, behind=months_behind, ahead=months_ahead):
         child = partition_table_name(year, month)
@@ -199,6 +221,46 @@ def ensure_observation_partitions(
         _create_observation_partition(conn, year, month)
         created += 1
     return created
+
+
+def provision_observation_partition_runway(
+    conn: Any,
+    *,
+    now: datetime | None = None,
+    months_ahead: int = OBSERVATION_PARTITION_RUNWAY_MONTHS,
+) -> int:
+    """Top the partition runway up to *months_ahead* months past *now*.
+
+    The deploy-time entry point, run by the migration owner (the only principal
+    that may create a child and force RLS on it). Idempotent: re-running in the
+    same month creates nothing, and a later run fills only the new gap, so it is
+    safe to call on every ``alembic upgrade``.
+
+    ``months_behind=0`` so a top-up never resurrects a month that retention has
+    already detached and dropped.
+    """
+    return ensure_observation_partitions(conn, now=now, months_ahead=months_ahead, months_behind=0)
+
+
+def observation_runway_end(conn: Any) -> date | None:
+    """Exclusive upper bound of the provisioned runway (``None`` if unprovisioned).
+
+    A plain ``pg_catalog`` read, so the DML-only runtime roles can always answer
+    it even when they are denied the DDL that would extend it.
+    """
+    ends = [end for end in (_partition_end_date(name) for name in list_observation_partition_names(conn)) if end is not None]
+    return max(ends) if ends else None
+
+
+def observation_runway_months_remaining(conn: Any, *, now: datetime | None = None) -> int | None:
+    """Whole months of runway left after the current month; negative once lapsed."""
+    runway_end = observation_runway_end(conn)
+    if runway_end is None:
+        return None
+    # ``runway_end`` is exclusive, so the last covered month is the month before it.
+    last_covered = runway_end - timedelta(days=1)
+    anchor = (now or _utc_now()).date()
+    return _month_index(last_covered) - _month_index(anchor)
 
 
 # Guard against absurd backdating (bad data / clock skew) creating unbounded
@@ -263,7 +325,7 @@ def ensure_observation_partition_for(
     month = _parse_observed_at_month(observed_at)
     if month is None:
         return False
-    anchor = (now or datetime.now(timezone.utc)).date().replace(day=1)
+    anchor = (now or _utc_now()).date().replace(day=1)
     delta_months = _month_index(month) - _month_index(anchor)
     if delta_months > months_ahead or delta_months < -months_behind:
         raise ObservationPartitionRangeError(observed_at, months_ahead=months_ahead, months_behind=months_behind)
@@ -320,7 +382,7 @@ def rollover_observation_partitions(
     """Detach and drop monthly partitions wholly older than *retention_days*."""
     if retention_days <= 0 or not is_observations_partitioned(conn):
         return 0
-    anchor = now or datetime.now(timezone.utc)
+    anchor = now or _utc_now()
     cutoff = (anchor - timedelta(days=retention_days)).date()
     dropped = 0
     for partition_name in list_observation_partition_names(conn):
@@ -374,7 +436,7 @@ def migrate_observations_to_partitioned(conn: Any) -> bool:
         else:
             cursor = date(cursor.year, cursor.month + 1, 1)
 
-    ensure_observation_partitions(conn, now=datetime.now(timezone.utc), months_ahead=2, months_behind=0)
+    provision_observation_partition_runway(conn)
     ensure_observation_partition_children_rls(conn)
 
     conn.execute(
@@ -389,8 +451,76 @@ def migrate_observations_to_partitioned(conn: Any) -> bool:
     return True
 
 
+def _should_emit_runway_alert(key: str) -> bool:
+    """Throttle a repeated runway alert to once an hour per distinct state."""
+    global _runway_alert_state
+    monotonic = time.monotonic()
+    if _runway_alert_state is not None:
+        last_key, last_at = _runway_alert_state
+        if last_key == key and monotonic - last_at < _RUNWAY_ALERT_MIN_INTERVAL_SECONDS:
+            return False
+    _runway_alert_state = (key, monotonic)
+    return True
+
+
+def _describe_runway(runway_end: date | None, *, now: datetime | None = None) -> tuple[str, int | None]:
+    """Render the last covered day plus the whole months of runway remaining."""
+    if runway_end is None:
+        return "unprovisioned", None
+    last_covered = runway_end - timedelta(days=1)
+    anchor = (now or _utc_now()).date()
+    return last_covered.isoformat(), _month_index(last_covered) - _month_index(anchor)
+
+
+def _alert_observation_partition_runway(
+    runway_end: date | None,
+    *,
+    provisioning_failed: bool,
+    now: datetime | None = None,
+) -> None:
+    """Report the runway, naming the date current-dated ingest starts failing.
+
+    Severity follows urgency rather than the immediate cause. A denied top-up is
+    the *expected* steady state — provisioning is migration-owned and both
+    runtime roles are DML-only — so reporting it at ERROR on every healthy
+    deployment would train operators to filter the one message that matters near
+    the cliff. It stays visible at WARNING and escalates to ERROR once the runway
+    falls below the alert threshold or has already lapsed. It is never silent.
+    """
+    last_covered, months_left = _describe_runway(runway_end, now=now)
+    urgent = months_left is None or months_left < OBSERVATION_PARTITION_RUNWAY_ALERT_MONTHS
+    if not provisioning_failed and not urgent:
+        return
+    key = f"{'denied' if provisioning_failed else 'low'}:{last_covered}"
+    if not _should_emit_runway_alert(key):
+        return
+    if provisioning_failed:
+        reason = "the runtime database role was denied the DDL that extends it"
+    else:
+        reason = "it is not being topped up by deploys"
+    logger.log(
+        logging.ERROR if urgent else logging.WARNING,
+        "%s partition runway ends %s (%s month(s) left) and %s. Partition provisioning is "
+        "migration-owned: run the Alembic migrations (deploy/supabase/postgres/compose_migrate.py) "
+        "to extend it. Once the runway lapses, every current-dated hub ingest fails with HTTP 500 "
+        "until a migration runs.",
+        OBSERVATIONS_TABLE,
+        last_covered,
+        "unknown" if months_left is None else months_left,
+        reason,
+        exc_info=provisioning_failed,
+    )
+
+
 def run_hub_observations_retention(*, retention_days: int | None = None) -> int:
-    """Postgres-only retention rollover; no-op for SQLite and legacy tables."""
+    """Postgres-only retention rollover; no-op for SQLite and legacy tables.
+
+    Also re-attempts the partition top-up so a deployment whose runtime role
+    *does* own the tables self-heals. Under the shipped DML-only role model that
+    attempt is denied, which is exactly why the failure is reported at ERROR
+    naming the runway end instead of being swallowed at DEBUG: provisioning is
+    migration-owned and an operator needs months of warning, not a silent cliff.
+    """
     days = HUB_OBSERVATIONS_RETENTION_DAYS if retention_days is None else retention_days
     if days <= 0:
         return 0
@@ -400,13 +530,34 @@ def run_hub_observations_retention(*, retention_days: int | None = None) -> int:
         from agent_bom.api.postgres_common import _maintenance_connection, bypass_tenant_rls
 
         with bypass_tenant_rls(audit=False), _maintenance_connection() as conn:
-            ensure_observation_partitions(conn)
-            ensure_observation_partition_children_rls(conn)
-            dropped = rollover_observation_partitions(conn, retention_days=days)
-            conn.commit()
+            # A legacy single-table install has no runway to report on.
+            partitioned = is_observations_partitioned(conn)
+            # Read the runway before touching DDL: a catalog SELECT the DML-only
+            # role can always run, so the alert can name a real date even when
+            # every write below is denied.
+            runway_end = observation_runway_end(conn) if partitioned else None
+            try:
+                ensure_observation_partitions(conn)
+                ensure_observation_partition_children_rls(conn)
+                dropped = rollover_observation_partitions(conn, retention_days=days)
+                conn.commit()
+            except Exception:  # noqa: BLE001 — cleanup loop must stay fail-open
+                conn.rollback()
+                if partitioned:
+                    _alert_observation_partition_runway(runway_end, provisioning_failed=True)
+                else:
+                    logger.error("hub observations retention failed on a legacy unpartitioned table", exc_info=True)
+                return 0
+            if partitioned:
+                _alert_observation_partition_runway(observation_runway_end(conn), provisioning_failed=False)
             return dropped
     except Exception:  # noqa: BLE001 — cleanup loop must stay fail-open
-        logger.debug("hub observations retention skipped", exc_info=True)
+        logger.error(
+            "hub observations partition maintenance could not open a maintenance connection; "
+            "the %s partition runway cannot be checked or extended",
+            OBSERVATIONS_TABLE,
+            exc_info=True,
+        )
         return 0
 
 

--- a/tests/test_compose_alembic_migrate.py
+++ b/tests/test_compose_alembic_migrate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -71,6 +72,51 @@ def test_alembic_env_normalizes_driverless_postgres_urls() -> None:
     env_source = (Path(__file__).parents[1] / "deploy/supabase/postgres/alembic/env.py").read_text(encoding="utf-8")
     assert "from deploy.supabase.postgres.compose_migrate import _normalize_sqlalchemy_url" in env_source
     assert "url = _normalize_sqlalchemy_url(url)" in env_source
+
+
+def test_partition_runway_top_up_runs_on_every_upgrade(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Partition provisioning is migration-owned, so each deploy must top it up.
+
+    A one-shot migration would fix the runway once and let it lapse again; the
+    top-up has to ride every ``alembic upgrade``.
+    """
+    from agent_bom.api import hub_observations_partition as partitions
+
+    driver_connection = object()
+    connection = SimpleNamespace(connection=SimpleNamespace(driver_connection=driver_connection))
+    seen: list[tuple[object, int]] = []
+
+    monkeypatch.setattr(
+        partitions,
+        "provision_observation_partition_runway",
+        lambda conn, **kwargs: seen.append((conn, kwargs.get("months_ahead", partitions.OBSERVATION_PARTITION_RUNWAY_MONTHS))) or 0,
+    )
+
+    cm.top_up_observation_partition_runway(connection)
+
+    assert seen == [(driver_connection, partitions.OBSERVATION_PARTITION_RUNWAY_MONTHS)]
+
+
+def test_partition_runway_top_up_failure_fails_the_deploy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Loud and early: a migration owner that cannot provision must not ship."""
+    from agent_bom.api import hub_observations_partition as partitions
+
+    def _boom(_conn: object, **_kwargs: object) -> int:
+        raise RuntimeError("permission denied for schema public")
+
+    monkeypatch.setattr(partitions, "provision_observation_partition_runway", _boom)
+    connection = SimpleNamespace(connection=SimpleNamespace(driver_connection=object()))
+
+    with pytest.raises(RuntimeError, match="permission denied"):
+        cm.top_up_observation_partition_runway(connection)
+
+
+def test_alembic_env_tops_up_the_partition_runway_after_migrations() -> None:
+    env_source = (Path(__file__).parents[1] / "deploy/supabase/postgres/alembic/env.py").read_text(encoding="utf-8")
+    assert "top_up_observation_partition_runway" in env_source
+    run_at = env_source.index("context.run_migrations()")
+    top_up_at = env_source.index("top_up_observation_partition_runway(connection)")
+    assert top_up_at > run_at, "the runway top-up must run after the migrations, not before"
 
 
 def test_alembic_env_never_falls_back_to_the_runtime_app_url() -> None:

--- a/tests/test_http_client_proxy_env.py
+++ b/tests/test_http_client_proxy_env.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import threading
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 
+import httpcore
 import httpx
 import pytest
 
@@ -79,9 +80,16 @@ def test_no_proxy_exclusions_are_still_honoured(proxy_server, monkeypatch) -> No
     monkeypatch.setenv("HTTP_PROXY", proxy_server)
     monkeypatch.setenv("NO_PROXY", "blocked.example")
 
+    # The proxy answers every absolute-URI request with 418, so reaching it at
+    # all would mean NO_PROXY was ignored. Going direct is what must happen,
+    # and the host does not resolve — but the exact exception depends on the
+    # resolver: httpx wraps httpcore's error on some paths and lets it through
+    # on others, so a CI runner and a laptop raise different types for the same
+    # correct behaviour. Assert the property, not the type.
     with create_sync_client(timeout=5) as client:
-        with pytest.raises(httpx.ConnectError):
+        with pytest.raises((httpx.TransportError, httpcore.NetworkError)) as excinfo:
             client.get("http://blocked.example/resource")
+    assert not isinstance(excinfo.value, httpx.HTTPStatusError)
 
 
 def test_connection_retries_stay_enabled_without_a_proxy(monkeypatch) -> None:

--- a/tests/test_hub_observations_partition_runway.py
+++ b/tests/test_hub_observations_partition_runway.py
@@ -1,0 +1,321 @@
+"""Partition runway provisioning for ``hub_findings_current_observations``.
+
+The observations parent is monthly RANGE-partitioned and the runtime Postgres
+roles are deliberately DML-only, so no runtime code path can create a child
+partition. Provisioning is therefore migration/deploy-owned, and the guard that
+matters is *how far past today* the provisioned runway reaches — not merely
+"a partition exists". These tests freeze the clock so they assert a real runway
+rather than tracking the calendar.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from datetime import date, datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+from agent_bom.api import hub_observations_partition as partitions
+from agent_bom.api.hub_observations_partition import (
+    OBSERVATION_PARTITION_RUNWAY_ALERT_MONTHS,
+    OBSERVATION_PARTITION_RUNWAY_MONTHS,
+    month_range_bounds,
+    observation_runway_end,
+    observation_runway_months_remaining,
+    partition_table_name,
+    provision_observation_partition_runway,
+    run_hub_observations_retention,
+)
+
+_CREATE_RE = re.compile(r"CREATE TABLE IF NOT EXISTS hub_findings_current_observations_y(\d{4})m(\d{2})")
+
+
+class _Result:
+    def __init__(self, one: Any = None, many: list[Any] | None = None) -> None:
+        self._one = one
+        self._many = many or []
+
+    def fetchone(self) -> Any:
+        return self._one
+
+    def fetchall(self) -> list[Any]:
+        return self._many
+
+
+class _FakePartitionedConn:
+    """Minimal psycopg-shaped stand-in for the partitioned observations parent."""
+
+    def __init__(self, existing: set[str] | None = None, *, partitioned: bool = True) -> None:
+        self.statements: list[str] = []
+        self.existing = set(existing or ())
+        self.partitioned = partitioned
+        self.commits = 0
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> _Result:
+        self.statements.append(sql.strip())
+        if "c.relkind" in sql:
+            return _Result(("p",) if self.partitioned else ("r",))
+        if "pg_inherits" in sql:
+            return _Result(many=[(name,) for name in sorted(self.existing)])
+        if "pg_class" in sql and params:
+            name = str(params[0])
+            return _Result((1,) if name in self.existing else None)
+        if "information_schema.tables" in sql:
+            return _Result((1,))
+        match = _CREATE_RE.search(sql)
+        if match:
+            self.existing.add(partition_table_name(int(match.group(1)), int(match.group(2))))
+        return _Result()
+
+    def commit(self) -> None:
+        self.commits += 1
+
+    def rollback(self) -> None:  # pragma: no cover - exercised only on the failure path
+        pass
+
+    def created_months(self) -> list[tuple[int, int]]:
+        months = [(int(m.group(1)), int(m.group(2))) for m in (_CREATE_RE.search(s) for s in self.statements) if m]
+        return sorted(months)
+
+
+def _runway_end_of(months: list[tuple[int, int]]) -> date:
+    return max(month_range_bounds(year, month)[1] for year, month in months)
+
+
+# ── The runway guard: months past *today*, not "a partition exists" ──────────
+
+
+def test_provisioned_runway_reaches_at_least_twelve_months_past_today(monkeypatch) -> None:
+    """The provisioned runway must outlast a full year of not deploying."""
+    monkeypatch.setattr(partitions, "_ensure_observation_partition_rls", lambda *_a: None)
+    frozen_now = datetime(2026, 7, 31, tzinfo=timezone.utc)
+    conn = _FakePartitionedConn()
+
+    provision_observation_partition_runway(conn, now=frozen_now)
+
+    runway_end = _runway_end_of(conn.created_months())
+    assert runway_end - frozen_now.date() >= timedelta(days=365), (
+        f"runway ends {runway_end}, only {(runway_end - frozen_now.date()).days} days past {frozen_now.date()}"
+    )
+    assert OBSERVATION_PARTITION_RUNWAY_MONTHS >= 12
+
+
+@pytest.mark.parametrize(
+    "frozen_now",
+    [
+        datetime(2026, 1, 1, tzinfo=timezone.utc),
+        datetime(2026, 7, 31, tzinfo=timezone.utc),
+        datetime(2026, 12, 31, tzinfo=timezone.utc),
+        datetime(2027, 2, 28, tzinfo=timezone.utc),
+    ],
+)
+def test_runway_crosses_year_boundaries_without_a_gap(monkeypatch, frozen_now: datetime) -> None:
+    """Every month from today to the runway end is provisioned — no holes."""
+    monkeypatch.setattr(partitions, "_ensure_observation_partition_rls", lambda *_a: None)
+    conn = _FakePartitionedConn()
+
+    provision_observation_partition_runway(conn, now=frozen_now)
+
+    months = conn.created_months()
+    assert months[0] == (frozen_now.year, frozen_now.month)
+    indexes = [year * 12 + (month - 1) for year, month in months]
+    assert indexes == list(range(indexes[0], indexes[0] + len(indexes))), "gap in the provisioned month sequence"
+    assert _runway_end_of(months) - frozen_now.date() >= timedelta(days=365)
+
+
+def test_runway_top_up_is_idempotent_and_only_fills_the_gap(monkeypatch) -> None:
+    """A second deploy in the same month creates nothing; a later one tops up."""
+    monkeypatch.setattr(partitions, "_ensure_observation_partition_rls", lambda *_a: None)
+    frozen_now = datetime(2026, 7, 31, tzinfo=timezone.utc)
+    conn = _FakePartitionedConn()
+    first = provision_observation_partition_runway(conn, now=frozen_now)
+    assert first == OBSERVATION_PARTITION_RUNWAY_MONTHS + 1
+
+    conn.statements.clear()
+    assert provision_observation_partition_runway(conn, now=frozen_now) == 0
+    assert conn.created_months() == []
+
+    conn.statements.clear()
+    later = provision_observation_partition_runway(conn, now=datetime(2026, 10, 15, tzinfo=timezone.utc))
+    assert later == 3
+    assert _runway_end_of(conn.created_months()) == date(2027, 11, 1)
+
+
+def test_every_new_partition_child_gets_forced_tenant_rls(monkeypatch) -> None:
+    """New children do not inherit RLS; provisioning must apply it to each one."""
+    protected: list[str] = []
+    monkeypatch.setattr(partitions, "_ensure_observation_partition_rls", lambda _conn, child: protected.append(child))
+    conn = _FakePartitionedConn()
+
+    provision_observation_partition_runway(conn, now=datetime(2026, 7, 31, tzinfo=timezone.utc))
+
+    assert protected == [partition_table_name(y, m) for y, m in conn.created_months()]
+    assert len(protected) == OBSERVATION_PARTITION_RUNWAY_MONTHS + 1
+
+
+def test_provisioning_is_a_noop_on_an_unpartitioned_table() -> None:
+    conn = _FakePartitionedConn(partitioned=False)
+    assert provision_observation_partition_runway(conn, now=datetime(2026, 7, 31, tzinfo=timezone.utc)) == 0
+    assert conn.created_months() == []
+
+
+# ── Runway introspection ────────────────────────────────────────────────────
+
+
+def test_observation_runway_end_is_the_exclusive_upper_bound() -> None:
+    """The last *covered* day is 2026-09-30; the reported bound is exclusive."""
+    conn = _FakePartitionedConn({partition_table_name(2026, 6), partition_table_name(2026, 9)})
+    assert observation_runway_end(conn) == date(2026, 10, 1)
+
+
+def test_observation_runway_end_none_without_partitions() -> None:
+    assert observation_runway_end(_FakePartitionedConn()) is None
+
+
+def test_runway_months_remaining_counts_whole_months_ahead() -> None:
+    conn = _FakePartitionedConn({partition_table_name(2026, m) for m in (6, 7, 8, 9)})
+    assert observation_runway_months_remaining(conn, now=datetime(2026, 7, 15, tzinfo=timezone.utc)) == 2
+    # Ingest is already failing once today is past the last provisioned month.
+    assert observation_runway_months_remaining(conn, now=datetime(2026, 10, 1, tzinfo=timezone.utc)) == -1
+
+
+# ── The retention tick must not swallow the provisioning failure ─────────────
+
+
+class _FailingMaintenance:
+    """Stands in for ``_maintenance_connection``'s DML-only Postgres role."""
+
+    def __init__(self, existing: set[str], error: Exception) -> None:
+        self.conn = _FakePartitionedConn(existing)
+        self.error = error
+
+    def execute(self, sql: str, params: tuple[Any, ...] | None = None) -> _Result:
+        if "CREATE TABLE IF NOT EXISTS" in sql or "ALTER TABLE" in sql or "CREATE OR REPLACE FUNCTION" in sql:
+            raise self.error
+        return self.conn.execute(sql, params)
+
+    def commit(self) -> None:
+        self.conn.commit()
+
+    def rollback(self) -> None:
+        pass
+
+
+def _install_maintenance(monkeypatch, conn: Any, *, frozen_now: datetime) -> None:
+    import contextlib
+
+    @contextlib.contextmanager
+    def _maintenance_connection(_pool: Any = None):
+        yield conn
+
+    @contextlib.contextmanager
+    def _bypass(**_kwargs: Any):
+        yield
+
+    import agent_bom.api.postgres_common as postgres_common
+
+    monkeypatch.setattr(postgres_common, "_maintenance_connection", _maintenance_connection)
+    monkeypatch.setattr(postgres_common, "bypass_tenant_rls", _bypass)
+    monkeypatch.setenv("AGENT_BOM_POSTGRES_URL", "postgresql://agent_bom_app@127.0.0.1:5432/agent_bom")
+    # Freeze the clock and clear the hourly alert throttle so the assertion is
+    # about behaviour, not about today's date or test execution order.
+    monkeypatch.setattr(partitions, "_utc_now", lambda: frozen_now)
+    monkeypatch.setattr(partitions, "_runway_alert_state", None)
+
+
+def test_retention_failure_is_logged_at_error_naming_the_runway_end(monkeypatch, caplog) -> None:
+    """The only job that would extend the runway must not fail silently."""
+
+    class InsufficientPrivilegeError(Exception):
+        """Stands in for psycopg's ``InsufficientPrivilege`` (SQLSTATE 42501)."""
+
+    existing = {partition_table_name(2026, m) for m in (6, 7, 8, 9)}
+    maintenance = _FailingMaintenance(existing, InsufficientPrivilegeError("permission denied for schema public"))
+    _install_maintenance(monkeypatch, maintenance, frozen_now=datetime(2026, 8, 1, tzinfo=timezone.utc))
+
+    with caplog.at_level(logging.DEBUG, logger=partitions.logger.name):
+        assert run_hub_observations_retention(retention_days=365) == 0
+
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert errors, f"expected an ERROR record, got {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    message = " ".join(r.getMessage() for r in errors)
+    assert "2026-09-30" in message, f"runway end not named in operator alert: {message!r}"
+    assert "hub_findings_current_observations" in message
+    # The alert must carry the original privilege error, not just a bare string.
+    assert any(r.exc_info and r.exc_info[0] is InsufficientPrivilegeError for r in errors)
+    # Nothing may be reported at DEBUG-only any more.
+    assert not any(r.levelno == logging.DEBUG and "retention skipped" in r.getMessage() for r in caplog.records)
+
+
+def test_retention_alerts_while_the_runway_is_still_shrinking(monkeypatch, caplog) -> None:
+    """Below the alert threshold an operator gets months of warning, not a cliff."""
+    existing = {partition_table_name(2026, m) for m in (6, 7, 8, 9)}
+    conn = _FakePartitionedConn(existing)
+    _install_maintenance(monkeypatch, conn, frozen_now=datetime(2026, 8, 1, tzinfo=timezone.utc))
+    monkeypatch.setattr(partitions, "_ensure_observation_partition_rls", lambda *_a: None)
+    monkeypatch.setattr(partitions, "ensure_observation_partitions", lambda *_a, **_k: 0)
+    monkeypatch.setattr(partitions, "ensure_observation_partition_children_rls", lambda *_a: 0)
+    monkeypatch.setattr(partitions, "rollover_observation_partitions", lambda *_a, **_k: 0)
+
+    with caplog.at_level(logging.DEBUG, logger=partitions.logger.name):
+        run_hub_observations_retention(retention_days=365)
+
+    alerts = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert alerts, f"expected a runway alert, got {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    message = " ".join(r.getMessage() for r in alerts)
+    assert "2026-09-30" in message
+    assert OBSERVATION_PARTITION_RUNWAY_ALERT_MONTHS >= 1
+
+
+def test_denied_top_up_with_a_healthy_runway_warns_instead_of_paging(monkeypatch, caplog) -> None:
+    """The denial is the *expected* steady state under the DML-only role model.
+
+    Provisioning is migration-owned, so the runtime top-up is denied on every
+    healthy deployment. Reporting that at ERROR once an hour forever would train
+    operators to filter the very message that must be seen near the cliff — so
+    it stays visible at WARNING and escalates to ERROR only when it is urgent.
+    """
+
+    class InsufficientPrivilegeError(Exception):
+        """Stands in for psycopg's ``InsufficientPrivilege`` (SQLSTATE 42501)."""
+
+    existing = {partition_table_name(2027, m) for m in range(1, 13)} | {partition_table_name(2026, m) for m in range(7, 13)}
+    maintenance = _FailingMaintenance(existing, InsufficientPrivilegeError("permission denied for schema public"))
+    _install_maintenance(monkeypatch, maintenance, frozen_now=datetime(2026, 8, 1, tzinfo=timezone.utc))
+
+    with caplog.at_level(logging.DEBUG, logger=partitions.logger.name):
+        assert run_hub_observations_retention(retention_days=365) == 0
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert warnings, f"the denied top-up must stay visible, got {[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    # Still names the runway end, so the operator can see the cliff approaching.
+    assert "2027-12-31" in " ".join(r.getMessage() for r in warnings)
+
+
+def test_legacy_unpartitioned_table_raises_no_runway_alert(monkeypatch, caplog) -> None:
+    """A legacy single-table Postgres install has no runway to alert about."""
+    conn = _FakePartitionedConn(partitioned=False)
+    _install_maintenance(monkeypatch, conn, frozen_now=datetime(2026, 8, 1, tzinfo=timezone.utc))
+
+    with caplog.at_level(logging.DEBUG, logger=partitions.logger.name):
+        assert run_hub_observations_retention(retention_days=365) == 0
+
+    assert [r for r in caplog.records if r.levelno >= logging.WARNING] == []
+
+
+def test_retention_stays_quiet_while_the_runway_is_healthy(monkeypatch, caplog) -> None:
+    existing = {partition_table_name(2027, m) for m in range(1, 13)} | {partition_table_name(2026, m) for m in range(7, 13)}
+    conn = _FakePartitionedConn(existing)
+    _install_maintenance(monkeypatch, conn, frozen_now=datetime(2026, 8, 1, tzinfo=timezone.utc))
+    monkeypatch.setattr(partitions, "_ensure_observation_partition_rls", lambda *_a: None)
+    monkeypatch.setattr(partitions, "ensure_observation_partitions", lambda *_a, **_k: 0)
+    monkeypatch.setattr(partitions, "ensure_observation_partition_children_rls", lambda *_a: 0)
+    monkeypatch.setattr(partitions, "rollover_observation_partitions", lambda *_a, **_k: 0)
+
+    with caplog.at_level(logging.DEBUG, logger=partitions.logger.name):
+        run_hub_observations_retention(retention_days=365)
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []

--- a/tests/test_hub_observations_runway_live.py
+++ b/tests/test_hub_observations_runway_live.py
@@ -1,0 +1,153 @@
+"""Live Postgres contract for the hub observations partition runway.
+
+The unit guards in ``test_hub_observations_partition_runway`` freeze the clock
+against a fake connection. This one asserts the same two properties against a
+real ``alembic upgrade head`` database, because the failure mode was invisible
+to every fake: partitions are always fresh immediately after a migration, and
+partition children do not inherit the parent's row-level security.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date, timedelta
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("AGENT_BOM_POSTGRES_ADMIN_URL"),
+    reason="AGENT_BOM_POSTGRES_ADMIN_URL is required for the live partition runway contract",
+)
+
+REPO_ROOT = Path(__file__).parent.parent
+OBSERVATIONS_TABLE = "hub_findings_current_observations"
+
+# A deploy must leave enough runway that a year without upgrading cannot break
+# current-dated ingest.
+MIN_RUNWAY_DAYS = 365
+
+
+def _with_database(url: str, database: str) -> str:
+    parts = urlsplit(url)
+    return urlunsplit((parts.scheme, parts.netloc, f"/{database}", parts.query, parts.fragment))
+
+
+def _upgrade_head(database_url: str) -> None:
+    from alembic import command
+    from alembic.config import Config
+
+    config = Config(str(REPO_ROOT / "deploy" / "supabase" / "postgres" / "alembic.ini"))
+    config.set_main_option("script_location", str(REPO_ROOT / "deploy" / "supabase" / "postgres" / "alembic"))
+    previous = os.environ.get("ALEMBIC_DATABASE_URL")
+    os.environ["ALEMBIC_DATABASE_URL"] = database_url
+    try:
+        command.upgrade(config, "head")
+    finally:
+        if previous is None:
+            os.environ.pop("ALEMBIC_DATABASE_URL", None)
+        else:
+            os.environ["ALEMBIC_DATABASE_URL"] = previous
+
+
+@pytest.fixture()
+def migrated_database() -> str:
+    import psycopg
+    from psycopg import sql
+
+    admin_url = os.environ["AGENT_BOM_POSTGRES_ADMIN_URL"]
+    database = f"abom_runway_{uuid4().hex[:12]}"
+    database_url = _with_database(admin_url, database)
+    with psycopg.connect(admin_url, autocommit=True) as conn:
+        conn.execute(sql.SQL("CREATE DATABASE {}").format(sql.Identifier(database)))
+    try:
+        _upgrade_head(database_url)
+        yield database_url
+    finally:
+        with psycopg.connect(admin_url, autocommit=True) as conn:
+            conn.execute(sql.SQL("DROP DATABASE IF EXISTS {} WITH (FORCE)").format(sql.Identifier(database)))
+
+
+def test_upgrade_head_leaves_at_least_a_year_of_partition_runway(migrated_database: str) -> None:
+    """Not 'a partition exists' — how far past *today* the runway reaches."""
+    import psycopg
+
+    from agent_bom.api.hub_observations_partition import observation_runway_end
+
+    with psycopg.connect(migrated_database, autocommit=True) as conn:
+        runway_end = observation_runway_end(conn)
+
+    assert runway_end is not None, "upgrade head provisioned no observation partitions"
+    remaining = runway_end - date.today()
+    assert remaining >= timedelta(days=MIN_RUNWAY_DAYS), (
+        f"partition runway ends {runway_end}, only {remaining.days} days past today; "
+        "current-dated hub ingest will fail permanently from that date"
+    )
+
+
+def test_every_provisioned_partition_child_forces_tenant_isolation(migrated_database: str) -> None:
+    """Children do not inherit RLS; an unprotected one is a cross-tenant hole."""
+    import psycopg
+
+    with psycopg.connect(migrated_database, autocommit=True) as conn:
+        rows = conn.execute(
+            """
+            SELECT child.relname, child.relrowsecurity, child.relforcerowsecurity,
+                   (SELECT count(*) FROM pg_policies p
+                     WHERE p.tablename = child.relname
+                       AND p.policyname = child.relname || '_tenant_isolation')
+            FROM pg_inherits inh
+            JOIN pg_class parent ON parent.oid = inh.inhparent
+            JOIN pg_class child ON child.oid = inh.inhrelid
+            JOIN pg_namespace n ON n.oid = parent.relnamespace
+            WHERE n.nspname = current_schema() AND parent.relname = %s
+            ORDER BY child.relname
+            """,
+            (OBSERVATIONS_TABLE,),
+        ).fetchall()
+
+    assert rows, "no observation partition children were provisioned"
+    unprotected = [
+        (name, enabled, forced, policies) for name, enabled, forced, policies in rows if not (enabled and forced and policies == 1)
+    ]
+    assert unprotected == [], f"partition children without forced tenant isolation: {unprotected}"
+
+
+def test_re_running_upgrade_head_tops_the_runway_back_up(migrated_database: str) -> None:
+    """The top-up rides every deploy, not just the one revision that added it."""
+    import psycopg
+
+    from agent_bom.api.hub_observations_partition import observation_runway_end
+
+    keep = f"{OBSERVATIONS_TABLE}_y{date.today():%Ym%m}"
+    with psycopg.connect(migrated_database, autocommit=True) as conn:
+        children = [
+            str(row[0])
+            for row in conn.execute(
+                """
+                SELECT child.relname FROM pg_inherits inh
+                JOIN pg_class parent ON parent.oid = inh.inhparent
+                JOIN pg_class child ON child.oid = inh.inhrelid
+                WHERE parent.relname = %s ORDER BY child.relname
+                """,
+                (OBSERVATIONS_TABLE,),
+            ).fetchall()
+        ]
+        # Simulate a database whose runway has lapsed while sitting at head.
+        for child in children:
+            if child > keep:
+                conn.execute(f"ALTER TABLE {OBSERVATIONS_TABLE} DETACH PARTITION {child}")  # noqa: S608
+                conn.execute(f"DROP TABLE {child}")  # noqa: S608
+        lapsed_end = observation_runway_end(conn)
+
+    assert lapsed_end is not None and lapsed_end - date.today() < timedelta(days=MIN_RUNWAY_DAYS)
+
+    # No revision is pending — only the per-deploy top-up can restore this.
+    _upgrade_head(migrated_database)
+
+    with psycopg.connect(migrated_database, autocommit=True) as conn:
+        restored_end = observation_runway_end(conn)
+    assert restored_end is not None
+    assert restored_end - date.today() >= timedelta(days=MIN_RUNWAY_DAYS)

--- a/tests/test_postgres_migrations.py
+++ b/tests/test_postgres_migrations.py
@@ -28,6 +28,7 @@ GATEWAY_ACTIVITY_WINDOW_INDEX = VERSIONS_DIR / "20260729_02_gateway_activity_win
 PARTITION_CHILD_RLS = VERSIONS_DIR / "20260729_03_partition_child_rls.py"
 GRAPH_EDGE_SNAPSHOT_KEY_INDEX = VERSIONS_DIR / "20260730_01_graph_edge_snapshot_key_index.py"
 TEAMS_TENANT_RLS = VERSIONS_DIR / "20260730_02_teams_tenant_rls.py"
+OBSERVATION_PARTITION_RUNWAY = VERSIONS_DIR / "20260731_01_observation_partition_runway.py"
 POSTGRES_MCP_CONFIG_STORE = Path(__file__).parent.parent / "src" / "agent_bom" / "api" / "postgres_mcp_config.py"
 AUDIT_FORK_GUARD_INDEX = VERSIONS_DIR / "20260719_01_audit_fork_guard_index.py"
 HUB_OBSERVATIONS_PARTITION = VERSIONS_DIR / "20260705_01_hub_observations_partition.py"
@@ -434,7 +435,7 @@ def test_teams_tenant_rls_is_chained_idempotent_and_irreversible() -> None:
     assert "NO FORCE ROW LEVEL SECURITY" not in sql
 
 
-def test_teams_tenant_rls_is_the_alembic_head() -> None:
+def test_observation_partition_runway_is_the_alembic_head() -> None:
     """Nothing may chain past the new revision without being noticed."""
     revisions = {
         path.name: re.search(r'down_revision\s*=\s*"([^"]+)"', path.read_text())
@@ -442,7 +443,47 @@ def test_teams_tenant_rls_is_the_alembic_head() -> None:
         if path.name != "__init__.py"
     }
     parents = {match.group(1) for match in revisions.values() if match}
-    assert "20260730_02" not in parents
+    assert "20260731_01" not in parents
+    # And exactly one head: every other revision is some revision's parent.
+    all_revisions = {
+        match.group(1)
+        for match in (re.search(r'^revision\s*=\s*"([^"]+)"', path.read_text(), re.M) for path in VERSIONS_DIR.glob("*.py"))
+        if match
+    }
+    assert all_revisions - parents == {"20260731_01"}
+
+
+def test_observation_partition_runway_migration_provisions_a_year_ahead() -> None:
+    """The migration must extend the runway, not just create 'a' partition."""
+    from agent_bom.api.hub_observations_partition import OBSERVATION_PARTITION_RUNWAY_MONTHS
+
+    sql = OBSERVATION_PARTITION_RUNWAY.read_text()
+    assert re.search(r'revision\s*=\s*"20260731_01"', sql)
+    assert re.search(r'down_revision\s*=\s*"20260730_02"', sql)
+    assert "provision_observation_partition_runway" in sql
+    # Reuses the shared helper (which forces RLS on each new child) rather than
+    # hand-rolling CREATE TABLE ... PARTITION OF without tenant isolation.
+    assert "CREATE TABLE" not in sql
+    assert OBSERVATION_PARTITION_RUNWAY_MONTHS >= 12
+    # Forward-only: dropping provisioned partitions would discard observations.
+    assert "DROP TABLE" not in sql
+    assert "DETACH PARTITION" not in sql
+
+
+def test_observation_partition_runway_migration_uses_the_psycopg_driver_connection(monkeypatch) -> None:
+    """Same psycopg ``%s`` execute contract unwrap as 20260705_01."""
+    monkeypatch.setitem(sys.modules, "alembic", SimpleNamespace(op=SimpleNamespace(get_bind=lambda: None)))
+    module = _load_module(OBSERVATION_PARTITION_RUNWAY, "abom_observation_partition_runway")
+    driver_connection = object()
+    bind = SimpleNamespace(connection=SimpleNamespace(driver_connection=driver_connection))
+    seen: list[object] = []
+
+    monkeypatch.setattr(module.op, "get_bind", lambda: bind)
+    monkeypatch.setattr(module, "provision_observation_partition_runway", lambda conn: seen.append(conn))
+
+    module.upgrade()
+
+    assert seen == [driver_connection]
 
 
 def test_graph_edge_snapshot_key_index_is_chained_and_matches_bootstrap() -> None:


### PR DESCRIPTION
> **Release blocker.** On `main` today, all current-dated compliance-hub ingest breaks
> **permanently from 2026-10-01** — not a one-month blip. Postgres deployments only, which is
> every shipped compose file and the Helm chart.

## Root cause

`20260705_01` provisioned the observations partitions as a `behind=1 / ahead=2` window **at
migration time**, leaving a head database with runway to 2026-09-30. No runtime principal can
create another child: `init.sql:1364` grants `agent_bom_app` USAGE but `:1373` revokes CREATE on
schema `public`, `agent_bom_maintenance` is equally DML-only, and the children are owned by the
migration role. So the window could never be extended, and every month after the last provisioned
one is uncovered.

## Verified live against PostgreSQL 16.14, not inferred

A throwaway cluster built from `init.sql` + `alembic upgrade head` reproduced the exact head state
(4 partitions, `2026m06`–`2026m09`) and then:

```
ensure_observation_partition_for(conn, "2026-10-15T00:00:00Z", now=2026-10-01)
  -> psycopg.errors.InsufficientPrivilege: permission denied for schema public
     ... as BOTH agent_bom_app AND agent_bom_maintenance
     has_schema_privilege(...,'CREATE') = f | f ; children owned by postgres

run_hub_observations_retention()
  -> returned 0, partitions unchanged, single [DEBUG] "hub observations retention skipped"
```

### A larger finding than the brief anticipated

**The retention tick was already inert on every shipped deployment — not merely after the cliff.**
Re-applying child RLS calls `_ensure_rls_helpers` → `CREATE OR REPLACE FUNCTION public.abom_*`,
which also needs schema CREATE. So `rollover_observation_partitions` never ran either. Retention
has been entirely non-functional, silently, for the same reason. Same root cause, same fix.

## The fix

- `alembic/versions/20260731_01_observation_partition_runway.py` — provisions **12 months ahead**.
- `hub_observations_partition.py:226` `provision_observation_partition_runway` (`months_behind=0`,
  so a top-up can never resurrect a month retention deliberately dropped), plus `:243`
  `observation_runway_end` and `:254` `observation_runway_months_remaining`.
- `compose_migrate.py:41` `top_up_observation_partition_runway`, invoked from `alembic/env.py:84`
  **after** `context.run_migrations()` — this is what makes the runway self-topping on every
  deploy rather than fixed once by a migration that has already run.
- Every new child gets `ENABLE`/`FORCE ROW LEVEL SECURITY` plus the tenant policy. Children do not
  inherit these, and provisioning 12 months without them would have reopened the cross-tenant hole
  `20260729_03` just closed.

## Runtime story: migration-only, loud and early

Granting the maintenance role CREATE on `public` was rejected deliberately: that role already holds
`agent_bom_rls_maintenance` (RLS bypass), so it would gain arbitrary object creation in `public`;
and children it created would be owned by it, outside the migration owner's
`ALTER DEFAULT PRIVILEGES`, so `agent_bom_app`'s grants would not follow. `agent_bom_app` is
untouched.

**Deliberate deviation from the brief, called out rather than buried.** The instruction was to log
the swallowed failure at ERROR. Severity now follows *urgency* instead: the denied top-up is the
expected steady state under this role model, so it logs **WARNING** while the runway is healthy and
escalates to **ERROR** below 3 months or once lapsed, throttled hourly. Reporting an expected
denial at ERROR every 60 seconds forever is how alerts get filtered — which would recreate exactly
the invisibility this fixes. It is never silent and never DEBUG. Both paths verified live:

```
healthy    -> [WARNING] ...runway ends 2027-07-31 (12 month(s) left)...
near cliff -> [ERROR]   ...runway ends 2026-09-30 (2 month(s) left)... + InsufficientPrivilege
```

## Before / after (live)

| | Before | After |
|---|---|---|
| Partitions | 4 | 14 |
| Runway ends | 2026-09-30 (62 days) | 2027-07-31 (366 days) |

Adversarial check on the new children: inserted a `2026-10-15` observation as `agent_bom_app`;
tenant-b's direct read of `..._y2026m10` returns 0 while tenant-a returns 1, and a cross-tenant
write is refused by the child's `WITH CHECK`. `compose_migrate.py` was also run end-to-end against
a deliberately lapsed database — restored 14 children, all FORCE RLS, with zero pending revisions.

## Guards

`tests/test_hub_observations_partition_runway.py` (16) — runway ≥365 days past a **frozen** today
(time-dependent, so the clock is pinned rather than trusted); no month gaps across four
year-boundary clocks; idempotent top-up; every new child routed through RLS; ERROR names the runway
end and carries the exception; WARNING-not-ERROR when healthy; no alert on a legacy unpartitioned
table.

`tests/test_hub_observations_runway_live.py` (3, gated on `AGENT_BOM_POSTGRES_ADMIN_URL`) — a real
`upgrade head` leaves ≥365 days; **every** child carries `relrowsecurity` + `relforcerowsecurity` +
policy; re-running `upgrade head` with zero pending revisions restores a lapsed runway.

## Verification

**356 passed, 7 skipped** across partition/hub/migration/schema-authority/RLS/deploy suites · 4
live-Postgres tests pass · `ruff check src tests` clean · `mypy` no new errors (`compose_migrate.py`
union-attr is pre-existing, confirmed on HEAD) · `check_package_layout`, `export_openapi --check`,
`generate_v1_schemas --check`, `generate_env_var_reference --check` all OK. Rebased onto current
`main` and re-run after; migration chain has a single head.

## Follow-ups, not fixed here

- `routes/scan.py:2748` still surfaces an uncaught `InsufficientPrivilege` as HTTP 500. With the
  runway fixed that path should not trigger, and a blanket privilege→4xx mapping risks masking
  unrelated failures.
- The runway signal lives in the retention tick's log rather than on the readiness endpoint. A
  health-route contract would turn it into a monitorable metric.

**Why CI could never have caught this:** partitions are always fresh immediately after migration,
so the window is never stale during a test run. The new frozen-clock test is what closes that gap.
