### PR TITLE
feat(demo): scale the enterprise estate and make its evidence correlate

### DIFF
--- a/docs/PRODUCT_METRICS.json
+++ b/docs/PRODUCT_METRICS.json
@@ -28,7 +28,7 @@
     },
     {
       "name": "Test files",
-      "value": 1136,
+      "value": 1137,
       "source": "tests/",
       "notes": "Counts files matching test_*.py."
     },
@@ -46,7 +46,7 @@
     },
     {
       "name": "Python modules",
-      "value": 832,
+      "value": 835,
       "source": "src/agent_bom",
       "notes": "Counts all Python files recursively."
     },

--- a/docs/PRODUCT_METRICS.md
+++ b/docs/PRODUCT_METRICS.md
@@ -14,10 +14,10 @@ Keep counts out of public positioning copy and update this file from the repo in
 | MCP resources | 6 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card resources. |
 | MCP prompts | 8 | `src/agent_bom/mcp_server_metadata.py` | Counted from the advertised server-card workflow prompts. |
 | GitHub workflow files | 38 | `.github/workflows` | Counts .yml and .yaml workflow definitions. |
-| Test files | 1136 | `tests/` | Counts files matching test_*.py. |
+| Test files | 1137 | `tests/` | Counts files matching test_*.py. |
 | API route modules | 46 | `src/agent_bom/api/routes` | Counts Python files in the routes package, including __init__.py. |
 | UI app pages | 41 | `ui/app` | Counts page.tsx and page.jsx files recursively. |
-| Python modules | 832 | `src/agent_bom` | Counts all Python files recursively. |
+| Python modules | 835 | `src/agent_bom` | Counts all Python files recursively. |
 | Supported package ecosystems | 15 | `src/agent_bom/ecosystems.py` | Counted from SUPPORTED_PACKAGE_ECOSYSTEMS. |
 | Compliance surfaces | 16 | `src/agent_bom/compliance_coverage.py` | 15 tag-mapped frameworks plus the OWASP AISVS benchmark surface. |
 | Proxy inline detectors | 7 | `src/agent_bom/proxy.py` | Inline detector chain used by the MCP proxy path. |

--- a/docs/openapi/v1.json
+++ b/docs/openapi/v1.json
@@ -5337,6 +5337,11 @@
             "title": "Observed At",
             "type": "string"
           },
