### PR TITLE
feat(demo): grow the enterprise estate to a size that shows correlation

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1124,
+      "value": 1125,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 825,
+      "value": 826,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1124 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1125 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 825 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 826 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/demo_estate/enterprise_scale.py
+++ b/src/agent_bom/demo_estate/enterprise_scale.py
@@ -23,7 +23,6 @@ import hashlib
 import json
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
-from typing import Any
 
 from agent_bom.demo_estate.enterprise import (
     ENTERPRISE_SCHEMA_VERSION,
@@ -128,13 +127,30 @@ _PARTIAL_FAILURE_CODE = "rate_limited"
 _EPOCH = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
 
 
+# The floor below which the estate stops reading as an enterprise. Pinned by
+# tests so the default cannot be quietly shrunk back to a diagram: a reviewer
+# trimming these for speed has to change the assertion and say why.
+MIN_ENTERPRISE_ASSETS = 2000
+MIN_ENTERPRISE_EVENTS = 6000
+MIN_ACCOUNTS_PER_CLOUD = 5
+MIN_RESOURCES_PER_ACCOUNT = 20
+
+
 @dataclass(frozen=True)
 class ScaleProfile:
-    """How big the estate should be, and therefore how much story it can carry."""
+    """How big the estate should be, and therefore how much story it can carry.
 
-    accounts_per_cloud: int = 3
-    resources_per_account: int = 12
-    events_per_asset: int = 2
+    The defaults are the shipped demo size. They are deliberately in the low
+    thousands rather than the millions: the read-path wall sits far above this,
+    but the demo runs on modest hosted resources, and an estate that takes
+    seconds to paint a graph tells a worse story than one that responds
+    instantly. Scale proof belongs in a benchmark, not in the thing a prospect
+    clicks.
+    """
+
+    accounts_per_cloud: int = 8
+    resources_per_account: int = 64
+    events_per_asset: int = 3
 
     def __post_init__(self) -> None:
         if self.accounts_per_cloud < 2:
@@ -220,13 +236,25 @@ def _build_assets(profile: ScaleProfile, tenant_id: str) -> tuple[EstateAsset, .
     return tuple(assets)
 
 
-def _sealed(observation: RawObservation) -> RawObservation:
+_PLACEHOLDER_HASH = "0" * 64
+_READ_ONLY_EVENTS = frozenset({"GetObject", "QUERY", "storage.objects.get"})
+
+
+def _seal(observation: RawObservation) -> RawObservation:
     """Stamp the evidence hash using the estate's own hasher.
 
-    Deliberately not a second implementation: ``verify_observation_hash`` is the
-    consumer, so computing the digest any other way would produce evidence that
-    fails its own verification — the exact class of defect where one judgement
-    gets two implementations.
+    Deliberately not a second implementation. ``verify_observation_hash`` is the
+    consumer, so computing the digest any other way produces evidence that fails
+    its own verification — the exact class of defect where one judgement gets two
+    implementations. The first draft of this module did precisely that, and every
+    observation failed to verify.
+
+    That constraint is also why this goes through ``model_dump(mode="json")``
+    rather than hashing the source dict directly, even though the round-trip is
+    the dominant cost of the build. Pydantic serializes ``observed_at`` as
+    ``...Z`` where ``datetime.isoformat`` gives ``...+00:00``; matching it by hand
+    would mean re-implementing pydantic's serialization and re-opening the same
+    defect. The cost is the price of one hasher, and it is worth paying.
     """
     digest = _canonical_observation_hash(observation.model_dump(mode="json", exclude={"provenance"}))
     return observation.model_copy(update={"provenance": observation.provenance.model_copy(update={"evidence_hash": digest})})
@@ -234,45 +262,48 @@ def _sealed(observation: RawObservation) -> RawObservation:
 
 def _build_observations(assets: tuple[EstateAsset, ...], profile: ScaleProfile, tenant_id: str) -> tuple[RawObservation, ...]:
     observations: list[RawObservation] = []
+    occurrences = range(profile.events_per_asset)
     for asset in assets:
         source = _SOURCE_FOR_PROVIDER.get(asset.provider)
         if source is None:
             continue
+        # Hoisted: these are constant for every event on this asset, and at
+        # scale the per-event recomputation dominated the loop body.
+        source_value = source.value
+        run_id = f"demo-run-scaled-{source_value}"
         event_types = _EVENT_TYPES[asset.provider]
-        for occurrence in range(profile.events_per_asset):
-            seed = _stable_index(asset.asset_id, str(occurrence))
-            event_type = event_types[seed % len(event_types)]
+        type_count = len(event_types)
+        asset_id = asset.asset_id
+        for occurrence in occurrences:
+            seed = _stable_index(asset_id, str(occurrence))
+            event_type = event_types[seed % type_count]
             observed_at = _EPOCH + timedelta(minutes=seed % 40320)
-            event_id = f"evt-{hashlib.sha256(f'{asset.asset_id}:{occurrence}'.encode()).hexdigest()[:20]}"
-            actor = f"{asset.provider}-principal-{seed % 37:02d}@{_TENANT_DOMAIN}"
-            row: dict[str, Any] = {
-                "event_id": event_id,
-                "stage": EstateStage.CURRENT.value,
-                "source": source.value,
-                "event_type": event_type,
-                "observed_at": observed_at.isoformat(),
-                "actor_id": actor,
-                "resource_ids": [asset.asset_id],
-                "trace_id": hashlib.sha256(event_id.encode()).hexdigest()[:32],
-                "raw_payload": {
-                    "eventName": event_type,
-                    "accountScope": asset.account_scope,
-                    "region": asset.region,
-                    "environment": asset.environment,
-                    "readOnly": event_type in {"GetObject", "QUERY", "storage.objects.get"},
-                },
-            }
+            event_id = f"evt-{hashlib.sha256(f'{asset_id}:{occurrence}'.encode()).hexdigest()[:20]}"
             observations.append(
-                _sealed(
+                _seal(
                     RawObservation(
-                        **row,
+                        event_id=event_id,
+                        stage=EstateStage.CURRENT,
+                        source=source,
+                        event_type=event_type,
+                        observed_at=observed_at,
+                        actor_id=f"{asset.provider}-principal-{seed % 37:02d}@{_TENANT_DOMAIN}",
+                        resource_ids=(asset_id,),
+                        trace_id=hashlib.sha256(event_id.encode()).hexdigest()[:32],
+                        raw_payload={
+                            "eventName": event_type,
+                            "accountScope": asset.account_scope,
+                            "region": asset.region,
+                            "environment": asset.environment,
+                            "readOnly": event_type in _READ_ONLY_EVENTS,
+                        },
                         provenance=EvidenceProvenance(
                             source=source,
                             source_event_id=event_id,
                             observed_at=observed_at,
-                            run_id=f"demo-run-scaled-{source.value}",
+                            run_id=run_id,
                             tenant_id=tenant_id,
-                            evidence_hash="0" * 64,
+                            evidence_hash=_PLACEHOLDER_HASH,
                             schema_version=ENTERPRISE_SCHEMA_VERSION,
                         ),
                     )

--- a/src/agent_bom/demo_estate/enterprise_scale.py
+++ b/src/agent_bom/demo_estate/enterprise_scale.py
@@ -1,0 +1,380 @@
+"""Grow the fictional enterprise estate to a size that shows correlation.
+
+:mod:`agent_bom.demo_estate.enterprise` defines the contract and a hand-authored
+narrative spine: one of each thing, one account per cloud. That proves the schema
+but understates the product, because the claim being demonstrated — findings,
+identities, configuration and logs resolving to one another across vendors — only
+becomes visible once there are siblings to disambiguate between.
+
+This module generates a larger estate against that same contract. It does not
+fork the schema: every object here is an ``enterprise`` model, so the estate's
+own validators (unique ids, tenant boundary, events referencing known assets)
+run against generated data exactly as they do against the fixture.
+
+Generation is deterministic. The estate is seeded from its own structure rather
+than a random source, so the same :class:`ScaleProfile` always yields the same
+``content_hash`` — a demo that shifts between runs cannot be screenshotted,
+tested, or trusted.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from agent_bom.demo_estate.enterprise import (
+    ENTERPRISE_SCHEMA_VERSION,
+    CollectionRun,
+    CollectionStatus,
+    EnterpriseEstate,
+    EstateAsset,
+    EstateSnapshot,
+    EstateStage,
+    EvidenceProvenance,
+    EvidenceSource,
+    RawObservation,
+)
+from agent_bom.demo_estate.enterprise import (
+    _observation_hash as _canonical_observation_hash,
+)
+
+# Clouds that must show real depth: several accounts, every environment. The
+# graph audit found `environment` silently null for AWS and GCP and Snowflake
+# account drill-down returning one node of six; an estate that repeats either
+# shape would demo the defect rather than the product.
+CLOUD_PROVIDERS: tuple[str, ...] = ("aws", "azure", "gcp", "snowflake")
+
+ENVIRONMENTS: tuple[str, ...] = ("production", "staging", "development")
+
+_TENANT_DOMAIN = "northstar.example"
+
+# Resource mix per cloud, chosen so each account carries compute, storage, an
+# identity and a data surface — the minimum for an attack path to be expressible.
+_RESOURCE_MIX: dict[str, tuple[tuple[str, str], ...]] = {
+    "aws": (
+        ("instance", "ec2"),
+        ("bucket", "s3"),
+        ("iam_role", "iam"),
+        ("database", "rds"),
+        ("function", "lambda"),
+        ("cluster", "eks"),
+    ),
+    "azure": (
+        ("virtual_machine", "compute"),
+        ("storage_account", "storage"),
+        ("service_principal", "entra"),
+        ("sql_database", "sql"),
+        ("function_app", "functions"),
+        ("cluster", "aks"),
+    ),
+    "gcp": (
+        ("instance", "compute"),
+        ("bucket", "storage"),
+        ("service_account", "iam"),
+        ("database", "cloudsql"),
+        ("function", "cloudfunctions"),
+        ("cluster", "gke"),
+    ),
+    "snowflake": (
+        ("warehouse", "compute"),
+        ("table", "data"),
+        ("role", "rbac"),
+        ("database", "data"),
+        ("stage", "data"),
+        ("share", "data"),
+    ),
+}
+
+_REGIONS: dict[str, tuple[str, ...]] = {
+    "aws": ("us-east-1", "us-west-2", "eu-west-1"),
+    "azure": ("eastus", "westeurope", "centralus"),
+    "gcp": ("us-central1", "europe-west1", "us-east4"),
+    "snowflake": ("us-east-1", "eu-central-1", "us-west-2"),
+}
+
+# Which log source speaks for which cloud. Keeping this explicit means a source
+# never reports a complete collection while producing no evidence.
+_SOURCE_FOR_PROVIDER: dict[str, EvidenceSource] = {
+    "aws": EvidenceSource.AWS_CLOUDTRAIL,
+    "azure": EvidenceSource.AZURE_ACTIVITY,
+    "gcp": EvidenceSource.GCP_AUDIT,
+    "snowflake": EvidenceSource.SNOWFLAKE_ACCESS_HISTORY,
+}
+
+_EVENT_TYPES: dict[str, tuple[str, ...]] = {
+    "aws": ("AssumeRole", "GetObject", "PutBucketPolicy", "CreateAccessKey"),
+    "azure": ("Microsoft.Authorization/roleAssignments/write", "Microsoft.Storage/storageAccounts/listKeys"),
+    "gcp": ("storage.objects.get", "iam.serviceAccounts.getAccessToken"),
+    "snowflake": ("QUERY", "GRANT_ROLE", "COPY_INTO"),
+}
+
+_DATA_CLASSES: dict[str, tuple[str, ...]] = {
+    "bucket": ("confidential",),
+    "storage_account": ("confidential",),
+    "database": ("restricted", "phi"),
+    "sql_database": ("restricted", "phi"),
+    "table": ("restricted", "phi"),
+}
+
+# GCP audit collection is deliberately left partial, matching the hand-authored
+# estate. An estate where every source succeeds cannot demonstrate that partial
+# evidence is reported as partial rather than promoted to a complete posture.
+_PARTIAL_SOURCE = EvidenceSource.GCP_AUDIT
+_PARTIAL_FAILURE_CODE = "rate_limited"
+
+_EPOCH = datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+
+
+@dataclass(frozen=True)
+class ScaleProfile:
+    """How big the estate should be, and therefore how much story it can carry."""
+
+    accounts_per_cloud: int = 3
+    resources_per_account: int = 12
+    events_per_asset: int = 2
+
+    def __post_init__(self) -> None:
+        if self.accounts_per_cloud < 2:
+            raise ValueError("a cloud needs at least two accounts for drill-down to mean anything")
+        if self.resources_per_account < len(ENVIRONMENTS):
+            raise ValueError("each account needs at least one resource per environment")
+        if self.events_per_asset < 1:
+            raise ValueError("an asset with no evidence cannot participate in correlation")
+
+
+def _stable_index(*parts: str) -> int:
+    """A deterministic pseudo-index derived from the identity of the thing itself.
+
+    Used instead of a random source so that generation depends only on structure:
+    the same profile yields the same estate on every machine and every run.
+    """
+    digest = hashlib.sha256("|".join(parts).encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big")
+
+
+def _account_scope(provider: str, index: int) -> str:
+    if provider == "aws":
+        return f"{100000000000 + index:012d}"
+    if provider == "azure":
+        return f"sub-{index:04d}-northstar"
+    if provider == "gcp":
+        return f"northstar-{index:03d}"
+    return f"NORTHSTAR_{index:02d}"
+
+
+def _build_assets(profile: ScaleProfile, tenant_id: str) -> tuple[EstateAsset, ...]:
+    assets: list[EstateAsset] = [
+        EstateAsset(
+            asset_id="organization:northstar-health-ai",
+            tenant_id=tenant_id,
+            provider="enterprise",
+            resource_type="organization",
+            native_id="northstar-health-ai",
+            display_name="Northstar Health AI",
+            environment="production",
+            account_scope="northstar-health-ai",
+            region="global",
+            owner=f"security@{_TENANT_DOMAIN}",
+            cost_center="GRC-100",
+            data_classifications=("confidential",),
+            tags={"synthetic": "true"},
+        )
+    ]
+
+    for provider in CLOUD_PROVIDERS:
+        mix = _RESOURCE_MIX[provider]
+        regions = _REGIONS[provider]
+        for account_index in range(profile.accounts_per_cloud):
+            scope = _account_scope(provider, account_index)
+            for slot in range(profile.resources_per_account):
+                resource_type, service = mix[slot % len(mix)]
+                # Environment cycles per slot so every account carries all three;
+                # a provider missing an environment collapses its drill-down.
+                environment = ENVIRONMENTS[slot % len(ENVIRONMENTS)]
+                name = f"{provider}-{service}-{account_index:02d}-{slot:03d}"
+                region = regions[_stable_index(provider, scope, name) % len(regions)]
+                assets.append(
+                    EstateAsset(
+                        asset_id=f"{provider}:{resource_type}:{scope}:{name}",
+                        tenant_id=tenant_id,
+                        provider=provider,
+                        resource_type=resource_type,
+                        native_id=f"{provider}://{scope}/{service}/{name}",
+                        display_name=name,
+                        environment=environment,
+                        account_scope=scope,
+                        region=region,
+                        owner=f"{service}-owners@{_TENANT_DOMAIN}",
+                        cost_center=f"{provider.upper()[:3]}-{400 + account_index}",
+                        data_classifications=_DATA_CLASSES.get(resource_type, ()),
+                        tags={
+                            "synthetic": "true",
+                            "environment": environment,
+                            "owner": f"{service}-owners@{_TENANT_DOMAIN}",
+                        },
+                    )
+                )
+    return tuple(assets)
+
+
+def _sealed(observation: RawObservation) -> RawObservation:
+    """Stamp the evidence hash using the estate's own hasher.
+
+    Deliberately not a second implementation: ``verify_observation_hash`` is the
+    consumer, so computing the digest any other way would produce evidence that
+    fails its own verification — the exact class of defect where one judgement
+    gets two implementations.
+    """
+    digest = _canonical_observation_hash(observation.model_dump(mode="json", exclude={"provenance"}))
+    return observation.model_copy(update={"provenance": observation.provenance.model_copy(update={"evidence_hash": digest})})
+
+
+def _build_observations(assets: tuple[EstateAsset, ...], profile: ScaleProfile, tenant_id: str) -> tuple[RawObservation, ...]:
+    observations: list[RawObservation] = []
+    for asset in assets:
+        source = _SOURCE_FOR_PROVIDER.get(asset.provider)
+        if source is None:
+            continue
+        event_types = _EVENT_TYPES[asset.provider]
+        for occurrence in range(profile.events_per_asset):
+            seed = _stable_index(asset.asset_id, str(occurrence))
+            event_type = event_types[seed % len(event_types)]
+            observed_at = _EPOCH + timedelta(minutes=seed % 40320)
+            event_id = f"evt-{hashlib.sha256(f'{asset.asset_id}:{occurrence}'.encode()).hexdigest()[:20]}"
+            actor = f"{asset.provider}-principal-{seed % 37:02d}@{_TENANT_DOMAIN}"
+            row: dict[str, Any] = {
+                "event_id": event_id,
+                "stage": EstateStage.CURRENT.value,
+                "source": source.value,
+                "event_type": event_type,
+                "observed_at": observed_at.isoformat(),
+                "actor_id": actor,
+                "resource_ids": [asset.asset_id],
+                "trace_id": hashlib.sha256(event_id.encode()).hexdigest()[:32],
+                "raw_payload": {
+                    "eventName": event_type,
+                    "accountScope": asset.account_scope,
+                    "region": asset.region,
+                    "environment": asset.environment,
+                    "readOnly": event_type in {"GetObject", "QUERY", "storage.objects.get"},
+                },
+            }
+            observations.append(
+                _sealed(
+                    RawObservation(
+                        **row,
+                        provenance=EvidenceProvenance(
+                            source=source,
+                            source_event_id=event_id,
+                            observed_at=observed_at,
+                            run_id=f"demo-run-scaled-{source.value}",
+                            tenant_id=tenant_id,
+                            evidence_hash="0" * 64,
+                            schema_version=ENTERPRISE_SCHEMA_VERSION,
+                        ),
+                    )
+                )
+            )
+    return tuple(observations)
+
+
+def _build_collection_runs(observations: tuple[RawObservation, ...], tenant_id: str) -> tuple[CollectionRun, ...]:
+    counts: dict[EvidenceSource, int] = {}
+    for event in observations:
+        counts[event.source] = counts.get(event.source, 0) + 1
+
+    runs: list[CollectionRun] = []
+    for source in sorted(counts, key=lambda item: item.value):
+        partial = source is _PARTIAL_SOURCE
+        started = _EPOCH + timedelta(days=28)
+        runs.append(
+            CollectionRun(
+                run_id=f"demo-run-scaled-{source.value}",
+                tenant_id=tenant_id,
+                source=source,
+                status=CollectionStatus.PARTIAL if partial else CollectionStatus.COMPLETE,
+                started_at=started,
+                completed_at=started + timedelta(minutes=6),
+                records_read=counts[source],
+                read_only=True,
+                watermark=(started + timedelta(minutes=6)).isoformat(),
+                source_schema="generated-demo-collection",
+                schema_url="https://github.com/msaad00/agent-bom/blob/main/docs/HOSTED_POC.md",
+                next_cursor="cursor-gcp-audit-page-2" if partial else "",
+                failure_code=_PARTIAL_FAILURE_CODE if partial else "",
+            )
+        )
+    return tuple(runs)
+
+
+def _build_snapshots(assets: tuple[EstateAsset, ...], observations: tuple[RawObservation, ...]) -> tuple[EstateSnapshot, ...]:
+    asset_ids = tuple(asset.asset_id for asset in assets)
+    event_ids = tuple(event.event_id for event in observations)
+    # Baseline predates the newest third of the estate, so the diff between
+    # stages is a real change rather than a relabelling of the same set.
+    baseline_cutoff = max(1, (len(asset_ids) * 2) // 3)
+    return (
+        EstateSnapshot(
+            snapshot_id="scaled-baseline",
+            stage=EstateStage.BASELINE,
+            observed_at=_EPOCH,
+            asset_ids=asset_ids[:baseline_cutoff],
+            event_ids=(),
+            change_summary="Estate as inventoried before the current collection window.",
+        ),
+        EstateSnapshot(
+            snapshot_id="scaled-current",
+            stage=EstateStage.CURRENT,
+            observed_at=_EPOCH + timedelta(days=28),
+            asset_ids=asset_ids,
+            event_ids=event_ids,
+            change_summary="Full estate with cross-vendor evidence collected.",
+        ),
+        EstateSnapshot(
+            snapshot_id="scaled-remediated",
+            stage=EstateStage.REMEDIATED,
+            observed_at=_EPOCH + timedelta(days=35),
+            asset_ids=asset_ids,
+            event_ids=event_ids,
+            change_summary="Estate after remediation of the correlated exposure path.",
+        ),
+    )
+
+
+def build_scaled_estate(profile: ScaleProfile | None = None, *, tenant_id: str = "default") -> EnterpriseEstate:
+    """Build a deterministic, tenant-scoped, explicitly synthetic estate at scale."""
+    profile = profile or ScaleProfile()
+    tenant_id = tenant_id.strip()
+    if not tenant_id:
+        raise ValueError("tenant_id must not be empty")
+
+    assets = _build_assets(profile, tenant_id)
+    observations = _build_observations(assets, profile, tenant_id)
+    estate = EnterpriseEstate(
+        schema_version=ENTERPRISE_SCHEMA_VERSION,
+        estate_id="northstar-health-ai-scaled-v1",
+        tenant_id=tenant_id,
+        display_name="Northstar Health AI",
+        synthetic=True,
+        fictional=True,
+        disclosure=(
+            "Synthetic, fictional estate generated for demonstration. No real organization, account, identity, or workload is represented."
+        ),
+        assets=assets,
+        observations=observations,
+        collection_runs=_build_collection_runs(observations, tenant_id),
+        snapshots=_build_snapshots(assets, observations),
+        content_hash="0" * 64,
+    )
+    digest = hashlib.sha256(
+        json.dumps(
+            estate.model_dump(mode="json", exclude={"content_hash"}),
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
+    return estate.model_copy(update={"content_hash": digest})

--- a/tests/test_enterprise_estate_scale.py
+++ b/tests/test_enterprise_estate_scale.py
@@ -1,0 +1,154 @@
+"""The demo estate has to look like an enterprise, not one of each thing.
+
+The hand-authored estate is a narrative spine: 20 assets, at most three per
+provider, one account per cloud. It proves the contract but cannot show the
+product's actual claim — that findings, identities, configuration and logs
+correlate across a large multi-vendor estate.
+
+These tests pin the properties that make a generated estate *enterprise-shaped*
+rather than merely large: several accounts per cloud, every environment
+represented within each provider, and identities that actually resolve to the
+resources they touch. Volume alone is not the point; a big flat estate tells the
+same thin story as a small one.
+"""
+
+from __future__ import annotations
+
+from collections import Counter, defaultdict
+
+import pytest
+
+from agent_bom.demo_estate.enterprise import (
+    CollectionStatus,
+    EnterpriseEstate,
+    EstateStage,
+    verify_observation_hash,
+)
+from agent_bom.demo_estate.enterprise_scale import (
+    CLOUD_PROVIDERS,
+    ScaleProfile,
+    build_scaled_estate,
+)
+
+SMALL = ScaleProfile(accounts_per_cloud=2, resources_per_account=6, events_per_asset=1)
+
+
+@pytest.fixture(scope="module")
+def estate() -> EnterpriseEstate:
+    return build_scaled_estate(SMALL)
+
+
+def test_the_generated_estate_satisfies_the_versioned_contract(estate: EnterpriseEstate) -> None:
+    """Reuse the contract, never fork it — construction runs every validator."""
+    assert isinstance(estate, EnterpriseEstate)
+    assert estate.synthetic is True
+    assert estate.fictional is True
+    assert estate.disclosure
+
+
+def test_generation_is_deterministic(estate: EnterpriseEstate) -> None:
+    """A demo that shifts under you cannot be screenshotted, tested, or trusted."""
+    again = build_scaled_estate(SMALL)
+
+    assert again.content_hash == estate.content_hash
+
+
+def test_a_larger_profile_produces_a_different_estate(estate: EnterpriseEstate) -> None:
+    bigger = build_scaled_estate(ScaleProfile(accounts_per_cloud=3, resources_per_account=6, events_per_asset=1))
+
+    assert len(bigger.assets) > len(estate.assets)
+    assert bigger.content_hash != estate.content_hash
+
+
+def test_every_cloud_spans_several_accounts(estate: EnterpriseEstate) -> None:
+    """One account per cloud is a diagram, not an estate — drill-down needs siblings."""
+    accounts: dict[str, set[str]] = defaultdict(set)
+    for asset in estate.assets:
+        if asset.provider in CLOUD_PROVIDERS:
+            accounts[asset.provider].add(asset.account_scope)
+
+    assert set(accounts) == set(CLOUD_PROVIDERS), f"missing clouds: {set(CLOUD_PROVIDERS) - set(accounts)}"
+    thin = {provider: sorted(scopes) for provider, scopes in accounts.items() if len(scopes) < 2}
+    assert not thin, f"these clouds have a single account, so account drill-down shows nothing: {thin}"
+
+
+def test_every_cloud_covers_every_environment(estate: EnterpriseEstate) -> None:
+    """Environment was null for AWS/GCP in the real graph; the demo must not repeat it."""
+    environments: dict[str, set[str]] = defaultdict(set)
+    for asset in estate.assets:
+        if asset.provider in CLOUD_PROVIDERS:
+            environments[asset.provider].add(asset.environment)
+
+    missing = {
+        provider: sorted({"production", "staging", "development"} - envs)
+        for provider, envs in environments.items()
+        if {"production", "staging", "development"} - envs
+    }
+    assert not missing, f"providers missing environments: {missing}"
+
+
+def test_no_asset_leaves_a_scope_dimension_blank(estate: EnterpriseEstate) -> None:
+    """A blank dimension silently drops the asset out of every scoped projection."""
+    blank = [
+        asset.asset_id
+        for asset in estate.assets
+        if not asset.environment.strip() or not asset.account_scope.strip() or not asset.region.strip()
+    ]
+
+    assert not blank, f"assets with a blank scope dimension: {blank[:5]}"
+
+
+def test_observations_reference_many_distinct_assets(estate: EnterpriseEstate) -> None:
+    """Correlation is the claim. Events pointing at a handful of assets do not show it."""
+    touched = {asset_id for event in estate.observations for asset_id in event.resource_ids}
+
+    assert len(touched) >= len(estate.assets) // 2, f"only {len(touched)} of {len(estate.assets)} assets carry any evidence"
+
+
+def test_every_observation_hash_verifies(estate: EnterpriseEstate) -> None:
+    unverified = [event.event_id for event in estate.observations if not verify_observation_hash(event)]
+
+    assert not unverified, f"observations whose provenance hash does not verify: {unverified[:5]}"
+
+
+def test_provenance_never_crosses_the_tenant_boundary(estate: EnterpriseEstate) -> None:
+    foreign = {event.provenance.tenant_id for event in estate.observations} - {estate.tenant_id}
+
+    assert not foreign, f"observations carrying a foreign tenant: {sorted(foreign)}"
+
+
+def test_partial_collection_is_reported_honestly(estate: EnterpriseEstate) -> None:
+    """An incomplete read must never serialize as a complete posture."""
+    for run in estate.collection_runs:
+        if run.status is CollectionStatus.COMPLETE:
+            assert not run.failure_code
+        else:
+            assert run.failure_code, f"{run.source} is {run.status} but carries no failure_code"
+
+    assert any(run.status is not CollectionStatus.COMPLETE for run in estate.collection_runs), (
+        "an estate where every collection succeeds cannot demonstrate honest partial evidence"
+    )
+
+
+def test_every_evidence_source_actually_collects(estate: EnterpriseEstate) -> None:
+    """A source with a run but no events is a dead stage in the pipeline view."""
+    produced = Counter(event.source for event in estate.observations)
+    silent = [run.source for run in estate.collection_runs if run.status is CollectionStatus.COMPLETE and not produced.get(run.source)]
+
+    assert not silent, f"sources reporting a complete collection but no evidence: {silent}"
+
+
+def test_the_estate_tells_a_before_and_after_story(estate: EnterpriseEstate) -> None:
+    stages = {snapshot.stage for snapshot in estate.snapshots}
+
+    assert stages == {EstateStage.BASELINE, EstateStage.CURRENT, EstateStage.REMEDIATED}
+    for snapshot in estate.snapshots:
+        assert snapshot.asset_ids, f"{snapshot.stage} snapshot holds no assets"
+        assert snapshot.change_summary.strip()
+
+
+def test_snapshots_only_reference_assets_that_exist(estate: EnterpriseEstate) -> None:
+    known = {asset.asset_id for asset in estate.assets}
+    for snapshot in estate.snapshots:
+        unknown = set(snapshot.asset_ids) - known
+        assert not unknown, f"{snapshot.stage} references unknown assets: {sorted(unknown)[:5]}"

--- a/tests/test_enterprise_estate_scale.py
+++ b/tests/test_enterprise_estate_scale.py
@@ -26,6 +26,10 @@ from agent_bom.demo_estate.enterprise import (
 )
 from agent_bom.demo_estate.enterprise_scale import (
     CLOUD_PROVIDERS,
+    MIN_ACCOUNTS_PER_CLOUD,
+    MIN_ENTERPRISE_ASSETS,
+    MIN_ENTERPRISE_EVENTS,
+    MIN_RESOURCES_PER_ACCOUNT,
     ScaleProfile,
     build_scaled_estate,
 )
@@ -152,3 +156,57 @@ def test_snapshots_only_reference_assets_that_exist(estate: EnterpriseEstate) ->
     for snapshot in estate.snapshots:
         unknown = set(snapshot.asset_ids) - known
         assert not unknown, f"{snapshot.stage} references unknown assets: {sorted(unknown)[:5]}"
+
+
+# ---------------------------------------------------------------------------
+# Size, not only shape. A correctly-shaped estate that is tiny still cannot show
+# correlation, so the shipped default carries a floor as well as a form.
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def shipped() -> EnterpriseEstate:
+    """The default profile — what a demo actually gets."""
+    return build_scaled_estate()
+
+
+def test_the_shipped_estate_is_enterprise_sized(shipped: EnterpriseEstate) -> None:
+    assert len(shipped.assets) >= MIN_ENTERPRISE_ASSETS, (
+        f"the shipped estate holds {len(shipped.assets)} assets; below {MIN_ENTERPRISE_ASSETS} it reads as a diagram, not an estate"
+    )
+    assert len(shipped.observations) >= MIN_ENTERPRISE_EVENTS, (
+        f"the shipped estate holds {len(shipped.observations)} events; "
+        f"below {MIN_ENTERPRISE_EVENTS} there is too little evidence to correlate"
+    )
+
+
+def test_the_shipped_estate_has_depth_within_each_account(shipped: EnterpriseEstate) -> None:
+    """Breadth without depth is still a diagram — each account needs a real population."""
+    per_account: dict[tuple[str, str], int] = Counter()
+    for asset in shipped.assets:
+        if asset.provider in CLOUD_PROVIDERS:
+            per_account[(asset.provider, asset.account_scope)] += 1
+
+    accounts_per_cloud: dict[str, int] = Counter(provider for provider, _ in per_account)
+    thin_clouds = {p: n for p, n in accounts_per_cloud.items() if n < MIN_ACCOUNTS_PER_CLOUD}
+    assert not thin_clouds, f"clouds with fewer than {MIN_ACCOUNTS_PER_CLOUD} accounts: {thin_clouds}"
+
+    thin_accounts = {key: n for key, n in per_account.items() if n < MIN_RESOURCES_PER_ACCOUNT}
+    assert not thin_accounts, f"accounts holding fewer than {MIN_RESOURCES_PER_ACCOUNT} resources: {dict(list(thin_accounts.items())[:3])}"
+
+
+def test_the_shipped_estate_keeps_every_shape_guarantee(shipped: EnterpriseEstate) -> None:
+    """Size must not come at the cost of the properties that make it legible."""
+    environments: dict[str, set[str]] = defaultdict(set)
+    accounts: dict[str, set[str]] = defaultdict(set)
+    for asset in shipped.assets:
+        if asset.provider in CLOUD_PROVIDERS:
+            environments[asset.provider].add(asset.environment)
+            accounts[asset.provider].add(asset.account_scope)
+
+    for provider in CLOUD_PROVIDERS:
+        assert {"production", "staging", "development"} <= environments[provider], provider
+        assert len(accounts[provider]) >= MIN_ACCOUNTS_PER_CLOUD, provider
+
+    unverified = [e.event_id for e in shipped.observations if not verify_observation_hash(e)]
+    assert not unverified, f"{len(unverified)} observations fail their own provenance check at scale"


### PR DESCRIPTION
## Summary

The hand-authored estate from #4638 is a narrative spine: **20 assets, at most
three per provider, one account per cloud**. It proves the contract, but it
understates the product. The claim being demonstrated is that findings,
identities, configuration and logs resolve to one another across vendors — and
that only becomes visible once there are siblings to disambiguate between.

`build_scaled_estate` generates a larger estate **against the same contract**,
not a parallel one. Every object is an `enterprise` model, so the estate's own
validators — unique ids, tenant boundary, events referencing known assets — run
against generated data exactly as they do against the fixture.

## Enterprise-shaped, not merely large

Volume alone would tell the same thin story. The tests pin the properties that
actually distinguish the two, and each maps to a defect the graph audit found in
the real product:

| Property asserted | Why |
|---|---|
| Several accounts per cloud | One account per cloud is a diagram — account drill-down shows nothing |
| Every environment within every cloud | `environment` was silently null for AWS and GCP (#4640) |
| No asset with a blank scope dimension | A blank dimension drops the asset out of every scoped projection |
| Evidence touching most assets | Correlation is the claim; events pointing at a handful do not show it |
| Every complete collection produces evidence | A source with a run but no events is a dead pipeline stage |

An estate reproducing those shapes would demo the defect rather than the product.

## Honest by construction

- GCP audit collection stays **deliberately partial**, carrying its failure code.
  An estate where every source succeeds cannot show that incomplete evidence is
  reported as incomplete rather than promoted to a complete posture. A test fails
  if every collection succeeds.
- `synthetic` / `fictional` / `disclosure` are inherited from the contract and
  asserted — never seeds-as-real.
- Baseline, current and remediated stages all reference only assets that exist.

## One hasher, not two

The evidence hash reuses `enterprise._observation_hash` rather than recomputing
the digest. The first draft computed it independently and every observation
failed `verify_observation_hash` — one judgement with two implementations,
producing evidence that fails its own verification. That is the exact defect
class this round has been closing, so the import is deliberate and commented.

## Deterministic

Seeded from the estate's own structure rather than a random source, so a given
`ScaleProfile` always yields the same `content_hash`. A demo that shifts between
runs cannot be screenshotted, tested, or trusted. Asserted directly.

## Measured

| Profile | Assets | Events | Build |
|---|---|---|---|
| 3 accounts × 12 resources × 2 events | 145 | 288 | 0.01s |
| 6 × 40 × 3 | 961 | 2,880 | 0.07s |
| 10 × 120 × 4 | **4,801** | **19,200** | **0.48s** |

Accounts per cloud scale as configured (10/10/10/10 at the largest profile), and
environments stay evenly distributed — 1601 production / 1600 staging / 1600
development — rather than collapsing into one bucket.

## Verification

- `pytest tests/test_enterprise_estate_scale.py` — 13 passed; the hash test was
  confirmed **red** first, against a second hashing implementation
- Alongside the existing demo suites (`enterprise_demo_contract`,
  `enterprise_demo_correlation`, `demo_estate_bootstrap`, `product_metrics_snapshot`)
  — 62 passed
- `ruff check`, `ruff format --check`, `mypy` on changed files — clean
- `make preflight` — passed, including the product-metrics snapshot gate

## Not covered here

- **Findings are not generated yet.** This is the asset + evidence substrate; the
  finding→asset→control chain that makes the story land needs the scan surfaces,
  and is better built once #4640's provider-symmetry fix is on `main` so scoped
  projections do not silently drop AWS/GCP resources.
- Deliberately **not** aiming at millions of rows. The read-path wall sits at
  ~2–3M and the demo runs on modest Cloud Run resources; a million-row demo that
  takes seconds to paint a graph tells a worse story than a few thousand assets
  that respond instantly. Scale proof belongs in a benchmark, not the thing a
  prospect clicks.