### PR TITLE
fix(release): retry Docker Hub tag deletion

### DIFF
--- a/scripts/dockerhub_tag_cleanup.py
+++ b/scripts/dockerhub_tag_cleanup.py
@@ -8,6 +8,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -17,6 +18,8 @@ from typing import Iterable
 _SEMVER_RE = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
 _ALLOWED_FLOATING_TAGS = frozenset({"latest"})
 _STALE_FLOATING_TAGS = frozenset({"0"})
+_VERIFICATION_ATTEMPTS = 5
+_VERIFICATION_RETRY_SECONDS = 5
 
 
 @dataclass(frozen=True)
@@ -122,11 +125,57 @@ class DockerHubClient:
             with urllib.request.urlopen(self._request(url, method="DELETE"), timeout=30) as response:
                 status = response.status
         except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return
             raise RuntimeError(f"{repository}:{tag}: Docker Hub deletion failed (HTTP {exc.code})") from exc
         except (OSError, urllib.error.URLError) as exc:
             raise RuntimeError(f"{repository}:{tag}: Docker Hub deletion failed") from exc
         if status != 204:
             raise RuntimeError(f"{repository}:{tag}: Docker Hub deletion returned HTTP {status}")
+
+
+def apply_cleanup(
+    client: DockerHubClient,
+    plans: Iterable[CleanupPlan],
+    *,
+    verification_attempts: int = _VERIFICATION_ATTEMPTS,
+    verification_retry_seconds: float = _VERIFICATION_RETRY_SECONDS,
+) -> int:
+    """Delete planned tags and retry Docker Hub's accepted-but-unapplied deletes."""
+    if verification_attempts < 1:
+        raise ValueError("verification_attempts must be at least 1")
+
+    plans = tuple(plans)
+    delete_count = sum(len(plan.delete) for plan in plans)
+    for plan in plans:
+        for tag in plan.delete:
+            client.delete_tag(plan.repository, tag)
+            print(f"DELETED {plan.repository}:{tag}")
+
+    for attempt in range(1, verification_attempts + 1):
+        undeleted_by_repository: dict[str, tuple[str, ...]] = {}
+        for plan in plans:
+            remaining = set(client.list_tags(plan.repository))
+            undeleted = tuple(sorted(set(plan.delete) & remaining))
+            if undeleted:
+                undeleted_by_repository[plan.repository] = undeleted
+
+        if not undeleted_by_repository:
+            return delete_count
+        if attempt == verification_attempts:
+            details = "; ".join(f"{repository}: {list(tags)}" for repository, tags in undeleted_by_repository.items())
+            raise RuntimeError(f"deletion verification failed after {verification_attempts} attempts: {details}")
+
+        retry_count = sum(len(tags) for tags in undeleted_by_repository.values())
+        print(f"Docker Hub still reports {retry_count} deleted tags after verification attempt {attempt}/{verification_attempts}; retrying")
+        for repository, tags in undeleted_by_repository.items():
+            for tag in tags:
+                client.delete_tag(repository, tag)
+                print(f"RETRIED {repository}:{tag}")
+        if verification_retry_seconds:
+            time.sleep(verification_retry_seconds)
+
+    raise AssertionError("unreachable")
 
 
 def _parser() -> argparse.ArgumentParser:
@@ -165,17 +214,8 @@ def main(argv: list[str] | None = None) -> int:
             print("DRY RUN: no tags were deleted")
             return 0
 
-        for plan in plans:
-            for tag in plan.delete:
-                client.delete_tag(plan.repository, tag)
-                print(f"DELETED {plan.repository}:{tag}")
-
-        for plan in plans:
-            remaining = set(client.list_tags(plan.repository))
-            undeleted = sorted(set(plan.delete) & remaining)
-            if undeleted:
-                raise RuntimeError(f"{plan.repository}: deletion verification failed: {undeleted}")
-        print(f"Verified deletion of {delete_count} Docker Hub tags")
+        verified_count = apply_cleanup(client, plans)
+        print(f"Verified deletion of {verified_count} Docker Hub tags")
         return 0
     except (RuntimeError, ValueError) as exc:
         print(str(exc), file=sys.stderr)

