### PR TITLE
chore(release): align Docker Hub tag retention

### DIFF
--- a/.github/workflows/dockerhub-cleanup.yml
+++ b/.github/workflows/dockerhub-cleanup.yml
@@ -1,10 +1,13 @@
 name: Docker Hub Tag Cleanup
 
 on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       keep_count:
-        description: "Number of recent tags to keep (besides latest and floating)"
+        description: "Number of recent semantic-version tags to keep per repository"
         required: false
         default: "10"
       dry_run:
@@ -15,87 +18,50 @@ on:
         options:
           - "true"
           - "false"
+      expected_delete_count:
+        description: "Optional fail-closed assertion for the total number of deletions"
+        required: false
+        default: ""
+
+concurrency:
+  group: dockerhub-tag-cleanup
+  cancel-in-progress: false
 
 permissions:
   contents: read
 
 jobs:
   cleanup:
-    name: Clean up old Docker Hub tags
+    name: Clean up old Docker Hub tags across release images
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Delete old tags
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Plan and apply bounded retention
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-          KEEP_COUNT: ${{ inputs.keep_count }}
-          DRY_RUN: ${{ inputs.dry_run }}
+          KEEP_COUNT: ${{ inputs.keep_count || '10' }}
+          DRY_RUN: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || 'false' }}
+          EXPECTED_DELETE_COUNT: ${{ inputs.expected_delete_count || '' }}
         run: |
           set -euo pipefail
-          REPO="agentbom/agent-bom"
-
-          # Authenticate
-          TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
-            | jq -r '.token')
-
-          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-            echo "::error::Docker Hub login failed"
-            exit 1
-          fi
-
-          # Fetch all tags sorted by last_updated, then keep the highest semver tags.
-          ALL_TAGS=$(curl -sf "https://hub.docker.com/v2/repositories/${REPO}/tags/?page_size=100&ordering=-last_updated" \
-            -H "Authorization: Bearer $TOKEN" | jq -r '.results[].name')
-
-          # Tags to always keep
-          KEEP_PATTERNS="^(latest|0)$"
-
-          # Build keep list: floating tags + highest N semver tags
-          SEMVER_TAGS=$(printf '%s\n' "$ALL_TAGS" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr || true)
-          KEEP_SEMVER=$(printf '%s\n' "$SEMVER_TAGS" | head -n "${KEEP_COUNT}")
-
-          echo "=== Tags to KEEP ==="
-          echo "  latest, 0 (floating)"
-          echo "$KEEP_SEMVER" | sed 's/^/  /'
-
-          DELETE_COUNT=0
-          echo ""
-          echo "=== Tags to DELETE ==="
-
-          while IFS= read -r tag; do
-            [ -z "$tag" ] && continue
-            # Skip floating tags
-            if echo "$tag" | grep -qE "$KEEP_PATTERNS"; then
-              continue
-            fi
-
-            # Skip if in keep list
-            if echo "$KEEP_SEMVER" | grep -qxF "$tag"; then
-              continue
-            fi
-
-            echo "  $tag"
-            DELETE_COUNT=$((DELETE_COUNT + 1))
-
-            if [ "$DRY_RUN" = "false" ]; then
-              HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" \
-                -X DELETE "https://hub.docker.com/v2/repositories/${REPO}/tags/${tag}" \
-                -H "Authorization: Bearer $TOKEN")
-
-              if [ "$HTTP_CODE" = "204" ]; then
-                echo "    ✓ deleted"
-              else
-                echo "    ✗ failed (HTTP $HTTP_CODE)"
-              fi
-            fi
-          done <<< "$ALL_TAGS"
-
-          echo ""
+          args=(
+            --repository agentbom/agent-bom
+            --repository agentbom/agent-bom-ui
+            --repository agentbom/agent-bom-collector
+            --keep-count "$KEEP_COUNT"
+          )
           if [ "$DRY_RUN" = "true" ]; then
-            echo "DRY RUN: would delete $DELETE_COUNT tags. Re-run with dry_run=false to execute."
-          else
-            echo "Deleted $DELETE_COUNT tags."
+            args+=(--dry-run)
           fi
+          if [ -n "$EXPECTED_DELETE_COUNT" ]; then
+            args+=(--expected-delete-count "$EXPECTED_DELETE_COUNT")
+          fi
+          python3 scripts/dockerhub_tag_cleanup.py "${args[@]}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,47 +460,6 @@ jobs:
           fi
           rm -f "$RESPONSE_FILE"
 
