### PR TITLE
docs(readme): make the diagrams legible and cut the repeated paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,6 @@
 <p align="center"><b>Open security scanner and self-hosted control plane for AI, MCP, and cloud infrastructure.</b></p>
 
 <p align="center">
-  Scan repositories, images, and cloud accounts; centralize evidence across environments; and enforce AI and MCP runtime policy in infrastructure you control.
-</p>
-
-<p align="center">
   <b>15</b> package ecosystems · <b>16</b> compliance surfaces · <b>77</b> MCP tools · no account required<br />
   <a href="#quick-start"><b>Quick start</b></a> ·
   <a href="https://agent-bom-demo-82102570041.us-central1.run.app">Live demo</a> ·
@@ -32,19 +28,17 @@
 
 ## What it is
 
-`agent-bom` is an open scanner and self-hosted control plane for software,
-cloud, identity, AI-agent, and MCP evidence. One Finding + UnifiedGraph model
-powers CLI and CI artifacts, fleet and browser investigations, compliance
-evidence, and runtime policy.
+`agent-bom` scans repositories, images, and cloud accounts, then correlates what
+it finds into one Finding + UnifiedGraph model — powering CLI and CI artifacts,
+fleet and browser investigations, compliance evidence, and runtime policy. Run
+the scanner without an account, or deploy the control plane inside your own
+cloud, VPC, cluster, database, identity, and audit boundary.
 
-Use the scanner without an account, or deploy the shared control plane inside
-your own cloud, VPC, Kubernetes cluster, database, identity, and audit boundary.
-
-Graph provenance remains explicit: collected, inferred, static, and runtime
-relationships stay distinct, and unavailable evidence is never upgraded to
+Graph provenance stays explicit: collected, inferred, static, and runtime
+relationships remain distinct, and unavailable evidence is never upgraded to
 observed.
 
-<details>
+<details open>
 <summary><b>Control-plane architecture</b></summary>
 
 <p align="center">

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -5,125 +5,125 @@
 <rect width="960" height="620" rx="14" fill="#0a0a0c"/>
 <rect x="12" y="12" width="936" height="596" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>
 <rect x="842" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>
-<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
-<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#f4f4f5">Control-plane architecture</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
+<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.4" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="26.0" font-weight="800" fill="#f4f4f5">Control-plane architecture</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
 <rect x="28" y="78" width="904" height="102" rx="12" fill="#0f0f13" stroke="#38bdf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="78" width="904" height="3" rx="12" fill="#38bdf8" opacity="0.55"/>
-<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#bae6fd">read-only</text>
+<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#bae6fd">read-only</text>
 <rect x="40" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="48" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Supply chain</text>