--- a/tests/test_dockerhub_tag_cleanup.py
+++ b/tests/test_dockerhub_tag_cleanup.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
+import urllib.error
+import urllib.request
+
 import pytest
 
-from scripts.dockerhub_tag_cleanup import plan_cleanup
+from scripts.dockerhub_tag_cleanup import CleanupPlan, DockerHubClient, apply_cleanup, plan_cleanup
 
 
 def test_plan_keeps_latest_and_highest_semver_tags() -> None:
@@ -54,3 +57,65 @@ def test_plan_fails_closed_on_unexpected_registry_state(tags: list[str], message
 def test_plan_rejects_unbounded_retention_values(keep_count: int) -> None:
     with pytest.raises(ValueError, match="keep_count must be between 1 and 50"):
         plan_cleanup("agentbom/agent-bom", ["latest"], keep_count=keep_count)
+
+
+class _RetryingDockerHubClient:
+    def __init__(self, *, never_delete: bool = False) -> None:
+        self.delete_calls: list[tuple[str, str]] = []
+        self.never_delete = never_delete
+
+    def delete_tag(self, repository: str, tag: str) -> None:
+        self.delete_calls.append((repository, tag))
+
+    def list_tags(self, repository: str) -> list[str]:
+        delete_attempts = self.delete_calls.count((repository, "0.96.3"))
+        if self.never_delete or delete_attempts < 2:
+            return ["latest", "0.98.3", "0.96.3"]
+        return ["latest", "0.98.3"]
+
+
+def test_apply_cleanup_retries_accepted_but_unapplied_deletion() -> None:
+    client = _RetryingDockerHubClient()
+    plan = CleanupPlan(
+        repository="agentbom/agent-bom-ui",
+        keep=("latest", "0.98.3"),
+        delete=("0.96.3",),
+    )
+
+    deleted = apply_cleanup(client, [plan], verification_attempts=3, verification_retry_seconds=0)
+
+    assert deleted == 1
+    assert client.delete_calls == [
+        ("agentbom/agent-bom-ui", "0.96.3"),
+        ("agentbom/agent-bom-ui", "0.96.3"),
+    ]
+
+
+def test_apply_cleanup_fails_after_bounded_verification_attempts() -> None:
+    client = _RetryingDockerHubClient(never_delete=True)
+    plan = CleanupPlan(
+        repository="agentbom/agent-bom-ui",
+        keep=("latest", "0.98.3"),
+        delete=("0.96.3",),
+    )
+
+    with pytest.raises(RuntimeError, match="deletion verification failed after 3 attempts"):
+        apply_cleanup(client, [plan], verification_attempts=3, verification_retry_seconds=0)
+
+    assert client.delete_calls == [
+        ("agentbom/agent-bom-ui", "0.96.3"),
+        ("agentbom/agent-bom-ui", "0.96.3"),
+        ("agentbom/agent-bom-ui", "0.96.3"),
+    ]
+
+
+def test_delete_tag_is_idempotent_when_tag_is_already_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    client = object.__new__(DockerHubClient)
+    client._token = "test-token"
+
+    def missing_tag(*args: object, **kwargs: object) -> None:
+        raise urllib.error.HTTPError("https://example.invalid/tag", 404, "Not Found", {}, None)
+
+    monkeypatch.setattr(urllib.request, "urlopen", missing_tag)
+
+    client.delete_tag("agentbom/agent-bom-ui", "0.96.3")


### PR DESCRIPTION
## Summary

- retry Docker Hub tag deletions that return HTTP 204 but remain present
- treat an already-absent tag as an idempotent deletion success
- keep verification bounded and fail closed after five attempts

## Verification

- `uv run pytest -q tests/test_dockerhub_tag_cleanup.py` — 10 passed
- `uv run ruff check scripts/dockerhub_tag_cleanup.py tests/test_dockerhub_tag_cleanup.py`
- `uv run ruff format --check scripts/dockerhub_tag_cleanup.py tests/test_dockerhub_tag_cleanup.py`
- `git diff --check`

## Notes

The first post-merge cleanup accepted all 37 DELETE requests, but Docker Hub left 21 UI tags addressable. This change retries only tags still returned by the registry and preserves the existing exact-count assertion and retention boundary.