-      - name: Clean up old Docker Hub tags (keep last 10)
-        env:
-          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          REPO="agentbom/agent-bom"
-          CURRENT_VERSION="${{ steps.meta.outputs.version }}"
-          TOKEN=$(curl -sf -X POST "https://hub.docker.com/v2/users/login" \
-            -H "Content-Type: application/json" \
-            -d "{\"username\":\"${DOCKERHUB_USERNAME}\",\"password\":\"${DOCKERHUB_TOKEN}\"}" \
-            | jq -r '.token') || {
-            echo "::error::Docker Hub login curl failed during cleanup"
-            exit 1
-          }
-          if [ -z "$TOKEN" ] || [ "$TOKEN" = "null" ]; then
-            echo "::error::Docker Hub login returned empty token during cleanup"
-            exit 1
-          fi
-          echo "::add-mask::$TOKEN"
-
-          ALL_TAGS=$(curl -sf "https://hub.docker.com/v2/repositories/${REPO}/tags/?page_size=100&ordering=-last_updated" \
-            -H "Authorization: Bearer $TOKEN" | jq -r '.results[].name')
-          SEMVER_TAGS=$(printf '%s\n' "$ALL_TAGS" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -Vr || true)
-          KEEP=$(printf '%s\n%s\n' "$CURRENT_VERSION" "$SEMVER_TAGS" | awk 'NF && !seen[$0]++' | head -n 10)
-
-          echo "Keeping Docker Hub tags:"
-          printf '  %s\n' latest 0
-          printf '%s\n' "$KEEP" | sed '/^$/d;s/^/  /'
-
-          while IFS= read -r tag; do
-            [ -z "$tag" ] && continue
-            echo "$tag" | grep -qE '^(latest|0)$' && continue
-            [ "$tag" = "$CURRENT_VERSION" ] && continue
-            echo "$KEEP" | grep -qxF "$tag" && continue
-            echo "Deleting $tag"
-            curl -sf -o /dev/null -X DELETE \
-              "https://hub.docker.com/v2/repositories/${REPO}/tags/${tag}" \
-              -H "Authorization: Bearer $TOKEN" || true
-          done <<< "$ALL_TAGS"
-
   docker-publish-collector:
     name: Publish cloud-SDK collector image
     needs: [build, self-scan-gate, container-gate]

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-02",
+  "generated_on": "2026-08-03",
   "version": "0.98.3",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1104,
