### PR TITLE
fix(scan): close the remaining MCP tool-detection gaps, and add Kotlin

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 826,
+      "value": 828,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -17,7 +17,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | Test files | 1125 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 826 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 828 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/ast/js_ts/facade.py
+++ b/src/agent_bom/ast/js_ts/facade.py
@@ -13,7 +13,6 @@ Layering
 Do not add a third parallel JS/TS analyzer — extend this facade or the engine.
 """
 
-
 from __future__ import annotations
 
 import re
@@ -21,7 +20,7 @@ from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING
 
 from agent_bom.ast_models import CallEdge, DependencySymbolReach, DetectedGuardrail, ExtractedPrompt, FlowFinding, ToolSignature
-from agent_bom.ast_signal_utils import _GUARDRAIL_CALL_PATTERNS, check_prompt_risks, classify_prompt_type
+from agent_bom.ast_signal_utils import _GUARDRAIL_CALL_PATTERNS, _balanced_segment, check_prompt_risks, classify_prompt_type
 from agent_bom.ast_source_mask import mask_line_comments_and_strings
 
 if TYPE_CHECKING:
@@ -40,6 +39,20 @@ _JS_TOOL_CALL_START_RE = re.compile(
     re.IGNORECASE,
 )
 _JS_STRING_ARG_RE = re.compile(r"""\s*(?P<quote>["'`])(?P<name>[^"'`]*)(?P=quote)""")
+# Servers built on the low-level ``Server`` class rather than the ``McpServer``
+# wrapper declare their tools in the ListTools response. The v1 SDK passes the
+# schema object and the v2 SDK the method string -- the SDK's own v1->v2 codemod
+# rewrites ``ListToolsRequestSchema`` to ``'tools/list'`` -- so both are matched.
+_JS_SET_REQUEST_HANDLER_START_RE = re.compile(r"""\bsetRequestHandler\s*\(""")
+_JS_LIST_TOOLS_SELECTOR_RE = re.compile(r"""\(\s*(?:ListToolsRequestSchema\b|(?P<quote>["'`])tools/list(?P=quote))""")
+_JS_TOOLS_ARRAY_START_RE = re.compile(r"""\btools\s*:\s*\[""")
+_JS_NAME_KEY_RE = re.compile(r"""\bname\s*:""")
+# The Vercel AI SDK and Mastra pass a tools MAP whose KEY is the tool name:
+#   tools: { weather: tool({ description, inputSchema, execute }) }
+# Requiring ``{``, ``,`` or a newline before the key keeps ``cond ? a : tool(x)``
+# and ``case foo: tool()`` from being read as a registration.
+_JS_OBJECT_KEY_BEFORE_RE = re.compile(r"""[{,\n]\s*(?P<key>[A-Za-z_$][\w$]*)\s*:\s*$""")
+_JS_OBJECT_KEY_LOOKBEHIND = 120
 _JS_IMPORT_MODULE_RE = re.compile(
     r"""\bimport\s+(?:[\s\S]{0,200}?\s+from\s+)?["'`](?P<module>[^"'`]+)["'`]""",
     re.IGNORECASE,
@@ -115,6 +128,112 @@ def _js_first_string_argument(source: str, open_paren_index: int) -> str:
         return ""
     match = _JS_STRING_ARG_RE.match(source, open_paren_index + 1)
     return match.group("name").strip() if match else ""
+
+
+def _js_bracket_depths(masked: str) -> list[int]:
+    """Return the bracket depth at every offset of *masked*.
+
+    An opening bracket reports the depth it opens and a closing bracket the
+    depth it closes, so the contents of a literal that starts at offset 0 all
+    read as depth 1. Only comment/string-masked text may be passed: a bracket
+    inside a string literal would otherwise skew every following depth.
+    """
+    depths: list[int] = []
+    depth = 0
+    for char in masked:
+        if char in "{[(":
+            depth += 1
+            depths.append(depth)
+        elif char in "}])":
+            depths.append(depth)
+            depth -= 1
+        else:
+            depths.append(depth)
+    return depths
+
+
+def _js_name_property_at_depth_one(masked_literal: str, source_literal: str) -> str:
+    """Return the ``name: "…"`` value declared directly on a masked object literal."""
+    depths = _js_bracket_depths(masked_literal)
+    for key_match in _JS_NAME_KEY_RE.finditer(masked_literal):
+        if depths[key_match.start()] != 1:
+            continue
+        value_match = _JS_STRING_ARG_RE.match(source_literal, key_match.end())
+        return value_match.group("name").strip() if value_match else ""
+    return ""
+
+
+def _js_object_literals_at_depth(masked: str, source: str, *, depth: int) -> list[tuple[int, str, str]]:
+    """Return ``(offset, masked, real)`` for each ``{…}`` opening at *depth* in *masked*."""
+    literals: list[tuple[int, str, str]] = []
+    depths = _js_bracket_depths(masked)
+    index = 0
+    while index < len(masked):
+        if masked[index] != "{" or depths[index] != depth:
+            index += 1
+            continue
+        segment = _balanced_segment(masked, index, open_char="{", close_char="}")
+        if segment is None:
+            break
+        masked_literal, end = segment
+        literals.append((index, masked_literal, source[index : index + len(masked_literal)]))
+        index = end
+    return literals
+
+
+def _js_named_option_argument(source: str, masked_source: str, open_paren_index: int) -> str:
+    """Return a ``name:`` declared on an options object passed to a tool call.
+
+    LangChain JS puts the name there rather than in a leading string argument:
+    ``tool(fn, { name: 'search_database', description, schema })``.
+    """
+    segment = _balanced_segment(masked_source, open_paren_index, open_char="(", close_char=")")
+    if segment is None:
+        return ""
+    masked_args, _ = segment
+    source_args = source[open_paren_index : open_paren_index + len(masked_args)]
+    for _offset, masked_literal, source_literal in _js_object_literals_at_depth(masked_args, source_args, depth=2):
+        name = _js_name_property_at_depth_one(masked_literal, source_literal)
+        if name:
+            return name
+    return ""
+
+
+def _js_object_key_before(masked_source: str, index: int) -> str:
+    """Return the object key a tool call is assigned to, as in ``{ weather: tool(…) }``."""
+    window = masked_source[max(0, index - _JS_OBJECT_KEY_LOOKBEHIND) : index]
+    match = _JS_OBJECT_KEY_BEFORE_RE.search(window)
+    return match.group("key") if match else ""
+
+
+def _js_low_level_tool_declarations(source: str, masked_source: str) -> list[tuple[str, int]]:
+    """Return ``(tool_name, line_number)`` declared by low-level ListTools handlers."""
+    declarations: list[tuple[str, int]] = []
+    for match in _JS_SET_REQUEST_HANDLER_START_RE.finditer(masked_source):
+        open_index = match.end() - 1
+        # The schema identifier survives masking; the ``'tools/list'`` method
+        # string does not, so the selector is read from the real source.
+        if _JS_LIST_TOOLS_SELECTOR_RE.match(source, open_index) is None:
+            continue
+        call_segment = _balanced_segment(masked_source, open_index, open_char="(", close_char=")")
+        if call_segment is None:
+            continue
+        masked_call, _ = call_segment
+        array_match = _JS_TOOLS_ARRAY_START_RE.search(masked_call)
+        if array_match is None:
+            continue
+        array_index = open_index + array_match.end() - 1
+        array_segment = _balanced_segment(masked_source, array_index, open_char="[", close_char="]")
+        if array_segment is None:
+            continue
+        masked_array, _ = array_segment
+        source_array = source[array_index : array_index + len(masked_array)]
+        for offset, masked_literal, source_literal in _js_object_literals_at_depth(masked_array, source_array, depth=2):
+            name = _js_name_property_at_depth_one(masked_literal, source_literal)
+            if not name:
+                continue
+            declarations.append((name, source[: array_index + offset].count("\n") + 1))
+    return declarations
 
 
 def _first_match_line(source: str, pattern: str) -> int:
@@ -581,7 +700,15 @@ def scan_js_ts_file(
     # offsets, so the tool name is still read from the real source.
     masked_source = mask_line_comments_and_strings(source, backtick_strings=True, single_line_quotes=True)
     for match in _JS_TOOL_CALL_START_RE.finditer(masked_source):
-        tool_name = _js_first_string_argument(source, match.end() - 1)
+        open_paren_index = match.end() - 1
+        # Three name-bearing shapes, most explicit first: the leading string
+        # argument of the MCP SDK, the ``name:`` of a LangChain JS options
+        # object, and finally the ``tools`` map key of the Vercel AI SDK.
+        tool_name = _js_first_string_argument(source, open_paren_index)
+        if not tool_name:
+            tool_name = _js_named_option_argument(source, masked_source, open_paren_index)
+        if not tool_name:
+            tool_name = _js_object_key_before(masked_source, match.start())
         line_num = source[: match.start()].count("\n") + 1
         dedup_key = (tool_name, line_num)
         if not tool_name or dedup_key in seen_tool_names:
@@ -596,6 +723,27 @@ def scan_js_ts_file(
                 file_path=rel_path,
                 line_number=line_num,
                 decorators=["tool()"],
+                is_async=False,
+            )
+        )
+
+    # Low-level ``Server`` tools have no per-tool handler function to bind -- the
+    # CallTool handler dispatches on the name -- so they contribute inventory
+    # only, never a tool_registration that would fake a resolved entrypoint.
+    for tool_name, line_num in _js_low_level_tool_declarations(source, masked_source):
+        dedup_key = (tool_name, line_num)
+        if dedup_key in seen_tool_names:
+            continue
+        seen_tool_names.add(dedup_key)
+        tools.append(
+            ToolSignature(
+                name=tool_name,
+                parameters=[],
+                return_type="unknown",
+                description="JS/TS MCP tool definition",
+                file_path=rel_path,
+                line_number=line_num,
+                decorators=["tools/list"],
                 is_async=False,
             )
         )

--- a/src/agent_bom/ast/kotlin/__init__.py
+++ b/src/agent_bom/ast/kotlin/__init__.py
@@ -1,0 +1,25 @@
+"""Single public entry point for Kotlin analysis.
+
+Mirrors ``agent_bom.ast.js_ts``: the analyzer module holds the implementation
+and this package exposes the stable names ``ast_analyzer`` imports.
+"""
+
+from __future__ import annotations
+
+from agent_bom.ast.kotlin.analyzer import (
+    KOTLIN_EXTS,
+    _kotlin_function_key,
+    build_kotlin_dependency_symbol_reach,
+    kotlin_source_imports_mcp_module,
+    scan_kotlin_file,
+)
+
+kotlin_function_key = _kotlin_function_key
+
+__all__ = [
+    "KOTLIN_EXTS",
+    "build_kotlin_dependency_symbol_reach",
+    "kotlin_function_key",
+    "kotlin_source_imports_mcp_module",
+    "scan_kotlin_file",
+]

--- a/src/agent_bom/ast/kotlin/analyzer.py
+++ b/src/agent_bom/ast/kotlin/analyzer.py
@@ -1,0 +1,443 @@
+"""Kotlin analyzer helpers for MCP symbol-level reachability.
+
+Regex-backed and conservative, mirroring ``agent_bom.ast_java``: Maven
+coordinates must be declared in ``pom.xml`` or a Gradle build before
+import/local-variable bindings are trusted, and unresolved MCP tool handlers are
+dropped so headless agents do not inherit false ``function_reachable`` upgrades
+at CVE join time.
+
+The registration idiom is ``addTool`` from ``io.modelcontextprotocol:kotlin-sdk``
+(the official kotlin-sdk), which carries the tool name as a named argument:
+
+    mcpServer.addTool(
+        name = "example-tool",
+        description = "An example tool",
+    ) { request -> CallToolResult(...) }
+
+``addTool`` is an ordinary-looking method name, so -- as the Swift analyzer does
+with ``import MCP`` -- a registration is only trusted in a file that imports an
+MCP module. ``addPrompt`` and ``addResource`` are sibling registrations that
+declare no tool and are deliberately not matched.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from agent_bom.ast_models import (
+    CallEdge,
+    DependencySymbolReach,
+    DetectedGuardrail,
+    ExtractedPrompt,
+    FlowFinding,
+    ToolSignature,
+    _KotlinCallSite,
+    _KotlinFileAnalysis,
+    _KotlinFunctionAnalysis,
+    _KotlinToolRegistration,
+)
+from agent_bom.ast_signal_utils import _balanced_segment, _line_number_from_index
+from agent_bom.ast_source_mask import mask_line_comments_and_strings
+from agent_bom.ast_symbol_reach_guards import is_actionable_dependency_symbol
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+_MAX_FILE_SIZE = 512 * 1024
+KOTLIN_EXTS = frozenset({".kt", ".kts"})
+
+_KOTLIN_IMPORT_RE = re.compile(r"^\s*import\s+(?P<path>[\w.]+)(?:\s+as\s+(?P<alias>\w+))?", re.MULTILINE)
+_KOTLIN_SCOPE_RE = re.compile(r"\b(?:class|object|interface)\s+(?P<name>\w+)")
+_KOTLIN_FUN_RE = re.compile(r"\bfun\s+(?:<[^>]*>\s*)?(?:[\w.<>]+\.)?(?P<name>\w+)\s*\(", re.MULTILINE)
+_KOTLIN_CALL_RE = re.compile(r"\b(?P<name>\w+(?:\.\w+)+)\s*\(")
+_KOTLIN_CALL_SKIP = frozenset(
+    {
+        "if",
+        "for",
+        "while",
+        "when",
+        "return",
+        "catch",
+        "throw",
+        "class",
+        "object",
+        "fun",
+        "val",
+        "var",
+        "import",
+        "package",
+    }
+)
+# Only the call head is matched, so the scan can run over comment/string-masked
+# text; the name literal is then read from the real source at the same offset.
+_KOTLIN_ADD_TOOL_START_RE = re.compile(r"\.addTool\s*\(")
+_KOTLIN_TOOL_NAME_ARG_RE = re.compile(r"""\bname\s*=\s*"(?P<name>[^"]*)\"""")
+_KOTLIN_LEADING_STRING_RE = re.compile(r"""\s*"(?P<name>[^"]*)\"""")
+_KOTLIN_LOCAL_BINDING_RE = re.compile(r"\b(?:val|var)\s+(?P<var>\w+)\s*(?::\s*(?P<type>[\w.]+))?\s*=\s*(?P<ctor>[\w.]+)\s*\(")
+_KOTLIN_MCP_IMPORT_PREFIXES = ("io.modelcontextprotocol", "org.modelcontextprotocol")
+_KOTLIN_FRAMEWORK_HINTS: dict[str, str] = {
+    "modelcontextprotocol": "MCP",
+    "com.anthropic": "Anthropic",
+    "com.openai": "OpenAI",
+    "dev.langchain4j": "LangChain",
+}
+
+
+def kotlin_source_imports_mcp_module(source: str) -> bool:
+    """Return whether *source* imports an official MCP Kotlin SDK package."""
+    return any(match.group("path").startswith(_KOTLIN_MCP_IMPORT_PREFIXES) for match in _KOTLIN_IMPORT_RE.finditer(source))
+
+
+def _kotlin_import_bindings(source: str, maven_map: Mapping[str, str]) -> dict[str, str]:
+    """Map Kotlin type names to the ``groupId:artifactId`` that declares them."""
+    from agent_bom.ast_java import _maven_coord_from_import
+
+    bindings: dict[str, str] = {}
+    for match in _KOTLIN_IMPORT_RE.finditer(source):
+        import_path = match.group("path").strip()
+        coord = _maven_coord_from_import(import_path, maven_map)
+        if not coord:
+            continue
+        simple = import_path.rsplit(".", 1)[-1]
+        bindings[simple] = coord
+        bindings[import_path] = coord
+        if alias := match.group("alias"):
+            bindings[alias] = coord
+        if "." in import_path:
+            bindings[import_path.rsplit(".", 1)[0]] = coord
+    return bindings
+
+
+def _kotlin_local_bindings(body: str, import_bindings: Mapping[str, str]) -> dict[str, str]:
+    """Bind ``val client = HttpClient()`` locals to their declaring coordinate."""
+    locals_map: dict[str, str] = {}
+    for match in _KOTLIN_LOCAL_BINDING_RE.finditer(body):
+        var_name = match.group("var")
+        for candidate in (match.group("type"), match.group("ctor")):
+            if not candidate:
+                continue
+            coord = import_bindings.get(candidate) or import_bindings.get(candidate.rsplit(".", 1)[-1])
+            if coord:
+                locals_map[var_name] = coord
+                break
+    return locals_map
+
+
+def _kotlin_call_sites(body: str, *, line_offset: int) -> list[_KotlinCallSite]:
+    masked = mask_line_comments_and_strings(body)
+    sites: list[_KotlinCallSite] = []
+    for match in _KOTLIN_CALL_RE.finditer(masked):
+        name = match.group("name")
+        if name.split(".", 1)[0] in _KOTLIN_CALL_SKIP:
+            continue
+        sites.append(
+            _KotlinCallSite(
+                name=name,
+                line_number=line_offset + masked[: match.start()].count("\n") + 1,
+            )
+        )
+    return sites
+
+
+def _kotlin_function_key(scope_name: str, name: str) -> str:
+    return f"{scope_name}::{name}"
+
+
+def _kotlin_function_display_name(scope_name: str, name: str, name_counts: Mapping[str, int]) -> str:
+    if name_counts.get(name, 0) > 1:
+        return _kotlin_function_key(scope_name, name)
+    return name
+
+
+def _collect_kotlin_functions(
+    source: str,
+    *,
+    rel_path: str,
+    scope_name: str,
+    bindings: Mapping[str, str],
+) -> dict[str, _KotlinFunctionAnalysis]:
+    functions: dict[str, _KotlinFunctionAnalysis] = {}
+    masked = mask_line_comments_and_strings(source)
+    for match in _KOTLIN_FUN_RE.finditer(masked):
+        name = match.group("name")
+        brace_index = masked.find("{", match.end())
+        body_segment = _balanced_segment(masked, brace_index, open_char="{", close_char="}") if brace_index >= 0 else None
+        call_sites: list[_KotlinCallSite] = []
+        function_bindings = dict(bindings)
+        if body_segment is not None:
+            masked_body, _ = body_segment
+            body_text = source[brace_index : brace_index + len(masked_body)]
+            body_line_offset = _line_number_from_index(source, brace_index) - 1
+            call_sites = _kotlin_call_sites(body_text, line_offset=body_line_offset)
+            function_bindings.update(_kotlin_local_bindings(body_text, bindings))
+        functions[_kotlin_function_key(scope_name, name)] = _KotlinFunctionAnalysis(
+            name=name,
+            line_number=_line_number_from_index(source, match.start()),
+            file_path=rel_path,
+            scope_name=scope_name,
+            import_bindings=function_bindings,
+            call_sites=call_sites,
+        )
+    return functions
+
+
+def _kotlin_tool_name(source: str, masked: str, open_paren_index: int) -> str:
+    """Return the tool name declared by the ``addTool`` call at *open_paren_index*."""
+    segment = _balanced_segment(masked, open_paren_index, open_char="(", close_char=")")
+    if segment is None:
+        return ""
+    masked_args, _ = segment
+    args_text = source[open_paren_index : open_paren_index + len(masked_args)]
+    # ``name = "…"`` is the README idiom; a leading string literal covers the
+    # positional call Kotlin also allows.
+    named = _KOTLIN_TOOL_NAME_ARG_RE.search(args_text)
+    if named:
+        return named.group("name").strip()
+    leading = _KOTLIN_LEADING_STRING_RE.match(args_text, 1)
+    return leading.group("name").strip() if leading else ""
+
+
+def _collect_kotlin_tool_registrations(
+    source: str,
+    *,
+    rel_path: str,
+    scope_name: str,
+    bindings: Mapping[str, str],
+    functions: dict[str, _KotlinFunctionAnalysis],
+) -> list[_KotlinToolRegistration]:
+    """Collect ``addTool`` registrations, capturing the trailing-lambda handler."""
+    registrations: list[_KotlinToolRegistration] = []
+    seen: set[tuple[str, int]] = set()
+    # Scan masked source so a commented-out or quoted registration is never a
+    # live tool; masking preserves offsets, so names are read from the real text.
+    masked = mask_line_comments_and_strings(source)
+    for match in _KOTLIN_ADD_TOOL_START_RE.finditer(masked):
+        open_paren_index = match.end() - 1
+        tool_name = _kotlin_tool_name(source, masked, open_paren_index)
+        if not tool_name:
+            continue
+        key = (tool_name, match.start())
+        if key in seen:
+            continue
+        seen.add(key)
+
+        # The trailing lambda has no declared name, so it is registered as a
+        # synthetic ``tool:<name>`` function. The key must be scope-qualified the
+        # same way real functions are, because ``ast_analyzer`` re-keys every
+        # function by ``(scope_name, name)`` before resolving handlers.
+        handler_function_name = f"tool:{tool_name}"
+        handler_name = _kotlin_function_key(scope_name, handler_function_name)
+        call_segment = _balanced_segment(masked, open_paren_index, open_char="(", close_char=")")
+        if call_segment is not None:
+            _masked_args, args_end = call_segment
+            brace_index = masked.find("{", args_end)
+            # Only a lambda that follows the argument list on the same statement
+            # is this tool's handler.
+            if brace_index >= 0 and not masked[args_end:brace_index].strip():
+                body_segment = _balanced_segment(masked, brace_index, open_char="{", close_char="}")
+                if body_segment is not None:
+                    masked_body, _ = body_segment
+                    body_text = source[brace_index : brace_index + len(masked_body)]
+                    handler_bindings = dict(bindings)
+                    handler_bindings.update(_kotlin_local_bindings(body_text, bindings))
+                    functions[handler_name] = _KotlinFunctionAnalysis(
+                        name=handler_function_name,
+                        line_number=_line_number_from_index(source, brace_index),
+                        file_path=rel_path,
+                        scope_name=scope_name,
+                        import_bindings=handler_bindings,
+                        call_sites=_kotlin_call_sites(body_text, line_offset=_line_number_from_index(source, brace_index) - 1),
+                    )
+
+        registrations.append(
+            _KotlinToolRegistration(
+                tool_name=tool_name,
+                handler_name=handler_name,
+                line_number=_line_number_from_index(source, match.start()),
+                file_path=rel_path,
+                scope_name=scope_name,
+                import_bindings=dict(bindings),
+            )
+        )
+    return registrations
+
+
+def _resolve_kotlin_callee_key(
+    call_name: str,
+    *,
+    scope_name: str,
+    functions: Mapping[str, _KotlinFunctionAnalysis],
+) -> str | None:
+    bare = call_name.split("(", 1)[0].strip()
+    if "." in bare:
+        head, tail = bare.split(".", 1)
+        for candidate in (_kotlin_function_key(scope_name, tail), _kotlin_function_key(head, tail)):
+            if candidate in functions:
+                return candidate
+    candidate = _kotlin_function_key(scope_name, bare)
+    return candidate if candidate in functions else None
+
+
+def _resolve_kotlin_external_dependency_symbol(
+    function: _KotlinFunctionAnalysis,
+    call_name: str,
+) -> tuple[str, str, str] | None:
+    """Resolve an external import call to ``(package, module, symbol)``."""
+    if not call_name or "." not in call_name:
+        return None
+    head, tail = call_name.split(".", 1)
+    coord = function.import_bindings.get(head)
+    if not coord:
+        return None
+    symbol = tail.split(".", 1)[0]
+    if not is_actionable_dependency_symbol(symbol):
+        return None
+    return coord, coord, symbol
+
+
+def build_kotlin_dependency_symbol_reach(
+    *,
+    functions: Mapping[str, _KotlinFunctionAnalysis],
+    tool_registrations: Sequence[_KotlinToolRegistration],
+    max_depth: int = 4,
+) -> list[DependencySymbolReach]:
+    """Build bounded MCP tool-entrypoint -> Maven dependency symbol reach."""
+    if not functions or not tool_registrations:
+        return []
+
+    adjacency: dict[str, set[str]] = {name: set() for name in functions}
+    name_counts: dict[str, int] = {}
+    for function in functions.values():
+        name_counts[function.name] = name_counts.get(function.name, 0) + 1
+
+    for function_key, function in functions.items():
+        for call_site in function.call_sites:
+            callee_key = _resolve_kotlin_callee_key(
+                call_site.name,
+                scope_name=function.scope_name,
+                functions=functions,
+            )
+            if callee_key and callee_key != function_key:
+                adjacency[function_key].add(callee_key)
+
+    reached: list[DependencySymbolReach] = []
+    seen: set[tuple[str, str, str, str, int]] = set()
+
+    def display_name(function_key: str) -> str:
+        function = functions[function_key]
+        return _kotlin_function_display_name(function.scope_name, function.name, name_counts)
+
+    for registration in tool_registrations:
+        handler_key = registration.handler_name
+        if handler_key not in functions:
+            continue
+        queue: list[tuple[str, list[str]]] = [(handler_key, [handler_key])]
+        visited: set[str] = set()
+        while queue:
+            current_key, path = queue.pop(0)
+            if len(path) > max_depth or current_key in visited:
+                continue
+            visited.add(current_key)
+            current = functions[current_key]
+            for call_site in current.call_sites:
+                external = _resolve_kotlin_external_dependency_symbol(current, call_site.name)
+                if external is None:
+                    continue
+                package, module_name, symbol = external
+                dedup_key = (registration.tool_name, module_name, symbol, current.file_path, call_site.line_number)
+                if dedup_key in seen:
+                    continue
+                seen.add(dedup_key)
+                reached.append(
+                    DependencySymbolReach(
+                        entrypoint=registration.tool_name,
+                        package=package,
+                        module=module_name,
+                        symbol=symbol,
+                        file_path=current.file_path,
+                        line_number=call_site.line_number,
+                        call_path=[registration.tool_name, *[display_name(name) for name in path], f"{module_name}.{symbol}"],
+                        depth=max(0, len(path) - 1),
+                        ecosystem="maven",
+                    )
+                )
+            for next_callee in sorted(adjacency.get(current_key, ())):
+                queue.append((next_callee, [*path, next_callee]))
+
+    return reached
+
+
+def scan_kotlin_file(
+    file_path: Path,
+    rel_path: str,
+    *,
+    maven_map: Mapping[str, str],
+) -> tuple[
+    list[ExtractedPrompt],
+    list[DetectedGuardrail],
+    list[ToolSignature],
+    list[FlowFinding],
+    list[str],
+    list[CallEdge],
+    _KotlinFileAnalysis | None,
+]:
+    """Extract MCP/tool signals and call sites from Kotlin source files."""
+    try:
+        source = file_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return [], [], [], [], [], [], None
+
+    if len(source) > _MAX_FILE_SIZE:
+        return [], [], [], [], [], [], None
+
+    scope_match = _KOTLIN_SCOPE_RE.search(mask_line_comments_and_strings(source))
+    scope_name = scope_match.group("name") if scope_match else Path(rel_path).stem
+    bindings = _kotlin_import_bindings(source, maven_map)
+    frameworks = sorted(
+        {
+            framework
+            for prefix, framework in _KOTLIN_FRAMEWORK_HINTS.items()
+            for match in _KOTLIN_IMPORT_RE.finditer(source)
+            if prefix in match.group("path")
+        }
+    )
+    functions = _collect_kotlin_functions(source, rel_path=rel_path, scope_name=scope_name, bindings=bindings)
+    tool_registrations: list[_KotlinToolRegistration] = []
+    if kotlin_source_imports_mcp_module(source):
+        tool_registrations = _collect_kotlin_tool_registrations(
+            source,
+            rel_path=rel_path,
+            scope_name=scope_name,
+            bindings=bindings,
+            functions=functions,
+        )
+
+    tools = [
+        ToolSignature(
+            name=registration.tool_name,
+            parameters=[],
+            return_type="unknown",
+            description="Kotlin MCP/tool registration",
+            file_path=rel_path,
+            line_number=registration.line_number,
+            decorators=["kotlin-tool"],
+            is_async=False,
+        )
+        for registration in tool_registrations
+    ]
+
+    return (
+        [],
+        [],
+        tools,
+        [],
+        frameworks,
+        [],
+        _KotlinFileAnalysis(
+            scope_name=scope_name,
+            functions=functions,
+            tool_registrations=tool_registrations,
+        ),
+    )

--- a/src/agent_bom/ast_analyzer.py
+++ b/src/agent_bom/ast_analyzer.py
@@ -13,8 +13,9 @@ Extends the regex-based scanner with semantic analysis:
 Python files use full AST parsing. JS/TS files contribute prompt/tool/guardrail
 signals plus parser-backed import, handler, and call-chain extraction so
 non-Python agent projects participate in the same inventory and flow model.
-Go, Rust, Java, C#, Ruby, PHP (Composer), and Swift sources also contribute MCP tool
-entrypoints and dependency-symbol reach for Cargo/Maven/NuGet/RubyGems/Composer/SPM CVE join.
+Go, Rust, Java, Kotlin, C#, Ruby, PHP (Composer), and Swift sources also contribute MCP
+tool entrypoints and dependency-symbol reach for Cargo/Maven/NuGet/RubyGems/Composer/SPM
+CVE join.
 
 Compliance mapping:
 - OWASP LLM01 (Prompt Injection) — prompt inventory and risk review signals
@@ -35,6 +36,10 @@ from agent_bom.ast.js_ts import build_js_ts_dependency_symbol_reach
 from agent_bom.ast.js_ts import build_js_ts_flow_findings as _build_js_ts_flow_findings
 from agent_bom.ast.js_ts import js_ts_function_key as _js_ts_function_key
 from agent_bom.ast.js_ts import scan_js_ts_file as _scan_js_ts_file
+from agent_bom.ast.kotlin import KOTLIN_EXTS as _KOTLIN_EXTS
+from agent_bom.ast.kotlin import build_kotlin_dependency_symbol_reach
+from agent_bom.ast.kotlin import kotlin_function_key as _kotlin_function_key
+from agent_bom.ast.kotlin import scan_kotlin_file as _scan_kotlin_file
 from agent_bom.ast_csharp import _csharp_method_key, build_csharp_dependency_symbol_reach, load_nuget_namespace_map
 from agent_bom.ast_csharp import scan_csharp_file as _scan_csharp_file
 from agent_bom.ast_go import _go_function_key, build_go_dependency_symbol_reach
@@ -52,6 +57,8 @@ from agent_bom.ast_models import (
     _GoToolRegistration,
     _JavaMethodAnalysis,
     _JavaToolRegistration,
+    _KotlinFunctionAnalysis,
+    _KotlinToolRegistration,
     _PhpMethodAnalysis,
     _PhpToolRegistration,
     _RubyMethodAnalysis,
@@ -86,9 +93,7 @@ from agent_bom.ast_swift import scan_swift_file as _scan_swift_file
 
 _max_taint_depth = _python_max_taint_depth
 
-_ANALYZABLE_SUFFIXES = frozenset(
-    {".py", ".go", ".java", ".rb", ".php", ".swift", ".rs", ".cs", *_JS_TS_EXTS}
-)
+_ANALYZABLE_SUFFIXES = frozenset({".py", ".go", ".java", ".rb", ".php", ".swift", ".rs", ".cs", *_JS_TS_EXTS, *_KOTLIN_EXTS})
 
 
 def project_has_analyzable_sources(project_path: str | Path) -> bool:
@@ -175,6 +180,16 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
             continue
         java_files.append(f)
 
+    kotlin_files = []
+    for f in sorted(project.rglob("*")):
+        if f.suffix.lower() not in _KOTLIN_EXTS:
+            continue
+        if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
+            continue
+        if any(skip in f.name.lower() for skip in _SKIP_FILE_PATTERNS):
+            continue
+        kotlin_files.append(f)
+
     csharp_files = []
     for f in sorted(project.rglob("*.cs")):
         if any(part in _SKIP_DIRS for part in f.relative_to(project).parts):
@@ -219,6 +234,12 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     swift_files = swift_files[
         : max(0, remaining - len(rust_files) - len(java_files) - len(csharp_files) - len(ruby_files) - len(php_files))
     ]
+    kotlin_files = kotlin_files[
+        : max(
+            0,
+            remaining - len(rust_files) - len(java_files) - len(csharp_files) - len(ruby_files) - len(php_files) - len(swift_files),
+        )
+    ]
     result.files_analyzed = (
         len(py_files)
         + len(js_ts_files)
@@ -229,6 +250,7 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
         + len(ruby_files)
         + len(php_files)
         + len(swift_files)
+        + len(kotlin_files)
     )
     function_analyses: list[_FunctionAnalysis] = []
     js_ts_functions: dict[str, JSTSFunction] = {}
@@ -247,6 +269,8 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
     php_tool_registrations: list[_PhpToolRegistration] = []
     swift_functions: dict[str, _SwiftFunctionAnalysis] = {}
     swift_tool_registrations: list[_SwiftToolRegistration] = []
+    kotlin_functions: dict[str, _KotlinFunctionAnalysis] = {}
+    kotlin_tool_registrations: list[_KotlinToolRegistration] = []
     maven_dependency_map = _load_maven_dependency_map(project)
     nuget_namespace_map = load_nuget_namespace_map(project)
     ruby_gem_map = load_ruby_gem_map(project)
@@ -401,6 +425,24 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
                 swift_functions[_swift_function_key(swift_function.scope_name, swift_function.name)] = swift_function
             swift_tool_registrations.extend(swift_analysis.tool_registrations)
 
+    for kotlin_file in kotlin_files:
+        rel = str(kotlin_file.relative_to(project))
+        prompts, guardrails, tools, flow_findings, frameworks, kotlin_call_edges, kotlin_analysis = _scan_kotlin_file(
+            kotlin_file,
+            rel,
+            maven_map=maven_dependency_map,
+        )
+        result.prompts.extend(prompts)
+        result.guardrails.extend(guardrails)
+        result.tools.extend(tools)
+        result.flow_findings.extend(flow_findings)
+        result.frameworks_detected.extend(frameworks)
+        result.call_edges.extend(kotlin_call_edges)
+        if kotlin_analysis is not None:
+            for kotlin_function in kotlin_analysis.functions.values():
+                kotlin_functions[_kotlin_function_key(kotlin_function.scope_name, kotlin_function.name)] = kotlin_function
+            kotlin_tool_registrations.extend(kotlin_analysis.tool_registrations)
+
     python_call_edges, interprocedural_findings = _build_call_graph(function_analyses)
     result.call_edges.extend(python_call_edges)
     result.flow_findings.extend(interprocedural_findings)
@@ -473,6 +515,13 @@ def analyze_project(project_path: str | Path) -> ASTAnalysisResult:
             functions=swift_functions,
             tool_registrations=swift_tool_registrations,
             package_map=swift_package_map,
+            max_depth=_python_max_taint_depth(),
+        )
+    )
+    result.dependency_symbol_reach.extend(
+        build_kotlin_dependency_symbol_reach(
+            functions=kotlin_functions,
+            tool_registrations=kotlin_tool_registrations,
             max_depth=_python_max_taint_depth(),
         )
     )

--- a/src/agent_bom/ast_csharp.py
+++ b/src/agent_bom/ast_csharp.py
@@ -247,23 +247,25 @@ def _collect_csharp_tool_registrations(
             )
         )
 
-    # Scan masked source so a commented-out attribute is not a tool; the
-    # attribute text itself is re-read from the real source at the same offset.
+    # Scan masked source so a commented-out attribute is not a tool. The span is
+    # then sliced out of the real source so the declared name is readable. The
+    # span must come from the MASKED match: brackets inside a ``Description``
+    # string are blanked there, but in the real source a ``]`` would close the
+    # group early and a ``[`` would stop the match from being found at all.
     masked = mask_line_comments_and_strings(source)
     for masked_match in _CS_MCP_TOOL_ATTR_RE.finditer(masked):
-        attr_match = _CS_MCP_TOOL_ATTR_RE.match(source, masked_match.start())
-        if attr_match is None:
-            continue
-        method_match = _CS_METHOD_RE.search(source, attr_match.end())
+        attr_start, attr_end = masked_match.span()
+        attr_text = source[attr_start:attr_end]
+        method_match = _CS_METHOD_RE.search(source, attr_end)
         if not method_match:
             continue
         method_name = method_match.group("name")
         # ``[McpServerTool(Name = "weather_ui")]`` renames the wire-level tool;
         # the method name is only the fallback.
-        declared_name = _CS_ATTR_NAME_RE.search(attr_match.group(0))
+        declared_name = _CS_ATTR_NAME_RE.search(attr_text)
         tool_name = declared_name.group("name").strip() if declared_name else ""
         tool_name = tool_name or method_name
-        registration_key = (tool_name, attr_match.start())
+        registration_key = (tool_name, attr_start)
         if registration_key in seen:
             continue
         seen.add(registration_key)
@@ -274,7 +276,7 @@ def _collect_csharp_tool_registrations(
             _CSharpToolRegistration(
                 tool_name=tool_name,
                 handler_name=handler_key,
-                line_number=_line_number_from_index(source, attr_match.start()),
+                line_number=_line_number_from_index(source, attr_start),
                 file_path=rel_path,
                 class_name=class_name,
                 import_bindings=dict(bindings),

--- a/src/agent_bom/ast_go.py
+++ b/src/agent_bom/ast_go.py
@@ -27,7 +27,7 @@ from agent_bom.ast_signal_utils import (
 from agent_bom.ast_source_mask import mask_line_comments_and_strings
 
 if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
+    from collections.abc import Iterable, Mapping, Sequence
 
 _MAX_FILE_SIZE = 512 * 1024  # 512KB
 _GO_PROMPT_ASSIGN_RE = re.compile(
@@ -40,7 +40,17 @@ _GO_PROMPT_ASSIGN_RE = re.compile(
 # A bare ``Tool(`` alternative used to be listed here, but with IGNORECASE it
 # claimed any ordinary call spelled ``inventory.Tool("hammer-42")``. Only the
 # registration verbs stay.
-_GO_TOOL_START_RE = re.compile(r"""\b(?:AddTool|RegisterTool|NewTool)\s*\(""", re.IGNORECASE)
+_GO_TOOL_START_RE = re.compile(r"""\b(?P<verb>AddTool|RegisterTool|NewTool)\s*\(""", re.IGNORECASE)
+# ``NewTool`` is the name-bearing call of the mainstream community MCP library,
+# but ``NewX`` is also the ordinary Go constructor idiom, so an unrelated
+# ``mcp.NewTool("wrench-7")`` in a hardware package would otherwise register a
+# tool. It is only trusted in a file that imports an MCP module -- the same gate
+# the Swift analyzer applies to ``Tool(name:)`` via ``import MCP``. ``AddTool``
+# and ``RegisterTool`` stay ungated: they are registration verbs rather than
+# constructors, and real servers call them through a handle whose own package
+# may not be imported by name in that file.
+_GO_NEW_TOOL_VERB = "newtool"
+_GO_MCP_MODULE_SEGMENT_RE = re.compile(r"(?:^|[/.-])(?:mcp|modelcontextprotocol)(?:$|[/.-])", re.IGNORECASE)
 # github.com/modelcontextprotocol/go-sdk carries the tool name in a composite
 # literal instead of a leading string argument, in both registration forms:
 #   mcp.AddTool(server, &mcp.Tool{Name: "greet"}, SayHi)   // generic function
@@ -394,6 +404,11 @@ def _go_tool_name_from_args(args: Sequence[str]) -> str:
     return ""
 
 
+def go_source_imports_mcp_module(imported_modules: Iterable[str]) -> bool:
+    """Return whether any imported Go module path is an MCP library."""
+    return any(_GO_MCP_MODULE_SEGMENT_RE.search(module) for module in imported_modules)
+
+
 def _collect_go_tool_registrations(
     source: str,
     *,
@@ -401,6 +416,7 @@ def _collect_go_tool_registrations(
     rel_path: str,
     scope_name: str,
     imported_aliases: dict[str, str],
+    imports_mcp_module: bool,
     package_name: str,
     functions: dict[str, _GoFunctionAnalysis],
 ) -> list[_GoToolRegistration]:
@@ -410,6 +426,8 @@ def _collect_go_tool_registrations(
     # offsets, so every span below is still read from the real source.
     masked = mask_line_comments_and_strings(source, backtick_strings=True)
     for match in _GO_TOOL_START_RE.finditer(masked):
+        if match.group("verb").lower() == _GO_NEW_TOOL_VERB and not imports_mcp_module:
+            continue
         open_index = source.find("(", match.start())
         args_segment = _balanced_segment(source, open_index, open_char="(", close_char=")")
         if args_segment is None:
@@ -986,6 +1004,7 @@ def scan_go_file(
         rel_path=rel_path,
         scope_name=scope_name,
         imported_aliases=imported_aliases,
+        imports_mcp_module=go_source_imports_mcp_module(imported_modules),
         package_name=package_name,
         functions=functions,
     )

--- a/src/agent_bom/ast_models.py
+++ b/src/agent_bom/ast_models.py
@@ -320,6 +320,39 @@ class _JavaFileAnalysis:
 
 
 @dataclass
+class _KotlinCallSite:
+    name: str
+    line_number: int
+
+
+@dataclass
+class _KotlinFunctionAnalysis:
+    name: str
+    line_number: int
+    file_path: str = ""
+    scope_name: str = ""
+    import_bindings: dict[str, str] = field(default_factory=dict)
+    call_sites: list[_KotlinCallSite] = field(default_factory=list)
+
+
+@dataclass
+class _KotlinToolRegistration:
+    tool_name: str
+    handler_name: str
+    line_number: int
+    file_path: str = ""
+    scope_name: str = ""
+    import_bindings: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass
+class _KotlinFileAnalysis:
+    scope_name: str
+    functions: dict[str, _KotlinFunctionAnalysis] = field(default_factory=dict)
+    tool_registrations: list[_KotlinToolRegistration] = field(default_factory=list)
+
+
+@dataclass
 class _CSharpCallSite:
     name: str
     line_number: int

--- a/src/agent_bom/ast_php.py
+++ b/src/agent_bom/ast_php.py
@@ -227,9 +227,10 @@ def _collect_php_tool_registrations(
             ),
         )
 
-    # Scan masked source so a commented-out attribute is not a tool. ``#`` line
-    # comments stay unmasked here because ``#[`` is PHP's attribute syntax.
-    masked = mask_line_comments_and_strings(source, heredoc=True)
+    # Scan masked source so a commented-out attribute is not a tool. ``#``
+    # comments are masked too, but only when they do not open an attribute --
+    # ``#[`` is PHP attribute syntax, while ``# #[McpTool(…)]`` is a comment.
+    masked = mask_line_comments_and_strings(source, hash_comments=True, hash_attributes=True, heredoc=True)
     for masked_match in _PHP_MCP_TOOL_ATTR_RE.finditer(masked):
         attr_match = _PHP_MCP_TOOL_ATTR_RE.match(source, masked_match.start())
         if attr_match is None:

--- a/src/agent_bom/ast_source_mask.py
+++ b/src/agent_bom/ast_source_mask.py
@@ -65,6 +65,7 @@ def mask_line_comments_and_strings(
     source: str,
     *,
     hash_comments: bool = False,
+    hash_attributes: bool = False,
     heredoc: bool = False,
     backtick_strings: bool = False,
     single_line_quotes: bool = False,
@@ -72,6 +73,12 @@ def mask_line_comments_and_strings(
     """Return ``source`` with comments and quoted literals replaced by spaces.
 
     ``hash_comments`` also masks ``#`` line comments (PHP/Ruby/Swift-adjacent).
+    ``hash_attributes`` refines that for PHP, where ``#[`` opens an attribute
+    rather than a comment: a ``#`` is a comment only when the next character is
+    not ``[``. Without it a commented-out ``# #[McpTool(…)]`` still reads as a
+    live tool registration; with plain ``hash_comments`` the real attribute
+    would be masked away instead. It has no effect unless ``hash_comments``
+    is also set.
     ``heredoc`` masks PHP heredoc/nowdoc (``<<<EOT`` / ``<<<'EOT'``) bodies,
     where an identifier such as ``$client->request`` inside a SQL/HTML template
     must not be mistaken for a call site.
@@ -114,7 +121,7 @@ def mask_line_comments_and_strings(
                 result.extend("  ")
                 i += 2
                 continue
-            if hash_comments and char == "#":
+            if hash_comments and char == "#" and not (hash_attributes and nxt == "["):
                 state = "line_comment"
                 result.append(" ")
                 i += 1

--- a/src/agent_bom/reachability_cve.py
+++ b/src/agent_bom/reachability_cve.py
@@ -42,10 +42,10 @@ is a three-state reachability signal on the finding:
 * ``unreachable`` — the package is present in the dependency set but no
   entrypoint reaches it at all.
 
-Honest scope: Python, npm, Go, Maven/Java, Cargo/Rust, NuGet/C#, RubyGems, Composer/PHP,
-and Swift SPM symbol-level call graphs are supported when import proof is available
-(``use`` / ``pom.xml`` / ``build.gradle`` / ``packages.lock.json`` / ``Gemfile.lock`` /
-``composer.lock`` / ``Package.resolved``).
+Honest scope: Python, npm, Go, Maven/Java, Maven/Kotlin, Cargo/Rust, NuGet/C#, RubyGems,
+Composer/PHP, and Swift SPM symbol-level call graphs are supported when import proof is
+available (``use`` / ``pom.xml`` / ``build.gradle`` / ``build.gradle.kts`` /
+``packages.lock.json`` / ``Gemfile.lock`` / ``composer.lock`` / ``Package.resolved``).
 Regex parsers apply conservative guards and omit heuristic rows so headless MCP
 consumers do not receive false ``function_reachable`` upgrades.
 

--- a/tests/test_ast_analyzer.py
+++ b/tests/test_ast_analyzer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from click.testing import CliRunner
 
-from agent_bom.ast_analyzer import analyze_project
+from agent_bom.ast_analyzer import analyze_project, project_has_analyzable_sources
 from agent_bom.ast_go import scan_go_file
 from agent_bom.cli import main
 
@@ -576,6 +576,39 @@ def test_analyze_project_surfaces_csharp_dependency_symbol_reach(tmp_path: Path)
     reach = next(item for item in nuget_reaches if item.symbol == "ExecuteAsync")
     assert reach.entrypoint == "fetch_url"
     assert reach.package == "RestSharp"
+
+
+def test_analyze_project_surfaces_kotlin_dependency_symbol_reach(tmp_path: Path) -> None:
+    (tmp_path / "build.gradle.kts").write_text(
+        'dependencies {\n    implementation("io.modelcontextprotocol:kotlin-sdk:0.9.0")\n'
+        '    implementation("com.squareup.okhttp3:okhttp:4.12.0")\n}\n'
+    )
+    (tmp_path / "Server.kt").write_text(
+        "import io.modelcontextprotocol.kotlin.sdk.server.Server\n"
+        "import com.squareup.okhttp3.OkHttpClient\n\n"
+        "fun register(server: Server) {\n"
+        '    server.addTool(name = "fetch_url", description = "Fetch a URL") { request ->\n'
+        "        val client = OkHttpClient()\n"
+        "        client.newCall(request)\n"
+        "    }\n"
+        "}\n"
+    )
+
+    result = analyze_project(tmp_path)
+
+    assert {tool.name for tool in result.tools} == {"fetch_url"}
+    maven_reaches = [reach for reach in result.dependency_symbol_reach if reach.ecosystem == "maven"]
+    reach = next(item for item in maven_reaches if item.symbol == "newCall")
+    assert reach.entrypoint == "fetch_url"
+    assert reach.package == "com.squareup.okhttp3:okhttp"
+    assert reach.file_path == "Server.kt"
+
+
+def test_analyze_project_counts_kotlin_files_as_analyzable(tmp_path: Path) -> None:
+    (tmp_path / "Plain.kt").write_text('fun main() {\n    println("hi")\n}\n')
+
+    assert project_has_analyzable_sources(tmp_path) is True
+    assert analyze_project(tmp_path).files_analyzed == 1
 
 
 def test_analyze_project_surfaces_ruby_dependency_symbol_reach(tmp_path: Path) -> None:

--- a/tests/test_ast_multilang_tool_detection.py
+++ b/tests/test_ast_multilang_tool_detection.py
@@ -485,3 +485,412 @@ def test_swift_ordinary_tool_type_without_mcp_is_not_an_agent_tool(tmp_path: Pat
     (tmp_path / "Hardware.swift").write_text(SWIFT_ORDINARY_TOOL_TYPE)
 
     assert _tool_names(tmp_path) == set()
+
+
+# --------------------------------------------------------------------------
+# Kotlin -- io.modelcontextprotocol:kotlin-sdk (official kotlin-sdk)
+# --------------------------------------------------------------------------
+
+# README.md "Creating a Server": addTool carries the name as a named argument.
+KOTLIN_ADD_TOOL = """import io.ktor.server.cio.CIO
+import io.ktor.server.engine.embeddedServer
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.server.ServerOptions
+import io.modelcontextprotocol.kotlin.sdk.server.mcpStreamableHttp
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.ServerCapabilities
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+
+fun main(args: Array<String>) {
+    val port = args.firstOrNull()?.toIntOrNull() ?: 3000
+    val mcpServer = Server(
+        serverInfo = Implementation(
+            name = "example-server",
+            version = "1.0.0"
+        ),
+        options = ServerOptions(
+            capabilities = ServerCapabilities(
+                tools = ServerCapabilities.Tools(listChanged = true),
+            ),
+        )
+    )
+
+    mcpServer.addTool(
+        name = "example-tool",
+        description = "An example tool",
+        inputSchema = ToolSchema(
+            properties = buildJsonObject {
+                put("input", buildJsonObject { put("type", "string") })
+            }
+        )
+    ) { request ->
+        CallToolResult(content = listOf(TextContent("Hello, world!")))
+    }
+
+    embeddedServer(CIO, host = "127.0.0.1", port = port) {
+        mcpStreamableHttp {
+            mcpServer
+        }
+    }.start(wait = true)
+}
+"""
+
+# README.md "Tools": the short form, with the handler as a trailing lambda.
+KOTLIN_ADD_TOOL_SHORT = """import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+import io.modelcontextprotocol.kotlin.sdk.types.TextContent
+
+val server = Server(
+    serverInfo = Implementation(
+        name = "example-server",
+        version = "1.0.0"
+    )
+)
+
+server.addTool(
+    name = "echo",
+    description = "Return whatever the user sent back to them",
+) { request ->
+    val text = request.arguments?.get("text")?.jsonPrimitive?.content ?: "(empty)"
+    CallToolResult(content = listOf(TextContent(text = "Echo: $text")))
+}
+"""
+
+# README.md "Prompts"/"Resources": neither registers a tool.
+KOTLIN_PROMPT_AND_RESOURCE = """import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.Implementation
+
+val server = Server(serverInfo = Implementation(name = "example-server", version = "1.0.0"))
+
+server.addPrompt(
+    name = "code-review",
+    description = "Ask the model to review a diff",
+) { request -> null }
+
+server.addResource(
+    uri = "note://release/latest",
+    name = "Release notes",
+    description = "Last deployment summary",
+) { request -> null }
+"""
+
+KOTLIN_ORDINARY_ADD_TOOL = """package com.example.workshop
+
+class Workbench {
+    private val tools = mutableListOf<String>()
+
+    fun addTool(name: String, weightKg: Double) {
+        tools.add(name)
+    }
+}
+
+fun setUp(bench: Workbench) {
+    bench.addTool(name = "wrench-7", weightKg = 0.4)
+}
+"""
+
+KOTLIN_COMMENTED_OUT = """import io.modelcontextprotocol.kotlin.sdk.server.Server
+
+// Older builds registered server.addTool(name = "retired_tool") here.
+val usage = "call server.addTool(name = \\"documented_example\\")"
+
+/* server.addTool(name = "block_commented_tool") { request -> null } */
+fun help(): String = usage
+"""
+
+
+def test_kotlin_official_sdk_add_tool_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "Main.kt").write_text(KOTLIN_ADD_TOOL)
+
+    assert _tool_names(tmp_path) == {"example-tool"}
+
+
+def test_kotlin_official_sdk_short_add_tool_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "Echo.kt").write_text(KOTLIN_ADD_TOOL_SHORT)
+
+    assert _tool_names(tmp_path) == {"echo"}
+
+
+def test_kotlin_prompt_and_resource_registrations_are_not_tools(tmp_path: Path) -> None:
+    (tmp_path / "Extras.kt").write_text(KOTLIN_PROMPT_AND_RESOURCE)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_kotlin_ordinary_add_tool_without_mcp_is_not_an_agent_tool(tmp_path: Path) -> None:
+    (tmp_path / "Workbench.kt").write_text(KOTLIN_ORDINARY_ADD_TOOL)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_kotlin_commented_out_add_tool_is_not_a_tool(tmp_path: Path) -> None:
+    (tmp_path / "Docs.kt").write_text(KOTLIN_COMMENTED_OUT)
+
+    assert _tool_names(tmp_path) == set()
+
+
+# --------------------------------------------------------------------------
+# TypeScript -- the low-level Server class of @modelcontextprotocol/sdk
+# --------------------------------------------------------------------------
+
+# Servers built on `Server` rather than the `McpServer` wrapper declare their
+# tools in the ListTools response instead of through registerTool.
+TS_LOW_LEVEL_LIST_TOOLS = """import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema
+} from '@modelcontextprotocol/sdk/types.js';
+
+const server = new Server(
+  { name: 'calculator', version: '1.0.0' },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: 'calculate_sum',
+        description: 'Add two numbers together',
+        inputSchema: {
+          type: 'object',
+          properties: { a: { type: 'number' }, b: { type: 'number' } },
+          required: ['a', 'b']
+        }
+      },
+      {
+        name: 'calculate_product',
+        description: 'Multiply two numbers together',
+        inputSchema: { type: 'object', properties: {} }
+      }
+    ]
+  };
+});
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  return { content: [{ type: 'text', text: 'ok' }] };
+});
+"""
+
+# The v2 SDK migrates the schema identifier to the method string; the codemod's
+# own test asserts `server.setRequestHandler('tools/list', …)` is the output.
+TS_LOW_LEVEL_METHOD_STRING = """import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+
+const server = new Server({ name: 'calculator', version: '1.0.0' });
+
+server.setRequestHandler('tools/list', async () => ({
+  tools: [{ name: 'calculate_sum', description: 'Add two numbers together' }]
+}));
+"""
+
+TS_LOW_LEVEL_LIST_RESOURCES = """import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { ListResourcesRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+
+const server = new Server({ name: 'notes', version: '1.0.0' });
+
+server.setRequestHandler(ListResourcesRequestSchema, async () => ({
+  resources: [{ uri: 'note://1', name: 'First note' }]
+}));
+"""
+
+JS_ORDINARY_NAMED_OBJECTS = """const contributors = [
+  { name: 'ada', role: 'maintainer' },
+  { name: 'grace', role: 'reviewer' }
+];
+
+export function listContributors() {
+  return { tools: contributors };
+}
+"""
+
+
+def test_ts_low_level_list_tools_handler_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "server.ts").write_text(TS_LOW_LEVEL_LIST_TOOLS)
+
+    assert _tool_names(tmp_path) == {"calculate_sum", "calculate_product"}
+
+
+def test_ts_low_level_tools_list_method_string_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "server.ts").write_text(TS_LOW_LEVEL_METHOD_STRING)
+
+    assert _tool_names(tmp_path) == {"calculate_sum"}
+
+
+def test_ts_low_level_list_resources_handler_declares_no_tools(tmp_path: Path) -> None:
+    (tmp_path / "resources.ts").write_text(TS_LOW_LEVEL_LIST_RESOURCES)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_js_ordinary_named_objects_are_not_tools(tmp_path: Path) -> None:
+    (tmp_path / "contributors.js").write_text(JS_ORDINARY_NAMED_OBJECTS)
+
+    assert _tool_names(tmp_path) == set()
+
+
+# --------------------------------------------------------------------------
+# JS/TS agent frameworks that carry the tool name outside the first argument
+# --------------------------------------------------------------------------
+
+# ai-sdk.dev/docs/ai-sdk-core/tools-and-tool-calling: the tool NAME is the key
+# of the `tools` object, not an argument of `tool()`.
+TS_VERCEL_AI_OBJECT_KEY = """import { z } from 'zod';
+import { generateText, tool, isStepCount } from 'ai';
+
+const result = await generateText({
+  model: 'xai/grok-4.5',
+  tools: {
+    weather: tool({
+      description: 'Get the weather in a location',
+      inputSchema: z.object({
+        location: z.string().describe('The location to get the weather for'),
+      }),
+      execute: async ({ location }) => ({
+        location,
+        temperature: 72 + Math.floor(Math.random() * 21) - 10,
+      }),
+    }),
+  },
+  stopWhen: isStepCount(5),
+  prompt: 'What is the weather in San Francisco?',
+});
+"""
+
+# docs.langchain.com/oss/javascript/langchain/tools: the name lives in the
+# options object that follows the handler function.
+TS_LANGCHAIN_OPTIONS_NAME = """import * as z from 'zod';
+import { tool } from 'langchain';
+
+const searchDatabase = tool(
+  ({ query, limit }) => `Found ${limit} results for '${query}'`,
+  {
+    name: 'search_database',
+    description: 'Search the customer database for records matching the query.',
+    schema: z.object({
+      query: z.string().describe('Search terms to look for'),
+      limit: z.number().describe('Maximum number of results to return'),
+    }),
+  }
+);
+"""
+
+JS_ORDINARY_OBJECT_KEY_CALL = """import { buildHandler } from './handlers.js';
+
+export const handlers = {
+  weather: buildHandler({ description: 'Get the weather in a location' }),
+};
+"""
+
+
+def test_ts_vercel_ai_object_key_tool_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "agent.ts").write_text(TS_VERCEL_AI_OBJECT_KEY)
+
+    assert _tool_names(tmp_path) == {"weather"}
+
+
+def test_ts_langchain_options_object_name_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "tools.ts").write_text(TS_LANGCHAIN_OPTIONS_NAME)
+
+    assert _tool_names(tmp_path) == {"search_database"}
+
+
+def test_js_ordinary_object_key_call_is_not_a_tool(tmp_path: Path) -> None:
+    (tmp_path / "handlers.js").write_text(JS_ORDINARY_OBJECT_KEY_CALL)
+
+    assert _tool_names(tmp_path) == set()
+
+
+# --------------------------------------------------------------------------
+# Residual precision gaps
+# --------------------------------------------------------------------------
+
+# ``NewTool`` is the name-bearing call of the mainstream community Go library,
+# but ``NewX`` is also the ordinary Go constructor idiom. Without an MCP import
+# in the file there is nothing agentic to claim.
+GO_ORDINARY_NEW_TOOL = """package hardware
+
+type toolFactory struct{}
+
+func (f *toolFactory) NewTool(sku string) string {
+\treturn sku
+}
+
+func Setup() string {
+\tmcp := &toolFactory{}
+\treturn mcp.NewTool("wrench-7")
+}
+"""
+
+PHP_HASH_COMMENTED_ATTRIBUTE = """<?php
+
+namespace Mcp\\Example\\Server;
+
+use Mcp\\Capability\\Attribute\\McpTool;
+
+final class McpElements
+{
+    # #[McpTool(name: 'retired_tool', description: 'Removed in v2')]
+    public function retiredTool(): array
+    {
+        return [];
+    }
+}
+"""
+
+# A ``]`` inside the Description string must not truncate the attribute span.
+CSHARP_BRACKET_IN_DESCRIPTION = """using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+[McpServerToolType]
+public sealed class EchoTool
+{
+    [McpServerTool, Description("Echoes the input back [verbatim] to the client.")]
+    public static string Echo(string message)
+    {
+        return "hello " + message;
+    }
+}
+"""
+
+CSHARP_BRACKET_BEFORE_NAME = """using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+[McpServerToolType]
+public sealed class ItemTools
+{
+    [Description("Returns items] in order."), McpServerTool(Name = "list_items")]
+    public static string ListItems()
+    {
+        return "ok";
+    }
+}
+"""
+
+
+def test_go_ordinary_new_tool_without_mcp_import_is_not_an_agent_tool(tmp_path: Path) -> None:
+    (tmp_path / "hardware.go").write_text(GO_ORDINARY_NEW_TOOL)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_php_hash_commented_out_mcp_tool_attribute_is_not_a_tool(tmp_path: Path) -> None:
+    (tmp_path / "McpElements.php").write_text(PHP_HASH_COMMENTED_ATTRIBUTE)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_csharp_bracket_inside_description_still_finds_the_tool(tmp_path: Path) -> None:
+    (tmp_path / "EchoTool.cs").write_text(CSHARP_BRACKET_IN_DESCRIPTION)
+
+    assert _tool_names(tmp_path) == {"Echo"}
+
+
+def test_csharp_bracket_before_the_declared_name_still_finds_the_tool(tmp_path: Path) -> None:
+    (tmp_path / "ItemTools.cs").write_text(CSHARP_BRACKET_BEFORE_NAME)
+
+    assert _tool_names(tmp_path) == {"list_items"}


