### PR TITLE
fix(demo): stop the graph serving a Python repr, and name the correlation that is actually cross-vendor

### DIFF
--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -2870,6 +2870,12 @@
             "title": "Correlations",
             "type": "integer"
           },
+          "cross_source_correlations": {
+            "default": 0,
+            "minimum": 0.0,
+            "title": "Cross Source Correlations",
+            "type": "integer"
+          },
           "evidence_sources": {
             "minimum": 0.0,
             "title": "Evidence Sources",

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -1991,6 +1991,11 @@ components:
           minimum: 0.0
           title: Correlations
           type: integer
+        cross_source_correlations:
+          default: 0
+          minimum: 0.0
+          title: Cross Source Correlations
+          type: integer
         evidence_sources:
           minimum: 0.0
           title: Evidence Sources

--- a/src/agent_bom/cli/_demo.py
+++ b/src/agent_bom/cli/_demo.py
@@ -38,7 +38,10 @@ def _render_story(story: EnterpriseDemoStory) -> str:
                 f"Evidence: {story.summary.assets} assets · "
                 f"{story.summary.observations} observations · "
                 f"{story.summary.evidence_sources} sources · "
-                f"{story.summary.correlations} correlations"
+                # Qualified, because the bare row count reads as a cross-vendor
+                # claim it cannot support: most rows are a single-source trace.
+                f"{story.summary.correlations} correlations "
+                f"({story.summary.cross_source_correlations} cross-source)"
             ),
             (
                 f"Posture: {posture.total} findings on {posture.assets_affected} of "

--- a/src/agent_bom/demo_estate/estate_graph.py
+++ b/src/agent_bom/demo_estate/estate_graph.py
@@ -340,7 +340,14 @@ def project_estate_into_graph(
                     "check_id": str(finding.evidence.get("control_id") or ""),
                     "cloud_provider": finding.provider or "",
                     "resource_ids": [asset_id],
-                    "recommendation": finding.remediation or "",
+                    # The prose, not the structured advisory. ``Finding.remediation``
+                    # is a ``Remediation`` dataclass; the graph store persists
+                    # attributes with ``json.dumps(..., default=str)``, so putting
+                    # it here did not fail — it froze the object's Python ``repr``
+                    # into the snapshot and served it as the node's remediation
+                    # text. ``remediation_guidance`` is the plain string the live
+                    # cloud builder already puts under this key.
+                    "recommendation": finding.remediation_guidance or "",
                     "configuration": finding.evidence.get("configuration") or {},
                     "synthetic": True,
                     "estate_id": estate.estate_id,

--- a/src/agent_bom/demo_estate/presentation.py
+++ b/src/agent_bom/demo_estate/presentation.py
@@ -41,6 +41,16 @@ class EnterpriseDemoSummary(BaseModel):
     complete_sources: int = Field(ge=0)
     partial_sources: int = Field(ge=0)
     correlations: int = Field(ge=0)
+    # Correlation rows that actually span more than one evidence source.
+    #
+    # ``correlations`` counts trace groups, and the generated population gives
+    # almost every observation its own trace — so at estate scale that number
+    # runs into the thousands while the rows that join evidence *across vendors*
+    # stay in single digits. Publishing only the first invites every surface to
+    # read a labelled event as a cross-vendor correlation. This is the figure the
+    # graph already agrees with: ``project_estate_into_graph`` draws a chain only
+    # for a correlation with more than one inventoried asset.
+    cross_source_correlations: int = Field(default=0, ge=0)
     snapshots: int = Field(ge=0)
     findings: int = Field(default=0, ge=0)
 
@@ -136,6 +146,7 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
             complete_sources=result.complete_source_count,
             partial_sources=result.partial_source_count,
             correlations=len(result.correlations),
+            cross_source_correlations=sum(1 for row in result.correlations if len(set(row.sources)) >= 2),
             snapshots=len(estate.snapshots),
             findings=finding_summary.total,
         ),

--- a/src/agent_bom/demo_estate/showcase_graph.py
+++ b/src/agent_bom/demo_estate/showcase_graph.py
@@ -27,12 +27,17 @@ ShowcaseProfile = Literal["baseline", "current"]
 SHOWCASE_TENANT = "default"
 SHOWCASE_SCAN_ID = "showcase"
 SHOWCASE_BASELINE_SCAN_ID = "showcase-baseline"
-# Bumped when the seeded snapshot's *shape* changes so ``_showcase_seed_is_current``
-# treats an older seed as stale and refreshes it. A DB seeded before the
-# enterprise estate was projected in still holds the 112-node showcase; without a
-# bump it would keep it forever and the demo would silently under-report.
-SHOWCASE_BASELINE_CREATED_AT = "2026-08-01T12:00:00+00:00"
-SHOWCASE_CURRENT_CREATED_AT = "2026-08-08T12:00:00+00:00"
+# Bumped when the seeded snapshot's *shape or content* changes so
+# ``_showcase_seed_is_current`` treats an older seed as stale and refreshes it. A
+# DB seeded before the enterprise estate was projected in still holds the
+# 112-node showcase; without a bump it would keep it forever and the demo would
+# silently under-report. The same applies to what the projection *writes*: the
+# 08-01/08-08 pair shipped estate finding nodes whose ``recommendation`` was a
+# ``Remediation`` object frozen to its Python repr, and a running demo would have
+# served that snapshot forever. The seven-day gap is the drift lens's window and
+# is preserved on every bump.
+SHOWCASE_BASELINE_CREATED_AT = "2026-08-08T12:00:00+00:00"
+SHOWCASE_CURRENT_CREATED_AT = "2026-08-15T12:00:00+00:00"
 
 # The estate's containment root, once projected, becomes the graph's single
 # top-level container. The hand-built showcase org hangs off it so the demo reads

--- a/tests/test_demo_estate_graph_projection.py
+++ b/tests/test_demo_estate_graph_projection.py
@@ -283,3 +283,47 @@ def test_projection_is_deterministic(estate, estate_findings) -> None:
             )
         )
     assert shapes[0] == shapes[1]
