### PR TITLE
fix(cli): check the inventory path before refreshing the vuln DB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `agent-bom scan --inventory <path>` refreshed the entire vulnerability
+  database before checking whether the path existed, so a typo'd inventory
+  cost a full cold-start download — minutes on a machine with no cache —
+  before the CLI reported "Inventory file not found". Existence is now
+  decided first; format and parse errors still surface from the loader.
+
+### Changed
+
+- The test suite no longer downloads the advisory corpus. It already ran under
+  `-m "not network"`, but that marker only deselects tests that declare it and
+  could not stop a CLI scan from going to the network, which made three CLI
+  tests the whole CI job's critical path. Tests that drive `sync_db` itself opt
+  out with `@pytest.mark.real_vuln_db_sync`.
+
 ## [0.98.3] - 2026-08-02
 
 Behaviour changes in this release move numbers you may already be reporting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -339,6 +339,7 @@ markers = [
     "network: tests that require network access (OSV API)",
     "slow: slow tests (e.g. large-scale perf benchmarks) — opt-in only",
     "live_cluster: tests that require a reachable local Kubernetes cluster (e.g. kind) — opt-in only",
+    "real_vuln_db_sync: test drives sync_db itself; opts out of the autouse no-download patch",
 ]
 
 [tool.mypy]

