### PR TITLE
fix(automation): reconcile deployment and registry drift

### DIFF
--- a/.github/workflows/deployment-freshness.yml
+++ b/.github/workflows/deployment-freshness.yml
@@ -153,15 +153,21 @@ jobs:
           PUBLIC="${{ steps.public.outputs.public_version }}"
           PUBLIC_TOOLS="${{ steps.public.outputs.tool_count }}"
           PUBLIC_AUTH="${{ steps.public.outputs.auth_required }}"
-          TITLE="supply-chain-drift: deployment surfaces out of sync with $EXPECTED"
+          TITLE="supply-chain-drift: deployment surfaces out of sync"
+          LEGACY_TITLE_PREFIX="${TITLE} with "
 
           gh label create supply-chain-drift --color FBCA04 --description "Automated supply-chain or deployment drift detection" >/dev/null 2>&1 || true
           gh label create security-preventive --color 0E8A16 --description "Preventive daily security automation findings" >/dev/null 2>&1 || true
           gh label create automated --color 5319E7 --description "Opened or updated automatically by CI" >/dev/null 2>&1 || true
 
-          # Check if an issue already exists
-          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
+          # Match the stable title and migrate version-bound alerts created by
+          # older workflow revisions. Labels and the exact prefix keep the
+          # separate distribution-surface alert out of scope.
+          EXISTING=$(gh issue list --state open --label automated --label supply-chain-drift --limit 100 --json number,title |
+            jq -r --arg title "$TITLE" --arg legacy "$LEGACY_TITLE_PREFIX" '.[] | select(.title == $title or (.title | startswith($legacy))) | .number' |
+            head -n 1)
           if [ -n "$EXISTING" ]; then
+            gh issue edit "$EXISTING" --title "$TITLE"
             gh issue comment "$EXISTING" --body "$(cat <<EOF
           ## Supply-Chain Drift Check Failed
 
@@ -250,12 +256,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          EXPECTED="${{ steps.expected.outputs.version }}"
-          TITLE="supply-chain-drift: deployment surfaces out of sync with $EXPECTED"
-          # Match by title (not just label) so we never close the separate
-          # surface-freshness or unmonitored-surface tracking issues that share
-          # the supply-chain-drift label.
-          EXISTING=$(gh issue list --state open --search "$TITLE in:title" --json number --jq '.[0].number // empty')
-          if [ -n "$EXISTING" ]; then
-            gh issue close "$EXISTING" --comment "Deployment freshness check is clean again; closing the automated supply-chain drift alert."
-          fi
+          TITLE="supply-chain-drift: deployment surfaces out of sync"
+          LEGACY_TITLE_PREFIX="${TITLE} with "
+          # Close every stable or legacy deployment alert. The title predicate
+          # deliberately excludes the separate distribution-surface issue.
+          gh issue list --state open --label automated --label supply-chain-drift --limit 100 --json number,title |
+            jq -r --arg title "$TITLE" --arg legacy "$LEGACY_TITLE_PREFIX" '.[] | select(.title == $title or (.title | startswith($legacy))) | .number' |
+            while read -r issue; do
+              if [ -n "$issue" ]; then
+                gh issue close "$issue" --comment "Deployment freshness check is clean again; closing the automated supply-chain drift alert."
+              fi
+            done

--- a/scripts/check_glama_listing.py
+++ b/scripts/check_glama_listing.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import os
 import re
@@ -11,6 +12,7 @@ import subprocess
 import sys
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -19,6 +21,7 @@ PYPROJECT = ROOT / "pyproject.toml"
 README = ROOT / "README.md"
 DEFAULT_URL = "https://glama.ai/mcp/servers/msaad00/agent-bom"
 DEFAULT_API_URL = "https://glama.ai/api/mcp/v1/servers/msaad00/agent-bom"
+DEFAULT_SCHEMA_URL = f"{DEFAULT_URL}/schema"
 
 
 def _env_or(name: str, default: str) -> str:
@@ -124,7 +127,37 @@ def _fetch_json(url: str, timeout: int) -> dict[str, object]:
     return payload
 
 
+def _visible_text(page: str) -> str:
+    """Return user-visible page text, excluding metadata and serialized state."""
+
+    visible = re.sub(
+        r"<(head|script|style|template)\b[^>]*>.*?</\1\s*>",
+        " ",
+        page,
+        flags=re.IGNORECASE | re.DOTALL,
+    )
+    visible = re.sub(r"<[^>]+>", " ", visible)
+    return re.sub(r"\s+", " ", html.unescape(visible)).strip()
+
+
+def _extract_schema_tool_names(schema_page: str, listing_url: str) -> list[str]:
+    """Extract the unique tools Glama renders on the public Schema page."""
+
+    listing_path = urllib.parse.urlsplit(listing_url).path.rstrip("/")
+    tool_prefix = f"{listing_path}/tools/"
+    names: set[str] = set()
+    for href in re.findall(r"\bhref\s*=\s*['\"]([^'\"]+)['\"]", schema_page, flags=re.IGNORECASE):
+        path = urllib.parse.urlsplit(html.unescape(href)).path
+        if not path.startswith(tool_prefix):
+            continue
+        name = urllib.parse.unquote(path.removeprefix(tool_prefix)).strip("/")
+        if name and "/" not in name:
+            names.add(name)
+    return sorted(names)
+
+
 def _check(page: str, version: str, tool_count: int) -> list[str]:
