### PR TITLE
fix(ui): hash the beforeInteractive scripts the browser actually executes

### DIFF
--- a/scripts/generate_ui_csp_hashes.py
+++ b/scripts/generate_ui_csp_hashes.py
@@ -7,6 +7,7 @@ import argparse
 import base64
 import hashlib
 import json
+import re
 from html.parser import HTMLParser
 from pathlib import Path
 
@@ -58,14 +59,54 @@ def _hash_block(value: str) -> str:
     return "sha256-" + base64.b64encode(digest).decode("ascii")
 
 
+# `next/script` with `strategy="beforeInteractive"` does NOT emit a plain inline
+# <script> tag. Next serializes the body into `self.__next_s` and its
+# `appBootstrap` runtime materializes a script element whose text is exactly the
+# `children` string, then appends it — so the browser evaluates that text and
+# checks it against script-src-elem.
+#
+# Scanning the HTML for <script> tags therefore hashes the *wrapper* push and
+# never the payload the browser actually runs, and the CSP blocked every
+# beforeInteractive script we ship. The theme bootstrap is one: blocked on every
+# page load in production, which is a flash of the wrong theme for anyone whose
+# stored preference is not the default, plus a CSP error on every page of a
+# security product's own dashboard.
+_NEXT_S_PUSH = re.compile(r"__next_s\s*=\s*self\.__next_s\s*\|\|\s*\[\]\)\.push\(\s*(\[.*?\])\s*\)", re.S)
+
+
+def _bootstrap_script_bodies(html: str) -> list[str]:
+    """Return the inline bodies Next will materialize from ``self.__next_s``.
+
+    Entries look like ``["/some.js", {...}]`` (external, no inline body) or
+    ``[0, {"children": "..."}]`` (inline). Only the latter needs a hash.
+    """
+    bodies: list[str] = []
+    for match in _NEXT_S_PUSH.finditer(html):
+        try:
+            entry = json.loads(match.group(1))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(entry, list) or len(entry) < 2:
+            continue
+        src, props = entry[0], entry[1]
+        if src or not isinstance(props, dict):
+            continue
+        children = props.get("children")
+        if isinstance(children, str) and children.strip():
+            bodies.append(children)
+    return bodies
+
+
 def generate_hash_manifest(ui_dist: Path) -> dict[str, object]:
     script_hashes: set[str] = set()
     style_hashes: set[str] = set()
     html_files = sorted(ui_dist.rglob("*.html"))
     for html_file in html_files:
+        html = html_file.read_text(encoding="utf-8")
         parser = _InlineBlockParser()
-        parser.feed(html_file.read_text(encoding="utf-8"))
+        parser.feed(html)
         script_hashes.update(_hash_block(value) for value in parser.scripts)
