### PR TITLE
test: stop the openai stub leaking into later test files

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1122,
+      "value": 1123,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,7 +14,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1122 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1123 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 45 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 40 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
 | Python modules | 822 | `src/agent_bom` | Counts all Python files recursively. |

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -428,6 +428,7 @@ def pytest_runtest_call(item: pytest.Item) -> None:
     del item
     _sync_api_auth_after_local_fixtures()
 
+
 _STORAGE_ENV_VARS = (
     "AGENT_BOM_POSTGRES_URL",
     "AGENT_BOM_POSTGRES_DSN",
@@ -645,6 +646,7 @@ _STUB_SDK_ROOTS = (
     "databricks",
     "google",
     "googleapiclient",
+    "openai",
     "snowflake",
 )
 

--- a/tests/test_stub_sdk_isolation.py
+++ b/tests/test_stub_sdk_isolation.py
@@ -1,0 +1,52 @@
+"""A faked provider SDK must not outlive the test that installed it.
+
+`tests/cloud/test_cloud.py:1616` installs a hand-rolled `openai` double with
+`sys.modules.setdefault(...)` and never removes it. `openai` was missing from the
+conftest snapshot/restore list, so the stub survived into later files: any test
+that then imports something resolving `openai._models` — `litellm` does — fails
+with ModuleNotFoundError against the double. It is order-dependent, so a
+randomized run hides it until it doesn't.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+CONFTEST = Path(__file__).resolve().parent / "conftest.py"
+
+
+def _conftest() -> Any:
+    spec = importlib.util.spec_from_file_location("_abom_conftest_probe", CONFTEST)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+# Every provider SDK a test fakes by writing straight into sys.modules.
+FAKED_SDK_ROOTS = ["boto3", "botocore", "databricks", "google", "googleapiclient", "snowflake", "openai"]
+
+
+@pytest.mark.parametrize("root", FAKED_SDK_ROOTS)
+def test_a_faked_sdk_stub_does_not_survive_the_test_that_installed_it(root: str) -> None:
+    conftest = _conftest()
+    snapshot = conftest._snapshot_stub_sdk_modules()
+
+    installed = root not in sys.modules
+    if installed:
+        sys.modules[root] = types.ModuleType(root)
+    try:
+        conftest._restore_stub_sdk_modules(snapshot)
+        assert sys.modules.get(root) is not None or True
+        assert root not in sys.modules or not conftest._is_stub_module(sys.modules[root]), (
+            f"a {root} stub installed by one test is still in sys.modules for the next one"
+        )
+    finally:
+        if installed:
+            sys.modules.pop(root, None)


### PR DESCRIPTION
## Summary

`tests/cloud/test_cloud.py:1616` installs a hand-rolled `openai` double with
`sys.modules.setdefault(...)` and never removes it.

`tests/conftest.py` has a snapshot/restore fixture built for exactly this defect
class — its own comment describes stubs that *"outlive the test that wrote them"*
— but `_STUB_SDK_ROOTS` listed `boto3, botocore, databricks, google,
googleapiclient, snowflake` and **not `openai`**. So the double survived into
later files.

Anything then importing a module that resolves `openai._models` fails against the
stub. `litellm` does:

```
$ pytest tests/cloud/test_cloud.py tests/test_extra_gated_sdk_imports.py -q -p no:randomly
2 failed, 157 passed, 50 skipped
ModuleNotFoundError: No module named 'openai._models'
```

It reproduces identically at commits predating this branch, so it is latent, not
new. It is order-dependent, which is why randomized runs hide it until they
don't — the same run is green or red depending on which file went first.

## What changed

One line: `openai` added to `_STUB_SDK_ROOTS`.

The test is the more useful part. It parametrizes over **every** faked SDK root,
so adding another stub without registering it here fails immediately and
specifically, rather than surfacing later as an unrelated `ModuleNotFoundError`
in whichever file happened to run next.

## Verification

Confirmed **red first**, and only on `openai`:

```
FAILED test_a_faked_sdk_stub_does_not_survive_the_test_that_installed_it[openai]
  AssertionError: a openai stub installed by one test is still in sys.modules for the next one
1 failed, 6 passed
```

The other six roots passed, which is what makes the missing entry the cause
rather than a coincidence.

- `pytest tests/test_stub_sdk_isolation.py` — 7 passed
- `pytest tests/cloud/` — 724 passed, 3 skipped (no regression from restoring the
  namespace)
- `pytest tests/cloud/test_cloud.py tests/test_extra_gated_sdk_imports.py -p no:randomly`
  — passes in the order that previously failed
- `ruff check`, `ruff format --check`, `make preflight` — clean

## Note on how it was found

It surfaced as two failures in an unrelated branch's full-suite run and looked
like that branch's regression. Chasing it there would have meant editing shared
test state to fix an environment artifact — a real change for a non-real defect.
The installed `openai`/`litellm` versions match `uv.lock` exactly, and
`openai._models` imports fine in a clean process; the leak is the whole story.