--- a/src/agent_bom/cli/agents/scan_cmd.py
+++ b/src/agent_bom/cli/agents/scan_cmd.py
@@ -772,6 +772,16 @@ def scan(
         except Exception:
             pass  # DB not available, will use network
 
+    # ── Fail on an unusable --inventory before paying for anything ───────────
+    # A path that does not exist invalidates the whole scan, and detecting it
+    # costs one stat(). The refresh below is a multi-minute cold-start download
+    # on a machine with no cache, so checking afterwards makes a typo'd path
+    # cost minutes before the CLI admits the file was never there. Only
+    # existence is decided here; format and parse errors still surface from the
+    # loader during discovery, which owns that reporting.
+    if inventory and inventory != "-" and not Path(inventory).exists():
+        raise click.BadParameter(f"Inventory file not found: {inventory}", param_hint="--inventory")
+
     # ── Vuln-data freshness snapshot + auto-refresh ──────────────────────────
     # Single source of truth for "where did the vuln data come from, how old is
     # it, is it stale". Computed once here, surfaced to the user below, and

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,6 +44,44 @@ os.environ.setdefault(
 os.environ.setdefault("AGENT_BOM_EPHEMERAL_STORE", "1")
 
 
+@pytest.fixture(autouse=True)
+def _no_vuln_db_download(request):
+    """Keep the suite off the network when a CLI scan decides to refresh.
+
+    The suite runs under ``-m "not network"``, but that marker only deselects
+    tests that declare it — it cannot stop a scan from auto-refreshing the vuln
+    DB, which downloads the advisory corpus. With no cache (every CI runner)
+    that cost made three CLI tests the whole job's critical path at 750-990s
+    each.
+
+    Patched at the module attribute rather than via ``AGENT_BOM_VULN_DB_OFFLINE``
+    on purpose: that env var also disables network *enrichment*, so setting it
+    suite-wide silently changes what the NVD/CWE/EPSS paths do. This stops the
+    download and nothing else. ``scan_cmd`` imports ``sync_db`` inside the
+    function, so it resolves this patch; tests that import it directly keep the
+    real one, and tests that patch it themselves still override this. Tests of
+    ``sync_db`` itself opt out with ``@pytest.mark.real_vuln_db_sync``.
+
+    Restores by hand rather than via ``monkeypatch``: requesting that fixture
+    here would construct it before every module-local fixture, moving its
+    env-restoring teardown after theirs. A module that reloads config on
+    teardown would then reload it against environment the test had not yet
+    finished unwinding.
+    """
+    if "real_vuln_db_sync" in request.keywords:
+        yield
+        return
+
+    import agent_bom.db.sync as db_sync
+
+    original = db_sync.sync_db
+    db_sync.sync_db = lambda *a, **k: 0
+    try:
+        yield
+    finally:
+        db_sync.sync_db = original
+
+
 def _reset_runtime_state() -> None:
     # Remove the kill-switch state file between tests so a blocked/CRITICAL
     # state from one test never restores into the next on the same worker.

--- a/tests/test_cli_p1_polish.py
+++ b/tests/test_cli_p1_polish.py
@@ -143,3 +143,26 @@ def test_resolve_output_path_still_rejects_unrelated_extension() -> None:
     with pytest.raises(SystemExit) as exc:
         _resolve_output_path("out.png", "cyclonedx")
     assert exc.value.code == 2
+
+
+def test_missing_inventory_is_reported_before_any_vuln_db_refresh(monkeypatch) -> None:
+    """A bad `--inventory` path must be reported without first refreshing the
+    vuln DB.
+
+    The refresh is a multi-minute cold-start cost; the file check that
+    invalidates it is free. Ordering them the other way makes a typo'd path
+    cost minutes before the CLI admits the file was never there.
+    """
+    import agent_bom.db.sync as db_sync
+    import agent_bom.vuln_freshness as vuln_freshness
+
+    refreshes: list[tuple] = []
+    monkeypatch.setattr(vuln_freshness, "should_refresh", lambda *a, **k: True)
+    monkeypatch.setattr(db_sync, "sync_db", lambda *a, **k: refreshes.append(a))
+
+    result = CliRunner().invoke(main, ["scan", "--inventory", "/tmp/__does_not_exist_agent_bom.json"])
+
+    assert result.exit_code != 0
+    assert "Inventory file not found" in result.output
+    assert refreshes == [], "vuln DB was refreshed before the inventory path was validated"
+    assert "Refreshing local vuln DB" not in result.output

--- a/tests/test_local_vuln_db.py
+++ b/tests/test_local_vuln_db.py
@@ -940,6 +940,7 @@ def test_sync_alpine_secdb_downloads_selected_branches(tmp_db):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.real_vuln_db_sync
 def test_sync_db_single_kev_source(tmp_path):
     """sync_db with sources=['kev'] only calls sync_kev."""
     from agent_bom.db.sync import sync_db
@@ -950,6 +951,7 @@ def test_sync_db_single_kev_source(tmp_path):
     mock_kev.assert_called_once()
 
 
+@pytest.mark.real_vuln_db_sync
 def test_sync_db_single_epss_source(tmp_path):
     """sync_db with sources=['epss'] only calls sync_epss."""
     from agent_bom.db.sync import sync_db
@@ -960,6 +962,7 @@ def test_sync_db_single_epss_source(tmp_path):
     mock_epss.assert_called_once()
 
 
+@pytest.mark.real_vuln_db_sync
 def test_sync_db_single_alpine_source(tmp_path):
     """sync_db with sources=['alpine'] only calls sync_alpine_secdb."""
     from agent_bom.db.sync import sync_db


### PR DESCRIPTION
Found while diagnosing why `main`'s pipeline stopped completing. The CI symptom and a real UX bug turned out to be the same defect.

## 1. A missing file reported after a multi-minute download

`agent-bom scan --inventory <path>` refreshes the entire vulnerability database *before* checking whether the path exists:

```
IMPORT  0.9s
INVOKE  178.8s   exit=2
OUTPUT: "Refreshing local vuln DB …"   →  then "Inventory file not found"
```

Same test, same machine, only the cache differs: **1.54s warm vs 200s cold**. A typo'd inventory path costs minutes before the CLI admits the file was never there. Existence is now decided first; format and parse errors still surface from the loader during discovery, which owns that reporting.

The existing test beside it asserts the *banner* is deferred until after validation — the work was not.

## 2. The same cost was setting CI's wall clock

`Test (Python 3.11)` on `a035ee4e` was cancelled at the 25-minute job cap, and the log showed 13 minutes of silence at 99%. Not a hang — the coverage leg has no cache, so scan tests download the corpus. Three of them were the entire job's critical path across three consecutive green runs:

| test | 3 green runs |
|---|---|
| `test_discovery_banner_deferred_until_after_inventory_validation` | 934s · 990s · 888s |
| `test_cli_image_output_json_extension_writes_report` | 852s · 848s · 527s |
| `test_cli_scan_empty_dir_exits_0` | 751s · 145s · — |

One test at ~16 minutes means no worker count brings the job under that, which is why 25 minutes kept being hit.

The suite already runs `-m "not network"`, but that marker only deselects tests that *declare* it — it cannot stop a scan from reaching the network. An autouse fixture now neutralises the download, so the marker's promise is actually enforced.

**Measured on a cold HOME:** those three tests go from 2537s in CI to **1.27s combined**. Full suite wall clock **22:15 → 6:06**.

## Two things this fix deliberately does *not* do

Both were tried first and rejected because the suite caught them:

- **Not `AGENT_BOM_VULN_DB_OFFLINE`.** Pinning it suite-wide broke 5 enrichment tests: that variable also disables network *enrichment* (`enrichment.py:118-124`), so it silently changes what the NVD, CWE and EPSS paths do. Patching `sync_db` stops the download and nothing else.
- **Not via `monkeypatch`.** Requesting it from a conftest autouse fixture constructs it before every module-local fixture, moving its env-restoring teardown *after* theirs — which broke 7 tests in `test_api_operator_policy.py`, a module that reloads config on teardown and then saw half-unwound environment. The fixture restores by hand.

Tests that drive `sync_db` itself opt out with a registered `real_vuln_db_sync` marker.

## Verification

- Full suite, CI environment and invocation (`uv run pytest -n 4 --dist worksteal`): **18584 passed, 94 skipped, 0 failed**.
- Non-vacuity: reverting the ordering fix turns the new test red; without the fixture the previously-slow test is still running at 90s against 1.27s with it.
- Every failure seen along the way was baselined against `main` before being attributed — including one that turned out to be a local `.venv` drifting from the lockfile and passes under `uv run`.
- `ruff check` clean. `scripts/preflight_release.sh` → "Pre-flight OK — safe to tag".