+    page = _visible_text(page)
     expected_tokens = [
         f"v{version}",
         # Accept either phrasing while Glama's rendered README catches up.
@@ -153,6 +186,7 @@ def _check(page: str, version: str, tool_count: int) -> list[str]:
 def _extract_listing_version(page: str) -> str:
     """Best-effort version extraction from Glama's rendered listing."""
 
+    page = _visible_text(page)
     patterns = [
         r"uses:\s*msaad00/agent-bom@v([0-9]+\.[0-9]+\.[0-9]+)",
         r"\bv([0-9]+\.[0-9]+\.[0-9]+)\b",
@@ -167,6 +201,7 @@ def _extract_listing_version(page: str) -> str:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--url", default=_env_or("GLAMA_LISTING_URL", DEFAULT_URL))
+    parser.add_argument("--schema-url", default=_env_or("GLAMA_SCHEMA_URL", DEFAULT_SCHEMA_URL))
     parser.add_argument("--api-url", default=_env_or("GLAMA_API_URL", DEFAULT_API_URL))
     parser.add_argument("--expected", default=None, help="Expected version; defaults to pyproject.toml.")
     parser.add_argument(
@@ -209,9 +244,11 @@ def main(argv: list[str] | None = None) -> int:
     last_error = ""
     listing_version = "unknown"
     actual_tool_count: int | None = None
+    inventory_source: str | None = None
     last_probe_unreachable = False
     for attempt in range(1, max(1, args.retries) + 1):
         actual_tool_count = None
+        inventory_source = None
         last_probe_unreachable = False
         try:
             page = _fetch(args.url, args.timeout)
@@ -221,22 +258,39 @@ def main(argv: list[str] | None = None) -> int:
         else:
             listing_version = _extract_listing_version(page)
             failures = _check(page, version, tool_count)
+            schema_tools: list[str] = []
             try:
-                api_payload = _fetch_json(args.api_url, args.timeout)
-                tools = api_payload.get("tools")
-                if not isinstance(tools, list):
-                    raise ValueError("Glama public API tools field is not a list")
-                actual_tool_count = len(tools)
-                tool_names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
-                if len(tool_names) != actual_tool_count or any(not isinstance(name, str) or not name.strip() for name in tool_names):
-                    failures.append("Glama public API inventory contains a tool without a name")
-                elif len(set(tool_names)) != actual_tool_count:
-                    failures.append("Glama public API inventory contains duplicate tool names")
+                schema_tools = _extract_schema_tool_names(_fetch(args.schema_url, args.timeout), args.url)
+            except (urllib.error.URLError, TimeoutError):
+                # The directory API remains a valid fallback when the rendered
+                # Schema page cannot be fetched or has not populated yet.
+                pass
+
+            if schema_tools:
+                inventory_source = "schema"
+                actual_tool_count = len(schema_tools)
                 if actual_tool_count != tool_count:
-                    failures.append(f"Glama public API exposes {actual_tool_count} tools; expected {tool_count}")
-            except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
-                failures.append(f"failed to verify Glama public API tool inventory: {exc}")
-                last_probe_unreachable = True
+                    failures.append(f"Glama public Schema exposes {actual_tool_count} tools; expected {tool_count}")
+            else:
+                inventory_source = "api"
+                try:
+                    api_payload = _fetch_json(args.api_url, args.timeout)
+                    tools = api_payload.get("tools")
+                    if not isinstance(tools, list):
+                        raise ValueError("Glama public API tools field is not a list")
+                    actual_tool_count = len(tools)
+                    tool_names = [tool.get("name") for tool in tools if isinstance(tool, dict)]
+                    if len(tool_names) != actual_tool_count or any(
+                        not isinstance(name, str) or not name.strip() for name in tool_names
+                    ):
+                        failures.append("Glama public API inventory contains a tool without a name")
+                    elif len(set(tool_names)) != actual_tool_count:
+                        failures.append("Glama public API inventory contains duplicate tool names")
+                    if actual_tool_count != tool_count:
+                        failures.append(f"Glama public API exposes {actual_tool_count} tools; expected {tool_count}")
+                except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, ValueError) as exc:
+                    failures.append(f"failed to verify Glama public API tool inventory: {exc}")
+                    last_probe_unreachable = True
             if not failures:
                 if args.json:
                     print(
@@ -248,6 +302,7 @@ def main(argv: list[str] | None = None) -> int:
                                 "listing_version": listing_version,
                                 "tool_count": actual_tool_count,
                                 "expected_tool_count": tool_count,
+                                "inventory_source": inventory_source,
                             },
                             separators=(",", ":"),
                         )
@@ -271,6 +326,7 @@ def main(argv: list[str] | None = None) -> int:
                     "listing_version": listing_version,
                     "tool_count": actual_tool_count,
                     "expected_tool_count": tool_count,
+                    "inventory_source": inventory_source,
                     "error": last_error,
                 },
                 separators=(",", ":"),

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -486,6 +486,16 @@ def test_deployment_freshness_workflow_uses_bearer_token_and_parses_tool_count()
     assert "--resolve-only" in workflow
 
 
