### PR TITLE
feat(demo): correlate cross-vendor enterprise evidence

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -1,5 +1,5 @@
 {
-  "generated_on": "2026-08-03",
+  "generated_on": "2026-08-04",
   "version": "0.98.3",
   "metrics": [
     {
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1118,
+      "value": 1119,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 821,
+      "value": 822,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -5,7 +5,7 @@
 This appendix is the canonical home for volatile product counts.
 Keep counts out of public positioning copy and update this file from the repo instead of hand-editing numbers.
 
-- Generated on: `2026-08-03`
+- Generated on: `2026-08-04`
 - Version: `0.98.3`
 
 | Metric | Value | Source | Notes |
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1118 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1119 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 821 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 822 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/demo_estate/enterprise_correlation.py
+++ b/src/agent_bom/demo_estate/enterprise_correlation.py
@@ -1,0 +1,380 @@
+"""Normalize and correlate the versioned enterprise demo evidence.
+
+The adapter deliberately uses the same relationship and graph-projection
+builders as live proxy/runtime events. Provider payloads remain in the raw
+fixture; normalized output carries only stable references and provenance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent_bom.demo_estate.enterprise import (
+    CollectionStatus,
+    EnterpriseEstate,
+    EstateAsset,
+    EstateStage,
+    EvidenceSource,
+    RawObservation,
+    verify_observation_hash,
+)
+from agent_bom.event_normalization import (
+    build_agentic_identity_graph_projection,
+    build_event_ref,
+    build_event_relationships,
+)
+
+NORMALIZATION_VERSION = "enterprise_event.v1"
+CORRELATION_VERSION = "enterprise_correlation.v1"
+
+
+class NormalizedEnterpriseEvent(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    normalization_version: str = NORMALIZATION_VERSION
+    event_id: str
+    tenant_id: str
+    stage: EstateStage
+    source: EvidenceSource
+    event_type: str
+    observed_at: datetime
+    trace_id: str
+    actor_id: str
+    resource_ids: tuple[str, ...]
+    evidence_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+    source_run_id: str
+    event_relationships: dict[str, Any]
+    graph_projection: dict[str, Any]
+
+
+class EnterpriseCorrelation(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    correlation_version: str = CORRELATION_VERSION
+    correlation_id: str
+    tenant_id: str
+    trace_id: str
+    kind: str
+    outcome: str
+    started_at: datetime
+    ended_at: datetime
+    event_ids: tuple[str, ...]
+    sources: tuple[EvidenceSource, ...]
+    asset_ids: tuple[str, ...]
+    asset_path: tuple[str, ...]
+    data_classifications: tuple[str, ...]
+    evidence_hashes: tuple[str, ...]
+    evidence_quality: str
+    incomplete_sources: tuple[EvidenceSource, ...] = ()
+
+
+class EnterpriseCollectionHealth(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    source: EvidenceSource
+    status: CollectionStatus
+    records_read: int
+    watermark: str
+    source_schema: str
+    schema_url: str
+    failure_code: str = ""
+
+
+class EnterpriseCorrelationResult(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: str = CORRELATION_VERSION
+    estate_id: str
+    tenant_id: str
+    estate_content_hash: str
+    events: tuple[NormalizedEnterpriseEvent, ...]
+    correlations: tuple[EnterpriseCorrelation, ...]
+    collection_health: tuple[EnterpriseCollectionHealth, ...]
+    content_hash: str = Field(pattern=r"^[0-9a-f]{64}$")
+
+    @property
+    def complete_source_count(self) -> int:
+        return sum(1 for row in self.collection_health if row.status is CollectionStatus.COMPLETE)
+
+    @property
+    def partial_source_count(self) -> int:
+        return sum(1 for row in self.collection_health if row.status is CollectionStatus.PARTIAL)
+
+    def correlation_by_trace(self, trace_id: str) -> EnterpriseCorrelation | None:
+        return next((row for row in self.correlations if row.trace_id == trace_id), None)
+
+
+def _canonical_json(value: Any) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def _actor_type(actor_id: str) -> str:
+    lowered = actor_id.casefold()
+    if lowered.startswith("agent:"):
+        return "agent"
+    if "service-principal" in lowered:
+        return "service_principal"
+    if "serviceaccount" in lowered or "service_account" in lowered:
+        return "service_account"
+    if lowered.startswith("arn:aws:sts"):
+        return "federated_identity"
+    if lowered.startswith("snowflake_role:"):
+        return "service_account"
+    return "user"
+
+
+def _asset_ref_type(asset: EstateAsset) -> str:
+    if asset.provider == "mcp" and asset.resource_type == "tool":
+        return "tool"
+    if asset.provider == "mcp" and asset.resource_type == "server":
+        return "server"
+    if asset.resource_type == "service_principal":
+        return "service_principal"
+    if asset.resource_type == "service_account":
+        return "service_account"
+    if asset.resource_type in {"database", "table"}:
+        return "dataset"
+    if asset.provider in {"aws", "azure", "gcp", "kubernetes"}:
+        return "cloud_resource"
+    return "resource"
+
+
+def _asset_ref(asset: EstateAsset, *, role: str) -> dict[str, Any]:
+    ref = build_event_ref(
+        ref_type=_asset_ref_type(asset),
+        ref_id=asset.asset_id,
+        name=asset.display_name,
+        role=role,
+        source_field="resource_ids",
+        attributes={
+            "provider": asset.provider,
+            "resource_type": asset.resource_type,
+            "environment": asset.environment,
+            "account_scope": asset.account_scope,
+        },
+    )
+    if ref is None:  # validated assets always carry a non-empty stable id
+        raise ValueError(f"could not normalize asset reference: {asset.asset_id}")
+    return ref
+
+
+def _normalize_event(
+    observation: RawObservation,
+    *,
+    tenant_id: str,
+    assets_by_id: dict[str, EstateAsset],
+) -> NormalizedEnterpriseEvent:
+    if not verify_observation_hash(observation):
+        raise ValueError(f"evidence hash mismatch for event {observation.event_id}")
+
+    actor = build_event_ref(
+        ref_type=_actor_type(observation.actor_id),
+        ref_id=observation.actor_id,
+        name=observation.actor_id,
+        role="actor",
+        source_field="actor_id",
+    )
+    if actor is None:
+        raise ValueError(f"could not normalize actor for event {observation.event_id}")
+
+    targets: list[dict[str, Any]] = []
+    resources: list[dict[str, Any]] = []
+    for resource_id in observation.resource_ids:
+        asset = assets_by_id[resource_id]
+        ref_type = _asset_ref_type(asset)
+        if ref_type == "tool":
+            targets.append(_asset_ref(asset, role="invoked_tool"))
+        else:
+            resources.append(_asset_ref(asset, role="observed_resource"))
+
+    relationships = build_event_relationships(
+        source=observation.source.value,
+        actor=actor,
+        targets=targets,
+        resources=resources,
+    )
+    if relationships is None:
+        raise ValueError(f"event {observation.event_id} produced no relationships")
+    projection = build_agentic_identity_graph_projection(
+        relationships,
+        event_id=observation.event_id,
+        tenant_id=tenant_id,
+    )
+    if projection is None:
+        raise ValueError(f"event {observation.event_id} produced no graph projection")
+
+    return NormalizedEnterpriseEvent(
+        event_id=observation.event_id,
+        tenant_id=tenant_id,
+        stage=observation.stage,
+        source=observation.source,
+        event_type=observation.event_type,
+        observed_at=observation.observed_at,
+        trace_id=observation.trace_id,
+        actor_id=observation.actor_id,
+        resource_ids=observation.resource_ids,
+        evidence_hash=observation.provenance.evidence_hash,
+        source_run_id=observation.provenance.run_id,
+        event_relationships=relationships,
+        graph_projection=projection,
+    )
+
+
+def _unique_in_order(values: Iterable[str]) -> tuple[str, ...]:
+    return tuple(dict.fromkeys(value for value in values if value))
+
+
+def _correlation_kind(events: tuple[NormalizedEnterpriseEvent, ...]) -> tuple[str, str]:
+    if any(event.stage is EstateStage.REMEDIATED for event in events):
+        return "remediation", "enforced"
+    if any(event.source is EvidenceSource.OTEL_LLM for event in events):
+        return "data_egress_attempt", "blocked"
+    if any("roleAssignments/write" in event.event_type for event in events):
+        return "privilege_change", "observed"
+    if any("CreateServiceAccountKey" in event.event_type for event in events):
+        return "credential_issuance", "observed"
+    return "activity_sequence", "observed"
+
+
+_PATH_TYPES = ("workflow", "iam_role", "deployment", "tool", "table", "hosted_model")
+
+
+def _asset_path(
+    events: tuple[NormalizedEnterpriseEvent, ...], assets_by_id: dict[str, EstateAsset]
+) -> tuple[str, ...]:
+    ordered_ids = _unique_in_order(
+        resource_id for event in events for resource_id in event.resource_ids
+    )
+    selected: list[str] = []
+    for resource_type in _PATH_TYPES:
+        match = next(
+            (
+                resource_id
+                for resource_id in ordered_ids
+                if assets_by_id[resource_id].resource_type == resource_type
+            ),
+            None,
+        )
+        if match is not None:
+            selected.append(match)
+    return tuple(selected or ordered_ids)
+
+
+def _data_classifications(
+    asset_ids: tuple[str, ...], assets_by_id: dict[str, EstateAsset]
+) -> tuple[str, ...]:
+    classifications = {
+        classification
+        for asset_id in asset_ids
+        for classification in assets_by_id[asset_id].data_classifications
+    }
+    regulated = classifications & {"phi", "pii", "pci", "restricted"}
+    return tuple(sorted(regulated or classifications))
+
+
+def _build_correlations(
+    events: tuple[NormalizedEnterpriseEvent, ...],
+    *,
+    tenant_id: str,
+    assets_by_id: dict[str, EstateAsset],
+    status_by_source: dict[EvidenceSource, CollectionStatus],
+) -> tuple[EnterpriseCorrelation, ...]:
+    by_trace: dict[str, list[NormalizedEnterpriseEvent]] = {}
+    for event in events:
+        if event.trace_id:
+            by_trace.setdefault(event.trace_id, []).append(event)
+
+    correlations: list[EnterpriseCorrelation] = []
+    for trace_id, trace_events in sorted(by_trace.items()):
+        ordered = tuple(sorted(trace_events, key=lambda row: (row.observed_at, row.event_id)))
+        kind, outcome = _correlation_kind(ordered)
+        sources = tuple(event.source for event in ordered)
+        asset_ids = _unique_in_order(
+            resource_id for event in ordered for resource_id in event.resource_ids
+        )
+        incomplete_sources = tuple(
+            dict.fromkeys(
+                source
+                for source in sources
+                if status_by_source.get(source) is not CollectionStatus.COMPLETE
+            )
+        )
+        correlation_seed = f"{tenant_id}:{trace_id}:{CORRELATION_VERSION}".encode()
+        correlations.append(
+            EnterpriseCorrelation(
+                correlation_id=f"correlation:{hashlib.sha256(correlation_seed).hexdigest()[:24]}",
+                tenant_id=tenant_id,
+                trace_id=trace_id,
+                kind=kind,
+                outcome=outcome,
+                started_at=ordered[0].observed_at,
+                ended_at=ordered[-1].observed_at,
+                event_ids=tuple(event.event_id for event in ordered),
+                sources=sources,
+                asset_ids=asset_ids,
+                asset_path=_asset_path(ordered, assets_by_id),
+                data_classifications=_data_classifications(asset_ids, assets_by_id),
+                evidence_hashes=tuple(event.evidence_hash for event in ordered),
+                evidence_quality="partial" if incomplete_sources else "complete",
+                incomplete_sources=incomplete_sources,
+            )
+        )
+    return tuple(correlations)
+
+
+def correlate_enterprise_estate(estate: EnterpriseEstate) -> EnterpriseCorrelationResult:
+    """Normalize one estate and build deterministic, tenant-scoped correlations."""
+    assets_by_id = {asset.asset_id: asset for asset in estate.assets}
+    events = tuple(
+        _normalize_event(observation, tenant_id=estate.tenant_id, assets_by_id=assets_by_id)
+        for observation in estate.observations
+    )
+    health = tuple(
+        EnterpriseCollectionHealth(
+            source=run.source,
+            status=run.status,
+            records_read=run.records_read,
+            watermark=run.watermark,
+            source_schema=run.source_schema,
+            schema_url=run.schema_url,
+            failure_code=run.failure_code,
+        )
+        for run in estate.collection_runs
+    )
+    status_by_source = {row.source: row.status for row in health}
+    correlations = _build_correlations(
+        events,
+        tenant_id=estate.tenant_id,
+        assets_by_id=assets_by_id,
+        status_by_source=status_by_source,
+    )
+    result = EnterpriseCorrelationResult(
+        estate_id=estate.estate_id,
+        tenant_id=estate.tenant_id,
+        estate_content_hash=estate.content_hash,
+        events=events,
+        correlations=correlations,
+        collection_health=health,
+        content_hash="0" * 64,
+    )
+    digest = hashlib.sha256(
+        _canonical_json(result.model_dump(mode="json", exclude={"content_hash"}))
+    ).hexdigest()
+    return result.model_copy(update={"content_hash": digest})
+
+
+__all__ = [
+    "CORRELATION_VERSION",
+    "NORMALIZATION_VERSION",
+    "EnterpriseCollectionHealth",
+    "EnterpriseCorrelation",
+    "EnterpriseCorrelationResult",
+    "NormalizedEnterpriseEvent",
+    "correlate_enterprise_estate",
+]

--- a/tests/test_enterprise_demo_correlation.py
+++ b/tests/test_enterprise_demo_correlation.py
@@ -1,0 +1,118 @@
+"""Production-path normalization and correlation for the enterprise demo estate."""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.demo_estate.enterprise import load_enterprise_estate
+from agent_bom.demo_estate.enterprise_correlation import correlate_enterprise_estate
+
+INCIDENT_TRACE_ID = "7f3a9b12c4d5e6f7890abcde12345678"
+REMEDIATION_TRACE_ID = "5e2a1c9d8b7f60431234567890abcdef"
+AZURE_TRACE_ID = "91ab42cd63ef4087b2157d0300000001"
+
+
+def test_every_observation_normalizes_without_copying_raw_payloads() -> None:
+    estate = load_enterprise_estate()
+    result = correlate_enterprise_estate(estate)
+
+    assert len(result.events) == len(estate.observations) == 15
+    for event in result.events:
+        original = next(row for row in estate.observations if row.event_id == event.event_id)
+        assert event.evidence_hash == original.provenance.evidence_hash
+        assert event.tenant_id == estate.tenant_id
+        assert not hasattr(event, "raw_payload")
+        assert event.event_relationships["normalization_version"] == "1"
+        assert event.graph_projection["schema_version"] == "agentic_identity_graph.v1"
+        assert event.graph_projection["source"] == original.source
+        for edge in event.graph_projection["edges"]:
+            assert edge["evidence"]["event_id"] == event.event_id
+            assert edge["evidence"]["tenant_id"] == estate.tenant_id
+
+
+def test_primary_incident_correlates_ci_cloud_workload_mcp_data_and_llm() -> None:
+    result = correlate_enterprise_estate(load_enterprise_estate())
+    incident = result.correlation_by_trace(INCIDENT_TRACE_ID)
+
+    assert incident is not None
+    assert incident.kind == "data_egress_attempt"
+    assert incident.outcome == "blocked"
+    assert incident.event_ids == (
+        "github-current-001",
+        "aws-current-001",
+        "k8s-current-001",
+        "mcp-current-001",
+        "snowflake-current-001",
+        "otel-current-001",
+    )
+    assert incident.sources == (
+        "github_actions",
+        "aws_cloudtrail",
+        "kubernetes_audit",
+        "mcp_gateway",
+        "snowflake_access_history",
+        "otel_llm",
+    )
+    assert incident.asset_path == (
+        "github:workflow:member-copilot/deploy-prod",
+        "cloud_resource:aws:iam:role:member-copilot-prod",
+        "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
+        "mcp:tool:clinical-analytics/execute_sql",
+        "snowflake:table:nh_prod/analytics/phi/patient_summary",
+        "model:openai:gpt-4.1",
+    )
+    assert incident.data_classifications == ("phi", "pii")
+    assert len(incident.evidence_hashes) == len(incident.event_ids)
+    assert incident.evidence_quality == "complete"
+
+
+def test_secondary_vendor_and_remediation_correlations_are_distinct() -> None:
+    result = correlate_enterprise_estate(load_enterprise_estate())
+    azure = result.correlation_by_trace(AZURE_TRACE_ID)
+    remediation = result.correlation_by_trace(REMEDIATION_TRACE_ID)
+
+    assert azure is not None
+    assert azure.kind == "privilege_change"
+    assert azure.outcome == "observed"
+    assert azure.sources == ("entra_signin", "azure_activity")
+    assert "identity:azure:service-principal:claims-enrichment" in azure.asset_ids
+
+    assert remediation is not None
+    assert remediation.kind == "remediation"
+    assert remediation.outcome == "enforced"
+    assert remediation.sources == ("aws_cloudtrail", "azure_activity", "mcp_gateway")
+
+
+def test_partial_collection_health_survives_normalization() -> None:
+    result = correlate_enterprise_estate(load_enterprise_estate())
+    health = {row.source: row for row in result.collection_health}
+
+    assert health["gcp_audit"].status == "partial"
+    assert health["gcp_audit"].failure_code == "rate_limited_after_page_2"
+    assert health["gcp_audit"].records_read == 2
+    assert health["aws_cloudtrail"].status == "complete"
+    assert result.complete_source_count == 8
+    assert result.partial_source_count == 1
+
+
+def test_replay_is_deterministic_and_tenant_scoped() -> None:
+    first = correlate_enterprise_estate(load_enterprise_estate(tenant_id="tenant-a"))
+    replay = correlate_enterprise_estate(load_enterprise_estate(tenant_id="tenant-a"))
+    other = correlate_enterprise_estate(load_enterprise_estate(tenant_id="tenant-b"))
+
+    assert first.model_dump(mode="json") == replay.model_dump(mode="json")
+    assert first.content_hash == replay.content_hash
+    assert {row.correlation_id for row in first.correlations}.isdisjoint(
+        {row.correlation_id for row in other.correlations}
+    )
+    assert first.content_hash != other.content_hash
+
+
+def test_tampered_raw_evidence_fails_closed() -> None:
+    estate = load_enterprise_estate()
+    original = estate.observations[0]
+    tampered = original.model_copy(update={"raw_payload": {"eventName": "tampered"}})
+    broken = estate.model_copy(update={"observations": (tampered, *estate.observations[1:])})
+
+    with pytest.raises(ValueError, match="evidence hash mismatch.*aws-baseline-001"):
+        correlate_enterprise_estate(broken)


### PR DESCRIPTION
## Summary

- normalize the versioned enterprise observations through the existing event-relationship and agentic-identity graph builders
- correlate the GitHub, AWS, Kubernetes, MCP, Snowflake, and OpenAI incident path alongside Azure privilege activity, GCP collection health, and cross-provider remediation
- preserve tenant and provenance boundaries, exclude raw provider payloads from normalized output, and fail closed when evidence hashes do not verify

## Verification

- `uv run pytest -q tests/test_enterprise_demo_contract.py tests/test_demo_estate_bootstrap.py tests/test_enterprise_demo_correlation.py tests/test_product_metrics_snapshot.py` (49 passed)
- `uv run ruff check src/agent_bom/demo_estate/enterprise_correlation.py tests/test_enterprise_demo_correlation.py`
- `uv run mypy src/agent_bom/demo_estate/enterprise_correlation.py`
- `uv run python scripts/product_metrics_snapshot.py --check`
- `make preflight`
- `git diff --cached --check`

## Notes

- Foundation PR #4638 is merged. This branch is rebased onto current `main`, so the review diff contains only the correlation layer and its generated metric updates.
- GCP collection remains explicitly partial with its rate-limit failure code; correlation does not convert incomplete evidence into a complete posture claim.
