### PR TITLE
build(demo): lock enterprise story across surfaces

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1397,6 +1397,10 @@ jobs:
         # models change.
         run: uv run python scripts/export_openapi.py --check
 
+      - name: Verify synthetic enterprise demo surfaces
+        if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
+        run: uv run python scripts/check_enterprise_demo_surfaces.py
+
       - name: Validate canonical README commands parse
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
         run: |
@@ -1448,6 +1452,7 @@ jobs:
           required = {
               "agent_bom/data/inventory.schema.json",
               "agent_bom/data/mcp-intelligence.schema.json",
+              "agent_bom/demo_estate/data/enterprise_observations.jsonl",
           }
           with ZipFile(wheel) as archive:
               names = set(archive.namelist())

--- a/.github/workflows/demo-deploy-cloudrun.yml
+++ b/.github/workflows/demo-deploy-cloudrun.yml
@@ -193,11 +193,57 @@ jobs:
             echo "::error::demo serves ${SERVED} but its estate has zero findings"
             exit 1
           fi
+
+          STORY_PATH="${RUNNER_TEMP}/enterprise-demo-story.json"
+          curl -fsS --max-time 30 "${URL}/v1/demo-estate/story" -o "${STORY_PATH}"
+          STORY_SUMMARY="$(STORY_PATH="${STORY_PATH}" python3 - <<'PY'
+          import json
+          import os
+          from pathlib import Path
+
+          payload = json.loads(Path(os.environ["STORY_PATH"]).read_text())
+          assert payload["synthetic"] is True and payload["fictional"] is True
+          summary = payload["summary"]
+          assert summary == {
+              "assets": 20,
+              "observations": 15,
+              "evidence_sources": 9,
+              "complete_sources": 8,
+              "partial_sources": 1,
+              "correlations": 4,
+              "snapshots": 3,
+          }
+          assert payload["primary_correlation"]["outcome"] == "blocked"
+          assert payload["primary_correlation"]["sources"] == [
+              "github_actions",
+              "aws_cloudtrail",
+              "kubernetes_audit",
+              "mcp_gateway",
+              "snowflake_access_history",
+              "otel_llm",
+          ]
+          gcp = next(row for row in payload["collection_health"] if row["source"] == "gcp_audit")
+          assert gcp["status"] == "partial"
+          assert gcp["failure_code"] == "rate_limited_after_page_2"
+
+          def contains_raw(value):
+              if isinstance(value, dict):
+                  return "raw_payload" in value or any(contains_raw(child) for child in value.values())
+              if isinstance(value, list):
+                  return any(contains_raw(child) for child in value)
+              return False
+
+          assert not contains_raw(payload)
+          print(f'{summary["assets"]} assets · {summary["observations"]} observations · {summary["evidence_sources"]} sources')
+          PY
+          )"
+          echo "enterprise demo story=${STORY_SUMMARY}"
           {
             echo "### Demo deployed"
             echo ""
             echo "- URL: ${URL}"
             echo "- Version: ${SERVED}"
             echo "- Seeded findings: ${TOTAL}"
+            echo "- Enterprise story: ${STORY_SUMMARY}"
             echo "- Min instances: ${{ vars.DEMO_MIN_INSTANCES || '0' }} (0 = scales to zero, no idle cost)"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ preflight:  ## Run the drift gates that CI's "Version Alignment" job runs — do
 	@echo "→ agent capability manifest";             python scripts/generate_agent_capability_manifest.py --check
 	@echo "→ product surface contract";             python scripts/check_product_surface_contract.py
 	@echo "→ graph proof fixtures";                 python scripts/check_graph_epic_proof.py
+	@echo "→ enterprise demo surfaces";             python scripts/check_enterprise_demo_surfaces.py
 	@echo "→ release/README consistency";           python scripts/check_release_consistency.py
 	@echo "→ product metrics snapshot";             python scripts/product_metrics_snapshot.py --check
 	@echo "→ env-var reference";                    python scripts/generate_env_var_reference.py --check

--- a/deploy/helm/agent-bom/examples/README.md
+++ b/deploy/helm/agent-bom/examples/README.md
@@ -9,6 +9,7 @@ product split.
 | Profile | File | Intended use |
 |---|---|---|
 | `sqlite-pilot` | `eks-control-plane-sqlite-pilot-values.yaml` | Single-node packaged demo or short-lived pilot where Postgres is not ready yet |
+| `synthetic-enterprise-story` | `synthetic-enterprise-story-values.yaml` | Explicitly fictional Northstar Health AI story with a viewer-only dashboard; never combine with live customer collection |
 | `focused-pilot` | `eks-mcp-pilot-values.yaml` | Narrow EKS pilot with control plane, scanner, and tightened ingress |
 | `enterprise-demo` | `eks-mcp-pilot-values.yaml` + `eks-enterprise-demo-overlay.yaml` | Focused pilot plus scheduled AWS estate inventory (IRSA, `AGENT_BOM_AWS_INVENTORY=1`) |
 | `byo-postgres` | `byo-postgres-values.yaml` | Overlay for operator-owned Postgres-compatible databases, including Snowflake Postgres candidates |
@@ -115,6 +116,7 @@ Which keys each profile requires, and its first-run login posture:
 | `focused-pilot` (`eks-mcp-pilot`) | `agent-bom-control-plane-db` + `agent-bom-control-plane-maintenance` + `agent-bom-control-plane-admin` + `agent-bom-control-plane-auth` | app: `AGENT_BOM_POSTGRES_URL`; maintenance: `AGENT_BOM_POSTGRES_MAINTENANCE_URL`; admin: `ALEMBIC_DATABASE_URL`; auth: browser-session, connections, and API keys | Seeded `AGENT_BOM_API_KEYS` admin key |
 | `eks-vanilla` | same four split Secrets | app: `AGENT_BOM_POSTGRES_URL`; maintenance: `AGENT_BOM_POSTGRES_MAINTENANCE_URL`; admin: `ALEMBIC_DATABASE_URL`; auth: `AGENT_BOM_BROWSER_SESSION_SIGNING_KEY`, `AGENT_BOM_AUDIT_HMAC_KEY`, `AGENT_BOM_CONNECTIONS_KEY`, `AGENT_BOM_API_KEYS` | Seeded `AGENT_BOM_API_KEYS` admin key |
 | `sqlite-pilot` | `agent-bom-control-plane` (demo) | `AGENT_BOM_CONNECTIONS_KEY` only (sqlite, replicas 1) | Anonymous — the profile sets a **visible, demo-only** `AGENT_BOM_ALLOW_UNAUTHENTICATED_API=1` (viewer role). Not for production |
+| `synthetic-enterprise-story` | `agent-bom-control-plane` (demo) | `AGENT_BOM_CONNECTIONS_KEY` only (sqlite, replicas 1) | Anonymous viewer — synthetic fixture only, explicitly labeled, and not for production or live collection |
 
 Swap `AGENT_BOM_API_KEYS` for the OIDC block
 (`AGENT_BOM_OIDC_ISSUER` / `AGENT_BOM_OIDC_CLIENT_ID` /

--- a/deploy/helm/agent-bom/examples/synthetic-enterprise-story-values.yaml
+++ b/deploy/helm/agent-bom/examples/synthetic-enterprise-story-values.yaml
@@ -1,0 +1,63 @@
+# Explicitly synthetic, single-node enterprise story profile.
+#
+# This profile is for demonstrations and evaluation only. It seeds the bundled
+# fictional Northstar Health AI estate and exposes viewer-only anonymous access
+# so the dashboard works on first boot. It must not be used for production or
+# combined with live customer collection.
+#
+# Install:
+#   python scripts/install_helm_profile.py synthetic-enterprise-story
+
+controlPlane:
+  enabled: true
+  migrations:
+    postgres:
+      enabled: false
+  api:
+    replicas: 1
+    envFrom:
+      - secretRef:
+          name: agent-bom-control-plane
+    env:
+      - name: AGENT_BOM_DB
+        value: /var/lib/agent-bom/control-plane.sqlite
+      - name: AGENT_BOM_DEMO_ESTATE
+        value: "1"
+      # DEMO ONLY — viewer role, synthetic data, single-node evaluation.
+      - name: AGENT_BOM_ALLOW_UNAUTHENTICATED_API
+        value: "1"
+      - name: AGENT_BOM_NO_AUTH_ROLE
+        value: viewer
+    extraVolumes:
+      - name: sqlite-data
+        persistentVolumeClaim:
+          claimName: agent-bom-synthetic-enterprise-story
+    extraVolumeMounts:
+      - name: sqlite-data
+        mountPath: /var/lib/agent-bom
+  ui:
+    replicas: 1
+    env:
+      - name: NEXT_PUBLIC_API_URL
+        value: ""
+  ingress:
+    enabled: true
+    className: nginx
+    hosts:
+      - host: agent-bom-demo.internal.example.com
+        apiPaths:
+          - path: /v1
+            pathType: Prefix
+          - path: /health
+            pathType: Prefix
+          - path: /docs
+            pathType: Prefix
+        uiPaths:
+          - path: /
+            pathType: Prefix
+
+scanner:
+  enabled: false
+
+pdb:
+  enabled: false

--- a/docs/ENTERPRISE_DEMO.md
+++ b/docs/ENTERPRISE_DEMO.md
@@ -1,0 +1,84 @@
+# Synthetic enterprise evidence demo
+
+The bundled **Northstar Health AI** estate is a fictional, deterministic data
+set for showing how agent-bom joins evidence across cloud, identity, data, AI,
+and runtime systems. It contains no customer telemetry and is not an audit
+verdict. Do not combine this fixture with live customer collection.
+
+## First command: inspect the evidence offline
+
+```bash
+agent-bom demo story --output enterprise-demo-story.json
+```
+
+The terminal prints the primary incident path and collection limits. The JSON
+artifact contains the normalized events, cross-vendor correlations, source
+health, tenant ID, source-run IDs, evidence hashes, and graph projections. Raw
+provider payloads are intentionally excluded.
+
+The primary story follows one trace through:
+
+```text
+GitHub Actions → AWS CloudTrail → Kubernetes Audit → MCP Gateway
+               → Snowflake Access History → OpenTelemetry GenAI
+```
+
+It proves a GitHub deployment assumed an AWS workload identity, reached a
+Kubernetes copilot and an MCP SQL tool, read a synthetic PHI-classified
+Snowflake table, and was blocked before model egress. Separate correlations
+show an Azure privilege change, partial GCP credential activity, and an
+enforced multi-provider remediation. GCP remains `partial` with
+`rate_limited_after_page_2`; the demo never turns missing evidence into a
+complete posture claim.
+
+## Open the dashboard locally
+
+```bash
+agent-bom serve --demo-estate --allow-insecure-no-auth
+```
+
+Open `http://127.0.0.1:8422/demo-estate`. The anonymous viewer flag is suitable
+only for a loopback, single-user demonstration. The page uses the same
+versioned read model as the CLI and `GET /v1/demo-estate/story`; it does not
+maintain a second UI-only copy of the scenario.
+
+Next steps from the story page:
+
+- open **Security graph** to inspect identity and resource relationships;
+- open **Runtime traces** to inspect tool-call enforcement;
+- open **Findings** to move from evidence to remediation.
+
+## Run the packaged Kubernetes profile
+
+Create the `agent-bom-control-plane` Secret described in
+`deploy/helm/agent-bom/examples/control-plane-auth-secret.example.yaml`, then:
+
+```bash
+python scripts/install_helm_profile.py synthetic-enterprise-story --print-command
+python scripts/install_helm_profile.py synthetic-enterprise-story
+```
+
+The profile is single-node SQLite, seeds only the synthetic estate, disables
+the scanner, and grants anonymous viewer access. Change the example ingress
+host before installation. For a shared or persistent environment, remove
+`AGENT_BOM_ALLOW_UNAUTHENTICATED_API`, configure API-key or OIDC authentication,
+and keep synthetic and live collection in separate deployments.
+
+Validate the rendered profile without installing it:
+
+```bash
+python scripts/validate_helm_profiles.py --profile synthetic-enterprise-story
+```
+
+## Evidence contract
+
+The checked-in guard fails when any of these surfaces drift:
+
+```bash
+python scripts/check_enterprise_demo_surfaces.py
+```
+
+It verifies fixture packaging, hashes, counts, tenant propagation, the blocked
+primary path, partial GCP collection, raw-payload exclusion, CLI/API/UI wiring,
+the Helm profile, and this runbook. CI also inspects the built wheel for the
+versioned enterprise JSONL fixture and smokes the hosted demo story endpoint.

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ material. The index below groups the canonical docs by audience.
 ## Orientation (start here)
 
 - [`FIRST_RUN.md`](FIRST_RUN.md) — install → first scan → first artifact (canonical first-run path)
+- [`ENTERPRISE_DEMO.md`](ENTERPRISE_DEMO.md) — fictional cross-vendor estate: offline artifact → dashboard → packaged Helm profile
 - [`START_HERE.md`](START_HERE.md) — role-based entry paths (security engineer / platform-SRE / AI-agent developer)
 - [`HOW_IT_WORKS.md`](HOW_IT_WORKS.md) — five-stage evidence flow (canonical product story)
 - [`PRODUCT_BRIEF.md`](PRODUCT_BRIEF.md) — positioning and persona contract
@@ -55,7 +56,7 @@ Two hubs cover the clustered material — start at the hub, then follow it to th
 - [`PERMISSIONS.md`](PERMISSIONS.md) — RBAC roles and permissions
 - [`DATABASE_EVIDENCE.md`](DATABASE_EVIDENCE.md) — persistence and evidence stores
 - [`RELEASE_VERIFICATION.md`](RELEASE_VERIFICATION.md) — release verification
-- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (321 paths / 380 operations)
+- [`openapi/v1.json`](openapi/v1.json) — canonical REST contract (322 paths / 381 operations)
 
 ## AI / agent developers (MCP · clients · tools)
 

--- a/scripts/check_enterprise_demo_surfaces.py
+++ b/scripts/check_enterprise_demo_surfaces.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Fail when the versioned synthetic enterprise story drifts across surfaces."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from agent_bom.cli import main
+from agent_bom.demo_estate.presentation import build_enterprise_demo_story
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+EXPECTED_FIXTURES = {
+    "enterprise_observations.jsonl",
+}
+EXPECTED_PRIMARY_SOURCES = (
+    "github_actions",
+    "aws_cloudtrail",
+    "kubernetes_audit",
+    "mcp_gateway",
+    "snowflake_access_history",
+    "otel_llm",
+)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise SystemExit(f"enterprise demo surface drift: {message}")
+
+
+def _contains_key(value: Any, key: str) -> bool:
+    if isinstance(value, dict):
+        return key in value or any(_contains_key(child, key) for child in value.values())
+    if isinstance(value, list):
+        return any(_contains_key(child, key) for child in value)
+    return False
+
+
+def _read(relative_path: str) -> str:
+    path = REPO_ROOT / relative_path
+    _require(path.is_file(), f"missing {relative_path}")
+    return path.read_text(encoding="utf-8")
+
+
+def main_check() -> None:
+    story = build_enterprise_demo_story(tenant_id="contract-tenant")
+    payload = story.model_dump(mode="json")
+
+    _require(story.schema_version == "enterprise_demo_story.v1", "story schema version changed")
+    _require(story.synthetic is True and story.fictional is True, "synthetic disclosure flags missing")
+    _require(story.tenant_id == "contract-tenant", "tenant ID was not propagated")
+    _require(story.summary.assets == 20, "asset count changed")
+    _require(story.summary.observations == 15, "observation count changed")
+    _require(story.summary.evidence_sources == 9, "evidence-source count changed")
+    _require(story.summary.correlations == 4, "correlation count changed")
+    _require(story.summary.snapshots == 3, "snapshot count changed")
+    _require(story.primary_correlation.outcome == "blocked", "primary outcome is no longer blocked")
+    _require(
+        tuple(source.value for source in story.primary_correlation.sources)
+        == EXPECTED_PRIMARY_SOURCES,
+        "primary cross-vendor path changed",
+    )
+    gcp = next((row for row in story.collection_health if row.source.value == "gcp_audit"), None)
+    _require(gcp is not None, "GCP collection health missing")
+    _require(gcp.status.value == "partial", "GCP collection was promoted beyond available evidence")
+    _require(gcp.failure_code == "rate_limited_after_page_2", "GCP failure provenance changed")
+    _require(not _contains_key(payload, "raw_payload"), "normalized output exposes a raw payload")
+    _require(len(story.estate_content_hash) == 64, "estate content hash is invalid")
+    _require(len(story.story_content_hash) == 64, "story content hash is invalid")
+
+    fixture_dir = REPO_ROOT / "src" / "agent_bom" / "demo_estate" / "data"
+    fixtures = {path.name for path in fixture_dir.glob("enterprise*.jsonl")}
+    _require(EXPECTED_FIXTURES <= fixtures, "one or more versioned fixture files are missing")
+    package_config = _read("pyproject.toml")
+    _require("demo_estate/data/*.jsonl" in package_config, "wheel package-data glob is missing")
+
+    demo_group = main.commands.get("demo")
+    _require(demo_group is not None, "CLI demo group is not registered")
+    _require("story" in getattr(demo_group, "commands", {}), "CLI demo story command is not registered")
+
+    openapi = json.loads(_read("docs/openapi/v1.json"))
+    operation = openapi.get("paths", {}).get("/v1/demo-estate/story", {}).get("get", {})
+    response_ref = (
+        operation.get("responses", {})
+        .get("200", {})
+        .get("content", {})
+        .get("application/json", {})
+        .get("schema", {})
+        .get("$ref")
+    )
+    _require(response_ref == "#/components/schemas/EnterpriseDemoStory", "OpenAPI story contract is missing")
+
+    api_client = _read("ui/lib/api.ts")
+    dashboard = _read("ui/app/demo-estate/page.tsx")
+    _require('get<EnterpriseDemoStory>("/v1/demo-estate/story")' in api_client, "UI API client drifted")
+    for marker in (
+        "Synthetic enterprise evidence",
+        "Fictional data boundary",
+        "Normalized evidence timeline",
+        "Collection truth",
+        "Verified provenance",
+    ):
+        _require(marker in dashboard, f"dashboard lost required marker: {marker}")
+
+    helm_profile = _read(
+        "deploy/helm/agent-bom/examples/synthetic-enterprise-story-values.yaml"
+    )
+    for marker in (
+        "AGENT_BOM_DEMO_ESTATE",
+        "AGENT_BOM_ALLOW_UNAUTHENTICATED_API",
+        "AGENT_BOM_NO_AUTH_ROLE",
+        "viewer",
+    ):
+        _require(marker in helm_profile, f"Helm demo profile lost {marker}")
+
+    runbook = _read("docs/ENTERPRISE_DEMO.md")
+    for marker in (
+        "agent-bom demo story --output enterprise-demo-story.json",
+        "agent-bom serve --demo-estate --allow-insecure-no-auth",
+        "rate_limited_after_page_2",
+        "contains no customer telemetry",
+        "python scripts/install_helm_profile.py synthetic-enterprise-story",
+    ):
+        _require(marker in runbook, f"runbook lost required operator evidence: {marker}")
+
+    print("enterprise demo surface contract passed")
+
+
+if __name__ == "__main__":
+    main_check()

--- a/src/agent_bom/deploy_profiles.py
+++ b/src/agent_bom/deploy_profiles.py
@@ -91,6 +91,11 @@ def helm_validation_profiles(repo_root: Path) -> list[HelmValidationProfile]:
             values_files=(examples / "eks-control-plane-sqlite-pilot-values.yaml",),
         ),
         HelmValidationProfile(
+            name="synthetic-enterprise-story",
+            description="Single-node dashboard seeded only with the fictional cross-vendor enterprise story.",
+            values_files=(examples / "synthetic-enterprise-story-values.yaml",),
+        ),
+        HelmValidationProfile(
             name="focused-pilot",
             description="Focused EKS pilot with control plane, scanner, and narrowed ingress.",
             values_files=(examples / "eks-mcp-pilot-values.yaml",),

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -51,6 +51,20 @@ def test_non_required_heavy_jobs_are_path_gated() -> None:
     assert "needs.changes.result != 'success'" in jobs["helm-profiles"]["if"]
 
 
+def test_enterprise_demo_contract_is_gated_and_packaged() -> None:
+    workflow_text = CI_WORKFLOW.read_text(encoding="utf-8")
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    deploy_workflow = (
+        ROOT / ".github" / "workflows" / "demo-deploy-cloudrun.yml"
+    ).read_text(encoding="utf-8")
+
+    assert "scripts/check_enterprise_demo_surfaces.py" in workflow_text
+    assert "scripts/check_enterprise_demo_surfaces.py" in makefile
+    assert "agent_bom/demo_estate/data/enterprise_observations.jsonl" in workflow_text
+    assert "/v1/demo-estate/story" in deploy_workflow
+    assert "rate_limited_after_page_2" in deploy_workflow
+
+
 def test_dependency_security_skips_only_proven_docs_only_changes() -> None:
     workflow_path = ROOT / ".github" / "workflows" / "pr-security-gate.yml"
     workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))

