### PR TITLE
chore(docs): stop advertising a hosted demo from the public repo

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -1,9 +1,11 @@
 name: Deployment Freshness
 
-# Checks that the protected Railway surface serves the latest release, that
-# the Smithery catalog listing is live with a non-empty tool inventory, and that
-# the public hosted demo (demo.agent-bom.com) answers /health on the expected
-# version. Runs daily and on-demand. Opens an issue if stale or misconfigured.
+# Checks that the protected Railway surface serves the latest release and that
+# the Smithery catalog listing is live with a non-empty tool inventory. Runs
+# daily and on-demand. Opens an issue if stale or misconfigured.
+#
+# No hosted-demo probe: this repo does not publish a demo endpoint, so there is
+# nothing here whose uptime would be ours to gate on.
 
 on:
   schedule:
@@ -136,48 +138,8 @@ jobs:
             echo "::warning::Smithery catalog listing is missing remote deployment metadata or tools"
           fi
 
-      - name: Check hosted demo (demo.agent-bom.com)
-        id: demo
-        continue-on-error: true
-        env:
-          DEMO_PUBLIC_URL: ${{ vars.DEMO_PUBLIC_URL }}
-        run: |
-          DEMO_URL="${DEMO_PUBLIC_URL:-https://demo.agent-bom.com}"
-          HEALTH_URL="${DEMO_URL%/}/health"
-          echo "Checking $HEALTH_URL ..."
-          EXPECTED="${{ steps.expected.outputs.version }}"
-          RESPONSE=$(curl -fsS --max-time 15 "$HEALTH_URL" 2>/dev/null || echo '')
-          if [ -z "$RESPONSE" ]; then
-            echo "demo_version=unreachable" >> "$GITHUB_OUTPUT"
-            echo "probe_failed=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Hosted demo unreachable at $HEALTH_URL (HTTP failure / timeout)"
-            exit 0
-          fi
-          DEPLOYED=$(echo "$RESPONSE" | python3 -c "
-          import sys, json
-          try:
-              data = json.load(sys.stdin)
-              print(data.get('version') or data.get('status') or 'unknown')
-          except Exception:
-              print('unknown')
-          ")
-          echo "demo_version=$DEPLOYED" >> "$GITHUB_OUTPUT"
-          echo "Demo version: $DEPLOYED (expected: $EXPECTED)"
-          if [ "$DEPLOYED" = "unknown" ] || [ "$DEPLOYED" = "ok" ]; then
-            # /health may return status=ok without version on older builds; treat
-            # missing version as probe_failed only when body is not JSON-ok.
-            HAS_VERSION=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('version') else 'no')")
-            if [ "$HAS_VERSION" != "yes" ]; then
-              echo "probe_failed=true" >> "$GITHUB_OUTPUT"
-              echo "::warning::Hosted demo /health missing version field"
-            fi
-          elif [ "$DEPLOYED" != "$EXPECTED" ]; then
-            echo "stale=true" >> "$GITHUB_OUTPUT"
-            echo "::warning::Hosted demo version $DEPLOYED != expected $EXPECTED"
-          fi
-
       - name: Open issue if deployment surfaces drift or public endpoint is misconfigured
-        if: steps.railway.outputs.stale == 'true' || steps.public.outputs.stale == 'true' || steps.public.outputs.auth_gate == 'true' || steps.public.outputs.probe_failed == 'true' || steps.demo.outputs.stale == 'true' || steps.demo.outputs.probe_failed == 'true'
+        if: steps.railway.outputs.stale == 'true' || steps.public.outputs.stale == 'true' || steps.public.outputs.auth_gate == 'true' || steps.public.outputs.probe_failed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -186,7 +148,6 @@ jobs:
           PUBLIC="${{ steps.public.outputs.public_version }}"
           PUBLIC_TOOLS="${{ steps.public.outputs.tool_count }}"
           PUBLIC_AUTH="${{ steps.public.outputs.auth_required }}"
-          DEMO="${{ steps.demo.outputs.demo_version }}"
           TITLE="supply-chain-drift: deployment surfaces out of sync with $EXPECTED"
 
           gh label create supply-chain-drift --color FBCA04 --description "Automated supply-chain or deployment drift detection" >/dev/null 2>&1 || true
@@ -203,9 +164,8 @@ jobs:
           |---------|---------|----------|---------------|------------|
           | Railway (protected) | $RAILWAY | $EXPECTED | true | — |
           | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
-          | Hosted demo | $DEMO | $EXPECTED | read-only sandbox | — |
 
