### PR TITLE
fix(scan): scan the whole archive, promote every model flag, run the IaC rules

### DIFF
--- a/src/agent_bom/cli/agents/_discovery.py
+++ b/src/agent_bom/cli/agents/_discovery.py
@@ -406,6 +406,14 @@ def run_local_discovery(
             con.print(f"\n[bold blue]Auto-detected lockfiles in {cwd}[/bold blue]")
 
     if not iac_paths and not inventory and (not no_discover and not skill_only and not images and not image_tars and not sbom_file):
+        # Fallback for a bare ``agent-bom scan`` with no ``--project``: the scan
+        # root is the ambient cwd, which may be an arbitrarily large tree (a
+        # home directory), so detection stays a cheap top-level glob here.
+        #
+        # When the operator NAMES a root with ``--project``/``--repo``, the
+        # recursive detector in ``expand_project_scan_targets`` has already
+        # filled ``iac_paths`` with that root, so nested IaC under infra/,
+        # deploy/ or charts/ is covered there.
         cwd = Path(project) if project else Path.cwd()
         _auto_iac: list[str] = []
         for name in ["Dockerfile", "docker-compose.yml", "docker-compose.yaml"]:

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -1019,6 +1019,7 @@ def scan(
             gha_path=gha_path,
             agent_projects=agent_projects,
             ai_inventory_paths=ai_inventory_paths,
+            iac_paths=iac_paths,
         )
         if auto_targets.auto_enabled:
             jupyter_dirs = auto_targets.jupyter_dirs
@@ -1028,6 +1029,7 @@ def scan(
             gha_path = auto_targets.gha_path
             agent_projects = auto_targets.agent_projects
             ai_inventory_paths = auto_targets.ai_inventory_paths
+            iac_paths = auto_targets.iac_paths
             if not quiet:
                 con.print(f"[dim]Auto-detected project scan surfaces: {', '.join(auto_targets.auto_enabled)}[/dim]")
 
@@ -1849,6 +1851,11 @@ def scan(
         _scan_sources.append("filesystem")
     if tf_dirs:
         _scan_sources.append("terraform")
+    # ``iac`` is claimed only when the misconfiguration rules actually executed
+    # — ``ctx.iac_findings_data`` is set by the IaC step itself, so the source
+    # list can never advertise a scan that was skipped.
+    if ctx.iac_findings_data is not None:
+        _scan_sources.append("iac")
     if gha_path:
         _scan_sources.append("github_actions")
     if ctx.skill_audit_data is not None:
@@ -2322,7 +2329,9 @@ def scan(
             report.model_files.extend(mf_results)
             _existing_finding_ids = {finding.id for finding in report.findings}
             report.findings.extend(
-                finding for finding in model_file_findings(mf_results) if finding.id not in _existing_finding_ids
+                finding
+                for finding in model_file_findings(mf_results, require_model_signatures=require_model_signatures)
+                if finding.id not in _existing_finding_ids
             )
             report.model_manifests.extend(manifest_results)
             for w in mf_warnings:

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -56,6 +56,7 @@ class FindingType(str, Enum):
     COMBINATION = "COMBINATION"  # Toxic combination — multiple signals chained into one exploitable path
     MALICIOUS_PACKAGE = "MALICIOUS_PACKAGE"  # Known-malicious / typosquat package with no CVE row
     MALICIOUS_MODEL = "MALICIOUS_MODEL"  # Content-confirmed executable payload in a model artifact
+    MODEL_INTEGRITY = "MODEL_INTEGRITY"  # Model artifact provenance/integrity gap (tampered, unsigned, unscanned)
     CIEM_OVER_PRIVILEGE = "CIEM_OVER_PRIVILEGE"  # Cloud identity granted permissions it never uses (right-sizing)
     SENSITIVE_DATA = "SENSITIVE_DATA"  # Content-confirmed sensitive data at rest (DSPM object/database sampling)
 

--- a/src/agent_bom/framework_mapping.py
+++ b/src/agent_bom/framework_mapping.py
@@ -335,6 +335,7 @@ _FINDING_TYPE_ADDITIONS: dict[FindingType, tuple[str, ...]] = {
     FindingType.INJECTION: _AI_FRAMEWORKS,
     FindingType.EXFILTRATION: _AI_FRAMEWORKS + (FRAMEWORK_SOC2,),
     FindingType.MALICIOUS_MODEL: _AI_FRAMEWORKS,
+    FindingType.MODEL_INTEGRITY: _AI_FRAMEWORKS,
     FindingType.CIS_FAIL: (FRAMEWORK_CIS,),
     FindingType.CIS_ERROR: (FRAMEWORK_CIS,),
     FindingType.CLOUD_BEST_PRACTICE_FAIL: (),

--- a/src/agent_bom/iac/__init__.py
+++ b/src/agent_bom/iac/__init__.py
@@ -41,6 +41,7 @@ from agent_bom.iac.terraform_security import scan_terraform_security
 _DCM_AVAILABLE = True  # dcm.py is on main (#2222 merged)
 
 __all__ = [
+    "is_iac_file",
     "scan_iac_directory",
     "scan_iac_with_context",
     "scan_chart_yaml",
@@ -114,6 +115,33 @@ def _is_k8s_manifest(path: Path) -> bool:
         return "apiVersion:" in head and "kind:" in head
     except OSError:
         return False
+
+
+def is_iac_file(path: Path, root: Path | None = None) -> bool:
+    """True when :func:`scan_iac_with_context` would dispatch a scanner for ``path``.
+
+    The single source of truth for "does this tree contain IaC?". Callers that
+    auto-detect scan surfaces (the CLI ``--project`` expansion, the API repo
+    tree scan) MUST use this rather than their own glob, or detection and
+    dispatch drift apart — which is how ``scan`` came to report ``terraform``
+    as a completed scan source while running zero IaC rules.
+
+    ``root`` is only needed to recognise dbt project layouts; omit it for a
+    cheap filename/marker check.
+    """
+    if _is_chart_yaml(path) or _is_values_yaml(path):
+        return True
+    if _is_dockerfile(path):
+        return True
+    if path.suffix == ".tf":
+        return True
+    if is_dcm_migration(path):
+        return True
+    if root is not None and is_dbt_file(path, root):
+        return True
+    if _is_k8s_manifest(path):
+        return True
+    return bool(_is_cloudformation(path))
 
 
 def scan_iac_with_context(

--- a/src/agent_bom/model_files.py
+++ b/src/agent_bom/model_files.py
@@ -296,13 +296,161 @@ def scan_model_files(
     return results, warnings
 
 
-def model_file_findings(model_files: list[dict]) -> list["Finding"]:
-    """Convert content-confirmed malicious model flags to unified findings.
+# ── Model security flag → finding promotion ──────────────────────────────
+#
+# Every ``security_flags`` type the model scanners can attach to a model-file
+# entry MUST appear in exactly one of the two tables below. A flag that is in
+# neither reaches no user-visible surface — the defect class this file has
+# shipped three times (``--require-model-signatures`` silently a no-op, a
+# CRITICAL ``HASH_MISMATCH`` promoted to nothing). ``tests/test_model_files.py``
+# reads the emitters' source and fails when a new type is left unclassified.
+#
+# ``severity`` is always taken from the emitted flag; ``default_severity`` is
+# only the fallback used when a flag arrives without one.
 
-    Extension-only warnings such as ``PICKLE_DESERIALIZATION`` describe an
-    unsafe format, not a proven malicious payload, and intentionally remain
-    inventory metadata. Only ``MALICIOUS_PICKLE`` flags emitted by bounded
-    static opcode disassembly are promoted to fail-closed findings.
+_MALICIOUS_REMEDIATION = (
+    "Quarantine the artifact, verify its publisher and digest, and replace it with a trusted "
+    "safetensors or ONNX artifact. Do not deserialize the flagged file."
+)
+_INTEGRITY_REMEDIATION = (
+    "Re-fetch the artifact from its authoritative source, verify the publisher digest and signature, "
+    "and prefer signed safetensors/ONNX distributions before loading it."
+)
+
+MODEL_FLAG_PROMOTIONS: dict[str, dict] = {
+    "MALICIOUS_PICKLE": {
+        "detector": "pickletools-static-disassembly",
+        "finding_type": "MALICIOUS_MODEL",
+        "default_severity": "CRITICAL",
+        "title": "Malicious model payload",
+        "is_malicious": True,
+        "malicious_reason": "Content-confirmed executable pickle payload",
+        "cwe_ids": ["CWE-502"],
+        "risk_score": 10.0,
+        "remediation": _MALICIOUS_REMEDIATION,
+        "requires_signature_policy": False,
+    },
+    "SUSPICIOUS_PICKLE": {
+        "detector": "pickletools-static-disassembly",
+        "finding_type": "MALICIOUS_MODEL",
+        "default_severity": "HIGH",
+        "title": "Suspicious model payload",
+        "is_malicious": False,
+        "malicious_reason": None,
+        "cwe_ids": ["CWE-502"],
+        "risk_score": 7.0,
+        "remediation": _MALICIOUS_REMEDIATION,
+        "requires_signature_policy": False,
+    },
+    "HASH_MISMATCH": {
+        "detector": "sha256-digest-verification",
+        "finding_type": "MODEL_INTEGRITY",
+        "default_severity": "CRITICAL",
+        "title": "Model digest mismatch",
+        "is_malicious": False,
+        "malicious_reason": None,
+        "cwe_ids": ["CWE-345"],
+        "risk_score": 9.0,
+        "remediation": _INTEGRITY_REMEDIATION,
+        "requires_signature_policy": False,
+    },
+    "OVERSIZE_PICKLE_UNSCANNED": {
+        "detector": "pickletools-static-disassembly",
+        "finding_type": "MODEL_INTEGRITY",
+        "default_severity": "HIGH",
+        "title": "Model artifact not fully scanned",
+        "is_malicious": False,
+        "malicious_reason": None,
+        "cwe_ids": ["CWE-502"],
+        "risk_score": 6.5,
+        "remediation": (
+            "The artifact exceeds the pickle scan byte cap, so part of it is unverified — padding past the cap "
+            "is a known evasion. Raise AGENT_BOM_PICKLE_MAX_BYTES to scan it fully, or replace it with "
+            "safetensors/ONNX."
+        ),
+        "requires_signature_policy": False,
+    },
+    "PICKLE_SCAN_ERROR": {
+        "detector": "pickletools-static-disassembly",
+        "finding_type": "MODEL_INTEGRITY",
+        "default_severity": "LOW",
+        "title": "Model artifact could not be scanned",
+        "is_malicious": False,
+        "malicious_reason": None,
+        "cwe_ids": ["CWE-502"],
+        "risk_score": 3.0,
+        "remediation": (
+            "The static pickle scan could not complete, so this artifact carries NO malicious-payload verdict. "
+            "Treat it as unverified: re-fetch it from its authoritative source and re-scan."
+        ),
+        "requires_signature_policy": False,
+    },
+    "HASH_ERROR": {
+        "detector": "sha256-digest-verification",
+        "finding_type": "MODEL_INTEGRITY",
+        "default_severity": "MEDIUM",
+        "title": "Model digest could not be computed",
+        "is_malicious": False,
+        "malicious_reason": None,
+        "cwe_ids": ["CWE-345"],
+        "risk_score": 4.0,
+        "remediation": (
+            "The artifact could not be read for hashing, so its integrity is unverified. Check file permissions "
+            "and storage health, then re-run the scan."
+        ),
+        "requires_signature_policy": False,
+    },
+    "UNSIGNED": {
+        "detector": "sigstore-signature-presence",
+        "finding_type": "MODEL_INTEGRITY",
+        "default_severity": "MEDIUM",
+        "title": "Unsigned model artifact",
+        "is_malicious": False,
+        "malicious_reason": None,
+        "cwe_ids": ["CWE-347"],
+        "risk_score": 5.0,
+        "remediation": (
+            "No Sigstore/cosign signature was found next to the artifact. Publish and verify a signature, or "
+            "source the model from a signed distribution."
+        ),
+        # Absence of a signature is a policy violation only when the operator
+        # asked for signatures; otherwise it stays inventory metadata.
+        "requires_signature_policy": True,
+    },
+}
+
+INVENTORY_ONLY_MODEL_FLAGS: dict[str, str] = {
+    "PICKLE_DESERIALIZATION": (
+        "Describes the FORMAT of every .pkl file, not a property of this artifact. Promoting it would emit a "
+        "finding for every pickle in the estate regardless of content; the content verdict comes from "
+        "MALICIOUS_PICKLE / SUSPICIOUS_PICKLE instead."
+    ),
+    "JOBLIB_DESERIALIZATION": (
+        "Same format-shape warning as PICKLE_DESERIALIZATION, for joblib artifacts. Content verdicts come from "
+        "the opcode scan, not from the extension."
+    ),
+    "FILE_NOT_FOUND": (
+        "A scan-input error (the caller named a path that does not exist), not a property of a discovered "
+        "artifact. Surfaced to the caller as a scan warning; there is no asset to hang a finding on."
+    ),
+}
+
+
+def model_file_findings(
+    model_files: list[dict],
+    *,
+    require_model_signatures: bool = False,
+) -> list["Finding"]:
+    """Convert model artifact security flags to unified findings.
+
+    Promotion is driven by :data:`MODEL_FLAG_PROMOTIONS`; anything listed in
+    :data:`INVENTORY_ONLY_MODEL_FLAGS` stays inventory metadata with a
+    documented reason. Severity is read off the emitted flag so the scanner
+    that produced it remains the single source of truth.
+
+    ``require_model_signatures`` promotes signature-policy flags (``UNSIGNED``)
+    that are otherwise inventory-only, so ``--require-model-signatures``
+    actually gates a scan.
     """
     from agent_bom.compliance_hub import apply_hub_classification
     from agent_bom.finding import Asset, Finding, FindingSource, FindingType
@@ -316,10 +464,16 @@ def model_file_findings(model_files: list[dict]) -> list["Finding"]:
         path = sanitize_text(model_file.get("path", "") or "", max_len=1000)
         filename = sanitize_text(model_file.get("filename", "") or Path(path).name or "model artifact", max_len=255)
         for raw_flag in model_file.get("security_flags", []) or []:
-            if not isinstance(raw_flag, dict) or raw_flag.get("type") != "MALICIOUS_PICKLE":
+            if not isinstance(raw_flag, dict):
+                continue
+            flag_type = raw_flag.get("type")
+            spec = MODEL_FLAG_PROMOTIONS.get(flag_type) if isinstance(flag_type, str) else None
+            if spec is None:
+                continue
+            if spec["requires_signature_policy"] and not require_model_signatures:
                 continue
             description = sanitize_text(
-                raw_flag.get("description", "") or "Static pickle analysis found an executable payload.",
+                raw_flag.get("description", "") or f"Model artifact scan reported {flag_type}.",
                 max_len=2000,
             )
             dangerous_imports = [
@@ -334,7 +488,7 @@ def model_file_findings(model_files: list[dict]) -> list["Finding"]:
             ][:32]
             finding = apply_hub_classification(
                 Finding(
-                    finding_type=FindingType.MALICIOUS_MODEL,
+                    finding_type=FindingType(spec["finding_type"]),
                     source=FindingSource.MODEL_SCAN,
                     asset=Asset(
                         name=filename,
@@ -342,21 +496,18 @@ def model_file_findings(model_files: list[dict]) -> list["Finding"]:
                         identifier=path or filename,
                         location=path or None,
                     ),
-                    severity=str(raw_flag.get("severity") or "critical"),
-                    title=f"Malicious model payload: {filename}",
+                    severity=str(raw_flag.get("severity") or spec["default_severity"]),
+                    title=f"{spec['title']}: {filename}",
                     description=description,
-                    cwe_ids=["CWE-502"],
-                    is_malicious=True,
-                    malicious_reason="Content-confirmed executable pickle payload",
-                    remediation_guidance=(
-                        "Quarantine the artifact, verify its publisher and digest, and replace it with a trusted "
-                        "safetensors or ONNX artifact. Do not deserialize the flagged file."
-                    ),
+                    cwe_ids=list(spec["cwe_ids"]),
+                    is_malicious=spec["is_malicious"],
+                    malicious_reason=spec["malicious_reason"],
+                    remediation_guidance=spec["remediation"],
                     is_actionable=True,
-                    risk_score=10.0,
+                    risk_score=spec["risk_score"],
                     evidence={
-                        "detector": "pickletools-static-disassembly",
-                        "detection_type": "MALICIOUS_PICKLE",
+                        "detector": spec["detector"],
+                        "detection_type": flag_type,
                         "format": sanitize_text(model_file.get("format", "") or "", max_len=120),
                         "extension": sanitize_text(model_file.get("extension", "") or "", max_len=40),
                         "size_bytes": model_file.get("size_bytes") if isinstance(model_file.get("size_bytes"), int) else None,

--- a/src/agent_bom/model_pickle_scan.py
+++ b/src/agent_bom/model_pickle_scan.py
@@ -216,49 +216,60 @@ class PickleScanResult:
     declared_size: int | None = None  # declared (uncompressed) size when oversize
 
     def to_security_flag(self) -> dict | None:
-        """Render a ``security_flags``-shaped dict, or ``None`` when clean."""
-        if self.verdict in {"clean", "not_pickle"}:
-            if self.oversize_unscanned:
-                # A pickle-bearing member larger than the byte cap could only be
-                # disassembled up to the cap; bytes beyond it are UNVERIFIED. Fail
-                # safe — surface a finding even when the scanned prefix is clean,
-                # because an attacker can pad a malicious pickle past the cap to
-                # evade the scanner.
-                location = f" (zip member {self.member})" if self.member else ""
-                size_note = f"declared size {self.declared_size} bytes; " if self.declared_size else ""
-                return {
-                    "severity": "HIGH",
-                    "type": "OVERSIZE_PICKLE_UNSCANNED",
-                    "description": (
-                        f"Pickle-bearing member{location} exceeds the scan byte cap "
-                        f"({size_note}cap {_max_pickle_bytes()} bytes); only the leading slice was "
-                        "disassembled and the remainder was NOT scanned. Padding a pickle past the "
-                        "cap is a known evasion — treat as suspicious; prefer safetensors/ONNX or "
-                        "raise AGENT_BOM_PICKLE_MAX_BYTES to scan it fully."
-                    ),
-                }
-            return None
+        """Render a ``security_flags``-shaped dict, or ``None`` when clean.
+
+        Branch order is load-bearing, strongest signal first:
+
+        1. ``malicious`` / ``suspicious`` — a payload was actually observed.
+        2. ``oversize_unscanned`` — the fail-safe that stops padding evasion.
+           It must be checked BEFORE ``error`` so an oversized member that
+           also failed to read keeps its HIGH signal instead of collapsing to
+           a LOW scan error (which the finding promoter treats as coverage
+           loss, not as evasion).
+        3. ``error`` — the scan could not complete.
+        """
+        if self.verdict in {"malicious", "suspicious"}:
+            location = f" (zip member {self.member})" if self.member else ""
+            imports = ", ".join(sorted(set(self.dangerous_imports))[:12]) or "none captured"
+            opcodes = ", ".join(sorted(set(self.code_exec_opcodes)))
+            return {
+                "severity": self.severity or "HIGH",
+                "type": "MALICIOUS_PICKLE" if self.verdict == "malicious" else "SUSPICIOUS_PICKLE",
+                "description": (
+                    f"Pickle opcode disassembly{location} found code-execution opcodes "
+                    f"[{opcodes}] referencing dangerous imports [{imports}]. "
+                    "Detected by static opcode walk (pickletools.genops); the model was NOT deserialized. "
+                    "Treat as a potential supply-chain implant — prefer safetensors/ONNX."
+                ),
+                "dangerous_imports": sorted(set(self.dangerous_imports)),
+                "code_exec_opcodes": sorted(set(self.code_exec_opcodes)),
+            }
+        if self.oversize_unscanned:
+            # A pickle-bearing stream larger than the byte cap could only be
+            # disassembled up to the cap; bytes beyond it are UNVERIFIED. Fail
+            # safe — surface a finding even when the scanned prefix is clean,
+            # because an attacker can pad a malicious pickle past the cap to
+            # evade the scanner.
+            location = f" (zip member {self.member})" if self.member else ""
+            size_note = f"declared size {self.declared_size} bytes; " if self.declared_size else ""
+            return {
+                "severity": "HIGH",
+                "type": "OVERSIZE_PICKLE_UNSCANNED",
+                "description": (
+                    f"Pickle-bearing stream{location} exceeds the scan byte cap "
+                    f"({size_note}cap {_max_pickle_bytes()} bytes); only the leading slice was "
+                    "disassembled and the remainder was NOT scanned. Padding a pickle past the "
+                    "cap is a known evasion — treat as suspicious; prefer safetensors/ONNX or "
+                    "raise AGENT_BOM_PICKLE_MAX_BYTES to scan it fully."
+                ),
+            }
         if self.verdict == "error":
             return {
                 "severity": "LOW",
                 "type": "PICKLE_SCAN_ERROR",
                 "description": (f"Pickle opcode scan could not complete (no deserialization attempted): {self.error}"),
             }
-        location = f" (zip member {self.member})" if self.member else ""
-        imports = ", ".join(sorted(set(self.dangerous_imports))[:12]) or "none captured"
-        opcodes = ", ".join(sorted(set(self.code_exec_opcodes)))
-        return {
-            "severity": self.severity or "HIGH",
-            "type": "MALICIOUS_PICKLE" if self.verdict == "malicious" else "SUSPICIOUS_PICKLE",
-            "description": (
-                f"Pickle opcode disassembly{location} found code-execution opcodes "
-                f"[{opcodes}] referencing dangerous imports [{imports}]. "
-                "Detected by static opcode walk (pickletools.genops); the model was NOT deserialized. "
-                "Treat as a potential supply-chain implant — prefer safetensors/ONNX."
-            ),
-            "dangerous_imports": sorted(set(self.dangerous_imports)),
-            "code_exec_opcodes": sorted(set(self.code_exec_opcodes)),
-        }
+        return None
 
 
 def _int_env(name: str, default: int) -> int:
@@ -450,16 +461,22 @@ def _looks_like_zip(data: bytes) -> bool:
     return data[:4] == b"PK\x03\x04" or data[:4] == b"PK\x05\x06"
 
 
-def _scan_zip(data: bytes, path: str) -> list[PickleScanResult]:
+def _scan_zip(archive: Path, path: str) -> list[PickleScanResult]:
     """Find and scan embedded pickle members inside a torch/zip archive.
 
     Torch ``.pt`` files are ZIP archives containing ``data.pkl`` (and shards).
     We enumerate members and disassemble those that are pickle streams, without
     extracting to disk and without deserializing.
+
+    The archive is opened **by path**, never from a byte buffer. A ZIP's
+    central directory lives at the END of the file, so reading a bounded
+    prefix into memory destroys it and makes every real (GB-scale) model
+    unreadable. Bounding happens per member instead — see ``cap`` below — so
+    a hostile archive still cannot force unbounded work.
     """
     results: list[PickleScanResult] = []
     try:
-        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        with zipfile.ZipFile(archive) as zf:
             members = zf.namelist()[:_MAX_ZIP_MEMBERS]
             scanned = 0
             for member in members:
@@ -488,8 +505,27 @@ def _scan_zip(data: bytes, path: str) -> list[PickleScanResult]:
                         if not (is_pkl_ext or starts_pickle):
                             continue
                         body = head + fh.read(cap)
-                except (OSError, zipfile.BadZipFile, RuntimeError, NotImplementedError) as exc:
-                    results.append(PickleScanResult(path=path, member=member, error=f"could not read zip member: {exc}", verdict="error"))
+                except Exception as exc:  # noqa: BLE001 — a hostile member must never crash the scan
+                    # Decompression of a corrupted member raises ``zlib.error``,
+                    # which is not an OSError; catching narrowly here let a
+                    # crafted archive crash a scanner documented as never
+                    # raising. Any read failure is reported, never propagated.
+                    #
+                    # An unreadable member that ALSO declares a size past the
+                    # cap keeps the oversize fail-safe: a hostile archive must
+                    # not be able to downgrade the evasion signal to a LOW
+                    # scan error simply by corrupting the member it padded.
+                    results.append(
+                        PickleScanResult(
+                            path=path,
+                            member=member,
+                            error=f"could not read zip member: {exc}",
+                            verdict="error",
+                            oversize_unscanned=oversize,
+                            declared_size=info.file_size if oversize else None,
+                        )
+                    )
+                    scanned += 1
                     continue
                 res = _scan_opcode_stream(body, path=path, member=member)
                 if oversize:
@@ -518,23 +554,39 @@ def scan_pickle_file(file_path: str | Path) -> list[PickleScanResult]:
     """
     p = Path(file_path)
     path_str = str(p)
+    cap = _max_pickle_bytes()
     try:
         with open(p, "rb") as fh:
-            data = fh.read(_max_pickle_bytes() + 1)
+            # Sniff the container magic first. A ZIP must NOT be read into a
+            # bounded buffer: its central directory sits at the end of the
+            # file, so a truncated buffer is an unreadable archive and every
+            # embedded pickle would go unscanned. ZIPs are handed to
+            # ``_scan_zip`` by path, which bounds each member instead.
+            magic = fh.read(4)
+            if not magic:
+                return [PickleScanResult(path=path_str, verdict="not_pickle")]
+            if _looks_like_zip(magic):
+                return _scan_zip(p, path=path_str)
+            data = magic + fh.read(cap - len(magic))
+            # One extra byte tells us whether the raw stream ran past the cap
+            # without keeping the remainder in memory.
+            oversize = bool(fh.read(1))
     except OSError as exc:
         return [PickleScanResult(path=path_str, error=f"could not open file: {exc}", verdict="error")]
 
     if not data:
         return [PickleScanResult(path=path_str, verdict="not_pickle")]
 
-    if len(data) > _max_pickle_bytes():
-        # Truncate the working buffer to the cap; opcode walk still bounded.
-        data = data[: _max_pickle_bytes()]
-
-    if _looks_like_zip(data):
-        return _scan_zip(data, path=path_str)
-
-    return [_scan_opcode_stream(data, path=path_str, member=None)]
+    result = _scan_opcode_stream(data, path=path_str, member=None)
+    if oversize:
+        # Same evasion as an oversized zip member: a raw pickle padded past
+        # the cap has an UNVERIFIED tail. Fail safe rather than report clean.
+        result.oversize_unscanned = True
+        try:
+            result.declared_size = p.stat().st_size
+        except OSError:
+            result.declared_size = None
+    return [result]
 
 
 def scan_pickle_file_flags(file_path: str | Path) -> tuple[list[dict], list[PickleScanResult]]:

--- a/src/agent_bom/repo_auto_detect.py
+++ b/src/agent_bom/repo_auto_detect.py
@@ -64,7 +64,7 @@ REPO_STATIC_SURFACES: tuple[RepoStaticSurface, ...] = (
     RepoStaticSurface("python_agents", "Python agent frameworks", cli_auto_key="python_agents", api_repo_tree=True),
     RepoStaticSurface("ai_inventory", "AI SDK / observability inventory", cli_auto_key="ai_inventory", api_repo_tree=True),
     RepoStaticSurface("skills", "Skills & instruction files", api_repo_tree=True),
-    RepoStaticSurface("iac", "IaC & deployment configs", api_repo_tree=True),
+    RepoStaticSurface("iac", "IaC & deployment configs", cli_auto_key="iac", api_repo_tree=True),
     RepoStaticSurface("dependencies", "Lockfiles & manifests", api_repo_tree=True),
     RepoStaticSurface("secrets", "Secrets & credentials", api_repo_tree=True),
     RepoStaticSurface("weak_crypto", "Weak cryptography", api_repo_tree=True),
@@ -100,6 +100,7 @@ class ProjectScanTargets:
     gha_path: str | None
     agent_projects: tuple[str, ...]
     ai_inventory_paths: tuple[str, ...] = ()
+    iac_paths: tuple[str, ...] = ()
     auto_enabled: list[str] = field(default_factory=list)
 
 
@@ -148,6 +149,23 @@ def project_has_terraform(root: Path) -> bool:
     )
 
 
+def project_has_iac(root: Path) -> bool:
+    """True when the tree holds any file the IaC scanners would dispatch on.
+
+    Delegates to :func:`agent_bom.iac.is_iac_file` so detection can never
+    disagree with what ``scan_iac_with_context`` actually scans, and walks
+    recursively — IaC normally lives under ``infra/``, ``deploy/`` or
+    ``charts/``, not at the repo root.
+    """
+    if not root.is_dir():
+        return False
+    from agent_bom.iac import is_iac_file
+
+    return any(
+        is_iac_file(path, root) for path in iter_discovery_files(root, extra_skip_dirs=_SKIP_DIRS, max_files=4000)
+    )
+
+
 def project_has_github_actions(root: Path) -> bool:
     workflows = root / ".github" / "workflows"
     if not workflows.is_dir():
@@ -183,6 +201,7 @@ def expand_project_scan_targets(
     gha_path: str | None = None,
     agent_projects: tuple[str, ...] = (),
     ai_inventory_paths: tuple[str, ...] = (),
+    iac_paths: tuple[str, ...] = (),
 ) -> ProjectScanTargets:
     """Fill empty scan targets from project tree content."""
     root = Path(project).resolve()
@@ -194,6 +213,7 @@ def expand_project_scan_targets(
     out_gha = gha_path
     out_agents = agent_projects
     out_ai_inventory = ai_inventory_paths
+    out_iac = iac_paths
 
     if not jupyter_dirs and project_has_notebooks(root):
         out_jupyter = (str(root),)
@@ -210,6 +230,13 @@ def expand_project_scan_targets(
     if not tf_dirs and project_has_terraform(root):
         out_tf = (str(root),)
         auto.append("terraform")
+
+    # The IaC security rules run on the whole tree, exactly as the API repo-tree
+    # scan does. Without this the CLI reported ``terraform`` as a scan source
+    # while every misconfiguration rule stayed unexecuted.
+    if not iac_paths and project_has_iac(root):
+        out_iac = (str(root),)
+        auto.append("iac")
 
     if not gha_path and project_has_github_actions(root):
         out_gha = str(root)
@@ -233,5 +260,6 @@ def expand_project_scan_targets(
         gha_path=out_gha,
         agent_projects=out_agents,
         ai_inventory_paths=out_ai_inventory,
+        iac_paths=out_iac,
         auto_enabled=auto,
     )

--- a/tests/test_iac_findings_surface.py
+++ b/tests/test_iac_findings_surface.py
@@ -90,3 +90,71 @@ def test_iac_not_in_cyclonedx():
     cdx = to_cyclonedx(report)
     vulns = cdx.get("vulnerabilities", []) or []
     assert not any("AVD-AWS-0088" in str(v) for v in vulns)
+
+
+# ── Default `scan` must actually run the IaC rules it reports ─────────────
+# ``scan -p`` auto-detected terraform recursively and listed ``terraform`` in
+# ``scan_sources`` with empty ``warnings``/``coverage_warnings`` — while the
+# IaC rules stayed gated behind a top-level-only glob, so a repo with
+# ``infra/main.tf`` was reported as scanned and produced zero misconfigurations.
+
+
+def _write_nested_iac(root):
+    infra = root / "infra"
+    infra.mkdir(parents=True, exist_ok=True)
+    (infra / "main.tf").write_text(
+        'resource "aws_s3_bucket" "training_data" {\n  bucket = "public-training-data"\n  acl    = "public-read"\n}\n',
+        encoding="utf-8",
+    )
+
+
+def _run_scan(project, output, *extra):
+    import json as _json
+    from unittest.mock import patch
+
+    from click.testing import CliRunner
+
+    from agent_bom.cli import main
+
+    with (
+        patch("agent_bom.cli.agents.discover_all", return_value=[]),
+        patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
+        patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+    ):
+        result = CliRunner().invoke(
+            main,
+            ["scan", "-p", str(project), "--no-scan", "--no-auto-update-db", "--format", "json", "--output", str(output), *extra],
+            catch_exceptions=False,
+        )
+    return result, _json.loads(output.read_text(encoding="utf-8"))
+
+
+def test_default_scan_runs_iac_rules_on_nested_files(tmp_path):
+    """A default scan must find the same misconfigurations as an explicit --iac."""
+    _write_nested_iac(tmp_path)
+
+    _, default_payload = _run_scan(tmp_path, tmp_path / "default.json")
+    _, explicit_payload = _run_scan(tmp_path, tmp_path / "explicit.json", "--iac", str(tmp_path))
+
+    default_iac = (default_payload.get("iac_findings") or {}).get("findings", [])
+    explicit_iac = (explicit_payload.get("iac_findings") or {}).get("findings", [])
+
+    assert explicit_iac, "fixture produced no IaC findings even with --iac — test is vacuous"
+    assert default_iac, "default scan ran zero IaC rules on an auto-detected IaC tree"
+    assert {f["rule_id"] for f in default_iac} == {f["rule_id"] for f in explicit_iac}
+    assert any(f["severity"] == "critical" for f in default_iac)
+
+
+def test_scan_sources_names_iac_only_when_its_rules_ran(tmp_path):
+    """``scan_sources`` is a claim about work performed, not files noticed."""
+    _write_nested_iac(tmp_path)
+    _, payload = _run_scan(tmp_path, tmp_path / "report.json")
+
+    assert "terraform" in payload["scan_sources"]
+    assert "iac" in payload["scan_sources"], "IaC rules ran but the report does not say so"
+
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    (plain / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    _, plain_payload = _run_scan(plain, tmp_path / "plain.json")
+    assert "iac" not in plain_payload["scan_sources"], "IaC claimed on a tree with no IaC files"

--- a/tests/test_model_files.py
+++ b/tests/test_model_files.py
@@ -168,3 +168,190 @@ def test_scan_config_manifest_flags_explicit_floating_revision(tmp_path: Path):
     assert manifests[0]["revision"] == "main"
     assert manifests[0]["security_flags"][0]["type"] == "FLOATING_MODEL_REFERENCE"
     assert any("FLOATING_MODEL_REFERENCE" in warning for warning in warnings)
+
+
+# ── Flag → finding promotion ─────────────────────────────────────────────
+# ``model_file_findings`` used to promote exactly one string
+# (``MALICIOUS_PICKLE``), silently discarding every other flag the model
+# scanners emit — including CRITICAL ``HASH_MISMATCH`` and the ``UNSIGNED``
+# evidence that ``--require-model-signatures`` depends on. The guard that
+# matters is not any single case but the completeness test below: every flag
+# type the scanners can emit must either map to a finding or sit on a
+# documented inventory-only allowlist.
+
+import ast  # noqa: E402
+
+import pytest  # noqa: E402
+
+from agent_bom import model_files as model_files_mod  # noqa: E402
+from agent_bom import model_pickle_scan  # noqa: E402
+from agent_bom.model_files import (  # noqa: E402
+    INVENTORY_ONLY_MODEL_FLAGS,
+    MODEL_FLAG_PROMOTIONS,
+    model_file_findings,
+)
+
+
+def _model_file(*flags: dict) -> dict:
+    return {
+        "path": "/models/weights.pt",
+        "filename": "weights.pt",
+        "extension": ".pt",
+        "format": "PyTorch",
+        "size_bytes": 1024,
+        "security_flags": list(flags),
+    }
+
+
+def _literal_strings(node: ast.AST) -> set[str]:
+    """Collect string literals from a value node, following ternaries."""
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return {node.value}
+    if isinstance(node, ast.IfExp):
+        return _literal_strings(node.body) | _literal_strings(node.orelse)
+    return set()
+
+
+def _emitted_flag_types() -> set[str]:
+    """Every ``security_flags`` type that can land on a model-file entry.
+
+    Read from the emitters' SOURCE rather than from a hand-kept list, so a new
+    flag type added to any of them fails the completeness test until it is
+    explicitly classified as promoted or inventory-only.
+    """
+    types = {flag["type"] for flag in model_files_mod._SECURITY_FLAGS.values()}
+    emitters = {
+        model_pickle_scan: {"to_security_flag"},
+        model_files_mod: {"verify_model_hash", "check_sigstore_signature"},
+    }
+    for module, wanted in emitters.items():
+        tree = ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+        found = set()
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name in wanted:
+                found.add(node.name)
+                for sub in ast.walk(node):
+                    if not isinstance(sub, ast.Dict):
+                        continue
+                    for key, value in zip(sub.keys, sub.values):
+                        if isinstance(key, ast.Constant) and key.value == "type":
+                            types |= _literal_strings(value)
+        assert found == wanted, f"emitter(s) renamed or removed in {module.__name__}: expected {wanted}, found {found}"
+    return types
+
+
+def test_flag_type_extraction_is_not_vacuous() -> None:
+    """The completeness guard is only meaningful if it really sees the emitters."""
+    emitted = _emitted_flag_types()
+    # Anchors from each of the three emitter sites.
+    for anchor in ("MALICIOUS_PICKLE", "OVERSIZE_PICKLE_UNSCANNED", "HASH_MISMATCH", "UNSIGNED", "PICKLE_DESERIALIZATION"):
+        assert anchor in emitted, f"{anchor} was not discovered — the extraction is broken, not the code"
+    assert len(emitted) >= 9
+
+
+def test_every_emitted_model_flag_is_promoted_or_documented_inventory_only() -> None:
+    """No model security flag may be silently dropped.
+
+    This defect has now shipped three times in this file. A flag type that is
+    neither promoted to a finding nor listed as inventory-only with a reason
+    fails here — adding the flag without deciding its fate is the bug.
+    """
+    emitted = _emitted_flag_types()
+    classified = set(MODEL_FLAG_PROMOTIONS) | set(INVENTORY_ONLY_MODEL_FLAGS)
+
+    unclassified = emitted - classified
+    assert not unclassified, (
+        f"model security flag(s) {sorted(unclassified)} reach nothing: add them to "
+        "MODEL_FLAG_PROMOTIONS or document them in INVENTORY_ONLY_MODEL_FLAGS"
+    )
+    stale = classified - emitted
+    assert not stale, f"classified flag(s) {sorted(stale)} are no longer emitted — remove them"
+
+    # The allowlist must carry a real reason, not an empty placeholder.
+    for flag_type, reason in INVENTORY_ONLY_MODEL_FLAGS.items():
+        assert reason.strip(), f"{flag_type} is allowlisted without a documented reason"
+
+    # Pin the types whose loss caused user-visible defects.
+    for required in ("MALICIOUS_PICKLE", "HASH_MISMATCH", "OVERSIZE_PICKLE_UNSCANNED", "PICKLE_SCAN_ERROR", "UNSIGNED"):
+        assert required in MODEL_FLAG_PROMOTIONS, f"{required} must be promoted to a finding"
+
+
+@pytest.mark.parametrize("flag_type", sorted(MODEL_FLAG_PROMOTIONS))
+def test_every_promoted_flag_actually_produces_a_finding(flag_type: str) -> None:
+    """Declaring a promotion is not enough — it must reach the findings spine."""
+    spec = MODEL_FLAG_PROMOTIONS[flag_type]
+    flag = {"severity": spec["default_severity"], "type": flag_type, "description": f"synthetic {flag_type}"}
+    findings = model_file_findings([_model_file(flag)], require_model_signatures=True)
+    assert len(findings) == 1, f"{flag_type} produced no finding"
+    assert findings[0].evidence["detection_type"] == flag_type
+    assert findings[0].asset.name == "weights.pt"
+
+
+def test_inventory_only_flags_produce_no_finding() -> None:
+    """Extension-shape warnings stay inventory metadata, not findings."""
+    for flag_type in INVENTORY_ONLY_MODEL_FLAGS:
+        flag = {"severity": "HIGH", "type": flag_type, "description": "format warning"}
+        assert model_file_findings([_model_file(flag)], require_model_signatures=True) == [], (
+            f"{flag_type} is documented as inventory-only but produced a finding"
+        )
+
+
+def test_hash_mismatch_becomes_a_critical_finding() -> None:
+    """A tampered weight file must not stop at an inventory flag."""
+    flag = {
+        "severity": "CRITICAL",
+        "type": "HASH_MISMATCH",
+        "description": "SHA-256 mismatch — expected abc..., got def... File may be tampered.",
+    }
+    findings = model_file_findings([_model_file(flag)])
+    assert len(findings) == 1
+    assert findings[0].severity == "critical"
+    assert "tampered" in findings[0].description.lower()
+
+
+def test_severity_comes_from_the_flag_not_a_hardcoded_default() -> None:
+    """Severity is read off the flag so the emitter stays the source of truth."""
+    high = model_file_findings([_model_file({"severity": "HIGH", "type": "HASH_MISMATCH", "description": "d"})])
+    critical = model_file_findings([_model_file({"severity": "CRITICAL", "type": "HASH_MISMATCH", "description": "d"})])
+    assert high[0].severity == "high"
+    assert critical[0].severity == "critical"
+
+
+def test_unsigned_is_promoted_only_under_the_signature_policy() -> None:
+    """UNSIGNED is inventory metadata until the operator demands signatures."""
+    flag = {"severity": "MEDIUM", "type": "UNSIGNED", "description": "No Sigstore signature found."}
+    assert model_file_findings([_model_file(flag)]) == []
+    gated = model_file_findings([_model_file(flag)], require_model_signatures=True)
+    assert len(gated) == 1
+    assert gated[0].evidence["detection_type"] == "UNSIGNED"
+
+
+def test_malicious_pickle_finding_is_the_only_one_marked_malicious() -> None:
+    """Honesty: an unsigned or unscanned model is not a confirmed implant."""
+    malicious = model_file_findings([_model_file({"severity": "CRITICAL", "type": "MALICIOUS_PICKLE", "description": "payload"})])
+    assert malicious[0].is_malicious is True
+    assert malicious[0].finding_type.value == "MALICIOUS_MODEL"
+
+    for flag_type in ("HASH_MISMATCH", "OVERSIZE_PICKLE_UNSCANNED", "PICKLE_SCAN_ERROR", "UNSIGNED"):
+        spec = MODEL_FLAG_PROMOTIONS[flag_type]
+        findings = model_file_findings(
+            [_model_file({"severity": spec["default_severity"], "type": flag_type, "description": "d"})],
+            require_model_signatures=True,
+        )
+        assert findings[0].is_malicious is False, f"{flag_type} must not claim a confirmed malicious payload"
+        assert findings[0].finding_type.value == "MODEL_INTEGRITY"
+
+
+def test_multiple_flags_on_one_file_all_reach_findings() -> None:
+    """A file can carry several signals; none may be swallowed by the first."""
+    findings = model_file_findings(
+        [
+            _model_file(
+                {"severity": "CRITICAL", "type": "MALICIOUS_PICKLE", "description": "payload"},
+                {"severity": "CRITICAL", "type": "HASH_MISMATCH", "description": "tampered"},
+                {"severity": "HIGH", "type": "PICKLE_DESERIALIZATION", "description": "format"},
+            )
+        ]
+    )
+    types = {f.evidence["detection_type"] for f in findings}
+    assert types == {"MALICIOUS_PICKLE", "HASH_MISMATCH"}

--- a/tests/test_model_pickle_scan.py
+++ b/tests/test_model_pickle_scan.py
@@ -513,3 +513,200 @@ def test_benign_non_pickle_files_are_not_discovered(tmp_path: Path):
     (tmp_path / "data.csv").write_bytes(b"a,b,c\n1,2,3\n")
     results, _ = scan_model_files(tmp_path)
     assert results == []
+
+
+# ── ZIP containers larger than the byte cap ──────────────────────────────
+# A ZIP's central directory lives at the END of the file. Reading only the
+# leading ``AGENT_BOM_PICKLE_MAX_BYTES`` bytes into memory destroys it, so
+# ``zipfile`` rejects the archive and every embedded pickle goes unscanned.
+# Since real models are GB-scale, that made the detector a no-op in
+# production. The container must be opened BY PATH; the byte cap belongs on
+# each member, not on the whole-file buffer.
+
+
+def _stored_zip_over(path: Path, *, first_member: bytes, total_bytes: int) -> None:
+    """Write an uncompressed .pt whose on-disk size exceeds ``total_bytes``."""
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED, allowZip64=True) as zf:
+        zf.writestr("archive/data.pkl", first_member)
+        zf.writestr("archive/version", "3")
+        with zf.open("archive/data/0", "w") as fh:
+            written = 0
+            chunk = b"\x00" * 65536
+            while written <= total_bytes:
+                fh.write(chunk)
+                written += len(chunk)
+    assert path.stat().st_size > total_bytes
+
+
+def test_zip_container_larger_than_byte_cap_is_still_scanned(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """A malicious pickle inside a .pt bigger than the cap must still be flagged.
+
+    Regression guard for the silent-miss: truncating the whole-file buffer to
+    the cap discarded the ZIP central directory, so the archive was
+    unreadable and the payload was reported as a LOW scan error instead of a
+    CRITICAL malicious pickle.
+    """
+    cap = 100_000
+    monkeypatch.setenv("AGENT_BOM_PICKLE_MAX_BYTES", str(cap))
+    p = tmp_path / "oversized.pt"
+    _stored_zip_over(p, first_member=_malicious_bytes(), total_bytes=cap)
+
+    results = scan_pickle_file(p)
+    assert not any(r.verdict == "error" for r in results), (
+        "container above the byte cap was rejected as unreadable — central directory was truncated away"
+    )
+    malicious = [r for r in results if r.verdict == "malicious"]
+    assert malicious, "malicious pickle inside an over-cap container was not flagged"
+    assert malicious[0].member is not None and "data.pkl" in malicious[0].member
+    assert malicious[0].severity == "CRITICAL"
+
+    flags, _ = scan_pickle_file_flags(p)
+    assert "MALICIOUS_PICKLE" in {f["type"] for f in flags}
+
+
+def test_over_cap_container_scan_stays_bounded_per_member(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Opening the container by path must NOT relax the per-member byte cap.
+
+    The DoS bound moved from the whole file to each member; prove no single
+    disassembly is ever handed more than the cap.
+    """
+    cap = 100_000
+    monkeypatch.setenv("AGENT_BOM_PICKLE_MAX_BYTES", str(cap))
+    p = tmp_path / "bomb.pt"
+    # Every member is a pickle-looking stream far larger than the cap.
+    big_member = pickle.dumps(b"\x00" * (cap * 8))
+    with zipfile.ZipFile(p, "w", compression=zipfile.ZIP_DEFLATED, allowZip64=True) as zf:
+        for i in range(12):
+            zf.writestr(f"archive/shard{i}.pkl", big_member)
+    assert p.stat().st_size < cap, "compressed zip bomb should stay small on disk"
+
+    sizes: list[int] = []
+    real_stream = model_pickle_scan._scan_opcode_stream
+
+    def _recording(data: bytes, path: str, member: str | None):
+        sizes.append(len(data))
+        return real_stream(data, path, member)
+
+    monkeypatch.setattr(model_pickle_scan, "_scan_opcode_stream", _recording)
+    flags, results = scan_pickle_file_flags(p)
+
+    assert sizes, "no member was disassembled"
+    # +2 for the two-byte magic sniff read that precedes the capped body read.
+    assert max(sizes) <= cap + 2, f"a member was read past the cap: {max(sizes)} > {cap}"
+    assert len(results) <= model_pickle_scan._MAX_EMBEDDED_PICKLES
+    # Every oversized member still fails safe rather than being dropped.
+    assert all(r.oversize_unscanned for r in results)
+    assert {f["type"] for f in flags} == {"OVERSIZE_PICKLE_UNSCANNED"}
+
+
+def test_unreadable_oversize_member_reports_oversize_not_scan_error():
+    """``oversize_unscanned`` must win over ``verdict == "error"``.
+
+    OVERSIZE_PICKLE_UNSCANNED (HIGH) is the fail-safe written to stop padding
+    evasion. Checking the error branch first made it unreachable whenever the
+    oversized member also failed to read, downgrading the evasion signal to a
+    LOW PICKLE_SCAN_ERROR that the finding promoter drops.
+    """
+    res = model_pickle_scan.PickleScanResult(
+        path="/models/evil.pt",
+        member="archive/data.pkl",
+        verdict="error",
+        error="could not read zip member: bad CRC",
+        oversize_unscanned=True,
+        declared_size=999_999_999,
+    )
+    flag = res.to_security_flag()
+    assert flag is not None
+    assert flag["type"] == "OVERSIZE_PICKLE_UNSCANNED"
+    assert flag["severity"] == "HIGH"
+
+
+def test_corrupt_oversize_member_keeps_the_oversize_failsafe(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """End-to-end: a member that declares a huge size and cannot be read.
+
+    A hostile archive can advertise an enormous member and then corrupt it so
+    decompression fails. That must not silently downgrade to a LOW error.
+    """
+    cap = 20_000
+    monkeypatch.setenv("AGENT_BOM_PICKLE_MAX_BYTES", str(cap))
+    p = tmp_path / "corrupt.pt"
+    with zipfile.ZipFile(p, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("archive/data.pkl", pickle.dumps(b"\x00" * (cap * 4)))
+
+    # Corrupt ONLY the member's compressed payload, leaving the central
+    # directory intact — the archive must stay openable so the failure lands
+    # on the member read, which is the branch under test.
+    with zipfile.ZipFile(p) as zf:
+        info = zf.getinfo("archive/data.pkl")
+        header_offset, compress_size = info.header_offset, info.compress_size
+    raw = bytearray(p.read_bytes())
+    name_len = int.from_bytes(raw[header_offset + 26 : header_offset + 28], "little")
+    extra_len = int.from_bytes(raw[header_offset + 28 : header_offset + 30], "little")
+    data_start = header_offset + 30 + name_len + extra_len
+    for offset in range(data_start, data_start + compress_size):
+        raw[offset] ^= 0xFF
+    p.write_bytes(bytes(raw))
+    with zipfile.ZipFile(p) as zf:  # sanity: the container itself still parses
+        assert zf.namelist() == ["archive/data.pkl"]
+
+    flags, results = scan_pickle_file_flags(p)  # must not raise
+    assert results, "corrupt oversized member was dropped entirely"
+    assert results[0].member == "archive/data.pkl"
+    types = {f["type"] for f in flags}
+    assert "OVERSIZE_PICKLE_UNSCANNED" in types, f"oversize fail-safe lost, got {types}"
+
+
+@pytest.mark.slow
+def test_real_gb_scale_pt_above_default_cap_fails_the_scan_gate(tmp_path: Path):
+    """The production shape: a >256 MiB .pt with a malicious first member.
+
+    Every realistic model artifact is far larger than the 256 MiB default cap.
+    This builds a real one on disk (and deletes it in teardown) to prove the
+    CLI exits 1 with a MALICIOUS_MODEL finding, exactly as it does for a small
+    .pt carrying the identical payload.
+    """
+    import shutil
+
+    free_bytes = shutil.disk_usage(tmp_path).free
+    if free_bytes < 2 * 1024 * 1024 * 1024:
+        pytest.skip(f"needs ~300 MiB of scratch space, only {free_bytes // (1 << 20)} MiB free")
+
+    default_cap = model_pickle_scan._MAX_PICKLE_BYTES
+    model_dir = tmp_path / "models"
+    model_dir.mkdir()
+    model = model_dir / "pytorch_model.pt"
+    output = tmp_path / "report.json"
+    try:
+        _stored_zip_over(model, first_member=_malicious_bytes(), total_bytes=default_cap)
+        assert model.stat().st_size > default_cap
+
+        with (
+            patch("agent_bom.cli.agents.discover_all", return_value=[]),
+            patch("agent_bom.cli.agents.scan_agents_sync", return_value=[]),
+            patch("agent_bom.cli.agents.resolve_all_versions_sync", return_value=[]),
+        ):
+            result = CliRunner().invoke(
+                main,
+                [
+                    "scan",
+                    "--model-files",
+                    str(model_dir),
+                    "--no-discover",
+                    "--no-scan",
+                    "--no-auto-update-db",
+                    "--format",
+                    "json",
+                    "--output",
+                    str(output),
+                ],
+                catch_exceptions=False,
+            )
+
+        assert result.exit_code == 1, f"a {model.stat().st_size >> 20} MiB malicious model did not fail the gate"
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        malicious = [f for f in payload["findings"] if f["finding_type"] == "MALICIOUS_MODEL"]
+        assert malicious, "no MALICIOUS_MODEL finding for the GB-scale artifact"
+        assert malicious[0]["severity"] == "critical"
+        assert malicious[0]["evidence"]["deserialized"] is False
+    finally:
+        model.unlink(missing_ok=True)

--- a/tests/test_repo_auto_detect.py
+++ b/tests/test_repo_auto_detect.py
@@ -83,6 +83,89 @@ def test_repo_static_surface_catalog_lists_api_surfaces() -> None:
     assert any(entry["api_repo_tree"] for entry in catalog)
 
 
+def test_expand_project_scan_targets_auto_iac_in_subdir(tmp_path: Path) -> None:
+    """IaC nested below the project root must be auto-detected.
+
+    ``tf_dirs`` detection has always been recursive, so a repo with
+    ``infra/main.tf`` reported ``terraform`` as a completed scan source while
+    the IaC rules — gated behind a top-level-only glob — never ran.
+    """
+    (tmp_path / "infra").mkdir()
+    (tmp_path / "infra" / "main.tf").write_text('resource "aws_s3_bucket" "x" {}\n', encoding="utf-8")
+
+    targets = expand_project_scan_targets(str(tmp_path))
+
+    assert "iac" in targets.auto_enabled
+    assert targets.iac_paths == (str(tmp_path),)
+    # The recursive terraform surface and the IaC surface must agree.
+    assert "terraform" in targets.auto_enabled
+
+
+def test_expand_project_scan_targets_auto_iac_covers_non_terraform_formats(tmp_path: Path) -> None:
+    """Dockerfile / K8s / Helm nested anywhere count as IaC, not just ``*.tf``."""
+    for relative, body in (
+        ("deploy/Dockerfile.prod", "FROM python:3.13\nUSER root\n"),
+        ("charts/app/values.yaml", "image:\n  tag: latest\n"),
+        ("k8s/deployment.yaml", "apiVersion: apps/v1\nkind: Deployment\n"),
+    ):
+        target = tmp_path / relative
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(body, encoding="utf-8")
+        targets = expand_project_scan_targets(str(tmp_path))
+        assert "iac" in targets.auto_enabled, f"{relative} was not detected as IaC"
+        target.unlink()
+
+
+def test_expand_project_scan_targets_no_iac_when_tree_has_none(tmp_path: Path) -> None:
+    """Detection must not fire on a plain source tree (no false scan source)."""
+    (tmp_path / "app.py").write_text("print('hi')\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("# hi\n", encoding="utf-8")
+
+    targets = expand_project_scan_targets(str(tmp_path))
+
+    assert "iac" not in targets.auto_enabled
+    assert targets.iac_paths == ()
+
+
+def test_expand_project_scan_targets_respects_explicit_iac(tmp_path: Path) -> None:
+    (tmp_path / "main.tf").write_text('resource "aws_s3_bucket" "x" {}\n', encoding="utf-8")
+    custom = tmp_path / "custom"
+    custom.mkdir()
+
+    targets = expand_project_scan_targets(str(tmp_path), iac_paths=(str(custom),))
+
+    assert targets.iac_paths == (str(custom),)
+    assert "iac" not in targets.auto_enabled
+
+
+def test_iac_detection_agrees_with_the_scanner_dispatch(tmp_path: Path) -> None:
+    """Auto-detect and the scanner must share one definition of "is IaC".
+
+    If they drift, the CLI can again report a scan source whose rules never
+    ran. ``is_iac_file`` is that single source of truth.
+    """
+    from agent_bom.iac import is_iac_file, scan_iac_with_context
+
+    tf = tmp_path / "infra" / "main.tf"
+    tf.parent.mkdir()
+    tf.write_text('resource "aws_s3_bucket" "b" {\n  acl = "public-read"\n}\n', encoding="utf-8")
+
+    assert is_iac_file(tf, tmp_path) is True
+    assert is_iac_file(tmp_path / "notes.md", tmp_path) is False
+    # The scanner really dispatches terraform for this tree.
+    verdicts = {v.scanner_id: v.status for v in scan_iac_with_context(tmp_path).verdicts}
+    assert verdicts["terraform"] == "ran"
+
+
+def test_repo_static_surface_catalog_marks_iac_as_cli_auto() -> None:
+    """The published catalog must not claim IaC is API-only once the CLI runs it."""
+    from agent_bom.repo_auto_detect import repo_static_surface_catalog
+
+    iac = next(entry for entry in repo_static_surface_catalog() if entry["id"] == "iac")
+    assert iac["cli_auto_key"] == "iac"
+    assert iac["api_repo_tree"] is True
+
+
 def test_expand_project_scan_targets_respects_explicit_ai_inventory(tmp_path: Path) -> None:
     (tmp_path / "requirements.txt").write_text("langchain==0.2.0\n", encoding="utf-8")
     custom = tmp_path / "custom"


### PR DESCRIPTION
Three defects, all of the same shape: **the product detected something and then failed to act on it.**

## P0 — malicious models above 256 MiB were silently unscanned

`scan_pickle_file` read the file into a buffer capped at `AGENT_BOM_PICKLE_MAX_BYTES` and truncated
it. A `.pt` is a ZIP, and **a ZIP's central directory lives at the end of the file** — so truncation
destroyed it, `zipfile` rejected the archive, and the payload was never disassembled. The result was
a LOW `PICKLE_SCAN_ERROR` that reached no finding, no export, and no gate.

Identical `__reduce__ → os.system` payload, real 261 MiB fixture:

| | before | after |
|---|---|---|
| small `.pt` (4,378 B) | exit 1, 1 `MALICIOUS_MODEL` | exit 1, 1 `MALICIOUS_MODEL` |
| **261 MiB `.pt`** | **exit 0, 0 findings** | **exit 1, 1 `MALICIOUS_MODEL`** |

Every realistic model is GB-scale, so the detector repaired in #4567 was inert in production — and
silently so. ZIPs are now opened **by path** so the directory survives; the byte cap stays
per-member, which `_scan_zip` already applied correctly. Raw non-ZIP pickles past the cap now get
the oversize fail-safe instead of silent truncation.

`to_security_flag` also checked `verdict == "error"` **before** the oversize branch, making
`OVERSIZE_PICKLE_UNSCANNED` — the fail-safe written specifically to stop padding evasion —
unreachable. Branches are now ordered by signal strength: malicious/suspicious → oversize → error.

### A second bug the new tests surfaced

Writing the corrupt-member test found that `zf.open(member).read()` raises
**`zlib.error: Error -3 while decompressing data`**, and `zlib.error` subclasses `Exception`, **not
`OSError`** — so the handler `except (OSError, zipfile.BadZipFile, RuntimeError, NotImplementedError)`
never caught it. A crafted archive crashed a scanner whose own module docstring promises *"Truncated
or garbage input never raises."* Now guarded, reporting the member as an error result rather than
propagating, and an unreadable member declaring a size past the cap keeps its HIGH oversize signal
instead of downgrading to LOW.

## P1 — the promotion filter was a one-string allowlist

`model_files.py:319` filtered on `flag["type"] != "MALICIOUS_PICKLE"` and dropped everything else —
including `HASH_MISMATCH` (CRITICAL) and `UNSIGNED`, which is why `--require-model-signatures` was a
**no-op**: `rc 0`, 0 findings, with an unsigned model present.

Replaced with `MODEL_FLAG_PROMOTIONS`, an explicit table carrying finding type, CWE, risk score,
detector and remediation per flag, severity read off the flag. `INVENTORY_ONLY_MODEL_FLAGS`
documents the three deliberate exclusions **with reasons**.

**The guard that matters:** `test_every_emitted_model_flag_is_promoted_or_documented_inventory_only`
AST-parses the three emitters for every `"type"` literal and fails if one is neither promoted nor
allowlisted — and also catches stale entries and empty reasons. Proven non-vacuous by adding a
`NEWLY_ADDED_FLAG_TYPE` to a detector: it failed by name, then passed on revert. This defect class
has now shipped three times in this file; that test is what stops a fourth.

**Judgement call:** a new `FindingType.MODEL_INTEGRITY` rather than labelling an unsigned or merely
unscanned artifact `MALICIOUS_MODEL`, which would over-claim a confirmed implant. Blast radius
wired: enum, `framework_mapping`, `finding_scope` lanes (verified `aispm`), schema gates re-checked.

## P1 — `agent-bom scan` ran no IaC rules while reporting `terraform` as a scan source

**The original diagnosis was wrong and the corrected one is more interesting.** An IaC auto-detect
*does* exist at `_discovery.py:408`, but it is a **top-level-only glob** (`cwd.glob("*.tf")`, `*.yaml`
only, bare `Dockerfile`), while `tf_dirs` detection is recursive. So IaC under `infra/`, `deploy/` or
`charts/` — the normal layout — was reported as scanned and never was.

Detection is now recursive in `expand_project_scan_targets`, delegating to a new
`agent_bom.iac.is_iac_file` that **reuses the scanner's own dispatch predicates**, so detection and
dispatch cannot drift apart again. `scan_sources` reports `iac` from `ctx.iac_findings_data` — i.e.
from the step having actually run.

Nested `infra/main.tf` + `deploy/Dockerfile.prod`: `scan_sources: ['terraform']` with **0** IaC
findings → `['terraform', 'iac']` with **8 findings (1 critical, 2 high)**, matching `agent-bom iac`
and `scan -p --iac` exactly.

**Scope correction, worth reading:** the first version applied the recursive walk to the bare-cwd
path too, which broke `test_two_tier_severity.py::test_warn_on_no_findings_exits_zero` — that test
runs `scan` with no `-p` and picked up agent-bom's own Helm/Docker IaC. The recursive walk is now
scoped to an explicit `--project`/`--repo`; a bare `agent-bom scan` takes the ambient cwd (possibly
`$HOME`) as root and keeps its cheap glob.

## Verification

`2160 passed, 9 skipped` across model/pickle/IaC/scan-CLI/discovery/severity suites · `tests/api/`
**1149 passed** · the slow >256 MiB test passes against a genuine 268,501,381-byte fixture (deleted
in `finally`) · `ruff check src tests` clean · `mypy` clean on all 7 changed modules · OpenAPI, v1
schemas, package-layout and env-var gates OK. Re-verified after rebase onto current `main`:
**1210 passed**. All commits signed (`G`).

## Notes

- `ruff format` was not run: the venv has ruff 0.16.0 while `.pre-commit-config.yaml` pins v0.9.7,
  and `origin/main`'s own `tests/test_repo_auto_detect.py` fails `format --check` under 0.16.0.
  Applying it would churn committed code against a different formatter than the repo uses.
- `product_metrics_snapshot.py --write` produced a **date-only** diff (`generated_on` rolling to the
  next day) with no metric change; reverted rather than commit churn.
