### PR TITLE
feat(demo): put the incident inside an enterprise, and bound what the story shows

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1131,
+      "value": 1132,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 829,
+      "value": 830,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1131 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1132 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 829 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 830 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/scripts/check_enterprise_demo_surfaces.py
+++ b/scripts/check_enterprise_demo_surfaces.py
@@ -50,15 +50,24 @@ def main_check() -> None:
     _require(story.schema_version == "enterprise_demo_story.v1", "story schema version changed")
     _require(story.synthetic is True and story.fictional is True, "synthetic disclosure flags missing")
     _require(story.tenant_id == "contract-tenant", "tenant ID was not propagated")
-    _require(story.summary.assets == 20, "asset count changed")
-    _require(story.summary.observations == 15, "observation count changed")
+    # The demo serves the narrative estate composed into a generated population,
+    # so these are floors rather than fixed counts: pinning exact totals would
+    # make every scale-profile change a gate failure, while a floor still catches
+    # the regression that matters — the estate silently shrinking back to the
+    # 20-asset spine, where nothing has to be correlated out of anything.
+    _require(story.summary.assets >= 2000, "estate is no longer enterprise-sized")
+    _require(story.summary.observations >= 6000, "estate carries too little evidence to correlate")
     _require(story.summary.evidence_sources == 9, "evidence-source count changed")
-    _require(story.summary.correlations == 4, "correlation count changed")
+    # Floor, not a fixed count: the composed estate correlates thousands of rows.
+    _require(story.summary.correlations >= 4, "the narrative correlations are gone")
+    # The view is bounded so the incident stays visible; the summary must still
+    # report the unbounded truth, never the page size.
+    _require(len(story.correlations) <= story.summary.correlations, "story claims more rows than it holds")
+    _require(story.correlations[0] == story.primary_correlation, "the incident is no longer surfaced first")
     _require(story.summary.snapshots == 3, "snapshot count changed")
     _require(story.primary_correlation.outcome == "blocked", "primary outcome is no longer blocked")
     _require(
-        tuple(source.value for source in story.primary_correlation.sources)
-        == EXPECTED_PRIMARY_SOURCES,
+        tuple(source.value for source in story.primary_correlation.sources) == EXPECTED_PRIMARY_SOURCES,
         "primary cross-vendor path changed",
     )
     gcp = next((row for row in story.collection_health if row.source.value == "gcp_audit"), None)
@@ -82,12 +91,7 @@ def main_check() -> None:
     openapi = json.loads(_read("docs/openapi/v1.json"))
     operation = openapi.get("paths", {}).get("/v1/demo-estate/story", {}).get("get", {})
     response_ref = (
-        operation.get("responses", {})
-        .get("200", {})
-        .get("content", {})
-        .get("application/json", {})
-        .get("schema", {})
-        .get("$ref")
+        operation.get("responses", {}).get("200", {}).get("content", {}).get("application/json", {}).get("schema", {}).get("$ref")
     )
     _require(response_ref == "#/components/schemas/EnterpriseDemoStory", "OpenAPI story contract is missing")
 
@@ -103,9 +107,7 @@ def main_check() -> None:
     ):
         _require(marker in dashboard, f"dashboard lost required marker: {marker}")
 