### PR DESCRIPTION
## Summary

Six proven detection gaps left open by #4630, all closed. Ten tests confirmed
**red** first:

```
FAILED test_kotlin_official_sdk_add_tool_is_detected            assert set() == {'example-tool'}
FAILED test_ts_low_level_list_tools_handler_is_detected          assert set() == {'calculate_sum', ...}
FAILED test_ts_vercel_ai_object_key_tool_is_detected             assert set() == {'weather'}
FAILED test_ts_langchain_options_object_name_is_detected         assert set() == {'search_database'}
FAILED test_go_ordinary_new_tool_without_mcp_import_...          assert {'wrench-7'} == set()
FAILED test_php_hash_commented_out_mcp_tool_attribute_...        assert {'retired_tool'} == set()
FAILED test_csharp_bracket_inside_description_...                assert set() == {'Echo'}
10 failed, 31 passed
```

The six false-positive guards passed from the start and never regressed.

## Kotlin — a whole language was invisible

New `ast/kotlin/analyzer.py`, modelled on `ast_java.py`. It lands in a package
rather than `ast_kotlin.py` because `check_package_layout.py` freezes the flat
top-level module set. Samples are verbatim from the kotlin-sdk README (fetched,
not recalled). Gated on an MCP import — the discriminator the Swift path already
uses — since `addTool` is an ordinary method name.