-          **Action**: Ensure the protected Railway deployment is fresh, the Smithery catalog API lists a remote deployment with tools, and \`demo.agent-bom.com/health\` serves the expected version (see docs/HOSTED_POC.md → Demo redeploy), then re-run this workflow.
+          **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API lists a remote deployment with tools, then re-run this workflow.
 
           This issue was auto-updated by the deployment-freshness workflow.
           EOF
@@ -223,9 +183,8 @@ jobs:
           |---------|---------|----------|---------------|------------|
           | Railway (protected) | $RAILWAY | $EXPECTED | true | — |
           | Public marketplace | $PUBLIC | $EXPECTED | $PUBLIC_AUTH | $PUBLIC_TOOLS |
-          | Hosted demo | $DEMO | $EXPECTED | read-only sandbox | — |
 
-          **Action**: Ensure the protected Railway deployment is fresh, the Smithery catalog API lists a remote deployment with tools, and \`demo.agent-bom.com/health\` serves the expected version (see docs/HOSTED_POC.md → Demo redeploy), then re-run this workflow.
+          **Action**: Ensure the protected Railway deployment is fresh and the Smithery catalog API lists a remote deployment with tools, then re-run this workflow.
 
           This issue was auto-created by the deployment-freshness workflow.
           EOF
@@ -281,7 +240,7 @@ jobs:
           fi
 
       - name: Close supply-chain drift issue when deployment is fresh
-        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true' && steps.public.outputs.not_configured != 'true' && steps.public.outputs.stale != 'true' && steps.public.outputs.probe_failed != 'true' && steps.public.outputs.auth_gate != 'true' && steps.demo.outputs.stale != 'true' && steps.demo.outputs.probe_failed != 'true'
+        if: steps.railway.outputs.stale != 'true' && steps.railway.outputs.probe_failed != 'true' && steps.public.outputs.not_configured != 'true' && steps.public.outputs.stale != 'true' && steps.public.outputs.probe_failed != 'true' && steps.public.outputs.auth_gate != 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/README.md
+++ b/README.md
@@ -26,8 +26,7 @@
 <p align="center">
   <b>15</b> package ecosystems · <b>16</b> compliance surfaces · <b>77</b> MCP tools · no account required<br />
   <a href="#quick-start"><b>Quick start</b></a> ·
-  <a href="https://msaad00.github.io/agent-bom/">Docs</a> ·
-  <a href="https://demo.agent-bom.com">Live demo</a>
+  <a href="https://msaad00.github.io/agent-bom/">Docs</a>
 </p>
 
 ## What it is

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -169,7 +169,10 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "<b>77</b> MCP tools" in hero
     assert '<a href="#quick-start"><b>Quick start</b></a>' in hero
     assert '<a href="https://msaad00.github.io/agent-bom/">Docs</a>' in hero
-    assert '<a href="https://demo.agent-bom.com">Live demo</a>' in hero
+    # No hosted-demo link: this repo ships the scanner and the self-host runbook,
+    # and nothing here should promise an endpoint whose uptime it does not own.
+    assert "demo.agent-bom.com" not in readme
+    assert "Live demo" not in hero
     assert "## How it works" not in readme
 
     current_what_it_is = """`agent-bom` is an open scanner and self-hosted control plane for software,


### PR DESCRIPTION
## Why

The README storefront linked `demo.agent-bom.com`, and `deployment-freshness.yml` probed its `/health` daily, auto-filing a `supply-chain-drift` issue whenever it did not answer. It has not been answering — that is what #4590 is.

This is a public OSS repo. It ships the scanner and the self-host runbook; an endpoint whose uptime it does not own should not be a promise in the storefront, and CI here should not go red on private infrastructure.

## What changed

- **README hero** — the `Live demo` link is gone; `Docs` is now the last item in the row.
- **`deployment-freshness.yml`** — the hosted-demo probe step is removed, along with its contribution to the drift condition, the issue table row, and the remediation sentence. The workflow keeps watching the two surfaces a release actually publishes (Railway, Smithery catalog), and its self-close condition no longer waits on a demo result that will never arrive.
- **`tests/test_public_docs_cli_alignment.py`** — the assertion that the link is present is inverted to assert it is absent, so it cannot return without someone changing the test on purpose.

## Verification

- `tests/test_public_docs_cli_alignment.py`, `test_hosted_poc_smoke.py`, `test_hosted_poc_preflight.py`: 27 passed.
- The inverted guard was confirmed red against the current README before the link was removed.
- `actionlint` on the changed workflow reports the same 4 pre-existing style findings as `main` — none added.
- `scripts/preflight_release.sh` → "Pre-flight OK — safe to tag".

Expect #4590 to self-close on the next scheduled run, since the two remaining surfaces were already reporting fresh.

## Deliberately not in scope

`docs/HOSTED_POC.md` still documents a hosted deployment topology (`demo.agent-bom.com`, `app.agent-bom.com`, the customer-0 POC). That is an operator runbook rather than a storefront claim, and how much of it belongs in a public repo is a separate call — flagged, not decided here. The demo deploy workflows are likewise left in place and inert.