### PR TITLE
fix(monitor): derive the tool-count expectation, and pin GHCR pagination

### DIFF
--- a/scripts/check_surface_freshness.py
+++ b/scripts/check_surface_freshness.py
@@ -26,6 +26,7 @@ while still surfacing drift through the issue tracker.
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import os
 import re
@@ -45,12 +46,31 @@ GLAMA_SCRIPT = ROOT / "scripts" / "check_glama_listing.py"
 PYPI_PACKAGE = "agent-bom"
 DEFAULT_DOCKER_IMAGE = "ghcr.io/msaad00/agent-bom"
 DEFAULT_SMITHERY_SERVER = "agent-bom/agent-bom"
+# Requests to this origin carry an anonymous-pull bearer token, so pagination
+# links must never move off it.
+GHCR_ORIGIN = "https://ghcr.io"
 DEFAULT_TIMEOUT = 15.0
 DEFAULT_ATTEMPTS = 3
 DEFAULT_BACKOFF = 5.0
 
 OK_STATUSES = {"fresh"}
 ALERT_STATUSES = {"stale", "not_configured", "unreachable"}
+
+
+def expected_tool_count() -> int:
+    """Return the shipped MCP tool inventory size, from the one place it lives.
+
+    ``check_glama_listing.py`` already derives this from the README contract
+    sentence. Re-deriving it here would be a second answer to one question, and
+    the two would eventually disagree — so this delegates to that module rather
+    than re-reading the README.
+    """
+    spec = importlib.util.spec_from_file_location("_glama_listing_contract", GLAMA_SCRIPT)
+    if spec is None or spec.loader is None:  # pragma: no cover - packaging accident
+        raise SystemExit(f"could not load {GLAMA_SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return int(module._load_readme_tool_count())
 
 
 def _env_or(name: str, default: str) -> str:
@@ -159,6 +179,19 @@ def probe_pypi(expected: str, **kw: Any) -> dict[str, Any]:
         return _classify("PyPI", None, expected, error=str(exc))
 
 
+def _require_origin(url: str, origin: str) -> str:
+    """Return ``url`` only if it stays on ``origin``.
+
+    Anything we follow while holding a token has to be pinned to the origin that
+    issued it. ``scripts/dockerhub_tag_cleanup.py`` makes the same check for
+    Docker Hub; this is the second caller, not a second rule.
+    """
+    parts = urllib.parse.urlsplit(url)
+    if f"{parts.scheme}://{parts.netloc}" != origin:
+        raise RuntimeError(f"refusing to follow off-origin pagination URL: {url!r}")
+    return url
+
+
 def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
     """Confirm the expected tag exists on the registry.
 
@@ -178,7 +211,7 @@ def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
                 **kw,
             )
             token = token_data.get("token", "")
-            tags = set()
+            tags: set[str] = set()
             next_url = f"https://ghcr.io/v2/{path_repo}/tags/list?n=100"
             auth_headers = {"Authorization": f"Bearer {token}"} if token else None
             for _page in range(20):
@@ -188,9 +221,13 @@ def probe_docker(expected: str, image: str, **kw: Any) -> dict[str, Any]:
                 match = re.search(r'<([^>]+)>;\s*rel="next"', link)
                 if not match:
                     break
-                next_url = urllib.parse.urljoin("https://ghcr.io", match.group(1))
+                # urljoin returns an absolute URL unchanged, so a registry-supplied
+                # ``Link: <https://elsewhere/…>`` would move the host while the
+                # bearer token stayed attached. Every page of this walk is
+                # authenticated, so every page must stay on the registry.
+                next_url = _require_origin(urllib.parse.urljoin(GHCR_ORIGIN, match.group(1)), GHCR_ORIGIN)
         else:
-            tags: set[str] = set()
+            tags = set()
             url = f"https://hub.docker.com/v2/repositories/{repo}/tags?page_size=100"
             data = _http_json(url, **kw)
             for entry in data.get("results", []):
@@ -304,13 +341,18 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     expected = (args.expected or _expected_version()).lstrip("v").strip()
+    # Default it rather than leaving it None. An unset expectation used to turn
+    # the tool-count assertion off for Smithery entirely, so a bare local run
+    # reported a catalog advertising 36 of 77 tools as fresh — the drift this
+    # monitor exists to catch, invisible to the person most likely to look.
+    tool_count = args.expected_tool_count if args.expected_tool_count is not None else expected_tool_count()
     kw = {"timeout": args.timeout, "attempts": args.attempts, "backoff": args.backoff_seconds}
 
     surfaces = [
         probe_pypi(expected, **kw),
         probe_docker(expected, args.docker_image, **kw),
-        probe_glama(expected, expected_tool_count=args.expected_tool_count, **kw),
-        probe_smithery(expected, args.smithery_server, expected_tool_count=args.expected_tool_count, **kw),
+        probe_glama(expected, expected_tool_count=tool_count, **kw),
+        probe_smithery(expected, args.smithery_server, expected_tool_count=tool_count, **kw),
     ]
 
     drift = [s for s in surfaces if s["status"] in ALERT_STATUSES]

--- a/tests/test_surface_freshness.py
+++ b/tests/test_surface_freshness.py
@@ -435,3 +435,101 @@ def test_surface_freshness_main_skips_blank_docker_and_smithery_env(monkeypatch,
     assert report["all_fresh"] is True
     assert seen["docker"] == script.DEFAULT_DOCKER_IMAGE
     assert seen["smithery"] == script.DEFAULT_SMITHERY_SERVER
+
+
+def test_default_invocation_derives_the_expected_tool_count(monkeypatch, tmp_path):
+    """Running the monitor with no flags must still gate the tool count.
+
+    ``--expected-tool-count`` defaulted to ``None``, and only the Glama probe
+    fell back to deriving it from the README. So the workflows — which pass the
+    flag — gated the count, while a bare ``python scripts/check_surface_freshness.py``
+    reported Smithery **fresh at 36 of 77**: the exact drift the sibling test
+    above calls "invisible". One shipped inventory means one derivation, not one
+    derivation and one caller-supplied argument that silently defaults to off.
+    """
+    script = _load_script("check_surface_freshness.py")
+    seen = {}
+
+    def record(name):
+        def probe(expected, *args, **kwargs):
+            seen[name] = kwargs.get("expected_tool_count")
+            return {"surface": name, "status": "fresh", "version": expected, "expected": expected}
+
+        return probe
+
+    for name, attribute in (
+        ("PyPI", "probe_pypi"),
+        ("Docker", "probe_docker"),
+        ("Glama", "probe_glama"),
+        ("Smithery", "probe_smithery"),
+    ):
+        monkeypatch.setattr(script, attribute, record(name))
+
+    out = tmp_path / "report.json"
+    script.main(["--expected", "0.98.3", "--out", str(out)])
+
+    expected = int(script.expected_tool_count())
+    assert expected > 1, "the README contract should be a real inventory, not a placeholder"
+    assert seen["Glama"] == expected
+    assert seen["Smithery"] == expected
+
+
+def test_expected_tool_count_has_a_single_derivation():
+    """Both scripts must read the same sentence, not keep separate copies."""
+    freshness = _load_script("check_surface_freshness.py")
+    glama = _load_script("check_glama_listing.py")
+
+    assert int(freshness.expected_tool_count()) == int(glama._load_readme_tool_count())
+
+
+def test_ghcr_pagination_never_carries_the_token_off_origin(monkeypatch):
+    """A registry-supplied ``next`` link must not redirect our bearer token.
+
+    The GHCR tag walk resolved each page with
+    ``urljoin("https://ghcr.io", link)``, and ``urljoin`` returns an absolute
+    URL unchanged — so a ``Link: <https://attacker.example/...>; rel="next"``
+    header replaced the host while ``auth_headers`` kept the GHCR bearer token
+    attached. #4626 closed exactly this on the Docker Hub cleanup path; the
+    monitor kept the second copy.
+    """
+    script = _load_script("check_surface_freshness.py")
+    dialled = []
+
+    monkeypatch.setattr(script, "_http_json", lambda url, **_kw: {"token": "ghcr-secret"})
+
+    def fake_http_json_response(url, headers=None, **_kw):
+        dialled.append((url, dict(headers or {})))
+        if "attacker.example" in url:
+            return {"tags": ["9.9.9"]}, {}
+        return {"tags": ["0.98.3"]}, {"Link": '<https://attacker.example/v2/x/tags/list?n=100>; rel="next"'}
+
+    monkeypatch.setattr(script, "_http_json_response", fake_http_json_response)
+
+    result = script.probe_docker("0.98.3", "ghcr.io/msaad00/agent-bom", timeout=1, attempts=1, backoff=0)
+
+    off_origin = [url for url, _ in dialled if "ghcr.io" not in url]
+    assert not off_origin, f"followed a link off ghcr.io: {off_origin}"
+    leaked = [url for url, sent in dialled if "ghcr.io" not in url and sent.get("Authorization")]
+    assert not leaked, f"bearer token sent off-origin to {leaked}"
+    # Fail closed rather than judging on the pages we did get. The expected tag
+    # was on page one here, so a laxer probe would report "fresh" and bury the
+    # fact that the registry handed back a link pointing somewhere else.
+    assert result["status"] == "unreachable"
+    assert "off-origin" in result["error"]
+
+
+def test_ghcr_pagination_still_follows_a_same_origin_next_link(monkeypatch):
+    """The guard must not break real pagination — the tag is on page two."""
+    script = _load_script("check_surface_freshness.py")
+    monkeypatch.setattr(script, "_http_json", lambda url, **_kw: {"token": "ghcr-secret"})
+    pages = iter(
+        [
+            ({"tags": ["0.98.1"]}, {"Link": '</v2/msaad00/agent-bom/tags/list?n=100&last=0.98.1>; rel="next"'}),
+            ({"tags": ["0.98.3"]}, {}),
+        ]
+    )
+    monkeypatch.setattr(script, "_http_json_response", lambda url, headers=None, **_kw: next(pages))
+
+    result = script.probe_docker("0.98.3", "ghcr.io/msaad00/agent-bom", timeout=1, attempts=1, backoff=0)
+
+    assert result["status"] == "fresh"


### PR DESCRIPTION
## Summary

Found while re-probing #4513. Two defects in the freshness monitor itself, both
the shape this release keeps closing — one question, two answers, and the second
one wrong.

### 1. The tool-count gate switched itself off for a human

`--expected-tool-count` defaults to `None`. Only the **Glama** probe falls back
to deriving it (`check_glama_listing.py:241` reads the README contract
sentence); Smithery had no fallback, so an unset expectation skipped the
assertion entirely.

The workflows pass the flag, so CI was right. A bare
`python scripts/check_surface_freshness.py` — what a person actually runs —
reported:

```
Smithery   fresh   tool_count=36
```

against a release shipping 77. The sibling test in this very file
(`test_smithery_listing_advertising_fewer_tools_than_shipped_is_stale`) calls
that exact scenario *"the months-long drift this script was written to prevent,
and it was invisible."* The default invocation restored it.

After:

```
Glama      fresh   77 -> 77
Smithery   stale   36 -> 77   catalog advertises 36 tools; expected 77
```

The expectation is now defaulted once in `main()` and delegates to
`check_glama_listing`, so there is one derivation, not two.

### 2. GHCR pagination carried the bearer token off-origin

```python
next_url = urllib.parse.urljoin("https://ghcr.io", match.group(1))
```

`urljoin` returns an **absolute** URL unchanged, so a registry-supplied
`Link: <https://attacker.example/…>; rel="next"` replaced the host while
`auth_headers` kept the GHCR bearer token attached. #4626 closed precisely this
on the Docker Hub cleanup path; the monitor still held the second copy. Both
callers now share one origin check.

A refused link fails the probe **closed** (`unreachable`) rather than judging on
the pages that did arrive — in the test the expected tag is on page one, so a
laxer probe would report `fresh` and bury the fact that the registry handed back
a link pointing somewhere else.

## Verification

- Both new tests confirmed **red** first: the count test failed with
  `AttributeError: no attribute 'expected_tool_count'`, the token test with
  `followed a link off ghcr.io: ['https://attacker.example/...']`.
- `pytest tests/test_surface_freshness.py` — 25 passed.
- Against the **live** registries, not fixtures: Docker still resolves through
  real pagination after the origin pin, and the bare local run now reports
  Smithery stale at 36/77 — agreeing with what CI already saw.
- `ruff check` and `mypy` clean on the changed script (the pre-existing
  `no-redef` on `tags` is gone as a side effect of the annotation move).

## Does not close #4513

That issue is accurate and its fix is external. The Smithery catalog genuinely
advertises 36 of 77 tools, and its listing description still reads *"7 tools for
CVE scanning…"* — two generations stale. The remedy is re-publishing the listing
so it re-indexes; no code change here or elsewhere closes it. This PR only makes
the monitor tell the truth from every entry point.