### PR TITLE
fix(gcp): degrade on an incomplete SDK, and stop the fake SDK leaking real modules

### DIFF
--- a/src/agent_bom/cloud/gcp_authorization_collector.py
+++ b/src/agent_bom/cloud/gcp_authorization_collector.py
@@ -196,6 +196,26 @@ def _pab_binding_record(binding: Any) -> dict[str, Any]:
     }
 
 
+def _client_class(module: Any, attribute: str) -> Any:
+    """Return ``module.attribute``, or raise ``ImportError`` when the SDK lacks it.
+
+    ``google.cloud`` is a namespace package assembled from one distribution per
+    service, so the modules can import while still missing the client classes we
+    need — a partial ``[gcp]`` install, or a version predating a client. That is
+    the same operator condition as an absent SDK, so it is reported the same way:
+    the caller's ``ImportError`` handler degrades to ``SDK_MISSING``. Letting the
+    raw ``AttributeError`` escape would abort the whole GCP inventory walk, whose
+    call site does not guard it.
+    """
+    try:
+        return getattr(module, attribute)
+    except AttributeError as exc:
+        raise ImportError(
+            f"{getattr(module, '__name__', module)} has no {attribute} — the installed "
+            "google-cloud SDKs are incomplete. Install with: pip install 'agent-bom[gcp]'"
+        ) from exc
+
+
 def _load_clients(credentials: Any) -> Any:
     from google.cloud import (  # type: ignore[attr-defined]  # namespace package exports
         asset_v1,
@@ -206,14 +226,14 @@ def _load_clients(credentials: Any) -> Any:
     )
 
     return SimpleNamespace(
-        assets=asset_v1.AssetServiceClient(credentials=credentials),
-        projects=resourcemanager_v3.ProjectsClient(credentials=credentials),
-        folders=resourcemanager_v3.FoldersClient(credentials=credentials),
-        organizations=resourcemanager_v3.OrganizationsClient(credentials=credentials),
-        roles=iam_admin_v1.IAMClient(credentials=credentials),
-        denies=iam_v2.PoliciesClient(credentials=credentials),
-        pabs=iam_v3.PrincipalAccessBoundaryPoliciesClient(credentials=credentials),
-        policy_bindings=iam_v3.PolicyBindingsClient(credentials=credentials),
+        assets=_client_class(asset_v1, "AssetServiceClient")(credentials=credentials),
+        projects=_client_class(resourcemanager_v3, "ProjectsClient")(credentials=credentials),
+        folders=_client_class(resourcemanager_v3, "FoldersClient")(credentials=credentials),
+        organizations=_client_class(resourcemanager_v3, "OrganizationsClient")(credentials=credentials),
+        roles=_client_class(iam_admin_v1, "IAMClient")(credentials=credentials),
+        denies=_client_class(iam_v2, "PoliciesClient")(credentials=credentials),
+        pabs=_client_class(iam_v3, "PrincipalAccessBoundaryPoliciesClient")(credentials=credentials),
+        policy_bindings=_client_class(iam_v3, "PolicyBindingsClient")(credentials=credentials),
     )
 
 