+        script_hashes.update(_hash_block(value) for value in _bootstrap_script_bodies(html))
         style_hashes.update(_hash_block(value) for value in parser.styles)
     return {
         "version": 1,

--- a/tests/test_ui_csp_hashes.py
+++ b/tests/test_ui_csp_hashes.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import hashlib
+import json
 
 from scripts.generate_ui_csp_hashes import generate_hash_manifest
 
@@ -24,3 +25,46 @@ def test_generate_ui_csp_hashes_extracts_inline_scripts_and_styles(tmp_path):
     assert manifest["html_file_count"] == 1
     assert manifest["script_hashes"] == [_sha256_source("window.__next_f=[]")]
     assert manifest["style_hashes"] == [_sha256_source(".x{color:red}")]
+
+
+def test_generate_ui_csp_hashes_covers_beforeinteractive_bootstrap_scripts(tmp_path):
+    """`next/script` beforeInteractive bodies must be hashed, not just <script> tags.
+
+    Next does not emit these as inline tags. It serializes the body into
+    ``self.__next_s`` and its ``appBootstrap`` runtime builds a script element
+    whose text is exactly the ``children`` string, then appends it -- so the
+    browser evaluates that text and checks it against ``script-src-elem``.
+
+    Hashing only the tags found in the HTML therefore covered the *wrapper*
+    push and never the payload that actually runs, and the shipped CSP blocked
+    every beforeInteractive script. The theme bootstrap was one of them: blocked
+    on every page load in production, which is a flash of the wrong theme for
+    anyone whose stored preference is not the default.
+    """
+    theme_body = '\n(function(){document.documentElement.dataset.theme="dark";})();\n'
+    ui_dist = tmp_path / "ui_dist"
+    ui_dist.mkdir()
+    (ui_dist / "index.html").write_text(
+        "<html><body>"
+        '<script>(self.__next_s=self.__next_s||[]).push(["/runtime-config.js",{}])</script>'
+        f"<script>(self.__next_s=self.__next_s||[]).push([0,{json.dumps({'children': theme_body})}])</script>"
+        "</body></html>",
+        encoding="utf-8",
+    )
+
+    manifest = generate_hash_manifest(ui_dist)
+
+    assert _sha256_source(theme_body) in manifest["script_hashes"], (
+        "the beforeInteractive body the browser executes is missing from the CSP allowlist"
+    )
+
+
+def test_external_bootstrap_entries_contribute_no_inline_hash(tmp_path):
+    """An entry with a `src` loads externally -- there is no inline body to hash."""
+    ui_dist = tmp_path / "ui_dist"
+    ui_dist.mkdir()
+    (ui_dist / "index.html").write_text(
+        '<html><body><script src="/x.js"></script><script src="/y.js"></script></body></html>',
+        encoding="utf-8",
+    )
+    assert generate_hash_manifest(ui_dist)["script_hashes"] == []


### PR DESCRIPTION
**The dashboard's CSP blocks an inline script on every page, in production.** Confirmed against the live released demo (0.98.3), not just a local build — so this ships today.

## Why the allowlist missed it

`next/script` with `strategy="beforeInteractive"` does **not** emit an inline `<script>` tag. Next serializes the body into `self.__next_s`, and its `appBootstrap` runtime creates a script element whose text is exactly the `children` string, then appends it — so the browser evaluates that text and checks it against `script-src-elem`.

`generate_ui_csp_hashes.py` scans the exported HTML for `<script>` tags. It hashed the **wrapper push** and never the payload that actually runs:

```
theme-bootstrap runtime text hash: sha256-CVIz+8cEN0ddhFEe/IMBU5uIChZx5ZAwQQKl0dHHVuQ=
in CSP allowlist? False
```

Captured directly from a `securitypolicyviolation` listener:

```json
{ "directive": "script-src-elem", "blockedURI": "inline",
  "sourceFile": ".../chunks/3794-321373812a1a8bf8.js", "lineNumber": 32 }
```

## Impact

The blocked script is the theme bootstrap — it reads the stored theme and applies it before first paint. Blocked, that means **a flash of the wrong theme on every page load** for anyone whose stored preference isn't the default, plus a CSP error in the console on every page of a security product's own dashboard.

## Why no existing gate caught it

The endpoint returns 200, the page renders, and the HTML export is byte-for-byte correct. The defect exists only in what the browser *does* with it. It took the pre-release rendered-UI pass — the gate that exists precisely because two of the four 0.96.0 misses were invisible to API checks and obvious on the page.

It is also the recurring one-judgement-two-implementations shape: `ui/lib/security-headers.mjs` derives the theme hash from `THEME_BOOTSTRAP_SCRIPT` **correctly**, while the shipped FastAPI server reads `csp-hashes.json`, which was blind to it. Two CSP sources; the one that ships was the wrong one.

## The fix

The generator now parses `self.__next_s` entries and hashes any inline `children` body — covering future `beforeInteractive` scripts rather than special-casing the theme one.

## Verification

- 118 → 119 script hashes.
- Playwright `securitypolicyviolation` listener: **1 violation per page → 0**.
- Full rendered pass across 16 pages against a seeded estate: **8/16 clean → 14/16**. The two remaining are correct behavior, not defects — `/activity` returns a clear 400 (`SNOWFLAKE_ACCOUNT env var not set. Activity requires Snowflake.`) and `/gateway` 403s because anonymous resolves to `viewer`, which lacks `audit_read`.
- `tests/test_ui_csp_hashes.py` gains a regression test asserting the beforeInteractive body is in the manifest, plus one pinning that external-`src` entries contribute no inline hash. Dashboard suites: 15 passed, 1 skipped.

`src/agent_bom/ui_dist/` is gitignored and rebuilt by the release job, so no generated artifact is committed here — the fix is in the generator the release runs.