### PR TITLE
fix: give the persona cards room, and declare Smithery's upstream credential

### DIFF
--- a/.github/workflows/publish-registries.yml
+++ b/.github/workflows/publish-registries.yml
@@ -3,6 +3,10 @@ name: Publish to Registries
 # Auto-publishes to Smithery and ClawHub after a successful Release workflow.
 # Secrets needed (add via Settings → Secrets):
 #   SMITHERY_API_TOKEN  — Smithery service token (smithery.ai → API tokens)
+#   SMITHERY_UPSTREAM_TOKEN — bearer token Smithery presents to our own MCP
+#     endpoint. Without it Smithery cannot enumerate tools and the release
+#     settles as AUTH_REQUIRED, which is why the public catalog listed 36 of
+#     the 77 tools the server actually serves.
 #   CLAWHUB_TOKEN       — ClawHub auth token (clawhub.ai → Settings)
 # Optional vars:
 #   SMITHERY_MCP_URL    — Public Streamable HTTP MCP endpoint for Smithery
@@ -213,12 +217,17 @@ jobs:
                 \"configSchema\": {
                   \"type\": \"object\",
                   \"properties\": {
+                    \"bearerToken\": {
+                      \"type\": \"string\",
+                      \"title\": \"Access token\",
+                      \"description\": \"Bearer token for the agent-bom MCP endpoint. Required — the endpoint authenticates every request and will not enumerate tools without it.\"
+                    },
                     \"NVD_API_KEY\": {
                       \"type\": \"string\",
                       \"description\": \"NVD API key for higher rate limits on CVSS enrichment (optional)\"
                     }
                   },
-                  \"required\": []
+                  \"required\": [\"bearerToken\"]
                 }
               }")
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Graph provenance stays explicit: collected, inferred, static, and runtime
 relationships remain distinct, and unavailable evidence is never upgraded to
 observed.
 
-<details open>
+<details>
 <summary><b>Control-plane architecture</b></summary>
 
 <p align="center">

--- a/docs/images/architecture-dark.svg
+++ b/docs/images/architecture-dark.svg
@@ -5,125 +5,125 @@
 <rect width="960" height="620" rx="14" fill="#0a0a0c"/>
 <rect x="12" y="12" width="936" height="596" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>
 <rect x="842" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>
-<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.4" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
-<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="26.0" font-weight="800" fill="#f4f4f5">Control-plane architecture</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
+<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.8" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="22.0" font-weight="800" fill="#f4f4f5">Control-plane architecture</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="11.0" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
 <rect x="28" y="78" width="904" height="102" rx="12" fill="#0f0f13" stroke="#38bdf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="78" width="904" height="3" rx="12" fill="#38bdf8" opacity="0.55"/>
-<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#bae6fd">read-only</text>
+<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#bae6fd">read-only</text>
 <rect x="40" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="48" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Supply chain</text>
