### PR TITLE
build(preflight): cover the product-metrics snapshot gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ preflight:  ## Run the drift gates that CI's "Version Alignment" job runs — do
 	@echo "→ product surface contract";             python scripts/check_product_surface_contract.py
 	@echo "→ graph proof fixtures";                 python scripts/check_graph_epic_proof.py
 	@echo "→ release/README consistency";           python scripts/check_release_consistency.py
+	@echo "→ product metrics snapshot";             python scripts/product_metrics_snapshot.py --check
 	@echo "→ env-var reference";                    python scripts/generate_env_var_reference.py --check
 	@echo "→ SDK patterns.json";                    python sdks/shared/generate-patterns.py --check
 	@echo "→ documentation SVGs";                    python scripts/generate_doc_architecture_svgs.py --check
@@ -53,6 +54,7 @@ preflight-fix:  ## Regenerate every drift artifact so you never push stale OpenA
 	python scripts/generate_v1_schemas.py
 	python scripts/generate_env_var_reference.py
 	python sdks/shared/generate-patterns.py
+	python scripts/product_metrics_snapshot.py --write
 	@echo "✓ regenerated — run 'git status', review, and commit the artifacts"
 
 docker-build:  ## Build Docker image

--- a/scripts/product_metrics_snapshot.py
+++ b/scripts/product_metrics_snapshot.py
@@ -10,7 +10,7 @@ import re
 import subprocess
 from datetime import date
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 
 ROOT = Path(__file__).resolve().parent.parent
 
@@ -271,15 +271,51 @@ def render_markdown(snapshot: dict[str, object]) -> str:
     return "\n".join(lines) + "\n"
 
 
-def main() -> int:
+def _metric_value(snapshot: dict[str, Any], name: str) -> object:
+    """Value of a named metric in *snapshot*, or None when it carries no such metric."""
+    for metric in snapshot.get("metrics", []):
+        if isinstance(metric, dict) and metric.get("name") == name:
+            return metric.get("value")
+    return None
+
+
+def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--write", action="store_true", help="Write docs/PRODUCT_METRICS.md and docs/PRODUCT_METRICS.json")
+    parser.add_argument("--check", action="store_true", help="Exit non-zero if the committed snapshot is stale")
     parser.add_argument("--markdown-out", default="docs/PRODUCT_METRICS.md", help="Markdown output path when writing")
     parser.add_argument("--json-out", default="docs/PRODUCT_METRICS.json", help="JSON output path when writing")
-    args = parser.parse_args()
+    args = parser.parse_args(argv)
 
     snapshot = build_snapshot()
     markdown = render_markdown(snapshot)