Not inventory-only: a test proves a Gradle-declared okhttp symbol reached from a
`fetch_url` tool through the trailing-lambda handler. Two real bugs surfaced
building that and are fixed — the handler's local `val` bindings weren't merged,
and the synthetic handler key wasn't scope-qualified, so `ast_analyzer`'s
re-keying broke the lookup.

## The rest

- **JS/TS `setRequestHandler`** — matches both v1 `ListToolsRequestSchema` and
  the v2 `'tools/list'` string, the latter confirmed against the SDK's own
  codemod test. Names read only from depth-1 `{…}` entries, so an `inputSchema`
  property named `name` can't be claimed. *Deliberate boundary:* inventory only —
  the CallTool handler dispatches on name, so there is no per-tool function to
  bind, and inventing one would hand headless agents a false `function_reachable`.
- **Object-key / options-object names** — broader than specified. LangChain JS
  actually puts the name in an options object (`tool(fn, { name: … })`), not an
  object key; both shapes implemented, most-explicit-first.
- **Go `NewTool`** — closed with a precise discriminator. Only `NewTool` is gated
  on an MCP import; `AddTool`/`RegisterTool` stay ungated. That distinction is
  load-bearing: an existing test uses `server.AddTool("run_cmd")` with only
  `import "os/exec"`, so gating all three would have traded the false positive
  for a false negative — exactly what the prior attempt hit.
