### PR TITLE
feat(demo): project the enterprise estate into the graph

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1134,
+      "value": 1135,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 831,
+      "value": 832,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1134 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1135 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 831 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 832 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/src/agent_bom/demo_estate/estate_graph.py
+++ b/src/agent_bom/demo_estate/estate_graph.py
@@ -1,0 +1,473 @@
+"""Project the enterprise demo estate into the unified graph.
+
+:mod:`agent_bom.demo_estate.enterprise_composition` inventories 2,068 assets and
+:mod:`agent_bom.demo_estate.enterprise_findings` raises 439 findings on 407 of
+them, but that evidence reached only the demo story endpoint. The graph a
+prospect actually clicks was seeded independently from a 112-node hand-built
+showcase, so "one correlated graph at enterprise scale" rested on the 112.
+
+This module closes the gap. Three decisions carry the weight:
+
+**One id scheme.** A projected asset's graph node id *is* its estate
+``asset_id`` — the same string ``Finding.asset.identifier`` carries, the same
+string a correlation's ``asset_path`` walks, the same string an observation's
+``resource_ids`` names. Translating it here would be the split identity #4637
+removed for live cloud scans, re-created inside the demo. The grouping nodes the
+estate does not inventory (accounts, environments) use the graph builder's own
+identity-node spellings — ``account:<provider>:<id>``,
+``env:<provider>:<account>:<environment>`` — so an account discovered by a live
+scan and the same account in the estate are one node, not two.
+
+**Findings land on the inventoried asset.** Every misconfiguration node is
+``AFFECTS``-linked to a node that already exists because the estate inventoried
+it; a finding never materialises its own stub target. The node carries the
+``Finding.id`` it was projected from, so the findings list and the graph join on
+an identifier rather than on a label heuristic.
+
+**The hierarchy is the readable view.** Assets hang off
+org → account → environment via ``CONTAINS``, which is the only structure
+:mod:`agent_bom.graph.rollup` can collapse. Without it a 2,000-node estate
+renders as a hairball at any framerate.
+
+Nothing here invents severity or exposure: a node's severity is the worst
+severity of the findings actually raised against it, and an asset with no
+finding stays unrated rather than being quietly coloured.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from agent_bom.demo_estate.enterprise import EnterpriseEstate, EstateAsset
+from agent_bom.graph.container import AttackPath, UnifiedGraph
+from agent_bom.graph.edge import UnifiedEdge
+from agent_bom.graph.node import NodeDimensions, UnifiedNode
+from agent_bom.graph.severity import SEVERITY_RISK_SCORE, normalize_severity
+from agent_bom.graph.types import EntityType, RelationshipType
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from agent_bom.demo_estate.enterprise_correlation import EnterpriseCorrelation
+    from agent_bom.finding import Finding
+
+ESTATE_GRAPH_VERSION = "estate_graph.v1"
+
+# Data source stamped on every projected node/edge so a demo estate can always
+# be told apart from a real scan in the same graph.
+ESTATE_DATA_SOURCE = "demo-estate"
+
+# The estate resource type that *is* the organization, lifted out of the
+# account/environment hierarchy because it is the hierarchy's root.
+_ORG_RESOURCE_TYPE = "organization"
+
+# Estate resource type → graph entity type. Deliberately explicit rather than a
+# heuristic: an unmapped type falls back to CLOUD_RESOURCE, which the canvas
+# renders, instead of an ad-hoc string the canvas would silently drop (#4640).
+_RESOURCE_ENTITY_TYPES: dict[str, EntityType] = {
+    # Identities — the principal half of every correlated finding.
+    "iam_role": EntityType.ROLE,
+    "role": EntityType.ROLE,
+    "service_account": EntityType.SERVICE_ACCOUNT,
+    "service_principal": EntityType.SERVICE_PRINCIPAL,
+    # Data surfaces — what an attack path is trying to reach.
+    "bucket": EntityType.DATA_STORE,
+    "storage_account": EntityType.DATA_STORE,
+    "database": EntityType.DATA_STORE,
+    "sql_database": EntityType.DATA_STORE,
+    "table": EntityType.DATA_STORE,
+    "stage": EntityType.DATA_STORE,
+    "share": EntityType.DATA_STORE,
+    # Compute / platform.
+    "instance": EntityType.CLOUD_RESOURCE,
+    "virtual_machine": EntityType.CLOUD_RESOURCE,
+    "function": EntityType.CLOUD_RESOURCE,
+    "function_app": EntityType.CLOUD_RESOURCE,
+    "warehouse": EntityType.CLOUD_RESOURCE,
+    "key_vault": EntityType.CLOUD_RESOURCE,
+    "cluster": EntityType.CLUSTER,
+    "deployment": EntityType.CONTAINER,
+    "container_image": EntityType.CONTAINER,
+    # Code / CI.
+    "repository": EntityType.APPLICATION,
+    "workflow": EntityType.CI_JOB,
+    # AI estate.
+    "hosted_model": EntityType.MODEL,
+    "model_artifact": EntityType.MODEL,
+    "server": EntityType.SERVER,
+    "tool": EntityType.TOOL,
+}
+
+_DEFAULT_ENTITY_TYPE = EntityType.CLOUD_RESOURCE
+
+# Which provider names an account scope when several report assets into it. An
+# EKS cluster and the S3 buckets beside it share one AWS account number, so
+# keying the account node on ``(provider, scope)`` verbatim would split one
+# account into two. Preference order is fixed so the choice is deterministic and
+# the cloud that owns the billing boundary always wins.
+_ACCOUNT_PROVIDER_PREFERENCE: tuple[str, ...] = (
+    "aws",
+    "azure",
+    "gcp",
+    "snowflake",
+    "kubernetes",
+    "github",
+    "mcp",
+    "openai",
+    "anthropic",
+    "huggingface",
+    "enterprise",
+)
+
+# Correlation kinds whose asset path is a real multi-hop chain worth drawing.
+# A single-asset correlation has no path to draw.
+_MIN_CHAIN_HOPS = 2
+
+
+def estate_org_node_id(estate: EnterpriseEstate) -> str:
+    """The estate's organization asset id — the containment root."""
+    for asset in estate.assets:
+        if asset.resource_type == _ORG_RESOURCE_TYPE:
+            return asset.asset_id
+    return f"organization:{estate.estate_id}"
+
+
+def _account_providers(estate: EnterpriseEstate) -> dict[str, str]:
+    """Map every account scope to the one provider that names its node."""
+    seen: dict[str, set[str]] = {}
+    for asset in estate.assets:
+        if asset.resource_type == _ORG_RESOURCE_TYPE:
+            continue
+        seen.setdefault(asset.account_scope, set()).add(asset.provider)
+    resolved: dict[str, str] = {}
+    for scope, providers in seen.items():
+        for candidate in _ACCOUNT_PROVIDER_PREFERENCE:
+            if candidate in providers:
+                resolved[scope] = candidate
+                break
+        else:
+            resolved[scope] = sorted(providers)[0]
+    return resolved
+
+
+def estate_account_node_id(estate: EnterpriseEstate, account_scope: str) -> str:
+    """Graph node id for an account scope, in the builder's own spelling."""
+    provider = _account_providers(estate).get(account_scope, "cloud")
+    return f"account:{provider}:{account_scope}"
+
+
+def estate_environment_node_id(estate: EnterpriseEstate, account_scope: str, environment: str) -> str:
+    """Graph node id for one environment inside one account."""
+    provider = _account_providers(estate).get(account_scope, "cloud")
+    return f"env:{provider}:{account_scope}:{environment}"
+
+
+def entity_type_for_resource_type(resource_type: str) -> EntityType:
+    """Map an estate resource type onto a canvas-renderable entity type."""
+    return _RESOURCE_ENTITY_TYPES.get(resource_type, _DEFAULT_ENTITY_TYPE)
+
+
+def _compliance_tags(asset: EstateAsset) -> list[str]:
+    return sorted({classification.upper() for classification in asset.data_classifications})
+
+
+def _asset_node(asset: EstateAsset, estate: EnterpriseEstate) -> UnifiedNode:
+    """An inventory node, deliberately unrated.
+
+    Severity belongs to the finding, not to the thing it was raised against —
+    which is also what the live graph builder does for cloud resources. Copying
+    the worst finding's severity onto the asset would make the roll-up histogram
+    count the same risk twice and stop it reconciling with
+    ``summarize_estate_findings``.
+    """
+    return UnifiedNode(
+        id=asset.asset_id,
+        entity_type=entity_type_for_resource_type(asset.resource_type),
+        label=asset.display_name,
+        attributes={
+            "asset_id": asset.asset_id,
+            "native_id": asset.native_id,
+            "resource_id": asset.native_id,
+            "resource_name": asset.display_name,
+            "resource_type": asset.resource_type,
+            "cloud_provider": asset.provider,
+            "account_id": asset.account_scope,
+            "account_scope": asset.account_scope,
+            "region": asset.region,
+            "environment": asset.environment,
+            "owner": asset.owner,
+            "cost_center": asset.cost_center,
+            "data_classifications": list(asset.data_classifications),
+            "tags": dict(asset.tags),
+            "synthetic": True,
+            "fictional": True,
+            "estate_id": estate.estate_id,
+        },
+        compliance_tags=_compliance_tags(asset),
+        data_sources=[ESTATE_DATA_SOURCE],
+        dimensions=NodeDimensions(
+            cloud_provider=asset.provider,
+            environment=asset.environment,
+            surface=asset.resource_type,
+        ),
+    )
+
+
+def _finding_node_id(finding: Finding) -> str:
+    return f"misconfig:demo-estate:{finding.id}"
+
+
+def project_estate_into_graph(
+    graph: UnifiedGraph,
+    estate: EnterpriseEstate,
+    *,
+    findings: Sequence[Finding] = (),
+    correlations: Sequence[EnterpriseCorrelation] = (),
+) -> dict[str, object]:
+    """Project ``estate`` — inventory, posture, identity and incident chain — into ``graph``.
+
+    Returns the shape it produced so a caller (the demo bootstrap, a test, the
+    surfaces gate) can assert on it instead of re-counting the graph.
+
+    The graph is *extended*, never cleared: ``UnifiedGraph.add_node`` merges by
+    id, so an id the caller already seeded keeps its attributes and gains the
+    estate's. That is what lets the hand-built showcase chain and the estate
+    occupy one snapshot.
+    """
+    org_id = estate_org_node_id(estate)
+    account_providers = _account_providers(estate)
+
+    org_asset = next((a for a in estate.assets if a.asset_id == org_id), None)
+    graph.add_node(
+        UnifiedNode(
+            id=org_id,
+            entity_type=EntityType.ORG,
+            label=org_asset.display_name if org_asset is not None else estate.display_name,
+            attributes={
+                "org_id": org_asset.native_id if org_asset is not None else estate.estate_id,
+                "estate_id": estate.estate_id,
+                "synthetic": True,
+                "fictional": True,
+                "disclosure": estate.disclosure,
+            },
+            data_sources=[ESTATE_DATA_SOURCE],
+        )
+    )
+
+    def _edge(source: str, target: str, relationship: RelationshipType, **kwargs: object) -> None:
+        graph.add_edge(UnifiedEdge(source=source, target=target, relationship=relationship, **kwargs))  # type: ignore[arg-type]
+
+    accounts: set[str] = set()
+    environments: set[str] = set()
+    for asset in estate.assets:
+        if asset.asset_id == org_id:
+            continue
+        provider = account_providers[asset.account_scope]
+        account_id = f"account:{provider}:{asset.account_scope}"
+        env_id = f"env:{provider}:{asset.account_scope}:{asset.environment}"
+
+        if account_id not in accounts:
+            accounts.add(account_id)
+            graph.add_node(
+                UnifiedNode(
+                    id=account_id,
+                    entity_type=EntityType.ACCOUNT,
+                    label=asset.account_scope,
+                    attributes={
+                        "account_id": asset.account_scope,
+                        "cloud_provider": provider,
+                        "estate_id": estate.estate_id,
+                        "synthetic": True,
+                    },
+                    data_sources=[ESTATE_DATA_SOURCE],
+                    dimensions=NodeDimensions(cloud_provider=provider),
+                )
+            )
+            _edge(org_id, account_id, RelationshipType.CONTAINS)
+
+        if env_id not in environments:
+            environments.add(env_id)
+            graph.add_node(
+                UnifiedNode(
+                    id=env_id,
+                    entity_type=EntityType.ENVIRONMENT,
+                    label=asset.environment,
+                    attributes={
+                        "environment": asset.environment,
+                        "account_id": asset.account_scope,
+                        "cloud_provider": provider,
+                        "estate_id": estate.estate_id,
+                        "synthetic": True,
+                    },
+                    data_sources=[ESTATE_DATA_SOURCE],
+                    dimensions=NodeDimensions(cloud_provider=provider, environment=asset.environment),
+                )
+            )
+            _edge(account_id, env_id, RelationshipType.CONTAINS)
+
+        graph.add_node(_asset_node(asset, estate))
+        _edge(env_id, asset.asset_id, RelationshipType.CONTAINS)
+
+    finding_count = 0
+    identity_edges = 0
+    known_assets = {asset.asset_id for asset in estate.assets}
+    # Worst finding risk per asset. The asset node itself stays unrated (see
+    # ``_asset_node``), so this is the only place the posture on a hop is
+    # available to score a chain.
+    risk_by_asset: dict[str, float] = {}
+    for finding in findings:
+        asset_id = finding.asset.identifier or ""
+        if asset_id not in known_assets:
+            # A finding whose asset was never inventoried would need a stub
+            # target, which is precisely the split identity this module exists
+            # to avoid. ``enterprise_findings`` guarantees this never happens;
+            # skipping rather than fabricating keeps that guarantee testable.
+            continue
+        severity = normalize_severity(finding.severity)
+        risk = SEVERITY_RISK_SCORE.get(severity, 0.0)
+        risk_by_asset[asset_id] = max(risk_by_asset.get(asset_id, 0.0), risk)
+        node_id = _finding_node_id(finding)
+        graph.add_node(
+            UnifiedNode(
+                id=node_id,
+                entity_type=EntityType.MISCONFIGURATION,
+                label=finding.title,
+                severity=severity,
+                risk_score=SEVERITY_RISK_SCORE.get(severity, 0.0),
+                attributes={
+                    "finding_id": finding.id,
+                    "canonical_finding_id": finding.canonical_id,
+                    "finding_type": finding.finding_type.value,
+                    "check_id": str(finding.evidence.get("control_id") or ""),
+                    "cloud_provider": finding.provider or "",
+                    "resource_ids": [asset_id],
+                    "recommendation": finding.remediation or "",
+                    "configuration": finding.evidence.get("configuration") or {},
+                    "synthetic": True,
+                    "estate_id": estate.estate_id,
+                },
+                compliance_tags=[f"{tag.framework}:{tag.control}" for tag in finding.normalized_controls()],
+                data_sources=[ESTATE_DATA_SOURCE],
+                dimensions=NodeDimensions(
+                    cloud_provider=finding.provider or "",
+                    environment=finding.environment or "",
+                ),
+            )
+        )
+        # Two edges, two jobs. AFFECTS is the correlation the rest of the
+        # product reads (it is what the live builder emits for a CIS
+        # misconfiguration, and what attack-path fusion and the CNAPP overlay
+        # traverse). CONTAINS is what the roll-up walks: without it 439 findings
+        # sit outside the containment tree, blow past the 200-orphan cap, and the
+        # default estate view degrades into a truncated chip list instead of
+        # account → environment → resource → finding.
+        _edge(node_id, asset_id, RelationshipType.AFFECTS)
+        _edge(asset_id, node_id, RelationshipType.CONTAINS)
+        finding_count += 1
+
+        principal = str(finding.evidence.get("identity_asset_id") or "")
+        if principal and principal in known_assets and principal != asset_id:
+            _edge(
+                principal,
+                asset_id,
+                RelationshipType.CAN_ACCESS,
+                evidence={"reason": "estate_posture_finding", "finding_id": finding.id},
+            )
+            identity_edges += 1
+
+    chain_edges, paths = _project_incident_chains(graph, correlations, known_assets, risk_by_asset)
+
+    return {
+        "version": ESTATE_GRAPH_VERSION,
+        "estate_id": estate.estate_id,
+        "assets": len(estate.assets),
+        "accounts": len(accounts),
+        "environments": len(environments),
+        "findings": finding_count,
+        "identity_edges": identity_edges,
+        "chain_edges": chain_edges,
+        "attack_paths": paths,
+    }
+
+
+def _project_incident_chains(
+    graph: UnifiedGraph,
+    correlations: Sequence[EnterpriseCorrelation],
+    known_assets: set[str],
+    risk_by_asset: dict[str, float],
+) -> tuple[int, int]:
+    """Draw every multi-hop correlated chain as consecutive traversable edges.
+
+    ``ACCESSED`` is the runtime relationship: each hop is a step the estate's own
+    audit evidence recorded, not an inferred network reachability claim.
+    """
+    chain_edges = 0
+    paths = 0
+    # ``UnifiedGraph.add_node``/``add_edge`` dedupe by identity, but
+    # ``attack_paths`` is a plain list: re-projecting onto the same graph
+    # appended a second copy of every chain, which double-counts on the
+    # exposure-path queue and in ``stats.attack_path_count``.
+    existing_paths = {tuple(path.hops) for path in graph.attack_paths}
+    for correlation in sorted(correlations, key=lambda c: c.correlation_id):
+        hops = [asset_id for asset_id in correlation.asset_path if asset_id in known_assets]
+        if len(hops) < _MIN_CHAIN_HOPS or tuple(hops) in existing_paths:
+            continue
+        existing_paths.add(tuple(hops))
+        edge_ids: list[str] = []
+        for source, target in zip(hops, hops[1:], strict=False):
+            graph.add_edge(
+                UnifiedEdge(
+                    source=source,
+                    target=target,
+                    relationship=RelationshipType.ACCESSED,
+                    evidence={
+                        "correlation_id": correlation.correlation_id,
+                        "correlation_kind": correlation.kind,
+                        "evidence_quality": correlation.evidence_quality,
+                    },
+                    provenance={"source": ESTATE_DATA_SOURCE, "trace_id": correlation.trace_id},
+                )
+            )
+            edge_ids.append(f"{RelationshipType.ACCESSED.value}:{source}:{target}")
+            chain_edges += 1
+        graph.attack_paths.append(
+            AttackPath(
+                source=hops[0],
+                target=hops[-1],
+                hops=list(hops),
+                edges=edge_ids,
+                composite_risk=_chain_risk(graph, hops, risk_by_asset),
+                summary=(
+                    f"{correlation.kind.replace('_', ' ')} correlated across "
+                    f"{len(hops)} assets from {len(correlation.sources)} evidence source(s)"
+                ),
+            )
+        )
+        paths += 1
+    return chain_edges, paths
+
+
+def _chain_risk(graph: UnifiedGraph, hops: Sequence[str], risk_by_asset: dict[str, float]) -> float:
+    """Worst risk anywhere on the chain — from the hops' findings, not the hops.
+
+    Inventory nodes are deliberately unrated, so scoring a chain from
+    ``node.risk_score`` alone always returned 0.0 and sorted the estate's own
+    incident below every hand-built path in the exposure-path queue.
+    """
+    worst = 0.0
+    for hop in hops:
+        worst = max(worst, risk_by_asset.get(hop, 0.0))
+        node = graph.nodes.get(hop)
+        if node is not None:
+            worst = max(worst, float(node.risk_score or 0.0))
+    return worst
+
+
+__all__ = [
+    "ESTATE_DATA_SOURCE",
+    "ESTATE_GRAPH_VERSION",
+    "entity_type_for_resource_type",
+    "estate_account_node_id",
+    "estate_environment_node_id",
+    "estate_org_node_id",
+    "project_estate_into_graph",
+]

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -27,8 +27,17 @@ ShowcaseProfile = Literal["baseline", "current"]
 SHOWCASE_TENANT = "default"
 SHOWCASE_SCAN_ID = "showcase"
 SHOWCASE_BASELINE_SCAN_ID = "showcase-baseline"