+      "value": 1105,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-02`
+- Generated on: `2026-08-03`
 - Version: `0.98.3`
 
 | Metric | Value | Source | Notes |
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 39 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1104 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1105 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 819 | `src/agent_bom` | Counts all Python files recursively. |

--- a/scripts/dockerhub_tag_cleanup.py
+++ b/scripts/dockerhub_tag_cleanup.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Apply bounded Docker Hub tag retention after a successful release."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from typing import Iterable
+
+_SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+_ALLOWED_FLOATING_TAGS = frozenset({"latest"})
+_STALE_FLOATING_TAGS = frozenset({"0"})
+
+
+@dataclass(frozen=True)
+class CleanupPlan:
+    repository: str
+    keep: tuple[str, ...]
+    delete: tuple[str, ...]
+
+
+def _semver_key(tag: str) -> tuple[int, int, int]:
+    match = _SEMVER_RE.fullmatch(tag)
+    if match is None:
+        raise ValueError(f"not a stable semantic-version tag: {tag!r}")
+    return (int(match.group(1)), int(match.group(2)), int(match.group(3)))
+
+
+def plan_cleanup(repository: str, tags: Iterable[str], keep_count: int) -> CleanupPlan:
+    """Return a fail-closed retention plan without changing Docker Hub."""
+    if not 1 <= keep_count <= 50:
+        raise ValueError("keep_count must be between 1 and 50")
+
+    unique_tags = sorted(set(tags))
+    if "latest" not in unique_tags:
+        raise ValueError(f"{repository}: required floating tag 'latest' is missing")
+
+    unexpected = sorted(
+        tag
+        for tag in unique_tags
+        if tag not in _ALLOWED_FLOATING_TAGS and tag not in _STALE_FLOATING_TAGS and _SEMVER_RE.fullmatch(tag) is None
+    )
+    if unexpected:
+        raise ValueError(f"{repository}: refusing to delete unexpected tags: {unexpected}")
+
+    semver_tags = sorted(
+        (tag for tag in unique_tags if _SEMVER_RE.fullmatch(tag)),
+        key=_semver_key,
+        reverse=True,
+    )
+    keep_semver = tuple(semver_tags[:keep_count])
+    old_semver = tuple(semver_tags[keep_count:])
+    stale_floating = tuple(tag for tag in sorted(_STALE_FLOATING_TAGS) if tag in unique_tags)
+
+    return CleanupPlan(
+        repository=repository,
+        keep=("latest", *keep_semver),
+        delete=(*stale_floating, *old_semver),
+    )
+
+
+class DockerHubClient:
+    def __init__(self, username: str, password: str) -> None:
+        payload = json.dumps({"username": username, "password": password}).encode()
+        request = urllib.request.Request(
+            "https://hub.docker.com/v2/users/login",
+            data=payload,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=30) as response:
+                body = json.load(response)
+        except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+            raise RuntimeError("Docker Hub authentication failed") from exc
+        token = body.get("token")
+        if not isinstance(token, str) or not token:
+            raise RuntimeError("Docker Hub authentication returned no token")
+        self._token = token
+
+    def _request(self, url: str, *, method: str = "GET") -> urllib.request.Request:
+        return urllib.request.Request(
+            url,
+            headers={"Authorization": f"Bearer {self._token}", "Accept": "application/json"},
+            method=method,
+        )
+
+    def list_tags(self, repository: str) -> list[str]:
+        encoded_repository = urllib.parse.quote(repository, safe="/")
+        url = f"https://hub.docker.com/v2/repositories/{encoded_repository}/tags/?page_size=100&ordering=-last_updated"
+        tags: list[str] = []
+        while url:
+            try:
+                with urllib.request.urlopen(self._request(url), timeout=30) as response:
+                    body = json.load(response)
+            except (OSError, urllib.error.URLError, json.JSONDecodeError) as exc:
+                raise RuntimeError(f"{repository}: could not list Docker Hub tags") from exc
+            results = body.get("results")
+            if not isinstance(results, list):
+                raise RuntimeError(f"{repository}: Docker Hub tag response is malformed")
+            for result in results:
+                name = result.get("name") if isinstance(result, dict) else None
+                if not isinstance(name, str) or not name:
+                    raise RuntimeError(f"{repository}: Docker Hub returned an invalid tag record")
+                tags.append(name)
+            next_url = body.get("next")
+            url = next_url if isinstance(next_url, str) else ""
+        return tags
+
+    def delete_tag(self, repository: str, tag: str) -> None:
+        encoded_repository = urllib.parse.quote(repository, safe="/")
+        encoded_tag = urllib.parse.quote(tag, safe="")
+        url = f"https://hub.docker.com/v2/repositories/{encoded_repository}/tags/{encoded_tag}"
+        try:
+            with urllib.request.urlopen(self._request(url, method="DELETE"), timeout=30) as response:
+                status = response.status
+        except urllib.error.HTTPError as exc:
+            raise RuntimeError(f"{repository}:{tag}: Docker Hub deletion failed (HTTP {exc.code})") from exc
+        except (OSError, urllib.error.URLError) as exc:
+            raise RuntimeError(f"{repository}:{tag}: Docker Hub deletion failed") from exc
+        if status != 204:
+            raise RuntimeError(f"{repository}:{tag}: Docker Hub deletion returned HTTP {status}")
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repository", action="append", required=True)
+    parser.add_argument("--keep-count", type=int, default=10)
+    parser.add_argument("--expected-delete-count", type=int)
+    parser.add_argument("--dry-run", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    username = os.environ.get("DOCKERHUB_USERNAME", "")
+    password = os.environ.get("DOCKERHUB_TOKEN", "")
+    if not username or not password:
+        print("Docker Hub credentials are required", file=sys.stderr)
+        return 2
+
+    try:
+        client = DockerHubClient(username, password)
+        plans = [plan_cleanup(repository, client.list_tags(repository), args.keep_count) for repository in args.repository]
+        delete_count = sum(len(plan.delete) for plan in plans)
+
+        for plan in plans:
+            print(f"{plan.repository}: keep {len(plan.keep)}, delete {len(plan.delete)}")
+            for tag in plan.keep:
+                print(f"  KEEP   {tag}")
+            for tag in plan.delete:
+                print(f"  DELETE {tag}")
+        print(f"Total tags selected for deletion: {delete_count}")
+
+        if args.expected_delete_count is not None and delete_count != args.expected_delete_count:
+            raise RuntimeError(f"refusing cleanup: expected {args.expected_delete_count} deletions but calculated {delete_count}")
+        if args.dry_run:
+            print("DRY RUN: no tags were deleted")
+            return 0
+
+        for plan in plans:
+            for tag in plan.delete:
+                client.delete_tag(plan.repository, tag)
+                print(f"DELETED {plan.repository}:{tag}")
+
+        for plan in plans:
+            remaining = set(client.list_tags(plan.repository))
+            undeleted = sorted(set(plan.delete) & remaining)
+            if undeleted:
+                raise RuntimeError(f"{plan.repository}: deletion verification failed: {undeleted}")
+        print(f"Verified deletion of {delete_count} Docker Hub tags")
+        return 0
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_dockerhub_tag_cleanup.py
+++ b/tests/test_dockerhub_tag_cleanup.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from scripts.dockerhub_tag_cleanup import plan_cleanup
+
+
+def test_plan_keeps_latest_and_highest_semver_tags() -> None:
+    plan = plan_cleanup(
+        "agentbom/agent-bom-ui",
+        ["0.98.1", "latest", "0.96.4", "0.98.3", "0.98.2"],
+        keep_count=2,
+    )
+
+    assert plan.keep == ("latest", "0.98.3", "0.98.2")
+    assert plan.delete == ("0.98.1", "0.96.4")
+
+
+def test_plan_deletes_stale_major_floating_tag() -> None:
+    plan = plan_cleanup(
+        "agentbom/agent-bom",
+        ["latest", "0", "0.98.3", "0.98.2"],
+        keep_count=2,
+    )
+
+    assert plan.keep == ("latest", "0.98.3", "0.98.2")
+    assert plan.delete == ("0",)
+
+
+def test_plan_sorts_semver_numerically() -> None:
+    plan = plan_cleanup(
+        "agentbom/agent-bom",
+        ["latest", "0.9.9", "0.10.0", "0.98.3"],
+        keep_count=2,
+    )
+
+    assert plan.keep == ("latest", "0.98.3", "0.10.0")
+    assert plan.delete == ("0.9.9",)
+
+
+@pytest.mark.parametrize(
+    ("tags", "message"),
+    [
+        (["0.98.3"], "required floating tag 'latest' is missing"),
+        (["latest", "sha-deadbeef"], "refusing to delete unexpected tags"),
+    ],
+)
+def test_plan_fails_closed_on_unexpected_registry_state(tags: list[str], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        plan_cleanup("agentbom/agent-bom", tags, keep_count=10)
+
+
+@pytest.mark.parametrize("keep_count", [0, 51])
+def test_plan_rejects_unbounded_retention_values(keep_count: int) -> None:
+    with pytest.raises(ValueError, match="keep_count must be between 1 and 50"):
+        plan_cleanup("agentbom/agent-bom", ["latest"], keep_count=keep_count)

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -5371,9 +5371,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9276,9 +9276,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "funding": [
         {
           "type": "opencollective",
@@ -9295,7 +9295,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,7 +40,8 @@
     "sigma": "^3.0.3"
   },
   "overrides": {
-    "postcss": "8.5.18",
+    "brace-expansion": "5.0.9",
+    "postcss": "8.5.23",
     "minimatch@3.1.5": "10.2.5",
     "sharp": "^0.35.0"
   },


### PR DESCRIPTION
## Summary

- apply a fail-closed 10-version retention policy to the API, UI, and collector Docker Hub repositories
- remove the stale floating `0` tag from the retained set while preserving `latest`
- run cleanup after successful releases and retain manual dry-run plus exact deletion-count safeguards
- remove the duplicated API-only cleanup logic from the release critical path
- clear the live filesystem security gate with `brace-expansion` 5.0.9 and `postcss` 8.5.23
- refresh the generated product metric after adding the cleanup regression-test file

## Verification

- `uv run ruff check scripts/dockerhub_tag_cleanup.py tests/test_dockerhub_tag_cleanup.py`
- `uv run pytest -q tests/test_dockerhub_tag_cleanup.py` (7 passed)
- `uv run mypy scripts/dockerhub_tag_cleanup.py`
- `actionlint .github/workflows/dockerhub-cleanup.yml .github/workflows/release.yml`
- `uv run python scripts/lint_release_workflow.py .github/workflows/release.yml .github/workflows/dockerhub-cleanup.yml`
- `make preflight`
- `git diff --check`
- `npm audit` (0 vulnerabilities)
- `npm run verify:toolchain` under Node 24.15.0 and npm 10.9.7
- `npm run typecheck`
- `npm test -- --run` (979 passed)
- `npm run build`
- `uv run pytest -q tests/test_product_metrics_snapshot.py tests/test_dockerhub_tag_cleanup.py` (12 passed)

## Notes

- Current public registry inventory yields 37 deletions: API 1, UI 36, collector 0.
- The first cleanup will be dispatched as an exact-count dry run before mutation.
- Git tags, GitHub releases and assets, PyPI artifacts, SBOMs, signatures, provenance, and the v0.81.2 draft are unchanged.
