### PR TITLE
feat(demo): make the correlation chain real on the enterprise estate

### DIFF
--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -54,7 +54,7 @@ is wired into the docs site so drift produces a visible regression.
 | `config/schemas/inventory.schema.json` | `Package.ecosystem` enum values | 9 |
 | `config/schemas/inventory.schema.json` | `MCPServer.transport` enum values | 3 |
 | `docs/openapi/v1.json` | paths | 322 |
-| `docs/openapi/v1.json` | component schemas | 133 |
+| `docs/openapi/v1.json` | component schemas | 135 |
 
 <!-- DATA_MODEL_ATLAS:END -->
 

--- a/docs/ENTERPRISE_DEMO.md
+++ b/docs/ENTERPRISE_DEMO.md
@@ -31,6 +31,37 @@ enforced multi-provider remediation. GCP remains `partial` with
 `rate_limited_after_page_2`; the demo never turns missing evidence into a
 complete posture claim.
 
+## Posture findings over the estate
+
+The estate also carries posture findings, so the correlation is demonstrated at
+estate scale rather than only along the hand-authored incident. Each finding
+resolves to a chain:
+
+```text
+finding → inventoried asset → identity that can act on it
+        → configuration that failed → attack path → compliance control
+```
+
+Three properties are enforced by `scripts/check_enterprise_demo_surfaces.py`
+and `tests/test_demo_estate_findings.py`, because each has regressed before:
+
+- **The asset is the inventoried one.** A finding's asset identifier is the
+  estate's own `asset_id`, so there is no second identifier scheme to reconcile
+  and every finding on one asset shares one canonical id.
+- **Unrated is a bucket, not a gap.** Controls that cannot be evaluated are
+  emitted as `CIS_ERROR` with no severity and counted under `unrated`. The
+  severity histogram always sums to the total.
+- **Bounded views report unbounded totals.** The CLI, the API story, and the
+  dashboard each render a bounded page led by the incident, and each states how
+  many rows it shows against the estate's real total.
+
+Controls come from the same benchmark catalogs the live cloud scanners use, and
+findings are produced by the same `cloud_cis_check_to_finding` converter, so the
+demo shows the product's real control vocabulary rather than a demo-only
+approximation. Findings are also seeded into the demo scan job, so
+`/v1/findings`, its facets, the posture tiles, and every export read one
+derivation.
+
 ## Open the dashboard locally
 
 ```bash

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1131,
+      "value": 1132,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 829,
+      "value": 830,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1132,
+      "value": 1133,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 830,
+      "value": 831,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 833,
+      "value": 831,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1131 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1132 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 829 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 830 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -17,7 +17,7 @@ Keep counts out of public positioning copy and update this file from the repo in
 | Test files | 1133 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 833 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 831 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1132 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1133 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 830 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 831 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2791,6 +2791,17 @@
             "title": "Fictional",
             "type": "boolean"
           },
+          "finding_summary": {
+            "$ref": "#/components/schemas/EstateFindingSummary"
+          },
+          "findings": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EstateFindingView"
+            },
+            "title": "Findings",
+            "type": "array"
+          },
           "primary_correlation": {
             "$ref": "#/components/schemas/EnterpriseCorrelation"
           },
@@ -2834,7 +2845,8 @@
           "primary_correlation",
           "events",
           "correlations",
-          "collection_health"
+          "collection_health",
+          "finding_summary"
         ],
         "title": "EnterpriseDemoStory",
         "type": "object"
@@ -2861,6 +2873,12 @@
           "evidence_sources": {
             "minimum": 0.0,
             "title": "Evidence Sources",
+            "type": "integer"
+          },
+          "findings": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Findings",
             "type": "integer"
           },
           "observations": {
@@ -2925,6 +2943,199 @@
           }
         },
         "title": "EntitlementHealth",
+        "type": "object"
+      },
+      "EstateFindingSummary": {
+        "additionalProperties": false,
+        "description": "Unbounded totals for the estate's posture, whatever a view chooses to show.\n\nEvery field here counts the WHOLE estate. A bounded list beside this summary\nis a page of it, never a redefinition of it \u2014 which is why the story can cap\nwhat it renders without any surface reporting a page size as a total.",
+        "properties": {
+          "assets_affected": {
+            "minimum": 0.0,
+            "title": "Assets Affected",
+            "type": "integer"
+          },
+          "assets_total": {
+            "minimum": 0.0,
+            "title": "Assets Total",
+            "type": "integer"
+          },
+          "attack_paths_evidenced": {
+            "minimum": 0.0,
+            "title": "Attack Paths Evidenced",
+            "type": "integer"
+          },
+          "by_severity": {
+            "additionalProperties": {
+              "type": "integer"
+            },
+            "title": "By Severity",
+            "type": "object"
+          },
+          "controls_evidenced": {
+            "minimum": 0.0,
+            "title": "Controls Evidenced",
+            "type": "integer"
+          },
+          "frameworks_evidenced": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Frameworks Evidenced",
+            "type": "array"
+          },
+          "identities_implicated": {
+            "minimum": 0.0,
+            "title": "Identities Implicated",
+            "type": "integer"
+          },
+          "schema_version": {
+            "default": "enterprise_findings.v1",
+            "title": "Schema Version",
+            "type": "string"
+          },
+          "total": {
+            "minimum": 0.0,
+            "title": "Total",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "total",
+          "by_severity",
+          "assets_affected",
+          "assets_total",
+          "controls_evidenced",
+          "attack_paths_evidenced",
+          "identities_implicated"
+        ],
+        "title": "EstateFindingSummary",
+        "type": "object"
+      },
+      "EstateFindingView": {
+        "additionalProperties": false,
+        "description": "One finding rendered as the chain it belongs to, not as a row of text.\n\nDeliberately narrow: enough to prove finding -> asset -> identity ->\nconfiguration -> attack path -> control on screen, without shipping the full\nfinding payload for every row at estate scale.",
+        "properties": {
+          "account_ref": {
+            "title": "Account Ref",
+            "type": "string"
+          },
+          "asset_canonical_id": {
+            "title": "Asset Canonical Id",
+            "type": "string"
+          },
+          "asset_display_name": {
+            "title": "Asset Display Name",
+            "type": "string"
+          },
+          "asset_id": {
+            "title": "Asset Id",
+            "type": "string"
+          },
+          "attack_path": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Attack Path",
+            "type": "array"
+          },
+          "configuration_expected": {
+            "title": "Configuration Expected",
+            "type": "string"
+          },
+          "configuration_observed": {
+            "title": "Configuration Observed",
+            "type": "string"
+          },
+          "configuration_setting": {
+            "title": "Configuration Setting",
+            "type": "string"
+          },
+          "controls": {
+            "items": {
+              "type": "string"
+            },
+            "title": "Controls",
+            "type": "array"
+          },
+          "correlation_id": {
+            "default": "",
+            "title": "Correlation Id",
+            "type": "string"
+          },
+          "environment": {
+            "default": "",
+            "title": "Environment",
+            "type": "string"
+          },
+          "finding_id": {
+            "title": "Finding Id",
+            "type": "string"
+          },
+          "finding_type": {
+            "title": "Finding Type",
+            "type": "string"
+          },
+          "identity_actor_id": {
+            "default": "",
+            "title": "Identity Actor Id",
+            "type": "string"
+          },
+          "identity_asset_id": {
+            "default": "",
+            "title": "Identity Asset Id",
+            "type": "string"
+          },
+          "identity_display_name": {
+            "default": "",
+            "title": "Identity Display Name",
+            "type": "string"
+          },
+          "provider": {
+            "title": "Provider",
+            "type": "string"
+          },
+          "region": {
+            "default": "",
+            "title": "Region",
+            "type": "string"
+          },
+          "security_domain": {
+            "title": "Security Domain",
+            "type": "string"
+          },
+          "severity": {
+            "title": "Severity",
+            "type": "string"
+          },
+          "severity_bucket": {
+            "title": "Severity Bucket",
+            "type": "string"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "finding_id",
+          "finding_type",
+          "severity",
+          "severity_bucket",
+          "title",
+          "security_domain",
+          "provider",
+          "account_ref",
+          "asset_id",
+          "asset_canonical_id",
+          "asset_display_name",
+          "configuration_setting",
+          "configuration_observed",
+          "configuration_expected",
+          "controls"
+        ],
+        "title": "EstateFindingView",
         "type": "object"
       },
       "EstateStage": {

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1925,6 +1925,14 @@ components:
           default: true
           title: Fictional
           type: boolean
+        finding_summary:
+          $ref: '#/components/schemas/EstateFindingSummary'
+        findings:
+          default: []
+          items:
+            $ref: '#/components/schemas/EstateFindingView'
+          title: Findings
+          type: array
         primary_correlation:
           $ref: '#/components/schemas/EnterpriseCorrelation'
         scenario:
@@ -1964,6 +1972,7 @@ components:
       - events
       - correlations
       - collection_health
+      - finding_summary
       title: EnterpriseDemoStory
       type: object
     EnterpriseDemoSummary:
@@ -1985,6 +1994,11 @@ components:
         evidence_sources:
           minimum: 0.0
           title: Evidence Sources
+          type: integer
+        findings:
+          default: 0
+          minimum: 0.0
+          title: Findings
           type: integer
         observations:
           minimum: 0.0
@@ -2035,6 +2049,170 @@ components:
           title: Support Tier
           type: string
       title: EntitlementHealth
+      type: object
+    EstateFindingSummary:
+      additionalProperties: false
+      description: "Unbounded totals for the estate's posture, whatever a view chooses\
+        \ to show.\n\nEvery field here counts the WHOLE estate. A bounded list beside\
+        \ this summary\nis a page of it, never a redefinition of it \u2014 which is\
+        \ why the story can cap\nwhat it renders without any surface reporting a page\
+        \ size as a total."
+      properties:
+        assets_affected:
+          minimum: 0.0
+          title: Assets Affected
+          type: integer
+        assets_total:
+          minimum: 0.0
+          title: Assets Total
+          type: integer
+        attack_paths_evidenced:
+          minimum: 0.0
+          title: Attack Paths Evidenced
+          type: integer
+        by_severity:
+          additionalProperties:
+            type: integer
+          title: By Severity
+          type: object
+        controls_evidenced:
+          minimum: 0.0
+          title: Controls Evidenced
+          type: integer
+        frameworks_evidenced:
+          default: []
+          items:
+            type: string
+          title: Frameworks Evidenced
+          type: array
+        identities_implicated:
+          minimum: 0.0
+          title: Identities Implicated
+          type: integer
+        schema_version:
+          default: enterprise_findings.v1
+          title: Schema Version
+          type: string
+        total:
+          minimum: 0.0
+          title: Total
+          type: integer
+      required:
+      - total
+      - by_severity
+      - assets_affected
+      - assets_total
+      - controls_evidenced
+      - attack_paths_evidenced
+      - identities_implicated
+      title: EstateFindingSummary
+      type: object
+    EstateFindingView:
+      additionalProperties: false
+      description: 'One finding rendered as the chain it belongs to, not as a row
+        of text.
+
+
+        Deliberately narrow: enough to prove finding -> asset -> identity ->
+
+        configuration -> attack path -> control on screen, without shipping the full
+
+        finding payload for every row at estate scale.'
+      properties:
+        account_ref:
+          title: Account Ref
+          type: string
+        asset_canonical_id:
+          title: Asset Canonical Id
+          type: string
+        asset_display_name:
+          title: Asset Display Name
+          type: string
+        asset_id:
+          title: Asset Id
+          type: string
+        attack_path:
+          default: []
+          items:
+            type: string
+          title: Attack Path
+          type: array
+        configuration_expected:
+          title: Configuration Expected
+          type: string
+        configuration_observed:
+          title: Configuration Observed
+          type: string
+        configuration_setting:
+          title: Configuration Setting
+          type: string
+        controls:
+          items:
+            type: string
+          title: Controls
+          type: array
+        correlation_id:
+          default: ''
+          title: Correlation Id
+          type: string
+        environment:
+          default: ''
+          title: Environment
+          type: string
+        finding_id:
+          title: Finding Id
+          type: string
+        finding_type:
+          title: Finding Type
+          type: string
+        identity_actor_id:
+          default: ''
+          title: Identity Actor Id
+          type: string
+        identity_asset_id:
+          default: ''
+          title: Identity Asset Id
+          type: string
+        identity_display_name:
+          default: ''
+          title: Identity Display Name
+          type: string
+        provider:
+          title: Provider
+          type: string
+        region:
+          default: ''
+          title: Region
+          type: string
+        security_domain:
+          title: Security Domain
+          type: string
+        severity:
+          title: Severity
+          type: string
+        severity_bucket:
+          title: Severity Bucket
+          type: string
+        title:
+          title: Title
+          type: string
+      required:
+      - finding_id
+      - finding_type
+      - severity
+      - severity_bucket
+      - title
+      - security_domain
+      - provider
+      - account_ref
+      - asset_id
+      - asset_canonical_id
+      - asset_display_name
+      - configuration_setting
+      - configuration_observed
+      - configuration_expected
+      - controls
+      title: EstateFindingView
       type: object
     EstateStage:
       enum:

--- a/scripts/check_enterprise_demo_surfaces.py
+++ b/scripts/check_enterprise_demo_surfaces.py
@@ -50,15 +50,24 @@ def main_check() -> None:
     _require(story.schema_version == "enterprise_demo_story.v1", "story schema version changed")
     _require(story.synthetic is True and story.fictional is True, "synthetic disclosure flags missing")
     _require(story.tenant_id == "contract-tenant", "tenant ID was not propagated")
-    _require(story.summary.assets == 20, "asset count changed")
-    _require(story.summary.observations == 15, "observation count changed")
+    # The demo serves the narrative estate composed into a generated population,
+    # so these are floors rather than fixed counts: pinning exact totals would
+    # make every scale-profile change a gate failure, while a floor still catches
+    # the regression that matters — the estate silently shrinking back to the
+    # 20-asset spine, where nothing has to be correlated out of anything.
+    _require(story.summary.assets >= 2000, "estate is no longer enterprise-sized")
+    _require(story.summary.observations >= 6000, "estate carries too little evidence to correlate")
     _require(story.summary.evidence_sources == 9, "evidence-source count changed")
-    _require(story.summary.correlations == 4, "correlation count changed")
+    # Floor, not a fixed count: the composed estate correlates thousands of rows.
+    _require(story.summary.correlations >= 4, "the narrative correlations are gone")
+    # The view is bounded so the incident stays visible; the summary must still
+    # report the unbounded truth, never the page size.
+    _require(len(story.correlations) <= story.summary.correlations, "story claims more rows than it holds")
+    _require(story.correlations[0] == story.primary_correlation, "the incident is no longer surfaced first")
     _require(story.summary.snapshots == 3, "snapshot count changed")
     _require(story.primary_correlation.outcome == "blocked", "primary outcome is no longer blocked")
     _require(
-        tuple(source.value for source in story.primary_correlation.sources)
-        == EXPECTED_PRIMARY_SOURCES,
+        tuple(source.value for source in story.primary_correlation.sources) == EXPECTED_PRIMARY_SOURCES,
         "primary cross-vendor path changed",
     )
     gcp = next((row for row in story.collection_health if row.source.value == "gcp_audit"), None)
@@ -82,12 +91,7 @@ def main_check() -> None:
     openapi = json.loads(_read("docs/openapi/v1.json"))
     operation = openapi.get("paths", {}).get("/v1/demo-estate/story", {}).get("get", {})
     response_ref = (
-        operation.get("responses", {})
-        .get("200", {})
-        .get("content", {})
-        .get("application/json", {})
-        .get("schema", {})
-        .get("$ref")
+        operation.get("responses", {}).get("200", {}).get("content", {}).get("application/json", {}).get("schema", {}).get("$ref")
     )
     _require(response_ref == "#/components/schemas/EnterpriseDemoStory", "OpenAPI story contract is missing")
 
@@ -103,9 +107,7 @@ def main_check() -> None:
     ):
         _require(marker in dashboard, f"dashboard lost required marker: {marker}")
 
-    helm_profile = _read(
-        "deploy/helm/agent-bom/examples/synthetic-enterprise-story-values.yaml"
-    )
+    helm_profile = _read("deploy/helm/agent-bom/examples/synthetic-enterprise-story-values.yaml")
     for marker in (
         "AGENT_BOM_DEMO_ESTATE",
         "AGENT_BOM_ALLOW_UNAUTHENTICATED_API",

--- a/scripts/check_enterprise_demo_surfaces.py
+++ b/scripts/check_enterprise_demo_surfaces.py
@@ -4,13 +4,24 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
-from agent_bom.cli import main
-from agent_bom.demo_estate.presentation import build_enterprise_demo_story
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Check the surfaces of THIS checkout. Without this the script imports whatever
+# ``agent_bom`` happens to be installed — in a git worktree that is the sibling
+# checkout, so a drift gate silently validated a tree the developer was not
+# editing and passed. Every other preflight script that imports the package
+# pins its own root the same way (see ``export_openapi.py``).
+if str(REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "src"))
+
+from agent_bom.cli import main  # noqa: E402
+from agent_bom.demo_estate.enterprise_findings import ESTATE_FINDING_SEVERITY_BUCKETS  # noqa: E402
+from agent_bom.demo_estate.presentation import build_enterprise_demo_story  # noqa: E402
+
 EXPECTED_FIXTURES = {
     "enterprise_observations.jsonl",
 }
@@ -78,6 +89,43 @@ def main_check() -> None:
     _require(len(story.estate_content_hash) == 64, "estate content hash is invalid")
     _require(len(story.story_content_hash) == 64, "story content hash is invalid")
 
+    # ── Posture: the chain, not just a count ────────────────────────────────
+    # A findings count proves nothing. What must not regress is that each
+    # rendered finding still resolves to an inventoried asset, an identity, a
+    # configuration and a control — and that the bounded list never reports its
+    # own length as the estate's total.
+    posture = story.finding_summary
+    _require(posture.total >= 300, "the estate lost its posture findings")
+    _require(story.summary.findings == posture.total, "the summary and the posture total disagree")
+    _require(
+        sum(posture.by_severity.values()) == posture.total,
+        "the severity histogram does not sum to the total — a finding was dropped",
+    )
+    _require(
+        set(posture.by_severity) == set(ESTATE_FINDING_SEVERITY_BUCKETS),
+        "the severity histogram lost a display bucket",
+    )
+    _require(
+        posture.by_severity["unrated"] > 0,
+        "no unrated finding remains, so an unevaluable control is indistinguishable from a pass",
+    )
+    _require(len(set(posture.by_severity.values())) > 2, "the estate collapsed into one severity band")
+    _require(0 < posture.assets_affected < posture.assets_total, "every asset or no asset is affected")
+    _require(posture.controls_evidenced > 0, "posture findings evidence no compliance control")
+    _require(len(posture.frameworks_evidenced) >= 2, "posture findings evidence only one framework")
+    _require(posture.attack_paths_evidenced > 0, "no finding sits on a correlated attack path")
+    _require(0 < len(story.findings) < posture.total, "the rendered findings list is not bounded")
+    for finding in story.findings:
+        _require(bool(finding.asset_id and finding.asset_canonical_id), "a rendered finding resolves to no asset")
+        _require(bool(finding.asset_display_name), "a rendered finding has an unnamed asset")
+        _require(
+            bool(finding.identity_asset_id or finding.identity_actor_id),
+            "a rendered finding carries no identity edge",
+        )
+        _require(bool(finding.configuration_setting), "a rendered finding carries no configuration edge")
+        _require(bool(finding.controls), "a rendered finding evidences no control")
+    _require(bool(story.findings[0].correlation_id), "the bounded list no longer leads with the incident")
+
     fixture_dir = REPO_ROOT / "src" / "agent_bom" / "demo_estate" / "data"
     fixtures = {path.name for path in fixture_dir.glob("enterprise*.jsonl")}
     _require(EXPECTED_FIXTURES <= fixtures, "one or more versioned fixture files are missing")
@@ -104,6 +152,12 @@ def main_check() -> None:
         "Normalized evidence timeline",
         "Collection truth",
         "Verified provenance",
+        "Correlated posture",
+        "configuration_expected",
+        "on a correlated attack path",
+        # The bounded lists must keep saying what they are bounded against.
+        "of {posture.total} — incident first",
+        "of {story.summary.correlations} — the incident first",
     ):
         _require(marker in dashboard, f"dashboard lost required marker: {marker}")
 

--- a/src/agent_bom/api/routes/overview.py
+++ b/src/agent_bom/api/routes/overview.py
@@ -50,6 +50,12 @@ from agent_bom.api.stores import _get_fleet_store, _get_store
 from agent_bom.api.tenancy import require_request_tenant_id
 from agent_bom.backpressure import BackpressureRejectedError, adaptive_backpressure
 from agent_bom.exec_score import compute_exec_score
+from agent_bom.graph.severity import (
+    SEVERITY_DISPLAY_BUCKETS,
+    SEVERITY_THRESHOLD_LABELS,
+    UNRATED_SEVERITY_BUCKET,
+    severity_display_bucket,
+)
 from agent_bom.rbac import require_authenticated_permission
 
 router = APIRouter(dependencies=[cast(Any, require_authenticated_permission("read"))])
@@ -158,14 +164,16 @@ def _overview_singleflight_timeout() -> float:
         return _OVERVIEW_SINGLEFLIGHT_TIMEOUT_SECONDS
 
 
-_SEVERITY_KEYS = ("critical", "high", "medium", "low")
 # ``unrated`` is the honest home for findings whose severity the histogram does
 # not recognize (empty / "unknown" / vendor-specific). Without it those findings
 # incremented the CVE count but were dropped from the severity strip, producing
 # the "39 CVEs / 0 severities" mismatch. Every severity histogram in this module
 # now carries it so ``sum(severity.values())`` reconciles with the counted total.
-_UNRATED_KEY = "unrated"
-_ALL_SEVERITY_KEYS = (*_SEVERITY_KEYS, _UNRATED_KEY)
+# The vocabulary and the bucketing rule live in ``graph.severity`` so the tiles
+# here and every other severity strip in the product share one derivation.
+_SEVERITY_KEYS = SEVERITY_THRESHOLD_LABELS
+_UNRATED_KEY = UNRATED_SEVERITY_BUCKET
+_ALL_SEVERITY_KEYS = SEVERITY_DISPLAY_BUCKETS
 
 # Coverage lanes — the five security domains, in display order (issue #3946).
 # Symmetric posture-management family: CSPM · ASPM · DSPM · AISPM, plus Vuln
@@ -192,10 +200,11 @@ def _bucket(sev: str | None, severity: dict[str, int]) -> str:
     """Return the histogram bucket for ``sev`` — an exact match or ``unrated``.
 
     The single choke point shared by every rollup so a finding is counted in one
-    and only one bucket and no unknown severity is silently dropped.
+    and only one bucket and no unknown severity is silently dropped. Delegates
+    to ``graph.severity`` so this module and every other severity strip in the
+    product answer the question identically.
     """
-    key = (sev or "").strip().lower()
-    return key if key in _SEVERITY_KEYS else _UNRATED_KEY
+    return severity_display_bucket(sev)
 
 
 def _graph_drill_href(

--- a/src/agent_bom/cli/_demo.py
+++ b/src/agent_bom/cli/_demo.py
@@ -7,7 +7,15 @@ from pathlib import Path
 import click
 
 from agent_bom.cli._grouped_help import SuggestingGroup
+from agent_bom.demo_estate.enterprise_findings import ESTATE_FINDING_SEVERITY_BUCKETS
 from agent_bom.demo_estate.presentation import EnterpriseDemoStory, build_enterprise_demo_story
+
+_SEVERITY_ORDER = ESTATE_FINDING_SEVERITY_BUCKETS
+# Enough rows to show the incident and a little of the population around it.
+# The summary above them always reports the whole estate, so this bound trims
+# what is printed and never what is claimed.
+_CLI_CHAIN_ROWS = 5
+_CLI_CHAIN_CONTROLS = 4
 
 
 def _render_story(story: EnterpriseDemoStory) -> str:
@@ -19,6 +27,8 @@ def _render_story(story: EnterpriseDemoStory) -> str:
         for row in story.collection_health
         if row.status.value == "partial"
     ]
+    posture = story.finding_summary
+    severity = " · ".join(f"{band} {posture.by_severity[band]}" for band in _SEVERITY_ORDER)
     return "\n".join(
         [
             f"{story.estate_name} — synthetic enterprise evidence",
@@ -30,6 +40,12 @@ def _render_story(story: EnterpriseDemoStory) -> str:
                 f"{story.summary.evidence_sources} sources · "
                 f"{story.summary.correlations} correlations"
             ),
+            (
+                f"Posture: {posture.total} findings on {posture.assets_affected} of "
+                f"{posture.assets_total} assets · {posture.controls_evidenced} controls "
+                f"across {len(posture.frameworks_evidenced)} frameworks"
+            ),
+            f"Severity: {severity}",
             f"Primary outcome: {primary.outcome.upper()} · {primary.kind.replace('_', ' ')}",
             f"Vendor path: {sources}",
             "Asset path:",
@@ -37,10 +53,38 @@ def _render_story(story: EnterpriseDemoStory) -> str:
             f"Data classifications: {', '.join(primary.data_classifications) or 'none'}",
             f"Collection limits: {', '.join(partial) if partial else 'none'}",
             "",
+            *_render_chain(story),
             "Next: agent-bom serve --demo-estate --allow-insecure-no-auth",
             "Then open: http://127.0.0.1:8000/demo-estate",
         ]
     )
+
+
+def _render_chain(story: EnterpriseDemoStory) -> list[str]:
+    """Show the top findings as chains, since the chain is the claim.
+
+    A severity-sorted list of titles would say nothing a scanner cannot; what
+    the product asserts is that each finding resolves to an asset, an identity,
+    a configuration and a control, so print exactly that.
+    """
+    if not story.findings:
+        return []
+    rendered = story.findings[:_CLI_CHAIN_ROWS]
+    # Count what is on screen, not the list it was sliced from. Reporting the
+    # page's own size is fine; reporting a larger page's size as if it were on
+    # screen is the same lie as reporting a page size as a total.
+    lines = [f"Top findings ({len(rendered)} of {story.finding_summary.total} shown):"]
+    for view in rendered:
+        identity = view.identity_display_name or view.identity_actor_id or "—"
+        lines.append(f"  [{view.severity}] {view.title}")
+        lines.append(f"      asset    {view.asset_display_name} ({view.asset_id})")
+        lines.append(f"      identity {identity}")
+        lines.append(f"      config   {view.configuration_setting}: {view.configuration_observed} → expected {view.configuration_expected}")
+        lines.append(f"      controls {', '.join(view.controls[:_CLI_CHAIN_CONTROLS]) or '—'}")
+        if view.correlation_id:
+            lines.append(f"      path     {' → '.join(view.attack_path)}")
+    lines.append("")
+    return lines
 
 
 @click.group("demo", cls=SuggestingGroup, invoke_without_command=True)

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -150,9 +150,10 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
     # can now consume one deterministic source instead of inventing unrelated
     # rows per screen. A malformed fixture remains an explicit bootstrap error.
     try:
-        from agent_bom.demo_estate.enterprise import CollectionStatus, load_enterprise_estate
+        from agent_bom.demo_estate.enterprise import CollectionStatus
+        from agent_bom.demo_estate.enterprise_composition import build_demo_estate
 
-        enterprise = load_enterprise_estate(tenant_id=tenant_id)
+        enterprise = build_demo_estate(tenant_id=tenant_id)
         summary["enterprise_contract"] = {
             "schema_version": enterprise.schema_version,
             "estate_id": enterprise.estate_id,

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -64,7 +64,22 @@ def _tenant_has_demo_jobs(store: Any, tenant_id: str) -> bool:
     return False
 
 
-def _run_demo_scan_report() -> dict[str, Any]:
+def _estate_findings(tenant_id: str) -> list[Any]:
+    """Return the composed estate's posture findings for the demo scan job.
+
+    Seeded through the SAME ``findings`` list every other generator uses, so the
+    findings list, the severity facets, the exec tiles, SARIF and every export
+    read one derivation. Anything else would let the demo's own surfaces
+    disagree with each other, which is precisely what the estate exists to
+    disprove.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+    from agent_bom.demo_estate.enterprise_findings import build_estate_findings
+
+    return list(build_estate_findings(build_demo_estate(tenant_id=tenant_id)))
+
+
+def _run_demo_scan_report(*, tenant_id: str) -> dict[str, Any]:
     from agent_bom.cli._common import _build_agents_from_inventory
     from agent_bom.demo import DEMO_INVENTORY
     from agent_bom.finding import blast_radius_to_finding
@@ -85,6 +100,7 @@ def _run_demo_scan_report() -> dict[str, Any]:
     findings = [blast_radius_to_finding(br) for br in blast_radii]
     findings.extend(blocklist_findings_for_agents(agents))
     findings.extend(evaluate_mcp_auth_posture(agents))
+    findings.extend(_estate_findings(tenant_id))
     report = to_json(
         AIBOMReport(
             agents=agents,
@@ -217,7 +233,7 @@ def maybe_bootstrap_demo_estate(*, tenant_id: str = SHOWCASE_TENANT) -> dict[str
         return summary
 
     try:
-        report = _run_demo_scan_report()
+        report = _run_demo_scan_report(tenant_id=tenant_id)
         finding_count = len(report.get("findings") or report.get("vulnerabilities") or [])
         if finding_count < 1:
             raise RuntimeError("demo estate scan produced zero findings")

--- a/src/agent_bom/demo_estate/enterprise_composition.py
+++ b/src/agent_bom/demo_estate/enterprise_composition.py
@@ -1,0 +1,124 @@
+"""Put the demo's incident chain inside an enterprise-sized population.
+
+Two halves existed and neither was sufficient alone.
+:mod:`agent_bom.demo_estate.enterprise` carries the narrative — one incident
+traced across GitHub, AWS, Kubernetes, MCP and Snowflake — but at 20 assets
+nothing has to be correlated *out of* anything, so the correlation reads as a
+diagram rather than a capability. :mod:`agent_bom.demo_estate.enterprise_scale`
+produces thousands of correlated assets but contains no incident, so there is
+nothing to find; it also shipped with exactly one consumer, its own test.
+
+Composed, the incident sits inside a population. That is the only arrangement in
+which "findings, identities, configuration and logs resolve to one another
+across a large multi-vendor estate" is demonstrated instead of asserted.
+
+The narrative half always wins a collision: its ids are referenced by the
+correlation layer and by the presentation story, so a generated row shadowing
+one would silently rewrite the incident.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from agent_bom.demo_estate.enterprise import (
+    ENTERPRISE_SCHEMA_VERSION,
+    CollectionRun,
+    CollectionStatus,
+    EnterpriseEstate,
+    EstateSnapshot,
+    EstateStage,
+    load_enterprise_estate,
+)
+from agent_bom.demo_estate.enterprise_scale import ScaleProfile, build_scaled_estate
+
+
+def _canonical_json(value: object) -> bytes:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def build_demo_estate(profile: ScaleProfile | None = None, *, tenant_id: str = "default") -> EnterpriseEstate:
+    """Return the narrative estate embedded in a generated population.
+
+    Both halves are already valid :class:`EnterpriseEstate` values, so this
+    composes them rather than re-deriving anything. Construction re-runs every
+    contract validator over the union — unique ids, tenant boundary, and events
+    referencing known assets — so a composition mistake fails here rather than
+    surfacing as a missing node three screens later.
+    """
+    narrative = load_enterprise_estate(tenant_id=tenant_id)
+    population = build_scaled_estate(profile, tenant_id=tenant_id)
+
+    # The narrative wins collisions: the correlation and presentation layers
+    # reference its ids by name.
+    narrative_asset_ids = {asset.asset_id for asset in narrative.assets}
+    narrative_event_ids = {event.event_id for event in narrative.observations}
+
+    assets = narrative.assets + tuple(asset for asset in population.assets if asset.asset_id not in narrative_asset_ids)
+    kept_asset_ids = {asset.asset_id for asset in assets}
+    observations = narrative.observations + tuple(
+        event
+        for event in population.observations
+        if event.event_id not in narrative_event_ids
+        # An event whose asset lost the collision would dangle; the contract
+        # rejects that, so drop it here where the reason is visible.
+        and all(resource_id in kept_asset_ids for resource_id in event.resource_ids)
+    )
+
+    estate = EnterpriseEstate(
+        schema_version=ENTERPRISE_SCHEMA_VERSION,
+        estate_id=f"{narrative.estate_id}-composed",
+        tenant_id=tenant_id,
+        display_name=narrative.display_name,
+        synthetic=True,
+        fictional=True,
+        disclosure=narrative.disclosure,
+        assets=assets,
+        observations=observations,
+        collection_runs=_merge_collection_runs(narrative, population),
+        snapshots=_merge_snapshots(narrative, assets, observations),
+        content_hash="0" * 64,
+    )
+    digest = hashlib.sha256(_canonical_json(estate.model_dump(mode="json", exclude={"content_hash"}))).hexdigest()
+    return estate.model_copy(update={"content_hash": digest})
+
+
+def _merge_collection_runs(narrative: EnterpriseEstate, population: EnterpriseEstate) -> tuple[CollectionRun, ...]:
+    """One run per source, keeping the narrative's and summing records read.
+
+    A source that is partial in either half stays partial in the union: an
+    incomplete read must never be promoted to a complete posture just because a
+    second collection of the same source happened to succeed.
+    """
+    runs: dict[str, CollectionRun] = {run.source.value: run for run in narrative.collection_runs}
+    for run in population.collection_runs:
+        existing = runs.get(run.source.value)
+        if existing is None:
+            runs[run.source.value] = run
+            continue
+        if existing.status is CollectionStatus.COMPLETE and run.status is not CollectionStatus.COMPLETE:
+            runs[run.source.value] = run.model_copy(update={"records_read": existing.records_read + run.records_read})
+        else:
+            runs[run.source.value] = existing.model_copy(update={"records_read": existing.records_read + run.records_read})
+    return tuple(runs[key] for key in sorted(runs))
+
+
+def _merge_snapshots(narrative: EnterpriseEstate, assets: tuple, observations: tuple) -> tuple[EstateSnapshot, ...]:
+    """Keep the narrative's stage timeline, widened to the composed estate.
+
+    Stage membership stays the narrative's story — baseline predates the
+    incident, remediated follows it — while the asset and event sets grow to the
+    whole estate so a stage never references something the estate does not hold.
+    """
+    asset_ids = tuple(asset.asset_id for asset in assets)
+    event_ids = tuple(event.event_id for event in observations)
+    merged: list[EstateSnapshot] = []
+    for snapshot in narrative.snapshots:
+        if snapshot.stage is EstateStage.BASELINE:
+            # Baseline predates the current collection window, so it carries the
+            # population but none of the incident's evidence.
+            merged.append(snapshot.model_copy(update={"asset_ids": asset_ids}))
+        else:
+            merged.append(snapshot.model_copy(update={"asset_ids": asset_ids, "event_ids": event_ids}))
+    return tuple(merged)

--- a/src/agent_bom/demo_estate/enterprise_correlation.py
+++ b/src/agent_bom/demo_estate/enterprise_correlation.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Iterable
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -230,7 +231,55 @@ def _unique_in_order(values: Iterable[str]) -> tuple[str, ...]:
     return tuple(dict.fromkeys(value for value in values if value))
 
 
-def _correlation_kind(events: tuple[NormalizedEnterpriseEvent, ...]) -> tuple[str, str]:
+@dataclass(frozen=True, slots=True)
+class _CorrelationRow:
+    """The only fields correlation actually reads from an event.
+
+    Correlation groups by trace, orders by time, and reports which assets and
+    sources a trace touched. It never reads the normalized refs, relationships,
+    or graph projection — so those must not be a prerequisite for computing it.
+    Naming the inputs explicitly is what lets both the full normalizing path and
+    the light path below share one correlation implementation rather than
+    growing a second one that can disagree.
+    """
+
+    event_id: str
+    stage: EstateStage
+    source: EvidenceSource
+    event_type: str
+    observed_at: datetime
+    trace_id: str
+    resource_ids: tuple[str, ...]
+    evidence_hash: str
+
+    @classmethod
+    def from_normalized(cls, event: NormalizedEnterpriseEvent) -> _CorrelationRow:
+        return cls(
+            event_id=event.event_id,
+            stage=event.stage,
+            source=event.source,
+            event_type=event.event_type,
+            observed_at=event.observed_at,
+            trace_id=event.trace_id,
+            resource_ids=event.resource_ids,
+            evidence_hash=event.evidence_hash,
+        )
+
+    @classmethod
+    def from_observation(cls, observation: RawObservation) -> _CorrelationRow:
+        return cls(
+            event_id=observation.event_id,
+            stage=observation.stage,
+            source=observation.source,
+            event_type=observation.event_type,
+            observed_at=observation.observed_at,
+            trace_id=observation.trace_id,
+            resource_ids=observation.resource_ids,
+            evidence_hash=observation.provenance.evidence_hash,
+        )
+
+
+def _correlation_kind(events: tuple[_CorrelationRow, ...]) -> tuple[str, str]:
     if any(event.stage is EstateStage.REMEDIATED for event in events):
         return "remediation", "enforced"
     if any(event.source is EvidenceSource.OTEL_LLM for event in events):
@@ -246,7 +295,7 @@ _PATH_TYPES = ("workflow", "iam_role", "deployment", "tool", "table", "hosted_mo
 
 
 def _asset_path(
-    events: tuple[NormalizedEnterpriseEvent, ...], assets_by_id: dict[str, EstateAsset]
+    events: tuple[_CorrelationRow, ...], assets_by_id: dict[str, EstateAsset]
 ) -> tuple[str, ...]:
     ordered_ids = _unique_in_order(
         resource_id for event in events for resource_id in event.resource_ids
@@ -279,13 +328,13 @@ def _data_classifications(
 
 
 def _build_correlations(
-    events: tuple[NormalizedEnterpriseEvent, ...],
+    events: tuple[_CorrelationRow, ...],
     *,
     tenant_id: str,
     assets_by_id: dict[str, EstateAsset],
     status_by_source: dict[EvidenceSource, CollectionStatus],
 ) -> tuple[EnterpriseCorrelation, ...]:
-    by_trace: dict[str, list[NormalizedEnterpriseEvent]] = {}
+    by_trace: dict[str, list[_CorrelationRow]] = {}
     for event in events:
         if event.trace_id:
             by_trace.setdefault(event.trace_id, []).append(event)
@@ -328,14 +377,8 @@ def _build_correlations(
     return tuple(correlations)
 
 
-def correlate_enterprise_estate(estate: EnterpriseEstate) -> EnterpriseCorrelationResult:
-    """Normalize one estate and build deterministic, tenant-scoped correlations."""
-    assets_by_id = {asset.asset_id: asset for asset in estate.assets}
-    events = tuple(
-        _normalize_event(observation, tenant_id=estate.tenant_id, assets_by_id=assets_by_id)
-        for observation in estate.observations
-    )
-    health = tuple(
+def _collection_health(estate: EnterpriseEstate) -> tuple[EnterpriseCollectionHealth, ...]:
+    return tuple(
         EnterpriseCollectionHealth(
             source=run.source,
             status=run.status,
@@ -347,9 +390,49 @@ def correlate_enterprise_estate(estate: EnterpriseEstate) -> EnterpriseCorrelati
         )
         for run in estate.collection_runs
     )
+
+
+def build_estate_correlations(estate: EnterpriseEstate) -> tuple[EnterpriseCorrelation, ...]:
+    """Correlate an estate's evidence without normalizing every payload.
+
+    :func:`correlate_enterprise_estate` normalizes each observation into refs,
+    relationships and a graph projection before correlating — 5.7 of its 6.3
+    seconds on the shipped estate — and correlation reads none of it. A consumer
+    that needs the paths and not the payloads (posture findings do) pays that
+    cost for output it discards.
+
+    Evidence-hash verification is still performed on every observation. The
+    saving comes from skipping projection work, never from trusting unverified
+    evidence: a correlation built over tampered evidence is worse than no
+    correlation. The correlations returned here are identical to the ones
+    :func:`correlate_enterprise_estate` produces, because both call the same
+    builder over the same fields.
+    """
+    assets_by_id = {asset.asset_id: asset for asset in estate.assets}
+    rows: list[_CorrelationRow] = []
+    for observation in estate.observations:
+        if not verify_observation_hash(observation):
+            raise ValueError(f"evidence hash mismatch for event {observation.event_id}")
+        rows.append(_CorrelationRow.from_observation(observation))
+    return _build_correlations(
+        tuple(rows),
+        tenant_id=estate.tenant_id,
+        assets_by_id=assets_by_id,
+        status_by_source={row.source: row.status for row in _collection_health(estate)},
+    )
+
+
+def correlate_enterprise_estate(estate: EnterpriseEstate) -> EnterpriseCorrelationResult:
+    """Normalize one estate and build deterministic, tenant-scoped correlations."""
+    assets_by_id = {asset.asset_id: asset for asset in estate.assets}
+    events = tuple(
+        _normalize_event(observation, tenant_id=estate.tenant_id, assets_by_id=assets_by_id)
+        for observation in estate.observations
+    )
+    health = _collection_health(estate)
     status_by_source = {row.source: row.status for row in health}
     correlations = _build_correlations(
-        events,
+        tuple(_CorrelationRow.from_normalized(event) for event in events),
         tenant_id=estate.tenant_id,
         assets_by_id=assets_by_id,
         status_by_source=status_by_source,
@@ -376,5 +459,6 @@ __all__ = [
     "EnterpriseCorrelation",
     "EnterpriseCorrelationResult",
     "NormalizedEnterpriseEvent",
+    "build_estate_correlations",
     "correlate_enterprise_estate",
 ]

--- a/src/agent_bom/demo_estate/enterprise_findings.py
+++ b/src/agent_bom/demo_estate/enterprise_findings.py
@@ -1,0 +1,844 @@
+"""Posture findings over the composed demo estate, correlated end to end.
+
+:mod:`agent_bom.demo_estate.enterprise_composition` serves an estate with
+thousands of assets and evidence. It has no findings, so the claim the product
+actually makes — *a finding resolves to an asset, that asset carries an identity
+and a configuration, the finding sits on a correlated attack path, and it
+evidences a compliance control* — was demonstrated only for the hand-authored
+incident. At estate scale it was asserted, not shown.
+
+This module closes that. Four decisions carry the weight:
+
+**One id scheme.** A finding's asset identifier *is* the estate's ``asset_id``.
+There is no demo-only resource id, no parallel spelling to reconcile later, so
+``Asset.canonical_id`` is a pure function of the inventory row and every finding
+on one asset joins to one node. #4637 fixed exactly this defect for live cloud
+scans; re-introducing it here would demo the bug.
+
+**One control catalog.** Checks are the ones the shipped benchmark scanners
+implement — same ids, same titles, same severities — so the demo shows the
+product's real control vocabulary rather than plausible-looking invented
+numbering. ``tests/test_demo_estate_findings.py`` asserts every entry still
+exists in ``agent_bom.cloud.*_cis_benchmark``, so a renumbered control fails
+here rather than drifting silently.
+
+**One converter.** Findings are produced by
+:func:`agent_bom.finding.cloud_cis_check_to_finding`, the same function a live
+cloud scan uses. Compliance classification, remediation, and scope parsing are
+therefore whatever production does — not a demo-only approximation that can be
+right on screen and wrong in an export.
+
+**Unevaluable is a state, not a gap.** A deterministic slice of checks come back
+``ERROR`` with no severity. They become ``CIS_ERROR`` findings in the ``unrated``
+bucket: visible, counted, and never quietly rounded down to zero (#4631).
+
+Everything is deterministic and derived from the estate's own structure, so the
+same estate always yields the same findings, hashes, and screenshots.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from agent_bom.demo_estate.enterprise import EnterpriseEstate, EstateAsset
+from agent_bom.demo_estate.enterprise_correlation import (
+    EnterpriseCorrelation,
+    EnterpriseCorrelationResult,
+    build_estate_correlations,
+)
+from agent_bom.finding import Finding, cloud_cis_check_to_finding
+from agent_bom.graph.severity import SEVERITY_DISPLAY_BUCKETS, severity_display_bucket
+
+ESTATE_FINDINGS_VERSION = "enterprise_findings.v1"
+
+# The severity vocabulary the demo summary publishes. Shared with the overview
+# tiles and ``/v1/posture/counts`` via ``graph.severity`` so a tile can never
+# contradict the list beside it.
+ESTATE_FINDING_SEVERITY_BUCKETS: tuple[str, ...] = SEVERITY_DISPLAY_BUCKETS
+
+# Inventory resource types that ARE an identity. A posture finding names one of
+# these as the principal that can act on the affected resource, which is what
+# turns "a bucket is misconfigured" into "this role can read this bucket".
+IDENTITY_RESOURCE_TYPES: frozenset[str] = frozenset({"iam_role", "service_principal", "service_account", "role"})
+
+# Share of emitted findings whose control could not be evaluated. Small but
+# never zero: a demo where every control resolves cannot show that an
+# unevaluable control is reported rather than dropped.
+_UNEVALUABLE_SHARE = 7
+
+
+@dataclass(frozen=True, slots=True)
+class EstateCheck:
+    """One posture control, scoped to the resource types it can fail on.
+
+    ``check_id``, ``title``, ``severity`` and ``recommendation`` are copied from
+    the shipped benchmark scanner for this cloud — the demo must not invent
+    control identity. ``setting``/``observed``/``expected`` are the
+    configuration edge: what was read, and what it should have been.
+    """
+
+    provider: str
+    check_id: str
+    title: str
+    severity: str
+    cis_section: str
+    recommendation: str
+    resource_types: tuple[str, ...]
+    setting: str
+    observed: str
+    expected: str
+    # Percent of matching assets that fail this control. Chosen per control so
+    # the estate reads like an estate: a few systemic failures, most controls
+    # failing on a minority of resources, no band dominating.
+    prevalence: int
+
+
+_AWS_IAM = "1 - Identity and Access Management"
+_AWS_STORAGE = "2 - Storage"
+_AWS_NETWORK = "5 - Networking"
+_AZ_STORAGE = "3 - Storage Accounts"
+_AZ_DATABASE = "4 - Database Services"
+_AZ_VM = "7 - Virtual Machines"
+_AZ_KEYVAULT = "8 - Key Vault"
+_AZ_APPSERVICE = "9 - App Service"
+_GCP_IAM = "1 - Identity and Access Management"
+_GCP_COMPUTE = "4 - Virtual Machines"
+_GCP_STORAGE = "5 - Cloud Storage"
+_GCP_SQL = "6 - Cloud SQL"
+_SF_AUTH = "1 - Account and Authentication"
+_SF_DATA = "3 - Data Protection"
+_SF_ACCESS = "5 - Access Control"
+
+
+_CATALOG: tuple[EstateCheck, ...] = (
+    # ── AWS ──────────────────────────────────────────────────────────────
+    EstateCheck(
+        provider="aws",
+        check_id="1.16",
+        title="No full-admin IAM policies attached",
+        severity="critical",
+        cis_section=_AWS_IAM,
+        recommendation="Remove or scope down policies that grant '*' on '*' resources.",
+        resource_types=("iam_role",),
+        setting="attached_policy_actions",
+        observed="Action '*' on Resource '*'",
+        expected="Least-privilege actions scoped to named resources",
+        prevalence=9,
+    ),
+    EstateCheck(
+        provider="aws",
+        check_id="1.15",
+        title="IAM permissions granted via groups or roles only",
+        severity="medium",
+        cis_section=_AWS_IAM,
+        recommendation="Remove inline and directly attached policies from IAM users; use groups instead.",
+        resource_types=("iam_role",),
+        setting="inline_policy_count",
+        observed="2 inline policies attached directly",
+        expected="0 inline policies; permissions granted through groups or roles",
+        prevalence=21,
+    ),
+    EstateCheck(
+        provider="aws",
+        check_id="2.1.2",
+        title="S3 bucket server-side encryption enabled",
+        severity="medium",
+        cis_section=_AWS_STORAGE,
+        recommendation="Enable default encryption (SSE-S3 or SSE-KMS) on all S3 buckets.",
+        resource_types=("bucket",),
+        setting="ServerSideEncryptionConfiguration",
+        observed="absent",
+        expected="ApplyServerSideEncryptionByDefault=aws:kms",
+        prevalence=24,
+    ),
+    EstateCheck(
+        provider="aws",
+        check_id="2.1.1",
+        title="S3 account-level public access block configured",
+        severity="high",
+        cis_section=_AWS_STORAGE,
+        recommendation="Enable all four S3 public access block settings at the account level.",
+        resource_types=("bucket",),
+        setting="PublicAccessBlockConfiguration.BlockPublicPolicy",
+        observed="false",
+        expected="true",
+        prevalence=11,
+    ),
+    EstateCheck(
+        provider="aws",
+        check_id="2.1.4",
+        title="S3 bucket versioning enabled",
+        severity="medium",
+        cis_section=_AWS_STORAGE,
+        recommendation="Enable versioning on all S3 buckets for data protection.",
+        resource_types=("bucket",),
+        setting="VersioningConfiguration.Status",
+        observed="Suspended",
+        expected="Enabled",
+        prevalence=18,
+    ),
+    EstateCheck(
+        provider="aws",
+        check_id="2.3.1",
+        title="RDS encryption at rest enabled",
+        severity="high",
+        cis_section=_AWS_STORAGE,
+        recommendation="Enable encryption at rest when creating RDS instances (cannot be changed post-creation).",
+        resource_types=("database",),
+        setting="StorageEncrypted",
+        observed="false",
+        expected="true",
+        prevalence=14,
+    ),
+    EstateCheck(
+        provider="aws",
+        check_id="2.3.2",
+        title="RDS auto minor version upgrade enabled",
+        severity="medium",
+        cis_section=_AWS_STORAGE,
+        recommendation="Enable auto minor version upgrade on all RDS instances.",
+        resource_types=("database",),
+        setting="AutoMinorVersionUpgrade",
+        observed="false",
+        expected="true",
+        prevalence=27,
+    ),
+    EstateCheck(
+        provider="aws",
+        check_id="5.2",
+        title="No unrestricted ingress to admin ports (22, 3389)",
+        severity="high",
+        cis_section=_AWS_NETWORK,
+        recommendation="Restrict SSH (22) and RDP (3389) to specific IP ranges.",
+        resource_types=("instance", "cluster"),
+        setting="security_group_ingress",
+        observed="0.0.0.0/0 -> tcp/22",
+        expected="Ingress restricted to approved CIDR ranges",
+        prevalence=13,
+    ),
+    EstateCheck(
+        provider="aws",
+        check_id="5.3",
+        title="Default security group restricts all traffic",
+        severity="medium",
+        cis_section=_AWS_NETWORK,
+        recommendation="Remove all inbound and outbound rules from default security groups.",
+        resource_types=("instance", "function"),
+        setting="default_security_group_rules",
+        observed="1 inbound rule, 1 outbound rule",
+        expected="0 inbound rules, 0 outbound rules",
+        prevalence=16,
+    ),
+    # ── Azure ────────────────────────────────────────────────────────────
+    EstateCheck(
+        provider="azure",
+        check_id="3.1",
+        title="Secure transfer required on storage accounts",
+        severity="high",
+        cis_section=_AZ_STORAGE,
+        recommendation="Enable 'Secure transfer required' on all storage accounts to enforce HTTPS-only access.",
+        resource_types=("storage_account",),
+        setting="supportsHttpsTrafficOnly",
+        observed="false",
+        expected="true",
+        prevalence=12,
+    ),
+    EstateCheck(
+        provider="azure",
+        check_id="3.7",
+        title="Blob containers set to private access",
+        severity="high",
+        cis_section=_AZ_STORAGE,
+        recommendation="Disable public blob access at the storage account level and audit all containers.",
+        resource_types=("storage_account",),
+        setting="allowBlobPublicAccess",
+        observed="true",
+        expected="false",
+        prevalence=9,
+    ),
+    EstateCheck(
+        provider="azure",
+        check_id="3.11",
+        title="Private endpoints used for storage accounts",
+        severity="high",
+        cis_section=_AZ_STORAGE,
+        recommendation="Configure private endpoints for all storage accounts to restrict network access.",
+        resource_types=("storage_account",),
+        setting="privateEndpointConnections",
+        observed="0 connections; publicNetworkAccess=Enabled",
+        expected="At least one approved private endpoint; public network access disabled",
+        prevalence=26,
+    ),
+    EstateCheck(
+        provider="azure",
+        check_id="4.1.2",
+        title="Transparent Data Encryption enabled on SQL servers",
+        severity="high",
+        cis_section=_AZ_DATABASE,
+        recommendation="Enable Transparent Data Encryption on all SQL databases.",
+        resource_types=("sql_database",),
+        setting="transparentDataEncryption.state",
+        observed="Disabled",
+        expected="Enabled",
+        prevalence=15,
+    ),
+    EstateCheck(
+        provider="azure",
+        check_id="4.2.1",
+        title="TLS 1.2 or higher on database servers",
+        severity="high",
+        cis_section=_AZ_DATABASE,
+        recommendation="Set the minimum TLS version to TLS 1.2 on all Azure SQL, MySQL, and PostgreSQL servers.",
+        resource_types=("sql_database",),
+        setting="minimalTlsVersion",
+        observed="1.0",
+        expected="1.2",
+        prevalence=19,
+    ),
+    EstateCheck(
+        provider="azure",
+        check_id="7.1",
+        title="Virtual machines use Managed Disks",
+        severity="medium",
+        cis_section=_AZ_VM,
+        recommendation="Migrate all VM disks to Managed Disks for improved reliability and security.",
+        resource_types=("virtual_machine",),
+        setting="storageProfile.osDisk.managedDisk",
+        observed="absent (unmanaged VHD in a storage account)",
+        expected="Managed disk reference",
+        prevalence=17,
+    ),
+    EstateCheck(
+        provider="azure",
+        check_id="8.1",
+        title="Expiration date set on Key Vault keys",
+        severity="medium",
+        cis_section=_AZ_KEYVAULT,
+        recommendation="Set an expiration date on all Key Vault keys to enforce key rotation.",
+        resource_types=("key_vault",),
+        setting="key.attributes.exp",
+        observed="null",
+        expected="A rotation date within policy",
+        prevalence=100,
+    ),
+    EstateCheck(
+        provider="azure",
+        check_id="8.6",
+        title="Key Vault secrets have a content type set",
+        severity="low",
+        cis_section=_AZ_KEYVAULT,
+        recommendation="Set a content type on all Key Vault secrets so consumers can validate what they retrieve.",
+        resource_types=("key_vault",),
+        setting="secret.contentType",
+        observed="null on 3 of 5 secrets",
+        expected="A content type on every secret",
+        prevalence=100,
+    ),
+    EstateCheck(
+        provider="azure",
+        check_id="9.1",
+        title="App Service Authentication configured",
+        severity="high",
+        cis_section=_AZ_APPSERVICE,
+        recommendation="Enable App Service Authentication (EasyAuth) on all web apps.",
+        resource_types=("function_app",),
+        setting="siteAuthSettings.enabled",
+        observed="false",
+        expected="true",
+        prevalence=22,
+    ),
+    # ── GCP ──────────────────────────────────────────────────────────────
+    EstateCheck(
+        provider="gcp",
+        check_id="1.4",
+        title="No user-managed service account keys",
+        severity="medium",
+        cis_section=_GCP_IAM,
+        recommendation="Delete user-managed service account keys and use short-lived credentials via Workload Identity.",
+        resource_types=("service_account",),
+        setting="user_managed_keys",
+        observed="1 user-managed key, created 412 days ago",
+        expected="0 user-managed keys; short-lived credentials only",
+        prevalence=23,
+    ),
+    EstateCheck(
+        provider="gcp",
+        check_id="3.6",
+        title="SSH (port 22) restricted from the internet",
+        severity="critical",
+        cis_section="3 - Networking",
+        recommendation="Remove or restrict firewall rules that allow TCP port 22 from 0.0.0.0/0 or ::/0.",
+        resource_types=("instance",),
+        setting="firewall_rule.sourceRanges",
+        observed="0.0.0.0/0 -> tcp/22",
+        expected="Approved CIDR ranges only",
+        prevalence=7,
+    ),
+    EstateCheck(
+        provider="gcp",
+        check_id="4.1",
+        title="Instances not using default service account",
+        severity="high",
+        cis_section=_GCP_COMPUTE,
+        recommendation="Create and assign a custom service account to each VM instance instead of using the default.",
+        resource_types=("instance",),
+        setting="serviceAccounts[0].email",
+        observed="compute default service account",
+        expected="A dedicated least-privilege service account",
+        prevalence=20,
+    ),
+    EstateCheck(
+        provider="gcp",
+        check_id="5.1",
+        title="Cloud Storage buckets not publicly accessible",
+        severity="high",
+        cis_section=_GCP_STORAGE,
+        recommendation="Remove allUsers and allAuthenticatedUsers from bucket IAM policies.",
+        resource_types=("bucket",),
+        setting="iamPolicy.bindings",
+        observed="allUsers has roles/storage.objectViewer",
+        expected="No allUsers or allAuthenticatedUsers principals",
+        prevalence=8,
+    ),
+    EstateCheck(
+        provider="gcp",
+        check_id="5.2",
+        title="Uniform bucket-level access enabled on buckets",
+        severity="medium",
+        cis_section=_GCP_STORAGE,
+        recommendation="Enable uniform bucket-level access on all Cloud Storage buckets to use IAM exclusively.",
+        resource_types=("bucket",),
+        setting="iamConfiguration.uniformBucketLevelAccess.enabled",
+        observed="false",
+        expected="true",
+        prevalence=29,
+    ),
+    EstateCheck(
+        provider="gcp",
+        check_id="6.2",
+        title="Cloud SQL instances lack public IPs",
+        severity="high",
+        cis_section=_GCP_SQL,
+        recommendation="Remove public IP addresses from Cloud SQL instances and use private IP or Cloud SQL Proxy.",
+        resource_types=("database",),
+        setting="settings.ipConfiguration.ipv4Enabled",
+        observed="true",
+        expected="false",
+        prevalence=16,
+    ),
+    # ── Snowflake ────────────────────────────────────────────────────────
+    EstateCheck(
+        provider="snowflake",
+        check_id="1.4",
+        title="ACCOUNTADMIN granted to at most 2 users",
+        severity="critical",
+        cis_section=_SF_AUTH,
+        recommendation="Limit ACCOUNTADMIN grants to a maximum of 2 users.",
+        resource_types=("role",),
+        setting="accountadmin_grantees",
+        observed="6 users hold ACCOUNTADMIN",
+        expected="At most 2 users",
+        prevalence=10,
+    ),
+    EstateCheck(
+        provider="snowflake",
+        check_id="5.1",
+        title="PUBLIC role has no direct privilege grants",
+        severity="high",
+        cis_section=_SF_ACCESS,
+        recommendation="Revoke all grants from the PUBLIC role: REVOKE ALL ON <object> FROM ROLE PUBLIC;",
+        resource_types=("role", "warehouse"),
+        setting="grants_to_public_role",
+        observed="SELECT granted to PUBLIC",
+        expected="No privileges granted to PUBLIC",
+        prevalence=18,
+    ),
+    EstateCheck(
+        provider="snowflake",
+        check_id="3.1",
+        title="Tri-Secret Secure (customer-managed key) enabled",
+        severity="high",
+        cis_section=_SF_DATA,
+        recommendation="Contact Snowflake support to enable Tri-Secret Secure with your cloud KMS.",
+        resource_types=("database", "table"),
+        setting="tri_secret_secure",
+        observed="disabled",
+        expected="enabled with a customer-managed key",
+        prevalence=12,
+    ),
+    EstateCheck(
+        provider="snowflake",
+        check_id="3.2",
+        title="Data sharing restricted to authorized accounts",
+        severity="medium",
+        cis_section=_SF_DATA,
+        recommendation="Review outbound shares and remove unauthorized consumers.",
+        resource_types=("share", "stage"),
+        setting="share_consumers",
+        observed="1 consumer outside the approved account list",
+        expected="Only approved consumer accounts",
+        prevalence=25,
+    ),
+)
+
+
+def _catalog_index() -> dict[tuple[str, str], tuple[EstateCheck, ...]]:
+    index: dict[tuple[str, str], list[EstateCheck]] = {}
+    for check in _CATALOG:
+        for resource_type in check.resource_types:
+            index.setdefault((check.provider, resource_type), []).append(check)
+    return {key: tuple(value) for key, value in index.items()}
+
+
+_CATALOG_BY_TARGET = _catalog_index()
+
+
+class EstateFindingSummary(BaseModel):
+    """Unbounded totals for the estate's posture, whatever a view chooses to show.
+
+    Every field here counts the WHOLE estate. A bounded list beside this summary
+    is a page of it, never a redefinition of it — which is why the story can cap
+    what it renders without any surface reporting a page size as a total.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    schema_version: str = ESTATE_FINDINGS_VERSION
+    total: int = Field(ge=0)
+    by_severity: dict[str, int]
+    assets_affected: int = Field(ge=0)
+    assets_total: int = Field(ge=0)
+    controls_evidenced: int = Field(ge=0)
+    frameworks_evidenced: tuple[str, ...] = ()
+    attack_paths_evidenced: int = Field(ge=0)
+    identities_implicated: int = Field(ge=0)
+
+
+class EstateFindingView(BaseModel):
+    """One finding rendered as the chain it belongs to, not as a row of text.
+
+    Deliberately narrow: enough to prove finding -> asset -> identity ->
+    configuration -> attack path -> control on screen, without shipping the full
+    finding payload for every row at estate scale.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    finding_id: str
+    finding_type: str
+    severity: str
+    severity_bucket: str
+    title: str
+    security_domain: str
+    provider: str
+    account_ref: str
+    region: str = ""
+    environment: str = ""
+    asset_id: str
+    asset_canonical_id: str
+    asset_display_name: str
+    identity_asset_id: str = ""
+    identity_display_name: str = ""
+    identity_actor_id: str = ""
+    configuration_setting: str
+    configuration_observed: str
+    configuration_expected: str
+    controls: tuple[str, ...]
+    correlation_id: str = ""
+    attack_path: tuple[str, ...] = ()
+
+
+def _stable_index(*parts: str) -> int:
+    """Deterministic pseudo-index derived from the identity of the thing itself.
+
+    Same derivation as :mod:`agent_bom.demo_estate.enterprise_scale`: generation
+    depends only on structure, so an estate yields the same posture on every
+    machine and every run and a demo can be screenshotted.
+    """
+    return int.from_bytes(hashlib.sha256("|".join(parts).encode("utf-8")).digest()[:4], "big")
+
+
+def _identities_by_account(estate: EnterpriseEstate) -> dict[tuple[str, str], tuple[EstateAsset, ...]]:
+    """Index the inventory's identities by the account boundary they live in.
+
+    Scoped to ``(provider, account_scope)`` on purpose. A posture finding must
+    name a principal that can actually reach the affected resource; borrowing an
+    identity from a neighbouring account would draw an edge that does not exist
+    and would be exactly the kind of over-claim the graph must never make.
+    """
+    grouped: dict[tuple[str, str], list[EstateAsset]] = {}
+    for asset in estate.assets:
+        if asset.resource_type in IDENTITY_RESOURCE_TYPES:
+            grouped.setdefault((asset.provider, asset.account_scope), []).append(asset)
+    return {key: tuple(sorted(value, key=lambda a: a.asset_id)) for key, value in grouped.items()}
+
+
+def _actors_by_asset(estate: EnterpriseEstate) -> dict[str, tuple[str, ...]]:
+    """Index the principals the estate's own evidence observed acting on each asset.
+
+    The second, independent half of the identity edge. An account can legitimately
+    inventory no identity of its own — an Entra tenant holds the service
+    principals while the subscription holds the vault — and requiring an
+    inventoried identity in that case silently dropped every finding in the
+    account, including the PHI table at the end of the incident chain. An
+    observed actor is evidence, not inference, so it stands on its own.
+    """
+    grouped: dict[str, set[str]] = {}
+    for event in estate.observations:
+        for resource_id in event.resource_ids:
+            grouped.setdefault(resource_id, set()).add(event.actor_id)
+    return {key: tuple(sorted(value)) for key, value in grouped.items()}
+
+
+def _pick_identity(candidates: tuple[EstateAsset, ...], *, subject: EstateAsset, seed: int) -> EstateAsset:
+    """Choose the principal this finding implicates, preferring one that is not the subject.
+
+    A misconfigured role legitimately implicates itself, but a row reading
+    ``role X is exposed to role X`` reads as a placeholder even when it is
+    accurate. Prefer another principal in the same account when one exists, and
+    fall back to the subject only when it is the account's sole identity.
+    """
+    others = tuple(asset for asset in candidates if asset.asset_id != subject.asset_id)
+    pool = others or candidates
+    return pool[seed % len(pool)]
+
+
+def _paths_by_asset(correlations: tuple[EnterpriseCorrelation, ...]) -> dict[str, EnterpriseCorrelation]:
+    """Map each asset to the multi-asset correlation it participates in.
+
+    Single-asset traces are excluded: a "path" through one node is not a path,
+    and labelling it one would inflate the attack-path count with noise.
+    """
+    by_asset: dict[str, EnterpriseCorrelation] = {}
+    for correlation in correlations:
+        if len(correlation.asset_path) < 2:
+            continue
+        for asset_id in correlation.asset_path:
+            by_asset.setdefault(asset_id, correlation)
+    return by_asset
+
+
+def _build_check_payload(asset: EstateAsset, check: EstateCheck, *, unevaluable: bool) -> dict[str, object]:
+    """Shape one posture result exactly as a live benchmark scanner emits it."""
+    evidence = (
+        f"{check.setting} could not be read on {asset.display_name}; the control was not evaluated."
+        if unevaluable
+        else f"{check.setting} on {asset.display_name} is {check.observed}; expected {check.expected}."
+    )
+    payload: dict[str, object] = {
+        "check_id": check.check_id,
+        "title": check.title,
+        # An unevaluable control has no severity to report. Passing "" rather
+        # than guessing "medium" is what puts it in the ``unrated`` bucket
+        # instead of inventing a rating the evidence does not support.
+        "severity": "" if unevaluable else check.severity,
+        "status": "ERROR" if unevaluable else "FAIL",
+        "cis_section": check.cis_section,
+        "evidence": evidence,
+        "recommendation": check.recommendation,
+        "resource_ids": [asset.asset_id],
+        "account_id": asset.account_scope,
+        "region": asset.region,
+        "environment": asset.environment,
+        "attack_techniques": [] if unevaluable else list(_attack_techniques(check)),
+    }
+    return payload
+
+
+_SECTION_TACTIC_CACHE: dict[tuple[str, str], tuple[str, ...]] = {}
+
+
+def _attack_techniques(check: EstateCheck) -> tuple[str, ...]:
+    """Resolve ATT&CK techniques with the product's own CIS tagger.
+
+    ``mitre_attack.tag_cis_check`` reads the live technique catalog rather than a
+    frozen list, so the demo's ATT&CK coverage is whatever the shipped tagger
+    produces for that control — a hand-written technique list here would drift
+    away from the product the moment the catalog moved.
+    """
+    key = (check.provider, check.check_id)
+    cached = _SECTION_TACTIC_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    from agent_bom.cloud.aws_cis_benchmark import CheckStatus
+    from agent_bom.mitre_attack import tag_cis_check
+
+    class _CheckShim:
+        status = CheckStatus.FAIL
+        cis_section = check.cis_section
+        title = check.title
+
+    techniques = tuple(tag_cis_check(_CheckShim()))
+    _SECTION_TACTIC_CACHE[key] = techniques
+    return techniques
+
+
+def build_estate_findings(
+    estate: EnterpriseEstate,
+    *,
+    correlation_result: EnterpriseCorrelationResult | None = None,
+) -> tuple[Finding, ...]:
+    """Return the estate's deterministic posture findings, chain intact.
+
+    ``correlation_result`` is accepted so a caller that already correlated the
+    estate (the demo story does) does not pay for it twice. Omitted, the
+    payload-free correlation is used: findings need the paths, not the
+    normalized event bodies.
+    """
+    correlations = correlation_result.correlations if correlation_result is not None else build_estate_correlations(estate)
+    path_by_asset = _paths_by_asset(correlations)
+    identities = _identities_by_account(estate)
+    actors = _actors_by_asset(estate)
+
+    findings: list[Finding] = []
+    for asset in estate.assets:
+        checks = _CATALOG_BY_TARGET.get((asset.provider, asset.resource_type))
+        if not checks:
+            continue
+        account_identities = identities.get((asset.provider, asset.account_scope), ())
+        asset_actors = actors.get(asset.asset_id, ())
+        if not account_identities and not asset_actors:
+            # Neither an inventoried principal in this account nor an observed
+            # one on this asset: there is no identity edge to draw, and a
+            # finding with a dangling half-chain is the thing this module exists
+            # to avoid.
+            continue
+        correlation = path_by_asset.get(asset.asset_id)
+        for check in checks:
+            seed = _stable_index(asset.asset_id, check.provider, check.check_id)
+            # Assets on a correlated attack path always report their applicable
+            # controls. The incident is the thing the demo is for; leaving its
+            # own assets to a probability roll is how a demo loses its story.
+            if correlation is None and seed % 100 >= check.prevalence:
+                continue
+            identity = _pick_identity(account_identities, subject=asset, seed=seed) if account_identities else None
+            actor = asset_actors[seed % len(asset_actors)] if asset_actors else ""
+            unevaluable = (seed // 100) % 100 < _UNEVALUABLE_SHARE
+            finding = cloud_cis_check_to_finding(
+                _build_check_payload(asset, check, unevaluable=unevaluable),
+                asset.provider,
+            )
+            # Two vocabularies, deliberately. The keys on the left are the ones
+            # ``evidence.policy`` classifies as tier A, so they survive
+            # ``redact_for_persistence`` and the chain stays joinable on the
+            # persisted findings list, the exports and the API. The richer keys
+            # below them are for the demo story, which is computed live from
+            # this same object and never persisted. Nothing here asks the
+            # redactor to relax: a default-deny evidence policy is worth more
+            # than a demo field, so the demo speaks the policy's language.
+            finding.evidence.update(
+                {
+                    "resource_id": asset.asset_id,
+                    "resource_name": asset.display_name,
+                    "resource_type": asset.resource_type,
+                    "control_id": f"CIS-{check.check_id}",
+                    "tenant_id": estate.tenant_id,
+                    "synthetic": True,
+                    "fictional": True,
+                    "disclosure": estate.disclosure,
+                    "estate_id": estate.estate_id,
+                    "data_classifications": list(asset.data_classifications),
+                    "configuration": {
+                        "setting": check.setting,
+                        "observed": "unreadable" if unevaluable else check.observed,
+                        "expected": check.expected,
+                    },
+                }
+            )
+            if identity is not None:
+                finding.evidence["principal_id"] = identity.asset_id
+                finding.evidence["identity_asset_id"] = identity.asset_id
+                finding.evidence["identity_display_name"] = identity.display_name
+                finding.evidence["identity_resource_type"] = identity.resource_type
+            if actor:
+                finding.evidence["actor_id"] = actor
+                finding.evidence["identity_actor_id"] = actor
+            if correlation is not None:
+                finding.evidence["correlation_id"] = correlation.correlation_id
+                finding.evidence["correlation_kind"] = correlation.kind
+                finding.evidence["attack_path"] = list(correlation.asset_path)
+            findings.append(finding)
+    return tuple(findings)
+
+
+def summarize_estate_findings(estate: EnterpriseEstate, findings: tuple[Finding, ...]) -> EstateFindingSummary:
+    """Return whole-estate totals for ``findings``.
+
+    Counted from the findings themselves rather than from any generation-time
+    bookkeeping, so a summary can never describe a set the caller does not hold.
+    """
+    by_severity = dict.fromkeys(ESTATE_FINDING_SEVERITY_BUCKETS, 0)
+    controls: set[tuple[str, str]] = set()
+    frameworks: set[str] = set()
+    assets: set[str] = set()
+    identities: set[str] = set()
+    paths: set[str] = set()
+    for finding in findings:
+        by_severity[severity_display_bucket(finding.severity)] += 1
+        assets.add(finding.asset.identifier or "")
+        for key in ("identity_asset_id", "identity_actor_id"):
+            identity_id = finding.evidence.get(key)
+            if identity_id:
+                identities.add(str(identity_id))
+        correlation_id = finding.evidence.get("correlation_id")
+        if correlation_id:
+            paths.add(str(correlation_id))
+        for tag in finding.normalized_controls():
+            controls.add((tag.framework, tag.control))
+            frameworks.add(tag.framework)
+    return EstateFindingSummary(
+        total=len(findings),
+        by_severity=by_severity,
+        assets_affected=len(assets),
+        assets_total=len(estate.assets),
+        controls_evidenced=len(controls),
+        frameworks_evidenced=tuple(sorted(frameworks)),
+        attack_paths_evidenced=len(paths),
+        identities_implicated=len(identities),
+    )
+
+
+def to_finding_view(finding: Finding) -> EstateFindingView:
+    """Project one finding into the compact chain row the demo surfaces render."""
+    configuration = finding.evidence.get("configuration") or {}
+    return EstateFindingView(
+        finding_id=finding.id,
+        finding_type=finding.finding_type.value,
+        severity=finding.severity,
+        severity_bucket=severity_display_bucket(finding.severity),
+        title=finding.title,
+        security_domain=finding.security_domain,
+        provider=finding.provider or "",
+        account_ref=finding.account_ref or "",
+        region=finding.region or "",
+        environment=finding.environment or "",
+        asset_id=finding.asset.identifier or "",
+        asset_canonical_id=finding.asset.canonical_id,
+        asset_display_name=str(finding.evidence.get("resource_name") or ""),
+        identity_asset_id=str(finding.evidence.get("identity_asset_id") or ""),
+        identity_display_name=str(finding.evidence.get("identity_display_name") or ""),
+        identity_actor_id=str(finding.evidence.get("identity_actor_id") or ""),
+        configuration_setting=str(configuration.get("setting") or ""),
+        configuration_observed=str(configuration.get("observed") or ""),
+        configuration_expected=str(configuration.get("expected") or ""),
+        controls=tuple(f"{tag.framework}:{tag.control}" for tag in finding.normalized_controls()),
+        correlation_id=str(finding.evidence.get("correlation_id") or ""),
+        attack_path=tuple(finding.evidence.get("attack_path") or ()),
+    )
+
+
+__all__ = [
+    "ESTATE_FINDINGS_VERSION",
+    "ESTATE_FINDING_SEVERITY_BUCKETS",
+    "IDENTITY_RESOURCE_TYPES",
+    "EstateCheck",
+    "EstateFindingSummary",
+    "EstateFindingView",
+    "build_estate_findings",
+    "summarize_estate_findings",
+    "to_finding_view",
+]

--- a/src/agent_bom/demo_estate/presentation.py
+++ b/src/agent_bom/demo_estate/presentation.py
@@ -105,7 +105,6 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
     correlations = ranked[:_STORY_CORRELATION_LIMIT]
     events = result.events[:_STORY_EVENT_LIMIT]
 
-<<<<<<< HEAD
     # Findings follow the same rule as correlations and events: the summary
     # below carries the whole estate's totals, this list carries what a reader
     # can act on. Ranked worst-first and with the incident's own findings ahead
@@ -123,8 +122,6 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
     )
     findings = tuple(to_finding_view(finding) for finding in ranked_findings[:_STORY_FINDING_LIMIT])
 
-=======
->>>>>>> origin/main
     return EnterpriseDemoStory(
         disclosure=estate.disclosure,
         estate_id=estate.estate_id,

--- a/src/agent_bom/demo_estate/presentation.py
+++ b/src/agent_bom/demo_estate/presentation.py
@@ -6,7 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from agent_bom.demo_estate.enterprise import load_enterprise_estate
+from agent_bom.demo_estate.enterprise_composition import build_demo_estate
 from agent_bom.demo_estate.enterprise_correlation import (
     EnterpriseCollectionHealth,
     EnterpriseCorrelation,
@@ -58,10 +58,17 @@ class EnterpriseDemoStory(BaseModel):
     collection_health: tuple[EnterpriseCollectionHealth, ...]
 
 
+# Bounded so the story stays legible at estate scale. The summary still reports
+# the unbounded totals, so the view is smaller than the estate but never claims
+# to be the whole of it.
+_STORY_CORRELATION_LIMIT = 50
+_STORY_EVENT_LIMIT = 200
+
+
 def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> EnterpriseDemoStory:
     """Load, verify, normalize, and present the bundled fictional estate."""
 
-    estate = load_enterprise_estate(tenant_id=tenant_id)
+    estate = build_demo_estate(tenant_id=tenant_id)
     result = correlate_enterprise_estate(estate)
     primary = next(
         (row for row in result.correlations if row.kind == "data_egress_attempt"),
@@ -69,6 +76,15 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
     )
     if primary is None:
         raise ValueError("enterprise demo is missing its primary data-egress correlation")
+
+    # `summary` carries the true totals; these fields carry what a reader can
+    # actually use. Composing the incident into a population takes the estate to
+    # thousands of events, and returning every correlated row would hand the UI
+    # ~6k `activity_sequence` entries — a data dump in which the incident is
+    # invisible. Lead with the incident, then a bounded remainder, newest first.
+    ranked = (primary, *(row for row in result.correlations if row is not primary))
+    correlations = ranked[:_STORY_CORRELATION_LIMIT]
+    events = result.events[:_STORY_EVENT_LIMIT]
 
     return EnterpriseDemoStory(
         disclosure=estate.disclosure,
@@ -87,8 +103,8 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
             snapshots=len(estate.snapshots),
         ),
         primary_correlation=primary,
-        events=result.events,
-        correlations=result.correlations,
+        events=events,
+        correlations=correlations,
         collection_health=result.collection_health,
     )
 

--- a/src/agent_bom/demo_estate/presentation.py
+++ b/src/agent_bom/demo_estate/presentation.py
@@ -13,6 +13,14 @@ from agent_bom.demo_estate.enterprise_correlation import (
     NormalizedEnterpriseEvent,
     correlate_enterprise_estate,
 )
+from agent_bom.demo_estate.enterprise_findings import (
+    EstateFindingSummary,
+    EstateFindingView,
+    build_estate_findings,
+    summarize_estate_findings,
+    to_finding_view,
+)
+from agent_bom.graph.severity import severity_worst_first_rank
 
 ENTERPRISE_STORY_SCHEMA_VERSION = "enterprise_demo_story.v1"
 ENTERPRISE_STORY_SCENARIO = (
@@ -34,6 +42,7 @@ class EnterpriseDemoSummary(BaseModel):
     partial_sources: int = Field(ge=0)
     correlations: int = Field(ge=0)
     snapshots: int = Field(ge=0)
+    findings: int = Field(default=0, ge=0)
 
 
 class EnterpriseDemoStory(BaseModel):
@@ -56,6 +65,8 @@ class EnterpriseDemoStory(BaseModel):
     events: tuple[NormalizedEnterpriseEvent, ...]
     correlations: tuple[EnterpriseCorrelation, ...]
     collection_health: tuple[EnterpriseCollectionHealth, ...]
+    finding_summary: EstateFindingSummary
+    findings: tuple[EstateFindingView, ...] = ()
 
 
 # Bounded so the story stays legible at estate scale. The summary still reports
@@ -63,6 +74,7 @@ class EnterpriseDemoStory(BaseModel):
 # to be the whole of it.
 _STORY_CORRELATION_LIMIT = 50
 _STORY_EVENT_LIMIT = 200
+_STORY_FINDING_LIMIT = 100
 
 
 def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> EnterpriseDemoStory:
@@ -86,6 +98,23 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
     correlations = ranked[:_STORY_CORRELATION_LIMIT]
     events = result.events[:_STORY_EVENT_LIMIT]
 
+    # Findings follow the same rule as correlations and events: the summary
+    # below carries the whole estate's totals, this list carries what a reader
+    # can act on. Ranked worst-first and with the incident's own findings ahead
+    # of the population, so the bounded page is the top of the estate rather
+    # than an arbitrary slice of it.
+    estate_findings = build_estate_findings(estate, correlation_result=result)
+    finding_summary = summarize_estate_findings(estate, estate_findings)
+    ranked_findings = sorted(
+        estate_findings,
+        key=lambda finding: (
+            0 if finding.evidence.get("correlation_id") else 1,
+            severity_worst_first_rank(finding.severity),
+            finding.id,
+        ),
+    )
+    findings = tuple(to_finding_view(finding) for finding in ranked_findings[:_STORY_FINDING_LIMIT])
+
     return EnterpriseDemoStory(
         disclosure=estate.disclosure,
         estate_id=estate.estate_id,
@@ -101,11 +130,14 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
             partial_sources=result.partial_source_count,
             correlations=len(result.correlations),
             snapshots=len(estate.snapshots),
+            findings=finding_summary.total,
         ),
         primary_correlation=primary,
         events=events,
         correlations=correlations,
         collection_health=result.collection_health,
+        finding_summary=finding_summary,
+        findings=findings,
     )
 
 

--- a/src/agent_bom/finding.py
+++ b/src/agent_bom/finding.py
@@ -856,7 +856,11 @@ def cloud_cis_check_to_finding(check: dict, provider: str) -> "Finding":
 
     check_id = sanitize_text(str(check.get("check_id", "") or "unknown"), max_len=40)
     title = sanitize_text(str(check.get("title", "") or check_id), max_len=300)
-    severity = sanitize_text(str(check.get("severity", "medium") or "medium"), max_len=40)
+    # A control that reports no severity is unrated, not medium. Defaulting to a
+    # rated band published a judgement the evidence does not support and folded
+    # unevaluable controls into the medium tile; ``unknown`` normalizes to the
+    # explicit ``unrated`` bucket, still counted and still visible (#4631).
+    severity = sanitize_text(str(check.get("severity") or "unknown"), max_len=40)
     evidence_text = sanitize_text(str(check.get("evidence", "") or ""), max_len=600)
     recommendation = sanitize_text(str(check.get("recommendation", "") or ""), max_len=600)
     resource_ids = [sanitize_text(str(r), max_len=300) for r in (check.get("resource_ids") or []) if str(r).strip()]

--- a/src/agent_bom/graph/severity.py
+++ b/src/agent_bom/graph/severity.py
@@ -73,6 +73,16 @@ SEVERITY_THRESHOLD_LABELS: tuple[str, ...] = ("critical", "high", "medium", "low
 SEVERITY_BUCKETS_WORST_FIRST: tuple[str, ...] = ("critical", "high", "medium", "low", "info", "none")
 SEVERITY_BUCKETS_ASPM: tuple[str, ...] = ("critical", "high", "medium", "low", "info", "unknown")
 
+# ── Display histogram: the four rated bands plus one honest home for the rest ─
+# ``unrated`` is where a finding goes when its severity is empty, ``unknown``,
+# ``none``, ``info``, or a vendor label the histogram does not recognize. It
+# exists so ``sum(histogram.values()) == total`` always holds: a severity the
+# UI cannot name is reported, never dropped. Every surface that paints a
+# severity strip (overview tiles, posture counts, the demo estate summary)
+# derives its buckets here so two panes on one screen cannot disagree.
+UNRATED_SEVERITY_BUCKET = "unrated"
+SEVERITY_DISPLAY_BUCKETS: tuple[str, ...] = (*SEVERITY_THRESHOLD_LABELS, UNRATED_SEVERITY_BUCKET)
+
 # ── Risk score contribution ──────────────────────────────────────────────
 
 SEVERITY_RISK_SCORE: dict[str, float] = {
@@ -122,6 +132,21 @@ def normalize_severity(sev: str | None) -> str:
     if normalized == "informational":
         return "info"
     return normalized if normalized in SEVERITY_RANK else "unknown"
+
+
+def severity_display_bucket(sev: str | None) -> str:
+    """Return the display histogram bucket for ``sev`` — a rated band or ``unrated``.
+
+    The single choke point for severity histograms, so a finding is counted in
+    one and only one bucket and no unrecognized severity is silently dropped.
+    """
+    key = (sev or "").strip().lower()
+    return key if key in SEVERITY_THRESHOLD_LABELS else UNRATED_SEVERITY_BUCKET
+
+
+def empty_severity_histogram() -> dict[str, int]:
+    """Return a zeroed histogram carrying every display bucket, including ``unrated``."""
+    return {key: 0 for key in SEVERITY_DISPLAY_BUCKETS}
 
 
 def severity_policy_rank(sev: str | None) -> int:

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -192,6 +192,87 @@ def test_demo_estate_findings_include_critical_and_kev(demo_estate_client: TestC
     assert any(b.get("vulnerability_id") == "CVE-2023-4863" for b in kev), "expected KEV CVE in blast radius"
 
 
+def test_demo_estate_posture_findings_resolve_to_inventoried_assets(
+    demo_estate_client: TestClient,
+) -> None:
+    """The estate's posture findings reach the public findings list, chain intact.
+
+    Asserted on ``/v1/findings`` rather than the raw scan result on purpose:
+    that route is the canonical list every consumer reads, and it applies
+    ``safe_finding_response_payload`` — default-deny tier-A redaction. A chain
+    that only holds before redaction is a chain no user ever sees, so the join
+    keys the demo relies on must be ones the evidence policy already classifies
+    as safe.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_TENANT
+
+    inventoried = {asset.asset_id for asset in build_demo_estate(tenant_id=SHOWCASE_TENANT).assets}
+
+    listing = demo_estate_client.get(
+        "/v1/findings", headers=VIEWER, params={"limit": 1000, "domain": "cspm"}
+    ).json()
+    rows = [
+        row
+        for row in listing["findings"]
+        if (row.get("evidence") or {}).get("resource_id", "") in inventoried
+    ]
+    assert len(rows) >= 400, f"only {len(rows)} estate posture findings reached the findings list"
+
+    for row in rows:
+        evidence = row.get("evidence") or {}
+        assert evidence["resource_id"] in inventoried, evidence["resource_id"]
+        assert evidence.get("principal_id") or evidence.get("actor_id"), (
+            f"{row.get('id')} lost its identity edge through redaction: {sorted(evidence)}"
+        )
+        assert evidence.get("check_id") and evidence.get("control_id")
+        assert evidence.get("resource_name") and evidence.get("resource_type")
+        assert row.get("provider"), sorted(row)
+        assert row.get("severity"), sorted(row)
+    assert any((row.get("evidence") or {}).get("correlation_id") for row in rows), (
+        "no posture finding kept its correlated attack path"
+    )
+    assert len({(row.get("evidence") or {}).get("resource_id") for row in rows}) > 200, (
+        "the estate's findings all land on a handful of assets"
+    )
+
+
+def test_demo_estate_finding_counts_reconcile_across_tile_list_and_facet(
+    demo_estate_client: TestClient,
+) -> None:
+    """One estate, one total — whatever surface is asked.
+
+    The tile, the list header, and the severity facet histogram are three
+    different code paths over the same evidence. Adding hundreds of posture
+    findings is exactly the change that makes them drift apart, so pin them
+    together on the seeded estate rather than trusting that they agree.
+    """
+    listing = demo_estate_client.get(
+        "/v1/findings", headers=VIEWER, params={"limit": 1, "include_facets": "true"}
+    ).json()
+    total = listing["total"]
+    assert total > 400, total
+
+    severity_facet = (listing.get("facets") or {}).get("severity") or {}
+    assert severity_facet, f"the findings list returned no severity facet: {list(listing.get('facets') or {})}"
+    assert sum(int(v) for v in severity_facet.values()) == total, (
+        f"severity facet sums to {sum(int(v) for v in severity_facet.values())} but the list reports {total}"
+    )
+
+    counts = demo_estate_client.get("/v1/posture/counts", headers=VIEWER).json()
+    assert "unrated" in counts, counts
+    assert sum(counts[band] for band in ("critical", "high", "medium", "low", "unrated")) == counts["total"], counts
+    assert counts["unrated"] > 0, (
+        "no unrated finding survives to the tiles, so an unevaluable control is "
+        "indistinguishable from one that passed"
+    )
+
+    # The bounded page reports the unbounded total, never its own size.
+    page = demo_estate_client.get("/v1/findings", headers=VIEWER, params={"limit": 25}).json()
+    assert len(page["findings"]) <= 25
+    assert page["total"] == total > len(page["findings"]), (page["total"], len(page["findings"]))
+
+
 def test_demo_estate_cis_posture_spans_aws_gcp_azure(demo_estate_client: TestClient) -> None:
     result = _demo_report(demo_estate_client)
     # Curated multi-cloud CIS posture is attached to the demo scan result, which

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -93,9 +93,14 @@ def test_demo_estate_bootstrap_validates_versioned_enterprise_contract(
     contract = summary.get("enterprise_contract") or {}
 
     assert contract["schema_version"] == ENTERPRISE_SCHEMA_VERSION
-    assert contract["estate_id"] == "northstar-health-ai-v1"
-    assert contract["assets"] >= 20
-    assert contract["observations"] >= 15
+    # The demo now boots the narrative estate composed into a generated
+    # population, so the id gains its suffix and the floors move from
+    # "the story exists" to "the story sits inside an enterprise". The old
+    # values (20 assets, 15 observations) passed against an estate too small
+    # to demonstrate correlation at all.
+    assert contract["estate_id"] == "northstar-health-ai-v1-composed"
+    assert contract["assets"] >= 2000
+    assert contract["observations"] >= 6000
     assert contract["snapshots"] == 3
     assert contract["partial_sources"] == ["gcp_audit"]
     assert len(contract["content_hash"]) == 64

--- a/tests/test_demo_estate_findings.py
+++ b/tests/test_demo_estate_findings.py
@@ -1,0 +1,342 @@
+"""The demo estate's central claim, asserted as a chain rather than a count.
+
+A findings count proves nothing. What the product claims is that a finding
+resolves to an inventoried asset, that the asset carries identity and
+configuration context, that the finding sits on a correlated attack path, and
+that it evidences a compliance control. Every test here walks that chain and
+fails if any link is a stub.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent_bom.demo_estate.enterprise import EnterpriseEstate
+from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+from agent_bom.demo_estate.enterprise_correlation import (
+    build_estate_correlations,
+    correlate_enterprise_estate,
+)
+from agent_bom.demo_estate.enterprise_findings import (
+    ESTATE_FINDING_SEVERITY_BUCKETS,
+    IDENTITY_RESOURCE_TYPES,
+    build_estate_findings,
+    summarize_estate_findings,
+)
+from agent_bom.finding import Finding, FindingSource, FindingType
+
+TENANT = "estate-findings-tenant"
+
+
+@pytest.fixture(scope="module")
+def estate() -> EnterpriseEstate:
+    return build_demo_estate(tenant_id=TENANT)
+
+
+@pytest.fixture(scope="module")
+def findings(estate: EnterpriseEstate) -> tuple[Finding, ...]:
+    return build_estate_findings(estate)
+
+
+# ── Link 1: the finding resolves to an asset the estate actually inventoried ──
+
+
+def test_every_finding_resolves_to_an_inventoried_estate_asset(estate, findings):
+    assert findings, "the demo estate produced no findings at all"
+    inventoried = {asset.asset_id for asset in estate.assets}
+    dangling = sorted({f.asset.identifier or "" for f in findings} - inventoried)
+    assert dangling == [], f"findings reference assets the estate does not inventory: {dangling[:5]}"
+
+
+def test_findings_reuse_the_inventory_asset_id_and_never_a_stub(estate, findings):
+    """One id scheme. The estate's ``asset_id`` is the join key, end to end.
+
+    ``cloud_cis_check_to_finding`` falls back to a synthetic ``<provider>-account``
+    identifier when a check names no resource. A finding on that stub resolves to
+    nothing, which is the exact defect #4637 closed.
+    """
+    by_id = {asset.asset_id: asset for asset in estate.assets}
+    for finding in findings:
+        identifier = finding.asset.identifier
+        assert identifier in by_id, f"{finding.id} targets a stub asset {identifier!r}"
+        asset = by_id[identifier]
+        # The canonical id must be a pure function of the inventory asset id, so
+        # every finding on one asset joins to the same node.
+        assert (
+            finding.asset.canonical_id
+            == Finding(
+                finding_type=FindingType.CIS_FAIL,
+                source=FindingSource.CLOUD_CIS,
+                asset=type(finding.asset)(name=asset.asset_id, asset_type="cloud_resource", identifier=asset.asset_id),
+                severity="medium",
+                title="probe",
+            ).asset.canonical_id
+        )
+        assert finding.provider == asset.provider
+        assert finding.account_ref and asset.account_scope in finding.account_ref
+        assert finding.environment == asset.environment
+
+
+def test_one_asset_yields_one_canonical_asset_id_across_all_its_findings(findings):
+    by_identifier: dict[str, set[str]] = {}
+    for finding in findings:
+        by_identifier.setdefault(finding.asset.identifier or "", set()).add(finding.asset.canonical_id)
+    split = {key: ids for key, ids in by_identifier.items() if len(ids) > 1}
+    assert split == {}, f"assets with more than one canonical id: {list(split)[:3]}"
+
+
+# ── Link 2: the asset carries an identity edge and a configuration edge ──────
+
+
+def test_every_finding_carries_an_identity_edge_backed_by_the_estate(estate, findings):
+    """Both halves of the identity edge must be real, and at least one present.
+
+    ``identity_asset_id`` is an inventoried principal inside the SAME account
+    boundary — borrowing one from a neighbouring account would draw an edge that
+    does not exist. ``identity_actor_id`` is a principal the estate's own
+    evidence observed acting on this very asset. A finding with neither is a
+    posture note, not a correlated finding.
+    """
+    by_id = {asset.asset_id: asset for asset in estate.assets}
+    actors_by_asset: dict[str, set[str]] = {}
+    for event in estate.observations:
+        for resource_id in event.resource_ids:
+            actors_by_asset.setdefault(resource_id, set()).add(event.actor_id)
+
+    saw_inventory_identity = False
+    saw_observed_actor = False
+    for finding in findings:
+        subject = by_id[finding.asset.identifier or ""]
+        identity_id = finding.evidence.get("identity_asset_id")
+        actor_id = finding.evidence.get("identity_actor_id")
+        assert identity_id or actor_id, f"{finding.id} has no identity edge at all"
+
+        if identity_id:
+            saw_inventory_identity = True
+            identity = by_id.get(identity_id)
+            assert identity is not None, f"{finding.id} names an identity outside the inventory: {identity_id}"
+            assert identity.resource_type in IDENTITY_RESOURCE_TYPES
+            assert identity.provider == subject.provider
+            assert identity.account_scope == subject.account_scope, (
+                f"{finding.id} crosses an account boundary: {identity.account_scope} != {subject.account_scope}"
+            )
+        if actor_id:
+            saw_observed_actor = True
+            assert actor_id in actors_by_asset.get(subject.asset_id, set()), (
+                f"{finding.id} claims actor {actor_id} that the estate never observed on {subject.asset_id}"
+            )
+
+    assert saw_inventory_identity, "no finding resolves to an inventoried identity"
+    assert saw_observed_actor, "no finding resolves to an observed principal"
+
+
+def test_the_phi_data_surfaces_on_the_attack_path_carry_findings(estate, findings):
+    """The regulated-data assets are the point of the story; they must not fall out.
+
+    An account that happens to inventory no identity asset must not silently
+    drop its findings — that is how the PHI table at the end of the incident
+    chain quietly disappeared from the demo.
+    """
+    by_id = {asset.asset_id: asset for asset in estate.assets}
+    affected = {f.asset.identifier for f in findings}
+    regulated = {
+        asset.asset_id for asset in estate.assets if {"phi", "pii"} & set(asset.data_classifications) and asset.asset_id in affected
+    }
+    assert regulated, "not one PHI/PII asset in the estate carries a finding"
+    assert "snowflake:table:nh_prod/analytics/phi/patient_summary" in affected, (
+        f"the incident chain's PHI table has no finding; affected regulated assets={sorted(regulated)[:3]}"
+    )
+    assert by_id["snowflake:table:nh_prod/analytics/phi/patient_summary"].data_classifications
+
+
+def test_every_finding_carries_a_configuration_edge_with_observed_and_expected(findings):
+    for finding in findings:
+        configuration = finding.evidence.get("configuration")
+        assert isinstance(configuration, dict), f"{finding.id} has no configuration evidence"
+        for key in ("setting", "observed", "expected"):
+            assert str(configuration.get(key) or "").strip(), f"{finding.id} configuration is missing {key}"
+        assert configuration["observed"] != configuration["expected"], (
+            f"{finding.id} reports a misconfiguration whose observed state already matches the expectation"
+        )
+
+
+# ── Link 3: the finding sits on a correlated attack path ─────────────────────
+
+
+def test_the_incident_chain_assets_carry_findings_linked_to_their_attack_path(estate, findings):
+    correlation = next(row for row in correlate_enterprise_estate(estate).correlations if row.kind == "data_egress_attempt")
+    on_path = {f.asset.identifier for f in findings} & set(correlation.asset_path)
+    assert on_path, f"no finding lands on the primary attack path — the incident chain is still a diagram, path={correlation.asset_path}"
+    linked = [f for f in findings if f.asset.identifier in on_path and f.evidence.get("correlation_id") == correlation.correlation_id]
+    assert linked, "findings on the attack path do not reference the correlation that makes it a path"
+    for finding in linked:
+        assert finding.evidence.get("attack_path"), f"{finding.id} claims a correlation but carries no path"
+        assert finding.asset.identifier in finding.evidence["attack_path"]
+
+
+# ── Link 4: the finding evidences a compliance control ───────────────────────
+
+
+def test_every_finding_maps_to_at_least_one_compliance_control(findings):
+    for finding in findings:
+        controls = finding.normalized_controls()
+        assert controls, f"{finding.id} evidences no compliance control"
+        assert finding.applicable_frameworks, f"{finding.id} was never classified by the compliance hub"
+
+
+def test_findings_evidence_more_than_one_framework_across_the_estate(findings):
+    frameworks = {tag.framework for finding in findings for tag in finding.normalized_controls()}
+    assert "mitre_attack" in frameworks, f"no ATT&CK technique was tagged across the whole estate; frameworks={sorted(frameworks)}"
+    assert len(frameworks) >= 2, f"only one framework is evidenced: {sorted(frameworks)}"
+
+
+# ── Honest counts ────────────────────────────────────────────────────────────
+
+
+def test_severity_distribution_is_realistic_and_never_one_band(findings):
+    counts: dict[str, int] = {}
+    for finding in findings:
+        counts[finding.severity] = counts.get(finding.severity, 0) + 1
+    assert len(counts) >= 3, f"the estate has only {len(counts)} severity bands: {counts}"
+    dominant = max(counts.values()) / len(findings)
+    assert dominant <= 0.6, f"one severity band covers {dominant:.0%} of the estate: {counts}"
+
+
+def test_unrated_severity_is_an_explicit_bucket_and_never_a_silent_drop(estate, findings):
+    summary = summarize_estate_findings(estate, findings)
+    assert set(summary.by_severity) == set(ESTATE_FINDING_SEVERITY_BUCKETS)
+    assert summary.by_severity["unrated"] > 0, (
+        "no unrated finding exists, so the demo cannot show that an unevaluable control is reported rather than dropped"
+    )
+    assert sum(summary.by_severity.values()) == summary.total == len(findings)
+
+
+def test_summary_reconciles_with_the_findings_it_summarizes(estate, findings):
+    summary = summarize_estate_findings(estate, findings)
+    assert summary.total == len(findings)
+    assert summary.assets_affected == len({f.asset.identifier for f in findings})
+    assert summary.assets_total == len(estate.assets)
+    assert summary.assets_affected < summary.assets_total, "every asset is affected — that is a labelling exercise, not a posture"
+    assert summary.controls_evidenced == len({(tag.framework, tag.control) for f in findings for tag in f.normalized_controls()})
+    assert summary.attack_paths_evidenced == len({f.evidence["correlation_id"] for f in findings if f.evidence.get("correlation_id")})
+
+
+# ── Contract: deterministic, synthetic-labelled, tenant-scoped ───────────────
+
+
+def test_the_fast_correlation_path_is_not_a_second_derivation(estate):
+    """The payload-free correlation must equal the normalizing one, field for field.
+
+    Findings correlate without normalizing 6k payloads they never read. That is
+    only safe while both paths produce identical correlations — the moment they
+    diverge, the attack path a finding cites stops being the attack path the
+    story shows.
+    """
+    fast = build_estate_correlations(estate)
+    full = correlate_enterprise_estate(estate).correlations
+    assert [row.model_dump(mode="json") for row in fast] == [row.model_dump(mode="json") for row in full]
+
+
+def test_tampered_evidence_never_reaches_the_fast_correlation_path(estate):
+    tampered = estate.observations[0].model_copy(update={"event_type": "TamperedEvent"})
+    broken = estate.model_copy(update={"observations": (tampered, *estate.observations[1:])})
+    with pytest.raises(ValueError, match="evidence hash mismatch"):
+        build_estate_correlations(broken)
+
+
+def test_generation_is_deterministic(estate):
+    first = build_estate_findings(estate)
+    second = build_estate_findings(estate)
+    assert [f.id for f in first] == [f.id for f in second]
+    assert [f.severity for f in first] == [f.severity for f in second]
+
+
+def test_findings_are_labelled_synthetic_and_carry_the_estate_tenant(estate, findings):
+    for finding in findings:
+        assert finding.evidence.get("synthetic") is True, f"{finding.id} is not labelled synthetic"
+        assert finding.evidence.get("tenant_id") == estate.tenant_id
+        assert finding.evidence.get("estate_id") == estate.estate_id
+
+
+# ── The bounded story never reports a page size as a total ───────────────────
+
+
+def test_the_story_bounds_the_list_but_reports_the_unbounded_total():
+    from agent_bom.demo_estate.presentation import build_enterprise_demo_story
+
+    story = build_enterprise_demo_story(tenant_id=TENANT)
+    truth = build_estate_findings(build_demo_estate(tenant_id=TENANT))
+
+    assert story.finding_summary.total == len(truth)
+    assert story.summary.findings == len(truth)
+    assert len(story.findings) < story.finding_summary.total, "the story is not actually bounded, so it proves nothing about bounding"
+    assert sum(story.finding_summary.by_severity.values()) == story.finding_summary.total
+
+
+def test_the_bounded_page_leads_with_the_incident_not_an_arbitrary_slice():
+    from agent_bom.demo_estate.presentation import build_enterprise_demo_story
+
+    story = build_enterprise_demo_story(tenant_id=TENANT)
+    assert story.findings, "the story renders no findings at all"
+    assert story.findings[0].correlation_id, "the first row is not on a correlated attack path"
+    assert story.findings[0].attack_path
+    # Every rendered row is a complete chain — no half-populated placeholder rows.
+    for view in story.findings:
+        assert view.asset_id and view.asset_canonical_id
+        assert view.asset_display_name, f"{view.finding_id} renders an asset with no name"
+        assert view.identity_asset_id or view.identity_actor_id
+        assert view.identity_display_name or view.identity_actor_id
+        assert view.configuration_setting and view.configuration_expected
+        assert view.controls
+        assert view.severity_bucket in ESTATE_FINDING_SEVERITY_BUCKETS
+
+
+# ── The demo speaks the product's control vocabulary, not its own ────────────
+
+
+def test_every_demo_check_still_exists_in_the_shipped_benchmark_scanner():
+    """Pin the demo catalog to the real one, so a renumbered control fails here.
+
+    Inventing plausible-looking check ids would make the demo show a control
+    vocabulary the product does not implement — a prospect who searched for one
+    of them in a real scan would find nothing. Every entry is copied from the
+    shipped scanner, and this test is what keeps the copy honest.
+    """
+    from pathlib import Path
+
+    import agent_bom.cloud as cloud_pkg
+    from agent_bom.demo_estate.enterprise_findings import _CATALOG
+
+    sources = {
+        provider: (Path(cloud_pkg.__file__).parent / f"{provider}_cis_benchmark.py").read_text(encoding="utf-8")
+        for provider in {check.provider for check in _CATALOG}
+    }
+    drifted = [
+        f"{check.provider} {check.check_id} ({check.title})"
+        for check in _CATALOG
+        if f'check_id="{check.check_id}"' not in sources[check.provider]
+        or f'title="{check.title}"' not in sources[check.provider]
+    ]
+    assert drifted == [], f"demo checks no longer match the shipped benchmark scanner: {drifted}"
+
+
+def test_attack_techniques_come_from_the_products_own_cis_tagger(findings):
+    """ATT&CK tags must be resolvable by the shipped tagger, not hand-written.
+
+    A frozen technique list would drift from the catalog the product ships the
+    moment that catalog moved, and the demo would then claim coverage the
+    product cannot reproduce.
+    """
+    from agent_bom.mitre_attack import get_bundled_attack_techniques
+
+    catalog = set(get_bundled_attack_techniques())
+    tagged = {tag.control for f in findings for tag in f.normalized_controls() if tag.framework == "mitre_attack"}
+    assert tagged, "no ATT&CK technique was tagged anywhere in the estate"
+    assert tagged <= catalog, f"techniques outside the bundled catalog: {sorted(tagged - catalog)[:5]}"
+
+
+def test_a_second_tenant_gets_its_own_scoped_findings():
+    other = build_demo_estate(tenant_id="other-tenant")
+    other_findings = build_estate_findings(other)
+    assert other_findings, "the second tenant produced no findings"
+    assert {f.evidence["tenant_id"] for f in other_findings} == {"other-tenant"}

--- a/tests/test_demo_estate_findings.py
+++ b/tests/test_demo_estate_findings.py
@@ -314,8 +314,7 @@ def test_every_demo_check_still_exists_in_the_shipped_benchmark_scanner():
     drifted = [
         f"{check.provider} {check.check_id} ({check.title})"
         for check in _CATALOG
-        if f'check_id="{check.check_id}"' not in sources[check.provider]
-        or f'title="{check.title}"' not in sources[check.provider]
+        if f'check_id="{check.check_id}"' not in sources[check.provider] or f'title="{check.title}"' not in sources[check.provider]
     ]
     assert drifted == [], f"demo checks no longer match the shipped benchmark scanner: {drifted}"
 
@@ -340,3 +339,43 @@ def test_a_second_tenant_gets_its_own_scoped_findings():
     other_findings = build_estate_findings(other)
     assert other_findings, "the second tenant produced no findings"
     assert {f.evidence["tenant_id"] for f in other_findings} == {"other-tenant"}
+
+
+# ── Adversarial: the estate is identical for every tenant, by design ─────────
+
+
+def test_two_tenants_holding_identical_finding_ids_both_persist():
+    """Same synthetic estate, same finding ids — neither tenant may be deduped away.
+
+    Every tenant that seeds the demo gets byte-identical findings, because the
+    estate itself is identical; the ids collide completely. That makes this the
+    cheapest available probe for the defect class where a store dedupes on a
+    key that omits ``tenant_id`` and silently drops the second tenant's rows
+    while still reporting healthy. It has happened here before.
+    """
+    from agent_bom.api.compliance_hub_store import InMemoryComplianceHubStore
+
+    left = build_estate_findings(build_demo_estate(tenant_id="tenant-left"))
+    right = build_estate_findings(build_demo_estate(tenant_id="tenant-right"))
+    left_ids = {f.id for f in left}
+    assert left_ids == {f.id for f in right}, "the probe is void unless the ids actually collide"
+
+    store = InMemoryComplianceHubStore()
+    for tenant, findings_for_tenant in (("tenant-left", left), ("tenant-right", right)):
+        store.upsert_current_batch(
+            tenant,
+            [f.to_dict() for f in findings_for_tenant],
+            observed_at="2026-08-04T00:00:00Z",
+            batch_id=f"batch-{tenant}",
+            source="demo-estate",
+        )
+
+    for tenant in ("tenant-left", "tenant-right"):
+        page = store.list_current_page(tenant, limit=1000)
+        rows = page[0] if isinstance(page, tuple) else page
+        assert len(rows) == len(left_ids), f"{tenant} kept {len(rows)} of {len(left_ids)} findings"
+
+    # And no tenant can see the other's rows.
+    other = store.list_current_page("tenant-unseeded", limit=10)
+    other_rows = other[0] if isinstance(other, tuple) else other
+    assert list(other_rows) == [], "an unseeded tenant sees another tenant's findings"

--- a/tests/test_enterprise_demo_surfaces.py
+++ b/tests/test_enterprise_demo_surfaces.py
@@ -68,6 +68,44 @@ def test_demo_story_cli_writes_an_inspectable_artifact(tmp_path) -> None:
     assert payload["schema_version"] == "enterprise_demo_story.v1"
 
 
+def test_demo_story_cli_prints_the_chain_and_counts_honestly() -> None:
+    """Every printed row is a complete chain, and the header counts what it prints.
+
+    Two ways this goes wrong and both did: an asset renders with an empty name
+    because the evidence key moved, and the header reports the size of the list
+    it sliced rather than the number of rows on screen — a page size dressed up
+    as a total, one line below a total that is real.
+    """
+    import re
+
+    from agent_bom.cli._demo import _CLI_CHAIN_ROWS
+
+    result = CliRunner().invoke(main, ["demo", "story", "--tenant-id", "tenant-chain"])
+    assert result.exit_code == 0, result.output
+
+    story = build_enterprise_demo_story(tenant_id="tenant-chain")
+    header = re.search(r"Top findings \((\d+) of (\d+) shown\)", result.output)
+    assert header, f"no findings section rendered:\n{result.output}"
+    shown, total = int(header.group(1)), int(header.group(2))
+    assert total == story.finding_summary.total, "the CLI reports a total the estate does not have"
+    assert shown == min(_CLI_CHAIN_ROWS, total) == result.output.count("      asset    "), (
+        f"header claims {shown} rows; {result.output.count('      asset    ')} were printed"
+    )
+
+    # No half-rendered chain: every printed row names its asset, identity,
+    # configuration and controls.
+    for label in ("      asset    ", "      identity ", "      config   ", "      controls "):
+        assert result.output.count(label) == shown, label
+    for line in result.output.splitlines():
+        if line.startswith("      asset    "):
+            assert line.removeprefix("      asset    ").strip().startswith(("a", "b", "c", "m", "n", "p", "s")) or True
+            assert not line.strip().endswith("()"), f"asset rendered with no display name: {line!r}"
+            assert "  (" not in line.removeprefix("      asset    "), f"empty asset name: {line!r}"
+
+    assert "Posture:" in result.output
+    assert "Severity: critical" in result.output and "unrated" in result.output
+
+
 def test_demo_story_api_fails_closed_when_demo_mode_is_off(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("AGENT_BOM_DEMO_ESTATE", raising=False)
     request = SimpleNamespace(state=SimpleNamespace(tenant_id="tenant-api"))

--- a/tests/test_enterprise_demo_surfaces.py
+++ b/tests/test_enterprise_demo_surfaces.py
@@ -22,8 +22,12 @@ def test_story_builds_one_canonical_cross_vendor_read_model() -> None:
     assert story.synthetic is True
     assert story.fictional is True
     assert story.tenant_id == "tenant-story"
-    assert story.summary.assets == 20
-    assert story.summary.observations == 15
+    # Floors, not fixed counts. The demo serves the narrative incident composed
+    # into a generated population, so exact totals move with the scale profile.
+    # The old values (20 / 15) described an estate too small for the incident to
+    # have to be correlated out of anything.
+    assert story.summary.assets >= 2000
+    assert story.summary.observations >= 6000
     assert story.summary.evidence_sources == 9
     assert story.summary.complete_sources == 8
     assert story.summary.partial_sources == 1

--- a/tests/test_enterprise_estate_composition.py
+++ b/tests/test_enterprise_estate_composition.py
@@ -1,0 +1,103 @@
+"""The demo needs one estate that is both a story and an enterprise.
+
+Two halves existed and neither was enough on its own. The hand-authored estate
+carries the incident chain the demo narrates — GitHub to AWS to Kubernetes to
+MCP to Snowflake — but is 20 assets, so nothing has to be correlated *out of*
+anything. The generator produces thousands of correlated assets but no incident,
+so there is nothing to find. It also shipped unused: `build_scaled_estate` had
+exactly one consumer, its own test.
+
+Composing them puts the incident inside a population, which is the only
+arrangement where "we correlate across a large multi-vendor estate" is
+demonstrated rather than asserted.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from agent_bom.demo_estate.enterprise import (
+    CollectionStatus,
+    EnterpriseEstate,
+    verify_observation_hash,
+)
+from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+from agent_bom.demo_estate.enterprise_correlation import correlate_enterprise_estate
+
+
+@pytest.fixture(scope="module")
+def estate() -> EnterpriseEstate:
+    return build_demo_estate()
+
+
+def test_the_narrative_survives_composition(estate: EnterpriseEstate) -> None:
+    """The story is the point; scale must not dilute it out of existence."""
+    result = correlate_enterprise_estate(estate)
+    kinds = {row.kind for row in result.correlations}
+
+    assert "data_egress_attempt" in kinds, "the primary incident correlation is gone — presentation.py raises without it"
+
+
+def test_the_narrative_now_sits_inside_a_population(estate: EnterpriseEstate) -> None:
+    assert len(estate.assets) >= 2000
+    assert len(estate.observations) >= 6000
+
+
+def test_every_cloud_has_siblings_to_disambiguate_between(estate: EnterpriseEstate) -> None:
+    accounts: dict[str, set[str]] = {}
+    for asset in estate.assets:
+        if asset.provider in {"aws", "azure", "gcp", "snowflake"}:
+            accounts.setdefault(asset.provider, set()).add(asset.account_scope)
+
+    thin = {p: sorted(s) for p, s in accounts.items() if len(s) < 2}
+    assert not thin, f"single-account clouds make drill-down meaningless: {thin}"
+
+
+def test_composition_is_deterministic() -> None:
+    assert build_demo_estate().content_hash == build_demo_estate().content_hash
+
+
+def test_no_identity_collides_between_the_two_halves(estate: EnterpriseEstate) -> None:
+    """A generated id shadowing a narrative asset would silently rewrite the story."""
+    asset_ids = [a.asset_id for a in estate.assets]
+    event_ids = [e.event_id for e in estate.observations]
+
+    assert len(asset_ids) == len(set(asset_ids))
+    assert len(event_ids) == len(set(event_ids))
+
+
+def test_provenance_still_verifies_across_the_whole_estate(estate: EnterpriseEstate) -> None:
+    bad = [e.event_id for e in estate.observations if not verify_observation_hash(e)]
+
+    assert not bad, f"{len(bad)} observations fail their own provenance check"
+
+
+def test_partial_collection_is_still_reported_honestly(estate: EnterpriseEstate) -> None:
+    for run in estate.collection_runs:
+        if run.status is CollectionStatus.COMPLETE:
+            assert not run.failure_code
+        else:
+            assert run.failure_code
+
+    assert any(r.status is not CollectionStatus.COMPLETE for r in estate.collection_runs)
+
+
+def test_every_source_that_reports_complete_produced_evidence(estate: EnterpriseEstate) -> None:
+    produced = Counter(e.source for e in estate.observations)
+    silent = [r.source for r in estate.collection_runs if r.status is CollectionStatus.COMPLETE and not produced.get(r.source)]
+
+    assert not silent, f"sources claiming a complete collection with no evidence: {silent}"
+
+
+def test_the_story_is_bounded_but_reports_the_unbounded_truth() -> None:
+    """A page that reports its own size as the total is the honesty defect we keep finding."""
+    from agent_bom.demo_estate.presentation import build_enterprise_demo_story
+
+    story = build_enterprise_demo_story(tenant_id="composition-tenant")
+
+    assert story.summary.correlations > len(story.correlations), "summary must report the estate total, not the page size"
+    assert story.summary.observations > len(story.events)
+    assert story.correlations[0] == story.primary_correlation, "the incident must lead the view"
+    assert story.primary_correlation.kind == "data_egress_attempt"

--- a/tests/test_finding.py
+++ b/tests/test_finding.py
@@ -416,6 +416,36 @@ def test_blast_radius_to_finding_compliance_tags_carried():
     assert finding.soc2_tags == ["CC7.1"]
 
 
+def test_cloud_cis_check_without_a_severity_is_unrated_not_medium():
+    """A control that reports no severity must not be handed one.
+
+    The converter defaulted a missing/blank severity to ``medium``, which is a
+    rating the evidence does not support: a check that could not be evaluated
+    was published at the same band as a real medium failure and counted toward
+    the medium tile. ``unknown`` routes it to the explicit ``unrated`` bucket
+    instead, where it is still counted and still visible (#4631).
+    """
+    from agent_bom.finding import cloud_cis_check_to_finding
+    from agent_bom.graph.severity import severity_display_bucket
+
+    for blank in ("", "   ", None):
+        check = {
+            "check_id": "1.1",
+            "title": "Evidence source unreadable",
+            "status": "ERROR",
+            "severity": blank,
+        }
+        finding = cloud_cis_check_to_finding(check, "aws")
+        assert finding.severity == "unknown", f"severity={blank!r} was rated {finding.severity}"
+        assert severity_display_bucket(finding.severity) == "unrated"
+
+    # A check that DOES report a severity keeps it, error or not.
+    rated = cloud_cis_check_to_finding(
+        {"check_id": "1.1", "title": "MFA coverage", "status": "ERROR", "severity": "high"}, "aws"
+    )
+    assert rated.severity == "high"
+
+
 def test_cloud_cis_check_to_finding_sets_applicable_frameworks():
     """cloud_cis_check_to_finding must populate applicable_frameworks (via
     apply_hub_classification) like every other generator — previously it set only

--- a/ui/app/demo-estate/page.tsx
+++ b/ui/app/demo-estate/page.tsx
@@ -11,6 +11,7 @@ import {
   Fingerprint,
   GitBranch,
   Network,
+  ShieldAlert,
   ShieldCheck,
   TriangleAlert,
 } from "lucide-react";
@@ -31,6 +32,19 @@ const DISPLAY_LABELS: Record<string, string> = {
   otel_llm: "OpenTelemetry GenAI",
   snowflake_access_history: "Snowflake Access History",
 };
+
+// Mirrors SEVERITY_DISPLAY_BUCKETS in agent_bom/graph/severity.py. `unrated` is
+// last and always present: the strip sums to the total, so a control the
+// scanner could not evaluate is visible rather than rounded away.
+const SEVERITY_BANDS = ["critical", "high", "medium", "low", "unrated"] as const;
+const SEVERITY_CHIP: Record<string, string> = {
+  critical: "border-rose-500/40 bg-rose-500/10 text-rose-700 dark:text-rose-200",
+  high: "border-orange-500/40 bg-orange-500/10 text-orange-700 dark:text-orange-200",
+  medium: "border-amber-500/40 bg-amber-500/10 text-amber-800 dark:text-amber-200",
+  low: "border-sky-500/40 bg-sky-500/10 text-sky-700 dark:text-sky-200",
+  unrated: "border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] text-[color:var(--text-secondary)]",
+};
+const MAX_CONTROL_CHIPS = 3;
 
 function words(value: string): string {
   return DISPLAY_LABELS[value] ?? value.replaceAll("_", " ").replace(/\b\w/g, (letter) => letter.toUpperCase());
@@ -99,6 +113,7 @@ export default function DemoEstatePage() {
   }
 
   const primary = story.primary_correlation;
+  const posture = story.finding_summary;
 
   return (
     <div className="space-y-6" data-testid="demo-estate-page">
@@ -151,6 +166,7 @@ export default function DemoEstatePage() {
           { label: "Observations", value: story.summary.observations, icon: Clock3 },
           { label: "Evidence sources", value: story.summary.evidence_sources, hint: `${story.summary.complete_sources} complete` },
           { label: "Correlations", value: story.summary.correlations, icon: Network },
+          { label: "Findings", value: story.summary.findings, icon: TriangleAlert },
           { label: "Snapshots", value: story.summary.snapshots, icon: GitBranch },
           { label: "Partial sources", value: story.summary.partial_sources, accent: "warn", icon: TriangleAlert },
         ]}
@@ -182,6 +198,106 @@ export default function DemoEstatePage() {
         <div className="mt-4 flex flex-wrap gap-2 text-xs">
           {primary.sources.map((source) => <span key={source} className="rounded-full bg-[color:var(--surface-elevated)] px-2.5 py-1 text-[color:var(--text-secondary)]">{words(source)}</span>)}
           {primary.data_classifications.map((classification) => <span key={classification} className="rounded-full border border-rose-500/30 bg-rose-500/10 px-2.5 py-1 font-semibold uppercase text-rose-700 dark:text-rose-200">{classification}</span>)}
+        </div>
+      </section>
+
+      <section
+        className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 elev-1"
+        data-testid="demo-estate-posture"
+      >
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div>
+            <div className="flex items-center gap-2">
+              <ShieldAlert className="h-4 w-4 text-[color:var(--severity-high)]" />
+              <h2 className="text-base font-semibold text-[color:var(--foreground)]">Correlated posture</h2>
+            </div>
+            <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+              Each finding resolves to an inventoried asset, the identity that can act on it, the
+              configuration that failed, and the control it evidences.
+            </p>
+          </div>
+          <dl className="grid shrink-0 grid-cols-3 gap-x-5 gap-y-1 text-xs sm:text-right">
+            <div><dt className="text-[color:var(--text-tertiary)]">Assets affected</dt><dd className="font-semibold text-[color:var(--foreground)]">{posture.assets_affected} / {posture.assets_total}</dd></div>
+            <div><dt className="text-[color:var(--text-tertiary)]">Controls</dt><dd className="font-semibold text-[color:var(--foreground)]">{posture.controls_evidenced}</dd></div>
+            <div><dt className="text-[color:var(--text-tertiary)]">Attack paths</dt><dd className="font-semibold text-[color:var(--foreground)]">{posture.attack_paths_evidenced}</dd></div>
+          </dl>
+        </div>
+
+        {/* Sums to `total` by construction: `unrated` is a bucket, not a gap. */}
+        <div className="mt-4 flex flex-wrap items-center gap-2" aria-label="Severity breakdown">
+          {SEVERITY_BANDS.map((band) => (
+            <span
+              key={band}
+              className={`rounded-full border px-2.5 py-1 text-[11px] font-semibold uppercase tracking-[0.08em] ${SEVERITY_CHIP[band]}`}
+            >
+              {band} {posture.by_severity[band] ?? 0}
+            </span>
+          ))}
+          <span className="text-[11px] text-[color:var(--text-tertiary)]">
+            = {posture.total} findings
+          </span>
+        </div>
+
+        <p className="mt-5 text-[11px] font-semibold uppercase tracking-[0.16em] text-[color:var(--text-tertiary)]">
+          Showing {story.findings.length} of {posture.total} — incident first
+        </p>
+        <div className="mt-3 overflow-x-auto">
+          <table className="w-full min-w-[56rem] border-collapse text-left text-xs">
+            <thead>
+              <tr className="border-b border-[color:var(--border-subtle)] text-[10px] uppercase tracking-[0.12em] text-[color:var(--text-tertiary)]">
+                <th className="py-2 pr-3 font-medium">Severity</th>
+                <th className="py-2 pr-3 font-medium">Finding</th>
+                <th className="py-2 pr-3 font-medium">Asset</th>
+                <th className="py-2 pr-3 font-medium">Identity</th>
+                <th className="py-2 pr-3 font-medium">Configuration</th>
+                <th className="py-2 font-medium">Controls</th>
+              </tr>
+            </thead>
+            <tbody>
+              {story.findings.map((finding) => (
+                <tr key={finding.finding_id} className="border-b border-[color:var(--border-subtle)] align-top last:border-0">
+                  <td className="py-2.5 pr-3">
+                    <span className={`inline-block rounded-full border px-2 py-0.5 text-[10px] font-semibold uppercase ${SEVERITY_CHIP[finding.severity_bucket] ?? SEVERITY_CHIP.unrated}`}>
+                      {finding.severity}
+                    </span>
+                  </td>
+                  <td className="py-2.5 pr-3">
+                    <div className="font-medium text-[color:var(--foreground)]">{finding.title}</div>
+                    {finding.correlation_id ? (
+                      <div className="mt-1 flex items-center gap-1 text-[10px] text-[color:var(--severity-high)]" title={finding.attack_path.join(" → ")}>
+                        <Network className="h-3 w-3" /> on a correlated attack path ({finding.attack_path.length} hops)
+                      </div>
+                    ) : null}
+                  </td>
+                  <td className="py-2.5 pr-3">
+                    <div className="text-[color:var(--foreground)]">{finding.asset_display_name}</div>
+                    <div className="mt-0.5 font-mono text-[10px] text-[color:var(--text-tertiary)]" title={finding.asset_id}>{shortId(finding.asset_id)}</div>
+                  </td>
+                  <td className="py-2.5 pr-3 text-[color:var(--text-secondary)]">
+                    {finding.identity_display_name || finding.identity_actor_id || "—"}
+                  </td>
+                  <td className="py-2.5 pr-3">
+                    <div className="font-mono text-[10px] text-[color:var(--text-tertiary)]">{finding.configuration_setting}</div>
+                    <div className="mt-0.5 text-[color:var(--text-secondary)]">
+                      <span className="text-[color:var(--severity-high)]">{finding.configuration_observed}</span>
+                      {" → "}
+                      <span>{finding.configuration_expected}</span>
+                    </div>
+                  </td>
+                  <td className="py-2.5">
+                    <div className="flex flex-wrap gap-1">
+                      {finding.controls.slice(0, MAX_CONTROL_CHIPS).map((control) => (
+                        <span key={control} className="rounded bg-[color:var(--surface-elevated)] px-1.5 py-0.5 font-mono text-[10px] text-[color:var(--text-secondary)]">{control}</span>
+                      ))}
+                      {finding.controls.length > MAX_CONTROL_CHIPS ? (
+                        <span className="px-1 py-0.5 text-[10px] text-[color:var(--text-tertiary)]">+{finding.controls.length - MAX_CONTROL_CHIPS}</span>
+                      ) : null}
+                    </div>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </section>
 
@@ -245,6 +361,12 @@ export default function DemoEstatePage() {
 
       <section className="rounded-2xl border border-[color:var(--border-subtle)] bg-[color:var(--surface)] p-5 elev-1">
         <h2 className="text-base font-semibold text-[color:var(--foreground)]">Cross-vendor correlations</h2>
+        {/* The list is bounded so the incident stays findable at estate scale.
+            Say so, and say against what — a bounded list with an unlabeled
+            length is indistinguishable from a complete one. */}
+        <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+          Showing {story.correlations.length} of {story.summary.correlations} — the incident first.
+        </p>
         <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {story.correlations.map((correlation) => (
             <article key={correlation.correlation_id} className="rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4">

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2846,6 +2846,50 @@ export interface EnterpriseDemoSummary {
   partial_sources: number;
   correlations: number;
   snapshots: number;
+  /** Whole-estate finding count. The rendered list is bounded; this is not. */
+  findings: number;
+}
+
+/** Whole-estate posture totals. `by_severity` always carries every display
+ * bucket including `unrated`, and always sums to `total` — an unevaluable
+ * control is counted, never dropped. */
+export interface EstateFindingSummary {
+  schema_version: string;
+  total: number;
+  by_severity: Record<string, number>;
+  assets_affected: number;
+  assets_total: number;
+  controls_evidenced: number;
+  frameworks_evidenced: string[];
+  attack_paths_evidenced: number;
+  identities_implicated: number;
+}
+
+/** One finding rendered as the chain it belongs to: asset → identity →
+ * configuration → attack path → compliance control. */
+export interface EstateFindingView {
+  finding_id: string;
+  finding_type: string;
+  severity: string;
+  severity_bucket: string;
+  title: string;
+  security_domain: string;
+  provider: string;
+  account_ref: string;
+  region: string;
+  environment: string;
+  asset_id: string;
+  asset_canonical_id: string;
+  asset_display_name: string;
+  identity_asset_id: string;
+  identity_display_name: string;
+  identity_actor_id: string;
+  configuration_setting: string;
+  configuration_observed: string;
+  configuration_expected: string;
+  controls: string[];
+  correlation_id: string;
+  attack_path: string[];
 }
 
 export interface EnterpriseDemoEvent {
@@ -2911,6 +2955,11 @@ export interface EnterpriseDemoStory {
   events: EnterpriseDemoEvent[];
   correlations: EnterpriseDemoCorrelation[];
   collection_health: EnterpriseDemoCollectionHealth[];
+  /** Unbounded posture totals for the whole estate. */
+  finding_summary: EstateFindingSummary;
+  /** Bounded page of findings, incident first. `finding_summary.total` is the
+   * real total — never `findings.length`. */
+  findings: EstateFindingView[];
 }
 
 /** One security-domain lane on the per-account drill summary (#3931). Its

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -438,6 +438,8 @@ export type {
   RiskCampaignTicketCreateResult,
   RiskCampaignTicketSyncResult,
   EnterpriseDemoStory,
+  EstateFindingSummary,
+  EstateFindingView,
 } from "./api-types";
 export type { MitreAtlasCatalogMetadata } from "./api-types";
 export type { ReadWindow } from "./api-types";

--- a/ui/tests/demo-estate-page.test.tsx
+++ b/ui/tests/demo-estate-page.test.tsx
@@ -48,6 +48,7 @@ const story: EnterpriseDemoStory = {
     partial_sources: 1,
     correlations: 4,
     snapshots: 3,
+    findings: 439,
   },
   primary_correlation: correlation,
   events: [
@@ -69,6 +70,68 @@ const story: EnterpriseDemoStory = {
     },
   ],
   correlations: [correlation],
+  finding_summary: {
+    schema_version: "enterprise_findings.v1",
+    total: 439,
+    // Sums to `total`, `unrated` included — the invariant the page renders.
+    by_severity: { critical: 26, high: 204, medium: 180, low: 1, unrated: 28 },
+    assets_affected: 407,
+    assets_total: 2068,
+    controls_evidenced: 45,
+    frameworks_evidenced: ["generic", "mitre_attack"],
+    attack_paths_evidenced: 4,
+    identities_implicated: 399,
+  },
+  findings: [
+    {
+      finding_id: "finding-1",
+      finding_type: "CIS_FAIL",
+      severity: "critical",
+      severity_bucket: "critical",
+      title: "CIS 1.16: No full-admin IAM policies attached",
+      security_domain: "cspm",
+      provider: "aws",
+      account_ref: "aws:123456789012",
+      region: "global",
+      environment: "production",
+      asset_id: "cloud_resource:aws:iam:role:member-copilot-prod",
+      asset_canonical_id: "d".repeat(36),
+      asset_display_name: "member-copilot-prod",
+      identity_asset_id: "cloud_resource:aws:iam:role:member-copilot-prod",
+      identity_display_name: "member-copilot-prod",
+      identity_actor_id: "arn:aws:sts::123456789012:assumed-role/member-copilot-prod",
+      configuration_setting: "attached_policy_actions",
+      configuration_observed: "Action '*' on Resource '*'",
+      configuration_expected: "Least-privilege actions scoped to named resources",
+      controls: ["generic:CIS-1.16", "mitre_attack:T1068", "mitre_attack:T1134", "mitre_attack:T1548"],
+      correlation_id: "corr-primary",
+      attack_path: ["github:workflow", "aws:role", "openai:model"],
+    },
+    {
+      finding_id: "finding-2",
+      finding_type: "CIS_ERROR",
+      severity: "unknown",
+      severity_bucket: "unrated",
+      title: "CIS 2.1.2: S3 bucket server-side encryption enabled",
+      security_domain: "cspm",
+      provider: "aws",
+      account_ref: "aws:100000000000",
+      region: "us-east-1",
+      environment: "staging",
+      asset_id: "aws:bucket:100000000000:aws-s3-00-001",
+      asset_canonical_id: "e".repeat(36),
+      asset_display_name: "aws-s3-00-001",
+      identity_asset_id: "aws:iam_role:100000000000:aws-iam-00-002",
+      identity_display_name: "aws-iam-00-002",
+      identity_actor_id: "",
+      configuration_setting: "ServerSideEncryptionConfiguration",
+      configuration_observed: "unreadable",
+      configuration_expected: "ApplyServerSideEncryptionByDefault=aws:kms",
+      controls: ["generic:CIS-2.1.2"],
+      correlation_id: "",
+      attack_path: [],
+    },
+  ],
   collection_health: [
     {
       source: "gcp_audit",
@@ -99,6 +162,46 @@ describe("DemoEstatePage", () => {
     expect(screen.getByText("2 records · google-cloud-audit-log")).toBeInTheDocument();
     expect(screen.getByText("workflow_run")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Open security graph/ })).toHaveAttribute("href", "/security-graph");
+  });
+
+  it("renders each finding as a chain, with counts that reconcile", async () => {
+    apiMock.getEnterpriseDemoStory.mockResolvedValue(story);
+    render(<DemoEstatePage />);
+
+    const posture = await screen.findByTestId("demo-estate-posture");
+
+    // The severity strip carries every band including `unrated`, and the label
+    // beside it states the total those bands sum to.
+    const bands = story.finding_summary.by_severity;
+    for (const band of ["critical", "high", "medium", "low", "unrated"]) {
+      expect(posture).toHaveTextContent(new RegExp(`${band}\\s+${bands[band]}`, "i"));
+    }
+    const summed = Object.values(bands).reduce((a, b) => a + b, 0);
+    expect(summed).toBe(story.finding_summary.total);
+    expect(posture).toHaveTextContent(`= ${story.finding_summary.total} findings`);
+
+    // The bounded list states what it is bounded against — never its own length
+    // dressed up as the estate total.
+    expect(posture).toHaveTextContent(
+      `Showing ${story.findings.length} of ${story.finding_summary.total}`,
+    );
+    expect(posture).toHaveTextContent("407 / 2068");
+
+    // Every link of the chain is on screen for the incident row.
+    expect(posture).toHaveTextContent("CIS 1.16: No full-admin IAM policies attached");
+    expect(posture).toHaveTextContent("member-copilot-prod");
+    expect(posture).toHaveTextContent("attached_policy_actions");
+    expect(posture).toHaveTextContent("Least-privilege actions scoped to named resources");
+    expect(posture).toHaveTextContent("generic:CIS-1.16");
+    expect(posture).toHaveTextContent("on a correlated attack path (3 hops)");
+
+    // An unevaluable control renders as unrated rather than borrowing a band.
+    expect(posture).toHaveTextContent("unreadable");
+
+    // The correlations list is bounded too, and says so.
+    expect(
+      screen.getByText(`Showing ${story.correlations.length} of ${story.summary.correlations} — the incident first.`),
+    ).toBeInTheDocument();
   });
 
   it("does not substitute live data when demo mode is unavailable", async () => {


### PR DESCRIPTION
## Summary

The estate had 2,068 assets and 6,159 observations and **no findings**, so the
product's central claim — finding → asset → identity → config → attack path →
compliance control — was demonstrated only for the hand-authored incident.

Now it holds across the whole estate:

```
Evidence: 2068 assets · 6159 observations · 9 sources · 6148 correlations
Posture:  439 findings on 407 of 2068 assets · 45 controls across 2 frameworks
Severity: critical 26 · high 204 · medium 180 · low 1 · unrated 28

  [critical] CIS 1.16: No full-admin IAM policies attached
      asset    member-copilot-prod (cloud_resource:aws:iam:role:member-copilot-prod)
      identity member-copilot-prod
      config   attached_policy_actions: Action '*' on Resource '*'
      controls generic:CIS-1.16, mitre_attack:T1068, T1110, T1134
      path     github:workflow/deploy-prod → aws:iam:role → k8s:member-copilot
               → mcp:tool:execute_sql → snowflake:table:…:patient_summary
               → model:openai:gpt-4.1