+
+
+def test_projected_node_attributes_are_json_values_not_python_objects(projected) -> None:
+    """Every projected attribute must survive ``json.dumps`` untouched.
+
+    The graph store persists attributes with ``json.dumps(..., default=str)``
+    (``agent_bom/db/graph_store.py``), so a non-JSON value is not rejected — it
+    is silently frozen into the snapshot as its Python ``repr`` and served from
+    the API as a string. The graph node drawer then renders
+    ``Remediation(fix=RemediationFix(summary=...`` as the remediation text on
+    the surface a prospect clicks. Assert on the value, not on the encoder's
+    willingness to coerce it.
+    """
+    import json
+
+    graph, _ = projected
+    offenders: list[tuple[str, str, str]] = []
+    for node in graph.nodes.values():
+        for key, value in node.attributes.items():
+            try:
+                json.dumps(value)
+            except TypeError:
+                offenders.append((node.id, key, type(value).__name__))
+    assert not offenders, f"{len(offenders)} attribute(s) are not JSON values: {offenders[:3]}"
+
+
+def test_projected_finding_nodes_carry_readable_remediation_text(projected, estate_findings) -> None:
+    """``recommendation`` is prose the UI prints, so it must read as prose.
+
+    ``ui/lib/unified-graph-flow.ts`` uses ``recommendation`` as a
+    misconfiguration node's description, and ``graph/builder.py`` supplies a
+    plain string there for live cloud scans. The estate projection must speak
+    the same vocabulary rather than handing the same key a structured object.
+    """
+    graph, _ = projected
+    finding_nodes = [
+        node for node in graph.nodes.values() if node.entity_type is EntityType.MISCONFIGURATION and node.attributes.get("estate_id")
+    ]
+    assert len(finding_nodes) == len(estate_findings)
+    for node in finding_nodes:
+        recommendation = node.attributes.get("recommendation")
+        assert isinstance(recommendation, str), (node.id, type(recommendation).__name__)
+        assert recommendation, f"{node.id} lost its remediation text"
+        assert not recommendation.startswith("Remediation("), f"{node.id} renders a Python repr as its remediation: {recommendation[:80]!r}"

--- a/tests/test_enterprise_demo_surfaces.py
+++ b/tests/test_enterprise_demo_surfaces.py
@@ -45,6 +45,35 @@ def test_story_builds_one_canonical_cross_vendor_read_model() -> None:
     assert all(not hasattr(event, "raw_payload") for event in story.events)
 
 
