### PR TITLE
fix(scan): agree on what an agent tool is, across both detectors

### DIFF
--- a/.github/workflows/surface-freshness.yml
+++ b/.github/workflows/surface-freshness.yml
@@ -81,7 +81,7 @@ jobs:
         run: |
           PYTHONPATH=src python3 scripts/check_surface_freshness.py \
             --expected "$EXPECTED_VERSION" \
-            --expected-glama-tool-count "${{ steps.expected.outputs.tool_count }}" \
+            --expected-tool-count "${{ steps.expected.outputs.tool_count }}" \
             --out surface-freshness.json
           {
             echo "report<<EOF"

--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -245,14 +245,18 @@ def probe_glama(expected: str, *, expected_tool_count: int | None = None, **kw: 
     }
 
 
-def probe_smithery(expected: str, qualified_name: str, **kw: Any) -> dict[str, Any]:
+def probe_smithery(expected: str, qualified_name: str, *, expected_tool_count: int | None = None, **kw: Any) -> dict[str, Any]:
     """Probe Smithery's public catalog listing.
 
     Smithery-hosted remote servers are OAuth-gated and do not expose agent-bom's
     raw `/health` route. Freshness for this surface is therefore the catalog
     contract: the listing exists, is remote, has a deployment URL, and advertises
-    tools. Version freshness is covered by PyPI/Docker plus the protected Railway
-    health check.
+    the full shipped tool inventory. Version freshness is covered by PyPI/Docker
+    plus the protected Railway health check.
+
+    The tool count is part of that contract. A listing that advertises a strict
+    subset is a stale snapshot, and asserting only that the list is non-empty
+    cannot tell the two apart — which is how a partial listing sat unnoticed.
     """
 
     try:
@@ -267,7 +271,7 @@ def probe_smithery(expected: str, qualified_name: str, **kw: Any) -> dict[str, A
             return _classify("Smithery", "—", expected, error="catalog listing has no deploymentUrl")
         if not tools:
             return _classify("Smithery", "—", expected, error="catalog listing has no tools")
-        return {
+        result = {
             "surface": "Smithery",
             "status": "fresh",
             "version": "catalog-live",
@@ -275,6 +279,12 @@ def probe_smithery(expected: str, qualified_name: str, **kw: Any) -> dict[str, A
             "deployment_url": deployment_url,
             "tool_count": len(tools),
         }
+        if expected_tool_count is not None:
+            result["expected_tool_count"] = expected_tool_count
+            if len(tools) != expected_tool_count:
+                result["status"] = "stale"
+                result["error"] = f"catalog advertises {len(tools)} tools; expected {expected_tool_count}"
+        return result
     except (RuntimeError, ValueError) as exc:
         return _classify("Smithery", None, expected, error=str(exc))
 
@@ -282,7 +292,9 @@ def probe_smithery(expected: str, qualified_name: str, **kw: Any) -> dict[str, A
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--expected", default=None, help="Override expected version (defaults to pyproject.toml).")
-    parser.add_argument("--expected-glama-tool-count", type=int, default=None)
+    # One shipped tool inventory, so one expectation. The Glama-specific spelling
+    # stays accepted because the workflow passes it.
+    parser.add_argument("--expected-tool-count", "--expected-glama-tool-count", dest="expected_tool_count", type=int, default=None)
     parser.add_argument("--docker-image", default=_env_or("DOCKER_IMAGE", DEFAULT_DOCKER_IMAGE))
     parser.add_argument("--smithery-server", default=_env_or("SMITHERY_SERVER_QUALIFIED_NAME", DEFAULT_SMITHERY_SERVER))
     parser.add_argument("--timeout", type=float, default=DEFAULT_TIMEOUT)
@@ -297,8 +309,8 @@ def main(argv: list[str] | None = None) -> int:
     surfaces = [
         probe_pypi(expected, **kw),
         probe_docker(expected, args.docker_image, **kw),
-        probe_glama(expected, expected_tool_count=args.expected_glama_tool_count, **kw),
-        probe_smithery(expected, args.smithery_server, **kw),
+        probe_glama(expected, expected_tool_count=args.expected_tool_count, **kw),
+        probe_smithery(expected, args.smithery_server, expected_tool_count=args.expected_tool_count, **kw),
     ]
 
     drift = [s for s in surfaces if s["status"] in ALERT_STATUSES]

--- a/src/agent_bom/ai_components/framework_agents.py
+++ b/src/agent_bom/ai_components/framework_agents.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from agent_bom.ast_signal_utils import is_agent_tool_decorator
 from agent_bom.finding import stable_id
 
 _SKIP_DIRS = {
@@ -347,13 +348,19 @@ def _framework_for_call(imports: set[str], call_name: str, short_name: str) -> s
     return None
 
 
+def _decorator_name(node: ast.AST) -> str:
+    """Dotted name of a decorator, unwrapping the applied form ``@mcp.tool()``."""
+    if isinstance(node, ast.Call):
+        return _call_name(node.func)
+    return _call_name(node)
+
+
 def _collect_tools(tree: ast.Module) -> dict[str, FrameworkCapability]:
     tools: dict[str, FrameworkCapability] = {}
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             for decorator in node.decorator_list:
-                decorator_name = _call_name(decorator).split(".")[-1]
-                if decorator_name in {"tool", "function_tool", "skill", "action"}:
+                if is_agent_tool_decorator(_decorator_name(decorator)):
                     tools[node.name] = FrameworkCapability(node.name, "decorator", node.lineno, "high")
         elif isinstance(node, ast.Assign):
             for target in node.targets:

--- a/src/agent_bom/ast_python_analysis.py
+++ b/src/agent_bom/ast_python_analysis.py
@@ -20,6 +20,7 @@ from agent_bom.ast_models import (
 from agent_bom.ast_signal_utils import _GUARDRAIL_CALL_PATTERNS
 from agent_bom.ast_signal_utils import check_prompt_risks as _check_prompt_risks
 from agent_bom.ast_signal_utils import classify_prompt_type as _classify_prompt_type
+from agent_bom.ast_signal_utils import is_agent_tool_decorator as _is_agent_tool_decorator
 
 
 # Bounded depth for inter-procedural taint propagation. The taint analyzer
@@ -1010,38 +1011,6 @@ def _analyze_file(
             )
 
     return prompts, guardrails, tools, frameworks, function_analyses, flow_findings
-
-
-# Decorator name segments that actually register a function as an agent tool.
-# Matched per dotted segment so ``@mcp.tool`` and ``@FunctionTool.from_defaults``
-# resolve, while ``@action`` (Django REST) and ``@transaction.atomic`` — which a
-# substring test on "tool"/"action" used to accept — do not.
-_AGENT_TOOL_DECORATOR_SEGMENTS: frozenset[str] = frozenset(
-    {
-        "tool",
-        "tools",
-        "agent_tool",
-        "agenttool",
-        "function_tool",
-        "functiontool",
-        "structuredtool",
-        "basetool",
-        "tool_plugin",
-        "toolnode",
-        "kernel_function",
-        "ai_function",
-        "openai_function",
-        "skill",
-    }
-)
-
-
-def _is_agent_tool_decorator(decorator_name: str) -> bool:
-    """Return True when *decorator_name* marks a function as an agent tool."""
-    for segment in decorator_name.lower().split("."):
-        if segment in _AGENT_TOOL_DECORATOR_SEGMENTS or segment.endswith("_tool"):
-            return True
-    return False
 
 
 def _get_decorator_name(node: ast.expr) -> str | None:

--- a/src/agent_bom/ast_signal_utils.py
+++ b/src/agent_bom/ast_signal_utils.py
@@ -37,6 +37,7 @@ def _balanced_segment(source: str, open_index: int, *, open_char: str, close_cha
                 return source[open_index : index + 1], index + 1
     return None
 
+
 _GUARDRAIL_CALL_PATTERNS = re.compile(
     r"\b(?:content_filter|safety_check|moderate|moderation|validate_input|"
     r"validate_output|check_toxicity|check_bias|filter_response|sanitize|"
@@ -51,6 +52,40 @@ _PROMPT_RISK_PATTERNS: list[tuple[str, re.Pattern[str]]] = [
     ("data_exfil_instruction", re.compile(r"\b(?:send|forward|transmit|upload)\s+(?:data|results|output|findings)\s+to\b", re.IGNORECASE)),
     ("no_safety", re.compile(r"\b(?:bypass|skip|ignore|disable)\s+(?:safety|security|guardrail|filter|moderation)\b", re.IGNORECASE)),
 ]
+
+
+# Decorator name segments that actually register a function as an agent tool.
+# Matched per dotted segment so ``@mcp.tool``, ``@agent.tool_plain`` and
+# ``@FunctionTool.from_defaults`` resolve, while ``@action`` (Django REST) and
+# ``@transaction.atomic`` — which a substring test on "tool"/"action" used to
+# accept — do not.
+AGENT_TOOL_DECORATOR_SEGMENTS: frozenset[str] = frozenset(
+    {
+        "tool",
+        "tools",
+        "tool_plain",
+        "agent_tool",
+        "agenttool",
+        "function_tool",
+        "functiontool",
+        "structuredtool",
+        "basetool",
+        "tool_plugin",
+        "toolnode",
+        "kernel_function",
+        "ai_function",
+        "openai_function",
+        "skill",
+    }
+)
+
+
+def is_agent_tool_decorator(decorator_name: str) -> bool:
+    """Return True when *decorator_name* marks a function as an agent tool."""
+    for segment in decorator_name.lower().split("."):
+        if segment in AGENT_TOOL_DECORATOR_SEGMENTS or segment.endswith("_tool"):
+            return True
+    return False
 
 
 def check_prompt_risks(text: str) -> list[str]:

--- a/src/agent_bom/python_agents.py
+++ b/src/agent_bom/python_agents.py
@@ -38,6 +38,7 @@ import re
 from pathlib import Path
 from typing import Any, NamedTuple
 
+from agent_bom.ast_signal_utils import is_agent_tool_decorator
 from agent_bom.models import Agent, AgentType, MCPServer, MCPTool, Package, TransportType
 from agent_bom.traversal import iter_discovery_files
 
@@ -218,6 +219,13 @@ def _call_name(node: ast.AST) -> str:
     return ""
 
 
+def _decorator_name(node: ast.AST) -> str:
+    """Dotted name of a decorator, unwrapping the applied form ``@mcp.tool()``."""
+    if isinstance(node, ast.Call):
+        return _call_name(node.func)
+    return _call_name(node)
+
+
 def _keyword_value(node: ast.Call, name: str) -> ast.AST | None:
     for kw in node.keywords:
         if kw.arg == name:
@@ -391,8 +399,7 @@ def _extract_agent_defs(content: str, filename: str) -> list[_PythonAgentDef]:
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             for decorator in node.decorator_list:
-                decorator_name = _call_name(decorator).split(".")[-1]
-                if decorator_name in {"function_tool", "tool", "skill", "action"}:
+                if is_agent_tool_decorator(_decorator_name(decorator)):
                     tool_values[node.name] = (node.name, "decorator", "high")
                     break
 

--- a/tests/test_ast_tool_detection_precision.py
+++ b/tests/test_ast_tool_detection_precision.py
@@ -14,6 +14,22 @@ import pytest
 
 from agent_bom.ai_components.framework_agents import _collect_tools
 from agent_bom.ast_analyzer import analyze_project
+from agent_bom.python_agents import _extract_agent_defs
+
+# An agent definition, so the third detector's decorator-resolved tools have
+# somewhere to surface. Its tool table is local to the extraction pass.
+AGENT_HARNESS = """
+from langchain.agents import AgentExecutor
+
+agent = AgentExecutor(tools=[handler])
+"""
+
+
+def _python_agent_tool_names(source: str) -> set[str]:
+    """Tools the python_agents detector resolved from a decorator, at high confidence."""
+    defs = _extract_agent_defs(source + AGENT_HARNESS, "mod.py")
+    return {name for d in defs for name, kind, confidence in d.tools if kind == "decorator" and confidence == "high"}
+
 
 DJANGO_VIEWSET = '''
 from rest_framework import viewsets
@@ -143,10 +159,35 @@ def test_framework_scanner_ignores_non_agent_decorators(decorator: str) -> None:
     assert _collect_tools(tree) == {}
 
 
+@pytest.mark.parametrize("decorator", AGENT_TOOL_DECORATORS)
+def test_agent_scanner_collects_agent_tool_decorators(decorator: str) -> None:
+    source = f"{decorator}\ndef handler(query: str) -> str:\n    '''d'''\n"
+
+    assert "handler" in _python_agent_tool_names(source)
+
+
+@pytest.mark.parametrize("decorator", NON_AGENT_DECORATORS)
+def test_agent_scanner_ignores_non_agent_decorators(decorator: str) -> None:
+    source = f"{decorator}\ndef handler(self, request):\n    pass\n"
+
+    assert "handler" not in _python_agent_tool_names(source)
+
+
 @pytest.mark.parametrize("decorator", AGENT_TOOL_DECORATORS + NON_AGENT_DECORATORS)
-def test_both_tool_detectors_agree(tmp_path: Path, decorator: str) -> None:
-    """The two detectors must not disagree about what an agent tool is."""
+def test_all_three_tool_detectors_agree(tmp_path: Path, decorator: str) -> None:
+    """Three separate detectors decide this. They must not disagree.
+
+    Two of them were fixed independently and drifted apart; asserting the
+    agreement is what stops the next fix from landing in only one of them.
+    """
     source = f"{decorator}\ndef handler(query: str) -> str:\n    '''d'''\n"
     (tmp_path / "mod.py").write_text(source)
+    tree = ast.parse(source)
 
-    assert bool(_tool_names(tmp_path)) is bool(_collect_tools(ast.parse(source)))
+    verdicts = {
+        "ast": bool(_tool_names(tmp_path)),
+        "framework": bool(_collect_tools(tree)),
+        "agents": "handler" in _python_agent_tool_names(source),
+    }
+
+    assert len(set(verdicts.values())) == 1, verdicts

--- a/tests/test_ast_tool_detection_precision.py
+++ b/tests/test_ast_tool_detection_precision.py
@@ -7,10 +7,12 @@ the matching decorator was computed but never emitted.
 
 from __future__ import annotations
 
+import ast
 from pathlib import Path
 
 import pytest
 
+from agent_bom.ai_components.framework_agents import _collect_tools
 from agent_bom.ast_analyzer import analyze_project
 
 DJANGO_VIEWSET = '''
@@ -85,3 +87,66 @@ def test_emitted_tool_carries_the_decorator_that_matched(tmp_path: Path) -> None
     entry = next(t for t in payload["tools"] if t["name"] == "search_docs")
 
     assert entry["decorators"] == ["tool"]
+
+
+def test_pydantic_ai_tool_plain_is_still_an_agent_tool(tmp_path: Path) -> None:
+    """``@agent.tool_plain`` is pydantic-ai's decorator for tools taking no RunContext.
+
+    Tightening the substring match to whole dotted segments dropped it, which
+    turns a real agent tool invisible — a worse failure than the false positive
+    the tightening was fixing.
+    """
+    (tmp_path / "tools.py").write_text("@agent.tool_plain\ndef roll_die() -> str:\n    '''Roll a die.'''\n")
+
+    assert _tool_names(tmp_path) == {"roll_die"}
+
+
+# The framework-agent scanner is a second, independent tool detector. It carried
+# the same ``action`` false positive, and additionally never resolved the applied
+# decorator form ``@mcp.tool()`` because the name helper returned "" for a Call —
+# so the canonical FastMCP tool decorator registered nothing at all.
+AGENT_TOOL_DECORATORS = [
+    "@tool",
+    "@tool('search')",
+    "@mcp.tool()",
+    "@function_tool",
+    "@function_tool()",
+    "@agent.tool",
+    "@agent.tool_plain",
+    "@kernel_function",
+    "@FunctionTool.from_defaults",
+]
+
+NON_AGENT_DECORATORS = [
+    "@action",
+    "@action(detail=True)",
+    "@transaction.atomic",
+    "@celery_app.task",
+    "@app.route('/x')",
+    "@property",
+    "@staticmethod",
+    "@pytest.fixture",
+]
+
+
+@pytest.mark.parametrize("decorator", AGENT_TOOL_DECORATORS)
+def test_framework_scanner_collects_agent_tool_decorators(decorator: str) -> None:
+    tree = ast.parse(f"{decorator}\ndef handler(query: str) -> str:\n    '''d'''\n")
+
+    assert set(_collect_tools(tree)) == {"handler"}
+
+
+@pytest.mark.parametrize("decorator", NON_AGENT_DECORATORS)
+def test_framework_scanner_ignores_non_agent_decorators(decorator: str) -> None:
+    tree = ast.parse(f"{decorator}\ndef handler(self, request):\n    pass\n")
+
+    assert _collect_tools(tree) == {}
+
+
+@pytest.mark.parametrize("decorator", AGENT_TOOL_DECORATORS + NON_AGENT_DECORATORS)
+def test_both_tool_detectors_agree(tmp_path: Path, decorator: str) -> None:
+    """The two detectors must not disagree about what an agent tool is."""
+    source = f"{decorator}\ndef handler(query: str) -> str:\n    '''d'''\n"
+    (tmp_path / "mod.py").write_text(source)
+
+    assert bool(_tool_names(tmp_path)) is bool(_collect_tools(ast.parse(source)))

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -494,7 +494,10 @@ def test_surface_freshness_targets_the_latest_published_release():
     assert "repos/$GITHUB_REPOSITORY/releases/latest" in workflow
     assert "EXPECTED_VERSION: ${{ steps.expected.outputs.version }}" in workflow
     assert '--expected "$EXPECTED_VERSION"' in workflow
-    assert '--expected-glama-tool-count "${{ steps.expected.outputs.tool_count }}"' in workflow
+    # One shipped tool inventory, so one expectation, fed to every surface that
+    # advertises a tool list. The Glama-specific spelling this used to pin is
+    # still accepted by the script as an alias.
+    assert '--expected-tool-count "${{ steps.expected.outputs.tool_count }}"' in workflow
     assert 'git show "${RELEASE_SHA}:docs/PRODUCT_METRICS.json"' in workflow
     assert 'select(.name == "MCP tools")' in workflow
     assert 'METRICS_VERSION" != "$VERSION"' in workflow
@@ -572,13 +575,9 @@ def test_security_scan_npm_installs_use_network_retries():
 def test_postgres_ci_upgrade_checks_preserved_queue_through_scoped_maintenance_role():
     """FORCE RLS must not make the migration-preservation assertion self-contradictory."""
     workflow = (ROOT / ".github" / "workflows" / "ci.yml").read_text()
+    assert ("export AGENT_BOM_POSTGRES_MAINTENANCE_URL='postgresql://agent_bom_maintenance@127.0.0.1:5432/agentbom_migration'") in workflow
     assert (
-        "export AGENT_BOM_POSTGRES_MAINTENANCE_URL="
-        "'postgresql://agent_bom_maintenance@127.0.0.1:5432/agentbom_migration'"
-    ) in workflow
-    assert (
-        "PGPASSWORD=maintenancepass PGOPTIONS='-c app.bypass_rls=1' psql "
-        "-h 127.0.0.1 -U agent_bom_maintenance -d agentbom_migration"
+        "PGPASSWORD=maintenancepass PGOPTIONS='-c app.bypass_rls=1' psql -h 127.0.0.1 -U agent_bom_maintenance -d agentbom_migration"
     ) in workflow
     assert (
         "PGPASSWORD=migrationpass psql -h 127.0.0.1 "

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -208,6 +208,58 @@ def test_surface_freshness_reads_smithery_catalog_listing(monkeypatch):
     assert result["tool_count"] == 2
 
 
+def _smithery_listing_with(tool_count):
+    def fake_http_json(_url, **_kwargs):
+        return {
+            "qualifiedName": "agent-bom/agent-bom",
+            "remote": True,
+            "deploymentUrl": "https://agent-bom--agent-bom.run.tools",
+            "tools": [{"name": f"tool_{index}"} for index in range(tool_count)],
+        }
+
+    return fake_http_json
+
+
+def test_smithery_listing_advertising_fewer_tools_than_shipped_is_stale(monkeypatch):
+    """A partial catalog is the drift this monitor exists to catch.
+
+    The live listing advertised 36 of the 77 tools the release ships — a strict
+    subset, i.e. a stale snapshot — while the probe reported "fresh" because it
+    only asserted the tool list was non-empty. Under-advertising by 41 tools on
+    a public discovery surface is exactly the months-long drift this script was
+    written to prevent, and it was invisible.
+    """
+    script = _load_script("check_surface_freshness.py")
+    monkeypatch.setattr(script, "_http_json", _smithery_listing_with(36))
+
+    result = script.probe_smithery("0.98.3", "agent-bom/agent-bom", expected_tool_count=77, timeout=1, attempts=1, backoff=0)
+
+    assert result["status"] == "stale"
+    assert result["tool_count"] == 36
+    assert result["expected_tool_count"] == 77
+    assert "36" in result["error"] and "77" in result["error"]
+
+
+def test_smithery_listing_matching_the_shipped_tool_count_is_fresh(monkeypatch):
+    script = _load_script("check_surface_freshness.py")
+    monkeypatch.setattr(script, "_http_json", _smithery_listing_with(77))
+
+    result = script.probe_smithery("0.98.3", "agent-bom/agent-bom", expected_tool_count=77, timeout=1, attempts=1, backoff=0)
+
+    assert result["status"] == "fresh"
+    assert result["tool_count"] == 77
+
+
+def test_smithery_tool_count_is_not_gated_when_no_expectation_is_supplied(monkeypatch):
+    """Without an expected count the contract check stands on its own."""
+    script = _load_script("check_surface_freshness.py")
+    monkeypatch.setattr(script, "_http_json", _smithery_listing_with(36))
+
+    result = script.probe_smithery("0.98.3", "agent-bom/agent-bom", timeout=1, attempts=1, backoff=0)
+
+    assert result["status"] == "fresh"
+
+
 def test_surface_freshness_reads_paginated_ghcr_tags(monkeypatch):
     script = _load_script("check_surface_freshness.py")
 

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -250,6 +250,31 @@ def test_smithery_listing_matching_the_shipped_tool_count_is_fresh(monkeypatch):
     assert result["tool_count"] == 77
 
 
+def test_legacy_glama_tool_count_flag_is_still_accepted(monkeypatch, tmp_path):
+    """Renaming the flag must not break anything still passing the old spelling."""
+    script = _load_script("check_surface_freshness.py")
+    seen = {}
+
+    def record(name):
+        def probe(expected, *args, **kwargs):
+            seen[name] = kwargs.get("expected_tool_count")
+            return {"surface": name, "status": "fresh", "version": expected, "expected": expected}
+
+        return probe
+
+    monkeypatch.setattr(script, "probe_pypi", record("PyPI"))
+    monkeypatch.setattr(script, "probe_docker", record("Docker"))
+    monkeypatch.setattr(script, "probe_glama", record("Glama"))
+    monkeypatch.setattr(script, "probe_smithery", record("Smithery"))
+
+    out = tmp_path / "report.json"
+    script.main(["--expected", "0.98.3", "--expected-glama-tool-count", "77", "--out", str(out)])
+
+    # The one expectation reaches BOTH surfaces that advertise a tool list.
+    assert seen["Glama"] == 77
+    assert seen["Smithery"] == 77
+
+
 def test_smithery_tool_count_is_not_gated_when_no_expectation_is_supplied(monkeypatch):
     """Without an expected count the contract check stands on its own."""
     script = _load_script("check_surface_freshness.py")


### PR DESCRIPTION
## Summary

Validating #4623 against current `main` — not the 0.98.1 the reporter used — the Django REST false positive is genuinely gone, fixed by #4627. Probing the repro directly returns only the two real agent tools, each carrying the decorator that matched:

```
tools: [('search_docs', ['tool']), ('lookup', ['mcp.tool'])]
```

Two defects survived that fix, both found by testing the *inverse* of the reported symptom — what the tightened matcher now misses.

### 1. `@agent.tool_plain` stopped resolving (regression from #4627)

pydantic-ai's decorator for tools that take no `RunContext`. `pydantic-ai` is a
first-class supported framework (`python_agents.py:59`, `constants.py:36`). The
old substring test matched it; the whole-segment test does not, because
`tool_plain` is neither in the allowlist nor `*_tool`.

A real agent tool going invisible is a worse failure than the false positive the
tightening was fixing — an inventory that under-reports is trusted and wrong.

### 2. The framework-agent scanner is a second detector with the same bug — and a blind spot

`ai_components/framework_agents.py` detects tools independently of the Python AST
path and was untouched by #4627. It still matched a bare `action` decorator at
confidence `"high"`.

It also never resolved the **applied** decorator form. `_call_name` returns `""`
for an `ast.Call`, so `@mcp.tool()` — the canonical FastMCP tool decorator —
registered nothing at all. Nor did `@tool("search")` (CrewAI) or
`@function_tool()`.

The consequence is the one that matters for the agent graph. On a FastMCP +
crewai project where two real MCP tools and one Django `@action` handler are all
passed to the same agent:

| capability | before | after |
|---|---|---|
| `read_secrets` (`@mcp.tool()`) | `name-reference` / **low** | `decorator` / **high** |
| `exec_shell` (`@mcp.tool()`) | `name-reference` / **low** | `decorator` / **high** |
| `approve` (`@action(detail=True)`) | `name-reference` / low | `name-reference` / low |

A tool that reads credentials and one that runs a shell command were ranked
identically to a web handler.

### Why one change

Fixing the blind spot alone would have **reintroduced #4623** in this path:
resolving `@action(detail=True)` puts `"action"` back in front of the matcher.
The two must move together.

Both detectors now share one predicate, `is_agent_tool_decorator` in
`ast_signal_utils`, so they cannot disagree again. A test asserts that agreement
directly rather than trusting the two copies to stay in sync.

## Verification

- 17 decorator forms across langchain, llama-index, pydantic-ai, openai-agents,
  crewai, semantic-kernel, strands and FastMCP vs. Django REST, Celery, Flask,
  `@property`, `@staticmethod`, `@pytest.fixture`, `@transaction.atomic` — both
  detectors agree on every case, 0 mismatches
- `pytest tests/test_ast_tool_detection_precision.py tests/test_framework_agents.py` — 50 passed
- `pytest -k "ast or framework_agent or inventory or graph_builder or ai_component or scan_project"` — 1088 passed, 29 skipped
- `mypy` + `ruff check` + `ruff format` on all changed files
- `make preflight` — passed
- The #4623 repro re-run end-to-end against this branch

## Notes

Closes #4623 — the reported symptom was fixed by #4627; this closes the two
defects that fix left behind, so the issue's underlying ask (consumers can tell a
real agent tool from a web handler) holds in **both** detection paths, not one.

`@action` and `skill`-style Griptape/AutoGen registration decorators
(`@register_for_llm`) remain undetected by design — they are not agent-tool
markers, and adding them would recreate the reported false positive.