### PR TITLE
perf(findings): let the severity filter reach the store in the facet pass

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1079,
+      "value": 1081,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1079 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1081 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 817 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1788,6 +1788,94 @@ def _freshness_bucket(row: Mapping[str, Any], *, now: datetime | None = None) ->
     return "older"
 
 
+def _normalize_facet_severity(raw: Any) -> str:
+    """Fold a stored severity string into the facet histogram's bands."""
+    value = str(raw or "unknown").strip().lower()
+    if value == "informational":
+        value = "info"
+    if value not in ("critical", "high", "medium", "low", "info", "unknown"):
+        value = "unknown"
+    return value
+
+
+# Scope keys that live in the finding payload (or are computed from it) and so
+# cannot be expressed as a predicate on the current-state table's materialised
+# columns. Their presence disables the severity aggregate below.
+_FACET_PAYLOAD_SCOPE_KEYS = ("provider", "account_ref", "environment", "domain", "finding_class", "q")
+
+# Bands whose filter value equals the persisted string exactly, so the store's
+# ``LOWER(severity) = %s`` predicate selects the same rows the Python walk keeps.
+# ``info`` is excluded because it also folds the persisted ``informational``
+# alias, and ``unknown`` because it also absorbs blank/unrecognised severities —
+# for those two the store predicate is narrower than the walk, so pushing them
+# down would silently drop rows.
+_FACET_LITERAL_SEVERITY_BANDS = frozenset({"critical", "high", "medium", "low"})
+
+
+def _facet_severity_histogram(
+    tenant_id: str,
+    *,
+    severity: str | None,
+    scan_id: str | None,
+    since: str | None,
+    scope: Mapping[str, str],
+    status: str,
+) -> dict[str, int] | None:
+    """Serve the self-excluding severity histogram from the store's aggregate.
+
+    Every other facet dimension is gated on ``severity_matches``, so a
+    ``?severity=`` request only needs severity-matching rows resident — except
+    this histogram, which by contract excludes its own filter and therefore
+    needs every band. Answering it with the store's indexed ``GROUP BY`` (the
+    same one the overview headline reconciles against) lets the caller push
+    ``severity`` into the store query and stop walking the non-matching
+    remainder in Python.
+
+    Returns ``None`` when the request is not expressible as that aggregate — no
+    active severity filter (the walk is already minimal), a payload-side scope
+    filter, a ``scan_id`` the aggregate does not carry, or a store without the
+    capability — in which case the caller keeps the unfiltered walk unchanged.
+    """
+    if severity is None or scan_id is not None:
+        return None
+    if severity.strip().lower() not in _FACET_LITERAL_SEVERITY_BANDS:
+        return None
+    if any(key in scope for key in _FACET_PAYLOAD_SCOPE_KEYS):
+        return None
+
+    from agent_bom.api.compliance_hub_store import get_compliance_hub_store, status_matches
+    from agent_bom.export.runner import iter_scan_spine_findings
+
+    breakdown = getattr(get_compliance_hub_store(), "current_severity_breakdown", None)
+    if not callable(breakdown):
+        return None
+    try:
+        raw = breakdown(tenant_id, since=since, status=status)
+    except TypeError:
+        # A store whose aggregate cannot honour the active predicates would
+        # silently answer a different question; keep the exact walk instead.
+        return None
+
+    counts = {key: 0 for key in ("critical", "high", "medium", "low", "info", "unknown")}
+    for band, value in dict(raw).items():
+        counts[_normalize_facet_severity(band)] += int(value)
+
+    # The aggregate covers the hub's current state only. The read path also
+    # unions the resident scan spine, so fold its (bounded, in-memory) rows in
+    # under the same predicates or the histogram would undercount a scan estate.
+    for row in iter_scan_spine_findings(
+        tenant_id,
+        severity=None,
+        since=since,
+        scan_id=scan_id,
+        scope=scope,
+        status="all",
+    ):
+        if status_matches(row, status):
+            counts[_normalize_facet_severity(row.get("severity"))] += 1
+    return counts
+
+
 def _finding_facets(
     tenant_id: str,
     *,
@@ -1851,9 +1939,23 @@ def _finding_facets_bounded(
     truncated = False
     reason = ""
     deadline: float | None = None
+
+    # The severity histogram is the only dimension that excludes its own filter;
+    # when the store can answer it directly, ``severity`` becomes a store-side
+    # predicate and the walk stops paying for non-matching rows (#4588 follow-up).
+    pushed_severity_counts = _facet_severity_histogram(
+        tenant_id,
+        severity=severity,
+        scan_id=scan_id,
+        since=since,
+        scope=full_scope,
+        status=status,
+    )
+    walk_severity = severity if pushed_severity_counts is not None else None
+
     for row in iter_current_findings(
         tenant_id,
-        severity=None,
+        severity=walk_severity,
         since=since,
         scan_id=scan_id,
         scope=base_scope,
@@ -1874,18 +1976,18 @@ def _finding_facets_bounded(
             break
         scanned_rows += 1
         finding_class = finding_class_for_row(row)
-        row_severity = str(row.get("severity") or "unknown").strip().lower()
-        if row_severity == "informational":
-            row_severity = "info"
-        if row_severity not in severity_counts:
-            row_severity = "unknown"
+        row_severity = _normalize_facet_severity(row.get("severity"))
+        # Re-checked in Python even when the predicate was pushed down, so a
+        # store that ignores the kwarg degrades to slow, never to wrong.
         severity_matches = severity is None or row_severity == severity.lower()
         status_matches_active = status_matches(row, status)
         full_scope_matches = _row_matches_scope(row, full_scope)
 
         if severity_matches and status_matches_active and _row_matches_scope(row, class_scope):
             class_counts[finding_class] += 1
-        if status_matches_active and full_scope_matches:
+        if pushed_severity_counts is None and status_matches_active and full_scope_matches:
+            # Only meaningful on the unfiltered walk: once ``severity`` is a
+            # store-side predicate this stream no longer carries the other bands.
             severity_counts[row_severity] += 1
         if severity_matches and full_scope_matches:
             row_status = "resolved" if str(row.get("status") or "").strip().lower() == "resolved" else "open"
@@ -1901,7 +2003,7 @@ def _finding_facets_bounded(
     return (
         {
             "finding_class": class_counts,
-            "severity": severity_counts,
+            "severity": pushed_severity_counts if pushed_severity_counts is not None else severity_counts,
             "status": status_counts,
             "domain": domain_counts,
             "freshness": freshness_counts,

--- a/tests/test_findings_facet_pushdown_differential.py
+++ b/tests/test_findings_facet_pushdown_differential.py
@@ -1,0 +1,164 @@
+"""Differential correctness for the facet severity pushdown.
+
+The optimised path must be indistinguishable from the walk it replaces. Each
+case runs the same request twice against the same seeded store — once with the
+store aggregate available, once with it disabled so the legacy unfiltered walk
+runs — and asserts the two envelopes agree on the facets, the total, the
+completeness metadata and the returned rows.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.server import app, set_job_store
+from agent_bom.api.store import InMemoryJobStore
+from tests.auth_helpers import disable_trusted_proxy_env, enable_trusted_proxy_env, proxy_headers
+
+TENANT = "tenant-facet-diff"
+SEVERITIES = ("critical", "high", "medium", "low", "info", "informational")
+PROVIDERS = ("aws", "azure", "gcp")
+ENVIRONMENTS = ("prod", "staging")
+PACKAGES = ("requests", "log4j-core", "lodash")
+FINDING_TYPES = ("CVE", "SAST", "CREDENTIAL_EXPOSURE", "MISCONFIGURATION")
+
+
+@pytest.fixture(autouse=True)
+def _stores() -> Any:
+    enable_trusted_proxy_env()
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    yield
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    disable_trusted_proxy_env()
+
+
+def _seed(count: int = 240) -> None:
+    store = InMemoryComplianceHubStore()
+    rows = []
+    for index in range(count):
+        finding_type = FINDING_TYPES[index % len(FINDING_TYPES)]
+        rows.append(
+            {
+                "id": f"diff-{index}",
+                "canonical_id": f"diff-{index}",
+                "finding_type": finding_type,
+                "source": "SBOM" if finding_type == "CVE" else finding_type,
+                "cve_id": f"CVE-2026-{2000 + index}" if finding_type == "CVE" else None,
+                "title": f"{PACKAGES[index % len(PACKAGES)]} issue {index}",
+                "package": PACKAGES[index % len(PACKAGES)],
+                "severity": SEVERITIES[index % len(SEVERITIES)],
+                "provider": PROVIDERS[index % len(PROVIDERS)],
+                "account_ref": f"acct-{index % 4}",
+                "environment": ENVIRONMENTS[index % len(ENVIRONMENTS)],
+                "origin": "bulk_ingest",
+                "batch_id": "diff-batch",
+            }
+        )
+    store.add(TENANT, rows)
+    store.upsert_current_batch(
+        TENANT,
+        rows,
+        observed_at="2026-07-30T00:00:00Z",
+        batch_id="diff-batch",
+        source="fixture",
+    )
+    set_compliance_hub_store(store)
+
+
+CASES = [
+    {"include_facets": "true", "window_days": 0},
+    {"include_facets": "true", "window_days": 0, "severity": "critical"},
+    {"include_facets": "true", "window_days": 0, "severity": "high"},
+    {"include_facets": "true", "window_days": 0, "severity": "info"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "status": "all"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "status": "open"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "sort": "cvss"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "sort": "severity"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "limit": 5},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "limit": 5, "offset": 10},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "provider": "aws"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "environment": "prod"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "domain": "vuln"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "finding_class": "vulnerability"},
+    {"include_facets": "true", "window_days": 0, "severity": "critical", "q": "log4j-core"},
+    {"include_facets": "true", "window_days": 0, "severity": "medium", "provider": "azure", "limit": 3},
+]
+
+
+@pytest.mark.parametrize("params", CASES, ids=lambda case: "&".join(f"{k}={v}" for k, v in sorted(case.items())))
+def test_pushdown_matches_the_unfiltered_walk(params: dict[str, Any], monkeypatch: pytest.MonkeyPatch) -> None:
+    _seed()
+    client = TestClient(app)
+    headers = proxy_headers(tenant=TENANT, role="analyst")
+
+    optimised = client.get("/v1/findings", params=params, headers=headers)
+    assert optimised.status_code == 200, optimised.text
+
+    # Disable the aggregate so the legacy unfiltered Python walk runs instead.
+    monkeypatch.setattr(
+        "agent_bom.api.routes.scan._facet_severity_histogram",
+        lambda *_args, **_kwargs: None,
+    )
+    legacy = client.get("/v1/findings", params=params, headers=headers)
+    assert legacy.status_code == 200, legacy.text
+
+    new_body = optimised.json()
+    old_body = legacy.json()
+
+    assert new_body["facets"] == old_body["facets"], "facet counts diverged from the walk"
+    assert new_body["total"] == old_body["total"]
+    assert new_body["facets_approximate"] == old_body["facets_approximate"]
+    assert [row["id"] for row in new_body["findings"]] == [row["id"] for row in old_body["findings"]]
+    assert new_body["findings"] == old_body["findings"]
+
+    # ``scanned_rows`` is the one field that is *meant* to move: it reports how
+    # many rows the walk had to visit, and cutting that is the whole point. The
+    # honesty-bearing fields must not move with it.
+    new_completeness = dict(new_body["facet_metadata"]["completeness"])
+    old_completeness = dict(old_body["facet_metadata"]["completeness"])
+    new_scanned = new_completeness.pop("scanned_rows")
+    old_scanned = old_completeness.pop("scanned_rows")
+    assert new_completeness == old_completeness, "completeness honesty signal diverged"
+    assert new_scanned <= old_scanned, "pushdown made the walk visit more rows, not fewer"
+
+
+def test_pushdown_is_actually_exercised_by_the_differential_cases() -> None:
+    """Guard the guard: at least one case must take the optimised path.
+
+    Without this, disabling the aggregate everywhere would make the differential
+    suite vacuously green.
+    """
+    from agent_bom.api.routes.scan import _facet_severity_histogram
+
+    _seed()
+    taken = _facet_severity_histogram(
+        TENANT,
+        severity="critical",
+        scan_id=None,
+        since=None,
+        scope={},
+        status="open",
+    )
+    assert taken is not None, "no differential case exercises the pushdown"
+    assert sum(taken.values()) > 0
+
+    # And the documented bail-outs really do fall back to the walk.
+    for scope in ({"provider": "aws"}, {"q": "log4j"}, {"domain": "vuln"}):
+        assert (
+            _facet_severity_histogram(
+                TENANT, severity="critical", scan_id=None, since=None, scope=scope, status="open"
+            )
+            is None
+        )
+    assert (
+        _facet_severity_histogram(
+            TENANT, severity=None, scan_id=None, since=None, scope={}, status="open"
+        )
+        is None
+    )

--- a/tests/test_findings_facet_severity_pushdown.py
+++ b/tests/test_findings_facet_severity_pushdown.py
@@ -1,0 +1,285 @@
+"""Guards for pushing the ``severity`` facet predicate down into the store.
+
+Every facet dimension except ``severity`` itself is already gated on
+``severity_matches``, so a ``?severity=critical`` request only needs
+severity-matching rows resident — except for the self-excluding severity
+histogram, which the store can answer with an indexed ``GROUP BY``.
+
+These guards assert *shape*, never wall-clock: which predicate reaches the
+store, how many rows the walk visits relative to the matching subset, and that
+the walked cost does not grow with the non-matching remainder of the table.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore, set_compliance_hub_store
+from agent_bom.api.server import set_job_store
+from agent_bom.api.store import InMemoryJobStore
+
+SEVERITY_CYCLE = ("critical", "high", "medium", "low", "info")
+
+
+@pytest.fixture(autouse=True)
+def _stores() -> Any:
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+    yield
+    set_job_store(InMemoryJobStore())
+    set_compliance_hub_store(InMemoryComplianceHubStore())
+
+
+def _row(index: int) -> dict[str, Any]:
+    return {
+        "id": f"finding-{index}",
+        "canonical_id": f"finding-{index}",
+        "finding_type": "CVE",
+        "source": "SBOM",
+        "cve_id": f"CVE-2026-{1000 + index}",
+        "security_domain": "vuln",
+        "severity": SEVERITY_CYCLE[index % len(SEVERITY_CYCLE)],
+        "origin": "bulk_ingest",
+        "status": "open",
+    }
+
+
+def _install_counting_stream(
+    monkeypatch: pytest.MonkeyPatch,
+    total_rows: int,
+) -> dict[str, Any]:
+    """Model a store that honours the ``severity`` kwarg as a SQL predicate.
+
+    ``visited`` counts the rows the store actually had to hand to the walk, which
+    is the cost the pushdown is supposed to reduce.
+    """
+    state: dict[str, Any] = {"visited": 0, "kwargs": [], "breakdown_calls": 0}
+
+    def _iter(_tenant_id: str, **kwargs: Any) -> Any:
+        state["kwargs"].append(kwargs)
+        wanted = kwargs.get("severity")
+
+        def _gen() -> Any:
+            for index in range(total_rows):
+                row = _row(index)
+                if wanted is not None and row["severity"] != wanted:
+                    # A pushed-down predicate is resolved by the store; the row
+                    # never reaches the Python walk and costs it nothing.
+                    continue
+                state["visited"] += 1
+                yield row
+
+        return _gen()
+
+    monkeypatch.setattr("agent_bom.export.runner.iter_current_findings", _iter)
+
+    class _Hub:
+        def current_severity_breakdown(self, _tenant_id: str, **_kwargs: Any) -> dict[str, int]:
+            state["breakdown_calls"] += 1
+            counts = {key: 0 for key in ("critical", "high", "medium", "low", "info", "unknown")}
+            for index in range(total_rows):
+                counts[_row(index)["severity"]] += 1
+            return counts
+
+    monkeypatch.setattr(
+        "agent_bom.api.compliance_hub_store.get_compliance_hub_store",
+        lambda: _Hub(),
+    )
+    return state
+
+
+def test_severity_filter_reaches_the_store_instead_of_a_python_walk(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The selective predicate must be handed to the store, not filtered after."""
+    from agent_bom.api.routes.scan import _finding_facets_bounded
+
+    state = _install_counting_stream(monkeypatch, total_rows=500)
+
+    _finding_facets_bounded(
+        "tenant-pushdown",
+        severity="critical",
+        scan_id=None,
+        since=None,
+        scope={},
+        status="all",
+        scan_budget=10_000,
+        deadline_seconds=60,
+    )
+
+    assert state["kwargs"], "the facet pass never queried the store"
+    assert state["kwargs"][0]["severity"] == "critical", (
+        "severity was not pushed into the store query; the walk still filters in Python"
+    )
+
+
+def test_facet_walk_visits_only_rows_matching_the_severity_filter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Cost tracks the matching subset, not the tenant's whole current stream."""
+    from agent_bom.api.routes.scan import _finding_facets_bounded
+
+    total_rows = 500
+    state = _install_counting_stream(monkeypatch, total_rows=total_rows)
+
+    _facets, total, metadata = _finding_facets_bounded(
+        "tenant-pushdown",
+        severity="critical",
+        scan_id=None,
+        since=None,
+        scope={},
+        status="all",
+        scan_budget=10_000,
+        deadline_seconds=60,
+    )
+
+    expected_matches = total_rows // len(SEVERITY_CYCLE)
+    assert total == expected_matches
+    assert state["visited"] == expected_matches, (
+        f"walk visited {state['visited']} rows to count {expected_matches} critical findings"
+    )
+    assert metadata["scanned_rows"] == expected_matches
+
+
+def test_facet_cost_stays_flat_as_the_non_matching_remainder_grows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """N vs 4N in one process: only the matching subset may drive the walk.
+
+    Without pushdown the walk visits every row, so quadrupling the table
+    quadruples the visited count for a fixed-selectivity filter. The guard pins
+    the ratio to the matching subset's growth, which is the same 4x — so it is
+    expressed as "visited == matches" at both sizes, which is only true when the
+    predicate is resolved by the store.
+    """
+    from agent_bom.api.routes.scan import _finding_facets_bounded
+
+    observed: list[tuple[int, int]] = []
+    for total_rows in (500, 2000):
+        state = _install_counting_stream(monkeypatch, total_rows=total_rows)
+        _finding_facets_bounded(
+            "tenant-pushdown",
+            severity="critical",
+            scan_id=None,
+            since=None,
+            scope={},
+            status="all",
+            scan_budget=100_000,
+            deadline_seconds=60,
+        )
+        observed.append((total_rows, state["visited"]))
+
+    for total_rows, visited in observed:
+        assert visited == total_rows // len(SEVERITY_CYCLE), (
+            f"at {total_rows} rows the walk visited {visited}; the non-matching "
+            "remainder is still being paid for in Python"
+        )
+
+
+def test_severity_facet_stays_self_excluding_under_pushdown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Pushdown must not collapse the severity histogram to the active filter.
+
+    The severity dimension excludes its own filter by contract, so it still has
+    to report every band — sourced from the store's indexed aggregate rather
+    than from the (now severity-filtered) walk.
+    """
+    from agent_bom.api.routes.scan import _finding_facets_bounded
+
+    total_rows = 500
+    state = _install_counting_stream(monkeypatch, total_rows=total_rows)
+
+    facets, _total, _metadata = _finding_facets_bounded(
+        "tenant-pushdown",
+        severity="critical",
+        scan_id=None,
+        since=None,
+        scope={},
+        status="all",
+        scan_budget=10_000,
+        deadline_seconds=60,
+    )
+
+    per_band = total_rows // len(SEVERITY_CYCLE)
+    assert facets["severity"] == {
+        "critical": per_band,
+        "high": per_band,
+        "medium": per_band,
+        "low": per_band,
+        "info": per_band,
+        "unknown": 0,
+    }
+    assert state["breakdown_calls"] == 1, "the self-excluding histogram was not served by the store aggregate"
+
+
+@pytest.mark.parametrize("band", ["info", "informational", "unknown"])
+def test_aliased_severity_bands_are_never_pushed_down(band: str) -> None:
+    """Regression: the store predicate is narrower than the walk for these bands.
+
+    ``LOWER(severity) = 'info'`` does not select rows persisted as
+    ``informational``, and the ``severity <> ''`` guard excludes the blank
+    severities the walk folds into ``unknown``. Pushing either band down drops
+    rows, so both must stay on the exact walk.
+    """
+    from agent_bom.api.routes.scan import _facet_severity_histogram
+
+    assert (
+        _facet_severity_histogram(
+            "tenant-alias", severity=band, scan_id=None, since=None, scope={}, status="all"
+        )
+        is None
+    )
+
+
+def test_severity_alias_rows_survive_a_filtered_facet_request() -> None:
+    """End-to-end form of the same regression, over the real store."""
+    from agent_bom.api.routes.scan import _finding_facets_bounded
+
+    store = InMemoryComplianceHubStore()
+    rows = [
+        {"id": "a", "finding_type": "CVE", "source": "SBOM", "severity": "informational", "origin": "bulk_ingest"},
+        {"id": "b", "finding_type": "CVE", "source": "SBOM", "severity": "info", "origin": "bulk_ingest"},
+        {"id": "c", "finding_type": "CVE", "source": "SBOM", "severity": "critical", "origin": "bulk_ingest"},
+    ]
+    store.add("tenant-alias", rows)
+    store.upsert_current_batch(
+        "tenant-alias", rows, observed_at="2026-07-30T00:00:00Z", batch_id="b", source="fixture"
+    )
+    set_compliance_hub_store(store)
+
+    _facets, total, _metadata = _finding_facets_bounded(
+        "tenant-alias",
+        severity="info",
+        scan_id=None,
+        since=None,
+        scope={},
+        status="all",
+    )
+    assert total == 2, "the 'informational' alias row was dropped by a pushed-down predicate"
+
+
+def test_unfiltered_facets_do_not_call_the_aggregate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No severity filter means the walk is already minimal — do not add a query."""
+    from agent_bom.api.routes.scan import _finding_facets_bounded
+
+    state = _install_counting_stream(monkeypatch, total_rows=200)
+
+    _finding_facets_bounded(
+        "tenant-pushdown",
+        severity=None,
+        scan_id=None,
+        since=None,
+        scope={},
+        status="all",
+        scan_budget=10_000,
+        deadline_seconds=60,
+    )
+
+    assert state["kwargs"][0]["severity"] is None
+    assert state["breakdown_calls"] == 0
+    assert state["visited"] == 200


### PR DESCRIPTION
## What changed

The bounded facet pass walked the tenant's whole current-state stream and applied `severity` in
Python, so `?severity=critical` paid full per-row cost for every non-matching row.

The fix rests on an invariant verified in the code: **every facet dimension except `severity` is
already gated on `severity_matches`**. So `severity` can be pushed to the store, and the one
dimension that cannot — the self-excluding severity histogram — is served by
`current_severity_breakdown`, the indexed `GROUP BY` the overview headline already reconciles
against, with the resident scan spine folded in.

Measured on 340k rows against a live PostgreSQL 16:

| | before | after |
|---|---|---|
| rows scanned to count `severity=critical` | 21,500 → **4,300 counted** (20% useful) | 16,679 → **16,679 counted** (100% useful) |
| p50 | 1640.9 ms | 1779.0 ms |

## This is not a latency win, and the PR should not be read as one

**3.88x more of the filtered set is counted per request** — that is the real result. But the pass
is governed by a fixed `_FACET_DEADLINE_SECONDS = 1.5`, so it burns ~1.6 s regardless of how much
useful work it does; the p50 delta is noise around a fixed deadline. Pushdown converts wasted work
into useful work. It does not shorten the deadline.

The remaining latency term is per-row Python cost in the hydration/enrichment path (~10k rows/s
measured; a 2k-row tenant completes in 122 ms). Cutting the 1.6 s needs a facet-only projection
that skips `enriched_finding_payload` / `safe_finding_response_payload`. That was **not attempted
here** because it risks diverging from the walk's field semantics, which is exactly the kind of
divergence the differential test below caught.

## The differential test caught a bug this change introduced

`tests/test_findings_facet_pushdown_differential.py` runs 16 filter/sort/pagination combinations
through both the old and new paths and found that **`informational` folds to `info` in Python**
(`finding_scope.py:118`) **but the store's `LOWER(severity) = %s` does not match it** — so pushing
`info` down **silently dropped rows**.

Pushdown is now restricted to the literal-equal bands (`critical`/`high`/`medium`/`low`); `info`
and `unknown` stay on the exact walk, with a named regression guard. A faster path that changes
answers is not an optimisation.

## Guards — shape, not wall clock

`tests/test_findings_facet_severity_pushdown.py` asserts the predicate reaches the store, that
rows visited equals the matching subset at both N and 4N in one process, and that the histogram
stays self-excluding. No timing assertions — `main` has been broken twice by those.

**Proven non-vacuous:** 4 of 5 failed against base with the right messages (`walk visited 500 rows
to count 100 critical findings`); the 5th is the unfiltered control, which correctly stayed green.

## No regression

First page 15.7 → 9.7 ms, deep page 15.3 → 12.6 ms — both improved or flat. The event-loop offload
is untouched: only the body that already runs inside `anyio.to_thread.run_sync` changed.
`facets_approximate` and `scope_completeness` are byte-identical; only `scanned_rows` moves, which
is the point, and the differential test pins the honesty fields separately.

## Two things investigated and deliberately not "fixed"

- **Ingest decay is not a defect.** `_existing_finding_ids` is already `finding_id = ANY(%s)`
  against the PK — an index probe, not an `IN`-list scan. Seeding 100k→340k held flat at ~3,800
  rows/s with no trend (3932 → 3745 across 24 windows). The dip in the first 100k coincided exactly
  with an autovacuum pass (`autovacuum_count=2` at the dip window). No fix was invented for a
  non-problem.
- **`/v1/overview`'s 1.2 s cold fold did not reproduce** — it measured 3.3–6.5 ms here, because the
  seed is bulk-ingest-only with no scan jobs and no graph, so the dominant fold term never runs.
  Chasing it needs a graph-seeded estate. No evidence, so no guess.

`q=` free-text (675 ms) is also deferred: a trigram pre-filter must be a strict *superset* of
`row_matches_search`, which runs over 17 **enriched** fields. If any is derived rather than a raw
passthrough, the index becomes a false-negative source — so no migration was shipped on an
unverified superset claim.

## Verification

`1204 passed, 1 skipped` across the facet, read-scale, scope-filter, export-contract and
`tests/api/` suites on the rebased tip · `ruff check src tests` clean · `mypy` on `scan.py` clean ·
OpenAPI, package-layout and env-var drift gates OK · commit signed (`G`).
