### PR TITLE
chore(ci): lint every Python directory, from one definition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -415,13 +415,15 @@ jobs:
         # two calls to SDK methods that do not exist shipped and stayed green.
         run: uv sync --frozen --extra dev --extra aws --extra azure --extra gcp
 
+      # Paths live in the Makefile (LINT_PATHS) so CI and `make lint` cannot
+      # disagree about what is linted. They did: CI checked src/ only.
       - name: Ruff
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
-        run: uv run ruff check src/
+        run: uv run make lint-ruff
 
       - name: MyPy
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'
-        run: uv run mypy src/ --ignore-missing-imports --disable-error-code import-untyped
+        run: uv run make lint-mypy
 
       - name: Env-var reference is current (config.py + allowlist gate)
         if: needs.changes.result != 'success' || needs.changes.outputs.docs_only != 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install test lint preflight preflight-fix docker-build docker-run scan clean build-ui release-build publish-test publish analytics dev check-dupes clean-dupes secrets platform-up fullstack-up
+.PHONY: help install test lint lint-ruff lint-mypy preflight preflight-fix docker-build docker-run scan clean build-ui release-build publish-test publish analytics dev check-dupes clean-dupes secrets platform-up fullstack-up
 
 help:  ## Show this help message
 	@echo 'Usage: make [target]'
@@ -28,9 +28,20 @@ _dev-ui:
 test:  ## Run unit tests
 	pytest tests/ -v --cov=agent_bom
 
-lint:  ## Run linters (ruff + mypy)
-	ruff check src/ tests/
+# Every Python directory that ships or gates a release. `scripts/` was outside
+# this set, so a dead local in `generate_doc_architecture_svgs.py` sat on main
+# unnoticed — release gates, drift checks and the SVG generators all live there.
+# CI's Ruff step calls `lint-ruff` rather than repeating the paths, so the two
+# cannot disagree about what gets linted.
+LINT_PATHS := src/ tests/ scripts/ fuzz/
+
+lint-ruff:  ## Ruff over every linted path
+	ruff check $(LINT_PATHS)
+
+lint-mypy:  ## MyPy over the shipped package
 	mypy src/ --ignore-missing-imports --disable-error-code import-untyped
+
+lint: lint-ruff lint-mypy  ## Run linters (ruff + mypy)
 
 format:  ## Format code with ruff
 	ruff format src/ tests/

--- a/scripts/generate_doc_architecture_svgs.py
+++ b/scripts/generate_doc_architecture_svgs.py
@@ -1680,7 +1680,7 @@ def persona_value(theme: str) -> str:
     w, h = PERSONA_BAND_WIDTH, 236
     persona_bg = "#16161d" if theme == "dark" else t["bg"]
 
-    margin_x, margin_y = PERSONA_BAND_MARGIN_X, 18
+    margin_y = 18
     gap = PERSONA_BAND_GAP
     card_w = PERSONA_CARD_WIDTH
     card_h = 174

--- a/tests/test_ci_workflow_contract.py
+++ b/tests/test_ci_workflow_contract.py
@@ -185,3 +185,27 @@ def test_self_scan_upload_filters_first_party_informational_skill_rows() -> None
     post_merge = (ROOT / ".github" / "workflows" / "post-merge-self-scan.yml").read_text(encoding="utf-8")
     assert "filter_first_party_skill_sarif.py" in pr_gate
     assert "filter_first_party_skill_sarif.py" in post_merge
+
+
+def test_ci_lint_scope_is_defined_once_in_the_makefile() -> None:
+    """CI and ``make lint`` must not hold separate opinions about what is linted.
+
+    They did: CI ran ``ruff check src/`` while the Makefile ran ``src/ tests/``,
+    and neither covered ``scripts/`` — where the release gates, drift checks and
+    documentation generators live. A dead local in
+    ``scripts/generate_doc_architecture_svgs.py`` sat on ``main`` because no gate
+    could see it.
+    """
+    makefile = (ROOT / "Makefile").read_text(encoding="utf-8")
+    lint_paths = next(
+        line.split(":=", 1)[1].split()
+        for line in makefile.splitlines()
+        if line.startswith("LINT_PATHS")
+    )
+    for required in ("src/", "tests/", "scripts/"):
+        assert required in lint_paths, f"{required} is outside the linted scope"
+
+    lint_steps = _ci()["jobs"]["lint"]["steps"]
+    ruff = next(step for step in lint_steps if step.get("name") == "Ruff")
+    assert "make lint-ruff" in ruff["run"], "CI must call the Makefile target, not restate the paths"
+    assert "ruff check" not in ruff["run"], "CI restated the lint paths instead of reusing LINT_PATHS"


### PR DESCRIPTION
## Summary

Two gates held different opinions about what gets linted:

| | scope |
|---|---|
| CI `Ruff` step | `src/` |
| `make lint` | `src/ tests/` |
| neither | `scripts/` |

`scripts/` is where the release gates, drift checks and documentation generators
live. Nothing linted it, so a dead local (`margin_x`, F841) in
`scripts/generate_doc_architecture_svgs.py` sat on `main` with every gate green.
This is the same shape as the defects this release closes — one judgement, two
implementations, silently disagreeing — applied to the toolchain rather than the
product.

## Changes

- `LINT_PATHS := src/ tests/ scripts/ fuzz/` in the Makefile, used by a new
  `lint-ruff` target. `lint` is now `lint-ruff lint-mypy`, so `make lint`
  behaves exactly as before from the caller's side.
- CI's `Ruff` and `MyPy` steps call those targets instead of restating the
  paths. There is one place to change the scope.
- Removed the dead local. `PERSONA_BAND_MARGIN_X` itself is still used at
  `scripts/generate_doc_architecture_svgs.py:1519`; only the unpacked local was
  dead, which is why the SVGs are byte-identical.
- `tests/test_ci_workflow_contract.py` gains a test asserting `scripts/` is in
  scope **and** that CI does not reintroduce its own copy of the path list.

## Verification

- The new test was confirmed **red** against the pre-change workflow and
  Makefile (stashed both, ran it, `1 failed`), green after.
- Linted with the pinned **ruff 0.16.1 from `uv.lock`**, not the locally
  installed 0.15.10, since that is what CI resolves:
  `uv run --frozen --extra dev ruff check src/ tests/ scripts/ fuzz/` — all
  checks passed.
- `mypy src/` — no issues in 832 source files.
- `pytest tests/test_ci_workflow_contract.py` — 17 passed.
- `scripts/generate_doc_architecture_svgs.py --check` and `make preflight` —
  passed; no SVG output changed.

## Note, not fixed here

Three ruff versions currently gate this repo: `uv.lock` pins **0.16.1** (what CI
runs), `.pre-commit-config.yaml` pins **0.9.7**, and `pyproject.toml` only says
`ruff>=0.4`. The formatter's style changed between 0.9 and 0.16, so
`ruff format --check` reports ~240 files as unformatted under the newer version.
Reconciling that means a large mechanical reformat, which does not belong in a
release-week change — filing separately rather than bundling it.