### PR TITLE
fix(security): one answer per question — credentials, severity, guardrails, tools

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1116,
+      "value": 1117,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1113,
+      "value": 1116,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1116 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1117 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 820 | `src/agent_bom` | Counts all Python files recursively. |

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1113 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1116 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 820 | `src/agent_bom` | Counts all Python files recursively. |

--- a/src/agent_bom/ai_components/framework_agents.py
+++ b/src/agent_bom/ai_components/framework_agents.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Any
 
 from agent_bom.ast_signal_utils import is_agent_tool_decorator
+from agent_bom.constants import is_credential_key
 from agent_bom.finding import stable_id
 
 _SKIP_DIRS = {
@@ -443,11 +444,11 @@ def _extract_credential_refs(tree: ast.Module) -> list[str]:
             call_name = _call_name(node.func)
             if call_name in {"os.getenv", "getenv", "os.environ.get"} and node.args:
                 value = _string_literal(node.args[0])
-                if value and any(marker in value for marker in ("KEY", "TOKEN", "SECRET", "CREDENTIAL")):
+                if value and is_credential_key(value):
                     refs.append(value)
         elif isinstance(node, ast.Subscript) and _call_name(node.value) == "os.environ":
             value = _string_literal(node.slice)
-            if value and any(marker in value for marker in ("KEY", "TOKEN", "SECRET", "CREDENTIAL")):
+            if value and is_credential_key(value):
                 refs.append(value)
     return _dedupe_strings(refs)
 

--- a/src/agent_bom/ast_python_analysis.py
+++ b/src/agent_bom/ast_python_analysis.py
@@ -790,26 +790,24 @@ def _analyze_file(
     # Pass 1: Detect frameworks and guardrails from imports
     for node in ast.walk(tree):
         if isinstance(node, (ast.Import, ast.ImportFrom)):
-            module = ""
-            if isinstance(node, ast.Import):
-                for alias in node.names:
-                    module = alias.name
-            elif node.module:
-                module = node.module
+            # ``import a, b`` binds every alias; keeping only the last one made
+            # detection depend on where the guardrail sat in the list.
+            modules = [alias.name for alias in node.names] if isinstance(node, ast.Import) else [node.module or ""]
 
             # Check guardrail imports
-            for guard_module, (name, gtype) in _GUARDRAIL_IMPORTS.items():
-                if _import_matches_module(module, guard_module):
-                    guardrails.append(
-                        DetectedGuardrail(
-                            name=name,
-                            guardrail_type=gtype,
-                            file_path=rel_path,
-                            line_number=node.lineno,
-                            framework=name,
-                            description=f"Imported from {module}",
+            for module in modules:
+                for guard_module, (name, gtype) in _GUARDRAIL_IMPORTS.items():
+                    if _import_matches_module(module, guard_module):
+                        guardrails.append(
+                            DetectedGuardrail(
+                                name=name,
+                                guardrail_type=gtype,
+                                file_path=rel_path,
+                                line_number=node.lineno,
+                                framework=name,
+                                description=f"Imported from {module}",
+                            )
                         )
-                    )
 
     # Pass 2: Extract prompts from assignments and function calls
     for node in ast.walk(tree):

--- a/src/agent_bom/ast_python_analysis.py
+++ b/src/agent_bom/ast_python_analysis.py
@@ -127,6 +127,20 @@ _GUARDRAIL_IMPORTS = {
     "anthropic.types": ("Anthropic Safety", "content_filter"),
 }
 
+
+def _import_matches_module(module: str, target: str) -> bool:
+    """True when *module* is *target* or a submodule of it.
+
+    Whole dotted modules only. A substring test used to accept
+    ``nemoguardrails`` for the ``guardrails`` entry — NVIDIA's documented
+    ``from nemoguardrails import LLMRails`` then produced two guardrails, the
+    extra one credited to the wrong vendor — and accepted any project-local
+    module whose name merely contained a vendor's, such as
+    ``app.guardrails_config``.
+    """
+    return module == target or module.startswith(f"{target}.")
+
+
 _DYNAMIC_CODE_CALLS = {"eval", "exec", "compile", "__import__"}
 _SUBPROCESS_CALLS = {
     "os.system",
@@ -785,7 +799,7 @@ def _analyze_file(
 
             # Check guardrail imports
             for guard_module, (name, gtype) in _GUARDRAIL_IMPORTS.items():
-                if guard_module in module:
+                if _import_matches_module(module, guard_module):
                     guardrails.append(
                         DetectedGuardrail(
                             name=name,

--- a/src/agent_bom/cli/agents/_posture.py
+++ b/src/agent_bom/cli/agents/_posture.py
@@ -7,6 +7,8 @@ from typing import Any
 from rich.console import Console
 from rich.panel import Panel
 
+from agent_bom.constants import is_credential_key
+
 
 def render_posture_summary(agents: list[Any], blast_radii: list[Any]) -> None:
     """Render the compact --posture panel."""
@@ -21,11 +23,7 @@ def render_posture_summary(agents: list[Any], blast_radii: list[Any]) -> None:
         1
         for agent in agents
         for server in agent.mcp_servers
-        if any(
-            value
-            for key, value in (getattr(server, "env", None) or {}).items()
-            if any(keyword in key.upper() for keyword in ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL"))
-        )
+        if any(value for key, value in (getattr(server, "env", None) or {}).items() if is_credential_key(key))
     )
     floating = sum(
         1 for agent in agents for server in agent.mcp_servers if any("@latest" in str(arg) for arg in (getattr(server, "args", None) or []))

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -72,6 +72,36 @@ _SECURITY_SEVERITY_SCORE = {
     Severity.UNKNOWN: "0.0",
 }
 
+# ``info`` is the unified findings stream's spelling for "reported, not a
+# problem" — the same thing SARIF calls level ``none``.
+_SEVERITY_LABEL_ALIASES: dict[str, Severity] = {
+    "info": Severity.NONE,
+    "informational": Severity.NONE,
+}
+
+
+def _sarif_severity(label: object) -> tuple[str, str]:
+    """Return ``(level, security-severity)`` for a finding severity label.
+
+    Every result stream in a document resolves severity here. The unified
+    finding, IaC, AI and CIS streams each used to carry an inline copy of these
+    tables keyed by severity string; none of the copies had a ``none`` or
+    ``unknown`` key and they fell back to ``warning`` / ``4.0``, so a finding
+    rated ``none`` — or one the scanner could not rate — reached GitHub code
+    scanning as Medium while the CVE stream in the same document reported it as
+    ``note`` / ``0.0``. An unrecognised label resolves to ``unknown``: unrated
+    is never silently promoted to a rating.
+    """
+    name = str(label or "").strip().lower()
+    severity = _SEVERITY_LABEL_ALIASES.get(name)
+    if severity is None:
+        try:
+            severity = Severity(name)
+        except ValueError:
+            severity = Severity.UNKNOWN
+    return _SARIF_SEVERITY_MAP[severity], _SECURITY_SEVERITY_SCORE[severity]
+
+
 _FRAMEWORK_TAXONOMY_META: dict[str, tuple[str, str, str]] = {
     "owasp_tags": (
         "owasp-llm-top10",
@@ -385,6 +415,7 @@ _DEDICATED_CIS_BENCHMARKS: tuple[tuple[str, str], ...] = (
     ("snowflake", "snowflake_cis_benchmark_data"),
 )
 _DEDICATED_CIS_PROVIDERS = frozenset(provider for provider, _ in _DEDICATED_CIS_BENCHMARKS)
+
 
 def _finding_artifact_uri(report: AIBOMReport, finding: Finding) -> str:
     """Resolve a SARIF artifact URI from unified finding + report agent inventory."""
@@ -728,8 +759,6 @@ def to_sarif(
         )
 
     # Unified non-CVE findings, including MCP intelligence/blocklist matches.
-    finding_sev_map = {"critical": "error", "high": "error", "medium": "warning", "low": "note", "info": "none"}
-    finding_sev_score = {"critical": "9.0", "high": "7.0", "medium": "4.0", "low": "1.0", "info": "0.0"}
     for finding in apply_workload_runtime_evidence_for_export(list(report.to_findings())):
         if finding.finding_type == FindingType.CVE:
             continue
@@ -752,9 +781,8 @@ def to_sarif(
         # exactly one SARIF result.
         if finding.finding_type == FindingType.CIS_FAIL and evidence.get("iac"):
             continue
-        finding_severity_name = str(finding.severity or "medium").lower()
         rule_id = f"finding/{finding.finding_type.value}"
-        level = finding_sev_map.get(finding_severity_name, "warning")
+        level, security_severity = _sarif_severity(finding.severity or "medium")
         if rule_id not in seen_rule_ids:
             seen_rule_ids.add(rule_id)
             description = _sanitize_scanner_text(
@@ -768,7 +796,7 @@ def to_sarif(
                 "fullDescription": {"text": description},
                 "defaultConfiguration": {"level": level},
                 "properties": {
-                    "security-severity": finding_sev_score.get(finding_severity_name, "4.0"),
+                    "security-severity": security_severity,
                     "source": finding.source.value,
                     "finding_type": finding.finding_type.value,
                 },
@@ -842,12 +870,10 @@ def to_sarif(
     # IaC misconfiguration findings (Dockerfile, K8s, Terraform, CloudFormation)
     iac_data = getattr(report, "iac_findings_data", None)
     if iac_data:
-        iac_sev_map = {"critical": "error", "high": "error", "medium": "warning", "low": "note", "info": "none"}
-        iac_sev_score = {"critical": "9.0", "high": "7.0", "medium": "4.0", "low": "1.0", "info": "0.0"}
         for iac_finding in iac_data.get("findings", []):
             sev = iac_finding.get("severity", "medium").lower()
             rule_id = f"iac/{iac_finding.get('rule_id', 'unknown')}"
-            level = iac_sev_map.get(sev, "warning")
+            level, security_severity = _sarif_severity(sev)
             file_path = _to_relative_path(iac_finding.get("file_path", "unknown") or "unknown")
             line_num = iac_finding.get("line_number") or 1
 
@@ -864,7 +890,7 @@ def to_sarif(
                     "fullDescription": {"text": description},
                     "defaultConfiguration": {"level": level},
                     "properties": {
-                        "security-severity": iac_sev_score.get(sev, "4.0"),
+                        "security-severity": security_severity,
                         "category": iac_finding.get("category", "iac"),
                         "compliance": iac_finding.get("compliance", []),
                     },
@@ -905,8 +931,6 @@ def to_sarif(
     # AI inventory findings (shadow AI, deprecated models, API keys, invisible Unicode)
     ai_inv = getattr(report, "ai_inventory_data", None)
     if ai_inv:
-        ai_sev_map = {"critical": "error", "high": "error", "medium": "warning", "low": "note", "info": "none"}
-        ai_sev_score = {"critical": "9.0", "high": "7.0", "medium": "4.0", "low": "1.0", "info": "0.0"}
         for comp in ai_inv.get("components", []):
             sev = comp.get("severity", "info")
             if sev not in ("critical", "high", "medium"):
@@ -916,7 +940,7 @@ def to_sarif(
             raw_name = comp.get("name", "")
             name = "[REDACTED]" if comp_type == "api_key" else raw_name
             rule_id = f"ai-inventory/{comp_type}/{name}"
-            level = ai_sev_map.get(sev, "warning")
+            level, security_severity = _sarif_severity(sev)
 
             if rule_id not in seen_rule_ids:
                 seen_rule_ids.add(rule_id)
@@ -930,7 +954,7 @@ def to_sarif(
                     "shortDescription": {"text": sanitize_advisory_text("title", f"{sev.upper()}: {comp_type.replace('_', ' ')} - {name}")},
                     "fullDescription": {"text": description},
                     "defaultConfiguration": {"level": level},
-                    "properties": {"security-severity": ai_sev_score.get(sev, "0.0")},
+                    "properties": {"security-severity": security_severity},
                 }
                 help_body = advisory_help(
                     description,
@@ -966,8 +990,6 @@ def to_sarif(
     # check emits a SARIF result with the structured remediation dict
     # (issue #665) in ``properties.remediation`` so GitHub Code Scanning
     # and downstream SARIF consumers can surface fix guidance per finding.
-    cis_sev_map = {"critical": "error", "high": "error", "medium": "warning", "low": "note", "info": "none"}
-    cis_sev_score = {"critical": "9.0", "high": "7.0", "medium": "4.0", "low": "1.0", "info": "0.0"}
     from agent_bom.cloud.cis_remediation import fail_closed_cis_bundle
 
     for cloud_key, data_attr in _DEDICATED_CIS_BENCHMARKS:
@@ -981,7 +1003,7 @@ def to_sarif(
             cis_severity = str(check.get("severity") or "medium").lower()
             check_id = check.get("check_id") or "unknown"
             rule_id = f"cis/{cloud_key}/{check_id}"
-            level = cis_sev_map.get(cis_severity, "warning")
+            level, security_severity = _sarif_severity(cis_severity)
             remediation = check.get("remediation") or {}
             title = check.get("title") or rule_id
             help_uri = sanitize_url(str(remediation.get("docs") or "")) or ""
@@ -1005,7 +1027,7 @@ def to_sarif(
                     "fullDescription": {"text": recommendation},
                     "defaultConfiguration": {"level": level},
                     "properties": {
-                        "security-severity": cis_sev_score.get(cis_severity, "4.0"),
+                        "security-severity": security_severity,
                         "tags": ["cis", cloud_key, "compliance"],
                         "cis_section": check.get("cis_section") or "",
                     },

--- a/src/agent_bom/output/sarif.py
+++ b/src/agent_bom/output/sarif.py
@@ -73,11 +73,10 @@ _SECURITY_SEVERITY_SCORE = {
 }
 
 # ``info`` is the unified findings stream's spelling for "reported, not a
-# problem" — the same thing SARIF calls level ``none``.
-_SEVERITY_LABEL_ALIASES: dict[str, Severity] = {
-    "info": Severity.NONE,
-    "informational": Severity.NONE,
-}
+# problem" — the same thing SARIF calls level ``none``. Every other label is
+# read the way ``graph.severity.normalize_severity`` reads it, which is what
+# ``Finding.__post_init__`` has already applied to anything in that stream.
+_SARIF_INFO_LABELS = frozenset({"info", "informational"})
 
 
 def _sarif_severity(label: object) -> tuple[str, str]:
@@ -93,12 +92,12 @@ def _sarif_severity(label: object) -> tuple[str, str]:
     is never silently promoted to a rating.
     """
     name = str(label or "").strip().lower()
-    severity = _SEVERITY_LABEL_ALIASES.get(name)
-    if severity is None:
-        try:
-            severity = Severity(name)
-        except ValueError:
-            severity = Severity.UNKNOWN
+    if name in _SARIF_INFO_LABELS:
+        return _SARIF_SEVERITY_MAP[Severity.NONE], _SECURITY_SEVERITY_SCORE[Severity.NONE]
+    try:
+        severity = Severity(name)
+    except ValueError:
+        severity = Severity.UNKNOWN
     return _SARIF_SEVERITY_MAP[severity], _SECURITY_SEVERITY_SCORE[severity]
 
 

--- a/src/agent_bom/python_agents.py
+++ b/src/agent_bom/python_agents.py
@@ -83,9 +83,12 @@ _AGENT_NAME_RE = re.compile(
     r'Agent\s*\(\s*(?:name\s*=\s*)?["\']([^"\']+)["\']',
 )
 
-# Tool decorators: @tool, @function_tool, @agent.tool
+# Any decorator sitting directly on a def, in bare or applied form. Which of
+# them registers an agent tool is decided by ``is_agent_tool_decorator`` — the
+# same predicate the two AST detectors use — rather than by a fourth literal
+# list, which had drifted into claiming ``@action`` and missing ``@mcp.tool()``.
 _TOOL_DECORATOR_RE = re.compile(
-    r"@(?:\w+\.)?(?:function_tool|tool|skill|action)\s*\n\s*(?:async\s+)?def\s+(\w+)",
+    r"@((?:\w+\.)*\w+)\s*(?:\([^)]*\))?\s*\n\s*(?:async\s+)?def\s+(\w+)",
 )
 
 # tools=[foo, bar, baz] argument
@@ -290,7 +293,7 @@ def _extract_agent_defs_regex(content: str, filename: str) -> list[_PythonAgentD
     framework = _framework_from_content(content)
 
     # Extract @tool / @function_tool decorated functions
-    tool_names = _TOOL_DECORATOR_RE.findall(content)
+    tool_names = [func for decorator, func in _TOOL_DECORATOR_RE.findall(content) if is_agent_tool_decorator(decorator)]
 
     # Extract env var references
     env_refs = [v for v in _ENV_REF_RE.findall(content) if _CRED_ENV_RE.search(v)]

--- a/src/agent_bom/security.py
+++ b/src/agent_bom/security.py
@@ -290,11 +290,30 @@ def _is_obfuscated_credential(value: str) -> bool:
     return False
 
 
+def env_key_is_credential(key: str) -> bool:
+    """Whether an environment-variable *name* denotes a credential.
+
+    Environment variable names are classified product-wide by
+    ``constants.is_credential_key`` — it backs ``MCPServer.credential_names``
+    and therefore every surface that reports an exposed credential.  Redaction
+    has to cover at least those names, or a report can list a variable as an
+    exposed credential in one field while publishing its value in another.
+    ``SENSITIVE_PATTERNS`` adds forms that are not env-var-shaped (``api-key``,
+    ``jwt``); it stays regex-based and is not widened, because
+    :func:`_key_looks_sensitive` applies it to arbitrary payload keys where
+    over-matching collapses distinct graph nodes.
+    """
+    from agent_bom.constants import is_credential_key
+
+    low = key.lower()
+    return is_credential_key(key) or any(re.search(pattern, low) for pattern in SENSITIVE_PATTERNS)
+
+
 def sanitize_env_vars(env: dict[str, Any]) -> dict[str, str]:
     """
     Sanitize environment variables by redacting sensitive values.
 
-    Checks both key names (via SENSITIVE_PATTERNS) and values (via
+    Checks both key names (via :func:`env_key_is_credential`) and values (via
     _VALUE_CREDENTIAL_PATTERNS) to catch hardcoded credentials in
     custom-named variables.
 
@@ -306,10 +325,7 @@ def sanitize_env_vars(env: dict[str, Any]) -> dict[str, str]:
     """
     sanitized = {}
     for key, value in env.items():
-        # Check if key matches sensitive pattern
-        is_sensitive = any(re.search(pattern, key.lower()) for pattern in SENSITIVE_PATTERNS)
-
-        if is_sensitive:
+        if env_key_is_credential(key):
             sanitized[key] = "***REDACTED***"
         else:
             str_value = str(value)
@@ -498,9 +514,7 @@ def _key_looks_sensitive(key: object) -> bool:
 # labels and set-dedups them, collapsing distinct credentials into one phantom
 # node and inventing cross-agent ``reaches_tool``/``exposes_cred`` edges.  Only
 # the VALUE of a credential is sensitive, and values are never carried here.
-_CREDENTIAL_IDENTIFIER_KEYS = frozenset(
-    {"credential_env_vars", "credential_env_var", "credential_names", "credential_refs"}
-)
+_CREDENTIAL_IDENTIFIER_KEYS = frozenset({"credential_env_vars", "credential_env_var", "credential_names", "credential_refs"})
 
 
 def _key_is_credential_identifier(key: object) -> bool:

--- a/tests/test_agent_tool_regex_fallback_precision.py
+++ b/tests/test_agent_tool_regex_fallback_precision.py
@@ -1,0 +1,41 @@
+"""The regex fallback is a fourth agent-tool detector, and it had drifted.
+
+When a Python file fails to parse, ``python_agents._extract_agent_defs`` falls
+back to ``_extract_agent_defs_regex``. That path kept its own decorator list —
+``function_tool|tool|skill|action`` — so it still carried both defects the AST
+detectors were fixed for: Django REST's ``@action`` was reported as an agent
+tool at confidence "high", and the applied form ``@mcp.tool()`` (FastMCP's
+documented decorator) registered nothing, because the pattern requires a
+newline immediately after the decorator name.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.python_agents import _extract_agent_defs
+
+# A deliberate syntax error, so ``ast.parse`` fails and the regex path runs.
+# The Agent(...) call is what the regex path hangs its tool table off.
+UNPARSEABLE_TAIL = "\ndef broken(:\n    pass\n"
+AGENT_HARNESS = 'from crewai import Agent\n\nresearcher = Agent("researcher")\n'
+
+
+def _fallback_tools(decorated: str) -> set[str]:
+    source = AGENT_HARNESS + decorated + UNPARSEABLE_TAIL
+    defs = _extract_agent_defs(source, "mod.py")
+    assert defs, "regex fallback produced no agent definitions"
+    return {name for d in defs for name, kind, _confidence in d.tools if kind == "decorator"}
+
+
+@pytest.mark.parametrize(
+    "decorator",
+    ["@tool", "@tool('search')", "@mcp.tool()", "@function_tool", "@function_tool()", "@agent.tool", "@agent.tool_plain"],
+)
+def test_fallback_finds_agent_tool_decorators(decorator: str) -> None:
+    assert _fallback_tools(f"\n{decorator}\ndef handler(query):\n    return query\n") == {"handler"}
+
+
+@pytest.mark.parametrize("decorator", ["@action", "@action(detail=True)", "@app.route('/x')", "@celery_app.task"])
+def test_fallback_ignores_web_and_task_decorators(decorator: str) -> None:
+    assert _fallback_tools(f"\n{decorator}\ndef handler(self, request):\n    pass\n") == set()

--- a/tests/test_credential_key_detector_agreement.py
+++ b/tests/test_credential_key_detector_agreement.py
@@ -1,0 +1,115 @@
+"""One question — "is this env-var name a credential?" — had four answers.
+
+``constants.is_credential_key`` is the canonical predicate: it decides
+``MCPServer.credential_names``, which in turn drives blast-radius
+``exposed_credentials``, the graph's credential nodes and the compliance
+controls that key off them.  Three other modules re-implemented the same
+judgement with shorter literal lists, and they disagreed with it:
+
+* ``security.sanitize_env_vars`` left the *value* of a variable in cleartext
+  that the very same report lists as an exposed credential;
+* ``ai_components.framework_agents`` dropped ``PASSWORD``/``DATABASE_URL``
+  refs from framework-native agents;
+* the ``--posture`` panel's "N with credentials" count contradicted the
+  "N cred(s) reachable" line printed six rows below it.
+
+``enforcement.check_claude_config`` holds a fourth copy and is deliberately
+left alone: its question is "does this env var hold an inline *secret*", and
+the canonical name list is too broad to raise a high-severity finding from —
+it would report ``CERTIFICATE_PATH=/etc/ssl/ca.pem`` as a hardcoded secret.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from agent_bom.ai_components.framework_agents import _extract_credential_refs
+from agent_bom.cli.agents._posture import render_posture_summary
+from agent_bom.constants import is_credential_key
+from agent_bom.models import Agent, AgentType, BlastRadius, MCPServer, Package, Severity, Vulnerability
+from agent_bom.security import sanitize_env_vars
+
+# Env-var names taken from published MCP server and agent-framework setups.
+# Values are deliberately short and low-entropy so the value-based and
+# entropy-based redaction fallbacks cannot rescue a key-name miss.
+CREDENTIAL_ENV: dict[str, str] = {
+    "GITHUB_TOKEN": "abc",
+    "OPENAI_API_KEY": "abc",
+    "NEO4J_PASSWORD": "abc",
+    "DATABASE_URL": "abc",
+    "SSH_KEY": "abc",
+    "ENCRYPTION_KEY": "abc",
+    "AUTHORIZATION": "abc",
+    "CLIENT_SECRET": "abc",
+    "CA_CERT": "abc",
+}
+
+NON_CREDENTIAL_ENV: dict[str, str] = {
+    "PATH": "/usr/bin",
+    "HOME": "/root",
+    "LOG_LEVEL": "debug",
+    "PORT": "8080",
+    "NODE_ENV": "production",
+    "ALLOWED_DIRECTORIES": "/srv/data",
+}
+
+
+def test_fixture_names_match_the_canonical_predicate() -> None:
+    """Guard the fixtures themselves, so a drifting canonical list is visible here."""
+    assert [name for name in CREDENTIAL_ENV if not is_credential_key(name)] == []
+    assert [name for name in NON_CREDENTIAL_ENV if is_credential_key(name)] == []
+
+
+@pytest.mark.parametrize("name", sorted(CREDENTIAL_ENV))
+def test_credential_values_are_redacted(name: str) -> None:
+    """A name the product reports as a credential must have its value redacted."""
+    assert sanitize_env_vars({name: CREDENTIAL_ENV[name]})[name] == "***REDACTED***"
+
+
+@pytest.mark.parametrize("name", sorted(NON_CREDENTIAL_ENV))
+def test_non_credential_values_survive_redaction(name: str) -> None:
+    assert sanitize_env_vars({name: NON_CREDENTIAL_ENV[name]})[name] == NON_CREDENTIAL_ENV[name]
+
+
+def test_framework_agent_credential_refs_match_the_canonical_predicate() -> None:
+    """``_extract_credential_refs`` is the same judgement over Python source."""
+    reads = "\n".join(f'{name.lower()} = os.getenv("{name}")' for name in CREDENTIAL_ENV)
+    reads += "\n" + "\n".join(f'{name.lower()}_2 = os.environ["{name}"]' for name in NON_CREDENTIAL_ENV)
+    source = f"import os\nfrom crewai import Agent\n\n{reads}\n"
+
+    assert sorted(_extract_credential_refs(ast.parse(source))) == sorted(CREDENTIAL_ENV)
+
+
+def _agent_with_env(env: dict[str, str]) -> tuple[list[Agent], list[BlastRadius]]:
+    vuln = Vulnerability(id="GHSA-0000-0000-0001", summary="rce", severity=Severity.HIGH, cvss_score=8.1)
+    pkg = Package(name="requests", version="2.0.0", ecosystem="pypi", vulnerabilities=[vuln], is_direct=True)
+    server = MCPServer(name="warehouse", env=dict(env), packages=[pkg])
+    agent = Agent(
+        name="claude-desktop",
+        agent_type=AgentType.CLAUDE_DESKTOP,
+        config_path="/tmp/claude.json",
+        mcp_servers=[server],
+    )
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[server],
+        affected_agents=[agent],
+        exposed_credentials=server.credential_names,
+        exposed_tools=[],
+    )
+    br.calculate_risk_score()
+    return [agent], [br]
+
+
+def test_posture_credential_server_count_agrees_with_reachable_creds(capsys: pytest.CaptureFixture[str]) -> None:
+    """Both numbers are printed in one panel; they must come from one predicate."""
+    agents, blast_radii = _agent_with_env({"DATABASE_URL": "***REDACTED***"})
+
+    render_posture_summary(agents, blast_radii)
+
+    flat = " ".join(capsys.readouterr().out.split())
+    assert "1 MCP servers (1 with credentials)" in flat
+    assert "1 cred(s)" in flat

--- a/tests/test_guardrail_import_precision.py
+++ b/tests/test_guardrail_import_precision.py
@@ -58,6 +58,19 @@ def test_submodule_imports_still_resolve_to_their_vendor(tmp_path: Path, source:
 @pytest.mark.parametrize(
     "source",
     [
+        "import guardrails, os\n",
+        "import os, guardrails\n",
+        "import os, guardrails, sys\n",
+    ],
+)
+def test_a_guardrail_import_is_found_wherever_it_sits_in_the_alias_list(tmp_path: Path, source: str) -> None:
+    """``import a, b`` binds every alias; only the last one was inspected."""
+    assert _guardrails(tmp_path, source) == [("Guardrails AI", "content_filter")]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
         "from app.guardrails_config import RAILS\n",
         "from myproject.guardrails import policy\n",
         "import rebuff_stubs\n",

--- a/tests/test_guardrail_import_precision.py
+++ b/tests/test_guardrail_import_precision.py
@@ -1,0 +1,68 @@
+"""The guardrail-import table must match whole modules, not substrings.
+
+``_GUARDRAIL_IMPORTS`` was matched with ``guard_module in module``. ``guardrails``
+is a substring of ``nemoguardrails``, so NVIDIA's canonical
+``from nemoguardrails import LLMRails, RailsConfig`` matched two table entries:
+the AISPM inventory gained a phantom second guardrail, attributed to the wrong
+vendor ("Guardrails AI", described as "Imported from nemoguardrails").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent_bom.ast_analyzer import analyze_project
+
+
+def _guardrails(tmp_path: Path, source: str) -> list[tuple[str, str]]:
+    """Import-derived guardrails only.
+
+    The call-name regex detector is a separate judgement and tags its hits
+    ``framework="generic"``; this exercises the import table alone.
+    """
+    (tmp_path / "rails.py").write_text(source)
+    result = analyze_project(tmp_path)
+    return sorted((g.name, g.guardrail_type) for g in result.guardrails if g.framework != "generic")
+
+
+def test_nemoguardrails_import_is_only_nemo_guardrails(tmp_path: Path) -> None:
+    """NVIDIA NeMo Guardrails' documented import must resolve to one vendor."""
+    source = "from nemoguardrails import LLMRails, RailsConfig\n\nrails = LLMRails(RailsConfig.from_path('./config'))\n"
+
+    assert _guardrails(tmp_path, source) == [("NeMo Guardrails", "content_filter")]
+
+
+def test_guardrails_ai_import_is_still_detected(tmp_path: Path) -> None:
+    """Guardrails AI's documented import (``from guardrails import Guard``)."""
+    source = "from guardrails import Guard\n\nguard = Guard()\n"
+
+    assert _guardrails(tmp_path, source) == [("Guardrails AI", "content_filter")]
+
+
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        ("from guardrails.hub import ToxicLanguage\n", ("Guardrails AI", "content_filter")),
+        ("from langchain.callbacks.base import BaseCallbackHandler\n", ("LangChain Callbacks", "output_validator")),
+        ("from presidio_analyzer import AnalyzerEngine\n", ("Presidio", "pii_filter")),
+        ("import llm_guard\n", ("LLM Guard", "input_validator")),
+    ],
+)
+def test_submodule_imports_still_resolve_to_their_vendor(tmp_path: Path, source: str, expected: tuple[str, str]) -> None:
+    """Tightening to whole modules must keep dotted submodules matching."""
+    assert _guardrails(tmp_path, source) == [expected]
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "from app.guardrails_config import RAILS\n",
+        "from myproject.guardrails import policy\n",
+        "import rebuff_stubs\n",
+    ],
+)
+def test_project_local_modules_are_not_vendor_guardrails(tmp_path: Path, source: str) -> None:
+    """A project's own module whose name merely contains a vendor name is not that vendor."""
+    assert _guardrails(tmp_path, source) == []

--- a/tests/test_sarif_severity_agreement.py
+++ b/tests/test_sarif_severity_agreement.py
@@ -1,0 +1,99 @@
+"""One SARIF document must state one severity per finding severity.
+
+``to_sarif`` builds five result streams. The CVE stream uses the module-level
+``_SARIF_SEVERITY_MAP`` / ``_SECURITY_SEVERITY_SCORE`` tables; the unified
+finding, IaC, AI and CIS streams each carried their own inline copy keyed by
+severity *string*. Those copies had no ``none`` and no ``unknown`` key and fell
+back to ``warning`` / ``security-severity 4.0``, so a finding the scanner
+explicitly rated ``none`` — or one it could not rate at all — was published to
+GitHub code scanning as **Medium**, while the CVE stream in the same file
+published the identical severity as ``note`` / ``0.0``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from agent_bom.finding import Asset, Finding, FindingSource, FindingType
+from agent_bom.models import AIBOMReport, BlastRadius, Package, Severity, Vulnerability
+from agent_bom.output.sarif import to_sarif
+
+SEVERITIES = ["critical", "high", "medium", "low", "none", "unknown"]
+
+
+def _asset() -> Asset:
+    return Asset(name="warehouse", asset_type="file", location="infra/main.tf")
+
+
+def _rules_by_id(severity: str) -> dict[str, dict[str, Any]]:
+    """SARIF rules for a report carrying the same severity on every stream."""
+    report = AIBOMReport()
+    report.findings = [
+        Finding(
+            finding_type=FindingType.CIS_ERROR,
+            source=FindingSource.CLOUD_SECURITY,
+            asset=_asset(),
+            severity=severity,
+            title="Check could not be evaluated",
+            description="The provider API returned no data for this control.",
+            id=f"unified-{severity}",
+        )
+    ]
+    report.iac_findings_data = {
+        "findings": [
+            {
+                "rule_id": f"TF-{severity}",
+                "severity": severity,
+                "title": "Storage bucket is public",
+                "message": "Bucket grants public read.",
+                "file_path": "infra/main.tf",
+                "line_number": 12,
+            }
+        ]
+    }
+
+    # No CVSS score, so the CVE stream falls back to its severity table rather
+    # than echoing a numeric score.
+    vuln = Vulnerability(id=f"GHSA-0000-0000-{severity}", summary="s", severity=Severity(severity), cvss_score=None)
+    pkg = Package(name="left-pad", version="1.0.0", ecosystem="npm", vulnerabilities=[vuln], is_direct=True)
+    br = BlastRadius(
+        vulnerability=vuln,
+        package=pkg,
+        affected_servers=[],
+        affected_agents=[],
+        exposed_credentials=[],
+        exposed_tools=[],
+    )
+    br.calculate_risk_score()
+
+    doc = to_sarif(report, blast_radii=[br])
+    return {rule["id"]: rule for rule in doc["runs"][0]["tool"]["driver"]["rules"]}
+
+
+def _verdict(rule: dict[str, Any]) -> tuple[str, str]:
+    return rule["defaultConfiguration"]["level"], rule["properties"]["security-severity"]
+
+
+@pytest.mark.parametrize("severity", SEVERITIES)
+def test_every_result_stream_agrees_on_one_severity(severity: str) -> None:
+    rules = _rules_by_id(severity)
+    cve = rules[f"GHSA-0000-0000-{severity}"]
+    unified = rules["finding/CIS_ERROR"]
+    iac = rules[f"iac/TF-{severity}"]
+
+    verdicts = {"cve": _verdict(cve), "unified": _verdict(unified), "iac": _verdict(iac)}
+
+    assert len(set(verdicts.values())) == 1, verdicts
+
+
+@pytest.mark.parametrize("severity", ["none", "unknown"])
+def test_unrated_findings_are_never_published_as_medium(severity: str) -> None:
+    """GitHub reads security-severity 4.0–6.9 as Medium; unrated is not Medium."""
+    rules = _rules_by_id(severity)
+
+    for rule_id in ("finding/CIS_ERROR", f"iac/TF-{severity}"):
+        level, score = _verdict(rules[rule_id])
+        assert float(score) < 4.0, (rule_id, level, score)
+        assert level != "warning", (rule_id, level, score)

--- a/tests/test_sarif_severity_agreement.py
+++ b/tests/test_sarif_severity_agreement.py
@@ -18,7 +18,7 @@ import pytest
 
 from agent_bom.finding import Asset, Finding, FindingSource, FindingType
 from agent_bom.models import AIBOMReport, BlastRadius, Package, Severity, Vulnerability
-from agent_bom.output.sarif import to_sarif
+from agent_bom.output.sarif import _SARIF_SEVERITY_MAP, _SECURITY_SEVERITY_SCORE, to_sarif
 
 SEVERITIES = ["critical", "high", "medium", "low", "none", "unknown"]
 
@@ -86,6 +86,26 @@ def test_every_result_stream_agrees_on_one_severity(severity: str) -> None:
     verdicts = {"cve": _verdict(cve), "unified": _verdict(unified), "iac": _verdict(iac)}
 
     assert len(set(verdicts.values())) == 1, verdicts
+
+
+@pytest.mark.parametrize("label", ["info", "informational"])
+def test_informational_findings_render_as_sarif_level_none(label: str) -> None:
+    """``info`` is the unified stream's spelling for SARIF level ``none``."""
+    report = AIBOMReport()
+    report.findings = [
+        Finding(
+            finding_type=FindingType.CIS_ERROR,
+            source=FindingSource.CLOUD_SECURITY,
+            asset=_asset(),
+            severity=label,
+            title="t",
+            id=f"unified-{label}",
+        )
+    ]
+
+    rules = {rule["id"]: rule for rule in to_sarif(report)["runs"][0]["tool"]["driver"]["rules"]}
+
+    assert _verdict(rules["finding/CIS_ERROR"]) == (_SARIF_SEVERITY_MAP[Severity.NONE], _SECURITY_SEVERITY_SCORE[Severity.NONE])
 
 
 @pytest.mark.parametrize("severity", ["none", "unknown"])


### PR DESCRIPTION
## Summary

Hunting for the #4623 defect class — one semantic judgement implemented more
than once, where the copies disagree — across the rest of the codebase. Five
defects, each reproduced **red** before its fix.

The first one leaks secrets.

## 1. The redaction pass and the credential detector disagreed — in cleartext

`security.py:310` — `sanitize_env_vars` used only the redaction regexes, while
`constants.is_credential_key` is the canonical predicate backing
`MCPServer.credential_names`, blast-radius `exposed_credentials`, graph
credential nodes and the compliance controls keyed off them.

They disagree, so on `main` today:

```
SSH_KEY          is_credential=True   sanitized=ssh-rsa-SECRETVALUE
ENCRYPTION_KEY   is_credential=True   sanitized=enc-SECRETVALUE
PRIVATE_KEY      is_credential=True   sanitized=pk-SECRETVALUE
CA_CERT          is_credential=True   sanitized=cert-SECRETVALUE
DATABASE_URL     is_credential=True   sanitized=***REDACTED***
```

The same report names the variable as an exposed credential and prints its
value. Two further copies disagreed as well: `framework_agents.py:439` used
`("KEY","TOKEN","SECRET","CREDENTIAL")`, dropping `NEO4J_PASSWORD` and
`DATABASE_URL`; `cli/agents/_posture.py:27` had a fourth list, so "N servers with
credentials" contradicted "N cred(s) reachable" six rows below it in the same
panel.

All three now route through `is_credential_key`. `SENSITIVE_PATTERNS` is retained
for `_key_looks_sensitive`, where it applies to arbitrary payload keys and
widening would collapse graph nodes.

**A fourth copy was deliberately left alone.** `enforcement.py:544` was unified,
then measured: routing a *high-severity "Hardcoded secret"* finding through the
canonical list reports `CERTIFICATE_PATH=/etc/ssl/ca.pem` and
`DB_CONNECTION_POOL_SIZE=10` as hardcoded secrets. That is worse than the miss,
so it was reverted and the reason recorded in the test module docstring.

## 2. Unrated findings published to GitHub as Medium

`output/sarif.py` carried **five** severity tables. The CVE stream used
`_SARIF_SEVERITY_MAP`; the unified, IaC, AI and CIS streams each had an inline
copy with **no `none` and no `unknown` key**, defaulting to `warning`/`4.0`.

```
…[none]     - {'cve': ('none','0.0'), 'iac': ('warning','4.0'), 'unified': ('warning','4.0')}
…[unknown]  - {'cve': ('note','0.0'), 'iac': ('warning','4.0'), 'unified': ('warning','4.0')}
```

A finding rated `none` — or one the scanner could not rate, which
`cloud/*_cis_benchmark.py` emits as `severity="unknown"` — reached GitHub code
scanning as **Medium**. One `_sarif_severity` resolver now serves every stream;
an unrecognised label resolves to `unknown` and is never promoted.

Routing this through `scanners.risk.severity_from_label` for vendor aliases was
tried and **backed out**: `Finding.__post_init__` already normalises via
`graph.severity.normalize_severity`, so those aliases are unreachable, and a
second alias table would make the export disagree with the findings it describes.

## 3. `guardrails` is a substring of `nemoguardrails`

`ast_python_analysis.py:787` used `if guard_module in module`, so NVIDIA's
documented `from nemoguardrails import LLMRails, RailsConfig` matched two table
entries and produced two guardrails from one import:

```
{"name": "Guardrails AI",   "description": "Imported from nemoguardrails"}
{"name": "NeMo Guardrails", "description": "Imported from nemoguardrails"}
```

It also claimed project-local modules — `from myproject.guardrails import policy`,
`import rebuff_stubs`. Now matched as an exact module or dotted-submodule prefix,
so `guardrails.hub` and `langchain.callbacks.base` still resolve.

## 4. Multi-name imports dropped every alias but the last

Same pass: `import guardrails, os` found nothing, while `import os, guardrails`
found the guardrail. Now walks every alias.

## 5. A fourth copy of the agent-tool decorator judgement

`python_agents.py:87` — `_TOOL_DECORATOR_RE`, the regex fallback used when
`ast.parse` raises. It still matched `function_tool|tool|skill|action` and
required a newline after the name, so it carried **both** original defects:
`@action` registered at confidence "high", and FastMCP's documented `@mcp.tool()`
registered nothing.

It now defers to `is_agent_tool_decorator`. All four detectors answer from one
predicate: `ast_signal_utils.py:83`, called from `ast_python_analysis.py:865`,
`framework_agents.py:364`, and `python_agents.py:296,405`.

## Verification

| Gate | Result |
|---|---|
| `pytest tests/ -q -p no:randomly --timeout=900` | **18644 passed, 190 skipped**; the 1 failure + 2 errors all require a Docker daemon (`docker info` down) — image pull and a kind cluster |
| `pytest -k "python_agent or agent_tool or ast_ or discovery or scan"` | 2871 passed, 16 skipped |
| `pytest -k "sarif or interop or export or cli_check or core or compliance_hub or code_scan"` | 1382 passed, 7 skipped |
| `pytest -k "sanitiz or redact or security or enforcement or posture or credential or framework_agent or guardrail"` | 2189 passed, 20 skipped |
| `ruff check src/ tests/`, `ruff format --check`, `mypy` | clean |
| `make preflight` | passed |
| Independently re-verified before opening | redaction confirmed broken on `main` and fixed here; 780 passed across the security/sarif/guardrail suites |

## Suspected but NOT fixed — deliberately not guessed at

- **`constants.SENSITIVE_PATTERNS` is too broad for a credential *name***:
  `is_credential_key` returns True for `CERTIFICATE_PATH` and
  `DB_CONNECTION_POOL_SIZE`, so `credential_names` already over-claims those in
  blast radius, graph and compliance. Narrowing it moves graph node IDs,
  fingerprints and compliance mappings — its own scoped change. This is exactly
  why finding 1 stops short of `enforcement.py`.
- **`cli/agents/_preflight.py:192`** documents the flagged patterns and an
  exclusion list that the real predicate does not have. Copy-vs-code drift;
  needs the `PERMISSIONS.md` chain aligned in the same change.
- **`db/sync.py:199-217`** `_CVSS_SEVERITY` has range gaps at 3.9–4.0, 6.9–7.0,
  8.9–9.0. CVSS is specified to one decimal place, so no reachable input could be
  constructed — discarded rather than reported.
- **`scripts/code_scan_json_to_sarif.py`** is a sixth severity table, discarded:
  `_PUBLISH_SEVERITIES` filters everything but critical/high, which both tables
  land in the same GitHub band.
- **Transport detection** has ~9 copies with three SSE-from-URL heuristics, and
  **framework-name sets** are duplicated across ~12 modules with genuinely
  different memberships. Real drift, but no single wrong output could be
  demonstrated from either.