### PR TITLE
fix(output): stop reporting a posture the data does not support

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1111,
+      "value": 1113,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 819,
+      "value": 820,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1111 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1113 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 819 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 820 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/api/routes/discovery.py
+++ b/src/agent_bom/api/routes/discovery.py
@@ -25,6 +25,7 @@ from agent_bom.api.stores import _get_fleet_store, _get_mcp_observation_store, _
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.asset_provenance import agent_discovery_provenance, package_discovery_provenance, package_version_provenance
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
+from agent_bom.graph.severity import normalize_severity
 from agent_bom.mcp_blocklist import sanitize_security_intelligence_entry
 from agent_bom.security import (
     sanitize_command_args,
@@ -628,11 +629,14 @@ def _get_agent_detail_impl(request: Request, agent_name: str) -> dict:
     for s in agent.mcp_servers:
         all_credentials.extend(s.credential_names)
 
-    severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    # Every blast radius lands in exactly one bucket. Advisories with no CVSS
+    # vector normalise to ``unknown``; without an explicit bucket they fell out
+    # of the histogram entirely and the detail page rendered "N vulnerabilities"
+    # beside a 0/0/0/0 strip labelled Clean.
+    severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "unrated": 0}
     for br in agent_blast:
-        sev = (br.get("severity") or "").lower()
-        if sev in severity_counts:
-            severity_counts[sev] += 1
+        sev = normalize_severity(br.get("severity"))
+        severity_counts[sev if sev in severity_counts else "unrated"] += 1
 
     fleet_agent = None
     tenant_id = _tenant_id(request)

--- a/src/agent_bom/api/routes/proxy.py
+++ b/src/agent_bom/api/routes/proxy.py
@@ -161,9 +161,7 @@ def _alert_visible_to_tenant(alert: dict, tenant_id: str) -> bool:
     return alert_tenant == tenant_id
 
 
