### PR TITLE
test(gateway): assert the loop stayed free, not how fast the runner was

### DIFF
--- a/tests/test_gateway_feed_event_loop.py
+++ b/tests/test_gateway_feed_event_loop.py
@@ -62,18 +62,28 @@ def test_jsonl_fallback_reads_the_newest_bounded_records(tmp_path) -> None:
     assert alerts[-1]["event_id"] == "evt-1249"
 
 
-async def _max_stall_while(coro, *, tick: float = 0.001) -> tuple[object, float]:
-    """Run *coro*, sampling how long the loop ever went without servicing a tick."""
+async def _max_stall_while(coro, *, tick: float = 0.001) -> tuple[object, float, float, int]:
+    """Run *coro*, sampling how long the loop ever went without servicing a tick.
+
+    Returns the result, the worst stall, the total time the call took, and how
+    many times the heartbeat was serviced while it ran. The last two are what
+    make the assertion load-independent: a busy runner stretches the stall and
+    the total together, so their ratio still describes whether the loop was
+    free, while an absolute millisecond bound only describes how loaded the
+    machine was.
+    """
     worst = 0.0
+    beats = 0
     stop = False
 
     async def _heartbeat() -> None:
-        nonlocal worst
+        nonlocal worst, beats
         last = time.perf_counter()
         while not stop:
             await asyncio.sleep(tick)
             now = time.perf_counter()
             worst = max(worst, now - last)
+            beats += 1
             last = now
 
     beat = asyncio.create_task(_heartbeat())
@@ -82,13 +92,15 @@ async def _max_stall_while(coro, *, tick: float = 0.001) -> tuple[object, float]
     # measured as zero stall -- the instrument would exonerate the bug.
     for _ in range(5):
         await asyncio.sleep(tick)
+    started = time.perf_counter()
     try:
         result = await coro
     finally:
+        elapsed = time.perf_counter() - started
         stop = True
         await asyncio.sleep(0)
         beat.cancel()
-    return result, worst
+    return result, worst, elapsed, beats
 
 
 @pytest.mark.parametrize("route", ["feed", "kpis"])
@@ -111,11 +123,20 @@ def test_feed_routes_do_not_block_the_event_loop(tmp_path, monkeypatch, route):
     async def _drive():
         return await _max_stall_while(call)
 
-    _result, worst_stall = asyncio.run(_drive())
+    _result, worst_stall, elapsed, beats = asyncio.run(_drive())
 
-    # Before the fix this measured ~3.6 s: the whole process frozen, not merely
-    # a slow request. Off-loading brings it to ~0.19 s. The residue is GIL
-    # contention -- parsing 40k JSON lines is CPU-bound, so a worker thread
-    # interleaves with the loop rather than freeing it. Fully removing it needs
-    # the work bounded (pagination / a smaller cap), not more threading.
-    assert worst_stall < 0.35, f"event loop stalled {worst_stall * 1000:.0f} ms reading the audit log"
+    # Before the fix the loop was frozen for the whole call: one stall covering
+    # ~all of the ~3.6 s, and the heartbeat never serviced. Off-loading means
+    # the loop keeps running throughout -- that, not any particular duration,
+    # is the property. Asserting it as a ratio plus a liveness count keeps the
+    # guard meaningful on a loaded runner, where an absolute millisecond bound
+    # measures the machine rather than the code. (A hardcoded 0.35 s bound
+    # failed at 471 ms on a contended runner while the offload was working
+    # correctly.) The residue is GIL contention -- parsing 40k JSON lines is
+    # CPU-bound, so a worker thread interleaves with the loop rather than
+    # freeing it. Removing that needs the work bounded, not more threading.
+    assert beats > 10, f"event loop serviced only {beats} tick(s) while reading the audit log -- it was blocked"
+    assert worst_stall < 0.5 * elapsed, (
+        f"one stall of {worst_stall * 1000:.0f} ms covered most of the {elapsed * 1000:.0f} ms call -- "
+        "the read is running on the event loop, not a worker thread"
+    )


### PR DESCRIPTION
Closes #4607.

## What failed

`CI/CD Pipeline` on `main` @ `1f85429`:

```
FAILED tests/test_gateway_feed_event_loop.py::test_feed_routes_do_not_block_the_event_loop[feed]
  AssertionError: event loop stalled 471 ms reading the audit log
```

Not a regression from the commit it landed on — that PR changed a README link and a workflow, nothing that reaches the gateway feed. The test asserted `worst_stall < 0.35`, while the offload it guards lands near 0.19s. Under 2x headroom, on a runner already contended by the 22-minute coverage matrix.

## What it asserts now

The property is that the loop keeps getting serviced while a 40k-line audit log is read. That is inherently relative — a loaded machine stretches the stall and the call together — so it is asserted as a ratio plus a liveness count rather than a millisecond bound:

- the heartbeat is serviced many times during the call, and
- no single stall covers most of the call.

Same pattern as #4588 and #4591, which moved the scale tests off wall-clock for the same reason.

## It is stricter than what it replaces

Reverting both `anyio.to_thread.run_sync` offloads:

```
[feed]  event loop serviced only 9 tick(s) while reading the audit log -- it was blocked
[kpis]  one stall of 89 ms covered most of the 176 ms call -- the read is running on the event loop
```

Both parametrisations now fail. The old bound caught only `feed`: `kpis` blocks for ~89 ms at this data size, and 89 ms passes a 350 ms threshold. So the magic number was not merely flaky, it was also blind to a real blocking regression in one of the two routes it covers.

## Verification

- `tests/test_gateway_feed_event_loop.py`: 3 passed; every gateway suite: 348 passed, 4 skipped.
- Non-vacuity proven by reverting the production offload, as above, then restoring.
- `ruff check` and `ruff format --check` clean.

Test-only; no production code changes.