### PR TITLE
fix(scan): report the tool a low-level MCP server declares, not its dispatcher

### DIFF
--- a/src/agent_bom/ast/kotlin/analyzer.py
+++ b/src/agent_bom/ast/kotlin/analyzer.py
@@ -14,10 +14,18 @@ The registration idiom is ``addTool`` from ``io.modelcontextprotocol:kotlin-sdk`
         description = "An example tool",
     ) { request -> CallToolResult(...) }
 
-``addTool`` is an ordinary-looking method name, so -- as the Swift analyzer does
-with ``import MCP`` -- a registration is only trusted in a file that imports an
-MCP module. ``addPrompt`` and ``addResource`` are sibling registrations that
-declare no tool and are deliberately not matched.
+``Server.addTools`` is the bulk sibling, and carries each name one level deeper:
+
+    mcpServer.addTools(
+        listOf(
+            RegisteredTool(Tool("bulk-a", ToolSchema(), "Tool A")) { CallToolResult(...) },
+        ),
+    )
+
+``addTool``/``addTools`` are ordinary-looking method names, so -- as the Swift
+analyzer does with ``import MCP`` -- a registration is only trusted in a file
+that imports an MCP module. ``addPrompt`` and ``addResource`` are sibling
+registrations that declare no tool and are deliberately not matched.
 """
 
 from __future__ import annotations
@@ -73,6 +81,14 @@ _KOTLIN_CALL_SKIP = frozenset(
 # Only the call head is matched, so the scan can run over comment/string-masked
 # text; the name literal is then read from the real source at the same offset.
 _KOTLIN_ADD_TOOL_START_RE = re.compile(r"\.addTool\s*\(")
+# ``public fun addTools(toolsToAdd: List<RegisteredTool>)`` is the bulk sibling
+# of ``addTool``. Every name lives inside a ``Tool(...)`` nested two levels down,
+# so the argument list is walked rather than read as one registration. ``\b``
+# before ``Tool`` keeps ``RegisteredTool(`` from matching as the constructor, and
+# the ``\(`` keeps ``ToolSchema()`` out.
+_KOTLIN_ADD_TOOLS_START_RE = re.compile(r"\.addTools\s*\(")
+_KOTLIN_REGISTERED_TOOL_START_RE = re.compile(r"\bRegisteredTool\s*\(")
+_KOTLIN_TOOL_CTOR_START_RE = re.compile(r"\bTool\s*\(")
 _KOTLIN_TOOL_NAME_ARG_RE = re.compile(r"""\bname\s*=\s*"(?P<name>[^"]*)\"""")
 _KOTLIN_LEADING_STRING_RE = re.compile(r"""\s*"(?P<name>[^"]*)\"""")
 _KOTLIN_LOCAL_BINDING_RE = re.compile(r"\b(?:val|var)\s+(?P<var>\w+)\s*(?::\s*(?P<type>[\w.]+))?\s*=\s*(?P<ctor>[\w.]+)\s*\(")
@@ -199,6 +215,49 @@ def _kotlin_tool_name(source: str, masked: str, open_paren_index: int) -> str:
     return leading.group("name").strip() if leading else ""
 
 
+def _register_kotlin_handler_lambda(
+    source: str,
+    masked: str,
+    args_end: int,
+    *,
+    tool_name: str,
+    rel_path: str,
+    scope_name: str,
+    bindings: Mapping[str, str],
+    functions: dict[str, _KotlinFunctionAnalysis],
+) -> str:
+    """Register the trailing lambda at *args_end* as this tool's handler.
+
+    The lambda has no declared name, so it becomes a synthetic ``tool:<name>``
+    function. The key must be scope-qualified the same way real functions are,
+    because ``ast_analyzer`` re-keys every function by ``(scope_name, name)``
+    before resolving handlers.
+    """
+    handler_function_name = f"tool:{tool_name}"
+    handler_name = _kotlin_function_key(scope_name, handler_function_name)
+    brace_index = masked.find("{", args_end)
+    # Only a lambda that follows the argument list on the same statement is this
+    # tool's handler.
+    if brace_index < 0 or masked[args_end:brace_index].strip():
+        return handler_name
+    body_segment = _balanced_segment(masked, brace_index, open_char="{", close_char="}")
+    if body_segment is None:
+        return handler_name
+    masked_body, _ = body_segment
+    body_text = source[brace_index : brace_index + len(masked_body)]
+    handler_bindings = dict(bindings)
+    handler_bindings.update(_kotlin_local_bindings(body_text, bindings))
+    functions[handler_name] = _KotlinFunctionAnalysis(
+        name=handler_function_name,
+        line_number=_line_number_from_index(source, brace_index),
+        file_path=rel_path,
+        scope_name=scope_name,
+        import_bindings=handler_bindings,
+        call_sites=_kotlin_call_sites(body_text, line_offset=_line_number_from_index(source, brace_index) - 1),
+    )
+    return handler_name
+
+
 def _collect_kotlin_tool_registrations(
     source: str,
     *,
@@ -207,60 +266,80 @@ def _collect_kotlin_tool_registrations(
     bindings: Mapping[str, str],
     functions: dict[str, _KotlinFunctionAnalysis],
 ) -> list[_KotlinToolRegistration]:
-    """Collect ``addTool`` registrations, capturing the trailing-lambda handler."""
+    """Collect ``addTool``/``addTools`` registrations and their lambda handlers."""
     registrations: list[_KotlinToolRegistration] = []
     seen: set[tuple[str, int]] = set()
     # Scan masked source so a commented-out or quoted registration is never a
     # live tool; masking preserves offsets, so names are read from the real text.
     masked = mask_line_comments_and_strings(source)
-    for match in _KOTLIN_ADD_TOOL_START_RE.finditer(masked):
-        open_paren_index = match.end() - 1
-        tool_name = _kotlin_tool_name(source, masked, open_paren_index)
-        if not tool_name:
-            continue
-        key = (tool_name, match.start())
+
+    def add(tool_name: str, *, registration_index: int, handler_name: str) -> None:
+        key = (tool_name, registration_index)
         if key in seen:
-            continue
+            return
         seen.add(key)
-
-        # The trailing lambda has no declared name, so it is registered as a
-        # synthetic ``tool:<name>`` function. The key must be scope-qualified the
-        # same way real functions are, because ``ast_analyzer`` re-keys every
-        # function by ``(scope_name, name)`` before resolving handlers.
-        handler_function_name = f"tool:{tool_name}"
-        handler_name = _kotlin_function_key(scope_name, handler_function_name)
-        call_segment = _balanced_segment(masked, open_paren_index, open_char="(", close_char=")")
-        if call_segment is not None:
-            _masked_args, args_end = call_segment
-            brace_index = masked.find("{", args_end)
-            # Only a lambda that follows the argument list on the same statement
-            # is this tool's handler.
-            if brace_index >= 0 and not masked[args_end:brace_index].strip():
-                body_segment = _balanced_segment(masked, brace_index, open_char="{", close_char="}")
-                if body_segment is not None:
-                    masked_body, _ = body_segment
-                    body_text = source[brace_index : brace_index + len(masked_body)]
-                    handler_bindings = dict(bindings)
-                    handler_bindings.update(_kotlin_local_bindings(body_text, bindings))
-                    functions[handler_name] = _KotlinFunctionAnalysis(
-                        name=handler_function_name,
-                        line_number=_line_number_from_index(source, brace_index),
-                        file_path=rel_path,
-                        scope_name=scope_name,
-                        import_bindings=handler_bindings,
-                        call_sites=_kotlin_call_sites(body_text, line_offset=_line_number_from_index(source, brace_index) - 1),
-                    )
-
         registrations.append(
             _KotlinToolRegistration(
                 tool_name=tool_name,
                 handler_name=handler_name,
-                line_number=_line_number_from_index(source, match.start()),
+                line_number=_line_number_from_index(source, registration_index),
                 file_path=rel_path,
                 scope_name=scope_name,
                 import_bindings=dict(bindings),
             )
         )
+
+    for match in _KOTLIN_ADD_TOOL_START_RE.finditer(masked):
+        open_paren_index = match.end() - 1
+        tool_name = _kotlin_tool_name(source, masked, open_paren_index)
+        if not tool_name:
+            continue
+        handler_name = _kotlin_function_key(scope_name, f"tool:{tool_name}")
+        call_segment = _balanced_segment(masked, open_paren_index, open_char="(", close_char=")")
+        if call_segment is not None:
+            _masked_args, args_end = call_segment
+            handler_name = _register_kotlin_handler_lambda(
+                source,
+                masked,
+                args_end,
+                tool_name=tool_name,
+                rel_path=rel_path,
+                scope_name=scope_name,
+                bindings=bindings,
+                functions=functions,
+            )
+        add(tool_name, registration_index=match.start(), handler_name=handler_name)
+
+    for match in _KOTLIN_ADD_TOOLS_START_RE.finditer(masked):
+        call_segment = _balanced_segment(masked, match.end() - 1, open_char="(", close_char=")")
+        if call_segment is None:
+            continue
+        masked_args, _ = call_segment
+        args_offset = match.end() - 1
+        for registered in _KOTLIN_REGISTERED_TOOL_START_RE.finditer(masked_args):
+            registered_index = args_offset + registered.start()
+            registered_segment = _balanced_segment(masked, args_offset + registered.end() - 1, open_char="(", close_char=")")
+            if registered_segment is None:
+                continue
+            masked_registered_args, registered_end = registered_segment
+            tool_ctor = _KOTLIN_TOOL_CTOR_START_RE.search(masked_registered_args)
+            if tool_ctor is None:
+                continue
+            ctor_open_index = args_offset + registered.end() - 1 + tool_ctor.end() - 1
+            tool_name = _kotlin_tool_name(source, masked, ctor_open_index)
+            if not tool_name:
+                continue
+            handler_name = _register_kotlin_handler_lambda(
+                source,
+                masked,
+                registered_end,
+                tool_name=tool_name,
+                rel_path=rel_path,
+                scope_name=scope_name,
+                bindings=bindings,
+                functions=functions,
+            )
+            add(tool_name, registration_index=registered_index, handler_name=handler_name)
     return registrations
 
 

--- a/src/agent_bom/ast_python_analysis.py
+++ b/src/agent_bom/ast_python_analysis.py
@@ -853,19 +853,49 @@ def _analyze_file(
                             )
                         )
 
+    # Pass 3a: Tools a low-level ``Server`` declares in its ListTools handler.
+    low_level_tools: list[tuple[str, int]] = []
+    if _source_imports_mcp_module(tree) and _has_list_tools_handler(tree):
+        low_level_tools = _list_tools_declarations(tree)
+    for tool_name, tool_line in low_level_tools:
+        tools.append(
+            ToolSignature(
+                name=tool_name,
+                parameters=[],
+                return_type="unknown",
+                description="Python MCP low-level ListTools declaration",
+                file_path=rel_path,
+                line_number=tool_line,
+                decorators=["tools/list"],
+                is_async=False,
+            )
+        )
+
     # Pass 3: Extract tool signatures from decorated functions
     for node in ast.walk(tree):
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
             decorators = []
             is_tool = False
+            is_dispatch_handler = False
             for dec in node.decorator_list:
                 dec_name = _get_decorator_name(dec)
                 if dec_name:
                     decorators.append(dec_name)
                     if _is_agent_tool_decorator(dec_name):
                         is_tool = True
+                    if dec_name.rsplit(".", 1)[-1] in _MCP_DISPATCH_SEGMENTS:
+                        is_dispatch_handler = True
 
-            if is_tool:
+            # ``@server.call_tool()`` dispatches to every tool; it is not itself
+            # one. Suppressing its signature only once the real names are known
+            # means a server whose names are built dynamically keeps the signal
+            # it has today rather than going silent.
+            if is_dispatch_handler and low_level_tools:
+                is_tool_signature = False
+            else:
+                is_tool_signature = is_tool
+
+            if is_tool_signature:
                 params = _extract_params(node)
                 return_type = _get_return_annotation(node)
                 docstring = ast.get_docstring(node) or ""
@@ -1023,6 +1053,95 @@ def _analyze_file(
             )
 
     return prompts, guardrails, tools, frameworks, function_analyses, flow_findings
+
+
+# Servers built on the low-level ``Server`` class declare their tools in a
+# ListTools handler rather than one ``@mcp.tool()`` per function, so no decorator
+# on any function carries a tool name. The JS/TS analyzer reads the same shape
+# from ``setRequestHandler(ListToolsRequestSchema, ...)`` and Swift from
+# ``withMethodHandler(ListTools.self)``; this is the Python equivalent.
+#
+# ``list_tools`` and ``call_tool`` are protocol dispatch handlers, not tool
+# markers, so neither name is trusted on its own -- the file must also import an
+# MCP module, the same discriminator the Go analyzer applies to ``NewTool`` and
+# Swift to ``Tool(name:)``. That keeps an ordinary ``@registry.list_tools``
+# method on a plugin registry out.
+_MCP_ROOT_MODULES = frozenset({"mcp", "modelcontextprotocol"})
+_MCP_LIST_TOOLS_SEGMENT = "list_tools"
+_MCP_LIST_TOOLS_KEYWORD = "on_list_tools"
+# ``@server.call_tool()`` reaches the tool-decorator predicate through the
+# ``*_tool`` suffix, which named the dispatcher itself as a tool called
+# "call_tool". It stays a tool entrypoint for sink analysis; it just must not be
+# emitted as a tool name once the real names are known.
+_MCP_DISPATCH_SEGMENTS = frozenset({_MCP_LIST_TOOLS_SEGMENT, "call_tool"})
+
+
+def _imported_module_names(tree: ast.Module) -> list[str]:
+    names: list[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            names.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            names.append(node.module or "")
+    return names
+
+
+def _source_imports_mcp_module(tree: ast.Module) -> bool:
+    """Return whether the file imports an MCP SDK module.
+
+    Whole dotted segments only, so ``mcp.server.lowlevel`` and
+    ``modelcontextprotocol.server`` resolve while a project-local
+    ``mcp_client_utils`` or ``mcpherson.tools`` does not.
+    """
+    for module in _imported_module_names(tree):
+        if any(segment.lower() in _MCP_ROOT_MODULES for segment in module.split(".") if segment):
+            return True
+    return False
+
+
+def _decorator_last_segment(node: ast.expr) -> str:
+    """Last dotted segment of a decorator, unwrapping the applied form ``@x.y()``."""
+    return (_get_decorator_name(node) or "").rsplit(".", 1)[-1]
+
+
+def _has_list_tools_handler(tree: ast.Module) -> bool:
+    """Return whether the file wires a low-level ListTools handler.
+
+    Both SDK generations count: v1 registers the handler with a
+    ``@server.list_tools()`` decorator (bare or applied), v2 passes it to the
+    ``Server`` constructor as ``on_list_tools=``.
+    """
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if any(_decorator_last_segment(dec) == _MCP_LIST_TOOLS_SEGMENT for dec in node.decorator_list):
+                return True
+        elif isinstance(node, ast.Call):
+            if any(kw.arg == _MCP_LIST_TOOLS_KEYWORD for kw in node.keywords):
+                return True
+    return False
+
+
+def _list_tools_declarations(tree: ast.Module) -> list[tuple[str, int]]:
+    """Return ``(tool_name, line_number)`` for every ``types.Tool(name="…")``."""
+    declarations: list[tuple[str, int]] = []
+    seen: set[tuple[str, int]] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or _call_name(node.func).rsplit(".", 1)[-1] != "Tool":
+            continue
+        for keyword in node.keywords:
+            # A non-literal name cannot be resolved statically; guessing one
+            # would put a fabricated tool in the inventory.
+            if keyword.arg != "name" or not isinstance(keyword.value, ast.Constant):
+                continue
+            name = keyword.value.value
+            if not isinstance(name, str) or not name.strip():
+                continue
+            entry = (name.strip(), node.lineno)
+            if entry in seen:
+                continue
+            seen.add(entry)
+            declarations.append(entry)
+    return declarations
 
 
 def _get_decorator_name(node: ast.expr) -> str | None:

--- a/src/agent_bom/ast_ruby.py
+++ b/src/agent_bom/ast_ruby.py
@@ -4,6 +4,14 @@ Regex-backed and conservative: gem names must be declared in ``Gemfile.lock``
 (or ``Gemfile`` when no lock exists) before ``require`` bindings are trusted.
 Unresolved MCP tool handlers are dropped so headless agents do not inherit
 false ``function_reachable`` upgrades at CVE join time.
+
+The official ``mcp`` gem documents three ways to define a tool, and all three
+are matched: ``MCP::Server#define_tool`` with a block, ``MCP::Tool.define`` with
+a block, and a subclass of ``MCP::Tool`` (whose name comes from ``tool_name``
+when declared, and otherwise from the underscored class name -- the fallback
+``lib/mcp/tool.rb`` itself applies). The block- and class-bodied forms have no
+named handler to resolve, so they declare a tool without contributing a
+reachability path, exactly as ``define_tool`` already did.
 """
 
 from __future__ import annotations
@@ -73,6 +81,25 @@ _RUBY_DEFINE_TOOL_RE = re.compile(
 # The call head alone, for scanning comment/string-masked source where the name
 # literal has been blanked out; the name is then read from the real source.
 _RUBY_DEFINE_TOOL_START_RE = re.compile(r"""\.define_tool\s*\(\s*name:\s*""")
+# The mcp gem documents three ways to define a tool. ``Server#define_tool`` above
+# is one; the other two are ``MCP::Tool.define`` with a block, and a subclass of
+# ``MCP::Tool``.
+_RUBY_TOOL_DEFINE_RE = re.compile(r"""\b(?P<qualifier>(?:\w+::)*)Tool\.define\s*\(\s*name:\s*['"](?P<name>[^'"]+)['"]""")
+_RUBY_TOOL_DEFINE_START_RE = re.compile(r"""\b(?P<qualifier>(?:\w+::)*)Tool\.define\s*\(\s*name:\s*""")
+_RUBY_CLASS_DECL_RE = re.compile(r"""^[ \t]*class\s+(?P<name>[\w:]+)\s*<\s*(?P<superclass>[\w:]+)""", re.MULTILINE)
+_RUBY_TOOL_NAME_DECL_RE = re.compile(r"""^[ \t]*tool_name\s+['"](?P<name>[^'"]+)['"]""", re.MULTILINE)
+# Masking blanks the opening quote too, so the head stops before the literal.
+_RUBY_TOOL_NAME_DECL_START_RE = re.compile(r"""^[ \t]*tool_name[ \t]+""", re.MULTILINE)
+_RUBY_MCP_REQUIRE_HEADS = frozenset({"mcp", "modelcontextprotocol"})
+# ``MCP::Tool`` names the gem outright; a bare ``Tool`` is too ordinary a name to
+# trust on its own, so it needs the file to require the gem -- the discriminator
+# the Go analyzer applies to ``NewTool`` and Swift to ``Tool(name:)``.
+_RUBY_MCP_QUALIFIER = "mcp::"
+# lib/mcp/tool.rb: with no ``tool_name``, ``name_value`` falls back to
+# ``StringUtils.handle_from_class_name``, which demodulizes then underscores the
+# class name. These two substitutions are that method's, verbatim.
+_RUBY_ACRONYM_BOUNDARY_RE = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
+_RUBY_WORD_BOUNDARY_RE = re.compile(r"(?<=[a-z\d])(?=[A-Z])")
 _RUBY_FRAMEWORK_HINTS: dict[str, str] = {
     "modelcontextprotocol": "MCP",
     "mcp": "MCP",
@@ -226,6 +253,7 @@ def _collect_ruby_tool_registrations(
     class_name: str,
     bindings: dict[str, str],
     methods: Mapping[str, _RubyMethodAnalysis],
+    requires_mcp: bool,
 ) -> list[_RubyToolRegistration]:
     registrations: list[_RubyToolRegistration] = []
     seen: set[tuple[str, int]] = set()
@@ -269,6 +297,104 @@ def _collect_ruby_tool_registrations(
         if key in seen:
             continue
         seen.add(key)
+        registrations.append(
+            _RubyToolRegistration(
+                tool_name=tool_name,
+                handler_name=f"tool:{tool_name}",
+                line_number=_line_number_from_index(source, match.start()),
+                file_path=rel_path,
+                class_name=class_name,
+                import_bindings=dict(bindings),
+            )
+        )
+
+    for match in _RUBY_TOOL_DEFINE_START_RE.finditer(masked):
+        if match.group("qualifier").lower() != _RUBY_MCP_QUALIFIER and not requires_mcp:
+            continue
+        name_match = _RUBY_TOOL_DEFINE_RE.match(source, match.start())
+        tool_name = name_match.group("name").strip() if name_match else ""
+        if not tool_name:
+            continue
+        key = (tool_name, match.start())
+        if key in seen:
+            continue
+        seen.add(key)
+        registrations.append(
+            _RubyToolRegistration(
+                tool_name=tool_name,
+                handler_name=f"tool:{tool_name}",
+                line_number=_line_number_from_index(source, match.start()),
+                file_path=rel_path,
+                class_name=class_name,
+                import_bindings=dict(bindings),
+            )
+        )
+
+    for registration in _collect_ruby_tool_class_registrations(
+        source,
+        masked,
+        rel_path=rel_path,
+        bindings=bindings,
+        requires_mcp=requires_mcp,
+    ):
+        key = (registration.tool_name, registration.line_number)
+        if key in seen:
+            continue
+        seen.add(key)
+        registrations.append(registration)
+    return registrations
+
+
+def ruby_source_requires_mcp(source: str) -> bool:
+    """Return whether the file requires the official ``mcp`` gem."""
+    for match in _RUBY_REQUIRE_RE.finditer(source):
+        head = match.group("path").split("/", 1)[0].strip().lower()
+        if head in _RUBY_MCP_REQUIRE_HEADS:
+            return True
+    return False
+
+
+def _ruby_tool_name_from_class(class_name: str) -> str:
+    """Derive the gem's default tool name from a ``MCP::Tool`` subclass name."""
+    demodulized = class_name.split("::")[-1]
+    underscored = _RUBY_WORD_BOUNDARY_RE.sub("_", _RUBY_ACRONYM_BOUNDARY_RE.sub("_", demodulized))
+    return underscored.replace("-", "_").lower()
+
+
+def _is_ruby_mcp_tool_superclass(superclass: str, *, requires_mcp: bool) -> bool:
+    normalized = superclass.strip()
+    if normalized.lower().endswith("::tool"):
+        return normalized.lower().startswith(_RUBY_MCP_QUALIFIER)
+    return normalized == "Tool" and requires_mcp
+
+
+def _collect_ruby_tool_class_registrations(
+    source: str,
+    masked: str,
+    *,
+    rel_path: str,
+    bindings: dict[str, str],
+    requires_mcp: bool,
+) -> list[_RubyToolRegistration]:
+    """Collect ``class MyTool < MCP::Tool`` definitions as tool registrations."""
+    registrations: list[_RubyToolRegistration] = []
+    declarations = list(_RUBY_CLASS_DECL_RE.finditer(masked))
+    for index, match in enumerate(declarations):
+        if not _is_ruby_mcp_tool_superclass(match.group("superclass"), requires_mcp=requires_mcp):
+            continue
+        class_name = match.group("name")
+        body_end = declarations[index + 1].start() if index + 1 < len(declarations) else len(masked)
+        tool_name = _ruby_tool_name_from_class(class_name)
+        # ``tool_name "…"`` inside the class body overrides the derived name. The
+        # literal is blanked by masking, so the head is located in the masked
+        # text and the name read from the real source at the same offset.
+        declared = _RUBY_TOOL_NAME_DECL_START_RE.search(masked, match.end(), body_end)
+        if declared is not None:
+            explicit = _RUBY_TOOL_NAME_DECL_RE.match(source, declared.start())
+            if explicit is not None and explicit.group("name").strip():
+                tool_name = explicit.group("name").strip()
+        if not tool_name:
+            continue
         registrations.append(
             _RubyToolRegistration(
                 tool_name=tool_name,
@@ -435,6 +561,7 @@ def scan_ruby_file(
         class_name=class_name,
         bindings=bindings,
         methods=methods,
+        requires_mcp=ruby_source_requires_mcp(source),
     )
     tools: list[ToolSignature] = []
     for registration in tool_registrations:

--- a/tests/test_ast_multilang_tool_detection.py
+++ b/tests/test_ast_multilang_tool_detection.py
@@ -429,11 +429,142 @@ RUBY_ORDINARY_KEYWORD_HASH = """config = { name: "not_a_tool", description: "jus
 puts config[:name]
 """
 
+# README.md "Tools", form 1: a subclass of MCP::Tool. With no `tool_name`, the
+# gem derives the name from the class name -- lib/mcp/tool.rb `name_value` falls
+# back to StringUtils.handle_from_class_name, which underscores and downcases it.
+RUBY_TOOL_SUBCLASS = """class MyTool < MCP::Tool
+  title "My Tool"
+  description "This tool performs specific functionality..."
+  input_schema(
+    properties: {
+      message: { type: "string" },
+    },
+    required: ["message"]
+  )
+
+  def self.call(message:, server_context:)
+    MCP::Tool::Response.new([{ type: "text", text: "OK" }])
+  end
+end
+"""
+
+# README.md "Tool Output Schemas": `tool_name` overrides the derived name.
+RUBY_TOOL_SUBCLASS_EXPLICIT_NAME = """class WeatherTool < MCP::Tool
+  tool_name "get_weather"
+  description "Get current weather for a location"
+
+  def self.call(location:, server_context:)
+    MCP::Tool::Response.new([{ type: "text", text: "Sunny" }])
+  end
+end
+"""
+
+# README.md "Tools", form 2: MCP::Tool.define with the name as a keyword.
+RUBY_TOOL_DEFINE = """require "mcp"
+
+tool = MCP::Tool.define(
+  name: "my_tool",
+  title: "My Tool",
+  description: "This tool performs specific functionality...",
+  annotations: {
+    read_only_hint: true,
+    title: "My Tool"
+  }
+) do |args, server_context:|
+  MCP::Tool::Response.new([{ type: "text", text: "OK" }])
+end
+"""
+
+# Two tool classes in one file, only the second renamed. A `tool_name` must not
+# leak across the class boundary in either direction.
+RUBY_TWO_TOOL_SUBCLASSES = """class SearchTool < MCP::Tool
+  description "Search the corpus"
+end
+
+class LookupTool < MCP::Tool
+  tool_name "lookup_user"
+  description "Look a user up"
+end
+"""
+
+# An ActiveRecord model in a workshop app. The class name ends in Tool and it
+# even carries a `tool_name`, but nothing here is MCP.
+RUBY_ORDINARY_TOOL_CLASS = """class HammerTool < ActiveRecord::Base
+  belongs_to :workbench
+
+  def tool_name
+    "hammer-42"
+  end
+end
+"""
+
+RUBY_TOOL_DEFINE_COMMENTED_OUT = """require "mcp"
+
+# MCP::Tool.define(name: "retired_tool") do |args, server_context:|
+#   nothing
+# end
+"""
+
+# Inside `module MCP` the superclass is written bare. `Tool` on its own is too
+# ordinary a name to trust, so it needs the file to require the gem.
+RUBY_BARE_TOOL_SUPERCLASS = """class SummarizeTool < Tool
+  description "Summarize a document"
+end
+"""
+
 
 def test_ruby_official_define_tool_is_detected(tmp_path: Path) -> None:
     (tmp_path / "server.rb").write_text(RUBY_DEFINE_TOOL)
 
     assert _tool_names(tmp_path) == {"get_weather"}
+
+
+def test_ruby_official_tool_subclass_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "my_tool.rb").write_text(RUBY_TOOL_SUBCLASS)
+
+    assert _tool_names(tmp_path) == {"my_tool"}
+
+
+def test_ruby_tool_subclass_explicit_tool_name_wins(tmp_path: Path) -> None:
+    (tmp_path / "weather_tool.rb").write_text(RUBY_TOOL_SUBCLASS_EXPLICIT_NAME)
+
+    assert _tool_names(tmp_path) == {"get_weather"}
+
+
+def test_ruby_tool_name_does_not_leak_between_sibling_classes(tmp_path: Path) -> None:
+    (tmp_path / "tools.rb").write_text(RUBY_TWO_TOOL_SUBCLASSES)
+
+    assert _tool_names(tmp_path) == {"search_tool", "lookup_user"}
+
+
+def test_ruby_official_tool_define_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "my_tool.rb").write_text(RUBY_TOOL_DEFINE)
+
+    assert _tool_names(tmp_path) == {"my_tool"}
+
+
+def test_ruby_ordinary_class_named_tool_is_not_an_agent_tool(tmp_path: Path) -> None:
+    (tmp_path / "hammer_tool.rb").write_text(RUBY_ORDINARY_TOOL_CLASS)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_ruby_commented_out_tool_define_is_not_a_tool(tmp_path: Path) -> None:
+    (tmp_path / "retired.rb").write_text(RUBY_TOOL_DEFINE_COMMENTED_OUT)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_ruby_bare_tool_superclass_needs_the_gem_required(tmp_path: Path) -> None:
+    (tmp_path / "summarize_tool.rb").write_text(RUBY_BARE_TOOL_SUPERCLASS)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_ruby_bare_tool_superclass_is_detected_when_the_gem_is_required(tmp_path: Path) -> None:
+    (tmp_path / "summarize_tool.rb").write_text('require "mcp"\n\n' + RUBY_BARE_TOOL_SUPERCLASS)
+
+    assert _tool_names(tmp_path) == {"summarize_tool"}
 
 
 def test_ruby_commented_out_define_tool_is_not_a_tool(tmp_path: Path) -> None:
@@ -594,6 +725,54 @@ fun setUp(bench: Workbench) {
 }
 """
 
+# Server.kt `public fun addTools(toolsToAdd: List<RegisteredTool>)` -- the bulk
+# registration. Sample copied from the SDK's own
+# integration-test/.../server/ServerBulkFeaturesTest.kt, where the name is the
+# leading positional argument of each Tool rather than a named one.
+KOTLIN_ADD_TOOLS_BULK = """import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+import io.modelcontextprotocol.kotlin.sdk.types.CallToolResult
+import io.modelcontextprotocol.kotlin.sdk.types.Tool
+import io.modelcontextprotocol.kotlin.sdk.types.ToolSchema
+
+fun register(server: Server) {
+    server.addTools(
+        listOf(
+            RegisteredTool(Tool("bulk-a", ToolSchema(), "Tool A")) { CallToolResult(emptyList()) },
+            RegisteredTool(Tool("bulk-b", ToolSchema(), "Tool B")) { CallToolResult(emptyList()) },
+            RegisteredTool(Tool("bulk-c", ToolSchema(), "Tool C")) { CallToolResult(emptyList()) },
+        ),
+    )
+}
+"""
+
+# The same call built from a variable. No name is knowable statically, and
+# inventing one would be worse than reporting none.
+KOTLIN_ADD_TOOLS_NON_LITERAL = """import io.modelcontextprotocol.kotlin.sdk.server.RegisteredTool
+import io.modelcontextprotocol.kotlin.sdk.server.Server
+
+fun register(server: Server, discovered: List<RegisteredTool>) {
+    server.addTools(discovered)
+}
+"""
+
+KOTLIN_ORDINARY_ADD_TOOLS = """package com.example.workshop
+
+data class Tool(val name: String)
+
+class Workbench {
+    private val tools = mutableListOf<Tool>()
+
+    fun addTools(toolsToAdd: List<Tool>) {
+        tools.addAll(toolsToAdd)
+    }
+}
+
+fun setUp(bench: Workbench) {
+    bench.addTools(listOf(Tool("wrench-7"), Tool("hammer-42")))
+}
+"""
+
 KOTLIN_COMMENTED_OUT = """import io.modelcontextprotocol.kotlin.sdk.server.Server
 
 // Older builds registered server.addTool(name = "retired_tool") here.
@@ -630,6 +809,24 @@ def test_kotlin_ordinary_add_tool_without_mcp_is_not_an_agent_tool(tmp_path: Pat
 
 def test_kotlin_commented_out_add_tool_is_not_a_tool(tmp_path: Path) -> None:
     (tmp_path / "Docs.kt").write_text(KOTLIN_COMMENTED_OUT)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_kotlin_official_sdk_add_tools_bulk_is_detected(tmp_path: Path) -> None:
+    (tmp_path / "Bulk.kt").write_text(KOTLIN_ADD_TOOLS_BULK)
+
+    assert _tool_names(tmp_path) == {"bulk-a", "bulk-b", "bulk-c"}
+
+
+def test_kotlin_add_tools_from_a_variable_claims_no_name(tmp_path: Path) -> None:
+    (tmp_path / "Dynamic.kt").write_text(KOTLIN_ADD_TOOLS_NON_LITERAL)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_kotlin_ordinary_add_tools_without_mcp_is_not_an_agent_tool(tmp_path: Path) -> None:
+    (tmp_path / "Workbench.kt").write_text(KOTLIN_ORDINARY_ADD_TOOLS)
 
     assert _tool_names(tmp_path) == set()
 

--- a/tests/test_ast_tool_detection_precision.py
+++ b/tests/test_ast_tool_detection_precision.py
@@ -191,3 +191,227 @@ def test_all_three_tool_detectors_agree(tmp_path: Path, decorator: str) -> None:
     }
 
     assert len(set(verdicts.values())) == 1, verdicts
+
+
+# --------------------------------------------------------------------------
+# Low-level ``Server`` -- github.com/modelcontextprotocol/python-sdk
+# --------------------------------------------------------------------------
+# Servers built on the low-level ``Server`` class declare their tools in a
+# ListTools handler instead of via ``@mcp.tool()``. The tool NAME is the ``name``
+# of each ``types.Tool`` returned, never the handler's own function name --
+# emitting the handler name would be the same dishonesty as claiming a web
+# handler. Every sample below is copied from the SDK's own examples.
+
+# v1.x docs/low-level-server.md, from
+# examples/snippets/servers/lowlevel/structured_output.py.
+LOWLEVEL_V1_APPLIED_DECORATOR = '''"""Run from the repository root."""
+
+from typing import Any
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server.lowlevel import NotificationOptions, Server
+from mcp.server.models import InitializationOptions
+
+server = Server("example-server")
+
+
+@server.list_tools()
+async def list_tools() -> list[types.Tool]:
+    """List available tools with structured output schemas."""
+    return [
+        types.Tool(
+            name="get_weather",
+            description="Get current weather for a city",
+            inputSchema={
+                "type": "object",
+                "properties": {"city": {"type": "string", "description": "City name"}},
+                "required": ["city"],
+            },
+        )
+    ]
+
+
+@server.call_tool()
+async def call_tool(name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Handle tool calls with structured output."""
+    if name == "get_weather":
+        return {"temperature": 22.5, "city": arguments["city"]}
+    raise ValueError(f"Unknown tool: {name}")
+'''
+
+# The same handler registered with the bare decorator. ``@server.list_tools`` is
+# an ``ast.Attribute`` and ``@server.list_tools()`` an ``ast.Call``; a matcher
+# that unwraps only one of them silently registers nothing for the other.
+LOWLEVEL_V1_BARE_DECORATOR = """import mcp.types as types
+from mcp.server.lowlevel import Server
+
+server = Server("example-server")
+
+
+@server.list_tools
+async def handle_list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(name="query_db", description="Query the database", inputSchema={}),
+        types.Tool(name="fetch_url", description="Fetch a URL", inputSchema={}),
+    ]
+"""
+
+# v2 examples/snippets/servers/lowlevel/structured_output.py: the handler is a
+# plain function wired through the ``Server`` constructor, so there is no
+# decorator at all.
+LOWLEVEL_V2_CONSTRUCTOR_KWARG = '''"""Run from the repository root."""
+
+import mcp.server.stdio
+import mcp.types as types
+from mcp.server import Server, ServerRequestContext
+
+
+async def handle_list_tools(
+    ctx: ServerRequestContext, params: types.PaginatedRequestParams | None
+) -> types.ListToolsResult:
+    """List available tools with structured output schemas."""
+    return types.ListToolsResult(
+        tools=[
+            types.Tool(
+                name="get_weather",
+                description="Get current weather for a city",
+                input_schema={"type": "object", "properties": {"city": {"type": "string"}}},
+            )
+        ]
+    )
+
+
+server = Server(
+    "example-server",
+    on_list_tools=handle_list_tools,
+)
+'''
+
+# A plugin registry with a method named ``list_tools`` returning its own ``Tool``
+# records. Nothing here is MCP, and the shape is identical.
+ORDINARY_LIST_TOOLS_REGISTRY = """from dataclasses import dataclass
+
+from .registry import registry
+
+
+@dataclass
+class Tool:
+    name: str
+    description: str
+
+
+class HardwareInventory:
+    @registry.list_tools
+    def list_tools(self) -> list[Tool]:
+        return [
+            Tool(name="hammer-42", description="a claw hammer"),
+            Tool(name="wrench-7", description="an adjustable wrench"),
+        ]
+"""
+
+# An MCP project whose ``Tool`` is an unrelated domain record. Without a
+# ListTools handler to anchor it, an ``mcp`` import alone must not turn every
+# ``Tool(name=...)`` in the file into a tool.
+MCP_PROJECT_ORDINARY_TOOL_RECORD = '''from dataclasses import dataclass
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("workshop")
+
+
+@dataclass
+class Tool:
+    name: str
+
+
+BENCH = [Tool(name="hammer-42"), Tool(name="wrench-7")]
+
+
+@mcp.tool()
+def count_tools() -> int:
+    """Count the tools on the bench."""
+    return len(BENCH)
+'''
+
+
+def test_lowlevel_applied_list_tools_decorator_declares_its_tools(tmp_path: Path) -> None:
+    (tmp_path / "server.py").write_text(LOWLEVEL_V1_APPLIED_DECORATOR)
+
+    assert _tool_names(tmp_path) == {"get_weather"}
+
+
+def test_lowlevel_bare_list_tools_decorator_declares_its_tools(tmp_path: Path) -> None:
+    (tmp_path / "server.py").write_text(LOWLEVEL_V1_BARE_DECORATOR)
+
+    assert _tool_names(tmp_path) == {"query_db", "fetch_url"}
+
+
+def test_lowlevel_constructor_on_list_tools_handler_declares_its_tools(tmp_path: Path) -> None:
+    (tmp_path / "server.py").write_text(LOWLEVEL_V2_CONSTRUCTOR_KWARG)
+
+    assert _tool_names(tmp_path) == {"get_weather"}
+
+
+def test_lowlevel_handler_function_name_is_not_reported_as_a_tool(tmp_path: Path) -> None:
+    """The handler lists tools; it is not one. Emitting its name over-reports."""
+    (tmp_path / "server.py").write_text(LOWLEVEL_V1_BARE_DECORATOR)
+
+    assert "handle_list_tools" not in _tool_names(tmp_path)
+
+
+def test_lowlevel_tools_carry_the_signal_that_matched(tmp_path: Path) -> None:
+    (tmp_path / "server.py").write_text(LOWLEVEL_V1_APPLIED_DECORATOR)
+
+    entries = [t for t in analyze_project(tmp_path).to_dict()["tools"] if t["name"] == "get_weather"]
+
+    assert [t["decorators"] for t in entries] == [["tools/list"]]
+
+
+def test_ordinary_list_tools_method_without_mcp_is_not_an_agent_tool(tmp_path: Path) -> None:
+    (tmp_path / "inventory.py").write_text(ORDINARY_LIST_TOOLS_REGISTRY)
+
+    assert _tool_names(tmp_path) == set()
+
+
+def test_tool_records_without_a_list_tools_handler_are_not_agent_tools(tmp_path: Path) -> None:
+    (tmp_path / "workshop.py").write_text(MCP_PROJECT_ORDINARY_TOOL_RECORD)
+
+    assert _tool_names(tmp_path) == {"count_tools"}
+
+
+LOWLEVEL_CALL_TOOL_RUNS_A_SHELL = """import subprocess
+from typing import Any
+
+import mcp.types as types
+from mcp.server.lowlevel import Server
+
+server = Server("shell-server")
+
+
+@server.list_tools()
+async def handle_list_tools() -> list[types.Tool]:
+    return [types.Tool(name="run_command", description="Run a command", inputSchema={})]
+
+
+@server.call_tool()
+async def handle_call_tool(name: str, arguments: dict[str, Any]) -> list[types.TextContent]:
+    output = subprocess.run(arguments["cmd"], shell=True, capture_output=True)
+    return [types.TextContent(type="text", text=output.stdout.decode())]
+"""
+
+
+def test_lowlevel_call_tool_dispatcher_stays_a_sink_entrypoint(tmp_path: Path) -> None:
+    """Dropping its tool NAME must not drop its sink analysis.
+
+    ``@server.call_tool()`` is where a low-level server's dangerous work
+    actually happens, so it stays a tool entrypoint for flow findings even
+    though it is no longer emitted as a tool called "call_tool".
+    """
+    (tmp_path / "server.py").write_text(LOWLEVEL_CALL_TOOL_RUNS_A_SHELL)
+    result = analyze_project(tmp_path)
+
+    assert _tool_names(tmp_path) == {"run_command"}
+    assert [(f.entrypoint, f.sink) for f in result.flow_findings if f.category == "unguarded_tool_sink"] == [
+        ("handle_call_tool", "subprocess.run")
+    ]


### PR DESCRIPTION
Three detection gaps from the pre-release audit, plus a defect the tests surfaced
that nobody had listed.

## The one nobody knew about

On the **official `fetch` reference server**, `main` reports a tool named
`call_tool`:

```
main reports:  ['call_tool']     ← the dispatcher's function name
after fix:     ['fetch']         ← the tool it actually declares
```

`@server.call_tool()` reaches `is_agent_tool_decorator` through the `*_tool`
suffix, so the *dispatcher* registered as a tool while the real names — declared
in the `list_tools` handler — were never read. Every low-level Python MCP server
was inventoried under a wrong name.

## Gap 1 — Python low-level `Server`

Servers built on the low-level `Server` class declare tools in a `list_tools`
handler rather than via `@mcp.tool()`. JS/TS and Swift got their equivalents;
Python did not — and consolidating the decorator predicate removed the last
signal, since `list_tools` stopped matching.

```
FAILED test_lowlevel_applied_list_tools_decorator_declares_its_tools  - assert {'call_tool'} == {'get_weather'}
FAILED test_lowlevel_bare_list_tools_decorator_declares_its_tools     - assert set() == {'fetch_url', 'query_db'}
FAILED test_lowlevel_constructor_on_list_tools_handler_declares_its_tools - assert set() == {'get_weather'}
```

Verified against the SDK's own sources, fetched not recalled: v1
`docs/low-level-server.md` and `examples/snippets/servers/lowlevel/*`, plus v2
`main`, where the decorator was **replaced** by
`Server("…", on_list_tools=handle_list_tools)`. The repo pins `mcp>=1.26,<2`, but
the scanner reads *third-party* code, so both generations are matched — as are
bare (`ast.Attribute`) and applied (`ast.Call`) decorator forms, each asserted
separately.

`call_tool` keeps `is_tool=True` for sink analysis and is suppressed only as a
tool *name*, and only once real names exist — so a dynamically-built server keeps
the signal it has today. A test pins that the `unguarded_tool_sink` finding on
`handle_call_tool → subprocess.run` survives.

## Gap 2 — Ruby: 1 of 3 documented gem idioms

Added `MCP::Tool.define(name:)` and `class X < MCP::Tool`, with the class-name
fallback transcribed verbatim from `lib/mcp/string_utils.rb`. Per the Go
`NewTool` precedent, a bare `Tool` superclass requires `require "mcp"`;
`MCP::Tool` names the gem outright and is ungated.

## Gap 3 — Kotlin `addTools(...)`

`Server.kt:363` takes `List<RegisteredTool>`, and the SDK's own integration test
puts the name in `Tool`'s **leading positional** argument. `addTool`/`addTools`
now share one handler path, still behind the `import io.modelcontextprotocol` gate.

## Both directions, every gap

- `@registry.list_tools` on a plugin registry returning `Tool(name="hammer-42")` → `set()`
- an `mcp`-importing project whose `Tool` is a domain dataclass → only its real `@mcp.tool()`
- `class HammerTool < ActiveRecord::Base` with its own `tool_name` → `set()`
- commented-out `MCP::Tool.define` → `set()`; two sibling tool classes don't leak `tool_name` across the boundary
- `addTools(discovered)` from a variable → `set()` — no name is knowable, and inventing one is worse
- `Workbench.addTools(listOf(Tool("wrench-7")))` without the MCP import → `set()`

## Adversarial sweep

Per-file scanners called directly, branch vs `origin/main` via `git archive`, over
four official SDK repos + `modelcontextprotocol/servers` + **rails (3,580 `.rb`)**
and **okhttp (915 `.kt`)** as ordinary-code pressure + this repo + site-packages:

```
before: 586   after: 819   added: 234   removed: 1   errors: 0
added by corpus: python-sdk 201 · ruby-sdk 23 · kotlin-sdk 9 · mcp-servers 1
added in rails / okhttp / site-packages / agent-bom: 0
removed: mcp-servers/.../fetch/server.py:224  call_tool
```

**Zero claims added across ~4,500 files of ordinary Ruby and Kotlin.** The single
removal is the `call_tool` defect above — that same file gains `fetch`.
`Prompt(name="fetch")` in the adjacent `list_prompts` handler was correctly not
claimed.

## Gates

`tests/test_ast_multilang_tool_detection.py` + `test_ast_tool_detection_precision.py`
— **121 passed**. `pytest -k "ast or tool or mcp"` — **1734 passed, 7 skipped**.
`ruff check` + `format --check` on all 5 changed files, `mypy` clean on the 3
changed sources, `make preflight` passed.

## Left open, deliberately

- **Ruby class- and block-bodied tools contribute no reachability path** — the
  handler is `def self.call` or a block, which the method regex doesn't collect.
  Extending it would make every `foo.call` in the file resolve there, adding false
  reach edges. Documented in the module docstring.
- **A low-level Python server that builds its tool list dynamically** still reports
  only the handler name. Fixing that needs constant-folding beyond this scope.
- The `pre-commit` mypy hook is red on `main` — **39 identical errors on both**
  branch and `origin/main`, none in touched files. Pre-existing; worth its own
  cleanup, not a release blocker.