-<text x="78" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">15 eco</text>
+<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Supply chain</text>
+<text x="78" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">15 eco</text>
 <rect x="166" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="174" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(178,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
-<text x="204" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">29 clients</text>
+<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
+<text x="204" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">29 clients</text>
 <rect x="292" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="300" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(304,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Cloud</text>
-<text x="330" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">4 connect · 16 scan</text>
+<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Cloud</text>
+<text x="330" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">4 connect · 16 scan</text>
 <rect x="418" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="426" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(430,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
-<text x="456" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">TF·K8s·img</text>
+<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
+<text x="456" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">TF·K8s·img</text>
 <rect x="544" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="552" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(556,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Secrets</text>
-<text x="582" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">refs only</text>
+<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Secrets</text>
+<text x="582" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">refs only</text>
 <rect x="670" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="678" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(682,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Models</text>
-<text x="708" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">13 formats</text>
+<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Models</text>
+<text x="708" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">13 formats</text>
 <rect x="796" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="804" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(808,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">SBOM import</text>
-<text x="834" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">CDX·SPDX</text>
-<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
+<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">SBOM import</text>
+<text x="834" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">CDX·SPDX</text>
+<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
 <rect x="28" y="192" width="904" height="96" rx="12" fill="#0f0f13" stroke="#818cf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="192" width="904" height="3" rx="12" fill="#818cf8" opacity="0.55"/>
-<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#c7d2fe">local scan</text>
+<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#c7d2fe">local scan</text>
 <rect x="40" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="48" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">OSV scan</text>
-<text x="78" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">batch</text>
+<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">OSV scan</text>
+<text x="78" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">batch</text>
 <rect x="218" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="226" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Enrichment</text>
-<text x="256" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">NVD·EPSS</text>
+<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Enrichment</text>
+<text x="256" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">NVD·EPSS</text>
 <rect x="396" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="404" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Posture</text>
-<text x="434" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">CIS·MCP</text>
+<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Posture</text>
+<text x="434" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">CIS·MCP</text>
 <rect x="574" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="582" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(586,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Blast radius</text>
-<text x="612" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">fusion</text>
+<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Blast radius</text>
+<text x="612" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">fusion</text>
 <rect x="752" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="760" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(764,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Policy</text>
-<text x="790" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">as-code</text>
-<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
+<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Policy</text>
+<text x="790" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">as-code</text>
+<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
 <rect x="28" y="300" width="904" height="136" rx="12" fill="#0f0f13" stroke="#2dd4bf" stroke-width="1.2" opacity="0.95"/><rect x="28" y="300" width="904" height="3" rx="12" fill="#2dd4bf" opacity="0.55"/>
-<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
+<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
 <rect x="40" y="332" width="214" height="29" rx="8" fill="#15121f" stroke="#2dd4bf" stroke-width="1.5"/>
 <rect x="48" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,338) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
-<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Unified Finding</text>
-<text x="78" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#2dd4bf">one schema</text>
+<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Unified Finding</text>
+<text x="78" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#2dd4bf">one schema</text>
 <rect x="258" y="332" width="214" height="29" rx="8" fill="#15121f" stroke="#2dd4bf" stroke-width="1.5"/>
 <rect x="266" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(270,338) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
-<text x="296" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#2dd4bf">attack paths</text>
+<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
+<text x="296" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#2dd4bf">attack paths</text>
 <rect x="40" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="48" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Stores</text>
-<text x="78" y="389" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">PG·SQLite</text>
+<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Stores</text>
+<text x="78" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">PG·SQLite</text>
 <rect x="258" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="266" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(270,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Audit chain</text>
-<text x="296" y="389" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">signed</text>
+<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Audit chain</text>
+<text x="296" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">signed</text>
 <rect x="488" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">381 ops</text>
+<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">REST API</text>
+<text x="526" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">381 ops</text>
 <rect x="706" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Gateway</text>
-<text x="744" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">runtime</text>
+<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Gateway</text>
+<text x="744" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">runtime</text>
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">77 tools</text>
+<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">MCP server</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">77 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
-<text x="744" y="389" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">Helm·EKS</text>
+<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
+<text x="744" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">Helm·EKS</text>
 <rect x="488" y="398" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="400" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,404) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e9e9ec">Scheduler / events</text>
-<text x="526" y="422" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#82828c">cadence·change</text>
-<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
+<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Scheduler / events</text>
+<text x="526" y="422" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">cadence·change</text>
+<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
 <rect x="28" y="448" width="904" height="140" rx="12" fill="#0f0f13" stroke="#c084fc" stroke-width="1.2" opacity="0.95"/><rect x="28" y="448" width="904" height="3" rx="12" fill="#c084fc" opacity="0.55"/>
-<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#e9d5ff">deliver</text>
-<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
+<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#e9d5ff">deliver</text>
+<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
 <rect x="40" y="492" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
 <rect x="50" y="495" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(54,499) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">CLI</text>
+<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#e9e9ec">CLI</text>
 <rect x="40" y="527" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
 <rect x="50" y="530" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(54,534) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">Web UI</text>
-<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
+<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#e9e9ec">Web UI</text>
+<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
 <rect x="337" y="492" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
 <rect x="347" y="495" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(351,499) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">MCP</text>
+<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#e9e9ec">MCP</text>
 <rect x="337" y="527" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
 <rect x="347" y="530" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(351,534) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#e9e9ec">SDK</text>
-<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
-<rect x="634" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SARIF</text>
-<rect x="730" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">CDX</text>
-<rect x="826" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">SPDX</text>
-<rect x="634" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">OCSF</text>
-<rect x="730" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">HTML</text>
-<rect x="826" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#a1a1aa">JSON</text>
-<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
-<rect x="24" y="582" width="912" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#e9e9ec">SDK</text>
+<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
+<rect x="634" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">SARIF</text>
+<rect x="730" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">CDX</text>
+<rect x="826" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">SPDX</text>
+<rect x="634" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">OCSF</text>
+<rect x="730" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">HTML</text>
+<rect x="826" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">JSON</text>
+<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
+<rect x="24" y="582" width="912" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -5,125 +5,125 @@
 <rect width="960" height="620" rx="14" fill="#ffffff"/>
 <rect x="12" y="12" width="936" height="596" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>
 <rect x="842" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>
-<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
-<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="20" font-weight="800" fill="#18181b">Control-plane architecture</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
+<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.4" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="26.0" font-weight="800" fill="#18181b">Control-plane architecture</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
 <rect x="28" y="78" width="904" height="102" rx="12" fill="#fafafa" stroke="#38bdf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="78" width="904" height="3" rx="12" fill="#38bdf8" opacity="0.55"/>
-<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#bae6fd">read-only</text>
+<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#bae6fd">read-only</text>
 <rect x="40" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="48" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Supply chain</text>
-<text x="78" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">15 eco</text>
+<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Supply chain</text>
+<text x="78" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">15 eco</text>
 <rect x="166" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="174" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(178,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
-<text x="204" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">29 clients</text>
+<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
+<text x="204" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">29 clients</text>
 <rect x="292" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="300" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(304,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Cloud</text>
-<text x="330" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">4 connect · 16 scan</text>
+<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Cloud</text>
+<text x="330" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">4 connect · 16 scan</text>
 <rect x="418" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="426" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(430,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
-<text x="456" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">TF·K8s·img</text>
+<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
+<text x="456" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">TF·K8s·img</text>
 <rect x="544" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="552" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(556,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Secrets</text>
-<text x="582" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">refs only</text>
+<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Secrets</text>
+<text x="582" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">refs only</text>
 <rect x="670" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="678" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(682,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Models</text>
-<text x="708" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">13 formats</text>
+<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Models</text>
+<text x="708" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">13 formats</text>
 <rect x="796" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="804" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(808,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">SBOM import</text>
-<text x="834" y="142" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">CDX·SPDX</text>
-<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
+<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">SBOM import</text>
+<text x="834" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">CDX·SPDX</text>
+<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
 <rect x="28" y="192" width="904" height="96" rx="12" fill="#fafafa" stroke="#818cf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="192" width="904" height="3" rx="12" fill="#818cf8" opacity="0.55"/>
-<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#c7d2fe">local scan</text>
+<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#c7d2fe">local scan</text>
 <rect x="40" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="48" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">OSV scan</text>
-<text x="78" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">batch</text>
+<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">OSV scan</text>
+<text x="78" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">batch</text>
 <rect x="218" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="226" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Enrichment</text>
-<text x="256" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">NVD·EPSS</text>
+<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Enrichment</text>
+<text x="256" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">NVD·EPSS</text>
 <rect x="396" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="404" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Posture</text>
-<text x="434" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">CIS·MCP</text>
+<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Posture</text>
+<text x="434" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">CIS·MCP</text>
 <rect x="574" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="582" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(586,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Blast radius</text>
-<text x="612" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">fusion</text>
+<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Blast radius</text>
+<text x="612" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">fusion</text>
 <rect x="752" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="760" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(764,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Policy</text>
-<text x="790" y="264" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">as-code</text>
-<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
+<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Policy</text>
+<text x="790" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">as-code</text>
+<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
 <rect x="28" y="300" width="904" height="136" rx="12" fill="#fafafa" stroke="#2dd4bf" stroke-width="1.2" opacity="0.95"/><rect x="28" y="300" width="904" height="3" rx="12" fill="#2dd4bf" opacity="0.55"/>
-<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
+<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
 <rect x="40" y="332" width="214" height="29" rx="8" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.5"/>
 <rect x="48" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,338) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
-<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Unified Finding</text>
-<text x="78" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#2dd4bf">one schema</text>
+<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Unified Finding</text>
+<text x="78" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#2dd4bf">one schema</text>
 <rect x="258" y="332" width="214" height="29" rx="8" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.5"/>
 <rect x="266" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(270,338) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">UnifiedGraph</text>
-<text x="296" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#2dd4bf">attack paths</text>
+<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">UnifiedGraph</text>
+<text x="296" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#2dd4bf">attack paths</text>
 <rect x="40" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="48" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Stores</text>
-<text x="78" y="389" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">PG·SQLite</text>
+<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Stores</text>
+<text x="78" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">PG·SQLite</text>
 <rect x="258" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="266" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(270,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Audit chain</text>
-<text x="296" y="389" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">signed</text>
+<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Audit chain</text>
+<text x="296" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">signed</text>
 <rect x="488" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">381 ops</text>
+<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">REST API</text>
+<text x="526" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">381 ops</text>
 <rect x="706" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Gateway</text>
-<text x="744" y="356" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">runtime</text>
+<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Gateway</text>
+<text x="744" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">runtime</text>
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">77 tools</text>
+<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">MCP server</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">77 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Fleet jobs</text>
-<text x="744" y="389" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">Helm·EKS</text>
+<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Fleet jobs</text>
+<text x="744" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">Helm·EKS</text>
 <rect x="488" y="398" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="400" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,404) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#18181b">Scheduler / events</text>
-<text x="526" y="422" font-family="ui-monospace,monospace" font-size="6.5" font-weight="600" fill="#71717a">cadence·change</text>
-<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
+<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Scheduler / events</text>
+<text x="526" y="422" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">cadence·change</text>
+<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
 <rect x="28" y="448" width="904" height="140" rx="12" fill="#fafafa" stroke="#c084fc" stroke-width="1.2" opacity="0.95"/><rect x="28" y="448" width="904" height="3" rx="12" fill="#c084fc" opacity="0.55"/>
-<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="9.5" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="600" fill="#e9d5ff">deliver</text>
-<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
+<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#e9d5ff">deliver</text>
+<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
 <rect x="40" y="492" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
 <rect x="50" y="495" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(54,499) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">CLI</text>
+<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#18181b">CLI</text>
 <rect x="40" y="527" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
 <rect x="50" y="530" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(54,534) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">Web UI</text>
-<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
+<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#18181b">Web UI</text>
+<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
 <rect x="337" y="492" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
 <rect x="347" y="495" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(351,499) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">MCP</text>
+<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#18181b">MCP</text>
 <rect x="337" y="527" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
 <rect x="347" y="530" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(351,534) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="9" font-weight="700" fill="#18181b">SDK</text>
-<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.5" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
-<rect x="634" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SARIF</text>
-<rect x="730" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">CDX</text>
-<rect x="826" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">SPDX</text>
-<rect x="634" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">OCSF</text>
-<rect x="730" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">HTML</text>
-<rect x="826" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7" font-weight="700" fill="#52525b">JSON</text>
-<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
-<rect x="24" y="582" width="912" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#18181b">SDK</text>
+<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
+<rect x="634" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">SARIF</text>
+<rect x="730" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">CDX</text>
+<rect x="826" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">SPDX</text>
+<rect x="634" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">OCSF</text>
+<rect x="730" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">HTML</text>
+<rect x="826" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">JSON</text>
+<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
+<rect x="24" y="582" width="912" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -5,87 +5,87 @@
 <rect x="23" y="18" width="235" height="174" rx="12" fill="#a78bfa"/>
 <rect x="23" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="37" y="32" width="40" height="40" rx="11" fill="#a78bfa" opacity="0.16"/><g transform="translate(41,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#a78bfa"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#a78bfa"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#a78bfa"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#0f0f13" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#a78bfa" stroke-width="1.05"/></g></g>
-<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Developers</text>
+<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">Developers</text>
 <rect x="37" y="82" width="65" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">local scan</text>
+<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#a78bfa">local scan</text>
 <rect x="108" y="82" width="45" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">images</text>
+<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#a78bfa">images</text>
 <rect x="159" y="82" width="55" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">CI gates</text>
+<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#a78bfa">CI gates</text>
 <line x1="39" y1="110" x2="242" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="140,120 135,113 145,113" fill="#a78bfa" opacity="0.9"/>
 <rect x="35" y="126" width="211" height="52" rx="8" fill="#a78bfa" opacity="0.10"/>
 <rect x="35" y="126" width="211" height="52" rx="8" fill="none" stroke="#a78bfa" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#a78bfa"/>
-<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Accurate SCA</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro-aware</text>
+<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Accurate SCA</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro-aware</text>
 <rect x="272" y="18" width="235" height="174" rx="12" fill="#2dd4bf"/>
 <rect x="272" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="286" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(290,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>
-<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">AppSec</text>
+<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">AppSec</text>
 <rect x="286" y="82" width="40" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">SARIF</text>
+<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#2dd4bf">SARIF</text>
 <rect x="332" y="82" width="74" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">reachability</text>
+<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#2dd4bf">reachability</text>
 <rect x="412" y="82" width="69" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">graph paths</text>
+<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#2dd4bf">graph paths</text>
 <line x1="288" y1="110" x2="491" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="389,120 384,113 394,113" fill="#2dd4bf" opacity="0.9"/>
 <rect x="284" y="126" width="211" height="52" rx="8" fill="#2dd4bf" opacity="0.10"/>
 <rect x="284" y="126" width="211" height="52" rx="8" fill="none" stroke="#2dd4bf" opacity="0.4"/>
 <rect x="292" y="142" width="3" height="14" rx="1.5" fill="#2dd4bf"/>
-<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Triage by reachability</text>
-<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">blast radius · CI gates · exit codes</text>
+<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Triage by reachability</text>
+<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">blast radius · CI gates · exit codes</text>
 <rect x="521" y="18" width="235" height="174" rx="12" fill="#38bdf8"/>
 <rect x="521" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="535" y="32" width="40" height="40" rx="11" fill="#38bdf8" opacity="0.16"/><g transform="translate(539,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#38bdf8"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#38bdf8"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#38bdf8"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
-<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
+<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
 <rect x="535" y="82" width="65" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">fleet sync</text>
+<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#38bdf8">fleet sync</text>
 <rect x="606" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">Helm</text>
+<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#38bdf8">Helm</text>
 <rect x="647" y="82" width="25" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">CI</text>
+<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#38bdf8">CI</text>
 <rect x="678" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">SBOM</text>
+<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#38bdf8">SBOM</text>
 <line x1="537" y1="110" x2="740" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="638,120 633,113 643,113" fill="#38bdf8" opacity="0.9"/>
 <rect x="533" y="126" width="211" height="52" rx="8" fill="#38bdf8" opacity="0.10"/>
 <rect x="533" y="126" width="211" height="52" rx="8" fill="none" stroke="#38bdf8" opacity="0.4"/>
 <rect x="541" y="142" width="3" height="14" rx="1.5" fill="#38bdf8"/>
-<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
-<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">your VPC · Postgres · signed audit</text>
+<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
+<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">your VPC · Postgres · signed audit</text>
 <rect x="770" y="18" width="235" height="174" rx="12" fill="#fbbf24"/>
 <rect x="770" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="784" y="32" width="40" height="40" rx="11" fill="#fbbf24" opacity="0.16"/><g transform="translate(788,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fbbf24"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fbbf24"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fbbf24"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#0f0f13" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#0f0f13" stroke-width="1.0"/></g></g>
-<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">GRC / audit</text>
+<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">GRC / audit</text>
 <rect x="784" y="82" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">compliance</text>
+<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fbbf24">compliance</text>
 <rect x="855" y="82" width="55" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">evidence</text>
+<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fbbf24">evidence</text>
 <rect x="916" y="82" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">frameworks</text>
+<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fbbf24">frameworks</text>
 <line x1="786" y1="110" x2="989" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="887,120 882,113 892,113" fill="#fbbf24" opacity="0.9"/>
 <rect x="782" y="126" width="211" height="52" rx="8" fill="#fbbf24" opacity="0.10"/>
 <rect x="782" y="126" width="211" height="52" rx="8" fill="none" stroke="#fbbf24" opacity="0.4"/>
 <rect x="790" y="142" width="3" height="14" rx="1.5" fill="#fbbf24"/>
-<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Audit-ready exports</text>
-<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">control mappings · signed bundles</text>
+<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Audit-ready exports</text>
+<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">control mappings · signed bundles</text>
 <rect x="1019" y="18" width="235" height="174" rx="12" fill="#fb7185"/>
 <rect x="1019" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="1033" y="32" width="40" height="40" rx="11" fill="#fb7185" opacity="0.16"/><g transform="translate(1037,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fb7185"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fb7185"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fb7185"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
-<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">AI / MCP owners</text>
+<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">AI / MCP owners</text>
 <rect x="1033" y="82" width="79" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">MCP inventory</text>
+<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fb7185">MCP inventory</text>
 <rect x="1118" y="82" width="94" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">allow/warn/block</text>
+<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fb7185">allow/warn/block</text>
 <line x1="1035" y1="110" x2="1238" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="1136,120 1131,113 1141,113" fill="#fb7185" opacity="0.9"/>
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="#fb7185" opacity="0.10"/>
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
-<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#82828c">381 API ops · 77 MCP tools · SARIF</text>
-<rect x="24" y="196" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
+<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">381 API ops · 77 MCP tools · SARIF</text>
+<rect x="24" y="196" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -5,87 +5,87 @@
 <rect x="23" y="18" width="235" height="174" rx="12" fill="#7c3aed"/>
 <rect x="23" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="37" y="32" width="40" height="40" rx="11" fill="#7c3aed" opacity="0.10"/><g transform="translate(41,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#7c3aed"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#7c3aed"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#7c3aed"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#ffffff" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#7c3aed" stroke-width="1.05"/></g></g>
-<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Developers</text>
+<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">Developers</text>
 <rect x="37" y="82" width="65" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">local scan</text>
+<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#7c3aed">local scan</text>
 <rect x="108" y="82" width="45" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">images</text>
+<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#7c3aed">images</text>
 <rect x="159" y="82" width="55" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">CI gates</text>
+<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#7c3aed">CI gates</text>
 <line x1="39" y1="110" x2="242" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="140,120 135,113 145,113" fill="#7c3aed" opacity="0.9"/>
 <rect x="35" y="126" width="211" height="52" rx="8" fill="#7c3aed" opacity="0.07"/>
 <rect x="35" y="126" width="211" height="52" rx="8" fill="none" stroke="#7c3aed" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#7c3aed"/>
-<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Accurate SCA</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
+<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Accurate SCA</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
 <rect x="272" y="18" width="235" height="174" rx="12" fill="#0d9488"/>
 <rect x="272" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="286" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(290,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>
-<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">AppSec</text>
+<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">AppSec</text>
 <rect x="286" y="82" width="40" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">SARIF</text>
+<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0d9488">SARIF</text>
 <rect x="332" y="82" width="74" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">reachability</text>
+<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0d9488">reachability</text>
 <rect x="412" y="82" width="69" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">graph paths</text>
+<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0d9488">graph paths</text>
 <line x1="288" y1="110" x2="491" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="389,120 384,113 394,113" fill="#0d9488" opacity="0.9"/>
 <rect x="284" y="126" width="211" height="52" rx="8" fill="#0d9488" opacity="0.07"/>
 <rect x="284" y="126" width="211" height="52" rx="8" fill="none" stroke="#0d9488" opacity="0.4"/>
 <rect x="292" y="142" width="3" height="14" rx="1.5" fill="#0d9488"/>
-<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Triage by reachability</text>
-<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">blast radius · CI gates · exit codes</text>
+<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Triage by reachability</text>
+<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">blast radius · CI gates · exit codes</text>
 <rect x="521" y="18" width="235" height="174" rx="12" fill="#0284c7"/>
 <rect x="521" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="535" y="32" width="40" height="40" rx="11" fill="#0284c7" opacity="0.10"/><g transform="translate(539,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0284c7"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0284c7"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0284c7"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
-<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Platform / SRE</text>
+<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">Platform / SRE</text>
 <rect x="535" y="82" width="65" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">fleet sync</text>
+<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0284c7">fleet sync</text>
 <rect x="606" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">Helm</text>
+<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0284c7">Helm</text>
 <rect x="647" y="82" width="25" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">CI</text>
+<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0284c7">CI</text>
 <rect x="678" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">SBOM</text>
+<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0284c7">SBOM</text>
 <line x1="537" y1="110" x2="740" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="638,120 633,113 643,113" fill="#0284c7" opacity="0.9"/>
 <rect x="533" y="126" width="211" height="52" rx="8" fill="#0284c7" opacity="0.07"/>
 <rect x="533" y="126" width="211" height="52" rx="8" fill="none" stroke="#0284c7" opacity="0.4"/>
 <rect x="541" y="142" width="3" height="14" rx="1.5" fill="#0284c7"/>
-<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Self-hosted control plane</text>
-<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">your VPC · Postgres · signed audit</text>
+<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Self-hosted control plane</text>
+<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">your VPC · Postgres · signed audit</text>
 <rect x="770" y="18" width="235" height="174" rx="12" fill="#d97706"/>
 <rect x="770" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="784" y="32" width="40" height="40" rx="11" fill="#d97706" opacity="0.10"/><g transform="translate(788,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#d97706"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#d97706"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#d97706"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#ffffff" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#ffffff" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#ffffff" stroke-width="1.0"/></g></g>
-<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">GRC / audit</text>
+<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">GRC / audit</text>
 <rect x="784" y="82" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">compliance</text>
+<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#d97706">compliance</text>
 <rect x="855" y="82" width="55" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">evidence</text>
+<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#d97706">evidence</text>
 <rect x="916" y="82" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">frameworks</text>
+<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#d97706">frameworks</text>
 <line x1="786" y1="110" x2="989" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="887,120 882,113 892,113" fill="#d97706" opacity="0.9"/>
 <rect x="782" y="126" width="211" height="52" rx="8" fill="#d97706" opacity="0.07"/>
 <rect x="782" y="126" width="211" height="52" rx="8" fill="none" stroke="#d97706" opacity="0.4"/>
 <rect x="790" y="142" width="3" height="14" rx="1.5" fill="#d97706"/>
-<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Audit-ready exports</text>
-<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">control mappings · signed bundles</text>
+<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Audit-ready exports</text>
+<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">control mappings · signed bundles</text>
 <rect x="1019" y="18" width="235" height="174" rx="12" fill="#e11d48"/>
 <rect x="1019" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="1033" y="32" width="40" height="40" rx="11" fill="#e11d48" opacity="0.10"/><g transform="translate(1037,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#e11d48"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#e11d48"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#e11d48"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
-<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">AI / MCP owners</text>
+<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">AI / MCP owners</text>
 <rect x="1033" y="82" width="79" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">MCP inventory</text>
+<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#e11d48">MCP inventory</text>
 <rect x="1118" y="82" width="94" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">allow/warn/block</text>
+<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#e11d48">allow/warn/block</text>
 <line x1="1035" y1="110" x2="1238" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="1136,120 1131,113 1141,113" fill="#e11d48" opacity="0.9"/>
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="#e11d48" opacity="0.07"/>
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
-<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10" font-weight="600" fill="#71717a">381 API ops · 77 MCP tools · SARIF</text>
-<rect x="24" y="196" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Agent-native surface</text>
+<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">381 API ops · 77 MCP tools · SARIF</text>
+<rect x="24" y="196" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -591,7 +591,12 @@ def _legacy_how_it_works(theme_name: str) -> str:
             margin_x,
             60,
             "onboard read-only  ->  scan + enrich  ->  ContextGraph + blast radius  ->  agent-bom serve",
-            **{"font-family": "ui-monospace,SFMono-Regular,Menlo,monospace", "font-size": "10", "font-weight": "500", "fill": t["subtitle"]},
+            **{
+                "font-family": "ui-monospace,SFMono-Regular,Menlo,monospace",
+                "font-size": "10",
+                "font-weight": "500",
+                "fill": t["subtitle"],
+            },
         ),
     ]
 
@@ -671,9 +676,7 @@ def _legacy_how_it_works(theme_name: str) -> str:
     )
     for i, (icon, label, desc) in enumerate(steps):
         sy = step_top + i * step_h
-        parts.append(
-            f'<circle cx="{rail_x}" cy="{sy + 14}" r="8.5" fill="{t["card"]}" stroke="{scan_accent}" stroke-width="1.3"/>'
-        )
+        parts.append(f'<circle cx="{rail_x}" cy="{sy + 14}" r="8.5" fill="{t["card"]}" stroke="{scan_accent}" stroke-width="1.3"/>')
         parts.append(
             f'<text x="{rail_x}" y="{sy + 17}" text-anchor="middle" font-family="Inter,system-ui,sans-serif" '
             f'font-size="7.5" font-weight="800" fill="{scan_accent}">{i + 1}</text>'
@@ -731,9 +734,7 @@ def _legacy_how_it_works(theme_name: str) -> str:
     ]
     for nx, ny, _size, _label, _icon, center in hub_nodes:
         if not center:
-            parts.append(
-                f'<line x1="{cx}" y1="{cy}" x2="{nx}" y2="{ny}" stroke="{t["panel_stroke"]}" stroke-width="1.2" opacity="0.75"/>'
-            )
+            parts.append(f'<line x1="{cx}" y1="{cy}" x2="{nx}" y2="{ny}" stroke="{t["panel_stroke"]}" stroke-width="1.2" opacity="0.75"/>')
     for nx, ny, size, nlabel, icon, center in hub_nodes:
         parts.append(_hub_node(nx, ny, size, nlabel, icon, t, center=center))
 
@@ -806,9 +807,7 @@ def _legacy_how_it_works(theme_name: str) -> str:
         col, row = i % 3, i // 3
         gx = out_x + col * (glass_w + 4)
         gy = lane_top + 58 + row * 42
-        parts.append(
-            f'<rect x="{gx}" y="{gy}" width="{glass_w}" height="36" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
-        )
+        parts.append(f'<rect x="{gx}" y="{gy}" width="{glass_w}" height="36" rx="8" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
         parts.append(_icon_box(gx + 6, gy + 8, ICONS[icon], t, size=20))
         parts.append(
             _text(
@@ -837,9 +836,7 @@ def _legacy_how_it_works(theme_name: str) -> str:
         rw = (out_card_w - 8) // 3
         rx = out_x + i * (rw + 4)
         ry = lane_top + 252
-        parts.append(
-            f'<rect x="{rx}" y="{ry}" width="{rw}" height="36" rx="8" fill="{t["card"]}" stroke="{color}" stroke-width="1.1"/>'
-        )
+        parts.append(f'<rect x="{rx}" y="{ry}" width="{rw}" height="36" rx="8" fill="{t["card"]}" stroke="{color}" stroke-width="1.1"/>')
         parts.append(_icon_box(rx + 6, ry + 8, ICONS[icon], t, accent=True, size=20))
         parts.append(
             _text(
@@ -973,34 +970,134 @@ def how_it_works(theme_name: str) -> str:
             '<rect width="1120" height="420" rx="20" fill="url(#bg)"/>',
             f'<circle cx="180" cy="90" r="120" fill="{palette["glow1"]}" opacity="0.08" filter="url(#soft)"/>',
             f'<circle cx="920" cy="340" r="140" fill="{palette["glow2"]}" opacity="0.07" filter="url(#soft)"/>',
-            _text(48, 52, "AGENT-BOM", **{"font-family": "'IBM Plex Sans','Segoe UI',system-ui,sans-serif", "font-size": "13", "font-weight": "700", "letter-spacing": "0.22em", "fill": palette["brand"]}),
-            _text(48, 92, "One evidence model. Three ways in.", **{"font-family": "'IBM Plex Sans','Segoe UI',system-ui,sans-serif", "font-size": "28", "font-weight": "700", "fill": palette["title"]}),
-            _text(48, 118, "Scan / control plane / runtime enforcement. Same Finding + UnifiedGraph everywhere.", **{"font-family": "'IBM Plex Sans','Segoe UI',system-ui,sans-serif", "font-size": "14", "fill": palette["muted"]}),
+            _text(
+                48,
+                52,
+                "AGENT-BOM",
+                **{
+                    "font-family": "'IBM Plex Sans','Segoe UI',system-ui,sans-serif",
+                    "font-size": "13",
+                    "font-weight": "700",
+                    "letter-spacing": "0.22em",
+                    "fill": palette["brand"],
+                },
+            ),
+            _text(
+                48,
+                92,
+                "One evidence model. Three ways in.",
+                **{
+                    "font-family": "'IBM Plex Sans','Segoe UI',system-ui,sans-serif",
+                    "font-size": "28",
+                    "font-weight": "700",
+                    "fill": palette["title"],
+                },
+            ),
+            _text(
+                48,
+                118,
+                "Scan / control plane / runtime enforcement. Same Finding + UnifiedGraph everywhere.",
+                **{"font-family": "'IBM Plex Sans','Segoe UI',system-ui,sans-serif", "font-size": "14", "fill": palette["muted"]},
+            ),
         ]
     )
 
     lanes = (
-        (48, 320, "lane1", palette["scan_bar"], palette["scan"], "01  SCAN", "Local CLI / CI", ("Inventory, findings, fix-first,", "SARIF / SBOM / HTML - no server."), "agent-bom scan .", palette["scan_cmd"]),
-        (392, 320, "lane2", palette["central_bar"], palette["central"], "02  CENTRALIZE", "Self-hosted plane", ("Fleet, graph, compliance,", "audit - your VPC / Postgres."), "agent-bom serve", palette["central"]),
-        (736, 336, "lane3", palette["enforce_bar"], palette["enforce"], "03  ENFORCE", "Runtime gateway", ("Allow / warn / block MCP", "tool calls with signed audit."), "agent-bom gateway serve --help", palette["enforce"]),
+        (
+            48,
+            320,
+            "lane1",
+            palette["scan_bar"],
+            palette["scan"],
+            "01  SCAN",
+            "Local CLI / CI",
+            ("Inventory, findings, fix-first,", "SARIF / SBOM / HTML - no server."),
+            "agent-bom scan .",
+            palette["scan_cmd"],
+        ),
+        (
+            392,
+            320,
+            "lane2",
+            palette["central_bar"],
+            palette["central"],
+            "02  CENTRALIZE",
+            "Self-hosted plane",
+            ("Fleet, graph, compliance,", "audit - your VPC / Postgres."),
+            "agent-bom serve",
+            palette["central"],
+        ),
+        (
+            736,
+            336,
+            "lane3",
+            palette["enforce_bar"],
+            palette["enforce"],
+            "03  ENFORCE",
+            "Runtime gateway",
+            ("Allow / warn / block MCP", "tool calls with signed audit."),
+            "agent-bom gateway serve --help",
+            palette["enforce"],
+        ),
     )
     for x, width, gradient, bar, accent, label, title, body, command, command_color in lanes:
         parts.extend(
             [
                 f'<rect x="{x}" y="148" width="{width}" height="200" rx="4" fill="url(#{gradient})"/>',
                 f'<rect x="{x}" y="148" width="4" height="200" fill="{bar}"/>',
-                _text(x + 24, 178, label, **{"font-family": "'IBM Plex Mono',ui-monospace,monospace", "font-size": "11", "font-weight": "700", "letter-spacing": "0.16em", "fill": accent}),
-                _text(x + 24, 214, title, **{"font-family": "'IBM Plex Sans',system-ui,sans-serif", "font-size": "22", "font-weight": "700", "fill": palette["title"]}),
-                _text(x + 24, 242, body[0], **{"font-family": "'IBM Plex Sans',system-ui,sans-serif", "font-size": "13", "fill": palette["muted"]}),
-                _text(x + 24, 260, body[1], **{"font-family": "'IBM Plex Sans',system-ui,sans-serif", "font-size": "13", "fill": palette["muted"]}),
-                _text(x + 24, 312, command, **{"font-family": "'IBM Plex Mono',ui-monospace,monospace", "font-size": "12", "fill": command_color}),
+                _text(
+                    x + 24,
+                    178,
+                    label,
+                    **{
+                        "font-family": "'IBM Plex Mono',ui-monospace,monospace",
+                        "font-size": "11",
+                        "font-weight": "700",
+                        "letter-spacing": "0.16em",
+                        "fill": accent,
+                    },
+                ),
+                _text(
+                    x + 24,
+                    214,
+                    title,
+                    **{
+                        "font-family": "'IBM Plex Sans',system-ui,sans-serif",
+                        "font-size": "22",
+                        "font-weight": "700",
+                        "fill": palette["title"],
+                    },
+                ),
+                _text(
+                    x + 24,
+                    242,
+                    body[0],
+                    **{"font-family": "'IBM Plex Sans',system-ui,sans-serif", "font-size": "13", "fill": palette["muted"]},
+                ),
+                _text(
+                    x + 24,
+                    260,
+                    body[1],
+                    **{"font-family": "'IBM Plex Sans',system-ui,sans-serif", "font-size": "13", "fill": palette["muted"]},
+                ),
+                _text(
+                    x + 24,
+                    312,
+                    command,
+                    **{"font-family": "'IBM Plex Mono',ui-monospace,monospace", "font-size": "12", "fill": command_color},
+                ),
             ]
         )
 
     parts.extend(
         [
             f'<rect x="48" y="372" width="1024" height="1" fill="{palette["divider"]}"/>',
-            _text(48, 398, "Finding + UnifiedGraph is the spine - CLI, API, UI, and MCP share it.", **{"font-family": "'IBM Plex Sans',system-ui,sans-serif", "font-size": "12", "fill": palette["muted"]}),
+            _text(
+                48,
+                398,
+                "Finding + UnifiedGraph is the spine - CLI, API, UI, and MCP share it.",
+                **{"font-family": "'IBM Plex Sans',system-ui,sans-serif", "font-size": "12", "fill": palette["muted"]},
+            ),
             "</svg>",
         ]
     )
@@ -1207,9 +1304,7 @@ def architecture(theme_name: str) -> str:
 
     def _consumer_mini(y: int, x: int, cw: int, icon: str, label: str) -> int:
         mh = 30
-        parts.append(
-            f'<rect x="{x}" y="{y}" width="{cw}" height="{mh}" rx="7" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>'
-        )
+        parts.append(f'<rect x="{x}" y="{y}" width="{cw}" height="{mh}" rx="7" fill="{t["card"]}" stroke="{t["card_stroke"]}"/>')
         parts.append(_icon_box(x + 10, y + 3, ICONS[icon], t, size=22))
         parts.append(
             _text(
@@ -1320,7 +1415,7 @@ def architecture(theme_name: str) -> str:
         )
     )
     parts.append("</svg>")
-    return "\n".join(parts)
+    return _scale_type("\n".join(parts), _ARCHITECTURE_TYPE_SCALE)
 
 
 # Persona band accents — one restrained hue per buyer lane, on neutral cards.
@@ -1496,7 +1591,7 @@ def _persona_lane_card(
         f'<circle cx="18.5" cy="18" r="6" fill="{t["card"]}"/>'
         f'<circle cx="18.5" cy="18" r="4.6" fill="{accent}"/>'
         f'<g fill="none" stroke="{glyph_stroke}" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">'
-        f'{PERSONA_BADGES[accent_key].replace("GLYPH", glyph_stroke).replace("ACCENT", accent)}</g></g>'
+        f"{PERSONA_BADGES[accent_key].replace('GLYPH', glyph_stroke).replace('ACCENT', accent)}</g></g>"
     )
     parts.append(
         _text(
@@ -1534,10 +1629,7 @@ def _persona_lane_card(
         tag_x += tag_w + 6
 
     divider_y = y + 92
-    parts.append(
-        f'<line x1="{x + 16}" y1="{divider_y}" x2="{x + w - 16}" y2="{divider_y}" '
-        f'stroke="{t["card_stroke"]}" stroke-width="1"/>'
-    )
+    parts.append(f'<line x1="{x + 16}" y1="{divider_y}" x2="{x + w - 16}" y2="{divider_y}" stroke="{t["card_stroke"]}" stroke-width="1"/>')
     arrow_x = x + w // 2
     parts.append(
         f'<polygon points="{arrow_x},{divider_y + 10} {arrow_x - 5},{divider_y + 3} {arrow_x + 5},{divider_y + 3}" '
@@ -1546,18 +1638,12 @@ def _persona_lane_card(
 
     value_y = divider_y + 16
     value_h = h - (value_y - y) - 14
+    parts.append(f'<rect x="{x + 12}" y="{value_y}" width="{w - 24}" height="{value_h}" rx="8" fill="{accent}" opacity="{tint_opacity}"/>')
     parts.append(
-        f'<rect x="{x + 12}" y="{value_y}" width="{w - 24}" height="{value_h}" rx="8" '
-        f'fill="{accent}" opacity="{tint_opacity}"/>'
-    )
-    parts.append(
-        f'<rect x="{x + 12}" y="{value_y}" width="{w - 24}" height="{value_h}" rx="8" '
-        f'fill="none" stroke="{accent}" opacity="0.4"/>'
+        f'<rect x="{x + 12}" y="{value_y}" width="{w - 24}" height="{value_h}" rx="8" fill="none" stroke="{accent}" opacity="0.4"/>'
     )
     # Accent marker keys the headline value to the persona hue.
-    parts.append(
-        f'<rect x="{x + 20}" y="{value_y + 16}" width="3" height="14" rx="1.5" fill="{accent}"/>'
-    )
+    parts.append(f'<rect x="{x + 20}" y="{value_y + 16}" width="3" height="14" rx="1.5" fill="{accent}"/>')
     parts.append(
         _text(
             x + 30,
@@ -1605,7 +1691,60 @@ def persona_value(theme: str) -> str:
         )
     )
     parts.append("</svg>")
-    return "\n".join(parts)
+    return _scale_type("\n".join(parts), _PERSONA_TYPE_SCALE)
+
+
+# Average glyph advance for Inter/system-ui at a given font-size, in em. Used to
+# estimate rendered text width; deliberately generous so the audit errs toward
+# reporting an overflow that turns out to fit rather than passing one that clips.
+_GLYPH_ADVANCE_EM = 0.58
+
+# GitHub renders README images at roughly 900px wide. These two diagrams are
+# authored at 960 and 1280, so their type is downscaled to ~6px on screen —
+# below the 10px floor the flow diagrams already hold themselves to, which is
+# why they read as unreadable in the README while being correct at full size.
+# Scaled as far as `_audit_text_fit` allows without a relayout; persona-value
+# runs out of room first because its five cards share one 1280px row.
+_ARCHITECTURE_TYPE_SCALE = 1.3
+_PERSONA_TYPE_SCALE = 1.18
+
+
+def _scale_type(svg: str, factor: float) -> str:
+    """Scale every font-size so the diagram survives GitHub's downscale."""
+    return re.sub(
+        r'font-size="([\d.]+)"',
+        lambda m: f'font-size="{round(float(m.group(1)) * factor, 2)}"',
+        svg,
+    )
+
+
+def _audit_text_fit(svg: str, *, margin: int = 4) -> list[str]:
+    """Return text runs whose estimated width escapes the canvas.
+
+    ``_audit_layout`` only bounds ``<rect>`` elements, so it reported "OK" for
+    every font size tried — including ones that would clip. Type cannot be scaled
+    for legibility behind a check that never looks at type.
+
+    This estimates width from glyph count and honours ``text-anchor``. It is an
+    estimate, not a shaping engine: it catches a label growing past the canvas
+    edge, not one overlapping a neighbouring box.
+    """
+    vb = re.search(r'viewBox="0 0 (\d+) (\d+)"', svg)
+    if not vb:
+        return ["missing viewBox"]
+    width, _height = map(int, vb.groups())
+    issues: list[str] = []
+    for match in re.finditer(r'<text x="([\d.]+)"[^>]*?font-size="([\d.]+)"[^>]*?>([^<]*)</text>', svg):
+        x, size, content = float(match.group(1)), float(match.group(2)), match.group(3)
+        if not content.strip():
+            continue
+        run = len(content) * size * _GLYPH_ADVANCE_EM
+        anchor = re.search(r'text-anchor="(\w+)"', match.group(0))
+        kind = anchor.group(1) if anchor else "start"
+        left = x - run / 2 if kind == "middle" else x - run if kind == "end" else x
+        if left < -margin or left + run > width + margin:
+            issues.append(f"text {content[:24]!r} at x={x} spans {round(run)}px, outside 0..{width}")
+    return issues
 
 
 def _audit_layout(svg: str, *, margin: int = 2) -> list[str]:

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -187,3 +187,43 @@ def test_readme_flow_diagrams_keep_a_ten_pixel_rendered_text_floor() -> None:
     }.items():
         sizes = [float(value) for value in re.findall(r'font-size="([0-9.]+)"', svg)]
         assert sizes and min(sizes) * readme_scale >= 10, (name, min(sizes) * readme_scale)
+
+
+def test_dense_diagrams_hold_their_improved_rendered_text_floor() -> None:
+    """The two diagrams the 10px floor never covered — and still cannot.
+
+    `architecture` (960px) and `persona-value` (1280px) are authored wider than
+    GitHub's ~900px README column, so their type is downscaled on screen. They
+    rendered at 6.09px and 5.98px: correct at full size, unreadable in the
+    README, and invisible to the floor above because that test only lists the
+    two near-1:1 flow diagrams.
+
+    Type is now scaled as far as `_audit_text_fit` allows without relaying out
+    the boxes, reaching 7.92px and 7.05px. That is a real improvement and still
+    short of 10px — reaching the flow diagrams' floor needs fewer cards per row
+    or a narrower canvas, which is a design change, not a scale factor. This
+    pins what was achieved so it cannot silently regress, and records the gap.
+    """
+    for name, (svg, readme_scale, floor) in {
+        "architecture": (architecture("light"), 900 / 960, 7.5),
+        "persona-value": (persona_value("light"), 900 / 1280, 7.0),
+    }.items():
+        sizes = [float(value) for value in re.findall(r'font-size="([0-9.]+)"', svg)]
+        rendered = min(sizes) * readme_scale
+        assert rendered >= floor, (name, rendered, floor)
+
+
+def test_dense_diagram_text_stays_inside_the_canvas() -> None:
+    """Scaling type for legibility needs a check that actually looks at type.
+
+    `_audit_layout` bounds `<rect>` elements only, so it reported no issues at
+    every font scale tried, including ones that would clip.
+    """
+    from scripts.generate_doc_architecture_svgs import _audit_text_fit
+
+    for name, svg in {
+        "architecture": architecture("light"),
+        "persona-value": persona_value("light"),
+        "how-it-works": how_it_works("light"),
+    }.items():
+        assert _audit_text_fit(svg) == [], name

--- a/tests/test_public_docs_cli_alignment.py
+++ b/tests/test_public_docs_cli_alignment.py
@@ -160,10 +160,10 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
         )
         == 1
     )
-    assert (
-        "Scan repositories, images, and cloud accounts; centralize evidence across environments; "
-        "and enforce AI and MCP runtime policy in infrastructure you control."
-    ) in hero
+    # The hero is one claim plus the numbers. The scan/centralize/enforce
+    # sentence duplicated what "What it is" says a few lines later, so the
+    # storefront opened with the same paragraph twice.
+    assert "Scan repositories, images, and cloud accounts" not in hero
     assert "<b>15</b> package ecosystems" in hero
     assert "<b>16</b> compliance surfaces" in hero
     assert "<b>77</b> MCP tools" in hero
@@ -181,16 +181,16 @@ def test_readme_storefront_is_concise_ordered_and_actionable() -> None:
     assert "demo.agent-bom.com" not in readme
     assert "## How it works" not in readme
 
-    current_what_it_is = """`agent-bom` is an open scanner and self-hosted control plane for software,
-cloud, identity, AI-agent, and MCP evidence. One Finding + UnifiedGraph model
-powers CLI and CI artifacts, fleet and browser investigations, compliance
-evidence, and runtime policy.
+    # Two paragraphs, not three: what it does and where it runs, then the
+    # provenance guarantee. The middle paragraph restated the first.
+    current_what_it_is = """`agent-bom` scans repositories, images, and cloud accounts, then correlates what
+it finds into one Finding + UnifiedGraph model — powering CLI and CI artifacts,
+fleet and browser investigations, compliance evidence, and runtime policy. Run
+the scanner without an account, or deploy the control plane inside your own
+cloud, VPC, cluster, database, identity, and audit boundary.
 
-Use the scanner without an account, or deploy the shared control plane inside
-your own cloud, VPC, Kubernetes cluster, database, identity, and audit boundary.
-
-Graph provenance remains explicit: collected, inferred, static, and runtime
-relationships stay distinct, and unavailable evidence is never upgraded to
+Graph provenance stays explicit: collected, inferred, static, and runtime
+relationships remain distinct, and unavailable evidence is never upgraded to
 observed."""
     assert current_what_it_is in readme
 


### PR DESCRIPTION
## The diagrams were unreadable where people read them

GitHub renders README images at roughly 900px. `architecture` is authored at 960
and `persona-value` at 1280, so their smallest type landed at **6.09px** and
**5.98px** on screen — correct at full size, unreadable in the README.

The repo already holds its flow diagrams to a **10px rendered floor**
(`test_readme_flow_diagrams_keep_a_ten_pixel_rendered_text_floor`), but that test
lists only `how-it-works` and `blast-radius`, which are near 1:1. The two dense
diagrams — the ones that actually explain the product — were never covered.

| diagram | before | after |
|---|---|---|
| architecture | 6.09px | **7.92px** |
| persona-value | 5.98px | **7.05px** |

Real improvement, and **still short of 10px**. Closing the rest needs fewer cards
per row or a narrower canvas — a design change, not a scale factor. So the
achieved values are pinned by a new test and the gap is recorded rather than
papered over.

## A check that never looked at what it was checking

`_audit_layout` bounds `<rect>` elements only. It reported no issues at **every**
font scale tried, including 1.65×, because it never inspects text. Type cannot be
scaled for legibility behind a check like that — "OK" meant nothing.

`_audit_text_fit` estimates rendered width from glyph count, honours
`text-anchor`, and fails when a run escapes the canvas. It is what established
that architecture has headroom to 1.35× while persona-value overflows at 1.2× —
its five cards share one 1280px row — so the two scale factors differ for a
measured reason rather than a guessed one.

It is an estimate, not a shaping engine: it catches a label growing past the
canvas edge, not one overlapping a neighbouring box. Worth an eyeball before
merge.

## The copy said the same thing twice

The hero opened with *"Scan repositories, images, and cloud accounts; centralize
evidence across environments; and enforce AI and MCP runtime policy…"* — then
**What it is** opened by saying it again. The hero is now one claim plus the
numbers, and **What it is** is two paragraphs instead of three: what it does and
where it runs, then the provenance guarantee.

**Control-plane architecture now opens by default.** It sat behind a collapsed
`<details>`, so the diagram explaining the product was one click away from
everyone who never clicked.

## Verification

- `tests/test_doc_architecture_svgs.py` + `tests/test_public_docs_cli_alignment.py`
  + `tests/test_product_metrics_snapshot.py` — 34 passed
- Two new tests: the rendered floor for the dense diagrams, and text-fit across
  all three
- `ruff check` / `format --check` clean; `make preflight` passed

Both README assertions in `test_public_docs_cli_alignment` encoded the old copy
and were updated to the new intent, not deleted — the storefront stays pinned,
just to the current storefront.