--- a/tests/test_deploy_manifests.py
+++ b/tests/test_deploy_manifests.py
@@ -306,6 +306,7 @@ def test_helm_examples_readme_is_shipped():
     assert "enterprise-demo" in body
     assert "byo-postgres" in body
     assert "sqlite-pilot" in body
+    assert "synthetic-enterprise-story" in body
     assert "eks-vanilla" in body
     assert "gateway-runtime" in body
     assert "keda-autoscaling" in body

--- a/tests/test_deploy_profiles.py
+++ b/tests/test_deploy_profiles.py
@@ -26,6 +26,7 @@ def test_helm_validation_profiles_reference_existing_chart_assets():
     assert [profile.name for profile in profiles] == [
         "scanner-only",
         "sqlite-pilot",
+        "synthetic-enterprise-story",
         "focused-pilot",
         "enterprise-demo",
         "focused-pilot-byo-postgres",
@@ -54,6 +55,21 @@ def test_production_secret_sync_profile_layers_the_bootstrap_overlay() -> None:
         examples / "eks-production-values.yaml",
         examples / "eks-production-secret-sync-values.yaml",
     )
+
+
+def test_synthetic_enterprise_story_profile_is_explicit_and_demo_only() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    examples = repo_root / "deploy" / "helm" / "agent-bom" / "examples"
+    profiles = {profile.name: profile for profile in helm_validation_profiles(repo_root)}
+    profile = profiles["synthetic-enterprise-story"]
+
+    assert profile.values_files == (examples / "synthetic-enterprise-story-values.yaml",)
+    values = yaml.safe_load(profile.values_files[0].read_text())
+    env = {row["name"]: row["value"] for row in values["controlPlane"]["api"]["env"]}
+    assert env["AGENT_BOM_DEMO_ESTATE"] == "1"
+    assert env["AGENT_BOM_ALLOW_UNAUTHENTICATED_API"] == "1"
+    assert env["AGENT_BOM_NO_AUTH_ROLE"] == "viewer"
+    assert values["scanner"]["enabled"] is False
 
 
 def test_production_secret_sync_uses_a_separate_release_by_default() -> None:


