### PR TITLE
docs: correct the PCI coverage claim and record what shipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,97 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+Behaviour changes staged for the next release move numbers you may already be reporting.
+Read "Changed" before upgrading.
+
+### Breaking
+
+- The compliance evidence bundle's canonical signing form changed: the
+  `signature` key is now embedded in the document body and excluded from the
+  hash. External verifiers must drop that key before hashing. Bundles archived
+  before this release remain distinguishable by the field's absence.
+- `summary.attack_pass`, `summary.attack_warn` and `summary.attack_fail` are
+  removed, replaced by `attack_applicable` and `attack_not_applicable`. MITRE
+  ATT&CK is now an applicability overlay and no longer contributes to any score.
+- `observed_at` is required on `POST /v1/cloud/runtime-evidence/ingest`.
+  Collectors that omitted it now receive a 422.
+
+### Fixed — evidence the product detected but did not report
+
+- A scanned estate with nothing gradeable reported a compliance score of 100
+  across six surfaces — the REST aggregate, per-framework routes, the MCP tool,
+  the HTML report handed to auditors, the evidence bundle, and the Overview
+  landing page. The score is now derived from the status through one shared
+  scorer, so the two can no longer disagree.
+- Detective controls (RA-5, CM-8, ID.RA-01, ID.RA-02, DE.CM-09, CIS-02.1/07.1/07.5)
+  were failed by the very scan that evidences them. They now pass on fresh
+  evidence and fail on stale. RA-7 and IR-5, which a scanner cannot observe, are
+  reported as not evaluated rather than failed.
+- Undateable and future-dated scan evidence scored as fresh; both now fail closed.
+- Malicious model artifacts were shown in the console but never became findings,
+  so every CI gate passed a pickle implant. They are now `MALICIOUS_MODEL`
+  findings and gate correctly.
+- Prompt-injection audits of instruction-only files were skipped unless the file
+  also referenced a package, so `agent-bom scan .` missed a malicious `CLAUDE.md`.
+- A degraded scan reported `coverage_warnings: []` and exited 0. Warnings now
+  reach the written report, and a partial scan exits non-zero.
+- CISA KEV, EPSS and `kev_due_date` enrichment reached the report; an unavailable
+  KEV feed no longer reads as "not exploited".
+
+### Fixed — accuracy
+
+- Version ranges now fail closed when a bound cannot be compared. Maven
+  qualifier ordering (`.RELEASE`, `.GA`, `SNAPSHOT`) and all three Go
+  pseudo-version forms are implemented, and the GHSA path evaluates the
+  advisory's lower bound rather than only its fix version.
+- Reachability no longer claims function-level reach from a bare class token.
+- The posture grade is withheld when vulnerability coverage is incomplete,
+  instead of grading an unscanned estate an A.
+- Conflicting advisory severities resolve upward rather than by sort order.
+
+### Fixed — graph
+
+- Roll-ups, drill-downs and every derived view inherit the snapshot's truncation
+  instead of reporting a bounded result as complete.
+- Credential identity is scoped per server; a shared environment-variable *name*
+  no longer fabricates lateral-movement edges between unrelated agents.
+- Bottleneck rankings are sampled deterministically and declare their sample,
+  rather than presenting the first 50 nodes in insertion order as fact.
+- Postgres edge reconciliation is bounded, so a second scan no longer fails to
+  persist and silently freeze the graph.
+
+### Fixed — control plane and tenancy
+
+- Row-level security is forced on the `teams` table and on auto-created monthly
+  partition children, closing a cross-tenant read and delete path.
+- HTTP- and scheduler-triggered scans run bound to the job's tenant.
+- Compliance-hub observation partitions are provisioned a year ahead and topped
+  up on every deploy. The previous three-month window could not be extended at
+  runtime and would have broken all current-dated hub ingest permanently.
+- Malformed requests return a 4xx envelope instead of a bare 500, and validation
+  errors no longer reflect the submitted body.
+- An unreadable or non-UTF8 manifest degrades with a named coverage warning
+  instead of aborting the scan with no artifact.
+- `HTTP(S)_PROXY` is honoured; it was silently ignored, so pinned egress was not
+  actually pinned.
+- SIEM delivery rides the hardened delivery client: credentials are redacted,
+  URLs validated, and failures retried into a dead-letter queue.
+
+### Changed
+
+- Compliance scores can now move off zero, because controls the scan actually
+  evidenced can pass. An unchanged estate may therefore report a different
+  number than it did on 0.98.2.
+- Detective-control evidence older than 90 days fails
+  (`AGENT_BOM_COMPLIANCE_DETECTIVE_EVIDENCE_MAX_AGE_DAYS`).
+- Scope-filtered and free-text findings queries are bounded and report
+  `scope_completeness` when partial, rather than walking the whole tenant.
+- Read concurrency scales with the worker pool instead of a fixed limit of 8.
+- The PCI DSS coverage table now reports 12 *sub-requirements* across
+  requirements 2, 6, 8, 11 and 12. It previously read "12 requirements / 12",
+  which implied complete PCI coverage.
+
+
 ## [0.98.2] - 2026-07-27
 
 ### Changed

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -420,7 +420,7 @@ agent-bom ships a curated control set per framework, sized to the AI/MCP/agent t
 | Regulatory | SOC 2 TSC | 9 criteria | ~64 | Common Criteria 6.x / 7.x / 8.x / 9.x (access, monitoring, change mgmt, vendor risk) |
 | Regulatory | CIS Controls v8 | 10 safeguards | 153 | Software inventory, vulnerability mgmt, secure-dev (CIS 02 / 07 / 16) |
 | Regulatory | CMMC 2.0 Level 2 | 17 practices | 110 | RA / SI / SC / CM / AC / IA practices most relevant to vulnerable-package risk |