--- a/tests/_sdk_stub_helpers.py
+++ b/tests/_sdk_stub_helpers.py
@@ -1,0 +1,52 @@
+"""Install a fake provider SDK in ``sys.modules`` without leaking the real one.
+
+``patch.dict(sys.modules, fakes)`` shadows only the names it lists, which is not
+enough for a namespace package like ``google.cloud``. A stub parent is a bare
+``types.ModuleType`` with no ``__path__``, so ``_handle_fromlist`` skips it
+entirely and ``from google.cloud import asset_v1`` is resolved solely by
+CPython's ``IMPORT_FROM`` fallback to ``sys.modules["google.cloud.asset_v1"]``.
+Whatever an earlier test in the same process left resident there is handed back —
+so a test that stubs only part of a namespace silently binds real SDK modules,
+and its outcome depends on which tests ran before it.
+
+Mapping the extra names to ``None`` does not close the hole either: the same
+fallback returns the ``None`` object rather than raising, and the caller then
+fails on ``None.SomeClient``. The entries have to be removed outright, which is
+what :func:`patch_sdk_namespace` does — and restores on exit.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+
+@contextmanager
+def patch_sdk_namespace(fakes: dict[str, Any], *roots: str) -> Iterator[None]:
+    """Install *fakes* as the ONLY modules importable under *roots*.
+
+    Every other resident module under a root is removed for the duration, so the
+    code under test sees exactly the SDK surface the fakes describe — the same on
+    every run, whatever ran before. The real entries are restored on exit.
+    """
+    prefixes = tuple(f"{root}." for root in roots)
+
+    def in_scope(name: str) -> bool:
+        return name in roots or name.startswith(prefixes)
+
+    outside = sorted(name for name in fakes if not in_scope(name))
+    if outside:
+        raise ValueError(f"fake modules outside the declared roots {roots}: {outside}")
+
+    saved = {name: module for name, module in sys.modules.items() if in_scope(name)}
+    for name in saved:
+        del sys.modules[name]
+    sys.modules.update(fakes)
+    try:
+        yield
+    finally:
+        for name in [name for name in sys.modules if in_scope(name)]:
+            del sys.modules[name]
+        sys.modules.update(saved)

--- a/tests/cloud/test_cloud_gcp_inventory.py
+++ b/tests/cloud/test_cloud_gcp_inventory.py
@@ -20,6 +20,7 @@ from unittest.mock import patch
 import pytest
 
 from agent_bom.cloud import gcp_inventory
+from tests._sdk_stub_helpers import patch_sdk_namespace
 
 # ---------------------------------------------------------------------------
 # Fake google-cloud SDK objects
@@ -501,7 +502,13 @@ def _fake_discovery_build(*args: Any, **kwargs: Any) -> Any:
 
 
 def _install_fake_gcp() -> Any:
-    """Return a patch.dict context installing fake google-cloud SDK modules."""
+    """Return a context installing the fakes as the ONLY google/googleapiclient SDKs.
+
+    Stubbing a subset is not enough: ``google.cloud`` is a namespace package, so a
+    real sibling an earlier test left in ``sys.modules`` still resolves through the
+    stubbed parent and the results become test-order dependent. See
+    :func:`tests._sdk_stub_helpers.patch_sdk_namespace`.
+    """
     google_mod = types.ModuleType("google")
     cloud_mod = types.ModuleType("google.cloud")
     storage_mod = _FakeStorageModule("google.cloud.storage")
@@ -519,8 +526,7 @@ def _install_fake_gcp() -> Any:
     apiclient_mod = types.ModuleType("googleapiclient")
     discovery_mod = types.ModuleType("googleapiclient.discovery")
     discovery_mod.build = _fake_discovery_build  # type: ignore[attr-defined]
-    return patch.dict(
-        sys.modules,
+    return patch_sdk_namespace(
         {
             "google": google_mod,
             "google.cloud": cloud_mod,
@@ -539,7 +545,61 @@ def _install_fake_gcp() -> Any:
             "googleapiclient": apiclient_mod,
             "googleapiclient.discovery": discovery_mod,
         },
+        "google",
+        "googleapiclient",
     )
+
+
+# ---------------------------------------------------------------------------
+# SDK-namespace isolation (test-order independence)
+# ---------------------------------------------------------------------------
+
+
+class _StubClient:
+    def __init__(self, credentials: Any = None) -> None:
+        pass
+
+
+def _resident_sdk_siblings() -> dict[str, types.ModuleType]:
+    """The `google.cloud.*` modules `_install_fake_gcp` does NOT stub.
+
+    Stands in for the real distributions an earlier test in the same process can
+    leave resident in ``sys.modules`` — the ones the authorization collector
+    imports alongside the stubbed ``resourcemanager_v3``.
+    """
+    asset = types.ModuleType("google.cloud.asset_v1")
+    asset.AssetServiceClient = _StubClient  # type: ignore[attr-defined]
+    iam_v2 = types.ModuleType("google.cloud.iam_v2")
+    iam_v2.PoliciesClient = _StubClient  # type: ignore[attr-defined]
+    iam_v3 = types.ModuleType("google.cloud.iam_v3")
+    iam_v3.PrincipalAccessBoundaryPoliciesClient = _StubClient  # type: ignore[attr-defined]
+    iam_v3.PolicyBindingsClient = _StubClient  # type: ignore[attr-defined]
+    return {
+        "google.cloud.asset_v1": asset,
+        "google.cloud.iam_v2": iam_v2,
+        "google.cloud.iam_v3": iam_v3,
+    }
+
+
+def test_fake_sdk_shadows_siblings_it_does_not_stub() -> None:
+    """A resident `google.cloud.*` sibling must not resolve through the fake SDK.
+
+    `google.cloud` is a namespace package: with only part of it stubbed, CPython's
+    IMPORT_FROM falls back to ``sys.modules`` and hands back whatever an earlier
+    test imported, so this file's results would depend on what ran before it.
+    """
+    with patch.dict(sys.modules, _resident_sdk_siblings()), _install_fake_gcp(), pytest.raises(ImportError):
+        from google.cloud import asset_v1  # noqa: F401
+
+
+def test_inventory_unaffected_by_sdk_siblings_left_by_earlier_tests(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The estate walk must produce the same result whatever ran before it."""
+    monkeypatch.setenv(gcp_inventory.INVENTORY_ENV_FLAG, "1")
+    with patch.dict(sys.modules, _resident_sdk_siblings()), _install_fake_gcp():
+        payload = gcp_inventory.discover_inventory(project_id="proj-1")
+
+    assert payload["status"] == "ok"
+    assert {b["name"] for b in payload["buckets"]} == {"public-lake", "private-logs"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/cloud/test_gcp_service_account_usage_evidence.py
+++ b/tests/cloud/test_gcp_service_account_usage_evidence.py
@@ -16,15 +16,14 @@ so the fail-closed rules never fired. These tests pin:
 
 from __future__ import annotations
 
-import sys
 import types
 from typing import Any
-from unittest.mock import patch
 
 from agent_bom.cloud import gcp_inventory
 from agent_bom.graph.builder import build_unified_graph_from_report
 from agent_bom.graph.nhi_governance import build_ciem_over_privilege_findings
 from agent_bom.graph.types import EntityType
+from tests._sdk_stub_helpers import patch_sdk_namespace
 
 
 class _FakeSA:
@@ -50,13 +49,16 @@ def _install_fake_iam(accounts: list[_FakeSA]) -> Any:
     iam_mod = types.ModuleType("google.cloud.iam_admin_v1")
     iam_mod.IAMClient = _FakeIAMClient  # type: ignore[attr-defined]
     iam_mod.ListServiceAccountsRequest = _FakeReq  # type: ignore[attr-defined]
-    return patch.dict(
-        sys.modules,
+    # Shadow the whole namespace, not just the stubbed names: a real
+    # google.cloud.* sibling left resident by an earlier test would otherwise
+    # still resolve through the stub parent. See tests._sdk_stub_helpers.
+    return patch_sdk_namespace(
         {
             "google": types.ModuleType("google"),
             "google.cloud": types.ModuleType("google.cloud"),
             "google.cloud.iam_admin_v1": iam_mod,
         },
+        "google",
     )
 
 

--- a/tests/test_cis_denied_read_coverage.py
+++ b/tests/test_cis_denied_read_coverage.py
@@ -127,12 +127,26 @@ class TestAwsCheck116DeniedReads:
 # ---------------------------------------------------------------------------
 
 
+def _stub_namespace_module(name: str) -> types.ModuleType:
+    """Return the resident stub for *name*, installing a fresh one over any real package.
+
+    The fake below is bound as an ATTRIBUTE of what this returns, and an attribute
+    written onto the real `google.cloud` namespace package outlives the process —
+    conftest restores `sys.modules`, but it cannot undo a package attribute. Keeping
+    the fake on a stub keeps it inside that restore.
+    """
+    resident = sys.modules.get(name)
+    if isinstance(resident, types.ModuleType) and getattr(resident, "__spec__", None) is None:
+        return resident
+    stub = types.ModuleType(name)
+    sys.modules[name] = stub
+    return stub
+
+
 def _install_mock_gcp_storage(buckets):
     """Install a fake google.cloud.storage whose Client lists *buckets*."""
-    google_mod = sys.modules.get("google") or types.ModuleType("google")
-    sys.modules["google"] = google_mod
-    google_cloud = sys.modules.get("google.cloud") or types.ModuleType("google.cloud")
-    sys.modules["google.cloud"] = google_cloud
+    google_mod = _stub_namespace_module("google")
+    google_cloud = _stub_namespace_module("google.cloud")
     google_mod.cloud = google_cloud  # type: ignore[attr-defined]
 
     storage_mod = types.ModuleType("google.cloud.storage")

--- a/tests/test_gcp_authorization_collector.py
+++ b/tests/test_gcp_authorization_collector.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import sys
+import types
 from types import SimpleNamespace
 from typing import Any, Iterable
+from unittest.mock import patch
 
 import pytest
 
@@ -306,6 +309,48 @@ def test_missing_sdk_sets_every_required_source_explicitly(monkeypatch: pytest.M
     result = collect_gcp_authorization(None, "proj-1", warnings=[])
 
     assert set(_source_states(result).values()) == {EvidenceSourceState.SDK_MISSING.value}
+
+
+def test_incomplete_sdk_install_degrades_instead_of_crashing() -> None:
+    """A partially-installed `[gcp]` extra must degrade, never abort GCP discovery.
+
+    ``google.cloud`` is a namespace package assembled from one distribution per
+    service, so an operator can have importable modules that are missing the
+    client classes we need (a stale ``google-cloud-resource-manager``, a partial
+    install). That surfaced as an ``AttributeError`` escaping the collector and
+    killing the whole inventory walk, which is unguarded at its call site.
+    """
+
+    class _Client:
+        def __init__(self, credentials: Any = None) -> None:
+            pass
+
+    def _module(name: str, **attributes: Any) -> Any:
+        module = types.ModuleType(name)
+        for attribute, value in attributes.items():
+            setattr(module, attribute, value)
+        return module
+
+    incomplete = {
+        "google": types.ModuleType("google"),
+        "google.cloud": types.ModuleType("google.cloud"),
+        "google.cloud.asset_v1": _module("google.cloud.asset_v1", AssetServiceClient=_Client),
+        "google.cloud.iam_admin_v1": _module("google.cloud.iam_admin_v1", IAMClient=_Client),
+        "google.cloud.iam_v2": _module("google.cloud.iam_v2", PoliciesClient=_Client),
+        "google.cloud.iam_v3": _module(
+            "google.cloud.iam_v3",
+            PrincipalAccessBoundaryPoliciesClient=_Client,
+            PolicyBindingsClient=_Client,
+        ),
+        # Importable, but missing FoldersClient/OrganizationsClient.
+        "google.cloud.resourcemanager_v3": _module("google.cloud.resourcemanager_v3", ProjectsClient=_Client),
+    }
+    warnings: list[str] = []
+    with patch.dict(sys.modules, incomplete):
+        result = collect_gcp_authorization(None, "proj-1", warnings=warnings)
+
+    assert set(_source_states(result).values()) == {EvidenceSourceState.SDK_MISSING.value}
+    assert warnings
 
 
 def test_nonempty_pab_is_preserved_but_source_stays_partial_until_evaluated() -> None:

--- a/tests/test_gcp_cis_benchmark.py
+++ b/tests/test_gcp_cis_benchmark.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.machinery
 import sys
 import types
 from unittest.mock import MagicMock, patch
@@ -39,14 +40,47 @@ from agent_bom.cloud.gcp_cis_benchmark import (
 # ---------------------------------------------------------------------------
 
 
+def _stub_namespace_module(name: str) -> types.ModuleType:
+    """Return the resident stub for *name*, installing a fresh one over any real package.
+
+    The real `google` / `google.cloud` must never be reused here: the callers bind
+    their fakes as ATTRIBUTES of whatever this returns, and an attribute written
+    onto the real namespace package outlives the process. Keeping the fakes on a
+    stub puts them inside the sys.modules snapshot/restore that conftest's
+    `reset_global_test_state` already performs.
+    """
+    resident = sys.modules.get(name)
+    if isinstance(resident, types.ModuleType) and getattr(resident, "__spec__", None) is None:
+        return resident
+    stub = types.ModuleType(name)
+    sys.modules[name] = stub
+    return stub
+
+
 def _ensure_google_namespace() -> tuple:
-    """Ensure google / google.cloud namespace modules exist in sys.modules."""
-    google_mod = sys.modules.get("google") or types.ModuleType("google")
-    google_cloud = sys.modules.get("google.cloud") or types.ModuleType("google.cloud")
+    """Ensure stub google / google.cloud namespace modules exist in sys.modules."""
+    google_mod = _stub_namespace_module("google")
+    google_cloud = _stub_namespace_module("google.cloud")
     google_mod.cloud = google_cloud
-    sys.modules.setdefault("google", google_mod)
-    sys.modules.setdefault("google.cloud", google_cloud)
     return google_mod, google_cloud
+
+
+def test_installers_never_bind_fakes_onto_a_real_google_namespace() -> None:
+    """A fake must not be written as an attribute of the real `google.cloud`.
+
+    conftest snapshots and restores `sys.modules`, but nothing can undo a package
+    ATTRIBUTE write: a fake bound onto the real namespace package outlives the
+    session, and every later `from google.cloud import <name>` resolves to it
+    because the attribute lookup wins before the import machinery is consulted.
+    """
+    real_like = types.ModuleType("google.cloud")
+    real_like.__spec__ = importlib.machinery.ModuleSpec("google.cloud", None)
+    real_like.__path__ = []  # type: ignore[attr-defined]
+
+    with patch.dict(sys.modules, {"google.cloud": real_like}):
+        _install_mock_gcp_storage(buckets=[])
+        assert sys.modules["google.cloud"] is not real_like
+        assert not hasattr(real_like, "storage")
 
 
 def _install_mock_gcp_compute(networks_list=None, firewalls_list=None):


### PR DESCRIPTION
## Summary

Chasing an order-dependent suite failure found a **production defect**: a
partially-installed `[gcp]` extra crashes the inventory scan instead of
degrading with the warning that exists for exactly that case.

## The production bug

`gcp_authorization_collector._load_clients` (`:199`) imports five sibling
modules and builds seven clients. The caller guards it with `except ImportError`
(`:253`) and, on that path, warns *"GCP IAM evidence SDKs are incomplete. Install
with: pip install 'agent-bom[gcp]'"* and returns empty evidence.

That guard cannot catch the case where the module imports fine but a **client
class is missing** — a genuinely partial SDK install. Then `_load_clients` raises
`AttributeError: module 'google.cloud.resourcemanager_v3' has no attribute
'FoldersClient'` at `:211`, which escapes the `except ImportError` and the
unguarded call site at `gcp_inventory.py:431`, taking down the whole scan.

Crash-instead-of-degrade, against the project's own graceful-degradation rule.
`_load_clients` now converts a missing client class into `ImportError`, so the
documented path runs.

## Why the suite was flaky

`google.cloud` is a **PEP 420 namespace package**. The test fake
(`_install_fake_gcp`) installs a bare `types.ModuleType("google.cloud")` as the
parent, which has no `__path__` — so `_handle_fromlist` skips it and
`from google.cloud import asset_v1` is resolved **solely** by CPython's
`IMPORT_FROM` fallback to `sys.modules["google.cloud.asset_v1"]`.

Whatever an earlier test left resident there is handed back. The fake stubs only
`resourcemanager_v3` and `iam_admin_v1`, so depending on what ran first the
import either raised `ImportError` and degraded (green), or bound the **real**
`asset_v1`/`iam_v2`/`iam_v3` and walked into the fake `_FakeResourceManagerModule`,
which defines only `ProjectsClient` — hitting the production bug above.

That is why the same tree passed or failed depending on `pytest-randomly`'s draw.

Deterministic reproduction, no seed required — pre-import the real siblings and
run the victim file alone: **exactly 19 failed, 26 passed**, matching a pristine
`origin/main`. After the fix: **47 passed**.

## Why `_STUB_SDK_ROOTS` could never have fixed it

`"google"` and `"google.cloud"` are already listed in `tests/conftest.py`, and
the restore still did not prevent this — which is what made the obvious fix
wrong. `_restore_stub_sdk_modules` only deletes or replaces entries that
`_is_stub_module` judges to be stubs, and the leaking modules are genuinely
imported site-packages modules with a real `__spec__`, deliberately excluded
(`conftest.py:658-659`).

The leak is not a stub outliving its test. It is a **real module outliving its
import**, which is ordinary Python. No snapshot/restore policy fixes that — only
the stub site can, so `tests/_sdk_stub_helpers.patch_sdk_namespace` removes every
other resident module under the stubbed roots.

## Verification

- Three tests, all confirmed **red first**
- `tests/cloud/test_cloud_gcp_inventory.py` — 47 passed (was 19 failed / 26
  passed under the reproducing condition)
- Touched suites — 842 passed
- `ruff check`, `ruff format --check`, `mypy` — clean
- `make preflight` — passed, re-run after merging current `main`

## Not claimed

The **in-suite** poisoner is not named. A full-suite detector reached 70% with
zero hits, which suggests the poisoner is itself order-dependent. The mechanism
above is proven by deterministic reproduction rather than by identifying the
specific interleaving, and the fix addresses the mechanism, not a particular
ordering. Full-suite verification runs were still in flight at report time.