-_CANONICAL_GATEWAY_EVENT_TYPES = (
-    GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEWAY_DATA_FILTER_EVENT_TYPES
-)
+_CANONICAL_GATEWAY_EVENT_TYPES = GATEWAY_ALLOWED_EVENT_TYPES | GATEWAY_BLOCKED_EVENT_TYPES | GATEWAY_DATA_FILTER_EVENT_TYPES
 
 
 def _gateway_activity_record_from_alert(
@@ -210,13 +208,7 @@ def _gateway_activity_record_from_alert(
     if not isinstance(event_timestamp, str) or not event_timestamp.strip():
         raise ValueError("canonical gateway event requires event_timestamp")
     expected_decision = "deny" if event_type in GATEWAY_BLOCKED_EVENT_TYPES else "allow"
-    agent_id = str(
-        alert.get("agent_id")
-        or alert.get("agent_name")
-        or alert.get("source_agent")
-        or source_id
-        or "unknown"
-    )
+    agent_id = str(alert.get("agent_id") or alert.get("agent_name") or alert.get("source_agent") or source_id or "unknown")
     canonical: dict[str, Any] = {
         "schema_version": "gateway.runtime.event.v1",
         "event_id": event_id,
@@ -936,11 +928,20 @@ async def proxy_alerts(
     tenant_id = _request_tenant_id(request)
     alerts = _load_proxy_alerts(tenant_id)
 
+    # The summary describes the tenant's whole alert population, so it agrees
+    # with /v1/proxy/metrics and does not shrink to whatever page was asked for.
+    # Summarising the filtered/paged slice made the histogram read 100% of the
+    # requested severity and understated the estate by the page size.
+    summary = _summarize_proxy_alerts(alerts)
+    matched_total = len(alerts)
+
     # Apply filters
     if severity:
         alerts = [a for a in alerts if a.get("severity", "").lower() == severity.lower()]
     if detector:
         alerts = [a for a in alerts if a.get("detector", "").lower() == detector.lower()]
+    if severity or detector:
+        matched_total = len(alerts)
 
     # Newest first, apply limit
     alerts = alerts[-limit:][::-1]
@@ -948,7 +949,8 @@ async def proxy_alerts(
     return {
         "alerts": alerts,
         "count": len(alerts),
-        "summary": _summarize_proxy_alerts(alerts),
+        "matched_total": matched_total,
+        "summary": summary,
         "filters": {
             "severity": severity,
             "detector": detector,

--- a/src/agent_bom/governance.py
+++ b/src/agent_bom/governance.py
@@ -256,6 +256,9 @@ class GovernanceReport:
                     "columns": r.columns,
                     "operation": r.operation,
                     "is_write": r.is_write,
+                    # A view reads as one innocuous object name; the base
+                    # objects are the data actually touched.
+                    "base_objects": r.base_objects,
                 }
                 for r in self.access_records
             ],
@@ -267,6 +270,10 @@ class GovernanceReport:
                     "granted_on": g.granted_on,
                     "object_name": g.object_name,
                     "is_elevated": g.is_elevated,
+                    # WITH GRANT OPTION lets the grantee re-delegate this
+                    # privilege — the escalation primitive, not a detail.
+                    "grant_option": g.grant_option,
+                    "granted_by": g.granted_by,
                 }
                 for g in self.privilege_grants
             ],

--- a/src/agent_bom/graph/container.py
+++ b/src/agent_bom/graph/container.py
@@ -886,6 +886,11 @@ class UnifiedGraph:
             "interaction_risks": [r.to_dict() for r in self.interaction_risks],
             "analysis_status": analysis_status_map_to_dict(self.analysis_status),
             "stats": self.stats(),
+            # Whether this payload is the whole snapshot or a bounded slice of
+            # it. A budget-trimmed graph that serializes without this reads to
+            # every consumer as the complete estate — an empty blast radius
+            # becomes indistinguishable from one we stopped walking.
+            "completeness": self.completeness.to_dict(),
         }
 
     @classmethod
@@ -896,6 +901,14 @@ class UnifiedGraph:
             created_at=data.get("created_at", ""),
             analysis_status=analysis_status_map_from_dict(data.get("analysis_status", {})),
         )
+        completeness = data.get("completeness")
+        if isinstance(completeness, dict):
+            graph.completeness = GraphCompleteness(
+                truncated=bool(completeness.get("truncated", False)),
+                total_nodes=int(completeness.get("total", 0) or 0),
+                returned_nodes=int(completeness.get("returned", 0) or 0),
+                reason=str(completeness.get("reason", "") or ""),
+            )
         for nd in data.get("nodes", []):
             graph.add_node(UnifiedNode.from_dict(nd))
         for ed in data.get("edges", []):

--- a/src/agent_bom/output/cis_posture.py
+++ b/src/agent_bom/output/cis_posture.py
@@ -1,0 +1,74 @@
+"""One derivation of the CIS posture verdict, shared by every renderer.
+
+The console and the HTML report used to compute this independently and
+disagreed on the same scan: a bundle of ``[1 pass, 1 error, 0 fail]`` rendered
+INCOMPLETE in one and ERROR in the other. Both also printed a green PASS for a
+bundle in which nothing was ever evaluated — an account with none of the
+resources the benchmark inspects has zero passing controls, not a clean one.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent_bom.graph.severity import SEVERITY_THRESHOLD_LABELS, severity_worst_first_rank
+
+#: A control only counts as evaluated when it produced a real verdict.
+#: ``not_applicable`` and ``skipped`` checks are evidence of nothing.
+EVALUATED_STATUSES = ("pass", "fail")
+
+NOT_EVALUATED = "NOT EVALUATED"
+ERROR = "ERROR"
+INCOMPLETE = "INCOMPLETE"
+PASS = "PASS"
+
+
+def cis_check_tally(checks: list[dict[str, Any]]) -> dict[str, list[dict[str, Any]]]:
+    """Split ``checks`` into the buckets every CIS surface renders from."""
+    return {
+        "passed": [c for c in checks if str(c.get("status")) == "pass"],
+        "failed": [c for c in checks if str(c.get("status")) == "fail"],
+        "errored": [c for c in checks if str(c.get("status")) == "error"],
+        "evaluated": [c for c in checks if str(c.get("status")) in EVALUATED_STATUSES],
+    }
+
+
+def cis_verdict(checks: list[dict[str, Any]]) -> str:
+    """Return the posture verdict for one CIS bundle.
+
+    Ordered so a claim is never stronger than the evidence behind it:
+
+    ``NOT EVALUATED`` no control produced a pass or a fail — nothing was
+                      actually checked, so no verdict is earned.
+    ``ERROR``         every attempted control errored.
+    ``INCOMPLETE``    some controls errored, so coverage has holes.
+    ``PASS``          controls were evaluated and none failed.
+    ``<SEV> GAPS``    banded by the worst failing control.
+    """
+    tally = cis_check_tally(checks)
+    failed, errored, evaluated = tally["failed"], tally["errored"], tally["evaluated"]
+
+    if not evaluated:
+        # Nothing produced a verdict: an errored attempt is a failure to
+        # evaluate, an all-not-applicable bundle was never evaluated at all.
+        return ERROR if errored else NOT_EVALUATED
+    if errored:
+        return INCOMPLETE
+    if not failed:
+        return PASS
+
+    worst = min(failed, key=lambda c: severity_worst_first_rank(c.get("severity")))
+    worst_sev = (worst.get("severity") or "low").lower()
+    if worst_sev not in SEVERITY_THRESHOLD_LABELS:
+        worst_sev = "low"
+    return f"{worst_sev.upper()} GAPS"
+
+
+def cis_pass_rate(bundle: dict[str, Any], checks: list[dict[str, Any]]) -> float:
+    """Pass rate over *evaluated* controls, recomputed when the bundle omits it."""
+    rate = bundle.get("pass_rate")
+    if isinstance(rate, (int, float)):
+        return float(rate)
+    tally = cis_check_tally(checks)
+    evaluated = len(tally["evaluated"])
+    return (len(tally["passed"]) / evaluated * 100) if evaluated else 0.0

--- a/src/agent_bom/output/console_render.py
+++ b/src/agent_bom/output/console_render.py
@@ -12,6 +12,14 @@ from rich.tree import Tree
 
 from agent_bom.graph.severity import SEVERITY_THRESHOLD_LABELS, severity_rank, severity_worst_first_rank
 from agent_bom.models import AgentStatus, AIBOMReport, Severity
+from agent_bom.output.cis_posture import (
+    ERROR,
+    INCOMPLETE,
+    NOT_EVALUATED,
+    PASS,
+    cis_pass_rate,
+    cis_verdict,
+)
 from agent_bom.output.compact import _coverage_bar, _pct
 from agent_bom.output.finding_views import (
     active_cve_findings,
@@ -1622,6 +1630,14 @@ _SEV_TABLE_STYLE: dict[str, str] = {
 }
 
 
+_CIS_VERDICT_STYLE = {
+    NOT_EVALUATED: "dim",
+    ERROR: "bold red",
+    INCOMPLETE: "bold yellow",
+    PASS: "bold green",
+}
+
+
 def _cis_sev(check: dict) -> str:
     """Normalize a check's severity to a known lowercase band."""
     sev = str(check.get("severity") or "").lower()
@@ -1708,24 +1724,22 @@ def print_cis_findings(report: AIBOMReport, *, show_passed: bool = False) -> Non
         errored = [c for c in checks if str(c.get("status")) == "error"]
         actionable = failed + errored
         evaluated = len(failed) + len(passed)
-        pass_rate = bundle.get("pass_rate")
-        if not isinstance(pass_rate, (int, float)):
-            pass_rate = (len(passed) / evaluated * 100) if evaluated else 0.0
+        pass_rate = cis_pass_rate(bundle, checks)
 
         band = "green" if pass_rate >= 90 else "yellow" if pass_rate >= 70 else "red"
 
-        # Verdict driven by the worst failing severity.
-        if errored and not failed:
-            verdict = "[bold red]ERROR[/bold red]"
-        elif errored:
-            verdict = "[bold yellow]INCOMPLETE[/bold yellow]"
-        elif not failed:
-            verdict = "[bold green]PASS[/bold green]"
-        else:
-            worst_check = min(failed, key=lambda c: severity_worst_first_rank(c.get("severity")))
-            worst_band = _SEV_LABEL.get(_cis_sev(worst_check), "LOW")
-            vstyle = {"CRITICAL": "red bold", "HIGH": "#e67e22 bold", "MEDIUM": "yellow", "LOW": "dim"}[worst_band]
-            verdict = f"[{vstyle}]{worst_band} GAPS[/{vstyle}]"
+        # Verdict comes from the one shared derivation so this panel and the
+        # HTML report can never disagree about the same scan.
+        verdict_text = cis_verdict(checks)
+        if verdict_text == NOT_EVALUATED:
+            band = "dim"
+        vstyle = _CIS_VERDICT_STYLE.get(verdict_text) or {
+            "CRITICAL": "red bold",
+            "HIGH": "#e67e22 bold",
+            "MEDIUM": "yellow",
+            "LOW": "dim",
+        }.get(verdict_text.split()[0], "red bold")
+        verdict = f"[{vstyle}]{verdict_text}[/{vstyle}]"
 
         con.print()
         con.print(

--- a/src/agent_bom/output/finding_views.py
+++ b/src/agent_bom/output/finding_views.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from agent_bom.compliance_coverage import COMPLIANCE_TAG_FIELDS
 from agent_bom.finding import Finding, FindingType, blast_radius_to_finding
+from agent_bom.graph.severity import normalize_severity
 from agent_bom.models import AIBOMReport, BlastRadius, Severity
 
 _MACHINE_EXPORT_TYPES = (FindingType.CVE, FindingType.MALICIOUS_PACKAGE)
@@ -252,12 +253,29 @@ def finding_references(finding: Finding) -> list[str]:
     return []
 
 
+SEVERITY_COUNT_KEYS: tuple[str, ...] = (
+    "critical",
+    "high",
+    "medium",
+    "low",
+    "info",
+    "none",
+    "unknown",
+)
+
+
 def severity_counts(findings: list[Finding]) -> dict[str, int]:
-    counts = {severity.value: 0 for severity in Severity if severity != Severity.NONE}
+    """Bucket every finding by severity, losing none of them.
+
+    ``sum(severity_counts(f).values()) == len(f)`` always holds: a severity the
+    scanners never resolved lands in ``unknown`` rather than falling out of the
+    histogram. A total printed beside a breakdown that silently dropped its
+    unrated rows reads as "all of these are benign" when the truth is "we never
+    rated them".
+    """
+    counts = {key: 0 for key in SEVERITY_COUNT_KEYS}
     for finding in findings:
-        severity = severity_value(finding)
-        if severity in counts:
-            counts[severity] += 1
+        counts[normalize_severity(severity_value(finding))] += 1
     return counts
 
 

--- a/src/agent_bom/output/html/sections.py
+++ b/src/agent_bom/output/html/sections.py
@@ -12,6 +12,15 @@ from agent_bom.graph.severity import (
     severity_policy_rank,
     severity_worst_first_rank,
 )
+from agent_bom.output.cis_posture import (
+    ERROR,
+    EVALUATED_STATUSES,
+    INCOMPLETE,
+    NOT_EVALUATED,
+    PASS,
+    cis_pass_rate,
+    cis_verdict,
+)
 from agent_bom.output.exposure_path import exposure_path_brief_for_finding
 from agent_bom.output.finding_views import (
     compliance_row_dict,
@@ -809,6 +818,14 @@ _CIS_CLOUD_LABELS = {
 }
 
 
+_CIS_VERDICT_COLOR = {
+    NOT_EVALUATED: "#6b7280",
+    ERROR: "#dc2626",
+    INCOMPLETE: "#d97706",
+    PASS: "#16a34a",
+}
+
+
 def _cis_evidence_html(check: dict) -> str:
     """Affected-resource evidence cell: resource IDs when present, else text."""
     resources = check.get("resource_ids") or []
@@ -859,27 +876,17 @@ def _cis_benchmark_section(report: "AIBOMReport") -> str:
         failed = [c for c in checks if c.get("status") == "fail"]
         errored = [c for c in checks if c.get("status") == "error"]
         actionable = failed + errored
-        evaluated = [c for c in checks if c.get("status") in ("pass", "fail")]
+        evaluated = [c for c in checks if c.get("status") in EVALUATED_STATUSES]
         passed_n = bundle.get("passed", sum(1 for c in checks if c.get("status") == "pass"))
-        pass_rate = bundle.get("pass_rate", 0.0)
+        pass_rate = cis_pass_rate(bundle, checks)
         band_color = "#16a34a" if pass_rate >= 90 else "#eab308" if pass_rate >= 70 else "#ef4444"
 
         # Verdict + per-severity failed counts for the summary header.
         sev_counts = {s: sum(1 for c in failed if (c.get("severity") or "").lower() == s) for s in SEVERITY_THRESHOLD_LABELS}
-        if errored and not evaluated:
-            verdict_text, verdict_color = "ERROR", "#dc2626"
-        elif errored:
-            verdict_text, verdict_color = "INCOMPLETE", "#d97706"
-        elif not failed:
-            verdict_text, verdict_color = "PASS", "#16a34a"
-        else:
-            worst_check = min(failed, key=lambda c: severity_worst_first_rank(c.get("severity")))
-            worst_sev = (worst_check.get("severity") or "low").lower()
-            if worst_sev not in SEVERITY_THRESHOLD_LABELS:
-                worst_sev = "low"
-            worst_band = worst_sev.upper()
-            verdict_text = f"{worst_band} GAPS"
-            verdict_color = _SEV_COLOR.get(worst_sev, "#ef4444")
+        verdict_text = cis_verdict(checks)
+        verdict_color = _CIS_VERDICT_COLOR.get(verdict_text) or _SEV_COLOR.get(verdict_text.split()[0].lower(), "#ef4444")
+        if verdict_text == NOT_EVALUATED:
+            band_color = "#6b7280"
 
         top = sorted(actionable, key=_sort_key)[:3]
         top_html = ""

--- a/src/agent_bom/output/markdown.py
+++ b/src/agent_bom/output/markdown.py
@@ -65,6 +65,14 @@ def to_markdown(report: AIBOMReport, blast_radii: list[BlastRadius] | None = Non
     lines.append(f"| High | {sev_counts.get('high', 0)} |")
     lines.append(f"| Medium | {sev_counts.get('medium', 0)} |")
     lines.append(f"| Low | {sev_counts.get('low', 0)} |")
+    # Rated-but-informational and never-rated findings get their own rows so the
+    # severity rows add up to the totals printed directly above them. Without
+    # these an unrated finding reads as "counted, and benign".
+    if sev_counts.get("info", 0):
+        lines.append(f"| Info | {sev_counts['info']} |")
+    unrated = sev_counts.get("unknown", 0) + sev_counts.get("none", 0)
+    if unrated:
+        lines.append(f"| Unrated | {unrated} |")
     lines.append("")
 
     trust_lines = _trust_assessment_section(report)

--- a/src/agent_bom/secret_scanner.py
+++ b/src/agent_bom/secret_scanner.py
@@ -267,6 +267,11 @@ class SecretScanResult:
             "critical": self.critical_count,
             "by_type": _group_by(self.findings, "secret_type"),
             "by_category": _group_by(self.findings, "category"),
+            # A refused path or a file-capped walk both report ``total: 0``.
+            # Without the warnings that reads as "this tree holds no secrets"
+            # instead of "we did not finish looking".
+            "warnings": list(self.warnings),
+            "complete": not self.warnings,
         }
 
 

--- a/tests/test_posture_count_honesty.py
+++ b/tests/test_posture_count_honesty.py
@@ -1,0 +1,278 @@
+"""Every user-visible total reconciles with the breakdown printed beside it.
+
+Two numbers on one screen that describe the same population must derive from
+the same basis. A total counted over every row next to a histogram that only
+recognises four severity bands reads as "all of these are benign" when the
+truth is "we never rated them". An unrated finding needs an explicit bucket,
+never a silent drop.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from agent_bom.api.models import JobStatus, ScanJob, ScanRequest
+from agent_bom.api.server import app
+from agent_bom.api.store import InMemoryJobStore
+from agent_bom.models import Agent, AgentType, MCPServer
+
+# ── /v1/agents/{name}: total_vulnerabilities vs severity_breakdown ──────────
+
+
+def _agent_with_unrated_blast() -> list[Agent]:
+    return [
+        Agent(
+            name="unrated-agent",
+            agent_type=AgentType.CLAUDE_DESKTOP,
+            config_path="/tmp/unrated-config.json",
+            mcp_servers=[MCPServer(name="srv", command="npx", args=["-y", "srv"])],
+        )
+    ]
+
+
+def _job_store_with_unrated_blast() -> InMemoryJobStore:
+    """A scan whose blast radii are mostly advisories with no CVSS score."""
+    store = InMemoryJobStore()
+    job = ScanJob(
+        job_id="job-unrated",
+        tenant_id="default",
+        status=JobStatus.DONE,
+        created_at="2026-08-01T00:00:00Z",
+        completed_at="2026-08-01T00:01:00Z",
+        request=ScanRequest(),
+    )
+    blast = [{"severity": "critical", "affected_agents": ["unrated-agent"]}]
+    # GHSA advisories routinely carry no CVSS vector at all.
+    blast += [{"severity": "unknown", "affected_agents": ["unrated-agent"]} for _ in range(3)]
+    blast += [{"severity": "none", "affected_agents": ["unrated-agent"]}]
+    blast += [{"severity": "", "affected_agents": ["unrated-agent"]}]
+    job.result = {"scan_id": "scan-unrated", "blast_radius": blast}
+    store.put(job)
+    return store
+
+
+def test_agent_detail_severity_breakdown_sums_to_total(monkeypatch):
+    """``total_vulnerabilities`` must equal the sum of ``severity_breakdown``."""
+    monkeypatch.setattr("agent_bom.discovery.discover_all", _agent_with_unrated_blast)
+    monkeypatch.setattr("agent_bom.api.routes.discovery._get_store", _job_store_with_unrated_blast)
+
+    resp = TestClient(app).get("/v1/agents/unrated-agent")
+    assert resp.status_code == 200
+    summary = resp.json()["summary"]
+
+    total = summary["total_vulnerabilities"]
+    breakdown = summary["severity_breakdown"]
+    assert total == 6
+    assert sum(breakdown.values()) == total, (
+        f"{total} vulnerabilities reported but the severity breakdown accounts for only {sum(breakdown.values())}: {breakdown}"
+    )
+    # The five unscored rows land in one explicit bucket, not nowhere.
+    assert breakdown["unrated"] == 5
+
+
+# ── /v1/proxy/alerts: page-scoped summary presented as the estate total ─────
+
+
+def _write_alert_log(path: Path, count: int, *, tenant_id: str) -> None:
+    with open(path, "w", encoding="utf-8") as handle:
+        for index in range(count):
+            handle.write(
+                json.dumps(
+                    {
+                        "type": "runtime_alert",
+                        "tenant_id": tenant_id,
+                        "detector": "credential_leak",
+                        "severity": "critical" if index % 2 else "low",
+                        "event_id": f"log-{index:05d}",
+                        "ts": f"2026-07-{(index % 28) + 1:02d}T00:00:00+00:00",
+                    }
+                )
+                + "\n"
+            )
+
+
+@pytest.fixture
+def proxy_alert_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    from agent_bom.api.routes import proxy as proxy_routes
+
+    proxy_routes._reset_proxy_runtime_for_tests()
+    log_path = tmp_path / "audit.jsonl"
+    monkeypatch.setenv("AGENT_BOM_LOG", str(log_path))
+    try:
+        yield log_path
+    finally:
+        proxy_routes._reset_proxy_runtime_for_tests()
+
+
+def test_proxy_alerts_summary_reports_estate_total_not_page_total(proxy_alert_log):
+    """The alert summary must describe the estate, like /v1/proxy/metrics does."""
+    from agent_bom.api.routes import proxy as proxy_routes
+
+    tenant = "default"
+    _write_alert_log(proxy_alert_log, 250, tenant_id=tenant)
+
+    full = proxy_routes._summarize_proxy_alerts(proxy_routes._load_proxy_alerts(tenant))
+    assert full["total_alerts"] == 250
+
+    client = TestClient(app)
+    resp = client.get("/v1/proxy/alerts", params={"limit": 100})
+    assert resp.status_code == 200
+    body = resp.json()
+
+    assert len(body["alerts"]) == 100
+    assert body["count"] == 100
+    assert body["summary"]["total_alerts"] == full["total_alerts"], (
+        "the summary beside a 100-row page claims the whole estate holds only "
+        f"{body['summary']['total_alerts']} alerts, while /v1/proxy/metrics "
+        f"reports {full['total_alerts']}"
+    )
+    assert body["summary"]["alerts_by_severity"] == full["alerts_by_severity"]
+
+
+def test_proxy_alerts_severity_filter_does_not_claim_a_uniform_estate(proxy_alert_log):
+    """Filtering to one severity must not make the histogram 100% that severity."""
+    tenant = "default"
+    _write_alert_log(proxy_alert_log, 40, tenant_id=tenant)
+
+    resp = TestClient(app).get("/v1/proxy/alerts", params={"severity": "critical"})
+    assert resp.status_code == 200
+    by_sev = resp.json()["summary"]["alerts_by_severity"]
+
+    assert by_sev.get("low"), f"a severity-filtered view reports a whole-estate histogram of {by_sev} — the estate is not 100% critical"
+
+
+# ── CIS posture verdict: PASS with zero controls evaluated ─────────────────
+
+
+_ALL_NOT_APPLICABLE = [
+    {"check_id": "1.1", "title": "Bucket encryption", "status": "not_applicable", "severity": "high"},
+    {"check_id": "1.2", "title": "DB backups", "status": "not_applicable", "severity": "medium"},
+]
+_PASS_PLUS_ERROR = [
+    {"check_id": "1.1", "title": "Bucket encryption", "status": "pass", "severity": "high"},
+    {"check_id": "1.2", "title": "DB backups", "status": "error", "severity": "high"},
+]
+
+
+def _report_with_cis(checks: list[dict]):
+    """A report carrying one non-cloud CIS bundle (no fail-closed rewrite)."""
+    from agent_bom.models import AIBOMReport
+
+    report = AIBOMReport()
+    report.databricks_security_data = {
+        "checks": checks,
+        "passed": sum(1 for c in checks if c["status"] == "pass"),
+        "failed": sum(1 for c in checks if c["status"] == "fail"),
+        "pass_rate": 0.0,
+    }
+    return report
+
+
+def _rendered_html_verdict(checks: list[dict]) -> str:
+    import re
+
+    from agent_bom.output.html.sections import _cis_benchmark_section
+
+    html = _cis_benchmark_section(_report_with_cis(checks))
+    match = re.search(r">(NOT EVALUATED|INCOMPLETE|ERROR|PASS|\w+ GAPS)<", html)
+    return match.group(1) if match else ""
+
+
+def test_html_cis_verdict_is_not_pass_when_nothing_was_evaluated():
+    """An account with no in-scope resources evaluated zero controls."""
+    verdict = _rendered_html_verdict(_ALL_NOT_APPLICABLE)
+    assert verdict != "PASS", "the HTML report prints a green PASS beside '0% pass (0/0 checks)' — zero controls were actually evaluated"
+    assert verdict == "NOT EVALUATED"
+
+
+@pytest.mark.parametrize(
+    "checks",
+    [
+        _ALL_NOT_APPLICABLE,
+        _PASS_PLUS_ERROR,
+        [{"check_id": "2.1", "title": "t", "status": "error", "severity": "low"}],
+        [{"check_id": "3.1", "title": "t", "status": "pass", "severity": "low"}],
+        [{"check_id": "4.1", "title": "t", "status": "fail", "severity": "critical"}],
+    ],
+)
+def test_console_cis_verdict_matches_the_html_verdict(checks, monkeypatch):
+    """One scan cannot render two different verdicts on two surfaces."""
+    import re
+
+    from rich.console import Console
+
+    from agent_bom import output as output_mod
+    from agent_bom.output import console_render
+
+    # ``print_cis_findings`` writes to the shared ``agent_bom.output.console``.
+    # Swap in a recording console so capture does not depend on which other
+    # test last touched that global.
+    recorder = Console(record=True, width=200, no_color=True, force_terminal=False)
+    monkeypatch.setattr(output_mod, "console", recorder)
+
+    console_render.print_cis_findings(_report_with_cis(checks))
+    out = recorder.export_text()
+    match = re.search(r"(NOT EVALUATED|INCOMPLETE|ERROR|PASS|\w+ GAPS)", out)
+    console_verdict = match.group(1) if match else ""
+
+    assert console_verdict, f"console rendered no verdict at all for {checks}"
+    assert console_verdict == _rendered_html_verdict(checks), (
+        f"console rendered {console_verdict!r} where HTML rendered {_rendered_html_verdict(checks)!r} for the same checks"
+    )
+
+
+# ── Markdown report: severity rows never sum to the totals above them ──────
+
+
+def test_severity_counts_never_drops_a_finding():
+    """The shared histogram must account for every finding it is handed."""
+    from agent_bom.output.finding_views import severity_counts
+
+    findings = _findings_across_bands()
+    counts = severity_counts(findings)
+    assert sum(counts.values()) == len(findings), (
+        f"severity_counts dropped {len(findings) - sum(counts.values())} of {len(findings)} findings: {counts}"
+    )
+
+
+def test_markdown_summary_rows_account_for_every_finding():
+    """The severity rows must account for the totals printed directly above."""
+    import re
+
+    from agent_bom.models import AIBOMReport
+    from agent_bom.output.markdown import to_markdown
+
+    report = AIBOMReport()
+    report.findings = _findings_across_bands()
+
+    md = to_markdown(report)
+    rows = dict(re.findall(r"^\| (Critical|High|Medium|Low|Info|Unrated) \| (\d+) \|$", md, re.M))
+    policy_total = int(re.search(r"^\| Policy/security findings \| (\d+) \|$", md, re.M).group(1))
+
+    assert policy_total == 4
+    assert sum(int(v) for v in rows.values()) == policy_total, (
+        f"the summary table reports {policy_total} findings above severity rows that sum to {sum(int(v) for v in rows.values())}: {rows}"
+    )
+    # ``info`` is rated-and-benign; ``none``/``unknown`` were never rated at all.
+    assert rows.get("Info") == "1"
+    assert rows.get("Unrated") == "2"
+
+
+def _findings_across_bands() -> list:
+    """One rated finding plus three the scanners could not rate."""
+    from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+
+    return [
+        Finding(
+            finding_type=FindingType.MCP_BLOCKLIST,
+            source=FindingSource.MCP_SCAN,
+            asset=Asset(name=f"srv-{idx}", asset_type="mcp_server"),
+            severity=sev,
+            title=f"finding {idx}",
+        )
+        for idx, sev in enumerate(["critical", "unknown", "none", "info"])
+    ]

--- a/tests/test_posture_signal_surfacing.py
+++ b/tests/test_posture_signal_surfacing.py
@@ -107,3 +107,50 @@ def test_secret_scan_to_dict_stays_quiet_on_a_complete_scan(tmp_path: Path):
     (tmp_path / "mod.py").write_text("VALUE = 1\n", encoding="utf-8")
     payload = scan_secrets(str(tmp_path)).to_dict()
     assert payload["warnings"] == []
+
+
+# ── Snowflake governance: escalation and lineage signals never leave the report
+
+
+def _governance_report():
+    from agent_bom.governance import AccessRecord, GovernanceReport, PrivilegeGrant
+
+    report = GovernanceReport(account="acct-1", discovered_at="2026-08-01T00:00:00Z")
+    report.privilege_grants = [
+        PrivilegeGrant(
+            grantee="ANALYST",
+            grantee_type="ROLE",
+            privilege="SELECT",
+            granted_on="TABLE",
+            object_name="DB.PII.CUSTOMERS",
+            granted_by="SECURITYADMIN",
+            grant_option=True,
+        )
+    ]
+    report.access_records = [
+        AccessRecord(
+            query_id="q-1",
+            user_name="SVC_AGENT",
+            role_name="ANALYST",
+            query_start="2026-08-01T00:00:00Z",
+            object_name="DB.PUBLIC.SAFE_VIEW",
+            object_type="VIEW",
+            base_objects=["DB.PII.CUSTOMERS", "DB.PII.CARDS"],
+        )
+    ]
+    return report
+
+
+def test_governance_report_surfaces_the_regrant_right():
+    """WITH GRANT OPTION is the escalation primitive — it must be visible."""
+    grant = _governance_report().to_dict()["privilege_grants"][0]
+    assert grant["grant_option"] is True, "a grantee that can re-delegate SELECT on a PII table serializes identically to one that cannot"
+    assert grant["granted_by"] == "SECURITYADMIN"
+
+
+def test_governance_report_surfaces_view_base_object_lineage():
+    """A benign-looking view that fans out to PII must not serialize as benign."""
+    record = _governance_report().to_dict()["access_records"][0]
+    assert record["base_objects"] == ["DB.PII.CUSTOMERS", "DB.PII.CARDS"], (
+        "the view's underlying objects are dropped, so the data actually touched is invisible to any lineage or exfiltration analysis"
+    )

--- a/tests/test_posture_signal_surfacing.py
+++ b/tests/test_posture_signal_surfacing.py
@@ -1,0 +1,109 @@
+"""Signals the scanner computed must survive serialization to a consumer.
+
+A value derived correctly in the backend and then dropped by its own
+``to_dict`` is worse than one never computed: the product knows the answer and
+tells no one, and the consumer reads the silence as good news. Both cases here
+turn an incomplete scan into an indistinguishable clean bill of health.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_bom.graph.container import UnifiedGraph, apply_node_budget
+from agent_bom.graph.node import EntityType, UnifiedNode
+
+
+def _graph_with_nodes(count: int) -> UnifiedGraph:
+    graph = UnifiedGraph(scan_id="scan-trunc", tenant_id="default")
+    for index in range(count):
+        graph.add_node(
+            UnifiedNode(
+                id=f"n-{index:04d}",
+                entity_type=EntityType.PACKAGE,
+                label=f"pkg-{index}",
+                risk_score=float(index),
+            )
+        )
+    return graph
+
+
+def test_unified_graph_to_dict_declares_a_budget_truncated_load():
+    """A graph trimmed to a node budget must not serialize as the whole estate."""
+    graph = apply_node_budget(_graph_with_nodes(50), 10)
+
+    assert graph.completeness.truncated is True
+    assert graph.completeness.total_nodes == 50
+    assert graph.completeness.returned_nodes == 10
+
+    payload = graph.to_dict()
+    assert "completeness" in payload, (
+        "to_dict() drops the completeness descriptor — every file/CLI/session consumer reads 10 of 50 nodes as the complete estate"
+    )
+    completeness = payload["completeness"]
+    assert completeness["truncated"] is True
+    assert completeness["complete"] is False
+    assert completeness["returned"] == 10
+    assert completeness["total"] == 50
+    assert completeness["reason"] == "node_budget"
+
+
+def test_unified_graph_to_dict_declares_a_complete_load():
+    """A graph that fit inside its budget must say so, not stay silent."""
+    payload = apply_node_budget(_graph_with_nodes(5), 10).to_dict()
+    assert payload["completeness"]["complete"] is True
+    assert payload["completeness"]["truncated"] is False
+
+
+def test_unified_graph_round_trip_preserves_completeness():
+    """``from_dict(to_dict(g))`` must not launder a truncated graph clean."""
+    graph = apply_node_budget(_graph_with_nodes(50), 10)
+    restored = UnifiedGraph.from_dict(graph.to_dict())
+    assert restored.completeness.truncated is True
+    assert restored.completeness.total_nodes == 50
+    assert restored.completeness.returned_nodes == 10
+
+
+# ── Secret scan: a partial or refused scan must not read as a clean one ────
+
+
+def test_secret_scan_to_dict_surfaces_a_refused_scan(tmp_path: Path):
+    """A path that is not a directory reports zero secrets — say why."""
+    from agent_bom.secret_scanner import scan_secrets
+
+    not_a_dir = tmp_path / "config.json"
+    not_a_dir.write_text("{}", encoding="utf-8")
+
+    result = scan_secrets(str(not_a_dir))
+    assert result.warnings, "scan_secrets should record why it scanned nothing"
+
+    payload = result.to_dict()
+    assert payload["total"] == 0
+    assert payload["warnings"] == result.warnings, (
+        "to_dict() reports 'total: 0' with no indication the scan never ran — indistinguishable from a repo with no secrets"
+    )
+
+
+def test_secret_scan_to_dict_surfaces_a_file_capped_scan(monkeypatch, tmp_path: Path):
+    """A scan that blew the file cap covered part of the tree — say so."""
+    import agent_bom.secret_scanner as secret_scanner
+
+    monkeypatch.setattr(secret_scanner, "_MAX_FILES", 2)
+    for index in range(6):
+        (tmp_path / f"mod_{index}.py").write_text(f"VALUE = {index}\n", encoding="utf-8")
+
+    result = secret_scanner.scan_secrets(str(tmp_path))
+    assert result.warnings, "hitting _MAX_FILES should record a warning"
+
+    payload = result.to_dict()
+    assert payload["warnings"] == result.warnings
+    assert any("Stopped at" in w for w in payload["warnings"])
+
+
+def test_secret_scan_to_dict_stays_quiet_on_a_complete_scan(tmp_path: Path):
+    """A genuinely complete scan carries no warnings — no false alarm."""
+    from agent_bom.secret_scanner import scan_secrets
+
+    (tmp_path / "mod.py").write_text("VALUE = 1\n", encoding="utf-8")
+    payload = scan_secrets(str(tmp_path)).to_dict()
+    assert payload["warnings"] == []

--- a/ui/app/agents/page.tsx
+++ b/ui/app/agents/page.tsx
@@ -815,7 +815,12 @@ function AgentDetail({ agentName }: { agentName: string }) {
     high: summary.severity_breakdown.high ?? 0,
     medium: summary.severity_breakdown.medium ?? 0,
     low: summary.severity_breakdown.low ?? 0,
+    unrated: summary.severity_breakdown.unrated ?? 0,
   };
+  // The strip must reconcile with the Vulnerabilities tile beside it: anything
+  // the API could not band still has to be visible, and "Clean" may only show
+  // when there is genuinely nothing to report.
+  const sevTotal = sev.critical + sev.high + sev.medium + sev.low + sev.unrated;
 
   const toggleServer = (name: string) => {
     setExpandedServers((prev) => {
@@ -912,8 +917,16 @@ function AgentDetail({ agentName }: { agentName: string }) {
               {sev.high > 0 && <span className="text-orange-400 font-bold">{sev.high}H</span>}
               {sev.medium > 0 && <span className="text-yellow-400">{sev.medium}M</span>}
               {sev.low > 0 && <span className="text-blue-400">{sev.low}L</span>}
-              {sev.critical + sev.high + sev.medium + sev.low === 0 && (
+              {sev.unrated > 0 && (
+                <span className="text-[color:var(--text-secondary)]" title="Reported with no CVSS severity — not yet rated">
+                  {sev.unrated}U
+                </span>
+              )}
+              {sevTotal === 0 && summary.total_vulnerabilities === 0 && (
                 <span className="text-emerald-400 font-medium">Clean</span>
+              )}
+              {sevTotal === 0 && summary.total_vulnerabilities > 0 && (
+                <span className="text-[color:var(--text-secondary)]">Unrated</span>
               )}
             </div>
           </div>

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -3158,7 +3158,23 @@ export interface ProxyAlert {
 
 export interface ProxyAlertsResponse {
   alerts: ProxyAlert[];
+  /** Alerts on this page (bounded by `filters.limit`). */
   count: number;
+  /** Alerts matching the filters across the whole tenant, before paging. */
+  matched_total: number;
+  /**
+   * Whole-tenant alert summary, on the same basis as `/v1/proxy/metrics`.
+   * Deliberately NOT scoped to the page or the filters, so the histogram
+   * beside a filtered page never reads as the entire estate.
+   */
+  summary: {
+    total_alerts: number;
+    blocked_alerts: number;
+    alerts_by_severity: Record<string, number>;
+    alerts_by_detector: Record<string, number>;
+    latest_alert_at: string;
+    recent_alerts: { ts: string; detector: string; severity: string; message: string }[];
+  };
   filters: { severity: string | null; detector: string | null; limit: number };
 }
 


### PR DESCRIPTION
## Summary

Two classes audited: numbers that contradict the numbers beside them, and
signals the product computes but never tells anyone. Seven defects, each with a
test that was confirmed **red** before the fix.

Two of these are honest-counts violations in the direction that matters most —
one under-claims, one over-claims.

## Counts that contradict

### 1. A green "Clean" badge beside a non-zero vulnerability count

`api/routes/discovery.py:631` counted every blast radius into
`total_vulnerabilities`, but bucketed severity into a fixed four-band dict. Any
advisory without a CVSS vector — `unknown`, `none`, `""`, routine for GHSA — fell
out of the histogram entirely. `ui/app/agents/page.tsx:915` then rendered
**"Clean"** next to a tile that said there were vulnerabilities.

```
AssertionError: 6 vulnerabilities reported but the severity breakdown
accounts for only 1: {'critical': 1, 'high': 0, 'medium': 0, 'low': 0}
```

Fixed with `normalize_severity` plus an explicit `unrated` bucket. The UI renders
it, and "Clean" now requires `total_vulnerabilities` to actually be 0.

### 2. CIS PASS at zero controls evaluated — and two surfaces disagreeing

`output/html/sections.py:869` and `output/console_render.py:1718` derived the CIS
verdict independently. Both printed a green **PASS** for an all-`not_applicable`
bundle — an account holding none of the inspected resources — directly beside
"0% pass (0/0 checks)". Their first predicates also differed (`not evaluated` vs
`not failed`), so the same input could render two different verdicts.

```
AssertionError: the HTML report prints a green PASS beside '0% pass (0/0 checks)'
AssertionError: console rendered 'ERROR' where HTML rendered 'INCOMPLETE' for the same checks
```

One shared derivation now lives in `output/cis_posture.py`, with an explicit
`NOT EVALUATED` verdict. Also verified on the AWS fail-closed path, where
`skipped` now reads NOT EVALUATED rather than passing.

### 3. `/v1/proxy/alerts` summarized the page, not the estate

`api/routes/proxy.py:945` sliced `alerts[-limit:]` and *then* summarized, so
`total_alerts` collapsed to the page size and contradicted `/v1/proxy/metrics`.
With a severity filter applied first, the histogram read 100% of the requested
severity — a filtered view describing itself as the whole estate.

```
the summary beside a 100-row page claims the whole estate holds only 100 alerts,
while /v1/proxy/metrics reports 250 ... assert 100 == 250
```

Summary is now whole-tenant, with `matched_total` added for the pre-paging count.

### 4. Markdown severity rows that can never sum to their own total

`output/finding_views.py:255` built its key set from `Severity` minus `NONE` and
gated on `if severity in counts`, dropping `none` and `info`. `severity_counts`
is now total-preserving — `sum(...) == len(findings)` always — and markdown gains
Info/Unrated rows when non-empty. Additive for the three Prometheus exporters
that iterate it.

## Computed but never surfaced

### 5. A truncated graph was indistinguishable from a complete one

`graph/container.py:877` — `apply_node_budget` sets `truncated=True,
reason="node_budget"` (`:272`), but `to_dict()` never emitted it. A graph trimmed
from 50 nodes to 10 serialized byte-identically to the whole estate for every
file, CLI and session consumer, and `from_dict` laundered it clean on round-trip.
Both fixed, reusing the existing `graph_completeness` contract rather than adding
a second one.

### 6. A secret scan that stopped looking said so to nobody

`secret_scanner.py:262` dropped `warnings` from `to_dict()`. A refused path
(`:433`) or a `_MAX_FILES`-capped walk (`:444`) both reported `total: 0` with no
partial marker — a false negative wearing a clean bill of health. Now emits
`warnings` and `complete`.

### 7. `WITH GRANT OPTION` never left the process

`governance.py:234` dropped `grant_option`, `granted_by` and `base_objects`.
Re-grant rights are the privilege-escalation primitive: a grantee who can
re-delegate SELECT on a PII table serialized identically to one who cannot, and
`to_dict` was that field's only exit. `base_objects` means a benign-looking view
fanning out to PII base tables serialized as one innocuous name.

## Verification

| Gate | Result |
|---|---|
| `pytest tests/test_posture_count_honesty.py tests/test_posture_signal_surfacing.py` | 19 passed — **all 19 confirmed red first** |
| `pytest -k "cis or console or markdown or prometheus or secret or graph or discovery or proxy or severity"` | 3775 passed, 30 skipped |
| `pytest -k "governance or snowflake"` | 630 passed, 1 skipped |
| `make lint` (ruff + mypy) | clean, no issues in 820 source files |
| `make preflight` | passed (OpenAPI, v1 schemas, surface contract, check-counts) |
| `npm run lint` / `tsc --noEmit` / `vitest` | clean / clean / 979 passed |
| `npm run build` + `NEXT_EXPORT=1 npm run build` | both pass |
| Independently re-verified before opening | 19 passed; 4 confirmed failing against pre-fix code; preflight green |

## One process note

The console CIS test passed alone but failed in the full run: `print_cis_findings`
writes to the shared `agent_bom.output.console` global, so `capsys` capture
depends on which test last touched it. Fixed by injecting a recording console —
not by loosening the assertion.

## Suspected but NOT fixed (deliberately not guessed at)

- **`/v1/findings` facets** (`routes/scan.py:1951` vs `:1993`): the severity
  histogram is exact while `total` stops at the 50k row budget, so they can
  genuinely disagree at scale. Both are flagged `*_approximate`. Real, but no
  repro small enough to run in CI — worth a dedicated look.
- **Console `critical_vulns` vs the headline** (`console_render.py:114`/`:359`):
  CVE-only raw severity vs `effective_severity` including policy findings.
  Plausible, but no failing case could be built without changing what
  `test_console_reconciliation.py` already asserts.
- **Compliance hub ledger-basis vs current-state basis**
  (`routes/compliance.py:2837` vs `compliance_hub_store.py:537`): the divergence
  is intentional and documented; both surfaces just label the number identically.
  A labelling decision, not a correctness bug.
- **`Package.integrity_verified` / `provenance_attested`** (`models.py:407`)
  reach no machine-readable output — `--verify-integrity` is console-only. A real
  gap, but the fix spans JSON/CDX/SPDX/API and would have made this change set
  incoherent. Needs its own issue.