- **PHP `#` comments** — `#` opens a comment unless followed by `[`.
- **C# `]` inside `Description`** — root cause wasn't the regex but the re-match:
  the span was found in masked source then re-matched against real source. Now
  sliced from the masked span.

## Verification

- `pytest -k "ast or tool or mcp"` — 1695 passed, 8 skipped
- multilang + analyzer suites — 108 passed; merged-in neighbours — 178 passed
- `mypy` (10 files), `ruff check`, `ruff format --check`, `make preflight`,
  `check_package_layout.py` — all clean
- **Adversarial sweep**: diffed every tool claim against `origin/main` over ~22k
  real-world JS/TS files (`node_modules` shipping real Next.js MCP servers and a
  bundled `@modelcontextprotocol/sdk`) — **12 claims after, 12 before, zero added,
  zero removed**. The SDK's own minified schema definitions are not claimed.

## Flags

- `ast/js_ts/engine.py` fails `ruff format --check` on `origin/main` today
  (from #4630). Verified pre-existing against a clean extract; left untouched
  rather than pollute this diff. Worth a one-line follow-up.
- `tree_sitter` is not a declared dependency and isn't installed locally or in
  CI, so the regex facade is the live path everywhere. `engine.py` was read to
  confirm it would add no conflicting names for the three new shapes, but that
  path could not be executed.