+def test_story_never_presents_single_source_traces_as_cross_vendor_correlations() -> None:
+    """The headline correlation count must not be read as the cross-vendor claim.
+
+    ``_build_correlations`` groups evidence by ``trace_id``. The generated
+    population gives every observation its own trace, so almost every row is one
+    event from one source correlated with nothing — a labelled event, not a
+    correlation. At estate scale that inflates the number the demo leads with
+    from single digits into the thousands.
+
+    The graph already publishes the honest figure: ``project_estate_into_graph``
+    draws a chain only where a correlation spans at least two inventoried assets,
+    and ``/v1/graph/attack-paths`` returns those. The story must carry the same
+    reconcilable number rather than leaving the two surfaces to disagree.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+    from agent_bom.demo_estate.enterprise_correlation import build_estate_correlations
+
+    tenant = "tenant-honest"
+    story = build_enterprise_demo_story(tenant_id=tenant)
+    rows = build_estate_correlations(build_demo_estate(tenant_id=tenant))
+    cross_source = sum(1 for row in rows if len(set(row.sources)) >= 2)
+
+    # Precondition: the gap this test exists for is real on the shipped estate.
+    assert 0 < cross_source < story.summary.correlations / 100, (cross_source, story.summary.correlations)
+
+    assert story.summary.cross_source_correlations == cross_source
+    assert story.summary.cross_source_correlations <= story.summary.correlations
+
+
 def test_demo_story_cli_emits_complete_machine_readable_evidence() -> None:
     result = CliRunner().invoke(main, ["demo", "story", "--format", "json", "--tenant-id", "tenant-cli"])
 
@@ -104,6 +133,13 @@ def test_demo_story_cli_prints_the_chain_and_counts_honestly() -> None:
 
     assert "Posture:" in result.output
     assert "Severity: critical" in result.output and "unrated" in result.output
+
+    # The evidence line leads with the correlation row count; it must qualify it
+    # rather than let a reader take thousands of single-source traces as
+    # thousands of cross-vendor correlations.
+    evidence_line = next(line for line in result.output.splitlines() if line.startswith("Evidence:"))
+    assert f"{story.summary.correlations} correlations" in evidence_line, evidence_line
+    assert f"{story.summary.cross_source_correlations} cross-source" in evidence_line, evidence_line
 
 
 def test_demo_story_api_fails_closed_when_demo_mode_is_off(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_showcase_graph_seeding.py
+++ b/tests/test_showcase_graph_seeding.py
@@ -53,6 +53,66 @@ def test_seeds_when_empty(store: SQLiteGraphStore) -> None:
     assert store.latest_snapshot_id(tenant_id=SHOWCASE_TENANT) == SHOWCASE_SCAN_ID
 
 
+def test_persisted_finding_nodes_serve_prose_not_a_python_repr(store: SQLiteGraphStore) -> None:
+    """Read the attribute back out of the store, not off the in-memory graph.
+
+    The projection is where the value is chosen, but the store is where it stops
+    being checkable: ``json.dumps(..., default=str)`` accepts any object and
+    freezes its Python ``repr`` into the snapshot, so a projection bug survives
+    persistence as a plausible-looking string. Assert on what a reader is
+    actually served.
+    """
+    assert seed_showcase_graph_if_empty(store) is True
+
+    graph = store.load_graph(scan_id=SHOWCASE_SCAN_ID, tenant_id=SHOWCASE_TENANT)
+    estate_findings = [
+        node
+        for node in graph.nodes.values()
+        if node.entity_type is EntityType.MISCONFIGURATION and node.attributes.get("estate_id")
+    ]
+    assert len(estate_findings) >= 439, len(estate_findings)
+    for node in estate_findings:
+        recommendation = node.attributes.get("recommendation")
+        assert isinstance(recommendation, str) and recommendation, node.id
+        assert "RemediationFix(" not in recommendation, (
+            f"{node.id} serves a Python repr as remediation: {recommendation[:80]!r}"
+        )
+
+
+def test_a_seed_predating_this_build_is_treated_as_stale(store: SQLiteGraphStore) -> None:
+    """A deployed demo must pick up projection fixes without an operator reset.
+
+    ``seed_showcase_graph_if_empty`` early-returns when both snapshots carry the
+    expected ``created_at``, so a change to what the projection *writes* only
+    reaches an existing database if the stamp moved with it. Pin the stamps that
+    shipped with the repr defect: leaving either in place means every already-
+    running demo keeps serving the old snapshot forever.
+    """
+    from agent_bom.demo_estate.showcase_graph import SHOWCASE_BASELINE_CREATED_AT
+
+    shipped_with_the_defect = {
+        SHOWCASE_SCAN_ID: "2026-08-08T12:00:00+00:00",
+        SHOWCASE_BASELINE_SCAN_ID: "2026-08-01T12:00:00+00:00",
+    }
+    assert (
+        SHOWCASE_CURRENT_CREATED_AT != shipped_with_the_defect[SHOWCASE_SCAN_ID]
+        or SHOWCASE_BASELINE_CREATED_AT != shipped_with_the_defect[SHOWCASE_BASELINE_SCAN_ID]
+    ), "the seed stamp did not move, so a deployed demo keeps the old snapshot"
+
+    # And the mechanism still does its job for that exact pair of stamps.
+    store.save_graph(
+        _minimal_graph(scan_id=SHOWCASE_SCAN_ID, created_at=shipped_with_the_defect[SHOWCASE_SCAN_ID])
+    )
+    store.save_graph(
+        _minimal_graph(
+            scan_id=SHOWCASE_BASELINE_SCAN_ID,
+            created_at=shipped_with_the_defect[SHOWCASE_BASELINE_SCAN_ID],
+        )
+    )
+    assert seed_showcase_graph_if_empty(store) is True
+    assert _snapshot_created_at(store).get(SHOWCASE_SCAN_ID) == SHOWCASE_CURRENT_CREATED_AT
+
+
 def test_idempotent_when_current(store: SQLiteGraphStore) -> None:
     assert seed_showcase_graph_if_empty(store) is True
     # A fresh seed is not re-written on the next boot.

--- a/ui/app/demo-estate/page.tsx
+++ b/ui/app/demo-estate/page.tsx
@@ -165,7 +165,7 @@ export default function DemoEstatePage() {
           { label: "Assets", value: story.summary.assets, icon: Database },
           { label: "Observations", value: story.summary.observations, icon: Clock3 },
           { label: "Evidence sources", value: story.summary.evidence_sources, hint: `${story.summary.complete_sources} complete` },
-          { label: "Correlations", value: story.summary.correlations, icon: Network },
+          { label: "Correlations", value: story.summary.correlations, icon: Network, hint: `${story.summary.cross_source_correlations} cross-source` },
           { label: "Findings", value: story.summary.findings, icon: TriangleAlert },
           { label: "Snapshots", value: story.summary.snapshots, icon: GitBranch },
           { label: "Partial sources", value: story.summary.partial_sources, accent: "warn", icon: TriangleAlert },
@@ -307,7 +307,13 @@ export default function DemoEstatePage() {
             <GitBranch className="h-4 w-4 text-emerald-600 dark:text-emerald-300" />
             <h2 className="text-base font-semibold text-[color:var(--foreground)]">Normalized evidence timeline</h2>
           </div>
-          <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">Every row retains its source run and evidence hash; raw provider payloads are not returned.</p>
+          {/* Bounded like its two sibling lists, and labeled like them. The API
+              returns a page of the estate's observations; an unlabeled slice
+              beside a claim about "every row" reads as the whole estate. */}
+          <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
+            Showing {orderedEvents.length} of {story.summary.observations} normalized events — the correlated incident included, then oldest first.
+          </p>
+          <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">Every row shown retains its source run and evidence hash; raw provider payloads are not returned.</p>
           <ol className="mt-5 space-y-3">
             {orderedEvents.map((event) => (
               <li key={event.event_id} className="grid gap-3 rounded-xl border border-[color:var(--border-subtle)] bg-[color:var(--surface-muted)] p-4 sm:grid-cols-[8rem_1fr]">
@@ -365,7 +371,7 @@ export default function DemoEstatePage() {
             Say so, and say against what — a bounded list with an unlabeled
             length is indistinguishable from a complete one. */}
         <p className="mt-1 text-xs text-[color:var(--text-tertiary)]">
-          Showing {story.correlations.length} of {story.summary.correlations} — the incident first.
+          Showing {story.correlations.length} of {story.summary.correlations} — the incident first. {story.summary.cross_source_correlations} span more than one evidence source.
         </p>
         <div className="mt-4 grid gap-3 md:grid-cols-2 xl:grid-cols-3">
           {story.correlations.map((correlation) => (

--- a/ui/lib/api-types.ts
+++ b/ui/lib/api-types.ts
@@ -2844,7 +2844,11 @@ export interface EnterpriseDemoSummary {
   evidence_sources: number;
   complete_sources: number;
   partial_sources: number;
+  /** Correlation rows, which are trace groups — most hold a single event. */
   correlations: number;
+  /** Of `correlations`, the rows that join evidence from more than one source.
+   * The cross-vendor claim reconciles against this, never against the row count. */
+  cross_source_correlations: number;
   snapshots: number;
   /** Whole-estate finding count. The rendered list is bounded; this is not. */
   findings: number;

--- a/ui/tests/demo-estate-page.test.tsx
+++ b/ui/tests/demo-estate-page.test.tsx
@@ -47,6 +47,7 @@ const story: EnterpriseDemoStory = {
     complete_sources: 8,
     partial_sources: 1,
     correlations: 4,
+    cross_source_correlations: 1,
     snapshots: 3,
     findings: 439,
   },
@@ -200,8 +201,39 @@ describe("DemoEstatePage", () => {
 
     // The correlations list is bounded too, and says so.
     expect(
-      screen.getByText(`Showing ${story.correlations.length} of ${story.summary.correlations} — the incident first.`),
+      screen.getByText(
+        `Showing ${story.correlations.length} of ${story.summary.correlations} — the incident first. ${story.summary.cross_source_correlations} span more than one evidence source.`,
+      ),
     ).toBeInTheDocument();
+  });
+
+  it("labels every bounded list, including the evidence timeline", async () => {
+    apiMock.getEnterpriseDemoStory.mockResolvedValue(story);
+    render(<DemoEstatePage />);
+    await waitFor(() =>
+      expect(screen.getByTestId("demo-estate-summary")).toBeInTheDocument(),
+    );
+
+    // The timeline renders `events`, which the API bounds against the estate's
+    // whole observation count. A slice that serialises as the whole is the
+    // #4631 defect class, and the two sibling sections already say so.
+    expect(
+      screen.getByText(
+        `Showing ${story.events.length} of ${story.summary.observations} normalized events — the correlated incident included, then oldest first.`,
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("never presents single-source traces as cross-vendor correlations", async () => {
+    apiMock.getEnterpriseDemoStory.mockResolvedValue(story);
+    render(<DemoEstatePage />);
+
+    const strip = await screen.findByTestId("demo-estate-summary");
+    // The headline tile counts trace groups; on the shipped estate almost all
+    // of them are one event from one source. The tile must qualify itself.
+    expect(strip).toHaveTextContent(
+      `${story.summary.cross_source_correlations} cross-source`,
+    );
   });
 
   it("does not substitute live data when demo mode is unavailable", async () => {


### PR DESCRIPTION
Adversarial pre-release audit of the demo estate at its new scale. Two P1s, both
introduced by today's own work, both on the surface a prospect clicks.

## P1 — The graph served a Python `repr` as remediation text

All **439** estate finding nodes. `estate_graph.py:343` put `Finding.remediation`
— a `Remediation` dataclass — under the node's `recommendation` attribute.
Nothing rejected it: `db/graph_store.py:755` persists with
`json.dumps(..., default=str)`, so the object's repr was frozen into the snapshot
and served as a string. `ui/lib/unified-graph-flow.ts:598` uses `recommendation`
as a misconfiguration node's description and its `typeof value === "string"`
guard passes, so the drawer rendered:

```
Remediation(fix=RemediationFix(summary="Remove or scope down policies that
grant '*' on '*'", cli=None, console='AWS Console → IAM...
```

Estate-only — `graph/builder.py:658,849` puts a plain string there for live cloud
scans. Repro: `GET /v1/graph?limit=5000` → 439 of 439 matched
`recommendation.startswith("Remediation(")`.

Fixed via `remediation_guidance`, **plus a test asserting every projected
attribute is a JSON value**, so the next structured object fails a test instead
of reaching a prospect.

## P1 — "6,148 correlations" is not the cross-vendor claim every surface reads it as

`_build_correlations` groups by `trace_id`, and the generated population gives
nearly every observation its own trace. On the shipped estate:

| | count |
|---|---|
| correlations reported | **6,148** |
| spanning ≥2 evidence sources | **3** |
| spanning ≥2 assets | 4 |
| single event / source / asset | 6,145 |

The graph was already publishing the honest figure — `_MIN_CHAIN_HOPS = 2` gives
**4** estate chains from `/v1/graph/attack-paths`. Two surfaces, one estate, off
by ~1,500×. And the number appeared on the demo stat tile under a section headed
**"Cross-vendor correlations"**.

Fixed **additively**: `summary.cross_source_correlations` (3) now ships through
the model, OpenAPI, UI types, the tile hint, the section subtitle and the CLI
line. `correlations` is **not** renamed — that is a contract call, and the raw
figure is still true, just not the claim it was being read as.

## P2 — The evidence timeline was the only bounded list with no "showing N of M"

200 of 6,159 observations, beside copy reading "Every row retains its source run
and evidence hash", while both sibling sections already carried the label. Label
added; copy narrowed to "every row shown". The incident itself sits at positions
3–8, inside the bound — verified, not assumed.

## P2 — The fix would not have reached any running demo

`seed_showcase_graph_if_empty` early-returns while both snapshots match the
expected `created_at`, so changing what the projection *writes* strands existing
databases forever. Verified live: re-boot against an existing snapshot returned
`graph_seeded: false`. Both stamps moved (7-day drift window preserved), with a
test pinning the stamps that shipped with the defect.

## Verified SOUND — this matters as much as the findings

- **Counts reconcile.** Estate findings **439** across story summary, story
  `finding_summary`, graph misconfiguration nodes and `/v1/findings?domain=cspm`.
  Whole-tenant **458 = 458 = 458** across findings total, facet sum and posture
  buckets. `unrated: 28` explicit everywhere, never dropped.
- **Truncation is declared** on `/v1/graph`, rollup, attack-paths and
  exposure-paths. No bounded view reports its page size as the total.
- **Determinism holds** across `PYTHONHASHSEED=1/2/3` — identical `content_hash`,
  nodes, edges and attack paths. Pinned to a fixed `_EPOCH`, not `now()`.
- **Tenancy is clean.** Story cache is tenant-keyed with distinct per-tenant
  `estate_content_hash`; `X-Tenant-ID` cannot be spoofed unauthenticated.
- **Re-projection is idempotent** — the double-append regression is guarded at
  `estate_graph.py:409`.
- **GCP `partial` survives** every surface; `_merge_collection_runs` refuses to
  promote partial → complete. No unsupported "PASS"/"clean" anywhere.

## Known, not fixed

- **Concurrent boot double-seeds the demo job** (`bootstrap.py:231`, check-then-act
  with no cross-process guard) → 2 jobs × 458 findings. **Counts still reconcile**
  — 458 everywhere; the residue is `/v1/overview.headline.scans: 2` and duplicate
  storage. Repro included. Honest severity: low.
- **`/v1/graph/rollup` `summary.total_edges` reports a filtered subset** (2,661 vs
  3,669) under an unqualified name, with no `total_edges_source` twin though
  `total_nodes_source` exists for exactly this reason. Remedy is a breaking rename
  or another contract field — your call.
- **P3**: `/v1/graph` `stats.severity_counts` lacks the `severity_basis` label its
  own snapshots rows carry (30 vs 29 critical); no screen shows both, so it is an
  observation, not a proven contradiction.

## Gates

9 demo/estate suites **121 passed**; adjacent API/store/read-path **196 passed**;
broad `-k "demo or estate or graph or finding"` **2193 passed, 0 failed**;
`mypy` clean; `ruff` clean; `make preflight` green (it caught OpenAPI drift —
regenerated). UI: lint clean, `vitest` **1004 passed**, `npm run build` and
`NEXT_EXPORT=1 npm run build` both succeed. Every fix demonstrated **red first**;
the three UI tests were proven red by stashing only the source fix.