+
+    if args.check:
+        # Compare on the same basis the drift gate uses: version and metrics.
+        # ``generated_on`` deliberately does not participate — re-stamping on
+        # every run is churn with no signal.
+        json_path = ROOT / args.json_out
+        try:
+            committed = json.loads(json_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            print(f"cannot read {args.json_out}: {exc}")
+            return 1
+
+        drifted = [
+            f"  {metric['name']}: committed={_metric_value(committed, str(metric['name']))} actual={metric['value']}"
+            for metric in cast(list[dict[str, object]], snapshot["metrics"])
+            if _metric_value(committed, str(metric["name"])) != metric["value"]
+        ]
+        if drifted or committed.get("version") != snapshot["version"]:
+            print("PRODUCT_METRICS snapshot is stale:")
+            if committed.get("version") != snapshot["version"]:
+                print(f"  version: committed={committed.get('version')} actual={snapshot['version']}")
+            print("\n".join(drifted))
+            print("Regenerate with: python scripts/product_metrics_snapshot.py --write")
+            return 1
+
+        print(f"OK: {args.json_out} matches the repository.")
+        return 0
 
     if args.write:
         markdown_path = ROOT / args.markdown_out

--- a/tests/test_product_metrics_snapshot.py
+++ b/tests/test_product_metrics_snapshot.py
@@ -125,8 +125,7 @@ def test_write_preserves_the_stamp_when_no_metric_changed() -> None:
 
         rewritten = json.loads(METRICS_JSON.read_text(encoding="utf-8"))
         assert rewritten["generated_on"] == "2020-01-01", (
-            "--write re-stamped generated_on even though no metric changed; "
-            "that is churn every branch has to carry"
+            "--write re-stamped generated_on even though no metric changed; that is churn every branch has to carry"
         )
         assert rewritten["metrics"] == aged["metrics"], "metrics must be untouched when nothing moved"
     finally:
@@ -157,3 +156,27 @@ def test_write_restamps_when_a_metric_actually_moved() -> None:
     finally:
         METRICS_JSON.write_text(original_json, encoding="utf-8")
         METRICS_MARKDOWN.write_text(original_md, encoding="utf-8")
+
+
+def test_check_mode_reports_a_stale_snapshot(tmp_path: Path) -> None:
+    """`make preflight` claims CI's drift gate will be green; it must cover this one.
+
+    Adding a single test file moves the test-file count, so any branch that adds
+    a test leaves this snapshot stale. Without a --check mode the drift is only
+    discoverable from a full CI test run, several minutes after the push.
+    """
+    module = _load_metrics_script()
+    stale = json.loads(METRICS_JSON.read_text(encoding="utf-8"))
+    stale_metrics = cast(list[dict[str, object]], stale["metrics"])
+    stale_metrics[0]["value"] = cast(int, stale_metrics[0]["value"]) + 1
+
+    json_out = tmp_path / "PRODUCT_METRICS.json"
+    json_out.write_text(json.dumps(stale, indent=2) + "\n")
+
+    assert module.main(["--check", "--json-out", str(json_out)]) == 1
+
+
+def test_check_mode_accepts_the_committed_snapshot() -> None:
+    module = _load_metrics_script()
+
+    assert module.main(["--check"]) == 0


### PR DESCRIPTION
## Summary

`make preflight` ends by printing *"CI's Version Alignment gate will be green"*.
It never checked `docs/PRODUCT_METRICS.{json,md}`.

That snapshot counts tracked files, so **adding a single test file makes it
stale**. Three separate branches in this round each discovered that only from a
full CI test run, roughly nine minutes after pushing:

```
FAILED tests/test_product_metrics_snapshot.py::test_compliance_metric_uses_the_canonical_framework_count
FAILED tests/test_product_metrics_snapshot.py::test_write_preserves_the_stamp_when_no_metric_changed
  AssertionError: --write re-stamped generated_on even though no metric changed
```

The failure text points at `generated_on`, which is misleading — the real cause
is a drifted count, and you only see which one by diffing the regenerated file.

This is the same defect shape the rest of this round has been closing: a
description and its implementation disagreeing, with nothing asserting they
match.

## What changed

`scripts/product_metrics_snapshot.py` gains `--check`, mirroring the other drift
gates (`export_openapi.py --check`, `generate_v1_schemas.py --check`, …):

- compares on **the same basis the drift gate uses** — `version` and `metrics`.
  `generated_on` deliberately does not participate, since re-stamping on every
  run is churn with no signal
- names each drifted metric with both values, so the fix is obvious:

```
PRODUCT_METRICS snapshot is stale:
  Test files: committed=1116 actual=1109
Regenerate with: python scripts/product_metrics_snapshot.py --write
```

`make preflight` runs it; `make preflight-fix` regenerates it alongside the other
artifacts.

## Verification

- Both directions tested — a stale snapshot exits 1 naming the drifted metric,
  the committed snapshot exits 0. Both confirmed **red first**:
  `TypeError: main() takes 0 positional arguments but 1 was given`
- `pytest tests/test_product_metrics_snapshot.py` — 7 passed
- `ruff check`, `ruff format --check`, `mypy` on changed files — clean
- `make preflight` — passes, with the new gate reporting
  `OK: docs/PRODUCT_METRICS.json matches the repository.`

## Note

`main()` now takes an optional `argv` so the check is testable without
subprocessing. Behaviour when called with no arguments is unchanged.