-| Regulatory | PCI DSS v4.0 | 12 requirements | 12 | Requirements 2/3/4/5/6/7/8/10/11/12 for vulnerable-package and evidence risk |
+| Regulatory | PCI DSS v4.0 | 12 sub-requirements | 12 top-level requirements | Requirements 2, 6, 8, 11, 12 for vulnerable-package and evidence risk |
 <!-- compliance-coverage:end -->
 
 The bundled list is editable: see `src/agent_bom/compliance_coverage.py` for the framework metadata and `src/agent_bom/compliance_utils.py` for the `BlastRadius` field map. The UI consumes the same API response shape, so product coverage and dashboard controls should stay aligned with these catalogs.

--- a/src/agent_bom/compliance_coverage.py
+++ b/src/agent_bom/compliance_coverage.py
@@ -284,9 +284,13 @@ TAG_MAPPED_FRAMEWORKS: tuple[ComplianceFrameworkMetadata, ...] = (
         tag_field="pci_dss_tags",
         catalog=PCI_DSS_REQUIREMENTS,
         report_label="PCI DSS",
-        bundled_unit="requirements",
-        source_standard_size="12",
-        coverage="Requirements 2/3/4/5/6/7/8/10/11/12 for vulnerable-package and evidence risk",
+        # The bundled IDs are sub-requirements (6.2.4, 11.3.1, …), not the 12
+        # top-level requirements. Labelling them "12 requirements" against a
+        # source size of "12" read as complete PCI coverage, which it is not:
+        # they touch requirements 2, 6, 8, 11 and 12 only.
+        bundled_unit="sub-requirements",
+        source_standard_size="12 top-level requirements",
+        coverage="Requirements 2, 6, 8, 11, 12 for vulnerable-package and evidence risk",
     ),
 )
 


### PR DESCRIPTION
## The claim

`docs/ARCHITECTURE.md` advertised:

```
| Regulatory | PCI DSS v4.0 | 12 requirements | 12 | Requirements 2/3/4/5/6/7/8/10/11/12 ... |
```

Twelve bundled "requirements" against a source-standard size of twelve reads as **complete PCI
DSS coverage**. It is not. The bundled IDs are *sub*-requirements:

```
11.3.1  11.3.2  12.3.1  12.3.4  2.2.1  2.2.7  6.2.4  6.3.1  6.3.2  6.3.3  8.3.6  8.6.1
```

Top-level requirements actually touched: **2, 6, 8, 11, 12** — five, not the ten the row listed.
Requirements **1, 3, 4, 5, 7, 9 and 10 carry no controls at all**, including the cardholder-data
protection (3), encryption-in-transit (4) and logging (10) requirements a PCI assessor asks about
first.

The row now reads:

```
| Regulatory | PCI DSS v4.0 | 12 sub-requirements | 12 top-level requirements | Requirements 2, 6, 8, 11, 12 ... |
```

Generated from `compliance_coverage.py` and regenerated into `ARCHITECTURE.md` through the existing
drift gate, so the doc and the code cannot diverge.

## CHANGELOG

`## [Unreleased]` was empty after **52 commits**, including seven P0 fixes, ten migrations and
three contract changes an external consumer would otherwise hit silently. Those three lead the
entry:

- the compliance evidence bundle's **canonical signing form** changed — verifiers must drop the
  `signature` key before hashing
- `summary.attack_pass` / `_warn` / `_fail` were **removed**, replaced by `attack_applicable` /
  `attack_not_applicable`
- `observed_at` is now **required** on `POST /v1/cloud/runtime-evidence/ingest` — collectors that
  omit it get a 422

It also states plainly, under Changed, that compliance scores can now move off zero and that an
unchanged estate may report a different number than it did on 0.98.2. That is the single most
likely support question this release will generate.

## Deliberately *not* in this PR: the version bump

I prepared the bump to `0.99.0` and backed it out. `scripts/check_release_consistency.py` correctly
refused it:

```
ERROR: docs/images/dashboard-live.png manifest visible_version is stale: '0.98.2' != 0.99.0
```

`docs/images/product-screenshots.json` pins **21 screenshots**, each with a `visible_version` and a
`sha256` of the PNG. Those images visibly render `0.98.2` in the dashboard chrome. Bumping the
manifest without retaking them would make it assert something false — which is precisely the class
of defect this release is fixing everywhere else.

**Retaking them needs the Playwright capture harness against a built dashboard**, and `npm run
build` is currently unrunnable here (its standalone step exhausted the disk earlier). So the bump
is a separate, deliberate release step: recapture the 21 screenshots, then
`bump-version.py 0.99.0`, then move this Unreleased block under a dated heading.

`0.99.0` rather than `0.98.3` because behaviour changed: compliance scores move, detective controls
flipped polarity, a degraded scan now exits non-zero, and three response contracts changed.

## Verification

`check_release_consistency.py` passed · `check_version_alignment.py` OK at 0.98.2 ·
`generate_compliance_coverage_table.py --check` exit 0 · `tests/test_compliance_coverage.py`
5 passed · `ruff check src tests` clean.