### PR DESCRIPTION
## Summary

- add a packaged `synthetic-enterprise-story` Helm profile and operator runbook for the explicitly fictional Northstar Health AI estate
- add a deterministic preflight/CI guard that locks fixture packaging, evidence hashes/counts, tenant propagation, the blocked provider path, partial GCP collection, raw-payload exclusion, and CLI/API/UI/Helm/docs wiring
- extend wheel and hosted Cloud Run checks so distribution or deployment drift fails before an empty or misleading demo is published

## Why

The enterprise story needs to remain provable after packaging and deployment, not only in source-tree tests. This lock-in makes the first command, artifact, dashboard, packaged fixture, Kubernetes profile, and hosted endpoint part of one continuously verified contract.

## User impact

- `python scripts/install_helm_profile.py synthetic-enterprise-story` renders and installs a single-node, viewer-only synthetic evaluation profile
- `docs/ENTERPRISE_DEMO.md` documents offline inspection, the JSON artifact, dashboard drilldowns, deployment boundaries, and the next operational step
- package CI now fails when the enterprise JSONL fixture is absent from the built wheel
- hosted-demo deployment now verifies the exact counts, blocked path, fictional flags, partial GCP failure, and raw-payload exclusion returned by `/v1/demo-estate/story`

## Verification

- `.venv/bin/ruff check scripts/check_enterprise_demo_surfaces.py src/agent_bom/deploy_profiles.py tests/test_deploy_profiles.py tests/test_ci_workflow_contract.py tests/test_deploy_manifests.py`
- `.venv/bin/python scripts/check_enterprise_demo_surfaces.py`
- `.venv/bin/pytest -q tests/test_ci_workflow_contract.py tests/test_deploy_manifests.py tests/test_deploy_profiles.py tests/test_enterprise_demo_surfaces.py` (123 passed)
- `make preflight`
- `.venv/bin/python scripts/validate_helm_profiles.py --profile synthetic-enterprise-story`
- `.venv/bin/python scripts/check_public_docs_hygiene.py`
- parsed both modified workflow YAML files and ran `bash -n` against the hosted deployment verification script
- `uv run --with build==1.4.0 python -m build --wheel --outdir /private/tmp/agent-bom-pr4-wheel`
- inspected the built wheel for `agent_bom/demo_estate/data/enterprise_observations.jsonl`
- `git diff --cached --check`

## Notes

- stacked on #4642; the review diff contains only deployment, distribution, documentation, and CI lock-in
- the Helm profile is explicitly demo-only, disables live scanning, and must not be combined with customer collection