+          "policy_decision": {
+            "default": "",
+            "title": "Policy Decision",
+            "type": "string"
+          },
           "resource_ids": {
             "items": {
               "type": "string"

--- a/docs/openapi/v1.yaml
+++ b/docs/openapi/v1.yaml
@@ -3807,6 +3807,10 @@ components:
           format: date-time
           title: Observed At
           type: string
+        policy_decision:
+          default: ''
+          title: Policy Decision
+          type: string
         resource_ids:
           items:
             type: string

--- a/scripts/check_enterprise_demo_surfaces.py
+++ b/scripts/check_enterprise_demo_surfaces.py
@@ -20,6 +20,10 @@ if str(REPO_ROOT / "src") not in sys.path:
 
 from agent_bom.cli import main  # noqa: E402
 from agent_bom.demo_estate.enterprise_findings import ESTATE_FINDING_SEVERITY_BUCKETS  # noqa: E402
+from agent_bom.demo_estate.enterprise_scale import (  # noqa: E402
+    MIN_CROSS_SOURCE_CORRELATIONS,
+    MIN_ESTATE_FINDINGS,
+)
 from agent_bom.demo_estate.presentation import build_enterprise_demo_story  # noqa: E402
 
 EXPECTED_FIXTURES = {
@@ -71,6 +75,18 @@ def main_check() -> None:
     _require(story.summary.evidence_sources == 9, "evidence-source count changed")
     # Floor, not a fixed count: the composed estate correlates thousands of rows.
     _require(story.summary.correlations >= 4, "the narrative correlations are gone")
+    # ...and the number that actually carries the claim. ``correlations`` counts
+    # trace groups; only these join evidence across vendors. The estate once
+    # reported 6,148 correlations of which 3 were cross-source, and no gate
+    # noticed, because nothing checked the second number.
+    _require(
+        story.summary.cross_source_correlations >= MIN_CROSS_SOURCE_CORRELATIONS,
+        f"only {story.summary.cross_source_correlations} correlations span more than one vendor",
+    )
+    _require(
+        story.summary.cross_source_correlations <= story.summary.correlations,
+        "more cross-source correlations than correlations",
+    )
     # The view is bounded so the incident stays visible; the summary must still
     # report the unbounded truth, never the page size.
     _require(len(story.correlations) <= story.summary.correlations, "story claims more rows than it holds")
@@ -106,7 +122,13 @@ def main_check() -> None:
     # configuration and a control — and that the bounded list never reports its
     # own length as the estate's total.
     posture = story.finding_summary
-    _require(posture.total >= 300, "the estate lost its posture findings")
+    _require(posture.total >= MIN_ESTATE_FINDINGS, "the estate lost its findings")
+    # More than one scanner. Every one of the estate's 439 findings used to be a
+    # CIS check, so the demo's risk grew with control coverage rather than with
+    # the estate and an AI service, a leaked credential and a vulnerable image
+    # all read as "nothing found".
+    lanes = {finding.finding_type for finding in story.findings}
+    _require(len(lanes) >= 3, f"the rendered findings come from too few lanes: {sorted(lanes)}")
     _require(story.summary.findings == posture.total, "the summary and the posture total disagree")
     _require(
         sum(posture.by_severity.values()) == posture.total,

--- a/src/agent_bom/api/routes/graph.py
+++ b/src/agent_bom/api/routes/graph.py
@@ -758,6 +758,78 @@ def _rel_value(edge: UnifiedEdge) -> str:
     return edge.relationship.value if hasattr(edge.relationship, "value") else str(edge.relationship)
 
 
+# org → account → environment → resource. Four is the estate's containment depth
+# plus a level of slack; the loop stops early when a level yields no new parent,
+# so this only bounds a cycle.
+_MAX_CONTAINMENT_LEVELS = 5
+
+
+async def _containment_ancestors(
+    graph_store: Any,
+    *,
+    scan_id: str,
+    tenant_id: str,
+    node_ids: set[str],
+    known_edges: list[UnifiedEdge],
+) -> tuple[list[UnifiedNode], list[UnifiedEdge]]:
+    """Return the containment parents of a node page, and the edges reaching them.
+
+    Node pages are ordered by severity. That is right for "show me the worst
+    first" and wrong for structure: once an estate carries more high-severity
+    findings than the page holds, every org, account and environment falls off
+    page one, and the default graph response describes an estate with no shape.
+    It read as correct only while the estate was small enough that the spine
+    happened to fit.
+
+    Containment ancestors are bounded by the page, not by the estate: each page
+    node contributes at most one parent per level, and levels collapse fast
+    because pages share parents (measured on the demo estate: a 500-node page
+    resolves 552 ancestors, of which 104 are env/account/org). Adding them grows
+    the payload by roughly the page size — it does not scale with the estate —
+    so the page stays bounded while gaining a shape. ``completeness.ranked`` and
+    ``completeness.context_nodes`` report the split.
+    """
+    if not node_ids:
+        return [], []
+
+    ancestor_ids: set[str] = set()
+    ancestor_edges: dict[tuple[str, str], UnifiedEdge] = {}
+    frontier = set(node_ids)
+    frontier_edges = known_edges
+
+    for _level in range(_MAX_CONTAINMENT_LEVELS):
+        parents: set[str] = set()
+        for edge in frontier_edges:
+            # The roll-up already defines what containment means (contains /
+            # hosts / owns). Answering it again here is how the two drift.
+            if _rel_value(edge) not in ROLLUP_CONTAINMENT_RELATIONSHIPS:
+                continue
+            if edge.target in frontier and edge.source not in node_ids:
+                parents.add(edge.source)
+                ancestor_edges[(edge.source, edge.target)] = edge
+        parents -= ancestor_ids
+        if not parents:
+            break
+        ancestor_ids |= parents
+        frontier = parents
+        frontier_edges = await _graph_store_call(
+            graph_store.edges_for_node_ids,
+            scan_id=scan_id,
+            tenant_id=tenant_id,
+            node_ids=parents,
+        )
+
+    if not ancestor_ids:
+        return [], []
+    nodes = await _graph_store_call(
+        graph_store.nodes_by_ids,
+        scan_id=scan_id,
+        tenant_id=tenant_id,
+        node_ids=ancestor_ids,
+    )
+    return list(nodes), list(ancestor_edges.values())
+
+
 def _edge_relationships_for_hops(hops: list[str], edges: list[UnifiedEdge]) -> list[str]:
     """Return relationship names for consecutive hop pairs when topology is available."""
     if len(hops) < 2:
@@ -2155,7 +2227,14 @@ async def get_graph(
         tenant_id=tenant,
         node_ids=attack_path_hop_ids - paged_ids,
     )
-    nodes_by_id = {node.id: node for node in [*paged_nodes, *attack_path_nodes]}
+    ancestor_nodes, ancestor_edges = await _containment_ancestors(
+        graph_store,
+        scan_id=effective_scan_id,
+        tenant_id=tenant,
+        node_ids=paged_ids,
+        known_edges=paged_edges,
+    )
+    nodes_by_id = {node.id: node for node in [*paged_nodes, *attack_path_nodes, *ancestor_nodes]}
     snapshot_stats = await _graph_store_call(
         graph_store.snapshot_stats,
         scan_id=effective_scan_id,
@@ -2171,24 +2250,34 @@ async def get_graph(
         **snapshot_stats,
         "total_nodes_source": max(int(snapshot_stats.get("total_nodes", 0)), total),
     }
+    response_nodes = [*paged_nodes, *ancestor_nodes]
+    page_truncated = bool(next_cursor) or offset + len(paged_nodes) < total
     return {
         "scan_id": effective_scan_id,
         "tenant_id": tenant,
         "created_at": created_at,
-        "nodes": [n.to_dict() for n in paged_nodes],
-        "edges": [e.to_dict() for e in paged_edges],
+        "nodes": [n.to_dict() for n in response_nodes],
+        "edges": [e.to_dict() for e in [*paged_edges, *ancestor_edges]],
         "attack_paths": [
             _serialize_attack_path(path, paged_edges, nodes_by_id=nodes_by_id, scan_id=effective_scan_id) for path in source_attack_paths
         ],
         "interaction_risks": [],
         "stats": snapshot_stats,
         "pagination": _page_meta(total, offset, limit, cursor=cursor, next_cursor=next_cursor),
-        "completeness": graph_completeness(
-            returned=len(paged_nodes),
-            total=total,
-            truncated=bool(next_cursor) or offset + len(paged_nodes) < total,
-            reason="node_page_limit" if bool(next_cursor) or offset + len(paged_nodes) < total else "",
-        ),
+        "completeness": {
+            **graph_completeness(
+                returned=len(response_nodes),
+                total=total,
+                truncated=page_truncated,
+                reason="node_page_limit" if page_truncated else "",
+            ),
+            # ``returned`` counts every node in the payload; ``pagination`` counts
+            # only the ranked page. Containment ancestors are added on top of the
+            # page, so without naming them the two numbers cannot be reconciled
+            # and the extra nodes read as a paging bug.
+            "ranked": len(paged_nodes),
+            "context_nodes": len(ancestor_nodes),
+        },
     }
 
 

--- a/src/agent_bom/api/routes/scan.py
+++ b/src/agent_bom/api/routes/scan.py
@@ -579,16 +579,50 @@ def _package_base_name(finding: dict[str, Any]) -> str:
 def _canonical_group_key(finding: dict[str, Any]) -> str:
     """Collapse the three per-CVE representations onto one grouping key.
 
-    Findings that carry a CVE/advisory id group by ``(vuln_id, package_base)``
-    so the ``MCP_SCAN`` (unified), ``blast_radius`` and ``package_vulnerability``
-    rows for the same vulnerability merge into a single list row. Non-CVE
+    Findings that carry a CVE/advisory id group by
+    ``(vuln_id, package_base, asset)`` so the ``MCP_SCAN`` (unified),
+    ``blast_radius`` and ``package_vulnerability`` rows for the *same
+    vulnerability on the same asset* merge into a single list row. Non-CVE
     findings (posture, malicious-package, etc.) fall back to their stable
     identity so distinct findings stay distinct.
+
+    ``asset`` is in the key, and its absence was a real under-count. The three
+    representations this function exists to merge all describe one vulnerability
+    on **one** asset, so the asset was never needed to merge them — but leaving
+    it out also merged the same package version across *different* assets. A
+    scan of one repository never noticed, because a package appears once. An
+    estate does: the demo ships fifteen advisories across 768 inventoried
+    package rows in 129 container images, and ``/v1/findings`` reported 1,833 of
+    2,616 rows — the entire vulnerability lane folded to fifteen — while every
+    surface described the result as the total. A dedup key that omits the scope
+    of the thing it dedupes is the same defect class that once dropped a second
+    tenant's rows here.
     """
     vuln = _row_vuln_id(finding)
     if vuln:
-        return f"vuln:{vuln.lower()}:{_package_base_name(finding)}"
+        return f"vuln:{vuln.lower()}:{_package_base_name(finding)}:{_row_asset_key(finding)}"
     return f"id:{_finding_identity(finding)}"
+
+
+def _row_asset_key(finding: dict[str, Any]) -> str:
+    """The asset a row is about, in whichever spelling its representation uses.
+
+    Empty when a representation names no asset — which keeps the merge working:
+    a blast-radius row that identifies no asset still folds onto the unified row
+    for the same vulnerability and package rather than splitting off on its own.
+    """
+    raw_asset = finding.get("asset")
+    asset = raw_asset if isinstance(raw_asset, dict) else {}
+    for value in (
+        asset.get("identifier"),
+        asset.get("canonical_id"),
+        asset.get("stable_id"),
+        finding.get("resource_id"),
+    ):
+        text = str(value or "").strip()
+        if text:
+            return text.lower()
+    return ""
 
 
 _EMPTY_FIELD_VALUES: tuple[Any, ...] = (None, "", [], {})

--- a/src/agent_bom/demo_estate/bootstrap.py
+++ b/src/agent_bom/demo_estate/bootstrap.py
@@ -65,7 +65,7 @@ def _tenant_has_demo_jobs(store: Any, tenant_id: str) -> bool:
 
 
 def _estate_findings(tenant_id: str) -> list[Any]:
-    """Return the composed estate's posture findings for the demo scan job.
+    """Return the composed estate's findings for the demo scan job.
 
     Seeded through the SAME ``findings`` list every other generator uses, so the
     findings list, the severity facets, the exec tiles, SARIF and every export
@@ -77,6 +77,23 @@ def _estate_findings(tenant_id: str) -> list[Any]:
     from agent_bom.demo_estate.enterprise_findings import build_estate_findings
 
     return list(build_estate_findings(build_demo_estate(tenant_id=tenant_id)))
+
+
+def _estate_blast_radii(tenant_id: str) -> list[Any]:
+    """Return the blast radii behind the estate's CVE findings.
+
+    Not optional, and not a duplicate of the findings above.
+    ``output.finding_views.cve_findings`` resolves the report's CVE array from
+    ``report.blast_radii`` whenever that list is non-empty, and the unified
+    ``findings`` array excludes ``CVE`` by design. An estate that contributed
+    CVE findings but no blast radii therefore had its entire vulnerability lane
+    dropped between the seeder and the API — ``/v1/findings`` reported 1,833 of
+    2,601 seeded rows and no surface said a lane was missing.
+    """
+    from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+    from agent_bom.demo_estate.enterprise_risk import build_vulnerability_blast_radii
+
+    return list(build_vulnerability_blast_radii(build_demo_estate(tenant_id=tenant_id)))
 
 
 def _run_demo_scan_report(*, tenant_id: str) -> dict[str, Any]:
@@ -101,6 +118,9 @@ def _run_demo_scan_report(*, tenant_id: str) -> dict[str, Any]:
     findings.extend(blocklist_findings_for_agents(agents))
     findings.extend(evaluate_mcp_auth_posture(agents))
     findings.extend(_estate_findings(tenant_id))
+    # Both halves of the vulnerability lane, or neither surfaces (see
+    # ``_estate_blast_radii``).
+    blast_radii = [*blast_radii, *_estate_blast_radii(tenant_id)]
     report = to_json(
         AIBOMReport(
             agents=agents,

--- a/src/agent_bom/demo_estate/enterprise.py
+++ b/src/agent_bom/demo_estate/enterprise.py
@@ -337,8 +337,7 @@ _ASSET_SPECS: tuple[dict[str, Any], ...] = (
         "tags": {
             "cluster": "kubernetes:cluster:eks/member-ai-prod",
             "container_image": (
-                "cloud_resource:aws:ecr:image:member-copilot@sha256:"
-                "4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"
+                "cloud_resource:aws:ecr:image:member-copilot@sha256:4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"
             ),
             "uses_identity": "cloud_resource:aws:iam:role:member-copilot-prod",
             "reads_data": "snowflake:table:nh_prod/analytics/phi/patient_summary",

--- a/src/agent_bom/demo_estate/enterprise.py
+++ b/src/agent_bom/demo_estate/enterprise.py
@@ -19,6 +19,17 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator, model_valida
 ENTERPRISE_SCHEMA_VERSION = "1.0.0"
 _FIXTURE_NAME = "enterprise_observations.jsonl"
 
+# The hand-authored incident's trace, named rather than discovered.
+#
+# The presentation layer used to surface "the first correlation of kind
+# ``data_egress_attempt``", which was unambiguous only while the incident was the
+# estate's sole egress attempt. Once the generated population produces hundreds
+# of them, correlations sort by trace id and an arbitrary generated journey
+# becomes the headline. ``tests/test_enterprise_demo_contract.py`` asserts this
+# id still exists in the fixture, so a renumbered incident fails loudly instead
+# of silently promoting a different story.
+NARRATIVE_INCIDENT_TRACE_ID = "7f3a9b12c4d5e6f7890abcde12345678"
+
 
 class EstateStage(StrEnum):
     BASELINE = "baseline"
@@ -255,6 +266,7 @@ _ASSET_SPECS: tuple[dict[str, Any], ...] = (
         "display_name": "Deploy member copilot",
         "environment": "production",
         "account_scope": "northstar-health",
+        "tags": {"repository": "github:repository:northstar-health/member-copilot"},
         "owner": "ai-platform@northstar.example",
         "cost_center": "AI-410",
         "data_classifications": ["confidential"],
@@ -322,6 +334,15 @@ _ASSET_SPECS: tuple[dict[str, Any], ...] = (
         "display_name": "member-copilot",
         "environment": "production",
         "account_scope": "member-ai-prod",
+        "tags": {
+            "cluster": "kubernetes:cluster:eks/member-ai-prod",
+            "container_image": (
+                "cloud_resource:aws:ecr:image:member-copilot@sha256:"
+                "4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"
+            ),
+            "uses_identity": "cloud_resource:aws:iam:role:member-copilot-prod",
+            "reads_data": "snowflake:table:nh_prod/analytics/phi/patient_summary",
+        },
         "region": "us-east-1",
         "owner": "ai-platform@northstar.example",
         "cost_center": "AI-410",
@@ -347,6 +368,11 @@ _ASSET_SPECS: tuple[dict[str, Any], ...] = (
         "display_name": "execute_sql",
         "environment": "production",
         "account_scope": "member-ai-prod",
+        "tags": {
+            "mcp_server": "mcp:server:clinical-analytics",
+            "write_capable": "false",
+            "reads_data": "snowflake:table:nh_prod/analytics/phi/patient_summary",
+        },
         "owner": "data-platform@northstar.example",
         "cost_center": "DATA-320",
         "data_classifications": ["phi", "pii"],

--- a/src/agent_bom/demo_estate/enterprise_ai.py
+++ b/src/agent_bom/demo_estate/enterprise_ai.py
@@ -1,0 +1,740 @@
+"""Generate the AI, delivery and runtime estate *inside* the cloud accounts.
+
+:mod:`agent_bom.demo_estate.enterprise_scale` builds the cloud population —
+accounts, compute, identity, data. This module builds everything that runs *on*
+it, and the single decision that shapes the whole module is where it puts them.
+
+**First-party AI is an account resource, not a vendor lane.** A Bedrock agent, an
+Azure OpenAI deployment, a Vertex endpoint and a Cortex function are services of
+the account that owns them. They reuse that account's ``account_scope``,
+``region`` and ``environment``, they assume identities the account already
+inventoried, and they read data stores that already exist there. That shared
+context *is* the correlation the product claims: the same role, the same
+account, the same table. Modelling AI as a separate ``openai``/``anthropic``
+provider — the shape the estate had — makes every AI asset an island with
+nothing to correlate against, which is why nine of them read as an afterthought
+next to two thousand cloud rows.
+
+The third-party lane (external model providers, MCP servers and their tools,
+agents) is kept, because it is real, and kept *smaller*, because it is the
+minority of an enterprise's AI surface.
+
+Everything is derived from the identity of the thing itself, never from a random
+source, so the same profile always produces the same estate.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+
+from agent_bom.demo_estate.enterprise import EstateAsset
+
+# Tag key that says which AI lane an asset belongs to. Read by the graph
+# projection, the surfaces gate and the tests, so it lives in one place.
+AI_LANE_TAG = "ai_lane"
+
+_TENANT_DOMAIN = "northstar.example"
+
+# Identity and data resource types the cloud population already generates. An AI
+# service borrows from these rather than minting its own, which is the whole
+# point: the principal that answers for the model is the principal that already
+# answers for the bucket beside it.
+_IDENTITY_TYPES = frozenset({"iam_role", "service_principal", "service_account", "role"})
+_DATA_TYPES = frozenset({"bucket", "storage_account", "database", "sql_database", "table", "stage", "share"})
+_COMPUTE_TYPES = frozenset({"instance", "virtual_machine", "function", "function_app", "warehouse", "cluster"})
+
+
+def stable_index(*parts: str) -> int:
+    """Deterministic pseudo-index derived from the identity of the thing itself.
+
+    Same derivation as the cloud generator: structure in, structure out, so an
+    estate is byte-identical on every machine and every run.
+    """
+    return int.from_bytes(hashlib.sha256("|".join(parts).encode("utf-8")).digest()[:4], "big")
+
+
+@dataclass(frozen=True, slots=True)
+class CloudAccount:
+    """One generated cloud account, indexed by what an AI service needs from it.
+
+    Built by reading the population back rather than by re-deriving it. A second
+    derivation of "which identities does account X hold" would be a second source
+    of truth, free to disagree with the assets actually inventoried.
+    """
+
+    provider: str
+    scope: str
+    regions: tuple[str, ...]
+    environments: tuple[str, ...]
+    identities: tuple[str, ...]
+    data_stores: tuple[str, ...]
+    compute: tuple[str, ...]
+    # (region, environment) pairs that non-AI resources actually occupy. An AI
+    # service must land on one of these, not on an arbitrary product of the two:
+    # a scope no other resource occupies is a scope the drill-down shows empty.
+    placements: tuple[tuple[str, str], ...]
+
+    @property
+    def key(self) -> str:
+        return f"{self.provider}:{self.scope}"
+
+
+def index_cloud_accounts(assets: Sequence[EstateAsset]) -> tuple[CloudAccount, ...]:
+    """Group the generated cloud population into the accounts an AI service can join."""
+    identities: dict[tuple[str, str], list[str]] = {}
+    data_stores: dict[tuple[str, str], list[str]] = {}
+    compute: dict[tuple[str, str], list[str]] = {}
+    placements: dict[tuple[str, str], list[tuple[str, str]]] = {}
+    regions: dict[tuple[str, str], list[str]] = {}
+    environments: dict[tuple[str, str], list[str]] = {}
+
+    for asset in assets:
+        if asset.resource_type == "organization" or asset.tags.get(AI_LANE_TAG):
+            continue
+        key = (asset.provider, asset.account_scope)
+        placements.setdefault(key, [])
+        placement = (asset.region, asset.environment)
+        if placement not in placements[key]:
+            placements[key].append(placement)
+        for bucket, value in ((regions, asset.region), (environments, asset.environment)):
+            bucket.setdefault(key, [])
+            if value not in bucket[key]:
+                bucket[key].append(value)
+        if asset.resource_type in _IDENTITY_TYPES:
+            identities.setdefault(key, []).append(asset.asset_id)
+        elif asset.resource_type in _DATA_TYPES:
+            data_stores.setdefault(key, []).append(asset.asset_id)
+        elif asset.resource_type in _COMPUTE_TYPES:
+            compute.setdefault(key, []).append(asset.asset_id)
+
+    accounts: list[CloudAccount] = []
+    for provider, scope in sorted(placements):
+        key = (provider, scope)
+        accounts.append(
+            CloudAccount(
+                provider=provider,
+                scope=scope,
+                regions=tuple(regions.get(key, ("global",))),
+                environments=tuple(environments.get(key, ("production",))),
+                identities=tuple(sorted(identities.get(key, ()))),
+                data_stores=tuple(sorted(data_stores.get(key, ()))),
+                compute=tuple(sorted(compute.get(key, ()))),
+                placements=tuple(placements[key]),
+            )
+        )
+    return tuple(accounts)
+
+
+@dataclass(frozen=True, slots=True)
+class AiServiceSpec:
+    """One first-party AI service type offered by a cloud.
+
+    ``resource_type`` is the vocabulary the graph maps onto an entity type, and
+    ``service`` is the console name an operator would recognise. Both are the
+    vendor's own naming — an estate that invents plausible-looking service names
+    demonstrates a product that has never seen the real thing.
+    """
+
+    resource_type: str
+    service: str
+    label: str
+    # Whether this service type is reachable from the internet when exposed, and
+    # whether it reads a data store. Drives the exposure surface and the paths.
+    exposable: bool
+    reads_data: bool
+
+
+# Verified against each vendor's current service naming (AWS Bedrock agents /
+# knowledge bases / guardrails and SageMaker endpoints; Azure OpenAI deployments,
+# AI Foundry projects and Cognitive Services accounts; Vertex AI endpoints,
+# models and agents plus the Gemini API; Snowflake Cortex functions, Cortex
+# Search services and Snowpark Container Services).
+_FIRST_PARTY_AI: dict[str, tuple[AiServiceSpec, ...]] = {
+    "aws": (
+        AiServiceSpec("bedrock_agent", "bedrock", "Bedrock agent", exposable=False, reads_data=True),
+        AiServiceSpec("bedrock_knowledge_base", "bedrock", "Bedrock knowledge base", exposable=False, reads_data=True),
+        AiServiceSpec("bedrock_guardrail", "bedrock", "Bedrock guardrail", exposable=False, reads_data=False),
+        AiServiceSpec("foundation_model", "bedrock", "Bedrock foundation model", exposable=False, reads_data=False),
+        AiServiceSpec("sagemaker_endpoint", "sagemaker", "SageMaker endpoint", exposable=True, reads_data=True),
+        AiServiceSpec("sagemaker_model", "sagemaker", "SageMaker model", exposable=False, reads_data=False),
+        AiServiceSpec("training_dataset", "sagemaker", "SageMaker training dataset", exposable=False, reads_data=True),
+    ),
+    "azure": (
+        AiServiceSpec("azure_openai_deployment", "openai", "Azure OpenAI deployment", exposable=True, reads_data=False),
+        AiServiceSpec("ai_foundry_project", "aifoundry", "AI Foundry project", exposable=False, reads_data=True),
+        AiServiceSpec("cognitive_services_account", "cognitiveservices", "Cognitive Services account", exposable=True, reads_data=False),
+        AiServiceSpec("ai_search_index", "search", "AI Search index", exposable=False, reads_data=True),
+        AiServiceSpec("prompt_template", "aifoundry", "AI Foundry prompt flow", exposable=False, reads_data=False),
+    ),
+    "gcp": (
+        AiServiceSpec("vertex_endpoint", "aiplatform", "Vertex AI endpoint", exposable=True, reads_data=True),
+        AiServiceSpec("vertex_model", "aiplatform", "Vertex AI model", exposable=False, reads_data=False),
+        AiServiceSpec("vertex_agent", "aiplatform", "Vertex AI agent", exposable=False, reads_data=True),
+        AiServiceSpec("gemini_api", "generativelanguage", "Gemini API surface", exposable=True, reads_data=False),
+        AiServiceSpec("training_dataset", "aiplatform", "Vertex AI managed dataset", exposable=False, reads_data=True),
+    ),
+    "snowflake": (
+        AiServiceSpec("cortex_function", "cortex", "Cortex LLM function", exposable=False, reads_data=True),
+        AiServiceSpec("cortex_search_service", "cortex", "Cortex Search service", exposable=False, reads_data=True),
+        AiServiceSpec("spcs_service", "spcs", "Snowpark Container Services service", exposable=True, reads_data=True),
+        AiServiceSpec("prompt_template", "cortex", "Cortex prompt template", exposable=False, reads_data=False),
+    ),
+}
+
+_MODEL_FAMILIES: dict[str, tuple[str, ...]] = {
+    "aws": ("anthropic.claude-sonnet-4-5", "amazon.nova-pro-v1", "meta.llama-4-70b"),
+    "azure": ("gpt-4.1", "gpt-4o-mini", "o4-mini"),
+    "gcp": ("gemini-2.5-pro", "gemini-2.5-flash", "medlm-large"),
+    "snowflake": ("snowflake-arctic", "mistral-large2", "llama3.1-70b"),
+}
+
+
+def _owner_for(provider: str, service: str) -> str:
+    return f"{service}-ai-owners@{_TENANT_DOMAIN}"
+
+
+def build_first_party_ai_assets(accounts: Sequence[CloudAccount], *, tenant_id: str, per_account: int) -> tuple[EstateAsset, ...]:
+    """Emit first-party AI services into the accounts that already exist.
+
+    Each service reuses one of the account's real ``(region, environment)``
+    placements and, where the service type warrants it, names the identity it
+    assumes and the data store it reads. Those two tags are what the graph turns
+    into ``ASSUMES`` and ``CAN_ACCESS`` edges — the AI service, the principal and
+    the table become one reachable path rather than three unrelated rows.
+    """
+    assets: list[EstateAsset] = []
+    for account in accounts:
+        catalog = _FIRST_PARTY_AI.get(account.provider)
+        if not catalog or not account.placements:
+            continue
+        families = _MODEL_FAMILIES[account.provider]
+        for slot in range(per_account):
+            spec = catalog[slot % len(catalog)]
+            name = f"{account.provider}-{spec.service}-{account.scope[-4:]}-{slot:02d}"
+            seed = stable_index(account.provider, account.scope, name)
+            region, environment = account.placements[seed % len(account.placements)]
+            identity = account.identities[seed % len(account.identities)] if account.identities else ""
+            data_store = account.data_stores[(seed // 7) % len(account.data_stores)] if spec.reads_data and account.data_stores else ""
+            # A minority of the exposable services are actually exposed. An
+            # estate where every endpoint is public is not an estate, it is a
+            # test fixture for one control.
+            internet_facing = spec.exposable and seed % 5 == 0
+            tags = {
+                "synthetic": "true",
+                "environment": environment,
+                AI_LANE_TAG: "first_party",
+                "ai_service": spec.service,
+                "model_family": families[seed % len(families)],
+                "internet_facing": "true" if internet_facing else "false",
+            }
+            if identity:
+                tags["uses_identity"] = identity
+            if data_store:
+                tags["reads_data"] = data_store
+            if internet_facing and spec.reads_data and data_store:
+                # Public endpoint in front of regulated data: the shape an
+                # exposure path is supposed to find.
+                tags["public_access"] = "true"
+            assets.append(
+                EstateAsset(
+                    asset_id=f"{account.provider}:{spec.resource_type}:{account.scope}:{name}",
+                    tenant_id=tenant_id,
+                    provider=account.provider,
+                    resource_type=spec.resource_type,
+                    native_id=f"{account.provider}://{account.scope}/{spec.service}/{name}",
+                    display_name=f"{spec.label} {name}",
+                    environment=environment,
+                    account_scope=account.scope,
+                    region=region,
+                    owner=_owner_for(account.provider, spec.service),
+                    cost_center=f"AI-{410 + (seed % 6)}",
+                    data_classifications=("phi", "restricted") if data_store else ("confidential",),
+                    tags=tags,
+                )
+            )
+    return tuple(assets)
+
+
+# ── Third-party lane: external providers, MCP servers, agents ────────────────
+
+_MCP_SERVER_CATALOG: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("claims-intake", ("lookup_member", "submit_claim", "read_policy", "list_attachments")),
+    ("clinical-notes", ("search_notes", "summarize_encounter", "redact_phi", "export_note")),
+    ("provider-directory", ("find_provider", "check_network", "update_roster", "read_contract")),
+    ("pharmacy-benefits", ("check_formulary", "price_drug", "prior_auth", "read_claim")),
+    ("care-gap-analytics", ("execute_sql", "run_cohort", "export_csv", "read_measure")),
+    ("member-messaging", ("send_message", "read_thread", "list_templates", "attach_document")),
+)
+
+_EXTERNAL_MODELS: tuple[tuple[str, str, str], ...] = (
+    ("openai", "gpt-4.1-mini", "hosted_model"),
+    ("openai", "text-embedding-3-large", "hosted_model"),
+    ("anthropic", "claude-haiku-4-5", "hosted_model"),
+    ("anthropic", "claude-opus-4-1", "hosted_model"),
+    ("huggingface", "bge-base-en-v1.5", "model_artifact"),
+    ("huggingface", "clinical-bert-ner", "model_artifact"),
+)
+
+_AGENT_ROLES: tuple[str, ...] = (
+    "member-copilot",
+    "claims-triage",
+    "prior-auth-reviewer",
+    "care-gap-outreach",
+    "provider-onboarding",
+    "appeals-drafter",
+)
+
+
+def build_third_party_ai_assets(
+    accounts: Sequence[CloudAccount],
+    *,
+    tenant_id: str,
+    mcp_servers: int,
+    agents: int,
+    external_models: int,
+) -> tuple[EstateAsset, ...]:
+    """Emit the external AI lane — deliberately the smaller share.
+
+    MCP servers, their tools and the agents that call them still live inside a
+    cloud account, because that is where they run; what makes them third party is
+    the vendor, not the address. External model endpoints are the one genuinely
+    off-estate surface, and they are the terminus of the egress path.
+    """
+    hosts = [account for account in accounts if account.placements]
+    if not hosts:
+        return ()
+    assets: list[EstateAsset] = []
+
+    for index in range(mcp_servers):
+        catalog_name, tool_names = _MCP_SERVER_CATALOG[index % len(_MCP_SERVER_CATALOG)]
+        server_name = f"{catalog_name}-{index:02d}"
+        account = hosts[stable_index("mcp-server", server_name) % len(hosts)]
+        seed = stable_index(account.scope, server_name)
+        region, environment = account.placements[seed % len(account.placements)]
+        server_id = f"mcp:server:{server_name}"
+        # A gateway-fronted server is not internet facing; a directly published
+        # one is. Both exist in a real estate and the difference is the finding.
+        published = seed % 4 == 0
+        assets.append(
+            EstateAsset(
+                asset_id=server_id,
+                tenant_id=tenant_id,
+                provider="mcp",
+                resource_type="server",
+                native_id=f"mcp://{server_name}",
+                display_name=f"{catalog_name.replace('-', ' ').title()} MCP",
+                environment=environment,
+                account_scope=account.scope,
+                region=region,
+                owner=f"ai-platform@{_TENANT_DOMAIN}",
+                cost_center="AI-410",
+                data_classifications=("phi", "pii") if seed % 3 == 0 else ("confidential",),
+                tags={
+                    "synthetic": "true",
+                    "environment": environment,
+                    AI_LANE_TAG: "third_party",
+                    "internet_facing": "true" if published else "false",
+                    "transport": "streamable-http" if published else "stdio",
+                    "host_provider": account.provider,
+                },
+            )
+        )
+        for tool_index, tool_name in enumerate(tool_names):
+            tool_seed = stable_index(server_id, tool_name)
+            writes = tool_name.startswith(("submit", "update", "send", "export", "attach"))
+            assets.append(
+                EstateAsset(
+                    asset_id=f"mcp:tool:{server_name}/{tool_name}",
+                    tenant_id=tenant_id,
+                    provider="mcp",
+                    resource_type="tool",
+                    native_id=f"mcp://{server_name}/tools/{tool_name}",
+                    display_name=tool_name,
+                    environment=environment,
+                    account_scope=account.scope,
+                    region=region,
+                    owner=f"ai-platform@{_TENANT_DOMAIN}",
+                    cost_center="AI-410",
+                    data_classifications=("phi", "pii") if tool_seed % 3 == 0 else (),
+                    tags={
+                        "synthetic": "true",
+                        "environment": environment,
+                        AI_LANE_TAG: "third_party",
+                        "mcp_server": server_id,
+                        "tool_index": str(tool_index),
+                        "write_capable": "true" if writes else "false",
+                        "over_permissive": "true" if writes and tool_seed % 3 == 0 else "false",
+                    },
+                )
+            )
+
+    agent_ids: list[str] = []
+    for index in range(agents):
+        role = _AGENT_ROLES[index % len(_AGENT_ROLES)]
+        agent_name = f"{role}-{index:02d}"
+        account = hosts[stable_index("agent", agent_name) % len(hosts)]
+        seed = stable_index(account.scope, agent_name)
+        region, environment = account.placements[seed % len(account.placements)]
+        agent_id = f"agent:{agent_name}"
+        agent_ids.append(agent_id)
+        tags = {
+            "synthetic": "true",
+            "environment": environment,
+            AI_LANE_TAG: "third_party",
+            "agent_role": role,
+            "host_provider": account.provider,
+            "autonomy": "supervised" if seed % 3 else "autonomous",
+        }
+        if account.identities:
+            tags["uses_identity"] = account.identities[seed % len(account.identities)]
+        assets.append(
+            EstateAsset(
+                asset_id=agent_id,
+                tenant_id=tenant_id,
+                provider="agent",
+                resource_type="agent",
+                native_id=f"agent://{agent_name}",
+                display_name=agent_name,
+                environment=environment,
+                account_scope=account.scope,
+                region=region,
+                owner=f"ai-platform@{_TENANT_DOMAIN}",
+                cost_center="AI-410",
+                data_classifications=("confidential",),
+                tags=tags,
+            )
+        )
+
+    # Agent-to-agent topology, applied after the pool exists so a delegation
+    # always names an agent the estate holds. A supervisor delegates to the
+    # specialist in the next role, which is a ring rather than a star: a star
+    # would make one node the only interesting one.
+    delegated: list[EstateAsset] = []
+    for asset in assets:
+        if asset.resource_type != "agent":
+            delegated.append(asset)
+            continue
+        position = agent_ids.index(asset.asset_id)
+        if position % 3 == 0 and len(agent_ids) > 1:
+            target = agent_ids[(position + 1) % len(agent_ids)]
+            delegated.append(asset.model_copy(update={"tags": {**asset.tags, "delegates_to": target}}))
+        else:
+            delegated.append(asset)
+    assets = delegated
+
+    for index in range(external_models):
+        provider, model_name, resource_type = _EXTERNAL_MODELS[index % len(_EXTERNAL_MODELS)]
+        suffix = index // len(_EXTERNAL_MODELS)
+        display = model_name if suffix == 0 else f"{model_name}-{suffix}"
+        seed = stable_index(provider, display)
+        account = hosts[seed % len(hosts)]
+        _, environment = account.placements[seed % len(account.placements)]
+        assets.append(
+            EstateAsset(
+                asset_id=f"model:{provider}:{display}",
+                tenant_id=tenant_id,
+                provider=provider,
+                resource_type=resource_type,
+                native_id=f"{provider}://models/{display}",
+                display_name=display,
+                environment=environment,
+                account_scope="northstar-health-ai",
+                region="global",
+                owner=f"ai-platform@{_TENANT_DOMAIN}",
+                cost_center="AI-410",
+                data_classifications=("confidential",),
+                tags={
+                    "synthetic": "true",
+                    "environment": environment,
+                    AI_LANE_TAG: "third_party",
+                    "external_endpoint": "true",
+                    "internet_facing": "true",
+                },
+            )
+        )
+    return tuple(assets)
+
+
+# ── Delivery and runtime: repositories, workflows, clusters, images ──────────
+
+_REPO_NAMES: tuple[str, ...] = (
+    "member-portal",
+    "claims-engine",
+    "eligibility-api",
+    "care-gap-jobs",
+    "provider-sync",
+    "pharmacy-gateway",
+    "appeals-service",
+    "member-copilot-ui",
+)
+
+
+def _vulnerable_packages() -> tuple[tuple[str, str, str], ...]:
+    """``(name, version, ecosystem)`` drawn from the curated advisory catalog.
+
+    Derived rather than hand-listed on purpose. A hand-written package list is
+    free to drift from the advisories, and the moment it does the estate
+    inventories packages no CVE covers — a vulnerability lane that silently
+    produces nothing. Generating the inventory from the catalog makes the join
+    total by construction, and ``tests/test_estate_v2_scale.py`` asserts it.
+    """
+    from agent_bom.demo_estate.enterprise_risk import advisory_catalog
+
+    return tuple(
+        (advisory.package, version, ecosystem)
+        for ecosystem, _package, version, advisory in ((row[0], row[1], row[2], row[3]) for row in advisory_catalog())
+    )
+
+
+def build_delivery_assets(
+    accounts: Sequence[CloudAccount],
+    *,
+    tenant_id: str,
+    repositories: int,
+    clusters: int,
+    workloads_per_cluster: int,
+    packages_per_image: int,
+) -> tuple[EstateAsset, ...]:
+    """Emit the code -> image -> workload spine the cross-vendor trace walks.
+
+    Without it a trace has nowhere to start: the estate inventoried exactly one
+    repository, one workflow and one deployment, so every generated journey would
+    have converged on the same three nodes and the "cross-vendor" claim would
+    have rested on a single hand-authored chain.
+    """
+    hosts = [a for a in accounts if a.provider in {"aws", "azure", "gcp"} and a.placements]
+    if not hosts:
+        return ()
+    assets: list[EstateAsset] = []
+
+    for index in range(repositories):
+        base = _REPO_NAMES[index % len(_REPO_NAMES)]
+        repo_name = f"{base}-{index:02d}"
+        seed = stable_index("repo", repo_name)
+        environment = ("production", "staging", "development")[seed % 3]
+        repo_id = f"github:repository:northstar-health/{repo_name}"
+        assets.append(
+            EstateAsset(
+                asset_id=repo_id,
+                tenant_id=tenant_id,
+                provider="github",
+                resource_type="repository",
+                native_id=f"github://northstar-health/{repo_name}",
+                display_name=repo_name,
+                environment=environment,
+                account_scope="northstar-health",
+                region="global",
+                owner=f"ai-platform@{_TENANT_DOMAIN}",
+                cost_center=f"ENG-{500 + (seed % 8)}",
+                data_classifications=("confidential",),
+                tags={
+                    "synthetic": "true",
+                    "environment": environment,
+                    "visibility": "public" if seed % 11 == 0 else "private",
+                    "internet_facing": "true" if seed % 11 == 0 else "false",
+                },
+            )
+        )
+        assets.append(
+            EstateAsset(
+                asset_id=f"github:workflow:{repo_name}/deploy",
+                tenant_id=tenant_id,
+                provider="github",
+                resource_type="workflow",
+                native_id=f"github://northstar-health/{repo_name}/actions/deploy",
+                display_name=f"Deploy {repo_name}",
+                environment=environment,
+                account_scope="northstar-health",
+                region="global",
+                owner=f"ai-platform@{_TENANT_DOMAIN}",
+                cost_center=f"ENG-{500 + (seed % 8)}",
+                data_classifications=("confidential",),
+                tags={
+                    "synthetic": "true",
+                    "environment": environment,
+                    "repository": repo_id,
+                    # A workflow federating into a cloud role with no branch
+                    # condition is how CI becomes an entry point.
+                    "oidc_unconstrained": "true" if seed % 6 == 0 else "false",
+                },
+            )
+        )
+
+    for index in range(clusters):
+        account = hosts[stable_index("cluster", str(index)) % len(hosts)]
+        seed = stable_index(account.scope, "cluster", str(index))
+        region, environment = account.placements[seed % len(account.placements)]
+        distro = {"aws": "eks", "azure": "aks", "gcp": "gke"}[account.provider]
+        cluster_name = f"{distro}-{account.scope[-4:]}-{index:02d}"
+        cluster_id = f"kubernetes:cluster:{distro}/{cluster_name}"
+        assets.append(
+            EstateAsset(
+                asset_id=cluster_id,
+                tenant_id=tenant_id,
+                provider="kubernetes",
+                resource_type="cluster",
+                native_id=f"k8s://{distro}/{cluster_name}",
+                display_name=cluster_name,
+                environment=environment,
+                account_scope=account.scope,
+                region=region,
+                owner=f"cloud-platform@{_TENANT_DOMAIN}",
+                cost_center="PLAT-210",
+                data_classifications=("confidential",),
+                tags={
+                    "synthetic": "true",
+                    "environment": environment,
+                    "distribution": distro,
+                    "host_provider": account.provider,
+                    "api_server_public": "true" if seed % 5 == 0 else "false",
+                    "internet_facing": "true" if seed % 5 == 0 else "false",
+                },
+            )
+        )
+        for slot in range(workloads_per_cluster):
+            base = _REPO_NAMES[(seed + slot) % len(_REPO_NAMES)]
+            workload_name = f"{base}-{slot:02d}"
+            workload_seed = stable_index(cluster_id, workload_name)
+            image_tag = f"2026.08.{(workload_seed % 28) + 1:02d}"
+            digest = hashlib.sha256(f"{cluster_id}:{workload_name}".encode()).hexdigest()
+            image_id = f"cloud_resource:{account.provider}:registry:image:{workload_name}@sha256:{digest}"
+            workload_id = f"kubernetes:workload:{cluster_name}/{base}/{workload_name}"
+            exposed = workload_seed % 7 == 0
+            assets.append(
+                EstateAsset(
+                    asset_id=image_id,
+                    tenant_id=tenant_id,
+                    provider=account.provider,
+                    resource_type="container_image",
+                    native_id=f"registry.{account.provider}.example/{workload_name}@sha256:{digest}",
+                    display_name=f"{workload_name}:{image_tag}",
+                    environment=environment,
+                    account_scope=account.scope,
+                    region=region,
+                    owner=f"ai-platform@{_TENANT_DOMAIN}",
+                    cost_center="AI-410",
+                    data_classifications=("confidential",),
+                    tags={
+                        "synthetic": "true",
+                        "environment": environment,
+                        "image_tag": image_tag,
+                        "signed": "false" if workload_seed % 4 == 0 else "true",
+                    },
+                )
+            )
+            workload_tags = {
+                "synthetic": "true",
+                "environment": environment,
+                "cluster": cluster_id,
+                "container_image": image_id,
+                "host_provider": account.provider,
+                "internet_facing": "true" if exposed else "false",
+                "privileged": "true" if workload_seed % 9 == 0 else "false",
+            }
+            if account.identities:
+                workload_tags["uses_identity"] = account.identities[workload_seed % len(account.identities)]
+            if account.data_stores:
+                # The store this workload's identity actually reads. Declared on
+                # the workload rather than inferred later, so an internet-facing
+                # workload in front of regulated data is an EXPOSED_TO edge with
+                # two real ends instead of a property of one node.
+                workload_tags["reads_data"] = account.data_stores[(workload_seed // 11) % len(account.data_stores)]
+            assets.append(
+                EstateAsset(
+                    asset_id=workload_id,
+                    tenant_id=tenant_id,
+                    provider="kubernetes",
+                    resource_type="deployment",
+                    native_id=f"k8s://{cluster_name}/{base}/deployment/{workload_name}",
+                    display_name=workload_name,
+                    environment=environment,
+                    account_scope=account.scope,
+                    region=region,
+                    owner=f"ai-platform@{_TENANT_DOMAIN}",
+                    cost_center="AI-410",
+                    data_classifications=("phi", "pii") if workload_seed % 3 == 0 else ("confidential",),
+                    tags=workload_tags,
+                )
+            )
+            catalog = _vulnerable_packages()
+            for package_slot in range(packages_per_image):
+                name, version, ecosystem = catalog[(workload_seed + package_slot) % len(catalog)]
+                assets.append(
+                    EstateAsset(
+                        # Keyed by the image digest, not the workload name: the
+                        # same service name recurs across clusters, and keying on
+                        # it collapsed four images' package lists into one.
+                        asset_id=f"package:{ecosystem.lower()}:{name}@{version}:{digest[:12]}",
+                        tenant_id=tenant_id,
+                        provider=account.provider,
+                        resource_type="package",
+                        native_id=f"pkg:{ecosystem.lower()}/{name}@{version}",
+                        display_name=f"{name}@{version}",
+                        environment=environment,
+                        account_scope=account.scope,
+                        region=region,
+                        owner=f"ai-platform@{_TENANT_DOMAIN}",
+                        cost_center="AI-410",
+                        tags={
+                            "synthetic": "true",
+                            "environment": environment,
+                            "container_image": image_id,
+                            "ecosystem": ecosystem,
+                            "package_name": name,
+                            "package_version": version,
+                            # The identity the workload running this package
+                            # holds. A vulnerability's blast radius is whatever
+                            # the process can reach, so the principal belongs on
+                            # the package row, not only on the workload — that is
+                            # what lets a CVE finding carry an identity edge.
+                            **({"uses_identity": workload_tags["uses_identity"]} if "uses_identity" in workload_tags else {}),
+                            "workload": workload_id,
+                        },
+                    )
+                )
+    return tuple(assets)
+
+
+def mark_cloud_exposure(assets: Sequence[EstateAsset]) -> tuple[EstateAsset, ...]:
+    """Tag a deterministic minority of cloud resources as exposed or over-permissive.
+
+    Exposure has to be a property of the inventory, not of a finding, or the
+    graph cannot draw an ``EXPOSED_TO`` edge for a resource that happens to have
+    no finding raised against it — and "internet-facing with no finding" is
+    exactly the state a reviewer needs to see.
+    """
+    marked: list[EstateAsset] = []
+    for asset in assets:
+        if asset.tags.get("internet_facing") is not None or asset.tags.get(AI_LANE_TAG):
+            marked.append(asset)
+            continue
+        seed = stable_index("exposure", asset.asset_id)
+        tags = dict(asset.tags)
+        if asset.resource_type in _IDENTITY_TYPES:
+            tags["over_permissive"] = "true" if seed % 9 == 0 else "false"
+            tags["internet_facing"] = "false"
+        elif asset.resource_type in _DATA_TYPES:
+            public = seed % 13 == 0
+            tags["public_access"] = "true" if public else "false"
+            tags["internet_facing"] = "true" if public else "false"
+        elif asset.resource_type in _COMPUTE_TYPES:
+            tags["internet_facing"] = "true" if seed % 11 == 0 else "false"
+        else:
+            tags["internet_facing"] = "false"
+        marked.append(asset.model_copy(update={"tags": tags}))
+    return tuple(marked)
+
+
+__all__ = [
+    "AI_LANE_TAG",
+    "AiServiceSpec",
+    "CloudAccount",
+    "build_delivery_assets",
+    "build_first_party_ai_assets",
+    "build_third_party_ai_assets",
+    "index_cloud_accounts",
+    "mark_cloud_exposure",
+    "stable_index",
+]

--- a/src/agent_bom/demo_estate/enterprise_composition.py
+++ b/src/agent_bom/demo_estate/enterprise_composition.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from functools import lru_cache
 
 from agent_bom.demo_estate.enterprise import (
     ENTERPRISE_SCHEMA_VERSION,
@@ -38,8 +39,31 @@ def _canonical_json(value: object) -> bytes:
     return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
 
 
+@lru_cache(maxsize=2)
+def _build_demo_estate_cached(profile: ScaleProfile, tenant_id: str) -> EnterpriseEstate:
+    return _build_demo_estate(profile, tenant_id)
+
+
 def build_demo_estate(profile: ScaleProfile | None = None, *, tenant_id: str = "default") -> EnterpriseEstate:
     """Return the narrative estate embedded in a generated population.
+
+    Memoized because one demo boot builds it three times — once to validate and
+    fingerprint the contract, once for the posture findings, once for the graph
+    projection — and generation is a pure function of ``(profile, tenant_id)``
+    returning a frozen model, so a second build can only ever produce a
+    byte-identical estate. At the current size that repetition was a third of
+    the boot.
+
+    ``maxsize`` is deliberately small: an estate is thousands of assets and tens
+    of thousands of observations, and a cache that holds one per tenant would
+    trade a startup second for unbounded resident memory. Two covers the seeding
+    path (one tenant, several callers) and evicts anything else.
+    """
+    return _build_demo_estate_cached(profile or ScaleProfile(), tenant_id)
+
+
+def _build_demo_estate(profile: ScaleProfile | None, tenant_id: str) -> EnterpriseEstate:
+    """Compose the narrative estate into a generated population.
 
     Both halves are already valid :class:`EnterpriseEstate` values, so this
     composes them rather than re-deriving anything. Construction re-runs every

--- a/src/agent_bom/demo_estate/enterprise_correlation.py
+++ b/src/agent_bom/demo_estate/enterprise_correlation.py
@@ -52,6 +52,11 @@ class NormalizedEnterpriseEvent(BaseModel):
     source_run_id: str
     event_relationships: dict[str, Any]
     graph_projection: dict[str, Any]
+    # The enforcement verdict this event recorded, normalized out of the
+    # provider payload. A scalar, not the payload: normalized output still
+    # carries no raw provider body, but a correlation that has to report whether
+    # an egress was blocked cannot do it by guessing from the event's source.
+    policy_decision: str = ""
 
 
 class EnterpriseCorrelation(BaseModel):
@@ -128,6 +133,39 @@ def _actor_type(actor_id: str) -> str:
     if lowered.startswith("snowflake_role:"):
         return "service_account"
     return "user"
+
+
+_BLOCKED_DECISIONS = frozenset({"block", "blocked", "deny", "denied"})
+_ALLOWED_DECISIONS = frozenset({"allow", "allowed", "permit"})
+
+
+def normalize_policy_decision(observation: RawObservation) -> str:
+    """Read the enforcement verdict a provider recorded, in that provider's spelling.
+
+    An MCP gateway writes ``{"decision": "block"}`` at the top level; an OTel
+    GenAI span writes ``attributes["agent_bom.decision"]``. Both mean the same
+    thing and neither is inferable from the event's source — which is exactly
+    what :func:`_correlation_kind` used to do, labelling *every* trace that
+    touched an LLM span ``blocked``. That published a verdict the evidence did
+    not support on traces where nothing was blocked at all.
+
+    Returns ``""`` when the payload carries no verdict, so "not enforced" and
+    "allowed" stay distinguishable.
+    """
+    payload = observation.raw_payload
+    raw = payload.get("decision")
+    if raw is None:
+        attributes = payload.get("attributes")
+        if isinstance(attributes, dict):
+            raw = attributes.get("agent_bom.decision")
+    if raw is None:
+        return ""
+    lowered = str(raw).strip().casefold()
+    if lowered in _BLOCKED_DECISIONS:
+        return "blocked"
+    if lowered in _ALLOWED_DECISIONS:
+        return "allowed"
+    return ""
 
 
 def _asset_ref_type(asset: EstateAsset) -> str:
@@ -224,6 +262,7 @@ def _normalize_event(
         source_run_id=observation.provenance.run_id,
         event_relationships=relationships,
         graph_projection=projection,
+        policy_decision=normalize_policy_decision(observation),
     )
 
 
@@ -251,6 +290,7 @@ class _CorrelationRow:
     trace_id: str
     resource_ids: tuple[str, ...]
     evidence_hash: str
+    policy_decision: str = ""
 
     @classmethod
     def from_normalized(cls, event: NormalizedEnterpriseEvent) -> _CorrelationRow:
@@ -263,6 +303,7 @@ class _CorrelationRow:
             trace_id=event.trace_id,
             resource_ids=event.resource_ids,
             evidence_hash=event.evidence_hash,
+            policy_decision=event.policy_decision,
         )
 
     @classmethod
@@ -276,22 +317,97 @@ class _CorrelationRow:
             trace_id=observation.trace_id,
             resource_ids=observation.resource_ids,
             evidence_hash=observation.provenance.evidence_hash,
+            policy_decision=normalize_policy_decision(observation),
         )
 
 
 def _correlation_kind(events: tuple[_CorrelationRow, ...]) -> tuple[str, str]:
+    """Name what a trace is, and report the outcome its evidence recorded.
+
+    The outcome used to be a constant per kind — any trace touching an LLM span
+    was ``blocked``. On the hand-authored incident that was true; on a generated
+    estate where most model calls succeed it published a verdict nothing had
+    reached. Outcomes now come from the enforcement decision the span or gateway
+    actually wrote, and a trace with no decision recorded reports ``observed``
+    rather than picking one.
+    """
     if any(event.stage is EstateStage.REMEDIATED for event in events):
         return "remediation", "enforced"
+    decisions = {event.policy_decision for event in events if event.policy_decision}
     if any(event.source is EvidenceSource.OTEL_LLM for event in events):
-        return "data_egress_attempt", "blocked"
+        if "blocked" in decisions:
+            return "data_egress_attempt", "blocked"
+        if "allowed" in decisions:
+            return "data_egress_attempt", "allowed"
+        return "model_invocation", "observed"
     if any("roleAssignments/write" in event.event_type for event in events):
         return "privilege_change", "observed"
     if any("CreateServiceAccountKey" in event.event_type for event in events):
         return "credential_issuance", "observed"
-    return "activity_sequence", "observed"
+    if len({event.source for event in events}) >= 2:
+        return "cross_vendor_trace", "observed"
+    # One principal, one window, one system. A real grouping — and named so
+    # nobody reads a causal chain into it.
+    return "identity_session", "observed"
 
 
-_PATH_TYPES = ("workflow", "iam_role", "deployment", "tool", "table", "hosted_model")
+# The order a path is walked in, so consecutive hops are drawn as consecutive
+# edges: code, then the identity it federates into, then the runtime, then the
+# tool, then the AI service, then the data, then the model the data reaches.
+# A type missing from this list is not excluded from the estate — it is excluded
+# from the *path*, because a path that visits nodes in inventory order is a list.
+_PATH_TYPES = (
+    "repository",
+    "workflow",
+    "iam_role",
+    "service_principal",
+    "service_account",
+    "role",
+    "container_image",
+    "cluster",
+    "deployment",
+    "server",
+    "tool",
+    "bedrock_agent",
+    "vertex_agent",
+    "sagemaker_endpoint",
+    "vertex_endpoint",
+    "azure_openai_deployment",
+    "cognitive_services_account",
+    "cortex_function",
+    "cortex_search_service",
+    "spcs_service",
+    "gemini_api",
+    "bedrock_knowledge_base",
+    "ai_search_index",
+    "bucket",
+    "storage_account",
+    "database",
+    "sql_database",
+    "table",
+    "hosted_model",
+    "model_artifact",
+    "foundation_model",
+    "vertex_model",
+    "sagemaker_model",
+)
+
+# A path longer than this is a roster, not a route. Sessions can touch dozens of
+# assets; drawing all of them as one chain produces an unreadable edge and an
+# attack path nobody can act on.
+#
+# Twelve, not eight: the full pipeline is repository → workflow → identity →
+# image → cluster → workload → MCP server → tool → AI service → data store →
+# table → model. At eight the cap truncated from the tail, which is where the
+# *destination* lives — the incident's own path stopped at the MCP tool and
+# dropped the PHI table and the model it was trying to reach, turning the one
+# chain the demo exists to show into a chain that goes nowhere.
+_MAX_PATH_HOPS = 12
+
+# A trace containing one event is not a correlation — it is an event. Emitting
+# one anyway is what let the estate report 6,148 correlations of which 6,145
+# were a single row grouped with itself.
+_MIN_TRACE_EVENTS = 2
 
 
 def _asset_path(events: tuple[_CorrelationRow, ...], assets_by_id: dict[str, EstateAsset]) -> tuple[str, ...]:
@@ -304,7 +420,7 @@ def _asset_path(events: tuple[_CorrelationRow, ...], assets_by_id: dict[str, Est
         )
         if match is not None:
             selected.append(match)
-    return tuple(selected or ordered_ids)
+    return tuple((selected or list(ordered_ids))[:_MAX_PATH_HOPS])
 
 
 def _data_classifications(asset_ids: tuple[str, ...], assets_by_id: dict[str, EstateAsset]) -> tuple[str, ...]:
@@ -327,6 +443,8 @@ def _build_correlations(
 
     correlations: list[EnterpriseCorrelation] = []
     for trace_id, trace_events in sorted(by_trace.items()):
+        if len(trace_events) < _MIN_TRACE_EVENTS:
+            continue
         ordered = tuple(sorted(trace_events, key=lambda row: (row.observed_at, row.event_id)))
         kind, outcome = _correlation_kind(ordered)
         sources = tuple(event.source for event in ordered)

--- a/src/agent_bom/demo_estate/enterprise_findings.py
+++ b/src/agent_bom/demo_estate/enterprise_findings.py
@@ -7,7 +7,13 @@ and a configuration, the finding sits on a correlated attack path, and it
 evidences a compliance control* — was demonstrated only for the hand-authored
 incident. At estate scale it was asserted, not shown.
 
-This module closes that. Four decisions carry the weight:
+This module closes that for the CSPM lane, and hands the rest to
+:mod:`agent_bom.demo_estate.enterprise_risk`: vulnerability, secret, IaC and
+runtime findings, appended here so every lane joins the same assets, the same
+correlations and the same identity edges. An estate whose every finding is a CIS
+check grows its risk with control coverage rather than with the estate.
+
+Four decisions carry the weight:
 
 **One id scheme.** A finding's asset identifier *is* the estate's ``asset_id``.
 There is no demo-only resource id, no parallel spelling to reconcile later, so
@@ -43,12 +49,17 @@ from dataclasses import dataclass
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from agent_bom.demo_estate.enterprise import EnterpriseEstate, EstateAsset
+from agent_bom.demo_estate.enterprise import (
+    NARRATIVE_INCIDENT_TRACE_ID,
+    EnterpriseEstate,
+    EstateAsset,
+)
 from agent_bom.demo_estate.enterprise_correlation import (
     EnterpriseCorrelation,
     EnterpriseCorrelationResult,
     build_estate_correlations,
 )
+from agent_bom.demo_estate.enterprise_risk import build_risk_findings
 from agent_bom.finding import Finding, cloud_cis_check_to_finding
 from agent_bom.graph.severity import SEVERITY_DISPLAY_BUCKETS, severity_display_bucket
 
@@ -612,13 +623,44 @@ def _paths_by_asset(correlations: tuple[EnterpriseCorrelation, ...]) -> dict[str
     Single-asset traces are excluded: a "path" through one node is not a path,
     and labelling it one would inflate the attack-path count with noise.
     """
+    # Ranked, not first-wins. ``setdefault`` over an iteration order made the
+    # choice a function of trace-id sort order, so any change to how trace ids
+    # are derived silently reassigned assets to different correlations — and
+    # since a correlation's kind decides whether an asset reports every control,
+    # that changed the estate's finding count. Rank explicitly: the richest
+    # chain wins, ties broken by id.
+    def rank(correlation: EnterpriseCorrelation) -> tuple[int, int, int, str]:
+        # The hand-authored incident always claims its own assets. It is the
+        # thing the demo is for, and a generated journey that happens to span
+        # the same number of sources must not take its place on the surfaces
+        # that lead with "the incident".
+        return (
+            0 if correlation.trace_id == NARRATIVE_INCIDENT_TRACE_ID else 1,
+            -len(set(correlation.sources)),
+            -len(correlation.asset_path),
+            correlation.correlation_id,
+        )
+
     by_asset: dict[str, EnterpriseCorrelation] = {}
-    for correlation in correlations:
+    for correlation in sorted(correlations, key=rank):
         if len(correlation.asset_path) < 2:
             continue
         for asset_id in correlation.asset_path:
             by_asset.setdefault(asset_id, correlation)
     return by_asset
+
+
+# Correlation kinds whose assets report every applicable control rather than a
+# prevalence sample. Deliberately narrow.
+#
+# The rule used to be "any asset on any correlated path", which was safe while
+# four correlations existed. Now that the estate produces thousands of traces,
+# that rule reached most of the inventory and quadrupled the posture lane — the
+# estate's risk would once again have been a function of control coverage, just
+# arrived at from the other direction. An asset on an egress attempt or a
+# remediation is genuinely worth reporting in full; an asset seen in an identity
+# session is not.
+_FULL_CONTROL_KINDS: frozenset[str] = frozenset({"data_egress_attempt", "remediation"})
 
 
 def _build_check_payload(asset: EstateAsset, check: EstateCheck, *, unevaluable: bool) -> dict[str, object]:
@@ -710,10 +752,12 @@ def build_estate_findings(
         correlation = path_by_asset.get(asset.asset_id)
         for check in checks:
             seed = _stable_index(asset.asset_id, check.provider, check.check_id)
-            # Assets on a correlated attack path always report their applicable
+            # Assets on the *incident* path always report their applicable
             # controls. The incident is the thing the demo is for; leaving its
             # own assets to a probability roll is how a demo loses its story.
-            if correlation is None and seed % 100 >= check.prevalence:
+            # Everything else stays on prevalence — see ``_FULL_CONTROL_KINDS``.
+            full_report = correlation is not None and correlation.kind in _FULL_CONTROL_KINDS
+            if not full_report and seed % 100 >= check.prevalence:
                 continue
             identity = _pick_identity(account_identities, subject=asset, seed=seed) if account_identities else None
             actor = asset_actors[seed % len(asset_actors)] if asset_actors else ""
@@ -762,6 +806,50 @@ def build_estate_findings(
                 finding.evidence["correlation_kind"] = correlation.kind
                 finding.evidence["attack_path"] = list(correlation.asset_path)
             findings.append(finding)
+
+    # The other four scanners. Posture alone made the estate's risk a function of
+    # control coverage rather than of the estate — every one of 439 findings was
+    # a CIS check, so an AI service, a leaked credential and a vulnerable image
+    # all read as "no findings". They correlate onto the same paths through the
+    # same asset ids, so they are appended here rather than served separately.
+    assets_by_id = {asset.asset_id: asset for asset in estate.assets}
+    kept_risk_findings: list[Finding] = []
+    for finding in build_risk_findings(estate):
+        asset_id = finding.asset.identifier or ""
+        subject = assets_by_id.get(asset_id)
+        correlation = path_by_asset.get(asset_id)
+        if correlation is not None:
+            finding.evidence["correlation_id"] = correlation.correlation_id
+            finding.evidence["correlation_kind"] = correlation.kind
+            finding.evidence["attack_path"] = list(correlation.asset_path)
+        actor_pool = actors.get(asset_id, ())
+        if actor_pool:
+            actor = actor_pool[_stable_index(finding.id) % len(actor_pool)]
+            finding.evidence["actor_id"] = actor
+            finding.evidence["identity_actor_id"] = actor
+        # Every finding names a principal, in the same two vocabularies the
+        # posture lane uses. A vulnerability with no identity edge is a row of
+        # text: what makes it actionable is *which principal the vulnerable
+        # process holds*. The inventory already declares that on the asset, so
+        # this reads it rather than inferring one.
+        if subject is not None:
+            principal = assets_by_id.get(subject.tags.get("uses_identity", ""))
+            if principal is None:
+                pool = identities.get((subject.provider, subject.account_scope), ())
+                if pool:
+                    principal = _pick_identity(pool, subject=subject, seed=_stable_index(finding.id))
+            if principal is not None:
+                finding.evidence["principal_id"] = principal.asset_id
+                finding.evidence["identity_asset_id"] = principal.asset_id
+                finding.evidence["identity_display_name"] = principal.display_name
+                finding.evidence["identity_resource_type"] = principal.resource_type
+        # Same rule the posture lane above applies, for the same reason: neither
+        # an inventoried principal nor an observed actor means there is no
+        # identity edge to draw, and a finding with a dangling half-chain is
+        # what this module exists to avoid.
+        if finding.evidence.get("identity_asset_id") or finding.evidence.get("identity_actor_id"):
+            kept_risk_findings.append(finding)
+    findings.extend(kept_risk_findings)
     return tuple(findings)
 
 

--- a/src/agent_bom/demo_estate/enterprise_findings.py
+++ b/src/agent_bom/demo_estate/enterprise_findings.py
@@ -623,6 +623,7 @@ def _paths_by_asset(correlations: tuple[EnterpriseCorrelation, ...]) -> dict[str
     Single-asset traces are excluded: a "path" through one node is not a path,
     and labelling it one would inflate the attack-path count with noise.
     """
+
     # Ranked, not first-wins. ``setdefault`` over an iteration order made the
     # choice a function of trace-id sort order, so any change to how trace ids
     # are derived silently reassigned assets to different correlations — and

--- a/src/agent_bom/demo_estate/enterprise_journeys.py
+++ b/src/agent_bom/demo_estate/enterprise_journeys.py
@@ -1,0 +1,438 @@
+"""Emit multi-source traces — the evidence that makes a correlation a correlation.
+
+The estate used to give every observation its own ``trace_id``. Grouping by trace
+then produced one "correlation" per event: 6,148 rows of which 6,145 were a
+single event grouped with itself, and the surface headed *cross-vendor
+correlations* honestly reported 3. The count looked enormous and demonstrated
+nothing, which is the worst possible combination for a demo.
+
+A journey here is one actor, one trace id, and an ordered walk across vendors:
+a workflow federates into a cloud role, the role reaches a Kubernetes workload,
+the workload calls an MCP tool, the tool queries the warehouse, and the result is
+handed to a model — six sources, six systems, one story. The correlation layer
+does not need to be told any of this; it groups by trace exactly as it always
+has, and the chain falls out.
+
+Every choice — which assets, which actor, when, and whether the egress was
+blocked — is derived from the identity of the journey, so the estate is
+byte-identical on every run.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+
+from agent_bom.demo_estate.enterprise import (
+    ENTERPRISE_SCHEMA_VERSION,
+    EstateAsset,
+    EstateStage,
+    EvidenceProvenance,
+    EvidenceSource,
+    RawObservation,
+)
+from agent_bom.demo_estate.enterprise_ai import AI_LANE_TAG, stable_index
+
+_TENANT_DOMAIN = "northstar.example"
+_PLACEHOLDER_HASH = "0" * 64
+
+# The workforce the whole estate shares. Principals are deliberately NOT
+# per-provider: an identity that only ever appears in one cloud can never
+# produce a cross-vendor session, and an estate where nobody works across
+# clouds cannot demonstrate correlation across them.
+_HUMAN_ROLES: tuple[str, ...] = (
+    "a.okafor",
+    "l.mendes",
+    "s.raghavan",
+    "j.novak",
+    "m.delacruz",
+    "t.bergstrom",
+    "r.iyer",
+    "c.whitfield",
+)
+_WORKLOAD_PRINCIPALS: tuple[str, ...] = (
+    "svc-claims-etl",
+    "svc-care-gap",
+    "svc-feature-store",
+    "svc-model-router",
+    "svc-eligibility",
+    "svc-appeals",
+)
+_AGENT_PRINCIPALS: tuple[str, ...] = (
+    "agent:member-copilot",
+    "agent:claims-triage",
+    "agent:prior-auth-reviewer",
+    "agent:care-gap-outreach",
+)
+
+
+def principal_pool() -> tuple[str, ...]:
+    """The estate's actors, in one stable order.
+
+    Shared by the per-asset activity generator and by journeys so a principal
+    seen deploying in CI is the same string seen querying the warehouse — which
+    is the join the whole correlation rests on.
+    """
+    return (
+        *(f"{name}@{_TENANT_DOMAIN}" for name in _HUMAN_ROLES),
+        *(f"{name}@{_TENANT_DOMAIN}" for name in _WORKLOAD_PRINCIPALS),
+        *_AGENT_PRINCIPALS,
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _Pools:
+    """Assets grouped by the role they can play in a journey."""
+
+    workflows: tuple[EstateAsset, ...]
+    identities: tuple[EstateAsset, ...]
+    workloads: tuple[EstateAsset, ...]
+    tools: tuple[EstateAsset, ...]
+    tables: tuple[EstateAsset, ...]
+    models: tuple[EstateAsset, ...]
+    ai_services: tuple[EstateAsset, ...]
+
+    @property
+    def complete(self) -> bool:
+        return all((self.workflows, self.identities, self.workloads, self.tools, self.tables, self.models))
+
+
+_IDENTITY_TYPES = frozenset({"iam_role", "service_principal", "service_account", "role"})
+_AI_SERVICE_TYPES = frozenset(
+    {
+        "bedrock_agent",
+        "sagemaker_endpoint",
+        "vertex_endpoint",
+        "vertex_agent",
+        "azure_openai_deployment",
+        "cognitive_services_account",
+        "cortex_function",
+        "cortex_search_service",
+        "spcs_service",
+        "gemini_api",
+    }
+)
+_MODEL_TYPES = frozenset({"hosted_model", "model_artifact", "foundation_model", "vertex_model", "sagemaker_model"})
+
+
+def _pools(assets: Sequence[EstateAsset]) -> _Pools:
+    def pick(predicate) -> tuple[EstateAsset, ...]:
+        return tuple(sorted((a for a in assets if predicate(a)), key=lambda a: a.asset_id))
+
+    return _Pools(
+        workflows=pick(lambda a: a.resource_type == "workflow"),
+        identities=pick(lambda a: a.resource_type in _IDENTITY_TYPES),
+        workloads=pick(lambda a: a.resource_type == "deployment"),
+        tools=pick(lambda a: a.resource_type == "tool"),
+        tables=pick(lambda a: a.resource_type in {"table", "database"} and a.provider == "snowflake"),
+        models=pick(lambda a: a.resource_type in _MODEL_TYPES),
+        ai_services=pick(lambda a: a.resource_type in _AI_SERVICE_TYPES),
+    )
+
+
+# Which cloud audit log speaks for the identity a journey federates into.
+_AUDIT_SOURCE: dict[str, EvidenceSource] = {
+    "aws": EvidenceSource.AWS_CLOUDTRAIL,
+    "azure": EvidenceSource.AZURE_ACTIVITY,
+    "gcp": EvidenceSource.GCP_AUDIT,
+    "snowflake": EvidenceSource.SNOWFLAKE_ACCESS_HISTORY,
+}
+_FEDERATION_EVENT: dict[str, str] = {
+    "aws": "AssumeRoleWithWebIdentity",
+    "azure": "Microsoft.Authorization/roleAssignments/write",
+    "gcp": "iam.serviceAccounts.getAccessToken",
+    "snowflake": "GRANT_ROLE",
+}
+_AI_INVOKE_EVENT: dict[str, str] = {
+    "aws": "bedrock:InvokeModelWithResponseStream",
+    "azure": "Microsoft.CognitiveServices/accounts/deployments/action",
+    "gcp": "aiplatform.endpoints.predict",
+    "snowflake": "CORTEX_COMPLETE",
+}
+
+
+def _seal(observation: RawObservation) -> RawObservation:
+    """Stamp the evidence hash with the estate's own hasher, never a second one."""
+    from agent_bom.demo_estate.enterprise import _observation_hash
+
+    digest = _observation_hash(observation.model_dump(mode="json", exclude={"provenance"}))
+    return observation.model_copy(update={"provenance": observation.provenance.model_copy(update={"evidence_hash": digest})})
+
+
+def _observation(
+    *,
+    event_id: str,
+    source: EvidenceSource,
+    event_type: str,
+    observed_at: datetime,
+    actor_id: str,
+    resource_ids: tuple[str, ...],
+    trace_id: str,
+    payload: dict[str, object],
+    tenant_id: str,
+    run_id: str,
+) -> RawObservation:
+    return _seal(
+        RawObservation(
+            event_id=event_id,
+            stage=EstateStage.CURRENT,
+            source=source,
+            event_type=event_type,
+            observed_at=observed_at,
+            actor_id=actor_id,
+            resource_ids=resource_ids,
+            trace_id=trace_id,
+            raw_payload=payload,
+            provenance=EvidenceProvenance(
+                source=source,
+                source_event_id=event_id,
+                observed_at=observed_at,
+                run_id=run_id,
+                tenant_id=tenant_id,
+                evidence_hash=_PLACEHOLDER_HASH,
+                schema_version=ENTERPRISE_SCHEMA_VERSION,
+            ),
+        )
+    )
+
+
+def build_journeys(
+    assets: Sequence[EstateAsset],
+    *,
+    tenant_id: str,
+    count: int,
+    epoch: datetime,
+    window_days: int = 28,
+) -> tuple[RawObservation, ...]:
+    """Emit ``count`` multi-source traces across the estate's own assets.
+
+    A journey never invents a resource: every hop is an asset the caller already
+    inventoried, so the contract's own validator — events reference known assets
+    — is what proves the chain is joinable rather than a separate assertion.
+    """
+    pools = _pools(assets)
+    if not pools.complete or count <= 0:
+        return ()
+
+    principals = principal_pool()
+    observations: list[RawObservation] = []
+
+    for index in range(count):
+        journey_id = f"journey-{index:05d}"
+        # Tenant-independent for the same reason as ``session_trace_id``: the
+        # estate is one estate, whoever seeds it.
+        seed = stable_index(journey_id)
+        actor = principals[seed % len(principals)]
+        trace_id = hashlib.sha256(f"journey|{journey_id}".encode()).hexdigest()[:32]
+        run_id = "demo-run-journey"
+
+        workflow = pools.workflows[seed % len(pools.workflows)]
+        repository = workflow.tags.get("repository", "")
+        identity = pools.identities[(seed // 3) % len(pools.identities)]
+        workload = pools.workloads[(seed // 7) % len(pools.workloads)]
+        tool = pools.tools[(seed // 11) % len(pools.tools)]
+        table = pools.tables[(seed // 13) % len(pools.tables)]
+        model = pools.models[(seed // 17) % len(pools.models)]
+        ai_service = pools.ai_services[(seed // 19) % len(pools.ai_services)] if pools.ai_services else None
+        image = workload.tags.get("container_image", "")
+        cluster = workload.tags.get("cluster", "")
+        mcp_server = tool.tags.get("mcp_server", "")
+
+        audit_source = _AUDIT_SOURCE.get(identity.provider, EvidenceSource.AWS_CLOUDTRAIL)
+        # Steps run seconds to a couple of minutes apart, inside a window that
+        # spreads journeys across the collection period rather than stacking
+        # them on one timestamp.
+        start = epoch + timedelta(minutes=(seed // 23) % (window_days * 24 * 60))
+        step = timedelta(seconds=7 + (seed % 53))
+
+        # Was the egress blocked? Read from the journey's own policy decision
+        # below, never assumed: an estate where every attempt is blocked cannot
+        # show that the policy is evaluated rather than asserted.
+        blocked = seed % 3 != 0
+
+        def event(
+            offset: int,
+            source: EvidenceSource,
+            event_type: str,
+            resource_ids: tuple[str, ...],
+            payload: dict[str, object],
+        ) -> None:
+            resources = tuple(dict.fromkeys(r for r in resource_ids if r))
+            if not resources:
+                return
+            observations.append(
+                _observation(
+                    event_id=f"evtj-{hashlib.sha256(f'{journey_id}:{offset}'.encode()).hexdigest()[:20]}",
+                    source=source,
+                    event_type=event_type,
+                    observed_at=start + step * offset,
+                    actor_id=actor,
+                    resource_ids=resources,
+                    trace_id=trace_id,
+                    payload=payload,
+                    tenant_id=tenant_id,
+                    run_id=run_id,
+                )
+            )
+
+        event(
+            0,
+            EvidenceSource.GITHUB_ACTIONS,
+            "workflow_run.completed",
+            (repository, workflow.asset_id, image),
+            {
+                "action": "completed",
+                "workflow": workflow.display_name,
+                "conclusion": "success",
+                "head_branch": "main" if seed % 4 else f"release/{seed % 12}",
+                "oidcUnconstrained": workflow.tags.get("oidc_unconstrained") == "true",
+            },
+        )
+        event(
+            1,
+            audit_source,
+            _FEDERATION_EVENT.get(identity.provider, "AssumeRole"),
+            (workflow.asset_id, identity.asset_id),
+            {
+                "eventName": _FEDERATION_EVENT.get(identity.provider, "AssumeRole"),
+                "accountScope": identity.account_scope,
+                "region": identity.region,
+                "environment": identity.environment,
+                "readOnly": False,
+                "overPermissive": identity.tags.get("over_permissive") == "true",
+            },
+        )
+        event(
+            2,
+            EvidenceSource.KUBERNETES_AUDIT,
+            "pods/exec.create" if seed % 5 == 0 else "deployments.update",
+            (cluster, workload.asset_id, image, identity.asset_id),
+            {
+                "verb": "create" if seed % 5 == 0 else "update",
+                "namespace": workload.tags.get("environment", workload.environment),
+                "responseStatus": {"code": 201},
+                "privileged": workload.tags.get("privileged") == "true",
+            },
+        )
+        event(
+            3,
+            EvidenceSource.MCP_GATEWAY,
+            "tools/call",
+            (workload.asset_id, mcp_server, tool.asset_id, table.asset_id),
+            {
+                "jsonrpc": "2.0",
+                "method": "tools/call",
+                "params": {"name": tool.display_name, "bind_count": 1 + (seed % 3)},
+                "server": mcp_server,
+                "agent_id": workload.display_name,
+                "decision": "allow",
+                "policy_id": "mcp-prod-readonly-v3",
+                "latency_ms": 11 + (seed % 40),
+            },
+        )
+        event(
+            4,
+            EvidenceSource.SNOWFLAKE_ACCESS_HISTORY,
+            "ACCESS_HISTORY_QUERY_HISTORY_JOIN",
+            (tool.asset_id, table.asset_id),
+            {
+                "query_type": "SELECT",
+                "objects_accessed": [table.native_id],
+                "rows_produced": 40 + (seed % 4000),
+                "classifications": list(table.data_classifications),
+            },
+        )
+        if ai_service is not None:
+            event(
+                5,
+                _AUDIT_SOURCE.get(ai_service.provider, audit_source),
+                _AI_INVOKE_EVENT.get(ai_service.provider, "InvokeModel"),
+                (ai_service.asset_id, table.asset_id, ai_service.tags.get("uses_identity", "")),
+                {
+                    "eventName": _AI_INVOKE_EVENT.get(ai_service.provider, "InvokeModel"),
+                    "accountScope": ai_service.account_scope,
+                    "region": ai_service.region,
+                    "environment": ai_service.environment,
+                    "modelFamily": ai_service.tags.get("model_family", ""),
+                    "readOnly": True,
+                },
+            )
+        event(
+            6,
+            EvidenceSource.OTEL_LLM,
+            "gen_ai.chat",
+            (workload.asset_id, model.asset_id, table.asset_id),
+            {
+                "span_id": hashlib.sha256(journey_id.encode()).hexdigest()[:16],
+                "name": f"chat {model.display_name}",
+                "kind": "CLIENT",
+                "status": {
+                    "code": "ERROR" if blocked else "OK",
+                    "message": "blocked by data handling policy" if blocked else "completed",
+                },
+                "attributes": {
+                    "gen_ai.provider.name": model.provider,
+                    "gen_ai.request.model": model.display_name,
+                    "gen_ai.operation.name": "chat",
+                    "gen_ai.usage.input_tokens": 120 + (seed % 3000),
+                    "agent_bom.decision": "block" if blocked else "allow",
+                    "agent_bom.policy_id": "phi-egress-deny-v5",
+                    "agent_bom.classifications": list(table.data_classifications),
+                },
+            },
+        )
+    return tuple(observations)
+
+
+# A session is one principal's activity inside one window. Six hours, not a day:
+# a day-long window put seventeen events and up to twenty-six assets into a
+# single "path", which is not a path, it is a shift roster. Six hours yields
+# sessions of a handful of events — small enough that the assets in one plausibly
+# relate, large enough to span more than one system.
+SESSION_WINDOW_HOURS = 6
+
+
+def session_trace_id(actor_id: str, observed_at: datetime, tenant_id: str) -> str:
+    """Group one principal's activity into a bounded session trace.
+
+    The alternative — a trace id per event — is what produced six thousand
+    single-event "correlations". A session is a real grouping unit: the same
+    identity, the same window, whatever systems it touched. It is deliberately
+    NOT presented as a causal chain; ``_correlation_kind`` labels it
+    ``identity_session`` so nothing reads more into it than the evidence shows.
+    """
+    bucket = observed_at.hour // SESSION_WINDOW_HOURS
+    window = f"{observed_at.strftime('%Y-%m-%d')}T{bucket:02d}"
+    # ``tenant_id`` is deliberately NOT in the digest. Every tenant seeding the
+    # demo must get a byte-identical estate — that invariant is what makes
+    # ``test_two_tenants_holding_identical_finding_ids_both_persist`` a valid
+    # probe for a dedupe key that omits the tenant. Mixing the tenant in here
+    # gave each one a different trace ordering, which changed which correlation
+    # claimed each asset and therefore which findings the estate produced at
+    # all: two tenants, 2,290 and 2,309 findings, from one generator. Tenancy
+    # lives on the provenance and in ``correlation_id``, where it is enforced.
+    del tenant_id
+    return hashlib.sha256(f"session|{actor_id}|{window}".encode()).hexdigest()[:32]
+
+
+def actor_for(asset: EstateAsset, occurrence: int) -> str:
+    """Pick the principal that acted on ``asset`` — from the shared pool.
+
+    Deriving the actor from the asset rather than from its provider is what lets
+    one identity appear in CloudTrail on Monday and in Snowflake access history
+    the same afternoon, which is the only way a session can span vendors.
+    """
+    principals = principal_pool()
+    lane = asset.tags.get(AI_LANE_TAG)
+    seed = stable_index(asset.asset_id, str(occurrence), lane or "cloud")
+    return principals[seed % len(principals)]
+
+
+__all__ = [
+    "actor_for",
+    "build_journeys",
+    "principal_pool",
+    "session_trace_id",
+]

--- a/src/agent_bom/demo_estate/enterprise_risk.py
+++ b/src/agent_bom/demo_estate/enterprise_risk.py
@@ -1,0 +1,981 @@
+"""Findings from every scanner the product ships, not just the posture one.
+
+:mod:`agent_bom.demo_estate.enterprise_findings` raises CIS control failures over
+the estate. Every one of its findings was a CIS check, so the estate's risk grew
+with *control coverage* rather than with the estate — 439 findings across 2,068
+assets, none of them a vulnerability, a leaked credential, an infrastructure-as-
+code defect or a runtime policy violation. A security product whose demo shows
+one scanner is demonstrating one scanner.
+
+Four lanes are added here, and three decisions keep them honest.
+
+**Real advisories, not invented ones.** Vulnerability findings are built from
+:mod:`agent_bom.demo_advisories` — the curated catalog of genuine published
+CVE/GHSA ids with their real CWE, CVSS and KEV status that the bundled demo
+already uses. Inventing a CVE number, or pairing a real one with a version it
+does not affect, produces a demo that a reviewer can disprove in one lookup.
+
+**Production converters, then one explicit re-binding.** Each lane goes through
+the same function a live scan uses — :func:`blast_radius_to_finding`,
+:func:`secret_dict_to_finding`, :func:`iac_finding_to_finding` — so severity,
+compliance classification and remediation are whatever production does. Those
+converters key the asset on a *code-layer* identity (a purl, a ``file:line``),
+which is correct for a repository scan and wrong for an estate: #4637 requires
+one id scheme, and a finding whose asset id is a file path cannot join the
+inventory. :func:`bind_to_inventory` re-points it at the estate asset the file
+provisions or the image contains, keeping the code-layer location as evidence.
+It is one function, applied identically by every lane, so there is no second
+spelling to reconcile.
+
+**A finding never invents its target.** Every lane iterates the inventory, so
+the asset exists before the finding does. There is no path here that
+materialises a stub.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from agent_bom.demo_advisories import DEMO_ADVISORIES, DemoAdvisory
+from agent_bom.demo_estate.enterprise import EnterpriseEstate, EstateAsset
+from agent_bom.demo_estate.enterprise_ai import AI_LANE_TAG
+from agent_bom.finding import (
+    Asset,
+    Finding,
+    FindingSource,
+    FindingType,
+    blast_radius_to_finding,
+    iac_finding_to_finding,
+    secret_dict_to_finding,
+    stable_id,
+)
+
+ESTATE_RISK_VERSION = "enterprise_risk.v1"
+
+
+def _seed(*parts: str) -> int:
+    return int.from_bytes(hashlib.sha256("|".join(parts).encode("utf-8")).digest()[:4], "big")
+
+
+def vulnerable_version_for(advisory: DemoAdvisory) -> str:
+    """A version the advisory's own range says is affected.
+
+    The catalog records ``introduced="0"`` and a fixed version, so *any* release
+    below the fix is in range. Deriving one by stepping the fixed version's last
+    component down is therefore correct by construction — and does not require
+    asserting that some specific historical release existed, which is the kind
+    of detail a demo gets wrong and a reviewer notices.
+    """
+    parts = advisory.fixed.split(".")
+    for index in range(len(parts) - 1, -1, -1):
+        try:
+            value = int(parts[index])
+        except ValueError:
+            continue
+        if value > 0:
+            parts[index] = str(value - 1)
+            # Keep every component. Truncating turned ``9.0.0`` into ``8``,
+            # which is still in range but reads as a version nobody ships.
+            return ".".join(parts)
+    return advisory.fixed
+
+
+def advisory_catalog() -> tuple[tuple[str, str, str, DemoAdvisory], ...]:
+    """``(ecosystem, package, affected_version, advisory)`` for every curated row."""
+    return tuple((advisory.ecosystem, advisory.package, vulnerable_version_for(advisory), advisory) for advisory in DEMO_ADVISORIES)
+
+
+def _epss_for(advisory: DemoAdvisory) -> float:
+    """A deterministic exploit-probability score for the synthetic estate.
+
+    Anchored on the advisory's own severity and KEV status so the ordering is
+    defensible — a KEV entry outranks a medium — while the exact value is
+    synthetic and is labelled as such in the finding's evidence. The estate does
+    not claim to publish real EPSS.
+    """
+    base = {"critical": 0.55, "high": 0.28, "medium": 0.09, "low": 0.02}.get(advisory.severity, 0.03)
+    jitter = (_seed("epss", advisory.vuln_id) % 1000) / 10000.0
+    score = base + jitter + (0.3 if advisory.is_kev else 0.0)
+    return round(min(score, 0.97), 4)
+
+
+# One ``Asset.asset_type`` per estate asset, for every lane.
+#
+# ``Asset.canonical_id`` is ``stable_id(asset_type, identifier)``, so two lanes
+# that describe the SAME inventoried row with different asset_types mint two
+# canonical ids for one asset — and the findings list, the graph and the exports
+# stop joining. The posture lane goes through ``cloud_cis_check_to_finding``,
+# which always writes ``cloud_resource``; anything the posture lane can also
+# reach must therefore say ``cloud_resource`` too. This map holds only the rows
+# posture never touches.
+_ASSET_TYPE_OVERRIDES: dict[str, str] = {
+    "package": "package",
+    "container_image": "container",
+    "repository": "repository",
+    "workflow": "ci_job",
+    "server": "mcp_server",
+    "tool": "mcp_tool",
+    "agent": "agent",
+    "deployment": "workload",
+    "hosted_model": "model",
+    "model_artifact": "model",
+}
+
+_CLOUD_ASSET_TYPE = "cloud_resource"
+
+
+def estate_asset_type(asset: EstateAsset) -> str:
+    """The one ``Asset.asset_type`` every lane must use for this estate row."""
+    return _ASSET_TYPE_OVERRIDES.get(asset.resource_type, _CLOUD_ASSET_TYPE)
+
+
+def _classify(finding: Finding) -> Finding:
+    """Run the product's own framework selection over a finding.
+
+    Some converters call this internally and some do not. Applying it here for
+    the ones that do not is what keeps every lane visible in the compliance hub
+    posture instead of only the lanes whose converter happened to be written
+    after the hub existed.
+    """
+    from agent_bom.compliance_hub import apply_hub_classification
+
+    return apply_hub_classification(finding)
+
+
+def bind_to_inventory(finding: Finding, asset: EstateAsset, estate: EnterpriseEstate, *, location: str = "") -> Finding:
+    """Re-point a converter's finding at the inventoried asset it concerns.
+
+    The production converters name the artifact they read — a purl, a
+    ``file:line`` — which is the right identity for a repository scan and the
+    wrong one for an estate, where every finding must resolve to a row the
+    inventory already holds (#4637). The artifact identity is not discarded: it
+    stays in ``evidence`` and in ``asset.location``, so the chain still shows
+    *which file* and *which package*, it just hangs off the asset that owns them.
+
+    One function, used by every lane, so there is exactly one spelling of the
+    estate's finding-to-asset edge.
+    """
+    from agent_bom.finding_scope import normalize_account_ref
+
+    account_ref = normalize_account_ref(asset.provider, asset.account_scope)
+    finding.asset = Asset(
+        name=asset.display_name,
+        asset_type=estate_asset_type(asset),
+        identifier=asset.asset_id,
+        location=location or finding.asset.location or asset.native_id,
+        provider=asset.provider,
+        account_ref=account_ref,
+        region=asset.region or None,
+        environment=asset.environment or None,
+    )
+    finding.provider = asset.provider
+    finding.account_ref = account_ref
+    finding.region = asset.region or None
+    finding.environment = asset.environment or None
+    finding.evidence.update(
+        {
+            "resource_id": asset.asset_id,
+            "resource_name": asset.display_name,
+            "resource_type": asset.resource_type,
+            "tenant_id": estate.tenant_id,
+            "synthetic": True,
+            "fictional": True,
+            "disclosure": estate.disclosure,
+            "estate_id": estate.estate_id,
+            "data_classifications": list(asset.data_classifications),
+        }
+    )
+    return finding
+
+
+# ── Vulnerabilities ──────────────────────────────────────────────────────────
+
+
+def build_vulnerability_evidence(estate: EnterpriseEstate) -> tuple[tuple[Any, Finding], ...]:
+    """One CVE per inventoried package that a curated advisory actually covers.
+
+    The package rows were generated *from* the advisory catalog, so the join is
+    total by construction: a package with no matching advisory would mean the
+    inventory and the catalog had drifted, and it is skipped rather than given an
+    invented vulnerability.
+    """
+    from agent_bom.models import BlastRadius, Package, Severity, Vulnerability
+    from agent_bom.scanners.package_scan import apply_framework_tags
+
+    by_key = {(row[0], row[1], row[2]): row[3] for row in advisory_catalog()}
+    images = {asset.asset_id: asset for asset in estate.assets if asset.resource_type == "container_image"}
+
+    pairs: list[tuple[object, Finding]] = []
+    for asset in estate.assets:
+        if asset.resource_type != "package":
+            continue
+        ecosystem = asset.tags.get("ecosystem", "")
+        name = asset.tags.get("package_name", "")
+        version = asset.tags.get("package_version", "")
+        advisory = by_key.get((ecosystem.lower(), name, version))
+        if advisory is None:
+            continue
+
+        image = images.get(asset.tags.get("container_image", ""))
+        package = Package(name=name, version=version, ecosystem=ecosystem)
+        vulnerability = Vulnerability(
+            id=advisory.vuln_id,
+            summary=advisory.summary,
+            severity=Severity(advisory.severity),
+            cvss_score=advisory.cvss_score,
+            cwe_ids=[advisory.cwe] if advisory.cwe else [],
+            fixed_version=advisory.fixed,
+            is_kev=advisory.is_kev,
+            epss_score=_epss_for(advisory),
+            # Network exploitability is a property of the advisory, not of the
+            # host: a KEV entry with a network CVSS vector is exploitable
+            # wherever it runs. Derived from the catalog, never from whether the
+            # estate happened to mark the workload internet-facing, so the two
+            # signals stay independent when the graph fuses them.
+            network_exploitable=advisory.cvss_score >= 7.0,
+        )
+        blast_radius = BlastRadius(
+            vulnerability=vulnerability,
+            package=package,
+            affected_servers=[],
+            affected_agents=[],
+            exposed_credentials=[],
+            exposed_tools=[],
+        )
+        # The same stamping a live package scan does before converting. Without
+        # it the blast radius reaches the converter with every framework list
+        # empty, and the estate's vulnerabilities evidence no control at all —
+        # a demo showing a CVE lane that the compliance posture cannot see.
+        apply_framework_tags(blast_radius)
+        finding = blast_radius_to_finding(blast_radius)
+        bind_to_inventory(finding, asset, estate, location=asset.native_id)
+        # The converter keys a finding on (advisory, package) because a
+        # repository scan sees each package once. An estate ships the same
+        # package inside twenty-one images, so that key collapsed twenty-one
+        # distinct exposures onto one id — the same "dedupe key omits the scope"
+        # defect that has cost this repo a cross-tenant row before. The scope
+        # here is the inventoried package row.
+        finding.id = stable_id("estate-vuln", advisory.vuln_id, asset.asset_id)
+        finding.evidence.update(
+            {
+                # Every lane states what was observed and what was expected.
+                # For a vulnerability that is the version edge — not a
+                # fabricated "configuration", the actual finding: this version
+                # is installed, the advisory fixes it in that one.
+                "configuration": {
+                    "setting": f"{ecosystem} package version",
+                    "observed": f"{name}@{version}",
+                    "expected": f"{name}>={advisory.fixed}",
+                },
+                "package_purl": asset.native_id,
+                "package_ecosystem": ecosystem,
+                "advisory_source": advisory.source,
+                # The score is synthetic. Say so here rather than let a consumer
+                # read it as a published EPSS value.
+                "epss_source": "synthetic-demo",
+                "container_image": image.asset_id if image is not None else "",
+                "container_image_name": image.display_name if image is not None else "",
+                "image_signed": image.tags.get("signed", "") if image is not None else "",
+            }
+        )
+        pairs.append((blast_radius, finding))
+    return tuple(pairs)
+
+
+def build_vulnerability_findings(estate: EnterpriseEstate) -> tuple[Finding, ...]:
+    """The estate's CVE findings, without their blast radii."""
+    return tuple(finding for _blast_radius, finding in build_vulnerability_evidence(estate))
+
+
+def build_vulnerability_blast_radii(estate: EnterpriseEstate) -> tuple[Any, ...]:
+    """The blast radii behind those findings, for the report's legacy CVE array.
+
+    Both halves have to reach the scan report, and this is the reason.
+    ``output.finding_views.cve_findings`` reads ``report.blast_radii`` in
+    preference to the unified findings list, and the unified JSON ``findings``
+    array excludes ``CVE`` by design — CVEs travel in the vulnerability array.
+    So an estate that contributed CVE *findings* and no blast radii had all 768
+    of them silently dropped between the seeder and ``/v1/findings``: the demo
+    reported 1,833 of 2,601 seeded rows, with the entire vulnerability lane
+    missing and nothing anywhere saying so.
+    """
+    return tuple(blast_radius for blast_radius, _finding in build_vulnerability_evidence(estate))
+
+
+# ── Hardcoded secrets ────────────────────────────────────────────────────────
+
+_SECRET_KINDS: tuple[tuple[str, str, str, str], ...] = (
+    ("aws_access_key_id", "cloud_credential", "critical", ".github/workflows/deploy.yml"),
+    ("snowflake_password", "database_credential", "high", "src/warehouse/client.py"),
+    ("openai_api_key", "model_provider_key", "high", "services/copilot/config.py"),
+    ("github_pat", "vcs_token", "high", "scripts/release.sh"),
+    ("private_key_pem", "signing_key", "critical", "deploy/certs/service.pem"),
+    ("slack_webhook", "webhook_url", "medium", "ops/alerting/notify.py"),
+)
+
+
+def build_secret_findings(estate: EnterpriseEstate) -> tuple[Finding, ...]:
+    """Committed credentials, bound to the repository that holds them.
+
+    The scanner's own identity for a secret is ``file:line`` — correct for the
+    repository scan, unusable as an estate join. The repository is the
+    inventoried thing; the path stays in evidence, which is what a remediator
+    actually needs.
+    """
+    findings: list[Finding] = []
+    for asset in estate.assets:
+        if asset.resource_type != "repository":
+            continue
+        seed = _seed("secret", asset.asset_id)
+        # Roughly a third of repositories carry one. An estate where every
+        # repository leaks is a lint rule, not a posture.
+        if seed % 3 != 0:
+            continue
+        for offset in range(1 + (seed // 5) % 2):
+            kind, category, severity, path = _SECRET_KINDS[(seed + offset) % len(_SECRET_KINDS)]
+            line = 12 + ((seed >> (offset * 3)) % 180)
+            finding = secret_dict_to_finding(
+                {
+                    "file": f"{asset.display_name}/{path}",
+                    "line": line,
+                    "type": kind,
+                    "category": category,
+                    "severity": severity,
+                    # Never a value, not even a synthetic one: the converter
+                    # redacts, and handing it something that looks like a secret
+                    # teaches the demo to carry secret-shaped strings.
+                    "preview": "***REDACTED***",
+                }
+            )
+            bind_to_inventory(finding, asset, estate, location=f"{asset.display_name}/{path}")
+            # ``secret_dict_to_finding`` sets no framework classification — it
+            # predates the hub — so a secret would evidence no control and drop
+            # out of the compliance posture entirely. Every other lane's
+            # converter already does this internally.
+            # The controls a committed credential genuinely evidences, from the
+            # catalogs this repo ships. ``secret_dict_to_finding`` sets none.
+            finding.owasp_tags = ["LLM06"]
+            finding.owasp_mcp_tags = ["MCP01"]
+            finding.nist_800_53_tags = ["IA-5"]
+            _classify(finding)
+            finding.evidence.update(
+                {
+                    "configuration": {
+                        "setting": f"{kind} storage",
+                        "observed": f"hardcoded at {path}:{line}",
+                        "expected": "loaded from an environment variable or secret manager",
+                    },
+                    "repository": asset.asset_id,
+                    "commit_sha": hashlib.sha256(f"{asset.asset_id}:{offset}".encode()).hexdigest()[:40],
+                    "branch": "main",
+                }
+            )
+            findings.append(finding)
+    return tuple(findings)
+
+
+# ── Infrastructure as code ───────────────────────────────────────────────────
+
+
+class _IacRule:
+    """One infrastructure-as-code rule, with the declaration it checks.
+
+    ``setting``/``observed``/``expected`` are the block in the module and what it
+    should have said. Every lane in this file carries that pair, because a
+    finding that cannot say what it saw and what it wanted is not actionable —
+    and because the demo's rendered chain asserts the edge on every row.
+    """
+
+    __slots__ = (
+        "rule_id",
+        "title",
+        "message",
+        "remediation",
+        "severity",
+        "category",
+        "resource_types",
+        "setting",
+        "observed",
+        "expected",
+        "cis_checks",
+        "nist_800_53",
+    )
+
+    def __init__(
+        self,
+        rule_id: str,
+        title: str,
+        message: str,
+        remediation: str,
+        severity: str,
+        category: str,
+        resource_types: tuple[str, ...],
+        *,
+        setting: str,
+        observed: str,
+        expected: str,
+        cis_checks: dict[str, str] | None = None,
+        nist_800_53: tuple[str, ...] = (),
+    ) -> None:
+        self.rule_id = rule_id
+        self.title = title
+        self.message = message
+        self.remediation = remediation
+        self.severity = severity
+        self.category = category
+        self.resource_types = resource_types
+        self.setting = setting
+        self.observed = observed
+        self.expected = expected
+        # Keyed by provider: the same declaration is checked differently per
+        # cloud, and only some rules have a runtime CIS twin at all. A rule with
+        # no entry for the asset's provider claims no CIS coverage rather than
+        # borrowing another cloud's control id.
+        self.cis_checks = dict(cis_checks or {})
+        self.nist_800_53 = nist_800_53
+
+
+_IAC_RULES: tuple[_IacRule, ...] = (
+    _IacRule(
+        "TF-S3-001",
+        "Bucket declared without server-side encryption",
+        "The bucket resource omits a server_side_encryption_configuration block.",
+        "Add a server_side_encryption_configuration block with a KMS key reference.",
+        "high",
+        "terraform",
+        ("bucket", "storage_account"),
+        setting="server_side_encryption_configuration",
+        observed="block absent",
+        expected="block present with a kms_master_key_id",
+        cis_checks={"aws": "2.1.2"},
+        nist_800_53=("SC-28",),
+    ),
+    _IacRule(
+        "TF-IAM-002",
+        "Policy document grants Action '*' on Resource '*'",
+        "The policy document attached to this role grants unrestricted actions.",
+        "Replace the wildcard statement with the actions the workload actually calls.",
+        "critical",
+        "terraform",
+        ("iam_role", "service_principal", "service_account", "role"),
+        setting="policy_document.statement.action",
+        observed='Action "*" on Resource "*"',
+        expected="the actions the workload calls, on named resources",
+        cis_checks={"aws": "1.16"},
+        nist_800_53=("AC-6",),
+    ),
+    _IacRule(
+        "TF-NET-003",
+        "Security group opens an admin port to 0.0.0.0/0",
+        "An ingress rule allows tcp/22 from any address.",
+        "Restrict the ingress CIDR to the approved bastion range.",
+        "high",
+        "terraform",
+        ("instance", "virtual_machine", "cluster"),
+        setting="ingress.cidr_blocks",
+        observed="0.0.0.0/0 on tcp/22",
+        expected="the approved bastion CIDR",
+        cis_checks={"aws": "5.2", "gcp": "3.6"},
+        nist_800_53=("SC-7",),
+    ),
+    _IacRule(
+        "K8S-POD-004",
+        "Container runs without a read-only root filesystem",
+        "securityContext.readOnlyRootFilesystem is unset on the pod template.",
+        "Set securityContext.readOnlyRootFilesystem: true and mount writable paths explicitly.",
+        "medium",
+        "kubernetes",
+        ("deployment",),
+        setting="securityContext.readOnlyRootFilesystem",
+        observed="unset",
+        expected="true",
+        nist_800_53=("CM-7",),
+    ),
+    _IacRule(
+        "K8S-RBAC-005",
+        "ClusterRoleBinding grants cluster-admin to a workload identity",
+        "The binding gives a service account full cluster administration.",
+        "Bind the workload to a namespaced Role with the verbs it uses.",
+        "critical",
+        "kubernetes",
+        ("cluster",),
+        setting="roleRef.name",
+        observed="cluster-admin",
+        expected="a namespaced Role scoped to the verbs used",
+        nist_800_53=("AC-6",),
+    ),
+    _IacRule(
+        "TF-AI-006",
+        "Model endpoint declared with public network access",
+        "The endpoint sets public network access enabled and no private endpoint.",
+        "Disable public network access and front the endpoint with a private endpoint.",
+        "high",
+        "terraform",
+        ("sagemaker_endpoint", "vertex_endpoint", "azure_openai_deployment", "spcs_service", "gemini_api"),
+        setting="public_network_access",
+        observed="Enabled with no private endpoint",
+        expected="Disabled, fronted by a private endpoint",
+        nist_800_53=("SC-7",),
+    ),
+    _IacRule(
+        "TF-TAG-008",
+        "Resource declared without an ownership tag",
+        "The module omits the owner tag the tagging policy requires.",
+        "Add the owner tag to the module's default_tags so every resource it creates inherits it.",
+        "low",
+        "terraform",
+        ("bucket", "instance", "database", "virtual_machine", "table", "function", "warehouse", "share"),
+        setting="default_tags.owner",
+        observed="absent",
+        expected="the owning team's address",
+        nist_800_53=("CM-8",),
+    ),
+    _IacRule(
+        "DKR-IMG-007",
+        "Image build does not pin a digest for its base image",
+        "The Dockerfile FROM line references a mutable tag.",
+        "Pin the base image by digest and rebuild on advisory, not on tag movement.",
+        "medium",
+        "dockerfile",
+        ("container_image",),
+        setting="FROM",
+        observed="a mutable tag",
+        expected="a pinned image digest",
+        nist_800_53=("CM-2",),
+    ),
+)
+
+_IAC_BY_TYPE: dict[str, tuple[_IacRule, ...]] = {}
+for _rule in _IAC_RULES:
+    for _resource_type in _rule.resource_types:
+        _IAC_BY_TYPE[_resource_type] = (*_IAC_BY_TYPE.get(_resource_type, ()), _rule)
+
+
+def build_iac_findings(estate: EnterpriseEstate) -> tuple[Finding, ...]:
+    """Misconfigurations in the code that declares the resource.
+
+    Bound to the resource, not to the ``.tf`` file. The file path is the
+    remediation target and stays in evidence; the *asset* is what the graph, the
+    exposure path and the account roll-up need to join on.
+    """
+    findings: list[Finding] = []
+    for asset in estate.assets:
+        rules = _IAC_BY_TYPE.get(asset.resource_type)
+        if not rules:
+            continue
+        for rule in rules:
+            seed = _seed("iac", asset.asset_id, rule.rule_id)
+            # An IaC defect is a property of a module, so it repeats across the
+            # resources that module produces — but not across all of them.
+            if seed % 100 >= 24:
+                continue
+            module = f"infra/{asset.provider}/{asset.resource_type}s/main.tf"
+            if rule.category == "kubernetes":
+                module = f"deploy/k8s/{asset.display_name}.yaml"
+            elif rule.category == "dockerfile":
+                module = f"services/{asset.display_name.split(':')[0]}/Dockerfile"
+            # Claim only the frameworks this rule actually evidences. Every IaC
+            # rule used to declare ``["CIS", "NIST-800-53"]`` regardless — so
+            # "resource declared without an ownership tag" asserted CIS
+            # coverage it cannot support, and a consumer reading the compliance
+            # posture was told a control had been evaluated when nothing had
+            # evaluated it. Half these rules have no CIS twin at all, and
+            # saying so is the accurate answer.
+            cis_check = rule.cis_checks.get(asset.provider)
+            frameworks = (["CIS"] if cis_check else []) + (["NIST-800-53"] if rule.nist_800_53 else [])
+            finding = iac_finding_to_finding(
+                {
+                    "rule_id": rule.rule_id,
+                    "file_path": module,
+                    "line_number": 8 + (seed % 220),
+                    "category": rule.category,
+                    "severity": rule.severity,
+                    "title": rule.title,
+                    "message": f"{rule.message} Declared resource: {asset.display_name}.",
+                    "remediation": rule.remediation,
+                    "compliance": frameworks,
+                }
+            )
+            bind_to_inventory(finding, asset, estate, location=module)
+            finding.evidence["configuration"] = {
+                "setting": rule.setting,
+                "observed": rule.observed,
+                "expected": rule.expected,
+            }
+            # ``check_id`` is the join key every posture consumer reads. The
+            # rule id already IS the check identity, so emitting it only as
+            # ``rule_id`` left this lane unjoinable to everything the cspm
+            # domain is expected to support.
+            finding.evidence["check_id"] = rule.rule_id
+            if cis_check:
+                finding.evidence["control_id"] = f"CIS-{cis_check}"
+            if rule.nist_800_53:
+                finding.nist_800_53_tags = list(rule.nist_800_53)
+            # ``iac_finding_to_finding`` derives its id from the file path, and
+            # one module declares many resources — so without re-deriving it,
+            # every resource from one module collapsed onto a single finding id.
+            finding.id = stable_id("estate-iac", rule.rule_id, asset.asset_id)
+            _classify(finding)
+            findings.append(finding)
+    return tuple(findings)
+
+
+# ── Runtime and policy ───────────────────────────────────────────────────────
+
+
+class _RuntimeRule:
+    """A runtime detection, with the controls it genuinely evidences.
+
+    ``controls`` is spelled per framework because a finding with no control tag
+    is invisible to the compliance posture — it lands in the findings list and
+    nowhere else. Every code below is drawn from the catalogs this repo already
+    ships (``owasp.OWASP_LLM_TOP10``, ``owasp_mcp.OWASP_MCP_TOP10``,
+    ``owasp_agentic.OWASP_AGENTIC_TOP10``, ``nist_800_53.NIST_800_53``), never
+    invented, and ``tests/test_estate_v2_scale.py`` asserts they still exist.
+    """
+
+    __slots__ = (
+        "rule_id",
+        "finding_type",
+        "source",
+        "title",
+        "description",
+        "remediation",
+        "severity",
+        "setting",
+        "observed",
+        "expected",
+        "owasp",
+        "owasp_mcp",
+        "owasp_agentic",
+        "nist_800_53",
+    )
+
+    def __init__(
+        self,
+        rule_id: str,
+        finding_type: FindingType,
+        source: FindingSource,
+        title: str,
+        description: str,
+        remediation: str,
+        severity: str,
+        *,
+        setting: str,
+        observed: str,
+        expected: str,
+        owasp: tuple[str, ...] = (),
+        owasp_mcp: tuple[str, ...] = (),
+        owasp_agentic: tuple[str, ...] = (),
+        nist_800_53: tuple[str, ...] = (),
+    ) -> None:
+        # The rule *is* the check identity. Without it the runtime lane reached
+        # the findings list with nothing to join on, so every consumer keyed on
+        # ``check_id`` — posture rollups, the graph projection, the compliance
+        # hub — simply skipped it.
+        self.rule_id = rule_id
+        self.finding_type = finding_type
+        self.source = source
+        self.title = title
+        self.description = description
+        self.remediation = remediation
+        self.severity = severity
+        self.setting = setting
+        self.observed = observed
+        self.expected = expected
+        self.owasp = owasp
+        self.owasp_mcp = owasp_mcp
+        self.owasp_agentic = owasp_agentic
+        self.nist_800_53 = nist_800_53
+
+
+_TOOL_RULES: tuple[_RuntimeRule, ...] = (
+    _RuntimeRule(
+        "MCP-TOOL-001",
+        FindingType.INJECTION,
+        FindingSource.MCP_SCAN,
+        "Tool argument reaches a SQL statement without parameter binding",
+        "The tool interpolates a caller-supplied argument into the statement it executes.",
+        "Bind every caller-supplied value as a parameter and reject statements built by concatenation.",
+        "high",
+        setting="tool.arguments binding",
+        observed="interpolated into the statement",
+        expected="bound as a parameter",
+        owasp=("LLM01",),
+        owasp_mcp=("MCP05",),
+        owasp_agentic=("ASI02",),
+        nist_800_53=("SI-10",),
+    ),
+    _RuntimeRule(
+        "MCP-TOOL-002",
+        FindingType.TOOL_DRIFT,
+        FindingSource.MCP_SCAN,
+        "Tool description changed after approval",
+        "The advertised description differs from the version the gateway policy was written against.",
+        "Re-review the tool and re-approve it, or pin the gateway policy to the approved descriptor hash.",
+        "medium",
+        setting="tool.descriptor hash",
+        observed="differs from the approved descriptor",
+        expected="matches the approved descriptor",
+        owasp=("LLM05",),
+        owasp_mcp=("MCP03",),
+        owasp_agentic=("ASI04",),
+        nist_800_53=("CM-6",),
+    ),
+    _RuntimeRule(
+        "MCP-TOOL-003",
+        FindingType.RATE_LIMIT,
+        FindingSource.MCP_SCAN,
+        "Tool has no per-caller rate limit",
+        "The gateway policy applies no call ceiling, so one agent can exhaust the downstream quota.",
+        "Set a per-caller ceiling on the gateway policy for this tool.",
+        "low",
+        setting="gateway.rate_limit.per_caller",
+        observed="unset",
+        expected="a per-caller call ceiling",
+        owasp=("LLM10",),
+        owasp_mcp=("MCP02",),
+        owasp_agentic=("ASI01",),
+        nist_800_53=("AU-6",),
+    ),
+    _RuntimeRule(
+        "GW-DATA-004",
+        FindingType.EXFILTRATION,
+        FindingSource.PROXY,
+        "Write-capable tool returned regulated data to a model context",
+        "Gateway evidence shows a response carrying PHI-classified columns forwarded to a model call.",
+        "Scope the tool to read-only projections and enable response classification on the gateway policy.",
+        "critical",
+        setting="gateway.response_classification",
+        observed="off; PHI columns forwarded",
+        expected="on, blocking regulated columns",
+        owasp=("LLM06",),
+        owasp_mcp=("MCP10",),
+        owasp_agentic=("ASI02",),
+        nist_800_53=("AC-3",),
+    ),
+)
+
+_IDENTITY_RULES: tuple[_RuntimeRule, ...] = (
+    _RuntimeRule(
+        "IAM-CIEM-005",
+        FindingType.CIEM_OVER_PRIVILEGE,
+        FindingSource.CLOUD_SECURITY,
+        "Principal holds permissions it has never exercised",
+        "Ninety days of audit evidence show none of the write actions this principal is granted.",
+        "Right-size the attached policy to the actions observed, and re-review on a schedule.",
+        "high",
+        setting="policy.granted_actions",
+        observed="write actions granted, none exercised in 90 days",
+        expected="only the actions observed in use",
+        owasp_agentic=("ASI03",),
+        nist_800_53=("AC-6",),
+    ),
+)
+
+_AI_RULES: tuple[_RuntimeRule, ...] = (
+    _RuntimeRule(
+        "AI-PROMPT-006",
+        FindingType.PROMPT_SECURITY,
+        FindingSource.PROMPT_SCAN,
+        "System prompt embeds a data-access instruction with no guardrail",
+        "The template instructs the model to retrieve records without naming a classification boundary.",
+        "Move the retrieval boundary into the tool contract and attach a guardrail to the deployment.",
+        "medium",
+        setting="prompt.retrieval_boundary",
+        observed="no classification boundary named",
+        expected="the boundary declared in the tool contract",
+        owasp=("LLM01", "LLM07"),
+        owasp_agentic=("ASI01",),
+        nist_800_53=("CM-7",),
+    ),
+    _RuntimeRule(
+        "AI-MODEL-007",
+        FindingType.MODEL_INTEGRITY,
+        FindingSource.MODEL_SCAN,
+        "Model artifact has no verifiable provenance",
+        "The served artifact carries no signature or attestation linking it to a build.",
+        "Publish and verify an attestation for the artifact before it is promoted to production.",
+        "high",
+        setting="artifact.attestation",
+        observed="absent",
+        expected="a verified build attestation",
+        owasp=("LLM05",),
+        owasp_agentic=("ASI04",),
+        nist_800_53=("SR-4", "SI-7"),
+    ),
+)
+
+
+def _runtime_finding(rule: _RuntimeRule, asset: EstateAsset, estate: EnterpriseEstate, *, evidence: dict[str, object]) -> Finding:
+    from agent_bom.compliance_hub import apply_hub_classification
+    from agent_bom.finding_scope import normalize_account_ref
+
+    account_ref = normalize_account_ref(asset.provider, asset.account_scope)
+    finding = Finding(
+        finding_type=rule.finding_type,
+        source=rule.source,
+        asset=Asset(
+            name=asset.display_name,
+            asset_type=estate_asset_type(asset),
+            identifier=asset.asset_id,
+            location=asset.native_id,
+            provider=asset.provider,
+            account_ref=account_ref,
+            region=asset.region or None,
+            environment=asset.environment or None,
+        ),
+        severity=rule.severity,
+        provider=asset.provider,
+        account_ref=account_ref,
+        region=asset.region or None,
+        environment=asset.environment or None,
+        title=f"{rule.title}: {asset.display_name}",
+        description=rule.description,
+        remediation_guidance=rule.remediation,
+        evidence={
+            **evidence,
+            "check_id": rule.rule_id,
+            "configuration": {
+                "setting": rule.setting,
+                "observed": rule.observed,
+                "expected": rule.expected,
+            },
+        },
+        owasp_tags=list(rule.owasp),
+        owasp_mcp_tags=list(rule.owasp_mcp),
+        owasp_agentic_tags=list(rule.owasp_agentic),
+        nist_800_53_tags=list(rule.nist_800_53),
+        id=stable_id("estate-runtime", rule.finding_type.value, asset.asset_id),
+    )
+    bind_to_inventory(finding, asset, estate)
+    # Declare the frameworks whose controls this rule actually names. The hub's
+    # selection table has no row for every (source, finding_type) pair the
+    # product emits — ``CLOUD_SECURITY`` + ``CIEM_OVER_PRIVILEGE`` resolves to
+    # nothing — and a finding classified into no framework is invisible to the
+    # compliance posture no matter how many control tags it carries. This adds
+    # no crosswalk: it names exactly the frameworks whose codes are on the rule.
+    declared = [
+        slug
+        for slug, tags in (
+            ("owasp-llm", rule.owasp),
+            ("owasp-mcp", rule.owasp_mcp),
+            ("owasp-agentic", rule.owasp_agentic),
+            ("nist-800-53", rule.nist_800_53),
+        )
+        if tags
+    ]
+    finding.applicable_frameworks = declared
+    return apply_hub_classification(finding)
+
+
+def build_runtime_findings(estate: EnterpriseEstate) -> tuple[Finding, ...]:
+    """Runtime and policy violations on the AI surface and its identities.
+
+    These are the findings that only exist because the estate is *running*: a
+    tool whose arguments reach a statement, an identity whose grants exceed what
+    the audit log shows it using, a model served with no attestation. They are
+    the lane a posture scanner cannot produce, and without them the demo's AI
+    surface carries configuration risk and nothing else.
+    """
+    findings: list[Finding] = []
+    for asset in estate.assets:
+        if asset.resource_type == "tool":
+            for rule in _TOOL_RULES:
+                seed = _seed("runtime", asset.asset_id, rule.finding_type.value)
+                writes = asset.tags.get("write_capable") == "true"
+                if rule.finding_type is FindingType.EXFILTRATION and not writes:
+                    continue
+                if seed % 100 >= (32 if writes else 20):
+                    continue
+                findings.append(
+                    _runtime_finding(
+                        rule,
+                        asset,
+                        estate,
+                        evidence={
+                            "mcp_server": asset.tags.get("mcp_server", ""),
+                            "write_capable": writes,
+                            "gateway_policy": "mcp-prod-readonly-v3",
+                            "observed_calls": 40 + (seed % 900),
+                        },
+                    )
+                )
+        elif asset.resource_type in {"iam_role", "service_principal", "service_account", "role"}:
+            if asset.tags.get("over_permissive") != "true":
+                continue
+            for rule in _IDENTITY_RULES:
+                seed = _seed("runtime", asset.asset_id, rule.finding_type.value)
+                findings.append(
+                    _runtime_finding(
+                        rule,
+                        asset,
+                        estate,
+                        evidence={
+                            "granted_actions": 60 + (seed % 120),
+                            "used_actions": seed % 12,
+                            "evaluation_window_days": 90,
+                        },
+                    )
+                )
+        elif asset.tags.get(AI_LANE_TAG):
+            for rule in _AI_RULES:
+                seed = _seed("runtime", asset.asset_id, rule.finding_type.value)
+                if rule.finding_type is FindingType.PROMPT_SECURITY and asset.resource_type not in {
+                    "prompt_template",
+                    "bedrock_agent",
+                    "vertex_agent",
+                    "agent",
+                }:
+                    continue
+                if rule.finding_type is FindingType.MODEL_INTEGRITY and asset.resource_type not in {
+                    "hosted_model",
+                    "model_artifact",
+                    "foundation_model",
+                    "vertex_model",
+                    "sagemaker_model",
+                }:
+                    continue
+                if seed % 100 >= 38:
+                    continue
+                findings.append(
+                    _runtime_finding(
+                        rule,
+                        asset,
+                        estate,
+                        evidence={
+                            "ai_lane": asset.tags.get(AI_LANE_TAG, ""),
+                            "model_family": asset.tags.get("model_family", ""),
+                            "guardrail_attached": asset.tags.get("guardrail", "none"),
+                        },
+                    )
+                )
+    return tuple(findings)
+
+
+def build_risk_findings(estate: EnterpriseEstate) -> tuple[Finding, ...]:
+    """Every non-posture lane, in one deterministic order."""
+    lanes: Iterable[Sequence[Finding]] = (
+        build_vulnerability_findings(estate),
+        build_secret_findings(estate),
+        build_iac_findings(estate),
+        build_runtime_findings(estate),
+    )
+    return tuple(finding for lane in lanes for finding in lane)
+
+
+__all__ = [
+    "ESTATE_RISK_VERSION",
+    "advisory_catalog",
+    "build_vulnerability_blast_radii",
+    "build_vulnerability_evidence",
+    "bind_to_inventory",
+    "build_iac_findings",
+    "build_risk_findings",
+    "build_runtime_findings",
+    "build_secret_findings",
+    "build_vulnerability_findings",
+    "vulnerable_version_for",
+]

--- a/src/agent_bom/demo_estate/enterprise_scale.py
+++ b/src/agent_bom/demo_estate/enterprise_scale.py
@@ -164,6 +164,7 @@ def _event_types_for(asset: EstateAsset) -> tuple[str, ...]:
             return ai_types
     return _EVENT_TYPES[asset.provider]
 
+
 _DATA_CLASSES: dict[str, tuple[str, ...]] = {
     "bucket": ("confidential",),
     "storage_account": ("confidential",),
@@ -336,9 +337,7 @@ def _build_estate_assets(profile: ScaleProfile, tenant_id: str) -> tuple[EstateA
     """
     cloud = mark_cloud_exposure(_build_assets(profile, tenant_id))
     accounts = index_cloud_accounts(cloud)
-    first_party = build_first_party_ai_assets(
-        accounts, tenant_id=tenant_id, per_account=profile.ai_services_per_account
-    )
+    first_party = build_first_party_ai_assets(accounts, tenant_id=tenant_id, per_account=profile.ai_services_per_account)
     third_party = build_third_party_ai_assets(
         accounts,
         tenant_id=tenant_id,

--- a/src/agent_bom/demo_estate/enterprise_scale.py
+++ b/src/agent_bom/demo_estate/enterprise_scale.py
@@ -39,6 +39,19 @@ from agent_bom.demo_estate.enterprise import (
 from agent_bom.demo_estate.enterprise import (
     _observation_hash as _canonical_observation_hash,
 )
+from agent_bom.demo_estate.enterprise_ai import (
+    AI_LANE_TAG,
+    build_delivery_assets,
+    build_first_party_ai_assets,
+    build_third_party_ai_assets,
+    index_cloud_accounts,
+    mark_cloud_exposure,
+)
+from agent_bom.demo_estate.enterprise_journeys import (
+    actor_for,
+    build_journeys,
+    session_trace_id,
+)
 
 # Clouds that must show real depth: several accounts, every environment. The
 # graph audit found `environment` silently null for AWS and GCP and Snowflake
@@ -101,14 +114,55 @@ _SOURCE_FOR_PROVIDER: dict[str, EvidenceSource] = {
     "azure": EvidenceSource.AZURE_ACTIVITY,
     "gcp": EvidenceSource.GCP_AUDIT,
     "snowflake": EvidenceSource.SNOWFLAKE_ACCESS_HISTORY,
+    "github": EvidenceSource.GITHUB_ACTIONS,
+    "kubernetes": EvidenceSource.KUBERNETES_AUDIT,
+    "mcp": EvidenceSource.MCP_GATEWAY,
+    "agent": EvidenceSource.OTEL_LLM,
+    "openai": EvidenceSource.OTEL_LLM,
+    "anthropic": EvidenceSource.OTEL_LLM,
+    "huggingface": EvidenceSource.OTEL_LLM,
 }
+
+# Inventory rows a log never names on their own. A package appears in an SBOM
+# and in a vulnerability finding, never in CloudTrail; emitting a control-plane
+# event for one would be evidence the estate cannot justify.
+_UNOBSERVED_RESOURCE_TYPES: frozenset[str] = frozenset({"package"})
 
 _EVENT_TYPES: dict[str, tuple[str, ...]] = {
     "aws": ("AssumeRole", "GetObject", "PutBucketPolicy", "CreateAccessKey"),
     "azure": ("Microsoft.Authorization/roleAssignments/write", "Microsoft.Storage/storageAccounts/listKeys"),
     "gcp": ("storage.objects.get", "iam.serviceAccounts.getAccessToken"),
     "snowflake": ("QUERY", "GRANT_ROLE", "COPY_INTO"),
+    "github": ("workflow_run.completed", "workflow_job.queued"),
+    "kubernetes": ("deployments.update", "pods/exec.create", "secrets.get"),
+    "mcp": ("tools/call", "tools/list", "initialize"),
+    "agent": ("gen_ai.chat", "gen_ai.execute_tool"),
+    "openai": ("gen_ai.chat", "gen_ai.embeddings"),
+    "anthropic": ("gen_ai.chat", "gen_ai.execute_tool"),
+    "huggingface": ("gen_ai.embeddings",),
 }
+
+# Control-plane calls a first-party AI service actually produces. Without these
+# a Bedrock agent in an AWS account would emit ``GetObject`` — plausible-looking
+# evidence that names the wrong API, which is worse than none.
+_AI_SERVICE_EVENT_TYPES: dict[str, tuple[str, ...]] = {
+    "aws": ("bedrock:InvokeModelWithResponseStream", "bedrock:Retrieve", "sagemaker:InvokeEndpoint"),
+    "azure": (
+        "Microsoft.CognitiveServices/accounts/deployments/action",
+        "Microsoft.MachineLearningServices/workspaces/onlineEndpoints/score/action",
+    ),
+    "gcp": ("aiplatform.endpoints.predict", "aiplatform.models.get"),
+    "snowflake": ("CORTEX_COMPLETE", "CORTEX_SEARCH_QUERY"),
+}
+
+
+def _event_types_for(asset: EstateAsset) -> tuple[str, ...]:
+    """Which API calls this asset's own control plane emits."""
+    if asset.tags.get(AI_LANE_TAG) == "first_party":
+        ai_types = _AI_SERVICE_EVENT_TYPES.get(asset.provider)
+        if ai_types:
+            return ai_types
+    return _EVENT_TYPES[asset.provider]
 
 _DATA_CLASSES: dict[str, tuple[str, ...]] = {
     "bucket": ("confidential",),
@@ -135,6 +189,13 @@ MIN_ENTERPRISE_EVENTS = 6000
 MIN_ACCOUNTS_PER_CLOUD = 5
 MIN_RESOURCES_PER_ACCOUNT = 20
 
+# Floors for the properties that make the estate *demonstrate* rather than
+# assert. Each replaces a number that looked healthy while the thing it stood
+# for was absent: 6,148 correlations of which 3 spanned a second vendor, and 439
+# findings every one of which was the same CIS scanner.
+MIN_CROSS_SOURCE_CORRELATIONS = 300
+MIN_ESTATE_FINDINGS = 2000
+
 
 @dataclass(frozen=True)
 class ScaleProfile:
@@ -152,6 +213,30 @@ class ScaleProfile:
     resources_per_account: int = 64
     events_per_asset: int = 3
 
+    # The AI estate. ``ai_services_per_account`` are FIRST-PARTY services inside
+    # the cloud accounts above — Bedrock, Azure OpenAI, Vertex, Cortex — sharing
+    # those accounts' identities and data. The third-party counts below are
+    # deliberately smaller in total: external providers are the minority of an
+    # enterprise's AI surface, and modelling them as the whole of it is what made
+    # nine standalone assets read as the entire AI story.
+    ai_services_per_account: int = 14
+    mcp_servers: int = 24
+    agents: int = 48
+    external_models: int = 24
+
+    # Delivery and runtime — the spine a cross-vendor trace walks. One
+    # repository, one workflow and one deployment (what the estate had) means
+    # every journey converges on the same three nodes.
+    repositories: int = 56
+    clusters: int = 16
+    workloads_per_cluster: int = 8
+    packages_per_image: int = 6
+
+    # Multi-source traces. Each is one actor walking CI -> cloud identity ->
+    # Kubernetes -> MCP -> warehouse -> model, so this is very nearly the
+    # cross-source correlation count.
+    journeys: int = 420
+
     def __post_init__(self) -> None:
         if self.accounts_per_cloud < 2:
             raise ValueError("a cloud needs at least two accounts for drill-down to mean anything")
@@ -159,6 +244,10 @@ class ScaleProfile:
             raise ValueError("each account needs at least one resource per environment")
         if self.events_per_asset < 1:
             raise ValueError("an asset with no evidence cannot participate in correlation")
+        if self.journeys < 0:
+            raise ValueError("journey count cannot be negative")
+        if self.mcp_servers < 1 or self.agents < 1:
+            raise ValueError("the AI lane needs at least one server and one agent to correlate")
 
 
 def _stable_index(*parts: str) -> int:
@@ -236,6 +325,38 @@ def _build_assets(profile: ScaleProfile, tenant_id: str) -> tuple[EstateAsset, .
     return tuple(assets)
 
 
+def _build_estate_assets(profile: ScaleProfile, tenant_id: str) -> tuple[EstateAsset, ...]:
+    """Cloud population, then everything that runs on it, in one inventory.
+
+    Order matters: the AI and delivery lanes are generated *from* the cloud
+    accounts, reading back the identities and data stores actually inventoried
+    rather than re-deriving them. A second derivation would be free to name a
+    principal the estate never created, and the contract would only catch it if
+    the principal happened to be referenced by an event.
+    """
+    cloud = mark_cloud_exposure(_build_assets(profile, tenant_id))
+    accounts = index_cloud_accounts(cloud)
+    first_party = build_first_party_ai_assets(
+        accounts, tenant_id=tenant_id, per_account=profile.ai_services_per_account
+    )
+    third_party = build_third_party_ai_assets(
+        accounts,
+        tenant_id=tenant_id,
+        mcp_servers=profile.mcp_servers,
+        agents=profile.agents,
+        external_models=profile.external_models,
+    )
+    delivery = build_delivery_assets(
+        accounts,
+        tenant_id=tenant_id,
+        repositories=profile.repositories,
+        clusters=profile.clusters,
+        workloads_per_cluster=profile.workloads_per_cluster,
+        packages_per_image=profile.packages_per_image,
+    )
+    return (*cloud, *first_party, *third_party, *delivery)
+
+
 _PLACEHOLDER_HASH = "0" * 64
 _READ_ONLY_EVENTS = frozenset({"GetObject", "QUERY", "storage.objects.get"})
 
@@ -261,23 +382,38 @@ def _seal(observation: RawObservation) -> RawObservation:
 
 
 def _build_observations(assets: tuple[EstateAsset, ...], profile: ScaleProfile, tenant_id: str) -> tuple[RawObservation, ...]:
+    """Per-asset activity, grouped into per-principal daily sessions.
+
+    Two changes from the shape this replaces, and both exist to stop the
+    correlation layer from reporting work it never did.
+
+    **The actor comes from one shared pool**, not from ``f"{provider}-principal-…"``.
+    A principal that only ever appears in one cloud can never produce a
+    cross-vendor grouping, so the old estate could not have correlated across
+    vendors even in principle.
+
+    **The trace id is a session, not the event.** Minting a trace per event made
+    every group a group of one, which is how 6,148 "correlations" contained 3
+    that joined anything. A session — one identity, one day, whatever it touched
+    — is a grouping the evidence actually supports.
+    """
     observations: list[RawObservation] = []
     occurrences = range(profile.events_per_asset)
     for asset in assets:
         source = _SOURCE_FOR_PROVIDER.get(asset.provider)
-        if source is None:
+        if source is None or asset.resource_type in _UNOBSERVED_RESOURCE_TYPES:
             continue
         # Hoisted: these are constant for every event on this asset, and at
         # scale the per-event recomputation dominated the loop body.
-        source_value = source.value
-        run_id = f"demo-run-scaled-{source_value}"
-        event_types = _EVENT_TYPES[asset.provider]
+        run_id = f"demo-run-scaled-{source.value}"
+        event_types = _event_types_for(asset)
         type_count = len(event_types)
         asset_id = asset.asset_id
         for occurrence in occurrences:
             seed = _stable_index(asset_id, str(occurrence))
             event_type = event_types[seed % type_count]
             observed_at = _EPOCH + timedelta(minutes=seed % 40320)
+            actor_id = actor_for(asset, occurrence)
             event_id = f"evt-{hashlib.sha256(f'{asset_id}:{occurrence}'.encode()).hexdigest()[:20]}"
             observations.append(
                 _seal(
@@ -287,9 +423,9 @@ def _build_observations(assets: tuple[EstateAsset, ...], profile: ScaleProfile, 
                         source=source,
                         event_type=event_type,
                         observed_at=observed_at,
-                        actor_id=f"{asset.provider}-principal-{seed % 37:02d}@{_TENANT_DOMAIN}",
+                        actor_id=actor_id,
                         resource_ids=(asset_id,),
-                        trace_id=hashlib.sha256(event_id.encode()).hexdigest()[:32],
+                        trace_id=session_trace_id(actor_id, observed_at, tenant_id),
                         raw_payload={
                             "eventName": event_type,
                             "accountScope": asset.account_scope,
@@ -382,8 +518,11 @@ def build_scaled_estate(profile: ScaleProfile | None = None, *, tenant_id: str =
     if not tenant_id:
         raise ValueError("tenant_id must not be empty")
 
-    assets = _build_assets(profile, tenant_id)
-    observations = _build_observations(assets, profile, tenant_id)
+    assets = _build_estate_assets(profile, tenant_id)
+    observations = (
+        *_build_observations(assets, profile, tenant_id),
+        *build_journeys(assets, tenant_id=tenant_id, count=profile.journeys, epoch=_EPOCH),
+    )
     estate = EnterpriseEstate(
         schema_version=ENTERPRISE_SCHEMA_VERSION,
         estate_id="northstar-health-ai-scaled-v1",

--- a/src/agent_bom/demo_estate/estate_graph.py
+++ b/src/agent_bom/demo_estate/estate_graph.py
@@ -1,10 +1,10 @@
 """Project the enterprise demo estate into the unified graph.
 
-:mod:`agent_bom.demo_estate.enterprise_composition` inventories 2,068 assets and
-:mod:`agent_bom.demo_estate.enterprise_findings` raises 439 findings on 407 of
-them, but that evidence reached only the demo story endpoint. The graph a
-prospect actually clicks was seeded independently from a 112-node hand-built
-showcase, so "one correlated graph at enterprise scale" rested on the 112.
+:mod:`agent_bom.demo_estate.enterprise_composition` inventories the estate and
+:mod:`agent_bom.demo_estate.enterprise_findings` raises its findings, but that
+evidence reached only the demo story endpoint. The graph a prospect actually
+clicks was seeded independently from a 112-node hand-built showcase, so "one
+correlated graph at enterprise scale" rested on the 112.
 
 This module closes the gap. Three decisions carry the weight:
 
@@ -90,11 +90,36 @@ _RESOURCE_ENTITY_TYPES: dict[str, EntityType] = {
     # Code / CI.
     "repository": EntityType.APPLICATION,
     "workflow": EntityType.CI_JOB,
-    # AI estate.
+    "package": EntityType.PACKAGE,
+    # AI estate — third party.
     "hosted_model": EntityType.MODEL,
     "model_artifact": EntityType.MODEL,
     "server": EntityType.SERVER,
     "tool": EntityType.TOOL,
+    "agent": EntityType.AGENT,
+    # AI estate — first party, inside the cloud accounts. Mapped explicitly for
+    # the same reason as everything above: an unmapped type silently renders as a
+    # generic cloud resource, so a Bedrock agent and an EC2 instance would be
+    # indistinguishable on the canvas that is supposed to show the AI estate.
+    "bedrock_agent": EntityType.AGENT,
+    "vertex_agent": EntityType.AGENT,
+    "bedrock_knowledge_base": EntityType.DATASET,
+    "ai_search_index": EntityType.DATASET,
+    "training_dataset": EntityType.DATASET,
+    "bedrock_guardrail": EntityType.ACCESS_POLICY,
+    "prompt_template": EntityType.CONFIG_FILE,
+    "foundation_model": EntityType.MODEL,
+    "sagemaker_model": EntityType.MODEL,
+    "vertex_model": EntityType.MODEL,
+    "azure_openai_deployment": EntityType.MODEL,
+    "sagemaker_endpoint": EntityType.SERVER,
+    "vertex_endpoint": EntityType.SERVER,
+    "gemini_api": EntityType.SERVER,
+    "cognitive_services_account": EntityType.SERVER,
+    "cortex_function": EntityType.SERVER,
+    "cortex_search_service": EntityType.SERVER,
+    "spcs_service": EntityType.SERVER,
+    "ai_foundry_project": EntityType.APPLICATION,
 }
 
 _DEFAULT_ENTITY_TYPE = EntityType.CLOUD_RESOURCE
@@ -112,10 +137,33 @@ _ACCOUNT_PROVIDER_PREFERENCE: tuple[str, ...] = (
     "kubernetes",
     "github",
     "mcp",
+    "agent",
     "openai",
     "anthropic",
     "huggingface",
     "enterprise",
+)
+
+# The node budget the graph canvas fetches with (``GRAPH_FULL_FETCH_LIMIT`` in
+# ``ui/app/graph/graph-page-client.tsx``, itself capped by ``/v1/graph``'s own
+# ``limit <= 5000``). The projection does NOT trim itself to fit: the estate is
+# the estate, and shrinking it so one view never truncates would be tuning the
+# data to flatter the picture. What it does is *report* its size against the
+# budget, so a caller can say how much of the graph a canvas is showing instead
+# of implying it is showing all of it.
+GRAPH_CANVAS_NODE_BUDGET = 5000
+
+# Asset tags that describe a relationship to another inventoried asset. Each
+# becomes a real edge, which is the difference between "we have AI assets" and
+# "this AI service reaches that data through that identity".
+_TOPOLOGY_TAGS: tuple[tuple[str, RelationshipType], ...] = (
+    ("uses_identity", RelationshipType.ASSUMES),
+    ("reads_data", RelationshipType.CAN_ACCESS),
+    ("delegates_to", RelationshipType.DELEGATED_TO),
+    ("mcp_server", RelationshipType.PART_OF),
+    ("container_image", RelationshipType.DEPENDS_ON),
+    ("cluster", RelationshipType.PART_OF),
+    ("repository", RelationshipType.PART_OF),
 )
 
 # Correlation kinds whose asset path is a real multi-hop chain worth drawing.
@@ -179,12 +227,20 @@ def _asset_node(asset: EstateAsset, estate: EnterpriseEstate) -> UnifiedNode:
     count the same risk twice and stop it reconciling with
     ``summarize_estate_findings``.
     """
+    exposed = asset.tags.get("internet_facing") == "true"
     return UnifiedNode(
         id=asset.asset_id,
         entity_type=entity_type_for_resource_type(asset.resource_type),
         label=asset.display_name,
         attributes={
             "asset_id": asset.asset_id,
+            # The CNAPP overlay's own spelling for exposure, not a demo-only
+            # one, so the estate's exposed resources take part in the same
+            # toxic-combination and exposure-path logic a live scan does.
+            "internet_exposed": exposed,
+            "publicly_accessible": asset.tags.get("public_access") == "true",
+            "over_permissive": asset.tags.get("over_permissive") == "true",
+            "ai_lane": asset.tags.get("ai_lane", ""),
             "native_id": asset.native_id,
             "resource_id": asset.native_id,
             "resource_name": asset.display_name,
@@ -212,8 +268,23 @@ def _asset_node(asset: EstateAsset, estate: EnterpriseEstate) -> UnifiedNode:
     )
 
 
+# Finding types that are a VULNERABILITY on the graph rather than a
+# MISCONFIGURATION. The distinction is not cosmetic: ``cnapp_overlay`` builds its
+# set of vulnerable resources from ``VULNERABLE_TO`` edges, and its toxic
+# combination — internet-exposed AND vulnerable — cannot fire for a resource
+# whose CVEs were all projected as misconfigurations. Projecting 768 CVEs under
+# the wrong entity type would have made the estate's exposure story quietly
+# weaker than the evidence it holds.
+_VULNERABILITY_FINDING_TYPES: frozenset[str] = frozenset({"CVE", "MALICIOUS_PACKAGE", "MALICIOUS_MODEL"})
+
+
+def _is_vulnerability(finding: Finding) -> bool:
+    return finding.finding_type.value in _VULNERABILITY_FINDING_TYPES
+
+
 def _finding_node_id(finding: Finding) -> str:
-    return f"misconfig:demo-estate:{finding.id}"
+    prefix = "vuln" if _is_vulnerability(finding) else "misconfig"
+    return f"{prefix}:demo-estate:{finding.id}"
 
 
 def project_estate_into_graph(
@@ -307,9 +378,47 @@ def project_estate_into_graph(
         graph.add_node(_asset_node(asset, estate))
         _edge(env_id, asset.asset_id, RelationshipType.CONTAINS)
 
+    # Topology: the edges the estate's own inventory declares. Containment alone
+    # renders a tree, and a tree cannot express "this AI service assumes that
+    # role and reads that table" — which is the whole reason the AI estate was
+    # generated inside the cloud accounts rather than beside them.
+    known_asset_ids = {asset.asset_id for asset in estate.assets}
+    topology_edges = 0
+    exposure_edges = 0
+    for asset in estate.assets:
+        for tag, relationship in _TOPOLOGY_TAGS:
+            target = asset.tags.get(tag, "")
+            if not target or target not in known_asset_ids or target == asset.asset_id:
+                continue
+            _edge(
+                asset.asset_id,
+                target,
+                relationship,
+                evidence={"reason": f"estate_{tag}"},
+                provenance={"source": ESTATE_DATA_SOURCE},
+            )
+            topology_edges += 1
+        # An internet-facing service in front of regulated data is the shape an
+        # exposure path exists to surface. Drawn only when BOTH ends are real:
+        # exposure without a reachable data store is a property of one node, not
+        # a path, and inventing the far end would be the over-claim the graph
+        # must never make.
+        if asset.tags.get("internet_facing") == "true":
+            data_target = asset.tags.get("reads_data", "")
+            if data_target and data_target in known_asset_ids:
+                _edge(
+                    asset.asset_id,
+                    data_target,
+                    RelationshipType.EXPOSED_TO,
+                    weight=6.0,
+                    evidence={"reason": "internet_exposed_data_store"},
+                    provenance={"source": ESTATE_DATA_SOURCE},
+                )
+                exposure_edges += 1
+
     finding_count = 0
     identity_edges = 0
-    known_assets = {asset.asset_id for asset in estate.assets}
+    known_assets = known_asset_ids
     # Worst finding risk per asset. The asset node itself stays unrated (see
     # ``_asset_node``), so this is the only place the posture on a hop is
     # available to score a chain.
@@ -326,10 +435,11 @@ def project_estate_into_graph(
         risk = SEVERITY_RISK_SCORE.get(severity, 0.0)
         risk_by_asset[asset_id] = max(risk_by_asset.get(asset_id, 0.0), risk)
         node_id = _finding_node_id(finding)
+        vulnerability = _is_vulnerability(finding)
         graph.add_node(
             UnifiedNode(
                 id=node_id,
-                entity_type=EntityType.MISCONFIGURATION,
+                entity_type=EntityType.VULNERABILITY if vulnerability else EntityType.MISCONFIGURATION,
                 label=finding.title,
                 severity=severity,
                 risk_score=SEVERITY_RISK_SCORE.get(severity, 0.0),
@@ -369,6 +479,11 @@ def project_estate_into_graph(
         # account → environment → resource → finding.
         _edge(node_id, asset_id, RelationshipType.AFFECTS)
         _edge(asset_id, node_id, RelationshipType.CONTAINS)
+        if vulnerability:
+            # The reverse edge the live builder emits for a vulnerable
+            # component, and the one ``cnapp_overlay`` reads to decide which
+            # resources are vulnerable at all.
+            _edge(asset_id, node_id, RelationshipType.VULNERABLE_TO)
         finding_count += 1
 
         principal = str(finding.evidence.get("identity_asset_id") or "")
@@ -383,6 +498,7 @@ def project_estate_into_graph(
 
     chain_edges, paths = _project_incident_chains(graph, correlations, known_assets, risk_by_asset)
 
+    node_count = len(graph.nodes)
     return {
         "version": ESTATE_GRAPH_VERSION,
         "estate_id": estate.estate_id,
@@ -390,9 +506,26 @@ def project_estate_into_graph(
         "accounts": len(accounts),
         "environments": len(environments),
         "findings": finding_count,
+        # Projection is total: every finding on an inventoried asset becomes a
+        # node. These fields exist so a consumer can prove that rather than
+        # assume it, and so the day a bound IS introduced it has to be declared
+        # in the same breath rather than silently dropping rows.
+        "findings_total": len(findings),
+        "findings_truncated": finding_count < len(findings),
+        "findings_bound_reason": "" if finding_count == len(findings) else "asset_not_inventoried",
         "identity_edges": identity_edges,
+        "topology_edges": topology_edges,
+        "exposure_edges": exposure_edges,
         "chain_edges": chain_edges,
         "attack_paths": paths,
+        "nodes": node_count,
+        "edges": len(graph.edges),
+        # What one canvas fetch can hold, and whether this graph exceeds it. The
+        # canvas is a working surface with a render budget; the roll-up and the
+        # findings list carry the whole estate. Reporting the relationship is
+        # what keeps a truncated canvas from reading as the complete picture.
+        "node_budget": GRAPH_CANVAS_NODE_BUDGET,
+        "exceeds_canvas_budget": node_count > GRAPH_CANVAS_NODE_BUDGET,
     }
 
 
@@ -472,6 +605,7 @@ def _chain_risk(graph: UnifiedGraph, hops: Sequence[str], risk_by_asset: dict[st
 __all__ = [
     "ESTATE_DATA_SOURCE",
     "ESTATE_GRAPH_VERSION",
+    "GRAPH_CANVAS_NODE_BUDGET",
     "entity_type_for_resource_type",
     "estate_account_node_id",
     "estate_environment_node_id",

--- a/src/agent_bom/demo_estate/presentation.py
+++ b/src/agent_bom/demo_estate/presentation.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from agent_bom.demo_estate.enterprise import NARRATIVE_INCIDENT_TRACE_ID
 from agent_bom.demo_estate.enterprise_composition import build_demo_estate
 from agent_bom.demo_estate.enterprise_correlation import (
     EnterpriseCollectionHealth,
@@ -121,11 +122,12 @@ def build_enterprise_demo_story(*, tenant_id: str = "demo-tenant") -> Enterprise
 
     estate = build_demo_estate(tenant_id=tenant_id)
     result = correlate_enterprise_estate(estate)
-    primary = next(
-        (row for row in result.correlations if row.kind == "data_egress_attempt"),
-        None,
-    )
-    if primary is None:
+    # Named, not discovered. "The first data-egress correlation" identified the
+    # incident only while it was the only one; the population now produces
+    # hundreds, and correlations sort by trace id, so the headline would have
+    # become whichever generated journey happened to hash lowest.
+    primary = result.correlation_by_trace(NARRATIVE_INCIDENT_TRACE_ID)
+    if primary is None or primary.kind != "data_egress_attempt":
         raise ValueError("enterprise demo is missing its primary data-egress correlation")
 
     # `summary` carries the true totals; these fields carry what a reader can

--- a/tests/test_demo_estate_bootstrap.py
+++ b/tests/test_demo_estate_bootstrap.py
@@ -228,7 +228,17 @@ def test_demo_estate_posture_findings_resolve_to_inventoried_assets(
         assert evidence.get("principal_id") or evidence.get("actor_id"), (
             f"{row.get('id')} lost its identity edge through redaction: {sorted(evidence)}"
         )
-        assert evidence.get("check_id") and evidence.get("control_id")
+        # Every posture finding must say which check saw it — that is the join
+        # key the rest of the product reads. A control id is required *exactly
+        # when* the finding claims a framework: not every posture rule has a
+        # CIS twin ("resource declared without an ownership tag" has none), and
+        # a rule with no control must say so rather than borrow one. Requiring
+        # a control on every row is what forced the IaC lane to assert CIS and
+        # NIST coverage it could not support.
+        assert evidence.get("check_id"), f"{row.get('id')} has no check identity: {sorted(evidence)}"
+        claims_cis = any(str(tag).upper().startswith("CIS") for tag in (row.get("compliance_tags") or row.get("compliance") or []))
+        if claims_cis:
+            assert evidence.get("control_id"), f"{row.get('id')} claims CIS with no control_id behind it"
         assert evidence.get("resource_name") and evidence.get("resource_type")
         assert row.get("provider"), sorted(row)
         assert row.get("severity"), sorted(row)
@@ -436,8 +446,20 @@ def test_demo_estate_exec_severity_counts_reconcile_across_surfaces(
 
 
 def test_demo_estate_showcase_cloud_hierarchy_and_exposure(demo_estate_client: TestClient) -> None:
-    """Showcase graph carries org→account containment and a bastion→PII exposure edge."""
-    payload = demo_estate_client.get("/v1/graph", headers=VIEWER).json()
+    """Showcase graph carries org→account containment and a bastion→PII exposure edge.
+
+    Read through the cursor rather than from a single default page. This asserts
+    a property of the *graph* — two named low-severity leaves and the edge
+    between them — and node pages are ordered by severity, so at estate scale no
+    page-size choice can promise a particular leaf is on page one. Asserting it
+    against the default page passed only while the estate was small enough to
+    fit, which made the test a size check wearing a topology check's clothes.
+
+    The default page's own contract — that it still describes a shaped estate
+    rather than a heap of findings — is asserted separately in
+    ``test_default_graph_page_carries_the_containment_spine``.
+    """
+    payload = _full_graph(demo_estate_client)
     node_ids = {node.get("id") for node in payload.get("nodes") or []}
     assert "org:corp" in node_ids
     assert "account:aws:123456789012" in node_ids
@@ -755,16 +777,49 @@ def test_demo_estate_scan_findings_restored_after_restart(
 
 # ── Enterprise estate projected into the graph ────────────────────────────
 #
-# The estate holds 2,068 assets and 439 findings on 407 of them. Once it is in
-# the graph the snapshot no longer fits one severity-ranked API page, so these
-# read the whole snapshot explicitly and separately assert that the *default*
-# page says so rather than reading as the estate.
+# Once the estate is in the graph the snapshot no longer fits one severity-ranked
+# API page, so these read the whole snapshot explicitly and separately assert
+# that the *default* page says so rather than reading as the estate.
 
 
 def _full_graph(client: TestClient) -> dict:
-    payload = client.get("/v1/graph", headers=VIEWER, params={"limit": 5000}).json()
-    assert payload.get("completeness", {}).get("complete") is True, payload.get("completeness")
-    return payload
+    """Assemble the COMPLETE snapshot by walking the keyset cursor.
+
+    A single ``limit=5000`` request used to cover it. It no longer can: the
+    estate projects more nodes than ``/v1/graph``'s own ``limit <= 5000``
+    ceiling, so one request is a truncated page by definition and asserting
+    ``complete is True`` on it could only ever be satisfied by shrinking the
+    estate. ``cursor=`` is the route's documented deep-paging path; walking it
+    is how a client reads everything, and it is what these tests need.
+    """
+    nodes: list[dict] = []
+    edges: list[dict] = []
+    seen: set[str] = set()
+    payload: dict = {}
+    cursor: str | None = None
+    for _page in range(20):  # bounded so a paging bug fails rather than hangs
+        params: dict[str, object] = {"limit": 5000}
+        if cursor:
+            params["cursor"] = cursor
+        payload = client.get("/v1/graph", headers=VIEWER, params=params).json()
+        for node in payload.get("nodes") or []:
+            node_id = node.get("id")
+            if node_id not in seen:
+                seen.add(str(node_id))
+                nodes.append(node)
+        edges.extend(payload.get("edges") or [])
+        cursor = payload.get("next_cursor") or (payload.get("pagination") or {}).get("next_cursor")
+        if not cursor:
+            break
+    else:  # pragma: no cover - only reached when paging never terminates
+        raise AssertionError("graph paging did not terminate")
+
+    total = (payload.get("completeness") or {}).get("total")
+    assert total is None or len(nodes) >= int(total), (len(nodes), total)
+    merged = dict(payload)
+    merged["nodes"] = nodes
+    merged["edges"] = edges
+    return merged
 
 
 def test_demo_estate_graph_carries_the_projected_estate(demo_estate_client: TestClient) -> None:
@@ -796,9 +851,21 @@ def test_demo_estate_graph_carries_the_projected_estate(demo_estate_client: Test
 
 
 def test_demo_estate_graph_incident_chain_is_traversable(demo_estate_client: TestClient) -> None:
-    """workflow → role → workload → MCP tool → PHI table → hosted model."""
+    """workflow → role → workload → MCP tool → PHI table → hosted model.
+
+    Asserts each landmark is *reachable* from the one before it, not that the
+    two are directly adjacent. The chain names the six assets the incident story
+    is told through; how many hops sit between them is a property of the estate,
+    not of the story. Pinning adjacency made this a test of chain length — it
+    broke the moment the estate started modelling the real intermediate assets
+    (the ECR image the role deploys, the cluster hosting the workload, the MCP
+    server publishing the tool, the database holding the table), all of which
+    make the traversal *more* faithful, not less.
+    """
     payload = _full_graph(demo_estate_client)
-    pairs = {(row.get("source"), row.get("target")) for row in payload.get("edges") or []}
+    adjacency: dict[str, set[str]] = {}
+    for row in payload.get("edges") or []:
+        adjacency.setdefault(str(row.get("source")), set()).add(str(row.get("target")))
     chain = (
         "github:workflow:member-copilot/deploy-prod",
         "cloud_resource:aws:iam:role:member-copilot-prod",
@@ -810,8 +877,21 @@ def test_demo_estate_graph_incident_chain_is_traversable(demo_estate_client: Tes
     node_ids = {n.get("id") for n in payload.get("nodes") or []}
     for hop in chain:
         assert hop in node_ids, f"missing incident hop {hop}"
+
+    def _reaches(source: str, target: str, *, max_hops: int = 6) -> bool:
+        frontier = {source}
+        seen = {source}
+        for _ in range(max_hops):
+            frontier = {nxt for node in frontier for nxt in adjacency.get(node, ())} - seen
+            if target in frontier:
+                return True
+            if not frontier:
+                return False
+            seen |= frontier
+        return False
+
     for source, target in zip(chain, chain[1:], strict=False):
-        assert (source, target) in pairs, f"incident chain broken at {source} -> {target}"
+        assert _reaches(source, target), f"incident chain broken at {source} -> {target}"
 
 
 def test_demo_estate_findings_land_on_inventoried_graph_nodes(
@@ -878,3 +958,31 @@ def test_demo_estate_graph_rolls_up_to_a_readable_estate(demo_estate_client: Tes
 
     resources = demo_estate_client.get("/v1/graph/rollup", headers=VIEWER, params={"node": "env:aws:123456789012:production"}).json()
     assert resources.get("children"), resources
+
+
+def test_default_graph_page_carries_the_containment_spine(demo_estate_client: TestClient) -> None:
+    """The first page a client gets must describe a shaped estate, not a heap.
+
+    ``/v1/graph`` orders nodes by severity. Once the estate carries more
+    high-severity findings than a page holds — 2,582 findings against a default
+    limit of 500 — every org, account and environment ranks below the cut, and
+    the default response contains findings floating with no structure. It looked
+    correct only while the estate was small enough that the spine happened to
+    fit inside the page.
+
+    Containment ancestors are few at any estate size, so they are resolved
+    explicitly and added on top of the page rather than left to compete on rank.
+    """
+    payload = demo_estate_client.get("/v1/graph", headers=VIEWER).json()
+    nodes = payload.get("nodes") or []
+    kinds = {str(node.get("type") or node.get("entity_type") or "") for node in nodes}
+    assert {"org", "account"} <= kinds, f"default page has no containment spine: {sorted(kinds)}"
+
+    node_ids = {node.get("id") for node in nodes}
+    contains = {
+        (row.get("source"), row.get("target"))
+        for row in payload.get("edges") or []
+        if row.get("relationship") in {"contains", "hosts", "owns"}
+    }
+    linked = [pair for pair in contains if pair[0] in node_ids and pair[1] in node_ids]
+    assert linked, "containment nodes arrived with no edge joining them to the page"

--- a/tests/test_demo_estate_findings.py
+++ b/tests/test_demo_estate_findings.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import pytest
 
-from agent_bom.demo_estate.enterprise import EnterpriseEstate
+from agent_bom.demo_estate.enterprise import NARRATIVE_INCIDENT_TRACE_ID, EnterpriseEstate
 from agent_bom.demo_estate.enterprise_composition import build_demo_estate
 from agent_bom.demo_estate.enterprise_correlation import (
     build_estate_correlations,
@@ -23,6 +23,7 @@ from agent_bom.demo_estate.enterprise_findings import (
     build_estate_findings,
     summarize_estate_findings,
 )
+from agent_bom.demo_estate.enterprise_risk import estate_asset_type
 from agent_bom.finding import Finding, FindingSource, FindingType
 
 TENANT = "estate-findings-tenant"
@@ -60,14 +61,22 @@ def test_findings_reuse_the_inventory_asset_id_and_never_a_stub(estate, findings
         identifier = finding.asset.identifier
         assert identifier in by_id, f"{finding.id} targets a stub asset {identifier!r}"
         asset = by_id[identifier]
-        # The canonical id must be a pure function of the inventory asset id, so
-        # every finding on one asset joins to the same node.
+        # The canonical id must be a pure function of (asset_type, asset_id),
+        # and the estate must use ONE asset_type per inventoried row — that is
+        # what makes every finding on one asset join to one node. The expected
+        # asset_type comes from ``estate_asset_type``, the single place every
+        # lane reads it from; hardcoding "cloud_resource" here would assert that
+        # a package and an EC2 instance are the same kind of thing.
         assert (
             finding.asset.canonical_id
             == Finding(
                 finding_type=FindingType.CIS_FAIL,
                 source=FindingSource.CLOUD_CIS,
-                asset=type(finding.asset)(name=asset.asset_id, asset_type="cloud_resource", identifier=asset.asset_id),
+                asset=type(finding.asset)(
+                    name=asset.asset_id,
+                    asset_type=estate_asset_type(asset),
+                    identifier=asset.asset_id,
+                ),
                 severity="medium",
                 title="probe",
             ).asset.canonical_id
@@ -116,7 +125,11 @@ def test_every_finding_carries_an_identity_edge_backed_by_the_estate(estate, fin
             identity = by_id.get(identity_id)
             assert identity is not None, f"{finding.id} names an identity outside the inventory: {identity_id}"
             assert identity.resource_type in IDENTITY_RESOURCE_TYPES
-            assert identity.provider == subject.provider
+            # Same ACCOUNT boundary — deliberately not the same provider. A GKE
+            # workload assumes a GCP service account and an EKS pod assumes an
+            # IAM role: the principal legitimately belongs to the cloud that
+            # owns the account, while the workload is inventoried under
+            # ``kubernetes``. The boundary that must hold is the account.
             assert identity.account_scope == subject.account_scope, (
                 f"{finding.id} crosses an account boundary: {identity.account_scope} != {subject.account_scope}"
             )
@@ -149,8 +162,18 @@ def test_the_phi_data_surfaces_on_the_attack_path_carry_findings(estate, finding
     assert by_id["snowflake:table:nh_prod/analytics/phi/patient_summary"].data_classifications
 
 
-def test_every_finding_carries_a_configuration_edge_with_observed_and_expected(findings):
-    for finding in findings:
+def test_every_posture_finding_carries_a_configuration_edge_with_observed_and_expected(findings):
+    """The configuration edge is what a POSTURE finding is; other lanes differ.
+
+    A CIS control failure is a statement about a setting, so observed/expected
+    is the finding. A CVE is a statement about a package version, a secret about
+    a file and line: demanding a ``configuration`` block from them would force
+    every lane to fabricate one. The lane-specific evidence each carries is
+    asserted by its own test below.
+    """
+    posture = [f for f in findings if f.source is FindingSource.CLOUD_CIS]
+    assert posture, "the posture lane disappeared"
+    for finding in posture:
         configuration = finding.evidence.get("configuration")
         assert isinstance(configuration, dict), f"{finding.id} has no configuration evidence"
         for key in ("setting", "observed", "expected"):
@@ -164,7 +187,12 @@ def test_every_finding_carries_a_configuration_edge_with_observed_and_expected(f
 
 
 def test_the_incident_chain_assets_carry_findings_linked_to_their_attack_path(estate, findings):
-    correlation = next(row for row in correlate_enterprise_estate(estate).correlations if row.kind == "data_egress_attempt")
+    # The narrative incident by name. "The first data-egress correlation" picked
+    # it out only while it was the only one; the generated population produces
+    # hundreds, sorted by trace id, so that selector now returns an arbitrary
+    # journey and the test would assert nothing about the incident.
+    correlation = correlate_enterprise_estate(estate).correlation_by_trace(NARRATIVE_INCIDENT_TRACE_ID)
+    assert correlation is not None and correlation.kind == "data_egress_attempt"
     on_path = {f.asset.identifier for f in findings} & set(correlation.asset_path)
     assert on_path, f"no finding lands on the primary attack path — the incident chain is still a diagram, path={correlation.asset_path}"
     linked = [f for f in findings if f.asset.identifier in on_path and f.evidence.get("correlation_id") == correlation.correlation_id]
@@ -178,6 +206,13 @@ def test_the_incident_chain_assets_carry_findings_linked_to_their_attack_path(es
 
 
 def test_every_finding_maps_to_at_least_one_compliance_control(findings):
+    """Holds across every lane, not only posture.
+
+    Three converters had to be brought up to it: ``blast_radius_to_finding``
+    needs ``apply_framework_tags`` run over the blast radius first (a live scan
+    does), and neither ``secret_dict_to_finding`` nor ``iac_finding_to_finding``
+    classifies into the hub on its own.
+    """
     for finding in findings:
         controls = finding.normalized_controls()
         assert controls, f"{finding.id} evidences no compliance control"
@@ -371,7 +406,7 @@ def test_two_tenants_holding_identical_finding_ids_both_persist():
         )
 
     for tenant in ("tenant-left", "tenant-right"):
-        page = store.list_current_page(tenant, limit=1000)
+        page = store.list_current_page(tenant, limit=len(left_ids) + 100)
         rows = page[0] if isinstance(page, tuple) else page
         assert len(rows) == len(left_ids), f"{tenant} kept {len(rows)} of {len(left_ids)} findings"
 

--- a/tests/test_demo_estate_graph_projection.py
+++ b/tests/test_demo_estate_graph_projection.py
@@ -31,11 +31,25 @@ from agent_bom.graph.types import EntityType, RelationshipType
 # The correlated incident the estate exists to demonstrate: a workflow assumes a
 # role, the role runs a workload, the workload calls an MCP tool, the tool reads
 # a PHI table, and the table's rows leave through a hosted model.
+# The hand-authored incident, hop by hop. Longer than the six it used to be:
+# the correlation's ordering table now includes the repository behind the
+# workflow, the image the role deploys, the cluster the workload runs on, the
+# MCP server that owns the tool and the database above the table. All five were
+# always in the incident's evidence — the rendered chain simply jumped over
+# them, so the canvas drew a workflow reaching straight into an IAM role.
 INCIDENT_CHAIN: tuple[str, ...] = (
+    "github:repository:northstar-health/member-copilot",
     "github:workflow:member-copilot/deploy-prod",
     "cloud_resource:aws:iam:role:member-copilot-prod",
+    (
+        "cloud_resource:aws:ecr:image:member-copilot@sha256:"
+        "4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"
+    ),
+    "kubernetes:cluster:eks/member-ai-prod",
     "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
+    "mcp:server:clinical-analytics",
     "mcp:tool:clinical-analytics/execute_sql",
+    "snowflake:database:nh_prod/analytics",
     "snowflake:table:nh_prod/analytics/phi/patient_summary",
     "model:openai:gpt-4.1",
 )
@@ -127,19 +141,41 @@ def test_findings_attach_to_the_inventoried_asset(projected, estate, estate_find
     graph, summary = projected
     asset_ids = {asset.asset_id for asset in estate.assets}
 
-    finding_nodes = [n for n in graph.nodes.values() if n.entity_type is EntityType.MISCONFIGURATION]
-    assert len(finding_nodes) == len(estate_findings) == 439, len(finding_nodes)
+    # Findings split by kind: a CVE is a VULNERABILITY node, everything else a
+    # MISCONFIGURATION. Projecting all of them as misconfigurations left the
+    # CNAPP overlay unable to see a single vulnerable resource, so its
+    # internet-exposed-AND-vulnerable combination could never fire.
+    finding_nodes = [
+        n
+        for n in graph.nodes.values()
+        if n.entity_type in (EntityType.MISCONFIGURATION, EntityType.VULNERABILITY)
+    ]
+    assert len(finding_nodes) == len(estate_findings), (len(finding_nodes), len(estate_findings))
+    assert any(n.entity_type is EntityType.VULNERABILITY for n in finding_nodes), (
+        "no CVE was projected as a vulnerability node"
+    )
+    assert any(n.entity_type is EntityType.MISCONFIGURATION for n in finding_nodes)
 
     affected: set[str] = set()
     for edge in graph.edges:
         if edge.relationship is not RelationshipType.AFFECTS:
             continue
-        if graph.nodes[edge.source].entity_type is not EntityType.MISCONFIGURATION:
+        if graph.nodes[edge.source].entity_type not in (
+            EntityType.MISCONFIGURATION,
+            EntityType.VULNERABILITY,
+        ):
             continue
         assert edge.target in asset_ids, f"finding attached to a non-inventoried node: {edge.target}"
         affected.add(edge.target)
-    assert len(affected) == 407, len(affected)
-    assert summary["findings"] == 439
+    # Derived, not pinned: what must hold is that every finding lands on an
+    # inventoried asset and that the affected set is a real subset of the estate
+    # — "all assets" or "no assets" would both mean the posture is not being
+    # evaluated. Pinning 407 turned every estate change into a gate failure and
+    # said nothing extra.
+    assert 0 < len(affected) < len(asset_ids), (len(affected), len(asset_ids))
+    assert summary["findings"] == len(estate_findings)
+    assert summary["findings_total"] == len(estate_findings)
+    assert summary["findings_truncated"] is False
 
     # Every finding node carries the Finding.id it was projected from, so the
     # findings list and the graph join without a heuristic.
@@ -149,7 +185,7 @@ def test_findings_attach_to_the_inventoried_asset(projected, estate, estate_find
 
 
 def test_incident_chain_is_traversable_end_to_end(projected) -> None:
-    """The six-hop correlated chain renders as consecutive edges, not prose."""
+    """The correlated chain renders as consecutive edges, not prose."""
     graph, summary = projected
     pairs = {(source, target) for source, target, _ in _edge_pairs(graph)}
     for node_id in INCIDENT_CHAIN:
@@ -202,12 +238,17 @@ def test_rollup_collapses_the_estate_to_one_readable_root(projected, estate) -> 
     assert root["entity_type"] == EntityType.ORG.value
     assert root["aggregate"]["descendant_count"] >= 2000, root["aggregate"]["descendant_count"]
 
-    # 40 account scopes, not the 46 (provider, scope) pairs the inventory holds:
-    # an EKS cluster and the S3 buckets beside it share one AWS account number,
-    # and the projection must not split one account into two nodes.
+    # One node per account SCOPE, not one per (provider, scope) pair: an EKS
+    # cluster, the S3 buckets beside it, the Kubernetes workloads, the MCP
+    # servers and the Bedrock agents all share one AWS account number, and the
+    # projection must not split that into six nodes. Derived rather than pinned
+    # so growing the estate does not require editing the number — the property
+    # is the collapse, and it is strictly fewer nodes than pairs.
     accounts = drill_down(graph, org_id)["children"]
-    assert len(accounts) == 40, len(accounts)
-    assert len({(a.provider, a.account_scope) for a in estate.assets}) == 46
+    pairs = {(a.provider, a.account_scope) for a in estate.assets}
+    scopes = {a.account_scope for a in estate.assets if a.resource_type != "organization"}
+    assert len(accounts) == len(scopes), (len(accounts), len(scopes))
+    assert len(accounts) < len(pairs), (len(accounts), len(pairs))
     assert {row["entity_type"] for row in accounts} == {EntityType.ACCOUNT.value}
 
     envs = drill_down(graph, "account:aws:123456789012")["children"]
@@ -319,7 +360,10 @@ def test_projected_finding_nodes_carry_readable_remediation_text(projected, esta
     """
     graph, _ = projected
     finding_nodes = [
-        node for node in graph.nodes.values() if node.entity_type is EntityType.MISCONFIGURATION and node.attributes.get("estate_id")
+        node
+        for node in graph.nodes.values()
+        if node.entity_type in (EntityType.MISCONFIGURATION, EntityType.VULNERABILITY)
+        and node.attributes.get("estate_id")
     ]
     assert len(finding_nodes) == len(estate_findings)
     for node in finding_nodes:

--- a/tests/test_demo_estate_graph_projection.py
+++ b/tests/test_demo_estate_graph_projection.py
@@ -41,10 +41,7 @@ INCIDENT_CHAIN: tuple[str, ...] = (
     "github:repository:northstar-health/member-copilot",
     "github:workflow:member-copilot/deploy-prod",
     "cloud_resource:aws:iam:role:member-copilot-prod",
-    (
-        "cloud_resource:aws:ecr:image:member-copilot@sha256:"
-        "4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"
-    ),
+    ("cloud_resource:aws:ecr:image:member-copilot@sha256:4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"),
     "kubernetes:cluster:eks/member-ai-prod",
     "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
     "mcp:server:clinical-analytics",
@@ -145,15 +142,9 @@ def test_findings_attach_to_the_inventoried_asset(projected, estate, estate_find
     # MISCONFIGURATION. Projecting all of them as misconfigurations left the
     # CNAPP overlay unable to see a single vulnerable resource, so its
     # internet-exposed-AND-vulnerable combination could never fire.
-    finding_nodes = [
-        n
-        for n in graph.nodes.values()
-        if n.entity_type in (EntityType.MISCONFIGURATION, EntityType.VULNERABILITY)
-    ]
+    finding_nodes = [n for n in graph.nodes.values() if n.entity_type in (EntityType.MISCONFIGURATION, EntityType.VULNERABILITY)]
     assert len(finding_nodes) == len(estate_findings), (len(finding_nodes), len(estate_findings))
-    assert any(n.entity_type is EntityType.VULNERABILITY for n in finding_nodes), (
-        "no CVE was projected as a vulnerability node"
-    )
+    assert any(n.entity_type is EntityType.VULNERABILITY for n in finding_nodes), "no CVE was projected as a vulnerability node"
     assert any(n.entity_type is EntityType.MISCONFIGURATION for n in finding_nodes)
 
     affected: set[str] = set()
@@ -362,8 +353,7 @@ def test_projected_finding_nodes_carry_readable_remediation_text(projected, esta
     finding_nodes = [
         node
         for node in graph.nodes.values()
-        if node.entity_type in (EntityType.MISCONFIGURATION, EntityType.VULNERABILITY)
-        and node.attributes.get("estate_id")
+        if node.entity_type in (EntityType.MISCONFIGURATION, EntityType.VULNERABILITY) and node.attributes.get("estate_id")
     ]
     assert len(finding_nodes) == len(estate_findings)
     for node in finding_nodes:

--- a/tests/test_enterprise_demo_correlation.py
+++ b/tests/test_enterprise_demo_correlation.py
@@ -53,11 +53,24 @@ def test_primary_incident_correlates_ci_cloud_workload_mcp_data_and_llm() -> Non
         "snowflake_access_history",
         "otel_llm",
     )
+    # The path walks the pipeline in order and now includes the hops the
+    # ordering table used to skip: the repository behind the workflow, the image
+    # the role deploys, the cluster the workload runs on, the MCP server that
+    # owns the tool, and the database above the table. Every one was already in
+    # the incident's evidence — the rendered chain simply jumped over them.
     assert incident.asset_path == (
+        "github:repository:northstar-health/member-copilot",
         "github:workflow:member-copilot/deploy-prod",
         "cloud_resource:aws:iam:role:member-copilot-prod",
+        (
+            "cloud_resource:aws:ecr:image:member-copilot@sha256:"
+            "4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"
+        ),
+        "kubernetes:cluster:eks/member-ai-prod",
         "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
+        "mcp:server:clinical-analytics",
         "mcp:tool:clinical-analytics/execute_sql",
+        "snowflake:database:nh_prod/analytics",
         "snowflake:table:nh_prod/analytics/phi/patient_summary",
         "model:openai:gpt-4.1",
     )

--- a/tests/test_enterprise_demo_correlation.py
+++ b/tests/test_enterprise_demo_correlation.py
@@ -62,10 +62,7 @@ def test_primary_incident_correlates_ci_cloud_workload_mcp_data_and_llm() -> Non
         "github:repository:northstar-health/member-copilot",
         "github:workflow:member-copilot/deploy-prod",
         "cloud_resource:aws:iam:role:member-copilot-prod",
-        (
-            "cloud_resource:aws:ecr:image:member-copilot@sha256:"
-            "4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"
-        ),
+        ("cloud_resource:aws:ecr:image:member-copilot@sha256:4f2c8d66a10b490c6f5e7a2f91f7eb04cf9b1001df06d422ad2c42c5bc82f20a"),
         "kubernetes:cluster:eks/member-ai-prod",
         "kubernetes:workload:member-ai-prod/ai-prod/member-copilot",
         "mcp:server:clinical-analytics",

--- a/tests/test_enterprise_demo_surfaces.py
+++ b/tests/test_enterprise_demo_surfaces.py
@@ -46,18 +46,20 @@ def test_story_builds_one_canonical_cross_vendor_read_model() -> None:
 
 
 def test_story_never_presents_single_source_traces_as_cross_vendor_correlations() -> None:
-    """The headline correlation count must not be read as the cross-vendor claim.
+    """The headline correlation count and the cross-vendor claim must reconcile.
 
-    ``_build_correlations`` groups evidence by ``trace_id``. The generated
-    population gives every observation its own trace, so almost every row is one
-    event from one source correlated with nothing — a labelled event, not a
-    correlation. At estate scale that inflates the number the demo leads with
-    from single digits into the thousands.
+    This test used to assert ``cross_source < correlations / 100`` as its
+    *precondition* — it encoded the defect it was written beside. The estate gave
+    every observation its own ``trace_id``, so 6,145 of 6,148 "correlations" were
+    one event grouped with itself and only 3 joined a second vendor; the
+    assertion made that permanent.
 
-    The graph already publishes the honest figure: ``project_estate_into_graph``
-    draws a chain only where a correlation spans at least two inventoried assets,
-    and ``/v1/graph/attack-paths`` returns those. The story must carry the same
-    reconcilable number rather than leaving the two surfaces to disagree.
+    The generator no longer works that way: activity is grouped into per-principal
+    session traces, journeys walk CI → cloud → Kubernetes → MCP → warehouse →
+    model on one trace, and a single-event trace yields no correlation at all. So
+    the property to hold is not a ratio — it is that ``cross_source_correlations``
+    is an independent recount of the rows that genuinely span vendors, never
+    exceeds the total, and that the total contains no single-event row.
     """
     from agent_bom.demo_estate.enterprise_composition import build_demo_estate
     from agent_bom.demo_estate.enterprise_correlation import build_estate_correlations
@@ -67,11 +69,18 @@ def test_story_never_presents_single_source_traces_as_cross_vendor_correlations(
     rows = build_estate_correlations(build_demo_estate(tenant_id=tenant))
     cross_source = sum(1 for row in rows if len(set(row.sources)) >= 2)
 
-    # Precondition: the gap this test exists for is real on the shipped estate.
-    assert 0 < cross_source < story.summary.correlations / 100, (cross_source, story.summary.correlations)
-
     assert story.summary.cross_source_correlations == cross_source
-    assert story.summary.cross_source_correlations <= story.summary.correlations
+    assert 0 < cross_source <= story.summary.correlations
+
+    # No row may be a single event wearing a trace id — that is what made the
+    # old headline meaningless.
+    assert all(len(row.event_ids) >= 2 for row in rows), "a single-event trace is being served as a correlation"
+
+    # Every row the summary counts as cross-source really spans two sources.
+    for row in rows:
+        if len(set(row.sources)) < 2:
+            continue
+        assert len(row.event_ids) >= 2
 
 
 def test_demo_story_cli_emits_complete_machine_readable_evidence() -> None:

--- a/tests/test_enterprise_estate_scale.py
+++ b/tests/test_enterprise_estate_scale.py
@@ -103,10 +103,22 @@ def test_no_asset_leaves_a_scope_dimension_blank(estate: EnterpriseEstate) -> No
 
 
 def test_observations_reference_many_distinct_assets(estate: EnterpriseEstate) -> None:
-    """Correlation is the claim. Events pointing at a handful of assets do not show it."""
-    touched = {asset_id for event in estate.observations for asset_id in event.resource_ids}
+    """Correlation is the claim. Events pointing at a handful of assets do not show it.
 
-    assert len(touched) >= len(estate.assets) // 2, f"only {len(touched)} of {len(estate.assets)} assets carry any evidence"
+    Measured against the *observable* inventory. Some rows have no control plane
+    to be observed on: a package appears in an SBOM and in a vulnerability
+    finding, never in an audit log, and the organization root is a grouping node.
+    Counting them in the denominator would mean the only way to keep this green
+    is to emit an audit event for a package — evidence the estate cannot justify.
+    """
+    touched = {asset_id for event in estate.observations for asset_id in event.resource_ids}
+    observable = [
+        asset for asset in estate.assets if asset.resource_type not in {"package", "organization"}
+    ]
+
+    assert len(touched) >= len(observable) // 2, (
+        f"only {len(touched)} of {len(observable)} observable assets carry any evidence"
+    )
 
 
 def test_every_observation_hash_verifies(estate: EnterpriseEstate) -> None:

--- a/tests/test_enterprise_estate_scale.py
+++ b/tests/test_enterprise_estate_scale.py
@@ -112,13 +112,9 @@ def test_observations_reference_many_distinct_assets(estate: EnterpriseEstate) -
     is to emit an audit event for a package — evidence the estate cannot justify.
     """
     touched = {asset_id for event in estate.observations for asset_id in event.resource_ids}
-    observable = [
-        asset for asset in estate.assets if asset.resource_type not in {"package", "organization"}
-    ]
+    observable = [asset for asset in estate.assets if asset.resource_type not in {"package", "organization"}]
 
-    assert len(touched) >= len(observable) // 2, (
-        f"only {len(touched)} of {len(observable)} observable assets carry any evidence"
-    )
+    assert len(touched) >= len(observable) // 2, f"only {len(touched)} of {len(observable)} observable assets carry any evidence"
 
 
 def test_every_observation_hash_verifies(estate: EnterpriseEstate) -> None:

--- a/tests/test_estate_v2_scale.py
+++ b/tests/test_estate_v2_scale.py
@@ -1,0 +1,432 @@
+"""The demo estate must demonstrate scale and correlation, not assert them.
+
+Every assertion here is about a *chain* or a *reconciliation*. A test that only
+counts rows proves nothing: 6,148 "correlations" of which 6,145 were one event
+grouped with itself passed a count assertion for months while the surface headed
+"cross-vendor correlations" showed 3.
+
+The four properties under test:
+
+1. **Traces span vendors.** A correlation is a real multi-source trace with an
+   ordered asset path, not a single event wearing a trace id.
+2. **Findings come from more than one scanner.** Posture, vulnerability, secret,
+   IaC and runtime lanes, every one of them landing on an *inventoried* asset via
+   the canonical id path.
+3. **The AI estate lives inside the cloud accounts.** A first-party AI service
+   shares its account, region, environment, identity and data store with the
+   cloud resources beside it — that shared context is what the correlation is.
+4. **Counts reconcile and generation is deterministic**, including across
+   ``PYTHONHASHSEED``.
+"""
+
+from __future__ import annotations
+
+import collections
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent_bom.demo_estate.enterprise import EnterpriseEstate, EvidenceSource
+from agent_bom.demo_estate.enterprise_composition import build_demo_estate
+from agent_bom.demo_estate.enterprise_correlation import (
+    EnterpriseCorrelationResult,
+    correlate_enterprise_estate,
+)
+from agent_bom.demo_estate.enterprise_findings import (
+    build_estate_findings,
+    summarize_estate_findings,
+)
+from agent_bom.demo_estate.enterprise_scale import (
+    AI_LANE_TAG,
+    MIN_CROSS_SOURCE_CORRELATIONS,
+    MIN_ESTATE_FINDINGS,
+)
+from agent_bom.demo_estate.estate_graph import project_estate_into_graph
+from agent_bom.graph.container import UnifiedGraph
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture(scope="module")
+def estate() -> EnterpriseEstate:
+    return build_demo_estate(tenant_id="estate-v2")
+
+
+@pytest.fixture(scope="module")
+def correlated(estate: EnterpriseEstate) -> EnterpriseCorrelationResult:
+    return correlate_enterprise_estate(estate)
+
+
+@pytest.fixture(scope="module")
+def findings(estate: EnterpriseEstate, correlated: EnterpriseCorrelationResult):
+    return build_estate_findings(estate, correlation_result=correlated)
+
+
+# ── 1. Cross-vendor traces ────────────────────────────────────────────────────
+
+
+def test_cross_source_correlations_are_in_the_hundreds(correlated):
+    """The headline claim: evidence from different vendors joins on one trace."""
+    cross_source = [row for row in correlated.correlations if len(set(row.sources)) >= 2]
+    assert len(cross_source) >= MIN_CROSS_SOURCE_CORRELATIONS, f"only {len(cross_source)} correlations span more than one evidence source"
+
+
+def test_a_cross_vendor_trace_is_a_real_chain_not_a_relabelled_event(estate, correlated):
+    """Assert the CHAIN: distinct sources, ordered time, multi-provider asset path.
+
+    The defect this replaces was invisible to a count — every observation carried
+    its own trace id, so a "correlation" was one event grouped with itself. A
+    chain is only a chain if it has more than one event, from more than one
+    source, walking more than one provider's assets, in time order.
+    """
+    assets_by_id = {asset.asset_id: asset for asset in estate.assets}
+    events_by_id = {event.event_id: event for event in correlated.events}
+
+    deep = [row for row in correlated.correlations if len(set(row.sources)) >= 4 and len(row.asset_path) >= 3]
+    assert deep, "no correlation spans four evidence sources over three or more assets"
+
+    for row in deep[:25]:
+        assert len(row.event_ids) == len(row.sources)
+        assert len(set(row.event_ids)) == len(row.event_ids), "an event was counted twice"
+
+        timestamps = [events_by_id[event_id].observed_at for event_id in row.event_ids]
+        assert timestamps == sorted(timestamps), "trace events are not in time order"
+        assert row.started_at == timestamps[0]
+        assert row.ended_at == timestamps[-1]
+
+        # Every hop is an asset the estate actually inventoried — no stubs.
+        assert all(asset_id in assets_by_id for asset_id in row.asset_path)
+        providers = {assets_by_id[asset_id].provider for asset_id in row.asset_path}
+        assert len(providers) >= 2, f"asset path stays inside one provider: {providers}"
+
+        # One actor drives the whole trace; that is what makes it one story.
+        actors = {events_by_id[event_id].actor_id for event_id in row.event_ids}
+        assert len(actors) == 1, f"a single trace has {len(actors)} actors"
+
+
+def test_the_full_six_vendor_pipeline_is_represented(correlated):
+    """CI -> cloud audit -> Kubernetes -> MCP -> warehouse -> model, on one trace."""
+    pipeline = {
+        EvidenceSource.GITHUB_ACTIONS,
+        EvidenceSource.KUBERNETES_AUDIT,
+        EvidenceSource.MCP_GATEWAY,
+        EvidenceSource.SNOWFLAKE_ACCESS_HISTORY,
+        EvidenceSource.OTEL_LLM,
+    }
+    spanning = [row for row in correlated.correlations if pipeline <= set(row.sources)]
+    assert len(spanning) >= 50, f"only {len(spanning)} traces cover the whole pipeline"
+
+
+def test_trace_outcomes_are_read_from_evidence_not_assumed(correlated):
+    """A blocked egress and an allowed one must not both report 'blocked'.
+
+    ``_correlation_kind`` used to label *any* trace touching an LLM span as
+    ``blocked``, which is a verdict the evidence does not support. Outcomes now
+    come from the policy decision the span actually recorded, so both verdicts
+    have to be present.
+    """
+    egress = [row for row in correlated.correlations if row.kind == "data_egress_attempt"]
+    assert len(egress) >= 2
+    outcomes = collections.Counter(row.outcome for row in egress)
+    assert outcomes["blocked"] > 0, "no blocked egress attempt"
+    assert outcomes["allowed"] > 0, "every egress reads as blocked — the verdict is assumed"
+
+
+def test_the_narrative_incident_is_still_the_primary_correlation():
+    """The generated population must not shoulder the hand-authored incident aside."""
+    from agent_bom.demo_estate.presentation import build_enterprise_demo_story
+
+    story = build_enterprise_demo_story(tenant_id="estate-v2")
+    assert story.primary_correlation.outcome == "blocked"
+    assert tuple(source.value for source in story.primary_correlation.sources) == (
+        "github_actions",
+        "aws_cloudtrail",
+        "kubernetes_audit",
+        "mcp_gateway",
+        "snowflake_access_history",
+        "otel_llm",
+    )
+    assert story.correlations[0] == story.primary_correlation
+
+
+# ── 2. Findings from more than CIS ────────────────────────────────────────────
+
+
+def test_findings_reach_the_thousands_across_several_lanes(findings):
+    assert len(findings) >= MIN_ESTATE_FINDINGS
+
+    by_type = collections.Counter(finding.finding_type.value for finding in findings)
+    for required in ("CIS_FAIL", "CVE", "CREDENTIAL_EXPOSURE"):
+        assert by_type[required] > 0, f"no {required} findings — the estate is single-lane"
+
+    by_source = collections.Counter(finding.source.value for finding in findings)
+    assert len(by_source) >= 4, f"findings come from too few scanners: {dict(by_source)}"
+
+    # Realistic distribution: no lane may dominate the estate.
+    dominant = max(by_type.values())
+    assert dominant < len(findings) * 0.6, f"one finding type is {dominant}/{len(findings)}"
+
+
+def test_severity_is_a_distribution_not_a_wall_of_critical(estate, findings):
+    summary = summarize_estate_findings(estate, findings)
+    assert sum(summary.by_severity.values()) == summary.total == len(findings)
+    assert summary.by_severity["critical"] > 0
+    assert summary.by_severity["medium"] > 0
+    # Unrated is an explicit bucket, never a silent drop.
+    assert summary.by_severity["unrated"] > 0
+    assert summary.by_severity["critical"] < summary.total * 0.2, "most of the estate is critical"
+
+
+def test_vulnerability_findings_carry_exploitability_evidence(findings):
+    """A CVE without EPSS/KEV is a row of text, not a prioritisable risk."""
+    cves = [finding for finding in findings if finding.finding_type.value == "CVE"]
+    assert len(cves) >= 200
+    assert all(finding.cve_id for finding in cves)
+    assert any(finding.is_kev for finding in cves), "no KEV-flagged vulnerability"
+    scored = [finding for finding in cves if finding.epss_score is not None]
+    assert len(scored) == len(cves), "some CVEs carry no EPSS score"
+    assert len({round(finding.epss_score, 3) for finding in scored}) > 10, "EPSS is a constant"
+
+
+def test_every_finding_resolves_to_an_inventoried_asset(estate, findings):
+    """#4637: one id scheme. A finding's asset id IS an estate asset id."""
+    known = {asset.asset_id for asset in estate.assets}
+    orphans = [finding.asset.identifier for finding in findings if (finding.asset.identifier or "") not in known]
+    assert not orphans, f"{len(orphans)} findings point at assets the estate never inventoried"
+
+    # ... and the canonical id is a pure function of that row, so the findings
+    # list and the graph join on an identifier rather than on a label.
+    for finding in findings[:200]:
+        assert finding.asset.canonical_id
+        assert finding.evidence.get("resource_id") == finding.asset.identifier
+
+
+def test_secret_and_iac_findings_name_both_the_code_and_the_resource(findings):
+    """The code-layer location is evidence; the affected thing is the asset."""
+    secrets = [f for f in findings if f.finding_type.value == "CREDENTIAL_EXPOSURE"]
+    assert secrets
+    for finding in secrets[:50]:
+        assert finding.evidence.get("file"), "a secret finding names no file"
+        assert "REDACT" in str(finding.evidence.get("redacted_preview", "")).upper()
+
+    iac = [f for f in findings if f.evidence.get("iac") is True]
+    assert iac, "no IaC misconfiguration findings"
+    for finding in iac[:50]:
+        assert finding.evidence.get("file_path")
+        assert finding.evidence.get("rule_id")
+
+
+# ── 3. The AI estate lives inside the cloud accounts ──────────────────────────
+
+
+def test_first_party_ai_services_share_account_region_and_environment(estate):
+    """A Bedrock agent is an AWS account resource, not a separate vendor lane."""
+    native = [a for a in estate.assets if a.tags.get(AI_LANE_TAG) == "first_party"]
+    assert len(native) >= 300, f"only {len(native)} first-party AI services"
+
+    by_provider = collections.Counter(asset.provider for asset in native)
+    for cloud in ("aws", "azure", "gcp", "snowflake"):
+        assert by_provider[cloud] > 0, f"{cloud} has no first-party AI service"
+
+    # Every AI service sits in an account/region/environment that already holds
+    # non-AI resources from the same provider.
+    cloud_scopes: dict[str, set[tuple[str, str, str]]] = {}
+    for asset in estate.assets:
+        if asset.tags.get(AI_LANE_TAG):
+            continue
+        cloud_scopes.setdefault(asset.provider, set()).add((asset.account_scope, asset.region, asset.environment))
+    for asset in native:
+        assert (asset.account_scope, asset.region, asset.environment) in cloud_scopes[asset.provider], (
+            f"{asset.asset_id} lives in a scope no other resource occupies"
+        )
+
+
+def test_ai_services_attach_to_identities_and_data_that_already_exist(estate):
+    """The correlation is the shared identity and the shared data store."""
+    by_id = {asset.asset_id: asset for asset in estate.assets}
+    native = [a for a in estate.assets if a.tags.get(AI_LANE_TAG) == "first_party"]
+
+    linked = 0
+    for asset in native:
+        identity = asset.tags.get("uses_identity", "")
+        data_store = asset.tags.get("reads_data", "")
+        if not identity and not data_store:
+            continue
+        linked += 1
+        if identity:
+            principal = by_id[identity]
+            assert principal.provider == asset.provider
+            assert principal.account_scope == asset.account_scope
+        if data_store:
+            store = by_id[data_store]
+            assert store.account_scope == asset.account_scope
+    assert linked >= len(native) * 0.8, "most AI services borrow no existing identity or data"
+
+
+def test_third_party_ai_is_the_smaller_share(estate):
+    native = [a for a in estate.assets if a.tags.get(AI_LANE_TAG) == "first_party"]
+    third_party = [a for a in estate.assets if a.tags.get(AI_LANE_TAG) == "third_party"]
+    assert third_party, "the third-party AI lane disappeared"
+    assert len(third_party) < len(native), f"third-party ({len(third_party)}) is not the smaller share of native ({len(native)})"
+
+
+def test_mcp_servers_own_their_tools_and_agents_delegate(estate):
+    by_id = {asset.asset_id: asset for asset in estate.assets}
+    tools = [a for a in estate.assets if a.resource_type == "tool"]
+    servers = [a for a in estate.assets if a.resource_type == "server"]
+    agents = [a for a in estate.assets if a.resource_type == "agent"]
+    assert len(servers) >= 20 and len(tools) >= 80 and len(agents) >= 30
+
+    for tool in tools:
+        parent = tool.tags.get("mcp_server", "")
+        assert parent in by_id, f"tool {tool.asset_id} hangs off no inventoried server"
+        assert by_id[parent].resource_type == "server"
+
+    delegating = [a for a in agents if a.tags.get("delegates_to")]
+    assert delegating, "no agent-to-agent topology"
+    for agent in delegating:
+        assert by_id[agent.tags["delegates_to"]].resource_type == "agent"
+
+
+# ── 4. Exposure surfaces and attack paths ─────────────────────────────────────
+
+
+def test_exposure_surfaces_exist_and_are_labelled(estate):
+    public = [a for a in estate.assets if a.tags.get("internet_facing") == "true"]
+    permissive = [a for a in estate.assets if a.tags.get("over_permissive") == "true"]
+    public_data = [a for a in estate.assets if a.tags.get("public_access") == "true" and a.data_classifications]
+    assert len(public) >= 40
+    assert len(permissive) >= 20
+    assert public_data, "no publicly reachable data store"
+
+
+def test_attack_paths_are_a_rich_set_and_every_hop_is_inventoried(estate, correlated, findings):
+    graph = UnifiedGraph()
+    shape = project_estate_into_graph(graph, estate, findings=findings, correlations=correlated.correlations)
+    known = {asset.asset_id for asset in estate.assets}
+
+    assert shape["attack_paths"] >= 200, f"only {shape['attack_paths']} attack paths"
+    assert len(graph.attack_paths) == shape["attack_paths"]
+    for path in graph.attack_paths:
+        assert len(path.hops) >= 2
+        assert all(hop in known for hop in path.hops)
+        assert path.source == path.hops[0] and path.target == path.hops[-1]
+
+    # A path is only worth showing if it ends somewhere that matters.
+    by_id = {asset.asset_id: asset for asset in estate.assets}
+    to_data = [path for path in graph.attack_paths if by_id[path.target].data_classifications or by_id[path.target].tags.get(AI_LANE_TAG)]
+    assert len(to_data) >= 100, "attack paths rarely reach data or an AI service"
+
+
+def test_graph_projection_reports_its_size_against_the_canvas_budget(estate, correlated, findings):
+    """The projection is total, and says how it sits against the render budget.
+
+    The estate is not trimmed to fit one view — that would be tuning the data to
+    flatter the picture. What must never happen is a canvas showing part of the
+    estate while nothing says so, so the projection reports both halves of that
+    relationship and the API's ``completeness`` carries it to the client.
+    """
+    graph = UnifiedGraph()
+    shape = project_estate_into_graph(graph, estate, findings=findings, correlations=correlated.correlations)
+    # Every finding lands: none was dropped for want of an inventoried asset.
+    assert shape["findings"] == shape["findings_total"] == len(findings)
+    assert shape["findings_truncated"] is False
+    assert shape["findings_bound_reason"] == ""
+
+    assert shape["nodes"] == len(graph.nodes)
+    assert shape["edges"] == len(graph.edges)
+    assert shape["node_budget"] > 0
+    assert shape["exceeds_canvas_budget"] is (shape["nodes"] > shape["node_budget"])
+
+
+def test_topology_edges_make_the_ai_chain_traversable(estate, correlated, findings):
+    """AI service -> identity -> data store must be edges, not tags."""
+    from agent_bom.graph.types import RelationshipType
+
+    graph = UnifiedGraph()
+    shape = project_estate_into_graph(graph, estate, findings=findings, correlations=correlated.correlations)
+    assert shape["topology_edges"] >= 500
+    assert shape["exposure_edges"] > 0
+
+    by_relationship = collections.Counter(edge.relationship for edge in graph.edges)
+    for relationship in (
+        RelationshipType.ASSUMES,
+        RelationshipType.CAN_ACCESS,
+        RelationshipType.DELEGATED_TO,
+        RelationshipType.EXPOSED_TO,
+    ):
+        assert by_relationship[relationship] > 0, f"no {relationship.value} edges"
+
+    # Walk one: a first-party AI service, the role it assumes, the store it reads.
+    by_id = {asset.asset_id: asset for asset in estate.assets}
+    service = next(
+        a for a in estate.assets if a.tags.get(AI_LANE_TAG) == "first_party" and a.tags.get("uses_identity") and a.tags.get("reads_data")
+    )
+    assumed = by_id[service.tags["uses_identity"]]
+    store = by_id[service.tags["reads_data"]]
+    assert assumed.account_scope == service.account_scope == store.account_scope
+    assert {service.asset_id, assumed.asset_id, store.asset_id} <= set(graph.nodes)
+
+
+# ── 5. Reconciliation and determinism ─────────────────────────────────────────
+
+
+def test_story_counts_reconcile_with_the_estate_they_describe():
+    from agent_bom.demo_estate.presentation import build_enterprise_demo_story
+
+    story = build_enterprise_demo_story(tenant_id="estate-v2")
+    assert story.summary.findings == story.finding_summary.total
+    assert sum(story.finding_summary.by_severity.values()) == story.finding_summary.total
+    assert story.summary.cross_source_correlations >= MIN_CROSS_SOURCE_CORRELATIONS
+    assert story.summary.cross_source_correlations <= story.summary.correlations
+
+    for name, returned, total in (
+        ("events", len(story.events), story.summary.observations),
+        ("correlations", len(story.correlations), story.summary.correlations),
+        ("findings", len(story.findings), story.summary.findings),
+    ):
+        bound = getattr(story.bounds, name)
+        assert bound.returned == returned
+        assert bound.total == total
+        assert bound.truncated is (returned < total)
+
+
+def test_generation_is_deterministic_across_process_and_hash_seed():
+    """Same profile, same content hash — proved in fresh interpreters.
+
+    ``PYTHONHASHSEED`` randomises ``str.__hash__``, so any generator that let set
+    or dict iteration order leak into its output produces a different estate per
+    run. That cannot be caught in-process: this has to fork.
+    """
+    script = (
+        "import json;"
+        "from agent_bom.demo_estate.enterprise_composition import build_demo_estate;"
+        "from agent_bom.demo_estate.enterprise_correlation import correlate_enterprise_estate;"
+        "from agent_bom.demo_estate.enterprise_findings import build_estate_findings;"
+        "e=build_demo_estate(tenant_id='determinism');"
+        "c=correlate_enterprise_estate(e);"
+        "f=build_estate_findings(e, correlation_result=c);"
+        "print(json.dumps({"
+        "'estate':e.content_hash,'story':c.content_hash,"
+        "'assets':len(e.assets),'observations':len(e.observations),"
+        "'correlations':len(c.correlations),'findings':len(f),"
+        "'finding_ids':[x.id for x in f[:500]],"
+        "'asset_ids':[a.asset_id for a in e.assets[:500]]}))"
+    )
+    results = []
+    for seed in ("0", "1", "12345"):
+        proc = subprocess.run(
+            [sys.executable, "-c", script],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            env={"PYTHONHASHSEED": seed, "PATH": "/usr/bin:/bin", "PYTHONPATH": str(REPO_ROOT / "src")},
+        )
+        results.append(json.loads(proc.stdout))
+
+    assert results[0] == results[1] == results[2], "estate generation is not deterministic"
+    assert len(results[0]["estate"]) == 64

--- a/tests/test_showcase_graph_seeding.py
+++ b/tests/test_showcase_graph_seeding.py
@@ -183,17 +183,25 @@ def test_baseline_snapshot_carries_inventory_without_the_collection_window() -> 
 
     That is what makes the drift lens show posture *arriving* between the two
     snapshots rather than relabelling the same set.
+
+    Asserted as the relationship between the two snapshots rather than against
+    two frozen totals. The contract is that baseline and current inventory the
+    SAME estate and differ only in evidence; pinning the literal asset count
+    made this a size test, so growing the estate failed it while the property it
+    names held perfectly.
     """
     from agent_bom.demo_estate.showcase_graph import project_estate_onto_showcase
 
     baseline = UnifiedGraph(scan_id=SHOWCASE_BASELINE_SCAN_ID, tenant_id=SHOWCASE_TENANT)
     summary = project_estate_onto_showcase(baseline, tenant_id=SHOWCASE_TENANT, profile="baseline")
-    assert summary["assets"] == 2068
+    assert summary["assets"] > 0
     assert summary["findings"] == 0
     assert summary["chain_edges"] == 0
     assert not [n for n in baseline.nodes.values() if n.entity_type is EntityType.MISCONFIGURATION]
 
     current = UnifiedGraph(scan_id=SHOWCASE_SCAN_ID, tenant_id=SHOWCASE_TENANT)
     current_summary = project_estate_onto_showcase(current, tenant_id=SHOWCASE_TENANT, profile="current")
-    assert current_summary["findings"] == 439
+    # Same inventory in both snapshots — only the evidence window differs.
+    assert current_summary["assets"] == summary["assets"]
+    assert current_summary["findings"] > 0
     assert len(current.nodes) > len(baseline.nodes)

--- a/ui/app/graph/graph-page-client.tsx
+++ b/ui/app/graph/graph-page-client.tsx
@@ -162,6 +162,20 @@ import { graphTopologyKey, selectGraphSubgraph } from "@/lib/graph-presentation"
 // The bound matches the interactive render budget: past it, the overview
 // aggregates dense neighborhoods rather than splitting the topology across
 // pages, so edges never vanish across a page boundary.
+//
+// Deliberately NOT raised to `/v1/graph`'s own `limit <= 5000` ceiling, though
+// the demo estate now projects ~6,700 nodes and 5,000 would show more of them.
+// Measured against the seeded estate, `limit=5000` costs **3.19 s** versus
+// **0.77 s** at 3,000 — the response carries ~19k edges rather than ~9k — and
+// the WebGL overview can only draw
+// `LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES` of whatever arrives. Paying three
+// seconds of page load for nodes the canvas then discards is a worse trade than
+// showing fewer.
+//
+// Past this budget the canvas is the wrong surface, and the honest ones are
+// already fast: `/v1/graph/rollup` aggregates the COMPLETE snapshot in ~136 ms
+// (~387 ms drilling into the org), and `/v1/findings` carries every finding.
+// The completeness banner below names the budget and points at them.
 const GRAPH_FULL_FETCH_LIMIT = LARGE_GRAPH_OVERVIEW_MAX_RENDERED_NODES;
 
 const GraphDriftLegend = dynamic(
@@ -3404,7 +3418,7 @@ function GraphPageInner() {
                     complete: false,
                     sampled: false,
                     returned: displayNodes.length,
-                    reason: `Interactive render budget is ${GRAPH_FULL_FETCH_LIMIT.toLocaleString()} nodes. Dense neighborhoods are aggregated — filter or focus rather than treating this canvas as the full estate.`,
+                    reason: `Interactive render budget is ${GRAPH_FULL_FETCH_LIMIT.toLocaleString()} nodes, ranked by severity. Dense neighborhoods are aggregated — filter or focus here, or open the estate roll-up, which aggregates the complete graph. This canvas is not the full estate.`,
                   }
                 }
                 visibleCount={displayNodes.length}


### PR DESCRIPTION
The estate a prospect clicks was smaller than the estate we inventory, and several of its lanes asserted more than their evidence supported.

## Scale and shape

- First-party AI assets inside the cloud accounts (Bedrock, Vertex, SageMaker, Azure OpenAI, Cortex, SPCS) are inventoried and mapped to distinct entity types. An unmapped resource type renders as a generic cloud resource, so a Bedrock agent and an EC2 instance were indistinguishable on the canvas that exists to show the AI estate.
- Asset tags that name another inventoried asset now become real edges — the difference between "we have AI assets" and "this AI service reaches that data through that identity."
- Journeys and a runtime risk lane give the estate findings that only exist because it is *running*, not just configuration drift.

## Accuracy, where the old lanes over-claimed

- Every IaC rule declared `["CIS", "NIST-800-53"]` regardless of what it checks, so "resource declared without an ownership tag" asserted CIS coverage it cannot support. Rules now carry per-provider CIS checks and NIST controls and claim only the frameworks they evidence — half of them have no CIS twin, and saying so is the accurate answer.
- The runtime lane carried **no rule identity at all**, so 410 findings reached `/v1/findings` with no `evidence["check_id"]`. That is the join key every posture consumer reads, which made the lane invisible to all of them. Rules now have stable ids (`MCP-TOOL-001` … `AI-MODEL-007`).
- `_RuntimeRule.domain` had no readers, and the value it carried for the CIEM rule (`"ciem"`) is not one of the five posture lanes in `SECURITY_DOMAINS`, so `canonical_domain()` would reject it. Removed rather than wired.
- `normalize_policy_decision` reads the enforcement verdict a provider actually recorded. `_correlation_kind` used to infer it from the event source, labelling every trace that touched an LLM span `blocked`.

## Graph

`/v1/graph` orders nodes by severity. Once the estate carries more high-severity findings than a page holds, every org, account and environment ranks below the cut and the default response describes an estate with no shape. Containment ancestors are now resolved explicitly and added on top of the page. `completeness.returned` counts the payload, with `ranked` and `context_nodes` so it still reconciles against `pagination`.

Measured, not assumed: a 500-node page resolves 552 ancestors (each finding's own resource, then env/account/org). Bounded by the page, not the estate.

## Tests

Two assertions encoded assumptions the estate outgrew:

- The showcase hierarchy test read a single severity-ordered page, which no page size can promise a named low-severity leaf appears on. It now reads through the cursor.
- The incident-chain test asserted **direct adjacency**, which broke once the estate modelled the real intermediates (ECR image, cluster, MCP server, database). Those make the traversal more faithful, so it now asserts reachability — which is what its name always claimed.

## Verification

- 174 passed / 0 failed across the 9 affected suites (demo estate, estate-v2 scale, graph projection, findings, correlation, surfaces, estate scale, graph scope contract, graph export).
- `ruff format --check`, `ruff check`, and `mypy` clean.
- Full suite running locally against the merged tree; results to follow.