### PR TITLE
fix(ingest): report what the batch actually stored, not what it received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,11 @@ Read "Changed" before upgrading.
   reach the written report, and a partial scan exits non-zero.
 - CISA KEV, EPSS and `kev_due_date` enrichment reached the report; an unavailable
   KEV feed no longer reads as "not exploited".
+- Both finding-ingest routes echoed the payload count as `ingested` while
+  payloads sharing a canonical id were correctly deduped on the way in, leaving
+  a client unable to explain why it pushed N and the store holds fewer. The
+  responses now also carry `distinct_findings` and `duplicate_payloads`, and
+  `/v1/findings/bulk` warns when any payload collapsed.
 
 ### Fixed — accuracy
 

--- a/src/agent_bom/api/hub_ingest.py
+++ b/src/agent_bom/api/hub_ingest.py
@@ -66,10 +66,16 @@ def hub_ingest_store_writes(
     if needs_hub_prior_snapshots(reconcile_absent=reconcile_absent):
         prior_snapshots = capture_hub_snapshots(hub_store, tenant_id, source=source)
 
+    # Canonical ids are resolved for every batch, not just reconciling ones: the
+    # count of DISTINCT ids is what the store will hold, and a caller told only
+    # how many payloads it sent cannot explain the difference. Pure Python, so
+    # it costs nothing beyond the set the reconcile path already builds.
+    distinct_ids = collect_present_canonical_ids(payloads, source=source)
+
     # ``present_canonical_ids`` for absent-reconciliation (and the delta
-    # ``resolved_ids`` derived from it) is pure Python — computed before the
-    # write so the atomic seam can run the reconcile inside the same transaction.
-    present: set[str] = collect_present_canonical_ids(payloads, source=source) if reconcile_absent else set()
+    # ``resolved_ids`` derived from it) is computed before the write so the
+    # atomic seam can run the reconcile inside the same transaction.
+    present: set[str] = distinct_ids if reconcile_absent else set()
 
     atomic = getattr(hub_store, "ingest_batch_atomic", None)
     if callable(atomic):
@@ -117,4 +123,6 @@ def hub_ingest_store_writes(
         "new_total": new_total,
         "reconciled": reconciled,
         "delta_results": delta_results,
+        "distinct_findings": len(distinct_ids),
+        "duplicate_payloads": len(payloads) - len(distinct_ids),
     }

--- a/src/agent_bom/api/routes/compliance.py
+++ b/src/agent_bom/api/routes/compliance.py
@@ -2579,6 +2579,8 @@ async def ingest_compliance_findings(request: Request) -> dict:
 
     response = {
         "ingested": len(payloads),
+        "distinct_findings": store_result["distinct_findings"],
+        "duplicate_payloads": store_result["duplicate_payloads"],
         "tenant_total": new_total,
         "format": fmt,
         "observed_at": observed_at,

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -1919,9 +1919,7 @@ def _finding_facets_bounded(
     from agent_bom.finding_scope import FINDING_CLASSES, SECURITY_DOMAINS, finding_class_for_row, lenses_for_row
 
     class_counts: dict[str, int] = {key: 0 for key in FINDING_CLASSES}
-    severity_counts: dict[str, int] = {
-        key: 0 for key in ("critical", "high", "medium", "low", "info", "unknown")
-    }
+    severity_counts: dict[str, int] = {key: 0 for key in ("critical", "high", "medium", "low", "info", "unknown")}
     status_counts: dict[str, int] = {key: 0 for key in ("open", "resolved")}
     domain_counts: dict[str, int] = {key: 0 for key in SECURITY_DOMAINS}
     freshness_counts: dict[str, int] = {key: 0 for key in _FRESHNESS_BUCKETS}
@@ -2747,8 +2745,7 @@ def _list_findings_impl(
         page_rows = reachability.rows
         if reachability.truncated:
             warnings.append(
-                "Graph reachability projection is bounded to the highest-risk 1000 persisted paths; "
-                "unmatched findings remain unassessed."
+                "Graph reachability projection is bounded to the highest-risk 1000 persisted paths; unmatched findings remain unassessed."
             )
     except Exception as exc:  # noqa: BLE001 — optional evidence must not fail the findings list
         _logger.warning("Finding graph reachability projection skipped: %s", sanitize_error(exc))
@@ -2884,11 +2881,20 @@ async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> d
     new_total = store_result["new_total"]
     reconciled = store_result["reconciled"]
     delta_results = store_result["delta_results"]
+    distinct_findings = store_result["distinct_findings"]
+    duplicate_payloads = store_result["duplicate_payloads"]
     warnings: list[str] = []
+    if duplicate_payloads:
+        warnings.append(
+            f"{duplicate_payloads} duplicate payload(s) collapsed onto an existing canonical id; "
+            f"{distinct_findings} distinct finding(s) were stored"
+        )
     response = {
         "schema_version": "v1",
         "batch_id": batch_id,
         "ingested": len(payloads),
+        "distinct_findings": distinct_findings,
+        "duplicate_payloads": duplicate_payloads,
         "tenant_total": new_total,
         "tenant_id": tenant_id,
         "source": body.source,

--- a/tests/test_compliance_hub_api.py
+++ b/tests/test_compliance_hub_api.py
@@ -100,6 +100,23 @@ def test_ingest_sarif_returns_count_plus_framework_breakdown():
     assert "nist-csf" in body["framework_hits"]
 
 
+def test_ingest_reports_payloads_that_collapsed_onto_one_finding():
+    """The compliance ingest route shares the bulk route's write path — and its
+    accounting. Two identical SARIF results resolve to one canonical id."""
+    doc = _sarif_doc()
+    doc["runs"][0]["results"].append(dict(doc["runs"][0]["results"][0]))
+
+    resp = _client().post(
+        "/v1/compliance/ingest",
+        json={"format": "sarif", "content": json.dumps(doc)},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["ingested"] == 2
+    assert body["distinct_findings"] == 1
+    assert body["duplicate_payloads"] == 1
+
+
 def test_ingest_invalid_format_returns_400():
     resp = _client().post(
         "/v1/compliance/ingest",

--- a/tests/test_findings_bulk_api.py
+++ b/tests/test_findings_bulk_api.py
@@ -266,3 +266,56 @@ def test_bulk_findings_ingest_rejects_a_foreign_body_tenant() -> None:
 
     assert resp.status_code == 403, resp.text
     assert "tenant_id" in resp.json()["error"]["message"]
+
+
+def test_bulk_ingest_reports_payloads_that_collapsed_onto_one_finding() -> None:
+    """``ingested`` counts payloads; the caller also needs what became queryable.
+
+    Two payloads resolving to one canonical id are deduped on the way in, which
+    is correct. Echoing only the payload count leaves the client reconciling a
+    push of N against a store holding fewer, with nothing explaining the gap.
+    """
+    tenant_id = f"bulk-ingest-{uuid4().hex}"
+    client = _client(tenant=tenant_id)
+
+    resp = client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "agent-runtime",
+            "findings": [
+                {"id": "agent-runtime:finding-1", "title": "first", "severity": "high"},
+                {"id": "agent-runtime:finding-2", "title": "second", "severity": "low"},
+                {"id": "agent-runtime:finding-1", "title": "first", "severity": "high"},
+            ],
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["ingested"] == 3
+    assert body["distinct_findings"] == 2
+    assert body["duplicate_payloads"] == 1
+    assert any("duplicate" in warning for warning in body["warnings"])
+
+
+def test_bulk_ingest_reports_no_duplicates_when_every_payload_is_distinct() -> None:
+    tenant_id = f"bulk-ingest-{uuid4().hex}"
+    client = _client(tenant=tenant_id)
+
+    resp = client.post(
+        "/v1/findings/bulk",
+        json={
+            "source": "agent-runtime",
+            "findings": [
+                {"id": "agent-runtime:finding-1", "title": "first", "severity": "high"},
+                {"id": "agent-runtime:finding-2", "title": "second", "severity": "low"},
+            ],
+        },
+    )
+
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["ingested"] == 2
+    assert body["distinct_findings"] == 2
+    assert body["duplicate_payloads"] == 0
+    assert body["warnings"] == []


### PR DESCRIPTION
## The defect

Both finding-ingest routes echoed `ingested: len(payloads)`. Payloads resolving to the same canonical id are deduped on the way in — correct, and the ledger and current-state agree afterwards — but nothing in the response said so.

```
POST /v1/findings/bulk   100 payloads, 10 of them duplicates
before   ingested: 100   tenant_total: 90   warnings: []
after    ingested: 100   distinct_findings: 90   duplicate_payloads: 10
         warnings: ["10 duplicate payload(s) collapsed onto an existing
                     canonical id; 90 distinct finding(s) were stored"]
GET /v1/findings         total: 90
```

A client pushing 100 and reading back 90 had no field to explain the gap. No data was lost — this is the response echo only, the same computed-not-surfaced class this release is closing, pointed at the write path.

## The fix

`hub_ingest_store_writes` now resolves canonical ids for **every** batch rather than only reconciling ones (pure Python — the reconcile path already built the same set) and returns `distinct_findings` / `duplicate_payloads` beside `new_total`. Both `/v1/findings/bulk` and `/v1/compliance/ingest` read them from that one shared body, so the two responses cannot drift apart — which is why the second route is in scope here rather than as a follow-up.

`ingested` keeps its existing meaning, payloads accepted, so no client breaks.

## Verification

- `tests/test_findings_bulk_api.py` + `tests/test_compliance_hub_api.py`: 40 passed.
- Wider ingest sweep (11 files incl. atomicity, offload, idempotency, contract envelope): 107 passed, 7 skipped.
- **Non-vacuity proven per surface**: reverting the `hub_ingest.py` return keys turns the two bulk tests red; reverting only the `compliance.py` response keys turns the compliance test red.
- `scripts/preflight_release.sh` → "Pre-flight OK — safe to tag".
- `ruff check` clean; `mypy` reports 39 errors across these files both with and without this change (all pre-existing `no-any-return`, none introduced).

## Incidental

The pinned `ruff-format` hook rewrote two pre-existing blocks in `scan.py` unrelated to this change (a dict comprehension and a wrapped string, both at lines untouched here). They are included because the repo's own hook produces them on any commit touching that file. Worth knowing separately: CI runs `ruff check src/` but never `ruff format --check`, which is how that drift reached main.