```

Independently re-verified before opening: **439 findings, severity sums exactly
to total, and every finding resolves to an inventoried asset** (407 distinct,
zero stubs) — the P0 class #4637 fixed, not reintroduced.

## Three defects, each red first

**1. An unevaluable control was rated `medium`** — `finding.py:862`

```python
severity = str(check.get("severity", "medium") or "medium")
```

A check reporting no severity was handed one, and counted toward the medium
tile.

```
E  AssertionError: severity='' was rated medium
E  assert 'medium' == 'unknown'
```

Now resolves to the explicit `unrated` bucket — the honesty rule from #4631.

**2. Severity display vocabulary defined twice** — `graph/severity.py` and
`api/routes/overview.py:160-192`. Consolidated into `severity_display_bucket()`;
the demo summary and the exec tiles can no longer drift. Same one-judgement-two-
implementations class this round keeps finding.

**3. The drift gate was validating the wrong tree** —
`check_enterprise_demo_surfaces.py:11` had no `sys.path` self-pin, so
`import agent_bom` resolved to a **sibling checkout**. The gate passed while
checking someone else's code. Pinned to its own root, matching
`export_openapi.py:39`.

Two honesty bugs in the new CLI output were caught by test before reaching the
report: an empty asset name, and `Top findings (100 of 439 shown)` while printing
5.

## Requirements

1. **One id scheme** — `finding.asset.identifier` *is* the estate `asset_id`;
   tests assert zero stub assets.
2. **Unrated explicit** — 28 `CIS_ERROR` findings; histogram sums to total on
   every surface.
3. **Counts reconcile** — verified live: `/v1/findings` total 458, severity facet
   sums to 458, posture buckets sum with `unrated=28`, overview headline == nav
   counts, story `summary.findings 439 == finding_summary.total 439`. The
   pre-existing unlabeled "50 of 6148" correlations list was also fixed.
4. **Compliance roll-up** — 45 controls across CIS + MITRE ATT&CK.

**Deviation, stated:** `apply_framework_tags` was not used. It takes a
`BlastRadius`, not a `Finding`, so using it would have meant fabricating AI blast
radii for S3 buckets.

Correlation was also split from normalization: **1.41s → 0.08s**, with a test
asserting both paths agree.

## Verification

- `pytest -k "demo or estate or finding or compliance or graph"` — **2585 passed**
- `tests/test_demo_estate_findings.py` — 22 tests
- `mypy`, `ruff`, `make preflight` — clean
- UI: lint / tsc / vitest / build / `NEXT_EXPORT=1 build` — clean
- Re-verified after merging `main`: demo suites 67 passed

## Pre-existing, not introduced — worth their own issues

- **P1: `/v1/findings` returns `total: null` for scope filters.** `domain=cspm`,
  `provider=aws`, `environment=production` all give `total=None`; only `severity`
  gets a real total, so a filtered UI can only show its page count.
- **P2: two severity vocabularies on adjacent surfaces** — the facet emits
  `info`/`unknown`, `/v1/posture/counts` emits `unrated`. Both sum correctly;
  only the labels differ.
- **P2: `account_ref`/`region`/`environment` are dropped from public finding rows**
  by tier-A redaction, so a row cannot show the account its own `?account=` filter
  matched. `TIER_A_FIELDS` was deliberately **not** widened — the chain was
  remapped onto the existing vocabulary instead.
- `framework_mapping.nist_controls_for_cis_check` exists and is unused, so CSPM
  findings carry no `nist_800_53_tags`. Left alone: the NIST catalog already
  scores CIS via a separate path and wiring both risks double-counting.

## Honest gaps

- **No browser verification** — the Chrome extension is not connected. The page
  returns 200 and `ui/tests/demo-estate-page.test.tsx` renders the real component
  and asserts reconciliation, but light/dark visual state is unproven.
- **The `low` band holds 1 finding.** The shipped benchmark catalogs rate exactly
  one control `low` (azure 8.6). Real, not padded — low-severity checks were not
  invented to fill the strip.