### PR TITLE
fix(release): close 0.98.3 correctness gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,7 @@ jobs:
           python scripts/check_benchmark_drift.py
           python scripts/check_framework_catalog.py
           python scripts/check_product_surface_contract.py
+          python scripts/check_graph_epic_proof.py
           python sdks/shared/generate-patterns.py --check
 
       - uses: ./.github/actions/setup-python
@@ -1364,6 +1365,9 @@ jobs:
 
       - name: Verify product surface contract
         run: python scripts/check_product_surface_contract.py
+
+      - name: Verify graph proof fixtures and effective-reach contract
+        run: python scripts/check_graph_epic_proof.py
 
       - name: Install dependencies for CLI smoke checks
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,41 +9,6 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
-
-- Azure private-endpoint inventory called `private_endpoints.list_all()`, which
-  exists on no release of `azure-mgmt-network`. The call raised into a broad
-  `except`, so the scan reported a warning and inventoried nothing. It now uses
-  `list_by_subscription()`.
-- Azure ML online-endpoint discovery read `online_endpoints` /
-  `online_deployments` off the management client. Those moved to the v2 control
-  plane and are absent from every stable `azure-mgmt-machinelearningservices`
-  release, so no endpoint was ever discovered. Discovery now uses `MLClient`
-  from `azure-ai-ml`, scoped per workspace.
-
-### Changed
-
-- The type-check CI job installs the cloud extras. Without them
-  `--ignore-missing-imports` silenced every provider-SDK type error, which is
-  how both calls above shipped green. A companion guard asserts that each SDK
-  operation the scanners call exists on the installed client type.
-
-### Fixed
-
-- `agent-bom scan --inventory <path>` refreshed the entire vulnerability
-  database before checking whether the path existed, so a typo'd inventory
-  cost a full cold-start download — minutes on a machine with no cache —
-  before the CLI reported "Inventory file not found". Existence is now
-  decided first; format and parse errors still surface from the loader.
-
-### Changed
-
-- The test suite no longer downloads the advisory corpus. It already ran under
-  `-m "not network"`, but that marker only deselects tests that declare it and
-  could not stop a CLI scan from going to the network, which made three CLI
-  tests the whole CI job's critical path. Tests that drive `sync_db` itself opt
-  out with `@pytest.mark.real_vuln_db_sync`.
-
 ## [0.98.3] - 2026-08-02
 
 Behaviour changes in this release move numbers you may already be reporting.
@@ -98,6 +63,13 @@ Read "Changed" before upgrading.
 - The posture grade is withheld when vulnerability coverage is incomplete,
   instead of grading an unscanned estate an A.
 - Conflicting advisory severities resolve upward rather than by sort order.
+- Effective-reach scores are clamped to their documented 0–100 range; the
+  highest-risk graph fixture previously emitted 142.8.
+- Azure private-endpoint inventory now calls the supported
+  `list_by_subscription()` SDK operation; the previous `list_all()` call exists
+  on no stable `azure-mgmt-network` release and left inventory empty.
+- Azure ML online endpoints and deployments now use the v2 `MLClient`, scoped
+  per workspace, instead of operations absent from the management client.
 
 ### Fixed — graph
 
@@ -109,6 +81,9 @@ Read "Changed" before upgrading.
   rather than presenting the first 50 nodes in insertion order as fact.
 - Postgres edge reconciliation is bounded, so a second scan no longer fails to
   persist and silently freeze the graph.
+- A finding drill-down no longer substitutes an older graph when the requested
+  scan has no snapshot, and focused investigations no longer show an unrelated
+  global path when no path matches.
 
 ### Fixed — control plane and tenancy
 
@@ -119,7 +94,11 @@ Read "Changed" before upgrading.
   up on every deploy. The previous three-month window could not be extended at
   runtime and would have broken all current-dated hub ingest permanently.
 - Malformed requests return a 4xx envelope instead of a bare 500, and validation