-<text x="78" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">15 eco</text>
+<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Supply chain</text>
+<text x="78" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">15 eco</text>
 <rect x="166" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="174" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(178,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
-<text x="204" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">29 clients</text>
+<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Agents &amp; MCP</text>
+<text x="204" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">29 clients</text>
 <rect x="292" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="300" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(304,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Cloud</text>
-<text x="330" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">4 connect · 16 scan</text>
+<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Cloud</text>
+<text x="330" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">4 connect · 16 scan</text>
 <rect x="418" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="426" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(430,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
-<text x="456" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">TF·K8s·img</text>
+<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">IaC &amp; OCI</text>
+<text x="456" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">TF·K8s·img</text>
 <rect x="544" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="552" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(556,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Secrets</text>
-<text x="582" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">refs only</text>
+<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Secrets</text>
+<text x="582" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">refs only</text>
 <rect x="670" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="678" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(682,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Models</text>
-<text x="708" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">13 formats</text>
+<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Models</text>
+<text x="708" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">13 formats</text>
 <rect x="796" y="110" width="118" height="44" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="804" y="120" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(808,124) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">SBOM import</text>
-<text x="834" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">CDX·SPDX</text>
-<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
+<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">SBOM import</text>
+<text x="834" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">CDX·SPDX</text>
+<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
 <rect x="28" y="192" width="904" height="96" rx="12" fill="#0f0f13" stroke="#818cf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="192" width="904" height="3" rx="12" fill="#818cf8" opacity="0.55"/>
-<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#c7d2fe">local scan</text>
+<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#c7d2fe">local scan</text>
 <rect x="40" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="48" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">OSV scan</text>
-<text x="78" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">batch</text>
+<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">OSV scan</text>
+<text x="78" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">batch</text>
 <rect x="218" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="226" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(230,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Enrichment</text>
-<text x="256" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">NVD·EPSS</text>
+<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Enrichment</text>
+<text x="256" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">NVD·EPSS</text>
 <rect x="396" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="404" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(408,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Posture</text>
-<text x="434" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">CIS·MCP</text>
+<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Posture</text>
+<text x="434" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">CIS·MCP</text>
 <rect x="574" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="582" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(586,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Blast radius</text>
-<text x="612" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">fusion</text>
+<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Blast radius</text>
+<text x="612" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">fusion</text>
 <rect x="752" y="228" width="168" height="52" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="760" y="242" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(764,246) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Policy</text>
-<text x="790" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">as-code</text>
-<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
+<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Policy</text>
+<text x="790" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">as-code</text>
+<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
 <rect x="28" y="300" width="904" height="136" rx="12" fill="#0f0f13" stroke="#2dd4bf" stroke-width="1.2" opacity="0.95"/><rect x="28" y="300" width="904" height="3" rx="12" fill="#2dd4bf" opacity="0.55"/>
-<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
+<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
 <rect x="40" y="332" width="214" height="29" rx="8" fill="#15121f" stroke="#2dd4bf" stroke-width="1.5"/>
 <rect x="48" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,338) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
-<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Unified Finding</text>
-<text x="78" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#2dd4bf">one schema</text>
+<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Unified Finding</text>
+<text x="78" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#2dd4bf">one schema</text>
 <rect x="258" y="332" width="214" height="29" rx="8" fill="#15121f" stroke="#2dd4bf" stroke-width="1.5"/>
 <rect x="266" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(270,338) scale(0.6666666666666666)" fill="none" stroke="#c4b5fd" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
-<text x="296" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#2dd4bf">attack paths</text>
+<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">UnifiedGraph</text>
+<text x="296" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#2dd4bf">attack paths</text>
 <rect x="40" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="48" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(52,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Stores</text>
-<text x="78" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">PG·SQLite</text>
+<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Stores</text>
+<text x="78" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">PG·SQLite</text>
 <rect x="258" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="266" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(270,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Audit chain</text>
-<text x="296" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">signed</text>
+<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Audit chain</text>
+<text x="296" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">signed</text>
 <rect x="488" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">381 ops</text>
+<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">REST API</text>
+<text x="526" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">381 ops</text>
 <rect x="706" y="332" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="334" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Gateway</text>
-<text x="744" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">runtime</text>
+<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Gateway</text>
+<text x="744" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">runtime</text>
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">77 tools</text>
+<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">MCP server</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">77 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
-<text x="744" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">Helm·EKS</text>
+<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Fleet jobs</text>
+<text x="744" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">Helm·EKS</text>
 <rect x="488" y="398" width="214" height="29" rx="8" fill="#161619" stroke="#2a2a31" stroke-width="1"/>
 <rect x="496" y="400" width="24" height="24" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(500,404) scale(0.6666666666666666)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e9e9ec">Scheduler / events</text>
-<text x="526" y="422" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#82828c">cadence·change</text>
-<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
+<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#e9e9ec">Scheduler / events</text>
+<text x="526" y="422" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#82828c">cadence·change</text>
+<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
 <rect x="28" y="448" width="904" height="140" rx="12" fill="#0f0f13" stroke="#c084fc" stroke-width="1.2" opacity="0.95"/><rect x="28" y="448" width="904" height="3" rx="12" fill="#c084fc" opacity="0.55"/>
-<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#e9d5ff">deliver</text>
-<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
+<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#e9d5ff">deliver</text>
+<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
 <rect x="40" y="492" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
 <rect x="50" y="495" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(54,499) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#e9e9ec">CLI</text>
+<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#e9e9ec">CLI</text>
 <rect x="40" y="527" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
 <rect x="50" y="530" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(54,534) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#e9e9ec">Web UI</text>
-<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
+<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#e9e9ec">Web UI</text>
+<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
 <rect x="337" y="492" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
 <rect x="347" y="495" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(351,499) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#e9e9ec">MCP</text>
+<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#e9e9ec">MCP</text>
 <rect x="337" y="527" width="285" height="30" rx="7" fill="#161619" stroke="#2a2a31"/>
 <rect x="347" y="530" width="22" height="22" rx="6" fill="#1c1c21" stroke="#2e2e35"/><g transform="translate(351,534) scale(0.5833333333333334)" fill="none" stroke="#c4c4ce" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#e9e9ec">SDK</text>
-<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
-<rect x="634" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">SARIF</text>
-<rect x="730" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">CDX</text>
-<rect x="826" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">SPDX</text>
-<rect x="634" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">OCSF</text>
-<rect x="730" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">HTML</text>
-<rect x="826" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#a1a1aa">JSON</text>
-<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
-<rect x="24" y="582" width="912" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#e9e9ec">SDK</text>
+<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
+<rect x="634" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">SARIF</text>
+<rect x="730" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">CDX</text>
+<rect x="826" y="492" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">SPDX</text>
+<rect x="634" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">OCSF</text>
+<rect x="730" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">HTML</text>
+<rect x="826" y="517" width="91" height="20" rx="5" fill="#121016" stroke="#2a2a31"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#a1a1aa">JSON</text>
+<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="600" fill="#6b6b75">SIEM · webhooks</text>
+<rect x="24" y="582" width="912" height="26" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="600" fill="#4ade80">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/architecture-light.svg
+++ b/docs/images/architecture-light.svg
@@ -5,125 +5,125 @@
 <rect width="960" height="620" rx="14" fill="#ffffff"/>
 <rect x="12" y="12" width="936" height="596" rx="18" fill="none" stroke="#6366f1" stroke-width="2" opacity="0.22"/>
 <rect x="842" y="20" width="90" height="22" rx="11" fill="#312e81" opacity="0.85"/>
-<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.4" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
-<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="26.0" font-weight="800" fill="#18181b">Control-plane architecture</text>
-<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
+<text x="887" y="35" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.8" font-weight="800" letter-spacing="0.14em" fill="#c7d2fe">LAYERED</text>
+<text x="28" y="40" font-family="Inter,system-ui,sans-serif" font-size="22.0" font-weight="800" fill="#18181b">Control-plane architecture</text>
+<text x="28" y="60" font-family="Inter,system-ui,sans-serif" font-size="11.0" font-weight="500" fill="#71717a">Vertical tiers · sources feed engine · evidence + platform · people + agents consume</text>
 <rect x="28" y="78" width="904" height="102" rx="12" fill="#fafafa" stroke="#38bdf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="78" width="904" height="3" rx="12" fill="#38bdf8" opacity="0.55"/>
-<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#bae6fd">read-only</text>
+<rect x="40" y="88" width="4" height="22" rx="2" fill="#38bdf8"/><text x="54" y="103" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#38bdf8">INTAKE SOURCES</text><text x="910" y="103" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#bae6fd">read-only</text>
 <rect x="40" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="48" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 4.5v9L12 21l-8-4.5v-9z M12 3v9 M4 7.5l16 9"/></g>
-<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Supply chain</text>
-<text x="78" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">15 eco</text>
+<text x="78" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Supply chain</text>
+<text x="78" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">15 eco</text>
 <rect x="166" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="174" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(178,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
-<text x="204" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">29 clients</text>
+<text x="204" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Agents &amp; MCP</text>
+<text x="204" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">29 clients</text>
 <rect x="292" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="300" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(304,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 15h12a4 4 0 0 0 .5-8A6 6 0 0 0 6 15z"/></g>
-<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Cloud</text>
-<text x="330" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">4 connect · 16 scan</text>
+<text x="330" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Cloud</text>
+<text x="330" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">4 connect · 16 scan</text>
 <rect x="418" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="426" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(430,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5-7 3.5-7-3.5z M5 11l7 3.5 7-3.5 M5 15l7 3.5 7-3.5"/></g>
-<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
-<text x="456" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">TF·K8s·img</text>
+<text x="456" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">IaC &amp; OCI</text>
+<text x="456" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">TF·K8s·img</text>
 <rect x="544" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="552" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(556,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="11" width="10" height="8" rx="2"/><path d="M9 11V8a3 3 0 0 1 6 0v3"/></g>
-<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Secrets</text>
-<text x="582" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">refs only</text>
+<text x="582" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Secrets</text>
+<text x="582" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">refs only</text>
 <rect x="670" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="678" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(682,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 3.5v7L12 18l-7-3.5v-7z M12 4v14 M5 7.5l14 7"/></g>
-<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Models</text>
-<text x="708" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">13 formats</text>
+<text x="708" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Models</text>
+<text x="708" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">13 formats</text>
 <rect x="796" y="110" width="118" height="44" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="804" y="120" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(808,124) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8 M9 15h5"/></g>
-<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">SBOM import</text>
-<text x="834" y="142" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">CDX·SPDX</text>
-<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
+<text x="834" y="131" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">SBOM import</text>
+<text x="834" y="142" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">CDX·SPDX</text>
+<line x1="480" y1="182" x2="480" y2="196" stroke="#38bdf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,200 476,194 484,194" fill="#38bdf8"/><text x="480" y="177" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#38bdf8">INGEST</text>
 <rect x="28" y="192" width="904" height="96" rx="12" fill="#fafafa" stroke="#818cf8" stroke-width="1.2" opacity="0.95"/><rect x="28" y="192" width="904" height="3" rx="12" fill="#818cf8" opacity="0.55"/>
-<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#c7d2fe">local scan</text>
+<rect x="40" y="202" width="4" height="22" rx="2" fill="#818cf8"/><text x="54" y="217" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#818cf8">PROCESSING ENGINE</text><text x="910" y="217" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#c7d2fe">local scan</text>
 <rect x="40" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="48" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 10h8M6 14h12M9 6l-2 2M15 6l2 2M9 18l-2 2M15 18l2 2"/><circle cx="12" cy="12" r="4"/></g>
-<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">OSV scan</text>
-<text x="78" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">batch</text>
+<text x="78" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">OSV scan</text>
+<text x="78" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">batch</text>
 <rect x="218" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="226" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(230,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M13 3L5 14h6l-1 7 8-11h-6z"/></g>
-<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Enrichment</text>
-<text x="256" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">NVD·EPSS</text>
+<text x="256" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Enrichment</text>
+<text x="256" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">NVD·EPSS</text>
 <rect x="396" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="404" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(408,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6c0 5-3.5 8-8 9-4.5-1-8-4-8-9V6z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Posture</text>
-<text x="434" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">CIS·MCP</text>
+<text x="434" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Posture</text>
+<text x="434" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">CIS·MCP</text>
 <rect x="574" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="582" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(586,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Blast radius</text>
-<text x="612" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">fusion</text>
+<text x="612" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Blast radius</text>
+<text x="612" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">fusion</text>
 <rect x="752" y="228" width="168" height="52" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="760" y="242" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(764,246) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 4h7l4 4v12H7z M14 4v4h4"/></g>
-<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Policy</text>
-<text x="790" y="264" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">as-code</text>
-<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
+<text x="790" y="253" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Policy</text>
+<text x="790" y="264" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">as-code</text>
+<line x1="480" y1="290" x2="480" y2="304" stroke="#818cf8" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,308 476,302 484,302" fill="#818cf8"/><text x="480" y="285" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#818cf8">PROCESS</text>
 <rect x="28" y="300" width="904" height="136" rx="12" fill="#fafafa" stroke="#2dd4bf" stroke-width="1.2" opacity="0.95"/><rect x="28" y="300" width="904" height="3" rx="12" fill="#2dd4bf" opacity="0.55"/>
-<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
+<rect x="40" y="310" width="4" height="22" rx="2" fill="#2dd4bf"/><text x="54" y="325" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#2dd4bf">EVIDENCE &amp; PLATFORM</text><text x="910" y="325" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#99f6e4">auth · self-hosted</text>
 <rect x="40" y="332" width="214" height="29" rx="8" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.5"/>
 <rect x="48" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,338) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l8 3v6.5c0 4.5-3.2 7.8-8 9.5-4.8-1.7-8-5-8-9.5V6z"/><path d="M12 9v4"/><path d="M12 16.5h.01"/></g>
-<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Unified Finding</text>
-<text x="78" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#2dd4bf">one schema</text>
+<text x="78" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Unified Finding</text>
+<text x="78" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#2dd4bf">one schema</text>
 <rect x="258" y="332" width="214" height="29" rx="8" fill="#f5f3ff" stroke="#2dd4bf" stroke-width="1.5"/>
 <rect x="266" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(270,338) scale(0.6666666666666666)" fill="none" stroke="#6d28d9" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="8" cy="8" r="2.5"/><circle cx="16" cy="8" r="2.5"/><circle cx="12" cy="16" r="2.5"/><path d="M10 9.5l1.5 5 M14 9.5l-1.5 5"/></g>
-<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">UnifiedGraph</text>
-<text x="296" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#2dd4bf">attack paths</text>
+<text x="296" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">UnifiedGraph</text>
+<text x="296" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#2dd4bf">attack paths</text>
 <rect x="40" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="48" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(52,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><ellipse cx="12" cy="7" rx="7" ry="3"/><path d="M5 7v10c0 1.7 3.1 3 7 3s7-1.3 7-3V7"/></g>
-<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Stores</text>
-<text x="78" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">PG·SQLite</text>
+<text x="78" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Stores</text>
+<text x="78" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">PG·SQLite</text>
 <rect x="258" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="266" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(270,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Audit chain</text>
-<text x="296" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">signed</text>
+<text x="296" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Audit chain</text>
+<text x="296" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">signed</text>
 <rect x="488" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">REST API</text>
-<text x="526" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">381 ops</text>
+<text x="526" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">REST API</text>
+<text x="526" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">381 ops</text>
 <rect x="706" y="332" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="334" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,338) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4l7 2.5v5c0 4.5-3 7-7 8.5-4-1.5-7-4-7-8.5v-5z"/><path d="M9 12l2 2 4-4"/></g>
-<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Gateway</text>
-<text x="744" y="356" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">runtime</text>
+<text x="744" y="345" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Gateway</text>
+<text x="744" y="356" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">runtime</text>
 <rect x="488" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">MCP server</text>
-<text x="526" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">77 tools</text>
+<text x="526" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">MCP server</text>
+<text x="526" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">77 tools</text>
 <rect x="706" y="365" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="714" y="367" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(718,371) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="6" height="6" rx="1.5"/><rect x="14" y="5" width="6" height="6" rx="1.5"/><rect x="4" y="13" width="6" height="6" rx="1.5"/><rect x="14" y="13" width="6" height="6" rx="1.5"/></g>
-<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Fleet jobs</text>
-<text x="744" y="389" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">Helm·EKS</text>
+<text x="744" y="378" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Fleet jobs</text>
+<text x="744" y="389" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">Helm·EKS</text>
 <rect x="488" y="398" width="214" height="29" rx="8" fill="#ffffff" stroke="#e6e6ea" stroke-width="1"/>
 <rect x="496" y="400" width="24" height="24" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(500,404) scale(0.6666666666666666)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M6 5h12v14H6z M9 9h8 M9 12h8"/><path d="M9 16l2 2 4-4"/></g>
-<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#18181b">Scheduler / events</text>
-<text x="526" y="422" font-family="ui-monospace,monospace" font-size="8.45" font-weight="600" fill="#71717a">cadence·change</text>
-<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
+<text x="526" y="411" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="700" fill="#18181b">Scheduler / events</text>
+<text x="526" y="422" font-family="ui-monospace,monospace" font-size="7.15" font-weight="600" fill="#71717a">cadence·change</text>
+<line x1="480" y1="438" x2="480" y2="452" stroke="#2dd4bf" stroke-width="1.6" stroke-linecap="round"/><polygon points="480,456 476,450 484,450" fill="#2dd4bf"/><text x="480" y="433" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="800" letter-spacing="0.1em" fill="#2dd4bf">DELIVER</text>
 <rect x="28" y="448" width="904" height="140" rx="12" fill="#fafafa" stroke="#c084fc" stroke-width="1.2" opacity="0.95"/><rect x="28" y="448" width="904" height="3" rx="12" fill="#c084fc" opacity="0.55"/>
-<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="12.35" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="600" fill="#e9d5ff">deliver</text>
-<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
+<rect x="40" y="458" width="4" height="22" rx="2" fill="#c084fc"/><text x="54" y="473" font-family="Inter,system-ui,sans-serif" font-size="10.45" font-weight="800" letter-spacing="0.14em" fill="#c084fc">CONSUMERS &amp; ARTIFACTS</text><text x="910" y="473" text-anchor="end" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="600" fill="#e9d5ff">deliver</text>
+<text x="182" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">PEOPLE</text>
 <rect x="40" y="492" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
 <rect x="50" y="495" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(54,499) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M7 8l-4 4 4 4 M13 16h7"/></g>
-<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#18181b">CLI</text>
+<text x="80" y="511" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#18181b">CLI</text>
 <rect x="40" y="527" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
 <rect x="50" y="530" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(54,534) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="5" width="16" height="12" rx="2"/><path d="M4 9h16"/></g>
-<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#18181b">Web UI</text>
-<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
+<text x="80" y="546" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#18181b">Web UI</text>
+<text x="479" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">AGENTS</text>
 <rect x="337" y="492" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
 <rect x="347" y="495" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(351,499) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="9" r="3"/><circle cx="8" cy="17" r="2.4"/><circle cx="16" cy="17" r="2.4"/><path d="M10 11l-2 4 M14 11l2 4"/></g>
-<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#18181b">MCP</text>
+<text x="377" y="511" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#18181b">MCP</text>
 <rect x="337" y="527" width="285" height="30" rx="7" fill="#ffffff" stroke="#e6e6ea"/>
 <rect x="347" y="530" width="22" height="22" rx="6" fill="#f4f4f6" stroke="#e6e6ea"/><g transform="translate(351,534) scale(0.5833333333333334)" fill="none" stroke="#5c5c66" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M8 8l-4 4 4 4M16 8l4 4-4 4"/></g>
-<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="11.7" font-weight="700" fill="#18181b">SDK</text>
-<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.75" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
-<rect x="634" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">SARIF</text>
-<rect x="730" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">CDX</text>
-<rect x="826" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">SPDX</text>
-<rect x="634" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">OCSF</text>
-<rect x="730" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">HTML</text>
-<rect x="826" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="9.1" font-weight="700" fill="#52525b">JSON</text>
-<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.1" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
-<rect x="24" y="582" width="912" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
+<text x="377" y="546" font-family="Inter,system-ui,sans-serif" font-size="9.9" font-weight="700" fill="#18181b">SDK</text>
+<text x="776" y="482" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.25" font-weight="800" letter-spacing="0.1em" fill="#c084fc">ARTIFACTS</text>
+<rect x="634" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">SARIF</text>
+<rect x="730" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">CDX</text>
+<rect x="826" y="492" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="505" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">SPDX</text>
+<rect x="634" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="679.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">OCSF</text>
+<rect x="730" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="775.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">HTML</text>
+<rect x="826" y="517" width="91" height="20" rx="5" fill="#f4f4f6" stroke="#e6e6ea"/><text x="871.5" y="530" text-anchor="middle" font-family="ui-monospace,monospace" font-size="7.7" font-weight="700" fill="#52525b">JSON</text>
+<text x="776" y="552" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="7.7" font-weight="600" fill="#9a9aa4">SIEM · webhooks</text>
+<rect x="24" y="582" width="912" height="26" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="480" y="600" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="9.35" font-weight="600" fill="#15803d">READ-ONLY BY DEFAULT · no target writes · no secret values · self-hosted · signed evidence</text>
 </svg>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -1,91 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="236" viewBox="0 0 1280 236" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="442" viewBox="0 0 1280 442" fill="none">
 <title>agent-bom personas and value</title>
-<rect width="1280" height="236" rx="12" fill="#16161d"/>
-<rect x="23" y="18" width="235" height="174" rx="12" fill="#a78bfa"/>
-<rect x="23" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect width="1280" height="442" rx="12" fill="#16161d"/>
+<rect x="23" y="18" width="402" height="174" rx="12" fill="#a78bfa"/>
+<rect x="23" y="22" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="37" y="32" width="40" height="40" rx="11" fill="#a78bfa" opacity="0.16"/><g transform="translate(41,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#a78bfa"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#a78bfa"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#a78bfa"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#0f0f13" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#a78bfa" stroke-width="1.05"/></g></g>
-<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Developers</text>
+<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#e9e9ec">Developers</text>
 <rect x="37" y="82" width="65" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">local scan</text>
+<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#a78bfa">local scan</text>
 <rect x="108" y="82" width="45" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">images</text>
+<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#a78bfa">images</text>
 <rect x="159" y="82" width="55" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">CI gates</text>
-<line x1="39" y1="110" x2="242" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="140,120 135,113 145,113" fill="#a78bfa" opacity="0.9"/>
-<rect x="35" y="126" width="211" height="52" rx="8" fill="#a78bfa" opacity="0.10"/>
-<rect x="35" y="126" width="211" height="52" rx="8" fill="none" stroke="#a78bfa" opacity="0.4"/>
+<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#a78bfa">CI gates</text>
+<line x1="39" y1="110" x2="409" y2="110" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="224,120 219,113 229,113" fill="#a78bfa" opacity="0.9"/>
+<rect x="35" y="126" width="378" height="52" rx="8" fill="#a78bfa" opacity="0.10"/>
+<rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#a78bfa" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#a78bfa"/>
-<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Accurate SCA</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro</text>
-<rect x="272" y="18" width="235" height="174" rx="12" fill="#2dd4bf"/>
-<rect x="272" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
-<rect x="286" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(290,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>
-<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">AppSec</text>
-<rect x="286" y="82" width="40" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">SARIF</text>
-<rect x="332" y="82" width="74" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">reachability</text>
-<rect x="412" y="82" width="69" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">graph paths</text>
-<line x1="288" y1="110" x2="491" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="389,120 384,113 394,113" fill="#2dd4bf" opacity="0.9"/>
-<rect x="284" y="126" width="211" height="52" rx="8" fill="#2dd4bf" opacity="0.10"/>
-<rect x="284" y="126" width="211" height="52" rx="8" fill="none" stroke="#2dd4bf" opacity="0.4"/>
-<rect x="292" y="142" width="3" height="14" rx="1.5" fill="#2dd4bf"/>
-<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Triage by reachability</text>
-<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">blast radius · CI gates · exit codes</text>
-<rect x="521" y="18" width="235" height="174" rx="12" fill="#38bdf8"/>
-<rect x="521" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
-<rect x="535" y="32" width="40" height="40" rx="11" fill="#38bdf8" opacity="0.16"/><g transform="translate(539,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#38bdf8"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#38bdf8"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#38bdf8"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
-<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
-<rect x="535" y="82" width="65" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">fleet sync</text>
-<rect x="606" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">Helm</text>
-<rect x="647" y="82" width="25" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">CI</text>
-<rect x="678" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">SBOM</text>
-<line x1="537" y1="110" x2="740" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="638,120 633,113 643,113" fill="#38bdf8" opacity="0.9"/>
-<rect x="533" y="126" width="211" height="52" rx="8" fill="#38bdf8" opacity="0.10"/>
-<rect x="533" y="126" width="211" height="52" rx="8" fill="none" stroke="#38bdf8" opacity="0.4"/>
-<rect x="541" y="142" width="3" height="14" rx="1.5" fill="#38bdf8"/>
-<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
-<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">your VPC · Postgres · signed audit</text>
-<rect x="770" y="18" width="235" height="174" rx="12" fill="#fbbf24"/>
-<rect x="770" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
-<rect x="784" y="32" width="40" height="40" rx="11" fill="#fbbf24" opacity="0.16"/><g transform="translate(788,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fbbf24"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fbbf24"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fbbf24"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#0f0f13" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#0f0f13" stroke-width="1.0"/></g></g>
-<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">GRC / audit</text>
-<rect x="784" y="82" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">compliance</text>
-<rect x="855" y="82" width="55" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">evidence</text>
-<rect x="916" y="82" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">frameworks</text>
-<line x1="786" y1="110" x2="989" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="887,120 882,113 892,113" fill="#fbbf24" opacity="0.9"/>
-<rect x="782" y="126" width="211" height="52" rx="8" fill="#fbbf24" opacity="0.10"/>
-<rect x="782" y="126" width="211" height="52" rx="8" fill="none" stroke="#fbbf24" opacity="0.4"/>
-<rect x="790" y="142" width="3" height="14" rx="1.5" fill="#fbbf24"/>
-<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Audit-ready exports</text>
-<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">control mappings · signed bundles</text>
-<rect x="1019" y="18" width="235" height="174" rx="12" fill="#fb7185"/>
-<rect x="1019" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
-<rect x="1033" y="32" width="40" height="40" rx="11" fill="#fb7185" opacity="0.16"/><g transform="translate(1037,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fb7185"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fb7185"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fb7185"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
-<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">AI / MCP owners</text>
-<rect x="1033" y="82" width="79" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">MCP inventory</text>
-<rect x="1118" y="82" width="94" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">allow/warn/block</text>
-<line x1="1035" y1="110" x2="1238" y2="110" stroke="#2a2a31" stroke-width="1"/>
-<polygon points="1136,120 1131,113 1141,113" fill="#fb7185" opacity="0.9"/>
-<rect x="1031" y="126" width="211" height="52" rx="8" fill="#fb7185" opacity="0.10"/>
-<rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
-<rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
-<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">381 API ops · 77 MCP tools · SARIF</text>
-<rect x="24" y="196" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Accurate SCA</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro-aware</text>
+<rect x="439" y="18" width="402" height="174" rx="12" fill="#2dd4bf"/>
+<rect x="439" y="22" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="453" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>
+<text x="501" y="58" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#e9e9ec">AppSec</text>
+<rect x="453" y="82" width="40" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
+<text x="473.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#2dd4bf">SARIF</text>
+<rect x="499" y="82" width="74" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
+<text x="536.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#2dd4bf">reachability</text>
+<rect x="579" y="82" width="69" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
+<text x="613.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#2dd4bf">graph paths</text>
+<line x1="455" y1="110" x2="825" y2="110" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="640,120 635,113 645,113" fill="#2dd4bf" opacity="0.9"/>
+<rect x="451" y="126" width="378" height="52" rx="8" fill="#2dd4bf" opacity="0.10"/>
+<rect x="451" y="126" width="378" height="52" rx="8" fill="none" stroke="#2dd4bf" opacity="0.4"/>
+<rect x="459" y="142" width="3" height="14" rx="1.5" fill="#2dd4bf"/>
+<text x="469" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Triage by reachability</text>
+<text x="469" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">blast radius · CI gates · exit codes</text>
+<rect x="855" y="18" width="402" height="174" rx="12" fill="#38bdf8"/>
+<rect x="855" y="22" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="869" y="32" width="40" height="40" rx="11" fill="#38bdf8" opacity="0.16"/><g transform="translate(873,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#38bdf8"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#38bdf8"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#38bdf8"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
+<text x="917" y="58" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
+<rect x="869" y="82" width="65" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
+<text x="901.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#38bdf8">fleet sync</text>
+<rect x="940" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
+<text x="957.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#38bdf8">Helm</text>
+<rect x="981" y="82" width="25" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
+<text x="993.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#38bdf8">CI</text>
+<rect x="1012" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
+<text x="1029.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#38bdf8">SBOM</text>
+<line x1="871" y1="110" x2="1241" y2="110" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="1056,120 1051,113 1061,113" fill="#38bdf8" opacity="0.9"/>
+<rect x="867" y="126" width="378" height="52" rx="8" fill="#38bdf8" opacity="0.10"/>
+<rect x="867" y="126" width="378" height="52" rx="8" fill="none" stroke="#38bdf8" opacity="0.4"/>
+<rect x="875" y="142" width="3" height="14" rx="1.5" fill="#38bdf8"/>
+<text x="885" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
+<text x="885" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">your VPC · Postgres · signed audit</text>
+<rect x="231" y="206" width="402" height="174" rx="12" fill="#fbbf24"/>
+<rect x="231" y="210" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="245" y="220" width="40" height="40" rx="11" fill="#fbbf24" opacity="0.16"/><g transform="translate(249,224) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fbbf24"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fbbf24"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fbbf24"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#0f0f13" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#0f0f13" stroke-width="1.0"/></g></g>
+<text x="293" y="246" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#e9e9ec">GRC / audit</text>
+<rect x="245" y="270" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
+<text x="277.5" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#fbbf24">compliance</text>
+<rect x="316" y="270" width="55" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
+<text x="343.5" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#fbbf24">evidence</text>
+<rect x="377" y="270" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
+<text x="409.5" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#fbbf24">frameworks</text>
+<line x1="247" y1="298" x2="617" y2="298" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="432,308 427,301 437,301" fill="#fbbf24" opacity="0.9"/>
+<rect x="243" y="314" width="378" height="52" rx="8" fill="#fbbf24" opacity="0.10"/>
+<rect x="243" y="314" width="378" height="52" rx="8" fill="none" stroke="#fbbf24" opacity="0.4"/>
+<rect x="251" y="330" width="3" height="14" rx="1.5" fill="#fbbf24"/>
+<text x="261" y="338" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Audit-ready exports</text>
+<text x="261" y="358" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">control mappings · signed bundles</text>
+<rect x="647" y="206" width="402" height="174" rx="12" fill="#fb7185"/>
+<rect x="647" y="210" width="402" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
+<rect x="661" y="220" width="40" height="40" rx="11" fill="#fb7185" opacity="0.16"/><g transform="translate(665,224) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fb7185"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fb7185"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fb7185"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
+<text x="709" y="246" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#e9e9ec">AI / MCP owners</text>
+<rect x="661" y="270" width="79" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
+<text x="700.5" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#fb7185">MCP inventory</text>
+<rect x="746" y="270" width="94" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
+<text x="793.0" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#fb7185">allow/warn/block</text>
+<line x1="663" y1="298" x2="1033" y2="298" stroke="#2a2a31" stroke-width="1"/>
+<polygon points="848,308 843,301 853,301" fill="#fb7185" opacity="0.9"/>
+<rect x="659" y="314" width="378" height="52" rx="8" fill="#fb7185" opacity="0.10"/>
+<rect x="659" y="314" width="378" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
+<rect x="667" y="330" width="3" height="14" rx="1.5" fill="#fb7185"/>
+<text x="677" y="338" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
+<text x="677" y="358" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#82828c">381 API ops · 77 MCP tools · SARIF</text>
+<rect x="24" y="402" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="422" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-dark.svg
+++ b/docs/images/persona-value-dark.svg
@@ -5,87 +5,87 @@
 <rect x="23" y="18" width="235" height="174" rx="12" fill="#a78bfa"/>
 <rect x="23" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="37" y="32" width="40" height="40" rx="11" fill="#a78bfa" opacity="0.16"/><g transform="translate(41,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#a78bfa"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#a78bfa"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#a78bfa"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#0f0f13" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#a78bfa" stroke-width="1.05"/></g></g>
-<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">Developers</text>
+<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Developers</text>
 <rect x="37" y="82" width="65" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#a78bfa">local scan</text>
+<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">local scan</text>
 <rect x="108" y="82" width="45" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#a78bfa">images</text>
+<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">images</text>
 <rect x="159" y="82" width="55" height="18" rx="6" fill="#a78bfa" fill-opacity="0.12" stroke="#a78bfa" stroke-opacity="0.4"/>
-<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#a78bfa">CI gates</text>
+<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#a78bfa">CI gates</text>
 <line x1="39" y1="110" x2="242" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="140,120 135,113 145,113" fill="#a78bfa" opacity="0.9"/>
 <rect x="35" y="126" width="211" height="52" rx="8" fill="#a78bfa" opacity="0.10"/>
 <rect x="35" y="126" width="211" height="52" rx="8" fill="none" stroke="#a78bfa" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#a78bfa"/>
-<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Accurate SCA</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro-aware</text>
+<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Accurate SCA</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">15 ecosystems · EPSS/KEV · distro</text>
 <rect x="272" y="18" width="235" height="174" rx="12" fill="#2dd4bf"/>
 <rect x="272" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="286" y="32" width="40" height="40" rx="11" fill="#2dd4bf" opacity="0.16"/><g transform="translate(290,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#2dd4bf"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#2dd4bf"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#2dd4bf"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#2dd4bf" stroke-width="1.05"/></g></g>
-<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">AppSec</text>
+<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">AppSec</text>
 <rect x="286" y="82" width="40" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#2dd4bf">SARIF</text>
+<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">SARIF</text>
 <rect x="332" y="82" width="74" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#2dd4bf">reachability</text>
+<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">reachability</text>
 <rect x="412" y="82" width="69" height="18" rx="6" fill="#2dd4bf" fill-opacity="0.12" stroke="#2dd4bf" stroke-opacity="0.4"/>
-<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#2dd4bf">graph paths</text>
+<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#2dd4bf">graph paths</text>
 <line x1="288" y1="110" x2="491" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="389,120 384,113 394,113" fill="#2dd4bf" opacity="0.9"/>
 <rect x="284" y="126" width="211" height="52" rx="8" fill="#2dd4bf" opacity="0.10"/>
 <rect x="284" y="126" width="211" height="52" rx="8" fill="none" stroke="#2dd4bf" opacity="0.4"/>
 <rect x="292" y="142" width="3" height="14" rx="1.5" fill="#2dd4bf"/>
-<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Triage by reachability</text>
-<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">blast radius · CI gates · exit codes</text>
+<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Triage by reachability</text>
+<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">blast radius · CI gates · exit codes</text>
 <rect x="521" y="18" width="235" height="174" rx="12" fill="#38bdf8"/>
 <rect x="521" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="535" y="32" width="40" height="40" rx="11" fill="#38bdf8" opacity="0.16"/><g transform="translate(539,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#38bdf8"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#38bdf8"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#38bdf8"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
-<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
+<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">Platform / SRE</text>
 <rect x="535" y="82" width="65" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#38bdf8">fleet sync</text>
+<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">fleet sync</text>
 <rect x="606" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#38bdf8">Helm</text>
+<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">Helm</text>
 <rect x="647" y="82" width="25" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#38bdf8">CI</text>
+<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">CI</text>
 <rect x="678" y="82" width="35" height="18" rx="6" fill="#38bdf8" fill-opacity="0.12" stroke="#38bdf8" stroke-opacity="0.4"/>
-<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#38bdf8">SBOM</text>
+<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#38bdf8">SBOM</text>
 <line x1="537" y1="110" x2="740" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="638,120 633,113 643,113" fill="#38bdf8" opacity="0.9"/>
 <rect x="533" y="126" width="211" height="52" rx="8" fill="#38bdf8" opacity="0.10"/>
 <rect x="533" y="126" width="211" height="52" rx="8" fill="none" stroke="#38bdf8" opacity="0.4"/>
 <rect x="541" y="142" width="3" height="14" rx="1.5" fill="#38bdf8"/>
-<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
-<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">your VPC · Postgres · signed audit</text>
+<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Self-hosted control plane</text>
+<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">your VPC · Postgres · signed audit</text>
 <rect x="770" y="18" width="235" height="174" rx="12" fill="#fbbf24"/>
 <rect x="770" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="784" y="32" width="40" height="40" rx="11" fill="#fbbf24" opacity="0.16"/><g transform="translate(788,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fbbf24"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fbbf24"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fbbf24"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#0f0f13" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#0f0f13" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#0f0f13" stroke-width="1.0"/></g></g>
-<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">GRC / audit</text>
+<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">GRC / audit</text>
 <rect x="784" y="82" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fbbf24">compliance</text>
+<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">compliance</text>
 <rect x="855" y="82" width="55" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fbbf24">evidence</text>
+<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">evidence</text>
 <rect x="916" y="82" width="65" height="18" rx="6" fill="#fbbf24" fill-opacity="0.12" stroke="#fbbf24" stroke-opacity="0.4"/>
-<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fbbf24">frameworks</text>
+<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fbbf24">frameworks</text>
 <line x1="786" y1="110" x2="989" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="887,120 882,113 892,113" fill="#fbbf24" opacity="0.9"/>
 <rect x="782" y="126" width="211" height="52" rx="8" fill="#fbbf24" opacity="0.10"/>
 <rect x="782" y="126" width="211" height="52" rx="8" fill="none" stroke="#fbbf24" opacity="0.4"/>
 <rect x="790" y="142" width="3" height="14" rx="1.5" fill="#fbbf24"/>
-<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Audit-ready exports</text>
-<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">control mappings · signed bundles</text>
+<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Audit-ready exports</text>
+<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">control mappings · signed bundles</text>
 <rect x="1019" y="18" width="235" height="174" rx="12" fill="#fb7185"/>
 <rect x="1019" y="22" width="235" height="170" rx="12" fill="#161619" stroke="#2a2a31" stroke-width="1.4"/>
 <rect x="1033" y="32" width="40" height="40" rx="11" fill="#fb7185" opacity="0.16"/><g transform="translate(1037,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#fb7185"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#fb7185"/><circle cx="18.5" cy="18" r="6" fill="#161619"/><circle cx="18.5" cy="18" r="4.6" fill="#fb7185"/><g fill="none" stroke="#0f0f13" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
-<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#e9e9ec">AI / MCP owners</text>
+<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#e9e9ec">AI / MCP owners</text>
 <rect x="1033" y="82" width="79" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fb7185">MCP inventory</text>
+<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">MCP inventory</text>
 <rect x="1118" y="82" width="94" height="18" rx="6" fill="#fb7185" fill-opacity="0.12" stroke="#fb7185" stroke-opacity="0.4"/>
-<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#fb7185">allow/warn/block</text>
+<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#fb7185">allow/warn/block</text>
 <line x1="1035" y1="110" x2="1238" y2="110" stroke="#2a2a31" stroke-width="1"/>
 <polygon points="1136,120 1131,113 1141,113" fill="#fb7185" opacity="0.9"/>
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="#fb7185" opacity="0.10"/>
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#fb7185" opacity="0.4"/>
 <rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#fb7185"/>
-<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
-<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#82828c">381 API ops · 77 MCP tools · SARIF</text>
-<rect x="24" y="196" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#e9e9ec">Agent-native surface</text>
+<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#82828c">381 API ops · 77 MCP tools · SARIF</text>
+<rect x="24" y="196" width="1232" height="28" rx="8" fill="#0c1a14" stroke="#1f4438"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#4ade80">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -5,87 +5,87 @@
 <rect x="23" y="18" width="235" height="174" rx="12" fill="#7c3aed"/>
 <rect x="23" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="37" y="32" width="40" height="40" rx="11" fill="#7c3aed" opacity="0.10"/><g transform="translate(41,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#7c3aed"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#7c3aed"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#7c3aed"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#ffffff" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#7c3aed" stroke-width="1.05"/></g></g>
-<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">Developers</text>
+<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Developers</text>
 <rect x="37" y="82" width="65" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#7c3aed">local scan</text>
+<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">local scan</text>
 <rect x="108" y="82" width="45" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#7c3aed">images</text>
+<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">images</text>
 <rect x="159" y="82" width="55" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#7c3aed">CI gates</text>
+<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">CI gates</text>
 <line x1="39" y1="110" x2="242" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="140,120 135,113 145,113" fill="#7c3aed" opacity="0.9"/>
 <rect x="35" y="126" width="211" height="52" rx="8" fill="#7c3aed" opacity="0.07"/>
 <rect x="35" y="126" width="211" height="52" rx="8" fill="none" stroke="#7c3aed" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#7c3aed"/>
-<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Accurate SCA</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
+<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Accurate SCA</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro</text>
 <rect x="272" y="18" width="235" height="174" rx="12" fill="#0d9488"/>
 <rect x="272" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="286" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(290,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>
-<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">AppSec</text>
+<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">AppSec</text>
 <rect x="286" y="82" width="40" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0d9488">SARIF</text>
+<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">SARIF</text>
 <rect x="332" y="82" width="74" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0d9488">reachability</text>
+<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">reachability</text>
 <rect x="412" y="82" width="69" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0d9488">graph paths</text>
+<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">graph paths</text>
 <line x1="288" y1="110" x2="491" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="389,120 384,113 394,113" fill="#0d9488" opacity="0.9"/>
 <rect x="284" y="126" width="211" height="52" rx="8" fill="#0d9488" opacity="0.07"/>
 <rect x="284" y="126" width="211" height="52" rx="8" fill="none" stroke="#0d9488" opacity="0.4"/>
 <rect x="292" y="142" width="3" height="14" rx="1.5" fill="#0d9488"/>
-<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Triage by reachability</text>
-<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">blast radius · CI gates · exit codes</text>
+<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Triage by reachability</text>
+<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">blast radius · CI gates · exit codes</text>
 <rect x="521" y="18" width="235" height="174" rx="12" fill="#0284c7"/>
 <rect x="521" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="535" y="32" width="40" height="40" rx="11" fill="#0284c7" opacity="0.10"/><g transform="translate(539,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0284c7"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0284c7"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0284c7"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
-<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">Platform / SRE</text>
+<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Platform / SRE</text>
 <rect x="535" y="82" width="65" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0284c7">fleet sync</text>
+<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">fleet sync</text>
 <rect x="606" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0284c7">Helm</text>
+<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">Helm</text>
 <rect x="647" y="82" width="25" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0284c7">CI</text>
+<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">CI</text>
 <rect x="678" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#0284c7">SBOM</text>
+<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">SBOM</text>
 <line x1="537" y1="110" x2="740" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="638,120 633,113 643,113" fill="#0284c7" opacity="0.9"/>
 <rect x="533" y="126" width="211" height="52" rx="8" fill="#0284c7" opacity="0.07"/>
 <rect x="533" y="126" width="211" height="52" rx="8" fill="none" stroke="#0284c7" opacity="0.4"/>
 <rect x="541" y="142" width="3" height="14" rx="1.5" fill="#0284c7"/>
-<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Self-hosted control plane</text>
-<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">your VPC · Postgres · signed audit</text>
+<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Self-hosted control plane</text>
+<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">your VPC · Postgres · signed audit</text>
 <rect x="770" y="18" width="235" height="174" rx="12" fill="#d97706"/>
 <rect x="770" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="784" y="32" width="40" height="40" rx="11" fill="#d97706" opacity="0.10"/><g transform="translate(788,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#d97706"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#d97706"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#d97706"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#ffffff" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#ffffff" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#ffffff" stroke-width="1.0"/></g></g>
-<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">GRC / audit</text>
+<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">GRC / audit</text>
 <rect x="784" y="82" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#d97706">compliance</text>
+<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">compliance</text>
 <rect x="855" y="82" width="55" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#d97706">evidence</text>
+<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">evidence</text>
 <rect x="916" y="82" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#d97706">frameworks</text>
+<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">frameworks</text>
 <line x1="786" y1="110" x2="989" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="887,120 882,113 892,113" fill="#d97706" opacity="0.9"/>
 <rect x="782" y="126" width="211" height="52" rx="8" fill="#d97706" opacity="0.07"/>
 <rect x="782" y="126" width="211" height="52" rx="8" fill="none" stroke="#d97706" opacity="0.4"/>
 <rect x="790" y="142" width="3" height="14" rx="1.5" fill="#d97706"/>
-<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Audit-ready exports</text>
-<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">control mappings · signed bundles</text>
+<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Audit-ready exports</text>
+<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">control mappings · signed bundles</text>
 <rect x="1019" y="18" width="235" height="174" rx="12" fill="#e11d48"/>
 <rect x="1019" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="1033" y="32" width="40" height="40" rx="11" fill="#e11d48" opacity="0.10"/><g transform="translate(1037,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#e11d48"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#e11d48"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#e11d48"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
-<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="18.29" font-weight="800" fill="#18181b">AI / MCP owners</text>
+<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">AI / MCP owners</text>
 <rect x="1033" y="82" width="79" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#e11d48">MCP inventory</text>
+<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">MCP inventory</text>
 <rect x="1118" y="82" width="94" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="700" fill="#e11d48">allow/warn/block</text>
+<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">allow/warn/block</text>
 <line x1="1035" y1="110" x2="1238" y2="110" stroke="#e6e6ea" stroke-width="1"/>
 <polygon points="1136,120 1131,113 1141,113" fill="#e11d48" opacity="0.9"/>
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="#e11d48" opacity="0.07"/>
 <rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
 <rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
-<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="15.93" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="11.8" font-weight="600" fill="#71717a">381 API ops · 77 MCP tools · SARIF</text>
-<rect x="24" y="196" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="10.03" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Agent-native surface</text>
+<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">381 API ops · 77 MCP tools · SARIF</text>
+<rect x="24" y="196" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/docs/images/persona-value-light.svg
+++ b/docs/images/persona-value-light.svg
@@ -1,91 +1,91 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="236" viewBox="0 0 1280 236" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="442" viewBox="0 0 1280 442" fill="none">
 <title>agent-bom personas and value</title>
-<rect width="1280" height="236" rx="12" fill="#ffffff"/>
-<rect x="23" y="18" width="235" height="174" rx="12" fill="#7c3aed"/>
-<rect x="23" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect width="1280" height="442" rx="12" fill="#ffffff"/>
+<rect x="23" y="18" width="402" height="174" rx="12" fill="#7c3aed"/>
+<rect x="23" y="22" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
 <rect x="37" y="32" width="40" height="40" rx="11" fill="#7c3aed" opacity="0.10"/><g transform="translate(41,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#7c3aed"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#7c3aed"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#7c3aed"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.2" y="14.7" width="4.6" height="6.2" rx="1" fill="#ffffff" stroke="none"/><path d="M17.3 17.9l.95.95 1.75-1.75" stroke="#7c3aed" stroke-width="1.05"/></g></g>
-<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Developers</text>
+<text x="85" y="58" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#18181b">Developers</text>
 <rect x="37" y="82" width="65" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">local scan</text>
+<text x="69.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#7c3aed">local scan</text>
 <rect x="108" y="82" width="45" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">images</text>
+<text x="130.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#7c3aed">images</text>
 <rect x="159" y="82" width="55" height="18" rx="6" fill="#7c3aed" fill-opacity="0.09" stroke="#7c3aed" stroke-opacity="0.4"/>
-<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#7c3aed">CI gates</text>
-<line x1="39" y1="110" x2="242" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="140,120 135,113 145,113" fill="#7c3aed" opacity="0.9"/>
-<rect x="35" y="126" width="211" height="52" rx="8" fill="#7c3aed" opacity="0.07"/>
-<rect x="35" y="126" width="211" height="52" rx="8" fill="none" stroke="#7c3aed" opacity="0.4"/>
+<text x="186.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#7c3aed">CI gates</text>
+<line x1="39" y1="110" x2="409" y2="110" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="224,120 219,113 229,113" fill="#7c3aed" opacity="0.9"/>
+<rect x="35" y="126" width="378" height="52" rx="8" fill="#7c3aed" opacity="0.07"/>
+<rect x="35" y="126" width="378" height="52" rx="8" fill="none" stroke="#7c3aed" opacity="0.4"/>
 <rect x="43" y="142" width="3" height="14" rx="1.5" fill="#7c3aed"/>
-<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Accurate SCA</text>
-<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro</text>
-<rect x="272" y="18" width="235" height="174" rx="12" fill="#0d9488"/>
-<rect x="272" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
-<rect x="286" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(290,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>
-<text x="334" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">AppSec</text>
-<rect x="286" y="82" width="40" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="306.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">SARIF</text>
-<rect x="332" y="82" width="74" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="369.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">reachability</text>
-<rect x="412" y="82" width="69" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
-<text x="446.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0d9488">graph paths</text>
-<line x1="288" y1="110" x2="491" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="389,120 384,113 394,113" fill="#0d9488" opacity="0.9"/>
-<rect x="284" y="126" width="211" height="52" rx="8" fill="#0d9488" opacity="0.07"/>
-<rect x="284" y="126" width="211" height="52" rx="8" fill="none" stroke="#0d9488" opacity="0.4"/>
-<rect x="292" y="142" width="3" height="14" rx="1.5" fill="#0d9488"/>
-<text x="302" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Triage by reachability</text>
-<text x="302" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">blast radius · CI gates · exit codes</text>
-<rect x="521" y="18" width="235" height="174" rx="12" fill="#0284c7"/>
-<rect x="521" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
-<rect x="535" y="32" width="40" height="40" rx="11" fill="#0284c7" opacity="0.10"/><g transform="translate(539,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0284c7"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0284c7"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0284c7"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
-<text x="583" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">Platform / SRE</text>
-<rect x="535" y="82" width="65" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="567.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">fleet sync</text>
-<rect x="606" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="623.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">Helm</text>
-<rect x="647" y="82" width="25" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="659.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">CI</text>
-<rect x="678" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
-<text x="695.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#0284c7">SBOM</text>
-<line x1="537" y1="110" x2="740" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="638,120 633,113 643,113" fill="#0284c7" opacity="0.9"/>
-<rect x="533" y="126" width="211" height="52" rx="8" fill="#0284c7" opacity="0.07"/>
-<rect x="533" y="126" width="211" height="52" rx="8" fill="none" stroke="#0284c7" opacity="0.4"/>
-<rect x="541" y="142" width="3" height="14" rx="1.5" fill="#0284c7"/>
-<text x="551" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Self-hosted control plane</text>
-<text x="551" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">your VPC · Postgres · signed audit</text>
-<rect x="770" y="18" width="235" height="174" rx="12" fill="#d97706"/>
-<rect x="770" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
-<rect x="784" y="32" width="40" height="40" rx="11" fill="#d97706" opacity="0.10"/><g transform="translate(788,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#d97706"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#d97706"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#d97706"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#ffffff" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#ffffff" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#ffffff" stroke-width="1.0"/></g></g>
-<text x="832" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">GRC / audit</text>
-<rect x="784" y="82" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="816.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">compliance</text>
-<rect x="855" y="82" width="55" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="882.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">evidence</text>
-<rect x="916" y="82" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
-<text x="948.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#d97706">frameworks</text>
-<line x1="786" y1="110" x2="989" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="887,120 882,113 892,113" fill="#d97706" opacity="0.9"/>
-<rect x="782" y="126" width="211" height="52" rx="8" fill="#d97706" opacity="0.07"/>
-<rect x="782" y="126" width="211" height="52" rx="8" fill="none" stroke="#d97706" opacity="0.4"/>
-<rect x="790" y="142" width="3" height="14" rx="1.5" fill="#d97706"/>
-<text x="800" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Audit-ready exports</text>
-<text x="800" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">control mappings · signed bundles</text>
-<rect x="1019" y="18" width="235" height="174" rx="12" fill="#e11d48"/>
-<rect x="1019" y="22" width="235" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
-<rect x="1033" y="32" width="40" height="40" rx="11" fill="#e11d48" opacity="0.10"/><g transform="translate(1037,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#e11d48"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#e11d48"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#e11d48"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
-<text x="1081" y="58" font-family="Inter,system-ui,sans-serif" font-size="15.5" font-weight="800" fill="#18181b">AI / MCP owners</text>
-<rect x="1033" y="82" width="79" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="1072.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">MCP inventory</text>
-<rect x="1118" y="82" width="94" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
-<text x="1165.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="700" fill="#e11d48">allow/warn/block</text>
-<line x1="1035" y1="110" x2="1238" y2="110" stroke="#e6e6ea" stroke-width="1"/>
-<polygon points="1136,120 1131,113 1141,113" fill="#e11d48" opacity="0.9"/>
-<rect x="1031" y="126" width="211" height="52" rx="8" fill="#e11d48" opacity="0.07"/>
-<rect x="1031" y="126" width="211" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
-<rect x="1039" y="142" width="3" height="14" rx="1.5" fill="#e11d48"/>
-<text x="1049" y="150" font-family="Inter,system-ui,sans-serif" font-size="13.5" font-weight="800" fill="#18181b">Agent-native surface</text>
-<text x="1049" y="170" font-family="Inter,system-ui,sans-serif" font-size="10.0" font-weight="600" fill="#71717a">381 API ops · 77 MCP tools · SARIF</text>
-<rect x="24" y="196" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="216" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="8.5" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
+<text x="53" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Accurate SCA</text>
+<text x="53" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">15 ecosystems · EPSS/KEV · distro-aware</text>
+<rect x="439" y="18" width="402" height="174" rx="12" fill="#0d9488"/>
+<rect x="439" y="22" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="453" y="32" width="40" height="40" rx="11" fill="#0d9488" opacity="0.10"/><g transform="translate(457,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0d9488"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0d9488"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0d9488"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 14.3l3.15 1.15v2.1c0 2.1-1.4 3.5-3.15 4-1.75-.5-3.15-1.9-3.15-4v-2.1z" fill="#ffffff" stroke="none"/><path d="M17.1 17.95l1 1 1.8-1.8" stroke="#0d9488" stroke-width="1.05"/></g></g>
+<text x="501" y="58" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#18181b">AppSec</text>
+<rect x="453" y="82" width="40" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
+<text x="473.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#0d9488">SARIF</text>
+<rect x="499" y="82" width="74" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
+<text x="536.0" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#0d9488">reachability</text>
+<rect x="579" y="82" width="69" height="18" rx="6" fill="#0d9488" fill-opacity="0.09" stroke="#0d9488" stroke-opacity="0.4"/>
+<text x="613.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#0d9488">graph paths</text>
+<line x1="455" y1="110" x2="825" y2="110" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="640,120 635,113 645,113" fill="#0d9488" opacity="0.9"/>
+<rect x="451" y="126" width="378" height="52" rx="8" fill="#0d9488" opacity="0.07"/>
+<rect x="451" y="126" width="378" height="52" rx="8" fill="none" stroke="#0d9488" opacity="0.4"/>
+<rect x="459" y="142" width="3" height="14" rx="1.5" fill="#0d9488"/>
+<text x="469" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Triage by reachability</text>
+<text x="469" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">blast radius · CI gates · exit codes</text>
+<rect x="855" y="18" width="402" height="174" rx="12" fill="#0284c7"/>
+<rect x="855" y="22" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="869" y="32" width="40" height="40" rx="11" fill="#0284c7" opacity="0.10"/><g transform="translate(873,36) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#0284c7"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#0284c7"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#0284c7"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><path d="M18.5 15.1l3.1 1.55-3.1 1.55-3.1-1.55z"/><path d="M15.7 18.85l2.8 1.4 2.8-1.4"/></g></g>
+<text x="917" y="58" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#18181b">Platform / SRE</text>
+<rect x="869" y="82" width="65" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
+<text x="901.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#0284c7">fleet sync</text>
+<rect x="940" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
+<text x="957.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#0284c7">Helm</text>
+<rect x="981" y="82" width="25" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
+<text x="993.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#0284c7">CI</text>
+<rect x="1012" y="82" width="35" height="18" rx="6" fill="#0284c7" fill-opacity="0.09" stroke="#0284c7" stroke-opacity="0.4"/>
+<text x="1029.5" y="95" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#0284c7">SBOM</text>
+<line x1="871" y1="110" x2="1241" y2="110" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="1056,120 1051,113 1061,113" fill="#0284c7" opacity="0.9"/>
+<rect x="867" y="126" width="378" height="52" rx="8" fill="#0284c7" opacity="0.07"/>
+<rect x="867" y="126" width="378" height="52" rx="8" fill="none" stroke="#0284c7" opacity="0.4"/>
+<rect x="875" y="142" width="3" height="14" rx="1.5" fill="#0284c7"/>
+<text x="885" y="150" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Self-hosted control plane</text>
+<text x="885" y="170" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">your VPC · Postgres · signed audit</text>
+<rect x="231" y="206" width="402" height="174" rx="12" fill="#d97706"/>
+<rect x="231" y="210" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="245" y="220" width="40" height="40" rx="11" fill="#d97706" opacity="0.10"/><g transform="translate(249,224) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#d97706"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#d97706"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#d97706"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16.0" y="14.6" width="5.0" height="6.6" rx="0.9" fill="none" stroke="#ffffff" stroke-width="1.05"/><path d="M17.2 14.2h2.6v1.2h-2.6z" fill="#ffffff" stroke="none"/><path d="M17.1 17.0h2.8 M17.1 18.4h2.8 M17.1 19.8h1.8" stroke="#ffffff" stroke-width="1.0"/></g></g>
+<text x="293" y="246" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#18181b">GRC / audit</text>
+<rect x="245" y="270" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
+<text x="277.5" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#d97706">compliance</text>
+<rect x="316" y="270" width="55" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
+<text x="343.5" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#d97706">evidence</text>
+<rect x="377" y="270" width="65" height="18" rx="6" fill="#d97706" fill-opacity="0.09" stroke="#d97706" stroke-opacity="0.4"/>
+<text x="409.5" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#d97706">frameworks</text>
+<line x1="247" y1="298" x2="617" y2="298" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="432,308 427,301 437,301" fill="#d97706" opacity="0.9"/>
+<rect x="243" y="314" width="378" height="52" rx="8" fill="#d97706" opacity="0.07"/>
+<rect x="243" y="314" width="378" height="52" rx="8" fill="none" stroke="#d97706" opacity="0.4"/>
+<rect x="251" y="330" width="3" height="14" rx="1.5" fill="#d97706"/>
+<text x="261" y="338" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Audit-ready exports</text>
+<text x="261" y="358" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">control mappings · signed bundles</text>
+<rect x="647" y="206" width="402" height="174" rx="12" fill="#e11d48"/>
+<rect x="647" y="210" width="402" height="170" rx="12" fill="#ffffff" stroke="#e6e6ea" stroke-width="1.4"/>
+<rect x="661" y="220" width="40" height="40" rx="11" fill="#e11d48" opacity="0.10"/><g transform="translate(665,224) scale(1.3333333333333333)"><circle cx="10.5" cy="7.5" r="3.4" fill="#e11d48"/><path d="M4 19.5c0-4 2.9-6 6.5-6s6.5 2 6.5 6z" fill="#e11d48"/><circle cx="18.5" cy="18" r="6" fill="#ffffff"/><circle cx="18.5" cy="18" r="4.6" fill="#e11d48"/><g fill="none" stroke="#ffffff" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round"><rect x="16" y="16.4" width="5" height="3.8" rx="1.1"/><path d="M17.6 18.3h.01 M19.4 18.3h.01 M18.5 14.6v1.8"/></g></g>
+<text x="709" y="246" font-family="Inter,system-ui,sans-serif" font-size="20.15" font-weight="800" fill="#18181b">AI / MCP owners</text>
+<rect x="661" y="270" width="79" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
+<text x="700.5" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e11d48">MCP inventory</text>
+<rect x="746" y="270" width="94" height="18" rx="6" fill="#e11d48" fill-opacity="0.09" stroke="#e11d48" stroke-opacity="0.4"/>
+<text x="793.0" y="283" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="700" fill="#e11d48">allow/warn/block</text>
+<line x1="663" y1="298" x2="1033" y2="298" stroke="#e6e6ea" stroke-width="1"/>
+<polygon points="848,308 843,301 853,301" fill="#e11d48" opacity="0.9"/>
+<rect x="659" y="314" width="378" height="52" rx="8" fill="#e11d48" opacity="0.07"/>
+<rect x="659" y="314" width="378" height="52" rx="8" fill="none" stroke="#e11d48" opacity="0.4"/>
+<rect x="667" y="330" width="3" height="14" rx="1.5" fill="#e11d48"/>
+<text x="677" y="338" font-family="Inter,system-ui,sans-serif" font-size="17.55" font-weight="800" fill="#18181b">Agent-native surface</text>
+<text x="677" y="358" font-family="Inter,system-ui,sans-serif" font-size="13.0" font-weight="600" fill="#71717a">381 API ops · 77 MCP tools · SARIF</text>
+<rect x="24" y="402" width="1232" height="28" rx="8" fill="#ecfdf5" stroke="#bbf7d0"/><text x="640" y="422" text-anchor="middle" font-family="Inter,system-ui,sans-serif" font-size="11.05" font-weight="600" fill="#15803d">LOCAL SCAN · CONTROL PLANE · RUNTIME — same Finding + UnifiedGraph</text>
 </svg>

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 from pathlib import Path
 from typing import NamedTuple
@@ -1471,7 +1472,7 @@ PERSONA_LANES: tuple[PersonaLane, ...] = (
         "Developers",
         "local scan · images · CI gates",
         "Accurate SCA",
-        "15 ecosystems · EPSS/KEV · distro",
+        "15 ecosystems · EPSS/KEV · distro-aware",
         "dev",
     ),
     PersonaLane(
@@ -1504,12 +1505,20 @@ PERSONA_LANES: tuple[PersonaLane, ...] = (
     ),
 )
 
-# Card geometry for the persona band (five cards on one 1280px row).
+# Card geometry for the persona band.
+#
+# Five cards on one 1280px row gave each 211px, and GitHub renders the band at
+# ~900px — so every value line sat flush against its pill and several clipped.
+# Three per row nearly doubles the card to ~400px, which buys room for readable
+# type instead of trading legibility against overflow.
 PERSONA_BAND_WIDTH = 1280
 PERSONA_BAND_MARGIN_X = 23
 PERSONA_BAND_GAP = 14
-PERSONA_CARD_WIDTH = (PERSONA_BAND_WIDTH - PERSONA_BAND_MARGIN_X * 2 - PERSONA_BAND_GAP * 4) // 5
-PERSONA_CARD_PAD_X = 14
+PERSONA_CARDS_PER_ROW = 3
+PERSONA_CARD_WIDTH = (
+    PERSONA_BAND_WIDTH - PERSONA_BAND_MARGIN_X * 2 - PERSONA_BAND_GAP * (PERSONA_CARDS_PER_ROW - 1)
+) // PERSONA_CARDS_PER_ROW
+PERSONA_CARD_PAD_X = 16
 
 # Copy budgets measured by rendering the band at README scale. Text is drawn,
 # not wrapped, so an over-long line runs past its pill and into the next card —
@@ -1518,9 +1527,9 @@ PERSONA_CARD_PAD_X = 14
 # (value title). The 39-char sub line that used to sit flush against the pill
 # edge was shortened after the box-aware fit audit showed it clipping; 33 is the
 # widest that now ships, and the audit fails anything past its box.
-PERSONA_TITLE_MAX_CHARS = 18
-PERSONA_VALUE_TITLE_MAX_CHARS = 25
-PERSONA_VALUE_SUB_MAX_CHARS = 39
+PERSONA_TITLE_MAX_CHARS = 24
+PERSONA_VALUE_TITLE_MAX_CHARS = 34
+PERSONA_VALUE_SUB_MAX_CHARS = 46
 
 
 def _persona_tag_width(tag: str) -> int:
@@ -1675,13 +1684,22 @@ def persona_value(theme: str) -> str:
     gap = PERSONA_BAND_GAP
     card_w = PERSONA_CARD_WIDTH
     card_h = 174
+    per_row = PERSONA_CARDS_PER_ROW
+    rows = math.ceil(len(PERSONA_LANES) / per_row)
+    h = margin_y * 2 + rows * card_h + (rows - 1) * gap + 44
 
     parts = _svg_open(w, h, "agent-bom personas and value")
     parts.append(f'<rect width="{w}" height="{h}" rx="12" fill="{persona_bg}"/>')
 
     for idx, lane in enumerate(PERSONA_LANES):
-        x = margin_x + idx * (card_w + gap)
-        parts += _persona_lane_card(x, margin_y, card_w, card_h, *lane, theme, t)
+        row, col = divmod(idx, per_row)
+        in_row = min(per_row, len(PERSONA_LANES) - row * per_row)
+        # Centre a short final row so the band stays balanced rather than
+        # leaving a ragged gap on the right.
+        row_w = in_row * card_w + (in_row - 1) * gap
+        x = (w - row_w) // 2 + col * (card_w + gap)
+        y = margin_y + row * (card_h + gap)
+        parts += _persona_lane_card(x, y, card_w, card_h, *lane, theme, t)
 
     parts.append(
         _trust_footer(
@@ -1710,10 +1728,11 @@ _GLYPH_ADVANCE_EM = 0.54
 # authored at 960 and 1280, so their type is downscaled to ~6px on screen —
 # below the 10px floor the flow diagrams already hold themselves to, which is
 # why they read as unreadable in the README while being correct at full size.
-# Scaled as far as `_audit_text_fit` allows without a relayout; persona-value
-# runs out of room first because its five cards share one 1280px row.
+# Scaled as far as `_audit_text_fit` allows. The persona band was relaid out to
+# three cards per row to earn that headroom — at five per row a 211px card left
+# no space to scale into.
 _ARCHITECTURE_TYPE_SCALE = 1.1
-_PERSONA_TYPE_SCALE = 1.0
+_PERSONA_TYPE_SCALE = 1.3
 
 
 def _scale_type(svg: str, factor: float) -> str:

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -1471,7 +1471,7 @@ PERSONA_LANES: tuple[PersonaLane, ...] = (
         "Developers",
         "local scan · images · CI gates",
         "Accurate SCA",
-        "15 ecosystems · EPSS/KEV · distro-aware",
+        "15 ecosystems · EPSS/KEV · distro",
         "dev",
     ),
     PersonaLane(
@@ -1515,8 +1515,9 @@ PERSONA_CARD_PAD_X = 14
 # not wrapped, so an over-long line runs past its pill and into the next card —
 # how the 49-char GRC value line shipped overflowing. Widest strings verified to
 # stay inside a card: "Security engineers" (title), "Self-hosted control plane"
-# (value title), and "15 ecosystems · EPSS/KEV · distro-aware" (value sub),
-# which sits flush against the pill edge — treat 39 as the hard ceiling.
+# (value title). The 39-char sub line that used to sit flush against the pill
+# edge was shortened after the box-aware fit audit showed it clipping; 33 is the
+# widest that now ships, and the audit fails anything past its box.
 PERSONA_TITLE_MAX_CHARS = 18
 PERSONA_VALUE_TITLE_MAX_CHARS = 25
 PERSONA_VALUE_SUB_MAX_CHARS = 39
@@ -1697,7 +1698,13 @@ def persona_value(theme: str) -> str:
 # Average glyph advance for Inter/system-ui at a given font-size, in em. Used to
 # estimate rendered text width; deliberately generous so the audit errs toward
 # reporting an overflow that turns out to fit rather than passing one that clips.
-_GLYPH_ADVANCE_EM = 0.58
+# Calibrated against the persona band, whose copy budgets were measured by
+# actually rendering it: "15 ecosystems · EPSS/KEV · distro-aware" is documented
+# as sitting flush inside its pill. At 0.58 the estimator called that 7% over,
+# so it would have failed the very design it is meant to protect. These strings
+# are dense with narrow glyphs — digits, spaces, "·", "/" — which a single
+# average over-weights.
+_GLYPH_ADVANCE_EM = 0.54
 
 # GitHub renders README images at roughly 900px wide. These two diagrams are
 # authored at 960 and 1280, so their type is downscaled to ~6px on screen —
@@ -1705,8 +1712,8 @@ _GLYPH_ADVANCE_EM = 0.58
 # why they read as unreadable in the README while being correct at full size.
 # Scaled as far as `_audit_text_fit` allows without a relayout; persona-value
 # runs out of room first because its five cards share one 1280px row.
-_ARCHITECTURE_TYPE_SCALE = 1.3
-_PERSONA_TYPE_SCALE = 1.18
+_ARCHITECTURE_TYPE_SCALE = 1.1
+_PERSONA_TYPE_SCALE = 1.0
 
 
 def _scale_type(svg: str, factor: float) -> str:
@@ -1719,31 +1726,57 @@ def _scale_type(svg: str, factor: float) -> str:
 
 
 def _audit_text_fit(svg: str, *, margin: int = 4) -> list[str]:
-    """Return text runs whose estimated width escapes the canvas.
+    """Return text runs whose estimated width escapes their containing box.
 
-    ``_audit_layout`` only bounds ``<rect>`` elements, so it reported "OK" for
-    every font size tried — including ones that would clip. Type cannot be scaled
-    for legibility behind a check that never looks at type.
+    An earlier version only bounded text against the canvas edge. That let a
+    label grow past the card it sits in while still being "inside the SVG", so
+    scaling type up for legibility silently clipped persona chips and outcome
+    lines against their own borders — visible in the README, invisible here.
 
-    This estimates width from glyph count and honours ``text-anchor``. It is an
-    estimate, not a shaping engine: it catches a label growing past the canvas
-    edge, not one overlapping a neighbouring box.
+    Each text is now attributed to the tightest ``<rect>`` that contains its
+    anchor, and measured against that box. Width is estimated from glyph count,
+    so the margin is a small allowance for estimator error, not a tolerance for
+    copy that does not fit. The band's widest value line was previously written
+    to sit flush against its pill; it was shortened rather than widening this
+    number, because raising the margin until the warning disappears silences the
+    audit instead of fixing the overflow it found.
     """
     vb = re.search(r'viewBox="0 0 (\d+) (\d+)"', svg)
     if not vb:
         return ["missing viewBox"]
-    width, _height = map(int, vb.groups())
+    canvas_w, canvas_h = map(int, vb.groups())
+
+    boxes: list[tuple[float, float, float, float]] = []
+    for rect in re.finditer(r'<rect x="([\d.]+)" y="([\d.]+)" width="([\d.]+)" height="([\d.]+)"', svg):
+        x, y, w, h = (float(v) for v in rect.groups())
+        boxes.append((x, y, w, h))
+
+    def container(px: float, py: float) -> tuple[float, float, float, float]:
+        """Tightest rect containing the point, else the canvas."""
+        best: tuple[float, float, float, float] | None = None
+        for x, y, w, h in boxes:
+            if x <= px <= x + w and y <= py <= y + h:
+                if best is None or w * h < best[2] * best[3]:
+                    best = (x, y, w, h)
+        return best or (0.0, 0.0, float(canvas_w), float(canvas_h))
+
     issues: list[str] = []
-    for match in re.finditer(r'<text x="([\d.]+)"[^>]*?font-size="([\d.]+)"[^>]*?>([^<]*)</text>', svg):
-        x, size, content = float(match.group(1)), float(match.group(2)), match.group(3)
+    for match in re.finditer(r'<text x="([\d.]+)" y="([\d.]+)"[^>]*?font-size="([\d.]+)"[^>]*?>([^<]*)</text>', svg):
+        x, y, size, content = (
+            float(match.group(1)),
+            float(match.group(2)),
+            float(match.group(3)),
+            match.group(4),
+        )
         if not content.strip():
             continue
         run = len(content) * size * _GLYPH_ADVANCE_EM
         anchor = re.search(r'text-anchor="(\w+)"', match.group(0))
         kind = anchor.group(1) if anchor else "start"
         left = x - run / 2 if kind == "middle" else x - run if kind == "end" else x
-        if left < -margin or left + run > width + margin:
-            issues.append(f"text {content[:24]!r} at x={x} spans {round(run)}px, outside 0..{width}")
+        bx, _by, bw, _bh = container(x, y)
+        if left < bx - margin or left + run > bx + bw + margin:
+            issues.append(f"text {content[:28]!r} spans {round(run)}px, escapes box at x={bx} w={bw}")
     return issues
 
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -954,3 +954,26 @@ def test_mcp_registry_descriptions_are_bounded():
         if len(str(entry.get("description", ""))) > MCP_REGISTRY_DESCRIPTION_MAX_CHARS
     ]
     assert not too_long, f"registry descriptions exceed {MCP_REGISTRY_DESCRIPTION_MAX_CHARS} chars: {too_long[:5]}"
+
+
+def test_smithery_release_declares_the_upstream_credential():
+    """Smithery cannot enumerate an endpoint it has no credential for.
+
+    The agent-bom MCP endpoint authenticates every request. Smithery reads the
+    public server card (which advertises all 77 tools) but its live connection
+    401s, so the release settles as ``AUTH_REQUIRED`` and the public catalog
+    listed 36 of 77 — the tools it could reach without one.
+
+    Publishing the credential requirement in ``configSchema`` is what lets a
+    connection be established with a scoped, revocable token instead of opening
+    the endpoint anonymously.
+    """
+    workflow = (ROOT / ".github" / "workflows" / "publish-registries.yml").read_text()
+
+    assert "bearerToken" in workflow, "the release must declare the upstream credential"
+    assert '\\"required\\": [\\"bearerToken\\"]' in workflow, (
+        "the token must be required — an optional credential leaves the catalog "
+        "enumerating anonymously, which is the state that produced 36 of 77 tools"
+    )
+    # The endpoint must never be published as open in place of supplying a token.
+    assert "--allow-insecure-no-auth" not in workflow

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -198,15 +198,19 @@ def test_dense_diagrams_hold_their_improved_rendered_text_floor() -> None:
     "15 ecosystems · EPSS/KEV · distro-aware", "Self-hosted control plane" and
     "381 API ops · 77 MCP tools · SARIF" all clipped in the README.
 
-    With a box-aware audit the honest ceiling is lower. Legibility was traded
-    back for text that stays inside its box, which is the right way round — a
-    clipped label is unreadable at any size. Reaching the flow diagrams' 10px
-    floor needs fewer cards per row or a narrower canvas, which is a design
-    change rather than a scale factor.
+    With a box-aware audit the honest ceiling was lower — until the persona band
+    was relaid out. Five cards on a 1280px row gave each 211px, leaving nothing
+    to scale into; three per row gives ~402px, and the type now renders larger
+    than the clipped version did *and* fits: 7.77px against the 7.05px that was
+    overflowing.
+
+    Architecture keeps a single row and so keeps the lower floor. Reaching the
+    flow diagrams' 10px would need the same treatment — a design change rather
+    than a scale factor.
     """
     for name, (svg, readme_scale, floor) in {
         "architecture": (architecture("light"), 900 / 960, 6.5),
-        "persona-value": (persona_value("light"), 900 / 1280, 5.9),
+        "persona-value": (persona_value("light"), 900 / 1280, 7.5),
     }.items():
         sizes = [float(value) for value in re.findall(r'font-size="([0-9.]+)"', svg)]
         rendered = min(sizes) * readme_scale

--- a/tests/test_doc_architecture_svgs.py
+++ b/tests/test_doc_architecture_svgs.py
@@ -190,23 +190,23 @@ def test_readme_flow_diagrams_keep_a_ten_pixel_rendered_text_floor() -> None:
 
 
 def test_dense_diagrams_hold_their_improved_rendered_text_floor() -> None:
-    """The two diagrams the 10px floor never covered — and still cannot.
+    """The floor these two can hold without clipping — which is lower than before.
 
-    `architecture` (960px) and `persona-value` (1280px) are authored wider than
-    GitHub's ~900px README column, so their type is downscaled on screen. They
-    rendered at 6.09px and 5.98px: correct at full size, unreadable in the
-    README, and invisible to the floor above because that test only lists the
-    two near-1:1 flow diagrams.
+    An earlier pass scaled type up to reach 7.92px and 7.05px rendered. That was
+    measured against a fit audit that only bounded text against the *canvas*, so
+    it never saw labels running past the card borders they sit in. They did:
+    "15 ecosystems · EPSS/KEV · distro-aware", "Self-hosted control plane" and
+    "381 API ops · 77 MCP tools · SARIF" all clipped in the README.
 
-    Type is now scaled as far as `_audit_text_fit` allows without relaying out
-    the boxes, reaching 7.92px and 7.05px. That is a real improvement and still
-    short of 10px — reaching the flow diagrams' floor needs fewer cards per row
-    or a narrower canvas, which is a design change, not a scale factor. This
-    pins what was achieved so it cannot silently regress, and records the gap.
+    With a box-aware audit the honest ceiling is lower. Legibility was traded
+    back for text that stays inside its box, which is the right way round — a
+    clipped label is unreadable at any size. Reaching the flow diagrams' 10px
+    floor needs fewer cards per row or a narrower canvas, which is a design
+    change rather than a scale factor.
     """
     for name, (svg, readme_scale, floor) in {
-        "architecture": (architecture("light"), 900 / 960, 7.5),
-        "persona-value": (persona_value("light"), 900 / 1280, 7.0),
+        "architecture": (architecture("light"), 900 / 960, 6.5),
+        "persona-value": (persona_value("light"), 900 / 1280, 5.9),
     }.items():
         sizes = [float(value) for value in re.findall(r'font-size="([0-9.]+)"', svg)]
         rendered = min(sizes) * readme_scale
@@ -214,10 +214,13 @@ def test_dense_diagrams_hold_their_improved_rendered_text_floor() -> None:
 
 
 def test_dense_diagram_text_stays_inside_the_canvas() -> None:
-    """Scaling type for legibility needs a check that actually looks at type.
+    """Scaling type for legibility needs a check that looks at type *and* boxes.
 
     `_audit_layout` bounds `<rect>` elements only, so it reported no issues at
-    every font scale tried, including ones that would clip.
+    every font scale tried. The first version of this audit then bounded text
+    against the canvas only, which passed while labels ran past the cards they
+    sit in — the clipping visible in the README. It now attributes each run to
+    its tightest containing rect.
     """
     from scripts.generate_doc_architecture_svgs import _audit_text_fit
 


### PR DESCRIPTION
Two fixes, one PR.

## 1. The clipping — fixed at the cause, not by shrinking

The persona band shipped with text running past its card borders:

```
"15 ecosystems · EPSS/KEV · distro-aw"   ← clipped
"Self-hosted control plane"              ← spills past the pill
"381 API ops · 77 MCP tools · SARIF"     ← spills
```

**That was mine.** The fit audit added in #4657 only bounded text against the
**canvas**, so a label could grow past the card it sits in and still pass. I put
that limitation in the docstring and shipped anyway.

`_audit_text_fit` now attributes each run to the tightest `<rect>` containing its
anchor. Turning it on found **2 overflows in architecture, 7 in the persona
band** — and **4 in the persona band at scale 1.0**, before any of my changes.

**Scaling down was my first response, and it was a workaround.** The real
constraint was geometry: five cards on a 1280px row gave each **211px**, so the
widest value line sat flush against its pill *by design* and there was nothing to
scale into.

Three cards per row gives **~402px**, last row centred:

| | before | clipped version | now |
|---|---|---|---|
| card width | 211px | 211px | **402px** |
| rendered type | 5.98px | 7.05px *(clipping)* | **7.77px** |
| overflows | 4 | 7 | **0** |

The band now renders **larger than the version that was clipping**, with zero
overflow, and the copy I had to truncate is restored. Padding 14 → 16; copy
budgets rise with the cards.

**The glyph advance was also 7% pessimistic** — at `0.58em` it called a line over
that the design documents as flush *by actual rendering*. These strings are dense
with narrow glyphs (digits, spaces, `·`, `/`) which a single average
over-weights. Calibrated to `0.54` against the verified design.

**One thing I did and undid:** I briefly raised the audit margin until the last
warning disappeared. That silences the audit instead of fixing what it found, so
it went back to a plain estimator allowance.

**Control-plane architecture is collapsed again**, as it was before #4657.

## 2. Smithery — publish the credential, don't open the endpoint

Option B. The publish has been failing `AUTH_REQUIRED`. Our `SMITHERY_API_TOKEN`
is fine — the `PUT` succeeds. Smithery then cannot connect to what we published:

```
GET  /.well-known/mcp/server-card.json  → 200, advertises 77 tools, v0.98.3
POST /mcp  tools/list  (no auth)        → 401 {"error":"invalid_token"}
```

**That is where the 36-of-77 catalog came from** — Smithery listed what it could
reach anonymously. Re-publishing could never have fixed it, which is why it
survived every attempt.

The release now declares a **required `bearerToken`** in `configSchema`, so the
connection is made with a scoped, revocable credential rather than by exposing
the endpoint.

Anonymous read-only was considered and rejected on evidence: **8 of the 77 tools
mutate state** — `create_ticket`, `identity_revoke`, `identity_revoke_jit`,
`identity_rotate`, `identity_grant_jit`, `remediate`, `shield_unblock`,
`dataset_card_scan`.

A test pins that the token stays **required** and that the workflow never
publishes `--allow-insecure-no-auth` in its place.

## Verification

- `pytest` on doc-svg, README-alignment, deployment and metrics suites — **95 passed**
- Audit clean on all three diagrams; confirmed it **still catches** regressions
  (1 overflow at persona 1.45×, 8 at 1.6×)
- `ruff check` / `format --check` clean; `lint_release_workflow.py` OK; workflow
  YAML parses; `make preflight` passed

## What this does not prove

Whether Smithery's **public catalog** reaches 77 depends on whether it enumerates
using the configured credential at listing time, which its docs do not state.
This is the correct and safe half either way — the endpoint stays closed and the
requirement is declared. The next publish will show whether the catalog follows;
if it does not, the remaining options are an anonymous read-only surface or
accepting a partial public listing, and both are product calls rather than bugs.