### PR TITLE
fix(graph): make attack-path search honest about its bounds and stop it scanning the estate per hop

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-01",
+  "generated_on": "2026-08-02",
   "version": "0.98.2",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1092,
+      "value": 1093,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 821,
+      "value": 817,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-01`
+- Generated on: `2026-08-02`
 - Version: `0.98.2`
 
 | Metric | Value | Source | Notes |
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1092 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1093 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 817 | `src/agent_bom` | Counts all Python files recursively. |

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -17,7 +17,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | Test files | 1099 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 821 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 817 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/agent_manifest.py
+++ b/src/agent_bom/agent_manifest.py
@@ -411,8 +411,15 @@ def _graph(agents: list[dict[str, object]], servers: list[dict[str, object]]) ->
                 ref_name = str(ref.get("name") or "")
                 if not ref_name:
                     continue
-                cred_id = f"credential:{ref_name}"
-                nodes[cred_id] = _node(cred_id, "credential", ref_name, kind=ref.get("kind"))
+                # An env-var name identifies a credential *slot* on this server,
+                # not the underlying secret. Keying the node on the name alone
+                # merged every server that happens to read ``API_KEY`` into one
+                # node, joining unrelated estates into a single connected
+                # component and fabricating a lateral-movement route the scan
+                # has no evidence for. Same scoping as ``graph/builder.py`` and
+                # ``context_graph.py``; the label stays the bare name.
+                cred_id = f"credential:{server_id}:{ref_name}"
+                nodes[cred_id] = _node(cred_id, "credential", ref_name, kind=ref.get("kind"), server=server_id)
                 edges[f"{server_id}:exposes_cred:{cred_id}"] = _edge(
                     f"{server_id}:exposes_cred:{cred_id}",
                     server_id,

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -35,6 +35,7 @@ from agent_bom.graph import (
     technique_mappings_from_json,
 )
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
+from agent_bom.graph.completeness import bounded_walk_reason, impact_completeness
 from agent_bom.graph.container import apply_node_budget
 from agent_bom.graph.ocsf import FINDING_ENTITY_TYPES
 
@@ -271,13 +272,16 @@ class GraphStoreProtocol(Protocol):
         source: str,
         max_depth: int = 4,
         traversable_only: bool = True,
-    ) -> tuple[list[list[str]], set[str], bool]:
-        """Paths and reachable set from ``source``, plus whether the walk was bounded.
+    ) -> tuple[list[list[str]], set[str], bool, bool]:
+        """Paths and reachable set from ``source``, plus how the walk was bounded.
 
-        The third element is the traversal's own truncation flag. It is part of
-        the answer, not diagnostics: without it a caller cannot tell "these are
-        all the reachable nodes" from "these are the first ``max_nodes`` we got
-        to", and every surface downstream reports the bound as the total.
+        The last two elements are part of the answer, not diagnostics. Without
+        them a caller cannot tell "these are all the reachable nodes" from
+        "these are the first ``max_nodes`` we got to" (third element,
+        budget-bounded) or "these are the ones within ``max_depth``" (fourth,
+        depth-bounded, and only ever true when the frontier still had unwalked
+        neighbours). Either way the surface downstream must not report the
+        bound as the total.
         """
         ...
 
@@ -672,11 +676,11 @@ class SQLiteGraphStore:
         static_only: bool,
         dynamic_only: bool,
         include_roots: bool,
-    ) -> tuple[str, str, set[str], dict[str, int], dict[tuple[str, str, str], UnifiedEdge], dict[str, str], list[str], bool]:
+    ) -> tuple[str, str, set[str], dict[str, int], dict[tuple[str, str, str], UnifiedEdge], dict[str, str], list[str], bool, bool]:
         tenant_id = sqlite_graph_store.normalize_graph_tenant_id(tenant_id)
         effective_scan_id, created_at = sqlite_graph_store._resolve_snapshot(conn, tenant_id=tenant_id, scan_id=scan_id)
         if not effective_scan_id:
-            return scan_id, "", set(), {}, {}, {}, [], False
+            return scan_id, "", set(), {}, {}, {}, [], False, False
 
         existing_roots = {node.id for node in self.nodes_by_ids(tenant_id=tenant_id, scan_id=effective_scan_id, node_ids=set(roots))}
         visited: set[str] = set()
@@ -685,7 +689,33 @@ class SQLiteGraphStore:
         parent_by_node: dict[str, str] = {}
         discovery_order: list[str] = []
         truncated = False
+        depth_limited = False
         edge_count = 0
+
+        def _neighbors(node_id: str) -> list[str]:
+            found: list[str] = []
+            for row in self._filtered_edge_rows(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=effective_scan_id,
+                frontier={node_id},
+                traversable_only=traversable_only,
+                relationship_types=relationship_types,
+                static_only=static_only,
+                dynamic_only=dynamic_only,
+            ):
+                edge = self._edge_from_row(row)
+                if direction in {"forward", "both"}:
+                    if edge.source == node_id:
+                        found.append(edge.target)
+                    elif edge.is_bidirectional and edge.target == node_id:
+                        found.append(edge.source)
+                if direction in {"reverse", "both"}:
+                    if edge.target == node_id:
+                        found.append(edge.source)
+                    elif edge.is_bidirectional and edge.source == node_id:
+                        found.append(edge.target)
+            return found
 
         queue: list[tuple[str, int]] = []
         for root in roots:
@@ -704,6 +734,11 @@ class SQLiteGraphStore:
             current, depth = queue[index]
             index += 1
             if depth >= max_depth:
+                # Frontier node: only a *demonstrably* unwalked neighbour makes
+                # this an incomplete answer. Costs one edge lookup per frontier
+                # node, and only until the first one that leaves work behind.
+                if not depth_limited and any(neighbor not in visited for neighbor in _neighbors(current)):
+                    depth_limited = True
                 continue
             for row in self._filtered_edge_rows(
                 conn,
@@ -755,7 +790,17 @@ class SQLiteGraphStore:
         if include_roots:
             visited.update(existing_roots)
 
-        return effective_scan_id, created_at, visited, depth_by_node, traversed_edges, parent_by_node, discovery_order, truncated
+        return (
+            effective_scan_id,
+            created_at,
+            visited,
+            depth_by_node,
+            traversed_edges,
+            parent_by_node,
+            discovery_order,
+            truncated,
+            depth_limited,
+        )
 
     def bfs_paths(
         self,
@@ -765,10 +810,10 @@ class SQLiteGraphStore:
         source: str,
         max_depth: int = 4,
         traversable_only: bool = True,
-    ) -> tuple[list[list[str]], set[str], bool]:
+    ) -> tuple[list[list[str]], set[str], bool, bool]:
         conn = self._open_ro_conn()
         if conn is None:
-            return [], set(), False
+            return [], set(), False, False
         try:
             (
                 _effective_scan_id,
@@ -779,6 +824,7 @@ class SQLiteGraphStore:
                 parent_by_node,
                 discovery_order,
                 truncated,
+                depth_limited,
             ) = self._walk_graph(
                 conn,
                 tenant_id=tenant_id,
@@ -796,7 +842,7 @@ class SQLiteGraphStore:
                 include_roots=True,
             )
             if source not in visited:
-                return [], set(), truncated
+                return [], set(), truncated, depth_limited
 
             paths: list[list[str]] = []
             for node_id in discovery_order:
@@ -812,7 +858,7 @@ class SQLiteGraphStore:
                     paths.append(path)
             reachable = set(visited)
             reachable.discard(source)
-            return paths, reachable, truncated
+            return paths, reachable, truncated, depth_limited
         finally:
             conn.close()
 
@@ -828,7 +874,7 @@ class SQLiteGraphStore:
         if conn is None:
             return None
         try:
-            effective_scan_id, _created_at, visited, depth_by_node, _edges, _parents, _order, _truncated = self._walk_graph(
+            effective_scan_id, _created_at, visited, depth_by_node, _edges, _parents, _order, truncated, depth_limited = self._walk_graph(
                 conn,
                 tenant_id=tenant_id,
                 scan_id=scan_id,
@@ -860,6 +906,11 @@ class SQLiteGraphStore:
                 "affected_by_type": affected_by_type,
                 "affected_count": len(affected_nodes),
                 "max_depth_reached": max((depth_by_node.get(node, 0) for node in affected_nodes), default=0),
+                "completeness": impact_completeness(
+                    affected_count=len(affected_nodes),
+                    truncated=truncated,
+                    depth_limited=depth_limited,
+                ),
             }
         finally:
             conn.close()
@@ -885,21 +936,23 @@ class SQLiteGraphStore:
         if conn is None:
             return UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id), {}, False
         try:
-            effective_scan_id, created_at, visited, depth_by_node, traversed_edges, _parents, _order, truncated = self._walk_graph(
-                conn,
-                tenant_id=tenant_id,
-                scan_id=scan_id,
-                roots=roots,
-                direction=direction,
-                max_depth=max_depth,
-                max_nodes=max_nodes,
-                max_edges=max_edges,
-                deadline_monotonic=deadline_monotonic,
-                traversable_only=traversable_only,
-                relationship_types=relationship_types,
-                static_only=static_only,
-                dynamic_only=dynamic_only,
-                include_roots=include_roots,
+            effective_scan_id, created_at, visited, depth_by_node, traversed_edges, _parents, _order, truncated, depth_limited = (
+                self._walk_graph(
+                    conn,
+                    tenant_id=tenant_id,
+                    scan_id=scan_id,
+                    roots=roots,
+                    direction=direction,
+                    max_depth=max_depth,
+                    max_nodes=max_nodes,
+                    max_edges=max_edges,
+                    deadline_monotonic=deadline_monotonic,
+                    traversable_only=traversable_only,
+                    relationship_types=relationship_types,
+                    static_only=static_only,
+                    dynamic_only=dynamic_only,
+                    include_roots=include_roots,
+                )
             )
             graph = UnifiedGraph(scan_id=effective_scan_id, tenant_id=tenant_id, created_at=created_at)
             if not effective_scan_id:
@@ -910,6 +963,25 @@ class SQLiteGraphStore:
             for edge in traversed_edges.values():
                 if edge.source in graph.nodes and edge.target in graph.nodes:
                     graph.add_edge(edge)
+            # Same invariant #4595 pinned for Postgres: a store-side traversal
+            # returns a fresh UnifiedGraph, whose default completeness claims a
+            # complete walk of a 0-node graph beside the N nodes it just filled
+            # in. Describe what was actually returned, and why it stopped.
+            # Snapshot size for the completeness denominator: a primary-key
+            # lookup on (scan_id, tenant_id), never a COUNT over graph_nodes,
+            # which would put an O(snapshot) scan on every traversal.
+            row = conn.execute(
+                "SELECT node_count FROM graph_snapshots WHERE tenant_id = ? AND scan_id = ?",
+                (sqlite_graph_store.normalize_graph_tenant_id(tenant_id), effective_scan_id),
+            ).fetchone()
+            snapshot_nodes = int(row[0] or 0) if row else 0
+
+            graph.completeness.truncated = truncated
+            graph.completeness.depth_limited = depth_limited
+            graph.completeness.node_budget = max_nodes if truncated else None
+            graph.completeness.reason = bounded_walk_reason(truncated=truncated, depth_limited=depth_limited)
+            graph.completeness.total_nodes = snapshot_nodes or len(graph.nodes)
+            graph.completeness.returned_nodes = len(graph.nodes)
             return graph, depth_by_node, truncated
         finally:
             conn.close()

--- a/src/agent_bom/api/graph_store.py
+++ b/src/agent_bom/api/graph_store.py
@@ -577,6 +577,83 @@ class SQLiteGraphStore:
             activity_id=edge.activity_id,
         )
 
+    def _frontier_edge_query(
+        self,
+        *,
+        tenant_id: str,
+        scan_id: str,
+        frontier: set[str],
+        traversable_only: bool = False,
+        relationship_types: set[RelationshipType] | None = None,
+        static_only: bool = False,
+        dynamic_only: bool = False,
+    ) -> tuple[str, list[Any]]:
+        """Build the per-hop "edges touching these nodes" query, and its parameters.
+
+        Written as a UNION of two endpoint-anchored branches rather than the
+        obvious ``source_id IN (...) OR target_id IN (...)`` disjunction. SQLite
+        cannot drive a single index from that disjunction: it settles on
+        ``idx_ge_tenant_scan`` and reads every edge in the snapshot, once per
+        node the walk visits, making traversal cost visited x snapshot_edges.
+        Split into two branches, each is an index seek against
+        ``idx_ge_tenant_scan_source`` / ``idx_ge_tenant_scan_target``, so a hop
+        costs its own degree.
+
+        Both halves are load-bearing: the disjunction ignores those indexes even
+        when they exist, and the UNION falls back to a full snapshot scan when
+        they do not. Neither relies on ``sqlite_stat1``, which a freshly written
+        customer database does not have.
+
+        ``ORDER BY rowid`` reproduces the row order the scan happened to yield
+        (index entries for one snapshot are ordered by rowid, i.e. insertion
+        order), so ``discovery_order``, ``parent_by_node`` and every path built
+        from them are unchanged — and are now pinned to insertion order outright
+        instead of inherited from whichever plan the query planner picked.
+        """
+        placeholders = ",".join("?" for _ in frontier)
+        # Sorted so the emitted SQL and parameters are deterministic across runs.
+        ordered_frontier = sorted(frontier)
+        shared: list[str] = []
+        shared_params: list[Any] = []
+        if traversable_only:
+            shared.append("traversable = 1")
+        if relationship_types:
+            rel_values = sorted(rel.value if isinstance(rel, RelationshipType) else str(rel) for rel in relationship_types)
+            shared.append(f"relationship IN ({','.join('?' for _ in rel_values)})")
+            shared_params.extend(rel_values)
+        if static_only:
+            shared.append(f"relationship NOT IN ({','.join('?' for _ in _DYNAMIC_RELATIONSHIP_VALUES)})")
+            shared_params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
+        if dynamic_only:
+            shared.append(f"relationship IN ({','.join('?' for _ in _DYNAMIC_RELATIONSHIP_VALUES)})")
+            shared_params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
+        shared_sql = ("".join(f" AND {clause}" for clause in shared)) if shared else ""
+
+        def branch(column: str) -> str:
+            return f"SELECT rowid FROM graph_edges WHERE tenant_id = ? AND scan_id = ? AND {column} IN ({placeholders}){shared_sql}"
+
+        params: list[Any] = [
+            tenant_id,
+            scan_id,
+            *ordered_frontier,
+            *shared_params,
+            tenant_id,
+            scan_id,
+            *ordered_frontier,
+            *shared_params,
+        ]
+        sql = f"""
+            SELECT *
+            FROM graph_edges
+            WHERE rowid IN (
+                {branch("source_id")}
+                UNION
+                {branch("target_id")}
+            )
+            ORDER BY rowid
+            """  # nosec B608 - clause fragments and placeholders are generated internally
+        return sql, params
+
     def _filtered_edge_rows(
         self,
         conn: sqlite3.Connection,
@@ -591,36 +668,16 @@ class SQLiteGraphStore:
     ) -> list[sqlite3.Row]:
         if not frontier:
             return []
-        placeholders = ",".join("?" for _ in frontier)
-        where = [
-            "tenant_id = ?",
-            "scan_id = ?",
-            f"(source_id IN ({placeholders}) OR target_id IN ({placeholders}))",
-        ]
-        params: list[Any] = [tenant_id, scan_id, *frontier, *frontier]
-        if traversable_only:
-            where.append("traversable = 1")
-        if relationship_types:
-            rel_values = sorted(rel.value if isinstance(rel, RelationshipType) else str(rel) for rel in relationship_types)
-            rel_placeholders = ",".join("?" for _ in rel_values)
-            where.append(f"relationship IN ({rel_placeholders})")
-            params.extend(rel_values)
-        if static_only:
-            dynamic_placeholders = ",".join("?" for _ in _DYNAMIC_RELATIONSHIP_VALUES)
-            where.append(f"relationship NOT IN ({dynamic_placeholders})")
-            params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
-        if dynamic_only:
-            dynamic_placeholders = ",".join("?" for _ in _DYNAMIC_RELATIONSHIP_VALUES)
-            where.append(f"relationship IN ({dynamic_placeholders})")
-            params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
-        return conn.execute(
-            f"""
-            SELECT *
-            FROM graph_edges
-            WHERE {" AND ".join(where)}
-            """,  # nosec B608 - clause fragments and placeholders are generated internally
-            params,
-        ).fetchall()
+        sql, params = self._frontier_edge_query(
+            tenant_id=tenant_id,
+            scan_id=scan_id,
+            frontier=frontier,
+            traversable_only=traversable_only,
+            relationship_types=relationship_types,
+            static_only=static_only,
+            dynamic_only=dynamic_only,
+        )
+        return conn.execute(sql, params).fetchall()
 
     def nodes_by_ids(
         self,

--- a/src/agent_bom/api/neptune_graph.py
+++ b/src/agent_bom/api/neptune_graph.py
@@ -520,7 +520,7 @@ class NeptuneGraphStore:
     def nodes_by_ids(self, **_kwargs: Any) -> list[UnifiedNode]:
         self._unsupported("nodes_by_ids")
 
-    def bfs_paths(self, **_kwargs: Any) -> tuple[list[list[str]], set[str], bool]:
+    def bfs_paths(self, **_kwargs: Any) -> tuple[list[list[str]], set[str], bool, bool]:
         self._unsupported("bfs_paths")
 
     def impact_of(self, **_kwargs: Any) -> dict[str, Any] | None:

--- a/src/agent_bom/api/postgres_graph.py
+++ b/src/agent_bom/api/postgres_graph.py
@@ -27,6 +27,7 @@ from agent_bom.config import POSTGRES_GRAPH_SEARCH_TIMEOUT_MS, POSTGRES_STATEMEN
 from agent_bom.db.graph_store import DEFAULT_GRAPH_TENANT_ID, graph_retention_policy, normalize_graph_tenant_id
 from agent_bom.graph import EntityType, technique_mappings_from_json
 from agent_bom.graph.analysis import GraphAnalysisStatus, analysis_status_map_from_dict, analysis_status_map_to_dict
+from agent_bom.graph.completeness import bounded_walk_reason, impact_completeness
 from agent_bom.security import sanitize_text
 
 from .postgres_common import (
@@ -1390,7 +1391,7 @@ class PostgresGraphStore:
         static_only: bool,
         dynamic_only: bool,
         include_roots: bool,
-    ) -> tuple[str, str, set[str], dict[str, int], dict[tuple[str, str, str], Any], dict[str, str], list[str], bool]:
+    ) -> tuple[str, str, set[str], dict[str, int], dict[tuple[str, str, str], Any], dict[str, str], list[str], bool, bool]:
         tenant_id = normalize_graph_tenant_id(tenant_id)
         effective_scan_id = scan_id
         if not effective_scan_id:
@@ -1406,7 +1407,7 @@ class PostgresGraphStore:
             ).fetchone()
             effective_scan_id = str(latest[0]) if latest else ""
         if not effective_scan_id:
-            return scan_id, "", set(), {}, {}, {}, [], False
+            return scan_id, "", set(), {}, {}, {}, [], False, False
         snapshot = conn.execute(
             "SELECT created_at FROM graph_snapshots WHERE tenant_id = %s AND scan_id = %s",
             (tenant_id, effective_scan_id),
@@ -1437,7 +1438,36 @@ class PostgresGraphStore:
                 visited.add(root)
 
         truncated = False
+        depth_limited = False
         edge_count = 0
+
+        def _neighbors(node_id: str) -> list[str]:
+            found: list[str] = []
+            neighbor_rows, _hit = self._filtered_edge_rows(
+                conn,
+                tenant_id=tenant_id,
+                scan_id=effective_scan_id,
+                frontier={node_id},
+                traversable_only=traversable_only,
+                relationship_types=relationship_types,
+                static_only=static_only,
+                dynamic_only=dynamic_only,
+                limit=max_edges,
+            )
+            for neighbor_row in neighbor_rows:
+                edge = self._edge_from_row(neighbor_row)
+                if direction in {"forward", "both"}:
+                    if edge.source == node_id:
+                        found.append(edge.target)
+                    elif edge.is_bidirectional and edge.target == node_id:
+                        found.append(edge.source)
+                if direction in {"reverse", "both"}:
+                    if edge.target == node_id:
+                        found.append(edge.source)
+                    elif edge.is_bidirectional and edge.source == node_id:
+                        found.append(edge.target)
+            return found
+
         index = 0
         while index < len(queue):
             if deadline_monotonic is not None and time.monotonic() >= deadline_monotonic:
@@ -1446,6 +1476,11 @@ class PostgresGraphStore:
             current, depth = queue[index]
             index += 1
             if depth >= max_depth:
+                # Frontier node: only a *demonstrably* unwalked neighbour makes
+                # this an incomplete answer. Costs one edge lookup per frontier
+                # node, and only until the first one that leaves work behind.
+                if not depth_limited and any(neighbor not in visited for neighbor in _neighbors(current)):
+                    depth_limited = True
                 continue
             rows, hit_limit = self._filtered_edge_rows(
                 conn,
@@ -1494,10 +1529,7 @@ class PostgresGraphStore:
                     queue.append((neighbor, depth + 1))
             if hit_limit:
                 break
-            if truncated and (
-                edge_count > max_edges
-                or (deadline_monotonic is not None and time.monotonic() >= deadline_monotonic)
-            ):
+            if truncated and (edge_count > max_edges or (deadline_monotonic is not None and time.monotonic() >= deadline_monotonic)):
                 break
 
         if include_roots:
@@ -1511,6 +1543,7 @@ class PostgresGraphStore:
             parent_by_node,
             discovery_order,
             truncated,
+            depth_limited,
         )
 
     def bfs_paths(
@@ -1521,13 +1554,13 @@ class PostgresGraphStore:
         source: str,
         max_depth: int = 4,
         traversable_only: bool = True,
-    ) -> tuple[list[list[str]], set[str], bool]:
+    ) -> tuple[list[list[str]], set[str], bool, bool]:
         tenant_id = normalize_graph_tenant_id(tenant_id)
         timeout_ms = _graph_search_timeout_ms()
         deadline = time.monotonic() + (timeout_ms / 1000) if timeout_ms else None
         with _tenant_connection(self._pool) as conn:
             _apply_graph_search_timeout(conn)
-            _, _, visited, _, _, parents, order, truncated = self._walk_graph(
+            _, _, visited, _, _, parents, order, truncated, depth_limited = self._walk_graph(
                 conn,
                 tenant_id=tenant_id,
                 scan_id=scan_id,
@@ -1544,7 +1577,7 @@ class PostgresGraphStore:
                 include_roots=True,
             )
         if source not in visited:
-            return [], set(), truncated
+            return [], set(), truncated, depth_limited
         paths: list[list[str]] = []
         for node_id in order:
             path = [node_id]
@@ -1556,7 +1589,7 @@ class PostgresGraphStore:
             if path and path[0] == source:
                 paths.append(path)
         visited.discard(source)
-        return paths, visited, truncated
+        return paths, visited, truncated, depth_limited
 
     def impact_of(
         self,
@@ -1571,7 +1604,7 @@ class PostgresGraphStore:
         deadline = time.monotonic() + (timeout_ms / 1000) if timeout_ms else None
         with _tenant_connection(self._pool) as conn:
             _apply_graph_search_timeout(conn)
-            effective_scan_id, _, visited, depths, _, _, _, truncated = self._walk_graph(
+            effective_scan_id, _, visited, depths, _, _, _, truncated, depth_limited = self._walk_graph(
                 conn,
                 tenant_id=tenant_id,
                 scan_id=scan_id,
@@ -1601,7 +1634,14 @@ class PostgresGraphStore:
             "affected_by_type": by_type,
             "affected_count": len(affected),
             "max_depth_reached": max((depths.get(value, 0) for value in affected), default=0),
-            "completeness": "partial" if truncated else "complete",
+            # Was a bare "partial"/"complete" string here and absent entirely on
+            # SQLite: one field, two shapes, neither of which said that a
+            # depth-capped reverse walk had left ancestors unvisited.
+            "completeness": impact_completeness(
+                affected_count=len(affected),
+                truncated=truncated,
+                depth_limited=depth_limited,
+            ),
         }
 
     def traverse_subgraph(
@@ -1628,7 +1668,7 @@ class PostgresGraphStore:
             query_deadline = min(query_deadline, deadline_monotonic) if query_deadline is not None else deadline_monotonic
         with _tenant_connection(self._pool) as conn:
             _apply_graph_search_timeout(conn)
-            effective_scan_id, created_at, visited, depths, edges, _, _, truncated = self._walk_graph(
+            effective_scan_id, created_at, visited, depths, edges, _, _, truncated, depth_limited = self._walk_graph(
                 conn,
                 tenant_id=tenant_id,
                 scan_id=scan_id,
@@ -1668,7 +1708,8 @@ class PostgresGraphStore:
         # self-contradiction; matching the in-memory container's shape keeps a
         # store swap from changing what a client is told.
         graph.completeness.truncated = truncated
-        graph.completeness.reason = "traversal_budget" if truncated else ""
+        graph.completeness.depth_limited = depth_limited
+        graph.completeness.reason = bounded_walk_reason(truncated=truncated, depth_limited=depth_limited)
         graph.completeness.node_budget = max_nodes if truncated else None
         graph.completeness.total_nodes = snapshot_nodes or len(graph.nodes)
         graph.completeness.returned_nodes = len(graph.nodes)

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -56,7 +56,7 @@ from agent_bom.graph import (
     UnifiedGraph,
     UnifiedNode,
 )
-from agent_bom.graph.completeness import graph_completeness
+from agent_bom.graph.completeness import bounded_walk_reason, graph_completeness
 from agent_bom.graph.scope import GraphScopeKind, select_observed_scope
 from agent_bom.graph.semantic_clusters import SEMANTIC_CLUSTER_KINDS, build_semantic_clusters, semantic_cluster_stats
 from agent_bom.security import sanitize_error
@@ -2541,15 +2541,19 @@ async def post_graph_should_i_deploy(request: Request, body: GraphDeployDecision
     return cast("dict[str, Any]", payload)
 
 
-def _paths_truncation_reason(traversal_truncated: bool, page_truncated: bool) -> str:
+def _paths_truncation_reason(traversal_truncated: bool, page_truncated: bool, depth_limited: bool = False) -> str:
     """Name the *stronger* loss first.
 
-    A traversal budget is a harder limit than a page limit: paging further
-    cannot recover the nodes the walk never reached, so the traversal reason
-    must not be masked by the pagination one.
+    A traversal budget is a harder limit than a depth cap, which is harder than
+    a page limit: paging further cannot recover the nodes the walk never
+    reached, and raising ``max_depth`` cannot recover the nodes the node budget
+    never let it visit. So the deeper reason must not be masked by the shallower
+    one.
     """
     if traversal_truncated:
         return "traversal_budget"
+    if depth_limited:
+        return "depth_limit"
     return "path_page_limit" if page_truncated else ""
 
 
@@ -2575,7 +2579,7 @@ async def get_graph_paths(
     if not source_nodes:
         raise HTTPException(status_code=404, detail=f"Node '{source_node_id}' not found in graph")
 
-    all_paths, reachable, traversal_truncated = await _graph_store_call(
+    all_paths, reachable, traversal_truncated, depth_limited = await _graph_store_call(
         graph_store.bfs_paths,
         scan_id=requested_scan_id,
         tenant_id=tenant,
@@ -2619,15 +2623,19 @@ async def get_graph_paths(
         ],
         "pagination": pagination,
         "truncated": traversal_truncated,
-        # A budget-bounded BFS knows neither the reachable set nor the path
-        # count, so it cannot report a total: `len(all_paths)` is the bound, not
-        # the answer. Reporting it as `total` told a client that paged to
-        # exhaustion it had everything. Same invariant as /v1/graph/query.
+        "depth_limited": depth_limited,
+        # A bounded BFS knows neither the reachable set nor the path count, so
+        # it cannot report a total: `len(all_paths)` is the bound, not the
+        # answer. Reporting it as `total` told a client that paged to exhaustion
+        # it had everything. `max_depth` bounds it exactly as the node budget
+        # does — it defaults to 4 and is the server's choice when the caller
+        # passes nothing — so a walk that stopped with reachable nodes still
+        # unwalked is no more complete than one that ran out of budget.
         "completeness": graph_completeness(
             returned=len(paged_paths),
-            total=None if traversal_truncated else len(all_paths),
-            truncated=traversal_truncated or pagination["has_more"],
-            reason=_paths_truncation_reason(traversal_truncated, pagination["has_more"]),
+            total=None if (traversal_truncated or depth_limited) else len(all_paths),
+            truncated=traversal_truncated or depth_limited or pagination["has_more"],
+            reason=_paths_truncation_reason(traversal_truncated, pagination["has_more"], depth_limited),
         ),
     }
 
@@ -2846,6 +2854,9 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
         include_roots=body.include_roots,
     )
 
+    depth_limited = bool(getattr(traversal_graph.completeness, "depth_limited", False))
+    bounded = truncated or depth_limited
+
     filtered_graph = _filtered_query_graph(
         traversal_graph,
         roots=body.roots,
@@ -2893,6 +2904,7 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
         "timeout_ms": body.timeout_ms,
         "budget": budget,
         "truncated": truncated,
+        "depth_limited": depth_limited,
         "missing_roots": [],
         "depth_by_node": {node_id: depth for node_id, depth in depth_by_node.items() if node_id in filtered_graph.nodes},
         "nodes": [node.to_dict() for node in filtered_graph.nodes.values()],
@@ -2907,11 +2919,16 @@ async def query_graph(request: Request, body: GraphQueryRequest) -> dict:
             dynamic_only=body.dynamic_only,
             include_ids=set(body.roots),
         ).to_dict(),
+        # The traversal's own completeness carries a loss the `truncated` bool
+        # does not: a walk that stopped at `max_depth` with reachable nodes
+        # still unwalked. Reading only the bool reported such a walk as a
+        # complete answer, which is how a bounded traversal comes to read as
+        # "there is no attack path past here".
         "completeness": graph_completeness(
             returned=len(filtered_graph.nodes),
-            total=None if truncated else filtered_graph.stats().get("node_count", len(filtered_graph.nodes)),
-            truncated=truncated,
-            reason="traversal_budget" if truncated else "",
+            total=None if bounded else filtered_graph.stats().get("node_count", len(filtered_graph.nodes)),
+            truncated=bounded,
+            reason=bounded_walk_reason(truncated=truncated, depth_limited=depth_limited),
         ),
     }
 

--- a/src/agent_bom/db/graph_store.py
+++ b/src/agent_bom/db/graph_store.py
@@ -141,6 +141,13 @@ CREATE INDEX IF NOT EXISTS idx_ge_target ON graph_edges(target_id);
 CREATE INDEX IF NOT EXISTS idx_ge_rel ON graph_edges(relationship);
 CREATE INDEX IF NOT EXISTS idx_ge_scan ON graph_edges(scan_id);
 CREATE INDEX IF NOT EXISTS idx_ge_tenant_scan ON graph_edges(tenant_id, scan_id);
+-- Per-hop traversal indexes. A graph walk asks "which edges touch this node in
+-- this snapshot?" once per node it visits; without an endpoint column in the
+-- index that question degrades to a scan of the whole snapshot, so the walk
+-- costs visited x snapshot_edges. These mirror the Postgres store's
+-- idx_pg_graph_edges_scan_source / _scan_target.
+CREATE INDEX IF NOT EXISTS idx_ge_tenant_scan_source ON graph_edges(tenant_id, scan_id, source_id);
+CREATE INDEX IF NOT EXISTS idx_ge_tenant_scan_target ON graph_edges(tenant_id, scan_id, target_id);
 
 -- ── Snapshots ──
 CREATE TABLE IF NOT EXISTS graph_snapshots (
@@ -323,6 +330,9 @@ def _init_db(conn: sqlite3.Connection, *, backfill_legacy_tenants: bool = True) 
     conn.execute("UPDATE graph_edges SET valid_from = first_seen WHERE valid_from = '' OR valid_from IS NULL")
     conn.execute("UPDATE graph_edges SET source_scan_id = scan_id WHERE source_scan_id = '' OR source_scan_id IS NULL")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_ge_tenant_valid ON graph_edges(tenant_id, valid_from, valid_to)")
+    # Backfill the per-hop traversal indexes onto stores created before them.
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_ge_tenant_scan_source ON graph_edges(tenant_id, scan_id, source_id)")
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_ge_tenant_scan_target ON graph_edges(tenant_id, scan_id, target_id)")
     # Materialise the per-snapshot entity-type breakdown so inventory/summary
     # reads a cached count instead of a per-request GROUP BY over every node.
     # NULL marks pre-migration snapshots, which fall back to the live GROUP BY.
@@ -699,6 +709,7 @@ def save_graph_streaming(
     edge_count = 0
     severity_counts: dict[str, int] = defaultdict(int)
     type_counts: dict[str, int] = defaultdict(int)
+
     # ── Nodes ──
     def node_rows() -> Iterator[tuple[Any, ...]]:
         nonlocal node_count

--- a/src/agent_bom/graph/completeness.py
+++ b/src/agent_bom/graph/completeness.py
@@ -33,3 +33,32 @@ def graph_completeness(
     if reason:
         payload["reason"] = reason
     return payload
+
+
+def bounded_walk_reason(*, truncated: bool, depth_limited: bool) -> str:
+    """Name the *stronger* loss a bounded graph walk suffered.
+
+    A node/edge/deadline budget outranks a depth cap: raising ``max_depth``
+    cannot recover nodes the budget never let the walk visit, so the budget
+    reason must not be masked by the depth one.
+    """
+    if truncated:
+        return "traversal_budget"
+    return "depth_limit" if depth_limited else ""
+
+
+def impact_completeness(*, affected_count: int, truncated: bool, depth_limited: bool) -> dict[str, Any]:
+    """Completeness for a blast-radius walk.
+
+    A bounded reverse walk knows how many ancestors it *reached*, never how many
+    exist — so it reports no ``total``. Without this, ``affected_count`` read as
+    the whole blast radius, which is the difference between "nothing else
+    depends on this" and "we stopped looking".
+    """
+    bounded = truncated or depth_limited
+    return graph_completeness(
+        returned=affected_count,
+        total=None if bounded else affected_count,
+        truncated=bounded,
+        reason=bounded_walk_reason(truncated=truncated, depth_limited=depth_limited),
+    )

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -293,6 +293,16 @@ class GraphCompleteness:
     total_nodes: int = 0
     returned_nodes: int = 0
     reason: str = ""
+    depth_limited: bool = False
+    """The walk stopped at ``max_depth`` with reachable neighbours still unwalked.
+
+    Distinct from ``truncated``, which is a *budget* overrun: widening the node
+    budget recovers different nodes than widening the depth. Both mean the
+    result is not exhaustive, so both surface as ``truncated`` in ``to_dict``;
+    the reason names which one. Set only when the frontier was demonstrably
+    non-empty, so a walk that really did exhaust the graph inside its depth cap
+    still reports ``complete``.
+    """
 
     @property
     def omitted_nodes(self) -> int:
@@ -309,8 +319,8 @@ class GraphCompleteness:
         return graph_completeness(
             returned=self.returned_nodes,
             total=self.total_nodes,
-            truncated=self.truncated,
-            reason=self.reason,
+            truncated=self.truncated or self.depth_limited,
+            reason=self.reason or ("depth_limit" if self.depth_limited else ""),
         )
 
 
@@ -715,6 +725,7 @@ class UnifiedGraph:
             depth_by_node[root] = 0
 
         truncated = False
+        depth_limited = False
         edge_count = 0
 
         def _edge_allowed(edge: UnifiedEdge) -> bool:
@@ -733,14 +744,23 @@ class UnifiedGraph:
                 truncated = True
                 break
             current, depth = queue.popleft()
-            if depth >= max_depth:
-                continue
 
             candidates: list[tuple[str, UnifiedEdge]] = []
             if direction in {"forward", "both"}:
                 candidates.extend((edge.target, edge) for edge in self.adjacency.get(current, []))
             if direction in {"reverse", "both"}:
                 candidates.extend((edge.source, edge) for edge in self.reverse_adjacency.get(current, []))
+
+            if depth >= max_depth:
+                # The walk stops here. Say so only if it actually left something
+                # behind: a frontier node whose neighbours were all visited
+                # anyway cost the caller nothing, and flagging it would make
+                # `truncated` meaningless on every bounded query.
+                if not depth_limited and any(
+                    neighbor not in visited and neighbor in self.nodes and _edge_allowed(edge) for neighbor, edge in candidates
+                ):
+                    depth_limited = True
+                continue
 
             for neighbor, edge in candidates:
                 if not _edge_allowed(edge):
@@ -776,7 +796,13 @@ class UnifiedGraph:
             if edge.source in sub.nodes and edge.target in sub.nodes:
                 sub.add_edge(edge)
 
-        self._inherit_completeness(sub, truncated=truncated, reason="traversal_budget", node_budget=max_nodes if truncated else None)
+        self._inherit_completeness(
+            sub,
+            truncated=truncated,
+            reason="traversal_budget",
+            node_budget=max_nodes if truncated else None,
+            depth_limited=depth_limited,
+        )
         return sub, depth_by_node, truncated
 
     # ── Centrality ───────────────────────────────────────────────────────
@@ -1031,6 +1057,7 @@ class UnifiedGraph:
         truncated: bool = False,
         reason: str = "",
         node_budget: int | None = None,
+        depth_limited: bool = False,
     ) -> "UnifiedGraph":
         """Carry the source's truncation onto a derived view.
 
@@ -1052,6 +1079,7 @@ class UnifiedGraph:
         report completeness its source does not have.
         """
         view.completeness.truncated = self.completeness.truncated or truncated
+        view.completeness.depth_limited = self.completeness.depth_limited or depth_limited
         view.completeness.node_budget = self.completeness.node_budget if self.completeness.node_budget is not None else node_budget
         view.completeness.reason = self.completeness.reason or (reason if truncated else "")
         # An untruncated graph built by hand never populates total_nodes; falling

--- a/tests/test_attack_path_correctness.py
+++ b/tests/test_attack_path_correctness.py
@@ -1,0 +1,425 @@
+"""Attack paths must be real, and honest about where the walk stopped.
+
+Two independent failure modes, both worse than a missing feature:
+
+*Fabrication.* A credential node keyed by env-var *name* alone merges two
+unrelated servers' credential slots into one node, so agent-a's estate and
+agent-b's estate share a graph node they have no relationship through. Every
+downstream reader then sees a lateral-movement route that does not exist.
+``graph/builder.py`` and ``context_graph.py`` were scoped to the server for
+exactly this reason; the agent-manifest graph — the CLI ``manifest`` export and
+``GET /v1/agent-manifest`` — was not.
+
+*Silent depth cuts.* ``bfs_paths`` / ``traverse_subgraph`` / ``impact_of`` stop
+at ``max_depth`` (4 by default, chosen by the server when a caller passes
+nothing) and report the bound as the answer: ``complete: true`` with
+``total`` equal to what the bound happened to reach. That is the class #4595
+fixed for the node/edge budget, unfixed for the depth bound — and it reads as
+"there is no attack path past here" rather than "we stopped looking".
+
+Ground truth in every fixture is known by construction, so the assertions are
+counts, not judgements. Each honesty test is paired with a guard that the walk
+which really did exhaust the graph still reports ``truncated: False`` with the
+true total — a blanket "truncated" would be as dishonest as the bug.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api import stores as api_stores
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.api.server import app
+from agent_bom.api.stores import set_graph_store
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+CHAIN = 9
+"""``n0 -> n1 -> ... -> n8``: 8 nodes reachable from n0, 8 ancestors of n8.
+
+Kept under the routes' ``max_depth`` ceiling of 10 so the paired "the walk really
+did exhaust the graph" guard is reachable over HTTP, not only in-process."""
+
+
+def chain(total: int = CHAIN, *, scan_id: str = "chain", tenant_id: str = "default") -> UnifiedGraph:
+    graph = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
+    for index in range(total):
+        graph.add_node(UnifiedNode(id=f"n{index}", entity_type=EntityType.AGENT, label=f"n{index}"))
+    for index in range(total - 1):
+        graph.add_edge(
+            UnifiedEdge(
+                source=f"n{index}",
+                target=f"n{index + 1}",
+                relationship=RelationshipType.USES,
+                traversable=True,
+            )
+        )
+    return graph
+
+
+def components(node_ids: set[str], edges: list[tuple[str, str]]) -> list[list[str]]:
+    """Undirected connected components — the shape a fabricated edge changes."""
+    adjacency: dict[str, set[str]] = {node_id: set() for node_id in node_ids}
+    for source, target in edges:
+        if source in adjacency and target in adjacency:
+            adjacency[source].add(target)
+            adjacency[target].add(source)
+    seen: set[str] = set()
+    found: list[list[str]] = []
+    for node_id in sorted(node_ids):
+        if node_id in seen:
+            continue
+        stack, group = [node_id], []
+        seen.add(node_id)
+        while stack:
+            current = stack.pop()
+            group.append(current)
+            for neighbour in adjacency[current]:
+                if neighbour not in seen:
+                    seen.add(neighbour)
+                    stack.append(neighbour)
+        found.append(sorted(group))
+    return found
+
+
+SHORT_CHAIN = 5
+"""``POST /v1/graph/query`` is additionally capped by the tenant query budget at
+``max_depth`` 5, so the "walk really did exhaust the graph" guard for that route
+needs a chain a depth-5 walk can finish."""
+
+
+@pytest.fixture
+def store(tmp_path):
+    graph_store = SQLiteGraphStore(str(tmp_path / "graph.db"))
+    graph_store.save_graph(chain())
+    graph_store.save_graph(chain(SHORT_CHAIN, scan_id="short"))
+    return graph_store
+
+
+@pytest.fixture
+def client(store):
+    original = api_stores._graph_store
+    set_graph_store(store)
+    try:
+        yield TestClient(app)
+    finally:
+        set_graph_store(original)
+
+
+# ── Fabrication: credential identity ────────────────────────────────────────
+
+
+def manifest_graph(*creds: tuple[str, str]):
+    """Build the manifest graph for one server per ``(server_name, env_var)``."""
+    from agent_bom.agent_manifest import build_local_agent_manifest
+    from agent_bom.models import Agent, AgentType, MCPServer
+
+    agent_types = [AgentType.CLAUDE_DESKTOP, AgentType.CURSOR, AgentType.WINDSURF]
+    agents = [
+        Agent(
+            name=f"agent-{index}",
+            agent_type=agent_types[index % len(agent_types)],
+            config_path=f"/tmp/agent-{index}.json",
+            mcp_servers=[MCPServer(name=server_name, command=f"/usr/bin/{server_name}", env={env_var: "redacted"})],
+        )
+        for index, (server_name, env_var) in enumerate(creds)
+    ]
+    return build_local_agent_manifest(agents)["graph"]
+
+
+class TestCredentialIdentityIsNotFabricated:
+    def test_two_servers_reading_the_same_env_var_name_are_not_connected(self):
+        """Ground truth: two unrelated estates. Anything less than 2 components
+        is a lateral-movement route the scan has no evidence for."""
+        graph = manifest_graph(("srv-a", "API_KEY"), ("srv-b", "API_KEY"))
+
+        node_ids = {node["id"] for node in graph["nodes"]}
+        found = components(node_ids, [(edge["source"], edge["target"]) for edge in graph["edges"]])
+
+        assert len(found) == 2, f"same-named credential slots merged {len(found)} estates into one: {found}"
+
+    def test_each_server_still_keeps_its_own_credential_slot(self):
+        """Recall guard: scoping the node may not drop a credential."""
+        graph = manifest_graph(("srv-a", "API_KEY"), ("srv-b", "API_KEY"))
+
+        credentials = [node for node in graph["nodes"] if node["entity_type"] == "credential"]
+        exposures = [edge for edge in graph["edges"] if edge["relationship"] == "exposes_cred"]
+
+        assert len(credentials) == 2
+        assert len(exposures) == 2
+        assert {node["label"] for node in credentials} == {"API_KEY"}
+        assert len({edge["target"] for edge in exposures}) == 2, "both servers still point at one credential node"
+
+    def test_one_server_with_two_credentials_keeps_both(self):
+        """Recall guard on the other axis: distinct names on one server."""
+        from agent_bom.agent_manifest import build_local_agent_manifest
+        from agent_bom.models import Agent, AgentType, MCPServer
+
+        server = MCPServer(name="srv", command="/usr/bin/srv", env={"API_KEY": "x", "DB_PASSWORD": "y"})
+        agent = Agent(name="a", agent_type=AgentType.CLAUDE_DESKTOP, config_path="/tmp/a.json", mcp_servers=[server])
+
+        graph = build_local_agent_manifest([agent])["graph"]
+        credentials = [node for node in graph["nodes"] if node["entity_type"] == "credential"]
+
+        assert {node["label"] for node in credentials} == {"API_KEY", "DB_PASSWORD"}
+
+
+# ── Honesty: the depth cut ──────────────────────────────────────────────────
+
+
+class TestContainerDepthHonesty:
+    def test_a_walk_stopped_by_the_depth_cap_is_not_complete(self):
+        source = chain()
+
+        sub, _depths, _truncated = source.traverse_subgraph(["n0"], max_depth=4)
+        completeness = sub.completeness.to_dict()
+
+        assert len(sub.nodes) == 5
+        assert completeness["complete"] is False, "5 of 9 nodes returned while reporting a complete walk"
+        assert completeness["truncated"] is True
+        assert completeness["reason"] == "depth_limit"
+
+    def test_a_walk_that_exhausts_the_graph_inside_the_cap_stays_complete(self):
+        """Non-vacuity pair: the fix may not mark every bounded walk truncated.
+
+        ``max_depth`` is the exact eccentricity of the chain, so the last node
+        sits *at* the cap: the frontier check runs and must find nothing left,
+        rather than never running at all."""
+        source = chain()
+
+        sub, _depths, _truncated = source.traverse_subgraph(["n0"], max_depth=CHAIN - 1)
+        completeness = sub.completeness.to_dict()
+
+        assert len(sub.nodes) == CHAIN
+        assert completeness["complete"] is True
+        assert completeness["truncated"] is False
+        assert completeness["total"] == CHAIN
+
+    def test_the_deeper_node_budget_loss_still_names_itself_first(self):
+        """A budget overrun outranks a depth cut: widening depth cannot recover
+        nodes the budget never visited."""
+        source = chain()
+
+        sub, _depths, truncated = source.traverse_subgraph(["n0"], max_depth=4, max_nodes=3)
+
+        assert truncated is True
+        assert sub.completeness.to_dict()["reason"] == "traversal_budget"
+
+
+class TestSqliteTraversalHonesty:
+    def test_traverse_subgraph_reports_the_nodes_it_actually_returned(self, store):
+        """The #4595 self-contradiction, still live in the SQLite store:
+        N nodes returned beside ``returned: 0, total: 0, complete: true``."""
+        graph, _depths, _truncated = store.traverse_subgraph(tenant_id="default", scan_id="chain", roots=["n0"], max_depth=CHAIN - 1)
+        completeness = graph.completeness.to_dict()
+
+        assert len(graph.nodes) == CHAIN
+        assert completeness["returned"] == len(graph.nodes)
+        assert completeness["total"] == CHAIN
+
+    def test_traverse_subgraph_depth_cut_is_not_complete(self, store):
+        graph, _depths, _truncated = store.traverse_subgraph(tenant_id="default", scan_id="chain", roots=["n0"], max_depth=4)
+        completeness = graph.completeness.to_dict()
+
+        assert len(graph.nodes) == 5
+        assert completeness["complete"] is False
+        assert completeness["reason"] == "depth_limit"
+
+    def test_traverse_subgraph_that_exhausts_the_graph_stays_complete(self, store):
+        graph, _depths, truncated = store.traverse_subgraph(tenant_id="default", scan_id="chain", roots=["n0"], max_depth=CHAIN - 1)
+
+        assert truncated is False
+        assert graph.completeness.to_dict()["complete"] is True
+
+    def test_bfs_paths_reports_that_the_depth_cap_cut_the_walk(self, store):
+        paths, reachable, _truncated, depth_limited = store.bfs_paths(tenant_id="default", scan_id="chain", source="n0", max_depth=4)
+
+        assert len(paths) == 4
+        assert len(reachable) == 4
+        assert depth_limited is True, "4 of 8 reachable nodes walked, reported as the whole answer"
+
+    def test_bfs_paths_that_reaches_every_node_is_not_depth_limited(self, store):
+        paths, reachable, truncated, depth_limited = store.bfs_paths(tenant_id="default", scan_id="chain", source="n0", max_depth=CHAIN - 1)
+
+        assert len(reachable) == CHAIN - 1
+        assert len(paths) == CHAIN - 1
+        assert truncated is False
+        assert depth_limited is False
+
+
+# ── Honesty: the HTTP surfaces a user actually reads ────────────────────────
+
+
+class TestGraphPathsRoute:
+    def test_a_depth_bound_is_not_reported_as_the_path_total(self, client):
+        response = client.get("/v1/graph/paths?source_id=n0&scan_id=chain&max_depth=4")
+        body = response.json()
+
+        assert response.status_code == 200
+        assert len(body["paths"]) == 4
+        assert body["completeness"]["complete"] is False
+        assert body["completeness"]["truncated"] is True
+        assert body["completeness"]["reason"] == "depth_limit"
+        assert "total" not in body["completeness"], "a depth-bounded BFS cannot know the path total"
+
+    def test_a_walk_that_exhausts_the_graph_reports_the_true_total(self, client):
+        """#4595's paired invariant: a complete source still reports its total."""
+        response = client.get(f"/v1/graph/paths?source_id=n0&scan_id=chain&max_depth={CHAIN - 1}")
+        body = response.json()
+
+        assert body["reachable_count"] == CHAIN - 1
+        assert body["completeness"]["complete"] is True
+        assert body["completeness"]["truncated"] is False
+        assert body["completeness"]["total"] == CHAIN - 1
+
+
+class TestGraphImpactRoute:
+    def test_a_depth_bounded_blast_radius_says_so(self, client):
+        """``affected_count: 4`` over 8 true ancestors, with no completeness
+        field at all, reads as the whole blast radius."""
+        response = client.get(f"/v1/graph/impact?node=n{CHAIN - 1}&scan_id=chain&max_depth=4")
+        body = response.json()
+
+        assert response.status_code == 200
+        assert body["affected_count"] == 4
+        assert body["completeness"]["complete"] is False
+        assert body["completeness"]["reason"] == "depth_limit"
+
+    def test_an_exhaustive_blast_radius_reports_complete(self, client):
+        response = client.get(f"/v1/graph/impact?node=n{CHAIN - 1}&scan_id=chain&max_depth={CHAIN - 1}")
+        body = response.json()
+
+        assert body["affected_count"] == CHAIN - 1
+        assert body["completeness"]["complete"] is True
+        assert body["completeness"]["truncated"] is False
+
+
+class TestGraphQueryRoute:
+    def test_a_depth_cut_subgraph_is_not_reported_complete(self, client):
+        response = client.post("/v1/graph/query", json={"roots": ["n0"], "scan_id": "chain", "max_depth": 4})
+        body = response.json()
+
+        assert response.status_code == 200
+        assert len(body["nodes"]) == 5
+        assert body["completeness"]["complete"] is False
+        assert body["completeness"]["reason"] == "depth_limit"
+
+    def test_an_exhaustive_query_stays_complete(self, client):
+        response = client.post("/v1/graph/query", json={"roots": ["n0"], "scan_id": "short", "max_depth": SHORT_CHAIN})
+        body = response.json()
+
+        assert len(body["nodes"]) == SHORT_CHAIN
+        assert body["completeness"]["complete"] is True
+        assert body["completeness"]["truncated"] is False
+
+
+# ── Precision / recall of the walk itself ───────────────────────────────────
+
+
+class TestPathPrecisionAndRecall:
+    """Every path returned must be a real edge-by-edge walk of the graph, and
+    every truly reachable node must be reached when the walk is unbounded."""
+
+    def diamond(self) -> UnifiedGraph:
+        """Two disjoint estates. ``a0 -> a1 -> {a2, a3} -> a4`` and ``b0 -> b1``.
+        Reachable from a0: a1, a2, a3, a4 (4). From a0 to b*: nothing."""
+        graph = UnifiedGraph(scan_id="diamond", tenant_id="default")
+        for node_id in ("a0", "a1", "a2", "a3", "a4", "b0", "b1"):
+            graph.add_node(UnifiedNode(id=node_id, entity_type=EntityType.AGENT, label=node_id))
+        for source, target in (("a0", "a1"), ("a1", "a2"), ("a1", "a3"), ("a2", "a4"), ("a3", "a4"), ("b0", "b1")):
+            graph.add_edge(UnifiedEdge(source=source, target=target, relationship=RelationshipType.USES, traversable=True))
+        return graph
+
+    def test_no_path_crosses_into_an_unconnected_estate(self, tmp_path):
+        graph_store = SQLiteGraphStore(str(tmp_path / "d.db"))
+        graph_store.save_graph(self.diamond())
+
+        paths, reachable, _truncated, _depth_limited = graph_store.bfs_paths(
+            tenant_id="default", scan_id="diamond", source="a0", max_depth=10
+        )
+
+        assert reachable == {"a1", "a2", "a3", "a4"}, "reached a node the graph does not connect"
+        assert not any(hop.startswith("b") for path in paths for hop in path)
+
+    def test_every_returned_path_walks_real_edges(self, tmp_path):
+        graph = self.diamond()
+        real_edges = {(edge.source, edge.target) for edge in graph.edges}
+        graph_store = SQLiteGraphStore(str(tmp_path / "d.db"))
+        graph_store.save_graph(graph)
+
+        paths, _reachable, _truncated, _depth_limited = graph_store.bfs_paths(
+            tenant_id="default", scan_id="diamond", source="a0", max_depth=10
+        )
+
+        assert paths
+        for path in paths:
+            assert path[0] == "a0"
+            for step in range(len(path) - 1):
+                assert (path[step], path[step + 1]) in real_edges, f"fabricated hop {path[step]}->{path[step + 1]}"
+
+
+class TestFusedKillChainPrecisionAndRecall:
+    """The flagship surface: end-to-end internet -> ... -> crown-jewel chains.
+
+    The estate below is built so the answer is arithmetic, not opinion. Three
+    near-misses are included on purpose, because each is a way a looser walk
+    would manufacture a chain: a dead end, a sensitive store with no internet
+    entry, and an internet-reachable store holding nothing sensitive.
+    """
+
+    def estate(self) -> UnifiedGraph:
+        graph = UnifiedGraph(scan_id="fusion", tenant_id="default")
+
+        def node(node_id: str, entity_type: EntityType, **attributes: object) -> None:
+            graph.add_node(UnifiedNode(id=node_id, entity_type=entity_type, label=node_id, attributes=attributes))
+
+        for entry in ("entry-a", "entry-b", "entry-c", "entry-e"):
+            node(entry, EntityType.CLOUD_RESOURCE, internet_exposed=True)
+        for host in ("vm-a", "vm-b", "vm-c", "vm-d"):
+            node(host, EntityType.CLOUD_RESOURCE)
+        node("vuln-a", EntityType.VULNERABILITY)
+        for store in ("db-a", "db-b", "db-d"):
+            node(store, EntityType.DATA_STORE, data_sensitivity="pii")
+        node("db-e", EntityType.DATA_STORE)  # internet-reachable, but not a jewel
+
+        for source, target, rel in (
+            ("entry-a", "vm-a", RelationshipType.CONTAINS),
+            ("vm-a", "vuln-a", RelationshipType.VULNERABLE_TO),
+            ("vuln-a", "db-a", RelationshipType.CAN_ACCESS),
+            ("entry-b", "vm-b", RelationshipType.CONTAINS),
+            ("vm-b", "db-b", RelationshipType.STORES),
+            ("entry-c", "vm-c", RelationshipType.CONTAINS),  # dead end
+            ("vm-d", "db-d", RelationshipType.STORES),  # sensitive, no entry
+            ("entry-e", "db-e", RelationshipType.STORES),  # entry, not a jewel
+        ):
+            graph.add_edge(UnifiedEdge(source=source, target=target, relationship=rel))
+        return graph
+
+    TRUTH = {("entry-a", "db-a"), ("entry-b", "db-b")}
+
+    def test_fused_chains_are_exactly_the_true_kill_chains(self):
+        from agent_bom.graph.attack_path_fusion import compute_fused_attack_paths
+
+        graph = self.estate()
+
+        found = {(path.source, path.target) for path in compute_fused_attack_paths(graph)}
+
+        assert found - self.TRUTH == set(), "fabricated kill-chain"
+        assert self.TRUTH - found == set(), "missed a real kill-chain"
+
+    def test_every_hop_of_a_fused_chain_is_a_real_edge(self):
+        from agent_bom.graph.attack_path_fusion import compute_fused_attack_paths
+
+        graph = self.estate()
+        real_edges = {(edge.source, edge.target) for edge in graph.edges}
+
+        paths = compute_fused_attack_paths(graph)
+
+        assert paths
+        for path in paths:
+            for step in range(len(path.hops) - 1):
+                hop = (path.hops[step], path.hops[step + 1])
+                assert hop in real_edges, f"chain {path.hops} traverses an edge the graph does not hold: {hop}"

--- a/tests/test_graph_api.py
+++ b/tests/test_graph_api.py
@@ -1511,7 +1511,13 @@ class _RecordingGraphStore:
         self.calls.append(("bfs_paths", tenant_id, scan_id, source, max_depth, traversable_only))
         paths = self.graph.bfs(source, max_depth=max_depth, traversable_only=traversable_only)
         reachable = self.graph.reachable_from(source, max_depth=max_depth, traversable_only=traversable_only, include_source=False)
-        return paths, reachable, self.graph.completeness.truncated
+        # Depth-limitedness comes from the real traversal primitive rather than
+        # a hand-held constant, so the double cannot certify a completeness the
+        # store it stands in for would not.
+        walked, _depths, _truncated = self.graph.traverse_subgraph(
+            [source], max_depth=max_depth, traversable_only=traversable_only, max_nodes=10**9, max_edges=10**9
+        )
+        return paths, reachable, self.graph.completeness.truncated, walked.completeness.depth_limited
 
     def impact_of(self, *, tenant_id: str = "", scan_id: str = "", node_id: str, max_depth: int = 4):
         self.calls.append(("impact_of", tenant_id, scan_id, node_id, max_depth))

--- a/tests/test_graph_traversal_budget_honesty.py
+++ b/tests/test_graph_traversal_budget_honesty.py
@@ -110,7 +110,7 @@ class TestBfsPathsReportsItsBudget:
         store = SQLiteGraphStore(tmp_path / "graph.db")
         store.save_graph(tree(BIG_TREE_NODES, scan_id="big"))
 
-        paths, reachable, truncated = store.bfs_paths(tenant_id="default", scan_id="big", source="n0", max_depth=10)
+        paths, reachable, truncated, _depth_limited = store.bfs_paths(tenant_id="default", scan_id="big", source="n0", max_depth=10)
 
         true_reachable = BIG_TREE_NODES - 1
         assert truncated is True
@@ -124,9 +124,10 @@ class TestBfsPathsReportsItsBudget:
         store = SQLiteGraphStore(tmp_path / "graph.db")
         store.save_graph(tree(SMALL_TREE_NODES, scan_id="small"))
 
-        paths, reachable, truncated = store.bfs_paths(tenant_id="default", scan_id="small", source="n0", max_depth=10)
+        paths, reachable, truncated, depth_limited = store.bfs_paths(tenant_id="default", scan_id="small", source="n0", max_depth=10)
 
         assert truncated is False
+        assert depth_limited is False, "a 40-node tree three levels deep is not depth-bounded at 10"
         assert len(reachable) == SMALL_TREE_NODES - 1
         assert len(paths) == SMALL_TREE_NODES - 1
 

--- a/tests/test_graph_traversal_frontier_scale.py
+++ b/tests/test_graph_traversal_frontier_scale.py
@@ -1,0 +1,453 @@
+"""Attack-path search must cost the walk, not the snapshot.
+
+``bfs_paths`` (and every other caller of the shared SQLite ``_walk_graph``)
+issues one frontier query per node it dequeues. That query asked for
+``source_id IN (...) OR target_id IN (...)`` in a single disjunction, which
+SQLite cannot drive from either single-column index: the plan collapses to
+``SEARCH graph_edges USING INDEX idx_ge_tenant_scan (tenant_id=? AND scan_id=?)``
+— a scan of every edge in the snapshot, repeated once per visited node. The
+work is therefore O(visited x snapshot_edges): the *unreachable* remainder of
+the estate is re-read for every hop of a path that never touches it.
+
+Two guards live here, and they pull in opposite directions on purpose:
+
+* the **scale** guards pin the cost model — the frontier query must be driven
+  by an index on ``source_id``/``target_id``, and growing the part of the
+  snapshot the walk never reaches must not grow the walk's work;
+* the **differential** guards pin the answer — for a matrix of directions,
+  filters, depths and budgets, the optimised frontier query must return the
+  same rows in the same order as the pre-fix disjunction, so every downstream
+  ``discovery_order``/``parent_by_node``/path list is byte-identical.
+
+Without the differential half, "make it fast" could silently reorder or drop
+paths; without the scale half, "keep it correct" leaves the wall in place.
+
+Work is counted in SQLite VDBE steps via the progress handler rather than in
+milliseconds: opcode counts are deterministic for a given plan and dataset,
+where wall-clock on a shared host is not.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+import sqlite3
+from typing import Any
+
+import pytest
+
+from agent_bom.api.graph_store import SQLiteGraphStore
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import UnifiedNode
+from agent_bom.graph.types import EntityType, RelationshipType
+
+_PROGRESS_OPS = 1_000
+
+# SHA-256 of the 32-case attack-path answer matrix captured from src at
+# 3fc34db8f — the last commit before the frontier query was rewritten. See
+# TestFrontierQueryIsAnswerIdentical.test_reference_matches_pre_fix_release.
+PRE_FIX_GOLDEN_DIGEST = "c4b71ffd991e7de6c96954d8bf4c41af232876fdedc9dd9aa4efcfad7a3a6028"
+
+_DYNAMIC = (RelationshipType.INVOKED, RelationshipType.ACCESSED, RelationshipType.DELEGATED_TO)
+_STATIC = (RelationshipType.USES, RelationshipType.DEPENDS_ON, RelationshipType.CAN_ACCESS)
+
+
+def _tree_with_ballast(
+    *,
+    scan_id: str,
+    reachable_nodes: int,
+    ballast_edges: int,
+    tenant_id: str = "default",
+    branching: int = 4,
+) -> UnifiedGraph:
+    """A fixed reachable tree rooted at ``n0`` plus ``ballast_edges`` unreachable edges.
+
+    The walk from ``n0`` always visits exactly ``reachable_nodes`` nodes no
+    matter how large the ballast is, so any growth in traversal work as the
+    ballast grows is work spent on parts of the estate the answer never
+    contains. Branching keeps the tree inside the API's ``max_depth`` ceiling.
+    """
+    graph = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
+    for index in range(reachable_nodes):
+        graph.add_node(UnifiedNode(id=f"n{index}", entity_type=EntityType.AGENT, label=f"n{index}"))
+    for index in range(1, reachable_nodes):
+        graph.add_edge(
+            UnifiedEdge(
+                source=f"n{(index - 1) // branching}",
+                target=f"n{index}",
+                relationship=RelationshipType.USES,
+                traversable=True,
+            )
+        )
+    for index in range(ballast_edges):
+        left, right = f"b{index}", f"b{index}x"
+        graph.add_node(UnifiedNode(id=left, entity_type=EntityType.RESOURCE, label=left))
+        graph.add_node(UnifiedNode(id=right, entity_type=EntityType.RESOURCE, label=right))
+        graph.add_edge(UnifiedEdge(source=left, target=right, relationship=RelationshipType.USES, traversable=True))
+    return graph
+
+
+def _walk_ticks(store: SQLiteGraphStore, *, scan_id: str, source: str, max_depth: int = 10) -> tuple[int, int]:
+    """Return (VDBE ticks, paths found) for one ``bfs_paths`` call."""
+    ticks = 0
+    original_open = store._open_ro_conn
+
+    def counting_open() -> sqlite3.Connection | None:
+        conn = original_open()
+        if conn is not None:
+
+            def handler() -> int:
+                nonlocal ticks
+                ticks += 1
+                return 0
+
+            conn.set_progress_handler(handler, _PROGRESS_OPS)
+        return conn
+
+    store._open_ro_conn = counting_open  # type: ignore[method-assign]
+    try:
+        paths, _reachable, _truncated = store.bfs_paths(tenant_id="default", scan_id=scan_id, source=source, max_depth=max_depth)
+    finally:
+        store._open_ro_conn = original_open  # type: ignore[method-assign]
+    return ticks, len(paths)
+
+
+class TestFrontierQueryCostsTheWalkNotTheSnapshot:
+    def test_frontier_query_is_driven_by_an_endpoint_index(self, tmp_path):
+        """The per-hop query must SEARCH by ``source_id``/``target_id``, never scan the snapshot.
+
+        Asserted on the plan rather than the clock so it holds on a loaded host,
+        and asserted without ``ANALYZE`` so it cannot be satisfied by
+        ``sqlite_stat1`` statistics that a fresh customer database will not have.
+        """
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        store.save_graph(_tree_with_ballast(scan_id="plan", reachable_nodes=8, ballast_edges=200))
+
+        conn = store._open_ro_conn()
+        assert conn is not None
+        try:
+            sql, params = store._frontier_edge_query(
+                tenant_id="default",
+                scan_id="plan",
+                frontier={"n0"},
+                traversable_only=True,
+                relationship_types=None,
+                static_only=False,
+                dynamic_only=False,
+            )
+            plan_rows = conn.execute(f"EXPLAIN QUERY PLAN {sql}", params).fetchall()
+            assert conn.execute("SELECT count(*) FROM sqlite_master WHERE name = 'sqlite_stat1'").fetchone()[0] == 0
+        finally:
+            conn.close()
+
+        details = [str(row[3]) for row in plan_rows]
+        graph_edge_steps = [detail for detail in details if "graph_edges" in detail]
+        assert graph_edge_steps, f"no graph_edges access in the plan at all: {details}"
+        # Every touch of graph_edges must be anchored on an endpoint (or on the
+        # rowid the endpoint branches produced). A step keyed only on
+        # (tenant_id, scan_id) reads the whole snapshot.
+        unanchored = [
+            detail for detail in graph_edge_steps if not ("source_id=?" in detail or "target_id=?" in detail or "rowid=?" in detail)
+        ]
+        assert not unanchored, f"frontier query still scans the whole snapshot: {unanchored}"
+        assert [detail for detail in graph_edge_steps if "source_id=?" in detail], f"no source-side seek: {details}"
+        assert [detail for detail in graph_edge_steps if "target_id=?" in detail], f"no target-side seek: {details}"
+
+    def test_unreachable_estate_does_not_cost_the_walk(self, tmp_path):
+        """Hold the answer fixed, grow the rest of the estate 16x: work must stay flat.
+
+        The reachable chain is identical in both snapshots, so both calls return
+        the same paths. Only the edges the walk can never reach differ.
+        """
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        store.save_graph(_tree_with_ballast(scan_id="small", reachable_nodes=60, ballast_edges=500))
+        store.save_graph(_tree_with_ballast(scan_id="large", reachable_nodes=60, ballast_edges=8_000))
+
+        small_ticks, small_paths = _walk_ticks(store, scan_id="small", source="n0")
+        large_ticks, large_paths = _walk_ticks(store, scan_id="large", source="n0")
+
+        assert small_paths == large_paths == 59, "the reachable answer must be identical in both snapshots"
+        # Pre-fix this ratio tracks the ballast ratio (16x). An endpoint-indexed
+        # frontier pays only the b-tree descent, which grows with log(edges).
+        assert large_ticks <= max(small_ticks * 3, small_ticks + 200), (
+            f"traversal work scales with the unreachable snapshot: {small_ticks} -> {large_ticks} kticks"
+        )
+
+
+# ── Differential guard: the optimised frontier query must be answer-identical ──
+
+
+def _legacy_frontier_rows(
+    conn: sqlite3.Connection,
+    *,
+    tenant_id: str,
+    scan_id: str,
+    frontier: set[str],
+    traversable_only: bool = False,
+    relationship_types: set[RelationshipType] | None = None,
+    static_only: bool = False,
+    dynamic_only: bool = False,
+) -> list[sqlite3.Row]:
+    """The pre-fix frontier query, verbatim, as the differential reference.
+
+    Kept as literal SQL rather than by calling the store so that a future change
+    to the optimised query is compared against the historical contract and not
+    against itself.
+
+    ``INDEXED BY idx_ge_tenant_scan`` pins the plan the pre-fix query actually
+    ran under. It is not decoration: the disjunction never named an index, so
+    its row order was whatever the planner chose, and merely *adding* the
+    endpoint indexes moves the pre-fix query onto ``idx_ge_tenant_scan_target``
+    and reorders its rows. Forcing the historical index reproduces the
+    historical answer, which is what this reference exists to be. That the
+    reference needs pinning at all is the point: order used to be an accident of
+    the planner, and ``ORDER BY rowid`` in the shipped query now makes it a
+    contract. ``test_reference_matches_pre_fix_release`` cross-checks this
+    reference against output captured from the pre-fix code itself.
+    """
+    from agent_bom.api.graph_store import _DYNAMIC_RELATIONSHIP_VALUES
+
+    if not frontier:
+        return []
+    ordered = sorted(frontier)
+    placeholders = ",".join("?" for _ in ordered)
+    where = [
+        "tenant_id = ?",
+        "scan_id = ?",
+        f"(source_id IN ({placeholders}) OR target_id IN ({placeholders}))",
+    ]
+    params: list[Any] = [tenant_id, scan_id, *ordered, *ordered]
+    if traversable_only:
+        where.append("traversable = 1")
+    if relationship_types:
+        rel_values = sorted(rel.value if isinstance(rel, RelationshipType) else str(rel) for rel in relationship_types)
+        where.append(f"relationship IN ({','.join('?' for _ in rel_values)})")
+        params.extend(rel_values)
+    if static_only:
+        where.append(f"relationship NOT IN ({','.join('?' for _ in _DYNAMIC_RELATIONSHIP_VALUES)})")
+        params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
+    if dynamic_only:
+        where.append(f"relationship IN ({','.join('?' for _ in _DYNAMIC_RELATIONSHIP_VALUES)})")
+        params.extend(sorted(_DYNAMIC_RELATIONSHIP_VALUES))
+    return conn.execute(
+        f"SELECT * FROM graph_edges INDEXED BY idx_ge_tenant_scan WHERE {' AND '.join(where)}",  # nosec B608 - test-local reference query
+        params,
+    ).fetchall()
+
+
+def _as_store_method(reference):
+    """Bind the module-level reference query as a store method (drops ``self``)."""
+
+    def bound(_self, conn, **kwargs):
+        return reference(conn, **kwargs)
+
+    return bound
+
+
+def _tangled_graph(*, scan_id: str, tenant_id: str, nodes: int, edges: int, seed: int) -> UnifiedGraph:
+    """A dense, mixed-direction, mixed-relationship graph with dead ends and cycles."""
+    rng = random.Random(seed)
+    graph = UnifiedGraph(scan_id=scan_id, tenant_id=tenant_id)
+    entity_types = [EntityType.AGENT, EntityType.RESOURCE, EntityType.CREDENTIAL, EntityType.SERVER]
+    for index in range(nodes):
+        graph.add_node(
+            UnifiedNode(
+                id=f"v{index}",
+                entity_type=entity_types[index % len(entity_types)],
+                label=f"v{index}",
+            )
+        )
+    relationships = [*_STATIC, *_DYNAMIC]
+    for _ in range(edges):
+        left = rng.randrange(nodes)
+        right = rng.randrange(nodes)
+        if left == right:
+            continue
+        graph.add_edge(
+            UnifiedEdge(
+                source=f"v{left}",
+                target=f"v{right}",
+                relationship=rng.choice(relationships),
+                direction="bidirectional" if rng.random() < 0.25 else "directed",
+                traversable=rng.random() < 0.8,
+            )
+        )
+    return graph
+
+
+_FILTER_MATRIX = [
+    {},
+    {"traversable_only": True},
+    {"relationship_types": {RelationshipType.USES, RelationshipType.INVOKED}},
+    {"static_only": True},
+    {"dynamic_only": True},
+    {"traversable_only": True, "relationship_types": {RelationshipType.DEPENDS_ON}},
+]
+
+
+class TestFrontierQueryIsAnswerIdentical:
+    @pytest.fixture
+    def tangled_store(self, tmp_path):
+        store = SQLiteGraphStore(tmp_path / "graph.db")
+        store.save_graph(_tangled_graph(scan_id="main", tenant_id="default", nodes=120, edges=600, seed=11))
+        # Noise the walk must never pick up: a second snapshot and a second
+        # tenant sharing the very same node identifiers.
+        store.save_graph(_tangled_graph(scan_id="other", tenant_id="default", nodes=120, edges=600, seed=22))
+        store.save_graph(_tangled_graph(scan_id="main", tenant_id="tenant-b", nodes=120, edges=600, seed=33))
+        return store
+
+    @pytest.mark.parametrize("filters", _FILTER_MATRIX)
+    @pytest.mark.parametrize("frontier", [{"v0"}, {"v7"}, {"v0", "v7", "v42"}, {"missing"}, set()])
+    def test_rows_match_the_legacy_disjunction(self, tangled_store, filters, frontier):
+        """Same rows, same order, for every filter combination the walker uses."""
+        conn = tangled_store._open_ro_conn()
+        assert conn is not None
+        try:
+            expected = _legacy_frontier_rows(conn, tenant_id="default", scan_id="main", frontier=frontier, **filters)
+            actual = tangled_store._filtered_edge_rows(conn, tenant_id="default", scan_id="main", frontier=frontier, **filters)
+        finally:
+            conn.close()
+
+        def key(row: sqlite3.Row) -> tuple:
+            return (row["source_id"], row["target_id"], row["relationship"], row["direction"], row["traversable"])
+
+        assert [key(row) for row in actual] == [key(row) for row in expected]
+
+    @pytest.mark.parametrize("direction", ["forward", "reverse", "both"])
+    @pytest.mark.parametrize("max_depth", [1, 3, 6])
+    def test_traversal_output_matches_the_legacy_walk(self, tangled_store, direction, max_depth):
+        """The walk's own products — order, parents, budget flag — must not move."""
+        conn = tangled_store._open_ro_conn()
+        assert conn is not None
+        try:
+            optimised = tangled_store._walk_graph(
+                conn,
+                tenant_id="default",
+                scan_id="main",
+                roots=["v0"],
+                direction=direction,
+                max_depth=max_depth,
+                max_nodes=5000,
+                max_edges=25_000,
+                deadline_monotonic=None,
+                traversable_only=True,
+                relationship_types=None,
+                static_only=False,
+                dynamic_only=False,
+                include_roots=True,
+            )
+            original = SQLiteGraphStore._filtered_edge_rows
+            SQLiteGraphStore._filtered_edge_rows = _as_store_method(_legacy_frontier_rows)  # type: ignore[method-assign,assignment]
+            try:
+                legacy = tangled_store._walk_graph(
+                    conn,
+                    tenant_id="default",
+                    scan_id="main",
+                    roots=["v0"],
+                    direction=direction,
+                    max_depth=max_depth,
+                    max_nodes=5000,
+                    max_edges=25_000,
+                    deadline_monotonic=None,
+                    traversable_only=True,
+                    relationship_types=None,
+                    static_only=False,
+                    dynamic_only=False,
+                    include_roots=True,
+                )
+            finally:
+                SQLiteGraphStore._filtered_edge_rows = original  # type: ignore[method-assign]
+        finally:
+            conn.close()
+
+        # scan id, visited set, depths, parents, discovery order, truncated flag.
+        assert optimised[0] == legacy[0]
+        assert optimised[2] == legacy[2]
+        assert optimised[3] == legacy[3]
+        assert sorted(optimised[4]) == sorted(legacy[4])
+        assert optimised[5] == legacy[5]
+        assert optimised[6] == legacy[6]
+        assert optimised[7] == legacy[7]
+        assert optimised[6], "the differential fixture must actually reach nodes"
+
+    def test_budget_truncation_point_is_unchanged(self, tangled_store):
+        """A walk cut by ``max_nodes`` must be cut at the same node, in the same order."""
+        conn = tangled_store._open_ro_conn()
+        assert conn is not None
+        kwargs = dict(
+            tenant_id="default",
+            scan_id="main",
+            roots=["v0"],
+            direction="forward",
+            max_depth=10,
+            max_nodes=17,
+            max_edges=25_000,
+            deadline_monotonic=None,
+            traversable_only=False,
+            relationship_types=None,
+            static_only=False,
+            dynamic_only=False,
+            include_roots=True,
+        )
+        try:
+            optimised = tangled_store._walk_graph(conn, **kwargs)  # type: ignore[arg-type]
+            original = SQLiteGraphStore._filtered_edge_rows
+            SQLiteGraphStore._filtered_edge_rows = _as_store_method(_legacy_frontier_rows)  # type: ignore[method-assign,assignment]
+            try:
+                legacy = tangled_store._walk_graph(conn, **kwargs)  # type: ignore[arg-type]
+            finally:
+                SQLiteGraphStore._filtered_edge_rows = original  # type: ignore[method-assign]
+        finally:
+            conn.close()
+
+        assert optimised[7] is True, "the fixture must actually hit the node budget"
+        assert optimised[6] == legacy[6]
+        assert optimised[2] == legacy[2]
+        assert optimised[7] == legacy[7]
+
+    def test_reference_matches_pre_fix_release(self, tangled_store):
+        """Golden: the shipped answer must still hash to what the pre-fix code produced.
+
+        The in-test ``_legacy_frontier_rows`` reference proves the new query
+        agrees with a *reconstruction* of the old one. This proves it agrees
+        with the old code itself: the digest below was captured by running this
+        exact fixture and case matrix against ``src`` at 3fc34db8f, before the
+        UNION rewrite and before the endpoint indexes existed.
+
+        32 cases — ``bfs_paths`` over two tenants x three sources x five depths,
+        plus ``impact_of`` (the reverse walk over the same shared primitive).
+        A change here means attack-path results moved for real users; it is not
+        a snapshot to re-bless without deciding that the move is correct.
+        """
+        cases: dict[str, Any] = {}
+        for tenant in ("default", "tenant-b"):
+            for depth in (1, 2, 3, 5, 10):
+                for source in ("v0", "v7", "v42"):
+                    paths, reachable, truncated = tangled_store.bfs_paths(tenant_id=tenant, scan_id="main", source=source, max_depth=depth)
+                    cases[f"{tenant}|{source}|{depth}"] = {
+                        "paths": paths,
+                        "reachable": sorted(reachable),
+                        "truncated": truncated,
+                    }
+            cases[f"impact|{tenant}"] = tangled_store.impact_of(tenant_id=tenant, scan_id="main", node_id="v5", max_depth=4)
+
+        assert len(cases) == 32
+        payload = json.dumps(cases, indent=0, sort_keys=True).encode()
+        assert hashlib.sha256(payload).hexdigest() == PRE_FIX_GOLDEN_DIGEST, "attack-path output diverged from the pre-fix release"
+
+    def test_bfs_paths_output_is_identical_across_tenants_and_snapshots(self, tangled_store):
+        """End to end: the shipped path list, in order, plus tenant isolation."""
+        default_paths, default_reachable, default_truncated = tangled_store.bfs_paths(
+            tenant_id="default", scan_id="main", source="v0", max_depth=5
+        )
+        other_paths, _other_reachable, _ = tangled_store.bfs_paths(tenant_id="tenant-b", scan_id="main", source="v0", max_depth=5)
+
+        assert default_paths, "the fixture must produce paths"
+        assert default_truncated is False
+        assert all(path[0] == "v0" for path in default_paths)
+        assert {path[-1] for path in default_paths} <= default_reachable
+        # Tenant B holds the same node ids over a different edge set: identical
+        # answers would mean the frontier query lost its tenant predicate.
+        assert other_paths != default_paths

--- a/tests/test_graph_traversal_frontier_scale.py
+++ b/tests/test_graph_traversal_frontier_scale.py
@@ -17,7 +17,10 @@ Two guards live here, and they pull in opposite directions on purpose:
 * the **differential** guards pin the answer — for a matrix of directions,
   filters, depths and budgets, the optimised frontier query must return the
   same rows in the same order as the pre-fix disjunction, so every downstream
-  ``discovery_order``/``parent_by_node``/path list is byte-identical.
+  ``discovery_order``/``parent_by_node``/path list is byte-identical. The one
+  exception is deliberate and documented at the golden test: when a plan change
+  swaps between equally valid shortest routes, reachability and path counts
+  still hold and are asserted separately.
 
 Without the differential half, "make it fast" could silently reorder or drop
 paths; without the scale half, "keep it correct" leaves the wall in place.
@@ -45,10 +48,12 @@ from agent_bom.graph.types import EntityType, RelationshipType
 
 _PROGRESS_OPS = 1_000
 
-# SHA-256 of the 32-case attack-path answer matrix captured from src at
-# 3fc34db8f — the last commit before the frontier query was rewritten. See
+# SHA-256 of the 32-case attack-path answer matrix. Originally captured from
+# src at 3fc34db8f, then re-blessed once when endpoint indexes and ORDER BY
+# rowid changed which of several equal-length routes is reported. Reachability,
+# path counts and path validity were unchanged and are asserted directly. See
 # TestFrontierQueryIsAnswerIdentical.test_reference_matches_pre_fix_release.
-PRE_FIX_GOLDEN_DIGEST = "c4b71ffd991e7de6c96954d8bf4c41af232876fdedc9dd9aa4efcfad7a3a6028"
+ANSWER_GOLDEN_DIGEST = "6826d89b4c2ac7f86055a66185f4d18eed563b0aebfb1a22c28b4477e1a932c8"
 
 _DYNAMIC = (RelationshipType.INVOKED, RelationshipType.ACCESSED, RelationshipType.DELEGATED_TO)
 _STATIC = (RelationshipType.USES, RelationshipType.DEPENDS_ON, RelationshipType.CAN_ACCESS)
@@ -108,7 +113,9 @@ def _walk_ticks(store: SQLiteGraphStore, *, scan_id: str, source: str, max_depth
 
     store._open_ro_conn = counting_open  # type: ignore[method-assign]
     try:
-        paths, _reachable, _truncated = store.bfs_paths(tenant_id="default", scan_id=scan_id, source=source, max_depth=max_depth)
+        paths, _reachable, _truncated, _depth_limited = store.bfs_paths(
+            tenant_id="default", scan_id=scan_id, source=source, max_depth=max_depth
+        )
     finally:
         store._open_ro_conn = original_open  # type: ignore[method-assign]
     return ticks, len(paths)
@@ -408,24 +415,35 @@ class TestFrontierQueryIsAnswerIdentical:
         assert optimised[7] == legacy[7]
 
     def test_reference_matches_pre_fix_release(self, tangled_store):
-        """Golden: the shipped answer must still hash to what the pre-fix code produced.
-
-        The in-test ``_legacy_frontier_rows`` reference proves the new query
-        agrees with a *reconstruction* of the old one. This proves it agrees
-        with the old code itself: the digest below was captured by running this
-        exact fixture and case matrix against ``src`` at 3fc34db8f, before the
-        UNION rewrite and before the endpoint indexes existed.
+        """Golden: the shipped answer is fixed, and the invariants below hold.
 
         32 cases — ``bfs_paths`` over two tenants x three sources x five depths,
         plus ``impact_of`` (the reverse walk over the same shared primitive).
         A change here means attack-path results moved for real users; it is not
         a snapshot to re-bless without deciding that the move is correct.
+
+        This digest was re-blessed once, deliberately. It originally captured
+        ``src`` at 3fc34db8f. Two later changes altered which representative
+        route the walk reports: the roll-up work added endpoint indexes, and
+        this branch pinned the frontier to ``ORDER BY rowid``. A node reachable
+        by several equal-length routes has several equally valid shortest
+        paths, and the one returned follows edge visit order -- so a plan
+        change swaps the exemplar without changing the answer.
+
+        The re-bless was justified against the invariants that actually matter,
+        which are asserted below rather than left to the digest: the reachable
+        set, the number of paths, and the validity of every path are unchanged.
+        Only the choice among equal-length routes moved. Pre-change that choice
+        was an accident of whichever plan the query planner picked; it is now
+        pinned, so this digest is stable in a way the old one was not.
         """
         cases: dict[str, Any] = {}
         for tenant in ("default", "tenant-b"):
             for depth in (1, 2, 3, 5, 10):
                 for source in ("v0", "v7", "v42"):
-                    paths, reachable, truncated = tangled_store.bfs_paths(tenant_id=tenant, scan_id="main", source=source, max_depth=depth)
+                    paths, reachable, truncated, _depth_limited = tangled_store.bfs_paths(
+                        tenant_id=tenant, scan_id="main", source=source, max_depth=depth
+                    )
                     cases[f"{tenant}|{source}|{depth}"] = {
                         "paths": paths,
                         "reachable": sorted(reachable),
@@ -435,14 +453,35 @@ class TestFrontierQueryIsAnswerIdentical:
 
         assert len(cases) == 32
         payload = json.dumps(cases, indent=0, sort_keys=True).encode()
-        assert hashlib.sha256(payload).hexdigest() == PRE_FIX_GOLDEN_DIGEST, "attack-path output diverged from the pre-fix release"
+        assert hashlib.sha256(payload).hexdigest() == ANSWER_GOLDEN_DIGEST, (
+            "attack-path output diverged from the pinned answer. Before re-blessing, check the "
+            "invariants below: if they still hold, only the representative route changed; if they "
+            "do not, reachability itself moved and the digest is not the thing to edit."
+        )
+
+        # The invariants the digest is a proxy for. A future plan change may
+        # legitimately swap one equal-length route for another, but it must
+        # never change what is reachable, how many paths there are, or make a
+        # path that does not follow real edges.
+        real_edges: set[tuple[str, str]] = set()
+        for edge in _tangled_graph(scan_id="main", tenant_id="default", nodes=120, edges=600, seed=11).edges:
+            real_edges.add((edge.source, edge.target))
+            real_edges.add((edge.target, edge.source))
+        walked = cases["default|v0|10"]["paths"]
+        assert len(walked) == 118
+        assert cases["default|v0|10"]["reachable"] == sorted({node for path in walked for node in path[1:]})
+        for path in walked:
+            assert path[0] == "v0", "every path must start at the source"
+            assert len(set(path)) == len(path), "a path must not revisit a node"
+            for hop in zip(path, path[1:]):
+                assert hop in real_edges, f"path traverses an edge that does not exist: {hop}"
 
     def test_bfs_paths_output_is_identical_across_tenants_and_snapshots(self, tangled_store):
         """End to end: the shipped path list, in order, plus tenant isolation."""
-        default_paths, default_reachable, default_truncated = tangled_store.bfs_paths(
+        default_paths, default_reachable, default_truncated, _default_depth_limited = tangled_store.bfs_paths(
             tenant_id="default", scan_id="main", source="v0", max_depth=5
         )
-        other_paths, _other_reachable, _ = tangled_store.bfs_paths(tenant_id="tenant-b", scan_id="main", source="v0", max_depth=5)
+        other_paths, _other_reachable, _, _ = tangled_store.bfs_paths(tenant_id="tenant-b", scan_id="main", source="v0", max_depth=5)
 
         assert default_paths, "the fixture must produce paths"
         assert default_truncated is False

--- a/tests/test_postgres_store.py
+++ b/tests/test_postgres_store.py
@@ -1804,7 +1804,7 @@ def test_graph_walk_marks_query_limit_omissions_truncated(monkeypatch):
     store = object.__new__(PostgresGraphStore)
     monkeypatch.setattr(store, "_filtered_edge_rows", lambda *_args, **_kwargs: ([], True))
 
-    result = store._walk_graph(
+    *_, truncated, depth_limited = store._walk_graph(
         WalkConnection(),
         tenant_id="tenant-alpha",
         scan_id="scan-limited",
@@ -1821,7 +1821,14 @@ def test_graph_walk_marks_query_limit_omissions_truncated(monkeypatch):
         include_roots=True,
     )
 
-    assert result[-1] is True
+    # Unpacked by name rather than indexed off the end: the walk now reports
+    # two independent bounds, and a positional ``result[-1]`` silently began
+    # reading the depth flag when the second one was added.
+    assert truncated is True
+    # The query limit is what bound this walk. Nothing was cut by depth -- the
+    # frontier ran out of edges -- so the depth flag must stay clear, otherwise
+    # "truncated" stops distinguishing which bound actually applied.
+    assert depth_limited is False
 
 
 def test_graph_store_save_graph_batches_postgres_writes(mock_pool, mock_maintenance_pool, monkeypatch):


### PR DESCRIPTION
The correlated graph and its attack paths are the differentiator, so this batch treats a fabricated edge and a silently-partial answer as the same severity as a crash. Two lanes, combined and re-gated on the merged result.

## 1. A fabricated lateral-movement route

`agent_manifest.py` keyed credential nodes on the env-var name alone (`credential:{ref_name}`). Two unrelated agents reading a var that happens to be named `API_KEY` were joined through a shared node.

```
fixture: two unrelated agents, two unrelated servers, ground truth = 2 disjoint estates
before   connected components: 1   ['srv-a…','agent-a…','srv-b…','agent-b…','credential:API_KEY']
after    connected components: 2   two credential nodes, two exposes_cred edges
```

A fabricated path is worse than a missing one — it sends people chasing a route that does not exist. The canonical builders were already server-scoped (fixed by #4569); this sibling surface, which backs the CLI manifest export and `GET /v1/agent-manifest`, was not. **The lead as originally stated pointed at `graph/builder.py:358`, which was verified clean by running it.**

## 2. A depth cap certified as the whole answer

`max_depth` defaults to 4 and is the server's choice when a caller passes nothing — a server-imposed bound exactly like the node budget #4595 fixed. Ground truth: a 9-node chain, 8 reachable.

| surface | before | after |
|---|---|---|
| `GET /v1/graph/paths` | `{complete: true, total: 4, truncated: false}` | `{complete: false, truncated: true, reason: depth_limit}`, no `total` claimed |
| `GET /v1/graph/impact` | `affected_count: 4`, **no completeness field at all** | `completeness.complete: false, reason: depth_limit` |
| `POST /v1/graph/query` | 5 of 9 nodes, `{complete: true, total: 5}` | `{complete: false, reason: depth_limit}` |
| `traverse_subgraph` | 5 of 20 nodes, `{complete: true, total: 20}` | `truncated: true, reason: depth_limit` |

Also fixed: SQLite's `traverse_subgraph` returned 5 nodes beside `{returned: 0, total: 0, complete: true}` — the same self-contradiction #4595 fixed for Postgres, still live in the **default local store**, whose test only covered container + Postgres.

`depth_limited` fires only when the frontier demonstrably had unwalked neighbours, not on every capped walk — otherwise `truncated` would be set on nearly every bounded query and stop meaning anything. That choice is load-bearing: making it unconditional turns #4595's complete-snapshot guard red.

## 3. Path search hit its own deadline at 10k nodes

`bfs_paths` on a 10k-node estate measured **2.999 s against a 3 s deadline**. One edge more and the product stops looking.

The cause was not full materialisation and not missing early termination. Every dequeued node issued its own frontier query, and that query was a single disjunction (`source_id IN (...) OR target_id IN (...)`) — which SQLite cannot drive an index from. The plan collapsed to a scan of every edge in the snapshot, once per visited node: **O(visited × snapshot_edges)**, so the unreachable remainder of the estate dominated. Confirmed quadratic before the budget caps it (2.5× nodes → 6.24× ≈ 2.5² work).

Two probes ruled out the obvious fixes, which is why this was measured rather than assumed: **UNION alone** is not enough (SQLite picks the same index for both branches and scans twice — the roll-up's UNION fix does not transfer), and **indexes alone** are not enough (the disjunction still plans as a full scan). Both halves are required, and neither depends on `sqlite_stat1`, which a freshly written customer database does not have.

| nodes | VDBE ksteps | wall |
|---|---|---|
| 1,000 | 7,050 → 112 | 0.074 → 0.017 s |
| 10,000 | 350,359 → 754 | **2.999 → 0.111 s** |
| 40,000 | 1,400,569 → 1,134 | 19.628 → 0.252 s |

Work is counted in VDBE steps, not milliseconds — opcode counts are deterministic for a given plan where wall-clock on a loaded host is not. The fix lands in the shared `_walk_graph` primitive, so `impact_of` and `traverse_subgraph` get it too.

**The budget is unchanged.** Still `max_nodes=5000`, still `truncated=True` with `reason="traversal_budget"`. It is now reached in 0.25 s instead of 20 s. Raising it is now affordable (200k nodes walked in ~4 s) but changes what users see, so it is left as a product call with numbers attached.

## What did not reproduce

- **"Second persist fails silently at ~7k edges"** — star graphs at 1,000 / 6,999 / 7,000 / 7,001 / 12,000 edges, saved twice under two scan ids and reloaded: every case round-tripped both snapshots intact.
- **Credential collapse at `graph/builder.py:358`** — already fixed by #4569, verified by running it rather than reading the commit.

## Precision / recall

Fused kill-chain engine over a 12-node estate with three deliberate near-misses (a dead end; a sensitive store with no internet entry; an internet-reachable store that is not a jewel): **precision 1.00, recall 1.00, 0 fabricated hops**. `bfs_paths` on a two-estate diamond: no path crosses into the unconnected estate, every hop matches a real persisted edge. Both are committed regression tests now, not one-off scripts.

## The golden digest was re-blessed — deliberately, once

Combining the two lanes diverged the scale branch's pinned answer digest. Investigated rather than re-blessed on sight: **reachable sets, path counts and path validity are all unchanged.** What moved is which of several equal-length shortest routes is reported, because endpoint indexes and `ORDER BY rowid` changed edge visit order. Verified on the merged tree — 118 paths, **0 hops that do not follow a real edge**, every path rooted at the source, no revisits, identical across three fresh builds.

Those invariants are now asserted alongside the digest, so a future divergence tells the reader whether reachability moved or only the exemplar did. The old digest was never stable anyway: it recorded whichever plan the query planner happened to pick.

## Verification on the merged result

`2758 passed, 39 skipped` across graph / traversal / manifest / impact / path / store / migration / schema · `ruff check src tests` clean · `mypy` clean on all 8 changed source files · `bandit -r src/ --severity-level medium` (the CI invocation) reports **no issues** · all commits signed.

Three of the scale branch's guards broke on merge and none of them could have been caught on either branch alone — a fourth return value, and the digest above. That is what the combined gate is for.

## Not measured

**Postgres and Docker were down throughout.** The Postgres store received identical changes so the backends cannot drift, and the existing differential test compares nodes, edges, depths *and* the full completeness dict against the in-memory ground truth — but it did not run here (18 Postgres tests skipped). Its `_walk_graph` has the same per-node disjunction shape, but it already ships the equivalent indexes and its planner can BitmapOr a disjunction where SQLite cannot, so the SQLite defect likely does not reproduce there. **Unverified — someone with a live PG should EXPLAIN that frontier query before assuming it is fine.**

Also deferred: SQLite `bfs_paths` passes `deadline_monotonic=None`, so it has no time bound at all, only node/edge budgets. Post-fix the exposure is small (0.25 s at 40k), but the asymmetry with Postgres is real and unguarded; adding a deadline introduces a new truncation source and changes answers, which does not belong in this branch.