+def test_deployment_freshness_uses_a_version_stable_issue_identity():
+    """A clean release must close deployment alerts opened by an older version."""
+    workflow = (ROOT / ".github" / "workflows" / "deployment-freshness.yml").read_text()
+
+    assert 'TITLE="supply-chain-drift: deployment surfaces out of sync"' in workflow
+    assert 'LEGACY_TITLE_PREFIX="${TITLE} with "' in workflow
+    assert workflow.count("startswith($legacy)") == 2
+    assert 'TITLE="supply-chain-drift: deployment surfaces out of sync with $EXPECTED"' not in workflow
+
+
 def test_surface_freshness_targets_the_latest_published_release():
     """Unreleased source versions must not create distribution drift alerts."""
     workflow = (ROOT / ".github" / "workflows" / "surface-freshness.yml").read_text()

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -83,6 +83,53 @@ def test_glama_listing_accepts_exact_public_api_tool_inventory(monkeypatch, caps
     assert payload["expected_tool_count"] == 77
 
 
+def test_glama_listing_accepts_exact_public_schema_when_directory_api_is_empty(monkeypatch, capsys):
+    """The rendered Schema inventory is evidence even when the directory API lags."""
+    script = _load_script("check_glama_listing.py")
+    current_page = "v0.98.3 MCP server mode exposes 77 MCP tools"
+    schema_page = "".join(
+        f'<a href="/mcp/servers/msaad00/agent-bom/tools/tool_{index}">tool_{index}</a>'
+        for index in range(77)
+    )
+
+    def fetch(url, _timeout):
+        return schema_page if url.endswith("/schema") else current_page
+
+    monkeypatch.setattr(script, "_fetch", fetch)
+    monkeypatch.setattr(script, "_fetch_json", lambda _url, _timeout: {"tools": []})
+
+    assert script.main(["--expected", "0.98.3", "--expected-tool-count", "77", "--json", "--retries", "1"]) == 0
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "fresh"
+    assert payload["tool_count"] == 77
+    assert payload["inventory_source"] == "schema"
+
+
+def test_glama_listing_checks_visible_copy_not_hidden_stale_metadata(monkeypatch, capsys):
+    """Serialized metadata must not masquerade as user-visible stale copy."""
+    script = _load_script("check_glama_listing.py")
+    current_page = """
+    <html>
+      <head><meta name="description" content="18 tools for CVE scanning"></head>
+      <body>
+        <main>v0.98.3 MCP server mode exposes 77 MCP tools</main>
+        <script>window.__data = "18 tools for CVE scanning"</script>
+      </body>
+    </html>
+    """
+
+    monkeypatch.setattr(script, "_fetch", lambda _url, _timeout: current_page)
+    monkeypatch.setattr(
+        script,
+        "_fetch_json",
+        lambda _url, _timeout: {"tools": [{"name": f"tool_{index}"} for index in range(77)]},
+    )
+
+    assert script.main(["--expected", "0.98.3", "--expected-tool-count", "77", "--json", "--retries", "1"]) == 0
+    payload = json.loads(capsys.readouterr().out.strip().splitlines()[-1])
+    assert payload["status"] == "fresh"
+
+
 def test_glama_api_failure_is_unreachable_and_resets_previous_retry_count(monkeypatch, capsys):
     """A later API outage must not retain an earlier attempt's observed count."""
     script = _load_script("check_glama_listing.py")


### PR DESCRIPTION
## Summary

- use a version-stable deployment-drift issue identity and migrate legacy versioned alerts so a clean run can close #4590
- validate Glama's visible listing copy and accept its public Schema inventory as authoritative, with the directory API retained as a fallback
- add regression coverage for both automation failures

## Verification

- `UV_CACHE_DIR=/tmp/agent-bom-drift-uv-cache uv run pytest -q tests/test_surface_freshness.py tests/test_deployment.py` (79 passed)
- `UV_CACHE_DIR=/tmp/agent-bom-drift-uv-cache uv run ruff check scripts/check_glama_listing.py tests/test_surface_freshness.py tests/test_deployment.py`
- `git diff --check`
- live surface probe for 0.98.3 and 77 expected tools: PyPI fresh, Docker fresh, Glama fresh with 77 tools from the public Schema

## Notes

Smithery still advertises 36/77 tools. Its current replacement candidate is bearer-protected and does not expose a marketplace-compatible OAuth contract, so this PR does not repoint the public catalog to an endpoint users cannot authenticate to.

Fixes #4590.
Related to #4513.