-  errors no longer reflect the submitted body.
+  errors no longer reflect the submitted body. Bulk finding ingest now also
+  rejects a missing or ambiguous JSON content type instead of accepting it.
+- `agent-bom scan --inventory <path>` checks that the inventory exists before
+  refreshing the vulnerability database, so a typo fails immediately instead
+  of paying a full cold-start download.
 - An unreadable or non-UTF8 manifest degrades with a named coverage warning
   instead of aborting the scan with no artifact.
 - `HTTP(S)_PROXY` is honoured; it was silently ignored, so pinned egress was not
@@ -140,6 +119,12 @@ Read "Changed" before upgrading.
 - The PCI DSS coverage table now reports 12 *sub-requirements* across
   requirements 2, 6, 8, 11 and 12. It previously read "12 requirements / 12",
   which implied complete PCI coverage.
+- The test suite no longer downloads the advisory corpus unless a test opts in
+  with `@pytest.mark.real_vuln_db_sync`, removing accidental network work from
+  ordinary CI runs.
+- Type-check CI installs the cloud extras and asserts that scanner SDK
+  operations exist, so missing provider methods cannot be hidden by
+  `--ignore-missing-imports`.
 
 
 ## [0.98.2] - 2026-07-27

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ preflight:  ## Run the drift gates that CI's "Version Alignment" job runs — do
 	@echo "→ v1 schemas (docs/schemas/v1/)";        python scripts/generate_v1_schemas.py --check
 	@echo "→ agent capability manifest";             python scripts/generate_agent_capability_manifest.py --check
 	@echo "→ product surface contract";             python scripts/check_product_surface_contract.py
+	@echo "→ graph proof fixtures";                 python scripts/check_graph_epic_proof.py
 	@echo "→ release/README consistency";           python scripts/check_release_consistency.py
 	@echo "→ env-var reference";                    python scripts/generate_env_var_reference.py --check
 	@echo "→ SDK patterns.json";                    python sdks/shared/generate-patterns.py --check

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -40,7 +40,7 @@ from pathlib import Path
 from typing import Annotated, Any, NamedTuple, cast
 
 import anyio.to_thread
-from fastapi import APIRouter, HTTPException, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from fastapi.responses import PlainTextResponse, Response
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 from werkzeug.security import safe_join
@@ -99,6 +99,13 @@ _BULK_FINDINGS_SOURCE_MAX_LENGTH = 128
 
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _require_json_content_type(request: Request) -> None:
+    """Reject ambiguous bulk-ingest bodies before accepting caller data."""
+    media_type = request.headers.get("content-type", "").split(";", 1)[0].strip().lower()
+    if media_type != "application/json" and not media_type.endswith("+json"):
+        raise HTTPException(status_code=422, detail="Content-Type must be application/json")
 
 
 def _api_local_scans_enabled() -> bool:
@@ -2807,7 +2814,12 @@ def _list_findings_impl(
     return envelope
 
 
-@router.post("/findings/bulk", tags=["scan"], status_code=201)
+@router.post(
+    "/findings/bulk",
+    tags=["scan"],
+    status_code=201,
+    dependencies=[Depends(_require_json_content_type)],
+)
 async def ingest_bulk_findings(request: Request, body: BulkFindingsRequest) -> dict:
     """Append normalized findings for the request tenant.
 

--- a/src/agent_bom/cloud/gcp_authorization_collector.py
+++ b/src/agent_bom/cloud/gcp_authorization_collector.py
@@ -197,7 +197,13 @@ def _pab_binding_record(binding: Any) -> dict[str, Any]:
 
 
 def _load_clients(credentials: Any) -> Any:
-    from google.cloud import asset_v1, iam_admin_v1, iam_v2, iam_v3, resourcemanager_v3
+    from google.cloud import (  # type: ignore[attr-defined]  # namespace package exports
+        asset_v1,
+        iam_admin_v1,
+        iam_v2,
+        iam_v3,
+        resourcemanager_v3,
+    )
 
     return SimpleNamespace(
         assets=asset_v1.AssetServiceClient(credentials=credentials),

--- a/src/agent_bom/cloud/gcp_organizations.py
+++ b/src/agent_bom/cloud/gcp_organizations.py
@@ -353,7 +353,7 @@ def _collect_org_policies(
     unavailable — the org tree is still useful without it.
     """
     try:
-        from google.cloud import orgpolicy_v2
+        from google.cloud import orgpolicy_v2  # type: ignore[attr-defined]  # namespace package export
     except ImportError:
         warnings.append("google-cloud-org-policy not installed. Skipping org-policy constraint discovery.")
         return

--- a/src/agent_bom/effective_reach.py
+++ b/src/agent_bom/effective_reach.py
@@ -236,7 +236,8 @@ class ReachScore:
         )
         from agent_bom.symbol_reach_triage import apply_composite_delta
 