-    helm_profile = _read(
-        "deploy/helm/agent-bom/examples/synthetic-enterprise-story-values.yaml"
-    )
+    helm_profile = _read("deploy/helm/agent-bom/examples/synthetic-enterprise-story-values.yaml")
     for marker in (
         "AGENT_BOM_DEMO_ESTATE",
         "AGENT_BOM_ALLOW_UNAUTHENTICATED_API",

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -150,9 +150,10 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     # can now consume one deterministic source instead of inventing unrelated
     # rows per screen. A malformed fixture remains an explicit bootstrap error.
     try:
-        from agent_bom.demo_estate.enterprise import CollectionStatus, load_enterprise_estate
+        from agent_bom.demo_estate.enterprise import CollectionStatus
+        from agent_bom.demo_estate.enterprise_composition import build_demo_estate
 
-        enterprise = load_enterprise_estate(tenant_id=tenant_id)
+        enterprise = build_demo_estate(tenant_id=tenant_id)
         summary["enterprise_contract"] = {
             "schema_version": enterprise.schema_version,
             "estate_id": enterprise.estate_id,

--- a/src/agent_bom/demo_estate/enterprise_composition.py
+++ b/src/agent_bom/demo_estate/enterprise_composition.py
@@ -1,0 +1,124 @@
+"""Put the demo's incident chain inside an enterprise-sized population.
+
+Two halves existed and neither was sufficient alone.
+:mod:`agent_bom.demo_estate.enterprise` carries the narrative — one incident
+traced across GitHub, AWS, Kubernetes, MCP and Snowflake — but at 20 assets
+nothing has to be correlated *out of* anything, so the correlation reads as a
+diagram rather than a capability. :mod:`agent_bom.demo_estate.enterprise_scale`
+produces thousands of correlated assets but contains no incident, so there is
+nothing to find; it also shipped with exactly one consumer, its own test.
+
+Composed, the incident sits inside a population. That is the only arrangement in
+which "findings, identities, configuration and logs resolve to one another
+across a large multi-vendor estate" is demonstrated instead of asserted.
+
+The narrative half always wins a collision: its ids are referenced by the
+correlation layer and by the presentation story, so a generated row shadowing
+one would silently rewrite the incident.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from agent_bom.demo_estate.enterprise import (
+    ENTERPRISE_SCHEMA_VERSION,
+    CollectionRun,
+    CollectionStatus,
+    EnterpriseEstate,
+    EstateSnapshot,
+    EstateStage,
+    load_enterprise_estate,
+)
+from agent_bom.demo_estate.enterprise_scale import ScaleProfile, build_scaled_estate
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def build_demo_estate(profile: ScaleProfile | None = None, *, tenant_id: str = "default") -> EnterpriseEstate:
+    """Return the narrative estate embedded in a generated population.
+
+    Both halves are already valid :class:`EnterpriseEstate` values, so this
+    composes them rather than re-deriving anything. Construction re-runs every
+    contract validator over the union — unique ids, tenant boundary, and events
+    referencing known assets — so a composition mistake fails here rather than
+    surfacing as a missing node three screens later.
+    """
+    narrative = load_enterprise_estate(tenant_id=tenant_id)
+    population = build_scaled_estate(profile, tenant_id=tenant_id)
+
+    # The narrative wins collisions: the correlation and presentation layers
+    # reference its ids by name.
+    narrative_asset_ids = {asset.asset_id for asset in narrative.assets}
+    narrative_event_ids = {event.event_id for event in narrative.observations}
+
+    assets = narrative.assets + tuple(asset for asset in population.assets if asset.asset_id not in narrative_asset_ids)
+    kept_asset_ids = {asset.asset_id for asset in assets}
+    observations = narrative.observations + tuple(
+        event
+        for event in population.observations
+        if event.event_id not in narrative_event_ids
+        # An event whose asset lost the collision would dangle; the contract
+        # rejects that, so drop it here where the reason is visible.
+        and all(resource_id in kept_asset_ids for resource_id in event.resource_ids)
+    )
+
+    estate = EnterpriseEstate(
+        schema_version=ENTERPRISE_SCHEMA_VERSION,
+        estate_id=f"{narrative.estate_id}-composed",
+        tenant_id=tenant_id,
+        display_name=narrative.display_name,
+        synthetic=True,
+        fictional=True,
+        disclosure=narrative.disclosure,
+        assets=assets,
+        observations=observations,
+        collection_runs=_merge_collection_runs(narrative, population),
+        snapshots=_merge_snapshots(narrative, assets, observations),
+        content_hash="0" * 64,
+    )
+    digest = hashlib.sha256(_canonical_json(estate.model_dump(mode="json", exclude={"content_hash"}))).hexdigest()
+    return estate.model_copy(update={"content_hash": digest})
+
+
+def _merge_collection_runs(narrative: EnterpriseEstate, population: EnterpriseEstate) -> tuple[CollectionRun, ...]:
+    """One run per source, keeping the narrative's and summing records read.
+
+    A source that is partial in either half stays partial in the union: an
+    incomplete read must never be promoted to a complete posture just because a
+    second collection of the same source happened to succeed.
+    """
+    runs: dict[str, CollectionRun] = {run.source.value: run for run in narrative.collection_runs}
+    for run in population.collection_runs:
+        existing = runs.get(run.source.value)
+        if existing is None:
+            runs[run.source.value] = run
+            continue
+        if existing.status is CollectionStatus.COMPLETE and run.status is not CollectionStatus.COMPLETE:
+            runs[run.source.value] = run.model_copy(update={"records_read": existing.records_read + run.records_read})
+        else:
+            runs[run.source.value] = existing.model_copy(update={"records_read": existing.records_read + run.records_read})
+    return tuple(runs[key] for key in sorted(runs))
+
+
+def _merge_snapshots(narrative: EnterpriseEstate, assets: tuple, observations: tuple) -> tuple[EstateSnapshot, ...]:
+    """Keep the narrative's stage timeline, widened to the composed estate.
+
+    Stage membership stays the narrative's story — baseline predates the
+    incident, remediated follows it — while the asset and event sets grow to the
+    whole estate so a stage never references something the estate does not hold.
+    """
+    asset_ids = tuple(asset.asset_id for asset in assets)
+    event_ids = tuple(event.event_id for event in observations)
+    merged: list[EstateSnapshot] = []
+    for snapshot in narrative.snapshots:
+        if snapshot.stage is EstateStage.BASELINE:
+            # Baseline predates the current collection window, so it carries the
+            # population but none of the incident's evidence.
+            merged.append(snapshot.model_copy(update={"asset_ids": asset_ids}))
+        else:
+            merged.append(snapshot.model_copy(update={"asset_ids": asset_ids, "event_ids": event_ids}))
+    return tuple(merged)

--- a/src/agent_bom/demo_estate/presentation.py
+++ b/src/agent_bom/demo_estate/presentation.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from agent_bom.demo_estate.enterprise import load_enterprise_estate
+from agent_bom.demo_estate.enterprise_composition import build_demo_estate
 from agent_bom.demo_estate.enterprise_correlation import (
     EnterpriseCollectionHealth,
     EnterpriseCorrelation,
@@ -58,10 +58,17 @@ class EnterpriseDemoStory(BaseModel):
     collection_health: tuple[EnterpriseCollectionHealth, ...]
 
 
+# Bounded so the story stays legible at estate scale. The summary still reports
+# the unbounded totals, so the view is smaller than the estate but never claims
+# to be the whole of it.
+_STORY_CORRELATION_LIMIT = 50
+_STORY_EVENT_LIMIT = 200
+
+
 def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> EnterpriseDemoStory:
     """Load, verify, normalize, and present the bundled fictional estate."""
 
-    estate = load_enterprise_estate(tenant_id=tenant_id)
+    estate = build_demo_estate(tenant_id=tenant_id)
     result = correlate_enterprise_estate(estate)
     primary = next(
         (row for row in result.correlations if row.kind == "data_egress_attempt"),
@@ -69,6 +76,15 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
     )
     if primary is None:
         raise ValueError("enterprise demo is missing its primary data-egress correlation")
+
+    # `summary` carries the true totals; these fields carry what a reader can
+    # actually use. Composing the incident into a population takes the estate to
+    # thousands of events, and returning every correlated row would hand the UI
+    # ~6k `activity_sequence` entries — a data dump in which the incident is
+    # invisible. Lead with the incident, then a bounded remainder, newest first.
+    ranked = (primary, *(row for row in result.correlations if row is not primary))
+    correlations = ranked[:_STORY_CORRELATION_LIMIT]
+    events = result.events[:_STORY_EVENT_LIMIT]
 
     return EnterpriseDemoStory(
         disclosure=estate.disclosure,
@@ -87,8 +103,8 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
             snapshots=len(estate.snapshots),
         ),
         primary_correlation=primary,
-        events=result.events,
-        correlations=result.correlations,
+        events=events,
+        correlations=correlations,
         collection_health=result.collection_health,
     )
 

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -93,9 +93,14 @@ def test_demo_estate_bootstrap_validates_versioned_enterprise_contract(
     contract = summary.get("enterprise_contract") or {}
 
     assert contract["schema_version"] == ENTERPRISE_SCHEMA_VERSION
-    assert contract["estate_id"] == "northstar-health-ai-v1"
-    assert contract["assets"] >= 20
-    assert contract["observations"] >= 15
+    # The demo now boots the narrative estate composed into a generated
+    # population, so the id gains its suffix and the floors move from
+    # "the story exists" to "the story sits inside an enterprise". The old
+    # values (20 assets, 15 observations) passed against an estate too small
+    # to demonstrate correlation at all.
+    assert contract["estate_id"] == "northstar-health-ai-v1-composed"
+    assert contract["assets"] >= 2000
+    assert contract["observations"] >= 6000
     assert contract["snapshots"] == 3
     assert contract["partial_sources"] == ["gcp_audit"]
     assert len(contract["content_hash"]) == 64

--- a/tests/test_enterprise_demo_surfaces.py
+++ b/tests/test_enterprise_demo_surfaces.py
@@ -22,8 +22,12 @@ def test_story_builds_one_canonical_cross_vendor_read_model() -> None:
     assert story.synthetic is True
     assert story.fictional is True
     assert story.tenant_id == "tenant-story"
-    assert story.summary.assets == 20
-    assert story.summary.observations == 15
+    # Floors, not fixed counts. The demo serves the narrative incident composed
+    # into a generated population, so exact totals move with the scale profile.
+    # The old values (20 / 15) described an estate too small for the incident to
+    # have to be correlated out of anything.
+    assert story.summary.assets >= 2000
+    assert story.summary.observations >= 6000
     assert story.summary.evidence_sources == 9
     assert story.summary.complete_sources == 8
     assert story.summary.partial_sources == 1

--- a/tests/test_enterprise_estate_composition.py
+++ b/tests/test_enterprise_estate_composition.py
@@ -1,0 +1,103 @@
+"""The demo needs one estate that is both a story and an enterprise.
+
+Two halves existed and neither was enough on its own. The hand-authored estate
+carries the incident chain the demo narrates — GitHub to AWS to Kubernetes to
+MCP to Snowflake — but is 20 assets, so nothing has to be correlated *out of*
+anything. The generator produces thousands of correlated assets but no incident,
+so there is nothing to find. It also shipped unused: `build_scaled_estate` had
+exactly one consumer, its own test.
+
+Composing them puts the incident inside a population, which is the only
+arrangement where "we correlate across a large multi-vendor estate" is
+demonstrated rather than asserted.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from agent_bom.demo_estate.enterprise import (
+    CollectionStatus,
+    EnterpriseEstate,
+    verify_observation_hash,
+)
+from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+from agent_bom.demo_estate.enterprise_correlation import correlate_enterprise_estate
+
+
+@pytest.fixture(scope="module")
+def estate() -> EnterpriseEstate:
+    return build_demo_estate()
+
+
+def test_the_narrative_survives_composition(estate: EnterpriseEstate) -> None:
+    """The story is the point; scale must not dilute it out of existence."""
+    result = correlate_enterprise_estate(estate)
+    kinds = {row.kind for row in result.correlations}
+
+    assert "data_egress_attempt" in kinds, "the primary incident correlation is gone — presentation.py raises without it"
+
+
+def test_the_narrative_now_sits_inside_a_population(estate: EnterpriseEstate) -> None:
+    assert len(estate.assets) >= 2000
+    assert len(estate.observations) >= 6000
+
+
+def test_every_cloud_has_siblings_to_disambiguate_between(estate: EnterpriseEstate) -> None:
+    accounts: dict[str, set[str]] = {}
+    for asset in estate.assets:
+        if asset.provider in {"aws", "azure", "gcp", "snowflake"}:
+            accounts.setdefault(asset.provider, set()).add(asset.account_scope)
+
+    thin = {p: sorted(s) for p, s in accounts.items() if len(s) < 2}
+    assert not thin, f"single-account clouds make drill-down meaningless: {thin}"
+
+
+def test_composition_is_deterministic() -> None:
+    assert build_demo_estate().content_hash == build_demo_estate().content_hash
+
+
+def test_no_identity_collides_between_the_two_halves(estate: EnterpriseEstate) -> None:
+    """A generated id shadowing a narrative asset would silently rewrite the story."""
+    asset_ids = [a.asset_id for a in estate.assets]
+    event_ids = [e.event_id for e in estate.observations]
+
+    assert len(asset_ids) == len(set(asset_ids))
+    assert len(event_ids) == len(set(event_ids))
+
+
+def test_provenance_still_verifies_across_the_whole_estate(estate: EnterpriseEstate) -> None:
+    bad = [e.event_id for e in estate.observations if not verify_observation_hash(e)]
+
+    assert not bad, f"{len(bad)} observations fail their own provenance check"
+
+
+def test_partial_collection_is_still_reported_honestly(estate: EnterpriseEstate) -> None:
+    for run in estate.collection_runs:
+        if run.status is CollectionStatus.COMPLETE:
+            assert not run.failure_code
+        else:
+            assert run.failure_code
+
+    assert any(r.status is not CollectionStatus.COMPLETE for r in estate.collection_runs)
+
+
+def test_every_source_that_reports_complete_produced_evidence(estate: EnterpriseEstate) -> None:
+    produced = Counter(e.source for e in estate.observations)
+    silent = [r.source for r in estate.collection_runs if r.status is CollectionStatus.COMPLETE and not produced.get(r.source)]
+
+    assert not silent, f"sources claiming a complete collection with no evidence: {silent}"
+
+
+def test_the_story_is_bounded_but_reports_the_unbounded_truth() -> None:
+    """A page that reports its own size as the total is the honesty defect we keep finding."""
+    from agent_bom.demo_estate.presentation import build_enterprise_demo_story
+
+    story = build_enterprise_demo_story(tenant_id="composition-tenant")
+
+    assert story.summary.correlations > len(story.correlations), "summary must report the estate total, not the page size"
+    assert story.summary.observations > len(story.events)
+    assert story.correlations[0] == story.primary_correlation, "the incident must lead the view"
+    assert story.primary_correlation.kind == "data_egress_attempt"


### PR DESCRIPTION
## Summary

The demo had two halves and shipped neither usefully.

The hand-authored estate (#4638) carries the incident chain — GitHub → AWS →
Kubernetes → MCP → Snowflake — but at **20 assets** nothing has to be correlated
*out of* anything, so the correlation reads as a diagram rather than a
capability. The generator (#4643) produces thousands of correlated assets but
contains no incident, and shipped with **exactly one consumer: its own test**.

```
build_scaled_estate  consumers: tests/test_enterprise_estate_scale.py
load_enterprise_estate consumers: presentation.py, bootstrap.py   ← 20 assets
```

So the demo a prospect actually saw was still the spine. That is the
computed-but-not-surfaced defect this round has been closing, in our own work.

`build_demo_estate` composes them: **2,068 assets, 6,159 observations**, with the
incident inside a population.

## Composition, not re-derivation

Both halves are already valid `EnterpriseEstate` values, so this composes them
and lets construction re-run every contract validator over the union — unique
ids, tenant boundary, events referencing known assets. A composition mistake
fails there rather than surfacing as a missing node three screens later.

The narrative wins any id collision: the correlation and presentation layers
reference its ids by name, so a generated row shadowing one would silently
rewrite the incident. A partial collection stays partial in the union — an
incomplete read must never be promoted because a second collection of the same
source succeeded.

## What composing surfaced

The small estate was hiding a real problem. The correlation engine emits roughly
one row per event, so the story went to **6,148 correlations**, almost all
`activity_sequence`. Returning those hands the UI a data dump in which the
incident is invisible — the "2,000 raw nodes is unreadable" failure, arriving the
moment there were 2,000 of anything.

The story is now bounded: the incident leads, then 50 correlations and 200
events. `summary` continues to report the **unbounded** totals:

```
summary totals: assets 2068  observations 6159  correlations 6148
returned      : correlations 50   events 200
primary       : data_egress_attempt / blocked
```

A test pins that split. A page reporting its own size as the total is exactly the
honesty defect fixed in #4631 and #4647, and it would have been trivial to
reintroduce here.

## Gate changed from exact counts to floors

`check_enterprise_demo_surfaces.py` pinned `assets == 20`, `observations == 15`,
`correlations == 4`. Those fail on every scale-profile change while still passing
if the estate silently shrank back to the spine — the regression that actually
matters. They are now floors (`>= 2000`, `>= 6000`, `>= 4`), plus two new
assertions the old gate had no way to make: that the incident is surfaced
**first**, and that the summary never reports fewer rows than it holds.

## Verification

- `tests/test_enterprise_estate_composition.py` — 9 tests, narrative survival,
  determinism, no id collisions, provenance verifying across the whole estate,
  honest partial collection, and the bounded-view/honest-total split
- Demo suites together (`bootstrap`, `contract`, `correlation`, `scale`,
  `composition`) — **68 passed**
- `check_enterprise_demo_surfaces.py` — passes
- `ruff check`, `ruff format --check`, `mypy` — clean
- `make preflight` — passed

## Still to come

Findings are not generated on this estate yet, so `finding → asset → identity →
config → attack path → control` is still demonstrated only for the hand-authored
incident. That is the next piece, and it is why this stops here rather than
claiming the full chain.