-SHOWCASE_BASELINE_CREATED_AT = "2026-06-01T12:00:00+00:00"
-SHOWCASE_CURRENT_CREATED_AT = "2026-06-08T12:00:00+00:00"
+# Bumped when the seeded snapshot's *shape* changes so ``_showcase_seed_is_current``
+# treats an older seed as stale and refreshes it. A DB seeded before the
+# enterprise estate was projected in still holds the 112-node showcase; without a
+# bump it would keep it forever and the demo would silently under-report.
+SHOWCASE_BASELINE_CREATED_AT = "2026-08-01T12:00:00+00:00"
+SHOWCASE_CURRENT_CREATED_AT = "2026-08-08T12:00:00+00:00"
+
+# The estate's containment root, once projected, becomes the graph's single
+# top-level container. The hand-built showcase org hangs off it so the demo reads
+# as one estate rather than two unrelated roots.
+SHOWCASE_ORG_ID = "org:corp"
 
 _logger = logging.getLogger(__name__)
 
@@ -676,6 +685,10 @@ def seed_showcase_graph_if_empty(
     finalize_showcase_snapshot(baseline_graph, profile="baseline")
     _annotate_demo_identity_risk(baseline_graph)
     _materialize_showcase_attack_paths(baseline_graph)
+    # After the showcase's own attack paths are derived, so the hand-built hero
+    # chains stay first in the exposure-path queue and the estate's correlated
+    # chains extend it rather than displacing it.
+    project_estate_onto_showcase(baseline_graph, tenant_id=tenant_id, profile="baseline")
     graph_store.save_graph(baseline_graph)
 
     current_graph, identity_store, drift_store = build_showcase_graph(
@@ -694,8 +707,58 @@ def seed_showcase_graph_if_empty(
     finalize_showcase_snapshot(current_graph, profile="current")
     _annotate_demo_identity_risk(current_graph)
     _materialize_showcase_attack_paths(current_graph)
+    project_estate_onto_showcase(current_graph, tenant_id=tenant_id, profile="current")
     graph_store.save_graph(current_graph)
     return True
+
+
+def project_estate_onto_showcase(
+    graph: UnifiedGraph,
+    *,
+    tenant_id: str = SHOWCASE_TENANT,
+    profile: ShowcaseProfile = "current",
+) -> dict[str, object]:
+    """Extend a showcase snapshot with the enterprise estate.
+
+    *Extend*, not replace. The showcase's hand-built incident chain
+    (``agent:cursor`` → ``server:shell-runner-server`` → ``pkg:pyyaml@5.3`` →
+    ``vuln:CVE-2020-14343`` → ``cred:aws-secret``) is the demo's headline and is
+    asserted by ``tests/test_demo_estate_bootstrap.py``; it is untouched here.
+    Seeding the estate as a *separate* snapshot was the alternative and was
+    rejected: the read path serves the newest snapshot, so a prospect would land
+    on one of the two estates and the correlation between them — the AWS account
+    the hand-built chain runs in is an account the estate inventories — would
+    never be drawn.
+
+    ``profile`` follows the estate's own stage semantics: the baseline snapshot
+    predates the collection window, so it carries the inventory but neither the
+    posture findings nor the correlated chain that the window's evidence
+    produced. Both appear in ``current``, which is what makes the drift lens show
+    posture arriving rather than a relabelling of the same set.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+    from agent_bom.demo_estate.enterprise_correlation import build_estate_correlations
+    from agent_bom.demo_estate.enterprise_findings import build_estate_findings
+    from agent_bom.demo_estate.estate_graph import (
+        estate_org_node_id,
+        project_estate_into_graph,
+    )
+
+    estate = build_demo_estate(tenant_id=tenant_id)
+    is_baseline = profile == "baseline"
+    summary = project_estate_into_graph(
+        graph,
+        estate,
+        findings=() if is_baseline else build_estate_findings(estate),
+        correlations=() if is_baseline else build_estate_correlations(estate),
+    )
+    _ensure_showcase_edge(
+        graph,
+        estate_org_node_id(estate),
+        SHOWCASE_ORG_ID,
+        RelationshipType.CONTAINS,
+    )
+    return summary
 
 
 def _materialize_showcase_attack_paths(graph: UnifiedGraph) -> None:

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -122,7 +122,14 @@ def test_demo_estate_story_api_exposes_normalized_evidence_only(
 
 
 def test_demo_estate_graph_is_a_rich_multi_agent_estate(demo_estate_client: TestClient) -> None:
-    payload = demo_estate_client.get("/v1/graph", headers=VIEWER).json()
+    # Reads the whole snapshot rather than the default page. Since the
+    # enterprise estate is projected into this snapshot it holds ~2,900 nodes,
+    # and the default page is 500 ordered by severity — which the estate's 439
+    # posture findings now fill. The agents/servers/packages asserted here are
+    # unrated inventory, so a default-page read would be testing the pager, not
+    # the estate. ``test_demo_estate_default_graph_page_declares_its_truncation``
+    # covers the bounded read.
+    payload = _full_graph(demo_estate_client)
     nodes = payload.get("nodes") or []
     by_type = Counter(n.get("entity_type") for n in nodes)
 
@@ -150,8 +157,13 @@ def test_demo_estate_graph_is_a_rich_multi_agent_estate(demo_estate_client: Test
 
 def test_demo_estate_headline_blast_radius_chain(demo_estate_client: TestClient) -> None:
     """agent -> MCP server -> vulnerable package -> critical CVE -> reachable
-    credential + reachable run_shell tool -> potential RCE renders in the graph."""
-    payload = demo_estate_client.get("/v1/graph", headers=VIEWER).json()
+    credential + reachable run_shell tool -> potential RCE renders in the graph.
+
+    Whole snapshot, not the default page: the hand-built chain is *extended* by
+    the projected enterprise estate, never replaced, but its unrated inventory
+    nodes no longer land in a 500-row severity-ranked page.
+    """
+    payload = _full_graph(demo_estate_client)
     node_ids = {n.get("id") for n in payload.get("nodes") or []}
     edges = payload.get("edges") or []
     edge_pairs = {(e.get("source"), e.get("target")) for e in edges}
@@ -465,7 +477,9 @@ def test_demo_estate_showcase_cloud_hierarchy_and_exposure(demo_estate_client: T
 
 
 def test_demo_estate_graph_tags_runtime_evidence_tiers(demo_estate_client: TestClient) -> None:
-    payload = demo_estate_client.get("/v1/graph", headers=VIEWER).json()
+    # Whole snapshot: runtime-evidence tiers sit on unrated tool/tool-call nodes,
+    # which the estate's rated findings now outrank on the default page.
+    payload = _full_graph(demo_estate_client)
     attrs_by_id = {
         node.get("id"): (node.get("attributes") or {}) for node in payload.get("nodes") or []
     }
@@ -776,3 +790,138 @@ def test_demo_estate_scan_findings_restored_after_restart(
 
     after = demo_estate_client.get("/v1/findings", headers=VIEWER, params={"limit": 3}).json()
     assert after.get("total", 0) == before.get("total", 0), (before.get("total"), after.get("total"))
+
+
+# ── Enterprise estate projected into the graph ────────────────────────────
+#
+# The estate holds 2,068 assets and 439 findings on 407 of them. Once it is in
+# the graph the snapshot no longer fits one severity-ranked API page, so these
+# read the whole snapshot explicitly and separately assert that the *default*
+# page says so rather than reading as the estate.
+
+
+def _full_graph(client: TestClient) -> dict:
+    payload = client.get("/v1/graph", headers=VIEWER, params={"limit": 5000}).json()
+    assert payload.get("completeness", {}).get("complete") is True, payload.get("completeness")
+    return payload
+
+
+def test_demo_estate_graph_carries_the_projected_estate(demo_estate_client: TestClient) -> None:
+    """The graph a prospect clicks IS the estate, not a 112-node stand-in."""
+    payload = _full_graph(demo_estate_client)
+    nodes = payload.get("nodes") or []
+    node_ids = {n.get("id") for n in nodes}
+    by_type = Counter(n.get("entity_type") for n in nodes)
+
+    assert len(nodes) >= 2500, len(nodes)
+    # org → account → environment → asset, all four levels present.
+    assert "organization:northstar-health-ai" in node_ids
+    assert "account:aws:123456789012" in node_ids
+    assert "env:aws:123456789012:production" in node_ids
+    assert "cloud_resource:aws:iam:role:member-copilot-prod" in node_ids
+    assert by_type["account"] >= 40, by_type
+    assert by_type["environment"] >= 100, by_type
+    assert by_type["misconfiguration"] >= 439, by_type
+
+    contains = {
+        (row.get("source"), row.get("target"))
+        for row in payload.get("edges") or []
+        if row.get("relationship") == "contains"
+    }
+    assert ("organization:northstar-health-ai", "account:aws:123456789012") in contains
+    assert ("account:aws:123456789012", "env:aws:123456789012:production") in contains
+    assert (
+        "env:aws:123456789012:production",
+        "cloud_resource:aws:iam:role:member-copilot-prod",
+    ) in contains
+    # One estate, one root: the hand-built showcase org hangs off the estate org.
+    assert ("organization:northstar-health-ai", "org:corp") in contains
+
+
+def test_demo_estate_graph_incident_chain_is_traversable(demo_estate_client: TestClient) -> None:
+    """workflow → role → workload → MCP tool → PHI table → hosted model."""
+    payload = _full_graph(demo_estate_client)
+    pairs = {(row.get("source"), row.get("target")) for row in payload.get("edges") or []}
+    chain = (
+        "github:workflow:member-copilot/deploy-prod",
+        "cloud_resource:aws:iam:role:member-copilot-prod",
+        "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
+        "mcp:tool:clinical-analytics/execute_sql",
+        "snowflake:table:nh_prod/analytics/phi/patient_summary",
+        "model:openai:gpt-4.1",
+    )
+    node_ids = {n.get("id") for n in payload.get("nodes") or []}
+    for hop in chain:
+        assert hop in node_ids, f"missing incident hop {hop}"
+    for source, target in zip(chain, chain[1:], strict=False):
+        assert (source, target) in pairs, f"incident chain broken at {source} -> {target}"
+
+
+def test_demo_estate_findings_land_on_inventoried_graph_nodes(
+    demo_estate_client: TestClient,
+) -> None:
+    """No finding materialises its own stub target (the #4637 defect class)."""
+    payload = _full_graph(demo_estate_client)
+    nodes_by_id = {n.get("id"): n for n in payload.get("nodes") or []}
+    affected: set[str] = set()
+    for row in payload.get("edges") or []:
+        if row.get("relationship") != "affects":
+            continue
+        source = nodes_by_id.get(row.get("source")) or {}
+        if source.get("entity_type") != "misconfiguration":
+            continue
+        target = nodes_by_id.get(row.get("target"))
+        assert target is not None, row
+        if (target.get("attributes") or {}).get("estate_id"):
+            affected.add(row.get("target"))
+    assert len(affected) >= 407, len(affected)
+
+
+def test_demo_estate_default_graph_page_declares_its_truncation(
+    demo_estate_client: TestClient,
+) -> None:
+    """A bounded page must never read as the whole estate (#4631)."""
+    payload = demo_estate_client.get("/v1/graph", headers=VIEWER).json()
+    completeness = payload.get("completeness") or {}
+    stats = payload.get("stats") or {}
+
+    assert completeness.get("truncated") is True, completeness
+    assert completeness.get("complete") is False, completeness
+    assert completeness.get("returned") == len(payload.get("nodes") or [])
+    assert completeness.get("reason"), completeness
+    # The two numbers a reader reconciles must agree.
+    assert completeness.get("total") == stats.get("total_nodes_source"), (completeness, stats)
+    assert completeness["total"] > completeness["returned"]
+
+
+def test_demo_estate_graph_rolls_up_to_a_readable_estate(demo_estate_client: TestClient) -> None:
+    """2,000 raw nodes are unreadable — the default read is account → env → resource."""
+    rollup = demo_estate_client.get("/v1/graph/rollup", headers=VIEWER).json()
+    top_level = rollup.get("top_level") or []
+    containers = [row for row in top_level if row.get("is_container") and row.get("has_children")]
+    root_ids = {row.get("id") for row in containers}
+    assert "organization:northstar-health-ai" in root_ids, root_ids
+
+    root = next(row for row in containers if row["id"] == "organization:northstar-health-ai")
+    assert root["aggregate"]["descendant_count"] >= 2500, root["aggregate"]
+    assert rollup["summary"]["total_nodes_source"] >= 2500, rollup["summary"]
+
+    accounts = demo_estate_client.get(
+        "/v1/graph/rollup",
+        headers=VIEWER,
+        params={"node": "organization:northstar-health-ai"},
+    ).json()
+    account_ids = {row.get("id") for row in accounts.get("children") or []}
+    assert "account:aws:123456789012" in account_ids
+    assert len(account_ids) >= 40, len(account_ids)
+
+    envs = demo_estate_client.get(
+        "/v1/graph/rollup", headers=VIEWER, params={"node": "account:aws:123456789012"}
+    ).json()
+    env_children = {row.get("id"): row for row in envs.get("children") or []}
+    assert "env:aws:123456789012:production" in env_children, list(env_children)
+
+    resources = demo_estate_client.get(
+        "/v1/graph/rollup", headers=VIEWER, params={"node": "env:aws:123456789012:production"}
+    ).json()
+    assert resources.get("children"), resources

--- a/tests/test_demo_estate_graph_projection.py
+++ b/tests/test_demo_estate_graph_projection.py
@@ -1,0 +1,285 @@
+"""The enterprise demo estate must exist in the graph, not only in the story.
+
+``build_demo_estate`` produces 2,068 assets and ``build_estate_findings`` 439
+findings on 407 of them, yet the graph a prospect clicks was seeded separately
+from a 112-node hand-built showcase. These tests pin the projection: the estate
+is one correlated graph — org → account → environment → asset, each finding on
+the asset it was raised against, the incident chain traversable end to end — and
+the hand-built headline chain survives it.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+
+import pytest
+
+from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+from agent_bom.demo_estate.enterprise_correlation import build_estate_correlations
+from agent_bom.demo_estate.enterprise_findings import build_estate_findings
+from agent_bom.demo_estate.estate_graph import (
+    ESTATE_GRAPH_VERSION,
+    estate_account_node_id,
+    estate_environment_node_id,
+    estate_org_node_id,
+    project_estate_into_graph,
+)
+from agent_bom.graph.container import UnifiedGraph
+from agent_bom.graph.rollup import drill_down, rollup_view
+from agent_bom.graph.types import EntityType, RelationshipType
+
+# The correlated incident the estate exists to demonstrate: a workflow assumes a
+# role, the role runs a workload, the workload calls an MCP tool, the tool reads
+# a PHI table, and the table's rows leave through a hosted model.
+INCIDENT_CHAIN: tuple[str, ...] = (
+    "github:workflow:member-copilot/deploy-prod",
+    "cloud_resource:aws:iam:role:member-copilot-prod",
+    "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
+    "mcp:tool:clinical-analytics/execute_sql",
+    "snowflake:table:nh_prod/analytics/phi/patient_summary",
+    "model:openai:gpt-4.1",
+)
+
+
+@pytest.fixture(scope="module")
+def estate():
+    return build_demo_estate(tenant_id="default")
+
+
+@pytest.fixture(scope="module")
+def estate_findings(estate):
+    return build_estate_findings(estate)
+
+
+@pytest.fixture(scope="module")
+def projected(estate, estate_findings):
+    graph = UnifiedGraph(scan_id="estate-test", tenant_id="default")
+    summary = project_estate_into_graph(
+        graph,
+        estate,
+        findings=estate_findings,
+        correlations=build_estate_correlations(estate),
+    )
+    return graph, summary
+
+
+def _edge_pairs(graph: UnifiedGraph) -> set[tuple[str, str, str]]:
+    return {
+        (
+            edge.source,
+            edge.target,
+            edge.relationship.value if isinstance(edge.relationship, RelationshipType) else str(edge.relationship),
+        )
+        for edge in graph.edges
+    }
+
+
+def test_every_estate_asset_becomes_one_node_under_its_own_id(projected, estate) -> None:
+    """The estate's ``asset_id`` IS the node id — no second spelling to reconcile.
+
+    ``enterprise_findings`` guarantees a finding's asset identifier is the
+    estate's ``asset_id``; a translation layer here would reintroduce exactly the
+    split identity #4637 removed.
+    """
+    graph, summary = projected
+    for asset in estate.assets:
+        assert asset.asset_id in graph.nodes, f"estate asset absent from graph: {asset.asset_id}"
+    assert summary["assets"] == len(estate.assets)
+    assert summary["version"] == ESTATE_GRAPH_VERSION
+
+
+def test_hierarchy_is_org_account_environment_asset(projected, estate) -> None:
+    """Rollup can only collapse what CONTAINS connects."""
+    graph, _ = projected
+    pairs = _edge_pairs(graph)
+    contains = RelationshipType.CONTAINS.value
+
+    org_id = estate_org_node_id(estate)
+    assert graph.nodes[org_id].entity_type is EntityType.ORG
+
+    # The AWS account carrying the incident, its production environment, and the
+    # role the workflow assumes.
+    account_id = estate_account_node_id(estate, "123456789012")
+    env_id = estate_environment_node_id(estate, "123456789012", "production")
+    role_id = "cloud_resource:aws:iam:role:member-copilot-prod"
+
+    assert account_id == "account:aws:123456789012", account_id
+    assert graph.nodes[account_id].entity_type is EntityType.ACCOUNT
+    assert graph.nodes[env_id].entity_type is EntityType.ENVIRONMENT
+    assert (org_id, account_id, contains) in pairs
+    assert (account_id, env_id, contains) in pairs
+    assert (env_id, role_id, contains) in pairs
+
+    # Every asset reaches the root through exactly that three-hop spine.
+    parents = {edge.target: edge.source for edge in graph.edges if edge.relationship is RelationshipType.CONTAINS}
+    for asset in estate.assets:
+        if asset.asset_id == org_id:
+            continue
+        env = parents.get(asset.asset_id)
+        assert env is not None, f"asset has no environment parent: {asset.asset_id}"
+        account = parents.get(env)
+        assert account is not None, f"environment has no account parent: {env}"
+        assert parents.get(account) == org_id, f"account {account} is not under the estate root"
+
+
+def test_findings_attach_to_the_inventoried_asset(projected, estate, estate_findings) -> None:
+    """407 distinct inventoried assets, zero stubs — the guarantee #4658 shipped."""
+    graph, summary = projected
+    asset_ids = {asset.asset_id for asset in estate.assets}
+
+    finding_nodes = [n for n in graph.nodes.values() if n.entity_type is EntityType.MISCONFIGURATION]
+    assert len(finding_nodes) == len(estate_findings) == 439, len(finding_nodes)
+
+    affected: set[str] = set()
+    for edge in graph.edges:
+        if edge.relationship is not RelationshipType.AFFECTS:
+            continue
+        if graph.nodes[edge.source].entity_type is not EntityType.MISCONFIGURATION:
+            continue
+        assert edge.target in asset_ids, f"finding attached to a non-inventoried node: {edge.target}"
+        affected.add(edge.target)
+    assert len(affected) == 407, len(affected)
+    assert summary["findings"] == 439
+
+    # Every finding node carries the Finding.id it was projected from, so the
+    # findings list and the graph join without a heuristic.
+    finding_ids = {f.id for f in estate_findings}
+    for node in finding_nodes:
+        assert node.attributes.get("finding_id") in finding_ids
+
+
+def test_incident_chain_is_traversable_end_to_end(projected) -> None:
+    """The six-hop correlated chain renders as consecutive edges, not prose."""
+    graph, summary = projected
+    pairs = {(source, target) for source, target, _ in _edge_pairs(graph)}
+    for node_id in INCIDENT_CHAIN:
+        assert node_id in graph.nodes, f"incident hop missing: {node_id}"
+    for source, target in zip(INCIDENT_CHAIN, INCIDENT_CHAIN[1:], strict=False):
+        assert (source, target) in pairs, f"incident chain broken at {source} -> {target}"
+    assert summary["chain_edges"] >= len(INCIDENT_CHAIN) - 1
+
+    # ...and is materialized as an attack path so the exposure-path queue and the
+    # ranked views see it without re-deriving.
+    chains = [p for p in graph.attack_paths if list(p.hops) == list(INCIDENT_CHAIN)]
+    assert chains, [p.hops for p in graph.attack_paths]
+
+    # The exposure-path queue ranks by composite risk. Inventory nodes are
+    # deliberately unrated, so a chain scored only from its hops' node severity
+    # is always 0.0 and the estate's own incident sorts below every hand-built
+    # one — an under-claim that hides the thing the demo exists to show. Score it
+    # from the findings raised on the hops instead.
+    assert chains[0].composite_risk >= 8.0, chains[0].composite_risk
+
+
+def test_identity_reaches_the_asset_its_finding_names(projected, estate_findings) -> None:
+    """Turn "a bucket is misconfigured" into "this principal can read this bucket"."""
+    graph, _ = projected
+    pairs = {(s, t) for s, t, rel in _edge_pairs(graph) if rel == RelationshipType.CAN_ACCESS.value}
+    checked = 0
+    for finding in estate_findings:
+        principal = str(finding.evidence.get("identity_asset_id") or "")
+        if not principal or principal == finding.asset.identifier:
+            # A control raised *on* a role names that role as its own principal.
+            # A self-loop is not an access relationship and CONTAINS-shaped
+            # traversals would cycle on it, so the projection drops it.
+            continue
+        assert (principal, finding.asset.identifier) in pairs, (
+            f"finding names {principal} but the graph has no CAN_ACCESS edge to {finding.asset.identifier}"
+        )
+        checked += 1
+    assert checked > 300, checked
+
+
+def test_rollup_collapses_the_estate_to_one_readable_root(projected, estate) -> None:
+    """2,000 raw nodes are unreadable; the default read is account → env → resource."""
+    graph, _ = projected
+    view = rollup_view(graph)
+    containers = [row for row in view["top_level"] if row.get("is_container") and row.get("has_children")]
+    org_id = estate_org_node_id(estate)
+    roots = [row for row in containers if row["id"] == org_id]
+    assert roots, [row["id"] for row in containers]
+    root = roots[0]
+    assert root["entity_type"] == EntityType.ORG.value
+    assert root["aggregate"]["descendant_count"] >= 2000, root["aggregate"]["descendant_count"]
+
+    # 40 account scopes, not the 46 (provider, scope) pairs the inventory holds:
+    # an EKS cluster and the S3 buckets beside it share one AWS account number,
+    # and the projection must not split one account into two nodes.
+    accounts = drill_down(graph, org_id)["children"]
+    assert len(accounts) == 40, len(accounts)
+    assert len({(a.provider, a.account_scope) for a in estate.assets}) == 46
+    assert {row["entity_type"] for row in accounts} == {EntityType.ACCOUNT.value}
+
+    envs = drill_down(graph, "account:aws:123456789012")["children"]
+    assert {row["entity_type"] for row in envs} == {EntityType.ENVIRONMENT.value}
+    assert {row["label"] for row in envs} >= {"production"}
+
+    resources = drill_down(graph, estate_environment_node_id(estate, "123456789012", "production"))["children"]
+    assert resources, resources
+    assert EntityType.ENVIRONMENT.value not in {row["entity_type"] for row in resources}
+
+
+def test_projection_emits_only_entity_types_the_canvas_can_render(projected) -> None:
+    """A node type the canvas has no mapping for vanishes silently (#4640).
+
+    The UI's coverage test asserts every ``EntityType`` maps to a renderer, so
+    staying inside the enum is the guarantee — an ad-hoc string would not be.
+    """
+    graph, _ = projected
+    emitted = {node.entity_type for node in graph.nodes.values()}
+    assert emitted, "projection emitted no nodes"
+    for entity_type in emitted:
+        assert isinstance(entity_type, EntityType), entity_type
+    counts = Counter(n.entity_type.value for n in graph.nodes.values())
+    # The estate is genuinely multi-shaped: identities, data surfaces, compute,
+    # code and AI assets all present, not one undifferentiated bucket.
+    for required in ("role", "service_account", "service_principal", "data_store", "cluster", "model", "ci_job"):
+        assert counts.get(required, 0) > 0, counts
+
+
+def test_a_bounded_load_of_the_estate_never_reads_as_the_whole_estate(tmp_path, projected) -> None:
+    """A trimmed estate must not be byte-identical to a whole one (#4631).
+
+    The shipped 25,000-node investigation budget does NOT bind at this size — the
+    projected snapshot is ~2,800 nodes — so the honest thing to verify is that the
+    budget *path* still reports correctly when it does bind, and that
+    ``completeness.total`` and ``stats.total_nodes_source`` name the estate rather
+    than the page.
+    """
+    from agent_bom.api.graph_store import SQLiteGraphStore
+
+    graph, _ = projected
+    store = SQLiteGraphStore(db_path=tmp_path / "budget.db")
+    store.save_graph(graph)
+    total = len(graph.nodes)
+
+    unbounded = store.load_graph(tenant_id="default", scan_id="estate-test", node_budget=25_000)
+    assert unbounded.completeness.truncated is False
+    assert len(unbounded.nodes) == total
+    assert unbounded.stats()["total_nodes_source"] == total
+
+    bounded = store.load_graph(tenant_id="default", scan_id="estate-test", node_budget=1_000)
+    assert len(bounded.nodes) == 1_000
+    assert bounded.completeness.truncated is True
+    assert bounded.completeness.reason == "node_budget"
+    assert bounded.completeness.total_nodes == total
+    # The two numbers a reader reconciles agree, and neither reports the page.
+    assert bounded.stats()["total_nodes_source"] == total
+    assert bounded.stats()["total_nodes"] == 1_000
+    assert bounded.to_dict()["completeness"] != unbounded.to_dict()["completeness"]
+
+
+def test_projection_is_deterministic(estate, estate_findings) -> None:
+    """A demo that shifts between runs cannot be screenshotted or diffed."""
+    correlations = build_estate_correlations(estate)
+    shapes = []
+    for _ in range(2):
+        graph = UnifiedGraph(scan_id="estate-test", tenant_id="default")
+        project_estate_into_graph(graph, estate, findings=estate_findings, correlations=correlations)
+        shapes.append(
+            (
+                sorted(graph.nodes),
+                sorted((e.source, e.target, e.relationship.value) for e in graph.edges),
+            )
+        )
+    assert shapes[0] == shapes[1]

--- a/tests/test_showcase_graph_seeding.py
+++ b/tests/test_showcase_graph_seeding.py
@@ -90,3 +90,65 @@ def test_does_not_shadow_a_real_scan(store: SQLiteGraphStore) -> None:
     assert scan_ids.isdisjoint({SHOWCASE_SCAN_ID, SHOWCASE_BASELINE_SCAN_ID})
     # The fresh scan remains the graph the read path defaults to.
     assert store.latest_snapshot_id(tenant_id=SHOWCASE_TENANT) == "aws-scan-2026-07-14"
+
+
+def test_seeded_estate_is_isolated_per_tenant(store: SQLiteGraphStore) -> None:
+    """Two tenants seed the SAME node ids; neither may drop or leak.
+
+    The projected estate reuses its own ``asset_id`` values as graph node ids, so
+    every tenant seeds an identical id set. A dedup key that omitted the tenant
+    would silently drop the second tenant's rows and leave its graph reading as
+    the first tenant's — the isolation defect class the 2026-07-28 audit found in
+    the governance chain.
+    """
+    assert seed_showcase_graph_if_empty(store, tenant_id="tenant-a") is True
+    assert seed_showcase_graph_if_empty(store, tenant_id="tenant-b") is True
+
+    probe = "cloud_resource:aws:iam:role:member-copilot-prod"
+    for tenant in ("tenant-a", "tenant-b"):
+        graph = store.load_graph(tenant_id=tenant, scan_id=SHOWCASE_SCAN_ID)
+        assert len(graph.nodes) > 2500, (tenant, len(graph.nodes))
+        assert probe in graph.nodes, tenant
+        assert graph.tenant_id == tenant
+
+    # A third tenant that was never seeded sees nothing at all.
+    empty = store.load_graph(tenant_id="tenant-c", scan_id=SHOWCASE_SCAN_ID)
+    assert not empty.nodes
+
+
+def test_estate_projection_is_idempotent_on_one_graph() -> None:
+    """Re-projecting must merge, never duplicate.
+
+    ``seed_showcase_graph_if_empty`` projects once per snapshot today, but the
+    projection is a public entry point and a duplicated attack path or edge is
+    invisible until it double-counts on a screen.
+    """
+    from agent_bom.demo_estate.showcase_graph import project_estate_onto_showcase
+
+    graph = UnifiedGraph(scan_id=SHOWCASE_SCAN_ID, tenant_id=SHOWCASE_TENANT)
+    project_estate_onto_showcase(graph, tenant_id=SHOWCASE_TENANT, profile="current")
+    first = (len(graph.nodes), len(graph.edges), len(graph.attack_paths))
+
+    project_estate_onto_showcase(graph, tenant_id=SHOWCASE_TENANT, profile="current")
+    assert (len(graph.nodes), len(graph.edges), len(graph.attack_paths)) == first
+
+
+def test_baseline_snapshot_carries_inventory_without_the_collection_window() -> None:
+    """Baseline predates the evidence window: inventory yes, posture no.
+
+    That is what makes the drift lens show posture *arriving* between the two
+    snapshots rather than relabelling the same set.
+    """
+    from agent_bom.demo_estate.showcase_graph import project_estate_onto_showcase
+
+    baseline = UnifiedGraph(scan_id=SHOWCASE_BASELINE_SCAN_ID, tenant_id=SHOWCASE_TENANT)
+    summary = project_estate_onto_showcase(baseline, tenant_id=SHOWCASE_TENANT, profile="baseline")
+    assert summary["assets"] == 2068
+    assert summary["findings"] == 0
+    assert summary["chain_edges"] == 0
+    assert not [n for n in baseline.nodes.values() if n.entity_type is EntityType.MISCONFIGURATION]
+
+    current = UnifiedGraph(scan_id=SHOWCASE_SCAN_ID, tenant_id=SHOWCASE_TENANT)
+    current_summary = project_estate_onto_showcase(current, tenant_id=SHOWCASE_TENANT, profile="current")
+    assert current_summary["findings"] == 439
+    assert len(current.nodes) > len(baseline.nodes)

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -142,6 +142,7 @@ import {
   rollupDismissedForPreference,
   rollupViewHasContainers,
 } from "@/lib/graph-rollup-default";
+import { graphResponseIsTruncated } from "@/lib/graph-truncation";
 import {
   applyFilters,
   decodeFiltersFromParams,
@@ -2396,9 +2397,13 @@ function GraphPageInner() {
   );
 
   // No numbered pagination — the full current-scan graph loads at once (see the
-  // fetch effect). `graphTruncated` only fires when a scan exceeds the render
-  // budget, in which case the overview aggregates rather than paging.
-  const graphTruncated = graphData?.pagination.has_more === true;
+  // fetch effect). Two independent cuts can still make that partial: the render
+  // budget (surfaces as `pagination.has_more`) and the API's load-time node
+  // budget, which trims the snapshot BEFORE paging and therefore leaves
+  // `has_more` false while `completeness.truncated` is the only record of the
+  // loss. `graphResponseIsTruncated` reads both so a bounded estate can never
+  // render as the whole one.
+  const graphTruncated = graphResponseIsTruncated(graphData);
   if (loadingSnapshots) {
     return (
       <div className="flex items-center justify-center h-[80vh] text-[var(--text-secondary)]">

--- a/ui/lib/graph-truncation.ts
+++ b/ui/lib/graph-truncation.ts
@@ -1,0 +1,33 @@
+import type { GraphCompleteness, GraphPagination } from "@/lib/api-types";
+
+/**
+ * Whether a graph response is a partial view of its estate.
+ *
+ * Two independent cuts reach the canvas and only one of them is visible in
+ * `pagination`:
+ *
+ * - the **page limit** — the caller asked for fewer rows than exist
+ *   (`pagination.has_more`, `completeness.reason = "node_page_limit"`);
+ * - the **load-time node budget** — `GET /v1/graph`'s investigation branch
+ *   materializes the snapshot under `AGENT_BOM_GRAPH_INVESTIGATION_NODE_BUDGET`
+ *   and pages whatever survived, so the last page of a *trimmed* estate reports
+ *   `has_more: false` while `completeness.truncated` is the only record that
+ *   nodes were dropped before paging ever started
+ *   (`completeness.reason = "node_budget"`).
+ *
+ * `completeness` is authoritative because the server folds both cuts into it;
+ * `pagination` remains the fallback for a response that predates the block.
+ */
+export function graphResponseIsTruncated(
+  response:
+    | {
+        pagination?: GraphPagination | undefined;
+        completeness?: GraphCompleteness | undefined;
+      }
+    | null
+    | undefined,
+): boolean {
+  if (!response) return false;
+  if (response.completeness) return response.completeness.truncated === true;
+  return response.pagination?.has_more === true;
+}

--- a/ui/tests/graph-estate-canvas-survival.test.ts
+++ b/ui/tests/graph-estate-canvas-survival.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from "vitest";
+
+import { EXPANDED_LAYER_DEFAULTS } from "@/components/lineage-filter";
+import {
+  EntityType,
+  RelationshipType,
+  type UnifiedEdge,
+  type UnifiedGraphData,
+  type UnifiedNode,
+} from "@/lib/graph-schema";
+import { buildUnifiedFlowGraph } from "@/lib/unified-graph-flow";
+
+/**
+ * `graph-schema-canvas-coverage.test.ts` proves every backend `EntityType` has a
+ * lineage mapping and a registered renderer. That is necessary, not sufficient:
+ * the drop happens inside `buildUnifiedFlowGraph`, which skips a node whose type
+ * resolves to null and then prunes every edge touching it (#4640, api_gateway /
+ * PROTECTS). That regression was pinned for one entity type only.
+ *
+ * The enterprise demo estate is now projected into the graph, so a single
+ * snapshot carries org / account / environment / cluster / data_store /
+ * service_account / service_principal / role / application / ci_job /
+ * misconfiguration nodes wired by CONTAINS, AFFECTS, CAN_ACCESS and ACCESSED —
+ * types and relationships the 112-node showcase never exercised end to end.
+ * Rather than pin that list (which drifts the moment the projection grows), walk
+ * the whole backend schema through the real builder and assert nothing is lost.
+ */
+
+const ENTITY_TYPES = Object.values(EntityType);
+const RELATIONSHIP_TYPES = Object.values(RelationshipType);
+
+function node(entityType: EntityType): UnifiedNode {
+  return {
+    id: `${entityType}:probe`,
+    entity_type: entityType,
+    label: `${entityType} probe`,
+    category_uid: 5,
+    class_uid: 4001,
+    type_uid: 400101,
+    status: "active",
+    risk_score: 0,
+    severity: "none",
+    severity_id: 0,
+    first_seen: "2026-08-01T00:00:00Z",
+    last_seen: "2026-08-01T00:00:00Z",
+    attributes: {},
+    compliance_tags: [],
+    data_sources: [],
+    dimensions: {} as UnifiedNode["dimensions"],
+  };
+}
+
+function edge(
+  source: string,
+  target: string,
+  relationship: RelationshipType,
+): UnifiedEdge {
+  return {
+    id: `${source}:${relationship}:${target}`,
+    source,
+    target,
+    relationship,
+    direction: "directed",
+    weight: 1,
+    traversable: true,
+    first_seen: "2026-08-01T00:00:00Z",
+    last_seen: "2026-08-01T00:00:00Z",
+    evidence: {},
+    activity_id: 1,
+  };
+}
+
+// One node per entity type, and one edge per relationship type laid over them so
+// every node is connected and no relationship is unrepresented.
+const nodes = ENTITY_TYPES.map(node);
+const edges = RELATIONSHIP_TYPES.map((relationship, index) =>
+  edge(
+    `${ENTITY_TYPES[index % ENTITY_TYPES.length]}:probe`,
+    `${ENTITY_TYPES[(index + 1) % ENTITY_TYPES.length]}:probe`,
+    relationship,
+  ),
+);
+
+const graph: UnifiedGraphData = {
+  scan_id: "estate-survival",
+  tenant_id: "default",
+  created_at: "2026-08-01T00:00:00Z",
+  nodes,
+  edges,
+  attack_paths: [],
+  interaction_risks: [],
+  stats: {
+    total_nodes: nodes.length,
+    total_edges: edges.length,
+    node_types: {},
+    severity_counts: {},
+    relationship_types: {},
+    attack_path_count: 0,
+    interaction_risk_count: 0,
+    max_attack_path_risk: 0,
+    highest_interaction_risk: 0,
+  },
+};
+
+const flow = buildUnifiedFlowGraph(graph, {
+  layers: { ...EXPANDED_LAYER_DEFAULTS },
+  severity: null,
+  agentName: null,
+  vulnOnly: false,
+  maxDepth: 3,
+});
+
+describe("every backend entity and relationship survives the canvas builder", () => {
+  it("renders a node for every backend EntityType", () => {
+    const rendered = new Set(flow.nodes.map((entry) => entry.id));
+    const dropped = ENTITY_TYPES.filter(
+      (entityType) => !rendered.has(`${entityType}:probe`),
+    );
+    expect(dropped).toEqual([]);
+  });
+
+  it("gives every rendered node a concrete React Flow renderer", () => {
+    const untyped = flow.nodes.filter((entry) => !entry.type);
+    expect(untyped.map((entry) => entry.id)).toEqual([]);
+  });
+
+  it("keeps an edge for every backend RelationshipType", () => {
+    const rendered = new Set(
+      flow.edges.map((entry) => String(entry.data?.relationship ?? "")),
+    );
+    const dropped = RELATIONSHIP_TYPES.filter(
+      (relationship) => !rendered.has(relationship),
+    );
+    expect(dropped).toEqual([]);
+  });
+
+  it("keeps the estate hierarchy and posture relationships specifically", () => {
+    // The four the projected estate leans on: the containment spine the roll-up
+    // walks, the finding→asset correlation, the principal→resource claim, and
+    // the observed incident chain.
+    const rendered = new Set(
+      flow.edges.map((entry) => String(entry.data?.relationship ?? "")),
+    );
+    for (const relationship of [
+      RelationshipType.CONTAINS,
+      RelationshipType.AFFECTS,
+      RelationshipType.CAN_ACCESS,
+      RelationshipType.ACCESSED,
+    ]) {
+      expect(rendered.has(relationship)).toBe(true);
+    }
+  });
+
+  it("keeps the estate's own entity types specifically", () => {
+    const rendered = new Set(flow.nodes.map((entry) => entry.id));
+    for (const entityType of [
+      EntityType.ORG,
+      EntityType.ACCOUNT,
+      EntityType.ENVIRONMENT,
+      EntityType.CLUSTER,
+      EntityType.DATA_STORE,
+      EntityType.ROLE,
+      EntityType.SERVICE_ACCOUNT,
+      EntityType.SERVICE_PRINCIPAL,
+      EntityType.APPLICATION,
+      EntityType.CI_JOB,
+      EntityType.CONTAINER,
+      EntityType.MISCONFIGURATION,
+      EntityType.MODEL,
+    ]) {
+      expect(rendered.has(`${entityType}:probe`)).toBe(true);
+    }
+  });
+});

--- a/ui/tests/graph-truncation.test.ts
+++ b/ui/tests/graph-truncation.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import type { GraphCompleteness, GraphPagination } from "@/lib/api-types";
+import { graphResponseIsTruncated } from "@/lib/graph-truncation";
+
+function pagination(hasMore: boolean, total = 100): GraphPagination {
+  return { total, limit: 3000, offset: 0, has_more: hasMore };
+}
+
+function completeness(
+  overrides: Partial<GraphCompleteness> = {},
+): GraphCompleteness {
+  return {
+    status: "complete",
+    complete: true,
+    sampled: false,
+    truncated: false,
+    returned: 100,
+    total: 100,
+    ...overrides,
+  };
+}
+
+describe("graphResponseIsTruncated", () => {
+  it("is false when the whole snapshot came back", () => {
+    expect(
+      graphResponseIsTruncated({
+        pagination: pagination(false),
+        completeness: completeness(),
+      }),
+    ).toBe(false);
+  });
+
+  it("is true when the page limit cut the result", () => {
+    expect(
+      graphResponseIsTruncated({
+        pagination: pagination(true, 5000),
+        completeness: completeness({
+          status: "truncated",
+          complete: false,
+          truncated: true,
+          returned: 3000,
+          total: 5000,
+          reason: "node_page_limit",
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("is true when the LOAD-TIME node budget cut the snapshot before paging", () => {
+    // GET /v1/graph's investigation branch (any relationship / static-only /
+    // runtime-only filter) materializes the snapshot under
+    // AGENT_BOM_GRAPH_INVESTIGATION_NODE_BUDGET and then pages what survived.
+    // A 30,000-node estate trimmed to 25,000 and served as a 500-row page has
+    // `has_more: false` on the LAST page while `completeness.truncated` is the
+    // only record that 5,000 nodes were never loaded. Keying the banner off
+    // pagination alone reported that estate as complete.
+    expect(
+      graphResponseIsTruncated({
+        pagination: pagination(false, 25000),
+        completeness: completeness({
+          status: "truncated",
+          complete: false,
+          truncated: true,
+          returned: 500,
+          total: 30000,
+          reason: "node_budget",
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it("falls back to pagination when the server sent no completeness block", () => {
+    expect(graphResponseIsTruncated({ pagination: pagination(true) })).toBe(
+      true,
+    );
+    expect(graphResponseIsTruncated({ pagination: pagination(false) })).toBe(
+      false,
+    );
+  });
+
+  it("is false for an absent response rather than implying loss", () => {
+    expect(graphResponseIsTruncated(undefined)).toBe(false);
+    expect(graphResponseIsTruncated(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
The estate held 2,068 assets, 6,159 observations and 439 findings — and the graph
a prospect clicks rendered **112 nodes / 142 edges** from a hand-built fixture.
The "correlated graph at enterprise scale" claim rested on those 112 nodes.

| | before | after |
|---|---|---|
| nodes / edges | 112 / 142 | **2,766 / 3,669** |
| attack paths | 26 | 30 |
| seed time | 0.12s | 1.05–1.40s |

Added: `data_store` 871, `cloud_resource` +596, `cluster` 242, `misconfiguration`
439, `role` +177, `service_account` 89, `service_principal` 89, `environment`
+108, `account` +39. Edges: `contains` +2,655, `affects` +439, `can_access` +426.

Severity reconciles exactly with `summarize_estate_findings` — critical 26, high
204, medium 180, low 1, unrated 28.

## The chain, in the graph

```
ci_job     Deploy member copilot          github:workflow:member-copilot/deploy-prod
  --accessed--> role  member-copilot-prod  cloud_resource:aws:iam:role:member-copilot-prod
  --accessed--> container  member-copilot  kubernetes:workload:member-ai-prod/...
  --accessed--> tool  execute_sql          mcp:tool:clinical-analytics/execute_sql
  --accessed--> data_store  PATIENT_SUMMARY snowflake:table:nh_prod/analytics/phi/...
  --accessed--> model  GPT-4.1              model:openai:gpt-4.1

org --contains--> account:aws:123456789012 --contains--> env:...:production
    --contains--> cloud_resource:aws:iam:role:member-copilot-prod
      [critical] CIS 1.16 — controls=generic:CIS-1.16, mitre_attack:T1068/T1110/T1134/…
```

The hand-built headline chain is intact and still asserted:
`agent:cursor → server:shell-runner-server → pkg:pyyaml@5.3 → vuln:CVE-2020-14343
→ cred:aws-secret`.

## Decision: extend, not replace or seed alongside

Seeding alongside was **rejected** — the read path serves the newest snapshot, so
a prospect would land on one of two estates and the correlation between them
would never be drawn. The estate's AWS account and the showcase's
`account:aws:123456789012` are literally the same node, which is only true
because the projection reuses the builder's id spelling rather than inventing
one. `org:corp` now hangs off the estate root so there is a single top-level
container.

**Three bootstrap tests changed deliberately.** `headline_blast_radius_chain`,
`graph_is_a_rich_multi_agent_estate` and `graph_tags_runtime_evidence_tiers` read
`/v1/graph` at the default 500 rows and assumed the whole snapshot fit. With 439
rated findings filling that severity-ranked page, unrated inventory nodes fall
off it. They read the full snapshot now, and a new test asserts the default page
**declares its truncation**.

## Rollup

`/v1/graph/rollup` returns **1 container + 105 orphans, 45 KiB regardless of
estate size**. Drill: org → 41 children → environments → resources → findings.

Finding nodes had to go *inside* the containment tree — otherwise they were 439
orphans past the 200 cap and the default view degraded to a truncated chip list.
The UI already auto-enables rollup at ≥200 nodes, so no UI change was needed for
this part.

## Read path at the new size

| endpoint | before | after |
|---|---|---|
| `/v1/graph` default (500) | 9ms | **48ms**, truncated, total=2766 |
| `/v1/graph` limit=3000 (UI) | 9ms | **141ms**, 6.35 MiB → **366 KiB** gzipped |
| `/v1/graph/rollup` | 4ms | 47ms |
| `/v1/graph/rollup?node=<org>` | 2ms | **155ms** ← slowest |
| `/v1/demo-estate/story` | 7ms warm | 8ms warm / 1.69s cold |

#4660's primitives all still hold: `page_nodes` resolves through
`idx_gn_tenant_scan_rank` with **no temp b-tree** at 5,092 node rows, a 6-page
keyset walk medians 4.9ms/page, gzip level 6 gives 17.4×.

## A correction to the brief

**The node budget does not trigger.** `GRAPH_INVESTIGATION_NODE_BUDGET` is 25,000
(`config.py:372`) and the snapshot is 2,766 — what truncates the default read is
the **page limit**, not the budget. Both paths were verified anyway: forcing
`node_budget=1000` gives `truncated=True`, `reason="node_budget"`,
`completeness.total_nodes=2766`, `stats.total_nodes_source=2766`, and a
serialized `completeness` that differs from the unbounded one. Both pinned by
tests, so #4631 holds.

## Four defects the tests caught before shipping

1. **Re-projecting appended a second copy of every attack path** — nodes and
   edges dedupe, but `graph.attack_paths` is a plain list. Would have
   double-counted the exposure-path queue.
2. **Chains scored `composite_risk=0.0`** because inventory hops are unrated,
   sorting the estate's own incident *below* every hand-built path.
3. **A control raised on a role names that role as its own principal** →
   self-loop that containment traversals cycle on.
4. **UI: `graphTruncated` keyed to `pagination.has_more` alone**, so a snapshot
   trimmed by the load-time budget rendered with **no banner at all** —
   `has_more` is false on the last page of an already-trimmed estate.

## Gates

`pytest -k "graph or demo or estate or bootstrap or scope"` — **1825 passed, 39
skipped, 0 failed**. `mypy` clean, `ruff check` clean, `make preflight` all 12
gates green. UI: `tsc --noEmit`, `lint`, `vitest` (167 files / 1002 tests),
`npm run build` and `NEXT_EXPORT=1 npm run build` all pass.

## Not proven — read before merging

- **No live browser render.** vitest, both builds, tsc and lint pass, but
  **2,766 nodes has never been painted** at 1280/1440/1920 in both themes. This
  is the biggest gap and the catch-gaps rule calls for it explicitly.
- **SQLite only** — `postgres_graph.py` pushes the budget into SQL and has its
  own index; not measured.
- **UI fetch headroom is thin.** `GRAPH_FULL_FETCH_LIMIT` is 3,000 and we sit at
  2,766 (~234 spare). Past 3,000 the banner fires but there is no "load more" —
  the remainder is unreachable. Deliberately not raised; that is a product call.
- **Concurrent seeding** under two uvicorn workers booting at once is untested,
  and the window is now ~10× wider (0.12s → 1.4s). Pre-existing, but worse.
- Full suite not run — the required `-k` filter was, at 1,825 tests.