-        return apply_composite_delta(score, self.symbol_reachability)
+        adjusted = apply_composite_delta(score, self.symbol_reachability)
+        return round(max(0.0, min(adjusted, 100.0)), 2)
 
     @property
     def band(self) -> Literal["green", "amber", "red", "pulsing-red"]:

--- a/tests/fixtures/effective_reach_snapshots.json
+++ b/tests/fixtures/effective_reach_snapshots.json
@@ -2,7 +2,7 @@
   "high_reach": {
     "agent_breadth": 2,
     "band": "pulsing-red",
-    "composite": 142.8,
+    "composite": 100.0,
     "cred_visibility": 1.0,
     "cvss": 9.8,
     "epss": 0.92,

--- a/tests/test_effective_reach.py
+++ b/tests/test_effective_reach.py
@@ -162,7 +162,7 @@ def test_high_reach_lands_in_red_band() -> None:
     annotate_graph(graph)
     node = graph.nodes["vuln:CVE-2099-HIGH"]
     breakdown = node.metadata["effective_reach"]
-    assert breakdown["composite"] > 80, breakdown
+    assert breakdown["composite"] == 100.0, breakdown
     assert breakdown["band"] in ("red", "pulsing-red"), breakdown
     assert breakdown["is_kev"] is True
     # run_shell → 1.0 capability.
@@ -208,6 +208,18 @@ def test_determinism_low_reach_fixture() -> None:
         annotate_graph(graph)
         seen.add(graph.nodes["vuln:CVE-2099-LOW"].metadata["effective_reach"]["composite"])
     assert len(seen) == 1, seen
+
+
+def test_composite_never_exceeds_documented_range() -> None:
+    score = ReachScore(
+        cvss=10.0,
+        epss=1.0,
+        is_kev=True,
+        tool_capability=1.0,
+        cred_visibility=1.0,
+        agent_breadth=5,
+    )
+    assert score.composite == 100.0
 
 
 # ── Snapshot test ─────────────────────────────────────────────────────────

--- a/tests/test_extra_gated_sdk_imports.py
+++ b/tests/test_extra_gated_sdk_imports.py
@@ -275,4 +275,5 @@ def test_sdk_client_operation_exists(module_path: str, symbol: str, attribute: s
     owner = getattr(module, symbol, None)
     assert owner is not None, f"{module_path} no longer exports {symbol}"
     version = getattr(importlib.import_module(module_path.split(".")[0]), "__version__", "unknown")
-    assert hasattr(owner, attribute), f"{symbol}.{attribute} missing (installed {module_path.split('.')[0]}=={version}) — agent-bom calls it"
+    message = f"{symbol}.{attribute} missing (installed {module_path.split('.')[0]}=={version}) — agent-bom calls it"
+    assert hasattr(owner, attribute), message

--- a/ui/app/security-graph/page.tsx
+++ b/ui/app/security-graph/page.tsx
@@ -158,6 +158,16 @@ function SecurityGraphPageContent() {
     [pathname, router, searchParams],
   );
 
+  const selectSnapshot = useCallback(
+    (scanId: string) => {
+      setSelectedScanId(scanId);
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("scan", scanId);
+      router.replace(`${pathname}?${params.toString()}`, { scroll: false });
+    },
+    [pathname, router, searchParams],
+  );
+
   const handleStepHint = useCallback(
     (step: "expand" | "impact" | "fix") => {
       setCompletedSteps((current) => ({ ...current, path: true, [step]: true }));
@@ -172,6 +182,9 @@ function SecurityGraphPageContent() {
     const parts = [focus.nodeId, focus.cve, focus.packageName, focus.agentName].filter(Boolean);
     return parts.length > 0 ? parts.join(" · ") : null;
   }, [focus.agentName, focus.cve, focus.nodeId, focus.packageName]);
+  const hasFocusContext = Boolean(
+    focus.cve || focus.packageName || focus.agentName || focus.nodeId || focus.findingId,
+  );
 
   useEffect(() => {
     let cancelled = false;
@@ -191,7 +204,9 @@ function SecurityGraphPageContent() {
         const initialScanId =
           requestedScanId && snapshotList.some((snapshot) => snapshot.scan_id === requestedScanId)
             ? requestedScanId
-            : snapshotList[0]?.scan_id ?? "";
+            : requestedScanId
+              ? ""
+              : snapshotList[0]?.scan_id ?? "";
         setSelectedScanId(initialScanId);
         setApiError(null);
         setGraphLoadError(null);
@@ -270,6 +285,10 @@ function SecurityGraphPageContent() {
     () => snapshots.find((snapshot) => snapshot.scan_id === selectedScanId) ?? null,
     [snapshots, selectedScanId],
   );
+  const requestedSnapshotMissing =
+    !loadingSnapshots &&
+    Boolean(focus.scanId) &&
+    !snapshots.some((snapshot) => snapshot.scan_id === focus.scanId);
   // Stale/empty snapshots (0 persisted nodes) and unrelated older scans pile up
   // in a long-lived graph store and drown the real ones in the chip row.
   // Default to the current scan plus at most a couple of recent populated
@@ -325,14 +344,20 @@ function SecurityGraphPageContent() {
     const fromApi = [...(graphData?.attack_paths ?? [])].sort(
       (left, right) => right.composite_risk - left.composite_risk,
     );
-    const base =
-      fromApi.length > 0
+    const fromFixFirst = fixFirstCards.map((card) => card.attack_path);
+    const focusedPaths =
+      focus.nodeId || focus.findingId
+        ? fromFixFirst.filter((path) => matchesAttackPathFocus(path, graphNodeById, focus))
+        : fromFixFirst;
+    const base = hasFocusContext
+      ? focusedPaths
+      : fromApi.length > 0
         ? fromApi
-        : fixFirstCards.map((card) => card.attack_path);
+        : fromFixFirst;
     if (!selectedCampaign?.member_paths?.length) return base;
     const members = new Set(selectedCampaign.member_paths);
     return base.filter((path) => members.has(`${path.source}->${path.target}`));
-  }, [fixFirstCards, graphData?.attack_paths, selectedCampaign]);
+  }, [fixFirstCards, focus, graphData?.attack_paths, graphNodeById, hasFocusContext, selectedCampaign]);
   const attackPaths = useMemo(
     () => filterAttackPathsForInvestigation(allAttackPaths, graphNodeById, investigationFilters),
     [allAttackPaths, graphNodeById, investigationFilters],
@@ -423,7 +448,6 @@ function SecurityGraphPageContent() {
     [fixFirstCards, graphNodeById, visibleAttackPaths],
   );
 
-  const hasFocusContext = Boolean(focus.cve || focus.packageName || focus.agentName || focus.nodeId || focus.findingId);
   const selectedAttackPath = useMemo(
     () =>
       selectedAttackPathKey
@@ -740,7 +764,7 @@ function SecurityGraphPageContent() {
                       <button
                         key={snapshot.scan_id}
                         type="button"
-                        onClick={() => setSelectedScanId(snapshot.scan_id)}
+                        onClick={() => selectSnapshot(snapshot.scan_id)}
                         className={`rounded-xl border px-3 py-2 text-left text-xs transition ${
                           selected
                             ? "border-emerald-700 bg-emerald-500/10 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-200"
@@ -817,6 +841,34 @@ function SecurityGraphPageContent() {
                 <ArrowRight className="h-3.5 w-3.5" />
               </Link>
             )}
+          </div>
+        </section>
+      ) : requestedSnapshotMissing ? (
+        <section className="rounded-3xl border border-amber-500/30 bg-amber-500/5 p-4">
+          <GraphEmptyState
+            title="Snapshot unavailable for requested scan"
+            detail={`No persisted graph snapshot exists for scan ${focus.scanId}. The investigation did not substitute evidence from a different scan.`}
+            suggestions={[
+              "Run or re-sync the requested scan with graph persistence enabled.",
+              "Choose one of the available snapshots above to investigate older evidence explicitly.",
+              "Review the requested scan's findings while its graph snapshot is unavailable.",
+            ]}
+          />
+          <div className="mt-4 flex flex-wrap gap-3 border-t border-amber-500/20 pt-4">
+            <Link
+              href={buildFindingsHref({ scanId: focus.scanId })}
+              className="inline-flex items-center gap-2 rounded-full border border-amber-500/30 bg-amber-500/10 px-3 py-1.5 text-xs text-amber-800 transition hover:border-amber-600 dark:text-amber-200"
+            >
+              Review requested scan findings
+              <ArrowRight className="h-3.5 w-3.5" />
+            </Link>
+            <Link
+              href="/security-graph"
+              className="inline-flex items-center gap-2 rounded-full border border-[color:var(--border-subtle)] bg-[color:var(--surface-elevated)] px-3 py-1.5 text-xs text-[color:var(--text-secondary)] transition hover:border-[color:var(--border-strong)] hover:text-[color:var(--foreground)]"
+            >
+              Open latest snapshot
+              <GitBranch className="h-3.5 w-3.5" />
+            </Link>
           </div>
         </section>
       ) : allAttackPaths.length === 0 ? (

--- a/ui/components/demo-estate-label.tsx
+++ b/ui/components/demo-estate-label.tsx
@@ -18,8 +18,10 @@ export function DemoEstateLabel() {
   return (
     <div
       id="demo-estate-watermark"
-      className={`pointer-events-none fixed z-[120] max-w-[min(18rem,calc(100vw-1.5rem))] truncate rounded-full border border-emerald-500/40 bg-[color:var(--surface-elevated)]/95 px-3 py-1 font-medium uppercase tracking-[0.1em] text-emerald-700 dark:text-emerald-200 shadow-md shadow-black/20 ${
-        captureMode ? "right-5 top-16 text-[11px]" : "bottom-4 right-4 text-[11px]"
+      className={`pointer-events-none z-[120] max-w-[min(18rem,calc(100vw-1.5rem))] truncate rounded-full border border-emerald-500/40 bg-[color:var(--surface-elevated)]/95 px-3 py-1 font-medium uppercase tracking-[0.1em] text-emerald-700 dark:text-emerald-200 shadow-md shadow-black/20 ${
+        captureMode
+          ? "fixed right-5 top-16 text-[11px]"
+          : "absolute left-4 top-16 text-[10px] sm:fixed sm:bottom-4 sm:left-auto sm:right-4 sm:top-auto sm:text-[11px]"
       }`}
       aria-hidden="true"
     >

--- a/ui/e2e/security-graph-cockpit.spec.ts
+++ b/ui/e2e/security-graph-cockpit.spec.ts
@@ -150,7 +150,7 @@ function buildCockpitGraph(nodeCount = 5) {
 async function routeCockpit(
   page: Page,
   snapshotNodeCount?: number,
-  options: { emptyRollup?: boolean; rollupDelayMs?: number } = {},
+  options: { emptyFocusResults?: boolean; emptyRollup?: boolean; rollupDelayMs?: number } = {},
 ) {
   const graph = buildCockpitGraph(snapshotNodeCount);
 
@@ -199,13 +199,9 @@ async function routeCockpit(
   });
   await page.route("**/v1/graph/views/fix-first?**", async (route) => {
     const attackPath = graph.attack_paths[0]!;
-    await route.fulfill({
-      contentType: "application/json",
-      body: JSON.stringify({
-        scan_id: scanId,
-        tenant_id: "default",
-        created_at: createdAt,
-        cards: [
+    const cards = options.emptyFocusResults
+      ? []
+      : [
           {
             id: "card-cockpit-fixture",
             rank: 1,
@@ -237,13 +233,20 @@ async function routeCockpit(
               tools: ["create_pull_request"],
             },
           },
-        ],
+        ];
+    await route.fulfill({
+      contentType: "application/json",
+      body: JSON.stringify({
+        scan_id: scanId,
+        tenant_id: "default",
+        created_at: createdAt,
+        cards,
         summary: {
           total_paths: 1,
-          matched_paths: 1,
-          returned_paths: 1,
-          highest_risk: 9.8,
-          covered_findings: 1,
+          matched_paths: cards.length,
+          returned_paths: cards.length,
+          highest_risk: cards.length ? 9.8 : 0,
+          covered_findings: cards.length,
           node_count: graph.nodes.length,
           edge_count: graph.edges.length,
         },
@@ -365,6 +368,27 @@ test("security-graph cockpit stays usable on a mobile viewport", async ({ page }
   expect(overflows).toBe(false);
 
   await page.screenshot({ path: testInfo.outputPath("security-graph-cockpit-mobile.png"), fullPage: true });
+});
+
+test("requested scan without a graph snapshot never falls back to another scan", async ({ page }) => {
+  await routeCockpit(page);
+
+  await page.goto("/security-graph?scan=scan-without-graph&cve=CVE-2099-MISSING");
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.getByText("Snapshot unavailable for requested scan")).toBeVisible();
+  await expect(page.getByText(/did not substitute evidence from a different scan/i)).toBeVisible();
+  await expect(page.getByText("Critical package reachable from MCP server")).toHaveCount(0);
+});
+
+test("focused investigation never shows an unrelated global path", async ({ page }) => {
+  await routeCockpit(page, undefined, { emptyFocusResults: true });
+
+  await page.goto(`/security-graph?scan=${scanId}&cve=CVE-2099-NOT-IN-SNAPSHOT`);
+  await page.waitForLoadState("networkidle");
+
+  await expect(page.getByText("No attack paths matched the current focus")).toBeVisible();
+  await expect(page.getByText("Critical package reachable from MCP server")).toHaveCount(0);
 });
 
 test("ranked path selection focuses the in-place interactive graph and announces the change", async ({ page }) => {


### PR DESCRIPTION
## Summary

- clamp effective-reach scoring to its documented 0–100 contract, add regression coverage, and run the graph proof fixture in preflight and CI
- reject ambiguous bulk-finding request bodies and stop Security Graph focus links from substituting stale snapshots or unrelated attack paths
- correct the mobile demo label, optional Google Cloud namespace typing, provider smoke lint, and the `0.98.3` changelog boundary

## Impact

The release candidate now fails closed on malformed bulk-ingest media types, reports graph evidence without silently switching scan context, and keeps risk scoring within the published range. The UI remains readable on mobile, while preflight and CI cover the graph proof contract that previously ran only by hand.

## Root cause

The affected contracts were implemented in separate layers without a shared release gate: symbol-reach adjustment ran after score normalization, Starlette accepted JSON bodies without the declared JSON media type, and the graph page treated a missing requested snapshot as permission to fall back to the latest snapshot. The release changelog also still carried shipped changes under `Unreleased`.

## Verification

- `make preflight`
- `uv run ruff check src tests`
- `uv run mypy src/agent_bom`
- `uv run pytest -q tests/test_effective_reach.py tests/test_symbol_reach_triage.py tests/test_api_robustness.py tests/test_api_findings_bulk.py`
- `uv run pytest -q tests/test_extra_gated_sdk_imports.py tests/test_gcp_sdk_coverage.py tests/test_gcp_authorization_collector.py tests/test_gcp_organizations.py`
- `npm run verify:toolchain`
- `npm run typecheck`
- `npm test -- --run`
- `npm run build`
- targeted Playwright Security Graph cockpit suite: 13 passed
- live PostgreSQL integration suite: 181 passed
- all shipped Helm profiles linted and rendered
- release wheel/dashboard/CSP verification, authenticated API smoke, MCP 77-tool listing, runtime smoke, and container self-scan completed

## Notes

- Based on `origin/main` at `a081091d575645e945d8bfe6741f8e10a26df65d`.
- No version tag or release publication is included.
- External distribution-freshness issues #4513 and #4590 remain operational release gates.
